### PR TITLE
FIX: rescue OpenSSL::PKey::RSAError in UserApiKeysController

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -245,6 +245,8 @@ class UserApiKeysController < ApplicationController
 
   def parsed_public_key
     @parsed_public_key ||= OpenSSL::PKey::RSA.new(public_key_str)
+  rescue OpenSSL::PKey::RSAError
+    raise Discourse::InvalidParameters.new(:public_key)
   end
 
   def meets_tl?

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe UserApiKeysController do
       expect(response.headers["Auth-Api-Version"]).to eq("4")
     end
 
+    it "rejects a non-RSA public key with 400 even when not logged in" do
+      SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect]
+      ec_key = OpenSSL::PKey::EC.generate("prime256v1")
+      get "/user-api-key/new", params: args.merge(public_key: ec_key.to_pem)
+      expect(response.status).to eq(400)
+    end
+
     describe "as a normal user" do
       fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
 
@@ -58,6 +65,12 @@ RSpec.describe UserApiKeysController do
 
       it "rejects invalid padding parameter" do
         get "/user-api-key/new", params: args.merge(padding: "invalid")
+        expect(response.status).to eq(400)
+      end
+
+      it "rejects a non-RSA public key with 400" do
+        ec_key = OpenSSL::PKey::EC.generate("prime256v1")
+        get "/user-api-key/new", params: args.merge(public_key: ec_key.to_pem)
         expect(response.status).to eq(400)
       end
 
@@ -356,6 +369,13 @@ RSpec.describe UserApiKeysController do
       sign_in(Fabricate(:user, refresh_auto_groups: true))
 
       get "/user-api-key/otp", params: otp_args.merge(padding: "invalid")
+      expect(response.status).to eq(400)
+    end
+
+    it "rejects a non-RSA public key with 400" do
+      SiteSetting.allowed_user_api_auth_redirects = otp_args[:auth_redirect]
+      ec_key = OpenSSL::PKey::EC.generate("prime256v1")
+      get "/user-api-key/otp", params: otp_args.merge(public_key: ec_key.to_pem)
       expect(response.status).to eq(400)
     end
   end


### PR DESCRIPTION
Passing a non-RSA public key (e.g. an EC key PEM) to GET /user-api-key/new or GET /user-api-key/otp raised an unhandled OpenSSL::PKey::RSAError, resulting in a 500 response. Both endpoints skip login requirements, so any unauthenticated request with a malformed key could trigger this. Now raises Discourse::InvalidParameters instead, returning a clean 400.

ApplicationController already rescues this error for the user_api_public_key param path; this brings UserApiKeysController in line with that behavior.