### PR TITLE
FIX: tags_descriptions exposes PM tag metadata when PM tags are hidden

### DIFF
--- a/app/serializers/concerns/topic_tags_mixin.rb
+++ b/app/serializers/concerns/topic_tags_mixin.rb
@@ -12,6 +12,10 @@ module TopicTagsMixin
     scope.can_see_tags?(topic)
   end
 
+  def include_tags_descriptions?
+    include_tags?
+  end
+
   def tags
     all_tags.map { |tag| { id: tag.id, name: localized_tag_name(tag), slug: tag.slug_for_url } }
   end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2892,6 +2892,22 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(200)
     end
 
+    it "does not expose private message tag descriptions when the viewer cannot see tags" do
+      SiteSetting.tagging_enabled = true
+      SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:admins].to_s
+      pm_post = Fabricate(:private_message_post, user: admin, recipient: user)
+      pm_topic = pm_post.topic
+      pm_tag = Fabricate(:tag, name: "secret-pm-tag", description: "secret PM tag description")
+      pm_topic.tags << pm_tag
+
+      sign_in(user)
+      get "/t/#{pm_topic.slug}/#{pm_topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).not_to have_key("tags")
+      expect(response.parsed_body).not_to have_key("tags_descriptions")
+    end
+
     it "shows a blank-slug topic without redirecting" do
       topic.update_columns(title: "", slug: nil)
       topic.reload


### PR DESCRIPTION
Defense in depth, in rare cases where serializer is called with superfluous data ensure it is not exposed. 