### PR TITLE
FIX: Beacon pageview tracker drops query-param-only route transitions

### DIFF
--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -106,31 +106,29 @@ export default {
       return;
     }
 
-    if (!(transition.urlMethod === "replace" && transition.queryParamsOnly)) {
-      const trackingSessionId = document.querySelector(
-        "meta[name=discourse-track-view-session-id]"
-      )?.content;
-      const referrerUrl = transition.from
-        ? _preNavigationUrl
-        : document.referrer.length
-          ? document.referrer
-          : null;
+    const trackingSessionId = document.querySelector(
+      "meta[name=discourse-track-view-session-id]"
+    )?.content;
+    const referrerUrl = transition.from
+      ? _preNavigationUrl
+      : document.referrer.length
+        ? document.referrer
+        : null;
 
-      let topicId;
-      if (
-        transition.to.name === "topic.fromParamsNear" ||
-        transition.to.name === "topic.fromParams"
-      ) {
-        topicId = transition.to.parent.params.id;
-      }
-
-      sendBeaconPageview({
-        sessionId: trackingSessionId,
-        url: window.location.href,
-        referrer: referrerUrl,
-        topicId,
-      });
+    let topicId;
+    if (
+      transition.to.name === "topic.fromParamsNear" ||
+      transition.to.name === "topic.fromParams"
+    ) {
+      topicId = transition.to.parent.params.id;
     }
+
+    sendBeaconPageview({
+      sessionId: trackingSessionId,
+      url: window.location.href,
+      referrer: referrerUrl,
+      topicId,
+    });
 
     _preNavigationUrl = window.location.href;
   },

--- a/spec/system/page_objects/components/topic_list_header.rb
+++ b/spec/system/page_objects/components/topic_list_header.rb
@@ -51,7 +51,10 @@ module PageObjects
       def click_dismiss_read_confirm
         find("#dismiss-read-confirm").click
       end
-      ### /TODO
+
+      def click_sort_by(order)
+        find("#{TOPIC_LIST_HEADER_SELECTOR} th[data-sort-order='#{order}']").click
+      end
 
       private
 

--- a/spec/system/page_objects/pages/discovery.rb
+++ b/spec/system/page_objects/pages/discovery.rb
@@ -7,6 +7,10 @@ module PageObjects
         Components::TopicList.new
       end
 
+      def topic_list_header
+        Components::TopicListHeader.new
+      end
+
       def category_drop
         Components::SelectKit.new(".category-breadcrumb li:first-of-type .category-drop")
       end

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -829,10 +829,29 @@ describe "Request tracking" do
           expect(beacon_forward_event[:referrer]).to eq("#{Discourse.base_url}/")
         end
 
+        it "tracks pageviews via both trackers when sorting a topic list" do
+          visit "/latest"
+          wait_for_beacon_count(1)
+          wait_for_browser_count(1)
+
+          discovery.topic_list_header.click_sort_by("views")
+
+          expect(page).to have_current_path("/latest?ascending=false&order=views")
+          wait_for_beacon_count(2)
+          wait_for_browser_count(2)
+        end
+
         def wait_for_beacon_count(count)
           try_until_success do
             CachedCounting.flush
             expect(ApplicationRequest.stats["page_view_anon_browser_beacon_total"]).to eq(count)
+          end
+        end
+
+        def wait_for_browser_count(count)
+          try_until_success do
+            CachedCounting.flush
+            expect(ApplicationRequest.stats["page_view_anon_browser_total"]).to eq(count)
           end
         end
       end


### PR DESCRIPTION
`handleRouteDidChange` skipped beacon pageviews when a transition had `urlMethod === "replace"` and `queryParamsOnly`. That guard was modeled on the GA/GTM convention but doesn't match the legacy AJAX-tagged tracker, which counts these transitions (discovery filter, sort, and period changes) as pageviews. As a result, `page_view_anon_browser_beacon_total` undercounted real traffic.

This commit removes the guard, aligning the two trackers.