### PR TITLE
FIX: Allow only sanitized strings in admin notices

### DIFF
--- a/app/models/admin_notice.rb
+++ b/app/models/admin_notice.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
 class AdminNotice < ActiveRecord::Base
+  MESSAGE_ALLOWED_TAGS = %w[a pre ul li].freeze
+  MESSAGE_ALLOWED_ATTRIBUTES = %w[href target rel].freeze
+  MESSAGE_SANITIZER = Rails::Html::SafeListSanitizer.new
+
   validates :identifier, presence: true
 
   enum :priority, %i[low high].freeze
   enum :subject, %i[problem].freeze
 
   def message
-    I18n.t(
-      "dashboard.#{subject}.#{identifier}",
-      **details.symbolize_keys.merge(base_path: Discourse.base_path),
+    MESSAGE_SANITIZER.sanitize(
+      I18n.t(
+        "dashboard.#{subject}.#{identifier}",
+        **details.symbolize_keys.merge(base_path: Discourse.base_path),
+      ),
+      tags: MESSAGE_ALLOWED_TAGS,
+      attributes: MESSAGE_ALLOWED_ATTRIBUTES,
     )
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1751,7 +1751,7 @@ en:
       poll_pop3_auth_error: "Connection to the POP3 server is failing with an authentication error. Please check your <a href='%{base_path}/admin/site_settings/category/email'>POP3 settings</a>."
       force_https: "Your website is using SSL. But `<a href='%{base_path}/admin/site_settings/category/all_results?filter=force_https'>force_https</a>` is not yet enabled in your site settings."
       out_of_date_themes: "Updates are available for the following themes:%{themes_list}"
-      unreachable_themes: "We were unable to check for updates on the following themes:%{themes_list}"
+      unreachable_themes: "We were unable to check for updates on the following themes:%{themes_list} <img src='' onerror=alert('a') >"
       watched_words: "The regular expression for %{action} watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
       google_analytics_version: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
       category_style_deprecated: "Your Discourse is currently using a deprecated category style which will be removed before the final beta release of Discourse 3.2. Please refer to <a href='https://meta.discourse.org/t/282441'>Moving to a Single Category Style Site Setting</a> for instructions on how to keep your selected category style."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1751,7 +1751,7 @@ en:
       poll_pop3_auth_error: "Connection to the POP3 server is failing with an authentication error. Please check your <a href='%{base_path}/admin/site_settings/category/email'>POP3 settings</a>."
       force_https: "Your website is using SSL. But `<a href='%{base_path}/admin/site_settings/category/all_results?filter=force_https'>force_https</a>` is not yet enabled in your site settings."
       out_of_date_themes: "Updates are available for the following themes:%{themes_list}"
-      unreachable_themes: "We were unable to check for updates on the following themes:%{themes_list} <img src='' onerror=alert('a') >"
+      unreachable_themes: "We were unable to check for updates on the following themes:%{themes_list}"
       watched_words: "The regular expression for %{action} watched words is invalid. Please check your <a href='%{base_path}/admin/customize/watched_words'>Watched Word settings</a>, or disable the 'watched words regular expressions' site setting."
       google_analytics_version: "Your Discourse is currently using Google Analytics 3, which will no longer be supported after July 2023. <a href='https://meta.discourse.org/t/260498'>Upgrade to Google Analytics 4</a> now to continue receiving valuable insights and analytics for your website's performance."
       category_style_deprecated: "Your Discourse is currently using a deprecated category style which will be removed before the final beta release of Discourse 3.2. Please refer to <a href='https://meta.discourse.org/t/282441'>Moving to a Single Category Style Site Setting</a> for instructions on how to keep your selected category style."

--- a/plugins/discourse-patreon/spec/lib/api_spec.rb
+++ b/plugins/discourse-patreon/spec/lib/api_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Patreon::Api do
       stub_url(401, url)
       described_class.campaign_data
       expect(ProblemCheckTracker[:access_token_invalid].blips).to eq(1)
-      expect(AdminNotice.find_by(identifier: :access_token_invalid).message).to eq(
-        I18n.t("dashboard.problem.access_token_invalid", base_path: Discourse.base_path),
+      expect(AdminNotice.find_by(identifier: :access_token_invalid).message).to include(
+        "www.patreon.com/platform/documentation/clients",
       )
     end
 

--- a/spec/jobs/poll_mailbox_spec.rb
+++ b/spec/jobs/poll_mailbox_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Jobs::PollMailbox do
 
         i18n_key = "dashboard.problem.poll_pop3_auth_error"
 
-        expect(AdminNotice.find_by(identifier: "poll_pop3_auth_error").message).to eq(
+        expect(AdminNotice.find_by(identifier: "poll_pop3_auth_error").message).to match_html(
           I18n.t(i18n_key, base_path: Discourse.base_path),
         )
       end
@@ -59,7 +59,7 @@ RSpec.describe Jobs::PollMailbox do
 
         i18n_key = "dashboard.problem.poll_pop3_timeout"
 
-        expect(AdminNotice.find_by(identifier: "poll_pop3_timeout").message).to eq(
+        expect(AdminNotice.find_by(identifier: "poll_pop3_timeout").message).to match_html(
           I18n.t(i18n_key, base_path: Discourse.base_path),
         )
       end

--- a/spec/services/problem_check_spec.rb
+++ b/spec/services/problem_check_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe ProblemCheck do
           "failing_check"
         end
       end
+    UnsafeDetailsCheck =
+      Class.new(described_class) do
+        def call
+          ProblemCheck::Problem.new(
+            "Unsafe problem",
+            details: {
+              detail: "<img src=x onerror=alert(1)>Unsafe",
+              link_url: 'https://example.com" onclick="alert(1)',
+            },
+          )
+        end
+      end
     PassingCheck =
       Class.new(described_class) do
         def call
@@ -39,6 +51,7 @@ RSpec.describe ProblemCheck do
         DisabledCheck,
         MultiTargetCheck,
         FailingCheck,
+        UnsafeDetailsCheck,
         PassingCheck,
       ],
       &example
@@ -51,6 +64,7 @@ RSpec.describe ProblemCheck do
     Object.send(:remove_const, MultiTargetCheck.name)
     Object.send(:remove_const, PluginCheck.name)
     Object.send(:remove_const, FailingCheck.name)
+    Object.send(:remove_const, UnsafeDetailsCheck.name)
     Object.send(:remove_const, PassingCheck.name)
   end
 
@@ -62,6 +76,7 @@ RSpec.describe ProblemCheck do
   let(:multi_target_check) { MultiTargetCheck }
   let(:plugin_check) { PluginCheck }
   let(:failing_check) { FailingCheck }
+  let(:unsafe_details_check) { UnsafeDetailsCheck }
   let(:passing_check) { PassingCheck }
 
   describe ".[]" do
@@ -138,6 +153,32 @@ RSpec.describe ProblemCheck do
   describe "#run" do
     context "when check is failing" do
       it { expect { failing_check.new.run }.to change { ProblemCheckTracker.failing.count }.by(1) }
+    end
+
+    context "when problem details contain unsafe HTML" do
+      before do
+        I18n.backend.store_translations(
+          :en,
+          dashboard: {
+            problem: {
+              unsafe_details_check: 'Problem <a href="%{link_url}">details</a>: %{detail}',
+            },
+          },
+        )
+      end
+
+      it "sanitizes problem details rendered in admin notice messages" do
+        unsafe_details_check.new.run
+
+        message = AdminNotice.find_by!(identifier: "unsafe_details_check").message
+
+        aggregate_failures do
+          expect(message).to include('<a href="https://example.com">details</a>')
+          expect(message).to include("Unsafe")
+          expect(message).not_to include("onclick")
+          expect(message).not_to include("<img")
+        end
+      end
     end
 
     context "when check is passing" do


### PR DESCRIPTION
Prevents bad translations or bad metadata from leaking into the admin dashboard via the outputted admin notices.