### PR TITLE
UX: Auto-select shared draft composer type

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4014,6 +4014,7 @@ en:
         one: "%{count} post in topic"
         other: "%{count} posts in topic"
       create: "New Topic"
+      create_shared_draft: "New Shared Draft"
       create_long: "Create a new topic"
       create_group: "New topic and drafts"
       open_draft: "Open Draft"

--- a/frontend/discourse/app/components/create-topic-button.gjs
+++ b/frontend/discourse/app/components/create-topic-button.gjs
@@ -6,9 +6,24 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 export default class CreateTopicButton extends Component {
   @service router;
+  @service site;
 
   get label() {
-    return this.args.label ?? "topic.create";
+    const label = this.args.label ?? "topic.create";
+
+    const sharedDraftsCategoryId = this.site.shared_drafts_category_id;
+    const currentCategoryId =
+      this.router.currentRoute?.attributes?.category?.id;
+
+    if (
+      label === "topic.create" &&
+      sharedDraftsCategoryId &&
+      currentCategoryId === sharedDraftsCategoryId
+    ) {
+      return "topic.create_shared_draft";
+    }
+
+    return label;
   }
 
   get btnId() {

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -42,6 +42,7 @@ import { escapeExpression } from "discourse/lib/utilities";
 import { parseAttributesString } from "discourse/lib/wrap-utils";
 import Category from "discourse/models/category";
 import Composer, {
+  CREATE_SHARED_DRAFT,
   CREATE_TOPIC,
   EDIT,
   NEW_PRIVATE_MESSAGE_KEY,
@@ -1661,17 +1662,23 @@ export default class ComposerService extends Service {
 
   @action
   async openNewTopic({ title, body, category, tags, formTemplate } = {}) {
-    const readOnlyCategoryId = !category?.canCreateTopic ? category?.id : null;
+    const sharedDraftsCategoryId = this.site.shared_drafts_category_id;
+    const isSharedDraftCategory =
+      !!sharedDraftsCategoryId && category?.id === sharedDraftsCategoryId;
+    const categoryId = isSharedDraftCategory ? null : category?.id;
+    const readOnlyCategoryId =
+      !isSharedDraftCategory && !category?.canCreateTopic ? category?.id : null;
+
     tags = await this.filterTags(tags);
 
     return this.open({
-      prioritizedCategoryId: category?.id,
-      topicCategoryId: category?.id,
+      prioritizedCategoryId: categoryId,
+      topicCategoryId: categoryId,
       formTemplateId: formTemplate?.id,
       topicTitle: title,
       topicBody: body,
       topicTags: tags,
-      action: CREATE_TOPIC,
+      action: isSharedDraftCategory ? CREATE_SHARED_DRAFT : CREATE_TOPIC,
       draftKey: this.topicDraftKey,
       draftSequence: 0,
       locale: null,

--- a/frontend/discourse/tests/acceptance/composer-actions-test.js
+++ b/frontend/discourse/tests/acceptance/composer-actions-test.js
@@ -3,6 +3,7 @@ import { test } from "qunit";
 import sinon from "sinon";
 import { cloneJSON } from "discourse/lib/object";
 import Draft from "discourse/models/draft";
+import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
 import userFixtures from "discourse/tests/fixtures/user-fixtures";
 import {
   acceptance,
@@ -27,6 +28,13 @@ acceptance(`Composer Actions`, function (needs) {
     server.put("/u/kris.json", () => helper.response({ user: {} }));
     const cardResponse = cloneJSON(userFixtures["/u/shade/card.json"]);
     server.get("/u/shade/card.json", () => helper.response(cardResponse));
+    server.get("/c/shared-drafts/24/l/latest.json", () => {
+      const response = cloneJSON(discoveryFixtures["/c/bug/1/l/latest.json"]);
+      response.topic_list.can_create_topic = true;
+      response.topic_list.filter = "c/shared-drafts/24/l/latest";
+
+      return helper.response(response);
+    });
   });
 
   test("replying to post", async function (assert) {
@@ -221,6 +229,26 @@ acceptance(`Composer Actions`, function (needs) {
       "create_private_message"
     );
     assert.strictEqual(composerActions.rows().length, 5);
+  });
+
+  test("new topic in shared drafts category opens shared draft composer", async function (assert) {
+    await visit("/c/shared-drafts/24");
+
+    assert.dom("#create-topic").hasText(i18n("topic.create_shared_draft"));
+
+    await click("#create-topic");
+
+    assert
+      .dom("#reply-control .btn-primary.create .d-button-label")
+      .hasText(i18n("composer.create_shared_draft"));
+    assert
+      .dom(".composer-actions svg.d-icon-far-clipboard")
+      .exists("shared draft icon is visible");
+    assert.strictEqual(
+      selectKit(".category-chooser").header().value(),
+      null,
+      "shared drafts category is not selected as the destination category"
+    );
   });
 
   test("interactions - private message", async function (assert) {


### PR DESCRIPTION
When in a shared draft category, we should auto-select
"Shared Draft" instead of "New Topic" from the composer
dropdown at the top left, and change the "New Topic"
button to "New Shared Draft"


https://github.com/user-attachments/assets/fb82d22a-a6eb-4439-9704-65cb4e76e170

