### PR TITLE
DEV: Fix a flaky id assertion in d-solved specs

### DIFF
--- a/plugins/discourse-solved/spec/lib/post_mover_extension_spec.rb
+++ b/plugins/discourse-solved/spec/lib/post_mover_extension_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DiscourseSolved::PostMoverExtension do
   fab!(:another_reply) { Fabricate(:post, topic: topic) }
   fab!(:destination_topic) { Fabricate(:topic_with_op, category: category) }
 
-  let!(:post_ids) { topic.posts.pluck(:id) }
+  let!(:post_ids) { topic.posts.order(:post_number).pluck(:id) }
   let!(:solved) { Fabricate(:solved_topic, topic: topic, answer_post: reply) }
 
   before { SiteSetting.allow_solved_on_all_topics = true }


### PR DESCRIPTION
as always: the order of results is never guaranteed