### PR TITLE
FEATURE: Exclude AI bot PMs from regular notifications and inbox

### DIFF
--- a/app/models/private_message_topic_tracking_state.rb
+++ b/app/models/private_message_topic_tracking_state.rb
@@ -90,6 +90,7 @@ class PrivateMessageTopicTrackingState
       #{skip_new ? "" : "LEFT JOIN dismissed_topic_users ON dismissed_topic_users.topic_id = topics.id AND dismissed_topic_users.user_id = #{user.id.to_i}"}
       WHERE (tau.topic_id IS NOT NULL OR tag.topic_id IS NOT NULL) AND
         topics.archetype = 'private_message' AND
+        #{Topic.normal_personal_message_subtype_sql} AND
         ((#{unread}) OR (#{new})) AND
         topics.deleted_at IS NULL
         #{user.staff? ? "" : "AND topics.visible"}
@@ -98,7 +99,7 @@ class PrivateMessageTopicTrackingState
 
   def self.publish_unread(post)
     topic = post.topic
-    return unless topic.private_message?
+    return unless topic&.normal_personal_message?
 
     scope = TopicUser.tracking(post.topic_id).includes(user: %i[user_stat user_option])
 
@@ -152,7 +153,7 @@ class PrivateMessageTopicTrackingState
   end
 
   def self.publish_new(topic)
-    return unless topic.private_message?
+    return unless topic.normal_personal_message?
 
     message = {
       message_type: NEW_MESSAGE_TYPE,
@@ -182,7 +183,7 @@ class PrivateMessageTopicTrackingState
   end
 
   def self.publish_group_archived(topic:, group_id:, acting_user_id: nil)
-    return unless topic.private_message?
+    return unless topic.normal_personal_message?
 
     message = {
       message_type: GROUP_ARCHIVE_MESSAGE_TYPE,

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -390,6 +390,22 @@ class Topic < ActiveRecord::Base
 
   scope :with_subtype, ->(subtype) { where("topics.subtype = ?", subtype) }
 
+  scope :normal_personal_messages,
+        -> { private_messages.where(Topic.normal_personal_message_subtype_sql) }
+
+  def self.normal_personal_message_subtype_sql(table_name = "topics")
+    subtype_column = "#{table_name}.subtype"
+
+    sanitize_sql_array(
+      [
+        "(CASE WHEN #{subtype_column} IS NULL OR #{subtype_column} ~ ? THEN ? ELSE #{subtype_column} END) IN (?)",
+        "^\\s*$",
+        TopicSubtype.user_to_user,
+        TopicSubtype.normal_personal_message_subtypes,
+      ],
+    )
+  end
+
   attr_accessor :ignore_category_auto_close
   attr_accessor :skip_callbacks
   attr_accessor :advance_draft
@@ -698,6 +714,13 @@ class Topic < ActiveRecord::Base
 
   def private_message?
     self.archetype == Archetype.private_message
+  end
+
+  def normal_personal_message?
+    private_message? &&
+      TopicSubtype.normal_personal_message_subtypes.include?(
+        subtype.presence || TopicSubtype.user_to_user,
+      )
   end
 
   def regular?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -669,6 +669,22 @@ class User < ActiveRecord::Base
     @muted_user_ids ||= muted_users.pluck(:id)
   end
 
+  def self.exclude_non_normal_pm_notification_sql(topic_table = "t")
+    <<~SQL
+      AND (
+        #{topic_table}.archetype IS DISTINCT FROM :private_message_archetype
+        OR #{Topic.normal_personal_message_subtype_sql(topic_table)}
+      )
+    SQL
+  end
+
+  def self.exclude_non_normal_pm_notification_sql_params
+    {
+      private_message_notification_type: Notification.types[:private_message],
+      private_message_archetype: Archetype.private_message,
+    }
+  end
+
   def unread_notifications_of_type(notification_type, since: nil)
     # perf critical, much more efficient than AR
     sql = <<~SQL
@@ -676,14 +692,22 @@ class User < ActiveRecord::Base
           FROM notifications n
      LEFT JOIN topics t ON t.id = n.topic_id
          WHERE t.deleted_at IS NULL
-           AND n.notification_type = :notification_type
-           AND n.user_id = :user_id
-           AND NOT read
-           #{since ? "AND n.created_at > :since" : ""}
+            AND n.notification_type = :notification_type
+            AND n.user_id = :user_id
+            AND NOT read
+            #{self.class.exclude_non_normal_pm_notification_sql}
+            #{since ? "AND n.created_at > :since" : ""}
     SQL
 
     # to avoid coalesce we do to_i
-    DB.query_single(sql, user_id: id, notification_type: notification_type, since: since)[0].to_i
+    DB.query_single(
+      sql,
+      self.class.exclude_non_normal_pm_notification_sql_params.merge(
+        user_id: id,
+        notification_type: notification_type,
+        since: since,
+      ),
+    )[0].to_i
   end
 
   def unread_notifications_of_priority(high_priority:)
@@ -696,26 +720,41 @@ class User < ActiveRecord::Base
            AND n.high_priority = :high_priority
            AND n.user_id = :user_id
            AND NOT read
+           #{self.class.exclude_non_normal_pm_notification_sql}
     SQL
 
     # to avoid coalesce we do to_i
-    DB.query_single(sql, user_id: id, high_priority: high_priority)[0].to_i
+    DB.query_single(
+      sql,
+      self.class.exclude_non_normal_pm_notification_sql_params.merge(
+        user_id: id,
+        high_priority: high_priority,
+      ),
+    )[0].to_i
   end
 
   MAX_UNREAD_BACKLOG = 400
   def grouped_unread_notifications
-    results = DB.query(<<~SQL, user_id: self.id, limit: MAX_UNREAD_BACKLOG)
-      SELECT X.notification_type AS type, COUNT(*) FROM (
-        SELECT n.notification_type
-        FROM notifications n
-        LEFT JOIN topics t ON t.id = n.topic_id
-        WHERE t.deleted_at IS NULL
-          AND n.user_id = :user_id
-          AND NOT n.read
-        LIMIT :limit
-      ) AS X
-      GROUP BY X.notification_type
-    SQL
+    results =
+      DB.query(
+        <<~SQL,
+          SELECT X.notification_type AS type, COUNT(*) FROM (
+            SELECT n.notification_type
+            FROM notifications n
+            LEFT JOIN topics t ON t.id = n.topic_id
+            WHERE t.deleted_at IS NULL
+              AND n.user_id = :user_id
+              AND NOT n.read
+              #{self.class.exclude_non_normal_pm_notification_sql}
+            LIMIT :limit
+          ) AS X
+          GROUP BY X.notification_type
+        SQL
+        self.class.exclude_non_normal_pm_notification_sql_params.merge(
+          user_id: self.id,
+          limit: MAX_UNREAD_BACKLOG,
+        ),
+      )
     results.map! { |row| [row.type, row.count] }
     results.to_h
   end
@@ -725,19 +764,23 @@ class User < ActiveRecord::Base
   end
 
   def new_personal_messages_notifications_count
-    args = {
-      user_id: self.id,
-      seen_notification_id: self.seen_notification_id,
-      private_message: Notification.types[:private_message],
-    }
+    args =
+      self.class.exclude_non_normal_pm_notification_sql_params.merge(
+        user_id: self.id,
+        seen_notification_id: self.seen_notification_id,
+      )
 
     DB.query_single(<<~SQL, args).first
       SELECT COUNT(*)
       FROM notifications
-      WHERE user_id = :user_id
-      AND id > :seen_notification_id
-      AND NOT read
-      AND notification_type = :private_message
+      LEFT JOIN topics t ON t.id = notifications.topic_id
+      WHERE notifications.user_id = :user_id
+      AND notifications.id > :seen_notification_id
+      AND NOT notifications.read
+      AND notifications.notification_type = :private_message_notification_type
+      AND t.deleted_at IS NULL
+      AND t.archetype = :private_message_archetype
+      AND #{Topic.normal_personal_message_subtype_sql("t")}
     SQL
   end
 
@@ -768,15 +811,18 @@ class User < ActiveRecord::Base
             n.user_id = :user_id AND
             n.id > :seen_notification_id AND
             NOT read
+            #{self.class.exclude_non_normal_pm_notification_sql}
           LIMIT :limit
         ) AS X
       SQL
 
         DB.query_single(
           sql,
-          user_id: id,
-          seen_notification_id: seen_notification_id,
-          limit: User.max_unread_notifications,
+          self.class.exclude_non_normal_pm_notification_sql_params.merge(
+            user_id: id,
+            seen_notification_id: seen_notification_id,
+            limit: User.max_unread_notifications,
+          ),
         )[
           0
         ].to_i
@@ -795,15 +841,18 @@ class User < ActiveRecord::Base
             n.user_id = :user_id AND
             n.id > :seen_notification_id AND
             NOT read
+            #{self.class.exclude_non_normal_pm_notification_sql}
           LIMIT :limit
         ) AS X
       SQL
 
         DB.query_single(
           sql,
-          user_id: id,
-          seen_notification_id: seen_notification_id,
-          limit: User.max_unread_notifications,
+          self.class.exclude_non_normal_pm_notification_sql_params.merge(
+            user_id: id,
+            seen_notification_id: seen_notification_id,
+            limit: User.max_unread_notifications,
+          ),
         )[
           0
         ].to_i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -700,14 +700,17 @@ class User < ActiveRecord::Base
     SQL
 
     # to avoid coalesce we do to_i
-    DB.query_single(
-      sql,
-      self.class.exclude_non_normal_pm_notification_sql_params.merge(
-        user_id: id,
-        notification_type: notification_type,
-        since: since,
-      ),
-    )[0].to_i
+    DB
+      .query_single(
+        sql,
+        self.class.exclude_non_normal_pm_notification_sql_params.merge(
+          user_id: id,
+          notification_type: notification_type,
+          since: since,
+        ),
+      )
+      .first
+      .to_i
   end
 
   def unread_notifications_of_priority(high_priority:)
@@ -724,13 +727,16 @@ class User < ActiveRecord::Base
     SQL
 
     # to avoid coalesce we do to_i
-    DB.query_single(
-      sql,
-      self.class.exclude_non_normal_pm_notification_sql_params.merge(
-        user_id: id,
-        high_priority: high_priority,
-      ),
-    )[0].to_i
+    DB
+      .query_single(
+        sql,
+        self.class.exclude_non_normal_pm_notification_sql_params.merge(
+          user_id: id,
+          high_priority: high_priority,
+        ),
+      )
+      .first
+      .to_i
   end
 
   MAX_UNREAD_BACKLOG = 400

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -113,6 +113,7 @@ class UserAction < ActiveRecord::Base
    LEFT JOIN topic_users tu ON t.id = tu.topic_id AND tu.user_id = :user_id
        WHERE t.deleted_at IS NULL
          AND t.archetype = 'private_message'
+         AND #{Topic.normal_personal_message_subtype_sql("t")}
          AND t.id IN (SELECT topic_id FROM topic_allowed_users WHERE user_id = :user_id)
     SQL
 
@@ -127,6 +128,7 @@ class UserAction < ActiveRecord::Base
         JOIN groups g ON g.id = gu.group_id
        WHERE deleted_at IS NULL
          AND archetype = 'private_message'
+         AND #{Topic.normal_personal_message_subtype_sql("t")}
        GROUP BY g.name
     SQL
 
@@ -448,6 +450,12 @@ class UserAction < ActiveRecord::Base
         )
       end
     end
+
+    builder.where(
+      "(t.archetype <> :normal_pm_archetype OR #{Topic.normal_personal_message_subtype_sql("t")})",
+      normal_pm_archetype: Archetype.private_message,
+    )
+
     builder
   end
 

--- a/app/services/post_alerter.rb
+++ b/app/services/post_alerter.rb
@@ -139,6 +139,8 @@ class PostAlerter
   end
 
   def after_save_post(post, new_record = false)
+    return if post.topic&.private_message? && !post.topic.normal_personal_message?
+
     notified = [post.user, post.last_editor].uniq
 
     DiscourseEvent.trigger(:post_alerter_before_mentions, post, new_record, notified)
@@ -250,7 +252,7 @@ class PostAlerter
     if new_record && post.post_number == 1
       topic = post.topic
 
-      if topic.present?
+      if topic.present? && (!topic.private_message? || topic.normal_personal_message?)
         watchers = category_watchers(topic) + tag_watchers(topic) + group_watchers(topic)
         # Notify only users who can see the topic
         watchers &= topic.all_allowed_users.pluck(:id) if post.topic.private_message?
@@ -445,6 +447,7 @@ class PostAlerter
       JOIN topic_allowed_groups g ON g.group_id = :group_id AND g.topic_id = t.id
       LEFT JOIN group_archived_messages a ON a.topic_id = t.id AND a.group_id = g.group_id
       WHERE a.id IS NULL AND t.deleted_at is NULL AND t.archetype = 'private_message'
+        AND #{Topic.normal_personal_message_subtype_sql("t")}
     SQL
 
     topic.allowed_groups.map do |g|
@@ -846,6 +849,7 @@ class PostAlerter
 
   def notify_pm_users(post, reply_to_user, quoted_users, notified, new_record = false)
     return [] unless post.topic
+    return [] unless post.topic.normal_personal_message?
 
     warn_if_not_sidekiq
 

--- a/app/services/user_action_manager.rb
+++ b/app/services/user_action_manager.rb
@@ -26,6 +26,7 @@ class UserActionManager
     # no action to log here, this can happen if a user is deleted
     # then topic has no user_id
     return [] unless topic.user_id
+    return [] if topic.private_message? && !topic.normal_personal_message?
 
     row = {
       action_type: topic.private_message? ? UserAction::NEW_PRIVATE_MESSAGE : UserAction::NEW_TOPIC,
@@ -62,6 +63,7 @@ class UserActionManager
   def self.post_rows(post)
     # first post gets nada or if the author has been deleted
     return [] if post.is_first_post? || post.topic.blank? || post.user.blank?
+    return [] if post.topic.private_message? && !post.topic.normal_personal_message?
 
     row = {
       action_type: UserAction::REPLY,

--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -256,7 +256,7 @@ class TopicQuery
 
       result =
         Topic
-          .private_messages
+          .normal_personal_messages
           .includes(:allowed_users)
           .includes(:allowed_groups)
           .joins(

--- a/lib/topic_subtype.rb
+++ b/lib/topic_subtype.rb
@@ -43,6 +43,17 @@ class TopicSubtype
     "pending_users"
   end
 
+  def self.normal_personal_message_subtypes
+    @normal_personal_message_subtypes ||= [
+      user_to_user,
+      system_message,
+      moderator_warning,
+      notify_moderators,
+      notify_user,
+      pending_users_reminder,
+    ].freeze
+  end
+
   def self.register(name, options = {})
     @subtypes ||= {}
     @subtypes[name] = TopicSubtype.new(name, options)

--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/conversations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/conversations_controller.rb
@@ -16,12 +16,19 @@ module DiscourseAi
           Topic
             .private_messages_for_user(current_user)
             .where(user: current_user) # Only show PMs where the current user is the author
-            .joins(
-              "INNER JOIN topic_custom_fields tcf ON tcf.topic_id = topics.id
-                   AND tcf.name = '#{DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD}'
-                   AND tcf.value = 't'",
+            .where(
+              <<~SQL,
+                (
+                  topics.subtype = :ai_bot_subtype OR topics.id IN (
+                    SELECT topic_id
+                    FROM topic_custom_fields
+                    WHERE name = :custom_field_name AND value = 't'
+                  )
+                )
+              SQL
+              ai_bot_subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
+              custom_field_name: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD,
             )
-            .distinct
 
         total = base_query.count
         pms = base_query.order(last_posted_at: :desc).offset(page * per_page).limit(per_page)

--- a/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
@@ -54,6 +54,7 @@ module DiscourseAi
                 context: context,
               ),
             archetype: Archetype.private_message,
+            subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
             target_usernames: bot_username,
             skip_validations: true,
           )

--- a/plugins/discourse-ai/db/migrate/20260512042219_backfill_ai_bot_pm_subtype.rb
+++ b/plugins/discourse-ai/db/migrate/20260512042219_backfill_ai_bot_pm_subtype.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BackfillAiBotPmSubtype < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE topics
+      SET subtype = 'ai_bot'
+      FROM topic_custom_fields
+      WHERE topic_custom_fields.topic_id = topics.id
+        AND topics.archetype = 'private_message'
+        AND topic_custom_fields.name = 'is_ai_bot_pm'
+        AND topic_custom_fields.value = 't'
+        AND topics.subtype IS DISTINCT FROM 'ai_bot'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/discourse-ai/lib/ai_bot.rb
+++ b/plugins/discourse-ai/lib/ai_bot.rb
@@ -4,6 +4,7 @@ module DiscourseAi
   module AiBot
     USER_AGENT = "Discourse AI Bot 1.0 (https://www.discourse.org)"
     TOPIC_AI_BOT_PM_FIELD = "is_ai_bot_pm"
+    TOPIC_AI_BOT_PM_SUBTYPE = "ai_bot"
     POST_AI_LLM_NAME_FIELD = "ai_llm_name"
     POST_AI_LLM_MODEL_ID_FIELD = "ai_llm_model_id"
     POST_AI_AGENT_ID_FIELD = "ai_agent_id"

--- a/plugins/discourse-ai/lib/ai_bot/entry_point.rb
+++ b/plugins/discourse-ai/lib/ai_bot/entry_point.rb
@@ -12,6 +12,60 @@ module DiscourseAi
           .concat(LlmModel.where(id: LlmModel.enabled_chat_bot_ids).pluck(:user_id).compact)
       end
 
+      def self.ai_bot_pm_args?(user, args)
+        return false if user.blank? || args[:topic_id].present?
+        return false if args[:archetype] != Archetype.private_message
+        return false if DiscourseAi::AiBot::Playground.is_bot_user_id?(user.id)
+        return false if args[:target_emails].present? || args[:target_group_names].present?
+
+        recipient_ids = intended_user_recipient_ids(args)
+        return false if recipient_ids.blank?
+
+        recipient_ids -= [user.id]
+        recipient_ids.length == 1 && all_bot_ids.include?(recipient_ids.first)
+      end
+
+      def self.ai_bot_pm_topic?(topic)
+        return false if !topic.private_message?
+        return false if topic.topic_allowed_groups.exists?
+
+        creator = topic.user
+        return false if creator.blank?
+        return false if DiscourseAi::AiBot::Playground.is_bot_user_id?(creator.id)
+
+        recipients = topic.topic_allowed_users.pluck(:user_id) - [creator.id]
+        recipients.length == 1 && all_bot_ids.include?(recipients.first)
+      end
+
+      def self.intended_user_recipient_ids(args)
+        return if args[:target_user_ids].present? && args[:target_usernames].present?
+
+        if args[:target_user_ids].present?
+          return Array
+            .wrap(args[:target_user_ids])
+            .flat_map { |user_id| user_id.to_s.split(",") }
+            .map(&:to_i)
+            .uniq
+        end
+
+        return if args[:target_usernames].blank?
+
+        usernames =
+          Array
+            .wrap(args[:target_usernames])
+            .flat_map { |username| username.to_s.split(",") }
+            .map { |username| username.strip.downcase }
+            .reject(&:blank?)
+            .uniq
+
+        return if usernames.blank?
+
+        user_ids = User.where(username_lower: usernames).pluck(:id)
+        return if user_ids.length != usernames.length
+
+        user_ids
+      end
+
       def self.find_participant_in(participant_ids)
         model = LlmModel.includes(:user).where(user_id: participant_ids).last
         return if model.nil?
@@ -70,31 +124,30 @@ module DiscourseAi
         TopicView.default_post_custom_fields << POST_AI_LLM_NAME_FIELD
 
         plugin.register_topic_custom_field_type(TOPIC_AI_BOT_PM_FIELD, :string)
+        TopicSubtype.register(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+
+        NewPostManager.add_handler do |manager|
+          if DiscourseAi::AiBot::EntryPoint.ai_bot_pm_args?(manager.user, manager.args)
+            manager.args[:subtype] = DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE
+          end
+
+          false
+        end
 
         plugin.on(:topic_created) do |topic|
-          next if !topic.private_message?
-          creator = topic.user
+          next if !DiscourseAi::AiBot::EntryPoint.ai_bot_pm_topic?(topic)
 
-          # Only process if creator is not a bot or system user
-          next if DiscourseAi::AiBot::Playground.is_bot_user_id?(creator.id)
-
-          # Get all bot user IDs defined by the discourse-ai plugin
-          bot_ids = DiscourseAi::AiBot::EntryPoint.all_bot_ids
-
-          # Check if the only recipients are bots
-          recipients = topic.topic_allowed_users.pluck(:user_id)
-
-          # Remove creator from recipients for checking
-          recipients -= [creator.id]
-
-          # If all remaining recipients are AI bots and there's exactly one recipient
-          if recipients.length == 1 && (recipients - bot_ids).empty?
-            # The only recipient is an AI bot - add the custom field to the topic
-            topic.custom_fields[TOPIC_AI_BOT_PM_FIELD] = true
-
-            # Save the custom fields
-            topic.save_custom_fields
+          if topic.subtype != DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE
+            topic.update_column(:subtype, DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+            UserAction.where(
+              target_topic_id: topic.id,
+              action_type: [UserAction::NEW_PRIVATE_MESSAGE, UserAction::GOT_PRIVATE_MESSAGE],
+            ).delete_all
           end
+
+          # The custom field remains during the transition from the old marker to subtype.
+          topic.custom_fields[TOPIC_AI_BOT_PM_FIELD] = true
+          topic.save_custom_fields
         end
 
         plugin.register_modifier(:chat_allowed_bot_user_ids) do |user_ids, guardian|
@@ -141,7 +194,10 @@ module DiscourseAi
           :is_bot_pm,
           include_condition: -> do
             object.topic && object.topic.private_message? &&
-              object.topic.custom_fields[TOPIC_AI_BOT_PM_FIELD]
+              (
+                object.topic.subtype == DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE ||
+                  object.topic.custom_fields[TOPIC_AI_BOT_PM_FIELD]
+              )
           end,
         ) { true }
 

--- a/plugins/discourse-ai/lib/ai_bot/entry_point.rb
+++ b/plugins/discourse-ai/lib/ai_bot/entry_point.rb
@@ -41,11 +41,13 @@ module DiscourseAi
         return if args[:target_user_ids].present? && args[:target_usernames].present?
 
         if args[:target_user_ids].present?
-          return Array
-            .wrap(args[:target_user_ids])
-            .flat_map { |user_id| user_id.to_s.split(",") }
-            .map(&:to_i)
-            .uniq
+          return(
+            Array
+              .wrap(args[:target_user_ids])
+              .flat_map { |user_id| user_id.to_s.split(",") }
+              .map(&:to_i)
+              .uniq
+          )
         end
 
         return if args[:target_usernames].blank?

--- a/plugins/discourse-ai/lib/ai_bot/response_http_streamer.rb
+++ b/plugins/discourse-ai/lib/ai_bot/response_http_streamer.rb
@@ -100,6 +100,7 @@ module DiscourseAi
           else
             post_params[:title] = I18n.t("discourse_ai.ai_bot.default_pm_prefix")
             post_params[:archetype] = Archetype.private_message
+            post_params[:subtype] = DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE
             post_params[:target_usernames] = "#{user.username},#{agent.user.username}"
           end
 

--- a/plugins/discourse-ai/lib/ai_bot/stream_reply_custom_tools_session.rb
+++ b/plugins/discourse-ai/lib/ai_bot/stream_reply_custom_tools_session.rb
@@ -89,6 +89,7 @@ module DiscourseAi
         else
           post_params[:title] = I18n.t("discourse_ai.ai_bot.default_pm_prefix")
           post_params[:archetype] = Archetype.private_message
+          post_params[:subtype] = DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE
           post_params[:target_usernames] = "#{@user.username},#{@agent.user.username}"
         end
 

--- a/plugins/discourse-ai/spec/db/migrate/20260512042219_backfill_ai_bot_pm_subtype_spec.rb
+++ b/plugins/discourse-ai/spec/db/migrate/20260512042219_backfill_ai_bot_pm_subtype_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "plugins/discourse-ai/db/migrate/20260512042219_backfill_ai_bot_pm_subtype",
+        )
+
+RSpec.describe BackfillAiBotPmSubtype do
+  fab!(:user)
+  fab!(:bot_user, :user)
+
+  around { |example| ActiveRecord::Migration.suppress_messages { example.run } }
+
+  def fabricate_pm(subtype: nil, marked: false)
+    topic = Fabricate(:private_message_topic, user: user, recipient: bot_user, subtype: subtype)
+    if marked
+      topic.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD] = "t"
+      topic.save_custom_fields
+    end
+    topic
+  end
+
+  it "backfills custom-field marked PMs to the AI bot subtype" do
+    marked_pm = fabricate_pm(marked: true)
+    blank_marked_pm = fabricate_pm(subtype: "", marked: true)
+    unmarked_pm = fabricate_pm
+    public_topic = Fabricate(:topic)
+    public_topic.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD] = "t"
+    public_topic.save_custom_fields
+
+    described_class.new.up
+
+    expect(marked_pm.reload.subtype).to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+    expect(blank_marked_pm.reload.subtype).to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+    expect(unmarked_pm.reload.subtype).to be_nil
+    expect(public_topic.reload.subtype).to be_nil
+  end
+end

--- a/plugins/discourse-ai/spec/db/migrate/20260512042219_backfill_ai_bot_pm_subtype_spec.rb
+++ b/plugins/discourse-ai/spec/db/migrate/20260512042219_backfill_ai_bot_pm_subtype_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require Rails.root.join(
-          "plugins/discourse-ai/db/migrate/20260512042219_backfill_ai_bot_pm_subtype",
-        )
+require Rails.root.join("plugins/discourse-ai/db/migrate/20260512042219_backfill_ai_bot_pm_subtype")
 
 RSpec.describe BackfillAiBotPmSubtype do
   fab!(:user)

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/entry_point_spec.rb
@@ -37,17 +37,44 @@ RSpec.describe DiscourseAi::AiBot::EntryPoint do
         expect(serializer[:current_user][:can_debug_ai_bot_conversations]).to eq(true)
       end
 
-      describe "adding TOPIC_AI_BOT_PM_FIELD to topic custom fields" do
-        it "is added when user PMs a single bot" do
-          topic = PostCreator.create!(admin, post_args).topic
-          expect(topic.reload.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD]).to eq("t")
+      describe "marking AI bot PM topics" do
+        it "marks the topic when user PMs a single bot" do
+          topic = PostCreator.create!(admin, post_args).topic.reload
+
+          expect(topic.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD]).to eq("t")
+          expect(topic.subtype).to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+          expect(
+            UserAction.where(
+              target_topic_id: topic.id,
+              action_type: [UserAction::NEW_PRIVATE_MESSAGE, UserAction::GOT_PRIVATE_MESSAGE],
+            ),
+          ).to be_empty
         end
 
