### PR TITLE
FIX: AI: AWS Bedrock Converse image uploads were doubly base64-encoded

### DIFF
--- a/plugins/discourse-ai/lib/completions/dialects/converse.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/converse.rb
@@ -137,7 +137,11 @@ module DiscourseAi
             image: {
               format: details[:format] || detect_format(details[:mime_type]),
               source: {
-                bytes: details[:base64],
+                # AWS SDK for Ruby expects raw bytes here and will base64-encode them
+                # on the wire. Passing the already-base64-encoded string causes Bedrock
+                # to receive doubly-encoded data and respond with
+                # "Could not process image".
+                bytes: Base64.decode64(details[:base64]),
               },
             },
           }

--- a/plugins/discourse-ai/lib/completions/endpoints/aws_bedrock_converse.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/aws_bedrock_converse.rb
@@ -82,7 +82,15 @@ module DiscourseAi
           log = nil
 
           sdk_params = build_converse_params(prompt, model_params, dialect)
-          request_body = sdk_params.to_json
+          # Image bytes in sdk_params are raw binary (ASCII-8BIT) and cannot be
+          # encoded as UTF-8 JSON for logging. Fall back to a placeholder so the
+          # request can still proceed when binary payloads are present.
+          request_body =
+            begin
+              sdk_params.to_json
+            rescue EncodingError
+              "[converse params contained binary payload, omitted from log]"
+            end
 
           log =
             start_log(

--- a/plugins/discourse-ai/lib/completions/endpoints/aws_bedrock_converse.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/aws_bedrock_converse.rb
@@ -88,7 +88,7 @@ module DiscourseAi
           request_body =
             begin
               sdk_params.to_json
-            rescue EncodingError
+            rescue EncodingError, JSON::GeneratorError
               "[converse params contained binary payload, omitted from log]"
             end
 

--- a/plugins/discourse-ai/spec/lib/completions/dialects/converse_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/dialects/converse_spec.rb
@@ -59,5 +59,30 @@ RSpec.describe DiscourseAi::Completions::Dialects::Converse do
       expect(user_message[:content]).not_to include(hash_including(image: anything))
       expect(user_message[:content]).not_to include(hash_including(document: anything))
     end
+
+    it "passes raw bytes for image uploads, not the base64-encoded string" do
+      model.update!(vision_enabled: true)
+      raw_bytes = "\x89PNG\r\n\x1a\nbinary".b
+      prompt =
+        DiscourseAi::Completions::Prompt.new(
+          nil,
+          messages: [{ type: :user, content: ["Describe: ", { upload_id: 456 }] }],
+        )
+
+      allow(DiscourseAi::Completions::UploadEncoder).to receive(:encode).and_return(
+        [{ kind: :image, mime_type: "image/png", base64: Base64.strict_encode64(raw_bytes) }],
+      )
+
+      translated = described_class.new(prompt, model).translate
+      user_message = translated.messages.find { |msg| msg[:role] == "user" }
+      image_block = user_message[:content].find { |c| c[:image] }
+
+      expect(image_block).to be_present
+      expect(image_block.dig(:image, :format)).to eq("png")
+      # AWS SDK for Ruby expects raw bytes; it will base64-encode on the wire.
+      # Passing the base64 string would cause double-encoding and Bedrock would
+      # return "Could not process image".
+      expect(image_block.dig(:image, :source, :bytes)).to eq(raw_bytes)
+    end
   end
 end

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/aws_bedrock_converse_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/aws_bedrock_converse_spec.rb
@@ -181,6 +181,33 @@ RSpec.describe DiscourseAi::Completions::Endpoints::AwsBedrockConverse do
         expect(params[:system]).to be_present
       end
     end
+
+    it "logs a placeholder when image bytes are binary" do
+      model.update!(vision_enabled: true)
+      raw_bytes = "\x89PNG\r\n\x1a\nbinary".b
+      response = mock_converse_response
+      client = stub_sdk_client(response: response)
+      prompt =
+        DiscourseAi::Completions::Prompt.new(
+          nil,
+          messages: [{ type: :user, content: ["Describe: ", { upload_id: 456 }] }],
+        )
+
+      allow(DiscourseAi::Completions::UploadEncoder).to receive(:encode).and_return(
+        [{ kind: :image, mime_type: "image/png", base64: Base64.strict_encode64(raw_bytes) }],
+      )
+
+      llm = DiscourseAi::Completions::Llm.proxy("custom:#{model.id}")
+      result = llm.generate(prompt, user: user)
+
+      expect(result).to eq("Hello world")
+      expect(AiApiAuditLog.last.raw_request_payload).to eq(
+        "[converse params contained binary payload, omitted from log]",
+      )
+      expect(client).to have_received(:converse) do |params|
+        expect(params.dig(:messages, 0, :content, 1, :image, :source, :bytes)).to eq(raw_bytes)
+      end
+    end
   end
 
   describe "streaming completion" do


### PR DESCRIPTION
## Summary

Image uploads delivered through the `aws_bedrock_converse` LLM provider were rejected by Bedrock with `Could not process image` whenever an agent / LLM had `vision_enabled` set to true.

Two related bugs are fixed:

### 1. `Dialects::Converse#upload_node` — base64 string passed where raw bytes expected

In `plugins/discourse-ai/lib/completions/dialects/converse.rb`, image content was emitted as:

```ruby
source: { bytes: details[:base64] }
```

`details[:base64]` is the upload's base64-encoded string (as produced by `UploadEncoder`), but `Aws::BedrockRuntime::Client#converse` expects **raw bytes** on the `:bytes` key — the SDK then base64-encodes them on the wire. Passing the already-base64-encoded string causes Bedrock to receive **doubly-encoded** data, which it cannot decode into a valid image. Decoding back to raw bytes via `Base64.decode64(details[:base64])` resolves the round-trip.

### 2. `AwsBedrockConverse#perform_completion!` — JSON-logging fails on binary payloads

With raw bytes now flowing through `sdk_params`, the subsequent `sdk_params.to_json` call (used to record the request in `start_log`) raises `EncodingError` because PNG/JPEG bytes are not valid UTF-8. The call is wrapped in `begin / rescue EncodingError` so the request can still proceed; a placeholder string is recorded in the audit log instead of the binary payload.

## Test plan

- A new spec case in `plugins/discourse-ai/spec/lib/completions/dialects/converse_spec.rb` asserts that `details[:base64]` is decoded back to raw bytes before being emitted as `source: { bytes: ... }`. This guards against regression.
- Verified end-to-end against `us.anthropic.claude-sonnet-4-6` via Bedrock Converse on `ap-northeast-1` → `us-east-1` cross-region inference profile: with this patch the model correctly describes uploaded PNG attachments (a Loupe Browser version warning dialog) instead of returning `Could not process image`.

## Reproduction (before the fix)

1. Configure an `aws_bedrock_converse` LLM in Discourse and assign it to an `AiAgent` with `vision_enabled: true`.
2. Wire up `llm_triage` (or any path that goes through `Dialects::Converse#upload_node`) to reply to a topic that contains an image upload.
3. Observe: `DiscourseAi::Completions::Endpoints::Base::CompletionFailed: The model returned the following errors: Could not process image`

## Discovered while

Standing up a Discourse instance with Bedrock-backed AI as part of an internal forum spike. Happy to iterate on the patch (e.g. tighten the log fallback or extract a helper) if reviewers prefer a different shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)