### PR TITLE
UX: Allow more specific enabled for options for upcoming changes

### DIFF
--- a/.skills/discourse-upcoming-changes-authoring/SKILL.md
+++ b/.skills/discourse-upcoming-changes-authoring/SKILL.md
@@ -37,7 +37,7 @@ All services use `Service::Base`. They're organized under `app/services/upcoming
 | Service | Purpose |
 |---------|---------|
 | `List` | Admin-only, fetches all changes with metadata, group data, and images |
-| `Toggle` | Admin enable/disable — updates SiteSetting, clears groups if `disallow_enabled_for_groups`, logs staff action, fires DiscourseEvent |
+| `Toggle` | Admin enable/disable — updates SiteSetting, clears groups when neither `staff` nor `specific_groups` is in `allow_enabled_for`, validates the requested target against `allow_enabled_for`, logs staff action, fires DiscourseEvent |
 | `Track` | Orchestrator called by the scheduled job — delegates to three action sub-services |
 | `TrackNotifyAddedChanges` | Compares current settings against event history, creates `added` events |
 | `TrackRemovedChanges` | Creates `removed` events for settings no longer present |
@@ -148,7 +148,11 @@ Notifications for `added` and `promoted` changes are skipped on new sites (deter
 
 ### Group-Based Access
 
-Group restrictions use a separate `SiteSettingGroup` model rather than storing groups on the setting itself. This allows the caching layer (`site_setting_group_ids`) to work independently. When `disallow_enabled_for_groups` is set in metadata, the UI only shows Everyone/No One options. Group IDs are pipe-separated in the DB for efficient single-row storage.
+Group restrictions use a separate `SiteSettingGroup` model rather than storing groups on the setting itself. This allows the caching layer (`site_setting_group_ids`) to work independently. Group IDs are pipe-separated in the DB for efficient single-row storage.
+
+The `allow_enabled_for` metadata key on an upcoming change restricts which "Enabled for" dropdown options the admin sees. It accepts an array of any subset of `[everyone, staff, specific_groups]`; the `No one` option is always present and cannot be removed. When the key is omitted, all four options are shown (the permissive default). Rule: if `everyone` is present it must be the only value — `everyone` cannot combine with `staff` or `specific_groups`. The integrity spec enforces these rules. Server-side enforcement lives in `UpcomingChanges::Toggle` (validates the target when no groups are configured) and `SiteSetting::UpsertGroups` (validates group selection: a `[staff]`-only selection needs `staff` allowed; any other selection needs `specific_groups` allowed). When neither `staff` nor `specific_groups` is in the allow list, `Toggle` also clears any stale `SiteSettingGroup` records.
+
+**Auto-promoted display:** When `allow_enabled_for` excludes `:everyone` and a change is enabled without an explicit admin selection (typically because it reached the promotion threshold), `enabled_for_with_groups` returns the broadest allowed display target — the staff group name if `:staff` is permitted, otherwise `"groups"`. This is display-only; `enabled_for_user?` is unchanged and still treats the change as on for all users until the admin scopes it via the dropdown.
 
 ### Event Idempotency
 
@@ -178,6 +182,35 @@ The three main components to know:
 - **User view** (`admin-user-upcoming-changes.gjs`) — Read-only per-user view
 
 State is managed via `trackedObject` for reactivity. API calls go through `ajax()` directly in the item component.
+
+### Restricting "Enabled for" options
+
+To constrain which dropdown options an admin can pick for a change, add `allow_enabled_for` to its `upcoming_change:` metadata:
+
+```yaml
+my_upcoming_change_setting:
+  default: false
+  client: true
+  hidden: true
+  upcoming_change:
+    status: experimental
+    impact: feature,all_members
+    allow_enabled_for:
+      - staff
+      - specific_groups
+```
+
+Valid value sets:
+
+| `allow_enabled_for` | Dropdown options shown |
+|---|---|
+| *(omitted)* | No one, Everyone, Staff, Specific group(s) |
+| `[everyone]` | No one, Everyone |
+| `[staff]` | No one, Staff |
+| `[specific_groups]` | No one, Specific group(s) |
+| `[staff, specific_groups]` | No one, Staff, Specific group(s) |
+
+`everyone` cannot be combined with `staff` or `specific_groups` — when present, it must be the only value. `No one` is always available. The integrity spec rejects invalid combinations.
 
 ### Adding a Default Override
 

--- a/.skills/discourse-upcoming-changes/SKILL.md
+++ b/.skills/discourse-upcoming-changes/SKILL.md
@@ -63,6 +63,25 @@ enable_your_feature_name:
 
 **Optional:** Add `learn_more_url: "https://..."` for documentation link.
 
+**Optional:** Add `allow_enabled_for:` to restrict which "Enabled for" dropdown options the admin can choose. Accepts any subset of `everyone`, `staff`, `specific_groups`. "No one" is always available. If `everyone` is included it must be the only value. Omit the key to allow all options (the default).
+
+```yaml
+upcoming_change:
+  status: "experimental"
+  impact: "feature,all_members"
+  allow_enabled_for:
+    - staff
+    - specific_groups
+```
+
+| Value | Dropdown options |
+|---|---|
+| *(omitted)* | No one, Everyone, Staff, Specific group(s) |
+| `[everyone]` | No one, Everyone |
+| `[staff]` | No one, Staff |
+| `[specific_groups]` | No one, Specific group(s) |
+| `[staff, specific_groups]` | No one, Staff, Specific group(s) |
+
 ### 2. Add Translation
 
 Add to `config/locales/server.en.yml` under `site_settings:`:

--- a/app/services/site_setting/upsert_groups.rb
+++ b/app/services/site_setting/upsert_groups.rb
@@ -13,6 +13,7 @@ class SiteSetting::UpsertGroups
   end
 
   policy :current_user_is_admin
+  policy :allowed_enabled_for_target
   only_if(:provided_group_names) do
     model :group_ids
 
@@ -41,6 +42,13 @@ class SiteSetting::UpsertGroups
 
   def current_user_is_admin(guardian:)
     guardian.is_admin?
+  end
+
+  def allowed_enabled_for_target(params:)
+    return true if params.group_names.empty?
+
+    target = params.group_names == ["staff"] ? :staff : :specific_groups
+    UpcomingChanges.target_allowed?(params.setting, target)
   end
 
   def fetch_group_ids(params:)

--- a/app/services/upcoming_changes/list.rb
+++ b/app/services/upcoming_changes/list.rb
@@ -71,11 +71,11 @@ class UpcomingChanges::List
 
   def load_upcoming_change_groups(upcoming_changes:)
     group_ids =
-      upcoming_changes
-        .map { |change| SiteSetting.site_setting_group_ids[change[:setting]] }
-        .flatten
-        .compact
-        .uniq
+      (
+        upcoming_changes.flat_map do |change|
+          SiteSetting.site_setting_group_ids[change[:setting]]
+        end + [Group::AUTO_GROUPS[:staff]]
+      ).compact.uniq
     groups = Group.where(id: group_ids).pluck(:id, :name).to_h
 
     upcoming_changes.each do |setting|

--- a/app/services/upcoming_changes/toggle.rb
+++ b/app/services/upcoming_changes/toggle.rb
@@ -20,9 +20,10 @@ class UpcomingChanges::Toggle
 
   policy :current_user_is_admin
   policy :setting_is_available
+  policy :allowed_enabled_for_target
   transaction { step :toggle }
 
-  step :clear_groups_if_disallowed
+  step :clear_groups_if_groups_not_allowed
 
   only_if(:should_log_change) do
     step :log_change
@@ -46,9 +47,18 @@ class UpcomingChanges::Toggle
     SiteSetting.send("#{params.setting_name}=", params.enabled)
   end
 
-  def clear_groups_if_disallowed(params:)
-    metadata = SiteSetting.upcoming_change_metadata[params.setting_name]
-    return if !metadata || !metadata[:disallow_enabled_for_groups]
+  def allowed_enabled_for_target(params:)
+    return true if !params.enabled
+
+    # When enabling with no groups configured, the resulting target is "everyone".
+    # Otherwise the group target is validated by SiteSetting::UpsertGroups.
+    return true if SiteSettingGroup.exists?(name: params.setting_name)
+
+    UpcomingChanges.target_allowed?(params.setting_name, :everyone)
+  end
+
+  def clear_groups_if_groups_not_allowed(params:)
+    return if UpcomingChanges.groups_target_allowed?(params.setting_name)
 
     SiteSettingGroup.find_by(name: params.setting_name)&.destroy!
     SiteSetting.refresh_site_setting_group_ids!

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -31,8 +31,14 @@
 #                          - status: experimental | alpha | beta | stable
 #                          - impact: two parts separated by comma - feature|other|site_setting_default , staff|admins|moderators|all_members|developers
 #                          - learn_more_url: a url for more information
-#                          - disallow_enabled_for_groups: true (optional) - restricts "Enabled for"
-#                            to only "Everyone" and "No One", removing group-based options.
+#                          - allow_enabled_for: (optional array) restricts which "Enabled for"
+#                            dropdown options the admin can pick for this upcoming change.
+#                            Valid values: everyone, staff, specific_groups.
+#
+#                            "No one" is always present and cannot be removed. If `everyone` is included it must be
+#                            the only value (it cannot combine with staff or specific_groups).
+#                            Omit the key to allow all four options (the default permissive
+#                            behavior).
 # depends_on            - One or more boolean settings that must be true for this setting to take effect.
 # depends_behavior      - The behavior of the dependent setting. Only currently supported behaviour is "hidden"
 #                         to hide the setting if the dependent setting is false. If left blank, no special behavior
@@ -1981,7 +1987,8 @@ email:
     upcoming_change:
       status: "alpha"
       impact: "feature,all_members"
-      disallow_enabled_for_groups: true
+      allow_enabled_for:
+        - everyone
       learn_more_url: "https://meta.discourse.org/t/-/395927"
   reply_by_email_enabled:
     default: false
@@ -2539,7 +2546,8 @@ files:
     upcoming_change:
       status: "experimental"
       impact: "feature,all_members"
-      disallow_enabled_for_groups: true
+      allow_enabled_for:
+        - everyone
   composer_media_optimization_gif_conversion_threshold:
     default: 512000
     hidden: true
@@ -4375,7 +4383,9 @@ experimental:
       status: "alpha"
       impact: "feature,staff"
       learn_more_url: "https://meta.discourse.org/t/-/395768"
-      disallow_enabled_for_groups: true
+      allow_enabled_for:
+        - staff
+        - specific_groups
   enable_auto_grid_images:
     default: true
     client: true
@@ -4457,7 +4467,8 @@ experimental:
       status: "beta"
       impact: "site_setting_default,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/397098"
-      disallow_enabled_for_groups: true
+      allow_enabled_for:
+        - everyone
   experimental_topic_category_change_notification:
     default: false
     hidden: true
@@ -4479,7 +4490,8 @@ experimental:
       status: "experimental"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/402273"
-      disallow_enabled_for_groups: true
+      allow_enabled_for:
+        - everyone
   dashboard_improvements:
     default: false
     hidden: true

--- a/db/post_migrate/20260512061336_convert_reporting_improvements_everyone_to_staff.rb
+++ b/db/post_migrate/20260512061336_convert_reporting_improvements_everyone_to_staff.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# The `reporting_improvements` upcoming change moved from
+# `allow_enabled_for: [everyone]` to `[staff, specific_groups]`. Existing sites
+# where an admin had explicitly enabled it (DB value = 't') previously had it on
+# for "Everyone" since no SiteSettingGroup row existed. "Everyone" is no longer
+# a permitted target, so seed a SiteSettingGroup row pointing at the staff auto
+# group (id 3) for those sites, preserving the opt-in at the narrowest now-valid
+# scope.
+class ConvertReportingImprovementsEveryoneToStaff < ActiveRecord::Migration[8.0]
+  def up
+    execute(<<~SQL)
+      INSERT INTO site_setting_groups (name, group_ids, created_at, updated_at)
+      SELECT 'reporting_improvements', '3', NOW(), NOW()
+      WHERE EXISTS (
+        SELECT 1 FROM site_settings
+        WHERE name = 'reporting_improvements' AND value = 't'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM site_setting_groups WHERE name = 'reporting_improvements'
+      )
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -45,30 +45,40 @@ export default class UpcomingChangeItem extends Component {
   }
 
   get enabledForOptions() {
+    const allow = this.args.change.upcoming_change.allow_enabled_for ?? [
+      "everyone",
+      "staff",
+      "specific_groups",
+    ];
+
     const options = [
       {
         label: i18n("admin.upcoming_changes.enabled_for_options.no_one"),
         value: "no_one",
       },
-      {
-        label: i18n("admin.upcoming_changes.enabled_for_options.everyone"),
-        value: "everyone",
-      },
     ];
 
-    if (!this.args.change.upcoming_change.disallow_enabled_for_groups) {
-      options.push(
-        {
-          label: capitalize(this.staffGroupName),
-          value: this.staffGroupName,
-        },
-        {
-          label: i18n(
-            "admin.upcoming_changes.enabled_for_options.specific_groups"
-          ),
-          value: "groups",
-        }
-      );
+    if (allow.includes("everyone")) {
+      options.push({
+        label: i18n("admin.upcoming_changes.enabled_for_options.everyone"),
+        value: "everyone",
+      });
+    }
+
+    if (allow.includes("staff")) {
+      options.push({
+        label: capitalize(this.staffGroupName),
+        value: this.staffGroupName,
+      });
+    }
+
+    if (allow.includes("specific_groups")) {
+      options.push({
+        label: i18n(
+          "admin.upcoming_changes.enabled_for_options.specific_groups"
+        ),
+        value: "groups",
+      });
     }
 
     return options;

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -161,6 +161,10 @@ module SiteSettingExtension
   #     status: "alpha" (see UpcomingChanges.statuses.keys)
   #     impact: "feature,staff" (feature|other for the first part, staff|admins|moderators|all_members|developers for the second part)
   #     learn_more_url: ""
+  #     allow_enabled_for: (optional) array restricting which "Enabled for" dropdown
+  #       options are shown. Valid values: everyone, staff, specific_groups. "No one"
+  #       is always present. If `everyone` is included it must be the only value.
+  #       Omit to allow all options (the default permissive behavior).
   def upcoming_change_metadata
     @upcoming_change_metadata ||= {}
   end
@@ -1288,11 +1292,14 @@ module SiteSettingExtension
       if opts[:upcoming_change]
         upcoming_change_metadata[name] ||= {}
         impact_type, impact_role = opts[:upcoming_change][:impact].split(",")
+        allow_enabled_for = opts[:upcoming_change][:allow_enabled_for]
+        allow_enabled_for = Array(allow_enabled_for).map(&:to_sym) if allow_enabled_for
         upcoming_change_metadata[name].merge!(
-          **opts[:upcoming_change].except(:impact),
+          **opts[:upcoming_change].except(:impact, :allow_enabled_for),
           impact_type: impact_type,
           impact_role: impact_role,
           status: opts[:upcoming_change][:status].to_sym,
+          allow_enabled_for: allow_enabled_for,
         )
       end
 

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -145,6 +145,30 @@ module UpcomingChanges
     end
   end
 
+  # The `allow_enabled_for` metadata for an upcoming change, or nil if unset.
+  # When nil, every "Enabled for" dropdown option is permitted. Otherwise it
+  # is an array containing any subset of [:everyone, :staff, :specific_groups].
+  def self.allow_enabled_for(change_setting_name)
+    change_metadata(change_setting_name)[:allow_enabled_for]
+  end
+
+  # Whether a setting's `allow_enabled_for` permits a given dropdown target.
+  # `:no_one` is always allowed. Returns true when the metadata is absent.
+  def self.target_allowed?(change_setting_name, target)
+    return true if target.to_sym == :no_one
+    allow = allow_enabled_for(change_setting_name)
+    return true if allow.nil?
+    allow.include?(target.to_sym)
+  end
+
+  # True when the setting's `allow_enabled_for` permits any group-based target
+  # (`:staff` or `:specific_groups`). When metadata is absent, groups are allowed.
+  def self.groups_target_allowed?(change_setting_name)
+    allow = allow_enabled_for(change_setting_name)
+    return true if allow.nil?
+    allow.include?(:staff) || allow.include?(:specific_groups)
+  end
+
   def self.has_groups?(change_setting_name)
     group_ids_for(change_setting_name).present?
   end
@@ -276,7 +300,21 @@ module UpcomingChanges
       if !setting_value
         "no_one"
       elsif setting_groups.blank?
-        "everyone"
+        # When `allow_enabled_for` excludes `:everyone` and the change is enabled
+        # without an admin-configured scope (typically because it was auto-promoted
+        # past the promotion threshold) we surface the broadest allowed target as
+        # the dropdown's selected value, since `"everyone"` is no longer a valid
+        # option. Backend access (`enabled_for_user?`) is unchanged — until the
+        # admin picks a scope, the change is still effectively on for everyone.
+        allow = allow_enabled_for(setting_name)
+        if allow.nil? || allow.include?(:everyone)
+          "everyone"
+        elsif allow.include?(:staff)
+          # Have to do this because the staff auto group name is localized
+          upcoming_change_selected_groups[Group::AUTO_GROUPS[:staff]]
+        else
+          "groups"
+        end
       else
         if group_ids_for_setting == [Group::AUTO_GROUPS[:staff]]
           # Have to do this because the staff auto group name is localized

--- a/spec/integrity/upcoming_change_metadata_spec.rb
+++ b/spec/integrity/upcoming_change_metadata_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "upcoming change metadata integrity checks" do
 
     it "#{label} is valid" do
       metadata = setting[:upcoming_change]
-      allowed_keys = %i[status impact learn_more_url disallow_enabled_for_groups]
+      allowed_keys = %i[status impact learn_more_url allow_enabled_for]
       required_keys = %i[status impact]
       unsupported_keys = metadata.keys - allowed_keys
       missing_keys = required_keys - metadata.keys
@@ -79,9 +79,22 @@ RSpec.describe "upcoming change metadata integrity checks" do
           "#{label} has invalid upcoming_change impact role #{impact_role.inspect}. Valid roles: #{valid_upcoming_change_impact_roles.join(", ")}"
         end
 
-        if metadata.key?(:disallow_enabled_for_groups)
-          expect(metadata[:disallow_enabled_for_groups]).to eq(true),
-          "#{label} should omit `upcoming_change.disallow_enabled_for_groups` unless it is `true`"
+        if metadata.key?(:allow_enabled_for)
+          allow = metadata[:allow_enabled_for]
+          valid_values = %w[everyone staff specific_groups]
+          allow_strings = Array(allow).map(&:to_s)
+
+          expect(allow).to be_an(Array),
+          "#{label} `upcoming_change.allow_enabled_for` must be an array"
+          expect(allow_strings).not_to be_empty,
+          "#{label} `upcoming_change.allow_enabled_for` must not be empty"
+          expect(allow_strings - valid_values).to be_empty,
+          "#{label} `upcoming_change.allow_enabled_for` contains invalid values: #{(allow_strings - valid_values).join(", ")}. Valid values: #{valid_values.join(", ")}"
+
+          if allow_strings.include?("everyone")
+            expect(allow_strings).to eq(["everyone"]),
+            "#{label} `upcoming_change.allow_enabled_for` may not combine `everyone` with other values"
+          end
         end
       end
     end

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -484,6 +484,77 @@ RSpec.describe UpcomingChanges do
     end
   end
 
+  describe ".enabled_for_with_groups" do
+    let(:setting_name) { :enable_upload_debug_mode }
+    let(:groups_hash) { { Group::AUTO_GROUPS[:staff] => "staff" } }
+
+    def mock_allow(allow)
+      mock_upcoming_change_metadata(
+        {
+          enable_upload_debug_mode: {
+            impact: "other,developers",
+            status: :experimental,
+            impact_type: "other",
+            impact_role: "developers",
+            allow_enabled_for: allow,
+          },
+        },
+      )
+    end
+
+    context "when the setting is disabled" do
+      it "returns no_one" do
+        result = described_class.enabled_for_with_groups(setting_name, false, groups_hash)
+        expect(result[:enabled_for]).to eq("no_one")
+      end
+    end
+
+    context "when the setting is enabled with no admin-configured groups" do
+      context "when allow_enabled_for is omitted" do
+        it "returns everyone" do
+          result = described_class.enabled_for_with_groups(setting_name, true, groups_hash)
+          expect(result[:enabled_for]).to eq("everyone")
+        end
+      end
+
+      context "when allow_enabled_for is [everyone]" do
+        before { mock_allow([:everyone]) }
+
+        it "returns everyone" do
+          result = described_class.enabled_for_with_groups(setting_name, true, groups_hash)
+          expect(result[:enabled_for]).to eq("everyone")
+        end
+      end
+
+      context "when allow_enabled_for is [staff, specific_groups]" do
+        before { mock_allow(%i[staff specific_groups]) }
+
+        it "returns the staff group name as the broadest allowed display target" do
+          result = described_class.enabled_for_with_groups(setting_name, true, groups_hash)
+          expect(result[:enabled_for]).to eq("staff")
+        end
+      end
+
+      context "when allow_enabled_for is [staff]" do
+        before { mock_allow([:staff]) }
+
+        it "returns the staff group name" do
+          result = described_class.enabled_for_with_groups(setting_name, true, groups_hash)
+          expect(result[:enabled_for]).to eq("staff")
+        end
+      end
+
+      context "when allow_enabled_for is [specific_groups]" do
+        before { mock_allow([:specific_groups]) }
+
+        it "returns groups" do
+          result = described_class.enabled_for_with_groups(setting_name, true, groups_hash)
+          expect(result[:enabled_for]).to eq("groups")
+        end
+      end
+    end
+  end
+
   describe ".current_statuses" do
     include ActiveSupport::Testing::TimeHelpers
 

--- a/spec/services/site_setting/upsert_groups_spec.rb
+++ b/spec/services/site_setting/upsert_groups_spec.rb
@@ -46,6 +46,76 @@ RSpec.describe SiteSetting::UpsertGroups do
       it { is_expected.to fail_a_policy(:current_user_is_admin) }
     end
 
+    context "when the setting is an upcoming change with allow_enabled_for restrictions" do
+      let(:setting) { "enable_form_templates" }
+
+      context "when allow_enabled_for is [everyone]" do
+        before do
+          mock_upcoming_change_metadata(
+            enable_form_templates: {
+              impact: "feature,all_members",
+              status: :experimental,
+              impact_type: "feature",
+              impact_role: "all_members",
+              allow_enabled_for: [:everyone],
+            },
+          )
+        end
+
+        it { is_expected.to fail_a_policy(:allowed_enabled_for_target) }
+
+        context "when group_names is empty" do
+          let(:group_names) { [] }
+
+          it { is_expected.to run_successfully }
+        end
+      end
+
+      context "when allow_enabled_for is [staff]" do
+        before do
+          mock_upcoming_change_metadata(
+            enable_form_templates: {
+              impact: "feature,all_members",
+              status: :experimental,
+              impact_type: "feature",
+              impact_role: "all_members",
+              allow_enabled_for: [:staff],
+            },
+          )
+        end
+
+        context "with only the staff group" do
+          let(:group_names) { ["staff"] }
+
+          it { is_expected.to run_successfully }
+        end
+
+        context "with non-staff groups" do
+          let(:group_names) { %w[trust_level_0 admins] }
+
+          it { is_expected.to fail_a_policy(:allowed_enabled_for_target) }
+        end
+      end
+
+      context "when allow_enabled_for is [staff, specific_groups]" do
+        before do
+          mock_upcoming_change_metadata(
+            enable_form_templates: {
+              impact: "feature,all_members",
+              status: :experimental,
+              impact_type: "feature",
+              impact_role: "all_members",
+              allow_enabled_for: %i[staff specific_groups],
+            },
+          )
+        end
+
+        let(:group_names) { %w[trust_level_0 admins] }
+
+        it { is_expected.to run_successfully }
+      end
+    end
+
     context "when an admin user upserts groups for a setting" do
       it { is_expected.to run_successfully }
 

--- a/spec/services/upcoming_changes/toggle_spec.rb
+++ b/spec/services/upcoming_changes/toggle_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe UpcomingChanges::Toggle do
     context "when everything's ok" do
       it { is_expected.to run_successfully }
 
-      context "when disallow_enabled_for_groups is true" do
+      context "when allow_enabled_for restricts to [everyone]" do
         before do
           mock_upcoming_change_metadata(
             enable_form_templates: {
@@ -45,7 +45,7 @@ RSpec.describe UpcomingChanges::Toggle do
               status: :experimental,
               impact_type: "feature",
               impact_role: "all_members",
-              disallow_enabled_for_groups: true,
+              allow_enabled_for: [:everyone],
             },
           )
         end
@@ -82,13 +82,64 @@ RSpec.describe UpcomingChanges::Toggle do
           end
         end
 
-        context "when toggling with no existing groups" do
+        context "when toggling on with no existing groups" do
           let(:enabled) { true }
 
           before { SiteSetting.enable_form_templates = false }
 
           it { is_expected.to run_successfully }
         end
+      end
+
+      context "when allow_enabled_for is [staff, specific_groups]" do
+        before do
+          mock_upcoming_change_metadata(
+            enable_form_templates: {
+              impact: "feature,all_members",
+              status: :experimental,
+              impact_type: "feature",
+              impact_role: "all_members",
+              allow_enabled_for: %i[staff specific_groups],
+            },
+          )
+          SiteSetting.enable_form_templates = false
+        end
+
+        context "when toggling on with no existing groups (target would be everyone)" do
+          let(:enabled) { true }
+
+          it { is_expected.to fail_a_policy(:allowed_enabled_for_target) }
+        end
+
+        context "when toggling on with existing groups configured" do
+          let(:enabled) { true }
+
+          fab!(:site_setting_group) do
+            Fabricate(:site_setting_group, name: "enable_form_templates", group_ids: "1|2")
+          end
+
+          it { is_expected.to run_successfully }
+
+          it "preserves the SiteSettingGroup record" do
+            expect { result }.not_to change {
+              SiteSettingGroup.where(name: "enable_form_templates").count
+            }
+          end
+        end
+
+        context "when toggling off" do
+          let(:enabled) { false }
+
+          it { is_expected.to run_successfully }
+        end
+      end
+
+      context "when allow_enabled_for is omitted" do
+        let(:enabled) { true }
+
+        before { SiteSetting.enable_form_templates = false }
+
+        it { is_expected.to run_successfully }
       end
 
       context "when log_change is true" do

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -206,6 +206,62 @@ describe "Admin upcoming changes" do
     expect(SiteSetting.enable_upload_debug_mode).to be_truthy
   end
 
+  describe "allow_enabled_for restrictions" do
+    def mock_with_allow(allow)
+      mock_upcoming_change_metadata(
+        {
+          enable_upload_debug_mode: {
+            impact: "other,developers",
+            status: :experimental,
+            impact_type: "other",
+            impact_role: "developers",
+            allow_enabled_for: allow,
+          },
+        },
+      )
+    end
+
+    it "shows only No one and Everyone when allow_enabled_for is [everyone]" do
+      mock_with_allow([:everyone])
+      upcoming_changes_page.visit
+      item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
+      expect(item.enabled_for_options).to contain_exactly("no_one", "everyone")
+    end
+
+    it "shows only No one and Staff when allow_enabled_for is [staff]" do
+      mock_with_allow([:staff])
+      upcoming_changes_page.visit
+      item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
+      expect(item.enabled_for_options).to contain_exactly("no_one", "staff")
+    end
+
+    it "shows No one, Staff, and Specific group(s) when allow_enabled_for is [staff, specific_groups]" do
+      mock_with_allow(%i[staff specific_groups])
+      upcoming_changes_page.visit
+      item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
+      expect(item.enabled_for_options).to contain_exactly("no_one", "staff", "groups")
+    end
+
+    it "shows all four options when allow_enabled_for is omitted" do
+      upcoming_changes_page.visit
+      item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
+      expect(item.enabled_for_options).to contain_exactly("no_one", "everyone", "staff", "groups")
+    end
+
+    it "displays the broadest allowed target when an auto-promoted change has no admin scope" do
+      mock_with_allow(%i[staff specific_groups])
+      # Simulate the post-promotion state: setting is enabled globally but the
+      # admin has not configured a SiteSettingGroup. "Everyone" is no longer an
+      # allowed dropdown target, so the row should display "staff" as the
+      # broadest allowed scope.
+      SiteSetting.enable_upload_debug_mode = true
+
+      upcoming_changes_page.visit
+      item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
+      expect(item.enabled_for).to eq("staff")
+    end
+  end
+
   it "can filter by name, description, plugin, status, impact type, or enabled/disabled" do
     upcoming_changes_page.visit
 

--- a/spec/system/page_objects/pages/admin_upcoming_change_item.rb
+++ b/spec/system/page_objects/pages/admin_upcoming_change_item.rb
@@ -73,6 +73,10 @@ module PageObjects
         )
       end
 
+      def enabled_for_options
+        enabled_for_dropdown.select_element.all("option").map { |o| o["value"] }
+      end
+
       def group_selector
         PageObjects::Components::GroupSelector.new(change_item_selector(@setting_name))
       end


### PR DESCRIPTION
Certain upcoming changes do not make sense to enable for "Everyone",
like changes that will only affect the admin UI. We currently have
a disallow_enabled_for_groups option that changes the "Enabled for"
dropdown to only show Everyone and No one, but this is a bit of a blunt instrument.

This change adds an `allow_enabled_for` option for upcoming changes
which is a YAML array:

* When omitted, the "Enabled for" dropdown will show Everyone, Staff,
Specific group(s) and No one.
* When set to everyone, the dropdown will only show Everyone and No one.
* When set to staff, the dropdown will only show Staff and No one.
* It can also be set to staff and specific_groups

This commit also changes the reporting_improvements upcoming change
to be staff, specific_groups and adds a DB migration to account for
this.

<img width="1118" height="215" alt="image" src="https://github.com/user-attachments/assets/506674d5-713e-44f8-a57d-428818733ab0" />

