### PR TITLE
DEV: Stop mutating `allowed_iframes` for the discobot certificate

### DIFF
--- a/frontend/discourse-markdown-it/src/options.js
+++ b/frontend/discourse-markdown-it/src/options.js
@@ -68,7 +68,6 @@ export default function buildOptions(state) {
       : null,
     // Only allow urls with at least 3 slashes. Ex: 'https://example.com/'.
     allowedIframes: (
-      allowedIframes ??
       siteSettings.allowed_iframes?.split("|") ??
       []
     ).filter((str) => (str.match(/\//g) || []).length >= 3),

--- a/frontend/discourse-markdown-it/src/options.js
+++ b/frontend/discourse-markdown-it/src/options.js
@@ -66,8 +66,11 @@ export default function buildOptions(state) {
     allowedHrefSchemes: siteSettings.allowed_href_schemes
       ? siteSettings.allowed_href_schemes.split("|")
       : null,
+    // Server-side `pretty_text.rb` passes the modifier-applied list as `allowedIframes`;
+    // client-side composer preview falls back to deriving it from `siteSettings`.
     // Only allow urls with at least 3 slashes. Ex: 'https://example.com/'.
     allowedIframes: (
+      allowedIframes ??
       siteSettings.allowed_iframes?.split("|") ??
       []
     ).filter((str) => (str.match(/\//g) || []).length >= 3),

--- a/frontend/discourse-markdown-it/src/options.js
+++ b/frontend/discourse-markdown-it/src/options.js
@@ -33,6 +33,7 @@ export default function buildOptions(state) {
     hashtagTypesInPriorityOrder,
     hashtagIcons,
     hashtagLookup,
+    allowedIframes,
   } = state;
 
   let features = {};
@@ -65,11 +66,12 @@ export default function buildOptions(state) {
     allowedHrefSchemes: siteSettings.allowed_href_schemes
       ? siteSettings.allowed_href_schemes.split("|")
       : null,
-    allowedIframes: siteSettings.allowed_iframes
-      ? siteSettings.allowed_iframes
-          .split("|")
-          .filter((str) => (str.match(/\//g) || []).length >= 3)
-      : [], // Only allow urls with at least 3 slashes. Ex: 'https://example.com/'.
+    // Only allow urls with at least 3 slashes. Ex: 'https://example.com/'.
+    allowedIframes: (
+      allowedIframes ??
+      siteSettings.allowed_iframes?.split("|") ??
+      []
+    ).filter((str) => (str.match(/\//g) || []).length >= 3),
     markdownIt: true,
     previewing,
     disableEmojis,

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -200,12 +200,19 @@ module PrettyText
       custom_emoji = {}
       Emoji.custom.map { |e| custom_emoji[e.name] = e.url }
 
+      allowed_iframes =
+        DiscoursePluginRegistry.apply_modifier(
+          :pretty_text_allowed_iframes,
+          SiteSetting.allowed_iframes.split("|"),
+        )
+
       # note, any additional options added to __optInput here must be
       # also be added to the buildOptions function in pretty-text.js,
       # otherwise they will be discarded
       buffer = +<<~JS
         __optInput = {};
         __optInput.siteSettings = #{SiteSetting.client_settings_json};
+        __optInput.allowedIframes = #{allowed_iframes.to_json};
         #{"__optInput.disableEmojis = true" if opts[:disable_emojis]}
         __paths = #{paths_json};
         __optInput.getURL = __getURL;

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -43,7 +43,6 @@ after_initialize do
   end
 
   register_modifier(:pretty_text_allowed_iframes) do |list|
-    next list unless SiteSetting.discourse_narrative_bot_enabled
     certificate_path = "#{Discourse.base_url}/discobot/certificate.svg"
     list.include?(certificate_path) ? list : list + [certificate_path]
   end

--- a/plugins/discourse-narrative-bot/plugin.rb
+++ b/plugins/discourse-narrative-bot/plugin.rb
@@ -39,13 +39,13 @@ after_initialize do
     if SiteSetting.discourse_narrative_bot_enabled
       # Disable welcome message because that is what the bot is supposed to replace.
       SiteSetting.send_welcome_message = false if SiteSetting.send_welcome_message
-
-      certificate_path = "#{Discourse.base_url}/discobot/certificate.svg"
-      if !SiteSetting.allowed_iframes.include?(certificate_path)
-        SiteSetting.allowed_iframes =
-          SiteSetting.allowed_iframes.split("|").append(certificate_path).join("|")
-      end
     end
+  end
+
+  register_modifier(:pretty_text_allowed_iframes) do |list|
+    next list unless SiteSetting.discourse_narrative_bot_enabled
+    certificate_path = "#{Discourse.base_url}/discobot/certificate.svg"
+    list.include?(certificate_path) ? list : list + [certificate_path]
   end
 
   self.add_model_callback(User, :after_destroy) { DiscourseNarrativeBot::Store.remove(self.id) }


### PR DESCRIPTION
Previously, the narrative bot appended `/discobot/certificate.svg` onto `SiteSetting.allowed_iframes` on every Rails boot. This is inefficient, and prevents future default changes to this setting from taking effect.

This change adds a `:pretty_text_allowed_iframes` modifier where the cook flow assembles its `__optInput` (in `lib/pretty_text.rb`), passes the modifier-applied list to JS as a dedicated `allowedIframes` opt picked up by `buildOptions`, and has the plugin register against the modifier — so no derived state is persisted in the database.

Extracted from https://github.com/discourse/discourse/pull/39788.