### PR TITLE
FEATURE: Add post editing support to docked composers

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -227,5 +227,25 @@ body.embed-mode {
     &__replying-to-dismiss {
       padding: 0.25em;
     }
+
+    &__editing {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.35em 0.75em;
+      font-size: var(--font-down-1);
+      color: var(--primary-medium);
+      border-top: 1px solid var(--primary-low);
+    }
+
+    &__editing-text {
+      display: flex;
+      align-items: center;
+      gap: 0.35em;
+    }
+
+    &__editing-dismiss {
+      padding: 0.25em;
+    }
   }
 }

--- a/app/assets/stylesheets/common/components/docked-composer.scss
+++ b/app/assets/stylesheets/common/components/docked-composer.scss
@@ -64,6 +64,14 @@
     }
   }
 
+  &__header {
+    width: 100%;
+    max-width: var(--docked-composer-max-width);
+    padding-left: var(--docked-composer-content-offset);
+    margin: 0 auto;
+    box-sizing: border-box;
+  }
+
   &__inner {
     display: flex;
     align-items: flex-end;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -724,6 +724,7 @@ en:
       continue_as_guest: "Continue as Guest"
       be_first_to_reply: "Be the first to reply!"
       replying_to: "Replying to %{username}"
+      editing_post: "Editing post"
       reply_placeholder: "Write a reply..."
 
     topic_count_all:

--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -191,8 +191,15 @@ export default class DockedComposer extends Component {
   }
 
   @action
+  setReply(value) {
+    this.reply = value ?? "";
+    this.persistDraft(this.reply);
+  }
+
+  @action
   setupContainer(element) {
     this.#rootElement = element;
+    this.args.onRegisterApi?.({ setReply: this.setReply, focus: this.focus });
     this.loadDraft();
 
     this.uppyUpload = new UppyUpload(getOwner(this), {
@@ -398,6 +405,11 @@ export default class DockedComposer extends Component {
             {{on "pointercancel" this.onResizeEnd}}
             {{on "keydown" this.onResizeKeyDown}}
           ></div>
+        {{/if}}
+        {{#if (has-block "header")}}
+          <div class="docked-composer__header">
+            {{yield to="header"}}
+          </div>
         {{/if}}
         <div class="docked-composer__inner">
           <div class="docked-composer__editor">

--- a/frontend/discourse/app/components/embed-mode-composer.gjs
+++ b/frontend/discourse/app/components/embed-mode-composer.gjs
@@ -7,6 +7,7 @@ import { modifier } from "ember-modifier";
 import DButton from "discourse/components/d-button";
 import DockedComposer from "discourse/components/docked-composer";
 import avatar from "discourse/helpers/avatar";
+import { ajax } from "discourse/lib/ajax";
 import EmbedMode from "discourse/lib/embed-mode";
 import { i18n } from "discourse-i18n";
 
@@ -17,6 +18,7 @@ export default class EmbedModeComposer extends Component {
   @service store;
 
   @tracked replyingToPost = null;
+  @tracked editingPost = null;
   @tracked isSubmitting = false;
   @tracked footerVisible = true;
 
@@ -27,6 +29,7 @@ export default class EmbedModeComposer extends Component {
       this,
       this.handleReplyToPost
     );
+    this.appEvents.on("embed-composer:edit-post", this, this.handleEditPost);
     this.appEvents.on("embed-composer:focus", this, this.handleFocus);
 
     const footerButtons = document.querySelector("#topic-footer-buttons");
@@ -58,9 +61,12 @@ export default class EmbedModeComposer extends Component {
         this,
         this.handleReplyToPost
       );
+      this.appEvents.off("embed-composer:edit-post", this, this.handleEditPost);
       this.appEvents.off("embed-composer:focus", this, this.handleFocus);
     };
   });
+
+  #composerApi = null;
   #footerObserver = null;
   #rootElement = null;
 
@@ -85,6 +91,10 @@ export default class EmbedModeComposer extends Component {
 
   @action
   handleReplyToPost(post) {
+    if (this.editingPost) {
+      this.editingPost = null;
+      this.#composerApi?.setReply("");
+    }
     if (post && post.post_number !== 1) {
       this.replyingToPost = post;
     } else {
@@ -111,7 +121,66 @@ export default class EmbedModeComposer extends Component {
   }
 
   @action
+  registerComposerApi(api) {
+    this.#composerApi = api;
+  }
+
+  @action
+  async handleEditPost(post) {
+    this.replyingToPost = null;
+    const fullPost = await this.store.find("post", post.id);
+    this.editingPost = fullPost;
+    this.#composerApi?.setReply(fullPost.raw);
+    schedule("afterRender", () => {
+      this.#rootElement?.querySelector(".d-editor-input")?.focus();
+    });
+  }
+
+  @action
+  cancelEditing() {
+    this.editingPost = null;
+    this.#composerApi?.setReply("");
+  }
+
+  @action
   async handleSubmit({ raw }) {
+    if (this.editingPost) {
+      return this.#submitEdit(raw);
+    }
+    return this.#submitReply(raw);
+  }
+
+  async #submitEdit(raw) {
+    const post = this.editingPost;
+    this.isSubmitting = true;
+
+    try {
+      const result = await ajax(`/posts/${post.id}.json`, {
+        type: "PUT",
+        data: { post: { raw } },
+      });
+
+      const postStream = this.args.topic.postStream;
+      const loadedPost = postStream.findLoadedPost(post.id);
+      if (loadedPost) {
+        loadedPost.setProperties({
+          raw: result.post.raw,
+          cooked: result.post.cooked,
+          version: result.post.version,
+          updated_at: result.post.updated_at,
+        });
+      }
+
+      this.editingPost = null;
+      this.isSubmitting = false;
+      return { ok: true };
+    } catch (error) {
+      this.isSubmitting = false;
+      throw error;
+    }
+  }
+
+  async #submitReply(raw) {
     const topic = this.args.topic;
     const postStream = topic.postStream;
     const user = this.currentUser;
@@ -192,7 +261,19 @@ export default class EmbedModeComposer extends Component {
             />
           </div>
         {{/if}}
-        {{#if this.replyingToPost}}
+        {{#if this.editingPost}}
+          <div class="embed-mode-composer__editing">
+            <span class="embed-mode-composer__editing-text">
+              {{avatar this.editingPost imageSize="tiny"}}
+              {{i18n "embed_mode.editing_post"}}
+            </span>
+            <DButton
+              @icon="xmark"
+              @action={{this.cancelEditing}}
+              class="btn-transparent embed-mode-composer__editing-dismiss"
+            />
+          </div>
+        {{else if this.replyingToPost}}
           <div class="embed-mode-composer__replying-to">
             <span class="embed-mode-composer__replying-to-text">
               {{avatar this.replyingToPost imageSize="tiny"}}
@@ -212,6 +293,7 @@ export default class EmbedModeComposer extends Component {
           @topicId={{@topic.id}}
           @categoryId={{@topic.category.id}}
           @onSubmit={{this.handleSubmit}}
+          @onRegisterApi={{this.registerComposerApi}}
           @isSubmitting={{this.isSubmitting}}
           @resizable={{true}}
           @placeholder={{this.placeholder}}

--- a/frontend/discourse/app/controllers/topic.js
+++ b/frontend/discourse/app/controllers/topic.js
@@ -1067,6 +1067,17 @@ export default class TopicController extends Controller {
       return false;
     }
 
+    if (EmbedMode.enabled) {
+      this.appEvents.trigger("embed-composer:edit-post", post);
+      return;
+    }
+
+    const editEvent = { post, handled: false };
+    this.appEvents.trigger("topic:edit-post", editEvent);
+    if (editEvent.handled) {
+      return;
+    }
+
     const topic = this.model;
 
     const editingLocalizedPost =

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -4,11 +4,14 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import DockedComposer from "discourse/components/docked-composer";
+import avatar from "discourse/helpers/avatar";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
+import { ajax } from "discourse/lib/ajax";
 import { i18n } from "discourse-i18n";
 
 const DRAFT_KEY_PREFIX = "ai-bot-docked-draft-";
@@ -24,13 +27,17 @@ const DRAFT_KEY_PREFIX = "ai-bot-docked-draft-";
  * generating" icon while the bot is replying.
  */
 export default class AiBotDockedComposer extends Component {
+  @service appEvents;
   @service aiBotDockedSubmit;
   @service aiBotStreamingState;
   @service siteSettings;
+  @service store;
 
   @tracked showToolbar = false;
   @tracked hasContentBelow = false;
+  @tracked editingPost = null;
 
+  #composerApi = null;
   #resizeObserver = null;
   #keyboardOpen = false;
   #composerEl = null;
@@ -127,16 +134,6 @@ export default class AiBotDockedComposer extends Component {
   }
 
   @action
-  async onSubmit({ raw, uploads, inProgressUploadsCount }) {
-    return this.aiBotDockedSubmit.submitReply({
-      topicId: this.topicId,
-      raw,
-      uploads,
-      inProgressUploadsCount,
-    });
-  }
-
-  @action
   toggleToolbar() {
     this.showToolbar = !this.showToolbar;
   }
@@ -150,6 +147,71 @@ export default class AiBotDockedComposer extends Component {
   }
 
   @action
+  registerComposerApi(api) {
+    this.#composerApi = api;
+  }
+
+  @action
+  handleEditPost(event) {
+    if (!this.isBotPm) {
+      return;
+    }
+    event.handled = true;
+    this.#startEditing(event.post);
+  }
+
+  async #startEditing(post) {
+    const fullPost = await this.store.find("post", post.id);
+    this.editingPost = fullPost;
+    this.#composerApi?.setReply(fullPost.raw);
+    schedule("afterRender", () => {
+      this.#composerEl?.querySelector(".d-editor-input")?.focus();
+    });
+  }
+
+  @action
+  cancelEditing() {
+    this.editingPost = null;
+    this.#composerApi?.setReply("");
+  }
+
+  @action
+  async onSubmit({ raw, uploads, inProgressUploadsCount }) {
+    if (this.editingPost) {
+      return this.#submitEdit(raw);
+    }
+    return this.aiBotDockedSubmit.submitReply({
+      topicId: this.topicId,
+      raw,
+      uploads,
+      inProgressUploadsCount,
+    });
+  }
+
+  async #submitEdit(raw) {
+    const post = this.editingPost;
+
+    const result = await ajax(`/posts/${post.id}.json`, {
+      type: "PUT",
+      data: { post: { raw } },
+    });
+
+    const topic = this.topic;
+    const loadedPost = topic?.postStream?.findLoadedPost(post.id);
+    if (loadedPost) {
+      loadedPost.setProperties({
+        raw: result.post.raw,
+        cooked: result.post.cooked,
+        version: result.post.version,
+        updated_at: result.post.updated_at,
+      });
+    }
+
+    this.editingPost = null;
+    return { ok: true };
+  }
+
+  @action
   setupScrollListener(element) {
     this.#composerEl = element;
     window.addEventListener("scroll", this.#checkScroll, { passive: true });
@@ -158,6 +220,7 @@ export default class AiBotDockedComposer extends Component {
     this.#checkScroll();
     window.visualViewport?.addEventListener("resize", this.#onViewportChange);
     window.visualViewport?.addEventListener("scroll", this.#onViewportChange);
+    this.appEvents.on("topic:edit-post", this, this.handleEditPost);
   }
 
   @action
@@ -174,6 +237,7 @@ export default class AiBotDockedComposer extends Component {
       "scroll",
       this.#onViewportChange
     );
+    this.appEvents.off("topic:edit-post", this, this.handleEditPost);
   }
 
   @action
@@ -198,6 +262,7 @@ export default class AiBotDockedComposer extends Component {
       @submitTitle={{i18n "discourse_ai.ai_bot.conversations.header"}}
       @uploadTitle="discourse_ai.ai_bot.conversations.upload_files"
       @onSubmit={{this.onSubmit}}
+      @onRegisterApi={{this.registerComposerApi}}
       @isSubmitting={{this.aiBotDockedSubmit.loading}}
       @disabled={{this.isStreaming}}
       @resizable={{true}}
@@ -205,6 +270,21 @@ export default class AiBotDockedComposer extends Component {
       {{didInsert this.setupScrollListener}}
       {{willDestroy this.teardownScrollListener}}
     >
+      <:header>
+        {{#if this.editingPost}}
+          <div class="ai-bot-docked-composer__editing">
+            <span class="ai-bot-docked-composer__editing-text">
+              {{avatar this.editingPost imageSize="tiny"}}
+              {{i18n "discourse_ai.ai_bot.conversations.editing_post"}}
+            </span>
+            <DButton
+              @icon="xmark"
+              @action={{this.cancelEditing}}
+              class="btn-transparent ai-bot-docked-composer__editing-dismiss"
+            />
+          </div>
+        {{/if}}
+      </:header>
       <:submit as |ctx|>
         <DButton
           @icon={{if this.showToolbar "xmark" "plus"}}

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
@@ -2,11 +2,10 @@
 
 body.has-ai-bot-docked-composer {
   // hide the floating composer on bot PMs — the docked composer has
-  // replaced it. Scoped to the body class, which is only present while
-  // the DockedComposer component is rendered (cleared on unmount), so
-  // navigating to a non-bot-PM topic restores the popup composer.
-  // Allow it to show when editing a post (composer-action-edit class).
-  #reply-control:not(.composer-action-edit) {
+  // replaced it (including edits). Scoped to the body class, which is
+  // only present while the DockedComposer component is rendered (cleared
+  // on unmount), so navigating away restores the popup composer.
+  #reply-control {
     display: none !important;
   }
 
@@ -193,6 +192,28 @@ body.has-ai-bot-docked-composer {
 // Send button: vertically centered with toolbar icons.
 .docked-composer.ai-bot-docked-composer .docked-composer__submit-btn.btn {
   bottom: var(--space-2);
+}
+
+.docked-composer.ai-bot-docked-composer .ai-bot-docked-composer__editing {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.5em 0.75em;
+  border-top: 1px solid var(--primary-low);
+  box-sizing: border-box;
+  font-size: var(--font-down-1);
+  color: var(--primary-medium);
+}
+
+.ai-bot-docked-composer__editing-text {
+  display: flex;
+  align-items: center;
+  gap: 0.35em;
+}
+
+.ai-bot-docked-composer__editing-dismiss {
+  padding: 0.25em;
 }
 
 // Floating scroll indicator: appears above the composer when content is below.

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -1248,6 +1248,7 @@ en:
           hide_toolbar: "Hide formatting toolbar"
           scroll_to_bottom: "Scroll to bottom"
           streaming_below: "New content below"
+          editing_post: "Editing post"
       sentiments:
         dashboard:
           title: "Sentiment"

--- a/plugins/discourse-ai/spec/system/ai_bot/docked_composer_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/docked_composer_spec.rb
@@ -118,6 +118,22 @@ RSpec.describe "AI Bot docked composer" do
     expect(find(".ai-bot-docked-composer .d-editor-input").value).to eq("")
   end
 
+  it "edits a post through the docked composer" do
+    topic_page.visit_topic(pm)
+
+    find("#post_1 button.edit").click
+
+    expect(page).to have_css(".ai-bot-docked-composer__editing")
+    expect(page).to have_no_css("#reply-control.composer-action-edit")
+    expect(find(".ai-bot-docked-composer .d-editor-input").value).to eq("Hello bot")
+
+    find(".ai-bot-docked-composer .d-editor-input").fill_in(with: "Edited bot message")
+    find(".ai-bot-docked-composer .docked-composer__submit-btn").click
+
+    expect(page).to have_no_css(".ai-bot-docked-composer__editing")
+    expect(page).to have_css("#post_1", text: "Edited bot message")
+  end
+
   it "falls back to the standard composer when the docked composer is disabled" do
     SiteSetting.ai_bot_enable_docked_composer = false
     topic_page.visit_topic(pm)

--- a/spec/system/embed_mode_spec.rb
+++ b/spec/system/embed_mode_spec.rb
@@ -134,13 +134,20 @@ describe "Embed mode" do
         expect(page).to have_css(".topic-post", text: "Hello from the docked composer")
       end
 
-      it "shows the standard composer when editing a post" do
-        own_post = Fabricate(:post, topic: topic, user: user)
+      it "edits a post through the docked composer" do
+        own_post = Fabricate(:post, topic: topic, user: user, raw: "Original content")
         visit("/t/#{topic.slug}/#{topic.id}?embed_mode=true")
 
         find("#post_#{own_post.post_number} button.edit").click
 
-        expect(page).to have_css("#reply-control.composer-action-edit")
+        expect(page).to have_css(".embed-mode-composer__editing")
+        expect(page).to have_no_css("#reply-control.composer-action-edit")
+
+        find(".embed-mode-composer .d-editor-input").fill_in(with: "Edited content")
+        find(".embed-mode-composer .docked-composer__submit-btn").click
+
+        expect(page).to have_no_css(".embed-mode-composer__editing")
+        expect(page).to have_css("#post_#{own_post.post_number}", text: "Edited content")
       end
 
       context "with many replies" do


### PR DESCRIPTION
**Previously**, clicking "edit" on a post in embed mode or an AI bot PM would open the standard floating composer.

**This change** adds inline edit support to both the embed-mode and AI bot docked composers, intercepting the edit action via app events and handling the PUT request directly, so users never leave the docked composer flow.

----

Embed Mode:
<img width="670" height="401" alt="embed-mode" src="https://github.com/user-attachments/assets/bd11afc6-b7f0-456d-b0be-ddb48fdd964e" />

AI Bot:
<img width="786" height="230" alt="ai-bot" src="https://github.com/user-attachments/assets/7c63fa08-cb03-4a5a-9405-b0f204264d02" />
