### PR TITLE
FIX: TL4 PM participants can schedule system publication of private messages

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -650,6 +650,9 @@ class TopicsController < ApplicationController
       category = Category.find_by(id: params[:category_id])
       raise Discourse::NotFound if !category
       raise Discourse::InvalidAccess if !guardian.can_create_topic_on_category?(category)
+      if topic.private_message? && !guardian.can_convert_topic?(topic)
+        raise Discourse::InvalidAccess
+      end
     end
 
     options = { by_user: current_user, based_on_last_post: based_on_last_post }

--- a/app/jobs/regular/publish_topic_to_category.rb
+++ b/app/jobs/regular/publish_topic_to_category.rb
@@ -3,11 +3,16 @@
 module Jobs
   class PublishTopicToCategory < ::Jobs::TopicTimerBase
     def execute_timer_action(topic_timer, topic)
-      return unless Guardian.new(topic_timer.user).can_see?(topic)
+      user = topic_timer.user
+      guardian = Guardian.new(user)
+      category = topic_timer.category
 
-      TopicTimer.transaction do
-        TopicPublisher.new(topic, Discourse.system_user, topic_timer.category_id).publish!
-      end
+      return if category.blank?
+      return unless guardian.can_see?(topic)
+      return unless guardian.can_create_topic_on_category?(category)
+      return if topic.private_message? && !guardian.can_convert_topic?(topic)
+
+      TopicTimer.transaction { TopicPublisher.new(topic, user, category.id).publish! }
 
       Topic.find(topic.id).inherit_auto_close_from_category
     end

--- a/spec/jobs/publish_topic_to_category_spec.rb
+++ b/spec/jobs/publish_topic_to_category_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::PublishTopicToCategory do
+  fab!(:admin)
   fab!(:category)
   fab!(:another_category, :category)
 
@@ -11,6 +12,7 @@ RSpec.describe Jobs::PublishTopicToCategory do
       :topic_timer,
       status_type: TopicTimer.types[:publish_to_category],
       category_id: another_category.id,
+      user: admin,
       topic: topic,
       execute_at: 1.minute.ago,
       created_at: 5.minutes.ago,
@@ -68,8 +70,6 @@ RSpec.describe Jobs::PublishTopicToCategory do
         }.to(true)
       end
 
-      topic.allowed_users << topic.public_topic_timer.user
-
       now = freeze_time
 
       messages =
@@ -83,6 +83,13 @@ RSpec.describe Jobs::PublishTopicToCategory do
       expect(topic.category).to eq(another_category)
       expect(topic.visible).to eq(true)
       expect(topic.private_message?).to eq(false)
+      expect(
+        UserHistory.exists?(
+          action: UserHistory.actions[:topic_published],
+          acting_user_id: admin.id,
+          topic_id: topic.id,
+        ),
+      ).to eq(true)
 
       %w[created_at bumped_at updated_at last_posted_at].each do |attribute|
         expect(topic.public_send(attribute)).to eq_time(now)
@@ -102,7 +109,7 @@ RSpec.describe Jobs::PublishTopicToCategory do
       expect(topic.category).not_to eq(another_category)
     end
 
-    it "works if the user can see the PM" do
+    it "does nothing if the user can't convert the PM" do
       tl4_user = Fabricate(:trust_level_4)
       topic.convert_to_private_message(Discourse.system_user)
 
@@ -114,8 +121,8 @@ RSpec.describe Jobs::PublishTopicToCategory do
       described_class.new.execute(topic_timer_id: topic.public_topic_timer.id)
 
       topic.reload
-      expect(topic.private_message?).to eq(false)
-      expect(topic.category).to eq(another_category)
+      expect(topic.private_message?).to eq(true)
+      expect(topic.category).not_to eq(another_category)
     end
   end
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -6155,6 +6155,23 @@ RSpec.describe TopicsController do
         expect(response.parsed_body["error_type"]).to eq("invalid_access")
       end
 
+      it "raises an error when publishing a private message to a category" do
+        sign_in(trust_level_4)
+
+        pm_topic = Fabricate(:private_message_topic, user: trust_level_4)
+
+        post "/t/#{pm_topic.id}/timer.json",
+             params: {
+               time: 24,
+               status_type: "publish_to_category",
+               category_id: category.id,
+             }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(pm_topic.reload.public_topic_timer).to eq(nil)
+      end
+
       it "allows a category moderator to create a delete timer" do
         user.update!(trust_level: TrustLevel[4])
         Group.user_trust_level_change!(user.id, user.trust_level)


### PR DESCRIPTION
Tighted permission checks around scheduled publishing to resolve edge cases with tl4 publishing topics 