### PR TITLE
FIX: Anon pageview session id reused across cached responses

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,6 +71,12 @@ module ApplicationHelper
     ContentSecurityPolicy.nonce_placeholder(response.headers)
   end
 
+  def track_view_session_id_placeholder
+    response.headers[
+      ::Middleware::TrackViewSessionIdInjector::PLACEHOLDER_HEADER
+    ] ||= "[[track_view_session_id_placeholder_#{SecureRandom.hex}]]"
+  end
+
   def shared_session_key
     if SiteSetting.long_polling_base_url != "/" && current_user
       sk = "shared_session_key"
@@ -434,7 +440,10 @@ module ApplicationHelper
     end
 
     tags = +""
-    tags << tag.meta(name: "discourse-track-view-session-id", content: SecureRandom.base64(32))
+    tags << tag.meta(
+      name: "discourse-track-view-session-id",
+      content: track_view_session_id_placeholder,
+    )
     if SiteSetting.use_beacon_for_browser_page_views
       tags << tag.meta(name: "discourse-beacon-pageview-enabled", content: "true")
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -167,6 +167,9 @@ module Discourse
     require "middleware/csp_script_nonce_injector"
     config.middleware.insert_after(ActionDispatch::Flash, Middleware::CspScriptNonceInjector)
 
+    require "middleware/track_view_session_id_injector"
+    config.middleware.insert_after(ActionDispatch::Flash, Middleware::TrackViewSessionIdInjector)
+
     require "middleware/discourse_public_exceptions"
     config.exceptions_app = Middleware::DiscoursePublicExceptions.new(Rails.public_path)
 

--- a/lib/middleware/track_view_session_id_injector.rb
+++ b/lib/middleware/track_view_session_id_injector.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Middleware
+  class TrackViewSessionIdInjector
+    PLACEHOLDER_HEADER = "Discourse-Track-View-Session-Id-Placeholder"
+
+    def initialize(app, settings = {})
+      @app = app
+    end
+
+    def call(env)
+      status, headers, response = @app.call(env)
+
+      if placeholder = headers.delete(PLACEHOLDER_HEADER)
+        session_id = SecureRandom.alphanumeric(Middleware::RequestTracker::MAX_SESSION_ID_LENGTH)
+        parts = []
+        response.each { |part| parts << part.to_s.sub(placeholder, session_id) }
+        [status, headers, parts]
+      else
+        [status, headers, response]
+      end
+    end
+  end
+end

--- a/spec/integrity/middleware_order_spec.rb
+++ b/spec/integrity/middleware_order_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Middleware order" do
       Discourse::Cors,
       ActionDispatch::Flash,
       RspecErrorTracker,
+      Middleware::TrackViewSessionIdInjector,
       Middleware::CspScriptNonceInjector,
       Middleware::AnonymousCache,
       ContentSecurityPolicy::Middleware,

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1109,6 +1109,47 @@ RSpec.describe ApplicationController do
     end
   end
 
+  describe "browser pageview tracking session id" do
+    it "doesn't reuse session ids between requests served from the anon cache" do
+      global_setting :anon_cache_store_threshold, 1
+      Middleware::AnonymousCache.enable_anon_cache
+      Middleware::AnonymousCache.clear_all_cache!
+
+      SiteSetting.trigger_browser_pageview_events = true
+
+      get "/latest"
+
+      expect(response.headers["X-Discourse-Cached"]).to eq("store")
+      expect(response.headers).not_to include(
+        Middleware::TrackViewSessionIdInjector::PLACEHOLDER_HEADER,
+      )
+
+      session_id_format = /\A[A-Za-z0-9]{#{Middleware::RequestTracker::MAX_SESSION_ID_LENGTH}}\z/
+
+      first_session_id = extract_session_id_from_body(response.body)
+      expect(first_session_id).to match(session_id_format)
+
+      get "/latest"
+
+      expect(response.headers["X-Discourse-Cached"]).to eq("true")
+      expect(response.headers).not_to include(
+        Middleware::TrackViewSessionIdInjector::PLACEHOLDER_HEADER,
+      )
+
+      second_session_id = extract_session_id_from_body(response.body)
+      expect(second_session_id).to match(session_id_format)
+
+      expect(first_session_id).not_to eq(second_session_id)
+    end
+
+    def extract_session_id_from_body(body)
+      meta_tag =
+        Nokogiri::HTML5.fragment(body).css("meta[name='discourse-track-view-session-id']").first
+      expect(meta_tag).to be_present
+      meta_tag["content"]
+    end
+  end
+
   it "can respond to a request with */* accept header" do
     get "/", headers: { HTTP_ACCEPT: "*/*" }
     expect(response.status).to eq(200)

--- a/spec/system/page_objects/pages/pageview_tracking.rb
+++ b/spec/system/page_objects/pages/pageview_tracking.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class PageviewTracking < PageObjects::Pages::Base
+      def session_id
+        find("meta[name='discourse-track-view-session-id']", visible: :all)[:content]
+      end
+    end
+  end
+end

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -15,6 +15,8 @@ describe "Request tracking" do
     CachedCounting.disable
   end
 
+  let(:pageview_tracking) { PageObjects::Pages::PageviewTracking.new }
+
   describe "pageviews" do
     it "tracks an anonymous visit correctly" do
       events =
@@ -44,7 +46,7 @@ describe "Request tracking" do
       expect(event[:url]).to eq("#{Discourse.base_url_no_prefix}/")
       expect(event[:ip_address]).to eq("::1")
       expect(event[:referrer]).to be_blank
-      expect(event[:session_id]).to be_present
+      expect(event[:session_id]).to eq(pageview_tracking.session_id)
 
       events =
         DiscourseEvent.track_events(:browser_pageview) do


### PR DESCRIPTION
The `discourse-track-view-session-id` meta tag is generated inline when HTML is rendered, so when `Middleware::AnonymousCache` serves a cached response every anonymous visitor receives the same session id baked into the cached body. Browser pageview analytics that rely on this value to distinguish visitors collapse all cache-served visits into a single session.

This commit introduces `Middleware::TrackViewSessionIdInjector`, a Rack middleware that performs a late-stage substitution on the outbound response body. The `ApplicationHelper#discourse_pageview_tracking_meta_tags` helper now emits a placeholder string into the meta tag and registers it on a response header. The middleware reads that header, deletes it, and replaces the placeholder in the body with a fresh `SecureRandom.alphanumeric(Middleware::RequestTracker::MAX_SESSION_ID_LENGTH)` per request, so each visitor gets a unique session id even when the underlying HTML came from cache.