### PR TITLE
FIX: Enforce secure-upload ACL in AI bot prompt path

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -13,6 +13,7 @@ require "guardian/sidebar_guardian"
 require "guardian/staff_action_log_guardian"
 require "guardian/tag_guardian"
 require "guardian/topic_guardian"
+require "guardian/upload_guardian"
 require "guardian/user_guardian"
 require "guardian/localization_guardian"
 
@@ -32,6 +33,7 @@ class Guardian
   include StaffActionLogGuardian
   include TagGuardian
   include TopicGuardian
+  include UploadGuardian
   include UserGuardian
 
   class AnonymousUser

--- a/lib/guardian/upload_guardian.rb
+++ b/lib/guardian/upload_guardian.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module UploadGuardian
+  def can_see_upload?(upload)
+    return !upload.secure? if upload.access_control_post_id.blank?
+    can_see_post?(upload.access_control_post)
+  end
+end

--- a/lib/secure_upload_endpoint_helpers.rb
+++ b/lib/secure_upload_endpoint_helpers.rb
@@ -17,7 +17,7 @@ module SecureUploadEndpointHelpers
   def check_secure_upload_permission(upload)
     if upload.access_control_post_id.present?
       raise Discourse::InvalidAccess if current_user.nil? && SiteSetting.login_required
-      raise Discourse::InvalidAccess if !guardian.can_see?(upload.access_control_post)
+      raise Discourse::InvalidAccess if !guardian.can_see_upload?(upload)
     else
       raise Discourse::NotFound if current_user.nil?
     end

--- a/plugins/discourse-ai/lib/agents/tool_runner/upload.rb
+++ b/plugins/discourse-ai/lib/agents/tool_runner/upload.rb
@@ -28,6 +28,9 @@ module DiscourseAi
 
                 return nil if upload.nil?
 
+                guardian = @context.user&.guardian || Guardian.new
+                return nil if !guardian.can_see_upload?(upload)
+
                 max_pixels = max_pixels&.to_i
                 max_pixels = nil if max_pixels && max_pixels <= 0
 

--- a/plugins/discourse-ai/lib/automation/llm_tagger.rb
+++ b/plugins/discourse-ai/lib/automation/llm_tagger.rb
@@ -53,6 +53,7 @@ module DiscourseAi
             include_image_uploads: tagger_agent.vision_enabled,
             include_document_uploads: model.allowed_attachment_types.present?,
             allowed_attachment_types: model.allowed_attachment_types,
+            guardian: Guardian.new(post.user),
           )
         if upload_ids.present?
           input = [input]

--- a/plugins/discourse-ai/lib/automation/llm_triage.rb
+++ b/plugins/discourse-ai/lib/automation/llm_triage.rb
@@ -95,6 +95,7 @@ module DiscourseAi
             include_image_uploads: triage_agent.vision_enabled,
             include_document_uploads: model.allowed_attachment_types.present?,
             allowed_attachment_types: model.allowed_attachment_types,
+            guardian: Guardian.new(post.user),
           )
 
         if upload_ids.present?

--- a/plugins/discourse-ai/lib/completions/prompt_messages_builder.rb
+++ b/plugins/discourse-ai/lib/completions/prompt_messages_builder.rb
@@ -81,6 +81,7 @@ module DiscourseAi
                 include_image_uploads: include_image_uploads,
                 include_document_uploads: include_document_uploads,
                 allowed_attachment_types: allowed_attachment_types,
+                guardian: guardian,
               )
             mapped_message = m.message
 
@@ -156,6 +157,7 @@ module DiscourseAi
 
         builder = new
         builder.topic = post.topic
+        guardian = Guardian.new(post.user)
 
         context.reverse_each do |raw, username, custom_prompt, upload_ids, created_at|
           custom_prompt_translation =
@@ -193,6 +195,7 @@ module DiscourseAi
               include_image_uploads: include_image_uploads,
               include_document_uploads: include_document_uploads,
               allowed_attachment_types: allowed_attachment_types,
