### PR TITLE
UX: fix missing select-kit border in modernized foundation

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme.scss
@@ -275,6 +275,10 @@
     color: var(--primary);
   }
 
+  .select-kit .select-kit-header.btn-default {
+    border: var(--d-button-default-border);
+  }
+
   .d-multi-select__search-container {
     padding-block: 0;
   }


### PR DESCRIPTION
There's a case where select-kit CSS is overriding some modernized foundation CSS for select-kit, when a header has a button class. This adds a more specific style to fix it. 

Before:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/61867bc6-ba1e-49e2-8630-6c8629525984" />


After: 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/62ff91b8-2a55-4741-9c82-8ed3c19e1033" />
