### PR TITLE
DEV: Fix an AI post helper spec flake

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-post-helper-menu.gjs
@@ -171,7 +171,7 @@ export default class AiPostHelperMenu extends Component {
   async _updateResult(result) {
     if (isAiCreditLimitError(result)) {
       this.loading = false;
-      this.menuState = this.MENU_STATES.triggers;
+      this.menuState = this.MENU_STATES.options;
       popupAiCreditLimitError(result);
       return;
     }
@@ -226,7 +226,7 @@ export default class AiPostHelperMenu extends Component {
         popupAjaxError(error);
       }
       this.loading = false;
-      this.menuState = this.MENU_STATES.triggers;
+      this.menuState = this.MENU_STATES.options;
     }
 
     return this._activeAiRequest;

--- a/plugins/discourse-ai/spec/system/ai_helper/ai_post_helper_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_helper/ai_post_helper_spec.rb
@@ -37,8 +37,10 @@ RSpec.describe "AI Post helper" do
 
   def select_post_text(selected_post)
     topic_page.visit_topic(topic)
+    post_paragraph = "#{topic_page.post_by_number_selector(selected_post.post_number)} .cooked p"
+    expect(page).to have_css(post_paragraph)
     page.execute_script(
-      "var element = document.querySelector('#{topic_page.post_by_number_selector(selected_post.post_number)} .cooked p'); " +
+      "var element = document.querySelector('#{post_paragraph}'); " +
         "var range = document.createRange(); " + "range.selectNodeContents(element); " +
         "var selection = window.getSelection(); " + "selection.removeAllRanges(); " +
         "selection.addRange(range);" + "const event = new PointerEvent('pointerup');" +

--- a/plugins/discourse-ai/spec/system/page_objects/components/ai_post_helper_menu.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/components/ai_post_helper_menu.rb
@@ -28,7 +28,8 @@ module PageObjects
       end
 
       def has_suggestion_value?(value)
-        page.has_css?("#{SUGGESTION_SELECTOR}__text", text: value)
+        # Bumped wait because of: MessageBus, typing animation, text cooking.
+        page.has_css?("#{SUGGESTION_SELECTOR}__text:not(.streaming)", text: value, wait: 10)
       end
 
       def suggestion_value


### PR DESCRIPTION
Changes in `ai-post-helper-menu.gjs` are only semi-related (`MENU_STATES` doesn't have "triggers", so that was a bug)