### PR TITLE
DEV: Always pass `--force` to annotaterb and reorder annotations

### DIFF
--- a/app/models/admin_notice.rb
+++ b/app/models/admin_notice.rb
@@ -27,15 +27,15 @@ end
 # Table name: admin_notices
 #
 #  id         :bigint           not null, primary key
-#  subject    :integer          not null
-#  priority   :integer          not null
-#  identifier :string           not null
 #  details    :json             not null
+#  identifier :string           not null
+#  priority   :integer          not null
+#  subject    :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 # Indexes
 #
-#  index_admin_notices_on_subject     (subject)
 #  index_admin_notices_on_identifier  (identifier)
+#  index_admin_notices_on_subject     (subject)
 #

--- a/app/models/allowed_pm_user.rb
+++ b/app/models/allowed_pm_user.rb
@@ -10,10 +10,10 @@ end
 # Table name: allowed_pm_users
 #
 #  id                 :bigint           not null, primary key
-#  user_id            :integer          not null
-#  allowed_pm_user_id :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  allowed_pm_user_id :integer          not null
+#  user_id            :integer          not null
 #
 # Indexes
 #

--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -10,11 +10,11 @@ end
 # Table name: anonymous_users
 #
 #  id             :bigint           not null, primary key
-#  user_id        :integer          not null
-#  master_user_id :integer          not null
 #  active         :boolean          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  master_user_id :integer          not null
+#  user_id        :integer          not null
 #
 # Indexes
 #

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -132,18 +132,18 @@ end
 # Table name: api_keys
 #
 #  id            :integer          not null, primary key
-#  user_id       :integer
-#  created_by_id :integer
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
 #  allowed_ips   :inet             is an Array
+#  description   :text
 #  hidden        :boolean          default(FALSE), not null
+#  key_hash      :string           not null
 #  last_used_at  :datetime
 #  revoked_at    :datetime
-#  description   :text
-#  key_hash      :string           not null
-#  truncated_key :string           not null
 #  scope_mode    :integer
+#  truncated_key :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  created_by_id :integer
+#  user_id       :integer
 #
 # Indexes
 #

--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -358,12 +358,12 @@ end
 # Table name: api_key_scopes
 #
 #  id                 :bigint           not null, primary key
-#  api_key_id         :integer          not null
-#  resource           :string           not null
 #  action             :string           not null
 #  allowed_parameters :json
+#  resource           :string           not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  api_key_id         :integer          not null
 #
 # Indexes
 #

--- a/app/models/application_request.rb
+++ b/app/models/application_request.rb
@@ -83,9 +83,9 @@ end
 # Table name: application_requests
 #
 #  id       :integer          not null, primary key
+#  count    :integer          default(0), not null
 #  date     :date             not null
 #  req_type :integer          not null
-#  count    :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/models/associated_group.rb
+++ b/app/models/associated_group.rb
@@ -27,12 +27,12 @@ end
 # Table name: associated_groups
 #
 #  id            :bigint           not null, primary key
+#  last_used     :datetime         not null
 #  name          :string           not null
 #  provider_name :string           not null
-#  provider_id   :string           not null
-#  last_used     :datetime         not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  provider_id   :string           not null
 #
 # Indexes
 #

--- a/app/models/backup_draft_post.rb
+++ b/app/models/backup_draft_post.rb
@@ -10,11 +10,11 @@ end
 # Table name: backup_draft_posts
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  post_id    :integer          not null
 #  key        :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  post_id    :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/backup_draft_topic.rb
+++ b/app/models/backup_draft_topic.rb
@@ -10,10 +10,10 @@ end
 # Table name: backup_draft_topics
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  topic_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  topic_id   :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -345,27 +345,27 @@ end
 # Table name: badges
 #
 #  id                  :integer          not null, primary key
-#  name                :string           not null
-#  description         :text
-#  badge_type_id       :integer          not null
-#  grant_count         :integer          default(0), not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
 #  allow_title         :boolean          default(FALSE), not null
-#  multiple_grant      :boolean          default(FALSE), not null
+#  auto_revoke         :boolean          default(TRUE), not null
+#  description         :text
+#  enabled             :boolean          default(TRUE), not null
+#  grant_count         :integer          default(0), not null
 #  icon                :string           default("certificate")
 #  listable            :boolean          default(TRUE)
-#  target_posts        :boolean          default(FALSE)
+#  long_description    :text
+#  multiple_grant      :boolean          default(FALSE), not null
+#  name                :string           not null
 #  query               :text
-#  enabled             :boolean          default(TRUE), not null
-#  auto_revoke         :boolean          default(TRUE), not null
-#  badge_grouping_id   :integer          default(5), not null
-#  trigger             :integer
+#  show_in_post_header :boolean          default(FALSE), not null
 #  show_posts          :boolean          default(FALSE), not null
 #  system              :boolean          default(FALSE), not null
-#  long_description    :text
+#  target_posts        :boolean          default(FALSE)
+#  trigger             :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  badge_grouping_id   :integer          default(5), not null
+#  badge_type_id       :integer          not null
 #  image_upload_id     :integer
-#  show_in_post_header :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/badge_grouping.rb
+++ b/app/models/badge_grouping.rb
@@ -26,8 +26,8 @@ end
 # Table name: badge_groupings
 #
 #  id          :integer          not null, primary key
-#  name        :string           not null
 #  description :text
+#  name        :string           not null
 #  position    :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -216,17 +216,17 @@ end
 # Table name: bookmarks
 #
 #  id                     :bigint           not null, primary key
-#  user_id                :bigint           not null
+#  auto_delete_preference :integer          default(0), not null
+#  bookmarkable_type      :string
 #  name                   :string(100)
+#  pinned                 :boolean          default(FALSE)
 #  reminder_at            :datetime
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
 #  reminder_last_sent_at  :datetime
 #  reminder_set_at        :datetime
-#  auto_delete_preference :integer          default(0), not null
-#  pinned                 :boolean          default(FALSE)
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #  bookmarkable_id        :bigint
-#  bookmarkable_type      :string
+#  user_id                :bigint           not null
 #
 # Indexes
 #

--- a/app/models/category_custom_field.rb
+++ b/app/models/category_custom_field.rb
@@ -11,11 +11,11 @@ end
 # Table name: category_custom_fields
 #
 #  id          :integer          not null, primary key
-#  category_id :integer          not null
 #  name        :string(256)      not null
 #  value       :text
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  category_id :integer          not null
 #
 # Indexes
 #

--- a/app/models/category_featured_topic.rb
+++ b/app/models/category_featured_topic.rb
@@ -83,12 +83,12 @@ end
 #
 # Table name: category_featured_topics
 #
-#  category_id :integer          not null
-#  topic_id    :integer          not null
+#  id          :integer          not null, primary key
+#  rank        :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  rank        :integer          default(0), not null
-#  id          :integer          not null, primary key
+#  category_id :integer          not null
+#  topic_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/category_form_template.rb
+++ b/app/models/category_form_template.rb
@@ -10,10 +10,10 @@ end
 # Table name: category_form_templates
 #
 #  id               :bigint           not null, primary key
-#  category_id      :bigint           not null
-#  form_template_id :bigint           not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  category_id      :bigint           not null
+#  form_template_id :bigint           not null
 #
 # Indexes
 #

--- a/app/models/category_group.rb
+++ b/app/models/category_group.rb
@@ -16,11 +16,11 @@ end
 # Table name: category_groups
 #
 #  id              :integer          not null, primary key
-#  category_id     :integer          not null
-#  group_id        :integer          not null
+#  permission_type :integer          default(1)
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  permission_type :integer          default(1)
+#  category_id     :integer          not null
+#  group_id        :integer          not null
 #
 # Indexes
 #

--- a/app/models/category_localization.rb
+++ b/app/models/category_localization.rb
@@ -21,12 +21,12 @@ end
 # Table name: category_localizations
 #
 #  id          :bigint           not null, primary key
-#  category_id :bigint           not null
+#  description :string(1000)
 #  locale      :string(20)       not null
 #  name        :string(50)       not null
-#  description :string(1000)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  category_id :bigint           not null
 #
 # Indexes
 #

--- a/app/models/category_moderation_group.rb
+++ b/app/models/category_moderation_group.rb
@@ -10,10 +10,10 @@ end
 # Table name: category_moderation_groups
 #
 #  id          :bigint           not null, primary key
-#  category_id :integer
-#  group_id    :integer
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  category_id :integer
+#  group_id    :integer
 #
 # Indexes
 #

--- a/app/models/category_required_tag_group.rb
+++ b/app/models/category_required_tag_group.rb
@@ -14,12 +14,12 @@ end
 # Table name: category_required_tag_groups
 #
 #  id           :bigint           not null, primary key
-#  category_id  :bigint           not null
-#  tag_group_id :bigint           not null
 #  min_count    :integer          default(1), not null
 #  order        :integer          default(1), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  category_id  :bigint           not null
+#  tag_group_id :bigint           not null
 #
 # Indexes
 #

--- a/app/models/category_search_data.rb
+++ b/app/models/category_search_data.rb
@@ -8,11 +8,11 @@ end
 #
 # Table name: category_search_data
 #
-#  category_id :integer          not null, primary key
-#  search_data :tsvector
-#  raw_data    :text
 #  locale      :text
+#  raw_data    :text
+#  search_data :tsvector
 #  version     :integer          default(0)
+#  category_id :integer          not null, primary key
 #
 # Indexes
 #

--- a/app/models/category_tag.rb
+++ b/app/models/category_tag.rb
@@ -12,10 +12,10 @@ end
 # Table name: category_tags
 #
 #  id          :integer          not null, primary key
-#  category_id :integer          not null
-#  tag_id      :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  category_id :integer          not null
+#  tag_id      :integer          not null
 #
 # Indexes
 #

--- a/app/models/category_tag_group.rb
+++ b/app/models/category_tag_group.rb
@@ -12,10 +12,10 @@ end
 # Table name: category_tag_groups
 #
 #  id           :integer          not null, primary key
-#  category_id  :integer          not null
-#  tag_group_id :integer          not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  category_id  :integer          not null
+#  tag_group_id :integer          not null
 #
 # Indexes
 #

--- a/app/models/category_tag_stat.rb
+++ b/app/models/category_tag_stat.rb
@@ -85,9 +85,9 @@ end
 # Table name: category_tag_stats
 #
 #  id          :bigint           not null, primary key
+#  topic_count :integer          default(0), not null
 #  category_id :bigint           not null
 #  tag_id      :bigint           not null
-#  topic_count :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/models/category_user.rb
+++ b/app/models/category_user.rb
@@ -277,10 +277,10 @@ end
 # Table name: category_users
 #
 #  id                 :integer          not null, primary key
+#  last_seen_at       :datetime
+#  notification_level :integer          not null
 #  category_id        :integer          not null
 #  user_id            :integer          not null
-#  notification_level :integer          not null
-#  last_seen_at       :datetime
 #
 # Indexes
 #

--- a/app/models/child_theme.rb
+++ b/app/models/child_theme.rb
@@ -24,10 +24,10 @@ end
 # Table name: child_themes
 #
 #  id              :integer          not null, primary key
-#  parent_theme_id :integer
-#  child_theme_id  :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  child_theme_id  :integer
+#  parent_theme_id :integer
 #
 # Indexes
 #

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -30,11 +30,11 @@ end
 # Table name: custom_emojis
 #
 #  id         :integer          not null, primary key
+#  group      :string(20)
 #  name       :string           not null
-#  upload_id  :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  group      :string(20)
+#  upload_id  :integer          not null
 #  user_id    :integer          default(-1), not null
 #
 # Indexes

--- a/app/models/directory_column.rb
+++ b/app/models/directory_column.rb
@@ -60,14 +60,14 @@ end
 # Table name: directory_columns
 #
 #  id                 :bigint           not null, primary key
-#  name               :string
 #  automatic_position :integer
-#  icon               :string
-#  user_field_id      :integer
 #  enabled            :boolean          not null
+#  icon               :string
+#  name               :string
 #  position           :integer          not null
-#  created_at         :datetime
 #  type               :integer          default("automatic"), not null
+#  created_at         :datetime
+#  user_field_id      :integer
 #
 # Indexes
 #

--- a/app/models/dismissed_topic_user.rb
+++ b/app/models/dismissed_topic_user.rb
@@ -17,9 +17,9 @@ end
 # Table name: dismissed_topic_users
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer
-#  topic_id   :integer
 #  created_at :datetime
+#  topic_id   :integer
+#  user_id    :integer
 #
 # Indexes
 #

--- a/app/models/do_not_disturb_timing.rb
+++ b/app/models/do_not_disturb_timing.rb
@@ -15,10 +15,10 @@ end
 # Table name: do_not_disturb_timings
 #
 #  id        :bigint           not null, primary key
-#  user_id   :integer          not null
-#  starts_at :datetime         not null
 #  ends_at   :datetime         not null
 #  scheduled :boolean          default(FALSE)
+#  starts_at :datetime         not null
+#  user_id   :integer          not null
 #
 # Indexes
 #

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -352,14 +352,14 @@ end
 # Table name: drafts
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
-#  draft_key  :string           not null
 #  data       :text             not null
+#  draft_key  :string           not null
+#  owner      :string
+#  revisions  :integer          default(1), not null
+#  sequence   :bigint           default(0), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  sequence   :bigint           default(0), not null
-#  revisions  :integer          default(1), not null
-#  owner      :string
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/draft_sequence.rb
+++ b/app/models/draft_sequence.rb
@@ -51,9 +51,9 @@ end
 # Table name: draft_sequences
 #
 #  id        :integer          not null, primary key
-#  user_id   :integer          not null
 #  draft_key :string           not null
 #  sequence  :bigint           not null
+#  user_id   :integer          not null
 #
 # Indexes
 #

--- a/app/models/email_change_request.rb
+++ b/app/models/email_change_request.rb
@@ -35,15 +35,15 @@ end
 # Table name: email_change_requests
 #
 #  id                   :integer          not null, primary key
-#  user_id              :integer          not null
-#  old_email            :string
-#  new_email            :string           not null
-#  old_email_token_id   :integer
-#  new_email_token_id   :integer
 #  change_state         :integer          not null
+#  new_email            :string           not null
+#  old_email            :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  new_email_token_id   :integer
+#  old_email_token_id   :integer
 #  requested_by_user_id :integer
+#  user_id              :integer          not null
 #
 # Indexes
 #

--- a/app/models/email_log.rb
+++ b/app/models/email_log.rb
@@ -123,23 +123,23 @@ end
 # Table name: email_logs
 #
 #  id                        :integer          not null, primary key
-#  to_address                :string           not null
-#  email_type                :string           not null
-#  user_id                   :integer
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  post_id                   :integer
+#  bcc_addresses             :text
+#  bounce_error_code         :string
 #  bounce_key                :uuid
 #  bounced                   :boolean          default(FALSE), not null
-#  message_id                :string
-#  smtp_group_id             :integer
 #  cc_addresses              :text
 #  cc_user_ids               :integer          is an Array
+#  email_type                :string           not null
 #  raw                       :text
-#  topic_id                  :integer
-#  bounce_error_code         :string
 #  smtp_transaction_response :string(500)
-#  bcc_addresses             :text
+#  to_address                :string           not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  message_id                :string
+#  post_id                   :integer
+#  smtp_group_id             :integer
+#  topic_id                  :integer
+#  user_id                   :integer
 #
 # Indexes
 #

--- a/app/models/email_token.rb
+++ b/app/models/email_token.rb
@@ -107,14 +107,14 @@ end
 # Table name: email_tokens
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
-#  email      :string           not null
 #  confirmed  :boolean          default(FALSE), not null
+#  email      :string           not null
 #  expired    :boolean          default(FALSE), not null
+#  scope      :integer
+#  token_hash :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  token_hash :string           not null
-#  scope      :integer
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/embeddable_host.rb
+++ b/app/models/embeddable_host.rb
@@ -76,11 +76,11 @@ end
 # Table name: embeddable_hosts
 #
 #  id            :integer          not null, primary key
+#  allowed_paths :string
+#  class_name    :string
 #  host          :string           not null
-#  category_id   :integer          not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  class_name    :string
-#  allowed_paths :string
+#  category_id   :integer          not null
 #  user_id       :integer
 #

--- a/app/models/embeddable_host_tag.rb
+++ b/app/models/embeddable_host_tag.rb
@@ -14,10 +14,10 @@ end
 # Table name: embeddable_host_tags
 #
 #  id                 :bigint           not null, primary key
-#  embeddable_host_id :integer          not null
-#  tag_id             :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  embeddable_host_id :integer          not null
+#  tag_id             :integer          not null
 #
 # Indexes
 #

--- a/app/models/external_upload_stub.rb
+++ b/app/models/external_upload_stub.rb
@@ -54,17 +54,17 @@ end
 # Table name: external_upload_stubs
 #
 #  id                         :bigint           not null, primary key
+#  external_upload_identifier :string
+#  filesize                   :bigint           not null
 #  key                        :string           not null
+#  multipart                  :boolean          default(FALSE), not null
 #  original_filename          :string           not null
 #  status                     :integer          default(1), not null
 #  unique_identifier          :uuid             not null
-#  created_by_id              :integer          not null
 #  upload_type                :string           not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  multipart                  :boolean          default(FALSE), not null
-#  external_upload_identifier :string
-#  filesize                   :bigint           not null
+#  created_by_id              :integer          not null
 #
 # Indexes
 #

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -76,16 +76,16 @@ end
 # Table name: flags
 #
 #  id               :bigint           not null, primary key
