### PR TITLE
DEV: Move automatic `directory_columns` rows from migration to seed fixture

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1087,6 +1087,9 @@ users:
     default: 100
     hidden: true
     area: "users"
+  directory_columns_seeded:
+    default: false
+    hidden: true
   allow_anonymous_mode:
     default: false
     client: true

--- a/db/fixtures/008_directory_columns.rb
+++ b/db/fixtures/008_directory_columns.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+return if SiteSetting.directory_columns_seeded
+
+[
+  { name: "likes_received", position: 1, icon: "heart" },
+  { name: "likes_given", position: 2, icon: "heart" },
+  { name: "topic_count", position: 3, icon: nil },
+  { name: "post_count", position: 4, icon: nil },
+  { name: "topics_entered", position: 5, icon: nil },
+  { name: "posts_read", position: 6, icon: nil },
+  { name: "days_visited", position: 7, icon: nil },
+].each do |column|
+  DirectoryColumn.seed(:name) do |c|
+    c.name = column[:name]
+    c.automatic_position = column[:position]
+    c.position = column[:position]
+    c.icon = column[:icon]
+    c.enabled = true
+    c.type = DirectoryColumn.types[:automatic]
+  end
+end
+
+SiteSetting.directory_columns_seeded = true

--- a/db/migrate/20210527131318_create_directory_columns.rb
+++ b/db/migrate/20210527131318_create_directory_columns.rb
@@ -13,27 +13,9 @@ class CreateDirectoryColumns < ActiveRecord::Migration[6.1]
     end
 
     add_index :directory_columns, %i[enabled position user_field_id], name: "directory_column_index"
-
-    create_automatic_columns
   end
 
   def down
     drop_table :directory_columns
-  end
-
-  def create_automatic_columns
-    DB.exec(<<~SQL)
-      INSERT INTO directory_columns (
-        name, automatic, enabled, automatic_position, position, icon
-      )
-      VALUES
-        ( 'likes_received', true, true, 1, 1, 'heart' ),
-        ( 'likes_given', true, true, 2, 2, 'heart' ),
-        ( 'topic_count', true, true, 3, 3, NULL ),
-        ( 'post_count', true, true, 4, 4, NULL ),
-        ( 'topics_entered', true, true, 5, 5, NULL ),
-        ( 'posts_read', true, true, 6, 6, NULL ),
-        ( 'days_visited', true, true, 7, 7, NULL );
-      SQL
   end
 end

--- a/db/migrate/20260513101242_mark_existing_sites_directory_columns_seeded.rb
+++ b/db/migrate/20260513101242_mark_existing_sites_directory_columns_seeded.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class MarkExistingSitesDirectoryColumnsSeeded < ActiveRecord::Migration[8.0]
+  def up
+    return if Migration::Helpers.new_site?
+
+    execute(<<~SQL)
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      VALUES ('directory_columns_seeded', 5, 't', NOW(), NOW())
+      ON CONFLICT (name) DO UPDATE SET value = 't', updated_at = NOW()
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/db/migrate/20260513101242_mark_existing_sites_directory_columns_seeded_spec.rb
+++ b/spec/db/migrate/20260513101242_mark_existing_sites_directory_columns_seeded_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require Rails.root.join("db/migrate/20260513101242_mark_existing_sites_directory_columns_seeded.rb")
+
+RSpec.describe MarkExistingSitesDirectoryColumnsSeeded do
+  before do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after do
+    ActiveRecord::Migration.verbose = @original_verbose
+    Discourse.clear_site_creation_date_cache
+  end
+
+  it "is a no-op on fresh installs" do
+    DB.exec("UPDATE schema_migration_details SET created_at = NOW()")
+    Discourse.clear_site_creation_date_cache
+
+    expect { described_class.new.up }.not_to change {
+      DB.query_single(
+        "SELECT count(*) FROM site_settings WHERE name = 'directory_columns_seeded'",
+      ).first
+    }
+  end
+
+  context "when the site is an existing install" do
+    before do
+      DB.exec("UPDATE schema_migration_details SET created_at = NOW() - INTERVAL '2 hours'")
+      Discourse.clear_site_creation_date_cache
+    end
+
+    it "flips directory_columns_seeded to true so the seed bails on the next deploy" do
+      described_class.new.up
+
+      row = DB.query("SELECT value FROM site_settings WHERE name = 'directory_columns_seeded'")[0]
+      expect(row.value).to eq("t")
+    end
+  end
+end


### PR DESCRIPTION


Previously, `20210527131318_create_directory_columns.rb` both created the table and inserted the seven default automatic columns, mixing schema and data in a single migration.

This change moves the rows to `db/fixtures/008_directory_columns.rb`, gated by a hidden `directory_columns_seeded` site setting so admin customizations (renamed, reordered, or disabled columns) survive subsequent `db:seed` runs. A companion `20260513101242_mark_existing_sites_directory_columns_seeded.rb` flips the flag on existing sites so the seed bails immediately on the upgrade deploy.

Extracted from https://github.com/discourse/discourse/pull/39788.