### PR TITLE
FIX: long pressing reactions-counter shouldn't open ReactionsPicker

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions.gjs
@@ -199,10 +199,16 @@ export default class DiscourseReactionsActions extends Component {
   }
 
   @action
-  touchStart() {
-    this._validTouch = true;
+  touchStart(event) {
+    this._validTouch = !!event.target.closest(
+      ".discourse-reactions-reaction-button"
+    );
 
     cancel(this._touchTimeout);
+
+    if (!this._validTouch) {
+      return false;
+    }
 
     if (this.capabilities.touch) {
       document.documentElement?.classList?.toggle(


### PR DESCRIPTION
There exists a bug when `Enable new post reactions menu` is enabled, the left `discourse-reactions-actions-x-left` and `discourse-reactions-reaction-button` share the same component.

In mobile view, when long pressing the left `discourse-reactions-actions-x-left`, it triggers an unintended ReactionsPicker, which the console showing an error of `Uncaught (in promise) TypeError: Cannot read properties of null (reading 'getBoundingClientRect')` and a unresponsive picker panel.

This commit attach the event to element `.discourse-reactions-reaction-button` to prevent such things.

Before:

https://github.com/user-attachments/assets/5e7ea492-2cae-4d3b-8eba-cfedcbe204ff

After:

https://github.com/user-attachments/assets/35d63878-a23d-4386-8305-1f75a460a49d

On Meta:

https://github.com/user-attachments/assets/85b5e75c-5199-4f60-9845-8e1820088a55