-        it "is not added when user PMs a bot and another user" do
+        it "marks the topic before creation through NewPostManager" do
+          result = NewPostManager.new(admin, post_args).perform
+
+          expect(result.post.topic.subtype).to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+        end
+
+        it "does not mark the topic when user PMs a bot and another user" do
           user = Fabricate(:user)
           post_args[:target_usernames] = [gpt_bot.username, user.username].join(",")
-          topic = PostCreator.create!(admin, post_args).topic
-          expect(topic.reload.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD]).to be_nil
+          topic = PostCreator.create!(admin, post_args).topic.reload
+
+          expect(topic.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD]).to be_nil
+          expect(topic.subtype).not_to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
+        end
+
+        it "does not mark the topic when user PMs a bot and a group" do
+          group = Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone])
+          post_args[:target_usernames] = gpt_bot.username
+          post_args[:target_group_names] = group.name
+
+          topic = PostCreator.create!(admin, post_args).topic.reload
+
+          expect(topic.custom_fields[DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD]).to be_nil
+          expect(topic.subtype).not_to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
         end
       end
 

--- a/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
@@ -1420,6 +1420,7 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
           user,
           title: "Parallel Tool Topic",
           archetype: Archetype.private_message,
+          subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
           target_usernames: ai_agent.user.username,
           raw: "Initial context message",
           custom_fields: {
@@ -1761,6 +1762,7 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
           user,
           title: "Multi Round Tool Topic",
           archetype: Archetype.private_message,
+          subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
           target_usernames: ai_agent.user.username,
           raw: "Initial context message",
           custom_fields: {

--- a/plugins/discourse-ai/spec/requests/ai_bot/conversations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/conversations_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::AiBot::ConversationsController do
+  fab!(:user)
+  fab!(:other_user, :user)
+  fab!(:bot_user, :user)
+
+  before { enable_current_plugin }
+
+  def fabricate_pm(user:, recipient:, subtype: TopicSubtype.user_to_user, custom_fields: {})
+    topic =
+      Fabricate(
+        :private_message_topic,
+        user: user,
+        recipient: recipient,
+        subtype: subtype,
+      )
+    Fabricate(:post, topic: topic, user: user)
+    custom_fields.each { |name, value| topic.custom_fields[name] = value }
+    topic.save_custom_fields if custom_fields.present?
+    topic
+  end
+
+  describe "GET index" do
+    it "requires login" do
+      get "/discourse-ai/ai-bot/conversations.json"
+
+      expect(response.status).to eq(403)
+    end
+
+    it "returns authored AI bot conversations" do
+      sign_in(user)
+
+      ai_conversation =
+        fabricate_pm(
+          user: user,
+          recipient: bot_user,
+          subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
+        )
+      old_marker_conversation =
+        fabricate_pm(
+          user: user,
+          recipient: bot_user,
+          custom_fields: {
+            DiscourseAi::AiBot::TOPIC_AI_BOT_PM_FIELD => "t",
+          },
+        )
+      fabricate_pm(user: user, recipient: other_user)
+      fabricate_pm(
+        user: other_user,
+        recipient: user,
+        subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
+      )
+
+      get "/discourse-ai/ai-bot/conversations.json"
+
+      topic_ids = response.parsed_body["conversations"].map { |topic| topic["id"] }
+      expect(topic_ids).to contain_exactly(ai_conversation.id, old_marker_conversation.id)
+      expect(response.parsed_body["meta"]).to include("total" => 2, "page" => 0)
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/requests/ai_bot/conversations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/conversations_controller_spec.rb
@@ -8,13 +8,7 @@ RSpec.describe DiscourseAi::AiBot::ConversationsController do
   before { enable_current_plugin }
 
   def fabricate_pm(user:, recipient:, subtype: TopicSubtype.user_to_user, custom_fields: {})
-    topic =
-      Fabricate(
-        :private_message_topic,
-        user: user,
-        recipient: recipient,
-        subtype: subtype,
-      )
+    topic = Fabricate(:private_message_topic, user: user, recipient: recipient, subtype: subtype)
     Fabricate(:post, topic: topic, user: user)
     custom_fields.each { |name, value| topic.custom_fields[name] = value }
     topic.save_custom_fields if custom_fields.present?

--- a/plugins/discourse-ai/spec/requests/ai_bot/topic_serialization_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/topic_serialization_spec.rb
@@ -10,6 +10,24 @@ RSpec.describe "AI Bot Post Serializer" do
     sign_in(current_user)
   end
 
+  describe "is_bot_pm in topic_view serializer" do
+    it "is included when the PM has the AI bot subtype" do
+      pm_topic =
+        Fabricate(
+          :private_message_topic,
+          user: current_user,
+          recipient: bot_user,
+          subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
+        )
+      Fabricate(:post, topic: pm_topic, user: current_user)
+
+      get "/t/#{pm_topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["is_bot_pm"]).to eq(true)
+    end
+  end
+
   describe "llm_name in post serializer" do
     it "includes llm_name when custom field is set in a PM" do
       pm_topic = Fabricate(:private_message_topic, user: current_user)

--- a/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe DiscourseAi::Discover::DiscoveriesController do
         }.to change(Topic, :count).by(1)
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["topic_id"]).to be_present
+        topic = Topic.find(response.parsed_body["topic_id"])
+        expect(topic.subtype).to eq(DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE)
       end
 
       it "returns invalid parameters if the context is missing" do

