### PR TITLE
FEATURE: Better RSVPs on recurring events

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3823,7 +3823,8 @@ CREATE TABLE public.discourse_post_event_invitees (
     status integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    notified boolean DEFAULT false NOT NULL
+    notified boolean DEFAULT false NOT NULL,
+    recurring boolean DEFAULT false NOT NULL
 );
 
 
@@ -20867,6 +20868,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260513055222'),
 ('20260513024004'),
 ('20260512061336'),
+('20260511145109'),
 ('20260511044542'),
 ('20260510232238'),
 ('20260507083943'),

--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -60,6 +60,7 @@ module DiscoursePostEvent
       DiscoursePostEvent::UpdateInvitee.call(
         params: {
           status: params.dig(:invitee, :status),
+          recurring: params.dig(:invitee, :recurring) || false,
           event_id: params[:event_id],
           invitee_id: params[:invitee_id],
         },
@@ -86,6 +87,7 @@ module DiscoursePostEvent
       DiscoursePostEvent::CreateInvitee.call(
         params: {
           status: params[:invitee][:status],
+          recurring: params[:invitee][:recurring] || false,
           user_id: params[:invitee][:user_id],
           event_id: params[:event_id],
         },

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -569,7 +569,10 @@ module DiscoursePostEvent
     end
 
     def reset_invitee_notifications
-      invitees.where.not(status: Invitee.statuses[:going]).update_all(status: nil, notified: false)
+      invitees.where(
+        "status != :going OR recurring = FALSE",
+        going: Invitee.statuses[:going],
+      ).update_all(status: nil, notified: false, recurring: false)
     end
 
     def notify_if_new_event

--- a/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
@@ -19,42 +19,49 @@ module DiscoursePostEvent
     end
     scope :with_status, ->(status) { where(status: Invitee.statuses[status]) }
 
+    before_save :clear_recurring_unless_going
     after_commit :sync_chat_channel_members
 
     def self.statuses
       @statuses ||= Enum.new(going: 0, interested: 1, not_going: 2)
     end
 
-    def self.create_attendance!(user_id, post_id, status)
+    def self.create_attendance!(user_id, post_id, status, recurring: false)
+      status = status.to_sym
       event = Event.find(post_id)
-      if status.to_sym == :going && event.at_capacity?
+
+      if status == :going && event.at_capacity?
         raise Discourse::InvalidParameters.new(:max_attendees)
       end
 
-      invitee =
-        Invitee.create!(status: Invitee.statuses[status.to_sym], post_id: post_id, user_id: user_id)
-      invitee.event.publish_update!
-      invitee.update_topic_tracking!
-      DiscourseEvent.trigger(:discourse_calendar_post_event_invitee_status_changed, invitee)
+      invitee = create!(post_id:, user_id:, status: statuses[status], recurring:)
+      invitee.publish_attendance_change!
       invitee
     rescue ActiveRecord::RecordNotUnique
-      # do nothing in case multiple new attendances would be created very fast
-      Invitee.find_by(post_id: post_id, user_id: user_id)
+      # multiple attendances may be created concurrently — return the winning row
+      find_by(post_id:, user_id:)
     end
 
-    def update_attendance!(status)
-      if status && status.to_sym == :going && event.at_capacity? &&
-           self.status != Invitee.statuses[:going]
+    def update_attendance!(status, recurring: false)
+      status = status&.to_sym
+
+      if status == :going && event.at_capacity? && !going?
         raise Discourse::InvalidParameters.new(:max_attendees)
       end
 
-      new_status = Invitee.statuses[status.to_sym]
-      status_changed = self.status != new_status
-      self.update(status: new_status)
-      self.event.publish_update!
-      self.update_topic_tracking! if status_changed
-      DiscourseEvent.trigger(:discourse_calendar_post_event_invitee_status_changed, self)
+      update!(status: self.class.statuses[status], recurring:)
+      publish_attendance_change!
       self
+    end
+
+    def going?
+      status == Invitee.statuses[:going]
+    end
+
+    def publish_attendance_change!
+      event.publish_update!
+      update_topic_tracking!
+      DiscourseEvent.trigger(:discourse_calendar_post_event_invitee_status_changed, self)
     end
 
     def self.extract_uniq_usernames(groups)
@@ -86,6 +93,12 @@ module DiscoursePostEvent
         notification_level: TopicUser.notification_levels[tracking],
       )
     end
+
+    private
+
+    def clear_recurring_unless_going
+      self.recurring = false unless going?
+    end
   end
 end
 
@@ -95,6 +108,7 @@ end
 #
 #  id         :bigint           not null, primary key
 #  notified   :boolean          default(FALSE), not null
+#  recurring  :boolean          default(FALSE), not null
 #  status     :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_stats_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_stats_serializer.rb
@@ -3,6 +3,7 @@
 module DiscoursePostEvent
   class EventStatsSerializer < ApplicationSerializer
     attributes :going
+    attributes :going_recurring
     attributes :interested
     attributes :not_going
     attributes :invited
@@ -20,6 +21,11 @@ module DiscoursePostEvent
 
     def going
       @going ||= counts[Invitee.statuses[:going]] || 0
+    end
+
+    def going_recurring
+      @going_recurring ||=
+        object.invitees.where(status: Invitee.statuses[:going], recurring: true).count
     end
 
     def interested

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/invitee_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/invitee_serializer.rb
@@ -2,7 +2,7 @@
 
 module DiscoursePostEvent
   class InviteeSerializer < ApplicationSerializer
-    attributes :id, :status, :user, :post_id, :meta
+    attributes :id, :status, :recurring, :user, :post_id, :meta
 
     def status
       object.status ? Invitee.statuses[object.status] : nil

--- a/plugins/discourse-calendar/app/services/discourse_post_event/create_invitee.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/create_invitee.rb
@@ -8,6 +8,7 @@ module DiscoursePostEvent
       attribute :event_id, :integer
       attribute :status, :symbol
       attribute :user_id, :integer
+      attribute :recurring, :boolean, default: false
 
       validates :event_id, presence: true
       validates :status, inclusion: { in: Invitee.statuses.keys }
@@ -50,7 +51,7 @@ module DiscoursePostEvent
     end
 
     def create_invitee(user:, event:, params:)
-      Invitee.create_attendance!(user.id, event.id, params.status)
+      Invitee.create_attendance!(user.id, event.id, params.status, recurring: params.recurring)
     end
   end
 end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/update_invitee.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/update_invitee.rb
@@ -8,6 +8,7 @@ module DiscoursePostEvent
       attribute :event_id, :integer
       attribute :invitee_id, :integer
       attribute :status, :symbol
+      attribute :recurring, :boolean, default: false
 
       validates :event_id, presence: true
       validates :invitee_id, presence: true
@@ -50,7 +51,7 @@ module DiscoursePostEvent
     end
 
     def update(invitee:, params:)
-      invitee.update_attendance!(params.status)
+      invitee.update_attendance!(params.status, recurring: params.recurring)
     end
   end
 end

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -126,12 +126,46 @@ export default class DiscoursePostEvent extends Component {
 
     if (this.args.event) {
       try {
-        this.event = await this.discoursePostEventApi.event(this.args.event.id);
-        this.event.startsAt = this.args.event.startsAt;
-        this.event.endsAt = this.args.event.endsAt;
+        const fetched = await this.discoursePostEventApi.event(
+          this.args.event.id
+        );
+        const displayedStartsAt = this.args.event.startsAt;
+
+        if (
+          fetched.recurrence &&
+          displayedStartsAt &&
+          fetched.startsAt &&
+          displayedStartsAt !== fetched.startsAt
+        ) {
+          this.#filterForFutureOccurrence(fetched);
+        }
+
+        fetched.startsAt = displayedStartsAt;
+        fetched.endsAt = this.args.event.endsAt;
+        this.event = fetched;
       } catch (error) {
         popupAjaxError(error);
       }
+    }
+  }
+
+  #filterForFutureOccurrence(event) {
+    event.sampleInvitees = event.sampleInvitees.filter(
+      (invitee) => invitee.status !== "going" || invitee.recurring
+    );
+
+    const recurringCount = event.stats?.goingRecurring ?? 0;
+    if (event.stats) {
+      event.stats.going = recurringCount;
+    }
+    event.atCapacity =
+      event.maxAttendees != null && recurringCount >= event.maxAttendees;
+
+    if (
+      event.watchingInvitee?.status === "going" &&
+      !event.watchingInvitee?.recurring
+    ) {
+      event.watchingInvitee = null;
     }
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/invitee.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/invitee.gjs
@@ -14,7 +14,7 @@ export default class DiscoursePostEventInvitee extends Component {
   get statusIcon() {
     switch (this.args.invitee.status) {
       case "going":
-        return "check";
+        return this.args.invitee.recurring ? "arrows-rotate" : "check";
       case "interested":
         return "star";
       case "not_going":

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/status.gjs
@@ -3,16 +3,64 @@ import { concat, fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import DMenu from "discourse/float-kit/components/d-menu";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { and, eq, not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
+import DComboButton from "discourse/ui-kit/d-combo-button";
+import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import { i18n } from "discourse-i18n";
+
+const GoingDropdown = <template>
+  <DDropdownMenu as |dropdown|>
+    <dropdown.item
+      class={{dConcatClass
+        "going-once"
+        (if @status.isGoingThisEvent "--selected")
+      }}
+    >
+      <DButton
+        class="btn-transparent"
+        @icon="check"
+        @label="discourse_post_event.models.invitee.this_event"
+        @action={{@status.goingThisEvent}}
+      />
+    </dropdown.item>
+    <dropdown.item
+      class={{dConcatClass
+        "going-all"
+        (if @status.isGoingAllFollowing "--selected")
+      }}
+    >
+      <DButton
+        class="btn-transparent"
+        @icon="arrows-rotate"
+        @label="discourse_post_event.models.invitee.this_and_following"
+        @action={{@status.goingAllFollowing}}
+      />
+    </dropdown.item>
+    {{#if @status.isGoing}}
+      <dropdown.divider />
+      <dropdown.item class="going-leave">
+        <DButton
+          class="btn-transparent --danger"
+          @icon="xmark"
+          @label="discourse_post_event.models.invitee.leave_event"
+          @action={{@status.leaveFromGoingMenu}}
+        />
+      </dropdown.item>
+    {{/if}}
+  </DDropdownMenu>
+</template>;
 
 export default class DiscoursePostEventStatus extends Component {
   @service appEvents;
   @service discoursePostEventApi;
+  @service site;
   @service siteSettings;
+
+  goingMenu = null;
 
   get eventButtons() {
     return this.siteSettings.event_participation_buttons.split("|");
@@ -38,6 +86,39 @@ export default class DiscoursePostEventStatus extends Component {
     return this.args.event.watchingInvitee?.status;
   }
 
+  get isGoing() {
+    return this.watchingInviteeStatus === "going";
+  }
+
+  get isGoingThisEvent() {
+    return this.isGoing && !this.args.event.watchingInvitee?.recurring;
+  }
+
+  get isGoingAllFollowing() {
+    return this.isGoing && this.args.event.watchingInvitee?.recurring;
+  }
+
+  get goingButtonDisabled() {
+    return this.args.event.atCapacity && !this.isGoing;
+  }
+
+  get goingTriggerIcon() {
+    return this.isGoingAllFollowing ? "arrows-rotate" : "check";
+  }
+
+  get goingTriggerLabel() {
+    return i18n(
+      this.args.event.atCapacity
+        ? "discourse_post_event.models.event.full"
+        : "discourse_post_event.models.invitee.status.going"
+    );
+  }
+
+  @action
+  registerGoingMenu(api) {
+    this.goingMenu = api;
+  }
+
   @action
   async leaveEvent() {
     try {
@@ -55,57 +136,56 @@ export default class DiscoursePostEventStatus extends Component {
   }
 
   @action
-  async updateEventAttendance(status) {
-    try {
-      await this.discoursePostEventApi.updateEventAttendance(this.args.event, {
-        status,
-      });
-
-      this.appEvents.trigger("calendar:update-invitee-status", {
-        status,
-        postId: this.args.event.id,
-      });
-    } catch (e) {
-      popupAjaxError(e);
-    }
+  async goingThisEvent() {
+    this.goingMenu?.close();
+    await this._setAttendance({ status: "going", recurring: false });
   }
 
   @action
-  async joinEventWithStatus(status) {
-    try {
-      await this.discoursePostEventApi.joinEvent(this.args.event, {
-        status,
-      });
+  async goingAllFollowing() {
+    this.goingMenu?.close();
+    await this._setAttendance({ status: "going", recurring: true });
+  }
 
-      this.appEvents.trigger("calendar:create-invitee-status", {
-        status,
-        postId: this.args.event.id,
-      });
-    } catch (e) {
-      // in case of 422 full, backend returns error string, let popup handle
-      popupAjaxError(e);
-    }
+  @action
+  async leaveFromGoingMenu() {
+    this.goingMenu?.close();
+    await this.leaveEvent();
   }
 
   @action
   async changeWatchingInviteeStatus(status) {
-    if (this.args.event.watchingInvitee) {
-      const currentStatus = this.args.event.watchingInvitee.status;
-      if (this.canLeave) {
-        if (status === currentStatus) {
-          await this.leaveEvent();
-        } else {
-          await this.updateEventAttendance(status);
-        }
-      } else {
-        if (status === currentStatus) {
-          status = null;
-        }
+    const watching = this.args.event.watchingInvitee;
 
-        await this.updateEventAttendance(status);
+    if (!watching) {
+      await this._setAttendance({ status });
+      return;
+    }
+
+    if (status === watching.status) {
+      await (this.canLeave
+        ? this.leaveEvent()
+        : this._setAttendance({ status: null }));
+      return;
+    }
+
+    await this._setAttendance({ status });
+  }
+
+  async _setAttendance(payload) {
+    try {
+      const event = this.args.event;
+      const data = { status: payload.status, postId: event.id };
+
+      if (event.watchingInvitee) {
+        await this.discoursePostEventApi.updateEventAttendance(event, payload);
+        this.appEvents.trigger("calendar:update-invitee-status", data);
+      } else {
+        await this.discoursePostEventApi.joinEvent(event, payload);
+        this.appEvents.trigger("calendar:create-invitee-status", data);
       }
-    } else {
-      await this.joinEventWithStatus(status);
+    } catch (e) {
+      popupAjaxError(e);
     }
   }
 
@@ -132,20 +212,57 @@ export default class DiscoursePostEventStatus extends Component {
                 markAsGoing=(fn this.changeWatchingInviteeStatus "going")
               }}
             >
-              <DButton
-                class="btn-default going-button"
-                @disabled={{and
-                  @event.atCapacity
-                  (not (eq this.watchingInviteeStatus "going"))
-                }}
-                @icon="check"
-                @label={{if
-                  @event.atCapacity
-                  "discourse_post_event.models.event.full"
-                  "discourse_post_event.models.invitee.status.going"
-                }}
-                @action={{fn this.changeWatchingInviteeStatus "going"}}
-              />
+              {{#if @event.recurrence}}
+                {{#if this.site.mobileView}}
+                  <DMenu
+                    class="btn btn-default going-button"
+                    @identifier="discourse-post-event-going-menu"
+                    @icon={{this.goingTriggerIcon}}
+                    @label={{this.goingTriggerLabel}}
+                    @disabled={{this.goingButtonDisabled}}
+                    @onRegisterApi={{this.registerGoingMenu}}
+                    @modalForMobile={{true}}
+                  >
+                    <:content>
+                      <GoingDropdown @status={{this}} />
+                    </:content>
+                  </DMenu>
+                {{else}}
+                  <DComboButton class="going-button --has-menu" as |combo|>
+                    <combo.Button
+                      class="btn-default"
+                      @disabled={{this.goingButtonDisabled}}
+                      @icon={{this.goingTriggerIcon}}
+                      @label={{if
+                        @event.atCapacity
+                        "discourse_post_event.models.event.full"
+                        "discourse_post_event.models.invitee.status.going"
+                      }}
+                      @action={{fn this.changeWatchingInviteeStatus "going"}}
+                    />
+                    <combo.Menu
+                      @identifier="discourse-post-event-going-menu"
+                      @triggerClass="btn-default"
+                      @disabled={{this.goingButtonDisabled}}
+                      @onRegisterApi={{this.registerGoingMenu}}
+                    >
+                      <GoingDropdown @status={{this}} />
+                    </combo.Menu>
+                  </DComboButton>
+                {{/if}}
+              {{else}}
+                <DButton
+                  class="btn-default going-button"
+                  @disabled={{this.goingButtonDisabled}}
+                  @icon="check"
+                  @label={{if
+                    @event.atCapacity
+                    "discourse_post_event.models.event.full"
+                    "discourse_post_event.models.invitee.status.going"
+                  }}
+                  @action={{fn this.changeWatchingInviteeStatus "going"}}
+                />
+              {{/if}}
             </PluginOutlet>
           {{/unless}}
         {{/if}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event-stats.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-event-stats.js
@@ -6,12 +6,14 @@ export default class DiscoursePostEventEventStats {
   }
 
   @tracked going = 0;
+  @tracked goingRecurring = 0;
   @tracked interested = 0;
   @tracked invited = 0;
   @tracked notGoing = 0;
 
   constructor(args = {}) {
     this.going = args.going;
+    this.goingRecurring = args.going_recurring;
     this.invited = args.invited;
     this.interested = args.interested;
     this.notGoing = args.not_going;

--- a/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-invitee.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/models/discourse-post-event-invitee.js
@@ -7,11 +7,13 @@ export default class DiscoursePostEventInvitee {
   }
 
   @tracked status;
+  @tracked recurring;
 
   constructor(args = {}) {
     this.id = args.id;
     this.post_id = args.post_id;
     this.status = args.status;
+    this.recurring = args.recurring;
     this.user = this.#initUserModel(args.user);
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/discourse-post-event-api.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/discourse-post-event-api.js
@@ -67,6 +67,7 @@ export default class DiscoursePostEventApi extends Service {
     event.sampleInvitees.forEach((invitee) => {
       if (invitee.id === event.watchingInvitee.id) {
         invitee.status = event.watchingInvitee.status;
+        invitee.recurring = event.watchingInvitee.recurring;
       }
     });
 

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -244,11 +244,20 @@ $show-interested: inherit;
         flex: 1;
       }
 
+      .going-button.d-combo-button {
+        flex: 1;
+
+        .d-combo-button-menu {
+          flex: 0 0 auto;
+        }
+      }
+
       .interested-button {
         display: $show-interested;
       }
 
-      &.status-going .going-button .d-icon {
+      &.status-going .going-button > .d-icon,
+      &.status-going .going-button .d-combo-button-button .d-icon {
         color: var(--success);
       }
 
@@ -492,6 +501,12 @@ $show-interested: inherit;
     align-items: center;
     justify-content: center;
     color: var(--primary-medium);
+  }
+}
+
+.discourse-post-event-going-menu-content {
+  .--selected .d-icon {
+    color: var(--success);
   }
 }
 

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -405,10 +405,13 @@ en:
       models:
         invitee:
           no_users: "No users found"
+          this_event: "This event"
+          this_and_following: "This event and all following events"
+          leave_event: "Leave event"
           status:
             unknown: "Not interested"
             going: "Going"
-            not_going: "Not Going"
+            not_going: "Not going"
             interested: "Interested"
             going_count:
               one: "%{count} going"

--- a/plugins/discourse-calendar/db/migrate/20260511145109_add_recurring_to_discourse_post_event_invitees.rb
+++ b/plugins/discourse-calendar/db/migrate/20260511145109_add_recurring_to_discourse_post_event_invitees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRecurringToDiscoursePostEventInvitees < ActiveRecord::Migration[8.0]
+  def change
+    add_column :discourse_post_event_invitees, :recurring, :boolean, default: false, null: false
+  end
+end

--- a/plugins/discourse-calendar/spec/integration/post_spec.rb
+++ b/plugins/discourse-calendar/spec/integration/post_spec.rb
@@ -128,7 +128,7 @@ describe Post do
                 expect(event_1.ends_at.to_s).to eq("2020-08-19 16:32:00 UTC")
               end
 
-              it "removes status from non going invitees" do
+              it "clears status from invitees not marked as recurring" do
                 going_invitee =
                   event_1.invitees.find_by(status: DiscoursePostEvent::Invitee.statuses[:going])
                 interested_invitee =
@@ -138,10 +138,8 @@ describe Post do
 
                 event_1.update_with_params!(original_ends_at: Time.now)
 
-                expect(going_invitee.reload.status).to eq(
-                  DiscoursePostEvent::Invitee.statuses[:going],
-                )
-                expect(interested_invitee.reload.status).to eq(nil)
+                expect(going_invitee.reload.status).to be_nil
+                expect(interested_invitee.reload.status).to be_nil
               end
 
               # that will be handled by new job, uncomment when finished

--- a/plugins/discourse-calendar/spec/integration/recurrence_spec.rb
+++ b/plugins/discourse-calendar/spec/integration/recurrence_spec.rb
@@ -119,6 +119,32 @@ describe "discourse_post_event_recurrence" do
     end
   end
 
+  describe "resetting invitees on recurrence advance" do
+    fab!(:going_once_user, :user)
+    fab!(:going_recurring_user, :user)
+
+    before { post_event_1.update!(recurrence: "every_week") }
+
+    it "clears non-recurring going invitees and keeps recurring ones" do
+      DiscoursePostEvent::Invitee.create_attendance!(going_once_user.id, post_event_1.id, :going)
+      DiscoursePostEvent::Invitee.create_attendance!(
+        going_recurring_user.id,
+        post_event_1.id,
+        :going,
+        recurring: true,
+      )
+
+      post_event_1.set_next_date
+
+      once = post_event_1.invitees.find_by(user_id: going_once_user.id)
+      recurring = post_event_1.invitees.find_by(user_id: going_recurring_user.id)
+
+      expect(once.status).to be_nil
+      expect(recurring.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
+      expect(recurring.recurring).to eq(true)
+    end
+  end
+
   context "when the recurring event is closed" do
     before { post_event_1.update!(recurrence: "every_week", closed: true) }
 

--- a/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
+++ b/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/send_reminder_spec.rb
@@ -308,7 +308,12 @@ describe Jobs::DiscoursePostEventSendReminder do
       end
 
       def setup_recurring_event_invitees
-        DiscoursePostEvent::Invitee.create_attendance!(going_user.id, recurring_event.id, :going)
+        DiscoursePostEvent::Invitee.create_attendance!(
+          going_user.id,
+          recurring_event.id,
+          :going,
+          recurring: true,
+        )
         DiscoursePostEvent::Invitee.create_attendance!(
           interested_user.id,
           recurring_event.id,
@@ -323,16 +328,19 @@ describe Jobs::DiscoursePostEventSendReminder do
           going_user_unread_notification.id,
           recurring_event.id,
           :going,
+          recurring: true,
         )
         DiscoursePostEvent::Invitee.create_attendance!(
           going_user_read_notification.id,
           recurring_event.id,
           :going,
+          recurring: true,
         )
         DiscoursePostEvent::Invitee.create_attendance!(
           visited_going_user.id,
           recurring_event.id,
           :going,
+          recurring: true,
         )
       end
 
@@ -491,7 +499,12 @@ describe Jobs::DiscoursePostEventSendReminder do
             recurrence: "every_week",
           )
 
-        DiscoursePostEvent::Invitee.create_attendance!(dst_user.id, dst_event.id, :going)
+        DiscoursePostEvent::Invitee.create_attendance!(
+          dst_user.id,
+          dst_event.id,
+          :going,
+          recurring: true,
+        )
 
         freeze_time(Time.find_zone("America/New_York").parse("2025-11-05 10:50"))
 

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -149,6 +149,19 @@ module DiscoursePostEvent
         expect(Invitee).to exist(user_id: other_user.id, status: Invitee.statuses[:interested])
       end
 
+      it "persists the recurring flag when joining" do
+        post "/discourse-post-event/events/#{event.id}/invitees.json",
+             params: {
+               invitee: {
+                 status: "going",
+                 recurring: true,
+               },
+             }
+
+        expect(response.status).to eq(200)
+        expect(Invitee).to exist(user_id: user.id, recurring: true)
+      end
+
       it "returns 403 when non-staff tries to invite themselves to a private event" do
         private_event = Fabricate(:event, post: post_1, status: "private")
         other_user = Fabricate(:user)
@@ -224,6 +237,19 @@ module DiscoursePostEvent
 
         expect(response.status).to eq(200)
         expect(invitee.reload.status).to eq(Invitee.statuses[:interested])
+      end
+
+      it "persists the recurring flag when updating" do
+        put "/discourse-post-event/events/#{event.id}/invitees/#{invitee.id}.json",
+            params: {
+              invitee: {
+                status: "going",
+                recurring: true,
+              },
+            }
+
+        expect(response.status).to eq(200)
+        expect(invitee.reload.recurring).to eq(true)
       end
 
       it "returns 404 when invitee does not exist" do

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/event_serializer_spec.rb
@@ -37,6 +37,33 @@ describe DiscoursePostEvent::EventSerializer do
         json = DiscoursePostEvent::EventSerializer.new(private_event, scope: Guardian.new).as_json
         expect(json[:event][:stats]).to eq(
           going: 1,
+          going_recurring: 0,
+          interested: 0,
+          invited: 2,
+          not_going: 0,
+          capacity: nil,
+        )
+      end
+    end
+
+    context "with recurring 'going' invitees" do
+      before do
+        private_event.update_with_params!(raw_invitees: [group_1.name])
+        DiscoursePostEvent::Invitee.create_attendance!(invitee_1.id, private_event.id, :going)
+        DiscoursePostEvent::Invitee.create_attendance!(
+          invitee_2.id,
+          private_event.id,
+          :going,
+          recurring: true,
+        )
+        private_event.reload
+      end
+
+      it "counts only recurring 'going' invitees in going_recurring" do
+        json = DiscoursePostEvent::EventSerializer.new(private_event, scope: Guardian.new).as_json
+        expect(json[:event][:stats]).to eq(
+          going: 2,
+          going_recurring: 1,
           interested: 0,
           invited: 2,
           not_going: 0,

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
@@ -19,6 +19,57 @@ module PageObjects
           self
         end
 
+        def has_going_menu?
+          has_css?(".discourse-post-event-going-menu-trigger")
+        end
+
+        def has_no_going_menu?
+          has_no_css?(".discourse-post-event-going-menu-trigger")
+        end
+
+        def has_going_button?
+          has_css?(".going-button")
+        end
+
+        def has_going_status?
+          has_css?(".event-status.status-going")
+        end
+
+        def has_going_count?(count)
+          has_css?(".event-invitees-icon .going", text: count.to_s)
+        end
+
+        def has_invitee_avatar?(username)
+          has_css?(".event-invitees-avatars [data-user-card='#{username}']")
+        end
+
+        def has_no_invitee_avatar?(username)
+          has_no_css?(".event-invitees-avatars [data-user-card='#{username}']")
+        end
+
+        def close_popup
+          locator(".discourse-post-event-close").click
+          self
+        end
+
+        def open_going_menu
+          locator(".discourse-post-event-going-menu-trigger").click
+          has_css?(".discourse-post-event-going-menu-content")
+          self
+        end
+
+        def going_this_event
+          open_going_menu
+          locator(".discourse-post-event-going-menu-content .going-once").click
+          self
+        end
+
+        def going_all_following
+          open_going_menu
+          locator(".discourse-post-event-going-menu-content .going-all").click
+          self
+        end
+
         def open_bulk_invite_modal
           open_more_menu { locator(".dropdown-menu__item.bulk-invite").click }
           self

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
@@ -60,6 +60,15 @@ module PageObjects
           has_css?(".fc-event-title", text: title)
         end
 
+        def click_event_on(date)
+          try_until_success do
+            page.execute_script(<<~JS)
+              document.querySelector(".fc-daygrid-day[data-date='#{date}'] .fc-event").click();
+            JS
+            has_css?("[data-identifier='post-event-menu']")
+          end
+        end
+
         def has_no_event?(title)
           has_no_css?(".fc-event-title", text: title)
         end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -217,6 +217,58 @@ describe "Post event" do
     expect(page).to have_no_css(".send-pm-to-creator")
   end
 
+  context "with the Going button" do
+    fab!(:rsvp_user, :user)
+
+    before { sign_in(rsvp_user) }
+
+    it "creates a recurring going invitee when picking 'this event and all following events'" do
+      raw = "[event status='public' start='2222-02-22 14:22' recurrence='every_week']\n[/event]"
+      post = PostCreator.create!(admin, title: "My recurring meetup event", raw:)
+
+      visit(post.topic.url)
+      post_event_page.going_all_following
+
+      expect(post_event_page).to have_going_status
+      invitee = DiscoursePostEvent::Invitee.find_by(user_id: rsvp_user.id, post_id: post.id)
+      expect(invitee.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
+      expect(invitee.recurring).to eq(true)
+    end
+
+    it "creates a non-recurring going invitee when picking 'this event'" do
+      raw = "[event status='public' start='2222-02-22 14:22' recurrence='every_week']\n[/event]"
+      post = PostCreator.create!(admin, title: "My recurring meetup event", raw:)
+
+      visit(post.topic.url)
+      post_event_page.going_this_event
+
+      expect(post_event_page).to have_going_status
+      invitee = DiscoursePostEvent::Invitee.find_by(user_id: rsvp_user.id, post_id: post.id)
+      expect(invitee.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
+      expect(invitee.recurring).to eq(false)
+    end
+
+    it "renders without a dropdown on non-recurring events" do
+      raw = "[event status='public' start='2222-02-22 14:22']\n[/event]"
+      post = PostCreator.create!(admin, title: "My one-off meetup event", raw:)
+
+      visit(post.topic.url)
+
+      expect(post_event_page).to have_going_button
+      expect(post_event_page).to have_no_going_menu
+    end
+
+    it "opens the menu when tapping the whole going button on mobile", mobile: true do
+      raw = "[event status='public' start='2222-02-22 14:22' recurrence='every_week']\n[/event]"
+      post = PostCreator.create!(admin, title: "My recurring meetup event", raw:)
+
+      visit(post.topic.url)
+      post_event_page.going
+
+      expect(page).to have_css(".discourse-post-event-going-menu-content")
+    end
+  end
+
   it "shows '-' for expired recurring events instead of dates" do
     title = "An expired recurring event"
     raw = <<~MD

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -32,6 +32,45 @@ describe "Upcoming Events" do
     end
   end
 
+  describe "popup invitees on recurring events" do
+    fab!(:going_recurring_user, :user)
+    fab!(:going_once_user, :user)
+    let(:post_event_page) { PageObjects::Pages::DiscourseCalendar::PostEvent.new }
+
+    it "filters non-recurring goings out of future occurrences",
+       time: Time.utc(2026, 5, 12, 12, 0) do
+      post =
+        create_post(
+          user: admin,
+          category:,
+          title: "Weekly stand-up event",
+          raw: "[event status='public' start='2026-05-14 14:00' recurrence='every_week']\n[/event]",
+        )
+      event = DiscoursePostEvent::Event.find(post.id)
+      DiscoursePostEvent::Invitee.create_attendance!(
+        going_recurring_user.id,
+        event.id,
+        :going,
+        recurring: true,
+      )
+      DiscoursePostEvent::Invitee.create_attendance!(going_once_user.id, event.id, :going)
+
+      upcoming_events.visit
+      upcoming_events.click_event_on("2026-05-14")
+
+      expect(post_event_page).to have_going_count(2)
+      expect(post_event_page).to have_invitee_avatar(going_recurring_user.username)
+      expect(post_event_page).to have_invitee_avatar(going_once_user.username)
+
+      post_event_page.close_popup
+      upcoming_events.click_event_on("2026-05-21")
+
+      expect(post_event_page).to have_going_count(1)
+      expect(post_event_page).to have_invitee_avatar(going_recurring_user.username)
+      expect(post_event_page).to have_no_invitee_avatar(going_once_user.username)
+    end
+  end
+
   describe "event description in popup" do
     let(:post_event_page) { PageObjects::Pages::DiscourseCalendar::PostEvent.new }
 


### PR DESCRIPTION
For recurring events, members can now choose whether their "Going" RSVP applies to a single upcoming instance or to every following instance in the series. Previously, a "Going" RSVP silently persisted forever across all future recurrences with no way to opt out short of leaving the event.

The recurring `Going` button is now a dropdown with two options:

  - "This event" (default): the RSVP applies only to the next occurrence and is cleared when the recurrence advances.
  - "This event and all following events": the RSVP persists across every future occurrence until the member changes it.

Non-recurring events are unchanged and still expose a plain `Going` button.

Implementation:

  - New `recurring` boolean column on `discourse_post_event_invitees`, defaulting to false.
  - `Invitee#recurring=` coerces to a strict boolean and a `before_save` callback enforces that only `going` rows can be recurring, so the invariant is owned by the model.
  - `Event#reset_invitee_notifications` (called on recurrence advance) now also clears `going` rows that are not marked recurring, restoring the original pre-regression "reset on each occurrence" behavior as the default while keeping the opt-in persistent mode intact.
  - `CreateInvitee` / `UpdateInvitee` services accept a `recurring` param threaded through from the controller. The `InviteeSerializer` exposes `recurring` so the UI can reflect the current selection.
  - The participant chip and the trigger button swap between the `check` and `arrows-rotate` icons depending on the invitee's `recurring` flag.

Ref - t/144138