### PR TITLE
FIX: Reject cross-origin requests to anon pageview beacon

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -349,8 +349,17 @@ class Middleware::RequestTracker
 
     env["discourse.request_tracker"] = self
 
-    if self.class.is_beacon_tracking_request?(request) ||
-         self.class.is_pageview_tracking_request?(request)
+    if self.class.is_beacon_tracking_request?(request)
+      if self.class.same_origin_beacon_request?(request)
+        result = [204, {}, []]
+      else
+        env["discourse.request_tracker.skip"] = true
+        result = [403, {}, []]
+      end
+      return result
+    end
+
+    if self.class.is_pageview_tracking_request?(request)
       result = [204, {}, []]
       return result
     end
@@ -646,6 +655,19 @@ class Middleware::RequestTracker
   def self.is_beacon_tracking_request?(request)
     SiteSetting.use_beacon_for_browser_page_views && request.post? &&
       request.path == Discourse.beacon_pv_tracking_path
+  end
+
+  def self.same_origin_beacon_request?(request)
+    origin = request.get_header("HTTP_ORIGIN").presence || request.referer.presence
+    return false if origin.blank?
+
+    canonical_uri = URI.parse(Discourse.base_url_no_prefix)
+    origin_uri = URI.parse(origin)
+
+    canonical_uri.scheme == origin_uri.scheme && canonical_uri.host == origin_uri.host &&
+      canonical_uri.port == origin_uri.port
+  rescue URI::Error
+    false
   end
 
   def self.is_pageview_tracking_request?(request)

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -900,12 +900,15 @@ RSpec.describe Middleware::RequestTracker do
       env(
         {
           :path => "/srv/pv",
+          "HTTP_HOST" => "test.localhost",
           "REQUEST_METHOD" => "POST",
           "CONTENT_TYPE" => "application/json",
           "rack.input" => StringIO.new(json_body),
         }.merge(extra),
       )
     end
+
+    let(:same_origin) { { "HTTP_ORIGIN" => "http://test.localhost" } }
 
     it "returns 204 and does not call the app" do
       app_called = false
@@ -916,7 +919,7 @@ RSpec.describe Middleware::RequestTracker do
             [200, {}, ["OK"]]
           end,
         )
-      status, = middleware.call(beacon_env({}))
+      status, = middleware.call(beacon_env({}, same_origin))
 
       expect(status).to eq(204)
       expect(app_called).to eq(false)
@@ -925,7 +928,7 @@ RSpec.describe Middleware::RequestTracker do
     it "returns 204 for beacon requests in a subfolder setup" do
       set_subfolder "/forum"
       middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
-      status, = middleware.call(beacon_env({}, { path: "/forum/srv/pv" }))
+      status, = middleware.call(beacon_env({}, same_origin.merge(path: "/forum/srv/pv")))
 
       expect(status).to eq(204)
     end
@@ -936,6 +939,8 @@ RSpec.describe Middleware::RequestTracker do
         middleware.call(
           env(
             :path => "/srv/pv",
+            "HTTP_HOST" => "test.localhost",
+            "HTTP_ORIGIN" => "http://test.localhost",
             "REQUEST_METHOD" => "POST",
             "CONTENT_TYPE" => "application/json",
             "rack.input" => StringIO.new("not json"),
@@ -960,6 +965,7 @@ RSpec.describe Middleware::RequestTracker do
                 session_id: "abc123",
                 topic_id: 123,
               },
+              same_origin,
             ),
           )
         end
@@ -995,7 +1001,7 @@ RSpec.describe Middleware::RequestTracker do
     it "skips beacon page view when the remote IP resolves to a crawler ASN" do
       DiscourseIpInfo.stubs(:get).returns({ asn: SiteSetting.crawler_asns_map.first.to_i })
       middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
-      middleware.call(beacon_env({}, { "action_dispatch.remote_ip" => "1.2.3.4" }))
+      middleware.call(beacon_env({}, same_origin.merge("action_dispatch.remote_ip" => "1.2.3.4")))
       CachedCounting.flush
 
       expect(ApplicationRequest.page_view_anon_browser_beacon.first).to be_nil
@@ -1004,10 +1010,49 @@ RSpec.describe Middleware::RequestTracker do
     it "counts beacon page view when the remote IP is not a crawler ASN" do
       DiscourseIpInfo.stubs(:get).returns({ asn: 1 })
       middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
-      middleware.call(beacon_env({}, { "action_dispatch.remote_ip" => "1.2.3.4" }))
+      middleware.call(beacon_env({}, same_origin.merge("action_dispatch.remote_ip" => "1.2.3.4")))
       CachedCounting.flush
 
       expect(ApplicationRequest.page_view_anon_browser_beacon.first.count).to eq(1)
+    end
+
+    it "returns 403 for cross-origin beacon requests" do
+      middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
+      status, = middleware.call(beacon_env({}, { "HTTP_ORIGIN" => "https://evil.example" }))
+      CachedCounting.flush
+
+      expect(status).to eq(403)
+      expect(ApplicationRequest.page_view_anon_browser_beacon.first).to be_nil
+    end
+
+    it "returns 403 when Origin and Referer are both absent" do
+      middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
+      status, = middleware.call(beacon_env({}))
+      CachedCounting.flush
+
+      expect(status).to eq(403)
+      expect(ApplicationRequest.page_view_anon_browser_beacon.first).to be_nil
+    end
+
+    it "returns 403 when Origin matches the request Host but differs from the canonical hostname" do
+      SiteSetting.force_hostname = "canonical.example"
+      middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
+      status, =
+        middleware.call(
+          beacon_env({}, { "HTTP_HOST" => "evil.example", "HTTP_ORIGIN" => "http://evil.example" }),
+        )
+      CachedCounting.flush
+
+      expect(status).to eq(403)
+      expect(ApplicationRequest.page_view_anon_browser_beacon.first).to be_nil
+    end
+
+    it "accepts beacon when Origin is absent but Referer is same-origin" do
+      middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
+      status, =
+        middleware.call(beacon_env({}, { "HTTP_REFERER" => "http://test.localhost/some/page" }))
+
+      expect(status).to eq(204)
     end
 
     context "when SiteSetting.use_beacon_for_browser_page_views is false" do


### PR DESCRIPTION
The `/srv/pv` beacon endpoint short-circuits to 204 for any POST regardless of where the request originated, so a browser visiting an unrelated site can inflate the `page_view_anon_browser_beacon` counter by POSTing to a Discourse instance.

This commit gates the beacon branch in `Middleware::RequestTracker#call` on a same-origin check that compares the request's scheme, host, and port against the `Origin` header (falling back to `Referer`). Mismatched or missing origins return 403 and are excluded from counter logging via `discourse.request_tracker.skip`. 

Note this only blocks browser-driven cross-site abuse, since both headers are trivially forged outside a browser context.