### PR TITLE
FIX: enforce `full_name_requirement` on Discourse ID signups

### DIFF
--- a/frontend/discourse/app/instance-initializers/auth-complete.js
+++ b/frontend/discourse/app/instance-initializers/auth-complete.js
@@ -96,13 +96,17 @@ export default {
             }
 
             next(() => {
+              const site = owner.lookup("service:site");
               const props = {
                 accountEmail: options.email,
                 accountUsername: options.username,
                 accountName: options.name,
                 authOptions: EmberObject.create(options),
                 skipConfirmation:
-                  siteSettings.auth_skip_create_confirm && options.username,
+                  siteSettings.auth_skip_create_confirm &&
+                  options.username &&
+                  (!site.full_name_required_for_signup ||
+                    options.name_from_provider),
               };
 
               router.transitionTo("signup").then(() => {

--- a/frontend/discourse/app/instance-initializers/auth-complete.js
+++ b/frontend/discourse/app/instance-initializers/auth-complete.js
@@ -97,6 +97,10 @@ export default {
 
             next(() => {
               const site = owner.lookup("service:site");
+              const hasRequiredName =
+                !site.full_name_required_for_signup ||
+                options.name_from_provider;
+
               const props = {
                 accountEmail: options.email,
                 accountUsername: options.username,
@@ -105,8 +109,7 @@ export default {
                 skipConfirmation:
                   siteSettings.auth_skip_create_confirm &&
                   options.username &&
-                  (!site.full_name_required_for_signup ||
-                    options.name_from_provider),
+                  hasRequiredName,
               };
 
               router.transitionTo("signup").then(() => {

--- a/frontend/discourse/tests/acceptance/create-account-external-test.js
+++ b/frontend/discourse/tests/acceptance/create-account-external-test.js
@@ -73,6 +73,52 @@ acceptance(
   }
 );
 
+acceptance(
+  "Create Account - external auth with full name required but not from provider",
+  function (needs) {
+    needs.hooks.beforeEach(function () {
+      setupAuthData({ name: "Testuser", name_from_provider: false });
+    });
+    needs.hooks.afterEach(function () {
+      document.getElementById("data-authentication").remove();
+    });
+
+    needs.site({ full_name_required_for_signup: true });
+
+    test("when skip is enabled but name is required and not from provider, shows form", async function (assert) {
+      this.siteSettings.auth_skip_create_confirm = true;
+      await visit("/");
+
+      assert.dom(".signup-fullpage").exists("it shows the signup page");
+      assert.dom("#new-account-name").exists("it shows the name field");
+    });
+  }
+);
+
+acceptance(
+  "Create Account - external auth with full name required and from provider",
+  function (needs) {
+    needs.hooks.beforeEach(function () {
+      setupAuthData({ name: "John Doe", name_from_provider: true });
+    });
+    needs.hooks.afterEach(function () {
+      document.getElementById("data-authentication").remove();
+    });
+
+    needs.site({ full_name_required_for_signup: true });
+
+    test("when skip is enabled and name is from provider, skips form", async function (assert) {
+      this.siteSettings.auth_skip_create_confirm = true;
+      await visit("/");
+
+      assert.dom(".signup-fullpage").exists("it shows the signup page");
+      assert
+        .dom("#new-account-username")
+        .doesNotExist("it does not show the fields");
+    });
+  }
+);
+
 acceptance("Create account - with associate link", function (needs) {
   needs.hooks.beforeEach(function () {
     setupAuthData({ associate_url: "/associate/abcde" });

--- a/lib/auth/discourse_id_authenticator.rb
+++ b/lib/auth/discourse_id_authenticator.rb
@@ -24,6 +24,7 @@ class Auth::DiscourseIdAuthenticator < Auth::ManagedAuthenticator
     info do
       {
         nickname: access_token.params["info"]["username"],
+        name: access_token.params["info"]["name"],
         email: access_token.params["info"]["email"],
         image: access_token.params["info"]["image"],
       }

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -172,6 +172,7 @@ class Auth::Result
 
     if SiteSetting.enable_names?
       result[:name] = name.presence
+      result[:name_from_provider] = name.present?
       result[:name] ||= User.suggest_name(username || email) if can_edit_name
     end
 

--- a/spec/lib/auth/discourse_id_authenticator_spec.rb
+++ b/spec/lib/auth/discourse_id_authenticator_spec.rb
@@ -146,6 +146,7 @@ describe Auth::DiscourseIdAuthenticator do
       provider: "discourse_id",
       info: {
         "nickname" => "test_user",
+        "name" => "Test User",
         "email" => user.email,
         "image" => "http://example.com/avatar.png",
         "uuid" => "12345",
@@ -155,12 +156,13 @@ describe Auth::DiscourseIdAuthenticator do
   end
 
   describe "after_authenticate" do
-    it "works and syncs username, email, avatar" do
+    it "works and syncs username, email, name, avatar" do
       result = authenticator.after_authenticate(hash)
       expect(result.user).to eq(user)
       expect(result.failed).to eq(false)
 
       expect(result.username).to eq("test_user")
+      expect(result.name).to eq("Test User")
       expect(result.email).to eq(user.email)
 
       associated_record =
@@ -168,6 +170,26 @@ describe Auth::DiscourseIdAuthenticator do
 
       expect(associated_record[:info]["image"]).to eq("http://example.com/avatar.png")
       expect(associated_record[:info]["uuid"]).to eq("12345")
+    end
+
+    context "when name is not provided by the provider" do
+      let(:hash_without_name) do
+        OmniAuth::AuthHash.new(
+          provider: "discourse_id",
+          info: {
+            "nickname" => "test_user",
+            "email" => user.email,
+            "image" => "http://example.com/avatar.png",
+            "uuid" => "12345",
+          },
+          uid: "99",
+        )
+      end
+
+      it "result name is nil" do
+        result = authenticator.after_authenticate(hash_without_name)
+        expect(result.name).to be_nil
+      end
     end
   end
 end

--- a/spec/system/discourse_id_spec.rb
+++ b/spec/system/discourse_id_spec.rb
@@ -43,6 +43,38 @@ describe "discourse login client auth" do
         signup_form.open.click_social_button("discourse_id")
         expect(page).to have_css(".header-dropdown-toggle.current-user")
       end
+
+      context "when full_name_requirement is required_at_signup" do
+        before { SiteSetting.full_name_requirement = "required_at_signup" }
+
+        it "shows the signup form when name is not provided by the provider" do
+          visit("/")
+          signup_form.open.click_social_button("discourse_id")
+          expect(signup_form).to be_open
+          expect(page).to have_css("#new-account-name")
+        end
+
+        context "when name is provided by the provider" do
+          before do
+            OmniAuth.config.mock_auth[:discourse_id] = OmniAuth::AuthHash.new(
+              provider: "discourse_id",
+              uid: OmniauthHelpers::UID,
+              info:
+                OmniAuth::AuthHash::InfoHash.new(
+                  email: OmniauthHelpers::EMAIL,
+                  nickname: OmniauthHelpers::USERNAME,
+                  name: "John Doe",
+                ),
+            )
+          end
+
+          it "skips the signup form and creates the account directly" do
+            visit("/")
+            signup_form.open.click_social_button("discourse_id")
+            expect(page).to have_css(".header-dropdown-toggle.current-user")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**Previously**, when `full_name_requirement` was set to "required_at_signup" and `auth_skip_create_confirm` was enabled, Discourse ID signups bypassed the name requirement by auto-suggesting a name from the username.

**In this update**, the client authenticator extracts the provider-supplied name, and the signup flow no longer skips confirmation when a real name is required but not provided by the auth provider.