### PR TITLE
DEV: Skip Uncategorized insert in `add_uncategorized_category` on fresh installs

### DIFF
--- a/db/fixtures/500_categories.rb
+++ b/db/fixtures/500_categories.rb
@@ -2,4 +2,9 @@
 
 require "seed_data/categories"
 
-SeedData::Categories.with_default_locale.create if !Rails.env.test?
+if Rails.env.test?
+  # Tests need the Uncategorized category, but none of the others.
+  SeedData::Categories.with_default_locale.create(site_setting_names: ["uncategorized_category_id"])
+else
+  SeedData::Categories.with_default_locale.create
+end

--- a/db/migrate/20131022045114_add_uncategorized_category.rb
+++ b/db/migrate/20131022045114_add_uncategorized_category.rb
@@ -2,24 +2,31 @@
 
 class AddUncategorizedCategory < ActiveRecord::Migration[4.2]
   def up
-    result = execute "SELECT 1 FROM categories WHERE lower(name) = 'uncategorized'"
-    name = +"Uncategorized"
-    name << SecureRandom.hex if result.count > 0
+    needs_uncategorized =
+      execute(
+        "SELECT 1 FROM topics WHERE archetype = 'regular' AND category_id IS NULL LIMIT 1",
+      ).any?
 
-    result =
-      execute "INSERT INTO categories
-            (name,color,slug,description,text_color, user_id, created_at, updated_at, position)
-     VALUES ('#{name}', '0088CC', 'uncategorized', '', 'FFFFFF', -1, now(), now(), 0 )
-     RETURNING id
-    "
-    category_id = result[0]["id"].to_i
+    if needs_uncategorized
+      result = execute "SELECT 1 FROM categories WHERE lower(name) = 'uncategorized'"
+      name = +"Uncategorized"
+      name << SecureRandom.hex if result.count > 0
 
-    execute "INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
-             VALUES ('uncategorized_category_id', 3, #{category_id}, now(), now())"
+      result =
+        execute "INSERT INTO categories
+              (name,color,slug,description,text_color, user_id, created_at, updated_at, position)
+       VALUES ('#{name}', '0088CC', 'uncategorized', '', 'FFFFFF', -1, now(), now(), 0 )
+       RETURNING id
+      "
+      category_id = result[0]["id"].to_i
 
-    execute "DELETE from site_settings where name in ('uncategorized_name', 'uncategorized_text_color', 'uncategorized_color')"
+      execute "INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+               VALUES ('uncategorized_category_id', 3, #{category_id}, now(), now())"
 
-    execute "UPDATE topics SET category_id = #{category_id} WHERE archetype = 'regular' AND category_id IS NULL"
+      execute "DELETE from site_settings where name in ('uncategorized_name', 'uncategorized_text_color', 'uncategorized_color')"
+
+      execute "UPDATE topics SET category_id = #{category_id} WHERE archetype = 'regular' AND category_id IS NULL"
+    end
 
     execute "ALTER table topics ADD CONSTRAINT has_category_id CHECK (category_id IS NOT NULL OR archetype <> 'regular')"
   end

--- a/db/migrate/20140715190552_remove_uncategorized_parents.rb
+++ b/db/migrate/20140715190552_remove_uncategorized_parents.rb
@@ -3,8 +3,9 @@
 class RemoveUncategorizedParents < ActiveRecord::Migration[4.2]
   def up
     uncat = execute("SELECT value FROM site_settings WHERE name = 'uncategorized_category_id'")
-    if uncat && uncat[0] && uncat[0]["value"]
-      execute "UPDATE categories SET parent_category_id = NULL where id = #{uncat[0]["value"].to_i}"
+    row = uncat.first if uncat && uncat.ntuples > 0
+    if row && row["value"]
+      execute "UPDATE categories SET parent_category_id = NULL where id = #{row["value"].to_i}"
     end
   end
 

--- a/db/migrate/20150818190757_create_embeddable_hosts.rb
+++ b/db/migrate/20150818190757_create_embeddable_hosts.rb
@@ -19,10 +19,9 @@ class CreateEmbeddableHosts < ActiveRecord::Migration[4.2]
     category_id = category_row[0]["id"].to_i if category_row.cmd_tuples > 0
 
     if category_id == 0
-      category_id =
-        execute("SELECT value FROM site_settings WHERE name = 'uncategorized_category_id'")[0][
-          "value"
-        ].to_i
+      uncategorized =
+        execute("SELECT value FROM site_settings WHERE name = 'uncategorized_category_id'")
+      category_id = uncategorized[0]["value"].to_i if uncategorized.cmd_tuples > 0
     end
 
     embeddable_hosts = execute("SELECT value FROM site_settings WHERE name = 'embeddable_hosts'")


### PR DESCRIPTION


Previously, `20131022045114_add_uncategorized_category.rb` always created an Uncategorized category and wrote the matching `uncategorized_category_id` site setting, duplicating work that `db/fixtures/500_categories.rb` (via `SeedData::Categories`) already does on every fresh install.

This change gates the insert/update block on whether any category-less regular topics exist — the only case where the migration genuinely needs to backfill before the CHECK constraint can be added. The `ALTER TABLE … ADD CONSTRAINT has_category_id` still runs unconditionally so the schema is identical on both paths.

Two later migrations (`20140715190552_remove_uncategorized_parents.rb` and `20150818190757_create_embeddable_hosts.rb`) read `uncategorized_category_id` via `PG::Result#[](0)`, which raises `IndexError` rather than returning `nil` when the row is missing — previously dormant because the original migration always wrote the setting. They are updated here to guard with `cmd_tuples`/`ntuples` before indexing.

Extracted from https://github.com/discourse/discourse/pull/39788.