### PR TITLE
FIX: Allow post editing and fix fade overlap in embed mode

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -41,8 +41,9 @@ body.embed-mode {
     max-width: 100%;
   }
 
-  // Hide the standard composer in embed mode — the docked composer replaces it
-  #reply-control {
+  // Hide the standard composer in embed mode — the docked composer replaces it.
+  // Allow it to show when editing a post (composer-action-edit class).
+  #reply-control:not(.composer-action-edit) {
     display: none !important;
   }
 
@@ -179,13 +180,23 @@ body.embed-mode {
     background: var(--secondary);
     padding-inline: 0.5em;
 
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: -2.5em;
+      height: 2.5em;
+      background: linear-gradient(to bottom, transparent, var(--secondary));
+      pointer-events: none;
+    }
+
     .docked-composer {
       --docked-composer-input-min-height: 10em;
       margin-top: 0;
 
       &::before {
-        left: -0.5em;
-        right: -0.5em;
+        display: none;
       }
     }
 

--- a/spec/system/embed_mode_spec.rb
+++ b/spec/system/embed_mode_spec.rb
@@ -134,6 +134,15 @@ describe "Embed mode" do
         expect(page).to have_css(".topic-post", text: "Hello from the docked composer")
       end
 
+      it "shows the standard composer when editing a post" do
+        own_post = Fabricate(:post, topic: topic, user: user)
+        visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
+
+        find("#post_#{own_post.post_number} button.edit").click
+
+        expect(page).to have_css("#reply-control.composer-action-edit")
+      end
+
       context "with many replies" do
         before { 15.times { Fabricate(:post, topic: topic) } }
 


### PR DESCRIPTION
Previously, the embed mode stylesheet hid `#reply-control` unconditionally, which prevented the standard composer from opening when users clicked edit on their own posts. Additionally, the fade gradient on the docked composer overlapped the "Replying to" bar because it was positioned on the inner component rather than the outer wrapper.

This change excludes `.composer-action-edit` from the hidden composer rule (matching the pattern used by the AI bot docked composer) and moves the fade gradient to the `.embed-mode-composer` wrapper so it renders above all child content including the reply-to indicator.

|Before | After |
| ----- | ----- |
| <img width="727" height="345" alt="Screenshot 2026-05-08 at 09 49 55" src="https://github.com/user-attachments/assets/e6ef0eaa-9e1d-4768-b152-f19885cf6e07" /> | <img width="739" height="344" alt="Screenshot 2026-05-08 at 09 50 17" src="https://github.com/user-attachments/assets/b5f66e3e-5096-4d71-88fe-b44881b80df6" /> |
| <img width="729" height="940" alt="Screenshot 2026-05-08 at 09 50 42" src="https://github.com/user-attachments/assets/23d1a8f6-c65a-41cc-b3b0-6a2d39b54d27" /> | <img width="724" height="937" alt="Screenshot 2026-05-08 at 09 50 54" src="https://github.com/user-attachments/assets/9a36af59-4b9c-4a4b-bb10-e87af8a40602" /> |
