### PR TITLE
FIX: Unescaped username regex lets self-service rename rewrite other users' mentions

### DIFF
--- a/app/jobs/regular/update_username.rb
+++ b/app/jobs/regular/update_username.rb
@@ -19,12 +19,13 @@ module Jobs
 
       @quote_rewriter = QuoteRewriter.new(@user_id)
 
+      escaped_old_username = Regexp.escape(@old_username)
       @raw_mention_regex =
         /
         (?:
           (?<![\p{Alnum}\p{M}`])     # make sure there is no preceding letter, number or backtick
         )
-        @#{@old_username}
+        @#{escaped_old_username}
         (?:
           (?![\p{Alnum}\p{M}_\-.`])  # make sure there is no trailing letter, number, underscore, dash, dot or backtick
           |                          # or
@@ -33,9 +34,10 @@ module Jobs
       /ix
 
       cooked_username = PrettyText::Helpers.format_username(@old_username)
-      @cooked_mention_username_regex = /\A@#{cooked_username}\z/i
-      @cooked_mention_user_path_regex =
-        %r{\A/u(?:sers)?/#{UrlHelper.encode_component(cooked_username)}\z}i
+      escaped_cooked_username = Regexp.escape(cooked_username)
+      escaped_encoded_cooked_username = Regexp.escape(UrlHelper.encode_component(cooked_username))
+      @cooked_mention_username_regex = /\A@#{escaped_cooked_username}\z/i
+      @cooked_mention_user_path_regex = %r{\A/u(?:sers)?/#{escaped_encoded_cooked_username}\z}i
 
       update_posts
       update_revisions

--- a/spec/jobs/update_username_spec.rb
+++ b/spec/jobs/update_username_spec.rb
@@ -16,4 +16,29 @@ RSpec.describe Jobs::UpdateUsername do
 
     expect(events).to eq([])
   end
+
+  it "does not rewrite similar mentions when the old username contains a dot" do
+    renamed_user = Fabricate(:user, username: "foo.bar")
+    Fabricate(:user, username: "foo-bar")
+    author = Fabricate(:user)
+    topic = Fabricate(:topic, user: author)
+
+    Jobs.run_immediately!
+    UserActionManager.enable
+    post = create_post(user: author, topic: topic, raw: "@foo.bar @foo-bar")
+
+    described_class.new.execute(
+      user_id: renamed_user.id,
+      old_username: renamed_user.username,
+      new_username: "newname",
+      avatar_template: renamed_user.avatar_template,
+    )
+
+    post.reload
+
+    expect(post.raw).to eq("@newname @foo-bar")
+    expect(post.cooked).to match_html <<~HTML
+      <p><a class="mention" href="/u/newname">@newname</a> <a class="mention" href="/u/foo-bar">@foo-bar</a></p>
+    HTML
+  end
 end


### PR DESCRIPTION
Mention update should regex escape username cause username can have . in it which needs escaping. 