### PR TITLE
FIX: Avoid 'PG::UniqueViolation' when concurrent requests update visits

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1044,12 +1044,14 @@ class User < ActiveRecord::Base
   end
 
   def create_visit_record!(date, opts = {})
+    visit =
+      user_visits.create!(
+        visited_at: date,
+        posts_read: opts[:posts_read] || 0,
+        mobile: opts[:mobile] || false,
+      )
     user_stat.update_column(:days_visited, user_stat.days_visited + 1)
-    user_visits.create!(
-      visited_at: date,
-      posts_read: opts[:posts_read] || 0,
-      mobile: opts[:mobile] || false,
-    )
+    visit
   end
 
   def visit_record_for(date)
@@ -1058,6 +1060,8 @@ class User < ActiveRecord::Base
 
   def update_visit_record!(date)
     create_visit_record!(date) unless visit_record_for(date)
+  rescue ActiveRecord::RecordNotUnique
+    # concurrent "Updating Last Seen" defer block already inserted
   end
 
   def update_timezone_if_missing(timezone)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1490,6 +1490,44 @@ RSpec.describe User do
     end
   end
 
+  describe "#create_visit_record!" do
+    fab!(:user)
+    let(:date) { Date.current }
+
+    it "creates a UserVisit and increments days_visited" do
+      expect { user.create_visit_record!(date) }.to change {
+        user.user_visits.where(visited_at: date).count
+      }.by(1).and change { user.user_stat.reload.days_visited }.by(1)
+    end
+
+    it "does not increment days_visited when the insert raises" do
+      user.create_visit_record!(date)
+
+      expect {
+        expect { user.create_visit_record!(date) }.to raise_error(ActiveRecord::RecordNotUnique)
+      }.not_to change { user.user_stat.reload.days_visited }
+    end
+  end
+
+  describe "#update_visit_record!" do
+    fab!(:user)
+    let(:date) { Date.current }
+
+    it "creates a visit when none exists for the date" do
+      expect { user.update_visit_record!(date) }.to change {
+        user.user_visits.where(visited_at: date).count
+      }.by(1)
+    end
+
+    it "is a no-op when a visit already exists for the date" do
+      user.update_visit_record!(date)
+
+      expect { user.update_visit_record!(date) }.not_to change {
+        user.user_visits.where(visited_at: date).count
+      }
+    end
+  end
+
   describe "email_confirmed?" do
     fab!(:user)
 


### PR DESCRIPTION
Two near-simultaneous authenticated requests for the same user could both pass the existence check in `User#update_visit_record!` and race to insert the same `(user_id, visited_at)` row, raising `ActiveRecord::RecordNotUnique` from the `Updating Last Seen` deferred block.

This change rescues the unique-violation in `update_visit_record!` (mirroring `update_posts_read!`) and reorders `create_visit_record!` so `days_visited` is only incremented after the insert succeeds.