### PR TITLE
DEV: Partially restore download logic in specs

### DIFF
--- a/spec/system/helpers/downloads.rb
+++ b/spec/system/helpers/downloads.rb
@@ -2,6 +2,24 @@
 
 class Downloads
   FOLDER = Rails.root.join("tmp/downloads")
+  TIMEOUT = 10
+
+  # Waits for `path` to appear and finish writing.
+  def self.wait_for(path)
+    previous_size = -1
+    Timeout.timeout(TIMEOUT) do
+      loop do
+        size = File.size?(path)
+        break if size == previous_size
+
+        previous_size = size if size
+        sleep 0.1
+      end
+    end
+  rescue Timeout::Error
+    last = previous_size == -1 ? "never appeared" : "last size #{previous_size}"
+    raise Timeout::Error, "Timed out after #{TIMEOUT}s waiting for #{path} (#{last})"
+  end
 
   def self.clear
     FileUtils.rm_rf(FOLDER)

--- a/spec/system/page_objects/pages/csv_export_pm.rb
+++ b/spec/system/page_objects/pages/csv_export_pm.rb
@@ -9,18 +9,21 @@ module PageObjects
       end
 
       def download_and_extract
+        original_save_path = Capybara.save_path
+        Capybara.save_path = Downloads::FOLDER
+
         zip_name = find("a.attachment").text
         zip_path = File.join(Downloads::FOLDER, zip_name)
         @downloaded_files << zip_path
 
-        page.driver.with_playwright_page do |pw_page|
-          download = pw_page.expect_download { click_link ".zip" }
-          download.save_as(zip_path)
-        end
+        page.driver.with_playwright_page { |pw_page| pw_page.expect_download { click_link ".zip" } }
+        Downloads.wait_for(zip_path)
 
         csv_path = unzip(zip_path).first
         @downloaded_files << csv_path
         CSV.read(csv_path)
+      ensure
+        Capybara.save_path = original_save_path
       end
 
       def clear_downloads


### PR DESCRIPTION
A follow-up to 2d640d58adf80780b263223446b3b08471d50855.

There was a small regression, where the download directory has changed, resulting in spec artifact archive pollution. This change keeps all the improvements from the previous commit, but restores the original save path.