### PR TITLE
UX: fix unread dot color

### DIFF
--- a/app/assets/stylesheets/common/base/new-user.scss
+++ b/app/assets/stylesheets/common/base/new-user.scss
@@ -189,7 +189,7 @@
 %unread-icon {
   font-size: var(--font-down-4);
   margin: 0 0.375rem;
-  color: var(--tertiary);
+  color: var(--tertiary-medium);
 }
 
 .user-messages-page {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -35,7 +35,7 @@
   --d-sidebar-prefix-color: var(--d-sidebar-link-color);
 
   // example: unread dot
-  --d-sidebar-suffix-color: var(--token-color-background-accent-bolder);
+  --d-sidebar-suffix-color: var(--token-color-background-accent-subtle);
 
   // highlight applies to both hover and focus states
   --d-sidebar-highlight-background: var(--token-color-surface-hovered);


### PR DESCRIPTION
This color has drifted a bit (darker in the sidebar, dropdown), we should stay consistent with the lighter color

Before
<img width="2834" height="754" alt="image" src="https://github.com/user-attachments/assets/a74f7d4a-b129-4118-8fe8-f309cfd45a28" />


After
<img width="2836" height="752" alt="image" src="https://github.com/user-attachments/assets/dfc09676-4443-429c-969a-61d797f59a96" />
