### PR TITLE
FIX: Clear associated groups for user when OIDC groups claim is missing

### DIFF
--- a/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
+++ b/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
@@ -40,6 +40,7 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
 
     if provides_groups?
       claim = SiteSetting.openid_connect_groups_claim
+      result.associated_groups = []
       groups = auth_token.extra&.dig(:raw_info, claim)
 
       if groups.is_a?(Array)

--- a/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
@@ -108,16 +108,16 @@ describe OpenIDConnectAuthenticator do
         expect(result.associated_groups).to eq([])
       end
 
-      it "does not set associated_groups when the claim is missing" do
+      it "treats a missing claim as an empty groups list" do
         result = authenticator.after_authenticate(hash)
-        expect(result.associated_groups).to be_nil
+        expect(result.associated_groups).to eq([])
       end
 
-      it "logs an error when the claim is not an array" do
+      it "logs an error and clears groups when the claim is not an array" do
         hash[:extra][:raw_info][:groups] = "not_an_array"
         Rails.logger.expects(:error).with(includes("not an array"))
         result = authenticator.after_authenticate(hash)
-        expect(result.associated_groups).to be_nil
+        expect(result.associated_groups).to eq([])
       end
     end
 


### PR DESCRIPTION
A missing claim should be treated the same as an empty set of groups.