### PR TITLE
DEV: Respect unlisted topic visibility in `/solution/by_user`

### DIFF
--- a/plugins/discourse-solved/app/controllers/discourse_solved/solved_topics_controller.rb
+++ b/plugins/discourse-solved/app/controllers/discourse_solved/solved_topics_controller.rb
@@ -16,6 +16,8 @@ class DiscourseSolved::SolvedTopicsController < ::ApplicationController
     offset = [0, params[:offset].to_i].max
     limit = params.fetch(:limit, 30).to_i
 
+    include_unlisted_topics = current_user&.id == user.id || guardian.can_see_unlisted_topics?
+
     posts =
       Post
         .joins(
@@ -29,6 +31,11 @@ class DiscourseSolved::SolvedTopicsController < ::ApplicationController
           "topics.category_id IS NULL OR NOT categories.read_restricted OR topics.category_id IN (:secure_category_ids)",
           secure_category_ids: guardian.secure_category_ids,
         )
+
+    posts = posts.where(topics: { visible: true }) unless include_unlisted_topics
+
+    posts =
+      posts
         .includes(:user, topic: %i[category tags])
         .order("discourse_solved_solved_topics.created_at DESC")
         .offset(offset)

--- a/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
@@ -4,6 +4,7 @@ describe DiscourseSolved::SolvedTopicsController do
   fab!(:user)
   fab!(:another_user, :user)
   fab!(:admin)
+  fab!(:tl4_user, :trust_level_4)
   fab!(:topic)
   fab!(:post) { Fabricate(:post, topic:) }
   fab!(:answer_post) { Fabricate(:post, topic:, user:) }
@@ -123,6 +124,79 @@ describe DiscourseSolved::SolvedTopicsController do
         expect(response.status).to eq(200)
         result = response.parsed_body
         expect(result["user_solved_posts"]).to be_empty
+      end
+
+      context "with hidden posts" do
+        before do
+          answer_post.update!(
+            hidden: true,
+            hidden_at: Time.zone.now,
+            hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+          )
+        end
+
+        it "returns hidden posts when the topic is visible" do
+          sign_in(another_user)
+
+          get "/solution/by_user.json", params: { username: user.username }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["user_solved_posts"].length).to eq(1)
+          expect(result["user_solved_posts"][0]["post_id"]).to eq(answer_post.id)
+        end
+      end
+
+      context "with invisible topics" do
+        before { topic.update!(visible: false) }
+
+        it "does not return posts in invisible topics to another user" do
+          sign_in(another_user)
+
+          get "/solution/by_user.json", params: { username: user.username }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["user_solved_posts"]).to be_empty
+        end
+
+        it "does not return posts in invisible topics to anonymous users" do
+          get "/solution/by_user.json", params: { username: user.username }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["user_solved_posts"]).to be_empty
+        end
+
+        it "returns posts in invisible topics to the post owner" do
+          sign_in(user)
+
+          get "/solution/by_user.json", params: { username: user.username }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["user_solved_posts"].length).to eq(1)
+        end
+
+        it "returns posts in invisible topics to trust level 4 users" do
+          sign_in(tl4_user)
+
+          get "/solution/by_user.json", params: { username: user.username }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["user_solved_posts"].length).to eq(1)
+        end
+
+        it "returns posts in invisible topics to staff" do
+          sign_in(admin)
+
+          get "/solution/by_user.json", params: { username: user.username }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body
+          expect(result["user_solved_posts"].length).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Gate `GET /solution/by_user.json` endpoint in discourse-solved to only show authorized content to users.