### PR TITLE
FIX: Remove category and tag overrides on foundation modernization

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme.scss
@@ -300,9 +300,6 @@
 
   .extra-info-wrapper .title-wrapper {
     font-size: var(--font-down-1);
-
-    --category-badge-title-color: var(--primary-800);
-    --tag-text-color: var(--primary-800);
   }
 
   .header-sidebar-toggle button,


### PR DESCRIPTION
This PR removes two foundation modernization overrides forcing category badges and tag text in the topic header to `--primary-800`. They now fall back to the active palette's header text/icon color, fixing dark-on-dark rendering on palettes with a dark header and light header text.

| Before | After |                                                                                                        
| --- | --- |                                 
| <img width="471" height="133" alt="Screenshot 2026-05-08 at 8 57 13 AM" src="https://github.com/user-attachments/assets/aec42971-c77a-4954-bb85-751603aec13f" /> | <img width="476" height="139" alt="Screenshot 2026-05-08 at 8 57 26 AM" src="https://github.com/user-attachments/assets/5675c771-4174-4c16-b0b9-0f805c0d0549" /> |

<img width="688" height="125" alt="Screenshot 2026-05-08 at 8 56 35 AM" src="https://github.com/user-attachments/assets/3f7c9989-e368-43ed-b691-b4e2b20cc9cc" />
