### PR TITLE
UX: Apply border radius to category badge square in sidebar

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar-section-link.scss
+++ b/app/assets/stylesheets/common/base/sidebar-section-link.scss
@@ -237,6 +237,7 @@
     .prefix-square {
       width: 0.8em;
       height: 0.8em;
+      border-radius: var(--category-badge-border-radius);
     }
   }
 


### PR DESCRIPTION
| Before | After |
| - | - |
|<img width="518" height="442" alt="CleanShot 2026-05-12 at 15 31 04@2x" src="https://github.com/user-attachments/assets/0d2dfa62-4264-4ae3-bb23-cc3c6f52511e" />|<img width="538" height="438" alt="CleanShot 2026-05-12 at 15 30 40@2x" src="https://github.com/user-attachments/assets/6ecd4476-1954-4d48-9da9-daa199f263fc" />|