### PR TITLE
PERF: Memoize `fs_asset_cachebuster` in the test environment

### DIFF
--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -161,7 +161,7 @@ class Stylesheet::Manager
   private_class_method :manifest_full_path
 
   def self.use_file_hash_for_cachebuster?
-    Rails.env.production?
+    Rails.env.production? || Rails.env.test?
   end
   private_class_method :use_file_hash_for_cachebuster?
 

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -1062,8 +1062,25 @@ RSpec.describe Stylesheet::Manager do
   end
 
   describe ".fs_asset_cachebuster" do
-    it "returns a number in test/development mode" do
-      expect(Stylesheet::Manager.fs_asset_cachebuster).to match(/\A.*:[0-9]+\z/)
+    context "when memoizing via the filesystem manifest (production / test)" do
+      after do
+        path = Stylesheet::Manager.send(:manifest_full_path)
+        File.delete(path) if File.exist?(path)
+        Stylesheet::Manager.recalculate_fs_asset_cachebuster!
+      end
+
+      it "returns a content hash" do
+        expect(Stylesheet::Manager.fs_asset_cachebuster).to match(/\A.*:[0-9a-f]{40}\z/)
+      end
+    end
+
+    context "when memoizing in-process via mtime (development)" do
+      before { Stylesheet::Manager.stubs(:use_file_hash_for_cachebuster?).returns(false) }
+      after { Stylesheet::Manager.recalculate_fs_asset_cachebuster! }
+
+      it "returns an mtime number" do
+        expect(Stylesheet::Manager.fs_asset_cachebuster).to match(/\A.*:[0-9]+\z/)
+      end
     end
 
     context "with production mode enabled" do
@@ -1072,11 +1089,6 @@ RSpec.describe Stylesheet::Manager do
       after do
         path = Stylesheet::Manager.send(:manifest_full_path)
         File.delete(path) if File.exist?(path)
-      end
-
-      it "returns a hash" do
-        cachebuster = Stylesheet::Manager.fs_asset_cachebuster
-        expect(cachebuster).to match(/\A.*:[0-9a-f]{40}\z/)
       end
 
       it "caches the value on the filesystem" do


### PR DESCRIPTION
Previously, `Stylesheet::Manager.fs_asset_cachebuster` only memoized in production, so under `Rails.env.test?` every call re-walked `app/assets/stylesheets`, `app/assets/images`, `lib/stylesheet`, and every plugin's `assets/stylesheets` to compute an mtime — observable as ~13% of the themes seed under stackprof and ~380 redundant filesystem scans per `db:seed`.

This change widens the memoization branch to `Rails.env.production? || Rails.env.test?` so the existing `manifest_full_path` content-hash path is used in test too (it already handles parallel workers via `TEST_ENV_NUMBER`), and rewrites the spec to cover both the manifest path and the mtime path explicitly via a `use_file_hash_for_cachebuster?` stub.

Extracted from https://github.com/discourse/discourse/pull/39788.