### PR TITLE
UX: Add btn-default class to buttons for consistent base styling

### DIFF
--- a/frontend/discourse/admin/components/admin-config-areas/api-keys-show.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/api-keys-show.gjs
@@ -111,10 +111,12 @@ export default class AdminConfigAreasApiKeysShow extends Component {
             <DButton
               @action={{this.saveDescription}}
               @label="admin.api_keys.save"
+              class="btn-default"
             />
             <DButton
               @action={{this.toggleEditDescription}}
               @label="admin.api_keys.cancel"
+              class="btn-default"
             />
           {{else}}
             <DButton
@@ -164,6 +166,7 @@ export default class AdminConfigAreasApiKeysShow extends Component {
             <DButton
               @action={{fn this.undoRevokeKey @apiKey}}
               @label="admin.api.undo_revoke"
+              class="btn-default"
             />
             <DButton
               @action={{fn this.deleteKey @apiKey}}

--- a/frontend/discourse/admin/components/form-template/row-item.gjs
+++ b/frontend/discourse/admin/components/form-template/row-item.gjs
@@ -59,13 +59,13 @@ export default class FormTemplateRowItem extends Component {
           @title="admin.form_templates.list_table.actions.view"
           @icon="far-eye"
           @action={{fn (mut this.showViewTemplateModal) true}}
-          class="btn-view-template"
+          class="btn-default btn-view-template"
         />
         <DButton
           @title="admin.form_templates.list_table.actions.edit"
           @icon="pencil"
           @action={{this.editTemplate}}
-          class="btn-edit-template"
+          class="btn-default btn-edit-template"
         />
         <DButton
           @title="admin.form_templates.list_table.actions.delete"

--- a/frontend/discourse/admin/components/modal/edit-badge-groupings.gjs
+++ b/frontend/discourse/admin/components/modal/edit-badge-groupings.gjs
@@ -102,20 +102,31 @@ export default class EditBadgeGroupings extends Component {
                     <DButton
                       @action={{fn (mut wc.editing) false}}
                       @icon="check"
+                      class="btn-default"
                     />
                   {{else}}
                     <DButton
                       @action={{fn (mut wc.editing) true}}
                       @disabled={{wc.system}}
                       @icon="pencil"
+                      class="btn-default"
                     />
                   {{/if}}
-                  <DButton @action={{fn this.up wc}} @icon="chevron-up" />
-                  <DButton @action={{fn this.down wc}} @icon="chevron-down" />
+                  <DButton
+                    @action={{fn this.up wc}}
+                    @icon="chevron-up"
+                    class="btn-default"
+                  />
+                  <DButton
+                    @action={{fn this.down wc}}
+                    @icon="chevron-down"
+                    class="btn-default"
+                  />
                   <DButton
                     @action={{fn this.delete wc}}
                     @disabled={{wc.system}}
                     @icon="xmark"
+                    class="btn-default"
                   />
                 </div>
               </li>
@@ -124,7 +135,7 @@ export default class EditBadgeGroupings extends Component {
         </div>
         <DButton
           @action={{this.add}}
-          class="badge-groupings__add-grouping"
+          class="btn-default badge-groupings__add-grouping"
           @label="admin.badges.new"
         />
       </:body>

--- a/frontend/discourse/admin/components/webhook-event.gjs
+++ b/frontend/discourse/admin/components/webhook-event.gjs
@@ -123,16 +123,19 @@ export default class WebhookEvent extends Component {
           @icon={{this.expandRequestIcon}}
           @action={{this.toggleRequest}}
           @label="admin.web_hooks.events.request"
+          class="btn-default"
         />
         <DButton
           @icon={{this.expandResponseIcon}}
           @action={{this.toggleResponse}}
           @label="admin.web_hooks.events.response"
+          class="btn-default"
         />
         <DButton
           @icon="arrows-rotate"
           @action={{this.redeliver}}
           @label="admin.web_hooks.events.redeliver"
+          class="btn-default"
         />
       </div>
 

--- a/frontend/discourse/admin/components/webhook-events.gjs
+++ b/frontend/discourse/admin/components/webhook-events.gjs
@@ -230,6 +230,7 @@ export default class WebhookEvents extends Component {
           @label="admin.web_hooks.events.redeliver_failed"
           @action={{this.redeliverFailed}}
           @disabled={{not this.redeliverEnabled}}
+          class="btn-default"
         />
 
         <DButton
@@ -237,7 +238,7 @@ export default class WebhookEvents extends Component {
           @label="admin.web_hooks.events.ping"
           @action={{this.ping}}
           @disabled={{not this.pingEnabled}}
-          class="webhook-events__ping-button"
+          class="btn-default webhook-events__ping-button"
         />
       </div>
 

--- a/frontend/discourse/admin/templates/admin-customize-themes/edit.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-themes/edit.gjs
@@ -11,7 +11,7 @@ export default <template>
           @title="go_back"
           @action={{@controller.goBack}}
           @icon="chevron-left"
-          class="btn-small editor-back-button"
+          class="btn-default btn-small editor-back-button"
         />
 
         <span class="editor-theme-name-wrapper">

--- a/frontend/discourse/admin/templates/admin-email/advanced-test.gjs
+++ b/frontend/discourse/admin/templates/admin-email/advanced-test.gjs
@@ -18,6 +18,7 @@ export default <template>
     <DButton
       @action={{@controller.run}}
       @label="admin.email.advanced_test.run"
+      class="btn-default"
     />
   </div>
 

--- a/frontend/discourse/admin/templates/admin-permalinks/index.gjs
+++ b/frontend/discourse/admin/templates/admin-permalinks/index.gjs
@@ -95,6 +95,7 @@ export default <template>
                       @title={{i18n "admin.permalink.more_options"}}
                       @icon="ellipsis-vertical"
                       @onRegisterApi={{@controller.onRegisterApi}}
+                      @triggerClass="btn-default"
                     >
                       <:content>
                         <DropdownMenu as |dropdown|>

--- a/frontend/discourse/admin/templates/admin-user/index.gjs
+++ b/frontend/discourse/admin/templates/admin-user/index.gjs
@@ -806,7 +806,7 @@ export default <template>
               type="ReviewableFlaggedPost"
               status="all"
             }}
-            class="btn"
+            class="btn btn-default"
           >
             {{i18n "admin.user.show_flags_received"}}
           </LinkTo>
@@ -840,7 +840,7 @@ export default <template>
             @route="adminReports.show"
             @model="post_edits"
             @query={{hash filters=@controller.postEditsByEditorFilter}}
-            class="btn btn-icon"
+            class="btn btn-icon btn-default"
           >
             {{icon "far-eye"}}
             {{i18n "admin.user.view_edits"}}

--- a/frontend/discourse/admin/templates/admin-web-hooks/show.gjs
+++ b/frontend/discourse/admin/templates/admin-web-hooks/show.gjs
@@ -18,7 +18,7 @@ export default <template>
         @action={{@controller.edit}}
         @icon="far-pen-to-square"
         @title="admin.web_hooks.edit"
-        class="no-text admin-webhooks__edit-button"
+        class="btn-default no-text admin-webhooks__edit-button"
       />
 
       <DButton

--- a/frontend/discourse/app/components/group-manage-logs-row.gjs
+++ b/frontend/discourse/app/components/group-manage-logs-row.gjs
@@ -78,6 +78,7 @@ export default class GroupManageLogsRow extends Component {
           <DButton
             @action={{this.toggleDetails}}
             @icon={{if this.expandDetails "angle-up" "angle-down"}}
+            class="btn-default"
           />
         {{/if}}
       </td>

--- a/frontend/discourse/app/components/modal/edit-user-directory-columns.gjs
+++ b/frontend/discourse/app/components/modal/edit-user-directory-columns.gjs
@@ -151,12 +151,12 @@ export default class EditUserDirectoryColumns extends Component {
                   <DButton
                     @icon="arrow-up"
                     @action={{fn this.moveUp column}}
-                    class="button-secondary move-column-up"
+                    class="btn-default button-secondary move-column-up"
                   />
                   <DButton
                     @icon="arrow-down"
                     @action={{fn this.moveDown column}}
-                    class="button-secondary"
+                    class="btn-default button-secondary move-column-down"
                   />
                 </div>
               </div>
@@ -173,7 +173,7 @@ export default class EditUserDirectoryColumns extends Component {
         <DButton
           @label="directory.edit_columns.reset_to_default"
           @action={{this.resetToDefault}}
-          class="btn-secondary reset-to-default"
+          class="btn-default btn-secondary reset-to-default"
         />
       </:footer>
     </DModal>

--- a/frontend/discourse/app/components/user-preferences/user-passkeys.gjs
+++ b/frontend/discourse/app/components/user-preferences/user-passkeys.gjs
@@ -240,6 +240,7 @@ export default class UserPasskeys extends Component {
             @action={{this.addPasskey}}
             @icon="plus"
             @label="user.passkeys.add_passkey"
+            class="btn-default"
           />
         </div>
       {{/if}}

--- a/frontend/discourse/app/templates/user-invited/show.gjs
+++ b/frontend/discourse/app/templates/user-invited/show.gjs
@@ -68,7 +68,7 @@ export default <template>
                 @icon="xmark"
                 @action={{@controller.destroyAllExpired}}
                 @label="user.invited.remove_all"
-                class="bulk-remove-expired"
+                class="btn-default bulk-remove-expired"
               />
             {{/if}}
 
@@ -303,7 +303,7 @@ export default <template>
                             @title={{i18n "more_options"}}
                             @icon="ellipsis-vertical"
                             @onRegisterApi={{@controller.onRegisterApi}}
-                            class="btn-small"
+                            class="btn-default btn-small"
                           >
                             <:content>
                               <DropdownMenu as |dropdown|>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/connectors/user-custom-preferences/region.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/connectors/user-custom-preferences/region.gjs
@@ -41,6 +41,7 @@ export default class Region extends Component {
         @icon="globe"
         @label="discourse_calendar.region.use_current_region"
         @action={{this.useCurrentRegion}}
+        class="btn-default"
       />
     </div>
   </template>


### PR DESCRIPTION
Adds missing `btn-default` to some buttons that didn’t have a button style class before.

I used `btn-default` since it keeps the visual changes minimal.
The difference is barely noticeable (mostly slightly rounded corners).

See screenshot for before/after comparison:

<img width="1105" height="3039" alt="default button class" src="https://github.com/user-attachments/assets/c2891e16-7b19-470b-98a4-f37fbe29f9ec" />
