### PR TITLE
FIX: Sidebar shrinking when quoting text in AI bot composer

### DIFF
--- a/frontend/discourse/app/controllers/topic.js
+++ b/frontend/discourse/app/controllers/topic.js
@@ -599,6 +599,12 @@ export default class TopicController extends Controller {
         return;
       }
 
+      const quoteEvent = { post, buffer, opts, handled: false };
+      this.appEvents.trigger("topic:quote-post", quoteEvent);
+      if (quoteEvent.handled) {
+        return;
+      }
+
       const composer = this.composer;
       const viewOpen = composer.get("model.viewOpen");
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -12,6 +12,7 @@ import avatar from "discourse/helpers/avatar";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import { ajax } from "discourse/lib/ajax";
+import { buildQuote } from "discourse/lib/quote";
 import { i18n } from "discourse-i18n";
 
 const DRAFT_KEY_PREFIX = "ai-bot-docked-draft-";
@@ -160,6 +161,18 @@ export default class AiBotDockedComposer extends Component {
     this.#startEditing(event.post);
   }
 
+  @action
+  handleQuotePost(event) {
+    if (!this.isBotPm) {
+      return;
+    }
+    event.handled = true;
+    const quotedText = buildQuote(event.post, event.buffer, event.opts);
+    if (quotedText?.trim()) {
+      this.appEvents.trigger("composer:insert-block", quotedText);
+    }
+  }
+
   async #startEditing(post) {
     const fullPost = await this.store.find("post", post.id);
     this.editingPost = fullPost;
@@ -221,6 +234,7 @@ export default class AiBotDockedComposer extends Component {
     window.visualViewport?.addEventListener("resize", this.#onViewportChange);
     window.visualViewport?.addEventListener("scroll", this.#onViewportChange);
     this.appEvents.on("topic:edit-post", this, this.handleEditPost);
+    this.appEvents.on("topic:quote-post", this, this.handleQuotePost);
   }
 
   @action
@@ -238,6 +252,7 @@ export default class AiBotDockedComposer extends Component {
       this.#onViewportChange
     );
     this.appEvents.off("topic:edit-post", this, this.handleEditPost);
+    this.appEvents.off("topic:quote-post", this, this.handleQuotePost);
   }
 
   @action


### PR DESCRIPTION
Previously, quoting text on an AI bot PM opened the invisible standard composer, which set `composer-open`, `composer-has-preview`, and `--composer-height` on the document, shrinking the sidebar by 255px and creating a visible gap.

This change adds a `topic:quote-post` event that the AI bot docked composer intercepts, building the quote markdown and inserting it directly into its own editor without ever opening the standard composer.


| Before | After |
| -------|-------| 
| <img width="1200" height="700" alt="bug-sidebar-shrunk" src="https://github.com/user-attachments/assets/644ac41c-4d5d-4471-94a2-d9a4752bb8f5" /> | <img width="1200" height="700" alt="fix-sidebar-normal" src="https://github.com/user-attachments/assets/cad989e9-8a26-49f9-bc72-b4baf9e26b84" /> |

