### PR TITLE
FIX: topic_map exposes hidden-post URLs and titles through public topic details

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -46,6 +46,7 @@ class TopicLink < ActiveRecord::Base
              MIN(ftl.user_id) AS user_id,
              SUM(clicks) AS clicks
       FROM topic_links AS ftl
+      JOIN posts AS source_posts ON ftl.post_id = source_posts.id
       LEFT JOIN topics AS ft ON ftl.link_topic_id = ft.id
       LEFT JOIN categories AS c ON c.id = ft.category_id
       LEFT JOIN posts AS target_posts ON ftl.link_post_id = target_posts.id
@@ -56,6 +57,7 @@ class TopicLink < ActiveRecord::Base
     SQL
 
     builder.where("ftl.topic_id = :topic_id", topic_id: topic_id)
+    apply_source_post_visibility_filters(builder, guardian, source_post: "source_posts")
     apply_link_visibility_filters(
       builder,
       link: "ftl",
@@ -208,6 +210,16 @@ class TopicLink < ActiveRecord::Base
     SQL
   end
   private_class_method :apply_link_visibility_filters
+
+  def self.apply_source_post_visibility_filters(builder, guardian, source_post:)
+    builder.where("#{source_post}.deleted_at IS NULL")
+    builder.where(
+      "#{source_post}.post_type IN (:visible_post_types)",
+      visible_post_types: Topic.visible_post_types(guardian.user),
+    )
+    builder.where("#{source_post}.hidden = false") unless guardian.is_staff?
+  end
+  private_class_method :apply_source_post_visibility_filters
 
   private
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2908,6 +2908,34 @@ RSpec.describe TopicsController do
       expect(response.parsed_body).not_to have_key("tags_descriptions")
     end
 
+    it "does not expose links from hidden posts in topic details to non-staff viewers" do
+      visible_post =
+        create_post(topic:, user: post_author1, raw: "[Visible](https://visible-link.example.com)")
+      hidden_post =
+        create_post(topic:, user: post_author1, raw: "[Hidden](https://hidden-link.example.com)")
+
+      topic.topic_links.find_by!(post: visible_post).update!(clicks: 1, title: "Visible title")
+      topic.topic_links.find_by!(post: hidden_post).update!(clicks: 1, title: "Hidden title")
+
+      hidden_post.hide!(PostActionType.types[:off_topic])
+
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["details"]["links"]).to contain_exactly(
+        a_hash_including("url" => "https://visible-link.example.com", "title" => "Visible title"),
+      )
+
+      sign_in(moderator)
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["details"]["links"]).to contain_exactly(
+        a_hash_including("url" => "https://visible-link.example.com", "title" => "Visible title"),
+        a_hash_including("url" => "https://hidden-link.example.com", "title" => "Hidden title"),
+      )
+    end
+
     it "shows a blank-slug topic without redirecting" do
       topic.update_columns(title: "", slug: nil)
       topic.reload

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2909,17 +2909,30 @@ RSpec.describe TopicsController do
     end
 
     it "does not expose links from hidden posts in topic details to non-staff viewers" do
-      visible_post =
-        create_post(topic:, user: post_author1, raw: "[Visible](https://visible-link.example.com)")
-      hidden_post =
-        create_post(topic:, user: post_author1, raw: "[Hidden](https://hidden-link.example.com)")
+      test_topic = Fabricate(:topic, user: post_author1)
+      visible_post = Fabricate(:post, topic: test_topic, user: post_author1)
+      hidden_post = Fabricate(:post, topic: test_topic, user: post_author1)
 
-      topic.topic_links.find_by!(post: visible_post).update!(clicks: 1, title: "Visible title")
-      topic.topic_links.find_by!(post: hidden_post).update!(clicks: 1, title: "Hidden title")
+      Fabricate(
+        :topic_link,
+        post: visible_post,
+        url: "https://visible-link.example.com",
+        domain: "visible-link.example.com",
+        clicks: 1,
+        title: "Visible title",
+      )
+      Fabricate(
+        :topic_link,
+        post: hidden_post,
+        url: "https://hidden-link.example.com",
+        domain: "hidden-link.example.com",
+        clicks: 1,
+        title: "Hidden title",
+      )
 
       hidden_post.hide!(PostActionType.types[:off_topic])
 
-      get "/t/#{topic.slug}/#{topic.id}.json"
+      get "/t/#{test_topic.slug}/#{test_topic.id}.json"
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["details"]["links"]).to contain_exactly(
@@ -2927,7 +2940,7 @@ RSpec.describe TopicsController do
       )
 
       sign_in(moderator)
-      get "/t/#{topic.slug}/#{topic.id}.json"
+      get "/t/#{test_topic.slug}/#{test_topic.id}.json"
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["details"]["links"]).to contain_exactly(


### PR DESCRIPTION
If topic map links to a hidden / whisper post it shows it in the list of links which can be confusing to end users anyway. 