### PR TITLE
FIX: Clean up push subscriptions whose endpoint domain no longer resolves

### DIFF
--- a/app/services/push_notification_pusher.rb
+++ b/app/services/push_notification_pusher.rb
@@ -182,6 +182,9 @@ class PushNotificationPusher
       handle_generic_error(subscription, e, user, endpoint, message)
     rescue OpenSSL::SSL::SSLError => e
       handle_generic_error(subscription, e, user, endpoint, message)
+    rescue FinalDestination::SSRFDetector::LookupFailedError,
+           FinalDestination::SSRFDetector::DisallowedIpError => e
+      handle_generic_error(subscription, e, user, endpoint, message)
     end
   end
 

--- a/spec/services/push_notification_pusher_spec.rb
+++ b/spec/services/push_notification_pusher_spec.rb
@@ -228,6 +228,30 @@ RSpec.describe PushNotificationPusher do
       expect(subscription.error_count).to eq(1)
     end
 
+    it "handles DNS lookup failures for endpoints whose domain no longer resolves" do
+      WebPush.expects(:payload_send).raises(
+        FinalDestination::SSRFDetector::LookupFailedError.new("lookup failed"),
+      )
+      subscription = create_subscription
+
+      expect { execute_push }.to_not raise_exception
+
+      subscription.reload
+      expect(subscription.error_count).to eq(1)
+    end
+
+    it "handles endpoints that resolve to disallowed IPs" do
+      WebPush.expects(:payload_send).raises(
+        FinalDestination::SSRFDetector::DisallowedIpError.new("disallowed"),
+      )
+      subscription = create_subscription
+
+      expect { execute_push }.to_not raise_exception
+
+      subscription.reload
+      expect(subscription.error_count).to eq(1)
+    end
+
     describe "`watching_category_or_tag` notifications" do
       it "Uses the 'watching_first_post' translation when new topic was created" do
         message =


### PR DESCRIPTION
Previously, push notification jobs for subscriptions whose endpoint domain no longer resolved raised `FinalDestination::SSRFDetector::LookupFailedError` (or `DisallowedIpError`), which bypassed the existing rescue chain in `PushNotificationPusher.send_notification`. As a result `error_count` was never incremented, the subscription was never cleaned up, and the job kept retrying — flooding logs indefinitely.

This change rescues both errors and routes them through `handle_generic_error`, so dead-endpoint subscriptions participate in the standard 3-strikes-over-24h cleanup path like other transient failures.