### PR TITLE
Fix firefox cmd click search dropdown

### DIFF
--- a/frontend/discourse/app/components/search-menu/results/type/topic.gjs
+++ b/frontend/discourse/app/components/search-menu/results/type/topic.gjs
@@ -6,10 +6,17 @@ import HighlightedSearch from "discourse/components/search-menu/highlighted-sear
 import Blurb from "discourse/components/search-menu/results/blurb";
 import TopicStatus from "discourse/components/topic-status";
 import lazyHash from "discourse/helpers/lazy-hash";
-import { and } from "discourse/truth-helpers";
 import dCategoryLink from "discourse/ui-kit/helpers/d-category-link";
 import dDiscourseTags from "discourse/ui-kit/helpers/d-discourse-tags";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
+
+const MaybeAnchor = <template>
+  {{#if @href}}
+    <a href={{@href}}>{{yield}}</a>
+  {{else}}
+    {{yield}}
+  {{/if}}
+</template>;
 
 export default class Results extends Component {
   @service siteSettings;
@@ -17,6 +24,13 @@ export default class Results extends Component {
   get shouldShowPrivateMessageIcon() {
     // Only show PM icon if this is a PM AND we're not in a PM-only search
     return this.args.result.topic.isPrivateMessage && !this.args.isPMOnly;
+  }
+
+  get useHeadline() {
+    return (
+      this.siteSettings.use_pg_headlines_for_excerpt &&
+      this.args.result.topic_title_headline
+    );
   }
 
   <template>
@@ -29,20 +43,13 @@ export default class Results extends Component {
           @showPrivateMessageIcon={{this.shouldShowPrivateMessageIcon}}
         />
         <span class="topic-title" data-topic-id={{@result.topic.id}}>
-          {{#if
-            (and
-              this.siteSettings.use_pg_headlines_for_excerpt
-              @result.topic_title_headline
-            )
-          }}
-            <a href={{if @withTopicUrl @result.url}}>
+          <MaybeAnchor @href={{if @withTopicUrl @result.url}}>
+            {{#if this.useHeadline}}
               {{dReplaceEmoji (trustHTML @result.topic_title_headline)}}
-            </a>
-          {{else}}
-            <a href={{if @withTopicUrl @result.url}}>
+            {{else}}
               <HighlightedSearch @string={{@result.topic.fancyTitle}} />
-            </a>
-          {{/if}}
+            {{/if}}
+          </MaybeAnchor>
           <PluginOutlet
             @name="search-menu-results-topic-title-suffix"
             @outletArgs={{lazyHash topic=@result.topic}}

--- a/frontend/discourse/app/components/topic-status.gjs
+++ b/frontend/discourse/app/components/topic-status.gjs
@@ -31,11 +31,18 @@ export default class TopicStatus extends Component {
     {{~! no whitespace ~}}
     <this.wrapperElement class="topic-statuses">
       {{~#if @topic.bookmarked~}}
-        <a
-          href={{@topic.url}}
-          title={{i18n "topic_statuses.bookmarked.help"}}
-          class="topic-status --bookmarked"
-        >{{dIcon "bookmark"}}</a>
+        {{~#if this.canAct~}}
+          <a
+            href={{@topic.url}}
+            title={{i18n "topic_statuses.bookmarked.help"}}
+            class="topic-status --bookmarked"
+          >{{dIcon "bookmark"}}</a>
+        {{~else~}}
+          <span
+            title={{i18n "topic_statuses.bookmarked.help"}}
+            class="topic-status --bookmarked"
+          >{{dIcon "bookmark"}}</span>
+        {{~/if~}}
       {{~/if~}}
 
       {{~#if (and @topic.closed @topic.archived)~}}

--- a/frontend/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
+++ b/frontend/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
@@ -120,5 +120,31 @@ module(
           "title is wrapped in an anchor pointing to result.url"
         );
     });
+
+    test("bookmark status icon is not an anchor in the search dropdown", async function (assert) {
+      const store = getOwner(this).lookup("service:store");
+      const bookmarkedTopic = store.createRecord("topic", {
+        id: 6,
+        title: "Bookmarked Topic",
+        bookmarked: true,
+      });
+
+      await render(
+        <template>
+          <TopicResultComponent
+            @result={{hash topic=bookmarkedTopic url="/t/foo/6"}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".topic-status.--bookmarked")
+        .exists("bookmark icon renders for bookmarked topic");
+      assert
+        .dom("a.topic-status.--bookmarked")
+        .doesNotExist(
+          "bookmark icon is not an anchor when actions are disabled"
+        );
+    });
   }
 );

--- a/frontend/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
+++ b/frontend/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
@@ -75,5 +75,50 @@ module(
         .dom(".topic-status .d-icon-envelope")
         .doesNotExist("PM icon not shown for regular topic");
     });
+
+    test("does not wrap title in an anchor without @withTopicUrl", async function (assert) {
+      const store = getOwner(this).lookup("service:store");
+      const topic = store.createRecord("topic", {
+        id: 4,
+        title: "Topic Without URL",
+      });
+
+      await render(
+        <template>
+          <TopicResultComponent @result={{hash topic=topic url="/t/foo/4"}} />
+        </template>
+      );
+
+      assert
+        .dom(".topic-title a")
+        .doesNotExist(
+          "title is not wrapped in an anchor when @withTopicUrl is not passed"
+        );
+    });
+
+    test("wraps title in an anchor with @withTopicUrl", async function (assert) {
+      const store = getOwner(this).lookup("service:store");
+      const topic = store.createRecord("topic", {
+        id: 5,
+        title: "Topic With URL",
+      });
+
+      await render(
+        <template>
+          <TopicResultComponent
+            @result={{hash topic=topic url="/t/foo/5"}}
+            @withTopicUrl={{true}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".topic-title a")
+        .hasAttribute(
+          "href",
+          "/t/foo/5",
+          "title is wrapped in an anchor pointing to result.url"
+        );
+    });
   }
 );


### PR DESCRIPTION
## What

In Firefox on macOS, cmd-clicking a topic link in the search dropdown opened the current page with `/null` appended instead of opening the result in a new tab. Right-click → "Open in new tab" still worked, and Chrome
 was unaffected.

## Why

Two places in core were rendering nested `<a>` tags inside the search dropdown:

1. **Topic title** — `search-menu/results/types.gjs` wraps every result in an outer `<a class="search-link">` with the correct href. `search-menu/results/type/topic.gjs` then rendered the title inside *another* `<a>`
 whose href was bound to `{{if @withTopicUrl @result.url}}`. `@withTopicUrl` is only passed by `composer-messages/similar-topics`; from the search dropdown it was `undefined`, so the inner anchor had no href.
Firefox's cmd-click landed on that inner anchor and resolved the empty value to `/null` relative to the current URL.

2. **Bookmark status icon** — `topic-status.gjs` always rendered the bookmark indicator as `<a href={{@topic.url}}>`, regardless of `@disableActions`. The pinned/unpinned indicators next to it already gate on
`canAct`, but the bookmark branch had no such gate, so any bookmarked search result also produced nested anchors.

Nested anchors are invalid HTML — click resolution becomes browser-dependent, which is exactly what bit Firefox here.

## How

Split across two commits:

- **`FIX: Cmd-click on Firefox search dropdown results`** — only render the inner `<a>` in `topic.gjs` when `@withTopicUrl` is truthy. The search dropdown now produces a single anchor per result; the similar-topics
composer case is preserved. Refactor the `use_pg_headlines_for_excerpt` branch into a `useHeadline` getter and extract a small local `MaybeAnchor` helper to keep the template readable.
- **`FIX: Bookmark status icon rendered as a nested anchor`** — mirror the existing pinned/unpinned pattern: render the bookmark `<a>` only when `canAct`, fall back to a `<span>` with the same class/icon/title
otherwise.

## Test plan

- New integration tests in `tests/integration/components/search-menu/results/type/topic-test.gjs`:
  - `does not wrap title in an anchor without @withTopicUrl`
  - `wraps title in an anchor with @withTopicUrl` (protects the similar-topics caller)
  - `bookmark status icon is not an anchor in the search dropdown`
- All three were verified to fail on the pre-fix code.
- Full `search-test.js` (51) and `search-full-test.js` (26) acceptance suites still green.

## Manual verification

In Firefox on macOS:

1. Open the search dropdown, type a query.
2. Cmd-click a topic result → should open in a new background tab on the correct URL (previously: `<current-page>/null`).
3. Repeat on a bookmarked topic to confirm the bookmark indicator no longer creates a nested anchor.

Ref - t/183598