### PR TITLE
FIX: security hardening form `codes_to_img`

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -96,6 +96,7 @@ class Category < ActiveRecord::Base
   validates :num_featured_topics, numericality: { only_integer: true, greater_than: 0 }
   validates :search_priority, inclusion: { in: Searchable::PRIORITIES.values }
 
+  validate :emoji_exists
   validate :parent_category_validator
   validate :email_in_validator
   validate :ensure_slug
@@ -347,6 +348,10 @@ class Category < ActiveRecord::Base
       .flatten(1)
       .map { |setting| setting[:key].to_sym }
       .uniq
+  end
+
+  def emoji_exists
+    errors.add(:emoji, :invalid) if emoji.present? && !Emoji.exists?(emoji)
   end
 
   # Accepts an array of slugs with each item in the array

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -396,20 +396,38 @@ class Emoji
   def self.codes_to_img(str)
     return if str.blank?
 
-    str =
-      str.gsub(EMOJI_CODE_REGEXP) do |name|
-        code = $1
+    result = +""
+    last_index = 0
 
-        if code && Emoji.custom?(code)
-          emoji = Emoji[code]
-          "<img src=\"#{emoji.url}\" title=\"#{code}\" class=\"emoji\" alt=\"#{code}\" loading=\"lazy\" width=\"20\" height=\"20\">"
-        elsif code && Emoji.exists?(code)
-          "<img src=\"#{Emoji.url_for(code)}\" title=\"#{code}\" class=\"emoji\" alt=\"#{code}\" loading=\"lazy\" width=\"20\" height=\"20\">"
-        else
-          name
-        end
+    str.scan(EMOJI_CODE_REGEXP) do
+      match = Regexp.last_match
+      code = match[1]
+
+      result << ERB::Util.html_escape(str[last_index...match.begin(0)])
+
+      result << if code && Emoji.custom?(code)
+        emoji = Emoji[code]
+        emoji_img_tag(emoji.url, code)
+      elsif code && Emoji.exists?(code)
+        emoji_img_tag(Emoji.url_for(code), code)
+      else
+        ERB::Util.html_escape(match[0])
       end
+
+      last_index = match.end(0)
+    end
+
+    result << ERB::Util.html_escape(str[last_index..])
+    result
   end
+
+  def self.emoji_img_tag(url, code)
+    escaped_url = ERB::Util.html_escape(url)
+    escaped_code = ERB::Util.html_escape(code)
+
+    "<img src=\"#{escaped_url}\" title=\"#{escaped_code}\" class=\"emoji\" alt=\"#{escaped_code}\" loading=\"lazy\" width=\"20\" height=\"20\">"
+  end
+  private_class_method :emoji_img_tag
 
   def self.sanitize_emoji_name(name)
     name.gsub(/[^a-z0-9\+\-]+/i, "_").gsub(/_{2,}/, "_").downcase

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -163,6 +163,24 @@ RSpec.describe Emoji do
       HTML
     end
 
+    it "escapes non-emoji text" do
+      replaced_str = described_class.codes_to_img(%(This <img src=x onerror="alert('xss')"> :foo:))
+
+      expect(replaced_str).to eq(
+        "This &lt;img src=x onerror=&quot;alert(&#39;xss&#39;)&quot;&gt; :foo:",
+      )
+    end
+
+    it "escapes generated image attribute values" do
+      Plugin::CustomEmoji.register("xssxx", %q|" onerror="alert('xss')|)
+
+      replaced_str = described_class.codes_to_img(":xssxx:")
+
+      expect(replaced_str).to eq(
+        %(<img src="&quot; onerror=&quot;alert(&#39;xss&#39;)" title="xssxx" class="emoji" alt="xssxx" loading="lazy" width="20" height="20">),
+      )
+    end
+
     it "doesn't replace non-existing codes" do
       replaced_str =
         described_class.codes_to_img("This is a good day :woman: :foo: :bar:t4: :man:t8:")

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -483,6 +483,21 @@ RSpec.describe CategoriesController do
           expect(response.status).to eq(422)
         end
 
+        it "rejects invalid emoji names" do
+          post "/categories.json",
+               params: {
+                 name: "Emoji Category",
+                 color: "ff0",
+                 text_color: "fff",
+                 style_type: "emoji",
+                 emoji: %(<img src=x onerror="alert('xss')">),
+               }
+
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to include("Emoji is invalid")
+          expect(Category.find_by(name: "Emoji Category")).to be_nil
+        end
+
         it "returns errors with invalid group" do
           category = Fabricate(:category, user: admin)
           readonly = CategoryGroup.permission_types[:readonly]


### PR DESCRIPTION
Out of the box only admins can create categories, the emoji field there is not XSS protected. 

This introduces defense in depth for this field. 