### PR TITLE
FIX: Allow selecting synonyms in composer tag chooser

### DIFF
--- a/app/assets/stylesheets/common/select-kit/tag-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/tag-chooser.scss
@@ -5,14 +5,19 @@
     .select-kit-row {
       display: flex;
       align-items: baseline;
+      flex-wrap: wrap;
 
       .discourse-tag-count {
         margin-left: 5px;
       }
 
+      .synonym-hint {
+        margin-left: 0.5em;
+        color: var(--primary-medium);
+      }
+
       &.disabled {
         opacity: 1;
-        flex-wrap: wrap;
 
         .discourse-tag {
           opacity: 0.5;

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -472,7 +472,9 @@ class TopicsController < ApplicationController
     changes.delete(:title) if topic.title == changes[:title]
     changes.delete(:category_id) if topic.category_id.to_i == changes[:category_id].to_i
 
-    if Tag.include_tags? && changes.has_key?(:tags)
+    tags_submitted = Tag.include_tags? && changes.has_key?(:tags)
+
+    if tags_submitted
       if changes[:tags].present?
         incoming = changes[:tags]
 
@@ -482,13 +484,9 @@ class TopicsController < ApplicationController
             since: "2026.01",
             drop_from: "2026.07",
           )
-          changes.delete(:tags) if incoming.sort == topic.tags.map(&:name).sort
-        else
-          has_new = incoming.any? { |t| t[:id].blank? }
-          if !has_new && incoming.filter_map { |t| t[:id]&.to_i }.sort == topic.tags.pluck(:id).sort
-            changes.delete(:tags)
-          end
         end
+
+        changes.delete(:tags) if PostRevisor.tag_change_noop?(topic, incoming)
 
         # resolve to name strings before passing to PostRevisor
         changes[:tags] = resolve_tag_names(topic) if changes.has_key?(:tags)
@@ -513,7 +511,13 @@ class TopicsController < ApplicationController
     end
 
     # this is used to return the title to the client as it may have been changed by "TextCleaner"
-    success ? render_serialized(topic, BasicTopicSerializer) : render_json_error(topic)
+    if !success
+      render_json_error(topic)
+    elsif tags_submitted
+      render_topic_with_tags(topic)
+    else
+      render_serialized(topic, BasicTopicSerializer)
+    end
   end
 
   def update_tags
@@ -535,11 +539,16 @@ class TopicsController < ApplicationController
       )
     end
 
-    revisor = PostRevisor.new(topic.first_post, topic)
-    revised = revisor.revise!(current_user, { tags: }, validate_post: false)
+    unless PostRevisor.tag_change_noop?(topic, tags)
+      PostRevisor.new(topic.first_post, topic).revise!(
+        current_user,
+        { tags: },
+        validate_post: false,
+      )
+    end
 
-    if revised || topic.errors.blank?
-      render_serialized(topic, BasicTopicSerializer)
+    if topic.errors.blank?
+      render_topic_with_tags(topic)
     else
       render_json_error(topic)
     end
@@ -1341,6 +1350,14 @@ class TopicsController < ApplicationController
   end
 
   private
+
+  def render_topic_with_tags(topic)
+    payload = serialize_data(topic, BasicTopicSerializer)
+    payload[:tags] = topic
+      .visible_tags(guardian)
+      .map { |t| { id: t.id, name: t.name, slug: t.slug_for_url } }
+    render_json_dump(payload)
+  end
 
   def resolve_tag_names(topic)
     @resolved_tag_names ||=

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5633,6 +5633,7 @@ en:
       synonyms: "Synonyms"
       synonyms_description: "When the following tags are used, they will be replaced with <b>%{base_tag_name}</b>."
       synonyms_inline: "These synonyms will be replaced with %{base_tag_name}:"
+      synonym_hint: "→ %{tag_name}"
       save: "Save name and description of the tag"
       tag_groups_info:
         one: 'This tag belongs to the group "%{tag_groups}".'

--- a/frontend/discourse/app/models/topic.js
+++ b/frontend/discourse/app/models/topic.js
@@ -122,6 +122,9 @@ export default class Topic extends RestModel {
       // The title can be cleaned up server side
       props.title = result.basic_topic.title;
       props.fancy_title = result.basic_topic.fancy_title;
+      if (result.tags) {
+        props.tags = result.tags;
+      }
       if (topic.is_shared_draft) {
         props.destination_category_id = props.category_id;
         delete props.category_id;
@@ -1093,6 +1096,11 @@ export default class Topic extends RestModel {
     return ajax(`/t/${this.id}/tags`, {
       type: "PUT",
       data: { tags: tags || [] },
+    }).then((result) => {
+      if (result?.tags) {
+        this.set("tags", result.tags);
+      }
+      return result;
     });
   }
 }

--- a/frontend/discourse/select-kit/components/mini-tag-chooser.js
+++ b/frontend/discourse/select-kit/components/mini-tag-chooser.js
@@ -169,7 +169,6 @@ export default class MiniTagChooser extends MultiSelectComponent {
 
     if (!this.selectKit.options.everyTag) {
       data.filterForInput = true;
-      data.excludeSynonyms = true;
     }
 
     return this.tagUtils.searchTags(

--- a/frontend/discourse/select-kit/components/tag-row.gjs
+++ b/frontend/discourse/select-kit/components/tag-row.gjs
@@ -2,6 +2,7 @@ import { computed } from "@ember/object";
 import { classNames } from "@ember-decorators/component";
 import SelectKitRowComponent from "discourse/select-kit/components/select-kit/select-kit-row";
 import dDiscourseTag from "discourse/ui-kit/helpers/d-discourse-tag";
+import { i18n } from "discourse-i18n";
 
 @classNames("tag-row")
 export default class TagRow extends SelectKitRowComponent {
@@ -20,6 +21,10 @@ export default class TagRow extends SelectKitRowComponent {
       }}
       {{#if this.rowDisabled}}
         <span class="disabled-reason">{{this.title}}</span>
+      {{else if this.item.target_tag}}
+        <span class="synonym-hint">
+          {{i18n "tagging.synonym_hint" tag_name=this.item.target_tag.name}}
+        </span>
       {{/if}}
     {{else}}
       <span class="name">{{this.rowName}}</span>

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -243,6 +243,25 @@ class PostRevisor
     tag_list.sort.map { |tag_name| "##{tag_name}" }.join(", ")
   end
 
+  def self.tag_change_noop?(topic, incoming)
+    return topic.tags.empty? if incoming.blank?
+
+    ids =
+      if incoming.first.is_a?(String)
+        unique_names = incoming.map(&:downcase).uniq
+        found = Tag.where_name(unique_names).pluck(:id)
+        return false if found.size != unique_names.size
+        found
+      else
+        return false if incoming.any? { |t| t[:id].blank? }
+        incoming.filter_map { |t| t[:id]&.to_i }
+      end
+    return false if ids.blank?
+
+    canonical_ids = Tag.where(id: ids).pluck(Arel.sql("COALESCE(target_tag_id, id)")).uniq.sort
+    canonical_ids == topic.tags.pluck(:id).sort
+  end
+
   # Revises a post with the given fields and options.
   #
   # @param editor [User] The user performing the revision
@@ -268,7 +287,9 @@ class PostRevisor
     @fields[:raw] = cleanup_whitespaces(@fields[:raw]) if @fields.has_key?(:raw)
     @fields[:user_id] = @fields[:user_id].to_i if @fields.has_key?(:user_id)
     @fields[:category_id] = @fields[:category_id].to_i if @fields.has_key?(:category_id)
-    @fields.delete(:tags) if @fields.has_key?(:tags) && @fields[:tags].blank? && @topic.tags.empty?
+    if @fields.has_key?(:tags) && PostRevisor.tag_change_noop?(@topic, @fields[:tags])
+      @fields.delete(:tags)
+    end
 
     if @fields.has_key?(:reply_to_post_number)
       normalized = @fields[:reply_to_post_number].presence

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -267,6 +267,36 @@ describe PostRevisor do
       expect(post.topic.reload.tags).to match_array([have_attributes(name: "a-whole-new-tag")])
     end
 
+    it "does not create an empty revision when only synonyms of existing tags are submitted" do
+      canonical = Fabricate(:tag, name: "apple-inc")
+      aapl = Fabricate(:tag, name: "aapl", target_tag: canonical)
+      appl = Fabricate(:tag, name: "appl", target_tag: canonical)
+      post.topic.tags << canonical
+
+      expect do
+        post_revisor.revise!(
+          admin,
+          tags: [
+            { id: aapl.id, name: "aapl" },
+            { id: appl.id, name: "appl" },
+            { id: canonical.id, name: "apple-inc" },
+          ],
+        )
+      end.not_to change { PostRevision.count }
+      expect(post.topic.reload.tags).to contain_exactly(canonical)
+    end
+
+    it "does not create an empty revision when synonym names are submitted as strings" do
+      canonical = Fabricate(:tag, name: "tesla-inc")
+      Fabricate(:tag, name: "tsla", target_tag: canonical)
+      post.topic.tags << canonical
+
+      expect do post_revisor.revise!(admin, tags: %w[tsla tesla-inc]) end.not_to change {
+        PostRevision.count
+      }
+      expect(post.topic.reload.tags).to contain_exactly(canonical)
+    end
+
     describe "when `create_post_for_category_and_tag_changes` site setting is enabled" do
       fab!(:tag1) { Fabricate(:tag, name: "First tag") }
       fab!(:tag2) { Fabricate(:tag, name: "Second tag") }

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2470,6 +2470,53 @@ RSpec.describe TopicsController do
 
               expect(response.status).to eq(200)
             end
+
+            it "returns canonical tags in the response when synonyms are submitted" do
+              canonical = Fabricate(:tag, name: "apple-inc")
+              Fabricate(:tag, name: "aapl", target_tag: canonical)
+              Fabricate(:tag, name: "appl", target_tag: canonical)
+
+              put "/t/#{topic.slug}/#{topic.id}.json", params: { tags: %w[aapl appl apple-inc] }
+
+              expect(response.status).to eq(200)
+              expect(response.parsed_body["tags"].map { |t| t["name"] }).to contain_exactly(
+                "apple-inc",
+              )
+              expect(topic.reload.tags.pluck(:name)).to contain_exactly("apple-inc")
+            end
+
+            it "does not include tags in the response when tags were not part of the update" do
+              put "/t/#{topic.slug}/#{topic.id}.json",
+                  params: {
+                    title: "This is a new title for the topic",
+                  }
+
+              expect(response.status).to eq(200)
+              expect(response.parsed_body).not_to have_key("tags")
+            end
+
+            it "does not create a revision when only synonyms of existing tags are submitted" do
+              canonical = Fabricate(:tag, name: "apple-inc")
+              aapl = Fabricate(:tag, name: "aapl", target_tag: canonical)
+              appl = Fabricate(:tag, name: "appl", target_tag: canonical)
+              topic.tags << canonical
+
+              expect do
+                put "/t/#{topic.slug}/#{topic.id}.json",
+                    params: {
+                      tags: [
+                        { id: aapl.id, name: "aapl" },
+                        { id: appl.id, name: "appl" },
+                        { id: canonical.id, name: "apple-inc" },
+                      ],
+                    }
+              end.not_to change { topic.reload.first_post.revisions.count }
+
+              expect(response.status).to eq(200)
+              expect(response.parsed_body["tags"].map { |t| t["name"] }).to contain_exactly(
+                "apple-inc",
+              )
+            end
           end
 
           it "returns success when updating with empty tags on a topic with no tags" do
@@ -2516,6 +2563,29 @@ RSpec.describe TopicsController do
 
             expect(response.status).to eq(200)
             expect(topic.reload.tags.pluck(:name)).to contain_exactly("brand-new")
+          end
+
+          it "returns canonical tags and skips revision when only synonyms are submitted" do
+            canonical = Fabricate(:tag, name: "apple-inc")
+            aapl = Fabricate(:tag, name: "aapl", target_tag: canonical)
+            appl = Fabricate(:tag, name: "appl", target_tag: canonical)
+            topic.tags << canonical
+
+            expect do
+              put "/t/#{topic.id}/tags.json",
+                  params: {
+                    tags: [
+                      { id: aapl.id, name: "aapl" },
+                      { id: appl.id, name: "appl" },
+                      { id: canonical.id, name: "apple-inc" },
+                    ],
+                  }
+            end.not_to change { topic.reload.first_post.revisions.count }
+
+            expect(response.status).to eq(200)
+            expect(response.parsed_body["tags"].map { |t| t["name"] }).to contain_exactly(
+              "apple-inc",
+            )
           end
 
           it "does not remove tag if no params is given" do

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -148,6 +148,24 @@ module PageObjects
         has_css?("#{@context}.is-expanded .select-kit-row.is-selected[data-name='#{name}']")
       end
 
+      def has_disabled_row_name?(name)
+        expanded_component
+        has_css?("#{@context}.is-expanded .select-kit-row.disabled[data-name='#{name}']")
+      end
+
+      def has_no_disabled_row_name?(name)
+        expanded_component
+        has_no_css?("#{@context}.is-expanded .select-kit-row.disabled[data-name='#{name}']")
+      end
+
+      def has_row_synonym_hint?(name, hint_text)
+        expanded_component
+        has_css?(
+          "#{@context}.is-expanded .select-kit-row[data-name='#{name}'] .synonym-hint",
+          text: hint_text,
+        )
+      end
+
       def has_no_selected_row?
         expanded_component
         has_no_css?("#{@context}.is-expanded .select-kit-row.is-selected")

--- a/spec/system/tags/tag_search_hints_spec.rb
+++ b/spec/system/tags/tag_search_hints_spec.rb
@@ -32,9 +32,7 @@ describe "Tag search hints in composer" do
       tag_chooser.expand
       tag_chooser.search("ready-to-deploy")
 
-      expect(page).to have_css(
-        ".mini-tag-chooser .select-kit-row.disabled[data-name='ready-to-deploy']",
-      )
+      expect(tag_chooser).to have_disabled_row_name("ready-to-deploy")
     end
   end
 
@@ -55,7 +53,25 @@ describe "Tag search hints in composer" do
       tag_chooser.expand
       tag_chooser.search("sedan")
 
-      expect(page).to have_css(".mini-tag-chooser .select-kit-row.disabled[data-name='sedan']")
+      expect(tag_chooser).to have_disabled_row_name("sedan")
+    end
+  end
+
+  context "with a synonym tag" do
+    fab!(:apple_tag) { Fabricate(:tag, name: "apple-inc") }
+    fab!(:aapl_tag) { Fabricate(:tag, name: "aapl", target_tag: apple_tag) }
+
+    it "shows the synonym as selectable with a hint pointing to the target tag" do
+      sign_in(admin)
+      visit "/new-topic"
+      expect(composer).to be_opened
+
+      tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
+      tag_chooser.expand
+      tag_chooser.search("aapl")
+
+      expect(tag_chooser).to have_no_disabled_row_name("aapl")
+      expect(tag_chooser).to have_row_synonym_hint("aapl", "→ apple-inc")
     end
   end
 end


### PR DESCRIPTION
A recent change (#39072) made the composer tag autocomplete pass `excludeSynonyms: true` so synonyms appeared as disabled rows with a "Use canonical X instead" message. That blocked a legitimate workflow: a forum where company names are the canonical tags and stock tickers are the synonyms, so members can type the shorter ticker. The backend has always remapped synonym names to their canonical target at save time, so blocking the selection in the UI was overzealous.

This change keeps the disabled-row UX in admin surfaces where synonyms genuinely can't be the target (tag groups form, embedding hosts, webhooks, edit-category-tags, upsert-category/tags) — those still explicitly pass `excludeSynonyms: true`. In the composer (mini-tag- chooser) synonyms are now selectable, and the row shows an inline "→ canonical-tag" hint so the user understands what their typed tag will become.

Fixing the autocomplete surfaced two latent bugs that the previous block had been masking:

1. After saving, the topic header kept showing the typed synonym names until a full page reload, because the response of `TopicsController#update` and `#update_tags` only returned the `BasicTopicSerializer` fields (no tags), and the client used its in-memory pre-save tag list to update `topic.tags`. Both endpoints now include the canonical `tags` array in the response whenever tags were part of the request, and `Topic.update` / `Topic.updateTags` on the client overwrite `topic.tags` with that list.

2. Submitting only synonyms of existing tags created an empty `PostRevision` row. The controller's no-op detector compared raw tag IDs, so synonym IDs always looked like a change. `PostRevisor` would start a revision, `apply_tag_changes` would bail out after the canonical remap matched the existing set, but the bumped version and empty revision row had already been written. This is fixed at the PostRevisor level via a new `tag_change_noop?` class method that resolves incoming tag IDs/names through `COALESCE(target_tag_id, id)` and compares the canonical set with `topic.tags`. When it matches, `revise!` deletes `:tags` from `@fields` during normalization, so `should_revise?` correctly short-circuits before any version bump. The same helper replaces the controller-level no-op check and also subsumes the existing "empty tags on empty topic" branch.

Specs cover: synonym row appears selectable with the hint, server returns canonical tags after a synonym submission, no revision is created when only synonyms of existing tags are submitted (object and string forms), and the existing disabled-row UX still applies for `one_per_topic` and parent-tag groups.