### PR TITLE
FIX: Complete passkey 2FA WebAuthn assertions

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -534,8 +534,9 @@ class SessionController < ApplicationController
         backup_enabled: user.backup_codes_enabled?,
         allowed_methods: challenge[:allowed_methods],
       )
-      passkeys_for_2fa = user.passkeys_for_2fa_enabled?
-      if user.security_keys_enabled? || passkeys_for_2fa
+      security_keys_enabled = user.security_keys_enabled?
+      passkeys_for_2fa = user.passkeys_for_2fa_enabled? && !security_keys_enabled
+      if security_keys_enabled || passkeys_for_2fa
         DiscourseWebauthn.stage_challenge(user, server_session)
         json.merge!(
           DiscourseWebauthn.allowed_credentials(
@@ -544,7 +545,7 @@ class SessionController < ApplicationController
             include_passkeys: passkeys_for_2fa,
           ),
         )
-        json[:security_keys_enabled] = user.security_keys_enabled?
+        json[:security_keys_enabled] = security_keys_enabled
         json[:passkeys_enabled] = passkeys_for_2fa
       else
         json[:security_keys_enabled] = false

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -177,7 +177,9 @@ module SecondFactorManager
 
   def authenticate_security_key(server_session, security_key_credential)
     factor_types = [UserSecurityKey.factor_types[:second_factor]]
-    factor_types << UserSecurityKey.factor_types[:first_factor] if passkeys_for_2fa_enabled?
+    if passkeys_for_2fa_enabled? && !security_keys_enabled?
+      factor_types << UserSecurityKey.factor_types[:first_factor]
+    end
 
     ::DiscourseWebauthn::AuthenticationService.new(
       self,

--- a/frontend/discourse/app/controllers/second-factor-auth.js
+++ b/frontend/discourse/app/controllers/second-factor-auth.js
@@ -276,7 +276,7 @@ export default class SecondFactorAuthController extends Controller {
           this.displayError(errorMessage);
         }
       },
-      { userVerification: this.passkeysEnabled ? "preferred" : "discouraged" }
+      { userVerification: this.passkeysEnabled ? "required" : "discouraged" }
     );
   }
 

--- a/frontend/discourse/app/lib/webauthn.js
+++ b/frontend/discourse/app/lib/webauthn.js
@@ -14,6 +14,18 @@ export function bufferToBase64(buffer) {
   return btoa(String.fromCharCode(...new Uint8Array(buffer)));
 }
 
+function isArrayBuffer(value) {
+  return Object.prototype.toString.call(value) === "[object ArrayBuffer]";
+}
+
+function isAuthenticatorAssertionResponse(response) {
+  return (
+    isArrayBuffer(response?.signature) &&
+    isArrayBuffer(response?.clientDataJSON) &&
+    isArrayBuffer(response?.authenticatorData)
+  );
+}
+
 export function isWebauthnSupported() {
   return typeof PublicKeyCredential !== "undefined";
 }
