### PR TITLE
FIX: Image paste upload in form template composer fields

### DIFF
--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -1120,6 +1120,7 @@ export default class ComposerEditor extends Component {
               @initialValues={{this.composer.formTemplateInitialValues}}
               @onSelectFormTemplate={{this.composer.onSelectFormTemplate}}
               @onChange={{this.updateFormPreview}}
+              @uppyComposerUpload={{this.uppyComposerUpload}}
             />
           </form>
         </div>

--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -971,53 +971,9 @@ export default class ComposerEditor extends Component {
     this._refreshOneboxes(preview);
     this._expandShortUrls(preview);
 
-    // Only apply image size adjustments for form template previews
-    // Regular composer handles this through ProseMirror
-    if (this.composer.formTemplateIds?.length > 0) {
-      this._applyImageSizes(preview);
-    }
-
     this._decorateCookedElement(preview, helper);
 
     this.composer.afterRefresh(preview);
-  }
-
-  _applyImageSizes(preview) {
-    // Apply sizing to images to match regular composer behavior
-    // where percentage scales are relative to the max_image_width site setting
-    // not the original image dimensions
-    const maxImageWidth = this.siteSettings.max_image_width;
-
-    const images = preview.querySelectorAll("img.resizable[width][height]");
-
-    images.forEach((img) => {
-      const processImage = () => {
-        const width = parseInt(img.getAttribute("width"), 10);
-        const height = parseInt(img.getAttribute("height"), 10);
-        const naturalWidth = img.naturalWidth;
-
-        if (!naturalWidth || naturalWidth === 0) {
-          return;
-        }
-
-        if (width && height) {
-          const percentage = width / naturalWidth;
-
-          const constrainedBase = Math.min(naturalWidth, maxImageWidth);
-          const displayWidth = Math.round(constrainedBase * percentage);
-          const displayHeight = Math.round(height * (displayWidth / width));
-
-          img.setAttribute("width", displayWidth);
-          img.setAttribute("height", displayHeight);
-        }
-      };
-
-      if (img.complete && img.naturalWidth > 0) {
-        processImage();
-      } else {
-        img.addEventListener("load", processImage, { once: true });
-      }
-    });
   }
 
   @computed("composer.formTemplateIds")

--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -295,13 +295,6 @@ export default class ComposerEditor extends Component {
     }
   }
 
