### PR TITLE
FIX: Data Explorer post relations expose private post excerpts to group report users

### DIFF
--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -110,8 +110,18 @@ module DiscourseDataExplorer
         },
         post: {
           class: Post,
-          fields: %i[id topic_id post_number cooked user_id],
-          include: [:user],
+          fields: %i[
+            id
+            topic_id
+            post_number
+            cooked
+            user_id
+            post_type
+            deleted_at
+            deleted_by_id
+            hidden
+          ],
+          include: [:user, { topic: :category }],
           serializer: SmallPostWithExcerptSerializer,
         },
         topic: {
@@ -151,7 +161,7 @@ module DiscourseDataExplorer
           .compact
     end
 
-    def self.add_extra_data(pg_result)
+    def self.add_extra_data(pg_result, guardian: nil)
       needed_classes = {}
       ret = {}
       col_map = {}
@@ -199,8 +209,13 @@ module DiscourseDataExplorer
             .includes(support_info[:include])
             .order(:id)
 
+        if cls == :post && guardian
+          all_objs = all_objs.select { |post| guardian.can_see_post?(post) }
+        end
+
         opts = { each_serializer: support_info[:serializer] }
         opts[:only] = support_info[:only] if support_info[:only]
+        opts[:scope] = guardian if guardian
         ret[cls] = ActiveModel::ArraySerializer.new(all_objs, **opts)
       end
       [ret, col_map]

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -198,6 +198,7 @@ module DiscourseDataExplorer
         column_nums.each { |col_n| ids.merge(pg_result.column_values(col_n)) }
         ids.delete nil
         ids.map! &:to_i
+        ids = ids.take(SiteSetting.data_explorer_query_result_limit)
 
         object_class = support_info[:class]
         all_objs = object_class
@@ -205,12 +206,21 @@ module DiscourseDataExplorer
         all_objs =
           all_objs
             .select(support_info[:fields])
-            .where(id: ids.to_a.sort)
+            .where(id: ids.sort)
             .includes(support_info[:include])
             .order(:id)
 
-        if cls == :post && guardian
-          all_objs = all_objs.select { |post| guardian.can_see_post?(post) }
+        if guardian
+          all_objs =
+            case cls
+            when :post
+              all_objs.select { |post| guardian.can_see_post?(post) }
+            when :topic
+              allowed_topic_ids = guardian.can_see_topic_ids(topic_ids: ids)
+              all_objs.where(id: allowed_topic_ids)
+            else
+              all_objs
+            end
         end
 
         opts = { each_serializer: support_info[:serializer] }

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_runner.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_runner.rb
@@ -12,7 +12,8 @@ module DiscourseDataExplorer
 
       return { error: result[:error], duration_secs: result[:duration_secs] } if result[:error]
 
-      result_json = ResultFormatConverter.convert(:json, result, query_params:, explain:)
+      result_json =
+        ResultFormatConverter.convert(:json, result, query_params:, explain:, current_user:)
 
       if cacheable?(query, explain:) && default_limit?(limit)
         cache_key_params = resolve_params(query, raw_params)

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_format_converter.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/result_format_converter.rb
@@ -44,7 +44,8 @@ module DiscourseDataExplorer
       json[:explain] = result[:explain] if opts[:explain]
 
       if !opts[:download]
-        relations, colrender = DataExplorer.add_extra_data(pg_result)
+        guardian = Guardian.new(opts[:current_user])
+        relations, colrender = DataExplorer.add_extra_data(pg_result, guardian:)
         json[:relations] = relations
         json[:colrender] = colrender
       end

--- a/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
+++ b/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
@@ -139,6 +139,21 @@ describe DiscourseDataExplorer::DataExplorer do
         expect(colrender).to eq({ 1 => "json" })
       end
 
+      it "limits relation resolution to the query result limit per relation type" do
+        SiteSetting.data_explorer_query_result_limit = 2
+        topics = Fabricate.times(4, :topic)
+        query = DiscourseDataExplorer::Query.create!(name: "some query", sql: <<~SQL)
+              SELECT #{topics[0].id} AS topic_id, #{topics[2].id} AS related_topic_id
+              UNION ALL
+              SELECT #{topics[1].id} AS topic_id, #{topics[3].id} AS related_topic_id
+            SQL
+
+        pg_result = described_class.run_query(query)[:pg_result]
+        relations, _ = DiscourseDataExplorer::DataExplorer.add_extra_data(pg_result)
+
+        expect(relations[:topic].as_json.size).to eq(2)
+      end
+
       describe "serializing models to serializer" do
         it "serializes correctly to BasicTopicSerializer for topic relations" do
           topic = Fabricate(:topic, locale: "ja")

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -805,8 +805,8 @@ describe DiscourseDataExplorer::QueryController do
         expect(response.status).to eq(200)
         post_relations = response.parsed_body["relations"]["post"]
         expect(post_relations).to contain_exactly(include("id" => visible_post.id))
-        expect(response.body).to include("Visible data explorer excerpt")
-        expect(response.body).not_to include("hidden data explorer excerpt")
+        expect(response.body).to include(visible_post.raw)
+        expect(response.body).not_to include(private_post.raw)
       end
 
       it "does not include topic relations the user cannot see" do
@@ -832,8 +832,8 @@ describe DiscourseDataExplorer::QueryController do
         expect(response.status).to eq(200)
         topic_relations = response.parsed_body["relations"]["topic"]
         expect(topic_relations).to contain_exactly(include("id" => visible_topic.id))
-        expect(response.body).to include("Visible data explorer topic may render")
-        expect(response.body).not_to include("hidden data explorer topic")
+        expect(response.body).to include(visible_topic.title)
+        expect(response.body).not_to include(private_topic.title)
       end
 
       it "can accept parameters as a hash" do

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -789,8 +789,9 @@ describe DiscourseDataExplorer::QueryController do
             raw: "Ssshh! This hidden data explorer excerpt must not leak.",
           )
         visible_post = Fabricate(:post, raw: "Visible data explorer excerpt may render.")