+#  applies_to       :string           not null, is an Array
+#  auto_action_type :boolean          default(FALSE), not null
+#  description      :text
+#  enabled          :boolean          default(TRUE), not null
 #  name             :string
 #  name_key         :string
-#  description      :text
 #  notify_type      :boolean          default(FALSE), not null
-#  auto_action_type :boolean          default(FALSE), not null
-#  require_message  :boolean          default(FALSE), not null
-#  applies_to       :string           not null, is an Array
 #  position         :integer          not null
-#  enabled          :boolean          default(TRUE), not null
+#  require_message  :boolean          default(FALSE), not null
+#  score_type       :boolean          default(FALSE), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  score_type       :boolean          default(FALSE), not null
 #

--- a/app/models/given_daily_like.rb
+++ b/app/models/given_daily_like.rb
@@ -41,10 +41,10 @@ end
 #
 # Table name: given_daily_likes
 #
-#  user_id       :integer          not null
-#  likes_given   :integer          not null
 #  given_date    :date             not null
+#  likes_given   :integer          not null
 #  limit_reached :boolean          default(FALSE), not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/group_archived_message.rb
+++ b/app/models/group_archived_message.rb
@@ -60,10 +60,10 @@ end
 # Table name: group_archived_messages
 #
 #  id         :integer          not null, primary key
-#  group_id   :integer          not null
-#  topic_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  group_id   :integer          not null
+#  topic_id   :integer          not null
 #
 # Indexes
 #

--- a/app/models/group_associated_group.rb
+++ b/app/models/group_associated_group.rb
@@ -50,10 +50,10 @@ end
 # Table name: group_associated_groups
 #
 #  id                  :bigint           not null, primary key
-#  group_id            :bigint           not null
-#  associated_group_id :bigint           not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  associated_group_id :bigint           not null
+#  group_id            :bigint           not null
 #
 # Indexes
 #

--- a/app/models/group_category_notification_default.rb
+++ b/app/models/group_category_notification_default.rb
@@ -61,9 +61,9 @@ end
 # Table name: group_category_notification_defaults
 #
 #  id                 :bigint           not null, primary key
-#  group_id           :integer          not null
-#  category_id        :integer          not null
 #  notification_level :integer          not null
+#  category_id        :integer          not null
+#  group_id           :integer          not null
 #
 # Indexes
 #

--- a/app/models/group_custom_field.rb
+++ b/app/models/group_custom_field.rb
@@ -11,11 +11,11 @@ end
 # Table name: group_custom_fields
 #
 #  id         :integer          not null, primary key
-#  group_id   :integer          not null
 #  name       :string(256)      not null
 #  value      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  group_id   :integer          not null
 #
 # Indexes
 #

--- a/app/models/group_history.rb
+++ b/app/models/group_history.rb
@@ -55,15 +55,15 @@ end
 # Table name: group_histories
 #
 #  id             :integer          not null, primary key
-#  group_id       :integer          not null
-#  acting_user_id :integer          not null
-#  target_user_id :integer
 #  action         :integer          not null
-#  subject        :string
-#  prev_value     :text
 #  new_value      :text
+#  prev_value     :text
+#  subject        :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  acting_user_id :integer          not null
+#  group_id       :integer          not null
+#  target_user_id :integer
 #
 # Indexes
 #

--- a/app/models/group_mention.rb
+++ b/app/models/group_mention.rb
@@ -10,10 +10,10 @@ end
 # Table name: group_mentions
 #
 #  id         :integer          not null, primary key
-#  post_id    :integer
-#  group_id   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  group_id   :integer
+#  post_id    :integer
 #
 # Indexes
 #

--- a/app/models/group_request.rb
+++ b/app/models/group_request.rb
@@ -14,11 +14,11 @@ end
 # Table name: group_requests
 #
 #  id         :bigint           not null, primary key
-#  group_id   :integer
-#  user_id    :integer
 #  reason     :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  group_id   :integer
+#  user_id    :integer
 #
 # Indexes
 #

--- a/app/models/group_tag_notification_default.rb
+++ b/app/models/group_tag_notification_default.rb
@@ -53,9 +53,9 @@ end
 # Table name: group_tag_notification_defaults
 #
 #  id                 :bigint           not null, primary key
+#  notification_level :integer          not null
 #  group_id           :integer          not null
 #  tag_id             :integer          not null
-#  notification_level :integer          not null
 #
 # Indexes
 #

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -158,13 +158,13 @@ end
 # Table name: group_users
 #
 #  id                 :integer          not null, primary key
-#  group_id           :integer          not null
-#  user_id            :integer          not null
+#  first_unread_pm_at :datetime         not null
+#  notification_level :integer          default(2), not null
+#  owner              :boolean          default(FALSE), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  owner              :boolean          default(FALSE), not null
-#  notification_level :integer          default(2), not null
-#  first_unread_pm_at :datetime         not null
+#  group_id           :integer          not null
+#  user_id            :integer          not null
 #
 # Indexes
 #

--- a/app/models/ignored_user.rb
+++ b/app/models/ignored_user.rb
@@ -27,12 +27,12 @@ end
 # Table name: ignored_users
 #
 #  id              :bigint           not null, primary key
-#  user_id         :integer          not null
-#  ignored_user_id :integer          not null
+#  expiring_at     :datetime         not null
+#  summarized_at   :datetime
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  summarized_at   :datetime
-#  expiring_at     :datetime         not null
+#  ignored_user_id :integer          not null
+#  user_id         :integer          not null
 #
 # Indexes
 #

--- a/app/models/incoming_domain.rb
+++ b/app/models/incoming_domain.rb
@@ -36,8 +36,8 @@ end
 # Table name: incoming_domains
 #
 #  id    :integer          not null, primary key
-#  name  :string(100)      not null
 #  https :boolean          default(FALSE), not null
+#  name  :string(100)      not null
 #  port  :integer          not null
 #
 # Indexes

--- a/app/models/incoming_link.rb
+++ b/app/models/incoming_link.rb
@@ -119,12 +119,12 @@ end
 # Table name: incoming_links
 #
 #  id                  :integer          not null, primary key
-#  created_at          :datetime         not null
-#  user_id             :integer
 #  ip_address          :inet
+#  created_at          :datetime         not null
 #  current_user_id     :integer
-#  post_id             :integer          not null
 #  incoming_referer_id :integer
+#  post_id             :integer          not null
+#  user_id             :integer
 #
 # Indexes
 #

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -373,23 +373,23 @@ end
 # Table name: invites
 #
 #  id                      :integer          not null, primary key
-#  invite_key              :string(32)       not null
+#  custom_message          :text
+#  deleted_at              :datetime
+#  description             :string(100)
+#  domain                  :string
 #  email                   :string
-#  invited_by_id           :integer          not null
+#  email_token             :string
+#  emailed_status          :integer
+#  expires_at              :datetime         not null
+#  invalidated_at          :datetime
+#  invite_key              :string(32)       not null
+#  max_redemptions_allowed :integer          default(1), not null
+#  moderator               :boolean          default(FALSE), not null
+#  redemption_count        :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  deleted_at              :datetime
 #  deleted_by_id           :integer
-#  invalidated_at          :datetime
-#  moderator               :boolean          default(FALSE), not null
-#  custom_message          :text
-#  emailed_status          :integer
-#  max_redemptions_allowed :integer          default(1), not null
-#  redemption_count        :integer          default(0), not null
-#  expires_at              :datetime         not null
-#  email_token             :string
-#  domain                  :string
-#  description             :string(100)
+#  invited_by_id           :integer          not null
 #
 # Indexes
 #

--- a/app/models/invited_group.rb
+++ b/app/models/invited_group.rb
@@ -10,10 +10,10 @@ end
 # Table name: invited_groups
 #
 #  id         :integer          not null, primary key
-#  group_id   :integer
-#  invite_id  :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  group_id   :integer
+#  invite_id  :integer
 #
 # Indexes
 #

--- a/app/models/invited_user.rb
+++ b/app/models/invited_user.rb
@@ -27,11 +27,11 @@ end
 # Table name: invited_users
 #
 #  id          :bigint           not null, primary key
-#  user_id     :integer
-#  invite_id   :integer          not null
 #  redeemed_at :datetime
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  invite_id   :integer          not null
+#  user_id     :integer
 #
 # Indexes
 #

--- a/app/models/linked_topic.rb
+++ b/app/models/linked_topic.rb
@@ -9,11 +9,11 @@ end
 # Table name: linked_topics
 #
 #  id                :bigint           not null, primary key
-#  topic_id          :bigint           not null
-#  original_topic_id :bigint           not null
 #  sequence          :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  original_topic_id :bigint           not null
+#  topic_id          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/moved_post.rb
+++ b/app/models/moved_post.rb
@@ -19,20 +19,20 @@ end
 # Table name: moved_posts
 #
 #  id                :bigint           not null, primary key
-#  old_topic_id      :bigint           not null
-#  old_post_id       :bigint           not null
-#  old_post_number   :bigint           not null
-#  new_topic_id      :bigint           not null
-#  new_topic_title   :string           not null
-#  new_post_id       :bigint           not null
-#  new_post_number   :bigint           not null
 #  created_new_topic :boolean          default(FALSE), not null
+#  full_move         :boolean
+#  new_post_number   :bigint           not null
+#  new_topic_title   :string           not null
+#  old_post_number   :bigint           not null
+#  old_topic_title   :string
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  old_topic_title   :string
+#  new_post_id       :bigint           not null
+#  new_topic_id      :bigint           not null
+#  old_post_id       :bigint           not null
+#  old_topic_id      :bigint           not null
 #  post_user_id      :integer
 #  user_id           :integer
-#  full_move         :boolean
 #
 # Indexes
 #

--- a/app/models/muted_user.rb
+++ b/app/models/muted_user.rb
@@ -10,10 +10,10 @@ end
 # Table name: muted_users
 #
 #  id            :integer          not null, primary key
-#  user_id       :integer          not null
-#  muted_user_id :integer          not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  muted_user_id :integer          not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -462,17 +462,17 @@ end
 #
 # Table name: notifications
 #
-#  notification_type :integer          not null
-#  user_id           :integer          not null
+#  id                :bigint           not null, primary key
 #  data              :string(1000)     not null
+#  high_priority     :boolean          default(FALSE), not null
+#  notification_type :integer          not null
+#  post_number       :integer
 #  read              :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  topic_id          :integer
-#  post_number       :integer
 #  post_action_id    :integer
-#  high_priority     :boolean          default(FALSE), not null
-#  id                :bigint           not null, primary key
+#  topic_id          :integer
+#  user_id           :integer          not null
 #
 # Indexes
 #

--- a/app/models/oauth2_user_info.rb
+++ b/app/models/oauth2_user_info.rb
@@ -17,13 +17,13 @@ end
 # Table name: oauth2_user_infos
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
-#  uid        :string           not null
-#  provider   :string           not null
 #  email      :string
 #  name       :string
+#  provider   :string           not null
+#  uid        :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -378,17 +378,17 @@ end
 # Table name: optimized_images
 #
 #  id         :integer          not null, primary key
-#  sha1       :string(40)       not null
-#  extension  :string(10)       not null
-#  width      :integer          not null
-#  height     :integer          not null
-#  upload_id  :integer          not null
-#  url        :string           not null
-#  filesize   :integer
 #  etag       :string
+#  extension  :string(10)       not null
+#  filesize   :integer
+#  height     :integer          not null
+#  sha1       :string(40)       not null
+#  url        :string           not null
 #  version    :integer
+#  width      :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  upload_id  :integer          not null
 #
 # Indexes
 #

--- a/app/models/optimized_video.rb
+++ b/app/models/optimized_video.rb
@@ -63,11 +63,11 @@ end
 # Table name: optimized_videos
 #
 #  id                  :bigint           not null, primary key
-#  upload_id           :integer          not null
-#  optimized_upload_id :integer          not null
 #  adapter             :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  optimized_upload_id :integer          not null
+#  upload_id           :integer          not null
 #
 # Indexes
 #

--- a/app/models/permalink.rb
+++ b/app/models/permalink.rb
@@ -124,14 +124,14 @@ end
 # Table name: permalinks
 #
 #  id           :integer          not null, primary key
+#  external_url :string(1000)
 #  url          :string(1000)     not null
-#  topic_id     :integer
-#  post_id      :integer
-#  category_id  :integer
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  external_url :string(1000)
+#  category_id  :integer
+#  post_id      :integer
 #  tag_id       :integer
+#  topic_id     :integer
 #  user_id      :integer
 #
 # Indexes

--- a/app/models/plugin_store_row.rb
+++ b/app/models/plugin_store_row.rb
@@ -8,8 +8,8 @@ end
 # Table name: plugin_store_rows
 #
 #  id          :integer          not null, primary key
-#  plugin_name :string           not null
 #  key         :string           not null
+#  plugin_name :string           not null
 #  type_name   :string           not null
 #  value       :text
 #

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1261,57 +1261,57 @@ end
 # Table name: posts
 #
 #  id                      :integer          not null, primary key
-#  user_id                 :integer
-#  topic_id                :integer          not null
-#  post_number             :integer          not null
-#  raw                     :text             not null
-#  cooked                  :text             not null
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  reply_to_post_number    :integer
-#  reply_count             :integer          default(0), not null
-#  quote_count             :integer          default(0), not null
-#  deleted_at              :datetime
-#  off_topic_count         :integer          default(0), not null
-#  like_count              :integer          default(0), not null
-#  incoming_link_count     :integer          default(0), not null
-#  bookmark_count          :integer          default(0), not null
-#  score                   :float
-#  reads                   :integer          default(0), not null
-#  post_type               :integer          default(1), not null
-#  sort_order              :integer
-#  last_editor_id          :integer
-#  hidden                  :boolean          default(FALSE), not null
-#  hidden_reason_id        :integer
-#  notify_moderators_count :integer          default(0), not null
-#  spam_count              :integer          default(0), not null
-#  illegal_count           :integer          default(0), not null
-#  inappropriate_count     :integer          default(0), not null
-#  last_version_at         :datetime         not null
-#  user_deleted            :boolean          default(FALSE), not null
-#  reply_to_user_id        :integer
-#  percent_rank            :float            default(1.0)
-#  notify_user_count       :integer          default(0), not null
-#  like_score              :integer          default(0), not null
-#  deleted_by_id           :integer
-#  edit_reason             :string
-#  word_count              :integer
-#  version                 :integer          default(1), not null
-#  cook_method             :integer          default(1), not null
-#  wiki                    :boolean          default(FALSE), not null
+#  action_code             :string
 #  baked_at                :datetime
 #  baked_version           :integer
+#  bookmark_count          :integer          default(0), not null
+#  cook_method             :integer          default(1), not null
+#  cooked                  :text             not null
+#  deleted_at              :datetime
+#  edit_reason             :string
+#  hidden                  :boolean          default(FALSE), not null
 #  hidden_at               :datetime
-#  self_edits              :integer          default(0), not null
-#  reply_quoted            :boolean          default(FALSE), not null
-#  via_email               :boolean          default(FALSE), not null
-#  raw_email               :text
-#  public_version          :integer          default(1), not null
-#  action_code             :string
-#  locked_by_id            :integer
-#  image_upload_id         :bigint
-#  outbound_message_id     :string
+#  illegal_count           :integer          default(0), not null
+#  inappropriate_count     :integer          default(0), not null
+#  incoming_link_count     :integer          default(0), not null
+#  last_version_at         :datetime         not null
+#  like_count              :integer          default(0), not null
+#  like_score              :integer          default(0), not null
 #  locale                  :string(20)
+#  notify_moderators_count :integer          default(0), not null
+#  notify_user_count       :integer          default(0), not null
+#  off_topic_count         :integer          default(0), not null
+#  percent_rank            :float            default(1.0)
+#  post_number             :integer          not null
+#  post_type               :integer          default(1), not null
+#  public_version          :integer          default(1), not null
+#  quote_count             :integer          default(0), not null
+#  raw                     :text             not null
+#  raw_email               :text
+#  reads                   :integer          default(0), not null
+#  reply_count             :integer          default(0), not null
+#  reply_quoted            :boolean          default(FALSE), not null
+#  reply_to_post_number    :integer
+#  score                   :float
+#  self_edits              :integer          default(0), not null
+#  sort_order              :integer
+#  spam_count              :integer          default(0), not null
+#  user_deleted            :boolean          default(FALSE), not null
+#  version                 :integer          default(1), not null
+#  via_email               :boolean          default(FALSE), not null
+#  wiki                    :boolean          default(FALSE), not null
+#  word_count              :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  deleted_by_id           :integer
+#  hidden_reason_id        :integer
+#  image_upload_id         :bigint
+#  last_editor_id          :integer
+#  locked_by_id            :integer
+#  outbound_message_id     :string
+#  reply_to_user_id        :integer
+#  topic_id                :integer          not null
+#  user_id                 :integer
 #
 # Indexes
 #

--- a/app/models/post_action.rb
+++ b/app/models/post_action.rb
@@ -270,22 +270,22 @@ end
 # Table name: post_actions
 #
 #  id                  :integer          not null, primary key
-#  post_id             :integer          not null
-#  user_id             :integer          not null
-#  post_action_type_id :integer          not null
+#  agreed_at           :datetime
+#  deferred_at         :datetime
 #  deleted_at          :datetime
