### PR TITLE
DEV: add transformer to change new topic draft menu classes

### DIFF
--- a/frontend/discourse/app/components/create-topic-button.gjs
+++ b/frontend/discourse/app/components/create-topic-button.gjs
@@ -19,16 +19,20 @@ export default class CreateTopicButton extends Component {
     return this.args.btnTypeClass || "btn-default";
   }
 
+  get transformerContext() {
+    return {
+      disabled: this.args.disabled,
+      canCreateTopic: this.args.canCreateTopic,
+      category: this.router.currentRoute?.attributes?.category,
+      tag: this.router.currentRoute?.attributes?.tag,
+    };
+  }
+
   get btnClasses() {
     const additionalClasses = applyValueTransformer(
       "create-topic-button-class",
       [],
-      {
-        disabled: this.args.disabled,
-        canCreateTopic: this.args.canCreateTopic,
-        category: this.router.currentRoute?.attributes?.category,
-        tag: this.router.currentRoute?.attributes?.tag,
-      }
+      this.transformerContext
     );
 
     return concatClass(
@@ -38,6 +42,16 @@ export default class CreateTopicButton extends Component {
     );
   }
 
+  get draftMenuClasses() {
+    const additionalClasses = applyValueTransformer(
+      "create-topic-button-draft-menu-class",
+      [],
+      this.transformerContext
+    );
+
+    return concatClass(this.btnTypeClass, ...additionalClasses);
+  }
+
   <template>
     {{#if @canCreateTopic}}
       <TopicDraftsDropdown
@@ -45,7 +59,7 @@ export default class CreateTopicButton extends Component {
         @label={{this.label}}
         @btnId={{this.btnId}}
         @btnClasses={{this.btnClasses}}
-        @btnTypeClass={{this.btnTypeClass}}
+        @draftMenuClasses={{this.draftMenuClasses}}
         @showDrafts={{@showDrafts}}
         ...attributes
       />

--- a/frontend/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/frontend/discourse/app/components/topic-drafts-dropdown.gjs
@@ -121,7 +121,7 @@ export default class TopicDraftsDropdown extends Component {
           @onRegisterApi={{this.onRegisterApi}}
           @modalForMobile={{true}}
           aria-label={{i18n "drafts.dropdown.title"}}
-          class={{@btnTypeClass}}
+          class={{@draftMenuClasses}}
         >
           <DropdownMenu as |dropdown|>
             {{#each this.drafts as |draft|}}

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -52,6 +52,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "composer-service-cannot-submit-post",
   "composer-toggles-class",
   "create-topic-button-class",
+  "create-topic-button-draft-menu-class",
   "create-topic-label",
   "flag-button-disabled-state",
   "flag-button-dynamic-class",


### PR DESCRIPTION
This adds a new transformer `create-topic-button-draft-menu-class`, similar to `create-topic-button-class` that applies custom classes to the create topic draft dropdown button. 