### PR TITLE
FIX: Bookmarked hidden post excerpts leak to unauthorized bookmark owners

### DIFF
--- a/app/serializers/post_item_excerpt.rb
+++ b/app/serializers/post_item_excerpt.rb
@@ -19,6 +19,10 @@ module PostItemExcerpt
     can_see_post_item_excerpt?
   end
 
+  def include_cooked?
+    can_see_post_item_excerpt?
+  end
+
   def truncated
     true
   end
@@ -30,6 +34,7 @@ module PostItemExcerpt
   private
 
   def can_see_post_item_excerpt?
+    return true if !respond_to?(:post_item_excerpt_post) || post_item_excerpt_post.blank?
     scope&.can_see_post?(post_item_excerpt_post)
   end
 end

--- a/app/serializers/post_item_excerpt.rb
+++ b/app/serializers/post_item_excerpt.rb
@@ -10,8 +10,13 @@ module PostItemExcerpt
   end
 
   def excerpt
+    return nil unless can_see_post_item_excerpt?
     return nil unless cooked
     @excerpt ||= PrettyText.excerpt(cooked, 300, keep_emoji_images: true)
+  end
+
+  def include_excerpt?
+    can_see_post_item_excerpt?
   end
 
   def truncated
@@ -19,6 +24,12 @@ module PostItemExcerpt
   end
 
   def include_truncated?
-    cooked.length > 300
+    can_see_post_item_excerpt? && cooked.length > 300
+  end
+
+  private
+
+  def can_see_post_item_excerpt?
+    scope&.can_see_post?(post_item_excerpt_post)
   end
 end

--- a/app/serializers/user_post_bookmark_serializer.rb
+++ b/app/serializers/user_post_bookmark_serializer.rb
@@ -25,6 +25,10 @@ class UserPostBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
     post.cooked
   end
 
+  def post_item_excerpt_post
+    post
+  end
+
   def bookmarkable_user
     @bookmarkable_user ||= post.user
   end

--- a/app/serializers/user_topic_bookmark_serializer.rb
+++ b/app/serializers/user_topic_bookmark_serializer.rb
@@ -30,6 +30,10 @@ class UserTopicBookmarkSerializer < UserPostTopicBookmarkBaseSerializer
     first_post.cooked
   end
 
+  def post_item_excerpt_post
+    first_post
+  end
+
   def bookmarkable_user
     @bookmarkable_user ||= first_post.user
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7556,6 +7556,38 @@ RSpec.describe UsersController do
       expect(bookmark_list.first["excerpt"]).to eq(expected_excerpt)
     end
 
+    it "does not expose excerpts for hidden bookmarked posts the user cannot see" do
+      hidden_post_raw = "hidden post bookmark secret " * 20
+      hidden_topic_raw = "hidden topic bookmark secret " * 20
+      hidden_post = Fabricate(:post, raw: hidden_post_raw)
+      hidden_topic = Fabricate(:topic)
+      hidden_first_post = Fabricate(:post, topic: hidden_topic, raw: hidden_topic_raw)
+      hidden_post_bookmark = Fabricate(:bookmark, user: user, bookmarkable: hidden_post)
+      hidden_topic_bookmark = Fabricate(:bookmark, user: user, bookmarkable: hidden_topic)
+
+      TopicUser.change(user.id, hidden_post.topic_id, total_msecs_viewed: 1)
+      TopicUser.change(user.id, hidden_topic.id, total_msecs_viewed: 1)
+      hidden_post.update!(hidden: true)
+      hidden_first_post.update!(hidden: true)
+
+      sign_in(user)
+
+      get "/u/#{user.username}/bookmarks.json"
+      expect(response.status).to eq(200)
+      bookmark_list = response.parsed_body["user_bookmark_list"]["bookmarks"]
+      hidden_post_response = bookmark_list.find { |item| item["id"] == hidden_post_bookmark.id }
+      hidden_topic_response = bookmark_list.find { |item| item["id"] == hidden_topic_bookmark.id }
+
+      expect(hidden_post_response).to be_present
+      expect(hidden_post_response).not_to have_key("excerpt")
+      expect(hidden_post_response).not_to have_key("truncated")
+      expect(hidden_topic_response).to be_present
+      expect(hidden_topic_response).not_to have_key("excerpt")
+      expect(hidden_topic_response).not_to have_key("truncated")
+      expect(response.body).not_to include("hidden post bookmark secret")
+      expect(response.body).not_to include("hidden topic bookmark secret")
+    end
+
     describe "bookmarkable_url" do
       context "with the link_to_first_unread_post option" do
         it "is a full topic URL to the first unread post in the topic when the option is set" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7500,7 +7500,7 @@ RSpec.describe UsersController do
         Fabricate(:topic_localization, topic:, locale: "es", fancy_title: "Hola Mundo")
       end
       fab!(:topic_localization_ja) do
-        Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "���������������������")
+        Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "こんにちは世界")
       end
 
       before do
@@ -7908,7 +7908,7 @@ RSpec.describe UsersController do
         expect(notifications.first["data"]["bookmark_id"]).to eq(bookmark_with_reminder.id)
       end
 
-      it "doesn���t show unread notifications when the bookmark has been deleted" do
+      it "doesn't show unread notifications when the bookmark has been deleted" do
         bookmark_with_reminder.destroy!
 
         get "/u/#{user.username}/user-menu-bookmarks"

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7500,7 +7500,7 @@ RSpec.describe UsersController do
         Fabricate(:topic_localization, topic:, locale: "es", fancy_title: "Hola Mundo")
       end
       fab!(:topic_localization_ja) do
-        Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "こんにちは世界")
+        Fabricate(:topic_localization, topic:, locale: "ja", fancy_title: "���������������������")
       end
 
       before do
@@ -7581,9 +7581,11 @@ RSpec.describe UsersController do
       expect(hidden_post_response).to be_present
       expect(hidden_post_response).not_to have_key("excerpt")
       expect(hidden_post_response).not_to have_key("truncated")
+      expect(hidden_post_response).not_to have_key("cooked")
       expect(hidden_topic_response).to be_present
       expect(hidden_topic_response).not_to have_key("excerpt")
       expect(hidden_topic_response).not_to have_key("truncated")
+      expect(hidden_topic_response).not_to have_key("cooked")
       expect(response.body).not_to include("hidden post bookmark secret")
       expect(response.body).not_to include("hidden topic bookmark secret")
     end
@@ -7906,7 +7908,7 @@ RSpec.describe UsersController do
         expect(notifications.first["data"]["bookmark_id"]).to eq(bookmark_with_reminder.id)
       end
 
-      it "doesn’t show unread notifications when the bookmark has been deleted" do
+      it "doesn���t show unread notifications when the bookmark has been deleted" do
         bookmark_with_reminder.destroy!
 
         get "/u/#{user.username}/user-menu-bookmarks"


### PR DESCRIPTION
In rare occasions bookmarks can be made on spam posts that become hidden. In that case go ahead and hide the excerpts from the bookmark page.  