+#  disagreed_at        :datetime
+#  staff_took_action   :boolean          default(FALSE), not null
+#  targets_topic       :boolean          default(FALSE), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  deleted_by_id       :integer
-#  related_post_id     :integer
-#  staff_took_action   :boolean          default(FALSE), not null
-#  deferred_by_id      :integer
-#  targets_topic       :boolean          default(FALSE), not null
-#  agreed_at           :datetime
 #  agreed_by_id        :integer
-#  deferred_at         :datetime
-#  disagreed_at        :datetime
+#  deferred_by_id      :integer
+#  deleted_by_id       :integer
 #  disagreed_by_id     :integer
+#  post_action_type_id :integer          not null
+#  post_id             :integer          not null
+#  related_post_id     :integer
+#  user_id             :integer          not null
 #
 # Indexes
 #

--- a/app/models/post_action_type.rb
+++ b/app/models/post_action_type.rb
@@ -76,13 +76,13 @@ end
 #
 # Table name: post_action_types
 #
-#  name_key            :string(50)       not null
-#  is_flag             :boolean          default(FALSE), not null
+#  id                  :integer          not null, primary key
 #  icon                :string(20)
+#  is_flag             :boolean          default(FALSE), not null
+#  name_key            :string(50)       not null
+#  position            :integer          default(0), not null
+#  reviewable_priority :integer          default(0), not null
+#  score_bonus         :float            default(0.0), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  id                  :integer          not null, primary key
-#  position            :integer          default(0), not null
-#  score_bonus         :float            default(0.0), not null
-#  reviewable_priority :integer          default(0), not null
 #

--- a/app/models/post_detail.rb
+++ b/app/models/post_detail.rb
@@ -12,12 +12,12 @@ end
 # Table name: post_details
 #
 #  id         :integer          not null, primary key
-#  post_id    :integer
+#  extra      :text
 #  key        :string
 #  value      :string
-#  extra      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  post_id    :integer
 #
 # Indexes
 #

--- a/app/models/post_hotlinked_media.rb
+++ b/app/models/post_hotlinked_media.rb
@@ -26,12 +26,12 @@ end
 # Table name: post_hotlinked_media
 #
 #  id         :bigint           not null, primary key
-#  post_id    :bigint           not null
-#  url        :string           not null
 #  status     :enum             not null
-#  upload_id  :bigint
+#  url        :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  post_id    :bigint           not null
+#  upload_id  :bigint
 #
 # Indexes
 #

--- a/app/models/post_localization.rb
+++ b/app/models/post_localization.rb
@@ -27,14 +27,14 @@ end
 # Table name: post_localizations
 #
 #  id                :bigint           not null, primary key
-#  post_id           :integer          not null
-#  post_version      :integer          not null
-#  locale            :string(20)       not null
-#  raw               :text             not null
 #  cooked            :text             not null
-#  localizer_user_id :integer          not null
+#  locale            :string(20)       not null
+#  post_version      :integer          not null
+#  raw               :text             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  localizer_user_id :integer          not null
+#  post_id           :integer          not null
 #
 # Indexes
 #

--- a/app/models/post_reply.rb
+++ b/app/models/post_reply.rb
@@ -20,9 +20,9 @@ end
 #
 # Table name: post_replies
 #
-#  post_id       :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  post_id       :integer
 #  reply_post_id :integer
 #
 # Indexes

--- a/app/models/post_reply_key.rb
+++ b/app/models/post_reply_key.rb
@@ -24,11 +24,11 @@ end
 # Table name: post_reply_keys
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  post_id    :integer          not null
 #  reply_key  :uuid             not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  post_id    :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/post_search_data.rb
+++ b/app/models/post_search_data.rb
@@ -8,12 +8,12 @@ end
 #
 # Table name: post_search_data
 #
-#  post_id         :integer          not null, primary key
-#  search_data     :tsvector
-#  raw_data        :text
 #  locale          :string
-#  version         :integer          default(0)
 #  private_message :boolean          not null
+#  raw_data        :text
+#  search_data     :tsvector
+#  version         :integer          default(0)
+#  post_id         :integer          not null, primary key
 #
 # Indexes
 #

--- a/app/models/post_stat.rb
+++ b/app/models/post_stat.rb
@@ -18,15 +18,15 @@ end
 # Table name: post_stats
 #
 #  id                           :integer          not null, primary key
-#  post_id                      :integer
+#  composer_open_duration_msecs :integer
+#  composer_version             :integer
 #  drafts_saved                 :integer
 #  typing_duration_msecs        :integer
-#  composer_open_duration_msecs :integer
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  composer_version             :integer
 #  writing_device               :string
 #  writing_device_user_agent    :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  post_id                      :integer
 #
 # Indexes
 #

--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -252,10 +252,10 @@ end
 #
 # Table name: post_timings
 #
-#  topic_id    :integer          not null
-#  post_number :integer          not null
-#  user_id     :integer          not null
 #  msecs       :integer          not null
+#  post_number :integer          not null
+#  topic_id    :integer          not null
+#  user_id     :integer          not null
 #
 # Indexes
 #

--- a/app/models/published_page.rb
+++ b/app/models/published_page.rb
@@ -54,11 +54,11 @@ end
 # Table name: published_pages
 #
 #  id         :bigint           not null, primary key
-#  topic_id   :bigint           not null
+#  public     :boolean          default(FALSE), not null
 #  slug       :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  public     :boolean          default(FALSE), not null
+#  topic_id   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -13,10 +13,10 @@ end
 # Table name: push_subscriptions
 #
 #  id             :bigint           not null, primary key
-#  user_id        :integer          not null
 #  data           :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
 #  error_count    :integer          default(0), not null
 #  first_error_at :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :integer          not null
 #

--- a/app/models/quoted_post.rb
+++ b/app/models/quoted_post.rb
@@ -83,10 +83,10 @@ end
 # Table name: quoted_posts
 #
 #  id             :integer          not null, primary key
-#  post_id        :integer          not null
-#  quoted_post_id :integer          not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  post_id        :integer          not null
+#  quoted_post_id :integer          not null
 #
 # Indexes
 #

--- a/app/models/redelivering_webhook_event.rb
+++ b/app/models/redelivering_webhook_event.rb
@@ -9,10 +9,10 @@ end
 # Table name: redelivering_webhook_events
 #
 #  id                :bigint           not null, primary key
-#  web_hook_event_id :bigint           not null
 #  processing        :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  web_hook_event_id :bigint           not null
 #
 # Indexes
 #

--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -576,20 +576,20 @@ end
 # Table name: remote_themes
 #
 #  id                        :integer          not null, primary key
+#  about_url                 :string
+#  authors                   :string
+#  branch                    :string
+#  commits_behind            :integer
+#  last_error_text           :text
+#  license_url               :string
+#  local_version             :string
+#  maximum_discourse_version :string
+#  minimum_discourse_version :string
+#  private_key               :text
+#  remote_updated_at         :datetime
 #  remote_url                :string           not null
 #  remote_version            :string
-#  local_version             :string
-#  about_url                 :string
-#  license_url               :string
-#  commits_behind            :integer
-#  remote_updated_at         :datetime
+#  theme_version             :string
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  private_key               :text
-#  branch                    :string
-#  last_error_text           :text
-#  authors                   :string
-#  theme_version             :string
-#  minimum_discourse_version :string
-#  maximum_discourse_version :string
 #

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -888,26 +888,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
+#  force_review            :boolean          default(FALSE), not null
+#  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
 #  type                    :string           not null
 #  type_source             :string           default("unknown"), not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
 #  version                 :integer          default(0), not null
-#  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/app/models/reviewable_claimed_topic.rb
+++ b/app/models/reviewable_claimed_topic.rb
@@ -23,11 +23,11 @@ end
 # Table name: reviewable_claimed_topics
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  topic_id   :integer          not null
+#  automatic  :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  automatic  :boolean          default(FALSE), not null
+#  topic_id   :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -368,26 +368,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
+#  force_review            :boolean          default(FALSE), not null
+#  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
 #  type                    :string           not null
 #  type_source             :string           default("unknown"), not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
 #  version                 :integer          default(0), not null
-#  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/app/models/reviewable_history.rb
+++ b/app/models/reviewable_history.rb
@@ -15,13 +15,13 @@ end
 # Table name: reviewable_histories
 #
 #  id                      :bigint           not null, primary key
-#  reviewable_id           :integer          not null
+#  edited                  :json
 #  reviewable_history_type :integer          not null
 #  status                  :integer          not null
-#  created_by_id           :integer          not null
-#  edited                  :json
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  created_by_id           :integer          not null
+#  reviewable_id           :integer          not null
 #
 # Indexes
 #

--- a/app/models/reviewable_note.rb
+++ b/app/models/reviewable_note.rb
@@ -18,11 +18,11 @@ end
 # Table name: reviewable_notes
 #
 #  id            :bigint           not null, primary key
-#  reviewable_id :bigint           not null
-#  user_id       :bigint           not null
 #  content       :text             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  reviewable_id :bigint           not null
+#  user_id       :bigint           not null
 #
 # Indexes
 #

--- a/app/models/reviewable_post.rb
+++ b/app/models/reviewable_post.rb
@@ -136,26 +136,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
+#  force_review            :boolean          default(FALSE), not null
+#  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
 #  type                    :string           not null
 #  type_source             :string           default("unknown"), not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
 #  version                 :integer          default(0), not null
-#  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -242,26 +242,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
+#  force_review            :boolean          default(FALSE), not null
+#  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
 #  type                    :string           not null
 #  type_source             :string           default("unknown"), not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
 #  version                 :integer          default(0), not null
-#  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/app/models/reviewable_score.rb
+++ b/app/models/reviewable_score.rb
@@ -104,20 +104,20 @@ end
 # Table name: reviewable_scores
 #
 #  id                    :bigint           not null, primary key
-#  reviewable_id         :integer          not null
-#  user_id               :integer          not null
+#  context               :string
+#  reason                :string
 #  reviewable_score_type :integer          not null
-#  status                :integer          not null
-#  score                 :float            default(0.0), not null
-#  take_action_bonus     :float            default(0.0), not null
-#  reviewed_by_id        :integer
 #  reviewed_at           :datetime
-#  meta_topic_id         :integer
+#  score                 :float            default(0.0), not null
+#  status                :integer          not null
+#  take_action_bonus     :float            default(0.0), not null
+#  user_accuracy_bonus   :float            default(0.0), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  reason                :string
-#  user_accuracy_bonus   :float            default(0.0), not null
-#  context               :string
+#  meta_topic_id         :integer
+#  reviewable_id         :integer          not null
+#  reviewed_by_id        :integer
+#  user_id               :integer          not null
 #
 # Indexes
 #

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -164,26 +164,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
+#  force_review            :boolean          default(FALSE), not null
+#  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
 #  type                    :string           not null
 #  type_source             :string           default("unknown"), not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
 #  version                 :integer          default(0), not null
-#  latest_score            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/app/models/screened_email.rb
+++ b/app/models/screened_email.rb
@@ -73,13 +73,13 @@ end
 # Table name: screened_emails
 #
 #  id            :integer          not null, primary key
-#  email         :string           not null
 #  action_type   :integer          not null
-#  match_count   :integer          default(0), not null
+#  email         :string           not null
+#  ip_address    :inet
 #  last_match_at :datetime
+#  match_count   :integer          default(0), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  ip_address    :inet
 #
 # Indexes
 #

--- a/app/models/screened_ip_address.rb
+++ b/app/models/screened_ip_address.rb
@@ -168,10 +168,10 @@ end
 # Table name: screened_ip_addresses
 #
 #  id            :integer          not null, primary key
-#  ip_address    :inet             not null
 #  action_type   :integer          not null
-#  match_count   :integer          default(0), not null
+#  ip_address    :inet             not null
 #  last_match_at :datetime
+#  match_count   :integer          default(0), not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/app/models/screened_url.rb
+++ b/app/models/screened_url.rb
@@ -41,14 +41,14 @@ end
 # Table name: screened_urls
 #
 #  id            :integer          not null, primary key
-#  url           :string           not null
-#  domain        :string           not null
 #  action_type   :integer          not null
-#  match_count   :integer          default(0), not null
+#  domain        :string           not null
+#  ip_address    :inet
 #  last_match_at :datetime
+#  match_count   :integer          default(0), not null
+#  url           :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  ip_address    :inet
 #
 # Indexes
 #

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -175,14 +175,14 @@ end
 # Table name: search_logs
 #
 #  id                 :integer          not null, primary key
-#  term               :string           not null
-#  user_id            :integer
 #  ip_address         :inet
-#  search_result_id   :integer
-#  search_type        :integer          not null
-#  created_at         :datetime         not null
 #  search_result_type :integer
+#  search_type        :integer          not null
+#  term               :string           not null
 #  user_agent         :string(2000)
+#  created_at         :datetime         not null
+#  search_result_id   :integer
+#  user_id            :integer
 #
 # Indexes
 #

--- a/app/models/shared_draft.rb
+++ b/app/models/shared_draft.rb
@@ -9,11 +9,11 @@ end
 #
 # Table name: shared_drafts
 #
-#  topic_id    :integer          not null
-#  category_id :integer          not null
+#  id          :bigint           not null, primary key
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  id          :bigint           not null, primary key
+#  category_id :integer          not null
+#  topic_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -69,12 +69,12 @@ end
 # Table name: sidebar_sections
 #
 #  id           :bigint           not null, primary key
-#  user_id      :integer          not null
+#  public       :boolean          default(FALSE), not null
+#  section_type :integer
 #  title        :string(30)       not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  public       :boolean          default(FALSE), not null
-#  section_type :integer
+#  user_id      :integer          not null
 #
 # Indexes
 #

--- a/app/models/sidebar_section_link.rb
+++ b/app/models/sidebar_section_link.rb
@@ -43,13 +43,13 @@ end
 # Table name: sidebar_section_links
 #
 #  id                 :bigint           not null, primary key
-#  user_id            :integer          not null
-#  linkable_id        :integer          not null
 #  linkable_type      :string           not null
+#  position           :integer          default(0), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  linkable_id        :integer          not null
 #  sidebar_section_id :integer
-#  position           :integer          default(0), not null
+#  user_id            :integer          not null
 #
 # Indexes
 #

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -88,11 +88,11 @@ end
 # Table name: sidebar_urls
 #
 #  id         :bigint           not null, primary key
+#  external   :boolean          default(FALSE), not null
+#  icon       :string(40)       not null
 #  name       :string(80)       not null
+#  segment    :integer          default("primary"), not null
 #  value      :string(1000)     not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  icon       :string(40)       not null
-#  external   :boolean          default(FALSE), not null
-#  segment    :integer          default("primary"), not null
 #

--- a/app/models/single_sign_on_record.rb
+++ b/app/models/single_sign_on_record.rb
@@ -11,17 +11,17 @@ end
 # Table name: single_sign_on_records
 #
 #  id                              :integer          not null, primary key
-#  user_id                         :integer          not null
-#  external_id                     :string           not null
+#  external_avatar_url             :string(2000)
+#  external_card_background_url    :string
+#  external_email                  :string
+#  external_name                   :string
+#  external_profile_background_url :string
+#  external_username               :string
 #  last_payload                    :text             not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
-#  external_username               :string
-#  external_email                  :string
-#  external_name                   :string
-#  external_avatar_url             :string(2000)
-#  external_profile_background_url :string
-#  external_card_background_url    :string
+#  external_id                     :string           not null
+#  user_id                         :integer          not null
 #
 # Indexes
 #

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -415,8 +415,8 @@ end
 # Table name: site_settings
 #
 #  id         :integer          not null, primary key
-#  name       :string           not null
 #  data_type  :integer          not null
+#  name       :string           not null
 #  value      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -72,9 +72,9 @@ end
 # Table name: sitemaps
 #
 #  id             :bigint           not null, primary key
-#  name           :string           not null
-#  last_posted_at :datetime         not null
 #  enabled        :boolean          default(TRUE), not null
+#  last_posted_at :datetime         not null
+#  name           :string           not null
 #
 # Indexes
 #

--- a/app/models/skipped_email_log.rb
+++ b/app/models/skipped_email_log.rb
@@ -78,14 +78,14 @@ end
 # Table name: skipped_email_logs
 #
 #  id            :bigint           not null, primary key
-#  email_type    :string           not null
-#  to_address    :string           not null
-#  user_id       :integer
-#  post_id       :integer
-#  reason_type   :integer          not null
 #  custom_reason :text
+#  email_type    :string           not null
+#  reason_type   :integer          not null
+#  to_address    :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  post_id       :integer
+#  user_id       :integer
 #
 # Indexes
 #

--- a/app/models/stylesheet_cache.rb
+++ b/app/models/stylesheet_cache.rb
@@ -44,13 +44,13 @@ end
 # Table name: stylesheet_cache
 #
 #  id         :integer          not null, primary key
-#  target     :string           not null
-#  digest     :string           not null
 #  content    :text             not null
+#  digest     :string           not null
+#  source_map :text
+#  target     :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  theme_id   :integer          default(-1), not null
-#  source_map :text
 #
 # Indexes
 #

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -327,16 +327,16 @@ end
 # Table name: tags
 #
 #  id                 :integer          not null, primary key
+#  description        :string(1000)
 #  locale             :string(20)
 #  name               :string           not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
 #  pm_topic_count     :integer          default(0), not null
-#  target_tag_id      :integer
-#  description        :string(1000)
 #  public_topic_count :integer          default(0), not null
 #  slug               :string           default(""), not null
 #  staff_topic_count  :integer          default(0), not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  target_tag_id      :integer
 #
 # Indexes
 #

