### PR TITLE
DEV: Add `DashboardSection` component for admin dashboard redesign

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1285,6 +1285,7 @@ a.inline-editable-field {
 @import "admin/site-settings";
 @import "admin/admin_config_area";
 @import "admin/search";
+@import "admin/admin_dashboard";
 @import "admin/admin_table";
 @import "admin/admin_filter";
 @import "admin/admin_filter_controls";

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -1,0 +1,398 @@
+@use "lib/viewport";
+
+.db-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.db-toolbar {
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--space-8);
+
+  &__actions {
+    display: flex;
+    gap: var(--space-4);
+    margin-left: auto;
+  }
+}
+
+h1 {
+  margin: 0; // to be done proper
+}
+
+.db-delta {
+  font-size: var(--font-down-2-rem);
+  font-weight: bold;
+
+  &.--pos {
+    color: var(--success);
+  }
+
+  &.--neg {
+    color: var(--danger);
+  }
+}
+
+.db-pill {
+  font-size: var(--font-down-3);
+  border-radius: 6.25rem;
+  padding: var(--space-half) var(--space-2);
+
+  &.--pos {
+    background: var(--success-low);
+  }
+
+  &.--neg {
+    background: var(--danger-low);
+  }
+}
+
+.db-customise {
+  padding: var(--space-4);
+
+  &__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+
+    @include viewport.until(sm) {
+      gap: var(--space-5);
+    }
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  &__section-name {
+    margin-right: var(--space-4);
+  }
+
+  &__drag-handle {
+    color: var(--primary-low-mid);
+  }
+
+  .d-toggle-switch {
+    margin-left: auto;
+
+    @include viewport.from(sm) {
+      --toggle-switch-width: 32px;
+      --toggle-switch-height: 18px;
+    }
+
+    .d-icon-check {
+      display: none;
+    }
+  }
+}
+
+.db-link-arrow {
+  position: absolute;
+  opacity: 0;
+  font-size: var(--font-down-2-rem);
+  transform: translateX(-4px);
+  transition:
+    opacity 0.15s,
+    transform 0.15s;
+  color: var(--tertiary);
+}
+
+.db-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+
+  &__info {
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-low-mid);
+  }
+
+  &__header-row {
+    display: flex;
+    align-items: center;
+  }
+
+  &__header {
+    font-size: var(--font-down-2-rem);
+    font-weight: 600;
+    color: var(--primary-medium);
+    text-transform: uppercase;
+    margin: 0;
+    letter-spacing: 1px;
+  }
+
+  &__intro {
+    max-width: 60ch;
+    margin: 0;
+
+    .--kpi & {
+      font-size: var(--font-up-1-rem);
+    }
+  }
+
+  &__subheader {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-8);
+  }
+
+  &__subintro {
+    max-width: 60ch;
+
+    p {
+      font-size: var(--font-down-1-rem);
+      color: var(--primary-high);
+      margin-bottom: 0;
+    }
+  }
+
+  &__metrics {
+    display: flex;
+    justify-content: flex-end;
+    flex-grow: 1;
+    gap: var(--space-10);
+  }
+
+  &__metric-number {
+    white-space: nowrap;
+    font-size: var(--font-up-3);
+  }
+
+  &__metric-label {
+    white-space: nowrap;
+    font-size: var(--font-down-2-rem);
+    color: var(--primary-medium);
+  }
+
+  &__callout {
+    background: var(--primary-very-low);
+    border: 1px solid var(--primary-low-mid);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--d-border-radius-large);
+    font-size: var(--font-down-1-rem);
+  }
+
+  &__row {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: var(--space-4);
+    border-top: 1px solid var(--primary-low);
+    margin-inline: calc(var(--space-4) * -1);
+  }
+
+  &__row-block {
+    flex: 1;
+    padding: var(--space-4);
+
+    &:not(:last-child) {
+      border-right: 1px solid var(--primary-low);
+    }
+  }
+
+  &__row-block-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__row-block-title {
+    position: relative;
+    color: var(--primary);
+    margin-bottom: var(--space-2);
+    font-weight: bold;
+    font-size: var(--font-down-1-rem);
+
+    .db-link-arrow {
+      top: 0;
+      right: calc(var(--space-6) * -1);
+      margin-left: var(--space-4);
+    }
+
+    &:is(a):hover {
+      color: var(--primary);
+
+      .db-link-arrow {
+        opacity: 1;
+        transform: translateX(0);
+      }
+    }
+  }
+
+  &__wrapper {
+    border-radius: var(--d-border-radius-large);
+    border: 1px solid var(--primary-low);
+
+    &.--no-border {
+      border: none;
+      border-radius: 0;
+      padding: 0;
+    }
+
+    &.--grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: var(--space-4);
+    }
+
+    &.--row {
+      display: flex;
+      flex-wrap: nowrap;
+    }
+
+    &.--column {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+      padding: var(--space-4);
+
+      &:has(.db-section__row-block) {
+        padding-bottom: 0;
+      }
+    }
+  }
+}
+
+.db-kpi {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+
+  .db-link-arrow {
+    top: var(--space-4);
+    right: var(--space-4);
+  }
+
+  &:hover {
+    background: var(--primary-very-low);
+
+    .db-link-arrow {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  &__value-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  &__value {
+    font-size: var(--font-up-3-rem);
+    font-weight: 500;
+    color: var(--primary);
+  }
+
+  &__label {
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-medium);
+  }
+}
+
+.db-report {
+  &__card {
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-border-radius-large);
+    padding: var(--space-4);
+    box-sizing: border-box;
+    background: var(--secondary);
+    height: 250px; // to be removed when cards come in with aspect-ratio;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  &__name {
+    display: flex;
+    align-items: center;
+    font-size: var(--font-down-1-rem);
+    font-weight: 600;
+  }
+
+  &__label {
+    color: var(--primary-high);
+    background: var(--primary-low);
+    border-radius: 4px;
+    font-size: var(--font-down-3);
+    padding: var(--space-half) var(--space-2);
+    font-weight: 400;
+
+    &.--data-explorer {
+      background: var(--tertiary-low);
+      color: var(--tertiary);
+    }
+  }
+
+  &__remove {
+    margin-left: auto;
+  }
+
+  &__add-report {
+    border: 1px dashed var(--primary-low-mid);
+    border-radius: var(--d-border-radius-large);
+    background: var(--secondary);
+    color: var(--primary-medium);
+    padding: var(--space-2);
+
+    &:hover,
+    &:focus {
+      background: var(--tertiary-low);
+      border-color: var(--tertiary);
+      color: var(--tertiary);
+    }
+  }
+}
+
+.db-traffic {
+  &__chart {
+    height: 500px; // remove later
+  }
+
+  &__list-heading {
+    font-size: var(--font-down-1-rem);
+  }
+
+  &__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  &__list-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--font-down-1-rem);
+  }
+
+  &__count {
+    color: var(--primary-medium);
+  }
+}
+
+.db-upgrade-banner {
+  display: flex;
+  justify-content: space-between;
+  background: var(--tertiary-very-low);
+  color: var(--tertiary);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--d-border-radius-large);
+  font-size: var(--font-down-1-rem);
+
+  p {
+    margin: 0;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6813,6 +6813,16 @@ en:
         not_found_error: Sorry, this report doesn’t exist
         custom_date_range: Custom date range
 
+        sections:
+          highlights:
+            title: "Highlights"
+          reports:
+            title: "Reports"
+          traffic:
+            title: "Site traffic"
+          engagement:
+            title: "Engagement"
+
         reports:
           trend_title: "%{percent} change. Currently %{current}, was %{prev} in previous period."
           percent_change_tooltip: "%{percent} change."

--- a/frontend/discourse/admin/components/dashboard/engagement.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement.gjs
@@ -1,0 +1,69 @@
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import CategorySelector from "discourse/select-kit/components/category-selector";
+import { i18n } from "discourse-i18n";
+
+<template>
+  <DashboardSection
+    @title={{i18n "admin.dashboard.sections.engagement.title"}}
+    @startDate={{@startDate}}
+    @endDate={{@endDate}}
+  >
+    <div class="db-section__subheader">
+      <div class="db-section__subintro">
+        <h3>Members are forming a habit of coming back.</h3>
+        <p>Stickiness is steady at 21% and new sign-ups are up 9%, but
+          daily-engaged members slipped 5% — most active members are
+          participating less often than last month.</p>
+      </div>
+      <div class="db-section__metrics">
+        <div class="db-section__metric">
+          <div class="db-section__metric-number">38%</div>
+          <div class="db-section__metric-label">
+            DAU / MAU
+          </div>
+          <span class="db-pill --pos">stable</span>
+        </div>
+        <div class="db-section__metric">
+          <div class="db-section__metric-number">150</div>
+          <div class="db-section__metric-label">Daily visitors
+          </div>
+          <span class="db-delta --neg">-2%</span>
+        </div>
+        <div class="db-section__metric">
+          <div class="db-section__metric-number">248</div>
+          <div class="db-section__metric-label">New sign ups
+          </div>
+          <span class="db-delta --pos">+12%</span>
+        </div>
+      </div>
+    </div>
+    {{! only needed when adding multiple rows }}
+    <div class="db-section__row-group">
+      <div class="db-section__row">
+        <div class="db-section__row-block">
+          <div class="db-section__row-block-header">
+            <h3 class="db-section__row-block-title">Trust Level Pipeline</h3>
+            <span class="db-pill --pos">+72 climbing</span>
+          </div>
+        </div>
+        <div class="db-section__row-block">
+          <div class="db-section__row-block-header">
+            <h3 class="db-section__row-block-title">Who's contributing?</h3>
+          </div>
+        </div>
+      </div>
+      <div class="db-section__row">
+        <div class="db-section__row-block"><div
+            class="db-section__row-block-header"
+          >
+            <h3 class="db-section__row-block-title">Activity by category</h3>
+            <CategorySelector />
+          </div>
+          <div class="db-activity">
+            //table
+          </div>
+        </div>
+      </div>
+    </div>
+  </DashboardSection>
+</template>

--- a/frontend/discourse/admin/components/dashboard/highlights.gjs
+++ b/frontend/discourse/admin/components/dashboard/highlights.gjs
@@ -1,0 +1,62 @@
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+<template>
+  <DashboardSection
+    @title={{i18n "admin.dashboard.sections.highlights.title"}}
+    @description="Your community grew to 1,100 new members this month — and resolved 73% of questions without staff. Most growth came from a Hacker News spike on Mar 8–9."
+    @layout="row"
+    @startDate={{@startDate}}
+    @endDate={{@endDate}}
+  >
+    <a class="db-kpi db-section__row-block">
+      <div class="db-kpi__value">1,100</div>
+      <div class="db-kpi__label">New sign-ups</div>
+      <div class="db-delta --pos">+12%</div>
+      <span class="db-link-arrow">{{icon "arrow-right"}}</span>
+    </a>
+    <a class="db-kpi db-section__row-block">
+      <div class="db-kpi__value-row">
+        <div class="db-kpi__value">21%</div>
+        <span class="db-pill --pos">stable</span>
+      </div>
+      <div class="db-kpi__label">
+        DAU / MAU stickiness
+        <span
+          class="db-section__info"
+          aria-label="Daily active users divided by monthly active users. Higher means members come back more often."
+          title="Daily active users divided by monthly active users. Higher means members come back more often."
+        >{{icon "far-circle-question"}}</span>
+      </div>
+      <div class="db-delta --pos">+0.4pts</div>
+      <span class="db-link-arrow">{{icon "arrow-right"}}</span>
+    </a>
+    <a class="db-kpi db-section__row-block">
+      <div class="db-kpi__value">374</div>
+      <div class="db-kpi__label">
+        New contributors
+        <span
+          class="db-section__info"
+          aria-label="Members who posted, replied, or reacted for the first time this period."
+          title="Members who posted, replied, or reacted for the first time this period."
+        >{{icon "far-circle-question"}}</span>
+      </div>
+      <div class="db-delta --pos">+6%</div>
+      <span class="db-link-arrow">{{icon "arrow-right"}}</span>
+    </a>
+    <a class="db-kpi db-section__row-block">
+      <div class="db-kpi__value">73%</div>
+      <div class="db-kpi__label">
+        Questions resolved
+        <span
+          class="db-section__info"
+          aria-label="Topics in support categories with a marked solution, divided by total topics."
+          title="Topics in support categories with a marked solution, divided by total topics."
+        >{{icon "far-circle-question"}}</span>
+      </div>
+      <div class="db-delta --pos">+1%</div>
+      <span class="db-link-arrow">{{icon "arrow-right"}}</span>
+    </a>
+  </DashboardSection>
+</template>

--- a/frontend/discourse/admin/components/dashboard/reports.gjs
+++ b/frontend/discourse/admin/components/dashboard/reports.gjs
@@ -1,0 +1,92 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import DButton from "discourse/components/d-button";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+export default class DashboardReports extends Component {
+  @action
+  openReportsConfig() {
+    // eslint-disable-next-line no-console
+    console.log("Reports header action clicked", {
+      startDate: this.args.startDate,
+      endDate: this.args.endDate,
+    });
+  }
+
+  <template>
+    <DashboardSection
+      @title={{i18n "admin.dashboard.sections.reports.title"}}
+      @bordered={{false}}
+      @layout="grid"
+      @headerActionIcon="gear"
+      @headerAction={{this.openReportsConfig}}
+      @startDate={{@startDate}}
+      @endDate={{@endDate}}
+    >
+      <div class="db-report__card">
+        <div class="db-report__header">
+          <a class="db-report__name">Pageviews by type</a>
+          <div class="db-report__label">Standard</div>
+          <DButton
+            @icon="xmark"
+            @translatedAriaLabel="Remove"
+            class="db-report__remove btn-transparent btn-small"
+          />
+        </div>
+        <div class="db-report__chart">PLACEHOLDER</div>
+      </div>
+
+      <div class="db-report__card">
+        <div class="db-report__header">
+          <a class="db-report__name">New signups</a>
+          <div class="db-report__label --data-explorer">Data Explorer</div>
+          <DButton
+            @icon="xmark"
+            @translatedAriaLabel="Remove"
+            class="db-report__remove btn-transparent btn-small"
+          />
+        </div>
+        <div class="db-report__chart">PLACEHOLDER</div>
+      </div>
+
+      <div class="db-report__card">
+        <div class="db-report__header">
+          <a class="db-report__name">Active users</a>
+          <div class="db-report__label">Standard</div>
+          <DButton
+            @icon="xmark"
+            @translatedAriaLabel="Remove"
+            class="db-report__remove btn-transparent btn-small"
+          />
+        </div>
+        <div class="db-report__chart">PLACEHOLDER</div>
+      </div>
+
+      <div class="db-report__card">
+        <div class="db-report__header">
+          <a class="db-report__name">Active users</a>
+          <div class="db-report__label">Standard</div>
+          <DButton
+            @icon="xmark"
+            @translatedAriaLabel="Remove"
+            class="db-report__remove btn-transparent btn-small"
+          />
+        </div>
+        <div class="db-report__chart">PLACEHOLDER</div>
+      </div>
+
+      <button class="db-report__add-report" aria-label="Add report"><span>{{icon
+            "plus"
+          }}
+          Add report</span></button>
+    </DashboardSection>
+
+    <aside class="db-upgrade-banner">
+      <p>Upgrade to pin Data Explorer queries as charts to track anything
+        specific to your community.</p>
+      <DButton @display="link" @suffixIcon="arrow-right">Upgrade</DButton>
+    </aside>
+  </template>
+}

--- a/frontend/discourse/admin/components/dashboard/section.gjs
+++ b/frontend/discourse/admin/components/dashboard/section.gjs
@@ -1,0 +1,46 @@
+import Component from "@glimmer/component";
+import { concat, hash } from "@ember/helper";
+import DButton from "discourse/components/d-button";
+
+const LAYOUTS = ["column", "row", "grid"];
+
+export default class DashboardSection extends Component {
+  get bordered() {
+    return this.args.bordered ?? true;
+  }
+
+  get layoutModifier() {
+    return `--${LAYOUTS.includes(this.args.layout) ? this.args.layout : "column"}`;
+  }
+
+  <template>
+    <section class="db-section" ...attributes>
+      <div class="db-section__header-row">
+        <h2 class="db-section__header">{{@title}}</h2>
+        {{#if @headerActionIcon}}
+          <div class="db-section__header-action">
+            <DButton
+              @icon={{@headerActionIcon}}
+              @action={{@headerAction}}
+              class="btn-transparent no-text"
+            />
+          </div>
+        {{/if}}
+      </div>
+
+      {{#if @description}}
+        <p class="db-section__intro">{{@description}}</p>
+      {{/if}}
+
+      <div
+        class={{concat
+          "db-section__wrapper "
+          this.layoutModifier
+          (unless this.bordered " --no-border")
+        }}
+      >
+        {{yield (hash startDate=@startDate endDate=@endDate)}}
+      </div>
+    </section>
+  </template>
+}

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -1,0 +1,109 @@
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+<template>
+  <DashboardSection
+    @title={{i18n "admin.dashboard.sections.traffic.title"}}
+    @startDate={{@startDate}}
+    @endDate={{@endDate}}
+  >
+    <div class="db-section__subheader">
+      <div class="db-section__subintro">
+        <h3>712k pageviews this month — up 9%</h3>
+        <p>Logged-in traffic is growing steadily. Two spikes on Mar 8–9 drove a
+          burst of anonymous visitors who didn't log in, pulling the logged-in
+          share down slightly to 38%.</p>
+      </div>
+      <div class="db-section__metrics">
+        <div class="db-section__metric">
+          <div class="db-section__metric-number">38%</div>
+          <div class="db-section__metric-label">
+            Logged-in share
+            <span class="db-section__info">{{icon "far-circle-question"}}</span>
+          </div>
+        </div>
+        <div class="db-section__metric">
+          <div class="db-section__metric-number">3m 12s</div>
+          <div class="db-section__metric-label">Avg. session
+          </div>
+        </div>
+        <div class="db-section__metric">
+          <div class="db-section__metric-number">52%</div>
+          <div class="db-section__metric-label">Bounce rate
+            <span class="db-section__info">{{icon "far-circle-question"}}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="db-section__callout">
+      Spikes on Mar 8 and Mar 9 — a Hacker News post linking to the plugin
+      release docs drove a surge in anonymous pageviews.
+    </div>
+    <div class="db-traffic__chart">
+      PLACEHOLDER FOR TRAFFIC CHART
+    </div>
+
+    <div class="db-section__row">
+      <div class="db-section__row-block">
+        <div class="db-section__row-block-header">
+          <a class="db-section__row-block-title">Top referrers<span
+              class="db-link-arrow"
+            >{{icon "arrow-right"}}</span></a>
+        </div>
+        <ul class="db-traffic__list">
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">news.ycombinator.com</span>
+            <span class="db-traffic__value">41%
+              <span class="db-traffic__count">(34.2k)</span></span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">google.com</span>
+            <span class="db-traffic__value">29%
+              <span class="db-traffic__count">(24.5k)</span></span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">github.com</span>
+            <span class="db-traffic__value">15%
+              <span class="db-traffic__count">(12.3k)</span></span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">reddit.com/r/selfhosted</span>
+            <span class="db-traffic__value">10%
+              <span class="db-traffic__count">(8.0k)</span></span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">duckduckgo.com</span>
+            <span class="db-traffic__value">5%
+              <span class="db-traffic__count">(4.8k)</span></span>
+          </li>
+        </ul>
+      </div>
+      <div class="db-section__row-block">
+        <h3 class="db-section__row-block-title">Top countries</h3>
+        <ul class="db-traffic__list">
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">🇺🇸 United States</span>
+            <span class="db-traffic__value">41%</span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">🇬🇧 United Kingdom</span>
+            <span class="db-traffic__value">12%</span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">🇩🇪 Germany</span>
+            <span class="db-traffic__value">8%</span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">🇨🇦 Canada</span>
+            <span class="db-traffic__value">7%</span>
+          </li>
+          <li class="db-traffic__list-row">
+            <span class="db-traffic__name">🇦🇺 Australia</span>
+            <span class="db-traffic__value">4%</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </DashboardSection>
+</template>

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -1,5 +1,104 @@
-export default <template>
-  <div class="admin-dashboard">
-    <h2>Redesigned admin dashboard (coming soon)</h2>
-  </div>
-</template>
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { array, hash } from "@ember/helper";
+import DashboardEngagement from "discourse/admin/components/dashboard/engagement";
+import DashboardHighlights from "discourse/admin/components/dashboard/highlights";
+import DashboardReports from "discourse/admin/components/dashboard/reports";
+import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
+import DSegmentedControl from "discourse/components/d-segmented-control";
+import DToggleSwitch from "discourse/components/d-toggle-switch";
+import DMenu from "discourse/float-kit/components/d-menu";
+import icon from "discourse/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+const sections = [
+  {
+    id: "highlights",
+    label: "admin.dashboard.sections.highlights.title",
+    visible: true,
+  },
+  {
+    id: "reports",
+    label: "admin.dashboard.sections.reports.title",
+    visible: true,
+  },
+  {
+    id: "traffic",
+    label: "admin.dashboard.sections.traffic.title",
+    visible: true,
+  },
+  {
+    id: "engagement",
+    label: "admin.dashboard.sections.engagement.title",
+    visible: true,
+  },
+];
+
+export default class RedesignedAdminDashboard extends Component {
+  @tracked startDate = moment().subtract(30, "days").toDate();
+  @tracked endDate = moment().toDate();
+
+  <template>
+    <div class="db-toolbar">
+      <h1>Dashboard</h1>
+
+      <div class="db-toolbar__actions">
+        <DSegmentedControl
+          @name="period"
+          @value="month"
+          @items={{array
+            (hash value="day" label="Day")
+            (hash value="week" label="Week")
+            (hash value="month" label="Month")
+            (hash value="custom" label="Custom")
+          }}
+        />
+
+        <DMenu
+          @identifier="db-customise"
+          @icon="gear"
+          @label="Customise"
+          @triggerClass="btn-default"
+          @modalForMobile={{true}}
+        >
+          <:content>
+            <div class="db-customise">
+              <ul class="db-customise__list">
+                {{#each sections as |s|}}
+                  <li class="db-customise__row">
+                    <span class="db-customise__drag-handle">{{icon
+                        "grip-vertical"
+                      }}</span>
+                    <span class="db-customise__section-name">{{i18n
+                        s.label
+                      }}</span>
+                    <DToggleSwitch @state={{s.visible}} />
+                  </li>
+                {{/each}}
+              </ul>
+            </div>
+          </:content>
+        </DMenu>
+      </div>
+    </div>
+
+    <div class="db-main">
+      <DashboardHighlights
+        @startDate={{this.startDate}}
+        @endDate={{this.endDate}}
+      />
+      <DashboardReports
+        @startDate={{this.startDate}}
+        @endDate={{this.endDate}}
+      />
+      <DashboardTraffic
+        @startDate={{this.startDate}}
+        @endDate={{this.endDate}}
+      />
+      <DashboardEngagement
+        @startDate={{this.startDate}}
+        @endDate={{this.endDate}}
+      />
+    </div>
+  </template>
+}

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -35,7 +35,9 @@ const sections = [
 ];
 
 export default class RedesignedAdminDashboard extends Component {
+  // eslint-disable-next-line discourse/no-unnecessary-tracked
   @tracked startDate = moment().subtract(30, "days").toDate();
+  // eslint-disable-next-line discourse/no-unnecessary-tracked
   @tracked endDate = moment().toDate();
 
   <template>

--- a/frontend/discourse/tests/integration/components/dashboard/section-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/section-test.gjs
@@ -1,0 +1,175 @@
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DashboardSection from "discourse/admin/components/dashboard/section";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | Dashboard | Section", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders the @title in the section header", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports">content</DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__header").hasText("Reports");
+  });
+
+  test("renders @description when provided", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports" @description="Last 30 days">
+          content
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__intro").hasText("Last 30 days");
+  });
+
+  test("omits the description node when @description is missing", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports">content</DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__intro").doesNotExist();
+  });
+
+  test("yields content into the wrapper", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports">
+          <span class="my-child">hello</span>
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__wrapper .my-child").hasText("hello");
+  });
+
+  test("yields startDate and endDate to the default block", async function (assert) {
+    const startDate = "2026-01-01";
+    const endDate = "2026-01-31";
+
+    await render(
+      <template>
+        <DashboardSection
+          @title="Reports"
+          @startDate={{startDate}}
+          @endDate={{endDate}}
+        >
+          <:default as |section|>
+            <span class="start">{{section.startDate}}</span>
+            <span class="end">{{section.endDate}}</span>
+          </:default>
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".start").hasText("2026-01-01");
+    assert.dom(".end").hasText("2026-01-31");
+  });
+
+  test("renders the wrapper with a border by default", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports">content</DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__wrapper").doesNotHaveClass("--no-border");
+  });
+
+  test("adds --no-border modifier when @bordered is false", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports" @bordered={{false}}>
+          content
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__wrapper").hasClass("--no-border");
+  });
+
+  test("uses --column layout by default", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports">content</DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__wrapper").hasClass("--column");
+  });
+
+  test("applies the @layout modifier when set", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports" @layout="grid">
+          content
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__wrapper").hasClass("--grid");
+    assert.dom(".db-section__wrapper").doesNotHaveClass("--column");
+  });
+
+  test("falls back to --column when @layout is unrecognized", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports" @layout="bogus">
+          content
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__wrapper").hasClass("--column");
+  });
+
+  test("does not render a header action when @headerActionIcon is missing", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports">content</DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__header-action").doesNotExist();
+  });
+
+  test("renders a header action button when @headerActionIcon is set", async function (assert) {
+    await render(
+      <template>
+        <DashboardSection @title="Reports" @headerActionIcon="gear">
+          content
+        </DashboardSection>
+      </template>
+    );
+
+    assert.dom(".db-section__header-action button").exists();
+    assert.dom(".db-section__header-action .d-icon-gear").exists();
+  });
+
+  test("invokes @headerAction when the header action button is clicked", async function (assert) {
+    let called = false;
+    const handler = () => (called = true);
+
+    await render(
+      <template>
+        <DashboardSection
+          @title="Reports"
+          @headerActionIcon="gear"
+          @headerAction={{handler}}
+        >
+          content
+        </DashboardSection>
+      </template>
+    );
+
+    await click(".db-section__header-action button");
+    assert.true(called);
+  });
+});

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -183,6 +183,7 @@ module SvgSprite
         gift
         globe
         grip-lines
+        grip-vertical
         hand-point-right
         handshake-angle
         hashtag


### PR DESCRIPTION
This change introduces a reusable `Dashboard::Section` so every dashboard area shares a consistent layout, styling, and date-range plumbing, and extracts the existing sections (Highlights, Reports, Traffic, Engagement) into their own components that compose it.

<img width="3758" height="4540" alt="screencapture-localhost-4200-admin-2026-05-08-13_44_36" src="https://github.com/user-attachments/assets/77042b0f-3803-4fb2-9c92-5bf8eabe7147" />
