### PR TITLE
FEATURE: Allow admins to configure sections in the experimental admin dashboard

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -49,7 +49,7 @@ h1 {
   }
 }
 
-.db-customise {
+.db-configure {
   padding: var(--space-4);
 
   &__list {
@@ -69,28 +69,61 @@ h1 {
     display: flex;
     align-items: center;
     gap: var(--space-3);
+    padding: var(--space-1) 0;
+    border-top: 2px solid transparent;
+    border-bottom: 2px solid transparent;
+
+    &.dragging {
+      opacity: 0.5;
+    }
+
+    &.drag-above {
+      border-top-color: var(--tertiary);
+    }
+
+    &.drag-below {
+      border-bottom-color: var(--tertiary);
+    }
   }
 
   &__section-name {
-    margin-right: var(--space-4);
+    margin-right: var(--space-2);
   }
 
   &__drag-handle {
     color: var(--primary-low-mid);
+    cursor: grab;
+
+    @include viewport.until(sm) {
+      display: none;
+    }
+  }
+
+  &__arrows {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__arrow.btn {
+    padding: 0 var(--space-1);
+    min-height: 0;
   }
 
   .d-toggle-switch {
     margin-left: auto;
 
-    @include viewport.from(sm) {
-      --toggle-switch-width: 32px;
-      --toggle-switch-height: 18px;
-    }
-
     .d-icon-check {
       display: none;
     }
   }
+}
+
+.db-main__empty {
+  padding: var(--space-8);
+  text-align: center;
+  color: var(--primary-medium);
+  background: var(--primary-very-low);
+  border-radius: var(--d-border-radius);
 }
 
 .db-link-arrow {

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,15 +3,11 @@
 class Admin::DashboardController < Admin::StaffController
   def index
     if SiteSetting.dashboard_improvements
-      data = {
-        sections: {
-          highlights:
-            AdminDashboardHighlights.build(
-              start_date: params[:start_date],
-              end_date: params[:end_date],
-            ),
-        },
-      }
+      visible_ids = AdminDashboardSectionConfiguration.visible_section_ids
+      data = { sections: visible_ids.map { |id| { id: id, data: section_data(id) } } }
+      if current_user.admin?
+        data[:configuration] = { sections: AdminDashboardSectionConfiguration.sections }
+      end
     else
       data = AdminDashboardIndexData.fetch_cached_stats
 
@@ -21,6 +17,12 @@ class Admin::DashboardController < Admin::StaffController
     end
 
     render json: data
+  end
+
+  def update_configuration
+    sections = params.permit(sections: %i[id visible])[:sections] || []
+    AdminDashboardSectionConfiguration.update(sections, actor: current_user)
+    head :no_content
   end
 
   def moderation
@@ -89,6 +91,13 @@ class Admin::DashboardController < Admin::StaffController
   end
 
   private
+
+  def section_data(id)
+    case id
+    when "highlights"
+      AdminDashboardHighlights.build(start_date: params[:start_date], end_date: params[:end_date])
+    end
+  end
 
   def mark_new_features_as_seen
     DiscourseUpdates.mark_new_features_as_seen(current_user.id)

--- a/app/services/admin_dashboard_section_configuration.rb
+++ b/app/services/admin_dashboard_section_configuration.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AdminDashboardSectionConfiguration
+  KNOWN_SECTIONS = %w[highlights reports traffic engagement].freeze
+
+  def self.visible_section_ids
+    raw = SiteSetting.admin_dashboard_sections.to_s
+    return [] if raw.empty?
+
+    ids = raw.split("|").map(&:strip).uniq.select { |id| KNOWN_SECTIONS.include?(id) }
+    ids.empty? ? KNOWN_SECTIONS.dup : ids
+  end
+
+  def self.sections
+    visible = visible_section_ids
+    hidden = KNOWN_SECTIONS - visible
+    visible.map { |id| { id: id, visible: true } } + hidden.map { |id| { id: id, visible: false } }
+  end
+
+  def self.update(input_sections, actor:)
+    visible_ids =
+      Array(input_sections)
+        .select { |s| ActiveModel::Type::Boolean.new.cast(s[:visible] || s["visible"]) }
+        .map { |s| (s[:id] || s["id"]).to_s }
+        .uniq
+        .select { |id| KNOWN_SECTIONS.include?(id) }
+
+    SiteSetting.set_and_log("admin_dashboard_sections", visible_ids.join("|"), actor)
+    sections
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6836,6 +6836,17 @@ en:
           engagement:
             title: "Engagement"
 
+        configure:
+          button: "Configure"
+          tooltip: "Configure how this dashboard appears for everyone on this site."
+          menu_title: "Configure dashboard"
+          reorder_up: "Move %{label} up"
+          reorder_down: "Move %{label} down"
+          drag_handle: "Drag to reorder %{label}"
+          toggle_visibility: "Show %{label} on dashboard"
+          empty_state_admin: "No sections to show. Open Configure to enable one."
+          empty_state_moderator: "No sections enabled. Ask an admin to enable one."
+
         highlights:
           fetch_error: "Couldn't load highlights. Try refreshing the page."
           kpi:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2749,6 +2749,7 @@ en:
     dashboard_hidden_reports: "Allow to hide the specified reports from the dashboard."
     dashboard_visible_tabs: "Choose which dashboard tabs are visible."
     dashboard_general_tab_activity_metrics: "Choose reports to be displayed as activity metrics on the general tab."
+    admin_dashboard_sections: "Sections shown on the redesigned admin dashboard, in display order. Managed via the Configure menu on the dashboard."
 
     gravatar_enabled: "Use the <a href='https://gravatar.com/'>Gravatar</a> service for user avatars. Disabling this will prevent users from switching to Gravatar for their avatars, but will not impact users who already use it."
     gravatar_name: "Specify the name of the Gravatar service provider. This name is typically used to identify the source providing Gravatar avatars to the site."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -333,6 +333,8 @@ Discourse::Application.routes.draw do
       get "version_check" => "versions#show"
 
       get "dashboard" => "dashboard#index"
+      put "dashboard/configuration" => "dashboard#update_configuration",
+          :constraints => AdminConstraint.new
       get "dashboard/general" => "dashboard#general"
       get "dashboard/moderation" => "dashboard#moderation"
       get "dashboard/security" => "dashboard#security"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4347,6 +4347,7 @@ dashboard:
       - traffic
       - engagement
     area: "reports"
+    hidden: true
   dashboard_general_tab_activity_metrics:
     client: true
     type: list

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4336,6 +4336,17 @@ dashboard:
       - reports
       - features
     area: "reports"
+  admin_dashboard_sections:
+    type: list
+    list_type: compact
+    default: "highlights|reports|traffic|engagement"
+    allow_any: false
+    choices:
+      - highlights
+      - reports
+      - traffic
+      - engagement
+    area: "reports"
   dashboard_general_tab_activity_metrics:
     client: true
     type: list

--- a/frontend/discourse/admin/components/dashboard/configure-menu.gjs
+++ b/frontend/discourse/admin/components/dashboard/configure-menu.gjs
@@ -1,0 +1,223 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import discourseLater from "discourse/lib/later";
+import { eq } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+class ConfigureRow extends Component {
+  @service site;
+
+  @tracked dragCssClass;
+  dragCount = 0;
+
+  isAboveElement(event) {
+    event.preventDefault();
+    const target = event.currentTarget;
+    const domRect = target.getBoundingClientRect();
+    return event.offsetY < domRect.height / 2;
+  }
+
+  @action
+  dragStart(event) {
+    event.dataTransfer.effectAllowed = "move";
+    this.args.onDragStart(this.args.index);
+    this.dragCssClass = "dragging";
+  }
+
+  @action
+  dragOver(event) {
+    event.preventDefault();
+    if (this.dragCssClass === "dragging") {
+      return;
+    }
+    this.dragCssClass = this.isAboveElement(event)
+      ? "drag-above"
+      : "drag-below";
+  }
+
+  @action
+  dragEnter() {
+    this.dragCount++;
+  }
+
+  @action
+  dragLeave() {
+    this.dragCount--;
+    if (
+      this.dragCount === 0 &&
+      (this.dragCssClass === "drag-above" || this.dragCssClass === "drag-below")
+    ) {
+      discourseLater(() => (this.dragCssClass = null), 10);
+    }
+  }
+
+  @action
+  drop(event) {
+    event.stopPropagation();
+    this.dragCount = 0;
+    const dropAbove = this.isAboveElement(event);
+    this.dragCssClass = null;
+    this.args.onDrop(this.args.index, dropAbove);
+  }
+
+  @action
+  dragEnd() {
+    this.dragCount = 0;
+    this.dragCssClass = null;
+  }
+
+  get sectionLabel() {
+    return i18n(`admin.dashboard.sections.${this.args.section.id}.title`);
+  }
+
+  get reorderUpLabel() {
+    return i18n("admin.dashboard.configure.reorder_up", {
+      label: this.sectionLabel,
+    });
+  }
+
+  get reorderDownLabel() {
+    return i18n("admin.dashboard.configure.reorder_down", {
+      label: this.sectionLabel,
+    });
+  }
+
+  get dragHandleLabel() {
+    return i18n("admin.dashboard.configure.drag_handle", {
+      label: this.sectionLabel,
+    });
+  }
+
+  get toggleLabel() {
+    return i18n("admin.dashboard.configure.toggle_visibility", {
+      label: this.sectionLabel,
+    });
+  }
+
+  <template>
+    <li
+      {{on "dragstart" this.dragStart}}
+      {{on "dragover" this.dragOver}}
+      {{on "dragenter" this.dragEnter}}
+      {{on "dragleave" this.dragLeave}}
+      {{on "drop" this.drop}}
+      {{on "dragend" this.dragEnd}}
+      class={{dConcatClass "db-configure__row" this.dragCssClass}}
+      data-section-id={{@section.id}}
+      draggable="true"
+    >
+      {{#if this.site.desktopView}}
+        <span
+          class="db-configure__drag-handle"
+          aria-hidden="true"
+          tabindex="-1"
+          title={{this.dragHandleLabel}}
+        >{{dIcon "grip-vertical"}}</span>
+      {{else}}
+        <span class="db-configure__arrows">
+          <DButton
+            @icon="chevron-up"
+            @action={{fn @onMoveUp @index}}
+            @disabled={{@isFirst}}
+            @translatedAriaLabel={{this.reorderUpLabel}}
+            @translatedTitle={{this.reorderUpLabel}}
+            class="btn-flat db-configure__arrow"
+          />
+          <DButton
+            @icon="chevron-down"
+            @action={{fn @onMoveDown @index}}
+            @disabled={{@isLast}}
+            @translatedAriaLabel={{this.reorderDownLabel}}
+            @translatedTitle={{this.reorderDownLabel}}
+            class="btn-flat db-configure__arrow"
+          />
+        </span>
+      {{/if}}
+
+      <span class="db-configure__section-name">{{this.sectionLabel}}</span>
+
+      <DToggleSwitch
+        @state={{@section.visible}}
+        {{on "click" (fn @onToggle @section.id)}}
+        aria-label={{this.toggleLabel}}
+      />
+    </li>
+  </template>
+}
+
+export default class ConfigureMenu extends Component {
+  draggedIndex = null;
+
+  get lastIndex() {
+    return (this.args.sections?.length ?? 0) - 1;
+  }
+
+  @action
+  onDragStart(index) {
+    this.draggedIndex = index;
+  }
+
+  @action
+  onDrop(targetIndex, dropAbove) {
+    const fromIndex = this.draggedIndex;
+    this.draggedIndex = null;
+    if (fromIndex == null || fromIndex === targetIndex) {
+      return;
+    }
+
+    let toIndex = dropAbove ? targetIndex : targetIndex + 1;
+    if (fromIndex < toIndex) {
+      toIndex -= 1;
+    }
+    if (fromIndex === toIndex) {
+      return;
+    }
+
+    this.args.onReorder(fromIndex, toIndex);
+  }
+
+  @action
+  onMoveUp(index) {
+    if (index > 0) {
+      this.args.onReorder(index, index - 1);
+    }
+  }
+
+  @action
+  onMoveDown(index) {
+    if (index < this.args.sections.length - 1) {
+      this.args.onReorder(index, index + 1);
+    }
+  }
+
+  <template>
+    <div class="db-configure">
+      <ul
+        class="db-configure__list"
+        aria-label={{i18n "admin.dashboard.configure.menu_title"}}
+      >
+        {{#each @sections key="id" as |section index|}}
+          <ConfigureRow
+            @section={{section}}
+            @index={{index}}
+            @isFirst={{eq index 0}}
+            @isLast={{eq index this.lastIndex}}
+            @onDragStart={{this.onDragStart}}
+            @onDrop={{this.onDrop}}
+            @onMoveUp={{this.onMoveUp}}
+            @onMoveDown={{this.onMoveDown}}
+            @onToggle={{@onToggleVisibility}}
+          />
+        {{/each}}
+      </ul>
+    </div>
+  </template>
+}

--- a/frontend/discourse/admin/components/dashboard/date-range.gjs
+++ b/frontend/discourse/admin/components/dashboard/date-range.gjs
@@ -100,7 +100,6 @@ export default class DashboardDateRange extends Component {
         )
         (hash
           value=PERIOD_CUSTOM
-          icon="calendar-days"
           label=this.customLabel
           class="db-date-range__custom"
         )

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -10,23 +10,12 @@ import DashboardReports from "discourse/admin/components/dashboard/reports";
 import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
 import DMenu from "discourse/float-kit/components/d-menu";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { deepEqual } from "discourse/lib/object";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 function buildPending(committed) {
   return committed?.map((s) => ({ ...s })) ?? [];
-}
-
-function sectionsEqual(a, b) {
-  if (a.length !== b.length) {
-    return false;
-  }
-  for (let i = 0; i < a.length; i++) {
-    if (a[i].id !== b[i].id || !!a[i].visible !== !!b[i].visible) {
-      return false;
-    }
-  }
-  return true;
 }
 
 export default class RedesignedAdminDashboard extends Component {
@@ -72,7 +61,7 @@ export default class RedesignedAdminDashboard extends Component {
     if (this._saving || !this._opened) {
       return;
     }
-    if (sectionsEqual(this.pendingSections, this.committedSections)) {
+    if (deepEqual(this.pendingSections, this.committedSections)) {
       return;
     }
 

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -1,90 +1,163 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import ConfigureMenu from "discourse/admin/components/dashboard/configure-menu";
 import DashboardDateRange from "discourse/admin/components/dashboard/date-range";
 import DashboardEngagement from "discourse/admin/components/dashboard/engagement";
 import DashboardHighlights from "discourse/admin/components/dashboard/highlights";
 import DashboardReports from "discourse/admin/components/dashboard/reports";
 import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
 import DMenu from "discourse/float-kit/components/d-menu";
-import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
-import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
-const sections = [
-  {
-    id: "highlights",
-    label: "admin.dashboard.sections.highlights.title",
-    visible: true,
-  },
-  {
-    id: "reports",
-    label: "admin.dashboard.sections.reports.title",
-    visible: true,
-  },
-  {
-    id: "traffic",
-    label: "admin.dashboard.sections.traffic.title",
-    visible: true,
-  },
-  {
-    id: "engagement",
-    label: "admin.dashboard.sections.engagement.title",
-    visible: true,
-  },
-];
+function buildPending(committed) {
+  return committed?.map((s) => ({ ...s })) ?? [];
+}
 
-const RedesignedAdminDashboard = <template>
-  <div class="db-toolbar">
-    <h1>Dashboard</h1>
+function sectionsEqual(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].id !== b[i].id || !!a[i].visible !== !!b[i].visible) {
+      return false;
+    }
+  }
+  return true;
+}
 
-    <div class="db-toolbar__actions">
-      <DashboardDateRange
-        @period={{@period}}
-        @startDate={{@startDate}}
-        @endDate={{@endDate}}
-        @setPeriod={{@setPeriod}}
-        @setCustomDateRange={{@setCustomDateRange}}
-      />
+export default class RedesignedAdminDashboard extends Component {
+  @service currentUser;
 
-      <DMenu
-        @identifier="db-customise"
-        @icon="gear"
-        @label="Customise"
-        @triggerClass="btn-default"
-        @modalForMobile={{true}}
-      >
-        <:content>
-          <div class="db-customise">
-            <ul class="db-customise__list">
-              {{#each sections as |s|}}
-                <li class="db-customise__row">
-                  <span class="db-customise__drag-handle">{{dIcon
-                      "grip-vertical"
-                    }}</span>
-                  <span class="db-customise__section-name">{{i18n
-                      s.label
-                    }}</span>
-                  <DToggleSwitch @state={{s.visible}} />
-                </li>
-              {{/each}}
-            </ul>
-          </div>
-        </:content>
-      </DMenu>
+  @tracked pendingSections;
+
+  _saving = false;
+  _opened = false;
+
+  constructor() {
+    super(...arguments);
+    this.pendingSections = buildPending(this.committedSections);
+  }
+
+  get committedSections() {
+    return this.args.configuration?.sections ?? [];
+  }
+
+  @action
+  onMenuOpen() {
+    this._opened = true;
+    this.pendingSections = buildPending(this.committedSections);
+  }
+
+  @action
+  toggleVisibility(id) {
+    this.pendingSections = this.pendingSections.map((s) =>
+      s.id === id ? { ...s, visible: !s.visible } : s
+    );
+  }
+
+  @action
+  reorder(fromIndex, toIndex) {
+    const next = [...this.pendingSections];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+    this.pendingSections = next;
+  }
+
+  @action
+  onMenuClose() {
+    if (this._saving || !this._opened) {
+      return;
+    }
+    if (sectionsEqual(this.pendingSections, this.committedSections)) {
+      return;
+    }
+
+    this._saving = true;
+    this.args
+      .updateConfiguration(this.pendingSections)
+      .catch((e) => {
+        popupAjaxError(e);
+        this.pendingSections = buildPending(this.committedSections);
+      })
+      .finally(() => {
+        this._saving = false;
+      });
+  }
+
+  <template>
+    <div class="db-toolbar">
+      <h1>Dashboard</h1>
+
+      <div class="db-toolbar__actions">
+        <DashboardDateRange
+          @period={{@period}}
+          @startDate={{@startDate}}
+          @endDate={{@endDate}}
+          @setPeriod={{@setPeriod}}
+          @setCustomDateRange={{@setCustomDateRange}}
+        />
+
+        {{#if this.currentUser.admin}}
+          <DMenu
+            @identifier="db-configure"
+            @icon="gear"
+            @label={{i18n "admin.dashboard.configure.button"}}
+            @title={{i18n "admin.dashboard.configure.tooltip"}}
+            @triggerClass="btn-default"
+            @modalForMobile={{true}}
+            @onClose={{this.onMenuClose}}
+            @onShow={{this.onMenuOpen}}
+          >
+            <:content>
+              <ConfigureMenu
+                @sections={{this.pendingSections}}
+                @onReorder={{this.reorder}}
+                @onToggleVisibility={{this.toggleVisibility}}
+              />
+            </:content>
+          </DMenu>
+        {{/if}}
+      </div>
     </div>
-  </div>
 
-  <div class="db-main">
-    <DashboardHighlights
-      @highlights={{@sections.highlights}}
-      @period={{@period}}
-      @loading={{@loadingSections}}
-      @fetchError={{@sectionsFetchError}}
-      @startDate={{@startDate}}
-      @endDate={{@endDate}}
-    />
-    <DashboardReports @startDate={{@startDate}} @endDate={{@endDate}} />
-    <DashboardTraffic @startDate={{@startDate}} @endDate={{@endDate}} />
-    <DashboardEngagement @startDate={{@startDate}} @endDate={{@endDate}} />
-  </div>
-</template>;
+    <div class="db-main">
+      {{#each @sections key="id" as |section|}}
+        <div class="db-main__section" data-section-id={{section.id}}>
+          {{#if (eq section.id "highlights")}}
+            <DashboardHighlights
+              @highlights={{section.data}}
+              @period={{@period}}
+              @loading={{@loadingSections}}
+              @fetchError={{@sectionsFetchError}}
+              @startDate={{@startDate}}
+              @endDate={{@endDate}}
+            />
+          {{else if (eq section.id "reports")}}
+            <DashboardReports @startDate={{@startDate}} @endDate={{@endDate}} />
+          {{else if (eq section.id "traffic")}}
+            <DashboardTraffic @startDate={{@startDate}} @endDate={{@endDate}} />
+          {{else if (eq section.id "engagement")}}
+            <DashboardEngagement
+              @startDate={{@startDate}}
+              @endDate={{@endDate}}
+            />
+          {{/if}}
+        </div>
+      {{/each}}
 
-export default RedesignedAdminDashboard;
+      {{#unless @sections.length}}
+        <div class="db-main__empty" role="status" aria-live="polite">
+          {{#if this.currentUser.admin}}
+            {{i18n "admin.dashboard.configure.empty_state_admin"}}
+          {{else}}
+            {{i18n "admin.dashboard.configure.empty_state_moderator"}}
+          {{/if}}
+        </div>
+      {{/unless}}
+    </div>
+  </template>
+}

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -10,6 +10,7 @@ import {
 } from "discourse/admin/components/dashboard/date-range";
 import AdminDashboard from "discourse/admin/models/admin-dashboard";
 import VersionCheck from "discourse/admin/models/version-check";
+import { ajax } from "discourse/lib/ajax";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
 
 const PROBLEMS_CHECK_MINUTES = 1;
@@ -25,6 +26,7 @@ export default class AdminDashboardController extends Controller {
   @tracked start_date = null;
   @tracked end_date = null;
   @tracked sections = null;
+  @tracked configuration = null;
   @tracked loadingSections = false;
   @tracked sectionsFetchError = false;
   @autoTrackedArray problems;
@@ -81,6 +83,16 @@ export default class AdminDashboardController extends Controller {
     this.fetchSections();
   }
 
+  @action
+  async updateConfiguration(sections) {
+    await ajax("/admin/dashboard/configuration.json", {
+      type: "PUT",
+      contentType: "application/json",
+      data: JSON.stringify({ sections }),
+    });
+    await this.fetchSections();
+  }
+
   async fetchSections() {
     const id = ++this._sectionsLoadId;
     this.loadingSections = true;
@@ -95,6 +107,7 @@ export default class AdminDashboardController extends Controller {
         return;
       }
       this.sections = model.sections;
+      this.configuration = model.configuration;
     } catch {
       if (id !== this._sectionsLoadId) {
         return;

--- a/frontend/discourse/admin/models/admin-dashboard.js
+++ b/frontend/discourse/admin/models/admin-dashboard.js
@@ -23,6 +23,7 @@ export default class AdminDashboard extends EmberObject {
     model.setProperties({
       version_check: json.version_check,
       sections: json.sections,
+      configuration: json.configuration,
     });
 
     return model;

--- a/frontend/discourse/admin/templates/admin/dashboard.gjs
+++ b/frontend/discourse/admin/templates/admin/dashboard.gjs
@@ -16,6 +16,8 @@ export default <template>
       @setPeriod={{@controller.setPeriod}}
       @setCustomDateRange={{@controller.setCustomDateRange}}
       @sections={{@controller.sections}}
+      @configuration={{@controller.configuration}}
+      @updateConfiguration={{@controller.updateConfiguration}}
       @loadingSections={{@controller.loadingSections}}
       @sectionsFetchError={{@controller.sectionsFetchError}}
     />

--- a/frontend/discourse/tests/integration/components/dashboard/configure-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/configure-menu-test.gjs
@@ -1,0 +1,191 @@
+import { click, render, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import ConfigureMenu from "discourse/admin/components/dashboard/configure-menu";
+import { forceMobile } from "discourse/lib/mobile";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+const FOUR_SECTIONS = [
+  { id: "highlights", visible: true },
+  { id: "reports", visible: true },
+  { id: "traffic", visible: false },
+  { id: "engagement", visible: true },
+];
+
+function dataTransferStub() {
+  return { effectAllowed: null, setData() {}, getData: () => "" };
+}
+
+module("Integration | Component | Dashboard | ConfigureMenu", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders one row per section", async function (assert) {
+    const sections = FOUR_SECTIONS;
+    const noop = () => {};
+
+    await render(
+      <template>
+        <ConfigureMenu
+          @sections={{sections}}
+          @onReorder={{noop}}
+          @onToggleVisibility={{noop}}
+        />
+      </template>
+    );
+
+    assert.dom(".db-configure__row").exists({ count: 4 });
+    assert.dom('[data-section-id="highlights"]').exists();
+    assert.dom('[data-section-id="reports"]').exists();
+    assert.dom('[data-section-id="traffic"]').exists();
+    assert.dom('[data-section-id="engagement"]').exists();
+  });
+
+  test("toggle click fires @onToggleVisibility with the section id", async function (assert) {
+    const sections = FOUR_SECTIONS;
+    const calls = [];
+    const onToggle = (id) => calls.push(id);
+    const noop = () => {};
+
+    await render(
+      <template>
+        <ConfigureMenu
+          @sections={{sections}}
+          @onReorder={{noop}}
+          @onToggleVisibility={{onToggle}}
+        />
+      </template>
+    );
+
+    await click('[data-section-id="highlights"] .d-toggle-switch__checkbox');
+    assert.deepEqual(calls, ["highlights"]);
+  });
+
+  test("drag-and-drop fires @onReorder with computed indices", async function (assert) {
+    const sections = FOUR_SECTIONS;
+    const calls = [];
+    const onReorder = (from, to) => calls.push([from, to]);
+    const noop = () => {};
+
+    await render(
+      <template>
+        <ConfigureMenu
+          @sections={{sections}}
+          @onReorder={{onReorder}}
+          @onToggleVisibility={{noop}}
+        />
+      </template>
+    );
+
+    const source = '[data-section-id="reports"]';
+    const target = '[data-section-id="highlights"]';
+    const dataTransfer = dataTransferStub();
+
+    await triggerEvent(source, "dragstart", { dataTransfer });
+    await triggerEvent(target, "dragover", { dataTransfer, offsetY: 1 });
+    await triggerEvent(target, "drop", { dataTransfer, offsetY: 1 });
+
+    assert.deepEqual(
+      calls.at(-1),
+      [1, 0],
+      "drop above index 0 moves source from 1 to 0"
+    );
+  });
+
+  test("desktop renders the drag handle and not the arrows", async function (assert) {
+    const sections = FOUR_SECTIONS;
+    const noop = () => {};
+
+    await render(
+      <template>
+        <ConfigureMenu
+          @sections={{sections}}
+          @onReorder={{noop}}
+          @onToggleVisibility={{noop}}
+        />
+      </template>
+    );
+
+    assert.dom(".db-configure__drag-handle").exists({ count: 4 });
+    assert.dom(".db-configure__arrow").doesNotExist();
+  });
+});
+
+module(
+  "Integration | Component | Dashboard | ConfigureMenu | Mobile",
+  function (hooks) {
+    hooks.beforeEach(function () {
+      forceMobile();
+    });
+
+    setupRenderingTest(hooks);
+
+    test("hides the drag handle and renders arrow buttons", async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <ConfigureMenu
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert.dom(".db-configure__drag-handle").doesNotExist();
+      assert.dom(".db-configure__arrow").exists({ count: 8 });
+    });
+
+    test("arrow buttons fire @onReorder", async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const calls = [];
+      const onReorder = (from, to) => calls.push([from, to]);
+      const noop = () => {};
+
+      await render(
+        <template>
+          <ConfigureMenu
+            @sections={{sections}}
+            @onReorder={{onReorder}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      await click(
+        '[data-section-id="reports"] .db-configure__arrow:first-child'
+      );
+      assert.deepEqual(calls.at(-1), [1, 0]);
+
+      await click(
+        '[data-section-id="highlights"] .db-configure__arrow:last-child'
+      );
+      assert.deepEqual(calls.at(-1), [0, 1]);
+    });
+
+    test("first row's up button and last row's down button are disabled", async function (assert) {
+      const sections = FOUR_SECTIONS;
+      const noop = () => {};
+
+      await render(
+        <template>
+          <ConfigureMenu
+            @sections={{sections}}
+            @onReorder={{noop}}
+            @onToggleVisibility={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom('[data-section-id="highlights"] .db-configure__arrow:first-child')
+        .isDisabled("first row's up arrow is disabled");
+      assert
+        .dom('[data-section-id="engagement"] .db-configure__arrow:last-child')
+        .isDisabled("last row's down arrow is disabled");
+      assert
+        .dom('[data-section-id="reports"] .db-configure__arrow:first-child')
+        .isNotDisabled("middle row's up arrow is enabled");
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/dashboard/date-range-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/date-range-test.gjs
@@ -16,9 +16,6 @@ module("Integration | Component | Dashboard | DateRange", function (hooks) {
     assert.dom("input[value='last_30_days']").exists("renders Last 30 days");
     assert.dom("input[value='last_3_months']").exists("renders Last 3 months");
     assert.dom("input[value='custom']").exists("renders Custom");
-    assert
-      .dom(".db-date-range__custom .d-icon-calendar-days")
-      .exists("custom item has the calendar icon");
   });
 
   test("checks the input matching @period", async function (assert) {

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -96,13 +96,17 @@ RSpec.describe Admin::DashboardController do
       end
     end
 
-    describe "sections.highlights payload" do
+    describe "sections payload" do
       before do
         SiteSetting.dashboard_improvements = true
-        AdminDashboardData.unstub(:fetch_cached_stats)
-        AdminDashboardData.stubs(:fetch_cached_stats).returns(reports: [])
+        SiteSetting.admin_dashboard_sections = "highlights|reports|traffic|engagement"
         Discourse.cache.clear
         sign_in(admin)
+      end
+
+      def highlights_data
+        sections = response.parsed_body["sections"]
+        sections.find { |s| s["id"] == "highlights" }&.dig("data")
       end
 
       it "is omitted when dashboard_improvements is disabled" do
@@ -111,15 +115,38 @@ RSpec.describe Admin::DashboardController do
 
         expect(response.status).to eq(200)
         expect(response.parsed_body["sections"]).to be_nil
+        expect(response.parsed_body["configuration"]).to be_nil
       end
 
       it "includes a highlights section with kpis" do
         get "/admin/dashboard.json"
 
         expect(response.status).to eq(200)
-        highlights = response.parsed_body["sections"]["highlights"]
-        expect(highlights).to be_present
-        expect(highlights["kpis"]).to be_an(Array)
+        expect(highlights_data["kpis"]).to be_an(Array)
+      end
+
+      it "returns the sections as an ordered array of {id, data}" do
+        SiteSetting.admin_dashboard_sections = "reports|highlights"
+        get "/admin/dashboard.json"
+
+        ids = response.parsed_body["sections"].map { |s| s["id"] }
+        expect(ids).to eq(%w[reports highlights])
+      end
+
+      it "omits hidden sections from the data payload" do
+        SiteSetting.admin_dashboard_sections = "highlights|reports"
+        get "/admin/dashboard.json"
+
+        ids = response.parsed_body["sections"].map { |s| s["id"] }
+        expect(ids).not_to include("traffic", "engagement")
+      end
+
+      it "leaves data null for sections without a builder yet" do
+        SiteSetting.admin_dashboard_sections = "highlights|reports"
+        get "/admin/dashboard.json"
+
+        reports = response.parsed_body["sections"].find { |s| s["id"] == "reports" }
+        expect(reports["data"]).to be_nil
       end
 
       it "returns the documented payload shape for new_signups" do
@@ -127,7 +154,7 @@ RSpec.describe Admin::DashboardController do
           Fabricate(:user, created_at: 5.days.ago)
           get "/admin/dashboard.json", params: { start_date: "2026-03-01", end_date: "2026-04-28" }
 
-          kpis = response.parsed_body["sections"]["highlights"]["kpis"]
+          kpis = highlights_data["kpis"]
           signups = kpis.find { |k| k["type"] == "new_signups" }
 
           expect(signups).to include(
@@ -153,14 +180,14 @@ RSpec.describe Admin::DashboardController do
             }
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["sections"]["highlights"]["kpis"]).to be_an(Array)
+        expect(highlights_data["kpis"]).to be_an(Array)
       end
 
       it "ignores malformed date params and falls back to defaults" do
         get "/admin/dashboard.json", params: { start_date: "garbage", end_date: "also-garbage" }
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["sections"]["highlights"]).to be_present
+        expect(highlights_data).to be_present
       end
 
       it "denies non-staff users" do
@@ -170,12 +197,12 @@ RSpec.describe Admin::DashboardController do
         expect(response.status).to eq(404)
       end
 
-      it "allows moderators and returns the highlights payload" do
+      it "allows moderators and returns the sections payload" do
         sign_in(moderator)
         get "/admin/dashboard.json"
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["sections"]["highlights"]).to be_present
+        expect(highlights_data).to be_present
       end
 
       it "omits version_check when the flag is on" do
@@ -197,6 +224,177 @@ RSpec.describe Admin::DashboardController do
         expect(response.status).to eq(200)
         expect(response.parsed_body).to have_key("version_check")
       end
+    end
+
+    describe "configuration payload" do
+      before do
+        SiteSetting.dashboard_improvements = true
+        Discourse.cache.clear
+      end
+
+      it "is included for admins and lists every known section with a visibility flag" do
+        SiteSetting.admin_dashboard_sections = "highlights|reports"
+        sign_in(admin)
+        get "/admin/dashboard.json"
+
+        configuration = response.parsed_body["configuration"]
+        expect(configuration).to be_present
+        ids = configuration["sections"].map { |s| s["id"] }
+        expect(ids).to match_array(%w[highlights reports traffic engagement])
+        visible = configuration["sections"].select { |s| s["visible"] }.map { |s| s["id"] }
+        expect(visible).to eq(%w[highlights reports])
+      end
+
+      it "is omitted for moderators" do
+        sign_in(moderator)
+        get "/admin/dashboard.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).not_to have_key("configuration")
+      end
+
+      it "is omitted when dashboard_improvements is disabled" do
+        SiteSetting.dashboard_improvements = false
+        sign_in(admin)
+        get "/admin/dashboard.json"
+
+        expect(response.parsed_body).not_to have_key("configuration")
+      end
+    end
+  end
+
+  describe "#update_configuration" do
+    before do
+      SiteSetting.dashboard_improvements = true
+      SiteSetting.admin_dashboard_sections = "highlights|reports|traffic|engagement"
+    end
+
+    it "returns 204 and writes the site setting for admins" do
+      sign_in(admin)
+      put "/admin/dashboard/configuration.json",
+          params: {
+            sections: [
+              { id: "reports", visible: true },
+              { id: "highlights", visible: true },
+              { id: "traffic", visible: false },
+            ],
+          }
+
+      expect(response.status).to eq(204)
+      expect(SiteSetting.admin_dashboard_sections).to eq("reports|highlights")
+    end
+
+    it "leaves a change_site_setting UserHistory row attributed to the admin" do
+      sign_in(admin)
+      expect {
+        put "/admin/dashboard/configuration.json",
+            params: {
+              sections: [{ id: "highlights", visible: true }],
+            }
+      }.to change {
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "admin_dashboard_sections",
+        ).count
+      }.by(1)
+
+      entry =
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "admin_dashboard_sections",
+        ).last
+      expect(entry.acting_user_id).to eq(admin.id)
+      expect(entry.new_value).to eq("highlights")
+    end
+
+    it "does not write a duplicate UserHistory row when the payload is unchanged" do
+      SiteSetting.admin_dashboard_sections = "highlights"
+      sign_in(admin)
+      expect {
+        put "/admin/dashboard/configuration.json",
+            params: {
+              sections: [{ id: "highlights", visible: true }],
+            }
+      }.not_to change {
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "admin_dashboard_sections",
+        ).count
+      }
+    end
+
+    it "drops unknown section ids silently" do
+      sign_in(admin)
+      put "/admin/dashboard/configuration.json",
+          params: {
+            sections: [{ id: "frobnitz", visible: true }, { id: "highlights", visible: true }],
+          }
+
+      expect(response.status).to eq(204)
+      expect(SiteSetting.admin_dashboard_sections).to eq("highlights")
+    end
+
+    it "coerces non-boolean visible values" do
+      sign_in(admin)
+      put "/admin/dashboard/configuration.json",
+          params: {
+            sections: [
+              { id: "highlights", visible: "true" },
+              { id: "reports", visible: "false" },
+              { id: "engagement", visible: "1" },
+            ],
+          }
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("highlights|engagement")
+    end
+
+    it "treats an empty sections array as hide-everything" do
+      sign_in(admin)
+      put "/admin/dashboard/configuration.json", params: { sections: [] }
+
+      expect(response.status).to eq(204)
+      expect(SiteSetting.admin_dashboard_sections).to eq("")
+    end
+
+    it "treats a missing sections key the same as an empty array" do
+      sign_in(admin)
+      put "/admin/dashboard/configuration.json"
+
+      expect(response.status).to eq(204)
+      expect(SiteSetting.admin_dashboard_sections).to eq("")
+    end
+
+    it "returns 404 for moderators" do
+      sign_in(moderator)
+      put "/admin/dashboard/configuration.json",
+          params: {
+            sections: [{ id: "highlights", visible: true }],
+          }
+
+      expect(response.status).to eq(404)
+    end
+
+    it "returns 404 for anonymous users" do
+      put "/admin/dashboard/configuration.json",
+          params: {
+            sections: [{ id: "highlights", visible: true }],
+          }
+
+      expect(response.status).to eq(404)
+    end
+
+    it "reflects the new configuration for moderators on a subsequent GET" do
+      sign_in(admin)
+      put "/admin/dashboard/configuration.json",
+          params: {
+            sections: [{ id: "highlights", visible: true }],
+          }
+
+      sign_in(moderator)
+      get "/admin/dashboard.json"
+
+      ids = response.parsed_body["sections"].map { |s| s["id"] }
+      expect(ids).to eq(["highlights"])
     end
   end
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -284,45 +284,6 @@ RSpec.describe Admin::DashboardController do
       expect(SiteSetting.admin_dashboard_sections).to eq("reports|highlights")
     end
 
-    it "leaves a change_site_setting UserHistory row attributed to the admin" do
-      sign_in(admin)
-      expect {
-        put "/admin/dashboard/configuration.json",
-            params: {
-              sections: [{ id: "highlights", visible: true }],
-            }
-      }.to change {
-        UserHistory.where(
-          action: UserHistory.actions[:change_site_setting],
-          subject: "admin_dashboard_sections",
-        ).count
-      }.by(1)
-
-      entry =
-        UserHistory.where(
-          action: UserHistory.actions[:change_site_setting],
-          subject: "admin_dashboard_sections",
-        ).last
-      expect(entry.acting_user_id).to eq(admin.id)
-      expect(entry.new_value).to eq("highlights")
-    end
-
-    it "does not write a duplicate UserHistory row when the payload is unchanged" do
-      SiteSetting.admin_dashboard_sections = "highlights"
-      sign_in(admin)
-      expect {
-        put "/admin/dashboard/configuration.json",
-            params: {
-              sections: [{ id: "highlights", visible: true }],
-            }
-      }.not_to change {
-        UserHistory.where(
-          action: UserHistory.actions[:change_site_setting],
-          subject: "admin_dashboard_sections",
-        ).count
-      }
-    end
-
     it "drops unknown section ids silently" do
       sign_in(admin)
       put "/admin/dashboard/configuration.json",

--- a/spec/services/admin_dashboard_section_configuration_spec.rb
+++ b/spec/services/admin_dashboard_section_configuration_spec.rb
@@ -138,24 +138,5 @@ describe AdminDashboardSectionConfiguration do
         [{ id: "engagement", visible: true }, { id: "highlights", visible: true }],
       )
     end
-
-    it "logs the change via the site-settings audit trail" do
-      expect {
-        described_class.update([{ id: "highlights", visible: true }], actor: admin)
-      }.to change {
-        UserHistory.where(
-          action: UserHistory.actions[:change_site_setting],
-          subject: "admin_dashboard_sections",
-        ).count
-      }.by(1)
-
-      entry =
-        UserHistory.where(
-          action: UserHistory.actions[:change_site_setting],
-          subject: "admin_dashboard_sections",
-        ).last
-      expect(entry.acting_user_id).to eq(admin.id)
-      expect(entry.new_value).to eq("highlights")
-    end
   end
 end

--- a/spec/services/admin_dashboard_section_configuration_spec.rb
+++ b/spec/services/admin_dashboard_section_configuration_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+describe AdminDashboardSectionConfiguration do
+  fab!(:admin)
+
+  before { SiteSetting.admin_dashboard_sections = "highlights|reports|traffic|engagement" }
+
+  describe "the site setting" do
+    it "rejects unknown ids at the validator level" do
+      expect { SiteSetting.admin_dashboard_sections = "frobnitz|highlights" }.to raise_error(
+        Discourse::InvalidParameters,
+      )
+    end
+  end
+
+  describe ".visible_section_ids" do
+    it "returns ids in stored order" do
+      SiteSetting.admin_dashboard_sections = "reports|highlights|engagement"
+      expect(described_class.visible_section_ids).to eq(%w[reports highlights engagement])
+    end
+
+    it "dedupes repeated ids, keeping the first occurrence" do
+      SiteSetting.admin_dashboard_sections = "highlights|highlights|reports"
+      expect(described_class.visible_section_ids).to eq(%w[highlights reports])
+    end
+
+    it "returns an empty array when the setting is empty" do
+      SiteSetting.admin_dashboard_sections = ""
+      expect(described_class.visible_section_ids).to eq([])
+    end
+
+    it "falls back to canonical defaults when the raw value is non-empty but unusable" do
+      SiteSetting.stubs(:admin_dashboard_sections).returns("|||")
+      expect(described_class.visible_section_ids).to eq(described_class::KNOWN_SECTIONS)
+    end
+
+    it "falls back to canonical defaults when every id is unknown" do
+      SiteSetting.stubs(:admin_dashboard_sections).returns("frobnitz|wibble")
+      expect(described_class.visible_section_ids).to eq(described_class::KNOWN_SECTIONS)
+    end
+  end
+
+  describe ".sections" do
+    it "returns visible sections first, then hidden in canonical order" do
+      SiteSetting.admin_dashboard_sections = "reports|engagement"
+
+      expect(described_class.sections).to eq(
+        [
+          { id: "reports", visible: true },
+          { id: "engagement", visible: true },
+          { id: "highlights", visible: false },
+          { id: "traffic", visible: false },
+        ],
+      )
+    end
+
+    it "marks every known section visible: false when the setting is empty" do
+      SiteSetting.admin_dashboard_sections = ""
+
+      expect(described_class.sections.map { |s| s[:visible] }.uniq).to eq([false])
+      expect(described_class.sections.map { |s| s[:id] }).to match_array(
+        described_class::KNOWN_SECTIONS,
+      )
+    end
+  end
+
+  describe ".update" do
+    it "persists the visible ids as a pipe-delimited string" do
+      described_class.update(
+        [{ id: "reports", visible: true }, { id: "highlights", visible: true }],
+        actor: admin,
+      )
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("reports|highlights")
+    end
+
+    it "drops sections with visible: false" do
+      described_class.update(
+        [
+          { id: "highlights", visible: true },
+          { id: "traffic", visible: false },
+          { id: "reports", visible: true },
+        ],
+        actor: admin,
+      )
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("highlights|reports")
+    end
+
+    it "coerces non-boolean visible values" do
+      described_class.update(
+        [
+          { id: "highlights", visible: "true" },
+          { id: "reports", visible: "false" },
+          { id: "engagement", visible: 1 },
+        ],
+        actor: admin,
+      )
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("highlights|engagement")
+    end
+
+    it "drops unknown section ids" do
+      described_class.update(
+        [{ id: "frobnitz", visible: true }, { id: "highlights", visible: true }],
+        actor: admin,
+      )
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("highlights")
+    end
+
+    it "accepts string keys as well as symbols" do
+      described_class.update(
+        [{ "id" => "highlights", "visible" => true }, { "id" => "reports", "visible" => true }],
+        actor: admin,
+      )
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("highlights|reports")
+    end
+
+    it "writes empty string when all sections are hidden" do
+      described_class.update(
+        [{ id: "highlights", visible: false }, { id: "reports", visible: false }],
+        actor: admin,
+      )
+
+      expect(SiteSetting.admin_dashboard_sections).to eq("")
+    end
+
+    it "returns the new sections snapshot" do
+      result =
+        described_class.update(
+          [{ id: "engagement", visible: true }, { id: "highlights", visible: true }],
+          actor: admin,
+        )
+
+      expect(result.first(2)).to eq(
+        [{ id: "engagement", visible: true }, { id: "highlights", visible: true }],
+      )
+    end
+
+    it "logs the change via the site-settings audit trail" do
+      expect {
+        described_class.update([{ id: "highlights", visible: true }], actor: admin)
+      }.to change {
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "admin_dashboard_sections",
+        ).count
+      }.by(1)
+
+      entry =
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "admin_dashboard_sections",
+        ).last
+      expect(entry.acting_user_id).to eq(admin.id)
+      expect(entry.new_value).to eq("highlights")
+    end
+  end
+end

--- a/spec/system/admin_dashboard_configure_spec.rb
+++ b/spec/system/admin_dashboard_configure_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+describe "Admin Dashboard Configure menu" do
+  fab!(:admin)
+  fab!(:moderator)
+
+  let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
+
+  before do
+    SiteSetting.dashboard_improvements = true
+    SiteSetting.admin_dashboard_sections = "highlights|reports|traffic|engagement"
+  end
+
+  context "as an admin" do
+    before { sign_in(admin) }
+
+    it "toggles section visibility from the Configure menu, persists across reload, and shows an empty state when everything is hidden" do
+      dashboard.visit
+      expect(dashboard).to have_configure_button
+      %w[highlights reports traffic engagement].each { |id| expect(dashboard).to have_section(id) }
+
+      dashboard
+        .open_configure_menu
+        .toggle_section("traffic")
+        .toggle_section("engagement")
+        .close_configure_menu
+
+      expect(dashboard).to have_section("highlights")
+      expect(dashboard).to have_section("reports")
+      expect(dashboard).to have_no_section("traffic")
+      expect(dashboard).to have_no_section("engagement")
+
+      page.refresh
+
+      expect(dashboard).to have_section("highlights")
+      expect(dashboard).to have_section("reports")
+      expect(dashboard).to have_no_section("traffic")
+      expect(dashboard).to have_no_section("engagement")
+
+      dashboard
+        .open_configure_menu
+        .toggle_section("highlights")
+        .toggle_section("reports")
+        .close_configure_menu
+
+      expect(dashboard).to have_empty_state
+    end
+
+    it "reorders sections via the arrow buttons on mobile", mobile: true do
+      dashboard.visit
+
+      dashboard.open_configure_menu.move_section_up("reports").close_configure_menu
+
+      expect(dashboard.section_ids_in_order.first(2)).to eq(%w[reports highlights])
+    end
+  end
+
+  context "as a moderator" do
+    before { sign_in(moderator) }
+
+    it "does not show the Configure trigger" do
+      dashboard.visit
+      expect(dashboard).to have_no_configure_button
+    end
+
+    it "sees the same configured layout an admin set up" do
+      SiteSetting.admin_dashboard_sections = "highlights|reports"
+      dashboard.visit
+
+      expect(dashboard).to have_section("highlights")
+      expect(dashboard).to have_section("reports")
+      expect(dashboard).to have_no_section("traffic")
+    end
+  end
+end

--- a/spec/system/admin_dashboard_configure_spec.rb
+++ b/spec/system/admin_dashboard_configure_spec.rb
@@ -51,6 +51,7 @@ describe "Admin Dashboard Configure menu" do
 
       dashboard.open_configure_menu.move_section_up("reports").close_configure_menu
 
+      expect(page).to have_css(".db-main__section:first-child[data-section-id='reports']")
       expect(dashboard.section_ids_in_order.first(2)).to eq(%w[reports highlights])
     end
   end

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -5,7 +5,7 @@ module PageObjects
     class AdminDashboard < PageObjects::Pages::Base
       def visit
         page.visit("/admin")
-        has_css?(".db-main__section, .db-main__empty, .legacy-dashboard")
+        has_css?(".db-main__section, .db-main__empty, .nav-pills")
         self
       end
 

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -5,6 +5,7 @@ module PageObjects
     class AdminDashboard < PageObjects::Pages::Base
       def visit
         page.visit("/admin")
+        has_css?(".db-main__section, .db-main__empty, .legacy-dashboard")
         self
       end
 
@@ -39,6 +40,67 @@ module PageObjects
 
       def open_custom_date_range
         find(".db-date-range__custom").click
+        self
+      end
+
+      def has_configure_button?
+        has_css?(".btn[data-identifier='db-configure']")
+      end
+
+      def has_no_configure_button?
+        has_no_css?(".btn[data-identifier='db-configure']")
+      end
+
+      def open_configure_menu
+        find(".btn[data-identifier='db-configure']").click
+        has_css?(".db-configure")
+        self
+      end
+
+      def close_configure_menu
+        if page.has_css?(".d-modal__backdrop", wait: 0)
+          page.send_keys :escape
+        else
+          find(".btn[data-identifier='db-configure']").click
+        end
+        has_no_css?(".db-configure")
+        self
+      end
+
+      def has_section?(id)
+        has_css?(".db-main__section[data-section-id='#{id}']")
+      end
+
+      def has_no_section?(id)
+        has_no_css?(".db-main__section[data-section-id='#{id}']")
+      end
+
+      def section_ids_in_order
+        all(".db-main__section").map { |el| el["data-section-id"] }
+      end
+
+      def has_empty_state?
+        has_css?(".db-main__empty")
+      end
+
+      def toggle_section(id)
+        within(".db-configure__row[data-section-id='#{id}']") do
+          find(".d-toggle-switch__label").click
+        end
+        self
+      end
+
+      def move_section_down(id)
+        within(".db-configure__row[data-section-id='#{id}']") do
+          find(".db-configure__arrow:last-child").click
+        end
+        self
+      end
+
+      def move_section_up(id)
+        within(".db-configure__row[data-section-id='#{id}']") do
+          find(".db-configure__arrow:first-child").click
+        end
         self
       end
 


### PR DESCRIPTION
Allow admins to configure which sections they want to see.


https://github.com/user-attachments/assets/c3481a28-cef3-4a32-b2f6-85b160e904ee

A few tasks in this PR:
- rename the "Customise" menu to "Configure" and removes the calendar icon from the Custom date range option
- implements the Configure menu:
  - toggle section visibility
  - drag-and-drop reorder on desktop, up/down arrows on mobile
  - empty state when all sections are off
  - persists configuration site-wide on menu close via `admin_dashboard_sections` site setting
  - admins and moderators can view, but admins write and moderators read
- `AdminDashboardSectionConfiguration` owns configuration, so storage can change later if we move to per-user
  - `PUT /admin/dashboard/configuration.json` is admin-only (mentioned above)
  - ~~audit log (`SiteSetting.set_and_log`)~~ we've hidden the site setting
  - the backend filters `sections` payload to only the visible-and-ordered list, so mods render the layout admins set without seeing the configuration meta
    - hidden sections skip their server-side data computation
