### PR TITLE
DEV: Get rid of global notice in system specs

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -66,6 +66,7 @@ module SystemHelpers
   def setup_system_test
     SiteSetting.login_required = false
     SiteSetting.has_login_hint = false
+    SiteSetting.global_notice = ""
     SiteSetting.force_hostname = Capybara.server_host
     SiteSetting.port = Capybara.server_port
     SiteSetting.external_system_avatars_url = ""


### PR DESCRIPTION
This annoying message ends up in all system spec screenshots
and also pollutes the HTML content of the page which appears
in errrors when debugging has_content checks. It's created here:

https://github.com/discourse/discourse/blob/2d0d3222f1183aa9615eb017f9c45395b70c9554/config/initializers/006-ensure_login_hint.rb#L11-L13

We can just remove this in system specs, it doesn't matter
in the slightest here.

**Before**


<img width="1081" height="340" alt="image" src="https://github.com/user-attachments/assets/630ee6ae-96ac-4dcc-8675-58d4addd55bd" />


**After**

<img width="1088" height="313" alt="image" src="https://github.com/user-attachments/assets/dfdd8a5b-a4ca-41fc-967a-0c6e2285b7c2" />
