### PR TITLE
DEV: Fail fast on unknown upcoming change keys

### DIFF
--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -117,6 +117,10 @@ module UpcomingChanges
   def self.enabled?(change_setting_name)
     change_setting_name = change_setting_name.to_sym
 
+    if !exists?(change_setting_name)
+      raise ArgumentError, "Unknown upcoming change: #{change_setting_name}"
+    end
+
     # An admin has modified the setting and a value is stored
     # in the database, since the default for upcoming changes
     # is false.

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -392,6 +392,15 @@ RSpec.describe UpcomingChanges do
       UpcomingChanges.clear_caches!
     end
 
+    context "when the change is not registered" do
+      it "raises ArgumentError" do
+        expect { described_class.enabled?(:not_an_upcoming_change) }.to raise_error(
+          ArgumentError,
+          /Unknown upcoming change/,
+        )
+      end
+    end
+
     context "when the setting has no row in the database (admin has not saved it)" do
       before { SiteSetting.remove_override!(setting_name) }
 


### PR DESCRIPTION
Asking `UpcomingChanges.enabled?` about a key that isn't registered used to crash deep inside `meets_or_exceeds_status?` with a confusing `NoMethodError (undefined method '>=' for nil)`. That made stale callers (e.g. controllers still gating on a key whose `upcoming_change` metadata has been removed) hard to trace back from a 500.

Raise an `ArgumentError` at the public entry point instead, so the bug surfaces with a clear "Unknown upcoming change: X" message and points straight at the offending caller.