+              guardian: guardian,
             )
             context[:created_at] = created_at
 
@@ -218,6 +221,7 @@ module DiscourseAi
         upload_ids,
         include_image_uploads:,
         include_document_uploads:,
+        guardian:,
         allowed_attachment_types: nil
       )
         return if !include_image_uploads && !include_document_uploads
@@ -235,6 +239,7 @@ module DiscourseAi
                 include_image_uploads: include_image_uploads,
                 include_document_uploads: include_document_uploads,
                 allowed_attachment_types: allowed_attachment_types,
+                guardian: guardian,
               )
           end
 
@@ -245,6 +250,7 @@ module DiscourseAi
         uploads,
         include_image_uploads:,
         include_document_uploads:,
+        guardian:,
         allowed_attachment_types: nil
       )
         return if !include_image_uploads && !include_document_uploads
@@ -257,6 +263,7 @@ module DiscourseAi
               include_image_uploads: include_image_uploads,
               include_document_uploads: include_document_uploads,
               allowed_attachment_types: allowed_attachment_types,
+              guardian: guardian,
             )
           end
           .map(&:id)
@@ -267,14 +274,19 @@ module DiscourseAi
         upload,
         include_image_uploads:,
         include_document_uploads:,
+        guardian:,
         allowed_attachment_types: nil
       )
-        if image_upload?(upload)
-          include_image_uploads
-        else
-          include_document_uploads &&
-            document_upload_allowed_for_prompt?(upload, allowed_attachment_types)
-        end
+        type_allowed =
+          if image_upload?(upload)
+            include_image_uploads
+          else
+            include_document_uploads &&
+              document_upload_allowed_for_prompt?(upload, allowed_attachment_types)
+          end
+        return false if !type_allowed
+
+        guardian.can_see_upload?(upload)
       end
 
       def self.document_upload_allowed_for_prompt?(upload, allowed_attachment_types)
@@ -340,6 +352,7 @@ module DiscourseAi
                 include_image_uploads: include_image_uploads,
                 include_document_uploads: include_document_uploads,
                 allowed_attachment_types: allowed_attachment_types,
+                guardian: guardian,
               )
             upload_ids&.each { |upload_id| posts_context << { upload_id: upload_id } }
           end

--- a/plugins/discourse-ai/spec/lib/agents/tool_runner/upload_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tool_runner/upload_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
 
   describe "upload operations" do
     describe "upload base64 encoding" do
+      let(:base64_script) { <<~JS }
+        function invoke(params) {
+          return upload.getBase64(params.upload_id, params.max_pixels);
+        }
+      JS
+
       it "can get base64 data from upload ID and short URL" do
         upload = UploadCreator.new(jpg, "1x1.jpg").create_for(Discourse.system_user.id)
 
@@ -75,6 +81,66 @@ RSpec.describe DiscourseAi::Agents::ToolRunner do
         result_invalid = runner.invoke
 
         expect(result_invalid).to be_nil