--- a/app/models/tag_group.rb
+++ b/app/models/tag_group.rb
@@ -149,10 +149,10 @@ end
 #
 #  id            :integer          not null, primary key
 #  name          :string(100)      not null
+#  one_per_topic :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  parent_tag_id :integer
-#  one_per_topic :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/tag_group_membership.rb
+++ b/app/models/tag_group_membership.rb
@@ -10,10 +10,10 @@ end
 # Table name: tag_group_memberships
 #
 #  id           :integer          not null, primary key
-#  tag_id       :integer          not null
-#  tag_group_id :integer          not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  tag_group_id :integer          not null
+#  tag_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/tag_group_permission.rb
+++ b/app/models/tag_group_permission.rb
@@ -15,11 +15,11 @@ end
 # Table name: tag_group_permissions
 #
 #  id              :bigint           not null, primary key
-#  tag_group_id    :bigint           not null
-#  group_id        :bigint           not null
 #  permission_type :integer          default(1), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  group_id        :bigint           not null
+#  tag_group_id    :bigint           not null
 #
 # Indexes
 #

--- a/app/models/tag_localization.rb
+++ b/app/models/tag_localization.rb
@@ -24,12 +24,12 @@ end
 # Table name: tag_localizations
 #
 #  id          :bigint           not null, primary key
-#  tag_id      :bigint           not null
+#  description :string(1000)
 #  locale      :string(20)       not null
 #  name        :string           not null
-#  description :string(1000)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  tag_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/tag_search_data.rb
+++ b/app/models/tag_search_data.rb
@@ -8,11 +8,11 @@ end
 #
 # Table name: tag_search_data
 #
-#  tag_id      :integer          not null, primary key
-#  search_data :tsvector
-#  raw_data    :text
 #  locale      :text
+#  raw_data    :text
+#  search_data :tsvector
 #  version     :integer          default(0)
+#  tag_id      :integer          not null, primary key
 #
 # Indexes
 #

--- a/app/models/tag_user.rb
+++ b/app/models/tag_user.rb
@@ -252,11 +252,11 @@ end
 # Table name: tag_users
 #
 #  id                 :integer          not null, primary key
-#  tag_id             :integer          not null
-#  user_id            :integer          not null
 #  notification_level :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  tag_id             :integer          not null
+#  user_id            :integer          not null
 #
 # Indexes
 #

--- a/app/models/theme_field.rb
+++ b/app/models/theme_field.rb
@@ -742,17 +742,17 @@ end
 # Table name: theme_fields
 #
 #  id               :integer          not null, primary key
-#  theme_id         :integer          not null
-#  target_id        :integer          not null
+#  compiler_version :string(50)       default("0"), not null
+#  error            :string
 #  name             :string(255)      not null
 #  value            :text             not null
 #  value_baked      :text
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  compiler_version :string(50)       default("0"), not null
-#  error            :string
-#  upload_id        :integer
+#  target_id        :integer          not null
+#  theme_id         :integer          not null
 #  type_id          :integer          default(0), not null
+#  upload_id        :integer
 #
 # Indexes
 #

--- a/app/models/theme_setting.rb
+++ b/app/models/theme_setting.rb
@@ -94,11 +94,11 @@ end
 # Table name: theme_settings
 #
 #  id         :bigint           not null, primary key
-#  name       :string(255)      not null
 #  data_type  :integer          not null
+#  json_value :jsonb
+#  name       :string(255)      not null
 #  value      :text
-#  theme_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  json_value :jsonb
+#  theme_id   :integer          not null
 #

--- a/app/models/theme_settings_migration.rb
+++ b/app/models/theme_settings_migration.rb
@@ -40,12 +40,12 @@ end
 # Table name: theme_settings_migrations
 #
 #  id             :bigint           not null, primary key
-#  theme_id       :integer          not null
-#  theme_field_id :integer          not null
-#  version        :integer          not null
-#  name           :string(150)      not null
 #  diff           :json             not null
+#  name           :string(150)      not null
+#  version        :integer          not null
 #  created_at     :datetime         not null
+#  theme_field_id :integer          not null
+#  theme_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/theme_site_setting.rb
+++ b/app/models/theme_site_setting.rb
@@ -134,12 +134,12 @@ end
 # Table name: theme_site_settings
 #
 #  id         :bigint           not null, primary key
-#  theme_id   :integer          not null
-#  name       :string           not null
 #  data_type  :integer          not null
+#  name       :string           not null
 #  value      :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  theme_id   :integer          not null
 #
 # Indexes
 #

--- a/app/models/theme_svg_sprite.rb
+++ b/app/models/theme_svg_sprite.rb
@@ -14,11 +14,11 @@ end
 # Table name: theme_svg_sprites
 #
 #  id         :bigint           not null, primary key
-#  theme_id   :integer          not null
-#  upload_id  :integer          not null
 #  sprite     :binary           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  theme_id   :integer          not null
+#  upload_id  :integer          not null
 #
 # Indexes
 #

--- a/app/models/theme_translation_override.rb
+++ b/app/models/theme_translation_override.rb
@@ -14,12 +14,12 @@ end
 # Table name: theme_translation_overrides
 #
 #  id              :bigint           not null, primary key
-#  theme_id        :integer          not null
 #  locale          :string           not null
 #  translation_key :string           not null
 #  value           :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  theme_id        :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2279,54 +2279,54 @@ end
 # Table name: topics
 #
 #  id                        :integer          not null, primary key
-#  title                     :string           not null
+#  archetype                 :string           default("regular"), not null
+#  archived                  :boolean          default(FALSE), not null
+#  bannered_until            :datetime
+#  bumped_at                 :datetime         not null
+#  closed                    :boolean          default(FALSE), not null
+#  deleted_at                :datetime
+#  excerpt                   :string
+#  fancy_title               :string
+#  featured_link             :string
+#  has_summary               :boolean          default(FALSE), not null
+#  highest_post_number       :integer          default(0), not null
+#  highest_staff_post_number :integer          default(0), not null
+#  incoming_link_count       :integer          default(0), not null
 #  last_posted_at            :datetime
+#  like_count                :integer          default(0), not null
+#  locale                    :string(20)
+#  moderator_posts_count     :integer          default(0), not null
+#  notify_moderators_count   :integer          default(0), not null
+#  participant_count         :integer          default(1)
+#  percent_rank              :float            default(1.0), not null
+#  pinned_at                 :datetime
+#  pinned_globally           :boolean          default(FALSE), not null
+#  pinned_until              :datetime
+#  posts_count               :integer          default(0), not null
+#  reply_count               :integer          default(0), not null
+#  reviewable_score          :float            default(0.0), not null
+#  score                     :float
+#  slow_mode_seconds         :integer          default(0), not null
+#  slug                      :string
+#  spam_count                :integer          default(0), not null
+#  subtype                   :string
+#  title                     :string           not null
+#  views                     :integer          default(0), not null
+#  visible                   :boolean          default(TRUE), not null
+#  word_count                :integer
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  views                     :integer          default(0), not null
-#  posts_count               :integer          default(0), not null
-#  user_id                   :integer
-#  last_post_user_id         :integer          not null
-#  reply_count               :integer          default(0), not null
+#  category_id               :integer
+#  deleted_by_id             :integer
+#  external_id               :string
 #  featured_user1_id         :integer
 #  featured_user2_id         :integer
 #  featured_user3_id         :integer
-#  deleted_at                :datetime
-#  highest_post_number       :integer          default(0), not null
-#  like_count                :integer          default(0), not null
-#  incoming_link_count       :integer          default(0), not null
-#  category_id               :integer
-#  visible                   :boolean          default(TRUE), not null
-#  moderator_posts_count     :integer          default(0), not null
-#  closed                    :boolean          default(FALSE), not null
-#  archived                  :boolean          default(FALSE), not null
-#  bumped_at                 :datetime         not null
-#  has_summary               :boolean          default(FALSE), not null
-#  archetype                 :string           default("regular"), not null
 #  featured_user4_id         :integer
-#  notify_moderators_count   :integer          default(0), not null
-#  spam_count                :integer          default(0), not null
-#  pinned_at                 :datetime
-#  score                     :float
-#  percent_rank              :float            default(1.0), not null
-#  subtype                   :string
-#  slug                      :string
-#  deleted_by_id             :integer
-#  participant_count         :integer          default(1)
-#  word_count                :integer
-#  excerpt                   :string
-#  pinned_globally           :boolean          default(FALSE), not null
-#  pinned_until              :datetime
-#  fancy_title               :string
-#  highest_staff_post_number :integer          default(0), not null
-#  featured_link             :string
-#  reviewable_score          :float            default(0.0), not null
 #  image_upload_id           :bigint
-#  slow_mode_seconds         :integer          default(0), not null
-#  bannered_until            :datetime
-#  external_id               :string
+#  last_post_user_id         :integer          not null
+#  user_id                   :integer
 #  visibility_reason_id      :integer
-#  locale                    :string(20)
 #
 # Indexes
 #

--- a/app/models/topic_allowed_user.rb
+++ b/app/models/topic_allowed_user.rb
@@ -12,10 +12,10 @@ end
 # Table name: topic_allowed_users
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
-#  topic_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  topic_id   :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_embed.rb
+++ b/app/models/topic_embed.rb
@@ -374,15 +374,15 @@ end
 # Table name: topic_embeds
 #
 #  id                  :integer          not null, primary key
-#  topic_id            :integer          not null
-#  post_id             :integer          not null
-#  embed_url           :string(1000)     not null
 #  content_sha1        :string(40)
+#  deleted_at          :datetime
+#  embed_content_cache :text
+#  embed_url           :string(1000)     not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  deleted_at          :datetime
 #  deleted_by_id       :integer
-#  embed_content_cache :text
+#  post_id             :integer          not null
+#  topic_id            :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_group.rb
+++ b/app/models/topic_group.rb
@@ -73,11 +73,11 @@ end
 # Table name: topic_groups
 #
 #  id                    :bigint           not null, primary key
-#  group_id              :integer          not null
-#  topic_id              :integer          not null
 #  last_read_post_number :integer          default(0), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  group_id              :integer          not null
+#  topic_id              :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_hot_score.rb
+++ b/app/models/topic_hot_score.rb
@@ -194,13 +194,13 @@ end
 # Table name: topic_hot_scores
 #
 #  id                     :bigint           not null, primary key
-#  topic_id               :integer          not null
-#  score                  :float            default(0.0), not null
+#  recent_first_bumped_at :datetime
 #  recent_likes           :integer          default(0), not null
 #  recent_posters         :integer          default(0), not null
-#  recent_first_bumped_at :datetime
+#  score                  :float            default(0.0), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  topic_id               :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_invite.rb
+++ b/app/models/topic_invite.rb
@@ -15,10 +15,10 @@ end
 # Table name: topic_invites
 #
 #  id         :integer          not null, primary key
-#  topic_id   :integer          not null
-#  invite_id  :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  invite_id  :integer          not null
+#  topic_id   :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -437,22 +437,22 @@ end
 # Table name: topic_links
 #
 #  id            :integer          not null, primary key
-#  topic_id      :integer          not null
-#  post_id       :integer
-#  user_id       :integer          not null
-#  url           :string           not null
+#  clicks        :integer          default(0), not null
+#  crawled_at    :datetime
 #  domain        :string(100)      not null
+#  extension     :string(10)
 #  internal      :boolean          default(FALSE), not null
-#  link_topic_id :integer
+#  quote         :boolean          default(FALSE), not null
+#  reflection    :boolean          default(FALSE)
+#  title         :string
+#  url           :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  reflection    :boolean          default(FALSE)
-#  clicks        :integer          default(0), not null
 #  link_post_id  :integer
-#  title         :string
-#  crawled_at    :datetime
-#  quote         :boolean          default(FALSE), not null
-#  extension     :string(10)
+#  link_topic_id :integer
+#  post_id       :integer
+#  topic_id      :integer          not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -122,11 +122,11 @@ end
 # Table name: topic_link_clicks
 #
 #  id            :integer          not null, primary key
-#  topic_link_id :integer          not null
-#  user_id       :integer
+#  ip_address    :inet
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  ip_address    :inet
+#  topic_link_id :integer          not null
+#  user_id       :integer
 #
 # Indexes
 #

--- a/app/models/topic_localization.rb
+++ b/app/models/topic_localization.rb
@@ -30,14 +30,14 @@ end
 # Table name: topic_localizations
 #
 #  id                :bigint           not null, primary key
-#  topic_id          :integer          not null
+#  excerpt           :string
+#  fancy_title       :string           not null
 #  locale            :string(20)       not null
 #  title             :string           not null
-#  fancy_title       :string           not null
-#  localizer_user_id :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  excerpt           :string
+#  localizer_user_id :integer          not null
+#  topic_id          :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_search_data.rb
+++ b/app/models/topic_search_data.rb
@@ -8,11 +8,11 @@ end
 #
 # Table name: topic_search_data
 #
-#  topic_id    :integer          not null, primary key
-#  raw_data    :text
 #  locale      :string           not null
+#  raw_data    :text
 #  search_data :tsvector
 #  version     :integer          default(0)
+#  topic_id    :integer          not null, primary key
 #
 # Indexes
 #

--- a/app/models/topic_thumbnail.rb
+++ b/app/models/topic_thumbnail.rb
@@ -69,10 +69,10 @@ end
 # Table name: topic_thumbnails
 #
 #  id                 :bigint           not null, primary key
-#  upload_id          :bigint           not null
-#  optimized_image_id :bigint
-#  max_width          :integer          not null
 #  max_height         :integer          not null
+#  max_width          :integer          not null
+#  optimized_image_id :bigint
+#  upload_id          :bigint           not null
 #
 # Indexes
 #

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -546,22 +546,22 @@ end
 #
 # Table name: topic_users
 #
-#  user_id                  :integer          not null
-#  topic_id                 :integer          not null
-#  posted                   :boolean          default(FALSE), not null
+#  id                       :integer          not null, primary key
+#  bookmarked               :boolean          default(FALSE)
+#  cleared_pinned_at        :datetime
+#  first_visited_at         :datetime
+#  last_emailed_post_number :integer
+#  last_posted_at           :datetime
 #  last_read_post_number    :integer
 #  last_visited_at          :datetime
-#  first_visited_at         :datetime
+#  liked                    :boolean          default(FALSE)
 #  notification_level       :integer          default(1), not null
 #  notifications_changed_at :datetime
-#  notifications_reason_id  :integer
+#  posted                   :boolean          default(FALSE), not null
 #  total_msecs_viewed       :integer          default(0), not null
-#  cleared_pinned_at        :datetime
-#  id                       :integer          not null, primary key
-#  last_emailed_post_number :integer
-#  liked                    :boolean          default(FALSE)
-#  bookmarked               :boolean          default(FALSE)
-#  last_posted_at           :datetime
+#  notifications_reason_id  :integer
+#  topic_id                 :integer          not null
+#  user_id                  :integer          not null
 #
 # Indexes
 #

--- a/app/models/topic_view_item.rb
+++ b/app/models/topic_view_item.rb
@@ -68,10 +68,10 @@ end
 #
 # Table name: topic_views
 #
-#  topic_id   :integer          not null
-#  viewed_at  :date             not null
-#  user_id    :integer
 #  ip_address :inet
+#  viewed_at  :date             not null
+#  topic_id   :integer          not null
+#  user_id    :integer
 #
 # Indexes
 #

--- a/app/models/topic_view_stat.rb
+++ b/app/models/topic_view_stat.rb
@@ -28,10 +28,10 @@ end
 # Table name: topic_view_stats
 #
 #  id              :bigint           not null, primary key
-#  topic_id        :integer          not null
-#  viewed_at       :date             not null
 #  anonymous_views :integer          default(0), not null
 #  logged_in_views :integer          default(0), not null
+#  viewed_at       :date             not null
+#  topic_id        :integer          not null
 #
 # Indexes
 #

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -230,12 +230,12 @@ end
 #
 #  id                   :integer          not null, primary key
 #  locale               :string           not null
+#  original_translation :text
+#  status               :integer          default("up_to_date"), not null
 #  translation_key      :string           not null
 #  value                :string           not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  original_translation :text
-#  status               :integer          default("up_to_date"), not null
 #
 # Indexes
 #

--- a/app/models/unsubscribe_key.rb
+++ b/app/models/unsubscribe_key.rb
@@ -59,12 +59,12 @@ end
 # Table name: unsubscribe_keys
 #
 #  key                  :string(64)       not null, primary key
-#  user_id              :integer          not null
+#  unsubscribe_key_type :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
-#  unsubscribe_key_type :string
-#  topic_id             :integer
 #  post_id              :integer
+#  topic_id             :integer
+#  user_id              :integer          not null
 #
 # Indexes
 #

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -697,29 +697,29 @@ end
 # Table name: uploads
 #
 #  id                           :integer          not null, primary key
-#  user_id                      :integer          not null
-#  original_filename            :string           not null
-#  filesize                     :bigint           not null
-#  width                        :integer
-#  height                       :integer
-#  url                          :string           not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
-#  sha1                         :string(40)
-#  origin                       :string(2000)
-#  retain_hours                 :integer
-#  extension                    :string(10)
-#  thumbnail_width              :integer
-#  thumbnail_height             :integer
-#  etag                         :string
-#  secure                       :boolean          default(FALSE), not null
-#  access_control_post_id       :bigint
-#  original_sha1                :string
 #  animated                     :boolean