-        expect(Guardian.new(user).can_see_post?(private_post)).to eq(false)
-        expect(Guardian.new(user).can_see_post?(visible_post)).to eq(true)
+        guardian = user.guardian
+        expect(guardian.can_see_post?(private_post)).to eq(false)
+        expect(guardian.can_see_post?(visible_post)).to eq(true)
 
         query_sql = <<~SQL
           SELECT #{private_post.id} AS post_id
@@ -806,6 +807,33 @@ describe DiscourseDataExplorer::QueryController do
         expect(post_relations).to contain_exactly(include("id" => visible_post.id))
         expect(response.body).to include("Visible data explorer excerpt")
         expect(response.body).not_to include("hidden data explorer excerpt")
+      end
+
+      it "does not include topic relations the user cannot see" do
+        private_topic =
+          Fabricate(
+            :private_message_topic,
+            title: "Ssshh this hidden data explorer topic must not leak",
+          )
+        visible_topic = Fabricate(:topic, title: "Visible data explorer topic may render")
+        guardian = user.guardian
+        expect(guardian.can_see_topic?(private_topic)).to eq(false)
+        expect(guardian.can_see_topic?(visible_topic)).to eq(true)
+
+        query_sql = <<~SQL
+          SELECT #{private_topic.id} AS topic_id
+          UNION ALL
+          SELECT #{visible_topic.id} AS topic_id
+        SQL
+        query = make_query(query_sql, { name: "Topics" }, [group.id.to_s])
+
+        post "/g/#{group.name}/reports/#{query.id}/run.json"
+
+        expect(response.status).to eq(200)
+        topic_relations = response.parsed_body["relations"]["topic"]
+        expect(topic_relations).to contain_exactly(include("id" => visible_topic.id))
+        expect(response.body).to include("Visible data explorer topic may render")
+        expect(response.body).not_to include("hidden data explorer topic")
       end
 
       it "can accept parameters as a hash" do

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -782,6 +782,32 @@ describe DiscourseDataExplorer::QueryController do
         expect(response.parsed_body["rows"]).to eq([[1828]])
       end
 
+      it "does not include post relations the user cannot see" do
+        private_post =
+          Fabricate(
+            :private_message_post,
+            raw: "Ssshh! This hidden data explorer excerpt must not leak.",
+          )
+        visible_post = Fabricate(:post, raw: "Visible data explorer excerpt may render.")
+        expect(Guardian.new(user).can_see_post?(private_post)).to eq(false)
+        expect(Guardian.new(user).can_see_post?(visible_post)).to eq(true)
+
+        query_sql = <<~SQL
+          SELECT #{private_post.id} AS post_id
+          UNION ALL
+          SELECT #{visible_post.id} AS post_id
+        SQL
+        query = make_query(query_sql, { name: "Posts" }, [group.id.to_s])
+
+        post "/g/#{group.name}/reports/#{query.id}/run.json"
+
+        expect(response.status).to eq(200)
+        post_relations = response.parsed_body["relations"]["post"]
+        expect(post_relations).to contain_exactly(include("id" => visible_post.id))
+        expect(response.body).to include("Visible data explorer excerpt")
+        expect(response.body).not_to include("hidden data explorer excerpt")
+      end
+
       it "can accept parameters as a hash" do
         query_string = <<~SQL
         -- [params]


### PR DESCRIPTION
A non obvious issue in data explorer is that it can return sideloaded data (topic/user/post)
ensure side loaded data runs through security rules for account viewing it.

Can easily be bypassed by amending the query so it will have minimal impact. 