### PR TITLE
FEATURE: Date picker for new dash

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6823,6 +6823,13 @@ en:
           engagement:
             title: "Engagement"
 
+        period:
+          last_7_days: "Last 7 days"
+          last_30_days: "Last 30 days"
+          last_3_months: "Last 3 months"
+          custom: "Custom"
+          custom_range: "%{start} – %{end}"
+
         reports:
           trend_title: "%{percent} change. Currently %{current}, was %{prev} in previous period."
           percent_change_tooltip: "%{percent} change."

--- a/frontend/discourse/admin/components/dashboard/date-range.gjs
+++ b/frontend/discourse/admin/components/dashboard/date-range.gjs
@@ -1,0 +1,110 @@
+import Component from "@glimmer/component";
+import { array, hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DSegmentedControl from "discourse/components/d-segmented-control";
+import { i18n } from "discourse-i18n";
+import CustomDateRangeModal from "../modal/custom-date-range";
+
+export const PERIOD_LAST_7_DAYS = "last_7_days";
+export const PERIOD_LAST_30_DAYS = "last_30_days";
+export const PERIOD_LAST_3_MONTHS = "last_3_months";
+export const PERIOD_CUSTOM = "custom";
+
+export const DEFAULT_PERIOD = PERIOD_LAST_30_DAYS;
+
+export const VALID_PERIODS = [
+  PERIOD_LAST_7_DAYS,
+  PERIOD_LAST_30_DAYS,
+  PERIOD_LAST_3_MONTHS,
+  PERIOD_CUSTOM,
+];
+
+export function calculatePresetStartDate(period) {
+  const today = moment();
+  switch (period) {
+    case PERIOD_LAST_7_DAYS:
+      return today.subtract(7, "days").startOf("day").toDate();
+    case PERIOD_LAST_3_MONTHS:
+      return today.subtract(3, "months").startOf("day").toDate();
+    case PERIOD_LAST_30_DAYS:
+    default:
+      return today.subtract(30, "days").startOf("day").toDate();
+  }
+}
+
+export default class DashboardDateRange extends Component {
+  @service modal;
+
+  get isCustom() {
+    return this.args.period === PERIOD_CUSTOM;
+  }
+
+  get customLabel() {
+    if (!this.isCustom || !this.args.startDate || !this.args.endDate) {
+      return i18n("admin.dashboard.period.custom");
+    }
+
+    return i18n("admin.dashboard.period.custom_range", {
+      start: moment(this.args.startDate).format("MMM D"),
+      end: moment(this.args.endDate).format("MMM D"),
+    });
+  }
+
+  @action
+  selectPeriod(value) {
+    if (value === PERIOD_CUSTOM) {
+      // custom is handled via handleClick to support re-opening the modal when
+      // already-selected; skip preset state change here
+      return;
+    }
+    this.args.setPeriod?.(value);
+  }
+
+  @action
+  handleClick(value) {
+    if (value === PERIOD_CUSTOM) {
+      this.openCustomModal();
+    }
+  }
+
+  openCustomModal() {
+    this.modal.show(CustomDateRangeModal, {
+      model: {
+        startDate: this.args.startDate,
+        endDate: this.args.endDate,
+        setCustomDateRange: this.args.setCustomDateRange,
+      },
+    });
+  }
+
+  <template>
+    <DSegmentedControl
+      class="db-date-range"
+      @name="dashboard-period"
+      @value={{@period}}
+      @onSelect={{this.selectPeriod}}
+      @onClickItem={{this.handleClick}}
+      @items={{array
+        (hash
+          value=PERIOD_LAST_7_DAYS
+          label=(i18n "admin.dashboard.period.last_7_days")
+        )
+        (hash
+          value=PERIOD_LAST_30_DAYS
+          label=(i18n "admin.dashboard.period.last_30_days")
+        )
+        (hash
+          value=PERIOD_LAST_3_MONTHS
+          label=(i18n "admin.dashboard.period.last_3_months")
+        )
+        (hash
+          value=PERIOD_CUSTOM
+          icon="calendar-days"
+          label=this.customLabel
+          class="db-date-range__custom"
+        )
+      }}
+    />
+  </template>
+}

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -1,11 +1,8 @@
-import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
-import { array, hash } from "@ember/helper";
+import DashboardDateRange from "discourse/admin/components/dashboard/date-range";
 import DashboardEngagement from "discourse/admin/components/dashboard/engagement";
 import DashboardHighlights from "discourse/admin/components/dashboard/highlights";
 import DashboardReports from "discourse/admin/components/dashboard/reports";
 import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
-import DSegmentedControl from "discourse/components/d-segmented-control";
 import DToggleSwitch from "discourse/components/d-toggle-switch";
 import DMenu from "discourse/float-kit/components/d-menu";
 import icon from "discourse/helpers/d-icon";
@@ -34,73 +31,53 @@ const sections = [
   },
 ];
 
