### PR TITLE
FIX: Use hyphens instead of underscores for hreflang tags

### DIFF
--- a/app/views/common/_hreflang_tags.html.erb
+++ b/app/views/common/_hreflang_tags.html.erb
@@ -5,7 +5,7 @@
     <% canonical_url = "#{Discourse.base_url}#{current_path}" %>
     <link rel="alternate" href="<%= canonical_url %>" hreflang="x-default" />
     <% locales.each do |locale| %>
-      <link rel="alternate" href="<%= canonical_url %>?<%= Discourse::LOCALE_PARAM %>=<%= locale %>" hreflang="<%= locale %>" />
+      <link rel="alternate" href="<%= canonical_url %>?<%= Discourse::LOCALE_PARAM %>=<%= locale %>" hreflang="<%= locale.tr('_', '-') %>" />
     <% end %>
   <% end %>
 <% end %>

--- a/spec/requests/crawler_hreflang_spec.rb
+++ b/spec/requests/crawler_hreflang_spec.rb
@@ -25,6 +25,23 @@ describe "Crawler hreflang tags" do
       expect(response.body).to include("?#{Discourse::LOCALE_PARAM}=ja")
     end
 
+    it "uses hyphens instead of underscores in hreflang attribute for region-qualified locales" do
+      SiteSetting.content_localization_supported_locales = "en|pt_BR|zh_CN"
+
+      get "/t/#{post.topic.slug}/#{post.topic.id}",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      expect(response.body).to include('hreflang="pt-BR"')
+      expect(response.body).to include('hreflang="zh-CN"')
+      expect(response.body).not_to include('hreflang="pt_BR"')
+      expect(response.body).not_to include('hreflang="zh_CN"')
+
+      expect(response.body).to include("?#{Discourse::LOCALE_PARAM}=pt_BR")
+      expect(response.body).to include("?#{Discourse::LOCALE_PARAM}=zh_CN")
+    end
+
     it "doesn't include hreflang tags for normal users" do
       get "/t/#{post.topic.slug}/#{post.topic.id}"
 


### PR DESCRIPTION
## Problem
The AI localization feature currently generates `hreflang` tags using underscores (e.g., `pt_BR`). According to ISO 639-1 and SEO standards, search engines like Google expect hyphens (e.g., `pt-BR`). This causes validation errors in tools like PageSpeed Insights and Google Search Console ("Unexpected language code").

## Solution
This PR applies `.tr('_', '-')` to the `locale` string within the `hreflang` attribute. This ensures that:
1. The `href` URL remains functional (still using the internal underscore format for the parameter).
2. The `hreflang` metadata becomes SEO-compliant by using the hyphen format.

## Validation
Confirmed that this change transforms codes like `pt_BR` into `pt-BR` in the rendered HTML header, resolving the "Unexpected language code" error.