### PR TITLE
DEV: Add browser pageview events

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -429,7 +429,8 @@ module ApplicationHelper
 
   def discourse_pageview_tracking_meta_tags
     if !SiteSetting.trigger_browser_pageview_events &&
-         !SiteSetting.use_beacon_for_browser_page_views
+         !SiteSetting.use_beacon_for_browser_page_views &&
+         !SiteSetting.persist_browser_pageview_events
       return ""
     end
 

--- a/app/jobs/scheduled/clean_up_browser_pageview_events.rb
+++ b/app/jobs/scheduled/clean_up_browser_pageview_events.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Jobs
+  class CleanUpBrowserPageviewEvents < ::Jobs::Scheduled
+    every 1.day
+
+    RETENTION_PERIOD = 3.months
+
+    def execute(args)
+      return if !SiteSetting.clean_up_browser_pageview_events
+
+      BrowserPageviewEvent
+        .where("created_at < ?", RETENTION_PERIOD.ago)
+        .in_batches(of: 10_000)
+        .delete_all
+    end
+  end
+end

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class BrowserPageviewEvent < ActiveRecord::Base
+  MAX_SESSION_ID_LENGTH = 32
+  MAX_URL_LENGTH = 2000
+  MAX_REFERRER_LENGTH = 2000
+  MAX_USER_AGENT_LENGTH = 1000
+
+  before_save :truncate_fields
+
+  private
+
+  def truncate_fields
+    self.url = url.slice(0, MAX_URL_LENGTH) if url.present?
+    self.referrer = referrer.slice(0, MAX_REFERRER_LENGTH) if referrer.present?
+    self.user_agent = user_agent.slice(0, MAX_USER_AGENT_LENGTH) if user_agent.present?
+    self.session_id = session_id.slice(0, MAX_SESSION_ID_LENGTH) if session_id.present?
+  end
+end
+
+# == Schema Information
+#
+# Table name: browser_pageview_events
+#
+#  id           :bigint           not null, primary key
+#  country_code :string(2)
+#  ip_address   :inet             not null
+#  referrer     :string(2000)
+#  url          :string(2000)     not null
+#  user_agent   :string(1000)     not null
+#  created_at   :datetime         not null
+#  session_id   :string(32)       not null
+#  topic_id     :integer
+#  user_id      :integer
+#
+# Indexes
+#
+#  index_browser_pageview_events_on_created_at  (created_at) USING brin
+#  index_browser_pageview_events_on_topic_id    (topic_id)
+#  index_browser_pageview_events_on_user_id     (user_id)
+#

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -603,6 +603,12 @@ basic:
     default: false
     hidden: true
     client: true
+  persist_browser_pageview_events:
+    default: false
+    hidden: true
+  clean_up_browser_pageview_events:
+    default: false
+    hidden: true
   interface_color_selector:
     client: true
     enum: "InterfaceColorSelectorSetting"

--- a/db/migrate/20260511044542_create_pageview_events.rb
+++ b/db/migrate/20260511044542_create_pageview_events.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreatePageviewEvents < ActiveRecord::Migration[8.0]
+  def change
+    return if table_exists?(:browser_pageview_events)
+
+    create_table :browser_pageview_events do |t|
+      t.string :url, null: false, limit: 2000
+      t.inet :ip_address, null: false
+      t.string :referrer, null: true, limit: 2000
+      t.string :user_agent, null: false, limit: 1000
+      t.string :session_id, null: false, limit: 32
+      t.integer :topic_id, null: true
+      t.integer :user_id, null: true
+      t.string :country_code, null: true, limit: 2
+      t.timestamp :created_at, null: false
+    end
+
+    add_index :browser_pageview_events, :created_at, using: :brin
+    add_index :browser_pageview_events, :user_id
+    add_index :browser_pageview_events, :topic_id
+  end
+end

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -687,11 +687,37 @@ class Middleware::RequestTracker
   private_class_method :extract_beacon_view_tracking_data
 
   def self.trigger_browser_pageview_event(data)
-    if SiteSetting.trigger_browser_pageview_events
+    if SiteSetting.persist_browser_pageview_events
+      persist_browser_pageview_event(build_browser_pageview_event_payload(data))
+    elsif SiteSetting.trigger_browser_pageview_events
       DiscourseEvent.trigger(:browser_pageview, build_browser_pageview_event_payload(data))
     end
   end
   private_class_method :trigger_browser_pageview_event
+
+  def self.persist_browser_pageview_event(payload)
+    Scheduler::Defer.later "Create BrowserPageviewEvent" do
+      BrowserPageviewEvent.create!(
+        url: payload[:url],
+        ip_address: payload[:ip_address],
+        country_code: payload[:country_code],
+        referrer: payload[:referrer],
+        user_agent: payload[:user_agent],
+        session_id: payload[:session_id],
+        user_id: payload[:user_id],
+        topic_id: payload[:topic_id],
+        created_at: payload[:occurred_at],
+      )
+    rescue ActiveRecord::StatementInvalid => e
+      raise unless e.cause.is_a?(PG::NotNullViolation) && e.cause.message.include?("ip_address")
+      Rails.logger.debug("Discarding BrowserPageviewEvent: invalid IP #{payload[:ip_address]}")
+    rescue => e
+      Rails.logger.error(
+        "Failed to create BrowserPageviewEvent with payload #{payload}: #{e.message}",
+      )
+    end
+  end
+  private_class_method :persist_browser_pageview_event
 
   def self.trigger_beacon_browser_pageview_event(data)
     if SiteSetting.trigger_browser_pageview_events