-#  verification_status          :integer          default(1), not null
+#  dominant_color               :text
+#  etag                         :string
+#  extension                    :string(10)
+#  filesize                     :bigint           not null
+#  height                       :integer
+#  origin                       :string(2000)
+#  original_filename            :string           not null
+#  original_sha1                :string
+#  retain_hours                 :integer
+#  secure                       :boolean          default(FALSE), not null
 #  security_last_changed_at     :datetime
 #  security_last_changed_reason :string
-#  dominant_color               :text
+#  sha1                         :string(40)
+#  thumbnail_height             :integer
+#  thumbnail_width              :integer
+#  url                          :string           not null
+#  verification_status          :integer          default(1), not null
+#  width                        :integer
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  access_control_post_id       :bigint
+#  user_id                      :integer          not null
 #
 # Indexes
 #

--- a/app/models/upload_reference.rb
+++ b/app/models/upload_reference.rb
@@ -52,11 +52,11 @@ end
 # Table name: upload_references
 #
 #  id          :bigint           not null, primary key
-#  upload_id   :bigint           not null
 #  target_type :string           not null
-#  target_id   :bigint           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  target_id   :bigint           not null
+#  upload_id   :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2351,43 +2351,43 @@ end
 # Table name: users
 #
 #  id                        :integer          not null, primary key
-#  username                  :string(60)       not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  name                      :string
-#  last_posted_at            :datetime
 #  active                    :boolean          default(FALSE), not null
-#  username_lower            :string(60)       not null
-#  last_seen_at              :datetime
 #  admin                     :boolean          default(FALSE), not null
-#  last_emailed_at           :datetime
-#  trust_level               :integer          not null
 #  approved                  :boolean          default(FALSE), not null
-#  approved_by_id            :integer
 #  approved_at               :datetime
+#  date_of_birth             :date
+#  first_seen_at             :datetime
+#  flag_level                :integer          default(0), not null
+#  group_locked_trust_level  :integer
+#  ip_address                :inet
+#  last_emailed_at           :datetime
+#  last_posted_at            :datetime
+#  last_seen_at              :datetime
+#  locale                    :string(10)
+#  manual_locked_trust_level :integer
+#  moderator                 :boolean          default(FALSE)
+#  name                      :string
 #  previous_visit_at         :datetime
+#  registration_ip_address   :inet
+#  required_fields_version   :integer
+#  secure_identifier         :string
+#  silenced_till             :datetime
+#  staged                    :boolean          default(FALSE), not null
 #  suspended_at              :datetime
 #  suspended_till            :datetime
-#  date_of_birth             :date
-#  views                     :integer          default(0), not null
-#  flag_level                :integer          default(0), not null
-#  ip_address                :inet
-#  moderator                 :boolean          default(FALSE)
 #  title                     :string
-#  uploaded_avatar_id        :integer
-#  locale                    :string(10)
-#  primary_group_id          :integer
-#  registration_ip_address   :inet
-#  staged                    :boolean          default(FALSE), not null
-#  first_seen_at             :datetime
-#  silenced_till             :datetime
-#  group_locked_trust_level  :integer
-#  manual_locked_trust_level :integer
-#  secure_identifier         :string
+#  trust_level               :integer          not null
+#  username                  :string(60)       not null
+#  username_lower            :string(60)       not null
+#  views                     :integer          default(0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  approved_by_id            :integer
 #  flair_group_id            :integer
 #  last_seen_reviewable_id   :integer
-#  required_fields_version   :integer
+#  primary_group_id          :integer
 #  seen_notification_id      :bigint           default(0), not null
+#  uploaded_avatar_id        :integer
 #
 # Indexes
 #

--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -493,13 +493,13 @@ end
 #
 #  id              :integer          not null, primary key
 #  action_type     :integer          not null
-#  user_id         :integer          not null
-#  target_topic_id :integer
-#  target_post_id  :integer
-#  target_user_id  :integer
-#  acting_user_id  :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  acting_user_id  :integer
+#  target_post_id  :integer
+#  target_topic_id :integer
+#  target_user_id  :integer
+#  user_id         :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_api_key.rb
+++ b/app/models/user_api_key.rb
@@ -101,14 +101,14 @@ end
 # Table name: user_api_keys
 #
 #  id                     :integer          not null, primary key
-#  user_id                :integer          not null
+#  key_hash               :string           not null
+#  last_used_at           :datetime         not null
 #  push_url               :string
+#  revoked_at             :datetime
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  revoked_at             :datetime
-#  last_used_at           :datetime         not null
-#  key_hash               :string           not null
 #  user_api_key_client_id :bigint
+#  user_id                :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_api_key_client.rb
+++ b/app/models/user_api_key_client.rb
@@ -25,12 +25,12 @@ end
 # Table name: user_api_key_clients
 #
 #  id               :bigint           not null, primary key
-#  client_id        :string           not null
 #  application_name :string           not null
-#  public_key       :string
 #  auth_redirect    :string
+#  public_key       :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  client_id        :string           not null
 #
 # Indexes
 #

--- a/app/models/user_api_key_client_scope.rb
+++ b/app/models/user_api_key_client_scope.rb
@@ -19,8 +19,8 @@ end
 # Table name: user_api_key_client_scopes
 #
 #  id                     :bigint           not null, primary key
-#  user_api_key_client_id :bigint           not null
 #  name                   :string(100)      not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  user_api_key_client_id :bigint           not null
 #

--- a/app/models/user_api_key_scope.rb
+++ b/app/models/user_api_key_scope.rb
@@ -56,11 +56,11 @@ end
 # Table name: user_api_key_scopes
 #
 #  id                 :bigint           not null, primary key
-#  user_api_key_id    :integer          not null
+#  allowed_parameters :jsonb
 #  name               :string           not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  allowed_parameters :jsonb
+#  user_api_key_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_archived_message.rb
+++ b/app/models/user_archived_message.rb
@@ -42,10 +42,10 @@ end
 # Table name: user_archived_messages
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
-#  topic_id   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  topic_id   :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_associated_account.rb
+++ b/app/models/user_associated_account.rb
@@ -15,15 +15,15 @@ end
 # Table name: user_associated_accounts
 #
 #  id            :bigint           not null, primary key
-#  provider_name :string           not null
-#  provider_uid  :string           not null
-#  user_id       :integer
-#  last_used     :datetime         not null
-#  info          :jsonb            not null
 #  credentials   :jsonb            not null
 #  extra         :jsonb            not null
+#  info          :jsonb            not null
+#  last_used     :datetime         not null
+#  provider_name :string           not null
+#  provider_uid  :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  user_id       :integer
 #
 # Indexes
 #

--- a/app/models/user_associated_group.rb
+++ b/app/models/user_associated_group.rb
@@ -38,10 +38,10 @@ end
 # Table name: user_associated_groups
 #
 #  id                  :bigint           not null, primary key
-#  user_id             :bigint           not null
-#  associated_group_id :bigint           not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  associated_group_id :bigint           not null
+#  user_id             :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user_auth_token_log.rb
+++ b/app/models/user_auth_token_log.rb
@@ -10,13 +10,13 @@ end
 #
 #  id                 :integer          not null, primary key
 #  action             :string           not null
+#  auth_token         :string
+#  client_ip          :inet
+#  path               :string
+#  user_agent         :string
+#  created_at         :datetime
 #  user_auth_token_id :integer
 #  user_id            :integer
-#  client_ip          :inet
-#  user_agent         :string
-#  auth_token         :string
-#  created_at         :datetime
-#  path               :string
 #
 # Indexes
 #

--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -217,12 +217,12 @@ end
 # Table name: user_avatars
 #
 #  id                             :integer          not null, primary key
-#  user_id                        :integer          not null
-#  custom_upload_id               :integer
-#  gravatar_upload_id             :integer
 #  last_gravatar_download_attempt :datetime
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
+#  custom_upload_id               :integer
+#  gravatar_upload_id             :integer
+#  user_id                        :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_badge.rb
+++ b/app/models/user_badge.rb
@@ -133,16 +133,16 @@ end
 # Table name: user_badges
 #
 #  id              :integer          not null, primary key
-#  badge_id        :integer          not null
-#  user_id         :integer          not null
-#  granted_at      :datetime         not null
-#  granted_by_id   :integer          not null
-#  post_id         :integer
-#  seq             :integer          default(0), not null
 #  featured_rank   :integer
-#  created_at      :datetime         not null
+#  granted_at      :datetime         not null
 #  is_favorite     :boolean
+#  seq             :integer          default(0), not null
+#  created_at      :datetime         not null
+#  badge_id        :integer          not null
+#  granted_by_id   :integer          not null
 #  notification_id :bigint
+#  post_id         :integer
+#  user_id         :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -113,12 +113,12 @@ end
 # Table name: user_emails
 #
 #  id               :integer          not null, primary key
-#  user_id          :integer          not null
 #  email            :string(513)      not null
+#  normalized_email :string
 #  primary          :boolean          default(FALSE), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  normalized_email :string
+#  user_id          :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_export.rb
+++ b/app/models/user_export.rb
@@ -53,9 +53,9 @@ end
 #
 #  id         :integer          not null, primary key
 #  file_name  :string           not null
-#  user_id    :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  upload_id  :integer
 #  topic_id   :integer
+#  upload_id  :integer
+#  user_id    :integer          not null
 #

--- a/app/models/user_field_option.rb
+++ b/app/models/user_field_option.rb
@@ -9,8 +9,8 @@ end
 # Table name: user_field_options
 #
 #  id            :integer          not null, primary key
-#  user_field_id :integer          not null
 #  value         :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  user_field_id :integer          not null
 #

--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -470,23 +470,23 @@ end
 #
 #  id             :integer          not null, primary key
 #  action         :integer          not null
-#  acting_user_id :integer
-#  target_user_id :integer
+#  admin_only     :boolean          default(FALSE)
+#  context        :string
+#  custom_type    :string
 #  details        :text
+#  email          :string
+#  ip_address     :string
+#  new_value      :text
+#  previous_value :text
+#  subject        :text
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  context        :string
-#  ip_address     :string
-#  email          :string
-#  subject        :text
-#  previous_value :text
-#  new_value      :text
-#  topic_id       :integer
-#  admin_only     :boolean          default(FALSE)
-#  post_id        :integer
-#  custom_type    :string
+#  acting_user_id :integer
 #  category_id    :integer
+#  post_id        :integer
 #  reviewable_id  :bigint
+#  target_user_id :integer
+#  topic_id       :integer
 #
 # Indexes
 #

--- a/app/models/user_ip_address_history.rb
+++ b/app/models/user_ip_address_history.rb
@@ -12,10 +12,10 @@ end
 # Table name: user_ip_address_histories
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
 #  ip_address :inet             not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_notification_schedule.rb
+++ b/app/models/user_notification_schedule.rb
@@ -51,22 +51,22 @@ end
 # Table name: user_notification_schedules
 #
 #  id               :bigint           not null, primary key
-#  user_id          :integer          not null
-#  enabled          :boolean          default(FALSE), not null
-#  day_0_start_time :integer          not null
 #  day_0_end_time   :integer          not null
-#  day_1_start_time :integer          not null
+#  day_0_start_time :integer          not null
 #  day_1_end_time   :integer          not null
-#  day_2_start_time :integer          not null
+#  day_1_start_time :integer          not null
 #  day_2_end_time   :integer          not null
-#  day_3_start_time :integer          not null
+#  day_2_start_time :integer          not null
 #  day_3_end_time   :integer          not null
-#  day_4_start_time :integer          not null
+#  day_3_start_time :integer          not null
 #  day_4_end_time   :integer          not null
-#  day_5_start_time :integer          not null
+#  day_4_start_time :integer          not null
 #  day_5_end_time   :integer          not null
-#  day_6_start_time :integer          not null
+#  day_5_start_time :integer          not null
 #  day_6_end_time   :integer          not null
+#  day_6_start_time :integer          not null
+#  enabled          :boolean          default(FALSE), not null
+#  user_id          :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_open_id.rb
+++ b/app/models/user_open_id.rb
@@ -21,12 +21,12 @@ end
 # Table name: user_open_ids
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
+#  active     :boolean          not null
 #  email      :string           not null
 #  url        :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  active     :boolean          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_password.rb
+++ b/app/models/user_password.rb
@@ -78,13 +78,13 @@ end
 # Table name: user_passwords
 #
 #  id                  :integer          not null, primary key
-#  user_id             :integer          not null
-#  password_hash       :string(64)       not null
-#  password_salt       :string(32)       not null
 #  password_algorithm  :string(64)       not null
 #  password_expired_at :datetime
+#  password_hash       :string(64)       not null
+#  password_salt       :string(32)       not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -221,18 +221,18 @@ end
 #
 # Table name: user_profiles
 #
-#  user_id                      :integer          not null, primary key
-#  location                     :string(3000)
-#  website                      :string(3000)
-#  bio_raw                      :text
 #  bio_cooked                   :text
-#  dismissed_banner_key         :integer
 #  bio_cooked_version           :integer
+#  bio_raw                      :text
+#  dismissed_banner_key         :integer
+#  location                     :string(3000)
 #  views                        :integer          default(0), not null
-#  profile_background_upload_id :integer
+#  website                      :string(3000)
 #  card_background_upload_id    :integer
-#  granted_title_badge_id       :bigint
 #  featured_topic_id            :integer
+#  granted_title_badge_id       :bigint
+#  profile_background_upload_id :integer
+#  user_id                      :integer          not null, primary key
 #
 # Indexes
 #

--- a/app/models/user_profile_view.rb
+++ b/app/models/user_profile_view.rb
@@ -72,10 +72,10 @@ end
 # Table name: user_profile_views
 #
 #  id              :integer          not null, primary key
-#  user_profile_id :integer          not null
-#  viewed_at       :datetime         not null
 #  ip_address      :inet
+#  viewed_at       :datetime         not null
 #  user_id         :integer
+#  user_profile_id :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_search_data.rb
+++ b/app/models/user_search_data.rb
@@ -8,11 +8,11 @@ end
 #
 # Table name: user_search_data
 #
-#  user_id     :integer          not null, primary key
-#  search_data :tsvector
-#  raw_data    :text
 #  locale      :text
+#  raw_data    :text
+#  search_data :tsvector
 #  version     :integer          default(0)
+#  user_id     :integer          not null, primary key
 #
 # Indexes
 #

--- a/app/models/user_second_factor.rb
+++ b/app/models/user_second_factor.rb
@@ -46,14 +46,14 @@ end
 # Table name: user_second_factors
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  method     :integer          not null
 #  data       :string           not null
 #  enabled    :boolean          default(FALSE), not null
 #  last_used  :datetime
+#  method     :integer          not null
+#  name       :string(300)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  name       :string(300)
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_security_key.rb
+++ b/app/models/user_security_key.rb
@@ -33,15 +33,15 @@ end
 # Table name: user_security_keys
 #
 #  id            :bigint           not null, primary key
-#  user_id       :bigint           not null
-#  credential_id :string           not null
-#  public_key    :string           not null
-#  factor_type   :integer          default(0), not null
 #  enabled       :boolean          default(TRUE), not null
-#  name          :string(300)      not null
+#  factor_type   :integer          default(0), not null
 #  last_used     :datetime
+#  name          :string(300)      not null
+#  public_key    :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  credential_id :string           not null
+#  user_id       :bigint           not null
 #
 # Indexes
 #

--- a/app/models/user_stat.rb
+++ b/app/models/user_stat.rb
@@ -321,28 +321,28 @@ end
 #
 # Table name: user_stats
 #
-#  user_id                  :integer          not null, primary key
-#  topics_entered           :integer          default(0), not null
-#  time_read                :integer          default(0), not null
-#  days_visited             :integer          default(0), not null
-#  posts_read_count         :integer          default(0), not null
-#  likes_given              :integer          default(0), not null
-#  likes_received           :integer          default(0), not null
-#  new_since                :datetime         not null
-#  read_faq                 :datetime
-#  first_post_created_at    :datetime
-#  post_count               :integer          default(0), not null
-#  topic_count              :integer          default(0), not null
 #  bounce_score             :float            default(0.0), not null
-#  reset_bounce_score_after :datetime
+#  days_visited             :integer          default(0), not null
+#  digest_attempted_at      :datetime
+#  distinct_badge_count     :integer          default(0), not null
+#  draft_count              :integer          default(0), not null
+#  first_post_created_at    :datetime
+#  first_unread_at          :datetime         not null
+#  first_unread_pm_at       :datetime         not null
 #  flags_agreed             :integer          default(0), not null
 #  flags_disagreed          :integer          default(0), not null
 #  flags_ignored            :integer          default(0), not null
-#  first_unread_at          :datetime         not null
-#  distinct_badge_count     :integer          default(0), not null
-#  first_unread_pm_at       :datetime         not null
-#  digest_attempted_at      :datetime
-#  post_edits_count         :integer
-#  draft_count              :integer          default(0), not null
+#  likes_given              :integer          default(0), not null
+#  likes_received           :integer          default(0), not null
+#  new_since                :datetime         not null
 #  pending_posts_count      :integer          default(0), not null
+#  post_count               :integer          default(0), not null
+#  post_edits_count         :integer
+#  posts_read_count         :integer          default(0), not null
+#  read_faq                 :datetime
+#  reset_bounce_score_after :datetime
+#  time_read                :integer          default(0), not null
+#  topic_count              :integer          default(0), not null
+#  topics_entered           :integer          default(0), not null
+#  user_id                  :integer          not null, primary key
 #

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -29,9 +29,9 @@ end
 #
 # Table name: user_statuses
 #