+      end
+
+      context "with secure uploads" do
+        fab!(:invoking_user, :user)
+        fab!(:upload_owner, :user)
+        fab!(:private_group, :group)
+        fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+        fab!(:private_topic) { Fabricate(:topic, category: private_category, user: upload_owner) }
+        fab!(:private_post) { Fabricate(:post, topic: private_topic, user: upload_owner) }
+        let(:secure_upload) do
+          upload = UploadCreator.new(jpg, "1x1.jpg").create_for(upload_owner.id)
+          upload.update!(secure: true, access_control_post_id: private_post.id)
+          upload
+        end
+
+        it "returns nil for a secure upload the guardian cannot see" do
+          tool = create_tool(script: base64_script)
+
+          runner =
+            tool.runner(
+              { "upload_id" => secure_upload.id },
+              llm: nil,
+              bot_user: nil,
+              context: DiscourseAi::Agents::BotContext.new(user: invoking_user),
+            )
+
+          expect(runner.invoke).to be_nil
+        end
+
+        it "returns base64 when the guardian can see the access_control_post" do
+          private_group.add(invoking_user)
+
+          tool = create_tool(script: base64_script)
+
+          runner =
+            tool.runner(
+              { "upload_id" => secure_upload.id, "max_pixels" => 1_000_000 },
+              llm: nil,
+              bot_user: nil,
+              context: DiscourseAi::Agents::BotContext.new(user: invoking_user),
+            )
+
+          expect(runner.invoke).to be_a(String)
+        end
+
+        it "returns base64 when the context is built with only a user and the user can see the access_control_post" do
+          private_group.add(invoking_user)
+
+          tool = create_tool(script: base64_script)
+
+          runner =
+            tool.runner(
+              { "upload_id" => secure_upload.id, "max_pixels" => 1_000_000 },
+              llm: nil,
+              bot_user: nil,
+              context: DiscourseAi::Agents::BotContext.new(user: invoking_user),
+            )
+
+          expect(runner.invoke).to be_present
+        end
       end
     end
 

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -167,6 +167,43 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
       expect(upload_hashes).to be_present
       expect(upload_hashes.first[:upload_id]).to eq(upload.id)
     end
+
+    context "with a secure upload the chat guardian cannot see" do
+      fab!(:secure_upload) do
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+        private_topic = Fabricate(:topic, category: private_category)
+        private_post = Fabricate(:post, topic: private_topic)
+        Fabricate(
+          :secure_upload,
+          original_filename: "secure.png",
+          extension: "png",
+          access_control_post: private_post,
+        )
+      end
+
+      it "drops the upload from the chat context" do
+        SiteSetting.embedded_media_post_allowed_groups = Group::AUTO_GROUPS[:everyone]
+
+        post_with_secure_upload =
+          create_post(
+            topic_id: topic.id,
+            user: user,
+            raw: "Look at this ![image](#{secure_upload.short_url})",
+          )
+
+        builder = described_class.new
+        builder.set_chat_context_posts(
+          [post_with_secure_upload.id],
+          Guardian.new(user),
+          include_image_uploads: true,
+          include_document_uploads: false,
+        )
+
+        upload_hashes =
+          builder.chat_context_posts.select { |item| item.is_a?(Hash) && item[:upload_id] }
+        expect(upload_hashes).to be_empty
+      end
+    end
   end
 
   describe ".messages_from_chat" do
@@ -338,6 +375,46 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
           { upload_id: image_upload1.id },
         ],
       )
+    end
+
+    context "with a secure upload attached to a message the chat guardian cannot see" do
+      fab!(:secure_upload) do
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+        private_topic = Fabricate(:topic, category: private_category)
+        private_post = Fabricate(:post, topic: private_topic)
+        Fabricate(
+          :secure_upload,
+          original_filename: "secure.png",
+          extension: "png",
+          access_control_post: private_post,
+        )
+      end
+      fab!(:message_with_secure_upload) do
+        Fabricate(
+          :chat_message,
+          chat_channel: dm_channel,
+          user: user,
+          message: "Look at this",
+          upload_ids: [secure_upload.id],
+        )
+      end
+
+      it "drops the upload from the prompt" do
+        context =
+          described_class.messages_from_chat(
+            message_with_secure_upload,
+            channel: dm_channel,
+            context_post_ids: nil,
+            max_messages: 10,
+            include_uploads: true,
+            bot_user_ids: [bot_user.id],
+            instruction_message: nil,
+          )
+
+        content = Array(context.first[:content])
+        upload_hashes = content.select { |item| item.is_a?(Hash) && item[:upload_id] }
+        expect(upload_hashes).to be_empty
+      end
     end
 
     it "properly handles uploads in public channels with multiple users" do
