### PR TITLE
UX: replace hardcoded toggle switch position value with responsive param

### DIFF
--- a/app/assets/stylesheets/common/components/d-toggle-switch.scss
+++ b/app/assets/stylesheets/common/components/d-toggle-switch.scss
@@ -56,7 +56,9 @@
   }
 
   &__checkbox[aria-checked="true"] + .d-toggle-switch__checkbox-slider::before {
-    left: calc(var(--toggle-switch-width) - 22px);
+    left: calc(
+      var(--toggle-switch-width) - var(--toggle-switch-height) * 0.875
+    );
   }
 
   &__checkbox[disabled] + .d-toggle-switch__checkbox-slider {


### PR DESCRIPTION
  Previously, the "on" position of the toggle switch knob was hardcoded to `calc(var(--toggle-switch-width) - 22px)`,   
  which only looked right at the default 24px height and broke whenever a we would override `--toggle-switch-height`.   
                                                                                                                        
  This change derives the offset from the height itself (`var(--toggle-switch-height) * 0.875`), matching the knob's own
   height-based sizing so the resting position stays symmetrical at any size.    

Comically large example:

| BC | AC |
|--------|--------|
| <img width="576" height="298" alt="CleanShot 2026-05-11 at 15 48 55@2x" src="https://github.com/user-attachments/assets/19ea259e-96d3-4423-a470-fabf91a6eed5" /> | <img width="648" height="280" alt="CleanShot 2026-05-11 at 15 43 43@2x" src="https://github.com/user-attachments/assets/dec084bd-0a14-472a-8520-aa07594d2bf2" /> | 