### PR TITLE
DEV: remove form-kit__container-content override and use modifier

### DIFF
--- a/app/assets/stylesheets/common/base/uc-simplified-category-setup-edit-categories.scss
+++ b/app/assets/stylesheets/common/base/uc-simplified-category-setup-edit-categories.scss
@@ -12,10 +12,6 @@
     }
   }
 
-  .form-kit__container-content {
-    width: 100%;
-  }
-
   .edit-category-tab:not(.edit-category-tab-general) {
     .form-kit__container-optional {
       display: none;

--- a/frontend/discourse/admin/components/edit-category-localizations.gjs
+++ b/frontend/discourse/admin/components/edit-category-localizations.gjs
@@ -31,7 +31,7 @@ export default class EditCategoryLocalizations extends buildCategoryPanel(
         @name="locale"
         @title={{i18n "category.localization.language"}}
         @description={{i18n "category.localization.language_description"}}
-        @format="large"
+        @format="full"
         @type="select"
         as |field|
       >

--- a/frontend/discourse/admin/components/upsert-category/appearance.gjs
+++ b/frontend/discourse/admin/components/upsert-category/appearance.gjs
@@ -147,6 +147,7 @@ export default class UpsertCategoryAppearance extends Component {
       class={{concatClass
         "edit-category-tab"
         "edit-category-tab-images"
+        "--full"
         (if (eq @selectedTab "images") "active")
       }}
     >

--- a/frontend/discourse/admin/components/upsert-category/general.gjs
+++ b/frontend/discourse/admin/components/upsert-category/general.gjs
@@ -792,7 +792,7 @@ export default class UpsertCategoryGeneral extends Component {
         >
           <@form.Container
             @title={{i18n "category.description"}}
-            class="edit-category-description-container"
+            class="edit-category-description-container --full"
           >
             <div
               class={{concatClass

--- a/frontend/discourse/admin/components/upsert-category/moderation.gjs
+++ b/frontend/discourse/admin/components/upsert-category/moderation.gjs
@@ -153,6 +153,7 @@ export default class UpsertCategoryModeration extends Component {
       class={{concatClass
         "edit-category-tab"
         "edit-category-tab-moderation"
+        "--full"
         (if (eq @selectedTab "moderation") "active")
       }}
     >
@@ -187,6 +188,7 @@ export default class UpsertCategoryModeration extends Component {
         @name="auto_close_based_on_last_post"
         @title={{i18n "topic.auto_close.based_on_last_post"}}
         @type="checkbox"
+        @format="full"
         as |field|
       >
         <field.Control />

--- a/frontend/discourse/admin/components/upsert-category/security.gjs
+++ b/frontend/discourse/admin/components/upsert-category/security.gjs
@@ -200,7 +200,7 @@ export default class UpsertCategorySecurity extends Component {
       </@form.Alert>
 
       {{#unless @category.is_special}}
-        <@form.Container>
+        <@form.Container @format="full">
           <div class="category-permissions-table">
             <div class="permission-row row-header">
               <span class="group-name">{{i18n

--- a/frontend/discourse/admin/components/upsert-category/tags.gjs
+++ b/frontend/discourse/admin/components/upsert-category/tags.gjs
@@ -78,6 +78,7 @@ export default class UpsertCategoryTags extends Component {
           (i18n "category.tags_allowed_tag_groups" categoryName=@category.name)
           (i18n "category.tags_allowed_tag_groups_new_category")
         }}
+        @format="full"
       >
         <TagGroupChooser
           @id="category-allowed-tag-groups"

--- a/plugins/discourse-assign/assets/javascripts/discourse/connectors/category-custom-settings/assign-settings-upsert.gjs
+++ b/plugins/discourse-assign/assets/javascripts/discourse/connectors/category-custom-settings/assign-settings-upsert.gjs
@@ -28,6 +28,7 @@ export default class AssignSettingsUpsert extends Component {
             @title={{i18n "discourse_assign.add_unassigned_filter"}}
             @onSet={{this.onToggleUnassignedFilter}}
             @type="checkbox"
+            @format="full"
             as |field|
           >
             <field.Control checked={{this.enableUnassignedFilter}} />

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/category-custom-settings/feature-voting-settings-upsert.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/category-custom-settings/feature-voting-settings-upsert.gjs
@@ -35,6 +35,7 @@ export default class FeatureVotingSettingsUpsert extends Component {
             @title={{i18n "topic_voting.allow_topic_voting"}}
             @onSet={{this.onToggleTopicVoting}}
             @type="checkbox"
+            @format="full"
             as |field|
           >
             <field.Control checked={{this.enableTopicVoting}} />


### PR DESCRIPTION
This override was causing issues with other forms, switching to the modifier for the specific fields avoids the override.  