### PR TITLE
FIX: Chat channel onebox icons render and support channel emoji

### DIFF
--- a/plugins/chat/db/post_migrate/20260507083943_rebake_chat_onebox_posts.rb
+++ b/plugins/chat/db/post_migrate/20260507083943_rebake_chat_onebox_posts.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RebakeChatOneboxPosts < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE posts
+         SET baked_version = 0
+       WHERE cooked LIKE '%chat-onebox%'
+    SQL
+  end
+
+  def down
+  end
+end

--- a/plugins/chat/lib/chat/onebox_handler.rb
+++ b/plugins/chat/lib/chat/onebox_handler.rb
@@ -40,7 +40,7 @@ module Chat
       {
         channel_id: chat_channel.id,
         channel_name: chat_channel.name,
-        color: chat_channel.category_channel? ? chat_channel.chatable.color : nil,
+        color: chat_channel.chatable.color,
         channel_badge: build_channel_badge(chat_channel),
       }
     end
@@ -48,14 +48,8 @@ module Chat
     def self.build_channel_badge(chat_channel)
       return Emoji.codes_to_img(":#{chat_channel.emoji}:") if chat_channel.emoji.present?
 
-      if chat_channel.category_channel?
-        color = chat_channel.chatable.color
-        %(<span class="category-chat-badge" style="color: ##{color}"><svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg></span>)
-      elsif chat_channel.direct_message_channel?
-        %(<svg class="fa d-icon d-icon-users svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#users"></use></svg>)
-      else
-        ""
-      end
+      color = chat_channel.chatable.color
+      %(<span class="category-chat-badge" style="color: ##{color}"><svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg></span>)
     end
 
     def self.render_thread_onebox(args, thread)

--- a/plugins/chat/lib/chat/onebox_handler.rb
+++ b/plugins/chat/lib/chat/onebox_handler.rb
@@ -46,13 +46,15 @@ module Chat
     end
 
     def self.build_channel_badge(chat_channel)
-      return "" unless chat_channel.category_channel?
+      return Emoji.codes_to_img(":#{chat_channel.emoji}:") if chat_channel.emoji.present?
 
-      if chat_channel.emoji.present?
-        Emoji.codes_to_img(":#{chat_channel.emoji}:")
-      else
+      if chat_channel.category_channel?
         color = chat_channel.chatable.color
         %(<span class="category-chat-badge" style="color: ##{color}"><svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg></span>)
+      elsif chat_channel.direct_message_channel?
+        %(<svg class="fa d-icon d-icon-users svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#users"></use></svg>)
+      else
+        ""
       end
     end
 

--- a/plugins/chat/lib/chat/onebox_handler.rb
+++ b/plugins/chat/lib/chat/onebox_handler.rb
@@ -40,9 +40,20 @@ module Chat
       {
         channel_id: chat_channel.id,
         channel_name: chat_channel.name,
-        is_category: chat_channel.category_channel?,
         color: chat_channel.category_channel? ? chat_channel.chatable.color : nil,
+        channel_badge: build_channel_badge(chat_channel),
       }
+    end
+
+    def self.build_channel_badge(chat_channel)
+      return "" unless chat_channel.category_channel?
+
+      if chat_channel.emoji.present?
+        Emoji.codes_to_img(":#{chat_channel.emoji}:")
+      else
+        color = chat_channel.chatable.color
+        %(<span class="category-chat-badge" style="color: ##{color}"><svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg></span>)
+      end
     end
 
     def self.render_thread_onebox(args, thread)

--- a/plugins/chat/lib/onebox/templates/discourse_chat_channel.mustache
+++ b/plugins/chat/lib/onebox/templates/discourse_chat_channel.mustache
@@ -2,11 +2,7 @@
   <article class="onebox-body chat-onebox-body">
     <h3 class="chat-onebox-title">
       <a href="/chat/c/-/{{channel_id}}">
