### PR TITLE
DEV: Fix a hide_from_public_spec flake

### DIFF
--- a/spec/system/user_page/hide_from_public_spec.rb
+++ b/spec/system/user_page/hide_from_public_spec.rb
@@ -25,6 +25,6 @@ describe "hide_user_profiles_from_public" do
     expect(page).to have_current_path("/u/#{user.username}")
 
     find(".error-page .buttons .btn-primary", text: "Back").click
-    expect(page).to have_current_path(post.url)
+    expect(page).to have_current_path(post.url).or have_current_path(post.topic.relative_url)
   end
 end


### PR DESCRIPTION
The first post has two valid paths: `/slug/id` and `/slug/id/1`. Latter is automatically updated to former on the client side, but depending on how quick CI is, it might have either path at the time of that assertion.