### PR TITLE
FIX: Preserve original image order in grid lightbox

### DIFF
--- a/frontend/discourse/app/lib/columns.js
+++ b/frontend/discourse/app/lib/columns.js
@@ -86,7 +86,7 @@ export default class Columns {
     const columns = this._prepareColumns(count);
     const heights = Array(count).fill(0);
 
-    this.items.forEach((item) => {
+    this.items.forEach((item, index) => {
       let shortest = 0;
 
       for (let j = 1; j < count; ++j) {
@@ -102,6 +102,12 @@ export default class Columns {
       heights[shortest] += img && img.width > 0 ? img.height / img.width : 1;
 
       const wrappedItem = this._wrapDirectImage(item);
+      const lightboxEl = wrappedItem.matches(".lightbox")
+        ? wrappedItem
+        : wrappedItem.querySelector(".lightbox");
+      if (lightboxEl) {
+        lightboxEl.dataset.lightboxPosition = index;
+      }
       columns[shortest].append(wrappedItem);
     });
 

--- a/frontend/discourse/app/lib/lightbox.js
+++ b/frontend/discourse/app/lib/lightbox.js
@@ -11,6 +11,40 @@ import { i18n } from "discourse-i18n";
 
 const INIT_PROMISES = new WeakMap();
 
+export function sortLightboxItems(items) {
+  const result = [];
+  let i = 0;
+  while (i < items.length) {
+    const grid = items[i].closest(".d-image-grid");
+    if (!grid) {
+      result.push(items[i++]);
+      continue;
+    }
+    let j = i;
+    while (j < items.length && items[j].closest(".d-image-grid") === grid) {
+      j++;
+    }
+    const gridItems = items.slice(i, j);
+    const sorted = gridItems.every((item) => {
+      const position = item.dataset.lightboxPosition;
+      return (
+        position !== undefined &&
+        position !== "" &&
+        Number.isInteger(Number(position))
+      );
+    })
+      ? gridItems.sort(
+          (a, b) =>
+            Number(a.dataset.lightboxPosition) -
+            Number(b.dataset.lightboxPosition)
+        )
+      : gridItems;
+    result.push(...sorted);
+    i = j;
+  }
+  return result;
+}
+
 export default function lightbox(elem, additionalData = {}) {
   if (!elem) {
     return Promise.resolve();
@@ -44,7 +78,9 @@ async function initLightbox(elem, additionalData = {}) {
     !siteSettings.prevent_anons_from_downloading_files || !!currentUser;
   const canQuoteImage = !!currentUser;
   const rtl = isDocumentRTL();
-  const items = [...elem.querySelectorAll(SELECTORS.DEFAULT_ITEM_SELECTOR)];
+  const items = sortLightboxItems([
+    ...elem.querySelectorAll(SELECTORS.DEFAULT_ITEM_SELECTOR),
+  ]);
 
   if (rtl) {
     items.reverse();

--- a/frontend/discourse/tests/acceptance/lightbox-test.js
+++ b/frontend/discourse/tests/acceptance/lightbox-test.js
@@ -1,4 +1,4 @@
-import { click, visit, waitFor } from "@ember/test-helpers";
+import { click, visit, waitFor, waitUntil } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
@@ -62,5 +62,57 @@ acceptance("Lightbox", function (needs) {
     assert
       .dom(".pswp__caption .pswp__caption-title")
       .hasHtml(/^&lt;script&gt;image&lt;\/script&gt;/);
+  });
+});
+
+acceptance("Lightbox - grid order", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    const topicResponse = cloneJSON(topicFixtures["/t/280/1.json"]);
+
+    const anchor = (title) => `
+      <a class="lightbox" href="/images/d-logo-sketch.png"
+         data-large-src="/images/d-logo-sketch.png"
+         data-target-width="640" data-target-height="480"
+         title="${title}">
+        <img src="/images/d-logo-sketch-small.png" width="640" height="480" alt="${title}">
+        <div class="meta"><span class="informations">640×480</span></div>
+      </a>
+    `;
+
+    topicResponse.post_stream.posts[0].cooked = `
+      <div class="d-image-grid">
+        ${anchor("img1")}
+        ${anchor("img2")}
+        ${anchor("img3")}
+        ${anchor("img4")}
+      </div>
+    `;
+
+    server.get("/t/280.json", () => helper.response(topicResponse));
+    server.get("/t/280/:post_number.json", () =>
+      helper.response(topicResponse)
+    );
+  });
+
+  test("Arrow navigation follows original markdown order, not column-balanced DOM order", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    await click(".d-image-grid .lightbox[title='img1']");
+    await waitFor(".pswp--open");
+    assert.dom(".pswp__caption-title").hasText("img1");
+
+    for (const expected of ["img2", "img3", "img4"]) {
+      await click(".pswp__button--arrow--next");
+      await waitUntil(
+        () =>
+          document.querySelector(".pswp__caption-title")?.textContent ===
+          expected
+      );
+      assert.dom(".pswp__caption-title").hasText(expected);
+    }
+
+    await click(".pswp__button--close");
   });
 });

--- a/frontend/discourse/tests/unit/lib/columns-test.js
+++ b/frontend/discourse/tests/unit/lib/columns-test.js
@@ -151,6 +151,27 @@ module("Unit | Columns", function (hooks) {
     );
   });
 
+  test("adds original position to lightbox items", function (assert) {
+    document.getElementById("qunit-fixture").innerHTML =
+      `<div class="d-image-grid">
+<a class="lightbox" href="/1.png"><img src="/images/avatar.png" width="20" height="20" role="presentation"></a>
+<a class="lightbox" href="/2.png"><img src="/images/avatar.png" width="20" height="20" role="presentation"></a>
+<a class="lightbox" href="/3.png"><img src="/images/avatar.png" width="20" height="20" role="presentation"></a>
+<a class="lightbox" href="/4.png"><img src="/images/avatar.png" width="20" height="20" role="presentation"></a>
+</div>`;
+
+    const grid = document.querySelector(".d-image-grid");
+    const cols = new Columns(grid);
+
+    assert.strictEqual(cols.items.length, 4);
+    assert.deepEqual(
+      [...document.querySelectorAll(".lightbox")].map(
+        (item) => item.dataset.lightboxPosition
+      ),
+      ["0", "2", "1", "3"]
+    );
+  });
+
   test("renders a single item in a P tag", function (assert) {
     document.getElementById("qunit-fixture").innerHTML =
       `<div class="d-image-grid">

--- a/frontend/discourse/tests/unit/lib/lightbox-sort-test.js
+++ b/frontend/discourse/tests/unit/lib/lightbox-sort-test.js
@@ -1,0 +1,129 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { sortLightboxItems } from "discourse/lib/lightbox";
+
+module("Unit | lightbox | sortLightboxItems", function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    document.getElementById("qunit-fixture").innerHTML = "";
+  });
+
+  test("preserves order of items outside a grid", function (assert) {
+    document.getElementById("qunit-fixture").innerHTML = `
+      <a class="lightbox" href="/a.png"></a>
+      <a class="lightbox" href="/b.png"></a>
+      <div class="d-image-grid" data-columns="2">
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/1.png" data-lightbox-position="0"></a>
+          <a class="lightbox" href="/3.png" data-lightbox-position="2"></a>
+        </div>
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/2.png" data-lightbox-position="1"></a>
+          <a class="lightbox" href="/4.png" data-lightbox-position="3"></a>
+        </div>
+      </div>
+      <a class="lightbox" href="/c.png"></a>
+    `;
+
+    const items = sortLightboxItems([
+      ...document.querySelectorAll(".lightbox"),
+    ]);
+
+    assert.deepEqual(
+      items.map((el) => el.getAttribute("href")),
+      ["/a.png", "/b.png", "/1.png", "/2.png", "/3.png", "/4.png", "/c.png"]
+    );
+  });
+
+  test("sorts each grid independently", function (assert) {
+    document.getElementById("qunit-fixture").innerHTML = `
+      <div class="d-image-grid" data-columns="2">
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/a1.png" data-lightbox-position="0"></a>
+          <a class="lightbox" href="/a3.png" data-lightbox-position="2"></a>
+        </div>
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/a2.png" data-lightbox-position="1"></a>
+          <a class="lightbox" href="/a4.png" data-lightbox-position="3"></a>
+        </div>
+      </div>
+      <div class="d-image-grid" data-columns="2">
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/b1.png" data-lightbox-position="0"></a>
+          <a class="lightbox" href="/b3.png" data-lightbox-position="2"></a>
+        </div>
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/b2.png" data-lightbox-position="1"></a>
+          <a class="lightbox" href="/b4.png" data-lightbox-position="3"></a>
+        </div>
+      </div>
+    `;
+
+    const items = sortLightboxItems([
+      ...document.querySelectorAll(".lightbox"),
+    ]);
+
+    assert.deepEqual(
+      items.map((el) => el.getAttribute("href")),
+      [
+        "/a1.png",
+        "/a2.png",
+        "/a3.png",
+        "/a4.png",
+        "/b1.png",
+        "/b2.png",
+        "/b3.png",
+        "/b4.png",
+      ]
+    );
+  });
+
+  test("preserves grid DOM order when positions are missing", function (assert) {
+    document.getElementById("qunit-fixture").innerHTML = `
+      <div class="d-image-grid" data-columns="2">
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/1.png" data-lightbox-position="0"></a>
+          <a class="lightbox" href="/3.png" data-lightbox-position="2"></a>
+        </div>
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/2.png"></a>
+          <a class="lightbox" href="/4.png" data-lightbox-position="3"></a>
+        </div>
+      </div>
+    `;
+
+    const items = sortLightboxItems([
+      ...document.querySelectorAll(".lightbox"),
+    ]);
+
+    assert.deepEqual(
+      items.map((el) => el.getAttribute("href")),
+      ["/1.png", "/3.png", "/2.png", "/4.png"]
+    );
+  });
+
+  test("preserves grid DOM order when positions are invalid", function (assert) {
+    document.getElementById("qunit-fixture").innerHTML = `
+      <div class="d-image-grid" data-columns="2">
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/1.png" data-lightbox-position="0"></a>
+          <a class="lightbox" href="/3.png" data-lightbox-position="2"></a>
+        </div>
+        <div class="d-image-grid-column">
+          <a class="lightbox" href="/2.png" data-lightbox-position="1x"></a>
+          <a class="lightbox" href="/4.png" data-lightbox-position="3"></a>
+        </div>
+      </div>
+    `;
+
+    const items = sortLightboxItems([
+      ...document.querySelectorAll(".lightbox"),
+    ]);
+
+    assert.deepEqual(
+      items.map((el) => el.getAttribute("href")),
+      ["/1.png", "/3.png", "/2.png", "/4.png"]
+    );
+  });
+});


### PR DESCRIPTION
Inside a `[grid]` block, the lightbox arrow navigation followed column-balanced DOM order instead of the original markdown order. For four images this resulted in 1, 3, 2, 4 because `Columns` distributes items by height into the shortest column.

`lightbox.js` collects items via `querySelectorAll(".lightbox")`, which returns nodes in document order — the same scrambled order the layout algorithm produced.

`Columns` now tags each item with `data-lightbox-position` carrying its original index before reordering. A new `sortLightboxItems` helper in `lightbox.js` reorders items within each grid by that attribute before they reach PhotoSwipe. The existing RTL reverse continues to apply on top, so right-to-left navigation now mirrors logical order rather than the scrambled layout.

https://meta.discourse.org/t/402817