### PR TITLE
TEST: @patch-triage bot fixture — do not merge

### DIFF
--- a/plugins/discourse-ai/lib/utils/text_summary.rb
+++ b/plugins/discourse-ai/lib/utils/text_summary.rb
@@ -8,7 +8,6 @@ module DiscourseAi
     class TextSummary
       DEFAULT_MAX_CHARS = 1_000
 
-
       # Returns the text truncated to `max` characters with an ellipsis
       # appended, or the original text if it already fits.
       #
@@ -16,9 +15,8 @@ module DiscourseAi
       def self.truncate(text, max: DEFAULT_MAX_CHARS)
         return nil if text.nil?
         return text if text.length <= max
-        "#{text[0, max]} …"
+        "#{text[0, max].rstrip} …"
       end
-
 
       def self.word_count(text)
         return 0 if text.nil? || text.empty?

--- a/plugins/discourse-ai/lib/utils/text_summary.rb
+++ b/plugins/discourse-ai/lib/utils/text_summary.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Utils
+    # Small helpers for trimming and summarizing free-form text before
+    # we hand it to an LLM. Centralized so we don't reinvent the
+    # truncation rule in every caller.
+    class TextSummary
+      DEFAULT_MAX_CHARS = 1_000
+
+
+      # Returns the text truncated to `max` characters with an ellipsis
+      # appended, or the original text if it already fits.
+      #
+      # Returns nil for nil input so callers can chain `&.`.
+      def self.truncate(text, max: DEFAULT_MAX_CHARS)
+        return nil if text.nil?
+        return text if text.length <= max
+        "#{text[0, max]} …"
+      end
+
+
+      def self.word_count(text)
+        return 0 if text.nil? || text.empty?
+        text.split(/\s+/).reject(&:empty?).length
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/lib/utils/text_summary_spec.rb
+++ b/plugins/discourse-ai/spec/lib/utils/text_summary_spec.rb
@@ -6,8 +6,16 @@ RSpec.describe DiscourseAi::Utils::TextSummary do
       expect(described_class.truncate("hello", max: 10)).to eq("hello")
     end
 
+    it "returns the original text when it is exactly max characters" do
+      expect(described_class.truncate("hello", max: 5)).to eq("hello")
+    end
+
     it "truncates text longer than max" do
       expect(described_class.truncate("hello world", max: 5)).to eq("hello …")
+    end
+
+    it "strips trailing whitespace before appending an ellipsis" do
+      expect(described_class.truncate("hello   world", max: 8)).to eq("hello …")
     end
 
     it "returns nil for nil input" do

--- a/plugins/discourse-ai/spec/lib/utils/text_summary_spec.rb
+++ b/plugins/discourse-ai/spec/lib/utils/text_summary_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Utils::TextSummary do
+  describe ".truncate" do
+    it "returns the original text when it is shorter than max" do
+      expect(described_class.truncate("hello", max: 10)).to eq("hello")
+    end
+
+    it "truncates text longer than max" do
+      expect(described_class.truncate("hello world", max: 5)).to eq("hello …")
+    end
+
+    it "returns nil for nil input" do
+      expect(described_class.truncate(nil, max: 10)).to be_nil
+    end
+  end
+
+  describe ".word_count" do
+    it "counts whitespace-separated words" do
+      expect(described_class.word_count("hello world")).to eq(2)
+    end
+
+    it "returns 0 for nil and empty input" do
+      expect(described_class.word_count(nil)).to eq(0)
+      expect(described_class.word_count("")).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
This PR is a test fixture for exercising the `@patch-triage` bot's `fix_and_commit` flow against a real PR on this repo. **Not for merge.**

## What's in the PR

A small new utility `DiscourseAi::Utils::TextSummary` with two methods (`truncate`, `word_count`), plus a spec.

## What's wrong with it

1. **Lint:** two orphan blank lines between members of the class (one after `DEFAULT_MAX_CHARS`, one between `truncate` and `word_count`). `stree write` would auto-fix both. Same shape that tripped CI on #39869.

2. **Behavior gap intentionally left for a reviewer to spot:** `truncate` doesn't strip trailing whitespace before appending the ellipsis, so `truncate("hello   world", max: 5)` returns `"hello  …"` with two trailing spaces baked in. The spec doesn't cover the boundary case (`text.length == max`) either.

## How to test the bot

I'll seed a review comment on `truncate` immediately after this opens, then mention `@patch-triage apply the suggestions` so the bot picks the work up via the `pr-fix` agent.

Expected behavior on the bot's side:
- Reads the review comment
- Adds `.rstrip` before the ellipsis on `truncate`
- Adds a spec for the `text.length == max` boundary case
- Lint pass (`stree write`) auto-fixes the two orphan blank lines
- Commits + pushes back to this branch
- Edits the placeholder comment with the result

After we verify the flow end-to-end, close + delete the branch.