--- a/plugins/discourse-ai/spec/system/ai_bot/docked_composer_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/docked_composer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "AI Bot docked composer" do
       :private_message_topic,
       title: "A bot conversation",
       user: user,
+      subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
       last_posted_at: Time.zone.now,
       topic_allowed_users: [
         Fabricate.build(:topic_allowed_user, user: user),

--- a/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe "AI Bot - Homepage" do
       :private_message_topic,
       title: "This is my special PM",
       user: user,
+      subtype: DiscourseAi::AiBot::TOPIC_AI_BOT_PM_SUBTYPE,
       last_posted_at: Time.zone.now,
       topic_allowed_users: [
         Fabricate.build(:topic_allowed_user, user: user),

--- a/spec/lib/topic_query/private_message_lists_spec.rb
+++ b/spec/lib/topic_query/private_message_lists_spec.rb
@@ -46,6 +46,29 @@ RSpec.describe TopicQuery::PrivateMessageLists do
       expect(topics).to contain_exactly(private_message)
     end
 
+    it "includes only normal personal message subtypes" do
+      normal_subtype_topics =
+        TopicSubtype.normal_personal_message_subtypes.map do |subtype|
+          create_post(
+            user: user,
+            target_usernames: [user_2.username],
+            archetype: Archetype.private_message,
+            subtype: subtype,
+          ).topic
+        end
+
+      create_post(
+        user: user,
+        target_usernames: [user_2.username],
+        archetype: Archetype.private_message,
+        subtype: "custom_personal_message",
+      )
+
+      topics = TopicQuery.new(nil).list_private_messages(user_2).topics
+
+      expect(topics).to contain_exactly(private_message, *normal_subtype_topics)
+    end
+
     it "includes topics with moderator posts" do
       pm = Fabricate(:private_message_post, user: user_4).topic
 
@@ -189,9 +212,18 @@ RSpec.describe TopicQuery::PrivateMessageLists do
     end
 
     it "returns a list of private messages with unread posts that user is at least tracking" do
+      custom_pm =
+        create_post(
+          user: user,
+          target_usernames: [user_2.username],
+          archetype: Archetype.private_message,
+          subtype: "custom_personal_message",
+        ).topic
+
       freeze_time 1.minute.from_now do
         create_post(user: user_2, topic_id: pm.id)
         create_post(user: user_2, topic_id: pm_3.id)
+        create_post(user: user_2, topic_id: custom_pm.id)
       end
 
       TopicUser.find_by(user: user, topic: pm_3).update!(
@@ -223,6 +255,13 @@ RSpec.describe TopicQuery::PrivateMessageLists do
     end
 
     it "returns a list of new private messages" do
+      create_post(
+        user: user,
+        target_usernames: [user_2.username],
+        archetype: Archetype.private_message,
+        subtype: "custom_personal_message",
+      )
+
       expect(TopicQuery.new(user_2).list_private_messages_new(user_2).topics).to contain_exactly(
         pm,
         pm_2,

--- a/spec/models/private_message_topic_tracking_state_spec.rb
+++ b/spec/models/private_message_topic_tracking_state_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe PrivateMessageTopicTrackingState do
     ).topic
   end
 
+  fab!(:custom_private_message) do
+    create_post(
+      user: user,
+      target_usernames: [user_2.username],
+      archetype: Archetype.private_message,
+      subtype: "custom_personal_message",
+    ).topic
+  end
+
   describe ".report" do
     it "returns the right tracking state" do
       TopicUser.find_by(user: user_2, topic: group_message).update!(last_read_post_number: 1)
@@ -134,6 +143,12 @@ RSpec.describe PrivateMessageTopicTrackingState do
       expect(data["payload"]["group_ids"]).to eq([group.id])
       expect(data["payload"]["created_by_user_id"]).to eq(group_message.user_id)
     end
+
+    it "does not publish message_bus messages for non-normal private messages" do
+      messages = MessageBus.track_publish { described_class.publish_new(custom_private_message) }
+
+      expect(messages).to eq([])
+    end
   end
 
   describe ".publish_unread" do
@@ -152,6 +167,13 @@ RSpec.describe PrivateMessageTopicTrackingState do
       expect(data["payload"]["created_by_user_id"]).to eq(private_message.first_post.user_id)
       expect(data["payload"]["notification_level"]).to eq(NotificationLevels.all[:watching])
       expect(data["payload"]["group_ids"]).to eq([])
+    end
+
+    it "does not publish message_bus messages for non-normal private messages" do
+      messages =
+        MessageBus.track_publish { described_class.publish_unread(custom_private_message.first_post) }
+
+      expect(messages).to eq([])
     end
 
     it "does not publish message_bus message if post in topic is not new for user" do

--- a/spec/models/private_message_topic_tracking_state_spec.rb
+++ b/spec/models/private_message_topic_tracking_state_spec.rb
@@ -171,7 +171,9 @@ RSpec.describe PrivateMessageTopicTrackingState do
 
     it "does not publish message_bus messages for non-normal private messages" do
       messages =
-        MessageBus.track_publish { described_class.publish_unread(custom_private_message.first_post) }
+        MessageBus.track_publish do
+          described_class.publish_unread(custom_private_message.first_post)
+        end
 
       expect(messages).to eq([])
     end

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -8,6 +8,50 @@ RSpec.describe UserAction do
   it { is_expected.to validate_presence_of :action_type }
   it { is_expected.to validate_presence_of :user_id }
 
+  it "does not log private message actions for non-normal PM subtypes" do
+    sender = Fabricate(:user, refresh_auto_groups: true)
+    recipient = Fabricate(:user, refresh_auto_groups: true)
+
+    first_post =
+      create_post(
+        user: sender,
+        target_usernames: [recipient.username],
+        archetype: Archetype.private_message,
+        subtype: "custom_personal_message",
+      )
+    create_post(user: recipient, topic_id: first_post.topic_id)
+
+    expect(
+      UserAction.where(
+        target_topic_id: first_post.topic_id,
+        action_type: [UserAction::NEW_PRIVATE_MESSAGE, UserAction::GOT_PRIVATE_MESSAGE],
+      ),
+    ).to be_empty
+  end
+
+  describe ".private_messages_stats" do
+    it "counts only normal personal message subtypes" do
+      recipient = Fabricate(:user, refresh_auto_groups: true)
+      sender = Fabricate(:user, refresh_auto_groups: true)
+
+      create_post(
+        user: sender,
+        target_usernames: [recipient.username],
+        archetype: Archetype.private_message,
+      )
+      create_post(
+        user: sender,
+        target_usernames: [recipient.username],
+        archetype: Archetype.private_message,
+        subtype: "custom_personal_message",
+      )
+
+      stats = described_class.private_messages_stats(recipient.id, recipient.guardian)
+
+      expect(stats).to include(all: 1, mine: 0, unread: 1)
+    end
+  end
+
   describe "#stream" do
     fab!(:public_post, :post)
     let(:public_topic) { public_post.topic }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2641,12 +2641,10 @@ RSpec.describe User do
           read: false,
           user: user,
         )
-        Fabricate(
-          :notification,
-          user: user,
-          notification_type: Notification.types[:private_message],
-          read: false,
-        )
+        pm_sender = Fabricate(:user)
+        pm_topic = Fabricate(:private_message_topic, user: pm_sender, recipient: user)
+        pm_post = Fabricate(:post, topic: pm_topic, user: pm_sender)
+        Fabricate(:private_message_notification, user: user, topic: pm_topic, post: pm_post)
 
         messages =
           MessageBus.track_publish("/notification/#{user.id}") { user.publish_notifications_state }
@@ -2770,6 +2768,28 @@ RSpec.describe User do
       )
 
       expect(user.unread_high_priority_notifications).to eq(2)
+    end
+
+    it "excludes private_message notifications for non-normal PM subtypes" do
+      sender = Fabricate(:user)
+      custom_pm_topic =
+        Fabricate(
+          :private_message_topic,
+          user: sender,
+          recipient: user,
+          subtype: "custom_personal_message",
+        )
+      custom_pm_post = Fabricate(:post, topic: custom_pm_topic, user: sender)
+
+      Fabricate(
+        :private_message_notification,
+        user: user,
+        topic: custom_pm_topic,
+        post: custom_pm_post,
+        read: false,
+      )
+
+      expect(user.unread_high_priority_notifications).to eq(0)
     end
   end
 
@@ -3596,6 +3616,35 @@ RSpec.describe User do
 
       expect(user.all_unread_notifications_count).to eq(0)
     end
+
+    it "excludes private_message notifications for non-normal PM subtypes" do
+      sender = Fabricate(:user)
+      custom_pm_topic =
+        Fabricate(
+          :private_message_topic,
+          user: sender,
+          recipient: user,
+          subtype: "custom_personal_message",
+        )
+      custom_pm_post = Fabricate(:post, topic: custom_pm_topic, user: sender)
+
+      Fabricate(
+        :private_message_notification,
+        user: user,
+        topic: custom_pm_topic,
+        post: custom_pm_post,
+        read: false,
+      )
+      Fabricate(
+        :notification,
+        user: user,
+        topic: custom_pm_topic,
+        notification_type: Notification.types[:mentioned],
+        read: false,
+      )
+
+      expect(user.all_unread_notifications_count).to eq(0)
+    end
   end
 
   describe "#bump_last_seen_reviewable!" do
@@ -3746,35 +3795,41 @@ RSpec.describe User do
 
       Fabricate(:notification, user: user, read: false)
 
+      normal_pm_topic = Fabricate(:private_message_topic, user: another_user, recipient: user)
+      normal_pm_post = Fabricate(:post, topic: normal_pm_topic, user: another_user)
       last_seen_id =
         Fabricate(
-          :notification,
+          :private_message_notification,
           user: user,
+          topic: normal_pm_topic,
+          post: normal_pm_post,
           read: false,
-          notification_type: Notification.types[:private_message],
         ).id
 
       expect(user.new_personal_messages_notifications_count).to eq(1)
 
       Fabricate(
-        :notification,
+        :private_message_notification,
         user: user,
+        topic: normal_pm_topic,
+        post: normal_pm_post,
         read: false,
-        notification_type: Notification.types[:private_message],
       )
 
       Fabricate(
-        :notification,
+        :private_message_notification,
         user: another_user,
+        topic: normal_pm_topic,
+        post: normal_pm_post,
         read: false,
-        notification_type: Notification.types[:private_message],
       )
 
       Fabricate(
-        :notification,
+        :private_message_notification,
         user: user,
+        topic: normal_pm_topic,
+        post: normal_pm_post,
         read: true,
-        notification_type: Notification.types[:private_message],
       )
 
       Fabricate(
@@ -3782,6 +3837,22 @@ RSpec.describe User do
         user: user,
         read: false,
         notification_type: Notification.types[:replied],
+      )
+
+      custom_pm_topic =
+        Fabricate(
+          :private_message_topic,
+          user: another_user,
+          recipient: user,
+          subtype: "custom_personal_message",
+        )
+      custom_pm_post = Fabricate(:post, topic: custom_pm_topic, user: another_user)
+      Fabricate(
+        :private_message_notification,
+        user: user,
+        topic: custom_pm_topic,
+        post: custom_pm_post,
+        read: false,
       )
 
       user.update!(seen_notification_id: last_seen_id)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1119,11 +1119,19 @@ RSpec.describe ListController do
     it "succeeds when the user can see private messages" do
       pm = Fabricate(:private_message_topic, user: Fabricate(:user))
       pm.topic_allowed_users.create!(user: user)
+      custom_pm =
+        Fabricate(
+          :private_message_topic,
+          user: Fabricate(:user),
+          subtype: "custom_personal_message",
+        )
+      custom_pm.topic_allowed_users.create!(user: user)
+
       sign_in(user)
       get "/topics/private-messages/#{user.username}.json"
       expect(response.status).to eq(200)
       json = response.parsed_body
-      expect(json["topic_list"]["topics"].size).to eq(1)
+      expect(json["topic_list"]["topics"].map { |topic| topic["id"] }).to contain_exactly(pm.id)
     end
 
     it "sorts private messages by activity" do

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -272,11 +272,30 @@ RSpec.describe CurrentUserSerializer do
 
   describe "#new_personal_messages_notifications_count" do
     fab!(:notification) do
+      sender = Fabricate(:user)
+      pm_topic = Fabricate(:private_message_topic, user: sender, recipient: user)
+      pm_post = Fabricate(:post, topic: pm_topic, user: sender)
+
+      Fabricate(:private_message_notification, user: user, topic: pm_topic, post: pm_post, read: false)
+    end
+
+    fab!(:custom_pm_notification) do
+      sender = Fabricate(:user)
+      custom_pm_topic =
+        Fabricate(
+          :private_message_topic,
+          user: sender,
+          recipient: user,
+          subtype: "custom_personal_message",
+        )
+      custom_pm_post = Fabricate(:post, topic: custom_pm_topic, user: sender)
+
       Fabricate(
-        :notification,
+        :private_message_notification,
         user: user,
+        topic: custom_pm_topic,
+        post: custom_pm_post,
         read: false,
-        notification_type: Notification.types[:private_message],
       )
     end
 

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -276,7 +276,13 @@ RSpec.describe CurrentUserSerializer do
       pm_topic = Fabricate(:private_message_topic, user: sender, recipient: user)
       pm_post = Fabricate(:post, topic: pm_topic, user: sender)
 
-      Fabricate(:private_message_notification, user: user, topic: pm_topic, post: pm_post, read: false)
+      Fabricate(
+        :private_message_notification,
+        user: user,
+        topic: pm_topic,
+        post: pm_post,
+        read: false,
+      )
     end
 
     fab!(:custom_pm_notification) do

--- a/spec/serializers/user_notification_total_serializer_spec.rb
+++ b/spec/serializers/user_notification_total_serializer_spec.rb
@@ -4,11 +4,14 @@ RSpec.describe UserNotificationTotalSerializer do
   fab!(:user) { Fabricate(:user, trust_level: 3) }
 
   fab!(:notification) { Fabricate(:notification, user: user, read: false) }
+  fab!(:pm_sender, :user)
+  fab!(:pm_topic) { Fabricate(:private_message_topic, user: pm_sender, recipient: user) }
+  fab!(:pm_post) { Fabricate(:post, topic: pm_topic, user: pm_sender) }
   fab!(:pm_notification) do
-    Fabricate(:notification, user: user, notification_type: Notification.types[:private_message])
+    Fabricate(:private_message_notification, user: user, topic: pm_topic, post: pm_post)
   end
   fab!(:pm_notification2) do
-    Fabricate(:notification, user: user, notification_type: Notification.types[:private_message])
+    Fabricate(:private_message_notification, user: user, topic: pm_topic, post: pm_post)
   end
   fab!(:group_message_notification) do
     Fabricate(
@@ -30,6 +33,28 @@ RSpec.describe UserNotificationTotalSerializer do
 
   it "includes the user's unread private messages count" do
     expect(serialized_data[:unread_personal_messages]).to eq(2)
+  end
+
+  it "excludes non-normal PM subtypes from notification totals" do
+    sender = Fabricate(:user)
+    custom_pm_topic =
+      Fabricate(
+        :private_message_topic,
+        user: sender,
+        recipient: user,
+        subtype: "custom_personal_message",
+      )
+    custom_pm_post = Fabricate(:post, topic: custom_pm_topic, user: sender)
+
+    Fabricate(
+      :private_message_notification,
+      user: user,
+      topic: custom_pm_topic,
+      post: custom_pm_post,
+      read: false,
+    )
+
+    expect(serialized_data).to include(unread_notifications: 2, unread_personal_messages: 2)
   end
 
   context "when the user has PMs disabled" do

--- a/spec/services/post_alerter_spec.rb
+++ b/spec/services/post_alerter_spec.rb
@@ -113,6 +113,21 @@ RSpec.describe PostAlerter do
       expect(Notification.where(user_id: pm.user_id).count).to eq(1)
     end
 
+    it "does not create private message notifications for non-normal PM subtypes" do
+      sender = Fabricate(:user, refresh_auto_groups: true)
+      recipient = Fabricate(:user, refresh_auto_groups: true)
+      post =
+        create_post(
+          user: sender,
+          target_usernames: [recipient.username],
+          archetype: Archetype.private_message,
+          raw: "hello @#{recipient.username}",
+          subtype: "custom_personal_message",
+        )
+
+      expect { PostAlerter.post_created(post) }.not_to change { recipient.notifications.count }
+    end
+
     it "prioritises 'private_message' type even if direct mention" do
       pm = Fabricate(:topic, archetype: "private_message", category_id: nil)
       op =
@@ -171,6 +186,14 @@ RSpec.describe PostAlerter do
           user2.id,
           pm.id,
           notification_level: TopicUser.notification_levels[:tracking],
+        )
+
+        Fabricate(
+          :topic,
+          archetype: "private_message",
+          category_id: nil,
+          subtype: "custom_personal_message",
+          allowed_groups: [group],
         )
 
         PostAlerter.post_created(op)

--- a/spec/system/header_spec.rb
+++ b/spec/system/header_spec.rb
@@ -134,7 +134,14 @@ RSpec.describe "Glimmer Header" do
   end
 
   it "prioritizes new personal messages bubble over unseen reviewables and regular notifications bubbles" do
-    Fabricate(:private_message_notification, user: current_user)
+    sender = Fabricate(:user)
+    pm_post = Fabricate(:private_message_post, user: sender, recipient: current_user)
+    Fabricate(
+      :private_message_notification,
+      user: current_user,
+      topic: pm_post.topic,
+      post: pm_post,
+    )
     Fabricate(
       :notification,
       user: current_user,


### PR DESCRIPTION
AI bot conversations are now identified by a new `ai_bot` topic
subtype rather than the `is_ai_bot_pm` custom field. Personal message
lists, notification counters, the PM tracking state, and the
`UserAction` stream now filter out non-normal PM subtypes (bot PMs
included) so bot chatter no longer inflates unread badges or buries
real messages in the inbox.

Core:
- Add `TopicSubtype.normal_personal_message_subtypes` covering the
  existing user-to-user, system, moderator, notify_user/moderators
  and pending_users_reminder subtypes.
- Add `Topic#normal_personal_message?` and a
  `Topic.normal_personal_messages` scope built from a shared
  `normal_personal_message_subtype_sql` snippet.
- Use the snippet in `User` unread/grouped notification queries,
  `PrivateMessageTopicTrackingState`, `UserAction`, `PostAlerter`,
  and `TopicQuery#private_messages_list`.
- `UserActionManager` skips logging new-topic / reply rows for
  non-normal PMs.

discourse-ai:
- Register the `ai_bot` subtype and stamp it on bot PMs at creation
  via a `NewPostManager` handler, with a `topic_created` fallback
  that also clears any stale UserAction rows. The legacy
  `is_ai_bot_pm` custom field is still written during the transition.
- All bot-PM entry points (discoveries, response streamer, custom
  tools session) now set `subtype: "ai_bot"` explicitly.
- The conversations endpoint matches the new subtype or the legacy
  custom field so existing PMs keep working.
- Post-deploy migration backfills `topics.subtype = 'ai_bot'` for
  PMs that already carry the `is_ai_bot_pm` custom field.
