### PR TITLE
FIX: Correct the date range in d-rewind

### DIFF
--- a/plugins/discourse-rewind/app/services/discourse_rewind/fetch_report.rb
+++ b/plugins/discourse-rewind/app/services/discourse_rewind/fetch_report.rb
@@ -39,7 +39,7 @@ module DiscourseRewind
     private
 
     def fetch_date(params:, year:)
-      Date.new(year).all_year
+      Time.zone.local(year).all_year
     end
 
     def fetch_report(params:, for_user:, year:, date:)

--- a/plugins/discourse-rewind/app/services/discourse_rewind/fetch_reports.rb
+++ b/plugins/discourse-rewind/app/services/discourse_rewind/fetch_reports.rb
@@ -57,7 +57,7 @@ module DiscourseRewind
     private
 
     def fetch_date(params:, year:)
-      Date.new(year).all_year
+      Time.zone.local(year).all_year
     end
 
     def fetch_reports(date:, for_user:, year:)

--- a/plugins/discourse-rewind/plugin.rb
+++ b/plugins/discourse-rewind/plugin.rb
@@ -28,16 +28,6 @@ module ::DiscourseRewind
     date ||= Time.zone.now
     date.month == 1 ? date.year - 1 : date.year
   end
-
-  def self.year_date_range(date_override = nil)
-    current_date = date_override.presence || Time.zone.now
-
-    # Outside December/January, only available in development
-    is_rewind_period = current_date.month == 1 || current_date.month == 12
-    return false if !is_rewind_period && !Rails.env.development?
-
-    Date.new(current_date.year).all_year
-  end
 end
 
 require_relative "lib/discourse_rewind/engine"

--- a/plugins/discourse-rewind/spec/plugin_helper.rb
+++ b/plugins/discourse-rewind/spec/plugin_helper.rb
@@ -7,8 +7,7 @@ module DiscourseRewindSpecHelper
   end
 
   def random_datetime
-    # date should be defined via fab! in the spec
-    date.to_a.sample.to_datetime + rand(0..23).hours + rand(0..59).minutes + rand(0..59).seconds
+    rand(date.first.to_time...date.last.to_time)
   end
 end
 


### PR DESCRIPTION
Fixes the flakes we've been seeing.

1. The previous version of `random_datetime` could sometimes fall outside the desired range (roughly in 2% of runs)
2. `Date.new(year).all_year` is a `Date` range. It's turned into `BETWEEN '2021-01-01' AND '2021-12-31'` which pg reads as midnight timestamps, so we've been dropping any activity after Dec 31 00:00. (i.e. the last 24hrs)