### PR TITLE
UX: left-align account activation content

### DIFF
--- a/app/assets/stylesheets/common/base/activation.scss
+++ b/app/assets/stylesheets/common/base/activation.scss
@@ -56,19 +56,16 @@
   .activate-account-button,
   .continue-button {
     margin-top: 1em;
-    margin-inline: auto;
     display: block;
     width: fit-content;
   }
 
   .login-welcome-header {
-    margin-inline: auto;
     width: fit-content;
   }
 
   .tada-image {
     width: 150px;
-    margin: auto;
     padding-bottom: 1em;
   }
 }


### PR DESCRIPTION
We had some wonky mixed alignment here (in both Horizon and Foundation), but generally all the invite stuff is left aligned... so this gets it back to consistent

Before:
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/19c47b40-8769-476a-823d-3230c0121fcd" />

After: 
<img width="550" alt="image" src="https://github.com/user-attachments/assets/c3ef0a5f-30ce-480c-b989-04d68a2d15ee" />