-export default class RedesignedAdminDashboard extends Component {
-  // eslint-disable-next-line discourse/no-unnecessary-tracked
-  @tracked startDate = moment().subtract(30, "days").toDate();
-  // eslint-disable-next-line discourse/no-unnecessary-tracked
-  @tracked endDate = moment().toDate();
+const RedesignedAdminDashboard = <template>
+  <div class="db-toolbar">
+    <h1>Dashboard</h1>
 
-  <template>
-    <div class="db-toolbar">
-      <h1>Dashboard</h1>
+    <div class="db-toolbar__actions">
+      <DashboardDateRange
+        @period={{@period}}
+        @startDate={{@startDate}}
+        @endDate={{@endDate}}
+        @setPeriod={{@setPeriod}}
+        @setCustomDateRange={{@setCustomDateRange}}
+      />
 
-      <div class="db-toolbar__actions">
-        <DSegmentedControl
-          @name="period"
-          @value="month"
-          @items={{array
-            (hash value="day" label="Day")
-            (hash value="week" label="Week")
-            (hash value="month" label="Month")
-            (hash value="custom" label="Custom")
-          }}
-        />
-
-        <DMenu
-          @identifier="db-customise"
-          @icon="gear"
-          @label="Customise"
-          @triggerClass="btn-default"
-          @modalForMobile={{true}}
-        >
-          <:content>
-            <div class="db-customise">
-              <ul class="db-customise__list">
-                {{#each sections as |s|}}
-                  <li class="db-customise__row">
-                    <span class="db-customise__drag-handle">{{icon
-                        "grip-vertical"
-                      }}</span>
-                    <span class="db-customise__section-name">{{i18n
-                        s.label
-                      }}</span>
-                    <DToggleSwitch @state={{s.visible}} />
-                  </li>
-                {{/each}}
-              </ul>
-            </div>
-          </:content>
-        </DMenu>
-      </div>
+      <DMenu
+        @identifier="db-customise"
+        @icon="gear"
+        @label="Customise"
+        @triggerClass="btn-default"
+        @modalForMobile={{true}}
+      >
+        <:content>
+          <div class="db-customise">
+            <ul class="db-customise__list">
+              {{#each sections as |s|}}
+                <li class="db-customise__row">
+                  <span class="db-customise__drag-handle">{{icon
+                      "grip-vertical"
+                    }}</span>
+                  <span class="db-customise__section-name">{{i18n
+                      s.label
+                    }}</span>
+                  <DToggleSwitch @state={{s.visible}} />
+                </li>
+              {{/each}}
+            </ul>
+          </div>
+        </:content>
+      </DMenu>
     </div>
+  </div>
 
-    <div class="db-main">
-      <DashboardHighlights
-        @startDate={{this.startDate}}
-        @endDate={{this.endDate}}
-      />
-      <DashboardReports
-        @startDate={{this.startDate}}
-        @endDate={{this.endDate}}
-      />
-      <DashboardTraffic
-        @startDate={{this.startDate}}
-        @endDate={{this.endDate}}
-      />
-      <DashboardEngagement
-        @startDate={{this.startDate}}
-        @endDate={{this.endDate}}
-      />
-    </div>
-  </template>
-}
+  <div class="db-main">
+    <DashboardHighlights @startDate={{@startDate}} @endDate={{@endDate}} />
+    <DashboardReports @startDate={{@startDate}} @endDate={{@endDate}} />
+    <DashboardTraffic @startDate={{@startDate}} @endDate={{@endDate}} />
+    <DashboardEngagement @startDate={{@startDate}} @endDate={{@endDate}} />
+  </div>
+</template>;
+
+export default RedesignedAdminDashboard;

--- a/frontend/discourse/admin/controllers/admin-dashboard-tab.js
+++ b/frontend/discourse/admin/controllers/admin-dashboard-tab.js
@@ -8,32 +8,22 @@ export default class AdminDashboardTabController extends Controller {
   @tracked period = "monthly";
   queryParams = ["period"];
 
-  get start_date() {
-    return this.dashboardController.start_date;
-  }
-
-  set start_date(value) {
-    this.dashboardController.start_date = value;
-  }
-
-  get end_date() {
-    return this.dashboardController.end_date;
-  }
-
-  set end_date(value) {
-    this.dashboardController.end_date = value;
-  }
-
   get startDate() {
-    if (this.start_date) {
-      return moment.utc(this.start_date).locale("en").startOf("day");
+    if (this.dashboardController.start_date) {
+      return moment
+        .utc(this.dashboardController.start_date)
+        .locale("en")
+        .startOf("day");
     }
     return this.#calculateStartDate();
   }
 
   get endDate() {
-    if (this.end_date) {
-      return moment.utc(this.end_date).locale("en").endOf("day");
+    if (this.dashboardController.end_date) {
+      return moment
+        .utc(this.dashboardController.end_date)
+        .locale("en")
+        .endOf("day");
     }
     return moment().locale("en").utc().endOf("day");
   }
@@ -63,14 +53,15 @@ export default class AdminDashboardTabController extends Controller {
   @action
   setCustomDateRange(startDate, endDate) {
     this.period = "custom";
-    this.start_date = moment(startDate).format("YYYY-MM-DD");
-    this.end_date = moment(endDate).format("YYYY-MM-DD");
+    this.dashboardController.start_date =
+      moment(startDate).format("YYYY-MM-DD");
+    this.dashboardController.end_date = moment(endDate).format("YYYY-MM-DD");
   }
 
   @action
   setPeriod(period) {
     this.period = period;
-    this.start_date = null;
-    this.end_date = null;
+    this.dashboardController.start_date = null;
+    this.dashboardController.end_date = null;
   }
 }

--- a/frontend/discourse/admin/controllers/admin-dashboard-tab.js
+++ b/frontend/discourse/admin/controllers/admin-dashboard-tab.js
@@ -1,12 +1,28 @@
 import { tracked } from "@glimmer/tracking";
-import Controller from "@ember/controller";
+import Controller, { inject as controller } from "@ember/controller";
 import { action } from "@ember/object";
 
 export default class AdminDashboardTabController extends Controller {
+  @controller("admin.dashboard") dashboardController;
+
   @tracked period = "monthly";
-  @tracked start_date = null;
-  @tracked end_date = null;
-  queryParams = ["period", "start_date", "end_date"];
+  queryParams = ["period"];
+
+  get start_date() {
+    return this.dashboardController.start_date;
+  }
+
+  set start_date(value) {
+    this.dashboardController.start_date = value;
+  }
+
+  get end_date() {
+    return this.dashboardController.end_date;
+  }
+
+  set end_date(value) {
+    this.dashboardController.end_date = value;
+  }
 
   get startDate() {
     if (this.start_date) {

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -2,6 +2,12 @@ import { tracked } from "@glimmer/tracking";
 import Controller, { inject as controller } from "@ember/controller";
 import { action, computed } from "@ember/object";
 import { service } from "@ember/service";
+import {
+  calculatePresetStartDate,
+  DEFAULT_PERIOD,
+  PERIOD_CUSTOM,
+  VALID_PERIODS,
+} from "discourse/admin/components/dashboard/date-range";
 import AdminDashboard from "discourse/admin/models/admin-dashboard";
 import VersionCheck from "discourse/admin/models/version-check";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
@@ -15,10 +21,59 @@ export default class AdminDashboardController extends Controller {
 
   @tracked loadingProblems = false;
   @tracked problemsFetchedAt;
+  @tracked range = DEFAULT_PERIOD;
+  @tracked from = null;
+  @tracked to = null;
   @autoTrackedArray problems;
+
+  queryParams = ["range", "from", "to"];
 
   isLoading = false;
   dashboardFetchedAt = null;
+
+  get safePeriod() {
+    if (!VALID_PERIODS.includes(this.range)) {
+      return DEFAULT_PERIOD;
+    }
+    if (this.range === PERIOD_CUSTOM && (!this.from || !this.to)) {
+      return DEFAULT_PERIOD;
+    }
+    return this.range;
+  }
+
+  get startDate() {
+    if (this.safePeriod === PERIOD_CUSTOM && this.from) {
+      const parsed = moment(this.from, "YYYY-MM-DD", true);
+      if (parsed.isValid()) {
+        return parsed.startOf("day").toDate();
+      }
+    }
+    return calculatePresetStartDate(this.safePeriod);
+  }
+
+  get endDate() {
+    if (this.safePeriod === PERIOD_CUSTOM && this.to) {
+      const parsed = moment(this.to, "YYYY-MM-DD", true);
+      if (parsed.isValid()) {
+        return parsed.endOf("day").toDate();
+      }
+    }
+    return moment().endOf("day").toDate();
+  }
+
+  @action
+  setPeriod(period) {
+    this.range = period;
+    this.from = null;
+    this.to = null;
+  }
+
+  @action
+  setCustomDateRange(startDate, endDate) {
+    this.range = PERIOD_CUSTOM;
+    this.from = moment(startDate).format("YYYY-MM-DD");
+    this.to = moment(endDate).format("YYYY-MM-DD");
+  }
 
   @computed("siteSettings.version_checks")
   get showVersionChecks() {

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -22,11 +22,11 @@ export default class AdminDashboardController extends Controller {
   @tracked loadingProblems = false;
   @tracked problemsFetchedAt;
   @tracked range = DEFAULT_PERIOD;
-  @tracked from = null;
-  @tracked to = null;
+  @tracked start_date = null;
+  @tracked end_date = null;
   @autoTrackedArray problems;
 
-  queryParams = ["range", "from", "to"];
+  queryParams = ["range", "start_date", "end_date"];
 
   isLoading = false;
   dashboardFetchedAt = null;
@@ -35,15 +35,15 @@ export default class AdminDashboardController extends Controller {
     if (!VALID_PERIODS.includes(this.range)) {
       return DEFAULT_PERIOD;
     }
-    if (this.range === PERIOD_CUSTOM && (!this.from || !this.to)) {
+    if (this.range === PERIOD_CUSTOM && (!this.start_date || !this.end_date)) {
       return DEFAULT_PERIOD;
     }
     return this.range;
   }
 
   get startDate() {
-    if (this.safePeriod === PERIOD_CUSTOM && this.from) {
-      const parsed = moment(this.from, "YYYY-MM-DD", true);
+    if (this.safePeriod === PERIOD_CUSTOM && this.start_date) {
+      const parsed = moment(this.start_date, "YYYY-MM-DD", true);
       if (parsed.isValid()) {
         return parsed.startOf("day").toDate();
       }
@@ -52,8 +52,8 @@ export default class AdminDashboardController extends Controller {
   }
 
   get endDate() {
-    if (this.safePeriod === PERIOD_CUSTOM && this.to) {
-      const parsed = moment(this.to, "YYYY-MM-DD", true);
+    if (this.safePeriod === PERIOD_CUSTOM && this.end_date) {
+      const parsed = moment(this.end_date, "YYYY-MM-DD", true);
       if (parsed.isValid()) {
         return parsed.endOf("day").toDate();
       }
@@ -64,15 +64,15 @@ export default class AdminDashboardController extends Controller {
   @action
   setPeriod(period) {
     this.range = period;
-    this.from = null;
-    this.to = null;
+    this.start_date = null;
+    this.end_date = null;
   }
 
   @action
   setCustomDateRange(startDate, endDate) {
     this.range = PERIOD_CUSTOM;
-    this.from = moment(startDate).format("YYYY-MM-DD");
-    this.to = moment(endDate).format("YYYY-MM-DD");
+    this.start_date = moment(startDate).format("YYYY-MM-DD");
+    this.end_date = moment(endDate).format("YYYY-MM-DD");
   }
 
   @computed("siteSettings.version_checks")

--- a/frontend/discourse/admin/templates/admin/dashboard.gjs
+++ b/frontend/discourse/admin/templates/admin/dashboard.gjs
@@ -9,7 +9,13 @@ import { i18n } from "discourse-i18n";
 
 export default <template>
   {{#if @controller.siteSettings.dashboard_improvements}}
-    <RedesignedAdminDashboard />
+    <RedesignedAdminDashboard
+      @period={{@controller.safePeriod}}
+      @startDate={{@controller.startDate}}
+      @endDate={{@controller.endDate}}
+      @setPeriod={{@controller.setPeriod}}
+      @setCustomDateRange={{@controller.setCustomDateRange}}
+    />
   {{else}}
     <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />
 

--- a/frontend/discourse/app/components/d-segmented-control.gjs
+++ b/frontend/discourse/app/components/d-segmented-control.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { modifier as modifierFn } from "ember-modifier";
 import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
@@ -44,6 +45,11 @@ export default class DSegmentedControl extends Component {
     this.args.onSelect?.(value);
   }
 
+  @action
+  handleClick(value) {
+    this.args.onClickItem?.(value);
+  }
+
   <template>
     <fieldset
       class="d-segmented-control"
@@ -65,6 +71,7 @@ export default class DSegmentedControl extends Component {
             item.class
             (if item.disabled "is-disabled")
           }}
+          {{on "click" (fn this.handleClick item.value)}}
         >
           <input
             type="radio"
@@ -75,7 +82,10 @@ export default class DSegmentedControl extends Component {
             class="d-segmented-control__input"
             {{on "change" (fn this.handleChange item.value)}}
           />
-          <span class="d-segmented-control__text">{{item.label}}</span>
+          <span class="d-segmented-control__text">
+            {{#if item.icon}}{{icon item.icon}}{{/if}}
+            {{item.label}}
+          </span>
         </label>
       {{/each}}
     </fieldset>

--- a/frontend/discourse/tests/integration/components/dashboard/date-range-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/date-range-test.gjs
@@ -1,0 +1,131 @@
+import { tracked } from "@glimmer/tracking";
+import { click, render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DashboardDateRange from "discourse/admin/components/dashboard/date-range";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | Dashboard | DateRange", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders all four items in the segmented control", async function (assert) {
+    await render(
+      <template><DashboardDateRange @period="last_30_days" /></template>
+    );
+
+    assert.dom("input[value='last_7_days']").exists("renders Last 7 days");
+    assert.dom("input[value='last_30_days']").exists("renders Last 30 days");
+    assert.dom("input[value='last_3_months']").exists("renders Last 3 months");
+    assert.dom("input[value='custom']").exists("renders Custom");
+    assert
+      .dom(".db-date-range__custom .d-icon-calendar-days")
+      .exists("custom item has the calendar icon");
+  });
+
+  test("checks the input matching @period", async function (assert) {
+    await render(
+      <template><DashboardDateRange @period="last_7_days" /></template>
+    );
+
+    assert
+      .dom("input[value='last_7_days']")
+      .isChecked("active preset is checked");
+    assert
+      .dom("input[value='last_30_days']")
+      .isNotChecked("inactive preset is not checked");
+  });
+
+  test("checks the custom input when @period is 'custom'", async function (assert) {
+    const start = new Date("2026-03-01");
+    const end = new Date("2026-04-28");
+
+    await render(
+      <template>
+        <DashboardDateRange
+          @period="custom"
+          @startDate={{start}}
+          @endDate={{end}}
+        />
+      </template>
+    );
+
+    assert.dom("input[value='custom']").isChecked();
+  });
+
+  test("calls @setPeriod when a preset is clicked", async function (assert) {
+    const calls = [];
+    const setPeriod = (period) => calls.push(period);
+
+    await render(
+      <template>
+        <DashboardDateRange @period="last_30_days" @setPeriod={{setPeriod}} />
+      </template>
+    );
+
+    await click("input[value='last_7_days']");
+    assert.deepEqual(calls, ["last_7_days"], "fires with the chosen value");
+  });
+
+  test("does not call @setPeriod when the custom item is clicked", async function (assert) {
+    const calls = [];
+    const setPeriod = (period) => calls.push(period);
+
+    await render(
+      <template>
+        <DashboardDateRange @period="last_30_days" @setPeriod={{setPeriod}} />
+      </template>
+    );
+
+    await click(".db-date-range__custom");
+    assert.deepEqual(calls, [], "custom does not change preset state");
+  });
+
+  test("custom item label is 'Custom' when not in custom mode", async function (assert) {
+    await render(
+      <template><DashboardDateRange @period="last_30_days" /></template>
+    );
+
+    assert.dom(".db-date-range__custom").includesText("Custom");
+  });
+
+  test("custom item label shows the formatted range when in custom mode", async function (assert) {
+    const start = new Date("2026-03-01");
+    const end = new Date("2026-04-28");
+
+    await render(
+      <template>
+        <DashboardDateRange
+          @period="custom"
+          @startDate={{start}}
+          @endDate={{end}}
+        />
+      </template>
+    );
+
+    assert.dom(".db-date-range__custom").includesText("Mar 1");
+    assert.dom(".db-date-range__custom").includesText("Apr 28");
+  });
+
+  test("custom item label falls back to 'Custom' when dates are missing", async function (assert) {
+    await render(<template><DashboardDateRange @period="custom" /></template>);
+
+    assert.dom(".db-date-range__custom").includesText("Custom");
+  });
+
+  test("checked state on custom toggles when @period changes", async function (assert) {
+    class State {
+      @tracked period = "last_30_days";
+    }
+    const state = new State();
+
+    await render(
+      <template><DashboardDateRange @period={{state.period}} /></template>
+    );
+
+    assert.dom("input[value='custom']").isNotChecked();
+
+    state.period = "custom";
+    await settled();
+
+    assert.dom("input[value='custom']").isChecked();
+  });
+});

--- a/spec/system/admin_dashboard_redesign_spec.rb
+++ b/spec/system/admin_dashboard_redesign_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe "Admin Dashboard Redesign" do
+  fab!(:current_user, :admin)
+
+  let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
+
+  before do
+    SiteSetting.dashboard_improvements = true
+    sign_in(current_user)
+  end
+
+  describe "date picker" do
+    it "defaults to Last 30 days" do
+      dashboard.visit
+
+      expect(dashboard).to have_redesigned_toolbar
+      expect(dashboard).to have_active_period("last_30_days")
+    end
+
+    it "updates the URL when a preset is clicked" do
+      dashboard.visit
+      dashboard.select_preset("last_7_days")
+
+      expect(page).to have_current_path(/range=last_7_days/)
+      expect(dashboard).to have_active_period("last_7_days")
+    end
+
+    it "honours the range query param on initial load" do
+      page.visit("/admin?range=last_3_months")
+
+      expect(dashboard).to have_active_period("last_3_months")
+    end
+
+    it "falls back to default for an invalid range query param" do
+      page.visit("/admin?range=bogus_period")
+
+      expect(dashboard).to have_active_period("last_30_days")
+    end
+
+    it "rehydrates a custom range from query params" do
+      page.visit("/admin?range=custom&from=2026-03-01&to=2026-04-28")
+
+      expect(dashboard).to have_active_period("custom")
+      expect(dashboard).to have_custom_label_text("Mar 1")
+      expect(dashboard).to have_custom_label_text("Apr 28")
+    end
+
+    it "falls back to default when custom is missing dates" do
+      page.visit("/admin?range=custom")
+
+      expect(dashboard).to have_active_period("last_30_days")
+    end
+  end
+end

--- a/spec/system/admin_dashboard_redesign_spec.rb
+++ b/spec/system/admin_dashboard_redesign_spec.rb
@@ -39,7 +39,7 @@ describe "Admin Dashboard Redesign" do
     end
 
     it "rehydrates a custom range from query params" do
-      page.visit("/admin?range=custom&from=2026-03-01&to=2026-04-28")
+      page.visit("/admin?range=custom&start_date=2026-03-01&end_date=2026-04-28")
 
       expect(dashboard).to have_active_period("custom")
       expect(dashboard).to have_custom_label_text("Mar 1")

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -19,6 +19,41 @@ module PageObjects
       def dismiss_notice(message)
         find(".dashboard-problem", text: message).find(".btn").click
       end
+
+      def has_redesigned_toolbar?
+        has_css?(".db-toolbar")
+      end
+
+      def has_active_period?(period)
+        has_css?(".db-date-range input[value='#{period}']:checked")
+      end
+
+      def select_preset(period)
+        find(".db-date-range label", text: preset_label(period)).click
+        self
+      end
+
+      def has_custom_label_text?(text)
+        has_css?(".db-date-range__custom", text: text)
+      end
+
+      def open_custom_date_range
+        find(".db-date-range__custom").click
+        self
+      end
+
+      private
+
+      def preset_label(period)
+        case period
+        when "last_7_days"
+          "Last 7 days"
+        when "last_30_days"
+          "Last 30 days"
+        when "last_3_months"
+          "Last 3 months"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a `<DashboardDateRange>` component (3 presets + "custom") that flows the selected range through to all sections and persists it via `?range=` / `?from=` / `?to=` query params.

Note: 
- the dates dashboard section in the video is not committed in this PR. It is only there to illustrate the wiring of the component attributes.
- the `start_date` / `end_date` query params now live on the parent `AdminDashboardController` instead of the existing (legacy) AdminDashboardTabController, with the legacy proxying to the controller to allow both dashboards share the same URL params (otherwise we will meet with Ember's same-route-hierarchy URL-key collision).


https://github.com/user-attachments/assets/b89dd1d0-391f-40e9-959d-eca52aa2a254

