### PR TITLE
FIX: Tag settings leaks hidden tag metadata to non-staff tag editors

### DIFF
--- a/app/serializers/tag_settings_serializer.rb
+++ b/app/serializers/tag_settings_serializer.rb
@@ -28,7 +28,7 @@ class TagSettingsSerializer < ApplicationSerializer
   end
 
   def synonyms
-    object.synonyms.map { |t| { id: t.id, name: t.name } }
+    visible_synonyms.map { |t| { id: t.id, name: t.name } }
   end
 
   def categories
@@ -40,11 +40,11 @@ class TagSettingsSerializer < ApplicationSerializer
   end
 
   def tag_group_names
-    object.tag_groups.map(&:name)
+    visible_tag_groups.map(&:name)
   end
 
   def tag_groups
-    object.tag_groups.map { |tg| { id: tg.id, name: tg.name } }
+    visible_tag_groups.map { |tg| { id: tg.id, name: tg.name } }
   end
 
   def can_edit
@@ -65,5 +65,20 @@ class TagSettingsSerializer < ApplicationSerializer
 
   def include_localizations?
     SiteSetting.content_localization_enabled
+  end
+
+  private
+
+  def visible_synonyms
+    @visible_synonyms ||= object.synonyms.select { |tag| scope.can_see_tag?(tag) }
+  end
+
+  def visible_tag_groups
+    @visible_tag_groups ||=
+      begin
+        tag_groups = object.tag_groups
+        visible_tag_group_ids = TagGroup.visible(scope).where(id: tag_groups.map(&:id)).pluck(:id)
+        tag_groups.select { |tag_group| visible_tag_group_ids.include?(tag_group.id) }
+      end
   end
 end

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -860,6 +860,32 @@ RSpec.describe TagsController do
         expect(settings["can_edit"]).to eq(true)
         expect(settings["can_admin"]).to eq(false)
       end
+
+      it "does not leak hidden synonyms or tag groups to non-staff tag editors" do
+        SiteSetting.tags_listed_by_group = true
+        hidden_synonym = Fabricate(:tag, name: "hidden-synonym", target_tag: tag)
+        visible_tag_group = Fabricate(:tag_group, name: "Visible Tag Group", tags: [tag])
+        Fabricate(
+          :tag_group,
+          name: "Hidden Synonym Group",
+          permissions: {
+            "staff" => 1,
+          },
+          tags: [hidden_synonym],
+        )
+        Fabricate(:tag_group, name: "Hidden Tag Group", permissions: { "staff" => 1 }, tags: [tag])
+
+        sign_in(regular_user)
+        get "/tag/#{tag.id}/settings.json"
+        expect(response.status).to eq(200)
+
+        settings = response.parsed_body["tag_settings"]
+        expect(settings["synonyms"].map { |s| s["name"] }).to contain_exactly(synonym.name)
+        expect(settings["tag_group_names"]).to contain_exactly(visible_tag_group.name)
+        expect(settings["tag_groups"].map { |tg| tg["name"] }).to contain_exactly(
+          visible_tag_group.name,
+        )
+      end
     end
   end
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1010,7 +1010,7 @@ RSpec.describe TagsController do
         expect(tag.reload.name).to eq("user-updated")
       end
 
-      it "does not allow mutating hidden synonyms by ID" do
+      it "does not allow mutating or exposing hidden synonyms by ID" do
         hidden_synonym = Fabricate(:tag, name: "hidden-synonym", target_tag: tag)
         hidden_tag = Fabricate(:tag, name: "hidden-tag")
         Fabricate(
@@ -1031,9 +1031,13 @@ RSpec.describe TagsController do
             }
 
         expect(response.status).to eq(200)
-        synonym_names = response.parsed_body.dig("tag_settings", "synonyms").map { |s| s["name"] }
-        expect(synonym_names).to include(hidden_synonym.name)
+        synonyms = response.parsed_body.dig("tag_settings", "synonyms")
+        synonym_names = synonyms.map { |s| s["name"] }
+        synonym_ids = synonyms.map { |s| s["id"] }
+        expect(synonym_names).not_to include(hidden_synonym.name)
         expect(synonym_names).not_to include(hidden_tag.name)
+        expect(synonym_ids).not_to include(hidden_synonym.id)
+        expect(synonym_ids).not_to include(hidden_tag.id)
         expect(hidden_synonym.reload.target_tag_id).to eq(tag.id)
         expect(hidden_tag.reload.target_tag_id).to be_nil
       end


### PR DESCRIPTION
Under very rare conditions a user may have edit rights on a tag, but no rights on a tag group that includes the tag.

This will omit said tag groups (and synonyms) so they are not visible. 