### PR TITLE
FIX: Skip crawler localization for direct upload requests

### DIFF
--- a/lib/middleware/crawler_hooks.rb
+++ b/lib/middleware/crawler_hooks.rb
@@ -14,6 +14,7 @@ module Middleware
 
       if status == 200 && headers["X-Discourse-Crawler-View"] &&
            headers["Content-Type"]&.include?("text/html") &&
+           !non_localizable_path?(request_path_without_base_path(request)) &&
            SiteSetting.content_localization_enabled &&
            SiteSetting.content_localization_crawler_param
         response = transform_response(request:, response:)
@@ -50,6 +51,17 @@ module Middleware
     def non_localizable_path?(path)
       return false if path.blank?
       NON_LOCALIZABLE_PATH_PREFIXES.any? { |prefix| path.start_with?(prefix) }
+    end
+
+    def request_path_without_base_path(request)
+      path = request.path
+      base_path = Discourse.base_path
+
+      if base_path.present? && path.start_with?(base_path)
+        path.delete_prefix(base_path)
+      else
+        path
+      end
     end
   end
 end

--- a/spec/lib/middleware/crawler_hooks_spec.rb
+++ b/spec/lib/middleware/crawler_hooks_spec.rb
@@ -132,6 +132,85 @@ describe Middleware::CrawlerHooks do
       expect(response).to eq(["PK\x03\x04binarydata".b])
     end
 
+    it "does not parse direct upload requests served with an HTML content type" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_crawler_param = true
+
+      response_body = ["<div>" * 500]
+      def response_body.body
+        join("")
+      end
+
+      middleware =
+        Middleware::CrawlerHooks.new(
+          lambda do |_|
+            [
+              200,
+              {
+                "Content-Type" => "text/html; charset=utf-8",
+                "X-Discourse-Crawler-View" => "true",
+              },
+              response_body,
+            ]
+          end,
+        )
+
+      status, headers, response =
+        middleware.call(
+          env(
+            :path => "https://discourse.site/uploads/short-url/abc.zip",
+            :params => {
+              Discourse::LOCALE_PARAM => "fr",
+            },
+            "HTTP_USER_AGENT" => crawler_user_agent,
+          ),
+        )
+
+      expect(status).to eq(200)
+      expect(headers["Content-Type"]).to include("text/html")
+      expect(response).to eq(response_body)
+    end
+
+    it "does not parse direct upload requests served from a base path" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_crawler_param = true
+      Discourse.stubs(:base_path).returns("/forum")
+
+      response_body = ["<div>" * 500]
+      def response_body.body
+        join("")
+      end
+
+      middleware =
+        Middleware::CrawlerHooks.new(
+          lambda do |_|
+            [
+              200,
+              {
+                "Content-Type" => "text/html; charset=utf-8",
+                "X-Discourse-Crawler-View" => "true",
+              },
+              response_body,
+            ]
+          end,
+        )
+
+      status, headers, response =
+        middleware.call(
+          env(
+            :path => "https://discourse.site/forum/uploads/short-url/abc.zip",
+            :params => {
+              Discourse::LOCALE_PARAM => "fr",
+            },
+            "HTTP_USER_AGENT" => crawler_user_agent,
+          ),
+        )
+
+      expect(status).to eq(200)
+      expect(headers["Content-Type"]).to include("text/html")
+      expect(response).to eq(response_body)
+    end
+
     it "does not modify responses for non-200 status codes" do
       status, headers, response =
         error_middleware.call(env("HTTP_USER_AGENT" => crawler_user_agent))


### PR DESCRIPTION
Previously, direct upload requests with crawler localization parameters could still be parsed as HTML when the response carried crawler HTML headers, raising Nokogiri document depth errors.

This change skips localization rewriting for non-localizable request paths before parsing the response, including relative URL root installs.