### PR TITLE
FIX: Tag settings can reassign hidden synonym tags by ID

### DIFF
--- a/app/services/tag_settings_updater.rb
+++ b/app/services/tag_settings_updater.rb
@@ -6,6 +6,7 @@ class TagSettingsUpdater
   def initialize(tag, actor)
     @tag = tag
     @actor = actor
+    @guardian = Guardian.new(actor)
     @errors = []
   end
 
@@ -56,14 +57,20 @@ class TagSettingsUpdater
   def remove_synonyms(removed_ids)
     return if removed_ids.blank?
 
-    Tag.where(id: removed_ids, target_tag_id: @tag.id).update_all(target_tag_id: nil)
+    synonym_tag_ids = editable_synonym_ids(Tag.where(id: removed_ids, target_tag_id: @tag.id))
+    Tag.where(id: synonym_tag_ids, target_tag_id: @tag.id).update_all(target_tag_id: nil)
   end
 
   def add_synonyms(new_synonyms)
     return if new_synonyms.blank?
 
     synonym_tag_ids = new_synonyms.filter_map { |t| t[:id]&.to_i }
+    synonym_tag_ids = editable_synonym_ids(Tag.where(id: synonym_tag_ids))
     DiscourseTagging.add_or_create_synonyms(@tag, synonym_tag_ids:) if synonym_tag_ids.present?
+  end
+
+  def editable_synonym_ids(synonyms)
+    synonyms.filter_map { |synonym| synonym.id if @guardian.can_edit_tag?(synonym) }
   end
 
   def update_localizations(localizations)

--- a/app/services/tag_settings_updater.rb
+++ b/app/services/tag_settings_updater.rb
@@ -6,7 +6,6 @@ class TagSettingsUpdater
   def initialize(tag, actor)
     @tag = tag
     @actor = actor
-    @guardian = Guardian.new(actor)
     @errors = []
   end
 
@@ -70,7 +69,7 @@ class TagSettingsUpdater
   end
 
   def editable_synonym_ids(synonyms)
-    synonyms.filter_map { |synonym| synonym.id if @guardian.can_edit_tag?(synonym) }
+    synonyms.filter_map { |synonym| synonym.id if @actor.guardian.can_edit_tag?(synonym) }
   end
 
   def update_localizations(localizations)

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -961,6 +961,34 @@ RSpec.describe TagsController do
         expect(response.status).to eq(200)
         expect(tag.reload.name).to eq("user-updated")
       end
+
+      it "does not allow mutating hidden synonyms by ID" do
+        hidden_synonym = Fabricate(:tag, name: "hidden-synonym", target_tag: tag)
+        hidden_tag = Fabricate(:tag, name: "hidden-tag")
+        Fabricate(
+          :tag_group,
+          permissions: {
+            "staff" => 1,
+          },
+          tag_names: [hidden_synonym.name, hidden_tag.name],
+        )
+
+        sign_in(regular_user)
+        put "/tag/#{tag.id}/settings.json",
+            params: {
+              tag_settings: {
+                removed_synonym_ids: [hidden_synonym.id],
+                new_synonyms: [{ id: hidden_tag.id }],
+              },
+            }
+
+        expect(response.status).to eq(200)
+        synonym_names = response.parsed_body.dig("tag_settings", "synonyms").map { |s| s["name"] }
+        expect(synonym_names).to include(hidden_synonym.name)
+        expect(synonym_names).not_to include(hidden_tag.name)
+        expect(hidden_synonym.reload.target_tag_id).to eq(tag.id)
+        expect(hidden_tag.reload.target_tag_id).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Hidden tags (via groups) are pretty rare, hidden tag synonyms are even more rare.

The seals a small edge case where users who were not allowed access to a synonym got access. 