### PR TITLE
UX: make user search results inline with content

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -384,13 +384,14 @@
 
   .search-result-user .user-result img.avatar,
   .search-item-user {
-    display: flex;
-    align-self: center;
-    gap: var(--space-2);
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-1);
 
     img.avatar {
       width: 20px;
       height: 20px;
+      align-self: center;
     }
   }
 


### PR DESCRIPTION
These are meant to be a single line, but regressed at some point

Before:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/0fb0d5ab-d66e-43cb-b86c-16fdd21449e0" />


After:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/59b59194-977b-407f-b4f8-70169312cbc7" />
