### PR TITLE
FIX: Do not remove user from group with no association inadvertently

### DIFF
--- a/app/models/user_associated_group.rb
+++ b/app/models/user_associated_group.rb
@@ -16,15 +16,16 @@ class UserAssociatedGroup < ActiveRecord::Base
   def remove_from_associated_groups
     Group
       .where(
-        "NOT EXISTS(
-      SELECT 1
-      FROM user_associated_groups uag
-      JOIN group_associated_groups gag
-      ON gag.associated_group_id = uag.associated_group_id
-      WHERE uag.user_id = :user_id
-      AND uag.id != :uag_id
-      AND gag.group_id = groups.id
-    )",
+        "EXISTS(SELECT 1 FROM group_associated_groups WHERE group_id = groups.id)
+      AND NOT EXISTS(
+        SELECT 1
+        FROM user_associated_groups uag
+        JOIN group_associated_groups gag
+        ON gag.associated_group_id = uag.associated_group_id
+        WHERE uag.user_id = :user_id
+        AND uag.id != :uag_id
+        AND gag.group_id = groups.id
+      )",
         uag_id: id,
         user_id: user_id,
       )

--- a/spec/models/user_associated_group_spec.rb
+++ b/spec/models/user_associated_group_spec.rb
@@ -36,4 +36,12 @@ RSpec.describe UserAssociatedGroup do
     uag.destroy!
     expect(group.users.include?(user)).to eq(false)
   end
+
+  it "does not remove user from groups with no OIDC association when destroyed" do
+    unsynced_group = Fabricate(:group)
+    unsynced_group.add(user)
+
+    uag.destroy!
+    expect(unsynced_group.users.include?(user)).to eq(true)
+  end
 end


### PR DESCRIPTION
Fixes https://meta.discourse.org/t/openid-connect-group-can-kick-users-out-of-all-unsynced-groups/402416