-        {{#is_category}}
-          <span class="category-chat-badge" style="color: #{{color}}">
-            <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
-          </span>
-        {{/is_category}}
+        {{{channel_badge}}}
         <span class="clear-badge">{{channel_name}}</span>
       </a>
     </h3>

--- a/plugins/chat/lib/onebox/templates/discourse_chat_message.mustache
+++ b/plugins/chat/lib/onebox/templates/discourse_chat_message.mustache
@@ -15,16 +15,7 @@
       {{/thread_id}}
     </div>
     <a class="chat-transcript-channel" href="/chat/c/-/{{channel_id}}">
-      {{#is_category}}
-        <span class="category-chat-badge" style="color: #{{color}}">
-          <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
-        </span>
-      {{/is_category}}
-      {{#is_topic}}
-        <span class="topic-chat-icon">
-          <svg class="fa d-icon d-icon-far-comments svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#far-comments"></use></svg>
-        </span>
-      {{/is_topic}}
+      {{{channel_badge}}}
       {{channel_name}}
     </a>
     {{#thread_id}}

--- a/plugins/chat/lib/onebox/templates/discourse_chat_thread.mustache
+++ b/plugins/chat/lib/onebox/templates/discourse_chat_thread.mustache
@@ -11,9 +11,7 @@
       </h3>
       <span class="thread-title-connector">{{thread_title_connector}}</span>
       <a href="/chat/c/-/{{channel_id}}">
-        <span class="category-chat-badge" style="color: #{{color}}">
-          <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
-        </span>
+        {{{channel_badge}}}
         <span class="clear-badge">{{channel_name}}</span>
       </a>
     </div>

--- a/plugins/chat/spec/lib/chat/onebox_handler_spec.rb
+++ b/plugins/chat/spec/lib/chat/onebox_handler_spec.rb
@@ -30,7 +30,7 @@ describe Chat::OneboxHandler do
               <h3 class="chat-onebox-title">
                 <a href="/chat/c/-/#{public_channel.id}">
                   <span class="category-chat-badge" style="color: ##{public_channel.chatable.color}">
-                    <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
+                    <svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg>
                   </span>
                   <span class="clear-badge">#{public_channel.name}</span>
                 </a>
@@ -40,6 +40,28 @@ describe Chat::OneboxHandler do
                 <a class="trigger-user-card" data-user-card="#{user.username}" aria-hidden="true" tabindex="-1">
                   <img loading="lazy" alt="#{user.username}" width="30" height="30" src="#{user.avatar_template_url.gsub("{size}", "60")}" class="avatar">
                 </a>
+              </div>
+            </article>
+          </aside>
+        HTML
+      end
+
+      it "renders the channel emoji in place of the chat bubble when set" do
+        public_channel.update!(emoji: "tada")
+
+        onebox_html = Chat::OneboxHandler.handle(public_chat_url, { channel_id: public_channel.id })
+
+        expect(onebox_html).to match_html <<~HTML
+          <aside class="onebox chat-onebox">
+            <article class="onebox-body chat-onebox-body">
+              <h3 class="chat-onebox-title">
+                <a href="/chat/c/-/#{public_channel.id}">
+                  <img src="/images/emoji/twitter/tada.png?v=15" title="tada" class="emoji" alt="tada" loading="lazy" width="20" height="20">
+                  <span class="clear-badge">#{public_channel.name}</span>
+                </a>
+              </h3>
+              <div class="chat-onebox-members-count">0 members</div>
+              <div class="chat-onebox-members">
               </div>
             </article>
           </aside>
@@ -95,7 +117,7 @@ describe Chat::OneboxHandler do
               </div>
               <a class="chat-transcript-channel" href="/chat/c/-/#{public_channel.id}">
                 <span class="category-chat-badge" style="color: ##{public_channel.chatable.color}">
-                  <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
+                  <svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg>
                 </span>
                 #{public_channel.name}
               </a>
@@ -164,7 +186,7 @@ describe Chat::OneboxHandler do
                 <span class="thread-title-connector">in</span>
                 <a href="/chat/c/-/#{public_channel.id}">
                   <span class="category-chat-badge" style="color: ##{public_channel.chatable.color}">
-                    <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
+                    <svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg>
                   </span>
                   <span class="clear-badge">#{public_channel.name}</span>
                 </a>
@@ -206,7 +228,7 @@ describe Chat::OneboxHandler do
               <h3 class="chat-onebox-title">
                 <a href="/chat/c/-/#{public_channel.id}">
                   <span class="category-chat-badge" style="color: ##{public_channel.chatable.color}">
-                    <svg class="fa d-icon d-icon-d-chat svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#d-chat"></use></svg>
+                    <svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg>
                   </span>
                   <span class="clear-badge">#{public_channel.name}</span>
                 </a>

--- a/plugins/chat/spec/lib/chat/onebox_handler_spec.rb
+++ b/plugins/chat/spec/lib/chat/onebox_handler_spec.rb
@@ -245,44 +245,4 @@ describe Chat::OneboxHandler do
       end
     end
   end
-
-  describe ".build_channel_badge" do
-    fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user, user_2]) }
-
-    it "renders the channel emoji when set on a category channel" do
-      public_channel.update!(emoji: "tada")
-
-      badge = Chat::OneboxHandler.build_channel_badge(public_channel)
-
-      expect(badge).to eq(
-        %(<img src="/images/emoji/twitter/tada.png?v=15" title="tada" class="emoji" alt="tada" loading="lazy" width="20" height="20">),
-      )
-    end
-
-    it "renders the comment icon tinted with the category color when no emoji is set" do
-      badge = Chat::OneboxHandler.build_channel_badge(public_channel)
-
-      expect(badge).to eq(<<~HTML.strip)
-        <span class="category-chat-badge" style="color: ##{public_channel.chatable.color}"><svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg></span>
-      HTML
-    end
-
-    it "renders the channel emoji when set on a direct message channel" do
-      dm_channel.update!(emoji: "wave")
-
-      badge = Chat::OneboxHandler.build_channel_badge(dm_channel)
-
-      expect(badge).to eq(
-        %(<img src="/images/emoji/twitter/wave.png?v=15" title="wave" class="emoji" alt="wave" loading="lazy" width="20" height="20">),
-      )
-    end
-
-    it "renders the users icon for a direct message channel without an emoji" do
-      badge = Chat::OneboxHandler.build_channel_badge(dm_channel)
-
-      expect(badge).to eq(
-        %(<svg class="fa d-icon d-icon-users svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#users"></use></svg>),
-      )
-    end
-  end
 end

--- a/plugins/chat/spec/lib/chat/onebox_handler_spec.rb
+++ b/plugins/chat/spec/lib/chat/onebox_handler_spec.rb
@@ -245,4 +245,44 @@ describe Chat::OneboxHandler do
       end
     end
   end
+
+  describe ".build_channel_badge" do
+    fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [user, user_2]) }
+
+    it "renders the channel emoji when set on a category channel" do
+      public_channel.update!(emoji: "tada")
+
+      badge = Chat::OneboxHandler.build_channel_badge(public_channel)
+
+      expect(badge).to eq(
+        %(<img src="/images/emoji/twitter/tada.png?v=15" title="tada" class="emoji" alt="tada" loading="lazy" width="20" height="20">),
+      )
+    end
+
+    it "renders the comment icon tinted with the category color when no emoji is set" do
+      badge = Chat::OneboxHandler.build_channel_badge(public_channel)
+
+      expect(badge).to eq(<<~HTML.strip)
+        <span class="category-chat-badge" style="color: ##{public_channel.chatable.color}"><svg class="fa d-icon d-icon-comment svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#comment"></use></svg></span>
+      HTML
+    end
+
+    it "renders the channel emoji when set on a direct message channel" do
+      dm_channel.update!(emoji: "wave")
+
+      badge = Chat::OneboxHandler.build_channel_badge(dm_channel)
+
+      expect(badge).to eq(
+        %(<img src="/images/emoji/twitter/wave.png?v=15" title="wave" class="emoji" alt="wave" loading="lazy" width="20" height="20">),
+      )
+    end
+
+    it "renders the users icon for a direct message channel without an emoji" do
+      badge = Chat::OneboxHandler.build_channel_badge(dm_channel)
+
+      expect(badge).to eq(
+        %(<svg class="fa d-icon d-icon-users svg-icon svg-string" xmlns="http://www.w3.org/2000/svg"><use href="#users"></use></svg>),
+      )
+    end
+  end
 end


### PR DESCRIPTION
Chat channel oneboxes have been rendering with no icon next to the channel title since #20744. That PR changed the mustache templates to emit `<svg><use href="#d-chat"></use></svg>` and registered a JS-side `replaceIcon("d-chat", "comment")` to compensate. The replacement only runs through `iconHTML()` / `{{icon}}` at render time though — the mustache markup is cooked into the post HTML server-side, so the JS swap never touches it. `d-chat` has never been part of the SVG sprite, which means the browser cannot resolve `#d-chat` and the badge renders empty.

This commit pre-renders the channel badge in `Chat::OneboxHandler` and passes it to the templates as a single HTML blob:

* When the channel has an emoji, it is rendered via `Emoji.codes_to_img`.
* Otherwise we fall back to the chat bubble (`#comment`, which is in the sprite) tinted with the channel's category color.

The fix covers all three onebox templates (channel, message, thread). A post-deploy migration flips `baked_version` to 0 on every post whose cooked HTML contains `chat-onebox`, so the recurring `Post.rebake_old` job picks them up and rebakes them in the background with the fixed templates.

Ref - t/183234