@@ -761,6 +838,44 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
       expect(context).to eq(
         [{ type: :user, content: "This is a second reply by the user", id: user.username }],
       )
+    end
+
+    context "with a secure upload not visible to the triggering user" do
+      fab!(:secure_upload) do
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+        private_topic = Fabricate(:topic, category: private_category)
+        private_post = Fabricate(:post, topic: private_topic)
+        Fabricate(
+          :secure_upload,
+          original_filename: "secret.png",
+          extension: "png",
+          access_control_post: private_post,
+        )
+      end
+
+      before { SiteSetting.embedded_media_post_allowed_groups = Group::AUTO_GROUPS[:everyone] }
+
+      it "drops the upload from the prompt" do
+        post_with_secure_upload =
+          create_post(
+            topic_id: pm.id,
+            user: user,
+            raw: "Look at this ![image](#{secure_upload.short_url})",
+          )
+
+        context =
+          described_class.messages_from_post(
+            post_with_secure_upload,
+            max_posts: 1,
+            bot_usernames: [bot_user.username],
+            include_image_uploads: true,
+            include_document_uploads: false,
+          )
+
+        expect(context).to contain_exactly(
+          { type: :user, id: user.username, content: post_with_secure_upload.raw },
+        )
+      end
     end
 
     context "with custom prompts" do

--- a/spec/lib/guardian/upload_guardian_spec.rb
+++ b/spec/lib/guardian/upload_guardian_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe UploadGuardian do
+  fab!(:user)
+  fab!(:public_post, :post)
+  fab!(:private_group, :group)
+  fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+  fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+  fab!(:private_post) { Fabricate(:post, topic: private_topic) }
+
+  fab!(:non_secure_upload_without_access_control_post) do
+    Fabricate(:upload, access_control_post: nil)
+  end
+  fab!(:secure_upload_without_access_control_post) do
+    Fabricate(:secure_upload, access_control_post: nil)
+  end
+  fab!(:upload_with_visible_access_control_post) do
+    Fabricate(:upload, access_control_post: public_post)
+  end
+  fab!(:secure_upload_with_hidden_access_control_post) do
+    Fabricate(:secure_upload, access_control_post: private_post)
+  end
+
+  describe "#can_see_upload?" do
+    it "returns true for a non-secure upload with no access_control_post" do
+      expect(
+        Guardian.new(user).can_see_upload?(non_secure_upload_without_access_control_post),
+      ).to eq(true)
+    end
+
+    it "returns false for a secure upload with no access_control_post" do
+      expect(Guardian.new(user).can_see_upload?(secure_upload_without_access_control_post)).to eq(
+        false,
+      )
+    end
+
+    it "returns true for an upload whose access_control_post the user can see" do
+      expect(Guardian.new(user).can_see_upload?(upload_with_visible_access_control_post)).to eq(
+        true,
+      )
+
+      private_group.add(user)
+
+      expect(
+        Guardian.new(user).can_see_upload?(secure_upload_with_hidden_access_control_post),
+      ).to eq(true)
+    end
+
+    it "returns false for an upload whose access_control_post the user cannot see" do
+      expect(
+        Guardian.new(user).can_see_upload?(secure_upload_with_hidden_access_control_post),
+      ).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
The AI bot reads upload contents from posts and chat messages and feeds them into the LLM prompt. The lookup is gated by whether the requester can see the post, but not whether they can see the upload's secure access-control post, so an attacker can paste another user's secure short URL into their own post, summon the bot, and have it disclose the contents. The agent tool runner's `_upload_get_base64` has the same gap with no ACL check at all.

This commit introduces `Guardian#can_see_upload?` so upload visibility is checked in one place, and uses it from `PromptMessagesBuilder`, `ToolRunner::Upload`, and `SecureUploadEndpointHelpers#check_secure_upload_permission`.

Follow-up to fa54f62348a714c6d17d1dbfbe77c651d29b0c90.