@@ -67,16 +79,13 @@ export function getWebauthnCredential(
         challenge: challengeBuffer,
         allowCredentials,
         timeout: 60000, // this is just a hint
-        // "discouraged" for plain 2FA (security keys), "preferred" when passkeys
-        // may be present so the browser prompts for UV on passkey credentials
-        // while still allowing non-UV security keys.
         userVerification,
       },
       signal: WebauthnAbortHandler.signal(),
     })
     .then((credential) => {
-      // 3. If credential.response is not an instance of AuthenticatorAssertionResponse, abort the ceremony.
-      if (!(credential.response instanceof AuthenticatorAssertionResponse)) {
+      // 3. If credential.response is not an AuthenticatorAssertionResponse, abort the ceremony.
+      if (!isAuthenticatorAssertionResponse(credential.response)) {
         return errorCallback(i18n("login.security_key_invalid_response_error"));
       }
 
@@ -85,11 +94,12 @@ export function getWebauthnCredential(
 
       // 5. If options.allowCredentials is not empty, verify that credential.id identifies one of the public key
       // credentials listed in options.allowCredentials.
-      if (
-        !allowedCredentialIds.some(
-          (credentialId) => bufferToBase64(credential.rawId) === credentialId
-        )
-      ) {
+      const credentialId = allowedCredentialIds.find(
+        (allowedCredentialId) =>
+          bufferToBase64(credential.rawId) === allowedCredentialId
+      );
+
+      if (!credentialId) {
         return errorCallback(
           i18n("login.security_key_no_matching_credential_error")
         );
@@ -101,7 +111,7 @@ export function getWebauthnCredential(
         authenticatorData: bufferToBase64(
           credential.response.authenticatorData
         ),
-        credentialId: bufferToBase64(credential.rawId),
+        credentialId,
       };
 
       successCallback(credentialData);

--- a/frontend/discourse/tests/acceptance/second-factor-auth-test.js
+++ b/frontend/discourse/tests/acceptance/second-factor-auth-test.js
@@ -1,4 +1,10 @@
-import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
+import {
+  click,
+  currentURL,
+  fillIn,
+  visit,
+  waitUntil,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -40,6 +46,24 @@ const RESPONSES = {
     security_keys_enabled: true,
     allowed_methods: [BACKUP_CODE],
   },
+  okPasskey: {
+    totp_enabled: false,
+    backup_enabled: false,
+    security_keys_enabled: false,
+    passkeys_enabled: true,
+    allowed_methods: [SECURITY_KEY],
+    allowed_credential_ids: ["Y3JlZGVudGlhbC1pZA=="],
+    challenge: "challenge",
+  },
+  okPasskeyWithSecurityKey: {
+    totp_enabled: false,
+    backup_enabled: false,
+    security_keys_enabled: true,
+    passkeys_enabled: false,
+    allowed_methods: [SECURITY_KEY],
+    allowed_credential_ids: ["Y3JlZGVudGlhbC1pZA=="],
+    challenge: "challenge",
+  },
 };
 
 Object.keys(RESPONSES).forEach((k) => {
@@ -53,6 +77,7 @@ Object.keys(RESPONSES).forEach((k) => {
 });
 const WRONG_TOTP = "124323";
 let callbackCount = 0;
+let secondFactorCredentialId = null;
 
 acceptance("Second Factor Auth Page", function (needs) {
   needs.user();
@@ -66,6 +91,10 @@ acceptance("Second Factor Auth Page", function (needs) {
 
     server.post("/session/2fa", (request) => {
       const params = parsePostData(request.requestBody);
+      secondFactorCredentialId =
+        params.second_factor_token?.credentialId ||
+        params["second_factor_token[credentialId]"];
+
       if (params.second_factor_token === WRONG_TOTP) {
         return response(401, {
           error: "invalid token man",
@@ -89,7 +118,10 @@ acceptance("Second Factor Auth Page", function (needs) {
     });
   });
 
-  needs.hooks.beforeEach(() => (callbackCount = 0));
+  needs.hooks.beforeEach(() => {
+    callbackCount = 0;
+    secondFactorCredentialId = null;
+  });
 
   test("when challenge data fails to load", async function (assert) {
     await visit("/session/2fa?nonce=failed");
@@ -272,6 +304,135 @@ acceptance("Second Factor Auth Page", function (needs) {
       "user has been redirected to the redirect_url"
     );
     assert.strictEqual(callbackCount, 1, "callback request has been performed");
+  });
+
+  test("successful passkey submit from automatic prompt", async function (assert) {
+    const originalPublicKeyCredential = globalThis.PublicKeyCredential;
+    const originalCredentialsDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "credentials"
+    );
+
+    globalThis.PublicKeyCredential = class {};
+
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        get: async ({ publicKey }) => {
+          assert.strictEqual(
+            publicKey.userVerification,
+            "required",
+            "passkey authentication requires user verification"
+          );
+
+          assert.strictEqual(
+            publicKey.allowCredentials[0].id.byteLength,
+            13,
+            "credential IDs are passed to the browser request"
+          );
+
+          return {
+            response: {
+              signature: new Uint8Array([1]).buffer,
+              clientDataJSON: new Uint8Array([2]).buffer,
+              authenticatorData: new Uint8Array([3]).buffer,
+              userHandle: new Uint8Array([4]).buffer,
+            },
+            rawId: Uint8Array.from("credential-id", (char) =>
+              char.charCodeAt(0)
+            ).buffer,
+          };
+        },
+      },
+    });
+
+    try {
+      await visit("/session/2fa?nonce=okPasskey");
+      await waitUntil(() => callbackCount === 1);
+
+      assert.strictEqual(
+        secondFactorCredentialId,
+        "Y3JlZGVudGlhbC1pZA==",
+        "the matched credential ID is submitted"
+      );
+      assert.strictEqual(
+        currentURL(),
+        "/",
+        "user has been redirected to the redirect_url"
+      );
+      assert.strictEqual(
+        callbackCount,
+        1,
+        "callback request has been performed"
+      );
+    } finally {
+      globalThis.PublicKeyCredential = originalPublicKeyCredential;
+
+      if (originalCredentialsDescriptor) {
+        Object.defineProperty(
+          navigator,
+          "credentials",
+          originalCredentialsDescriptor
+        );
+      } else {
+        delete navigator.credentials;
+      }
+    }
+  });
+
+  test("security key prompt does not require user verification when passkeys are not advertised", async function (assert) {
+    const originalPublicKeyCredential = globalThis.PublicKeyCredential;
+    const originalCredentialsDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "credentials"
+    );
+    let requestedUserVerification;
+
+    globalThis.PublicKeyCredential = class {};
+
+    Object.defineProperty(navigator, "credentials", {
+      configurable: true,
+      value: {
+        get: async ({ publicKey }) => {
+          requestedUserVerification = publicKey.userVerification;
+
+          return {
+            response: {
+              signature: new Uint8Array([1]).buffer,
+              clientDataJSON: new Uint8Array([2]).buffer,
+              authenticatorData: new Uint8Array([3]).buffer,
+            },
+            rawId: Uint8Array.from("credential-id", (char) =>
+              char.charCodeAt(0)
+            ).buffer,
+          };
+        },
+      },
+    });
+
+    try {
+      await visit("/session/2fa?nonce=okPasskeyWithSecurityKey");
+      await click("#security-key-authenticate-button");
+      await waitUntil(() => callbackCount === 1);
+
+      assert.strictEqual(
+        requestedUserVerification,
+        "discouraged",
+        "security-key authentication does not require user verification"
+      );
+    } finally {
+      globalThis.PublicKeyCredential = originalPublicKeyCredential;
+
+      if (originalCredentialsDescriptor) {
+        Object.defineProperty(
+          navigator,
+          "credentials",
+          originalCredentialsDescriptor
+        );
+      } else {
+        delete navigator.credentials;
+      }
+    }
   });
 
   test("sidebar is disabled on 2FA route", async function (assert) {

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -3118,6 +3118,38 @@ RSpec.describe SessionController do
         end
       end
 
+      context "when the user has both a passkey and a second-factor security key" do
+        before { SiteSetting.allow_passkeys_for_2fa = true }
+
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        let!(:security_key) { Fabricate(:user_security_key_with_random_credential, user: user) }
+
+        it "exposes the security key credentials without passkeys" do
+          post "/session/2fa/test-action", xhr: true
+          nonce = response.parsed_body["second_factor_challenge_nonce"]
+          get "/session/2fa.json", params: { nonce: nonce }
+
+          expect(response.status).to eq(200)
+          challenge_data = response.parsed_body
+          expect(challenge_data["passkeys_enabled"]).to eq(false)
+          expect(challenge_data["security_keys_enabled"]).to eq(true)
+          expect(challenge_data["allowed_credential_ids"]).to include(security_key.credential_id)
+          expect(challenge_data["allowed_credential_ids"]).not_to include(
+            valid_passkey_data[:credential_id],
+          )
+          expect(challenge_data["challenge"]).to be_present
+        end
+      end
+
       context "when the user has a passkey and allow_passkeys_for_2fa is disabled" do
         before { SiteSetting.allow_passkeys_for_2fa = false }
 
@@ -3330,6 +3362,25 @@ RSpec.describe SessionController do
 
           expect(response.status).to eq(400)
           expect(response.parsed_body["error"]).to eq(I18n.t("webauthn.validation.not_found_error"))
+        end
+
+        it "rejects a passkey assertion when a second-factor security key is enabled" do
+          SiteSetting.allow_passkeys_for_2fa = true
+          simulate_localhost_passkey_challenge
+          Fabricate(:user_security_key_with_random_credential, user: user)
+
+          post "/session/2fa/test-action", xhr: true
+          nonce = response.parsed_body["second_factor_challenge_nonce"]
+
+          post "/session/2fa.json",
+               params: {
+                 nonce: nonce,
+                 second_factor_method: UserSecondFactor.methods[:security_key],
+                 second_factor_token: valid_passkey_auth_data,
+               }
+
+          expect(response.status).to eq(400)
+          expect(response.parsed_body["error"]).to eq(I18n.t("webauthn.validation.ownership_error"))
         end
       end
     end


### PR DESCRIPTION
Previously, passkey authentication on `/session/2fa` could complete in the browser but stop before submitting when the returned assertion response did not pass an `instanceof AuthenticatorAssertionResponse` check, and Safari could return passkey assertions without the user-verification bit required by the server.

This change validates assertion responses by the ArrayBuffer fields the WebAuthn flow actually uses, requests required user verification for passkey-only 2FA prompts, and keeps mixed passkey/security-key accounts on the security-key ceremony so legacy security-key fallback remains available.