### PR TITLE
DEV: Skip backfill INSERTs in old migrations on fresh installs

### DIFF
--- a/db/fixtures/990_settings.rb
+++ b/db/fixtures/990_settings.rb
@@ -10,3 +10,5 @@ if SiteSetting.notification_email == SiteSetting.defaults[:notification_email]
     end
   end
 end
+
+SiteSetting.api_key_last_used_epoch = Time.now if SiteSetting.api_key_last_used_epoch.blank?

--- a/db/migrate/20191101113230_add_revoked_at_to_api_key.rb
+++ b/db/migrate/20191101113230_add_revoked_at_to_api_key.rb
@@ -4,9 +4,6 @@ class AddRevokedAtToApiKey < ActiveRecord::Migration[5.2]
     add_column :api_keys, :revoked_at, :datetime
     add_column :api_keys, :description, :text
 
-    execute "INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
-             VALUES ('api_key_last_used_epoch', 1, now(), now(), now())"
-
     remove_index :api_keys, :user_id # Remove unique index
     add_index :api_keys, :user_id
   end

--- a/db/migrate/20220825054405_fill_personal_message_enabled_groups_based_on_deprecated_settings.rb
+++ b/db/migrate/20220825054405_fill_personal_message_enabled_groups_based_on_deprecated_settings.rb
@@ -2,6 +2,8 @@
 
 class FillPersonalMessageEnabledGroupsBasedOnDeprecatedSettings < ActiveRecord::Migration[7.0]
   def up
+    return if Migration::Helpers.new_site?
+
     enable_personal_messages_raw =
       DB.query_single(
         "SELECT value FROM site_settings WHERE name = 'enable_personal_messages'",

--- a/db/migrate/20260424004343_ensure_anonymous_and_logged_in_users_auto_groups.rb
+++ b/db/migrate/20260424004343_ensure_anonymous_and_logged_in_users_auto_groups.rb
@@ -38,18 +38,6 @@ class EnsureAnonymousAndLoggedInUsersAutoGroups < ActiveRecord::Migration[8.0]
         legacy_logged_in_users_group_id,
       )
     end
-
-    # The `anonymous` (id 4) and `logged_in_users` (id 5) auto groups are
-    # pseudogroups — they have no group_users rows; membership is implicit.
-    # Seed the rows here so callers that look them up by id don't fail before
-    # db/fixtures/002_groups.rb runs.
-    execute(<<~SQL)
-      INSERT INTO groups (id, name, automatic, visibility_level, created_at, updated_at)
-      VALUES
-        (4, 'anonymous', true, 3, NOW(), NOW()),
-        (5, 'logged_in_users', true, 3, NOW(), NOW())
-      ON CONFLICT (id) DO NOTHING
-    SQL
   end
 
   def down

--- a/plugins/chat/db/migrate/20240118120825_add_threads_enabled_site_setting.rb
+++ b/plugins/chat/db/migrate/20240118120825_add_threads_enabled_site_setting.rb
@@ -2,7 +2,13 @@
 
 class AddThreadsEnabledSiteSetting < ActiveRecord::Migration[7.0]
   def up
-    SiteSetting.chat_threads_enabled = false
+    return if Migration::Helpers.new_site?
+
+    execute(<<~SQL)
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      VALUES ('chat_threads_enabled', 5, 'f', NOW(), NOW())
+      ON CONFLICT (name) DO NOTHING
+    SQL
 
     threading_enabled_channels =
       DB.query_single("SELECT name FROM chat_channels WHERE threading_enabled = 't'")

--- a/plugins/discourse-assign/config/settings.yml
+++ b/plugins/discourse-assign/config/settings.yml
@@ -35,7 +35,7 @@ discourse_assign:
     client: true
     type: group_list
     list_type: compact
-    default: ""
+    default: "3"
     allow_any: false
     refresh: true
   enable_assign_status:

--- a/plugins/discourse-assign/db/migrate/20190718144722_set_assign_allowed_on_groups_default.rb
+++ b/plugins/discourse-assign/db/migrate/20190718144722_set_assign_allowed_on_groups_default.rb
@@ -2,6 +2,8 @@
 
 class SetAssignAllowedOnGroupsDefault < ActiveRecord::Migration[5.2]
   def up
+    return if Migration::Helpers.new_site?
+
     current_values =
       DB.query_single(
         "SELECT value FROM site_settings WHERE name = 'assign_allowed_on_groups'",


### PR DESCRIPTION
A handful of old migrations unconditionally inserted site_settings or groups rows that fresh installs already get from YAML defaults or seed fixtures. This change gates each on `Migration::Helpers.new_site?` (or drops the redundant insert entirely) so a fresh `db:migrate` leaves no application-level rows behind:

- `add_revoked_at_to_api_key.rb` no longer inserts `api_key_last_used_epoch`; `db/fixtures/990_settings.rb` now seeds it via `SiteSetting.api_key_last_used_epoch ||= Time.now`.
- `fill_personal_message_enabled_groups_based_on_deprecated_settings.rb` is gated; fresh installs use the YAML default.
- `ensure_anonymous_and_logged_in_users_auto_groups.rb` drops the `INSERT INTO groups (4, 5, ...)` block — `Group.ensure_automatic_groups!` in `db/fixtures/002_groups.rb` creates them. The legacy-group rename portion still runs unconditionally (no-op on fresh installs anyway).
- chat `add_threads_enabled_site_setting.rb` is gated and the unconditional `SiteSetting.chat_threads_enabled = false` is replaced with a raw `INSERT ... ON CONFLICT DO NOTHING` per the migration skill.
- discourse-assign `set_assign_allowed_on_groups_default.rb` is gated; the YAML `default` is bumped from `""` to `"3"` (`Group::AUTO_GROUPS[:staff]`) so fresh installs match what the migration would have written.

Extracted from https://github.com/discourse/discourse/pull/39788.