### PR TITLE
UX: Topic voting header updates

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme.scss
@@ -44,6 +44,7 @@
   #topic-progress-wrapper {
     &:not(
       .topic-voting-menu-trigger,
+      .voting-wrapper__button,
       .sidebar-footer-actions-button,
       #search-button,
       .btn-sidebar-toggle,
@@ -70,6 +71,7 @@
   .btn.no-text.btn-icon {
     &:not(
       .topic-voting-menu-trigger,
+      .voting-wrapper__button,
       .user-menu-tab,
       .user-menu-tab-active,
       .composer-actions-btn,
@@ -382,4 +384,9 @@
     height: 100%;
     align-items: center;
   }
+}
+
+.header-title-voting,
+.voting-wrapper {
+  margin-top: 0 !important;
 }

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-button.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-button.gjs
@@ -152,7 +152,7 @@ export default class VoteBox extends Component {
           <DButton
             @icon={{this.buttonIcon}}
             @disabled={{true}}
-            @ariaLabel={{this.ariaLabel}}
+            @translatedAriaLabel={{this.ariaLabel}}
             class={{this.buttonClasses}}
           />
         </:trigger>
@@ -261,7 +261,7 @@ export default class VoteBox extends Component {
       <DButton
         @icon={{this.buttonIcon}}
         @action={{this.onShowMenu}}
-        @ariaLabel={{this.ariaLabel}}
+        @translatedAriaLabel={{this.ariaLabel}}
         class={{this.buttonClasses}}
       />
     {{/if}}

--- a/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
+++ b/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
@@ -125,6 +125,12 @@
   .voting-wrapper__button {
     width: 100%;
     padding: var(--space-1);
+
+    .d-header .extra-info-wrapper & {
+      .d-icon {
+        color: var(--d-header-icon-color);
+      }
+    }
   }
 }
 

--- a/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
+++ b/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
@@ -127,7 +127,7 @@
     padding: var(--space-1);
 
     .d-header .extra-info-wrapper & {
-      .d-icon {
+      .d-icon:not(.d-icon-vote-up-filled) {
         color: var(--d-header-icon-color);
       }
     }

--- a/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
+++ b/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
@@ -111,6 +111,7 @@
   --primary-high: var(--header_primary-high);
   --primary-medium: var(--header_primary-high);
   --primary-low: var(--header_primary-low);
+  --d-button-default-icon-color: var(--header_primary-high);
   margin-top: 0.15em; // vertical alignment tweak
   margin-right: var(--space-2);
 
@@ -125,12 +126,6 @@
   .voting-wrapper__button {
     width: 100%;
     padding: var(--space-1);
-
-    .d-header .extra-info-wrapper & {
-      .d-icon:not(.d-icon-vote-up-filled) {
-        color: var(--d-header-icon-color);
-      }
-    }
   }
 }
 


### PR DESCRIPTION
This PR makes a few adjustments to the topic voting UI in the header.

- Uses `d-header-icon-color` for upvote icon
- Adjust foundation modernization overrides to fix some styling issues
- Fixes aria label for anon users

## Before
<img width="216" height="65" alt="Screenshot 2026-05-12 at 9 39 55 AM" src="https://github.com/user-attachments/assets/953d01db-4c85-4d74-9596-bf1203127f9f" />

Aria label wasn't rendering for anon users.
<img width="658" height="113" alt="Screenshot 2026-05-12 at 8 39 58 AM" src="https://github.com/user-attachments/assets/b583975b-ed82-4b61-9552-df3009272f40" />

## After

<img width="207" height="64" alt="Screenshot 2026-05-12 at 9 43 16 AM" src="https://github.com/user-attachments/assets/82c7d90c-88e0-49cd-b6be-b6aab88cde2a" />

<img width="219" height="68" alt="Screenshot 2026-05-12 at 9 55 20 AM" src="https://github.com/user-attachments/assets/f8b6cded-ad31-4db9-9510-6d486091dad7" />

<img width="613" height="146" alt="Screenshot 2026-05-12 at 9 43 47 AM" src="https://github.com/user-attachments/assets/7a3603b1-557f-44bc-bee4-3e6a38ad5eda" />
