### PR TITLE
DEV: Allow loading specific plugins in development

### DIFF
--- a/app/models/global_setting.rb
+++ b/app/models/global_setting.rb
@@ -388,14 +388,29 @@ class GlobalSetting
   end
 
   def self.load_plugins?
-    if ENV["LOAD_PLUGINS"] == "1"
-      true
-    elsif ENV["LOAD_PLUGINS"] == "0"
-      false
-    elsif Rails.env.test?
-      false
+    load_plugins_filter != :none
+  end
+
+  def self.plugins_to_load
+    filter = load_plugins_filter
+    filter.is_a?(Array) ? filter : nil
+  end
+
+  # Returns `:all`, `:none`, or an array of plugin directory names.
+  def self.load_plugins_filter
+    case ENV["LOAD_PLUGINS"]
+    when "0"
+      :none
+    when "1"
+      :all
+    when nil, ""
+      Rails.env.test? ? :none : :all
     else
-      true
+      unless Rails.env.local?
+        raise "LOAD_PLUGINS=#{ENV["LOAD_PLUGINS"].inspect} is only supported in development/test"
+      end
+      ENV["LOAD_PLUGINS"].split(",").map { |p| File.basename(p.strip) }.reject(&:empty?)
     end
   end
+  private_class_method :load_plugins_filter
 end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -133,15 +133,22 @@ class SiteSetting < ActiveRecord::Base
   end
 
   if GlobalSetting.load_plugins?
+    allowed_plugins = GlobalSetting.plugins_to_load
+    plugin_allowed = ->(name) { allowed_plugins.nil? || allowed_plugins.include?(name) }
+
     Dir[File.join(Rails.root, "plugins", "*", "config", "settings.yml")].each do |file|
-      load_settings(file, plugin: file.split("/")[-3])
+      plugin_name = file.split("/")[-3]
+      load_settings(file, plugin: plugin_name) if plugin_allowed.call(plugin_name)
     end
 
     # Sometimes plugins need to define their own fake site settings for testing
     if Rails.env.test?
       Dir[
         File.join(Rails.root, "plugins", "*", "spec", "support", "dummy_plugin_site_settings.yml")
-      ].each { |file| load_settings(file, plugin: file.split("/")[-4]) }
+      ].each do |file|
+        plugin_name = file.split("/")[-4]
+        load_settings(file, plugin: plugin_name) if plugin_allowed.call(plugin_name)
+      end
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,8 +20,9 @@ if GlobalSetting.load_plugins?
   # Support for plugins to register custom setting providers. They can do this
   # by having a file, `register_provider.rb` in their root that will be run
   # at this point.
-
+  allowed_plugins = GlobalSetting.plugins_to_load
   Dir.glob(File.join(File.dirname(__FILE__), "../plugins", "*", "register_provider.rb")) do |p|
+    next if allowed_plugins && !allowed_plugins.include?(File.basename(File.dirname(p)))
     require p
   end
 end

--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -242,9 +242,7 @@ class DiscoursePluginRegistry
 
   def self.seed_paths
     result = SeedFu.fixture_paths.dup
-    unless Rails.env.test? && ENV["LOAD_PLUGINS"] != "1"
-      seed_path_builders.each { |b| result += b.call }
-    end
+    seed_path_builders.each { |b| result += b.call } if GlobalSetting.load_plugins?
     result.uniq
   end
 

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -94,9 +94,13 @@ class Plugin::Instance
   end
 
   def self.find_all(parent_path)
+    allowed = GlobalSetting.plugins_to_load
     [].tap do |plugins|
       # also follows symlinks - http://stackoverflow.com/q/357754
-      Dir["#{parent_path}/*/plugin.rb"].sort.each { |path| plugins << parse_from_source(path) }
+      Dir["#{parent_path}/*/plugin.rb"].sort.each do |path|
+        next if allowed && !allowed.include?(File.basename(File.dirname(path)))
+        plugins << parse_from_source(path)
+      end
     end
   end
 

--- a/spec/models/global_setting_spec.rb
+++ b/spec/models/global_setting_spec.rb
@@ -179,4 +179,43 @@ RSpec.describe GlobalSetting::FileProvider do
 
     f.unlink
   end
+
+  describe ".load_plugins? and .plugins_to_load" do
+    around do |example|
+      original = ENV["LOAD_PLUGINS"]
+      example.run
+    ensure
+      original.nil? ? ENV.delete("LOAD_PLUGINS") : ENV["LOAD_PLUGINS"] = original
+    end
+
+    it "treats `1` as load-all" do
+      ENV["LOAD_PLUGINS"] = "1"
+      expect(GlobalSetting.load_plugins?).to eq(true)
+      expect(GlobalSetting.plugins_to_load).to be_nil
+    end
+
+    it "treats `0` as load-none" do
+      ENV["LOAD_PLUGINS"] = "0"
+      expect(GlobalSetting.load_plugins?).to eq(false)
+      expect(GlobalSetting.plugins_to_load).to be_nil
+    end
+
+    it "parses a comma-separated list, stripping whitespace and empty entries" do
+      ENV["LOAD_PLUGINS"] = "  chat , automation ,, "
+      expect(GlobalSetting.load_plugins?).to eq(true)
+      expect(GlobalSetting.plugins_to_load).to eq(%w[chat automation])
+    end
+
+    it "tolerates `plugins/foo` entries by taking the basename" do
+      ENV["LOAD_PLUGINS"] = "plugins/chat,plugins/automation"
+      expect(GlobalSetting.plugins_to_load).to eq(%w[chat automation])
+    end
+
+    it "raises when given a list outside of dev/test" do
+      ENV["LOAD_PLUGINS"] = "chat,automation"
+      allow(Rails.env).to receive(:local?).and_return(false)
+      expect { GlobalSetting.load_plugins? }.to raise_error(RuntimeError, /only supported/)
+      expect { GlobalSetting.plugins_to_load }.to raise_error(RuntimeError, /only supported/)
+    end
+  end
 end


### PR DESCRIPTION
`LOAD_PLUGINS` now accepts a comma-separated list of plugin directory names (e.g. `LOAD_PLUGINS="chat,automation"`) in addition to the existing `0` / `1` values. Production still only accepts `0` or `1`; anything else raises.

This lets tasks that need a deterministic plugin set (like `db:dump_structure`) run regardless of which extra plugins happen to be checked out under `plugins/`.

This is primarily intended for use in #39788, so that people can generate `structure.sql` without having to carefully prune their plugin directories.