### PR TITLE
UX: Hide embedded pageviews series on Site Traffic when no embedding

### DIFF
--- a/app/models/concerns/reports/site_traffic.rb
+++ b/app/models/concerns/reports/site_traffic.rb
@@ -70,19 +70,23 @@ module Reports::SiteTraffic
           color: report.colors[:purple],
           data: data.map { |row| { x: row.date, y: row.page_view_crawler } },
         },
-        {
+      ]
+
+      if EmbeddableHost.exists?
+        report.data << {
           req: "page_view_embed",
           label: I18n.t("reports.site_traffic.xaxis.page_view_embed"),
           color: report.colors[:yellow],
           data: data.map { |row| { x: row.date, y: row.page_view_embed } },
-        },
-        {
-          req: "page_view_other",
-          label: I18n.t("reports.site_traffic.xaxis.page_view_other"),
-          color: report.colors[:magenta],
-          data: data.map { |row| { x: row.date, y: row.page_view_other } },
-        },
-      ]
+        }
+      end
+
+      report.data << {
+        req: "page_view_other",
+        label: I18n.t("reports.site_traffic.xaxis.page_view_other"),
+        color: report.colors[:magenta],
+        data: data.map { |row| { x: row.date, y: row.page_view_other } },
+      }
     end
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1636,6 +1636,8 @@ RSpec.describe Report do
       end
 
       it "exposes embedded pageviews as their own series without polluting other series" do
+        Fabricate(:embeddable_host)
+
         2.times { ApplicationRequest.increment!(:page_view_anon) }
         1.times { ApplicationRequest.increment!(:page_view_anon_browser) }
         3.times { ApplicationRequest.increment!(:page_view_logged_in) }
@@ -1648,6 +1650,13 @@ RSpec.describe Report do
 
         expect(embed_series[:data][0][:y]).to eq(4)
         expect(other_series[:data][0][:y]).to eq(2)
+      end
+
+      it "omits the embedded pageviews series when no embeddable host is configured" do
+        4.times { ApplicationRequest.increment!(:page_view_embed) }
+        CachedCounting.flush
+
+        expect(reports.data.map { |r| r[:req] }).not_to include("page_view_embed")
       end
     end
   end


### PR DESCRIPTION
The Site Traffic stacked chart on the admin dashboard exposes a yellow `page_view_embed` band introduced in #39535. On forums that have never configured embedding (no `EmbeddableHost` records), this series is always zero and just adds noise to the legend.