### PR TITLE
DEV: moving BasicVoterSerializer to use BasicUserSerializer

### DIFF
--- a/plugins/discourse-post-voting/app/serializers/basic_voter_serializer.rb
+++ b/plugins/discourse-post-voting/app/serializers/basic_voter_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-class BasicVoterSerializer < ApplicationSerializer
-  attributes :id, :username, :name, :avatar_template, :direction
+class BasicVoterSerializer < BasicUserSerializer
+  attributes :direction
 
   def direction
     object.direction

--- a/plugins/discourse-post-voting/spec/requests/post_voting/votes_controller_spec.rb
+++ b/plugins/discourse-post-voting/spec/requests/post_voting/votes_controller_spec.rb
@@ -159,6 +159,31 @@ RSpec.describe PostVoting::VotesController do
       expect(response.status).to eq(404)
     end
 
+    it "serializes voters with BasicUserSerializer attributes plus direction" do
+      sign_in(user)
+
+      voter = Fabricate(:user)
+      Fabricate(:post_voting_vote, votable: answer, user: voter)
+
+      get "/post_voting/voters.json", params: { post_id: answer.id }
+
+      expect(response.status).to eq(200)
+      voters = JSON.parse(response.body)["voters"]
+      expect(voters).not_to be_empty
+
+      voter_payload = voters.find { |v| v["id"] == voter.id }
+      expect(voter_payload.keys).to contain_exactly(
+        "id",
+        "username",
+        "name",
+        "avatar_template",
+        "direction",
+      )
+      expect(voter_payload["username"]).to eq(voter.username)
+      expect(voter_payload["avatar_template"]).to eq(voter.avatar_template)
+      expect(voter_payload["direction"]).to eq(PostVotingVote.directions[:up])
+    end
+
     it "should return correct users respecting limits" do
       sign_in(user)
 


### PR DESCRIPTION
Removes the duplicate identity-attribute declarations in BasicVoterSerializer in favor of the canonical chain,  leaving only the voter-specific `direction` attribute on the subclass.