### PR TITLE
UX: Show "Approve this post?" heading on rejected queued posts

### DIFF
--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -870,14 +870,10 @@ export default class ReviewableItem extends Component {
                 <h3 class="review-item__aside-title">
                   {{#if this.editing}}
                     {{i18n "review.editing_post"}}
-                  {{else if (eq this.reviewable.status PENDING)}}
-                    {{#if this.displayContextQuestion}}
-                      {{this.reviewable.flaggedReviewableContextQuestion}}
-                    {{else if this.reviewable.userReviewableContextQuestion}}
-                      {{this.reviewable.userReviewableContextQuestion}}
-                    {{else}}
-                      {{i18n "review.moderator_actions"}}
-                    {{/if}}
+                  {{else if this.displayContextQuestion}}
+                    {{this.reviewable.flaggedReviewableContextQuestion}}
+                  {{else if this.reviewable.userReviewableContextQuestion}}
+                    {{this.reviewable.userReviewableContextQuestion}}
                   {{else}}
                     {{i18n "review.moderator_actions"}}
                   {{/if}}

--- a/frontend/discourse/app/models/reviewable.js
+++ b/frontend/discourse/app/models/reviewable.js
@@ -79,9 +79,13 @@ export default class Reviewable extends RestModel {
     });
   }
 
-  @computed("resolvedType", "reviewable_scores")
+  @computed("resolvedType", "reviewable_scores", "status")
   get userReviewableContextQuestion() {
     if (this.resolvedType === "ReviewableUser") {
+      // in this case the only remaining action is "scrub record" so the question shouldn't show
+      if (this.status !== PENDING) {
+        return null;
+      }
       const isSuspectUser = this.reviewable_scores?.some(
         (score) => score.reason_type === "suspect_user"
       );

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -152,6 +152,12 @@ module PageObjects
         end
       end
 
+      def has_no_context_question?(reviewable, text)
+        within(reviewable_by_id(reviewable.id)) do
+          page.has_no_css?(".review-item__aside-title", text: text)
+        end
+      end
+
       def flag_reason_component
         PageObjects::Components::Review::FlagReason.new
       end

--- a/spec/system/viewing_reviewable_spec.rb
+++ b/spec/system/viewing_reviewable_spec.rb
@@ -319,8 +319,11 @@ describe "Viewing reviewable item" do
     end
 
     it "shows context question for rejected queued post" do
+      reviewable_queued_post.update!(status: Reviewable.statuses[:rejected])
+
       review_page.visit_reviewable(reviewable_queued_post)
 
+      expect(review_page).to have_reviewable_with_rejected_status(reviewable_queued_post)
       expect(review_page).to have_context_question(
         reviewable_queued_post,
         I18n.t("js.review.context_question.approve_post"),
@@ -355,6 +358,11 @@ describe "Viewing reviewable item" do
       expect(review_page).to have_reviewable_with_rejected_status(reviewable)
 
       expect(page).to have_text(user.name)
+
+      expect(review_page).to have_no_context_question(
+        reviewable,
+        I18n.t("js.review.context_question.approve_user"),
+      )
 
       review_page.click_scrub_user_button
 


### PR DESCRIPTION
Related to the report here: https://meta.discourse.org/t/how-to-understand-the-request-revision-feature/397258

Currently a rejected queued post shows "Yes" under the heading "Moderator actions" because the context question was gated on `status === PENDING` — but that gate doesn't make sense here because there's still the possibility of approving the content after the post is rejected. 

<img width="650" height="166" alt="image" src="https://github.com/user-attachments/assets/9b090fb9-d028-47e9-ba32-0f51a57acc64" />

This adjusts the gating so that `userReviewableContextQuestion` will render regardless of status. So now we get the correct header after the item is rejected while suppressing it in the "scrub record" case

<img width="600" alt="image" src="https://github.com/user-attachments/assets/adba0a43-fa18-4738-88a0-4f309ec692c7" />

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/f8fe8631-8ffe-4a31-953e-232d97a1f05b" />



 Included a spec to make sure it doesn't regress. 