### PR TITLE
FIX: Trigger Discobot discoveries from category and tag pages

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-search-discoveries.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-search-discoveries.js
@@ -1,4 +1,5 @@
 import { apiInitializer } from "discourse/lib/api";
+import { isScopedSearch } from "../lib/search-discoveries-context";
 
 export default apiInitializer((api) => {
   const currentUser = api.getCurrentUser();
@@ -25,9 +26,8 @@ export default apiInitializer((api) => {
 
     const query = searchMenu.search.activeGlobalSearchTerm;
 
-    // We only trigger discover when searching on all topics.
     if (
-      searchMenu.search?.searchContext?.type ||
+      isScopedSearch(searchMenu.search) ||
       discobotDiscoveries.lastQuery === query
     ) {
       return true;
@@ -50,8 +50,7 @@ export default apiInitializer((api) => {
       return true;
     }
 
-    // We only trigger discover when searching on all topics.
-    if (search?.searchContext?.type) {
+    if (isScopedSearch(search)) {
       return true;
     }
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/search-discoveries-context.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/search-discoveries-context.js
@@ -1,0 +1,8 @@
+// Mirrors SearchMenu#searchContext: only topic and PM contexts actually scope
+// the search request. Category and tag pages set search.searchContext but the
+// menu still searches globally there, so discoveries should still trigger.
+export function isScopedSearch(search) {
+  return (
+    search?.inTopicContext || search?.searchContext?.type === "private_messages"
+  );
+}

--- a/plugins/discourse-ai/test/javascripts/unit/lib/search-discoveries-context-test.js
+++ b/plugins/discourse-ai/test/javascripts/unit/lib/search-discoveries-context-test.js
@@ -1,0 +1,44 @@
+import { module, test } from "qunit";
+import { isScopedSearch } from "discourse/plugins/discourse-ai/discourse/lib/search-discoveries-context";
+
+module("Unit | Lib | search-discoveries-context", function () {
+  test("returns false when there is no search context", function (assert) {
+    assert.false(isScopedSearch({}));
+    assert.false(isScopedSearch(null));
+    assert.false(isScopedSearch(undefined));
+  });
+
+  test("returns false on category and tag pages", function (assert) {
+    assert.false(
+      isScopedSearch({ searchContext: { type: "category" } }),
+      "category context still searches globally from the menu"
+    );
+    assert.false(
+      isScopedSearch({ searchContext: { type: "tag" } }),
+      "tag context still searches globally from the menu"
+    );
+    assert.false(
+      isScopedSearch({ searchContext: { type: "tagIntersection" } }),
+      "tag intersection context still searches globally from the menu"
+    );
+    assert.false(
+      isScopedSearch({ searchContext: { type: "user" } }),
+      "user context still searches globally from the menu"
+    );
+  });
+
+  test("returns true when scoped to a topic", function (assert) {
+    assert.true(
+      isScopedSearch({
+        inTopicContext: true,
+        searchContext: { type: "topic" },
+      })
+    );
+  });
+
+  test("returns true when scoped to the PM inbox", function (assert) {
+    assert.true(
+      isScopedSearch({ searchContext: { type: "private_messages" } })
+    );
+  });
+});


### PR DESCRIPTION
Previously, discoveries were suppressed whenever `search.searchContext` had a `type`, but `build-category-route` and `tag/show` set that on every category/tag page even though the search menu still searches globally there.

This change mirrors `SearchMenu#searchContext` and only treats `inTopicContext` and `private_messages` as scoped, so discoveries trigger from category and tag pages while remaining suppressed inside a topic or the PM inbox.