### PR TITLE
UX: fix control position in automations table

### DIFF
--- a/plugins/automation/assets/stylesheets/common/discourse-automation.scss
+++ b/plugins/automation/assets/stylesheets/common/discourse-automation.scss
@@ -71,6 +71,8 @@
 
       @include viewport.until(md) {
         order: 6;
+        position: initial;
+        justify-content: space-between;
       }
     }
   }


### PR DESCRIPTION
Need to undo the absolute positioning of the controls that's done upstream, otherwise they overlap the "last run" date 


Before:
<img width="240" alt="image" src="https://github.com/user-attachments/assets/dc833828-80a8-47cf-94f7-5b1b2041dea7" />



After: 
<img width="240" alt="image" src="https://github.com/user-attachments/assets/b6bc8343-7343-45db-a652-66138a04abe2" />
