### PR TITLE
FIX: 404 when switching categories with the "No tags" filter active

### DIFF
--- a/frontend/discourse/app/lib/url.js
+++ b/frontend/discourse/app/lib/url.js
@@ -563,29 +563,23 @@ export function getCategoryAndTagUrl(category, subcategories, tag) {
 
   if (category) {
     url = category.path;
-    if (category.default_list_filter === "none" && subcategories) {
-      if (subcategories) {
-        url += "/all";
-      } else {
-        url += "/none";
-      }
-    } else if (!subcategories) {
+    if (!subcategories) {
       url += "/none";
+    } else if (category.default_list_filter === "none") {
+      url += "/all";
     }
   }
 
   if (tag) {
-    // tag can be string "none" (special filter) or object with {id, name, slug}
-    if (typeof tag === "string") {
-      // special case: "none" filter
-      url = url ? "/tags" + url + "/" + tag : "/tag/" + tag;
-    } else {
-      if (url) {
-        url = "/tags" + url + "/" + tag.slug + "/" + tag.id;
-      } else {
-        url = "/tag/" + tag.slug + "/" + tag.id;
-      }
-    }
+    // tag can be string "none" (special filter) or object with {id, name, slug}.
+    // A Tag model with a null id also represents the "no tags" filter — handle
+    // it the same as the string form so we don't produce ".../none/null" URLs.
+    const isString = typeof tag === "string";
+    const slug = isString ? tag : tag.slug;
+    const id = isString ? null : tag.id;
+
+    const prefix = url ? `/tags${url}` : "/tag";
+    url = id ? `${prefix}/${slug}/${id}` : `${prefix}/${slug}`;
   }
 
   return getURL(url || "/");

--- a/frontend/discourse/tests/unit/lib/url-test.js
+++ b/frontend/discourse/tests/unit/lib/url-test.js
@@ -226,37 +226,34 @@ module("Unit | Utility | url", function (hooks) {
   });
 
   test("getCategoryAndTagUrl", function (assert) {
+    const cat = { path: "/c/foo/1", default_list_filter: "all" };
+    const noneCat = { path: "/c/foo/1", default_list_filter: "none" };
+    const noneTag = { slug: "none", id: null };
+    const bugTag = { slug: "bug", id: 7 };
+
+    // category only
+    assert.strictEqual(getCategoryAndTagUrl(cat, true), "/c/foo/1");
+    assert.strictEqual(getCategoryAndTagUrl(cat, false), "/c/foo/1/none");
+    assert.strictEqual(getCategoryAndTagUrl(noneCat, true), "/c/foo/1/all");
+    assert.strictEqual(getCategoryAndTagUrl(noneCat, false), "/c/foo/1/none");
+
+    // category + tag
     assert.strictEqual(
-      getCategoryAndTagUrl(
-        { path: "/c/foo/1", default_list_filter: "all" },
-        true
-      ),
-      "/c/foo/1"
+      getCategoryAndTagUrl(cat, true, "none"),
+      "/tags/c/foo/1/none"
+    );
+    assert.strictEqual(
+      getCategoryAndTagUrl(cat, true, noneTag),
+      "/tags/c/foo/1/none"
+    );
+    assert.strictEqual(
+      getCategoryAndTagUrl(cat, true, bugTag),
+      "/tags/c/foo/1/bug/7"
     );
 
-    assert.strictEqual(
-      getCategoryAndTagUrl(
-        { path: "/c/foo/1", default_list_filter: "all" },
-        false
-      ),
-      "/c/foo/1/none"
-    );
-
-    assert.strictEqual(
-      getCategoryAndTagUrl(
-        { path: "/c/foo/1", default_list_filter: "none" },
-        true
-      ),
-      "/c/foo/1/all"
-    );
-
-    assert.strictEqual(
-      getCategoryAndTagUrl(
-        { path: "/c/foo/1", default_list_filter: "none" },
-        false
-      ),
-      "/c/foo/1/none"
-    );
+    // tag only
+    assert.strictEqual(getCategoryAndTagUrl(null, true, "none"), "/tag/none");
+    assert.strictEqual(getCategoryAndTagUrl(null, true, bugTag), "/tag/bug/7");
   });
 
   test("routeTo redirects secure uploads URLS because they are server side only", async function (assert) {


### PR DESCRIPTION
When a user opened a category, selected "No tags" in the tag dropdown, and then picked another category from the breadcrumb, they landed on a 404 page instead of the new category with the "No tags" filter preserved.

The breadcrumb's `CategoryDrop` passes its `tag` argument straight to `getCategoryAndTagUrl`. On a `/tags/c/<slug>/<id>/none` page that `tag` is a `Tag` model with `slug: "none"` and `id: null` — not the literal string `"none"` that `TagDrop` passes from its own handler. The URL builder unconditionally appended `tag.slug + "/" + tag.id`, producing `/tags/c/<new-slug>/<new-id>/none/null`, which no route can resolve.

This normalizes the tag handling in `getCategoryAndTagUrl` so that any tag without an `id` (the "no tags" filter, whether expressed as a string or as a Tag model) renders as `.../<slug>` instead of `.../<slug>/null`. The category branch is also tidied up — it had an unreachable inner `else` because the outer condition already required `subcategories` to be true.

https://meta.discourse.org/t/402545