-#  user_id     :integer          not null, primary key
-#  emoji       :string           not null
 #  description :string           not null
-#  set_at      :datetime         not null
+#  emoji       :string           not null
 #  ends_at     :datetime
+#  set_at      :datetime         not null
+#  user_id     :integer          not null, primary key
 #

--- a/app/models/user_upload.rb
+++ b/app/models/user_upload.rb
@@ -10,9 +10,9 @@ end
 # Table name: user_uploads
 #
 #  id         :bigint           not null, primary key
+#  created_at :datetime         not null
 #  upload_id  :integer          not null
 #  user_id    :integer          not null
-#  created_at :datetime         not null
 #
 # Indexes
 #

--- a/app/models/user_visit.rb
+++ b/app/models/user_visit.rb
@@ -85,11 +85,11 @@ end
 # Table name: user_visits
 #
 #  id         :integer          not null, primary key
-#  user_id    :integer          not null
-#  visited_at :date             not null
-#  posts_read :integer          default(0)
 #  mobile     :boolean          default(FALSE)
+#  posts_read :integer          default(0)
 #  time_read  :integer          default(0), not null
+#  visited_at :date             not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/app/models/user_warning.rb
+++ b/app/models/user_warning.rb
@@ -11,11 +11,11 @@ end
 # Table name: user_warnings
 #
 #  id            :integer          not null, primary key
-#  topic_id      :integer          not null
-#  user_id       :integer          not null
-#  created_by_id :integer          not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  created_by_id :integer          not null
+#  topic_id      :integer          not null
+#  user_id       :integer          not null
 #
 # Indexes
 #

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -120,14 +120,14 @@ end
 # Table name: watched_words
 #
 #  id                    :integer          not null, primary key
-#  word                  :string           not null
 #  action                :integer          not null
+#  case_sensitive        :boolean          default(FALSE), not null
+#  html                  :boolean          default(FALSE), not null
+#  replacement           :string
+#  word                  :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  replacement           :string
-#  case_sensitive        :boolean          default(FALSE), not null
 #  watched_word_group_id :bigint
-#  html                  :boolean          default(FALSE), not null
 #
 # Indexes
 #

--- a/app/models/web_crawler_request.rb
+++ b/app/models/web_crawler_request.rb
@@ -40,9 +40,9 @@ end
 # Table name: web_crawler_requests
 #
 #  id         :bigint           not null, primary key
+#  count      :integer          default(0), not null
 #  date       :date             not null
 #  user_agent :string           not null
-#  count      :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -168,14 +168,14 @@ end
 # Table name: web_hooks
 #
 #  id                   :integer          not null, primary key
-#  payload_url          :string           not null
+#  active               :boolean          default(FALSE), not null
 #  content_type         :integer          default(1), not null
 #  last_delivery_status :integer          default(1), not null
-#  status               :integer          default(1), not null
+#  payload_url          :string           not null
 #  secret               :string           default("")
-#  wildcard_web_hook    :boolean          default(FALSE), not null
+#  status               :integer          default(1), not null
 #  verify_certificate   :boolean          default(TRUE), not null
-#  active               :boolean          default(FALSE), not null
+#  wildcard_web_hook    :boolean          default(FALSE), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #

--- a/app/models/web_hook_event_type.rb
+++ b/app/models/web_hook_event_type.rb
@@ -143,6 +143,6 @@ end
 # Table name: web_hook_event_types
 #
 #  id    :integer          not null, primary key
-#  name  :string           not null
 #  group :integer
+#  name  :string           not null
 #

--- a/app/models/web_hook_event_types_hook.rb
+++ b/app/models/web_hook_event_types_hook.rb
@@ -9,8 +9,8 @@ end
 #
 # Table name: web_hook_event_types_hooks
 #
-#  web_hook_id            :integer          not null
 #  web_hook_event_type_id :integer          not null
+#  web_hook_id            :integer          not null
 #
 # Indexes
 #

--- a/app/models/web_hook_events_daily_aggregate.rb
+++ b/app/models/web_hook_events_daily_aggregate.rb
@@ -43,13 +43,13 @@ end
 # Table name: web_hook_events_daily_aggregates
 #
 #  id                     :bigint           not null, primary key
-#  web_hook_id            :bigint           not null
 #  date                   :date
-#  successful_event_count :integer
 #  failed_event_count     :integer
 #  mean_duration          :integer          default(0)
+#  successful_event_count :integer
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  web_hook_id            :bigint           not null
 #
 # Indexes
 #

--- a/lib/tasks/annotate.rake
+++ b/lib/tasks/annotate.rake
@@ -2,14 +2,14 @@
 
 # Runs annotaterb in a TemporaryDb so the seed topics that
 # `annotate:ensure_all_indexes` creates don't leak into the persistent test DB.
-def annotate_in_temp_db(load_plugins:, annotaterb_args: "")
-  env = "RAILS_ENV=test LOAD_PLUGINS=#{load_plugins}"
+def annotate_in_temp_db(load_plugins:, annotaterb_args: [])
+  env = { "RAILS_ENV" => "test", "LOAD_PLUGINS" => load_plugins }
   db = TemporaryDb.new
   db.start
   db.with_env do
-    system("#{env} bin/rails db:migrate", exception: true)
-    system("#{env} bin/rails annotate:ensure_all_indexes", exception: true)
-    system("#{env} bin/annotaterb models #{annotaterb_args}".strip, exception: true)
+    system(env, "bin/rails", "db:migrate", exception: true)
+    system(env, "bin/rails", "annotate:ensure_all_indexes", exception: true)
+    system(env, "bin/annotaterb", "models", "--force", *annotaterb_args, exception: true)
   end
 ensure
   db&.stop
@@ -42,13 +42,16 @@ desc "regenerate core model annotations using a temporary database"
 task "annotate:clean" => :environment do |task, args|
   load_plugins = ENV["LOAD_PLUGINS"].presence || "0"
   model_dir = ENV["MODEL_DIR"].presence || "app/models"
-  annotate_in_temp_db(load_plugins: load_plugins, annotaterb_args: "--model-dir #{model_dir}")
+  annotate_in_temp_db(load_plugins: load_plugins, annotaterb_args: ["--model-dir", model_dir])
   STDERR.puts "Annotate executed successfully"
 end
 
 desc "regenerate plugin model annotations using a temporary database"
 task "annotate:clean:plugins", [:plugin] => :environment do |task, args|
-  specific_plugin = "--model-dir plugins/#{args[:plugin]}/app/models" if args[:plugin].present?
-  annotate_in_temp_db(load_plugins: "1", annotaterb_args: specific_plugin.to_s)
+  annotaterb_args = []
+  if args[:plugin].present?
+    annotaterb_args.push("--model-dir", "plugins/#{args[:plugin]}/app/models")
+  end
+  annotate_in_temp_db(load_plugins: "1", annotaterb_args: annotaterb_args)
   STDERR.puts "Annotate executed successfully"
 end

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -257,11 +257,11 @@ end
 # Table name: discourse_automation_automations
 #
 #  id                 :bigint           not null, primary key
+#  enabled            :boolean          default(FALSE), not null
 #  name               :string
 #  script             :string           not null
-#  enabled            :boolean          default(FALSE), not null
+#  trigger            :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #  last_updated_by_id :integer          not null
-#  trigger            :string
 #

--- a/plugins/automation/app/models/discourse_automation/field.rb
+++ b/plugins/automation/app/models/discourse_automation/field.rb
@@ -265,11 +265,11 @@ end
 # Table name: discourse_automation_fields
 #
 #  id            :bigint           not null, primary key
-#  automation_id :bigint           not null
-#  metadata      :jsonb            not null
 #  component     :string           not null
+#  metadata      :jsonb            not null
 #  name          :string           not null
+#  target        :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  target        :string
+#  automation_id :bigint           not null
 #

--- a/plugins/automation/app/models/discourse_automation/pending_automation.rb
+++ b/plugins/automation/app/models/discourse_automation/pending_automation.rb
@@ -13,8 +13,8 @@ end
 # Table name: discourse_automation_pending_automations
 #
 #  id            :bigint           not null, primary key
-#  automation_id :bigint           not null
 #  execute_at    :datetime         not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  automation_id :bigint           not null
 #

--- a/plugins/automation/app/models/discourse_automation/user_global_notice.rb
+++ b/plugins/automation/app/models/discourse_automation/user_global_notice.rb
@@ -13,12 +13,12 @@ end
 # Table name: discourse_automation_user_global_notices
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  notice     :text             not null
 #  identifier :string           not null
 #  level      :string           default("info")
+#  notice     :text             not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/all_mention.rb
+++ b/plugins/chat/app/models/chat/all_mention.rb
@@ -10,10 +10,10 @@ end
 # Table name: chat_mentions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint           not null
+#  type            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  type            :string           not null
+#  chat_message_id :bigint           not null
 #  target_id       :integer
 #
 # Indexes

--- a/plugins/chat/app/models/chat/category_channel.rb
+++ b/plugins/chat/app/models/chat/category_channel.rb
@@ -36,27 +36,27 @@ end
 # Table name: chat_channels
 #
 #  id                          :bigint           not null, primary key
-#  chatable_id                 :bigint           not null
-#  deleted_at                  :datetime
-#  deleted_by_id               :integer
-#  featured_in_category_id     :integer
-#  delete_after_seconds        :integer
+#  allow_channel_wide_mentions :boolean          default(TRUE), not null
+#  auto_join_users             :boolean          default(FALSE), not null
 #  chatable_type               :string           not null
+#  delete_after_seconds        :integer
+#  deleted_at                  :datetime
+#  description                 :text
+#  emoji                       :string
+#  messages_count              :integer          default(0), not null
+#  name                        :string
+#  slug                        :string
+#  status                      :integer          default("open"), not null
+#  threading_enabled           :boolean          default(FALSE), not null
+#  type                        :string
+#  user_count                  :integer          default(0), not null
+#  user_count_stale            :boolean          default(FALSE), not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  name                        :string
-#  description                 :text
-#  status                      :integer          default("open"), not null
-#  user_count                  :integer          default(0), not null
-#  auto_join_users             :boolean          default(FALSE), not null
-#  user_count_stale            :boolean          default(FALSE), not null
-#  slug                        :string
-#  type                        :string
-#  allow_channel_wide_mentions :boolean          default(TRUE), not null
-#  messages_count              :integer          default(0), not null
-#  threading_enabled           :boolean          default(FALSE), not null
+#  chatable_id                 :bigint           not null
+#  deleted_by_id               :integer
+#  featured_in_category_id     :integer
 #  last_message_id             :bigint
-#  emoji                       :string
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -293,27 +293,27 @@ end
 # Table name: chat_channels
 #
 #  id                          :bigint           not null, primary key
-#  chatable_id                 :bigint           not null
-#  deleted_at                  :datetime
-#  deleted_by_id               :integer
-#  featured_in_category_id     :integer
-#  delete_after_seconds        :integer
+#  allow_channel_wide_mentions :boolean          default(TRUE), not null
+#  auto_join_users             :boolean          default(FALSE), not null
 #  chatable_type               :string           not null
+#  delete_after_seconds        :integer
+#  deleted_at                  :datetime
+#  description                 :text
+#  emoji                       :string
+#  messages_count              :integer          default(0), not null
+#  name                        :string
+#  slug                        :string
+#  status                      :integer          default("open"), not null
+#  threading_enabled           :boolean          default(FALSE), not null
+#  type                        :string
+#  user_count                  :integer          default(0), not null
+#  user_count_stale            :boolean          default(FALSE), not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  name                        :string
-#  description                 :text
-#  status                      :integer          default("open"), not null
-#  user_count                  :integer          default(0), not null
-#  auto_join_users             :boolean          default(FALSE), not null
-#  user_count_stale            :boolean          default(FALSE), not null
-#  slug                        :string
-#  type                        :string
-#  allow_channel_wide_mentions :boolean          default(TRUE), not null
-#  messages_count              :integer          default(0), not null
-#  threading_enabled           :boolean          default(FALSE), not null
+#  chatable_id                 :bigint           not null
+#  deleted_by_id               :integer
+#  featured_in_category_id     :integer
 #  last_message_id             :bigint
-#  emoji                       :string
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/channel_archive.rb
+++ b/plugins/chat/app/models/chat/channel_archive.rb
@@ -30,17 +30,17 @@ end
 # Table name: chat_channel_archives
 #
 #  id                      :bigint           not null, primary key
-#  chat_channel_id         :bigint           not null
-#  archived_by_id          :integer          not null
-#  destination_topic_id    :integer
-#  destination_topic_title :string
-#  destination_category_id :integer
-#  destination_tags        :string           is an Array
-#  total_messages          :integer          not null
-#  archived_messages       :integer          default(0), not null
 #  archive_error           :string
+#  archived_messages       :integer          default(0), not null
+#  destination_tags        :string           is an Array
+#  destination_topic_title :string
+#  total_messages          :integer          not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  archived_by_id          :integer          not null
+#  chat_channel_id         :bigint           not null
+#  destination_category_id :integer
+#  destination_topic_id    :integer
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/channel_custom_field.rb
+++ b/plugins/chat/app/models/chat/channel_custom_field.rb
@@ -11,11 +11,11 @@ end
 # Table name: chat_channel_custom_fields
 #
 #  id         :bigint           not null, primary key
-#  channel_id :bigint           not null
 #  name       :string(256)      not null
 #  value      :string(1000000)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  channel_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/direct_message.rb
+++ b/plugins/chat/app/models/chat/direct_message.rb
@@ -94,7 +94,7 @@ end
 # Table name: direct_message_channels
 #
 #  id         :bigint           not null, primary key
+#  group      :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  group      :boolean          default(FALSE), not null
 #

--- a/plugins/chat/app/models/chat/direct_message_channel.rb
+++ b/plugins/chat/app/models/chat/direct_message_channel.rb
@@ -44,27 +44,27 @@ end
 # Table name: chat_channels
 #
 #  id                          :bigint           not null, primary key
-#  chatable_id                 :bigint           not null
-#  deleted_at                  :datetime
-#  deleted_by_id               :integer
-#  featured_in_category_id     :integer
-#  delete_after_seconds        :integer
+#  allow_channel_wide_mentions :boolean          default(TRUE), not null
+#  auto_join_users             :boolean          default(FALSE), not null
 #  chatable_type               :string           not null
+#  delete_after_seconds        :integer
+#  deleted_at                  :datetime
+#  description                 :text
+#  emoji                       :string
+#  messages_count              :integer          default(0), not null
+#  name                        :string
+#  slug                        :string
+#  status                      :integer          default("open"), not null
+#  threading_enabled           :boolean          default(FALSE), not null
+#  type                        :string
+#  user_count                  :integer          default(0), not null
+#  user_count_stale            :boolean          default(FALSE), not null
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
-#  name                        :string
-#  description                 :text
-#  status                      :integer          default("open"), not null
-#  user_count                  :integer          default(0), not null
-#  auto_join_users             :boolean          default(FALSE), not null
-#  user_count_stale            :boolean          default(FALSE), not null
-#  slug                        :string
-#  type                        :string
-#  allow_channel_wide_mentions :boolean          default(TRUE), not null
-#  messages_count              :integer          default(0), not null
-#  threading_enabled           :boolean          default(FALSE), not null
+#  chatable_id                 :bigint           not null
+#  deleted_by_id               :integer
+#  featured_in_category_id     :integer
 #  last_message_id             :bigint
-#  emoji                       :string
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/direct_message_user.rb
+++ b/plugins/chat/app/models/chat/direct_message_user.rb
@@ -16,10 +16,10 @@ end
 # Table name: direct_message_users
 #
 #  id                        :bigint           not null, primary key
-#  direct_message_channel_id :bigint           not null
-#  user_id                   :integer          not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
+#  direct_message_channel_id :bigint           not null
+#  user_id                   :integer          not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/draft.rb
+++ b/plugins/chat/app/models/chat/draft.rb
@@ -21,10 +21,10 @@ end
 # Table name: chat_drafts
 #
 #  id              :bigint           not null, primary key
-#  user_id         :integer          not null
-#  chat_channel_id :bigint           not null
 #  data            :text             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  chat_channel_id :bigint           not null
 #  thread_id       :bigint
+#  user_id         :integer          not null
 #

--- a/plugins/chat/app/models/chat/group_mention.rb
+++ b/plugins/chat/app/models/chat/group_mention.rb
@@ -11,10 +11,10 @@ end
 # Table name: chat_mentions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint           not null
+#  type            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  type            :string           not null
+#  chat_message_id :bigint           not null
 #  target_id       :integer
 #
 # Indexes

--- a/plugins/chat/app/models/chat/here_mention.rb
+++ b/plugins/chat/app/models/chat/here_mention.rb
@@ -10,10 +10,10 @@ end
 # Table name: chat_mentions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint           not null
+#  type            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  type            :string           not null
+#  chat_message_id :bigint           not null
 #  target_id       :integer
 #
 # Indexes

--- a/plugins/chat/app/models/chat/incoming_webhook.rb
+++ b/plugins/chat/app/models/chat/incoming_webhook.rb
@@ -29,14 +29,14 @@ end
 # Table name: incoming_chat_webhooks
 #
 #  id              :bigint           not null, primary key
-#  name            :string           not null
-#  key             :string           not null
-#  chat_channel_id :bigint           not null
-#  username        :string
 #  description     :string
 #  emoji           :string
