### PR TITLE
UX: constrain max tag width in header

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -440,6 +440,7 @@
 
       li {
         flex-wrap: nowrap;
+        max-width: 100%;
       }
 
       @include ellipsis;


### PR DESCRIPTION
Fixes a minor issue where sometimes a lone long tag won't truncate 

Before:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/86b21ebc-2edb-40ac-897e-e754797d98ec" />


After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/4ab61c7f-48c4-4319-964b-4c3bc6663379" />
