### PR TITLE
UX: hide disabled new topic btn

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1904,6 +1904,7 @@ en:
     post_excerpt_maxlength: "Maximum length of a post excerpt / summary."
     topic_excerpt_maxlength: "Maximum length of a topic excerpt / summary, generated from the first post in a topic."
     default_subcategory_on_read_only_category: "Enables 'New Topic' button and selects a default subcategory to post on categories where the user is not allowed to create a new topic."
+    hide_disabled_create_topic_button: "Hide the 'New Topic' button when viewing a category where the current user is not allowed to create a new topic."
     show_pinned_excerpt_mobile: "Show excerpt on pinned topics in mobile view."
     show_pinned_excerpt_desktop: "Show excerpt on pinned topics in desktop view."
     post_onebox_maxlength: "Maximum length of a oneboxed Discourse post in characters."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1904,7 +1904,6 @@ en:
     post_excerpt_maxlength: "Maximum length of a post excerpt / summary."
     topic_excerpt_maxlength: "Maximum length of a topic excerpt / summary, generated from the first post in a topic."
     default_subcategory_on_read_only_category: "Enables 'New Topic' button and selects a default subcategory to post on categories where the user is not allowed to create a new topic."
-    hide_disabled_create_topic_button: "Hide the 'New Topic' button when viewing a category where the current user is not allowed to create a new topic."
     show_pinned_excerpt_mobile: "Show excerpt on pinned topics in mobile view."
     show_pinned_excerpt_desktop: "Show excerpt on pinned topics in desktop view."
     post_onebox_maxlength: "Maximum length of a oneboxed Discourse post in characters."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1549,6 +1549,10 @@ posting:
     client: true
     default: false
     area: "posts_and_topics"
+  hide_disabled_create_topic_button:
+    client: true
+    default: false
+    area: "posts_and_topics"
   show_pinned_excerpt_mobile:
     client: true
     default: true

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1552,7 +1552,7 @@ posting:
   hide_disabled_create_topic_button:
     client: true
     default: false
-    area: "posts_and_topics"
+    hidden: true
   show_pinned_excerpt_mobile:
     client: true
     default: true

--- a/frontend/discourse/app/components/discovery/navigation.gjs
+++ b/frontend/discourse/app/components/discovery/navigation.gjs
@@ -24,6 +24,7 @@ export default class DiscoveryNavigation extends Component {
   @service currentUser;
   @service modal;
   @service router;
+  @service siteSettings;
 
   get filterMode() {
     return calculateFilterMode({
@@ -38,7 +39,18 @@ export default class DiscoveryNavigation extends Component {
   }
 
   get canCreateTopic() {
-    return this.currentUser?.can_create_topic;
+    if (!this.currentUser?.can_create_topic) {
+      return false;
+    }
+
+    if (
+      this.siteSettings.hide_disabled_create_topic_button &&
+      this.args.createTopicDisabled
+    ) {
+      return false;
+    }
+
+    return true;
   }
 
   get bodyClass() {

--- a/frontend/discourse/tests/acceptance/create-topic-button-visibility-test.js
+++ b/frontend/discourse/tests/acceptance/create-topic-button-visibility-test.js
@@ -1,0 +1,63 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import DiscoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance(
+  "Create Topic button visibility - hide_disabled_create_topic_button",
+  function (needs) {
+    needs.user();
+    needs.pretender((server, helper) => {
+      server.get("/c/writable-category/7/l/latest.json", () => {
+        return helper.response(
+          DiscoveryFixtures["/latest_can_create_topic.json"]
+        );
+      });
+      server.get("/c/read-only-category/8/l/latest.json", () => {
+        return helper.response(
+          DiscoveryFixtures["/latest_can_create_topic.json"]
+        );
+      });
+    });
+    needs.site({
+      categories: [
+        {
+          id: 7,
+          name: "writable category",
+          slug: "writable-category",
+          permission: 1,
+        },
+        {
+          id: 8,
+          name: "read only category",
+          slug: "read-only-category",
+          permission: null,
+        },
+      ],
+    });
+
+    test("shows the button on writable categories when setting is enabled", async function (assert) {
+      this.siteSettings.hide_disabled_create_topic_button = true;
+
+      await visit("/c/writable-category");
+
+      assert.dom("#create-topic").exists();
+    });
+
+    test("hides the button on read-only categories when setting is enabled", async function (assert) {
+      this.siteSettings.hide_disabled_create_topic_button = true;
+
+      await visit("/c/read-only-category");
+
+      assert.dom("#create-topic").doesNotExist();
+    });
+
+    test("shows the button on read-only categories when setting is disabled", async function (assert) {
+      this.siteSettings.hide_disabled_create_topic_button = false;
+
+      await visit("/c/read-only-category");
+
+      assert.dom("#create-topic").exists();
+    });
+  }
+);


### PR DESCRIPTION
In #33495 we made the new topic button stay visible regardless of posting permissions. When clicked while viewing a category that the user didn't have posting permissions for, they would see a greyed out category name in the select field with the **read-only** badge and be forced select a different category before posting.

This change adds a hidden site setting named `hide_disabled_create_topic_button`. When the setting is enabled:

- hides the "New Topic" button in read-only categories
- hides the "New Topic" button when the current user doesn't have create permissions
- shows the "New Topic" button on other categories where the user has permission to post

Note that this change is for core and other themes and components may implement a separate "New Topic" button that does not currently respect this site setting.