### PR TITLE
FEATURE: Impersonation countdown

### DIFF
--- a/app/controllers/admin/impersonate_controller.rb
+++ b/app/controllers/admin/impersonate_controller.rb
@@ -21,11 +21,11 @@ class Admin::ImpersonateController < Admin::AdminController
   end
 
   def destroy
-    raise Discourse::InvalidAccess unless current_user.is_impersonating
-
-    impersonated_user = current_user
-    stop_impersonating_user
-    StaffActionLogger.new(current_user).log_stop_impersonation(impersonated_user)
+    if current_user.is_impersonating
+      impersonated_user = current_user
+      stop_impersonating_user
+      StaffActionLogger.new(current_user).log_stop_impersonation(impersonated_user)
+    end
 
     render body: nil
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -254,8 +254,9 @@ class User < ActiveRecord::Base
   # Information if user was authenticated with OAuth
   attr_accessor :authenticated_with_oauth
 
-  # Flag used when admin is impersonating a user
+  # Attributes used when admin is impersonating a user
   attr_accessor :is_impersonating
+  attr_accessor :impersonation_expires_at
 
   scope :with_email,
         ->(email) { joins(:user_emails).where("lower(user_emails.email) IN (?)", email) }

--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -43,7 +43,10 @@ class UserAuthToken < ActiveRecord::Base
 
     return if !guardian.can_impersonate?(puppet)
 
-    puppet.tap { |u| u.is_impersonating = true }
+    puppet.tap do |user|
+      user.is_impersonating = true
+      user.impersonation_expires_at = impersonation_expires_at
+    end
   end
 
   def self.log(info)

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -84,6 +84,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :effective_locale,
              :can_see_ip,
              :is_impersonating,
+             :impersonation_expires_at,
              :can_change_post_owner,
              :show_site_owner_onboarding
 
@@ -107,6 +108,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def is_impersonating
     !!object.is_impersonating
+  end
+
+  def impersonation_expires_at
+    object.impersonation_expires_at
   end
 
   def include_can_change_post_owner?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -362,6 +362,9 @@ en:
 
     impersonation:
       notice: "You are impersonating %{username}"
+      time_left:
+        one: "(%{count} minute left)"
+        other: "(%{count} minutes left)"
       stop: "Stop impersonating"
 
     themes:

--- a/frontend/discourse/app/components/impersonation-notice.gjs
+++ b/frontend/discourse/app/components/impersonation-notice.gjs
@@ -12,9 +12,34 @@ export default class ImpersonationNotice extends Component {
   @service currentUser;
 
   @tracked stopping = false;
+  @tracked timeLeft = 0;
+
+  constructor() {
+    super(...arguments);
+    this.timeLeft = this.calculateTimeLeft();
+    this.startCountdown();
+  }
 
   get impersonatedUserName() {
     return this.currentUser.username;
+  }
+
+  startCountdown() {
+    this.countdown = setInterval(() => {
+      this.timeLeft = this.calculateTimeLeft();
+      if (this.timeLeft <= 0) {
+        this.stopImpersonating();
+      }
+    }, 1000);
+  }
+
+  calculateTimeLeft() {
+    return (
+      moment(this.currentUser.impersonation_expires_at).diff(
+        moment(),
+        "minutes"
+      ) + 1
+    );
   }
 
   @action
@@ -24,6 +49,7 @@ export default class ImpersonationNotice extends Component {
       await ajax("/admin/impersonate", {
         type: "DELETE",
       });
+      clearInterval(this.countdown);
       DiscourseURL.redirectTo("/");
     } catch (err) {
       popupAjaxError(err);
@@ -33,10 +59,14 @@ export default class ImpersonationNotice extends Component {
 
   <template>
     <div class="impersonation-notice">
-      <div>{{i18n
-          "impersonation.notice"
-          username=this.impersonatedUserName
-        }}</div>
+      <div>
+        <span>
+          {{i18n "impersonation.notice" username=this.impersonatedUserName}}
+        </span>
+        <span>
+          {{i18n "impersonation.time_left" count=this.timeLeft}}
+        </span>
+      </div>
       <DButton
         @action={{this.stopImpersonating}}
         @isLoading={{this.stopping}}

--- a/lib/impersonator_constraint.rb
+++ b/lib/impersonator_constraint.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
+# This constraint accounts for admins who are impersonating other users
+# and are therefore currently not identified as admins in their session.
 class ImpersonatorConstraint
   def matches?(request)
     current_user = CurrentUser.lookup_from_env(request.env)
-    !!current_user&.is_impersonating
+
+    # An admin who's not impersonating anyone. Cool.
+    return true if current_user&.admin?
+
+    # An admin who's impersonating someone. Also cool.
+    # We know this because only admins can impersonate others.
+    return true if current_user&.is_impersonating
+
+    false
   rescue Discourse::InvalidAccess, Discourse::ReadOnly
     false
   end

--- a/spec/models/user_auth_token_spec.rb
+++ b/spec/models/user_auth_token_spec.rb
@@ -18,11 +18,14 @@ RSpec.describe UserAuthToken do
 
         expect(token.user).to eq(user)
         expect(token.user.is_impersonating).to be_falsey
+        expect(token.user.impersonation_expires_at).to be_nil
       end
     end
 
     context "when impersonating another user" do
       it "returns the user being impersonated if not expired" do
+        freeze_time
+
         token =
           UserAuthToken.generate!(
             user_id: admin.id,
@@ -34,6 +37,7 @@ RSpec.describe UserAuthToken do
 
         expect(token.user).to eq(user)
         expect(token.user.is_impersonating).to eq(true)
+        expect(token.user.impersonation_expires_at).to eq_time(15.minutes.from_now)
       end
 
       it "returns the user associated with the session if expired" do
@@ -48,6 +52,7 @@ RSpec.describe UserAuthToken do
 
         expect(token.user).to eq(admin)
         expect(token.user.is_impersonating).to be_falsey
+        expect(token.user.impersonation_expires_at).to be_nil
       end
 
       it "returns the user associated with the session if can no longer impersonate" do
@@ -63,6 +68,7 @@ RSpec.describe UserAuthToken do
 
         expect(token.user).to eq(admin)
         expect(token.user.is_impersonating).to be_falsey
+        expect(token.user.impersonation_expires_at).to be_nil
       end
     end
   end

--- a/spec/requests/admin/impersonate_controller_spec.rb
+++ b/spec/requests/admin/impersonate_controller_spec.rb
@@ -130,10 +130,10 @@ RSpec.describe Admin::ImpersonateController do
       expect(session[:current_user_id]).to eq(admin.id)
     end
 
-    it "does not pass routing constraint when current user is not impersonating" do
+    it "does nothing and returns success if not impersonating" do
       delete "/admin/impersonate.json"
 
-      expect(response.status).to eq(404)
+      expect(response.status).to eq(200)
     end
 
     it "stops impersonating" do


### PR DESCRIPTION
### What is this change?

This PR adds a countdown to the impersonation banner, corresponding to the time left out of the allotted time in the site setting. When the countdown reaches 0 impersonation ends.

As part of this change, I made the `impersonate#destroy` endpoint idempotent and visible to all admins, whether they are impersonating or not. This prevents any "unexpected errors" from happening if there's a race to end impersonation.

**Screenshot:**

<img width="537" height="79" alt="Screenshot 2026-05-11 at 11 26 08 AM" src="https://github.com/user-attachments/assets/e44f6ef0-30ec-4050-ad08-e555c0e9f80a" />
