### PR TITLE
UX: change forced with on field-code to min-width

### DIFF
--- a/app/assets/stylesheets/common/form-kit/_field.scss
+++ b/app/assets/stylesheets/common/form-kit/_field.scss
@@ -9,7 +9,7 @@
   &-code,
   &-image {
     .form-kit__container-content {
-      width: var(--form-kit-large-input) !important;
+      min-width: var(--form-kit-large-input);
     }
   }
 


### PR DESCRIPTION
Remnant of the initial scaffolding – no longer needed (probably)