+#  key             :string           not null
+#  name            :string           not null
+#  username        :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  chat_channel_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/mention.rb
+++ b/plugins/chat/app/models/chat/mention.rb
@@ -17,10 +17,10 @@ end
 # Table name: chat_mentions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint           not null
+#  type            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  type            :string           not null
+#  chat_message_id :bigint           not null
 #  target_id       :integer
 #
 # Indexes

--- a/plugins/chat/app/models/chat/message_custom_field.rb
+++ b/plugins/chat/app/models/chat/message_custom_field.rb
@@ -11,11 +11,11 @@ end
 # Table name: chat_message_custom_fields
 #
 #  id         :bigint           not null, primary key
-#  message_id :bigint           not null
 #  name       :string(256)      not null
 #  value      :string(1000000)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  message_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/message_interaction.rb
+++ b/plugins/chat/app/models/chat/message_interaction.rb
@@ -14,11 +14,11 @@ end
 # Table name: chat_message_interactions
 #
 #  id              :bigint           not null, primary key
-#  user_id         :bigint           not null
-#  chat_message_id :bigint           not null
 #  action          :jsonb            not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  chat_message_id :bigint           not null
+#  user_id         :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/message_reaction.rb
+++ b/plugins/chat/app/models/chat/message_reaction.rb
@@ -16,11 +16,11 @@ end
 # Table name: chat_message_reactions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint
-#  user_id         :integer
 #  emoji           :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  chat_message_id :bigint
+#  user_id         :integer
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/message_revision.rb
+++ b/plugins/chat/app/models/chat/message_revision.rb
@@ -17,11 +17,11 @@ end
 # Table name: chat_message_revisions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint
-#  old_message     :text             not null
 #  new_message     :text             not null
+#  old_message     :text             not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  chat_message_id :bigint
 #  user_id         :integer          not null
 #
 # Indexes

--- a/plugins/chat/app/models/chat/null_user.rb
+++ b/plugins/chat/app/models/chat/null_user.rb
@@ -25,43 +25,43 @@ end
 # Table name: users
 #
 #  id                        :integer          not null, primary key
-#  username                  :string(60)       not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  name                      :string
-#  last_posted_at            :datetime
 #  active                    :boolean          default(FALSE), not null
-#  username_lower            :string(60)       not null
-#  last_seen_at              :datetime
 #  admin                     :boolean          default(FALSE), not null
-#  last_emailed_at           :datetime
-#  trust_level               :integer          not null
 #  approved                  :boolean          default(FALSE), not null
-#  approved_by_id            :integer
 #  approved_at               :datetime
+#  date_of_birth             :date
+#  first_seen_at             :datetime
+#  flag_level                :integer          default(0), not null
+#  group_locked_trust_level  :integer
+#  ip_address                :inet
+#  last_emailed_at           :datetime
+#  last_posted_at            :datetime
+#  last_seen_at              :datetime
+#  locale                    :string(10)
+#  manual_locked_trust_level :integer
+#  moderator                 :boolean          default(FALSE)
+#  name                      :string
 #  previous_visit_at         :datetime
+#  registration_ip_address   :inet
+#  required_fields_version   :integer
+#  secure_identifier         :string
+#  silenced_till             :datetime
+#  staged                    :boolean          default(FALSE), not null
 #  suspended_at              :datetime
 #  suspended_till            :datetime
-#  date_of_birth             :date
-#  views                     :integer          default(0), not null
-#  flag_level                :integer          default(0), not null
-#  ip_address                :inet
-#  moderator                 :boolean          default(FALSE)
 #  title                     :string
-#  uploaded_avatar_id        :integer
-#  locale                    :string(10)
-#  primary_group_id          :integer
-#  registration_ip_address   :inet
-#  staged                    :boolean          default(FALSE), not null
-#  first_seen_at             :datetime
-#  silenced_till             :datetime
-#  group_locked_trust_level  :integer
-#  manual_locked_trust_level :integer
-#  secure_identifier         :string
+#  trust_level               :integer          not null
+#  username                  :string(60)       not null
+#  username_lower            :string(60)       not null
+#  views                     :integer          default(0), not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  approved_by_id            :integer
 #  flair_group_id            :integer
 #  last_seen_reviewable_id   :integer
-#  required_fields_version   :integer
+#  primary_group_id          :integer
 #  seen_notification_id      :bigint           default(0), not null
+#  uploaded_avatar_id        :integer
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/reviewable_message.rb
+++ b/plugins/chat/app/models/chat/reviewable_message.rb
@@ -164,26 +164,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
-#  type                    :string           not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
-#  version                 :integer          default(0), not null
+#  force_review            :boolean          default(FALSE), not null
 #  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
+#  type                    :string           not null
+#  type_source             :string           default("unknown"), not null
+#  version                 :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
-#  type_source             :string           default("unknown"), not null
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/thread.rb
+++ b/plugins/chat/app/models/chat/thread.rb
@@ -183,16 +183,16 @@ end
 # Table name: chat_threads
 #
 #  id                       :bigint           not null, primary key
-#  channel_id               :bigint           not null
-#  original_message_id      :bigint           not null
-#  original_message_user_id :bigint           not null
+#  force                    :boolean          default(FALSE), not null
+#  replies_count            :integer          default(0), not null
 #  status                   :integer          default("open"), not null
 #  title                    :string
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
-#  replies_count            :integer          default(0), not null
+#  channel_id               :bigint           not null
 #  last_message_id          :bigint
-#  force                    :boolean          default(FALSE), not null
+#  original_message_id      :bigint           not null
+#  original_message_user_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/thread_custom_field.rb
+++ b/plugins/chat/app/models/chat/thread_custom_field.rb
@@ -11,11 +11,11 @@ end
 # Table name: chat_thread_custom_fields
 #
 #  id         :bigint           not null, primary key
-#  thread_id  :bigint           not null
 #  name       :string(256)      not null
 #  value      :string(1000000)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  thread_id  :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/user_chat_thread_membership.rb
+++ b/plugins/chat/app/models/chat/user_chat_thread_membership.rb
@@ -21,14 +21,14 @@ end
 # Table name: user_chat_thread_memberships
 #
 #  id                                  :bigint           not null, primary key
-#  user_id                             :bigint           not null
-#  thread_id                           :bigint           not null
-#  last_read_message_id                :bigint
 #  notification_level                  :integer          default("tracking"), not null
+#  thread_title_prompt_seen            :boolean          default(FALSE), not null
 #  created_at                          :datetime         not null
 #  updated_at                          :datetime         not null
-#  thread_title_prompt_seen            :boolean          default(FALSE), not null
+#  last_read_message_id                :bigint
 #  last_unread_message_when_emailed_id :bigint
+#  thread_id                           :bigint           not null
+#  user_id                             :bigint           not null
 #
 # Indexes
 #

--- a/plugins/chat/app/models/chat/user_mention.rb
+++ b/plugins/chat/app/models/chat/user_mention.rb
@@ -11,10 +11,10 @@ end
 # Table name: chat_mentions
 #
 #  id              :bigint           not null, primary key
-#  chat_message_id :bigint           not null
+#  type            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  type            :string           not null
+#  chat_message_id :bigint           not null
 #  target_id       :integer
 #
 # Indexes

--- a/plugins/chat/app/models/chat/webhook_event.rb
+++ b/plugins/chat/app/models/chat/webhook_event.rb
@@ -17,10 +17,10 @@ end
 # Table name: chat_webhook_events
 #
 #  id                       :bigint           not null, primary key
-#  chat_message_id          :bigint           not null
-#  incoming_chat_webhook_id :bigint           not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
+#  chat_message_id          :bigint           not null
+#  incoming_chat_webhook_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-adplugin/app/models/ad_plugin/ad_impression.rb
+++ b/plugins/discourse-adplugin/app/models/ad_plugin/ad_impression.rb
@@ -48,12 +48,12 @@ end
 #
 #  id                    :bigint           not null, primary key
 #  ad_type               :integer          not null
+#  clicked_at            :datetime
 #  placement             :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  ad_plugin_house_ad_id :bigint
 #  user_id               :integer
-#  clicked_at            :datetime
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/ai_artifact.rb
+++ b/plugins/discourse-ai/app/models/ai_artifact.rb
@@ -107,13 +107,13 @@ end
 # Table name: ai_artifacts
 #
 #  id         :bigint           not null, primary key
-#  user_id    :integer          not null
-#  post_id    :integer          not null
-#  name       :string(255)      not null
-#  html       :string(65535)
 #  css        :string(65535)
+#  html       :string(65535)
 #  js         :string(65535)
 #  metadata   :jsonb
+#  name       :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  post_id    :integer          not null
+#  user_id    :integer          not null
 #

--- a/plugins/discourse-ai/app/models/ai_artifact_key_value.rb
+++ b/plugins/discourse-ai/app/models/ai_artifact_key_value.rb
@@ -42,13 +42,13 @@ end
 # Table name: ai_artifact_key_values
 #
 #  id             :bigint           not null, primary key
-#  ai_artifact_id :bigint           not null
-#  user_id        :integer          not null
 #  key            :string(50)       not null
-#  value          :string(20000)    not null
 #  public         :boolean          default(FALSE), not null
+#  value          :string(20000)    not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  ai_artifact_id :bigint           not null
+#  user_id        :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/ai_artifact_version.rb
+++ b/plugins/discourse-ai/app/models/ai_artifact_version.rb
@@ -24,15 +24,15 @@ end
 # Table name: ai_artifact_versions
 #
 #  id                 :bigint           not null, primary key
-#  ai_artifact_id     :bigint           not null
-#  version_number     :integer          not null
-#  html               :string(65535)
+#  change_description :string
 #  css                :string(65535)
+#  html               :string(65535)
 #  js                 :string(65535)
 #  metadata           :jsonb
-#  change_description :string
+#  version_number     :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  ai_artifact_id     :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/ai_mcp_server.rb
+++ b/plugins/discourse-ai/app/models/ai_mcp_server.rb
@@ -466,8 +466,8 @@ end
 #  oauth_last_authorized_at         :datetime
 #  oauth_last_error                 :string(1000)
 #  oauth_last_refreshed_at          :datetime
-#  oauth_require_refresh_token      :boolean          default(FALSE), not null
 #  oauth_registration_endpoint      :string(1000)
+#  oauth_require_refresh_token      :boolean          default(FALSE), not null
 #  oauth_resource_metadata_url      :string(1000)
 #  oauth_revocation_endpoint        :string(1000)
 #  oauth_scopes                     :string(2000)

--- a/plugins/discourse-ai/app/models/ai_spam_log.rb
+++ b/plugins/discourse-ai/app/models/ai_spam_log.rb
@@ -11,16 +11,16 @@ end
 # Table name: ai_spam_logs
 #
 #  id                  :bigint           not null, primary key
-#  post_id             :bigint           not null
-#  llm_model_id        :bigint           not null
-#  ai_api_audit_log_id :bigint
-#  reviewable_id       :bigint
+#  error               :string(3000)
 #  is_spam             :boolean          not null
 #  payload             :string(20000)    default(""), not null
+#  reason              :text
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  error               :string(3000)
-#  reason              :text
+#  ai_api_audit_log_id :bigint
+#  llm_model_id        :bigint           not null
+#  post_id             :bigint           not null
+#  reviewable_id       :bigint
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/ai_summary.rb
+++ b/plugins/discourse-ai/app/models/ai_summary.rb
@@ -52,16 +52,16 @@ end
 # Table name: ai_summaries
 #
 #  id                    :bigint           not null, primary key
-#  target_id             :integer          not null
-#  target_type           :string           not null
-#  summarized_text       :string           not null
-#  original_content_sha  :string           not null
 #  algorithm             :string           not null
+#  highest_target_number :integer          default(1), not null
+#  origin                :integer
+#  original_content_sha  :string           not null
+#  summarized_text       :string           not null
+#  summary_type          :integer          default("complete"), not null
+#  target_type           :string           not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
-#  summary_type          :integer          default("complete"), not null
-#  origin                :integer
-#  highest_target_number :integer          default(1), not null
+#  target_id             :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/chat_message_custom_prompt.rb
+++ b/plugins/discourse-ai/app/models/chat_message_custom_prompt.rb
@@ -9,10 +9,10 @@ end
 # Table name: chat_message_custom_prompts
 #
 #  id            :bigint           not null, primary key
-#  message_id    :bigint           not null
 #  custom_prompt :json             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  message_id    :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/classification_result.rb
+++ b/plugins/discourse-ai/app/models/classification_result.rb
@@ -13,13 +13,13 @@ end
 # Table name: classification_results
 #
 #  id                  :bigint           not null, primary key
-#  model_used          :string
-#  classification_type :string
-#  target_id           :bigint
-#  target_type         :string
 #  classification      :jsonb
+#  classification_type :string
+#  model_used          :string
+#  target_type         :string
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  target_id           :bigint
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/completion_prompt.rb
+++ b/plugins/discourse-ai/app/models/completion_prompt.rb
@@ -72,15 +72,15 @@ end
 # Table name: completion_prompts
 #
 #  id              :bigint           not null, primary key
-#  name            :string           not null
-#  translated_name :string
-#  prompt_type     :integer          default("text"), not null
 #  enabled         :boolean          default(TRUE), not null
+#  messages        :jsonb
+#  name            :string           not null
+#  prompt_type     :integer          default("text"), not null
+#  stop_sequences  :string           is an Array
+#  temperature     :integer
+#  translated_name :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  messages        :jsonb
-#  temperature     :integer
-#  stop_sequences  :string           is an Array
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/inferred_concept_post.rb
+++ b/plugins/discourse-ai/app/models/inferred_concept_post.rb
@@ -13,10 +13,10 @@ end
 #
 # Table name: inferred_concept_posts
 #
-#  inferred_concept_id :bigint
-#  post_id             :bigint
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  inferred_concept_id :bigint
+#  post_id             :bigint
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/inferred_concept_topic.rb
+++ b/plugins/discourse-ai/app/models/inferred_concept_topic.rb
@@ -13,10 +13,10 @@ end
 #
 # Table name: inferred_concept_topics
 #
-#  inferred_concept_id :bigint
-#  topic_id            :bigint
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  inferred_concept_id :bigint
+#  topic_id            :bigint
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/llm_quota.rb
+++ b/plugins/discourse-ai/app/models/llm_quota.rb
@@ -70,13 +70,13 @@ end
 # Table name: llm_quotas
 #
 #  id               :bigint           not null, primary key
-#  group_id         :bigint           not null
-#  llm_model_id     :bigint           not null
+#  duration_seconds :integer          not null
 #  max_tokens       :integer
 #  max_usages       :integer
-#  duration_seconds :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  group_id         :bigint           not null
+#  llm_model_id     :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/llm_quota_usage.rb
+++ b/plugins/discourse-ai/app/models/llm_quota_usage.rb
@@ -103,15 +103,15 @@ end
 # Table name: llm_quota_usages
 #
 #  id                 :bigint           not null, primary key
-#  user_id            :bigint           not null
-#  llm_quota_id       :bigint           not null
 #  input_tokens_used  :integer          not null
 #  output_tokens_used :integer          not null
-#  usages             :integer          not null
-#  started_at         :datetime         not null
 #  reset_at           :datetime         not null
+#  started_at         :datetime         not null
+#  usages             :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  llm_quota_id       :bigint           not null
+#  user_id            :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/model_accuracy.rb
+++ b/plugins/discourse-ai/app/models/model_accuracy.rb
@@ -39,10 +39,10 @@ end
 # Table name: model_accuracies
 #
 #  id                  :bigint           not null, primary key
-#  model               :string           not null
 #  classification_type :string           not null
 #  flags_agreed        :integer          default(0), not null
 #  flags_disagreed     :integer          default(0), not null
+#  model               :string           not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #

--- a/plugins/discourse-ai/app/models/post_custom_prompt.rb
+++ b/plugins/discourse-ai/app/models/post_custom_prompt.rb
@@ -13,10 +13,10 @@ end
 # Table name: post_custom_prompts
 #
 #  id            :bigint           not null, primary key
-#  post_id       :integer          not null
 #  custom_prompt :json             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  post_id       :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/rag_document_fragment.rb
+++ b/plugins/discourse-ai/app/models/rag_document_fragment.rb
@@ -168,13 +168,13 @@ end
 #
 #  id              :bigint           not null, primary key
 #  fragment        :text             not null
-#  upload_id       :integer          not null
 #  fragment_number :integer          not null
+#  metadata        :text
+#  target_type     :string(800)      not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  metadata        :text
 #  target_id       :bigint           not null
-#  target_type     :string(800)      not null
+#  upload_id       :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/reviewable_ai_chat_message.rb
+++ b/plugins/discourse-ai/app/models/reviewable_ai_chat_message.rb
@@ -167,26 +167,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
-#  type                    :string           not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
-#  version                 :integer          default(0), not null
+#  force_review            :boolean          default(FALSE), not null
 #  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
+#  type                    :string           not null
+#  type_source             :string           default("unknown"), not null
+#  version                 :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
-#  type_source             :string           default("unknown"), not null
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/reviewable_ai_post.rb
+++ b/plugins/discourse-ai/app/models/reviewable_ai_post.rb
@@ -218,26 +218,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
-#  type                    :string           not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
-#  version                 :integer          default(0), not null
+#  force_review            :boolean          default(FALSE), not null
 #  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
