### PR TITLE
FIX: Chat channel creation skips category posting permission check for mods

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_controller.rb
@@ -80,6 +80,7 @@ class Chat::Api::ChannelsController < Chat::ApiController
       end
       on_model_not_found(:category) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:can_create_channel) { raise Discourse::InvalidAccess }
+      on_failed_policy(:can_create_channel_in_category) { raise Discourse::InvalidAccess }
       on_failed_policy(:category_channel_does_not_exist) do
         raise Discourse::InvalidParameters.new(I18n.t("chat.errors.channel_exists_for_category"))
       end

--- a/plugins/chat/app/services/chat/create_category_channel.rb
+++ b/plugins/chat/app/services/chat/create_category_channel.rb
@@ -52,6 +52,7 @@ module Chat
     end
 
     model :category
+    policy :can_create_channel_in_category
     policy :category_channel_does_not_exist
 
     transaction do
@@ -73,6 +74,10 @@ module Chat
 
     def fetch_category(params:)
       Category.find_by(id: params.category_id)
+    end
+
+    def can_create_channel_in_category(guardian:, category:)
+      guardian.can_post_in_category?(category)
     end
 
     def category_channel_does_not_exist(category:, params:)

--- a/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
@@ -347,6 +347,27 @@ RSpec.describe Chat::Api::ChannelsController do
       expect(new_channel.chatable_id).to eq(category.id)
     end
 
+    context "when the user cannot post in the category" do
+      fab!(:moderator)
+      fab!(:group)
+      fab!(:private_category) { Fabricate(:private_category, group:) }
+
+      before do
+        sign_in(moderator)
+        params[:channel][:chatable_id] = private_category.id
+      end
+
+      it "does not create a channel or membership" do
+        expect {
+          post "/chat/api/channels", params:, headers: { "ACCEPT" => "application/json" }
+        }.to not_change { Chat::Channel.count }.and not_change {
+                Chat::UserChatChannelMembership.count
+              }
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+      end
+    end
+
     it "creates a channel using the user-provided slug" do
       new_params = params.dup
       new_params[:channel][:slug] = "wow-so-cool"


### PR DESCRIPTION
A moderator can create a chat channel under a category they couldn't actually post in.

This PR adds a `can_create_channel_in_category` policy backed by`guardian.can_post_in_category?(category)`.

