### PR TITLE
DEV: Force `new_site?` to true in `PopulateImageQualitySetting` fresh-install spec

### DIFF
--- a/spec/db/migrate/20251024015907_populate_image_quality_setting_spec.rb
+++ b/spec/db/migrate/20251024015907_populate_image_quality_setting_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe PopulateImageQualitySetting do
   end
 
   it "is a no-op on fresh installs" do
+    DB.exec("UPDATE schema_migration_details SET created_at = NOW()")
+    Discourse.clear_site_creation_date_cache
+
     expect { PopulateImageQualitySetting.new.up }.not_to change {
       DB.query_single("SELECT count(*) FROM site_settings WHERE name = 'image_quality'").first
     }


### PR DESCRIPTION
Previously, the "is a no-op on fresh installs" example relied on the test database being less than an hour old.

This change forces `schema_migration_details.created_at` to `NOW()`, so that the spec will be reliable.