### PR TITLE
FIX: Allow push notification subscriptions on first launch of iOS PWA

### DIFF
--- a/app/views/static/service-worker.js.erb
+++ b/app/views/static/service-worker.js.erb
@@ -1,5 +1,13 @@
 'use strict';
 
+self.addEventListener('install', function() {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function(event) {
+  event.waitUntil(self.clients.claim());
+});
+
 // Plugins (and core features) can register handlers for notification action
 // buttons by calling self.registerNotificationActionHandler(action, handler).
 //

--- a/app/views/static/service-worker.js.erb
+++ b/app/views/static/service-worker.js.erb
@@ -1,9 +1,5 @@
 'use strict';
 
-self.addEventListener('install', function() {
-  self.skipWaiting();
-});
-
 self.addEventListener('activate', function(event) {
   event.waitUntil(self.clients.claim());
 });

--- a/frontend/discourse/app/lib/push-notifications.js
+++ b/frontend/discourse/app/lib/push-notifications.js
@@ -18,24 +18,24 @@ function sendSubscriptionToServer(subscription, sendConfirmation) {
   });
 }
 
-export function isPushNotificationsSupported() {
-  let caps = helperContext().capabilities;
-  if (
-    !(
-      "serviceWorker" in navigator &&
-      typeof ServiceWorkerRegistration !== "undefined" &&
-      typeof Notification !== "undefined" &&
-      "showNotification" in ServiceWorkerRegistration.prototype &&
-      "PushManager" in window &&
-      !caps.isAppWebview &&
-      navigator.serviceWorker.controller &&
-      navigator.serviceWorker.controller.state === "activated"
-    )
-  ) {
-    return false;
-  }
+export function canSubscribeToPushNotifications() {
+  const caps = helperContext().capabilities;
+  return (
+    "serviceWorker" in navigator &&
+    typeof ServiceWorkerRegistration !== "undefined" &&
+    typeof Notification !== "undefined" &&
+    "showNotification" in ServiceWorkerRegistration.prototype &&
+    "PushManager" in window &&
+    !caps.isAppWebview
+  );
+}
 
-  return true;
+export function isPushNotificationsSupported() {
+  return (
+    canSubscribeToPushNotifications() &&
+    navigator.serviceWorker.controller !== null &&
+    navigator.serviceWorker.controller.state === "activated"
+  );
 }
 
 export function isPushNotificationsEnabled(user) {
@@ -80,7 +80,7 @@ export function register(user, router, appEvents) {
 }
 
 export function subscribe(callback, applicationServerKey) {
-  if (!isPushNotificationsSupported()) {
+  if (!canSubscribeToPushNotifications()) {
     return;
   }
 

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -8,7 +8,7 @@ import {
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import KeyValueStore from "discourse/lib/key-value-store";
 import {
-  isPushNotificationsSupported,
+  canSubscribeToPushNotifications,
   keyValueStore as pushNotificationKeyValueStore,
   subscribe as subscribePushNotification,
   unsubscribe as unsubscribePushNotification,
@@ -84,7 +84,7 @@ export default class DesktopNotificationsService extends Service {
     return (
       (this.site.mobileView ||
         this.siteSettings.enable_desktop_push_notifications) &&
-      isPushNotificationsSupported()
+      canSubscribeToPushNotifications()
     );
   }
 

--- a/frontend/discourse/tests/unit/lib/push-notifications-test.js
+++ b/frontend/discourse/tests/unit/lib/push-notifications-test.js
@@ -1,0 +1,90 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import {
+  canSubscribeToPushNotifications,
+  isPushNotificationsSupported,
+  subscribe,
+} from "discourse/lib/push-notifications";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+
+module("Unit | Utility | push-notifications", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.capabilities = getOwner(this).lookup("service:capabilities");
+  });
+
+  test("canSubscribeToPushNotifications returns true when all required browser APIs are present", function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => false);
+
+    assert.true(canSubscribeToPushNotifications());
+  });
+
+  test("canSubscribeToPushNotifications returns false when inside an app webview", function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => true);
+
+    assert.false(canSubscribeToPushNotifications());
+  });
+
+  test("canSubscribeToPushNotifications does not require an active service worker controller", function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => false);
+    sinon.stub(navigator.serviceWorker, "controller").get(() => null);
+
+    assert.true(canSubscribeToPushNotifications());
+  });
+
+  test("isPushNotificationsSupported returns false when no service worker is controlling the page", function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => false);
+    sinon.stub(navigator.serviceWorker, "controller").get(() => null);
+
+    assert.false(isPushNotificationsSupported());
+  });
+
+  test("isPushNotificationsSupported returns false when controller is not yet activated", function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => false);
+    sinon
+      .stub(navigator.serviceWorker, "controller")
+      .get(() => ({ state: "activating" }));
+
+    assert.false(isPushNotificationsSupported());
+  });
+
+  test("isPushNotificationsSupported returns true when an activated controller is present", function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => false);
+    sinon
+      .stub(navigator.serviceWorker, "controller")
+      .get(() => ({ state: "activated" }));
+
+    assert.true(isPushNotificationsSupported());
+  });
+
+  test("subscribe proceeds even when the service worker does not control the page yet", async function (assert) {
+    sinon.stub(this.capabilities, "isAppWebview").get(() => false);
+    sinon.stub(navigator.serviceWorker, "controller").get(() => null);
+
+    const fakeSubscription = {
+      toJSON: () => ({ endpoint: "https://example.com/push" }),
+    };
+    const fakeRegistration = {
+      pushManager: {
+        subscribe: sinon.stub().resolves(fakeSubscription),
+      },
+    };
+    sinon
+      .stub(navigator.serviceWorker, "ready")
+      .get(() => Promise.resolve(fakeRegistration));
+
+    pretender.post("/push_notifications/subscribe", () => response({}));
+
+    const callback = sinon.stub();
+    await subscribe(callback, "1|2|3");
+
+    assert.true(
+      fakeRegistration.pushManager.subscribe.calledOnce,
+      "pushManager.subscribe was called despite no controller"
+    );
+    assert.true(callback.calledOnce, "success callback was invoked");
+  });
+});

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -578,9 +578,8 @@ RSpec.describe StaticController do
       expect(response.body).to include("addEventListener")
     end
 
-    it "includes skipWaiting and clients.claim to take immediate control of all clients" do
+    it "includes clients.claim to take immediate control of all clients" do
       get "/service-worker.js"
-      expect(response.body).to include("skipWaiting")
       expect(response.body).to include("clients.claim")
     end
   end

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -577,6 +577,12 @@ RSpec.describe StaticController do
       expect(response.content_type).to start_with("text/javascript")
       expect(response.body).to include("addEventListener")
     end
+
+    it "includes skipWaiting and clients.claim to take immediate control of all clients" do
+      get "/service-worker.js"
+      expect(response.body).to include("skipWaiting")
+      expect(response.body).to include("clients.claim")
+    end
   end
 
   describe "#llms_txt" do


### PR DESCRIPTION
This fixes a problem with the user flow to enable push notifications on
the iOS PWA, as describedn in this thread in meta.discourse:
https://meta.discourse.org/t/push-notification-subscription-in-ios-pwa-silently-failing-because-of-sw-not-controlling-the-app/402645

It splits the check for whether push notifications are enabled into two
parts. One can then be reused to check whether push notification
subscriptions are possible. For this check, the service worker does not
need to control the page yet.

Doing so, the subscription should go through to the server now.

However, what is still failing, would be receiving a push notification
and tabbing on it. Without the service worker controlling the page, the
in-app navigation is not yet possible.

I could also fix this as part of this PR if desired.
