### PR TITLE
FIX: Screened email list exposes IP addresses to moderators without IP-view permission

### DIFF
--- a/app/serializers/screened_email_serializer.rb
+++ b/app/serializers/screened_email_serializer.rb
@@ -10,4 +10,8 @@ class ScreenedEmailSerializer < ApplicationSerializer
   def ip_address
     object.ip_address.try(:to_s)
   end
+
+  def include_ip_address?
+    scope.can_see_ip?
+  end
 end

--- a/spec/requests/admin/screened_emails_controller_spec.rb
+++ b/spec/requests/admin/screened_emails_controller_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Admin::ScreenedEmailsController do
       end
 
       include_examples "screened emails accessible"
+
+      it "does not include IP addresses without permission to view IPs" do
+        SiteSetting.moderators_view_ips = false
+
+        get "/admin/logs/screened_emails.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.first).not_to have_key("ip_address")
+      end
     end
 
     context "when logged in as a non-staff user" do

--- a/spec/requests/admin/screened_emails_controller_spec.rb
+++ b/spec/requests/admin/screened_emails_controller_spec.rb
@@ -32,12 +32,15 @@ RSpec.describe Admin::ScreenedEmailsController do
       include_examples "screened emails accessible"
 
       it "does not include IP addresses without permission to view IPs" do
+        Fabricate(:screened_email, email: "test@example.com")
         SiteSetting.moderators_view_ips = false
 
         get "/admin/logs/screened_emails.json"
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body.first).not_to have_key("ip_address")
+        email = response.parsed_body.find { |e| e["email"] == "test@example.com" }
+        expect(email).to be_present
+        expect(email).not_to have_key("ip_address")
       end
     end
 


### PR DESCRIPTION
Edge case where in an outlier case moderators can see ip addresses and should not be allowed to