### PR TITLE
UX: improve position of flair on categories page

### DIFF
--- a/app/assets/stylesheets/common/base/categories-topic-list.scss
+++ b/app/assets/stylesheets/common/base/categories-topic-list.scss
@@ -26,10 +26,10 @@
   border-bottom: 1px solid var(--content-border-color);
   display: flex;
   align-items: center;
+  gap: var(--space-4);
 
   .topic-poster {
     position: relative;
-    width: 60px;
 
     .avatar-flair {
       position: absolute;


### PR DESCRIPTION
This improves the positioning of user flair on the /categories page when using the "categories and latest" or "categories and top" layouts. 





Before:
<img width="1564" height="318" alt="image" src="https://github.com/user-attachments/assets/8b3a6304-5cfe-4915-abbe-3abeb8aa4de3" />




After: 
<img width="1568" height="330" alt="image" src="https://github.com/user-attachments/assets/44c60344-e3b5-488b-8f34-27abe6b5d1e1" />