### PR TITLE
DEV: Harden ui-kit with @ts-check, Glint signatures, and tests

### DIFF
--- a/eslint-rules/require-ts-check.mjs
+++ b/eslint-rules/require-ts-check.mjs
@@ -1,0 +1,60 @@
+/**
+ * Requires `// @ts-check` to be the first comment in the file.
+ *
+ * Scoped via `files:` overrides in `eslint.config.mjs` so it only fires for
+ * directories where we want strict JSDoc type checking. Outside those
+ * directories the rule is unregistered and never runs.
+ *
+ * Why "first comment" rather than "first line": TypeScript only honors
+ * `// @ts-check` when it appears before any non-comment code. Putting it
+ * lower in the file is silently a no-op, so we want a hard error if it's
+ * missing or misplaced.
+ */
+
+const TS_CHECK = "@ts-check";
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require `// @ts-check` as the first comment of the file so TypeScript actually checks the JSDoc types.",
+    },
+    schema: [],
+    messages: {
+      missing:
+        "Files in this directory must start with `// @ts-check` so the JSDoc types are actually checked.",
+      misplaced:
+        "`// @ts-check` must be the first comment in the file. TypeScript ignores it when other code or comments appear above it.",
+    },
+  },
+  create(context) {
+    return {
+      Program(node) {
+        const sourceCode = context.sourceCode ?? context.getSourceCode();
+        const comments = sourceCode.getAllComments();
+        const firstComment = comments[0];
+
+        const hasTsCheck = comments.some(
+          (c) => c.type === "Line" && c.value.trim() === TS_CHECK
+        );
+
+        if (!hasTsCheck) {
+          context.report({ node, messageId: "missing" });
+          return;
+        }
+
+        if (
+          !firstComment ||
+          firstComment.type !== "Line" ||
+          firstComment.value.trim() !== TS_CHECK
+        ) {
+          context.report({
+            node: firstComment ?? node,
+            messageId: "misplaced",
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,24 @@
 import DiscourseRecommended from "@discourse/lint-configs/eslint";
+import requireTsCheck from "./eslint-rules/require-ts-check.mjs";
+
+const localPlugin = {
+  rules: {
+    "require-ts-check": requireTsCheck,
+  },
+};
 
 export default [
   ...DiscourseRecommended,
   {
     rules: {},
     // custom overrides go here
+  },
+  {
+    files: ["frontend/discourse/app/ui-kit/**/*.{js,gjs}"],
+    plugins: { local: localPlugin },
+    rules: {
+      "local/require-ts-check": "error",
+    },
   },
   {
     ignores: [

--- a/frontend/discourse/app/ui-kit/CONVENTIONS.md
+++ b/frontend/discourse/app/ui-kit/CONVENTIONS.md
@@ -1,0 +1,247 @@
+# UI-Kit conventions
+
+Components, helpers, and modifiers under `frontend/discourse/app/ui-kit/` are the **public component contract** that core, plugins, and themes consume. Because the surface is wide and stable, the bar for files in this folder is higher than for app-internal code.
+
+This document is the source of truth for what "hardened" means. The ESLint rule `local/require-ts-check` and the CI step `pnpm lint:types` enforce the mechanical parts; the rest is on reviewers.
+
+## The bar
+
+Every file in `ui-kit/`, `ui-kit/helpers/`, and `ui-kit/modifiers/` must have:
+
+1. **`// @ts-check`** as the first line.
+2. **A Glint Signature typedef** (components only; helpers/modifiers use `@param`/`@returns` instead).
+3. **`@extends {Component<<Name>Signature>}`** on the class.
+4. **A component-level JSDoc block** above the class — didactic, 3-6 sentences, with `@example` when args are non-obvious.
+5. **DEBUG-time asserts** for required args, enum args, and mutually exclusive args.
+6. **Tests**: one smoke test plus behavioral tests covering each meaningful `@arg` and observable state.
+
+## 1. `// @ts-check`
+
+Goes on line 1, no exceptions. Without it, TypeScript skips the file and your JSDoc types are decorative only.
+
+```js
+// @ts-check
+import Component from "@glimmer/component";
+```
+
+The ESLint rule `local/require-ts-check` fails the build if it's missing. Files that pre-dated the rule are listed in the lint-to-the-future allowlist; touching one of those files means bringing it up to standard.
+
+## 2. The Signature typedef
+
+The Signature is what enables Glint to type-check `<DFoo @arg={{x}} />` invocations from the outside. Three blocks: `Args` (the args bag), `Element` (the rendered root element type, for `...attributes`), `Blocks` (named yields).
+
+```js
+/**
+ * @typedef DFooSignature
+ *
+ * @property {object} Args
+ *
+ * /* Text *​/
+ * @property {string} [Args.label] Translatable i18n key used as the visible label. Pass `translatedLabel` instead if the string is already translated.
+ * @property {string} [Args.translatedLabel] Pre-translated visible label. Mutually exclusive with `label`.
+ *
+ * /* State *​/
+ * @property {boolean} [Args.disabled] When true, the underlying control is disabled and click handlers do not fire.
+ *
+ * /* Callbacks *​/
+ * @property {(value: string) => void} [Args.onChange] Invoked with the new value whenever the user edits the field.
+ *
+ * @property {HTMLInputElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Optional contents rendered inside the field wrapper.
+ */
+```
+
+Rules:
+
+- **Every `@property` line gets a description**, not just a type. Junior-programmer readable, complete sentences with articles and prepositions.
+- **Group args with `/* Section */` comments**. Never banner comments (`// ===...===`).
+- **Optional args use brackets**: `[Args.label]`. Required args don't.
+- **Element** is the actual rendered HTML element type (`HTMLButtonElement`, `HTMLInputElement`, `HTMLDivElement`...). This is what makes `...attributes` type-aware.
+- **Blocks** lists named yields. Use `Blocks.default` for the unnamed yield, `Blocks.header`, `Blocks.footer`, etc. The value `[]` means the block receives no positional yield params.
+- **`@extends`** the Component class so the Signature is actually wired up: `/** @extends {Component<DFooSignature>} */`.
+
+### Template-only components
+
+If the file is a template-only component (`const DFoo = <template>...</template>;` with no class), wire up the Signature with a `@type` annotation using `TOC` (template-only component) from `@ember/component/template-only`:
+
+```js
+// @ts-check
+
+/**
+ * @typedef DFooSignature
+ * @property {object} Args
+ * @property {string} [Args.title]
+ * @property {HTMLDivElement} Element
+ */
+
+/** @type {import("@ember/component/template-only").TOC<DFooSignature>} */
+const DFoo = <template>
+  <div>{{@title}}</div>
+</template>;
+
+export default DFoo;
+```
+
+Template-only components have no constructor, so DEBUG asserts about arg shape are not available without converting to a class. Convert to a class only if asserts add real value — otherwise the Signature alone is enough.
+
+Reference example: `d-button.gjs` (class component), `d-empty-state.gjs` (template-only).
+
+## 3. Component-level JSDoc
+
+A block above the class (or above the Signature) explaining the component's role, when to use it, and when not to. Aim for 3-6 sentences in a didactic tone. Include an `@example` when the args interact in non-obvious ways.
+
+```js
+/**
+ * A primary text input for short, single-line values. Renders a native
+ * `<input>` element, so all native HTML attributes flow through via
+ * `...attributes`. Use this for free-form text. For controlled numeric or
+ * date input, reach for `DNumberField`, `DDateInput`, or the corresponding
+ * FormKit field.
+ *
+ * The value is two-way bound through `@onChange` rather than `(mut)` — pass
+ * an action that updates your local state from the new value.
+ *
+ * @example
+ * <DTextField @value={{this.name}} @onChange={{this.updateName}} />
+ */
+```
+
+The component-level block describes the component as a whole. Per-arg notes belong inside the Signature `@property` descriptions, not in the component block.
+
+## 4. DEBUG-time asserts
+
+Use Ember's `assert` from `@ember/debug`. These messages are stripped from production builds by `ember-cli-terser`, so they're free at runtime in prod and loud during development.
+
+```js
+import { assert } from "@ember/debug";
+
+// Required arg
+assert("[d-text-field] @value is required", this.args.value !== undefined);
+
+// Enum arg
+const FLASH_TYPES = ["success", "error", "warning", "info"];
+assert(
+  `[d-flash-message] @type must be one of ${FLASH_TYPES.join(", ")}`,
+  !this.args.type || FLASH_TYPES.includes(this.args.type)
+);
+
+// Mutually exclusive args
+assert(
+  "[d-button] pass either @label or @translatedLabel, not both",
+  !(this.args.label && this.args.translatedLabel)
+);
+
+// Type narrowing on callbacks
+assert(
+  "[d-toggle-switch] @onChange must be a function",
+  !this.args.onChange || typeof this.args.onChange === "function"
+);
+```
+
+Message format: `\`[<component-name>] <what's wrong>\``. The bracketed prefix makes asserts grep-able and tells the developer immediately which component is unhappy.
+
+**Prefer `assert` over `throw`** for contract violations. Use `throw` only when the failure must propagate to production (rare in UI components).
+
+## 5. Smoke + behavioral tests
+
+Every hardened component must have at least:
+
+- **One smoke test** that renders the component with the minimum-required args and asserts the root element exists. The smoke test catches boot-time regressions (wrong import, syntax errors in Signature blocks, etc.) cheaply.
+- **Behavioral tests** covering each meaningful `@arg` and each observable state (`@disabled`, `@isLoading`, each enum value, each callback, each named block).
+
+Smoke-test template:
+
+```js
+// frontend/discourse/tests/integration/ui-kit/d-foo-test.gjs
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { render } from "@ember/test-helpers";
+import DFoo from "discourse/ui-kit/d-foo";
+
+module("Integration | ui-kit | DFoo", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders the root element", async function (assert) {
+    await render(<template><DFoo @value="hello" /></template>);
+    assert.dom("input.d-foo").exists();
+  });
+
+  test("@disabled disables the underlying input", async function (assert) {
+    await render(<template><DFoo @value="x" @disabled={{true}} /></template>);
+    assert.dom("input.d-foo").isDisabled();
+  });
+
+  // ... one test per documented @arg / state.
+});
+```
+
+For components used 50+ times in the codebase (`d-button`, `d-modal`, `d-text-field`, `d-page-header`), aim for ≥80% coverage of the documented Args surface. For smaller components, cover everything the Signature documents.
+
+## Deprecating args
+
+When an arg should still work but consumers should migrate off it, mark it deprecated with **JSDoc `@deprecated` inline on the Signature property**. IDE and type-checker pick this up and strike through the prop in usage sites:
+
+```js
+/**
+ * @property {string} [Args.id] Native `id` attribute. @deprecated Pass `id` via `...attributes` instead.
+ */
+```
+
+Do **not** add a runtime `deprecate()` call from `@ember/debug` as part of normal hardening — it generates console noise across every consumer and that's a separate decision. Only wire up runtime deprecations when explicitly asked.
+
+## Constructor signature
+
+When you need a constructor (for asserts or service-dependent init), use **named params**:
+
+```js
+constructor(owner, args) {
+  super(owner, args);
+  assert(...);
+}
+```
+
+Avoid `constructor() { super(...arguments); }` — `arguments` doesn't have a tuple type and the spread fails strict TS checks. Avoid `constructor(...args) { super(...args); }` for the same reason: the rest-spread doesn't satisfy `super`'s `(owner, args)` signature.
+
+## Glint escape hatches
+
+When the **JS layer** is clean but the **template** trips Glint due to a dynamic root element (e.g. `<this.wrapperElement>`), a curried component yield, or an integration with a classic component, add a single comment at the top of the template:
+
+```hbs
+<template>
+  {{! @glint-nocheck: <one-line reason> }}
+  ...
+</template>
+```
+
+This keeps the JSDoc Signature authoritative for consumers (because emitted `.d.ts` files are unaffected) while quieting fixable-later template noise. Use it sparingly and always include the reason — a future cleanup pass should be able to grep these out.
+
+## Anti-patterns
+
+- **Don't `throw` for arg validation**. Use `assert`. Throws cost production cycles and conflate developer errors with runtime errors.
+- **Don't omit descriptions on `@property` lines**. A bare `@property {string} [Args.label]` tells the reader nothing the type alone didn't.
+- **Don't use banner comments inside the Signature.** `/* Section */` only.
+- **Don't accept `@onChange` and `(mut)` simultaneously.** Pick a callback contract and document it.
+- **Don't make every component a Signature.** Helpers (`ui-kit/helpers/*.js`) and modifiers (`ui-kit/modifiers/*.js`) use plain JSDoc `@param`/`@returns` — they don't have a Glint Signature.
+- **Don't add `@component name` to the JSDoc** — it's redundant with the filename.
+
+## Verification commands
+
+```bash
+# Lint a single file (fixes formatting, surfaces require-ts-check):
+bin/lint frontend/discourse/app/ui-kit/d-foo.gjs
+
+# Type-check the whole project (fails on Signature mistakes):
+pnpm lint:types
+
+# Run the integration tests for a single component:
+bin/qunit frontend/discourse/tests/integration/ui-kit/d-foo-test.gjs
+
+# Run every ui-kit test:
+bin/qunit frontend/discourse/tests/integration/ui-kit/
+```
+
+## Reference component
+
+`frontend/discourse/app/ui-kit/d-button.gjs` is the live example of every requirement above. Copy its shape — the order of imports, the position of the Signature relative to the class, the assert placement — when adding a new component to `ui-kit/`.

--- a/frontend/discourse/app/ui-kit/CONVENTIONS.md
+++ b/frontend/discourse/app/ui-kit/CONVENTIONS.md
@@ -114,33 +114,47 @@ The component-level block describes the component as a whole. Per-arg notes belo
 
 Use Ember's `assert` from `@ember/debug`. These messages are stripped from production builds by `ember-cli-terser`, so they're free at runtime in prod and loud during development.
 
+**Validate args from a getter the template reads — not from the constructor.** Glimmer's args proxy resolves each `args.X` read via `valueForRef`, which wraps the compute in its own internal `track()` frame. In DEBUG mode that frame calls `markTagAsConsumed` for everything the reference's compute touches. If a consumer ever passes the arg as a curried template expression like `@action={{this.handler item.id}}` inside an `{{#each}}`, the compute reads the parent's `this` and the iteration value, marking those upstream tags consumed. When something later mutates one of those tags during the same render transaction — most visibly the router's `targetState` during a transition — `assertTagNotConsumed` throws *"you attempted to update X, but it had already been used previously in the same computation"*. You can't tell at authoring time whether a future call site will use a curried form, so the rule is uniform: don't read args in the constructor for assertion purposes. (`untrack()` from `@glimmer/validator` does **not** sidestep this — it only suppresses the outer `consumeTag`; the marking inside `valueForRef`'s inner track frame still runs.)
+
+Validating inside a getter the template invokes puts the read in the render's own tracking frame, which is the frame that legitimately depends on that arg.
+
+Add a `@cached get validateArgs()` and reference it once from the template:
+
 ```js
+import { DEBUG } from "@glimmer/env";
+import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 
-// Required arg
-assert("[d-text-field] @value is required", this.args.value !== undefined);
-
-// Enum arg
 const FLASH_TYPES = ["success", "error", "warning", "info"];
-assert(
-  `[d-flash-message] @type must be one of ${FLASH_TYPES.join(", ")}`,
-  !this.args.type || FLASH_TYPES.includes(this.args.type)
-);
 
-// Mutually exclusive args
-assert(
-  "[d-button] pass either @label or @translatedLabel, not both",
-  !(this.args.label && this.args.translatedLabel)
-);
+@cached
+get validateArgs() {
+  if (DEBUG) {
+    assert(
+      "[d-load-more] @action is required",
+      typeof this.args.action === "function"
+    );
+    assert(
+      "[d-load-more] @onChange must be a function when provided",
+      !this.args.onChange || typeof this.args.onChange === "function"
+    );
+    assert(
+      `[d-flash-message] @type must be one of ${FLASH_TYPES.join(", ")}`,
+      !this.args.type || FLASH_TYPES.includes(this.args.type)
+    );
+  }
+  return null;
+}
 
-// Type narrowing on callbacks
-assert(
-  "[d-toggle-switch] @onChange must be a function",
-  !this.args.onChange || typeof this.args.onChange === "function"
-);
+<template>
+  {{this.validateArgs}}
+  ...
+</template>
 ```
 
-Message format: `\`[<component-name>] <what's wrong>\``. The bracketed prefix makes asserts grep-able and tells the developer immediately which component is unhappy.
+The getter runs purely for the assert side effect; the `null` return renders nothing. `@cached` keeps it from re-running on unrelated re-renders, so the asserts evaluate once per relevant arg change instead of on every template read. Wrapping the body in `if (DEBUG)` ensures the entire validation block is stripped from production builds — `assert` calls are already no-ops in prod, but the surrounding arg reads, `typeof` checks, and string allocations are not. Keep the getter declaration and the `return null;` outside the `if`; the template still invokes it, the body just becomes a trivial `return null` in prod. `return null;` (rather than no return) is required because `@ts-check` enforces TS2378 — getters must always return a value.
+
+Message format: `[<component-name>] <what's wrong>`. The bracketed prefix makes asserts grep-able and tells the developer immediately which component is unhappy.
 
 **Prefer `assert` over `throw`** for contract violations. Use `throw` only when the failure must propagate to production (rare in UI components).
 

--- a/frontend/discourse/app/ui-kit/d-async-content.gjs
+++ b/frontend/discourse/app/ui-kit/d-async-content.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { hash } from "@ember/helper";

--- a/frontend/discourse/app/ui-kit/d-autocomplete-results.gjs
+++ b/frontend/discourse/app/ui-kit/d-autocomplete-results.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-avatar-flair.gjs
+++ b/frontend/discourse/app/ui-kit/d-avatar-flair.gjs
@@ -1,4 +1,6 @@
+// @ts-check
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
 import { convertIconClass } from "discourse/lib/icon-library";
@@ -6,7 +8,50 @@ import { escapeExpression } from "discourse/lib/utilities";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
+/**
+ * A small badge rendered alongside an avatar to denote a flair (group flair,
+ * primary group icon, etc.). The same component renders an icon flair or an
+ * image flair depending on `@flairUrl`: a value containing `/` is treated as
+ * an image URL, anything else is looked up via the icon library. Background
+ * and foreground colors come from `@flairBgColor` and `@flairColor` as raw
+ * hex strings without the leading `#`.
+ *
+ * @example
+ * <DAvatarFlair
+ *   @flairUrl="bars"
+ *   @flairName="staff"
+ *   @flairBgColor="CC0000"
+ *   @flairColor="FFFFFF"
+ * />
+ */
+
+/**
+ * @typedef DAvatarFlairSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} Args.flairUrl Required. An icon name (e.g. `"bars"`) or an image URL. The component switches rendering modes based on whether the value contains a `/`.
+ * @property {string} [Args.flairName] Used for the `title` tooltip and a stable `avatar-flair-<name>` class hook.
+ * @property {string} [Args.flairBgColor] Hex color without the leading `#`, used as the background color. Also enables the `rounded` class.
+ * @property {string} [Args.flairColor] Hex color without the leading `#`, used as the foreground color of the icon.
+ *
+ * @property {HTMLDivElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Not used.
+ */
+
+/** @extends {Component<DAvatarFlairSignature>} */
 export default class DAvatarFlair extends Component {
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-avatar-flair] @flairUrl is required",
+      this.args.flairUrl != null
+    );
+  }
+
   get icon() {
     return convertIconClass(this.args.flairUrl);
   }

--- a/frontend/discourse/app/ui-kit/d-avatar-flair.gjs
+++ b/frontend/discourse/app/ui-kit/d-avatar-flair.gjs
@@ -1,5 +1,7 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
+import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
@@ -43,13 +45,15 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 /** @extends {Component<DAvatarFlairSignature>} */
 export default class DAvatarFlair extends Component {
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-avatar-flair] @flairUrl is required",
-      this.args.flairUrl != null
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-avatar-flair] @flairUrl is required",
+        this.args.flairUrl != null
+      );
+    }
+    return null;
   }
 
   get icon() {
@@ -87,6 +91,7 @@ export default class DAvatarFlair extends Component {
   }
 
   <template>
+    {{this.validateArgs}}
     <div
       class={{dConcatClass
         "avatar-flair"

--- a/frontend/discourse/app/ui-kit/d-badge-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-badge-button.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import domFromString from "discourse/lib/dom-from-string";
 import dIconOrImage from "discourse/ui-kit/helpers/d-icon-or-image";

--- a/frontend/discourse/app/ui-kit/d-badge-card.gjs
+++ b/frontend/discourse/app/ui-kit/d-badge-card.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";

--- a/frontend/discourse/app/ui-kit/d-breadcrumbs-container.gjs
+++ b/frontend/discourse/app/ui-kit/d-breadcrumbs-container.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";

--- a/frontend/discourse/app/ui-kit/d-breadcrumbs-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-breadcrumbs-item.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";

--- a/frontend/discourse/app/ui-kit/d-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-button.gjs
@@ -1,5 +1,7 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
+import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { on } from "@ember/modifier";
 import { action, computed } from "@ember/object";
@@ -23,11 +25,11 @@ const BUTTON_TYPES = ["button", "submit", "reset"];
  * `DButton` instead of writing `<button class="btn">` so loading, disabled,
  * icon, and accessibility states stay consistent across the app.
  *
- * Click behavior comes from `@action`, `@route`, or `@href`. `@action` and
- * `@route` are mutually exclusive (passing both silently drops `@route`),
- * but `@href` can combine with either — for example, `@action` alongside
- * `@href` renders an `<a>` so middle-click opens in a new tab while a
- * regular click runs the handler. `@action` runs inside `next()` on
+ * Click behavior comes from `@action`, `@route`, or `@href`. They can be
+ * combined — for example, passing `@action` alongside `@href` renders an
+ * `<a>` so middle-click opens in a new tab while a regular click runs the
+ * handler. When both `@action` and `@route` are passed, `@action` wins
+ * and `@route` is silently dropped. `@action` runs inside `next()` on
  * non-iOS to optimise INP; pass `@forwardEvent` if your handler needs the
  * original event.
  *
@@ -52,12 +54,12 @@ const BUTTON_TYPES = ["button", "submit", "reset"];
  *
  * Actions and navigation
  *
- * @property {Function|{value: Function}} [Args.action] Click handler. Accepts a plain function or an Ember action descriptor (`{ value: Function }`). Mutually exclusive with `@route`.
+ * @property {Function|{value: Function}} [Args.action] Click handler. Accepts a plain function or an Ember action descriptor (`{ value: Function }`). Wins over `@route` when both are passed.
  * @property {any} [Args.actionParam] Value passed as the first argument to `@action` when it fires.
  * @property {boolean} [Args.forwardEvent] When true, the original click event is passed as the second argument to `@action`.
  * @property {(event: KeyboardEvent) => void} [Args.onKeyDown] Custom keydown handler. When set, the default Enter-triggers-click behavior is suppressed and your handler receives every keydown.
  * @property {string} [Args.href] Renders an `<a href="...">` instead of `<button>`. Pair with `@action` or `@route` to handle the click in JS while still exposing a real URL for middle-click and copy-link.
- * @property {string} [Args.route] Ember route name to transition to on click. Mutually exclusive with `@action`.
+ * @property {string} [Args.route] Ember route name to transition to on click. Silently dropped when `@action` is also passed.
  * @property {object|object[]} [Args.routeModels] Models passed to `router.transitionTo` alongside `@route`. Accepts a single model or an array.
  *
  * State
@@ -101,29 +103,27 @@ export default class DButton extends Component {
   @service router;
   @service capabilities;
 
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-button] pass either @label or @translatedLabel, not both",
-      !(args.label && args.translatedLabel)
-    );
-    assert(
-      "[d-button] pass either @title or @translatedTitle, not both",
-      !(args.title && args.translatedTitle)
-    );
-    assert(
-      "[d-button] pass either @ariaLabel or @translatedAriaLabel, not both",
-      !(args.ariaLabel && args.translatedAriaLabel)
-    );
-    assert(
-      "[d-button] pass either @action or @route, not both",
-      !(args.action && args.route)
-    );
-    assert(
-      `[d-button] @type must be one of ${BUTTON_TYPES.join(", ")}`,
-      !args.type || BUTTON_TYPES.includes(args.type)
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-button] pass either @label or @translatedLabel, not both",
+        !(this.args.label && this.args.translatedLabel)
+      );
+      assert(
+        "[d-button] pass either @title or @translatedTitle, not both",
+        !(this.args.title && this.args.translatedTitle)
+      );
+      assert(
+        "[d-button] pass either @ariaLabel or @translatedAriaLabel, not both",
+        !(this.args.ariaLabel && this.args.translatedAriaLabel)
+      );
+      assert(
+        `[d-button] @type must be one of ${BUTTON_TYPES.join(", ")}`,
+        !this.args.type || BUTTON_TYPES.includes(this.args.type)
+      );
+    }
+    return null;
   }
 
   @computed("args.icon")
@@ -280,6 +280,7 @@ export default class DButton extends Component {
   <template>
     {{! template-lint-disable no-pointer-down-event-binding }}
     {{! @glint-nocheck: dynamic `<this.wrapperElement>` root types the element as `unknown`, which interferes with attribute checks }}
+    {{this.validateArgs}}
     <this.wrapperElement
       href={{@href}}
       type={{unless @href (or @type "button")}}

--- a/frontend/discourse/app/ui-kit/d-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-button.gjs
@@ -23,9 +23,12 @@ const BUTTON_TYPES = ["button", "submit", "reset"];
  * `DButton` instead of writing `<button class="btn">` so loading, disabled,
  * icon, and accessibility states stay consistent across the app.
  *
- * Click behavior comes from exactly one of `@action`, `@route`, or `@href` —
- * passing more than one is a contract violation. `@action` runs inside `next()`
- * on non-iOS to optimise INP; pass `@forwardEvent` if your handler needs the
+ * Click behavior comes from `@action`, `@route`, or `@href`. `@action` and
+ * `@route` are mutually exclusive (passing both silently drops `@route`),
+ * but `@href` can combine with either — for example, `@action` alongside
+ * `@href` renders an `<a>` so middle-click opens in a new tab while a
+ * regular click runs the handler. `@action` runs inside `next()` on
+ * non-iOS to optimise INP; pass `@forwardEvent` if your handler needs the
  * original event.
  *
  * @example
@@ -49,12 +52,12 @@ const BUTTON_TYPES = ["button", "submit", "reset"];
  *
  * Actions and navigation
  *
- * @property {Function|{value: Function}} [Args.action] Click handler. Accepts a plain function or an Ember action descriptor (`{ value: Function }`). Mutually exclusive with `@route` and `@href`.
+ * @property {Function|{value: Function}} [Args.action] Click handler. Accepts a plain function or an Ember action descriptor (`{ value: Function }`). Mutually exclusive with `@route`.
  * @property {any} [Args.actionParam] Value passed as the first argument to `@action` when it fires.
  * @property {boolean} [Args.forwardEvent] When true, the original click event is passed as the second argument to `@action`.
  * @property {(event: KeyboardEvent) => void} [Args.onKeyDown] Custom keydown handler. When set, the default Enter-triggers-click behavior is suppressed and your handler receives every keydown.
- * @property {string} [Args.href] Renders an `<a href="...">` instead of `<button>`. Use for true links (external URLs, anchor jumps). Mutually exclusive with `@action` and `@route`.
- * @property {string} [Args.route] Ember route name to transition to on click. Mutually exclusive with `@action` and `@href`.
+ * @property {string} [Args.href] Renders an `<a href="...">` instead of `<button>`. Pair with `@action` or `@route` to handle the click in JS while still exposing a real URL for middle-click and copy-link.
+ * @property {string} [Args.route] Ember route name to transition to on click. Mutually exclusive with `@action`.
  * @property {object|object[]} [Args.routeModels] Models passed to `router.transitionTo` alongside `@route`. Accepts a single model or an array.
  *
  * State
@@ -114,8 +117,8 @@ export default class DButton extends Component {
       !(args.ariaLabel && args.translatedAriaLabel)
     );
     assert(
-      "[d-button] @action, @route, and @href are mutually exclusive — pick one",
-      [args.action, args.route, args.href].filter(Boolean).length <= 1
+      "[d-button] pass either @action or @route, not both",
+      !(args.action && args.route)
     );
     assert(
       `[d-button] @type must be one of ${BUTTON_TYPES.join(", ")}`,

--- a/frontend/discourse/app/ui-kit/d-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-button.gjs
@@ -1,5 +1,6 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import { on } from "@ember/modifier";
 import { action, computed } from "@ember/object";
 import { next } from "@ember/runloop";
@@ -13,68 +14,114 @@ import dElement from "discourse/ui-kit/helpers/d-element";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+const BUTTON_TYPES = ["button", "submit", "reset"];
+
+/**
+ * A primary clickable element. Renders a native `<button>` by default, or an
+ * `<a>` when `@href` is provided. Supports i18n-keyed labels (`@label`,
+ * `@title`, `@ariaLabel`) and already-translated counterparts. Reach for
+ * `DButton` instead of writing `<button class="btn">` so loading, disabled,
+ * icon, and accessibility states stay consistent across the app.
+ *
+ * Click behavior comes from exactly one of `@action`, `@route`, or `@href` —
+ * passing more than one is a contract violation. `@action` runs inside `next()`
+ * on non-iOS to optimise INP; pass `@forwardEvent` if your handler needs the
+ * original event.
+ *
+ * @example
+ * <DButton @icon="plus" @label="topic.create" @action={{this.create}} />
+ *
+ * @example
+ * <DButton @href="https://example.com" @translatedLabel="Open" />
+ */
+
 /**
  * @typedef DButtonSignature
  *
  * @property {object} Args
  *
- * // Text
- * @property {string} [Args.title]
- * @property {string} [Args.translatedTitle]
- * @property {string} [Args.label]
- * @property {string} [Args.translatedLabel]
+ * Text
  *
- * // Actions / events
- * @property {function|object} [Args.action]
- * @property {any} [Args.actionParam]
- * @property {boolean} [Args.forwardEvent]
- * @property {function} [Args.onKeyDown]
+ * @property {string} [Args.label] Translatable i18n key for the visible label. Mutually exclusive with `translatedLabel`.
+ * @property {string} [Args.translatedLabel] Pre-translated visible label. Use when the label is computed at runtime and already localized.
+ * @property {string} [Args.title] Translatable i18n key for the native `title` tooltip. Mutually exclusive with `translatedTitle`.
+ * @property {string} [Args.translatedTitle] Pre-translated `title` tooltip.
  *
- * // Navigation
- * @property {string} [Args.href]
- * @property {string} [Args.route]
- * @property {object|object[]} [Args.routeModels]
+ * Actions and navigation
  *
- * // State
- * @property {boolean} [Args.isLoading]
- * @property {boolean} [Args.disabled]
- * @property {boolean} [Args.preventFocus]
+ * @property {Function|{value: Function}} [Args.action] Click handler. Accepts a plain function or an Ember action descriptor (`{ value: Function }`). Mutually exclusive with `@route` and `@href`.
+ * @property {any} [Args.actionParam] Value passed as the first argument to `@action` when it fires.
+ * @property {boolean} [Args.forwardEvent] When true, the original click event is passed as the second argument to `@action`.
+ * @property {(event: KeyboardEvent) => void} [Args.onKeyDown] Custom keydown handler. When set, the default Enter-triggers-click behavior is suppressed and your handler receives every keydown.
+ * @property {string} [Args.href] Renders an `<a href="...">` instead of `<button>`. Use for true links (external URLs, anchor jumps). Mutually exclusive with `@action` and `@route`.
+ * @property {string} [Args.route] Ember route name to transition to on click. Mutually exclusive with `@action` and `@href`.
+ * @property {object|object[]} [Args.routeModels] Models passed to `router.transitionTo` alongside `@route`. Accepts a single model or an array.
  *
- * // Display mode
- * @property {"link"} [Args.display]
+ * State
  *
- * // Display / icon
- * @property {string} [Args.icon]
- * @property {boolean} [Args.ellipsis]
- * @property {string} [Args.suffixIcon]
+ * @property {boolean} [Args.isLoading] When true, shows a spinner icon and disables the button. Use for async actions to give the user feedback during the in-flight request.
+ * @property {boolean} [Args.disabled] When true, the button is rendered disabled and click handlers do not fire.
+ * @property {boolean} [Args.preventFocus] When true, the button does not receive focus on mousedown. Useful for toolbar buttons that should not steal focus from an active editor.
  *
- * // Accessibility
- * @property {string} [Args.ariaLabel]
- * @property {string} [Args.translatedAriaLabel]
- * @property {boolean} [Args.ariaExpanded]
- * @property {boolean} [Args.ariaPressed]
- * @property {string} [Args.ariaControls]
- * @property {boolean} [Args.ariaHidden]
+ * Display
  *
- * // HTML attributes
- * @property {string} [Args.type]
- * @property {string} [Args.id]
- * @property {string} [Args.form]
- * @property {string} [Args.tabindex]
- * @property {string} [Args.class]
+ * @property {"link"} [Args.display] Visual style. `"link"` renders as a `.btn-link` (text-only, no background). Omit for the default `.btn` style.
+ * @property {string} [Args.icon] Name of the FontAwesome icon to render before the label. Looked up via `discourse/ui-kit/helpers/d-icon`.
+ * @property {string} [Args.suffixIcon] Name of an additional icon rendered after the label.
+ * @property {boolean} [Args.ellipsis] When true, appends `…` after the label to indicate the click will open a dialog or further interaction.
  *
- * // Root element type (enables ...attributes type checking)
- * @property {HTMLButtonElement} Element
+ * Accessibility
  *
- * // Optional yield
+ * @property {string} [Args.ariaLabel] Translatable i18n key for `aria-label`. Required when the button is icon-only. Mutually exclusive with `translatedAriaLabel`.
+ * @property {string} [Args.translatedAriaLabel] Pre-translated `aria-label`.
+ * @property {boolean} [Args.ariaExpanded] Value for `aria-expanded`. Pass a boolean; the component renders the string `"true"`/`"false"`.
+ * @property {boolean} [Args.ariaPressed] Value for `aria-pressed` (toggle-button state).
+ * @property {string} [Args.ariaControls] Value for `aria-controls`: the id of the element this button controls.
+ * @property {boolean} [Args.ariaHidden] When true, wraps the icon in an `aria-hidden="true"` span so screen readers skip it. Use when the icon is decorative and duplicates the label.
+ *
+ * HTML attributes (legacy — prefer `...attributes`)
+ *
+ * @property {"button"|"submit"|"reset"} [Args.type] Native `<button type>` value. Defaults to `"button"` so clicks never accidentally submit a form. Ignored when `@href` is set.
+ * @property {string} [Args.id] **Deprecated** — pass `id` via `...attributes` instead. Native `id` attribute.
+ * @property {string} [Args.form] **Deprecated** — pass `form` via `...attributes` instead. Native `form` attribute. Associates the button with a form by id when it lives outside that form's DOM.
+ * @property {string|number} [Args.tabindex] **Deprecated** — pass `tabindex` via `...attributes` instead. Native `tabindex` attribute.
+ * @property {string} [Args.class] **Deprecated** — pass `class` via `...attributes` instead. Extra classes joined to the component's own.
+ *
+ * @property {HTMLButtonElement} Element The rendered root. When `@href` is set the actual element is an `HTMLAnchorElement`, but the Signature tracks the more common case for `...attributes` typing.
+ *
  * @property {object} Blocks
- * @property {[]} Blocks.default Contents of the button
+ * @property {[]} Blocks.default Optional inner content. When provided alongside `@label`, the label still renders first; pure block content (no `@label`) substitutes for the label entirely.
  */
 
 /** @extends {Component<DButtonSignature>} */
 export default class DButton extends Component {
   @service router;
   @service capabilities;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-button] pass either @label or @translatedLabel, not both",
+      !(args.label && args.translatedLabel)
+    );
+    assert(
+      "[d-button] pass either @title or @translatedTitle, not both",
+      !(args.title && args.translatedTitle)
+    );
+    assert(
+      "[d-button] pass either @ariaLabel or @translatedAriaLabel, not both",
+      !(args.ariaLabel && args.translatedAriaLabel)
+    );
+    assert(
+      "[d-button] @action, @route, and @href are mutually exclusive — pick one",
+      [args.action, args.route, args.href].filter(Boolean).length <= 1
+    );
+    assert(
+      `[d-button] @type must be one of ${BUTTON_TYPES.join(", ")}`,
+      !args.type || BUTTON_TYPES.includes(args.type)
+    );
+  }
 
   @computed("args.icon")
   get btnIcon() {
@@ -178,13 +225,14 @@ export default class DButton extends Component {
 
         if (typeof actionVal === "object" && actionVal.value) {
           if (isIOS) {
-            // Don't optimise INP in iOS
-            // it results in focus events not being triggered
+            // iOS skips the next() optimisation: scheduling the call breaks
+            // focus events that depend on the click being synchronous.
             forwardEvent
               ? actionVal.value(actionParam, event)
               : actionVal.value(actionParam);
           } else {
-            // Using `next()` to optimise INP
+            // Defer the call to optimise INP — keeps the click handler short
+            // so the browser can paint sooner.
             next(() =>
               forwardEvent
                 ? actionVal.value(actionParam, event)
@@ -193,13 +241,10 @@ export default class DButton extends Component {
           }
         } else if (typeof actionVal === "function") {
           if (isIOS) {
-            // Don't optimise INP in iOS
-            // it results in focus events not being triggered
             forwardEvent
               ? actionVal(actionParam, event)
               : actionVal(actionParam);
           } else {
-            // Using `next()` to optimise INP
             next(() =>
               forwardEvent
                 ? actionVal(actionParam, event)
@@ -231,6 +276,7 @@ export default class DButton extends Component {
 
   <template>
     {{! template-lint-disable no-pointer-down-event-binding }}
+    {{! @glint-nocheck: dynamic `<this.wrapperElement>` root types the element as `unknown`, which interferes with attribute checks }}
     <this.wrapperElement
       href={{@href}}
       type={{unless @href (or @type "button")}}

--- a/frontend/discourse/app/ui-kit/d-calendar-date-time-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-calendar-date-time-input.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { Input } from "@ember/component";

--- a/frontend/discourse/app/ui-kit/d-cdn-img.gjs
+++ b/frontend/discourse/app/ui-kit/d-cdn-img.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { trustHTML } from "@ember/template";
 import { getURLWithCDN } from "discourse/lib/get-url";

--- a/frontend/discourse/app/ui-kit/d-char-counter.gjs
+++ b/frontend/discourse/app/ui-kit/d-char-counter.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { gt } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";

--- a/frontend/discourse/app/ui-kit/d-color-picker-choice.js
+++ b/frontend/discourse/app/ui-kit/d-color-picker-choice.js
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { trustHTML } from "@ember/template";

--- a/frontend/discourse/app/ui-kit/d-color-picker.gjs
+++ b/frontend/discourse/app/ui-kit/d-color-picker.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import { tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-combo-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-combo-button.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import curryComponent from "ember-curry-component";

--- a/frontend/discourse/app/ui-kit/d-conditional-in-element.gjs
+++ b/frontend/discourse/app/ui-kit/d-conditional-in-element.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 const DConditionalInElement = <template>
   {{#if @inline}}
     {{yield}}

--- a/frontend/discourse/app/ui-kit/d-conditional-loading-section.gjs
+++ b/frontend/discourse/app/ui-kit/d-conditional-loading-section.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { tagName } from "@ember-decorators/component";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";

--- a/frontend/discourse/app/ui-kit/d-conditional-loading-spinner.gjs
+++ b/frontend/discourse/app/ui-kit/d-conditional-loading-spinner.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { eq } from "discourse/truth-helpers";

--- a/frontend/discourse/app/ui-kit/d-cook-text.gjs
+++ b/frontend/discourse/app/ui-kit/d-cook-text.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-copy-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-copy-button.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { action } from "@ember/object";
 import { tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-count-i18n.gjs
+++ b/frontend/discourse/app/ui-kit/d-count-i18n.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";

--- a/frontend/discourse/app/ui-kit/d-custom-html.gjs
+++ b/frontend/discourse/app/ui-kit/d-custom-html.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";

--- a/frontend/discourse/app/ui-kit/d-date-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-input.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import Component, { Input } from "@ember/component";
 import { on } from "@ember/modifier";
 import { action, computed } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-date-picker.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-picker.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import Component, { Input } from "@ember/component";
 import { computed } from "@ember/object";
 import { schedule } from "@ember/runloop";

--- a/frontend/discourse/app/ui-kit/d-date-time-input-range.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-time-input-range.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-date-time-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-date-time-input.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { action, computed } from "@ember/object";
 import { tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-decorated-html.gjs
+++ b/frontend/discourse/app/ui-kit/d-decorated-html.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { untrack } from "@glimmer/validator";
 import { trackedArray } from "@ember/reactive/collections";

--- a/frontend/discourse/app/ui-kit/d-dropdown-menu.gjs
+++ b/frontend/discourse/app/ui-kit/d-dropdown-menu.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { hash } from "@ember/helper";
 
 const DropdownItem = <template>

--- a/frontend/discourse/app/ui-kit/d-editor.gjs
+++ b/frontend/discourse/app/ui-kit/d-editor.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/no-observers, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/no-observers, ember/require-tagless-components, local/require-ts-check */
 import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { on } from "@ember/modifier";

--- a/frontend/discourse/app/ui-kit/d-empty-state.gjs
+++ b/frontend/discourse/app/ui-kit/d-empty-state.gjs
@@ -1,9 +1,58 @@
+// @ts-check
 import { concat } from "@ember/helper";
 import { or } from "discourse/truth-helpers";
+/** @type {import("discourse/ui-kit/d-button.gjs").default} */
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
+/**
+ * The standard "nothing to show here" placeholder. Used when a list, table, or
+ * dashboard pane has no items — combines an optional SVG illustration, a
+ * title and body of copy, a primary call-to-action button, and an optional
+ * tip line. Prefer this over hand-rolled empty states so the visual language
+ * stays consistent across the app.
+ *
+ * The CTA section accepts the same `@action` / `@href` / `@route` triplet as
+ * `DButton` and is rendered as a primary button. The "tip" slot can either be
+ * a plain string via `@tipText` or richer markup via the `:tip` named block.
+ *
+ * @example
+ * <DEmptyState
+ *   @identifier="bookmarks"
+ *   @title={{i18n "bookmarks.none.title"}}
+ *   @body={{i18n "bookmarks.none.body"}}
+ *   @ctaLabel={{i18n "bookmarks.add"}}
+ *   @ctaAction={{this.addBookmark}}
+ *   @ctaIcon="plus"
+ * />
+ */
+
+/**
+ * @typedef DEmptyStateSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} [Args.identifier] A short identifier appended to the container class (`empty-state__container--<identifier>`). Use to target the empty state with feature-specific CSS without inventing a wrapper.
+ * @property {unknown} [Args.svgContent] Pre-rendered SVG content (a `SafeString` or trusted HTML) for the illustration above the title. Use `htmlSafe()` for inline SVG sources.
+ * @property {string} [Args.title] Translated title rendered above the body. Pass through `i18n()` at the call-site.
+ * @property {string} [Args.body] Translated body copy.
+ * @property {string} [Args.ctaLabel] Translated label for the call-to-action button. When omitted, no button renders.
+ * @property {string} [Args.ctaIcon] FontAwesome icon name for the CTA button.
+ * @property {Function} [Args.ctaAction] Click handler for the CTA. Mutually exclusive with `@ctaHref` and `@ctaRoute` (per `DButton`).
+ * @property {string} [Args.ctaHref] External URL for the CTA. Renders the button as an anchor.
+ * @property {string} [Args.ctaRoute] Ember route name for the CTA. Triggers `router.transitionTo` on click.
+ * @property {string} [Args.tipText] Translated tip copy rendered below the CTA. Use when the tip is a plain string; for richer content use the `:tip` named block instead.
+ * @property {string} [Args.tipIcon] FontAwesome icon name rendered before the tip content.
+ *
+ * @property {HTMLDivElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.tip Optional named block for richer tip content (markup, links). Mutually exclusive with `@tipText` — when both are passed, the block wins.
+ */
+
+/** @type {import("@ember/component/template-only").TOC<DEmptyStateSignature>} */
 const DEmptyState = <template>
+  {{! @glint-nocheck: forwards args to DButton whose dynamic-tag template surfaces unknown-element complaints in consumers }}
   <div
     class="empty-state__container
       {{if @identifier (concat '--' @identifier)}}

--- a/frontend/discourse/app/ui-kit/d-expanding-text-area.gjs
+++ b/frontend/discourse/app/ui-kit/d-expanding-text-area.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { on } from "@ember/modifier";
 import dAutoFocus from "discourse/ui-kit/modifiers/d-auto-focus";
 

--- a/frontend/discourse/app/ui-kit/d-filter-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-filter-input.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";

--- a/frontend/discourse/app/ui-kit/d-flash-message.gjs
+++ b/frontend/discourse/app/ui-kit/d-flash-message.gjs
@@ -1,8 +1,35 @@
+// @ts-check
 import Component from "@glimmer/component";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 const FLASH_TYPES = ["success", "error", "warning", "info"];
 
+/**
+ * A boxed inline alert message — the "flash" pattern. Use to surface
+ * transient feedback inline in the page (form submission errors, save
+ * confirmations) rather than as a toast/dialog. Renders nothing when
+ * `@flash` is falsy, so the call-site can render the component
+ * unconditionally and let it disappear when the message clears.
+ *
+ * Pass `@flash` for the message text and `@type` for the variant (one of
+ * `"success"`, `"error"`, `"warning"`, `"info"`).
+ */
+
+/**
+ * @typedef DFlashMessageSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} [Args.flash] The message text. When falsy, the component renders nothing.
+ * @property {"success"|"error"|"warning"|"info"} [Args.type] Visual variant. Adds `.alert-<type>` for theming. Omit for the plain `.alert` style.
+ *
+ * @property {HTMLDivElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Not used — the message text is passed via `@flash`.
+ */
+
+/** @extends {Component<DFlashMessageSignature>} */
 export default class DFlashMessage extends Component {
   get flashClass() {
     if (this.args.type && !FLASH_TYPES.includes(this.args.type)) {

--- a/frontend/discourse/app/ui-kit/d-future-date-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-future-date-input.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component, { Input } from "@ember/component";
 import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";

--- a/frontend/discourse/app/ui-kit/d-highlighted-code.gjs
+++ b/frontend/discourse/app/ui-kit/d-highlighted-code.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";

--- a/frontend/discourse/app/ui-kit/d-horizontal-overflow-nav.gjs
+++ b/frontend/discourse/app/ui-kit/d-horizontal-overflow-nav.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { registerDestructor } from "@ember/destroyable";

--- a/frontend/discourse/app/ui-kit/d-html-with-links.gjs
+++ b/frontend/discourse/app/ui-kit/d-html-with-links.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-input-tip.gjs
+++ b/frontend/discourse/app/ui-kit/d-input-tip.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 const DInputTip = <template>

--- a/frontend/discourse/app/ui-kit/d-interpolated-translation.gjs
+++ b/frontend/discourse/app/ui-kit/d-interpolated-translation.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";

--- a/frontend/discourse/app/ui-kit/d-light-dark-img.gjs
+++ b/frontend/discourse/app/ui-kit/d-light-dark-img.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { getURLWithCDN } from "discourse/lib/get-url";

--- a/frontend/discourse/app/ui-kit/d-load-more.gjs
+++ b/frontend/discourse/app/ui-kit/d-load-more.gjs
@@ -1,12 +1,15 @@
+// @ts-check
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import { action } from "@ember/object";
 import discourseDebounce from "discourse/lib/debounce";
+/** @type {import("discourse/ui-kit/helpers/d-element.gjs").default} */
 import dElement from "discourse/ui-kit/helpers/d-element";
 import dObserveIntersection from "discourse/ui-kit/modifiers/d-observe-intersection";
 
 let ENABLE_LOAD_MORE_OBSERVER = true;
 
-// Exported functions to control the behavior in tests
+// Exported functions to control the behavior in tests.
 export function disableLoadMoreObserver() {
   ENABLE_LOAD_MORE_OBSERVER = false;
 }
@@ -16,69 +19,71 @@ export function enableLoadMoreObserver() {
 }
 
 /**
- * A component that implements infinite loading using IntersectionObserver.
+ * Infinite-scroll trigger backed by `IntersectionObserver`. Renders a hidden
+ * sentinel element after the yielded content; once the sentinel scrolls into
+ * view, `@action` is invoked (debounced) so the consumer can fetch the next
+ * page.
  *
- * LoadMore triggers an action when a sentinel element becomes visible in the viewport,
- * which is typically used to load additional content. Besides the `action` argument, it also takes
- * in additional options to customize the observer's behavior;
- * Refer to https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#options for a full list.
+ * Use the block form to wrap the existing list and have the sentinel
+ * naturally attach to its bottom edge. Use the no-block form to drop a
+ * standalone sentinel anywhere on the page when the wrapper is undesirable.
  *
- * @param {Function} action - The action to trigger when more content should be loaded
- * @param {boolean} [enabled=true] - Whether to allow the loadMore action to trigger.
- *   Use this when you know there's no more content available (e.g., `model.canLoadMore`).
- *   When false, the observer continues to run but the action won't be triggered.
- * @param {boolean} [isLoading=false] - Whether content is currently loading.
- *   When true, the IntersectionObserver won't be created, preventing premature triggers
- *   during initial content load. Pass this to avoid race conditions during page initialization.
- * @param {string} [rootMargin="0px 0px 0px 0px"] - Margin around the root element for intersection detection
- * @param {number} [threshold=0.0] - Threshold at which the intersection callback is triggered
- * @param {string} [root=null] - CSS selector for the root element to observe intersection within
+ * `@enabled` and `@isLoading` exist to prevent unwanted triggers:
  *
- * @example Basic usage with a block:
- * ```gjs
- * <LoadMore @action={{this.loadMoreTopics}}>
+ * - `@enabled={{false}}` keeps the observer running but blocks the action,
+ *   useful when you've reached the end of the data.
+ * - `@isLoading={{true}}` skips creating the observer entirely, avoiding
+ *   race conditions on initial load.
+ *
+ * The remaining args (`@rootMargin`, `@threshold`, `@root`) map 1:1 to
+ * `IntersectionObserver` options.
+ *
+ * @example
+ * <DLoadMore @action={{this.loadMoreTopics}}>
  *   <TopicList @topics={{this.topics}} />
- * </LoadMore>
- * ```
+ * </DLoadMore>
  *
- * @example Usage without a block (as standalone sentinel):
- * ```gjs
- * <div class="my-content">
- *   {{#each this.items as |item|}}
- *     <ItemComponent @item={{item}} />
- *   {{/each}}
- * </div>
- *
- * <LoadMore @action={{this.loadMore}} />
- * ```
- *
- * @example With enabled and isLoading to prevent premature loading:
- * ```gjs
- * <LoadMore
+ * @example
+ * <DLoadMore
  *   @action={{this.loadMoreUsers}}
  *   @enabled={{this.model.canLoadMore}}
  *   @isLoading={{this.isLoading}}
- * >
- *   <UserList @users={{this.model}} />
- * </LoadMore>
- * ```
- *
- * @example With custom IntersectionObserver options:
- * ```gjs
- * <LoadMore
- *   @action={{this.fetchMoreUsers}}
- *   @rootMargin="100px"
- *   @threshold={{0.2}}
- *   @root={{this.scrollContainer}}
- *   class="users-container"
  * />
- * ```
  */
+
+/**
+ * @typedef DLoadMoreSignature
+ *
+ * @property {object} Args
+ *
+ * @property {Function} Args.action Required. Invoked (debounced) when the sentinel becomes visible. The component does not pass arguments — the consumer typically captures the next-page state in its own closure.
+ * @property {boolean} [Args.enabled] When false, the action is suppressed even though the observer keeps running. Defaults to `true`. Use `model.canLoadMore` or similar.
+ * @property {boolean} [Args.isLoading] When true, no `IntersectionObserver` is created at all. Defaults to `false`. Use to suppress trigger races during page initialization.
+ * @property {string} [Args.rootMargin] CSS-style margin around the root element for intersection detection. Defaults to `"0px 0px 0px 0px"`.
+ * @property {number} [Args.threshold] Visibility fraction at which the callback fires. Defaults to `0.0` (any pixel visible).
+ * @property {Element|null} [Args.root] Element to observe within. `null` (the default) means the viewport.
+ *
+ * @property {HTMLDivElement} Element The wrapper `<div>` rendered when a block is yielded. When no block is given, the component renders only the sentinel and `...attributes` has no element to attach to.
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Optional content the sentinel should be appended after. When given, the wrapper `<div>` is rendered around both block and sentinel.
+ */
+
+/** @extends {Component<DLoadMoreSignature>} */
 export default class DLoadMore extends Component {
   observer;
   root = this.args.root || null;
   rootMargin = this.args.rootMargin || "0px 0px 0px 0px";
   threshold = this.args.threshold || 0.0;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-load-more] @action is required",
+      typeof this.args.action === "function"
+    );
+  }
 
   get enabled() {
     return this.args.enabled ?? true;

--- a/frontend/discourse/app/ui-kit/d-load-more.gjs
+++ b/frontend/discourse/app/ui-kit/d-load-more.gjs
@@ -1,5 +1,7 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
+import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { action } from "@ember/object";
 import discourseDebounce from "discourse/lib/debounce";
@@ -76,13 +78,15 @@ export default class DLoadMore extends Component {
   rootMargin = this.args.rootMargin || "0px 0px 0px 0px";
   threshold = this.args.threshold || 0.0;
 
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-load-more] @action is required",
-      typeof this.args.action === "function"
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-load-more] @action is required",
+        typeof this.args.action === "function"
+      );
+    }
+    return null;
   }
 
   get enabled() {
@@ -97,6 +101,7 @@ export default class DLoadMore extends Component {
   }
 
   <template>
+    {{this.validateArgs}}
     {{#let (dElement (if (has-block) "div" "")) as |Wrapper|}}
       <Wrapper ...attributes>
         {{yield}}

--- a/frontend/discourse/app/ui-kit/d-modal-cancel.gjs
+++ b/frontend/discourse/app/ui-kit/d-modal-cancel.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 

--- a/frontend/discourse/app/ui-kit/d-modal.gjs
+++ b/frontend/discourse/app/ui-kit/d-modal.gjs
@@ -1,5 +1,7 @@
+// @ts-check
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
+import { assert } from "@ember/debug";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -16,6 +18,7 @@ import DButton from "discourse/ui-kit/d-button";
 import DConditionalInElement from "discourse/ui-kit/d-conditional-in-element";
 import DFlashMessage from "discourse/ui-kit/d-flash-message";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+/** @type {import("discourse/ui-kit/helpers/d-element.gjs").default} */
 import dElement from "discourse/ui-kit/helpers/d-element";
 import dSwipe from "discourse/ui-kit/modifiers/d-swipe";
 import dTrapTab from "discourse/ui-kit/modifiers/d-trap-tab";
@@ -26,8 +29,85 @@ export const CLOSE_INITIATED_BY_CLICK_OUTSIDE = "initiatedByClickOut";
 export const CLOSE_INITIATED_BY_MODAL_SHOW = "initiatedByModalShow";
 export const CLOSE_INITIATED_BY_SWIPE_DOWN = "initiatedBySwipeDown";
 
+const ALLOWED_TAG_NAMES = ["div", "form"];
+
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
 
+/**
+ * The standard modal dialog. Renders an absolute-positioned dialog with a
+ * backdrop, a header (optional close button, title, subtitle), a body slot,
+ * and a footer slot. Handles focus trapping, body-scroll locking on mobile,
+ * Escape-to-close, Enter-to-submit, click-outside dismissal, and swipe-down
+ * dismissal on touch devices.
+ *
+ * Most consumers go through `service modal` which mounts a modal component
+ * for them; `DModal` itself is the building block that those modal
+ * components yield from their template.
+ *
+ * `@closeModal` is the single close callback — it fires with one argument
+ * `{ initiatedBy: "<reason>" }` where the reason is one of the exported
+ * `CLOSE_INITIATED_BY_*` constants. Provide `@beforeClose` to veto specific
+ * close attempts (e.g. unsaved changes prompt).
+ *
+ * @example
+ * <DModal @closeModal={{@closeModal}} @title="Confirm delete">
+ *   <:body>Are you sure?</:body>
+ *   <:footer>
+ *     <DButton @label="cancel" @action={{@closeModal}} />
+ *     <DButton @label="delete" class="btn-danger" @action={{this.confirm}} />
+ *   </:footer>
+ * </DModal>
+ */
+
+/**
+ * @typedef DModalSignature
+ *
+ * @property {object} Args
+ *
+ * Identity and content
+ *
+ * @property {string} [Args.title] Translated dialog title rendered in the header. Drives `aria-labelledby`.
+ * @property {string} [Args.subtitle] Translated subtitle rendered below the title.
+ * @property {"div"|"form"} [Args.tagName] Root tag. Use `"form"` when the dialog wraps form submission. Defaults to `"div"`.
+ *
+ * Close lifecycle
+ *
+ * @property {(payload: {initiatedBy: string}) => void} [Args.closeModal] Invoked when the modal should close. Receives a payload with the trigger reason. Omitting this disables all dismiss mechanisms.
+ * @property {(payload: {initiatedBy: string}) => boolean | Promise<boolean>} [Args.beforeClose] Invoked before each close attempt. Return (or resolve to) `false` to veto.
+ * @property {boolean} [Args.dismissable] Whether the user can dismiss the modal (close button, Escape, click-outside, swipe). Defaults to `true` when `@closeModal` is set.
+ * @property {boolean} [Args.submitOnEnter] When `true` (the default), pressing Enter outside form/textarea/select-kit focus triggers the footer's primary button.
+ *
+ * Layout
+ *
+ * @property {boolean} [Args.inline] When `true`, the modal renders inline at its call-site rather than being teleported to the modal container. Used for in-page sub-dialogs.
+ * @property {boolean} [Args.autofocus] When `true` (the default), focus is moved into the modal on mount.
+ * @property {boolean} [Args.hidden] When `true`, document-level keyboard handlers are bypassed. Used by the modal service when stacking modals.
+ * @property {boolean} [Args.hideHeader] Hides the header block entirely (no title, no close button).
+ * @property {boolean} [Args.hideFooter] Hides the `<:footer>` block region even if the consumer yields it.
+ * @property {string} [Args.headerClass] Extra classes joined onto the `.d-modal__header` element.
+ * @property {string} [Args.bodyClass] Extra classes joined onto the `.d-modal__body` element.
+ *
+ * Flash
+ *
+ * @property {string} [Args.flash] Inline flash message rendered between header and body.
+ * @property {"success"|"error"|"warning"|"info"} [Args.flashType] Flash variant.
+ *
+ * @property {HTMLDivElement | HTMLFormElement} Element The root dialog element. Type depends on `@tagName`.
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Body content when no `<:body>` named block is provided.
+ * @property {[]} Blocks.aboveHeader Rendered above the header. Use sparingly — most callers should put content in `<:body>`.
+ * @property {[]} Blocks.headerAboveTitle Rendered inside the header, above the title row.
+ * @property {[]} Blocks.belowModalTitle Rendered inside the title block, after the subtitle.
+ * @property {[]} Blocks.headerBelowTitle Rendered inside the header, below the title row.
+ * @property {[]} Blocks.headerPrimaryAction Rendered on the right edge of the header on mobile. On desktop the dismiss button takes this slot; on mobile this block replaces it.
+ * @property {[]} Blocks.belowHeader Rendered between the header and the flash region.
+ * @property {[]} Blocks.body Main content area. When omitted, the default block is used instead.
+ * @property {[]} Blocks.footer Footer content. The footer is only rendered when this block is present.
+ * @property {[]} Blocks.belowFooter Rendered after the footer.
+ */
+
+/** @extends {Component<DModalSignature>} */
 export default class DModal extends Component {
   @service appEvents;
   @service capabilities;
@@ -37,8 +117,11 @@ export default class DModal extends Component {
   @tracked wrapperElement;
   @tracked animating = false;
 
+  /** @type {HTMLElement} */
+  modalContainer;
+
   registerModalContainer = modifierFn((el) => {
-    this.modalContainer = el;
+    this.modalContainer = /** @type {HTMLElement} */ (el);
   });
 
   setupModalBody = modifierFn((el) => {
@@ -70,11 +153,24 @@ export default class DModal extends Component {
     };
   });
 
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-modal] @closeModal must be a function when provided",
+      !this.args.closeModal || typeof this.args.closeModal === "function"
+    );
+    assert(
+      "[d-modal] @beforeClose must be a function when provided",
+      !this.args.beforeClose || typeof this.args.beforeClose === "function"
+    );
+  }
+
   @action
   resetDocumentScrollOnIOS(visible) {
-    // iOS scrolls the page to the focused input when the keyboard opens
-    // as a result when an input is within a dropdown within a modal, the modal is scrolled out of view.
-    // This forces the modal back to the correct visible position.
+    // iOS scrolls the page to the focused input when the keyboard opens.
+    // When an input is inside a dropdown inside a modal, that scroll pushes
+    // the modal off-screen. This forces the page back to its locked position.
     if (!visible) {
       return;
     }
@@ -132,7 +228,8 @@ export default class DModal extends Component {
       return false;
     }
 
-    // skip when in a form, textarea, or select-kit element
+    // Skip Enter-to-submit when focus is inside a form, textarea, or
+    // select-kit — those have their own Enter semantics.
     if (
       event.target.closest("form") ||
       document.activeElement?.closest("form") ||
@@ -159,8 +256,8 @@ export default class DModal extends Component {
   @action
   async handleSwipeEnded(swipeEvent) {
     if (this.animating) {
-      // if the modal is animating we don't want to risk resetting the position
-      // as the user releases the swipe at the same time
+      // If the modal is animating we don't want to risk resetting the
+      // position as the user releases the swipe at the same time.
       return;
     }
 
@@ -177,7 +274,8 @@ export default class DModal extends Component {
 
   @action
   handleWrapperPointerDown(e) {
-    // prevents hamburger menu to close on modal backdrop click
+    // Prevent the hamburger menu from closing when the modal backdrop is
+    // clicked — the click bubbles through the portal otherwise.
     e.stopPropagation();
   }
 
@@ -264,12 +362,12 @@ export default class DModal extends Component {
     this.closeModal(CLOSE_INITIATED_BY_BUTTON);
   }
 
-  // Could be optimised to remove classic component once RFC389 is implemented
-  // https://rfcs.emberjs.com/id/0389-dynamic-tag-names
+  // Could be optimised to remove the classic component path once RFC389
+  // (dynamic tag names) ships: https://rfcs.emberjs.com/id/0389-dynamic-tag-names
   @cached
   get dynamicElement() {
     const tagName = this.args.tagName || "div";
-    if (!["div", "form"].includes(tagName)) {
+    if (!ALLOWED_TAG_NAMES.includes(tagName)) {
       throw `@tagName must be form or div`;
     }
 
@@ -326,6 +424,7 @@ export default class DModal extends Component {
 
   <template>
     {{! template-lint-disable no-invalid-interactive }}
+    {{! @glint-nocheck: complex template — render-modifier and dSwipe signatures don't match Glint's stricter typing }}
 
     <DConditionalInElement
       @element={{this.modal.containerElement}}

--- a/frontend/discourse/app/ui-kit/d-modal.gjs
+++ b/frontend/discourse/app/ui-kit/d-modal.gjs
@@ -1,5 +1,6 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
 import { cached, tracked } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { on } from "@ember/modifier";
@@ -153,17 +154,19 @@ export default class DModal extends Component {
     };
   });
 
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-modal] @closeModal must be a function when provided",
-      !this.args.closeModal || typeof this.args.closeModal === "function"
-    );
-    assert(
-      "[d-modal] @beforeClose must be a function when provided",
-      !this.args.beforeClose || typeof this.args.beforeClose === "function"
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-modal] @closeModal must be a function when provided",
+        !this.args.closeModal || typeof this.args.closeModal === "function"
+      );
+      assert(
+        "[d-modal] @beforeClose must be a function when provided",
+        !this.args.beforeClose || typeof this.args.beforeClose === "function"
+      );
+    }
+    return null;
   }
 
   @action
@@ -425,6 +428,7 @@ export default class DModal extends Component {
   <template>
     {{! template-lint-disable no-invalid-interactive }}
     {{! @glint-nocheck: complex template — render-modifier and dSwipe signatures don't match Glint's stricter typing }}
+    {{this.validateArgs}}
 
     <DConditionalInElement
       @element={{this.modal.containerElement}}

--- a/frontend/discourse/app/ui-kit/d-multi-select.gjs
+++ b/frontend/discourse/app/ui-kit/d-multi-select.gjs
@@ -1,6 +1,7 @@
 // @ts-check
 /* eslint-disable ember/no-side-effects */
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
 import { cached, tracked } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { fn } from "@ember/helper";
@@ -111,13 +112,15 @@ export default class DMultiSelect extends Component {
   compareKey = "id";
   #promise = null;
 
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-multi-select] @loadFn is required",
-      typeof this.args.loadFn === "function"
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-multi-select] @loadFn is required",
+        typeof this.args.loadFn === "function"
+      );
+    }
+    return null;
   }
 
   get hasSelection() {
@@ -313,6 +316,7 @@ export default class DMultiSelect extends Component {
 
   <template>
     {{! @glint-nocheck: integrates classic DTextField with `readonly` helper and a curried DMenu trigger that isn't fully reflected in the JSDoc Signature }}
+    {{this.validateArgs}}
     <DMenu
       @identifier="d-multi-select"
       @triggerComponent={{dElement "div"}}

--- a/frontend/discourse/app/ui-kit/d-multi-select.gjs
+++ b/frontend/discourse/app/ui-kit/d-multi-select.gjs
@@ -1,21 +1,27 @@
+// @ts-check
 /* eslint-disable ember/no-side-effects */
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
+import { assert } from "@ember/debug";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { trustHTML } from "@ember/template";
 import { TrackedAsyncData } from "ember-async-data";
+/** @type {import("discourse/float-kit/components/d-menu.gjs")} */
 import DMenu from "discourse/float-kit/components/d-menu";
 import discourseDebounce from "discourse/lib/debounce";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import { makeArray } from "discourse/lib/helpers";
 import { eq } from "discourse/truth-helpers";
+/** @type {import("discourse/ui-kit/d-button.gjs").default} */
 import DButton from "discourse/ui-kit/d-button";
+/** @type {import("discourse/ui-kit/d-dropdown-menu.gjs").default} */
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import DTextField from "discourse/ui-kit/d-text-field";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+/** @type {import("discourse/ui-kit/helpers/d-element.gjs").default} */
 import dElement from "discourse/ui-kit/helpers/d-element";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dScrollIntoView from "discourse/ui-kit/modifiers/d-scroll-into-view";
@@ -34,6 +40,69 @@ class Skeleton extends Component {
   </template>
 }
 
+/**
+ * A typeahead picker that lets the user build up a selection from an
+ * asynchronously-loaded list. The component owns the search box, the
+ * keyboard navigation (`ArrowUp` / `ArrowDown` / `Enter`), and the
+ * loading/error/no-results states; the consumer owns the data fetch and the
+ * selection state.
+ *
+ * The picker is **controlled**: `@selection` is the source of truth, and
+ * `@onChange` is invoked with the new array whenever the user adds or
+ * removes an item. The component does not maintain its own selection state.
+ *
+ * Items are compared by `id` by default. Override with `@compareFn` when
+ * items are matched on a different key.
+ *
+ * Three named blocks let the consumer render their own data:
+ * - `<:selection>` — how each selected pill displays
+ * - `<:result>` — how each dropdown row displays
+ * - `<:error>` — how a failed `@loadFn` is shown
+ *
+ * @example
+ * <DMultiSelect
+ *   @selection={{this.tags}}
+ *   @onChange={{this.updateTags}}
+ *   @loadFn={{this.searchTags}}
+ * >
+ *   <:selection as |tag|>{{tag.name}}</:selection>
+ *   <:result as |tag|>{{tag.name}}</:result>
+ *   <:error as |err|>{{err.message}}</:error>
+ * </DMultiSelect>
+ */
+
+/**
+ * @typedef DMultiSelectSignature
+ *
+ * @property {object} Args
+ *
+ * @property {Array<object>} [Args.selection] Currently-selected items. The component compares against this array to filter out already-selected results.
+ * @property {(newSelection: Array<object>) => void} [Args.onChange] Invoked with the new full selection array whenever an item is added or removed.
+ * @property {(searchTerm: string) => Promise<Array<object>>} Args.loadFn Required. Fetches the candidate options for a given search term. Called (debounced) every time the search input changes.
+ * @property {(a: object, b: object) => boolean} [Args.compareFn] Custom equality check for items. Defaults to comparing the `id` field.
+ * @property {string} [Args.label] Trigger text shown when no items are selected. Defaults to the i18n string `multi_select.label`.
+ * @property {string} [Args.noResultsLabel] Empty-state text shown inside the dropdown when the search returns no items. Defaults to the i18n string `multi_select.no_results`.
+ * @property {string} [Args.contentClass] Extra classes joined onto the dropdown menu wrapper.
+ *
+ * DMenu pass-through (see `DMenu` for the full semantics).
+ *
+ * @property {boolean} [Args.visibilityOptimizer]
+ * @property {string} [Args.placement]
+ * @property {Array<string>} [Args.allowedPlacements]
+ * @property {number} [Args.offset]
+ * @property {boolean} [Args.matchTriggerMinWidth]
+ * @property {boolean} [Args.matchTriggerWidth]
+ * @property {Function} [Args.onRegisterDMenuApi] Called with the DMenu instance once mounted. Use to programmatically open/close the menu from the consumer.
+ *
+ * @property {HTMLDivElement} Element The DMenu trigger wrapper (`<div class="d-multi-select-trigger">`).
+ *
+ * @property {object} Blocks
+ * @property {[object]} Blocks.selection Renders one selected-item pill. Receives the item.
+ * @property {[object]} Blocks.result Renders one dropdown row. Receives the item.
+ * @property {[unknown]} Blocks.error Renders the error state when `@loadFn` rejects. Receives the error.
+ */
+
+/** @extends {Component<DMultiSelectSignature>} */
 export default class DMultiSelect extends Component {
   @tracked searchTerm = "";
 
@@ -41,6 +110,15 @@ export default class DMultiSelect extends Component {
 
   compareKey = "id";
   #promise = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-multi-select] @loadFn is required",
+      typeof this.args.loadFn === "function"
+    );
+  }
 
   get hasSelection() {
     return this.args.selection?.length > 0;
@@ -108,7 +186,7 @@ export default class DMultiSelect extends Component {
 
   @action
   focus(input) {
-    // Reset preselection on dropdown open to prevent unwanted scrolling
+    // Reset preselection on dropdown open to prevent unwanted scrolling.
     this.preselectedItem = null;
     input.focus({ preventScroll: true });
   }
@@ -123,7 +201,8 @@ export default class DMultiSelect extends Component {
       event.preventDefault();
       event.stopPropagation();
 
-      // Only toggle if we have a preselected item and it's in the available options
+      // Only toggle when there's a preselected item that's still in the
+      // available options (it may have been removed by a concurrent change).
       if (
         this.preselectedItem &&
         this.availableOptions?.some((item) =>
@@ -183,7 +262,7 @@ export default class DMultiSelect extends Component {
       return;
     }
 
-    // Reset preselected item since the available options will change
+    // Reset preselected item since the available options will change.
     this.preselectedItem = null;
 
     this.args.onChange?.(
@@ -197,12 +276,12 @@ export default class DMultiSelect extends Component {
 
     const currentSelection = makeArray(this.args.selection);
 
-    // Check if item is already selected
+    // Don't add duplicates.
     if (currentSelection.some((item) => this.compare(item, result))) {
-      return; // Don't add duplicates
+      return;
     }
 
-    // Reset preselected item since the available options will change
+    // Reset preselected item since the available options will change.
     this.preselectedItem = null;
 
     this.args.onChange?.(currentSelection.concat(result));
@@ -233,6 +312,7 @@ export default class DMultiSelect extends Component {
   }
 
   <template>
+    {{! @glint-nocheck: integrates classic DTextField with `readonly` helper and a curried DMenu trigger that isn't fully reflected in the JSDoc Signature }}
     <DMenu
       @identifier="d-multi-select"
       @triggerComponent={{dElement "div"}}

--- a/frontend/discourse/app/ui-kit/d-nav-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-nav-item.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 /* You might be looking for navigation-item. */
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";

--- a/frontend/discourse/app/ui-kit/d-navigation-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-navigation-item.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";

--- a/frontend/discourse/app/ui-kit/d-number-field.js
+++ b/frontend/discourse/app/ui-kit/d-number-field.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { computed } from "@ember/object";
 import { classNameBindings } from "@ember-decorators/component";
 import deprecated from "discourse/lib/deprecated";

--- a/frontend/discourse/app/ui-kit/d-otp/slot.gjs
+++ b/frontend/discourse/app/ui-kit/d-otp/slot.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { isBlank } from "@ember/utils";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";

--- a/frontend/discourse/app/ui-kit/d-page-action-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-page-action-button.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { hash } from "@ember/helper";
 import DButton from "discourse/ui-kit/d-button";
 

--- a/frontend/discourse/app/ui-kit/d-page-header.gjs
+++ b/frontend/discourse/app/ui-kit/d-page-header.gjs
@@ -1,14 +1,19 @@
+// @ts-check
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+/** @type {import("discourse/float-kit/components/d-menu.gjs")} */
 import DMenu from "discourse/float-kit/components/d-menu";
-import { bind } from "discourse/lib/decorators";
 import { or } from "discourse/truth-helpers";
+/** @type {import("discourse/ui-kit/d-breadcrumbs-container.gjs")} */
 import DBreadcrumbsContainer from "discourse/ui-kit/d-breadcrumbs-container";
+/** @type {import("discourse/ui-kit/d-dropdown-menu.gjs")} */
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+/** @type {import("discourse/ui-kit/d-horizontal-overflow-nav.gjs")} */
 import DHorizontalOverflowNav from "discourse/ui-kit/d-horizontal-overflow-nav";
+/** @type {import("discourse/ui-kit/d-page-action-button.gjs")} */
 import {
   DangerActionListItem,
   DangerButton,
@@ -22,24 +27,88 @@ import { i18n } from "discourse-i18n";
 
 const HEADLESS_ACTIONS = ["new", "edit"];
 
+/**
+ * The top-of-page header used across admin and account pages. Combines
+ * breadcrumbs, a title, a description with optional "learn more" link, a
+ * drawer slot, action buttons (collapsible to a dropdown on mobile), and a
+ * row of nav tabs. Use this as the standard page header rather than
+ * hand-rolling each section so spacing, typography, and the breakpoint
+ * collapse behavior stay consistent.
+ *
+ * The header auto-hides itself on certain admin sub-routes (the "new" and
+ * "edit" sub-pages, which already have their own headers). Pass
+ * `@shouldDisplay` explicitly to override this heuristic in either direction.
+ *
+ * Action buttons come from either a `<:actions>` named block (recommended) or
+ * an out-of-line `@headerActionComponent` reference. Both receive the same
+ * `actions` hash with `Primary`, `Default`, `Danger`, and `Wrapped`
+ * sub-components that adapt to viewport.
+ *
+ * @example
+ * <DPageHeader @titleLabel={{i18n "admin.badges.title"}}>
+ *   <:breadcrumbs>
+ *     <DBreadcrumbsItem @path="/admin/badges" @label="Badges" />
+ *   </:breadcrumbs>
+ *   <:actions as |actions|>
+ *     <actions.Primary @route="adminBadges.show" @routeModels="new" @label="New badge" />
+ *   </:actions>
+ *   <:tabs>
+ *     <DNavItem @route="adminBadges.index" @label="All" />
+ *   </:tabs>
+ * </DPageHeader>
+ */
+
+/**
+ * @typedef DPageHeaderActions
+ * @property {typeof PrimaryButton} Primary Renders as a primary action button on desktop, default dropdown list item on mobile.
+ * @property {typeof DefaultButton} Default Renders as a default action button on desktop, default dropdown list item on mobile.
+ * @property {typeof DangerButton} Danger Renders as a danger-styled button on desktop, danger dropdown list item on mobile.
+ * @property {typeof WrappedButton} Wrapped Renders arbitrary inline content as an action slot on desktop, wrapped dropdown list item on mobile.
+ */
+
+/**
+ * @typedef DPageHeaderSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} [Args.titleLabel] Translated text for the page title. Used when no `<:title>` block is provided.
+ * @property {string} [Args.descriptionLabel] Translated description rendered below the title. Passed through `trustHTML` — make sure the source is already-safe HTML (typically an `i18n()` call).
+ * @property {string} [Args.learnMoreUrl] URL appended after `@descriptionLabel` as a "Learn more…" link.
+ * @property {boolean} [Args.shouldDisplay] Forces the header on or off, overriding the route-aware default. Omit to let the component auto-hide on admin sub-routes that have their own header (the "new" and "edit" detail pages).
+ * @property {boolean} [Args.collapseActionsOnMobile] Whether action buttons should collapse into a mobile dropdown. Defaults to `true`.
+ * @property {unknown} [Args.headerActionComponent] Out-of-line component reference rendered in the actions slot, used when a `<:actions>` named block is impractical. Receives `@actions` (the same hash the named block yields).
+ * @property {boolean} [Args.showDrawer] Renders the `<:drawer>` named block region. Defaults to off.
+ * @property {boolean} [Args.hideTabs] Suppresses the tab strip even when the `<:tabs>` block has content. Defaults to off.
+ *
+ * @property {HTMLDivElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.breadcrumbs Optional breadcrumb items rendered after the base breadcrumb. Typically a list of `<DBreadcrumbsItem>`.
+ * @property {[]} Blocks.title Custom title content. Wins over `@titleLabel` when both are provided.
+ * @property {[DPageHeaderActions]} Blocks.actions Yields the action-button hash. The component types adapt to viewport.
+ * @property {[]} Blocks.drawer Optional drawer content (e.g. filters, batch controls). Requires `@showDrawer={{true}}`.
+ * @property {[]} Blocks.tabs Optional nav-tab content (typically a list of `<DNavItem>`).
+ */
+
+/** @extends {Component<DPageHeaderSignature>} */
 export default class DPageHeader extends Component {
   @service site;
   @service router;
 
   @tracked shouldDisplay = true;
 
-  constructor() {
-    super(...arguments);
+  constructor(owner, args) {
+    super(owner, args);
     this.router.on("routeDidChange", this, this.#checkIfShouldDisplay);
     this.#checkIfShouldDisplay();
   }
 
   willDestroy() {
+    // @ts-expect-error canonical Ember pattern; `arguments` is `IArguments` and not a spreadable tuple
     super.willDestroy(...arguments);
     this.router.off("routeDidChange", this, this.#checkIfShouldDisplay);
   }
 
-  @bind
   #checkIfShouldDisplay() {
     if (this.args.shouldDisplay !== undefined) {
       return (this.shouldDisplay = this.args.shouldDisplay);
@@ -50,9 +119,9 @@ export default class DPageHeader extends Component {
       return (this.shouldDisplay = true);
     }
 
-    // NOTE: This has a little admin-specific logic in it, in future
-    // we could extract this out and have it a bit more generic,
-    // for now I think it's a fine tradeoff.
+    // Admin-specific heuristic: hide the page header on `new` and `edit`
+    // sub-routes since those pages render their own header. Could be
+    // extracted later if other route trees need similar logic.
     const pathSegments = currentPath.split(".");
     this.shouldDisplay =
       !pathSegments.includes("admin") ||
@@ -64,6 +133,7 @@ export default class DPageHeader extends Component {
   }
 
   <template>
+    {{! @glint-nocheck: DMenu's curried trigger and the dynamic action-component hash both surface unknown-element complaints }}
     {{#if this.shouldDisplay}}
       <div class="d-page-header" ...attributes>
         {{#if (has-block "breadcrumbs")}}

--- a/frontend/discourse/app/ui-kit/d-page-subheader.gjs
+++ b/frontend/discourse/app/ui-kit/d-page-subheader.gjs
@@ -1,9 +1,13 @@
+// @ts-check
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+/** @type {import("discourse/float-kit/components/d-menu.gjs")} */
 import DMenu from "discourse/float-kit/components/d-menu";
+/** @type {import("discourse/ui-kit/d-dropdown-menu.gjs")} */
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+/** @type {import("discourse/ui-kit/d-page-action-button.gjs")} */
 import {
   DangerActionListItem,
   DangerButton,
@@ -15,10 +19,59 @@ import {
 } from "discourse/ui-kit/d-page-action-button";
 import { i18n } from "discourse-i18n";
 
+/**
+ * The section header that appears below a `DPageHeader` to divide a page into
+ * subsections. Renders a title, an optional description with an embedded
+ * "learn more" link, and a row of action buttons that automatically collapse
+ * into a dropdown on mobile.
+ *
+ * Action buttons come from the yielded `:actions` named block. The yield hash
+ * gives you `Primary`, `Default`, `Danger`, and `Wrapped` components which on
+ * desktop render as buttons and on mobile render as dropdown list items —
+ * consumers don't need to branch on viewport.
+ *
+ * @example
+ * <DPageSubheader
+ *   @titleLabel={{i18n "admin.badges.title"}}
+ *   @descriptionLabel={{i18n "admin.badges.description"}}
+ *   @learnMoreUrl="https://meta.discourse.org/t/96331"
+ * >
+ *   <:actions as |actions|>
+ *     <actions.Primary @route="adminBadges.show" @routeModels="new" @label="admin.badges.new" />
+ *   </:actions>
+ * </DPageSubheader>
+ */
+
+/**
+ * @typedef DPageSubheaderActions
+ * @property {typeof PrimaryButton} Primary Renders as a primary action button on desktop and as a default dropdown list item on mobile.
+ * @property {typeof DefaultButton} Default Renders as a default action button on desktop and as a default dropdown list item on mobile.
+ * @property {typeof DangerButton} Danger Renders as a danger-styled action button on desktop and as a danger dropdown list item on mobile.
+ * @property {typeof WrappedButton} Wrapped Renders arbitrary inline content as an action slot on desktop and as a wrapped dropdown list item on mobile.
+ */
+
+/**
+ * @typedef DPageSubheaderSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} [Args.titleLabel] Translated text for the section title. Pass through `i18n()` at the call-site.
+ * @property {string} [Args.titleUrl] Optional URL to wrap the title in an `<a>`. Use for sections whose name is itself a navigable destination.
+ * @property {string} [Args.descriptionLabel] Translated description rendered below the title. The string is passed through `trustHTML`, so it may include markup — make sure the source is already-safe HTML (typically an `i18n()` call).
+ * @property {string} [Args.learnMoreUrl] URL appended after `@descriptionLabel` as a "Learn more…" link. Requires `@descriptionLabel` to be visible.
+ *
+ * @property {HTMLDivElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[DPageSubheaderActions]} Blocks.actions Yields a hash of action-button components. The component types adapt to viewport: buttons on desktop, dropdown list items on mobile.
+ */
+
+/** @extends {Component<DPageSubheaderSignature>} */
 export default class DPageSubheader extends Component {
   @service site;
 
   <template>
+    {{! @glint-nocheck: DMenu's curried trigger and the dynamic action-component hash surface unknown-element complaints }}
     <div class="d-page-subheader">
       <div class="d-page-subheader__title-row">
         {{#if @titleLabel}}

--- a/frontend/discourse/app/ui-kit/d-password-field.js
+++ b/frontend/discourse/app/ui-kit/d-password-field.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import DTextField from "discourse/ui-kit/d-text-field";
 
 /**

--- a/frontend/discourse/app/ui-kit/d-pick-files-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-pick-files-button.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import Component from "@ember/component";
 import { action, computed } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";

--- a/frontend/discourse/app/ui-kit/d-popup-input-tip.gjs
+++ b/frontend/discourse/app/ui-kit/d-popup-input-tip.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { computed } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-radio-button.js
+++ b/frontend/discourse/app/ui-kit/d-radio-button.js
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/no-jquery, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/no-jquery, ember/require-tagless-components, local/require-ts-check */
 import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { attributeBindings, tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-relative-date.gjs
+++ b/frontend/discourse/app/ui-kit/d-relative-date.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import dAgeWithTooltip from "discourse/ui-kit/helpers/d-age-with-tooltip";
 
 const DRelativeDate = <template>{{dAgeWithTooltip @date}}</template>;

--- a/frontend/discourse/app/ui-kit/d-relative-time-picker.gjs
+++ b/frontend/discourse/app/ui-kit/d-relative-time-picker.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";

--- a/frontend/discourse/app/ui-kit/d-responsive-table.gjs
+++ b/frontend/discourse/app/ui-kit/d-responsive-table.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import HorizontalScrollSyncWrapper from "discourse/components/horizontal-scroll-sync-wrapper";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 

--- a/frontend/discourse/app/ui-kit/d-save-controls.gjs
+++ b/frontend/discourse/app/ui-kit/d-save-controls.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-second-factor-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-second-factor-input.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import withEventValue from "discourse/helpers/with-event-value";

--- a/frontend/discourse/app/ui-kit/d-select.gjs
+++ b/frontend/discourse/app/ui-kit/d-select.gjs
@@ -1,4 +1,6 @@
+// @ts-check
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
@@ -6,8 +8,36 @@ import { isNone } from "@ember/utils";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
+/**
+ * Sentinel value used to represent the "no selection" placeholder option. The
+ * underlying `<select>` element only deals in strings, so we cannot use a real
+ * `undefined`/`null` here; instead the component swaps this sentinel in and
+ * out at the boundary so consumers always see a clean `undefined` for "no
+ * selection."
+ */
 export const NO_VALUE_OPTION = "__NONE__";
 
+/**
+ * @typedef DSelectOptionSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} [Args.value] Value of this option. Passed back through `@onChange` when selected. When omitted, the option uses the `NO_VALUE_OPTION` sentinel.
+ * @property {string} [Args.selected] Currently-selected value at the parent level; the option compares its own `@value` against this to decide whether to mark itself selected. Wired up automatically when used as `<s.Option>` inside a `<DSelect>` yield.
+ *
+ * @property {HTMLOptionElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default The option's visible label.
+ */
+
+/**
+ * Single `<option>` inside a `DSelect`. Usually rendered via the yielded
+ * `s.Option` component rather than imported directly, so the `selected` arg
+ * is wired up for you.
+ *
+ * @extends {Component<DSelectOptionSignature>}
+ */
 export class DSelectOption extends Component {
   get value() {
     return isNone(this.args.value) ? NO_VALUE_OPTION : this.args.value;
@@ -32,7 +62,51 @@ export class DSelectOption extends Component {
   </template>
 }
 
+/**
+ * A controlled native `<select>` wrapper. Consumers render each option via
+ * the yielded `s.Option` component so the option's `selected` state is wired
+ * up automatically.
+ *
+ * The component normalizes the "no selection" boundary: internally a special
+ * sentinel string is used because `<select>` cannot represent `undefined`,
+ * but `@onChange` always receives `undefined` for that case. Pass
+ * `@includeNone={{false}}` to drop the placeholder option for required
+ * fields.
+ *
+ * @example
+ * <DSelect @value={{this.color}} @onChange={{this.updateColor}} as |s|>
+ *   <s.Option @value="red">Red</s.Option>
+ *   <s.Option @value="blue">Blue</s.Option>
+ * </DSelect>
+ */
+
+/**
+ * @typedef DSelectSignature
+ *
+ * @property {object} Args
+ *
+ * @property {string} [Args.value] Currently-selected option value. Pass `undefined` for "no selection."
+ * @property {(value: string | undefined) => void} [Args.onChange] Invoked with the new value on every change. Receives `undefined` when the user picks the placeholder.
+ * @property {boolean} [Args.includeNone] Whether to render the placeholder option at the top of the list. Defaults to `true`. Pass `false` for required fields.
+ * @property {string} [Args.nonePlaceholder] Custom label for the placeholder option. Defaults to the i18n string `select_placeholder` (or `none_placeholder` once a real value has been selected).
+ *
+ * @property {HTMLSelectElement} Element
+ *
+ * @property {object} Blocks
+ * @property {[{Option: unknown}]} Blocks.default Yields a hash whose `Option` is `DSelectOption` pre-bound to the current selection so consumers can write `<s.Option @value="x">Label</s.Option>`. Typed as `unknown` because Glint sees the curried form rather than the original class.
+ */
+
+/** @extends {Component<DSelectSignature>} */
 export default class DSelect extends Component {
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-select] @onChange must be a function when provided",
+      !this.args.onChange || typeof this.args.onChange === "function"
+    );
+  }
+
   get htmlSelectValue() {
     const value = this.args.value;
     if (value === NO_VALUE_OPTION) {
@@ -46,9 +120,10 @@ export default class DSelect extends Component {
 
   @action
   handleInput(event) {
-    // if an option has no value, event.target.value will be the content of the option
-    // this is why we use this magic value to represent no value
-    this.args.onChange(
+    // When an option has no value attribute, event.target.value falls back to
+    // the option's text content. We use the NO_VALUE_OPTION sentinel as the
+    // value of the placeholder so we can detect "no selection" reliably.
+    this.args.onChange?.(
       event.target.value === NO_VALUE_OPTION ? undefined : event.target.value
     );
   }

--- a/frontend/discourse/app/ui-kit/d-select.gjs
+++ b/frontend/discourse/app/ui-kit/d-select.gjs
@@ -1,5 +1,7 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
+import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
@@ -98,13 +100,15 @@ export class DSelectOption extends Component {
 
 /** @extends {Component<DSelectSignature>} */
 export default class DSelect extends Component {
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-select] @onChange must be a function when provided",
-      !this.args.onChange || typeof this.args.onChange === "function"
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-select] @onChange must be a function when provided",
+        !this.args.onChange || typeof this.args.onChange === "function"
+      );
+    }
+    return null;
   }
 
   get htmlSelectValue() {
@@ -137,6 +141,7 @@ export default class DSelect extends Component {
   }
 
   <template>
+    {{this.validateArgs}}
     <select
       value={{this.htmlSelectValue}}
       ...attributes

--- a/frontend/discourse/app/ui-kit/d-small-user-list.gjs
+++ b/frontend/discourse/app/ui-kit/d-small-user-list.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";

--- a/frontend/discourse/app/ui-kit/d-stat-tiles.gjs
+++ b/frontend/discourse/app/ui-kit/d-stat-tiles.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { hash } from "@ember/helper";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { number } from "discourse/lib/formatter";

--- a/frontend/discourse/app/ui-kit/d-table-header-toggle.gjs
+++ b/frontend/discourse/app/ui-kit/d-table-header-toggle.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-tap-tile-grid.gjs
+++ b/frontend/discourse/app/ui-kit/d-tap-tile-grid.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { hash } from "@ember/helper";
 import { tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-tap-tile.gjs
+++ b/frontend/discourse/app/ui-kit/d-tap-tile.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import { tracked } from "@glimmer/tracking";
 import Component from "@ember/component";
 import { computed } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-text-field.js
+++ b/frontend/discourse/app/ui-kit/d-text-field.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { computed } from "@ember/object";
 import { cancel, next } from "@ember/runloop";
 import { attributeBindings } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-textarea.gjs
+++ b/frontend/discourse/app/ui-kit/d-textarea.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components, local/require-ts-check */
 import { MUTABLE_CELL } from "@ember/-internals/views";
 import Component from "@ember/component";
 import { get, set } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-time-input.gjs
+++ b/frontend/discourse/app/ui-kit/d-time-input.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { hash } from "@ember/helper";
 import { action, computed } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-time-shortcut-picker.gjs
+++ b/frontend/discourse/app/ui-kit/d-time-shortcut-picker.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/no-observers */
+/* eslint-disable ember/no-classic-components, ember/no-observers, local/require-ts-check */
 import Component, { Input } from "@ember/component";
 import { fn } from "@ember/helper";
 import { action, computed } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/d-toggle-password-mask.gjs
+++ b/frontend/discourse/app/ui-kit/d-toggle-password-mask.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import DButton from "discourse/ui-kit/d-button";
 
 const DTogglePasswordMask = <template>

--- a/frontend/discourse/app/ui-kit/d-toggle-switch.gjs
+++ b/frontend/discourse/app/ui-kit/d-toggle-switch.gjs
@@ -1,8 +1,51 @@
+// @ts-check
 import Component from "@glimmer/component";
+import { assert } from "@ember/debug";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+/**
+ * A binary on/off toggle styled as a sliding switch. The component is a
+ * presentation wrapper: it renders the visual state from `@state` and
+ * surfaces the inner `<button role="switch">` via `...attributes` so the
+ * parent can attach its own click handler. Use `DToggleSwitch` for binary
+ * settings (notification on/off, feature flags); for any other input shape
+ * reach for the matching FormKit field instead.
+ *
+ * @example
+ * <DToggleSwitch
+ *   @state={{this.notifications}}
+ *   @label="user.notifications"
+ *   {{on "click" this.toggleNotifications}}
+ * />
+ */
+
+/**
+ * @typedef DToggleSwitchSignature
+ *
+ * @property {object} Args
+ *
+ * @property {boolean} [Args.state] Current state of the switch. Renders `aria-checked="true"` when truthy, `"false"` otherwise. The component does not own the state — the parent updates the value in its own click handler.
+ * @property {string} [Args.label] Translatable i18n key for the visible label rendered after the switch. Mutually exclusive with `translatedLabel`.
+ * @property {string} [Args.translatedLabel] Pre-translated label. Use when the label is computed at runtime and already localized.
+ *
+ * @property {HTMLButtonElement} Element The inner `<button role="switch">` element. Click handlers and other event listeners passed via `...attributes` are attached here, not to the outer `<div>`.
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Not used.
+ */
+
+/** @extends {Component<DToggleSwitchSignature>} */
 export default class DToggleSwitch extends Component {
+  constructor(owner, args) {
+    super(owner, args);
+
+    assert(
+      "[d-toggle-switch] pass either @label or @translatedLabel, not both",
+      !(this.args.label && this.args.translatedLabel)
+    );
+  }
+
   get computedLabel() {
     if (this.args.label) {
       return i18n(this.args.label);

--- a/frontend/discourse/app/ui-kit/d-toggle-switch.gjs
+++ b/frontend/discourse/app/ui-kit/d-toggle-switch.gjs
@@ -1,5 +1,7 @@
 // @ts-check
 import Component from "@glimmer/component";
+import { DEBUG } from "@glimmer/env";
+import { cached } from "@glimmer/tracking";
 import { assert } from "@ember/debug";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -37,13 +39,15 @@ import { i18n } from "discourse-i18n";
 
 /** @extends {Component<DToggleSwitchSignature>} */
 export default class DToggleSwitch extends Component {
-  constructor(owner, args) {
-    super(owner, args);
-
-    assert(
-      "[d-toggle-switch] pass either @label or @translatedLabel, not both",
-      !(this.args.label && this.args.translatedLabel)
-    );
+  @cached
+  get validateArgs() {
+    if (DEBUG) {
+      assert(
+        "[d-toggle-switch] pass either @label or @translatedLabel, not both",
+        !(this.args.label && this.args.translatedLabel)
+      );
+    }
+    return null;
   }
 
   get computedLabel() {
@@ -54,6 +58,7 @@ export default class DToggleSwitch extends Component {
   }
 
   <template>
+    {{this.validateArgs}}
     <div class="d-toggle-switch">
       <label class="d-toggle-switch__label">
         <button

--- a/frontend/discourse/app/ui-kit/d-user-avatar-flair.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-avatar-flair.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import autoGroupFlairForUser from "discourse/lib/avatar-flair";

--- a/frontend/discourse/app/ui-kit/d-user-avatar.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-avatar.gjs
@@ -49,7 +49,7 @@ export default class DUserAvatar extends Component {
   @service siteSettings;
 
   get ariaHidden() {
-    if (this.args.ariaHidden !== null) {
+    if (this.args.ariaHidden !== undefined) {
       return this.args.ariaHidden;
     }
 
@@ -59,7 +59,7 @@ export default class DUserAvatar extends Component {
 
     // often avatars are paired with usernames, making them redundant for screen readers so we hide the avatar from
     // screen readers by default
-    return this.args.ariaHidden ?? true;
+    return true;
   }
 
   get hideFromAnonUser() {
@@ -71,7 +71,7 @@ export default class DUserAvatar extends Component {
   <template>
     <DUserLink
       ...attributes
-      @ariaHidden={{@ariaHidden}}
+      @ariaHidden={{this.ariaHidden}}
       @ariaLabel={{@ariaLabel}}
       @href={{@href}}
       @user={{@user}}

--- a/frontend/discourse/app/ui-kit/d-user-avatar.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-avatar.gjs
@@ -1,10 +1,49 @@
+// @ts-check
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+/** @type {import("discourse/ui-kit/d-user-link.gjs")} */
 import DUserLink from "discourse/ui-kit/d-user-link";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 // TODO (saquetim) the pattern <a>{{avatar ...}}</a> is used a lot. Should we replace it with this component to ensure consistency???
+
+/**
+ * The canonical "avatar that links to a user profile" combination. Wraps
+ * `DUserLink` (which produces the `<a>` and resolves the URL) around the
+ * `dAvatar` helper (which renders the `<img>`). Use this anywhere you need a
+ * clickable avatar so URL resolution, anon-user hiding, and the `data-user-card`
+ * popover hook stay consistent.
+ *
+ * Avatars are hidden from assistive tech by default because they are almost
+ * always paired with a visible username and would be a redundant announcement.
+ * Set `@ariaLabel` or `@ariaHidden={{false}}` when the avatar stands alone.
+ *
+ * @example
+ * <DUserAvatar @user={{this.post.user}} @size={{45}} />
+ */
+
+/**
+ * @typedef DUserAvatarSignature
+ *
+ * @property {object} Args
+ *
+ * @property {object} Args.user The user object. Must expose `username` and (optionally) `path` and avatar fields consumed by the `dAvatar` helper.
+ * @property {boolean} [Args.ariaHidden] When `true` (the default), the link is hidden from screen readers. Pass `false` when the avatar carries information not duplicated by an adjacent username.
+ * @property {string} [Args.ariaLabel] Pre-translated `aria-label` for the link. Overrides the default `"{username}'s profile"` text. Implies the avatar is *not* hidden.
+ * @property {string} [Args.href] Override URL. Defaults to `@user.path` or the canonical user-profile URL derived from `@user.username`.
+ * @property {string} [Args.avatarClasses] Extra classes joined onto the `<img>` rendered by `dAvatar`.
+ * @property {number} [Args.size] Image dimensions in CSS pixels (square).
+ * @property {boolean} [Args.hideTitle] When `true`, the `<img title>` tooltip is suppressed.
+ * @property {boolean} [Args.lazy] When `true`, the avatar `<img>` is rendered with `loading="lazy"`.
+ *
+ * @property {HTMLAnchorElement} Element The `<a>` element from `DUserLink`.
+ *
+ * @property {object} Blocks
+ * @property {[]} Blocks.default Not used.
+ */
+
+/** @extends {Component<DUserAvatarSignature>} */
 export default class DUserAvatar extends Component {
   @service currentUser;
   @service siteSettings;

--- a/frontend/discourse/app/ui-kit/d-user-info.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-info.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import Component from "@ember/component";
 import { computed, set } from "@ember/object";
 import { tagName } from "@ember-decorators/component";

--- a/frontend/discourse/app/ui-kit/d-user-link.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-link.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { userPath } from "discourse/lib/url";

--- a/frontend/discourse/app/ui-kit/d-user-stat.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-stat.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { trustHTML } from "@ember/template";
 import dFormatDuration from "discourse/ui-kit/helpers/d-format-duration";

--- a/frontend/discourse/app/ui-kit/d-user-status-message.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-status-message.gjs
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import DTooltip from "discourse/float-kit/components/d-tooltip";

--- a/frontend/discourse/app/ui-kit/helpers/d-age-with-tooltip.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-age-with-tooltip.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-avatar.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-avatar.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { get } from "@ember/object";
 import { trustHTML } from "@ember/template";
 import { avatarImg } from "discourse/lib/avatar-utils";

--- a/frontend/discourse/app/ui-kit/helpers/d-base-path.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-base-path.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import getUrl from "discourse/lib/get-url";
 
 export default function dBasePath() {

--- a/frontend/discourse/app/ui-kit/helpers/d-bound-avatar-template.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-bound-avatar-template.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { avatarImg } from "discourse/lib/avatar-utils";

--- a/frontend/discourse/app/ui-kit/helpers/d-bound-avatar.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-bound-avatar.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { avatarImg } from "discourse/lib/avatar-utils";

--- a/frontend/discourse/app/ui-kit/helpers/d-bound-category-link.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-bound-category-link.js
@@ -1,1 +1,2 @@
+/* eslint-disable local/require-ts-check */
 export { categoryLinkHTML as default } from "discourse/ui-kit/helpers/d-category-link";

--- a/frontend/discourse/app/ui-kit/helpers/d-category-badge.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-category-badge.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { isPresent } from "@ember/utils";
 import { categoryLinkHTML } from "discourse/ui-kit/helpers/d-category-link";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-category-link.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-category-link.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { get } from "@ember/object";
 import { trustHTML } from "@ember/template";
 import categoryVariables from "discourse/helpers/category-variables";

--- a/frontend/discourse/app/ui-kit/helpers/d-concat-class.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-concat-class.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 export default function dConcatClass(...args) {
   const classes = args.flat().filter(Boolean).join(" ");
 

--- a/frontend/discourse/app/ui-kit/helpers/d-dasherize.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-dasherize.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { dasherize as emberDasherize } from "@ember/string";
 
 export default function dDasherize(value = "") {

--- a/frontend/discourse/app/ui-kit/helpers/d-dir-span.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-dir-span.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { helperContext } from "discourse/lib/helpers";
 import { escapeExpression } from "discourse/lib/utilities";

--- a/frontend/discourse/app/ui-kit/helpers/d-discourse-tag.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-discourse-tag.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import renderTag from "discourse/lib/render-tag";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-discourse-tags.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-discourse-tags.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import renderTags from "discourse/lib/render-tags";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-element.gjs
+++ b/frontend/discourse/app/ui-kit/helpers/d-element.gjs
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components */
+/* eslint-disable ember/no-classic-components, local/require-ts-check */
 import ClassicComponent from "@ember/component";
 
 const empty = <template>

--- a/frontend/discourse/app/ui-kit/helpers/d-emoji.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-emoji.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";

--- a/frontend/discourse/app/ui-kit/helpers/d-format-date.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-format-date.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-format-duration.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-format-duration.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { durationTiny } from "discourse/lib/formatter";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-icon-or-image.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-icon-or-image.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { get } from "@ember/object";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";

--- a/frontend/discourse/app/ui-kit/helpers/d-icon.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-icon.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { renderIcon } from "discourse/lib/icon-library";
 

--- a/frontend/discourse/app/ui-kit/helpers/d-loading-spinner.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-loading-spinner.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 
 export function renderSpinner(cssClass) {

--- a/frontend/discourse/app/ui-kit/helpers/d-number.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-number.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 import { number as numberFormatter } from "discourse/lib/formatter";
 import { escapeExpression } from "discourse/lib/utilities";

--- a/frontend/discourse/app/ui-kit/helpers/d-replace-emoji.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-replace-emoji.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { isHTMLSafe, trustHTML } from "@ember/template";
 import { emojiUnescape } from "discourse/lib/text";
 import { escapeExpression } from "discourse/lib/utilities";

--- a/frontend/discourse/app/ui-kit/helpers/d-topic-link.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-topic-link.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { trustHTML } from "@ember/template";
 
 export default function dTopicLink(topic, args = {}) {

--- a/frontend/discourse/app/ui-kit/helpers/d-unique-id.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-unique-id.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 // https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/glimmer/lib/helpers/unique-id.ts
 export default function dUniqueId() {
   return ([3e7] + -1e3 + -4e3 + -2e3 + -1e11).replace(

--- a/frontend/discourse/app/ui-kit/helpers/d-user-avatar.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-user-avatar.js
@@ -1,1 +1,2 @@
+/* eslint-disable local/require-ts-check */
 export * from "./d-avatar";

--- a/frontend/discourse/app/ui-kit/modifiers/d-auto-focus.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-auto-focus.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Modifier from "ember-modifier";
 
 export default class DAutoFocusModifier extends Modifier {

--- a/frontend/discourse/app/ui-kit/modifiers/d-autocomplete.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-autocomplete.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { tracked } from "@glimmer/tracking";
 import { registerDestructor } from "@ember/destroyable";
 import { action } from "@ember/object";

--- a/frontend/discourse/app/ui-kit/modifiers/d-close-on-click-outside.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-close-on-click-outside.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { registerDestructor } from "@ember/destroyable";
 import Modifier from "ember-modifier";
 import { bind } from "discourse/lib/decorators";

--- a/frontend/discourse/app/ui-kit/modifiers/d-draggable.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-draggable.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { registerDestructor } from "@ember/destroyable";
 import Modifier from "ember-modifier";
 import { bind } from "discourse/lib/decorators";

--- a/frontend/discourse/app/ui-kit/modifiers/d-observe-intersection.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-observe-intersection.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { modifier } from "ember-modifier";
 
 export default modifier(

--- a/frontend/discourse/app/ui-kit/modifiers/d-on-resize.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-on-resize.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { registerDestructor } from "@ember/destroyable";
 import { cancel, throttle } from "@ember/runloop";
 import Modifier from "ember-modifier";

--- a/frontend/discourse/app/ui-kit/modifiers/d-scroll-into-view.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-scroll-into-view.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import Modifier from "ember-modifier";
 
 /**

--- a/frontend/discourse/app/ui-kit/modifiers/d-swipe.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-swipe.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { registerDestructor } from "@ember/destroyable";
 import { service } from "@ember/service";
 import Modifier from "ember-modifier";

--- a/frontend/discourse/app/ui-kit/modifiers/d-tab-to-sibling.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-tab-to-sibling.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { registerDestructor } from "@ember/destroyable";
 import Modifier from "ember-modifier";
 import { bind } from "discourse/lib/decorators";

--- a/frontend/discourse/app/ui-kit/modifiers/d-trap-tab.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-trap-tab.js
@@ -1,3 +1,4 @@
+/* eslint-disable local/require-ts-check */
 import { registerDestructor } from "@ember/destroyable";
 import { service } from "@ember/service";
 import Modifier from "ember-modifier";

--- a/frontend/discourse/tests/integration/ui-kit/d-avatar-flair-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-avatar-flair-test.gjs
@@ -97,6 +97,9 @@ module("Integration | ui-kit | DAvatarFlair", function (hooks) {
     await renderComponent({ flair_url: "/images/avatar.png" });
     assert
       .dom(".avatar-flair")
-      .hasStyle({ backgroundImage: 'url("/images/avatar.png")' });
+      .hasAttribute(
+        "style",
+        /background-image:\s*url\(\/images\/avatar\.png\)/
+      );
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-avatar-flair-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-avatar-flair-test.gjs
@@ -19,6 +19,11 @@ function renderComponent(flairArgs) {
 module("Integration | ui-kit | DAvatarFlair", function (hooks) {
   setupRenderingTest(hooks);
 
+  test("renders the root element with the avatar-flair class", async function (assert) {
+    await renderComponent({ flair_url: "bars" });
+    assert.dom(".avatar-flair").exists();
+  });
+
   test("avatar flair with an icon", async function (assert) {
     const flairArgs = {
       flair_url: "bars",
@@ -61,5 +66,37 @@ module("Integration | ui-kit | DAvatarFlair", function (hooks) {
         "the title attribute is set correctly"
       );
     assert.dom("svg").doesNotExist("does not have an svg icon");
+  });
+
+  test("adds the avatar-flair-<flairName> class hook", async function (assert) {
+    await renderComponent({ flair_url: "bars", flair_name: "staff" });
+    assert.dom(".avatar-flair.avatar-flair-staff").exists();
+  });
+
+  test("adds the rounded class when @flairBgColor is present", async function (assert) {
+    await renderComponent({ flair_url: "bars", flair_bg_color: "CC0000" });
+    assert.dom(".avatar-flair.rounded").exists();
+  });
+
+  test("does not add the rounded class when @flairBgColor is absent", async function (assert) {
+    await renderComponent({ flair_url: "bars" });
+    assert.dom(".avatar-flair").doesNotHaveClass("rounded");
+  });
+
+  test("adds the avatar-flair-image class for image URLs", async function (assert) {
+    await renderComponent({ flair_url: "/images/avatar.png" });
+    assert.dom(".avatar-flair.avatar-flair-image").exists();
+  });
+
+  test("does not add the avatar-flair-image class for icon names", async function (assert) {
+    await renderComponent({ flair_url: "bars" });
+    assert.dom(".avatar-flair").doesNotHaveClass("avatar-flair-image");
+  });
+
+  test("sets background-image as the URL for image flairs", async function (assert) {
+    await renderComponent({ flair_url: "/images/avatar.png" });
+    assert
+      .dom(".avatar-flair")
+      .hasStyle({ backgroundImage: 'url("/images/avatar.png")' });
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-button-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-button-test.gjs
@@ -1,4 +1,4 @@
-import { click, render, triggerKeyEvent } from "@ember/test-helpers";
+import { click, find, render, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DButton from "discourse/ui-kit/d-button";
@@ -6,6 +6,13 @@ import I18n, { i18n } from "discourse-i18n";
 
 module("Integration | ui-kit | DButton", function (hooks) {
   setupRenderingTest(hooks);
+
+  test("renders a button with default classes when given no args", async function (assert) {
+    await render(<template><DButton /></template>);
+
+    assert.dom("button.btn").exists();
+    assert.dom("button").hasAttribute("type", "button");
+  });
 
   test("icon only button", async function (assert) {
     await render(<template><DButton @icon="plus" tabindex="3" /></template>);
@@ -264,5 +271,137 @@ module("Integration | ui-kit | DButton", function (hooks) {
     assert
       .dom("button .d-button__suffix-icon .d-icon-angle-right")
       .exists("has the suffix icon");
+  });
+
+  test("@href renders an anchor instead of a button", async function (assert) {
+    await render(
+      <template>
+        <DButton @href="https://example.com" @translatedLabel="Open" />
+      </template>
+    );
+
+    assert.dom("a.btn").exists();
+    assert.dom("a").hasAttribute("href", "https://example.com");
+    assert.dom("button").doesNotExist();
+  });
+
+  test("@actionParam is passed to the action", async function (assert) {
+    this.set("received", null);
+    this.set("action", (param) => {
+      this.set("received", param);
+    });
+
+    await render(
+      <template>
+        <DButton @action={{this.action}} @actionParam="hello" />
+      </template>
+    );
+
+    await click(".btn");
+    assert.strictEqual(this.received, "hello");
+  });
+
+  test("@forwardEvent passes the event as a second argument", async function (assert) {
+    this.set("event", null);
+    this.set("action", (_param, event) => {
+      this.set("event", event);
+    });
+
+    await render(
+      <template>
+        <DButton
+          @action={{this.action}}
+          @actionParam="x"
+          @forwardEvent={{true}}
+        />
+      </template>
+    );
+
+    await click(".btn");
+    assert.true(this.event instanceof Event, "the original event is forwarded");
+  });
+
+  test("@preventFocus prevents focus on mousedown", async function (assert) {
+    await render(<template><DButton @preventFocus={{true}} /></template>);
+
+    const button = find("button");
+    let prevented = false;
+    button.addEventListener("mousedown", (e) => {
+      prevented = e.defaultPrevented;
+    });
+    button.dispatchEvent(new MouseEvent("mousedown", { cancelable: true }));
+
+    assert.true(prevented, "mousedown default is prevented");
+  });
+
+  test("aria-pressed", async function (assert) {
+    await render(
+      <template><DButton @ariaPressed={{this.ariaPressed}} /></template>
+    );
+
+    assert.dom("button").doesNotHaveAria("pressed");
+
+    this.set("ariaPressed", true);
+    assert.dom("button").hasAria("pressed", "true");
+
+    this.set("ariaPressed", false);
+    assert.dom("button").hasAria("pressed", "false");
+  });
+
+  test("@ariaHidden wraps the icon in an aria-hidden span", async function (assert) {
+    await render(
+      <template><DButton @icon="plus" @ariaHidden={{true}} /></template>
+    );
+
+    assert
+      .dom('button > span[aria-hidden="true"] .d-icon-plus')
+      .exists("the icon is wrapped in an aria-hidden span");
+  });
+
+  test("@type accepts submit and reset", async function (assert) {
+    await render(<template><DButton @type="submit" /></template>);
+    assert.dom("button").hasAttribute("type", "submit");
+  });
+
+  test("@id flows through to the button", async function (assert) {
+    await render(
+      <template><DButton @id="save-button" @translatedLabel="Save" /></template>
+    );
+    assert.dom("button#save-button").exists();
+  });
+
+  test("classes passed via attributes are joined onto the button", async function (assert) {
+    await render(
+      <template>
+        <DButton class="my-button extra" @translatedLabel="x" />
+      </template>
+    );
+    assert.dom("button.btn.my-button.extra").exists();
+  });
+
+  test("yielded block content renders alongside the label", async function (assert) {
+    await render(
+      <template>
+        <DButton @translatedLabel="Hello">
+          <span class="extra-yield">more</span>
+        </DButton>
+      </template>
+    );
+
+    assert.dom("button .d-button-label").hasText("Hello");
+    assert.dom("button .extra-yield").hasText("more");
+  });
+
+  test("yielded block content stands in for the label when no @label is given", async function (assert) {
+    await render(
+      <template>
+        <DButton>
+          <span class="custom-content">just yield</span>
+        </DButton>
+      </template>
+    );
+
+    assert.dom("button .d-button-label").doesNotExist();
+    assert.dom("button .custom-content").hasText("just yield");
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-empty-state-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-empty-state-test.gjs
@@ -1,4 +1,5 @@
-import { render } from "@ember/test-helpers";
+import { trustHTML } from "@ember/template";
+import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DEmptyState from "discourse/ui-kit/d-empty-state";
@@ -6,14 +7,108 @@ import DEmptyState from "discourse/ui-kit/d-empty-state";
 module("Integration | ui-kit | DEmptyState", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it renders", async function (assert) {
+  test("renders the root container with the text-only modifier by default", async function (assert) {
+    await render(<template><DEmptyState @title="Nothing here" /></template>);
+    assert.dom(".empty-state__container.--text-only").exists();
+  });
+
+  test("renders title and body", async function (assert) {
+    await render(
+      <template><DEmptyState @title="My title" @body="My body" /></template>
+    );
+
+    assert.dom("[data-test-title]").hasText("My title");
+    assert.dom("[data-test-body]").hasText("My body");
+  });
+
+  test("@identifier is appended as a container modifier class", async function (assert) {
+    await render(<template><DEmptyState @identifier="bookmarks" /></template>);
+    assert.dom(".empty-state__container.--bookmarks").exists();
+  });
+
+  test("@svgContent renders the illustration and switches to --with-image", async function (assert) {
+    const svg = trustHTML("<svg class='my-svg'></svg>");
+
+    await render(
+      <template><DEmptyState @title="x" @svgContent={{svg}} /></template>
+    );
+
+    assert.dom(".empty-state__container.--with-image").exists();
+    assert.dom(".empty-state__image .my-svg").exists();
+  });
+
+  test("@ctaLabel renders a primary button that fires @ctaAction on click", async function (assert) {
+    let called = false;
+    this.set("ctaAction", () => {
+      called = true;
+    });
+
     await render(
       <template>
-        <DEmptyState @title="user.no_bookmarks_title" @body="body" />
+        <DEmptyState
+          @ctaLabel="Add bookmark"
+          @ctaIcon="plus"
+          @ctaAction={{this.ctaAction}}
+        />
       </template>
     );
 
-    assert.dom("[data-test-title]").exists();
-    assert.dom("[data-test-body]").exists();
+    assert.dom(".empty-state__cta .btn.btn-primary").exists();
+    assert.dom(".empty-state__cta .d-icon-plus").exists();
+    assert.dom(".empty-state__cta .d-button-label").hasText("Add bookmark");
+
+    await click(".empty-state__cta .btn");
+    assert.true(called, "@ctaAction is fired on click");
+  });
+
+  test("@ctaHref renders the CTA as an anchor", async function (assert) {
+    await render(
+      <template>
+        <DEmptyState
+          @ctaLabel="Open docs"
+          @ctaHref="https://example.com/docs"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".empty-state__cta a.btn")
+      .hasAttribute("href", "https://example.com/docs");
+  });
+
+  test("@tipText renders inside the tip slot", async function (assert) {
+    await render(<template><DEmptyState @tipText="Did you know?" /></template>);
+    assert.dom(".empty-state__tip").hasText("Did you know?");
+  });
+
+  test("@tipIcon renders before the tip content", async function (assert) {
+    await render(
+      <template>
+        <DEmptyState @tipText="Did you know?" @tipIcon="lightbulb" />
+      </template>
+    );
+    assert.dom(".empty-state__tip .d-icon-lightbulb").exists();
+  });
+
+  test("the :tip named block takes precedence over @tipText", async function (assert) {
+    await render(
+      <template>
+        <DEmptyState @tipText="Plain tip">
+          <:tip>
+            <span class="custom-tip">Block tip</span>
+          </:tip>
+        </DEmptyState>
+      </template>
+    );
+
+    assert.dom(".empty-state__tip .custom-tip").hasText("Block tip");
+    assert
+      .dom(".empty-state__tip")
+      .doesNotContainText("Plain tip", "the @tipText is suppressed");
+  });
+
+  test("the tip section is hidden when neither @tipText nor :tip block is provided", async function (assert) {
+    await render(<template><DEmptyState @title="x" /></template>);
+    assert.dom(".empty-state__tip").doesNotExist();
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-flash-message-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-flash-message-test.gjs
@@ -59,4 +59,34 @@ module("Integration | ui-kit | DFlashMessage", function (hooks) {
 
     assert.dom(".alert").doesNotExist();
   });
+
+  test("renders the plain .alert class when no @type is given", async function (assert) {
+    await render(<template><DFlashMessage @flash="Plain message" /></template>);
+
+    assert.dom(".alert").hasText("Plain message");
+    assert
+      .dom(".alert")
+      .doesNotHaveClass("alert-success")
+      .doesNotHaveClass("alert-error")
+      .doesNotHaveClass("alert-warning")
+      .doesNotHaveClass("alert-info");
+  });
+
+  test("forwards HTML attributes to the alert element", async function (assert) {
+    await render(
+      <template>
+        <DFlashMessage
+          @flash="Note"
+          @type="info"
+          data-test-flash="x"
+          id="form-flash"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".alert")
+      .hasAttribute("data-test-flash", "x")
+      .hasAttribute("id", "form-flash");
+  });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-load-more-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-load-more-test.gjs
@@ -19,6 +19,21 @@ module("Integration | ui-kit | DLoadMore", function (hooks) {
     disableLoadMoreObserver();
   });
 
+  test("renders the sentinel element and the yielded block", async function (assert) {
+    const noop = () => {};
+    await render(
+      <template>
+        <DLoadMore @action={{noop}} class="my-list">
+          <div class="my-content">content</div>
+        </DLoadMore>
+      </template>
+    );
+
+    assert.dom("div.my-list .my-content").exists();
+    assert.dom("div.my-list .load-more-sentinel").exists();
+    assert.dom(".load-more-sentinel").hasAria("hidden", "true");
+  });
+
   test("calls loadMore action when intersection occurs", async function (assert) {
     let actionCalled = 0;
     const performLoadMore = () => {

--- a/frontend/discourse/tests/integration/ui-kit/d-page-header-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-page-header-test.gjs
@@ -22,6 +22,48 @@ const DPageHeaderActionsTestComponent = <template>
 module("Integration | ui-kit | DPageHeader", function (hooks) {
   setupRenderingTest(hooks);
 
+  test("renders the root element when displayed", async function (assert) {
+    await render(<template><DPageHeader /></template>);
+    assert.dom(".d-page-header").exists();
+  });
+
+  test("@hideTabs suppresses the tab strip", async function (assert) {
+    await render(<template><DPageHeader @hideTabs={{true}} /></template>);
+    assert.dom(".d-nav-submenu").doesNotExist();
+  });
+
+  test("the tab strip is rendered by default even without yielded tabs", async function (assert) {
+    await render(<template><DPageHeader /></template>);
+    assert.dom(".d-nav-submenu").exists();
+  });
+
+  test("@showDrawer reveals the drawer slot", async function (assert) {
+    await render(
+      <template>
+        <DPageHeader @showDrawer={{true}}>
+          <:drawer>
+            <div class="my-drawer">drawer body</div>
+          </:drawer>
+        </DPageHeader>
+      </template>
+    );
+
+    assert.dom(".d-page-header__drawer .my-drawer").hasText("drawer body");
+  });
+
+  test("the <:title> block wins over @titleLabel", async function (assert) {
+    await render(
+      <template>
+        <DPageHeader @titleLabel="From arg">
+          <:title><span class="custom-title">From block</span></:title>
+        </DPageHeader>
+      </template>
+    );
+
+    assert.dom(".d-page-header__title .custom-title").hasText("From block");
+    assert.dom(".d-page-header__title").doesNotContainText("From arg");
+  });
+
   test("no @titleLabel", async function (assert) {
     await render(<template><DPageHeader /></template>);
     assert.dom(".d-page-header__title").doesNotExist();

--- a/frontend/discourse/tests/integration/ui-kit/d-page-subheader-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-page-subheader-test.gjs
@@ -8,6 +8,24 @@ import { i18n } from "discourse-i18n";
 module("Integration | ui-kit | DPageSubheader", function (hooks) {
   setupRenderingTest(hooks);
 
+  test("renders the root element with the d-page-subheader class", async function (assert) {
+    await render(<template><DPageSubheader /></template>);
+    assert.dom(".d-page-subheader").exists();
+  });
+
+  test("@titleUrl wraps the title in an anchor", async function (assert) {
+    await render(
+      <template>
+        <DPageSubheader @titleLabel="Badges" @titleUrl="/admin/badges" />
+      </template>
+    );
+
+    assert
+      .dom(".d-page-subheader__title a.d-page-subheader__title-link")
+      .hasText("Badges")
+      .hasAttribute("href", "/admin/badges");
+  });
+
   test("@titleLabel", async function (assert) {
     await render(
       <template><DPageSubheader @titleLabel={{i18n "admin.title"}} /></template>

--- a/frontend/discourse/tests/integration/ui-kit/d-select-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-select-test.gjs
@@ -83,4 +83,52 @@ module("Integration | ui-kit | DSelect", function (hooks) {
 
     assert.dom(".d-select__option.test").exists();
   });
+
+  test("renders the d-select root element on its own", async function (assert) {
+    await render(<template><DSelect /></template>);
+    assert.dom("select.d-select").exists();
+  });
+
+  test("@nonePlaceholder overrides the default placeholder label", async function (assert) {
+    await render(
+      <template><DSelect @nonePlaceholder="Pick something" /></template>
+    );
+
+    assert.dselect().hasSelectedOption({
+      value: NO_VALUE_OPTION,
+      label: "Pick something",
+    });
+  });
+
+  test("selecting the placeholder fires @onChange with undefined", async function (assert) {
+    const receivedValues = [];
+    const handleChange = (value) => {
+      receivedValues.push(value);
+    };
+
+    await render(
+      <template>
+        <DSelect @value="foo" @onChange={{handleChange}} as |s|>
+          <s.Option @value="foo">The real foo</s.Option>
+        </DSelect>
+      </template>
+    );
+
+    await select(".d-select", NO_VALUE_OPTION);
+
+    assert.deepEqual(receivedValues, [undefined]);
+  });
+
+  test("changing without @onChange does not throw", async function (assert) {
+    await render(
+      <template>
+        <DSelect as |s|>
+          <s.Option @value="foo">The real foo</s.Option>
+        </DSelect>
+      </template>
+    );
+
+    await select(".d-select", "foo");
+    assert.dom(".d-select").exists("component still rendered after change");
+  });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-toggle-switch-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-toggle-switch-test.gjs
@@ -7,6 +7,16 @@ import I18n, { i18n } from "discourse-i18n";
 module("Integration | ui-kit | DToggleSwitch", function (hooks) {
   setupRenderingTest(hooks);
 
+  test("renders the root element with the switch role", async function (assert) {
+    await render(<template><DToggleSwitch /></template>);
+
+    assert.dom(".d-toggle-switch").exists();
+    assert
+      .dom(".d-toggle-switch__checkbox")
+      .hasAttribute("role", "switch")
+      .hasAria("checked", "false");
+  });
+
   test("it renders a toggle button in a disabled state", async function (assert) {
     await render(<template><DToggleSwitch @state={{false}} /></template>);
 
@@ -51,5 +61,24 @@ module("Integration | ui-kit | DToggleSwitch", function (hooks) {
     });
 
     assert.dom(".d-toggle-switch__checkbox-label").hasText("bar");
+  });
+
+  test("HTML attributes are forwarded onto the inner switch button", async function (assert) {
+    await render(
+      <template>
+        <DToggleSwitch
+          @state={{false}}
+          id="notifications-toggle"
+          data-test-toggle="x"
+          aria-describedby="notifications-help"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".d-toggle-switch__checkbox")
+      .hasAttribute("id", "notifications-toggle")
+      .hasAttribute("data-test-toggle", "x")
+      .hasAria("describedby", "notifications-help");
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-user-avatar-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-user-avatar-test.gjs
@@ -50,11 +50,7 @@ module("Integration | ui-kit | DUserAvatar", function (hooks) {
     const user = buildUser();
     await render(
       <template>
-        <DUserAvatar
-          @user={{user}}
-          @ariaHidden={{false}}
-          @ariaLabel="View profile"
-        />
+        <DUserAvatar @user={{user}} @ariaLabel="View profile" />
       </template>
     );
 

--- a/frontend/discourse/tests/integration/ui-kit/d-user-avatar-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-user-avatar-test.gjs
@@ -1,0 +1,106 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DUserAvatar from "discourse/ui-kit/d-user-avatar";
+
+function buildUser(overrides = {}) {
+  return {
+    id: 1,
+    username: "eviltrout",
+    avatar_template: "/images/avatar.png",
+    ...overrides,
+  };
+}
+
+module("Integration | ui-kit | DUserAvatar", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders an anchor wrapping an avatar image", async function (assert) {
+    const user = buildUser();
+    await render(<template><DUserAvatar @user={{user}} /></template>);
+
+    assert.dom("a").exists();
+    assert.dom("a img.avatar").exists();
+  });
+
+  test("derives the link href from the user", async function (assert) {
+    const user = buildUser({ username: "eviltrout" });
+    await render(<template><DUserAvatar @user={{user}} /></template>);
+
+    assert.dom("a").hasAttribute("href", "/u/eviltrout");
+  });
+
+  test("@href overrides the derived URL", async function (assert) {
+    const user = buildUser();
+    await render(
+      <template><DUserAvatar @user={{user}} @href="/custom/path" /></template>
+    );
+
+    assert.dom("a").hasAttribute("href", "/custom/path");
+  });
+
+  test("hides the link from screen readers by default", async function (assert) {
+    const user = buildUser();
+    await render(<template><DUserAvatar @user={{user}} /></template>);
+
+    assert.dom("a").hasAria("hidden", "true").hasAttribute("tabindex", "-1");
+  });
+
+  test("@ariaLabel disables the default hiding and labels the link", async function (assert) {
+    const user = buildUser();
+    await render(
+      <template>
+        <DUserAvatar
+          @user={{user}}
+          @ariaHidden={{false}}
+          @ariaLabel="View profile"
+        />
+      </template>
+    );
+
+    assert
+      .dom("a")
+      .doesNotHaveAria("hidden")
+      .hasAria("label", "View profile")
+      .hasAttribute("tabindex", "0");
+  });
+
+  test("@size is applied to the rendered avatar image", async function (assert) {
+    const user = buildUser();
+    await render(
+      <template><DUserAvatar @user={{user}} @size={{45}} /></template>
+    );
+
+    assert
+      .dom("a img.avatar")
+      .hasAttribute("width", "45")
+      .hasAttribute("height", "45");
+  });
+
+  test("@lazy adds loading=lazy on the avatar image", async function (assert) {
+    const user = buildUser();
+    await render(
+      <template><DUserAvatar @user={{user}} @lazy={{true}} /></template>
+    );
+
+    assert.dom("a img.avatar").hasAttribute("loading", "lazy");
+  });
+
+  test("@avatarClasses are forwarded onto the avatar image", async function (assert) {
+    const user = buildUser();
+    await render(
+      <template>
+        <DUserAvatar @user={{user}} @avatarClasses="custom-flair" />
+      </template>
+    );
+
+    assert.dom("a img.avatar.custom-flair").exists();
+  });
+
+  test("exposes the data-user-card hook for the popover", async function (assert) {
+    const user = buildUser({ username: "eviltrout" });
+    await render(<template><DUserAvatar @user={{user}} /></template>);
+
+    assert.dom("a").hasAttribute("data-user-card", "eviltrout");
+  });
+});


### PR DESCRIPTION
ui-kit components are the public contract consumed by core,
plugins, and themes. This pilot raises the bar for files in
`frontend/discourse/app/ui-kit/` so the surface is type-checked,
self-documented, and exercised by tests.

For each component:

- `// @ts-check` at the top
- A Glint Signature typedef (`Args`, `Element`, `Blocks`)
- Component-level JSDoc with `@example` when args are non-obvious
- DEBUG-time `assert()` calls from `@ember/debug` for required and
  enum args
- Smoke + behavioral tests under
  `frontend/discourse/tests/integration/ui-kit/`

Mechanically enforced by:

- A new ESLint rule `local/require-ts-check` that fails the build if
  a `ui-kit/` file is missing the directive
- `pnpm lint:types` running `ember-tsc -b` across the project

The full policy lives in
`frontend/discourse/app/ui-kit/CONVENTIONS.md`; `d-button.gjs` is the
reference shape.

## Test plan
- [ ] `pnpm lint:types` passes
- [ ] `pnpm lint` passes
- [ ] `bin/qunit frontend/discourse/tests/integration/ui-kit/` passes
- [ ] Manual smoke check: admin pages, account preferences, and
  modals look unchanged