### PR TITLE
DEV: Move Community sidebar section + links from migrations to seed fixture

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3350,6 +3350,9 @@ navigation:
       - "top"
       - "bottom"
     area: "navigation"
+  sidebar_seeded:
+    default: false
+    hidden: true
 
 embedding:
   embed_full_app:

--- a/db/fixtures/700_sidebar.rb
+++ b/db/fixtures/700_sidebar.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+return if SiteSetting.sidebar_seeded
+
+community_section =
+  SidebarSection
+    .seed(:section_type) do |s|
+      s.user_id = Discourse::SYSTEM_USER_ID
+      s.title = "Community"
+      s.public = true
+      s.section_type = SidebarSection.section_types[:community]
+    end
+    .first
+
+SidebarUrl::COMMUNITY_SECTION_LINKS.each_with_index do |link, position|
+  url =
+    SidebarUrl
+      .seed(:value, :name) do |u|
+        u.name = link[:name]
+        u.value = link[:path]
+        u.icon = link[:icon]
+        u.segment = link[:segment]
+        u.external = false
+      end
+      .first
+
+  SidebarSectionLink.seed(:sidebar_section_id, :linkable_type, :linkable_id) do |l|
+    l.user_id = Discourse::SYSTEM_USER_ID
+    l.linkable_id = url.id
+    l.linkable_type = "SidebarUrl"
+    l.sidebar_section_id = community_section.id
+    l.position = position
+  end
+end
+
+SiteSetting.sidebar_seeded = true

--- a/db/migrate/20230411032053_insert_community_to_sidebar_sections.rb
+++ b/db/migrate/20230411032053_insert_community_to_sidebar_sections.rb
@@ -13,6 +13,8 @@ class InsertCommunityToSidebarSections < ActiveRecord::Migration[7.0]
     { name: "Badges", path: "/badges", icon: "certificate", segment: 1 },
   ]
   def up
+    return if Migration::Helpers.new_site?
+
     result = DB.query <<~SQL
       INSERT INTO sidebar_sections(user_id, title, public, section_type, created_at, updated_at)
       VALUES (-1, 'Community', true, 0, now(), now())

--- a/db/migrate/20241025045928_add_invites_link_to_sidebar.rb
+++ b/db/migrate/20241025045928_add_invites_link_to_sidebar.rb
@@ -2,6 +2,8 @@
 
 class AddInvitesLinkToSidebar < ActiveRecord::Migration[7.1]
   def up
+    return if Migration::Helpers.new_site?
+
     community_section_id = DB.query_single(<<~SQL).first
       SELECT id
       FROM sidebar_sections

--- a/db/migrate/20250626090725_add_my_messages_link_to_sidebar.rb
+++ b/db/migrate/20250626090725_add_my_messages_link_to_sidebar.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class AddMyMessagesLinkToSidebar < ActiveRecord::Migration[7.2]
   def up
+    return if Migration::Helpers.new_site?
+
     # Find the community sidebar section
     community_section =
       DB.query_single(

--- a/db/migrate/20250721043317_add_filter_link_to_sidebar.rb
+++ b/db/migrate/20250721043317_add_filter_link_to_sidebar.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class AddFilterLinkToSidebar < ActiveRecord::Migration[7.0]
   def up
+    return if Migration::Helpers.new_site?
+
     # Find the community section
     community_section_id = execute(<<~SQL).first&.fetch("id")
       SELECT id FROM sidebar_sections WHERE section_type = 0 LIMIT 1

--- a/db/migrate/20260513105516_mark_existing_sites_sidebar_seeded.rb
+++ b/db/migrate/20260513105516_mark_existing_sites_sidebar_seeded.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class MarkExistingSitesSidebarSeeded < ActiveRecord::Migration[8.0]
+  def up
+    return if Migration::Helpers.new_site?
+
+    execute(<<~SQL)
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      VALUES ('sidebar_seeded', 5, 't', NOW(), NOW())
+      ON CONFLICT (name) DO UPDATE SET value = 't', updated_at = NOW()
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/spec/db/migrate/20260513105516_mark_existing_sites_sidebar_seeded_spec.rb
+++ b/spec/db/migrate/20260513105516_mark_existing_sites_sidebar_seeded_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require Rails.root.join("db/migrate/20260513105516_mark_existing_sites_sidebar_seeded.rb")
+
+RSpec.describe MarkExistingSitesSidebarSeeded do
+  before do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after do
+    ActiveRecord::Migration.verbose = @original_verbose
+    Discourse.clear_site_creation_date_cache
+  end
+
+  it "is a no-op on fresh installs" do
+    DB.exec("UPDATE schema_migration_details SET created_at = NOW()")
+    Discourse.clear_site_creation_date_cache
+
+    expect { described_class.new.up }.not_to change {
+      DB.query_single("SELECT count(*) FROM site_settings WHERE name = 'sidebar_seeded'").first
+    }
+  end
+
+  context "when the site is an existing install" do
+    before do
+      DB.exec("UPDATE schema_migration_details SET created_at = NOW() - INTERVAL '2 hours'")
+      Discourse.clear_site_creation_date_cache
+    end
+
+    it "flips sidebar_seeded to true so the seed bails on the next deploy" do
+      described_class.new.up
+
+      row = DB.query("SELECT value FROM site_settings WHERE name = 'sidebar_seeded'")[0]
+      expect(row.value).to eq("t")
+    end
+  end
+end


### PR DESCRIPTION


Previously, the Community sidebar section, its 12 default URLs, and the links binding them were inserted across four migrations (`20230411032053_insert_community_to_sidebar_sections.rb`, `20241025045928_add_invites_link_to_sidebar.rb`, `20250626090725_add_my_messages_link_to_sidebar.rb`, `20250721043317_add_filter_link_to_sidebar.rb`), mixing schema and data and re-running data inserts every time a new link was added.

This change moves the rows to `db/fixtures/700_sidebar.rb`, gated by a hidden `sidebar_seeded` site setting so admin customizations (renamed links, reordering, even destroying the public Community section via `sidebar_sections_controller#destroy`) survive subsequent `db:seed` runs. The fixture iterates `SidebarUrl::COMMUNITY_SECTION_LINKS` so adding a future link is a one-line model change plus a re-seed.

The four existing migrations are gated on `Migration::Helpers.new_site?` so they continue to upgrade existing sites past the point the link didn't yet exist, but no-op on fresh installs (where the fixture is the source of truth). A companion `20260513105516_mark_existing_sites_sidebar_seeded.rb` flips the flag for existing sites so the seed bails immediately on the upgrade deploy.

Extracted from https://github.com/discourse/discourse/pull/39788.