### PR TITLE
FIX: Saving an edit on a reply can fail after expanding replies

### DIFF
--- a/frontend/discourse/app/services/store.js
+++ b/frontend/discourse/app/services/store.js
@@ -433,7 +433,10 @@ export default class StoreService extends Service {
         // If a property value is unchanged, remove it from the update list
         updatedProperties &&
           Object.keys(updatedProperties).forEach((key) => {
-            if (existing[key] === updatedProperties[key]) {
+            if (
+              key.startsWith("__") ||
+              existing[key] === updatedProperties[key]
+            ) {
               delete updatedProperties[key];
             }
           });

--- a/frontend/discourse/tests/unit/services/store-test.js
+++ b/frontend/discourse/tests/unit/services/store-test.js
@@ -27,6 +27,22 @@ module("Unit | Service | store", function (hooks) {
     assert.strictEqual(widget.id, undefined, "there is no id");
   });
 
+  test("createRecord doesn't overwrite __-prefixed metadata", function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const widget = store.createRecord("widget", { id: 77, name: "first" });
+
+    store.createRecord("widget", {
+      id: 77,
+      name: "second",
+      __type: "evil",
+      __plugin: "evil",
+    });
+
+    assert.strictEqual(widget.name, "second");
+    assert.strictEqual(widget.__type, "widget");
+    assert.strictEqual(widget.__plugin, undefined);
+  });
+
   test("createRecord doesn't modify the input `id` field", function (assert) {
     const store = getOwner(this).lookup("service:store");
     const widget = store.createRecord("widget", { id: 1, name: "hello" });

--- a/spec/system/page_objects/components/post.rb
+++ b/spec/system/page_objects/components/post.rb
@@ -24,6 +24,12 @@ module PageObjects
         post.find(".show-replies").click
       end
 
+      def jump_to_reply(reply)
+        find(
+          "#embedded-posts__bottom--#{@post_number} .reply[data-post-id='#{reply.id}'] a.post-info.arrow",
+        ).click
+      end
+
       def load_more_replies
         find("#embedded-posts__bottom--#{@post_number} .load-more-replies").click
       end

--- a/spec/system/post_replies_spec.rb
+++ b/spec/system/post_replies_spec.rb
@@ -57,4 +57,31 @@ describe "Post replies" do
       expect(third_chained_reply).to have_no_parent_post_content("reply 3")
     end
   end
+
+  context "when editing a reply reached via expanded replies" do
+    fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+    fab!(:reply_1) { Fabricate(:post, topic:, reply_to_post_number: post.post_number) }
+    fab!(:reply_2) { Fabricate(:post, topic:, reply_to_post_number: post.post_number) }
+
+    let(:composer) { PageObjects::Components::Composer.new }
+    let(:reply_1_post) { PageObjects::Components::Post.new(reply_1.post_number) }
+
+    before do
+      PostReply.create!(post:, reply: reply_1)
+      PostReply.create!(post:, reply: reply_2)
+      post.update!(reply_count: 2)
+    end
+
+    it "saves a no-op edit without errors" do
+      sign_in(admin)
+      visit(topic.url)
+
+      first_post.show_replies
+      first_post.jump_to_reply(reply_1)
+      reply_1_post.edit
+      composer.submit
+
+      expect(page).to have_no_css(".dialog-body")
+    end
+  end
 end


### PR DESCRIPTION
Editing a post that's a reply produced a "The requested URL or resource could not be found" dialog when the post had been viewed via its parent's expanded replies list. The dialog came from a `PUT /post_replies/:id` request that 404s; the URL should be `PUT /posts/:id`.

`loadMoreReplies` calls `store.find("post-reply", …)` then `store.createRecord("post", reply)` on each result. The first stamps `__type = "post-reply"` (and `__munge`, `__state`) onto each model. The second re-hydrates the same `id` under `post` — and the topic stream's canonical post for that `id` is already in the store. `_hydrate`'s "update existing" path copies those internal fields onto the canonical record via `setProperties`, so a later `post.save()` builds its URL from the wrong `__type`.

Fix: skip every `__`-prefixed key when diffing in `_hydrate`'s update path. Internal store/RestModel metadata stamped at hydration time has no business being carried across types. The `__` prefix is the existing convention for "internal", so future additions are protected by the same guard.

https://meta.discourse.org/t/402747