### PR TITLE
FIX: Upcoming Changes guards on form templates

### DIFF
--- a/app/controllers/admin/form_templates_controller.rb
+++ b/app/controllers/admin/form_templates_controller.rb
@@ -73,8 +73,6 @@ class Admin::FormTemplatesController < Admin::StaffController
   private
 
   def ensure_form_templates_enabled
-    unless UpcomingChanges.enabled_for_user?(:enable_form_templates, current_user)
-      raise Discourse::InvalidAccess.new
-    end
+    raise Discourse::InvalidAccess.new unless SiteSetting.enable_form_templates
   end
 end

--- a/app/controllers/form_templates_controller.rb
+++ b/app/controllers/form_templates_controller.rb
@@ -24,8 +24,6 @@ class FormTemplatesController < ApplicationController
   private
 
   def ensure_form_templates_enabled
-    unless UpcomingChanges.enabled_for_user?(:enable_form_templates, current_user)
-      raise Discourse::InvalidAccess.new
-    end
+    raise Discourse::InvalidAccess.new unless SiteSetting.enable_form_templates
   end
 end


### PR DESCRIPTION
#39742 removed the upcoming changes metadata for form templates but left the guards in the form template controllers causing those pages to 500.

Change those to guard based on site setting instead.