### PR TITLE
UX: image grid carousel max-height

### DIFF
--- a/app/assets/stylesheets/common/base/d-image-grid.scss
+++ b/app/assets/stylesheets/common/base/d-image-grid.scss
@@ -128,6 +128,7 @@
       flex: 0 0 100%;
       width: 100%;
       height: 100%;
+      max-height: inherit;
       scroll-snap-align: center;
       scroll-snap-stop: always;
       display: flex;


### PR DESCRIPTION
The children werent inheriting the max height, making them awkwardly cut off on occasion