### PR TITLE
DEV: Fix a admin_customize_themes spec flake

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -382,6 +382,15 @@ describe "Admin Customize Themes" do
       visit("/")
       expect(banner).to be_visible
 
+      # Wait for the `/client_settings` subscription's first poll finish.
+      try_until_success do
+        expect(
+          page.evaluate_script(
+            "window.MessageBus.callbacks.find(c => c.channel === '/client_settings')?.last_id",
+          ),
+        ).not_to eq(-1)
+      end
+
       using_session(:admin) do
         sign_in(admin)
         theme_page.visit(theme.id)


### PR DESCRIPTION
Two sessions were racing: one trying to subscribe, the other sending a message