### PR TITLE
FIX: Moderators can receive another user's private bookmark content

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1908,7 +1908,7 @@ class UsersController < ApplicationController
 
   def bookmarks
     user = fetch_user_from_params
-    guardian.ensure_can_edit!(user)
+    guardian.ensure_can_see_bookmarks!(user)
     user_guardian = Guardian.new(user)
 
     respond_to do |format|

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -52,6 +52,10 @@ module UserGuardian
     is_me?(user) || is_admin?
   end
 
+  def can_see_bookmarks?(user)
+    is_me?(user) || is_admin?
+  end
+
   def can_silence_user?(user)
     user && is_staff? && not(user.staff?)
   end

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -152,6 +152,29 @@ RSpec.describe UserGuardian do
     end
   end
 
+  describe "#can_see_bookmarks?" do
+    fab!(:target_user, :user)
+    fab!(:other_user, :user)
+    fab!(:bookmark_moderator, :moderator)
+    fab!(:bookmark_admin, :admin)
+
+    it "allows only the target user and admins" do
+      aggregate_failures do
+        expect(Guardian.new(target_user).can_see_bookmarks?(target_user)).to eq(true)
+        expect(Guardian.new(bookmark_admin).can_see_bookmarks?(target_user)).to eq(true)
+        expect(Guardian.new(other_user).can_see_bookmarks?(target_user)).to eq(false)
+        expect(Guardian.new(bookmark_moderator).can_see_bookmarks?(target_user)).to eq(false)
+        expect(Guardian.new.can_see_bookmarks?(target_user)).to eq(false)
+      end
+    end
+
+    it "raises when the viewer cannot see bookmarks" do
+      expect {
+        Guardian.new(bookmark_moderator).ensure_can_see_bookmarks!(target_user)
+      }.to raise_error(Discourse::InvalidAccess)
+    end
+  end
+
   describe "#can_see_profile?" do
     fab!(:tl0_user) { Fabricate(:user, trust_level: 0) }
     fab!(:tl1_user) { Fabricate(:user, trust_level: 1) }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7409,6 +7409,23 @@ RSpec.describe UsersController do
       expect(response.status).to eq(403)
     end
 
+    it "does not allow moderators to view another user's private bookmarks" do
+      private_post =
+        Fabricate(:private_message_post, user: user1, raw: "Private bookmarked message content")
+      TopicUser.change(user1.id, private_post.topic, total_msecs_viewed: 1)
+      private_bookmark =
+        Fabricate(:bookmark, user: user1, bookmarkable: private_post, name: "Private bookmark note")
+
+      sign_in(moderator)
+      get "/u/#{user1.username}/bookmarks.json"
+
+      aggregate_failures do
+        expect(response.status).to eq(403)
+        expect(response.body).not_to include(private_bookmark.name)
+        expect(response.body).not_to include(private_post.raw)
+      end
+    end
+
     it "shows a helpful message if no bookmarks are found" do
       bookmark1.destroy
       bookmark2.destroy


### PR DESCRIPTION
Security hardening, disallow mods from seeing bookmarks on random users 