### PR TITLE
DEV: Do not cache chat onebox templates in development

### DIFF
--- a/plugins/chat/lib/chat/engine.rb
+++ b/plugins/chat/lib/chat/engine.rb
@@ -19,26 +19,23 @@ module Chat
   end
 
   def self.message_onebox_template
-    @message_onebox_template ||=
-      begin
-        path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_message.mustache"
-        File.read(path)
-      end
+    path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_message.mustache"
+    return File.read(path) if Rails.env.development?
+
+    @message_onebox_template ||= File.read(path)
   end
 
   def self.channel_onebox_template
-    @channel_onebox_template ||=
-      begin
-        path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_channel.mustache"
-        File.read(path)
-      end
+    path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_channel.mustache"
+    return File.read(path) if Rails.env.development?
+
+    @channel_onebox_template ||= File.read(path)
   end
 
   def self.thread_onebox_template
-    @thread_onebox_template ||=
-      begin
-        path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_thread.mustache"
-        File.read(path)
-      end
+    path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_thread.mustache"
+    return File.read(path) if Rails.env.development?
+
+    @thread_onebox_template ||= File.read(path)
   end
 end

--- a/plugins/chat/lib/chat/engine.rb
+++ b/plugins/chat/lib/chat/engine.rb
@@ -4,6 +4,15 @@ module Chat
   HAS_CHAT_ENABLED = "has_chat_enabled"
   LAST_CHAT_CHANNEL_ID = "last_chat_channel_id"
 
+  ONEBOX_TEMPLATE_PATH = Rails.root.join("plugins/chat/lib/onebox/templates")
+  MESSAGE_ONEBOX_TEMPLATE_PATH = ONEBOX_TEMPLATE_PATH.join("discourse_chat_message.mustache")
+  CHANNEL_ONEBOX_TEMPLATE_PATH = ONEBOX_TEMPLATE_PATH.join("discourse_chat_channel.mustache")
+  THREAD_ONEBOX_TEMPLATE_PATH = ONEBOX_TEMPLATE_PATH.join("discourse_chat_thread.mustache")
+  private_constant :ONEBOX_TEMPLATE_PATH,
+                   :MESSAGE_ONEBOX_TEMPLATE_PATH,
+                   :CHANNEL_ONEBOX_TEMPLATE_PATH,
+                   :THREAD_ONEBOX_TEMPLATE_PATH
+
   class Engine < ::Rails::Engine
     engine_name PLUGIN_NAME
     isolate_namespace Chat
@@ -19,23 +28,20 @@ module Chat
   end
 
   def self.message_onebox_template
-    path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_message.mustache"
-    return File.read(path) if Rails.env.development?
+    return File.read(MESSAGE_ONEBOX_TEMPLATE_PATH) if Rails.env.development?
 
-    @message_onebox_template ||= File.read(path)
+    @message_onebox_template ||= File.read(MESSAGE_ONEBOX_TEMPLATE_PATH)
   end
 
   def self.channel_onebox_template
-    path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_channel.mustache"
-    return File.read(path) if Rails.env.development?
+    return File.read(CHANNEL_ONEBOX_TEMPLATE_PATH) if Rails.env.development?
 
-    @channel_onebox_template ||= File.read(path)
+    @channel_onebox_template ||= File.read(CHANNEL_ONEBOX_TEMPLATE_PATH)
   end
 
   def self.thread_onebox_template
-    path = "#{Rails.root}/plugins/chat/lib/onebox/templates/discourse_chat_thread.mustache"
-    return File.read(path) if Rails.env.development?
+    return File.read(THREAD_ONEBOX_TEMPLATE_PATH) if Rails.env.development?
 
-    @thread_onebox_template ||= File.read(path)
+    @thread_onebox_template ||= File.read(THREAD_ONEBOX_TEMPLATE_PATH)
   end
 end


### PR DESCRIPTION
This is a minor QOL improvement for working on chat
onebox templates, we don't want to cache these locally
because you need to reboot the whole server to see changes
to the oneboxes.