+#  type                    :string           not null
+#  type_source             :string           default("unknown"), not null
+#  version                 :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
-#  type_source             :string           default("unknown"), not null
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/reviewable_ai_tool_action.rb
+++ b/plugins/discourse-ai/app/models/reviewable_ai_tool_action.rb
@@ -106,26 +106,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
-#  type                    :string           not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
-#  version                 :integer          default(0), not null
+#  force_review            :boolean          default(FALSE), not null
 #  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
+#  type                    :string           not null
+#  type_source             :string           default("unknown"), not null
+#  version                 :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
-#  type_source             :string           default("unknown"), not null
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/plugins/discourse-ai/app/models/shared_ai_conversation.rb
+++ b/plugins/discourse-ai/app/models/shared_ai_conversation.rb
@@ -221,16 +221,16 @@ end
 # Table name: shared_ai_conversations
 #
 #  id          :bigint           not null, primary key
-#  user_id     :integer          not null
-#  target_id   :integer          not null
+#  context     :jsonb            not null
+#  excerpt     :string           not null
+#  llm_name    :string           not null
+#  share_key   :string           not null
 #  target_type :string           not null
 #  title       :string           not null
-#  llm_name    :string           not null
-#  context     :jsonb            not null
-#  share_key   :string           not null
-#  excerpt     :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  target_id   :integer          not null
+#  user_id     :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-assign/app/models/assignment.rb
+++ b/plugins/discourse-assign/app/models/assignment.rb
@@ -133,17 +133,17 @@ end
 # Table name: assignments
 #
 #  id                  :bigint           not null, primary key
-#  topic_id            :integer          not null
-#  assigned_to_id      :integer          not null
-#  assigned_by_user_id :integer          not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  assigned_to_type    :string           not null
-#  target_id           :integer          not null
-#  target_type         :string           not null
 #  active              :boolean          default(TRUE)
+#  assigned_to_type    :string           not null
 #  note                :string
 #  status              :text
+#  target_type         :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  assigned_by_user_id :integer          not null
+#  assigned_to_id      :integer          not null
+#  target_id           :integer          not null
+#  topic_id            :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-assign/app/models/silenced_assignment.rb
+++ b/plugins/discourse-assign/app/models/silenced_assignment.rb
@@ -9,9 +9,9 @@ end
 # Table name: silenced_assignments
 #
 #  id            :bigint           not null, primary key
-#  assignment_id :bigint           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  assignment_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-calendar/app/models/calendar_event.rb
+++ b/plugins/discourse-calendar/app/models/calendar_event.rb
@@ -109,19 +109,19 @@ end
 # Table name: calendar_events
 #
 #  id          :bigint           not null, primary key
-#  topic_id    :integer          not null
-#  post_id     :integer
-#  post_number :integer
-#  user_id     :integer
-#  username    :string
 #  description :string
-#  start_date  :datetime         not null
 #  end_date    :datetime
+#  post_number :integer
 #  recurrence  :string
 #  region      :string
+#  start_date  :datetime         not null
+#  timezone    :string
+#  username    :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  timezone    :string
+#  post_id     :integer
+#  topic_id    :integer          not null
+#  user_id     :integer
 #
 # Indexes
 #

--- a/plugins/discourse-calendar/app/models/discourse_calendar/disabled_holiday.rb
+++ b/plugins/discourse-calendar/app/models/discourse_calendar/disabled_holiday.rb
@@ -12,9 +12,9 @@ end
 # Table name: discourse_calendar_disabled_holidays
 #
 #  id           :bigint           not null, primary key
+#  disabled     :boolean          default(TRUE), not null
 #  holiday_name :string           not null
 #  region_code  :string           not null
-#  disabled     :boolean          default(TRUE), not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -620,6 +620,7 @@ end
 # Table name: discourse_post_event_events
 #
 #  id                 :bigint           not null, primary key
+#  all_day            :boolean          default(FALSE), not null
 #  chat_enabled       :boolean          default(FALSE), not null
 #  closed             :boolean          default(FALSE), not null
 #  custom_fields      :jsonb            not null
@@ -636,7 +637,6 @@ end
 #  recurrence_until   :datetime
 #  reminders          :string
 #  show_local_time    :boolean          default(FALSE), not null
-#  all_day            :boolean          default(FALSE), not null
 #  status             :integer          default(0), not null
 #  timezone           :string
 #  url                :string(1000)

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event_date.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event_date.rb
@@ -86,7 +86,7 @@ end
 # Indexes
 #
 #  idx_discourse_calendar_post_event_dates_event_id_starts_at_uniq  (event_id,starts_at) UNIQUE
-#  index_discourse_calendar_post_event_dates_on_event_id_and_dates  (event_id,finished_at,starts_at DESC,updated_at DESC,id DESC)
 #  index_discourse_calendar_post_event_dates_on_event_id            (event_id)
+#  index_discourse_calendar_post_event_dates_on_event_id_and_dates  (event_id,finished_at,starts_at DESC,updated_at DESC,id DESC)
 #  index_discourse_calendar_post_event_dates_on_finished_at         (finished_at)
 #

--- a/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
@@ -94,12 +94,12 @@ end
 # Table name: discourse_post_event_invitees
 #
 #  id         :bigint           not null, primary key
-#  post_id    :integer          not null
-#  user_id    :integer          not null
+#  notified   :boolean          default(FALSE), not null
 #  status     :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  notified   :boolean          default(FALSE), not null
+#  post_id    :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query.rb
+++ b/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query.rb
@@ -68,12 +68,12 @@ end
 # Table name: data_explorer_queries
 #
 #  id          :bigint           not null, primary key
-#  name        :string
 #  description :text
-#  sql         :text             default("SELECT 1"), not null
-#  user_id     :integer
-#  last_run_at :datetime
 #  hidden      :boolean          default(FALSE), not null
+#  last_run_at :datetime
+#  name        :string
+#  sql         :text             default("SELECT 1"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :integer
 #

--- a/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query_group.rb
+++ b/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query_group.rb
@@ -16,8 +16,8 @@ end
 # Table name: data_explorer_query_groups
 #
 #  id       :bigint           not null, primary key
-#  query_id :bigint
 #  group_id :integer
+#  query_id :bigint
 #
 # Indexes
 #

--- a/plugins/discourse-gamification/app/models/discourse_gamification/gamification_score_event.rb
+++ b/plugins/discourse-gamification/app/models/discourse_gamification/gamification_score_event.rb
@@ -13,12 +13,12 @@ end
 # Table name: gamification_score_events
 #
 #  id          :bigint           not null, primary key
-#  user_id     :integer          not null
 #  date        :date             not null
-#  points      :integer          not null
 #  description :text
+#  points      :integer          not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  user_id     :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-policy/app/models/policy_user.rb
+++ b/plugins/discourse-policy/app/models/policy_user.rb
@@ -46,14 +46,14 @@ end
 # Table name: policy_users
 #
 #  id             :bigint           not null, primary key
-#  post_policy_id :bigint           not null
-#  user_id        :integer          not null
 #  accepted_at    :datetime
-#  revoked_at     :datetime
 #  expired_at     :datetime
+#  revoked_at     :datetime
 #  version        :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  post_policy_id :bigint           not null
+#  user_id        :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-policy/app/models/post_policy.rb
+++ b/plugins/discourse-policy/app/models/post_policy.rb
@@ -115,17 +115,17 @@ end
 # Table name: post_policies
 #
 #  id                 :bigint           not null, primary key
-#  post_id            :bigint           not null
-#  renew_start        :datetime
-#  renew_days         :integer
-#  next_renew_at      :datetime
-#  reminder           :string
+#  add_users_to_group :integer
+#  last_bumped_at     :datetime
 #  last_reminded_at   :datetime
+#  next_renew_at      :datetime
+#  private            :boolean          default(FALSE), not null
+#  reminder           :string
+#  renew_days         :integer
+#  renew_interval     :integer
+#  renew_start        :datetime
 #  version            :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  renew_interval     :integer
-#  private            :boolean          default(FALSE), not null
-#  last_bumped_at     :datetime
-#  add_users_to_group :integer
+#  post_id            :bigint           not null
 #

--- a/plugins/discourse-policy/app/models/post_policy_group.rb
+++ b/plugins/discourse-policy/app/models/post_policy_group.rb
@@ -10,10 +10,10 @@ end
 # Table name: post_policy_groups
 #
 #  id             :bigint           not null, primary key
-#  group_id       :integer          not null
-#  post_policy_id :bigint           not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  group_id       :integer          not null
+#  post_policy_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-post-voting/app/models/post_voting_comment.rb
+++ b/plugins/discourse-post-voting/app/models/post_voting_comment.rb
@@ -79,17 +79,17 @@ end
 # Table name: post_voting_comments
 #
 #  id             :bigint           not null, primary key
-#  post_id        :integer          not null
-#  user_id        :integer          not null
-#  raw            :text             not null
 #  cooked         :text             not null
 #  cooked_version :integer
 #  deleted_at     :datetime
-#  deleted_by_id  :integer
+#  qa_vote_count  :integer          default(0)
+#  raw            :text             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  qa_vote_count  :integer          default(0)
+#  deleted_by_id  :integer
 #  last_editor_id :integer          not null
+#  post_id        :integer          not null
+#  user_id        :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-post-voting/app/models/post_voting_comment_custom_field.rb
+++ b/plugins/discourse-post-voting/app/models/post_voting_comment_custom_field.rb
@@ -9,11 +9,11 @@ end
 # Table name: post_voting_comment_custom_fields
 #
 #  id                     :bigint           not null, primary key
-#  post_voting_comment_id :bigint           not null
 #  name                   :string(256)      not null
 #  value                  :text
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  post_voting_comment_id :bigint           not null
 #
 # Indexes
 #

--- a/plugins/discourse-post-voting/app/models/post_voting_vote.rb
+++ b/plugins/discourse-post-voting/app/models/post_voting_vote.rb
@@ -64,10 +64,10 @@ end
 # Table name: post_voting_votes
 #
 #  id           :bigint           not null, primary key
-#  user_id      :integer          not null
-#  created_at   :datetime         not null
 #  direction    :string           not null
 #  votable_type :string           not null
+#  created_at   :datetime         not null
+#  user_id      :integer          not null
 #  votable_id   :bigint           not null
 #
 # Indexes

--- a/plugins/discourse-post-voting/app/models/reviewable_post_voting_comment.rb
+++ b/plugins/discourse-post-voting/app/models/reviewable_post_voting_comment.rb
@@ -146,26 +146,26 @@ end
 # Table name: reviewables
 #
 #  id                      :bigint           not null, primary key
-#  type                    :string           not null
-#  status                  :integer          default("pending"), not null
-#  created_by_id           :integer          not null
-#  reviewable_by_moderator :boolean          default(FALSE), not null
-#  category_id             :integer
-#  topic_id                :integer
-#  score                   :float            default(0.0), not null
-#  potential_spam          :boolean          default(FALSE), not null
-#  target_id               :integer
-#  target_type             :string
-#  target_created_by_id    :integer
-#  payload                 :json
-#  version                 :integer          default(0), not null
+#  force_review            :boolean          default(FALSE), not null
 #  latest_score            :datetime
+#  payload                 :json
+#  potential_spam          :boolean          default(FALSE), not null
+#  potentially_illegal     :boolean          default(FALSE)
+#  reject_reason           :text
+#  reviewable_by_moderator :boolean          default(FALSE), not null
+#  score                   :float            default(0.0), not null
+#  status                  :integer          default("pending"), not null
+#  target_type             :string
+#  type                    :string           not null
+#  type_source             :string           default("unknown"), not null
+#  version                 :integer          default(0), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  force_review            :boolean          default(FALSE), not null
-#  reject_reason           :text
-#  potentially_illegal     :boolean          default(FALSE)
-#  type_source             :string           default("unknown"), not null
+#  category_id             :integer
+#  created_by_id           :integer          not null
+#  target_created_by_id    :integer
+#  target_id               :integer
+#  topic_id                :integer
 #
 # Indexes
 #

--- a/plugins/discourse-reactions/app/models/discourse_reactions/reaction.rb
+++ b/plugins/discourse-reactions/app/models/discourse_reactions/reaction.rb
@@ -58,12 +58,12 @@ end
 # Table name: discourse_reactions_reactions
 #
 #  id                   :bigint           not null, primary key
-#  post_id              :integer
 #  reaction_type        :integer
-#  reaction_value       :string
 #  reaction_users_count :integer
+#  reaction_value       :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  post_id              :integer
 #
 # Indexes
 #

--- a/plugins/discourse-reactions/app/models/discourse_reactions/reaction_user.rb
+++ b/plugins/discourse-reactions/app/models/discourse_reactions/reaction_user.rb
@@ -56,11 +56,11 @@ end
 # Table name: discourse_reactions_reaction_users
 #
 #  id          :bigint           not null, primary key
-#  reaction_id :bigint
-#  user_id     :integer
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  post_id     :integer
+#  reaction_id :bigint
+#  user_id     :integer
 #
 # Indexes
 #

--- a/plugins/discourse-solved/app/models/discourse_solved/solved_topic.rb
+++ b/plugins/discourse-solved/app/models/discourse_solved/solved_topic.rb
@@ -37,12 +37,12 @@ end
 # Table name: discourse_solved_solved_topics
 #
 #  id               :bigint           not null, primary key
-#  topic_id         :integer          not null
-#  answer_post_id   :integer          not null
-#  accepter_user_id :integer          not null
-#  topic_timer_id   :integer
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  accepter_user_id :integer          not null
+#  answer_post_id   :integer          not null
+#  topic_id         :integer          not null
+#  topic_timer_id   :integer
 #
 # Indexes
 #

--- a/plugins/discourse-subscriptions/app/models/discourse_subscriptions/customer.rb
+++ b/plugins/discourse-subscriptions/app/models/discourse_subscriptions/customer.rb
@@ -19,11 +19,11 @@ end
 # Table name: discourse_subscriptions_customers
 #
 #  id          :bigint           not null, primary key
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #  customer_id :string           not null
 #  product_id  :string
 #  user_id     :bigint
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
 #
 # Indexes
 #

--- a/plugins/discourse-subscriptions/app/models/discourse_subscriptions/product.rb
+++ b/plugins/discourse-subscriptions/app/models/discourse_subscriptions/product.rb
@@ -10,9 +10,9 @@ end
 # Table name: discourse_subscriptions_products
 #
 #  id          :bigint           not null, primary key
-#  external_id :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  external_id :string           not null
 #
 # Indexes
 #

--- a/plugins/discourse-subscriptions/app/models/discourse_subscriptions/subscription.rb
+++ b/plugins/discourse-subscriptions/app/models/discourse_subscriptions/subscription.rb
@@ -11,11 +11,11 @@ end
 # Table name: discourse_subscriptions_subscriptions
 #
 #  id          :bigint           not null, primary key
-#  customer_id :bigint           not null
-#  external_id :string           not null
+#  status      :string
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  status      :string
+#  customer_id :bigint           not null
+#  external_id :string           not null
 #
 # Indexes
 #

--- a/plugins/discourse-templates/app/models/discourse_templates/usage_count.rb
+++ b/plugins/discourse-templates/app/models/discourse_templates/usage_count.rb
@@ -15,10 +15,10 @@ end
 # Table name: discourse_templates_usage_count
 #
 #  id          :bigint           not null, primary key
-#  topic_id    :integer          not null
 #  usage_count :integer          default(0), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  topic_id    :integer          not null
 #
 # Indexes
 #

--- a/plugins/discourse-topic-voting/app/models/discourse_topic_voting/category_setting.rb
+++ b/plugins/discourse-topic-voting/app/models/discourse_topic_voting/category_setting.rb
@@ -44,9 +44,9 @@ end
 # Table name: topic_voting_category_settings
 #
 #  id          :bigint           not null, primary key
-#  category_id :integer
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  category_id :integer
 #
 # Indexes
 #

--- a/plugins/poll/app/models/poll_option.rb
+++ b/plugins/poll/app/models/poll_option.rb
@@ -18,12 +18,12 @@ end
 # Table name: poll_options
 #
 #  id              :bigint           not null, primary key
-#  poll_id         :bigint
+#  anonymous_votes :integer
 #  digest          :string           not null
 #  html            :text             not null
-#  anonymous_votes :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  poll_id         :bigint
 #
 # Indexes
 #

--- a/plugins/poll/app/models/poll_vote.rb
+++ b/plugins/poll/app/models/poll_vote.rb
@@ -10,12 +10,12 @@ end
 #
 # Table name: poll_votes
 #
+#  rank           :integer          default(0), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
 #  poll_id        :bigint
 #  poll_option_id :bigint
 #  user_id        :bigint
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  rank           :integer          default(0), not null
 #
 # Indexes
 #


### PR DESCRIPTION
`.annotaterb.yml` has carried `classified_sort: true` since the project switched from `annotate` to `annotaterb` (commit 0eab7daea4, July 2025), but annotaterb's default behaviour is to compare the existing schema block against what it would generate and skip the rewrite when the column list matches — even when the *ordering* of those columns differs. The result is that models which haven't had a schema change since the config landed never get reordered, and `classified_sort` drift accumulates indefinitely.

`--force` makes annotaterb always rewrite, so a single `bin/rake annotate:clean` run brings every model into the canonical format and keeps them there. Every schema block is now grouped primary-key → regular columns → timestamps → foreign keys (alphabetical within each group). Pure annotation comment change — no code modifications.

Also cleans up the rake task to avoid string interpolation for `system` calls.