--- a/spec/jobs/clean_up_browser_pageview_events_spec.rb
+++ b/spec/jobs/clean_up_browser_pageview_events_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::CleanUpBrowserPageviewEvents do
+  fab!(:fresh_event) do
+    BrowserPageviewEvent.create!(
+      url: "/t/topic/1",
+      ip_address: "1.2.3.4",
+      user_agent: "Firefox",
+      session_id: "abc",
+      created_at: 1.month.ago,
+    )
+  end
+
+  fab!(:old_event) do
+    BrowserPageviewEvent.create!(
+      url: "/t/topic/2",
+      ip_address: "1.2.3.4",
+      user_agent: "Firefox",
+      session_id: "def",
+      created_at: 4.months.ago,
+    )
+  end
+
+  it "does nothing when the site setting is disabled" do
+    SiteSetting.clean_up_browser_pageview_events = false
+
+    expect { described_class.new.execute({}) }.not_to change { BrowserPageviewEvent.count }
+  end
+
+  it "deletes events older than 3 months and keeps fresher ones" do
+    SiteSetting.clean_up_browser_pageview_events = true
+
+    expect { described_class.new.execute({}) }.to change { BrowserPageviewEvent.count }.by(-1)
+    expect(BrowserPageviewEvent.all).to contain_exactly(fresh_event)
+  end
+end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -885,6 +885,71 @@ RSpec.describe Middleware::RequestTracker do
           expect(events.length).to eq(0)
         end
       end
+
+      context "when SiteSetting.persist_browser_pageview_events is true" do
+        before { SiteSetting.persist_browser_pageview_events = true }
+
+        it "creates a BrowserPageviewEvent row and does not fire the :browser_pageview event" do
+          session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+          DiscourseIpInfo.stubs(:get).returns(country_code: "AU")
+
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
+                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
+                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://example.com",
+                "action_dispatch.remote_ip" => "1.2.3.4",
+              ),
+              ["200", { "Content-Type" => "text/html" }],
+              0.2,
+            )
+
+          events =
+            DiscourseEvent.track_events(:browser_pageview) do
+              expect { Middleware::RequestTracker.log_request(data) }.to change {
+                BrowserPageviewEvent.count
+              }.by(1)
+            end
+
+          expect(events).to be_empty
+
+          event = BrowserPageviewEvent.last
+          expect(event.session_id).to eq(session_id)
+          expect(event.url).to eq("https://discourse.org")
+          expect(event.referrer).to eq("https://example.com")
+          expect(event.country_code).to eq("AU")
+          expect(event.user_agent).to be_present
+          expect(event.ip_address.to_s).to eq("1.2.3.4")
+        end
+
+        it "takes precedence even when trigger_browser_pageview_events is also true" do
+          SiteSetting.trigger_browser_pageview_events = true
+          session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
+                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
+                "action_dispatch.remote_ip" => "1.2.3.4",
+              ),
+              ["200", { "Content-Type" => "text/html" }],
+              0.2,
+            )
+
+          events =
+            DiscourseEvent.track_events(:browser_pageview) do
+              expect { Middleware::RequestTracker.log_request(data) }.to change {
+                BrowserPageviewEvent.count
+              }.by(1)
+            end
+
+          expect(events).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe BrowserPageviewEvent do
+  it "truncates string fields before saving" do
+    event =
+      described_class.create!(
+        url: "a" * (described_class::MAX_URL_LENGTH + 1),
+        referrer: "a" * (described_class::MAX_REFERRER_LENGTH + 1),
+        user_agent: "a" * (described_class::MAX_USER_AGENT_LENGTH + 1),
+        ip_address: "1.2.3.4",
+        session_id: "a" * (described_class::MAX_SESSION_ID_LENGTH + 1),
+      )
+
+    expect(event.url.length).to eq(described_class::MAX_URL_LENGTH)
+    expect(event.referrer.length).to eq(described_class::MAX_REFERRER_LENGTH)
+    expect(event.user_agent.length).to eq(described_class::MAX_USER_AGENT_LENGTH)
+    expect(event.session_id.length).to eq(described_class::MAX_SESSION_ID_LENGTH)
+  end
+end


### PR DESCRIPTION
This change adds a hidden, opt-in path that writes pageview rows directly to a new `browser_pageview_events` table via `Scheduler::Defer`, gated by `persist_browser_pageview_events`. 

In addition,  a daily cleanup job was added, gated by `clean_up_browser_pageview_events` that prunes rows older than 3 months.