### PR TITLE
DEV: Stop overriding image_quality on new sites

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2469,7 +2469,7 @@ files:
   image_quality:
     enum: "ImageQualitySetting"
     client: true
-    default: 70
+    default: 90
   png_to_jpg_quality:
     default: 0
     min: 0

--- a/db/migrate/20251024015907_populate_image_quality_setting.rb
+++ b/db/migrate/20251024015907_populate_image_quality_setting.rb
@@ -2,6 +2,8 @@
 
 class PopulateImageQualitySetting < ActiveRecord::Migration[8.0]
   def up
+    return if Migration::Helpers.new_site?
+
     execute(<<~SQL)
       WITH src AS (
         SELECT

--- a/spec/db/migrate/20251024015907_populate_image_quality_setting_spec.rb
+++ b/spec/db/migrate/20251024015907_populate_image_quality_setting_spec.rb
@@ -8,26 +8,38 @@ RSpec.describe PopulateImageQualitySetting do
     ActiveRecord::Migration.verbose = false
   end
 
-  after { ActiveRecord::Migration.verbose = @original_verbose }
+  after do
+    ActiveRecord::Migration.verbose = @original_verbose
+    Discourse.clear_site_creation_date_cache
+  end
 
-  it "works" do
-    mapping = { 60 => 50, 75 => 70, 99 => 90, 100 => 100 }
+  it "is a no-op on fresh installs" do
+    expect { PopulateImageQualitySetting.new.up }.not_to change {
+      DB.query_single("SELECT count(*) FROM site_settings WHERE name = 'image_quality'").first
+    }
+  end
 
-    mapping.each do |current, expected|
-      # SETUP
-      DB.exec(<<~SQL)
-        INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
-        VALUES ('recompress_original_jpg_quality', 1, #{current}, NOW(), NOW())
-        ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value
-      SQL
+  context "when the site is an existing install" do
+    before do
+      DB.exec("UPDATE schema_migration_details SET created_at = NOW() - INTERVAL '2 hours'")
+      Discourse.clear_site_creation_date_cache
+    end
 
-      # EXERCISE
-      PopulateImageQualitySetting.new.up
+    it "maps recompress_original_jpg_quality into image_quality buckets" do
+      mapping = { 60 => 50, 75 => 70, 99 => 90, 100 => 100 }
 
-      # ASSERT
-      row = DB.query("SELECT value FROM site_settings WHERE name = 'image_quality'")[0]
+      mapping.each do |current, expected|
+        DB.exec(<<~SQL)
+          INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+          VALUES ('recompress_original_jpg_quality', 1, #{current}, NOW(), NOW())
+          ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value
+        SQL
 
-      expect(row.value.to_i).to eq(expected)
+        PopulateImageQualitySetting.new.up
+
+        row = DB.query("SELECT value FROM site_settings WHERE name = 'image_quality'")[0]
+        expect(row.value.to_i).to eq(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
The recompress_original_jpg_quality back-fill migration writes a redundant override row on every fresh install (the CTE's COALESCE(..., 90) maps to image_quality='90', which is also the default we want anyway).

Gate the migration on Migration::Helpers.existing_site? and bump the YAML default to 90 so behaviour on a fresh install is unchanged.

Extracted from https://github.com/discourse/discourse/pull/39788.