### PR TITLE
Fix/bulk import merge import and poll fixes

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -296,6 +296,8 @@ def insert_automatic_group_users
   Group::AUTO_GROUPS.each do |group_name, group_id|
     user_condition =
       case group_name
+      when :anonymous, :logged_in_users
+        next
       when :everyone
         "TRUE"
       when :admins

--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -238,12 +238,22 @@ class BulkImport::Base
   def load_index(type)
     map = {}
 
-    @raw_connection.send_query(
-      "SELECT original_id, discourse_id FROM migration_mappings WHERE type = #{type} AND original_id NOT LIKE '%:%'",
-    )
-    @raw_connection.set_single_row_mode
-
-    @raw_connection.get_result.stream_each { |row| map[row["original_id"]] = row["discourse_id"] }
+    if @import_prefix
+      @raw_connection.send_query(
+        "SELECT original_id, discourse_id FROM migration_mappings WHERE type = #{type} AND original_id LIKE '#{@import_prefix}:%'",
+      )
+      @raw_connection.set_single_row_mode
+      prefix_length = @import_prefix.length + 1
+      @raw_connection.get_result.stream_each do |row|
+        map[row["original_id"][prefix_length..]] = row["discourse_id"]
+      end
+    else
+      @raw_connection.send_query(
+        "SELECT original_id, discourse_id FROM migration_mappings WHERE type = #{type} AND original_id NOT LIKE '%:%'",
+      )
+      @raw_connection.set_single_row_mode
+      @raw_connection.get_result.stream_each { |row| map[row["original_id"]] = row["discourse_id"] }
+    end
 
     @raw_connection.get_result
 

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -1295,7 +1295,7 @@ class BulkImport::Generic < BulkImport::Base
         original_id: row["id"],
         post_id: post_id,
         name: poll_name(row),
-        closed_at: to_datetime(row["closed_at"]),
+        closed_at: to_datetime(row["close_at"]),
         type: row["type"],
         status: row["status"],
         results: row["results"],
@@ -1361,7 +1361,7 @@ class BulkImport::Generic < BulkImport::Base
       next unless poll_id
 
       option_ids = row["option_ids"].split(",")
-      option_ids.each { |option_id| next if poll_option_id_from_original_id(option_id).present? }
+      next if option_ids.all? { |oid| poll_option_id_from_original_id(oid).present? }
 
       {
         original_ids: option_ids,
@@ -3144,6 +3144,7 @@ class BulkImport::Generic < BulkImport::Base
       channel_id = chat_channel_id_from_original_id(row["chat_channel_id"])
       original_message_user_id = user_id_from_imported_id(row["original_message_user_id"])
 
+      next if chat_thread_id_from_original_id(row["id"]).present?
       next if channel_id.blank? || original_message_user_id.blank?
 
       # Messages aren't imported yet. Use a placeholder `original_message_id` for now.
@@ -3219,6 +3220,7 @@ class BulkImport::Generic < BulkImport::Base
       channel_id = chat_channel_id_from_original_id(row["chat_channel_id"])
       user_id = user_id_from_imported_id(row["user_id"])
 
+      next if chat_message_id_from_original_id(row["id"]).present?
       next if channel_id.blank? || user_id.blank?
       next if row["message"].blank? && row["upload_ids"].blank?
 


### PR DESCRIPTION
This PR fixes several bugs in the bulk import scripts that affect both regular imports and multi-source `MERGE_IMPORT` runs.

**`import.rake` - skip virtual auto-groups in `insert_automatic_group_users`**

The `anonymous` and `logged_in_users` groups are virtual groups with no real membership and no valid SQL condition. Iterating over them caused errors during import post-processing.

**`generic_bulk.rb` / `base.rb` - poll and MERGE_IMPORT re-run safety**

- **`closed_at` column name mismatch** (`import_polls`): the intermediate DB schema uses `close_at` but the importer was reading `closed_at`, causing all poll close dates to be silently imported as `nil`.

- **`import_poll_options` dedup guard was a no-op**: the `next if` was inside an `each` block, so it only skipped to the next iteration of the inner loop - never the outer `create_poll_options` block. Poll options would always be re-inserted on any re-run. Fixed with `next if option_ids.all? { ... }` on the outer block.

- **`load_index` cross-source ID collision under `MERGE_IMPORT`**: when running a second or third source with `MERGE_IMPORT=true`, `migration_mappings` entries from all prior sources were loaded into shared maps (`@uploads_mapping`, `@poll_mapping`, etc.). A Woltlab upload with `id=123` could incorrectly match against a vBulletin upload `id=123` and be skipped. The fix scopes the query to `original_id LIKE '<prefix>:%'` and strips the prefix when building the in-memory map, so each source's dedup is fully isolated. Regular (non-MERGE_IMPORT) runs are unaffected — `@import_prefix` is `nil` and the original `NOT LIKE '%:%'` path is taken.

- **Missing dedup guards on `import_chat_threads` and `import_chat_messages`**: unlike every other entity type, chat threads and messages had no `next if already_exists` guard. Re-running would duplicate all chat content. Guards added using the existing `@chat_thread_mapping` / `@chat_message_mapping` maps, already correctly prefix-scoped by the `load_index` fix above.