-  @action
-  _composerEditorDestroyFormTemplate() {
-    if (this.composer.allowUpload) {
-      this.uppyComposerUpload.teardown();
-    }
-  }
-
   /**
    * Sets up the editor with the given text manipulation instance
    *
@@ -1087,7 +1080,6 @@ export default class ComposerEditor extends Component {
           <form
             id="form-template-form"
             {{didInsert this._composerEditorInitFormTemplate}}
-            {{willDestroy this._composerEditorDestroyFormTemplate}}
           >
             <Wrapper
               @id={{this.selectedFormTemplateId}}

--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -288,6 +288,20 @@ export default class ComposerEditor extends Component {
     }
   }
 
+  @action
+  _composerEditorInitFormTemplate(formEl) {
+    if (this.composer.allowUpload) {
+      this.uppyComposerUpload.setup(formEl);
+    }
+  }
+
+  @action
+  _composerEditorDestroyFormTemplate() {
+    if (this.composer.allowUpload) {
+      this.uppyComposerUpload.teardown();
+    }
+  }
+
   /**
    * Sets up the editor with the given text manipulation instance
    *
@@ -1070,7 +1084,11 @@ export default class ComposerEditor extends Component {
               class="composer-select-form-template"
             />
           {{/if}}
-          <form id="form-template-form">
+          <form
+            id="form-template-form"
+            {{didInsert this._composerEditorInitFormTemplate}}
+            {{willDestroy this._composerEditorDestroyFormTemplate}}
+          >
             <Wrapper
               @id={{this.selectedFormTemplateId}}
               @initialValues={{this.composer.formTemplateInitialValues}}

--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -295,6 +295,13 @@ export default class ComposerEditor extends Component {
     }
   }
 
+  @action
+  _composerEditorDestroyFormTemplate() {
+    if (this.composer.allowUpload) {
+      this.uppyComposerUpload.teardown();
+    }
+  }
+
   /**
    * Sets up the editor with the given text manipulation instance
    *
@@ -1080,6 +1087,7 @@ export default class ComposerEditor extends Component {
           <form
             id="form-template-form"
             {{didInsert this._composerEditorInitFormTemplate}}
+            {{willDestroy this._composerEditorDestroyFormTemplate}}
           >
             <Wrapper
               @id={{this.selectedFormTemplateId}}

--- a/frontend/discourse/app/components/composer-editor.gjs
+++ b/frontend/discourse/app/components/composer-editor.gjs
@@ -129,6 +129,11 @@ export default class ComposerEditor extends Component {
     });
   }
 
+  willDestroyElement() {
+    super.willDestroyElement(...arguments);
+    this.uppyComposerUpload.teardown();
+  }
+
   get topic() {
     return this.composer.get("model.topic");
   }
@@ -292,13 +297,6 @@ export default class ComposerEditor extends Component {
   _composerEditorInitFormTemplate(formEl) {
     if (this.composer.allowUpload) {
       this.uppyComposerUpload.setup(formEl);
-    }
-  }
-
-  @action
-  _composerEditorDestroyFormTemplate() {
-    if (this.composer.allowUpload) {
-      this.uppyComposerUpload.teardown();
     }
   }
 
@@ -1087,7 +1085,6 @@ export default class ComposerEditor extends Component {
           <form
             id="form-template-form"
             {{didInsert this._composerEditorInitFormTemplate}}
-            {{willDestroy this._composerEditorDestroyFormTemplate}}
           >
             <Wrapper
               @id={{this.selectedFormTemplateId}}

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -2,11 +2,14 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import DEditor from "discourse/ui-kit/d-editor";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 export default class FormTemplateFieldComposer extends Component {
+  @service composer;
+
   @tracked composerValue = this.args.value || "";
 
   @action
@@ -15,6 +18,34 @@ export default class FormTemplateFieldComposer extends Component {
     next(this, () => {
       this.args.onChange?.(event);
     });
+  }
+
+  @action
+  onEditorSetup(textManipulation) {
+    if (
+      !textManipulation.textarea ||
+      !this.args.uppyComposerUpload ||
+      !this.composer.allowUpload
+    ) {
+      return;
+    }
+
+    const element = textManipulation.textarea.closest(".d-editor");
+    this.args.uppyComposerUpload.textManipulation = textManipulation;
+    this.args.uppyComposerUpload.setup(element);
+
+    const claimUploadTarget = () => {
+      this.args.uppyComposerUpload.textManipulation = textManipulation;
+    };
+    textManipulation.textarea.addEventListener("focusin", claimUploadTarget);
+
+    return () => {
+      textManipulation.textarea.removeEventListener(
+        "focusin",
+        claimUploadTarget
+      );
+      this.args.uppyComposerUpload.teardown(element);
+    };
   }
 
   <template>
@@ -39,6 +70,7 @@ export default class FormTemplateFieldComposer extends Component {
         @value={{this.composerValue}}
         @change={{this.handleInput}}
         @placeholder={{@attributes.placeholder}}
+        @onSetup={{this.onEditorSetup}}
       />
     </div>
   </template>

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -1,6 +1,8 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
@@ -12,6 +14,10 @@ export default class FormTemplateFieldComposer extends Component {
 
   @tracked composerValue = this.args.value || "";
 
+  _boundElement = null;
+  _focusTarget = null;
+  _claimUploadTarget = null;
+
   @action
   handleInput(event) {
     this.composerValue = event.target.value;
@@ -21,35 +27,67 @@ export default class FormTemplateFieldComposer extends Component {
   }
 
   @action
-  onEditorSetup(textManipulation) {
-    if (
-      !textManipulation.textarea ||
-      !this.args.uppyComposerUpload ||
-      !this.composer.allowUpload
-    ) {
+  setupUploads(wrapperElement) {
+    if (!this.args.uppyComposerUpload || !this.composer.allowUpload) {
       return;
     }
 
-    const element = textManipulation.textarea.closest(".d-editor");
+    const dEditor = wrapperElement.querySelector(".d-editor");
+    if (!dEditor) {
+      return;
+    }
+
+    this._boundElement = dEditor;
+    this.args.uppyComposerUpload.setup(dEditor);
+  }
+
+  @action
+  teardownUploads() {
+    if (this._focusTarget && this._claimUploadTarget) {
+      this._focusTarget.removeEventListener("focusin", this._claimUploadTarget);
+      this._focusTarget = null;
+      this._claimUploadTarget = null;
+    }
+
+    if (this._boundElement && this.args.uppyComposerUpload) {
+      this.args.uppyComposerUpload.teardown(this._boundElement);
+      this._boundElement = null;
+    }
+  }
+
+  @action
+  onEditorSetup(textManipulation) {
+    if (!this._boundElement || !this.args.uppyComposerUpload) {
+      return;
+    }
+
     this.args.uppyComposerUpload.textManipulation = textManipulation;
-    this.args.uppyComposerUpload.setup(element);
+
+    const editorTarget =
+      textManipulation.textarea || textManipulation.view?.dom;
+    if (!editorTarget) {
+      return;
+    }
+
+    if (this._focusTarget && this._claimUploadTarget) {
+      this._focusTarget.removeEventListener("focusin", this._claimUploadTarget);
+    }
 
     const claimUploadTarget = () => {
       this.args.uppyComposerUpload.textManipulation = textManipulation;
     };
-    textManipulation.textarea.addEventListener("focusin", claimUploadTarget);
-
-    return () => {
-      textManipulation.textarea.removeEventListener(
-        "focusin",
-        claimUploadTarget
-      );
-      this.args.uppyComposerUpload.teardown(element);
-    };
+    editorTarget.addEventListener("focusin", claimUploadTarget);
+    this._focusTarget = editorTarget;
+    this._claimUploadTarget = claimUploadTarget;
   }
 
   <template>
-    <div class="control-group form-template-field" data-field-type="composer">
+    <div
+      class="control-group form-template-field"
+      data-field-type="composer"
+      {{didInsert this.setupUploads}}
+      {{willDestroy this.teardownUploads}}
+    >
       {{#if @attributes.label}}
         <label class="form-template-field__label">
           {{@attributes.label}}

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -38,9 +38,7 @@ export default class FormTemplateFieldComposer extends Component {
       return;
     }
 
-    const escapedOldVal = oldVal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const regex = new RegExp(escapedOldVal, "g");
-    this.composerValue = this.composerValue.replace(regex, newVal ?? "");
+    this.composerValue = this.composerValue.replace(oldVal, newVal ?? "");
 
     schedule("afterRender", () => {
       this.args.onChange?.();

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -13,8 +13,7 @@ export default class FormTemplateFieldComposer extends Component {
 
   @tracked composerValue = this.args.value || "";
 
-  _focusTarget = null;
-  _claimUploadTarget = null;
+  _claimAbortController = null;
 
   constructor() {
     super(...arguments);
@@ -24,12 +23,7 @@ export default class FormTemplateFieldComposer extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.appEvents.off("composer:replace-text", this, this.handleReplaceText);
-
-    if (this._focusTarget && this._claimUploadTarget) {
-      this._focusTarget.removeEventListener("focusin", this._claimUploadTarget);
-      this._focusTarget = null;
-      this._claimUploadTarget = null;
-    }
+    this._claimAbortController?.abort();
   }
 
   @action
@@ -67,16 +61,17 @@ export default class FormTemplateFieldComposer extends Component {
       return;
     }
 
-    if (this._focusTarget && this._claimUploadTarget) {
-      this._focusTarget.removeEventListener("focusin", this._claimUploadTarget);
-    }
+    this._claimAbortController?.abort();
+    this._claimAbortController = new AbortController();
+    const { signal } = this._claimAbortController;
 
     const claimUploadTarget = () => {
       this.args.uppyComposerUpload.textManipulation = textManipulation;
     };
-    editorTarget.addEventListener("focusin", claimUploadTarget);
-    this._focusTarget = editorTarget;
-    this._claimUploadTarget = claimUploadTarget;
+
+    for (const event of ["focusin", "dragenter", "dragover"]) {
+      editorTarget.addEventListener(event, claimUploadTarget, { signal });
+    }
   }
 
   <template>

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -1,8 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
-import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
@@ -15,7 +13,6 @@ export default class FormTemplateFieldComposer extends Component {
 
   @tracked composerValue = this.args.value || "";
 
-  _boundElement = null;
   _focusTarget = null;
   _claimUploadTarget = null;
 
@@ -27,6 +24,12 @@ export default class FormTemplateFieldComposer extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.appEvents.off("composer:replace-text", this, this.handleReplaceText);
+
+    if (this._focusTarget && this._claimUploadTarget) {
+      this._focusTarget.removeEventListener("focusin", this._claimUploadTarget);
+      this._focusTarget = null;
+      this._claimUploadTarget = null;
+    }
   }
 
   @action
@@ -40,7 +43,7 @@ export default class FormTemplateFieldComposer extends Component {
     this.composerValue = this.composerValue.replace(regex, newVal ?? "");
 
     schedule("afterRender", () => {
-      this.args.onChange?.({ target: { value: this.composerValue } });
+      this.args.onChange?.();
     });
   }
 
@@ -53,37 +56,8 @@ export default class FormTemplateFieldComposer extends Component {
   }
 
   @action
-  setupUploads(wrapperElement) {
-    if (!this.args.uppyComposerUpload || !this.composer.allowUpload) {
-      return;
-    }
-
-    const dEditor = wrapperElement.querySelector(".d-editor");
-    if (!dEditor) {
-      return;
-    }
-
-    this._boundElement = dEditor;
-    this.args.uppyComposerUpload.setup(dEditor);
-  }
-
-  @action
-  teardownUploads() {
-    if (this._focusTarget && this._claimUploadTarget) {
-      this._focusTarget.removeEventListener("focusin", this._claimUploadTarget);
-      this._focusTarget = null;
-      this._claimUploadTarget = null;
-    }
-
-    if (this._boundElement && this.args.uppyComposerUpload) {
-      this.args.uppyComposerUpload.teardown(this._boundElement);
-      this._boundElement = null;
-    }
-  }
-
-  @action
   onEditorSetup(textManipulation) {
-    if (!this._boundElement || !this.args.uppyComposerUpload) {
+    if (!this.args.uppyComposerUpload || !this.composer.allowUpload) {
       return;
     }
 
@@ -108,12 +82,7 @@ export default class FormTemplateFieldComposer extends Component {
   }
 
   <template>
-    <div
-      class="control-group form-template-field"
-      data-field-type="composer"
-      {{didInsert this.setupUploads}}
-      {{willDestroy this.teardownUploads}}
-    >
+    <div class="control-group form-template-field" data-field-type="composer">
       {{#if @attributes.label}}
         <label class="form-template-field__label">
           {{@attributes.label}}

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
-import { next } from "@ember/runloop";
+import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import DEditor from "discourse/ui-kit/d-editor";
@@ -11,12 +11,38 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 export default class FormTemplateFieldComposer extends Component {
   @service composer;
+  @service appEvents;
 
   @tracked composerValue = this.args.value || "";
 
   _boundElement = null;
   _focusTarget = null;
   _claimUploadTarget = null;
+
+  constructor() {
+    super(...arguments);
+    this.appEvents.on("composer:replace-text", this, this.handleReplaceText);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.appEvents.off("composer:replace-text", this, this.handleReplaceText);
+  }
+
+  @action
+  handleReplaceText(oldVal, newVal) {
+    if (!this.composerValue?.includes(oldVal)) {
+      return;
+    }
+
+    const escapedOldVal = oldVal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const regex = new RegExp(escapedOldVal, "g");
+    this.composerValue = this.composerValue.replace(regex, newVal ?? "");
+
+    schedule("afterRender", () => {
+      this.args.onChange?.({ target: { value: this.composerValue } });
+    });
+  }
 
   @action
   handleInput(event) {

--- a/frontend/discourse/app/components/form-template-field/textarea.gjs
+++ b/frontend/discourse/app/components/form-template-field/textarea.gjs
@@ -25,15 +25,15 @@ export default class FormTemplateFieldTextarea extends Component {
 
   @action
   handleReplaceText(oldVal, newVal) {
-    if (this.value?.includes(oldVal)) {
-      const escapedOldVal = oldVal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regex = new RegExp(escapedOldVal, "g");
-      this.value = this.value.replace(regex, newVal ?? "");
-
-      schedule("afterRender", () => {
-        this.args.onChange?.();
-      });
+    if (!this.value?.includes(oldVal)) {
+      return;
     }
+
+    this.value = this.value.replace(oldVal, newVal ?? "");
+
+    schedule("afterRender", () => {
+      this.args.onChange?.();
+    });
   }
 
   @action

--- a/frontend/discourse/app/components/form-template-field/upload.gjs
+++ b/frontend/discourse/app/components/form-template-field/upload.gjs
@@ -40,22 +40,21 @@ export default class FormTemplateFieldUpload extends Component {
 
   @action
   handleReplaceText(oldVal, newVal) {
-    if (this.uploadValue?.includes(oldVal)) {
-      const escapedOldVal = oldVal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regex = new RegExp(escapedOldVal, "g");
-      this.uploadValue = this.uploadValue.replace(regex, newVal ?? "");
+    if (!this.uploadValue?.includes(oldVal)) {
+      return;
+    }
 
-      // If it was a deletion, try to find and remove the file from uploadedFiles list
-      if (!newVal) {
-        this.uploadedFiles = this.uploadedFiles.filter((file) => {
-          return !oldVal.includes(file.short_url);
-        });
-      }
+    this.uploadValue = this.uploadValue.replace(oldVal, newVal ?? "");
 
-      schedule("afterRender", () => {
-        this.args.onChange?.();
+    if (!newVal) {
+      this.uploadedFiles = this.uploadedFiles.filter((file) => {
+        return !oldVal.includes(file.short_url);
       });
     }
+
+    schedule("afterRender", () => {
+      this.args.onChange?.();
+    });
   }
 
   get uploadStatusLabel() {

--- a/frontend/discourse/app/components/form-template-field/wrapper.gjs
+++ b/frontend/discourse/app/components/form-template-field/wrapper.gjs
@@ -23,6 +23,7 @@ const FormTemplateField = <template>
     @validations={{@content.validations}}
     @value={{@initialValue}}
     @onChange={{@onChange}}
+    @uppyComposerUpload={{@uppyComposerUpload}}
   />
 </template>;
 
@@ -109,6 +110,7 @@ export default class FormTemplateFieldWrapper extends Component {
             @content={{content}}
             @initialValue={{get this.initialValues content.id}}
             @onChange={{this.onChange}}
+            @uppyComposerUpload={{@uppyComposerUpload}}
           />
         {{/each}}
       </div>

--- a/frontend/discourse/app/lib/uppy/composer-upload.js
+++ b/frontend/discourse/app/lib/uppy/composer-upload.js
@@ -135,6 +135,10 @@ export default class UppyComposerUpload {
   }
 
   setup(element) {
+    if (this.#uploadTargetBound) {
+      this.teardown();
+    }
+
     this.#editorEl = element;
     this.#fileInputEl = document.getElementById(this.fileUploadElementId);
 

--- a/frontend/discourse/app/lib/uppy/composer-upload.js
+++ b/frontend/discourse/app/lib/uppy/composer-upload.js
@@ -554,9 +554,7 @@ export default class UppyComposerUpload {
 
   @bind
   _pasteEventListener(event) {
-    if (
-      !document.querySelector(this.editorInputClass)?.contains(event.target)
-    ) {
+    if (!event.target.closest(this.editorInputClass)) {
       return;
     }
 

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -99,6 +99,129 @@ module(
       );
     });
 
+    test("re-claims the upload target on dragenter", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      await waitUntil(() => uppy.textManipulation);
+
+      const initialTextManipulation = uppy.textManipulation;
+      uppy.textManipulation = "trampled-by-another-field";
+
+      await triggerEvent(".d-editor-input", "dragenter");
+
+      assert.strictEqual(
+        uppy.textManipulation,
+        initialTextManipulation,
+        "dragenter restores this field's textManipulation as the upload target"
+      );
+    });
+
+    test("re-claims the upload target on dragover", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      await waitUntil(() => uppy.textManipulation);
+
+      const initialTextManipulation = uppy.textManipulation;
+      uppy.textManipulation = "trampled-by-another-field";
+
+      await triggerEvent(".d-editor-input", "dragover");
+
+      assert.strictEqual(
+        uppy.textManipulation,
+        initialTextManipulation,
+        "dragover restores this field's textManipulation as the upload target"
+      );
+    });
+
+    test("dragging onto an unfocused field claims its upload target", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      await waitUntil(() => uppy.textManipulation);
+
+      const textareas = document.querySelectorAll(
+        "[data-field-type='composer'] .d-editor-input"
+      );
+
+      await triggerEvent(textareas[0], "focusin");
+      const fieldATextManipulation = uppy.textManipulation;
+
+      await triggerEvent(textareas[1], "dragenter");
+
+      assert.notStrictEqual(
+        uppy.textManipulation,
+        fieldATextManipulation,
+        "dragenter on field B switches the upload target away from field A without requiring focus"
+      );
+    });
+
+    test("removes claim listeners when the component is destroyed", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+      this.set("show", true);
+
+      await render(
+        <template>
+          {{#if this.show}}
+            <FormComposer
+              @onChange={{noop}}
+              @uppyComposerUpload={{this.uppy}}
+            />
+          {{/if}}
+        </template>
+      );
+
+      await waitUntil(() => uppy.textManipulation);
+
+      const textarea = document.querySelector(
+        "[data-field-type='composer'] .d-editor-input"
+      );
+
+      this.set("show", false);
+      await settled();
+
+      uppy.textManipulation = "sentinel";
+
+      for (const event of ["focusin", "dragenter", "dragover"]) {
+        textarea.dispatchEvent(new Event(event, { bubbles: true }));
+      }
+
+      assert.strictEqual(
+        uppy.textManipulation,
+        "sentinel",
+        "claim listeners no longer fire after the component is destroyed"
+      );
+    });
+
     test("multiple fields route uploads to the focused field", async function (assert) {
       stubAllowUpload(this, true);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -1,5 +1,6 @@
+import { tracked } from "@glimmer/tracking";
 import { getOwner } from "@ember/owner";
-import { render, triggerEvent, waitUntil } from "@ember/test-helpers";
+import { render, settled, triggerEvent, waitUntil } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import FormComposer from "discourse/components/form-template-field/composer";
@@ -108,6 +109,81 @@ module(
         uppy.textManipulation,
         initialTextManipulation,
         "focusin restores this field's textManipulation as the upload target"
+      );
+    });
+
+    test("calls teardown when the field is destroyed", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      const state = new (class {
+        @tracked show = true;
+      })();
+      this.set("uppy", uppy);
+      this.set("state", state);
+
+      await render(
+        <template>
+          {{#if this.state.show}}
+            <FormComposer
+              @onChange={{noop}}
+              @uppyComposerUpload={{this.uppy}}
+            />
+          {{/if}}
+        </template>
+      );
+
+      await waitUntil(() => uppy.setup.called);
+      const setupElement = uppy.setup.firstCall.firstArg;
+
+      state.show = false;
+      await settled();
+
+      assert.true(uppy.teardown.called, "teardown runs on destroy");
+      assert.strictEqual(
+        uppy.teardown.firstCall.firstArg,
+        setupElement,
+        "teardown receives the same element setup was called with"
+      );
+    });
+
+    test("multiple fields each set up the shared uppy and route on focus", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      await waitUntil(() => uppy.setup.callCount === 2);
+
+      const textareas = document.querySelectorAll(
+        "[data-field-type='composer'] .d-editor-input"
+      );
+      assert.strictEqual(textareas.length, 2, "both fields render textareas");
+
+      await triggerEvent(textareas[0], "focusin");
+      const fieldATextManipulation = uppy.textManipulation;
+
+      await triggerEvent(textareas[1], "focusin");
+      const fieldBTextManipulation = uppy.textManipulation;
+
+      assert.notStrictEqual(
+        fieldATextManipulation,
+        fieldBTextManipulation,
+        "each field has its own textManipulation"
+      );
+
+      await triggerEvent(textareas[0], "focusin");
+      assert.strictEqual(
+        uppy.textManipulation,
+        fieldATextManipulation,
+        "focusing field A again restores its textManipulation"
       );
     });
   }

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -1,0 +1,114 @@
+import { getOwner } from "@ember/owner";
+import { render, triggerEvent, waitUntil } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import FormComposer from "discourse/components/form-template-field/composer";
+import noop from "discourse/helpers/noop";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+function fakeUppy() {
+  return {
+    setup: sinon.spy(),
+    teardown: sinon.spy(),
+    textManipulation: null,
+  };
+}
+
+module(
+  "Integration | Component | form-template-field | composer",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    function stubAllowUpload(context, value) {
+      const composerService = getOwner(context).lookup("service:composer");
+      sinon.stub(composerService, "allowUpload").value(value);
+    }
+
+    test("renders a composer with no uppy plumbing when none provided", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(<template><FormComposer @onChange={{noop}} /></template>);
+
+      assert
+        .dom("[data-field-type='composer'] .d-editor-input")
+        .exists("the markdown editor renders");
+    });
+
+    test("wires uploads onto the editor when uppyComposerUpload is provided", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      // setup() is called from DEditor's onSetup, which fires after the inner
+      // editor mounts asynchronously.
+      await waitUntil(() => uppy.setup.called);
+
+      assert.strictEqual(uppy.setup.callCount, 1, "setup is called once");
+      assert.true(
+        uppy.setup.firstCall.firstArg.classList.contains("d-editor"),
+        "setup receives the .d-editor wrapper element"
+      );
+      assert.true(
+        uppy.textManipulation?.textarea instanceof HTMLTextAreaElement,
+        "textManipulation is set so the upload pipeline can insert markdown"
+      );
+    });
+
+    test("skips wiring when allowUpload is false", async function (assert) {
+      stubAllowUpload(this, false);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      assert.false(uppy.setup.called, "setup is not called");
+      assert.strictEqual(
+        uppy.textManipulation,
+        null,
+        "textManipulation is left untouched"
+      );
+    });
+
+    test("re-claims the upload target on focusin", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const uppy = fakeUppy();
+      this.set("uppy", uppy);
+
+      await render(
+        <template>
+          <FormComposer @onChange={{noop}} @uppyComposerUpload={{this.uppy}} />
+        </template>
+      );
+
+      await waitUntil(() => uppy.setup.called);
+
+      const initialTextManipulation = uppy.textManipulation;
+      uppy.textManipulation = "trampled-by-another-field";
+
+      await triggerEvent(".d-editor-input", "focusin");
+
+      assert.strictEqual(
+        uppy.textManipulation,
+        initialTextManipulation,
+        "focusin restores this field's textManipulation as the upload target"
+      );
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -1,4 +1,3 @@
-import { tracked } from "@glimmer/tracking";
 import { getOwner } from "@ember/owner";
 import { render, settled, triggerEvent, waitUntil } from "@ember/test-helpers";
 import { module, test } from "qunit";
@@ -8,11 +7,7 @@ import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 function fakeUppy() {
-  return {
-    setup: sinon.spy(),
-    teardown: sinon.spy(),
-    textManipulation: null,
-  };
+  return { textManipulation: null };
 }
 
 module(
@@ -29,7 +24,7 @@ module(
       sinon.stub(composerService, "allowUpload").value(value);
     }
 
-    test("renders a composer with no uppy plumbing when none provided", async function (assert) {
+    test("renders the markdown editor", async function (assert) {
       stubAllowUpload(this, true);
 
       await render(<template><FormComposer @onChange={{noop}} /></template>);
@@ -39,7 +34,7 @@ module(
         .exists("the markdown editor renders");
     });
 
-    test("wires uploads onto the editor when uppyComposerUpload is provided", async function (assert) {
+    test("assigns textManipulation when uppyComposerUpload is provided", async function (assert) {
       stubAllowUpload(this, true);
 
       const uppy = fakeUppy();
@@ -51,22 +46,15 @@ module(
         </template>
       );
 
-      // setup() is called from DEditor's onSetup, which fires after the inner
-      // editor mounts asynchronously.
-      await waitUntil(() => uppy.setup.called);
+      await waitUntil(() => uppy.textManipulation);
 
-      assert.strictEqual(uppy.setup.callCount, 1, "setup is called once");
-      assert.true(
-        uppy.setup.firstCall.firstArg.classList.contains("d-editor"),
-        "setup receives the .d-editor wrapper element"
-      );
       assert.true(
         uppy.textManipulation?.textarea instanceof HTMLTextAreaElement,
-        "textManipulation is set so the upload pipeline can insert markdown"
+        "textManipulation reflects the active editor's text manipulation"
       );
     });
 
-    test("skips wiring when allowUpload is false", async function (assert) {
+    test("does not assign textManipulation when allowUpload is false", async function (assert) {
       stubAllowUpload(this, false);
 
       const uppy = fakeUppy();
@@ -78,7 +66,6 @@ module(
         </template>
       );
 
-      assert.false(uppy.setup.called, "setup is not called");
       assert.strictEqual(
         uppy.textManipulation,
         null,
@@ -98,7 +85,7 @@ module(
         </template>
       );
 
-      await waitUntil(() => uppy.setup.called);
+      await waitUntil(() => uppy.textManipulation);
 
       const initialTextManipulation = uppy.textManipulation;
       uppy.textManipulation = "trampled-by-another-field";
@@ -112,42 +99,7 @@ module(
       );
     });
 
-    test("calls teardown when the field is destroyed", async function (assert) {
-      stubAllowUpload(this, true);
-
-      const uppy = fakeUppy();
-      const state = new (class {
-        @tracked show = true;
-      })();
-      this.set("uppy", uppy);
-      this.set("state", state);
-
-      await render(
-        <template>
-          {{#if this.state.show}}
-            <FormComposer
-              @onChange={{noop}}
-              @uppyComposerUpload={{this.uppy}}
-            />
-          {{/if}}
-        </template>
-      );
-
-      await waitUntil(() => uppy.setup.called);
-      const setupElement = uppy.setup.firstCall.firstArg;
-
-      state.show = false;
-      await settled();
-
-      assert.true(uppy.teardown.called, "teardown runs on destroy");
-      assert.strictEqual(
-        uppy.teardown.firstCall.firstArg,
-        setupElement,
-        "teardown receives the same element setup was called with"
-      );
-    });
-
-    test("multiple fields each set up the shared uppy and route on focus", async function (assert) {
+    test("multiple fields route uploads to the focused field", async function (assert) {
       stubAllowUpload(this, true);
 
       const uppy = fakeUppy();
@@ -160,7 +112,7 @@ module(
         </template>
       );
 
-      await waitUntil(() => uppy.setup.callCount === 2);
+      await waitUntil(() => uppy.textManipulation);
 
       const textareas = document.querySelectorAll(
         "[data-field-type='composer'] .d-editor-input"
@@ -185,6 +137,68 @@ module(
         fieldATextManipulation,
         "focusing field A again restores its textManipulation"
       );
+    });
+
+    test("composer:replace-text replaces in composerValue and fires onChange", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const onChange = sinon.spy();
+      this.set("onChange", onChange);
+      this.set("initialValue", "before ![image|10x10](upload://abc.png) after");
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @value={{this.initialValue}}
+            @onChange={{this.onChange}}
+          />
+        </template>
+      );
+
+      const appEvents = getOwner(this).lookup("service:app-events");
+      appEvents.trigger(
+        "composer:replace-text",
+        "![image|10x10](upload://abc.png)",
+        "![image|10x10, 75%](upload://abc.png)"
+      );
+
+      await settled();
+
+      assert
+        .dom("input[name='field-1']")
+        .hasValue("before ![image|10x10, 75%](upload://abc.png) after");
+      assert.true(onChange.called, "onChange fires after the replacement");
+    });
+
+    test("composer:replace-text is a no-op when the field does not contain the markdown", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const onChange = sinon.spy();
+      this.set("onChange", onChange);
+      this.set("initialValue", "no images here");
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @value={{this.initialValue}}
+            @onChange={{this.onChange}}
+          />
+        </template>
+      );
+
+      const appEvents = getOwner(this).lookup("service:app-events");
+      appEvents.trigger(
+        "composer:replace-text",
+        "![image|10x10](upload://abc.png)",
+        "![image|10x10, 75%](upload://abc.png)"
+      );
+
+      await settled();
+
+      assert.dom("input[name='field-1']").hasValue("no images here");
+      assert.false(onChange.called, "onChange does not fire");
     });
   }
 );

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -165,10 +165,43 @@ module(
 
       await settled();
 
-      assert
-        .dom("input[name='field-1']")
-        .hasValue("before ![image|10x10, 75%](upload://abc.png) after");
+      const expected = "before ![image|10x10, 75%](upload://abc.png) after";
+      assert.dom("input[name='field-1']").hasValue(expected);
+      assert.dom(".d-editor-input").hasValue(expected);
       assert.true(onChange.called, "onChange fires after the replacement");
+    });
+
+    test("composer:replace-text only replaces the first occurrence", async function (assert) {
+      stubAllowUpload(this, true);
+
+      this.set(
+        "initialValue",
+        "![image|10x10](upload://abc.png) and ![image|10x10](upload://abc.png)"
+      );
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @value={{this.initialValue}}
+            @onChange={{noop}}
+          />
+        </template>
+      );
+
+      const appEvents = getOwner(this).lookup("service:app-events");
+      appEvents.trigger(
+        "composer:replace-text",
+        "![image|10x10](upload://abc.png)",
+        "![image|10x10, 75%](upload://abc.png)"
+      );
+
+      await settled();
+
+      const expected =
+        "![image|10x10, 75%](upload://abc.png) and ![image|10x10](upload://abc.png)";
+      assert.dom("input[name='field-1']").hasValue(expected);
+      assert.dom(".d-editor-input").hasValue(expected);
     });
 
     test("composer:replace-text is a no-op when the field does not contain the markdown", async function (assert) {
@@ -198,6 +231,7 @@ module(
       await settled();
 
       assert.dom("input[name='field-1']").hasValue("no images here");
+      assert.dom(".d-editor-input").hasValue("no images here");
       assert.false(onChange.called, "onChange does not fire");
     });
   }

--- a/frontend/discourse/tests/unit/lib/uppy/composer-upload-test.js
+++ b/frontend/discourse/tests/unit/lib/uppy/composer-upload-test.js
@@ -1,0 +1,139 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import UppyComposerUpload from "discourse/lib/uppy/composer-upload";
+import { createFile } from "discourse/tests/helpers/qunit-helpers";
+
+function fakeComposerModel() {
+  return { privateMessage: false };
+}
+
+function buildUploader(context) {
+  return new UppyComposerUpload(getOwner(context), {
+    composerEventPrefix: "composer",
+    composerModel: fakeComposerModel(),
+    uploadMarkdownResolvers: [],
+    uploadPreProcessors: [],
+    uploadHandlers: [],
+    fileUploadElementId: "file-uploader",
+  });
+}
+
+function buildPasteEvent(target, files) {
+  const event = new Event("paste", { cancelable: true, bubbles: true });
+  Object.defineProperty(event, "target", { value: target });
+  event.clipboardData = {
+    types: ["Files"],
+    files,
+    items: [],
+    getData: () => "",
+  };
+  return event;
+}
+
+module("Unit | Lib | uppy/composer-upload", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.fileInput = document.createElement("input");
+    this.fileInput.type = "file";
+    this.fileInput.id = "file-uploader";
+    document.body.appendChild(this.fileInput);
+
+    this.formEl = document.createElement("form");
+    this.editorInput = document.createElement("textarea");
+    this.editorInput.className = "d-editor-input";
+    this.formEl.appendChild(this.editorInput);
+    document.body.appendChild(this.formEl);
+  });
+
+  hooks.afterEach(function () {
+    this.fileInput.remove();
+    this.formEl.remove();
+    sinon.restore();
+  });
+
+  test("_pasteEventListener accepts paste from descendants of .d-editor-input", function (assert) {
+    const uploader = buildUploader(this);
+    uploader.uppyWrapper.uppyInstance = { addFiles: sinon.spy() };
+
+    const nested = document.createElement("span");
+    this.editorInput.appendChild(nested);
+
+    const file = createFile("paste.png", "image/png", "data");
+    const event = buildPasteEvent(nested, [file]);
+    uploader._pasteEventListener(event);
+
+    assert.true(
+      event.defaultPrevented,
+      "paste from a nested element inside .d-editor-input is captured"
+    );
+  });
+
+  test("_pasteEventListener accepts paste from a non-first .d-editor-input", function (assert) {
+    const earlierInput = document.createElement("textarea");
+    earlierInput.className = "d-editor-input";
+    document.body.insertBefore(earlierInput, this.formEl);
+
+    try {
+      const uploader = buildUploader(this);
+      uploader.uppyWrapper.uppyInstance = { addFiles: sinon.spy() };
+
+      const file = createFile("paste.png", "image/png", "data");
+      const event = buildPasteEvent(this.editorInput, [file]);
+      uploader._pasteEventListener(event);
+
+      assert.true(
+        event.defaultPrevented,
+        "paste from the second .d-editor-input is captured (closest() walks up from target, not document.querySelector)"
+      );
+    } finally {
+      earlierInput.remove();
+    }
+  });
+
+  test("_pasteEventListener ignores paste outside .d-editor-input", function (assert) {
+    const uploader = buildUploader(this);
+    uploader.uppyWrapper.uppyInstance = { addFiles: sinon.spy() };
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    const file = createFile("paste.png", "image/png", "data");
+    const event = buildPasteEvent(outside, [file]);
+    uploader._pasteEventListener(event);
+
+    assert.false(
+      event.defaultPrevented,
+      "paste outside .d-editor-input is not captured"
+    );
+
+    outside.remove();
+  });
+
+  test("setup() called twice tears down the first binding", function (assert) {
+    const uploader = buildUploader(this);
+
+    uploader.setup(this.formEl);
+    const firstUppy = uploader.uppyWrapper.uppyInstance;
+    assert.notStrictEqual(
+      firstUppy,
+      null,
+      "first setup creates an Uppy instance"
+    );
+
+    const teardownSpy = sinon.spy(uploader, "teardown");
+
+    uploader.setup(this.formEl);
+    assert.true(teardownSpy.calledOnce, "teardown is called once on re-setup");
+
+    assert.notStrictEqual(
+      firstUppy,
+      uploader.uppyWrapper.uppyInstance,
+      "second setup replaces the Uppy instance"
+    );
+
+    uploader.teardown();
+  });
+});


### PR DESCRIPTION
Image paste in form template composer fields was no-op when in markdown mode. Tracking down the fix also led to improving the image paste for the WYSIWYG editor in those same composers. Those now properly upload images when pasted, using `UppyComposerUpload`.

This also led to reintroducing broken image controls in the composer, and backing out faulty code from #37275 and letting the rebake do its thing properly.