### PR TITLE
FIX: Form templates page returning 500 error

### DIFF
--- a/app/controllers/admin/form_templates_controller.rb
+++ b/app/controllers/admin/form_templates_controller.rb
@@ -73,8 +73,6 @@ class Admin::FormTemplatesController < Admin::StaffController
   private
 
   def ensure_form_templates_enabled
-    unless UpcomingChanges.enabled_for_user?(:enable_form_templates, current_user)
-      raise Discourse::InvalidAccess.new
-    end
+    raise Discourse::InvalidAccess.new unless SiteSetting.enable_form_templates
   end
 end

--- a/app/controllers/form_templates_controller.rb
+++ b/app/controllers/form_templates_controller.rb
@@ -24,8 +24,6 @@ class FormTemplatesController < ApplicationController
   private
 
   def ensure_form_templates_enabled
-    unless UpcomingChanges.enabled_for_user?(:enable_form_templates, current_user)
-      raise Discourse::InvalidAccess.new
-    end
+    raise Discourse::InvalidAccess.new unless SiteSetting.enable_form_templates
   end
 end

--- a/spec/requests/admin/form_templates_controller_spec.rb
+++ b/spec/requests/admin/form_templates_controller_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Admin::FormTemplatesController do
   fab!(:user)
   fab!(:form_template)
 
-  before { SiteSetting.enable_form_templates = true }
-
   describe "#index" do
     context "when logged in as an admin" do
       before { sign_in(admin) }

--- a/spec/requests/form_templates_controller_spec.rb
+++ b/spec/requests/form_templates_controller_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe FormTemplatesController do
   fab!(:user)
 
-  before { SiteSetting.enable_form_templates = true }
-
   describe "#index" do
     fab!(:form_template)
     fab!(:form_template_2, :form_template)


### PR DESCRIPTION
The `enable_form_templates` site setting was recently demoted from an upcoming change to a regular site setting, but the controllers were still gating access through `UpcomingChanges.enabled_for_user?`. Without the upcoming change metadata, that path crashed with `NoMethodError (undefined method '>=' for nil)` whenever the setting sat at its default value, taking the admin Form Templates page down with it.

Switch the two controllers to a plain `SiteSetting.enable_form_templates` check, and drop the redundant `before` hooks from the request specs so they actually exercise the default-value path that broke in production.