### PR TITLE
DEV: Suppress an expected deprecation in the summary

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1053,10 +1053,13 @@ RSpec.configure do |config|
 
     expect(deprecation_error).to be_nil, deprecation_error
 
+    expected_deprecations = RSpec.current_example.metadata[:expected_js_deprecations] || []
+
     $playwright_logger&.logs&.each do |log|
       next if log[:level] != "count"
       deprecation_id = log[:message][/^deprecation_id:(.+?):\s*\d+$/, 1]
       next if deprecation_id.nil?
+      next if expected_deprecations.include?(deprecation_id)
 
       deprecations = RSpec.current_example.metadata[:js_deprecations] ||= Hash.new(0)
       deprecations[deprecation_id] += 1

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -54,7 +54,8 @@ describe "JS Deprecation Handling" do
     expect(message).to have_text(SiteSetting.warn_critical_js_deprecations_message)
   end
 
-  it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback" do
+  it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback",
+     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback] do
     t = Fabricate(:theme, name: "Theme With Hbs Connector")
     t.set_field(
       target: :extra_js,


### PR DESCRIPTION
This will allow us to eventually better surface all new deprecation warnings in PRs.