### PR TITLE
DEV: Optionally decode JPEG and PNG in WASM during composer upload

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2256,6 +2256,7 @@ en:
     composer_media_optimization_image_resize_width_target: "Images with widths larger than `composer_media_optimization_image_dimensions_resize_threshold` will be resized to this width. Must be >= than `composer_media_optimization_image_dimensions_resize_threshold`."
     composer_media_optimization_image_encode_quality: "JPG encode quality used in the re-encode process."
     composer_media_optimization_image_convert_enabled: "Enables client-side conversion of JXL, HEIC, and animated GIF images before upload. JXL and HEIC are converted to JPEG, animated GIFs larger than the threshold are converted to animated WEBP."
+    composer_media_optimization_image_wasm_decode_enabled: "Decode JPEG and PNG images in WASM inside the Web Worker instead of using browser canvas APIs. Avoids iOS canvas pixel limits and createImageBitmap flakiness, at the cost of a larger worker bundle."
     composer_media_optimization_gif_conversion_threshold: "Minimum GIF file size in bytes to trigger client-side conversion to animated WEBP."
 
     video_conversion_enabled: "Enable video conversion for uploaded video files. This allows videos to be converted to web-compatible formats."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2552,6 +2552,10 @@ files:
       learn_more_url: "https://meta.discourse.org/t/-/402705"
       allow_enabled_for:
         - everyone
+  composer_media_optimization_image_wasm_decode_enabled:
+    default: false
+    hidden: true
+    client: true
   composer_media_optimization_gif_conversion_threshold:
     default: 512000
     hidden: true

--- a/frontend/discourse/app/services/media-optimization-worker.js
+++ b/frontend/discourse/app/services/media-optimization-worker.js
@@ -52,6 +52,9 @@ export default class MediaOptimizationWorkerService extends Service {
     const isConvertFormat = CONVERT_FORMAT_REGEX.test(typeOrName);
     const isAnimatedGif = ANIMATED_GIF_REGEX.test(typeOrName);
     const isOptimizable = OPTIMIZABLE_REGEX.test(typeOrName);
+    const wasmDecodeOptimizable =
+      isOptimizable &&
+      this.siteSettings.composer_media_optimization_image_wasm_decode_enabled;
 
     if (!isConvertFormat && !isAnimatedGif && !isOptimizable) {
       return Promise.resolve();
@@ -120,7 +123,7 @@ export default class MediaOptimizationWorkerService extends Service {
         mediaOptimizationBundle: this.session.mediaOptimizationBundle,
       };
 
-      if (isConvertFormat) {
+      if (isConvertFormat || wasmDecodeOptimizable) {
         let arrayBuffer;
         try {
           arrayBuffer = await file.data.arrayBuffer();
@@ -135,7 +138,7 @@ export default class MediaOptimizationWorkerService extends Service {
             fileId: file.id,
             file: arrayBuffer,
             fileName: file.name,
-            fileType: file.type || file.data.type,
+            fileType: file.type || file.data.type || file.name,
             originalFileSize: file.size,
             settings,
           },

--- a/frontend/discourse/app/static/media-optimization-bundle.js
+++ b/frontend/discourse/app/static/media-optimization-bundle.js
@@ -1,7 +1,8 @@
 import { decodeAnimated as decodeGifAnimated } from "@discourse/gif";
 import { decode as decodeHeic } from "@discourse/heic";
-import { encode as encodeJpeg } from "@discourse/jpeg";
+import { decode as decodeJpeg, encode as encodeJpeg } from "@discourse/jpeg";
 import { decode as decodeJxl } from "@discourse/jxl";
+import { decode as decodePng } from "@discourse/png";
 import resize from "@discourse/resize";
 import {
   encode as encodeWebp,
@@ -184,6 +185,10 @@ globalThis.convert = async function (
     imageData = await decodeJxl(fileBuffer);
   } else if (/hei[cf]$/i.test(fileType)) {
     imageData = await decodeHeic(fileBuffer);
+  } else if (/jpe?g$/i.test(fileType)) {
+    imageData = await decodeJpeg(fileBuffer);
+  } else if (/png$/i.test(fileType)) {
+    imageData = await decodePng(fileBuffer);
   } else {
     throw `Unsupported file type for conversion: ${fileType}`;
   }

--- a/frontend/discourse/app/static/media-optimization-bundle.js
+++ b/frontend/discourse/app/static/media-optimization-bundle.js
@@ -186,7 +186,7 @@ globalThis.convert = async function (
   } else if (/hei[cf]$/i.test(fileType)) {
     imageData = await decodeHeic(fileBuffer);
   } else if (/jpe?g$/i.test(fileType)) {
-    imageData = await decodeJpeg(fileBuffer);
+    imageData = await decodeJpeg(fileBuffer, { preserveOrientation: true });
   } else if (/png$/i.test(fileType)) {
     imageData = await decodePng(fileBuffer);
   } else {

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -41,6 +41,7 @@
     "@discourse/heic": "^1.0.0",
     "@discourse/jpeg": "^1.0.0",
     "@discourse/jxl": "^1.0.0",
+    "@discourse/png": "^3.1.1",
     "@discourse/resize": "^2.1.0",
     "@discourse/webp": "^1.0.0",
     "ace-builds": "^1.43.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       '@discourse/jxl':
         specifier: ^1.0.0
         version: 1.3.0
+      '@discourse/png':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@discourse/resize':
         specifier: ^2.1.0
         version: 2.1.1
@@ -1696,6 +1699,9 @@ packages:
 
   '@discourse/moment-timezone-names-translations@1.0.0':
     resolution: {integrity: sha512-4xr1QWQ0nzmFa2ZXQgWZA+dtE/BU2ePA+qkJWPFzNpq4ZnQi8MmMMAS2285t3rc2ySMBQqYaAArmcSUiufUgRA==}
+
+  '@discourse/png@3.1.1':
+    resolution: {integrity: sha512-9Cv3CKItt7qhS13B74LK32SL4VPE8YzkbW1ecw5r67p0ny7KnCHXYsYd1KGN94lSXIKkyADDEG7M7Wbmz/y/gQ==}
 
   '@discourse/resize@2.1.1':
     resolution: {integrity: sha512-iSPfgyCWTXsLcYoUN7/TxTbCSMlSqCI2v9/dCmg5dQdr/qi0TtRKjMzmSy7+8+Ns2v076IQDtdyfvBT8CQPd3g==}
@@ -10172,6 +10178,8 @@ snapshots:
       - supports-color
 
   '@discourse/moment-timezone-names-translations@1.0.0': {}
+
+  '@discourse/png@3.1.1': {}
 
   '@discourse/resize@2.1.1': {}
 


### PR DESCRIPTION
Previously, JPEG/PNG client-side optimization decoded files on the main thread via `createImageBitmap` and `OffscreenCanvas`, which is flaky on iOS and silently downscales images past the 16M-pixel canvas cap (`media-optimization-utils.js`).

This change adds a hidden `composer_media_optimization_image_wasm_decode_enabled` setting that routes JPEG/PNG files through the existing `convert` worker path, so decoding happens in WASM (`@discourse/jpeg`, `@discourse/png`) alongside JXL/HEIC — bypassing the canvas pipeline entirely.

### Notes

- Off by default; existing canvas path is unchanged when the setting is disabled.
- Transparent PNGs that previously failed the transparency check are now re-encoded as WEBP by the shared `convert` logic (same behaviour JXL/HEIC already have).
- Worker message protocol is unchanged — JPEG/PNG just take the `"convert"` branch with `fileType` set from MIME or filename.