### PR TITLE
DEV: add hidden site setting for enable gifs

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2604,6 +2604,7 @@ en:
     emoji_autocomplete_min_chars: "Minimum number of characters required to trigger autocomplete emoji popup"
     enable_inline_emoji_translation: "Enables translation for inline emojis (without any space or punctuation before)"
     emoji_deny_list: "These emoji will not be available to use in menus or shortcodes."
+    enable_gifs: "Enable the GIF picker in the composer for inserting GIFs from Klipy."
 
     approve_post_count: "The amount of posts from a new or basic user that must be approved"
     approve_unless_allowed_groups: "Posts created by users not in these groups must be approved. Posts created by admins and moderators are always approved."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2604,7 +2604,7 @@ en:
     emoji_autocomplete_min_chars: "Minimum number of characters required to trigger autocomplete emoji popup"
     enable_inline_emoji_translation: "Enables translation for inline emojis (without any space or punctuation before)"
     emoji_deny_list: "These emoji will not be available to use in menus or shortcodes."
-    enable_gifs: "Enable the GIF picker in the composer for inserting GIFs from Klipy."
+    enable_gifs: "Adds a button to easily search and insert GIFs in posts."
 
     approve_post_count: "The amount of posts from a new or basic user that must be approved"
     approve_unless_allowed_groups: "Posts created by users not in these groups must be approved. Posts created by admins and moderators are always approved."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1602,6 +1602,10 @@ posting:
     client: true
     refresh: true
     area: "emojis"
+  enable_gifs:
+    default: false
+    client: true
+    hidden: true
   approve_post_count:
     default: 0
     area: "posts_and_topics"


### PR DESCRIPTION
Adds a hidden site setting that we can later use to feature flag the discourse-gifs move to core.

Internal ref: /t/173755/12