### PR TITLE
FIX: Render TopicStatus in topic header where it should be

### DIFF
--- a/frontend/discourse/app/components/nested/header.gjs
+++ b/frontend/discourse/app/components/nested/header.gjs
@@ -3,6 +3,7 @@ import { trustHTML } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TopicCategory from "discourse/components/topic-category";
 import TopicMetadata from "discourse/components/topic-metadata";
+import TopicStatus from "discourse/components/topic-status";
 import TopicTitleEditor from "discourse/components/topic-title-editor";
 import lazyHash from "discourse/helpers/lazy-hash";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -31,6 +32,7 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
       </div>
     {{else}}
       <h1 class="nested-view__title">
+        <TopicStatus @topic={{@topic}} />
         <a
           href={{@topic.url}}
           {{on "click" @startEditingTopic}}


### PR DESCRIPTION
<img width="1190" height="966" alt="Screenshot 2026-05-13 at 8 35 14 AM" src="https://github.com/user-attachments/assets/4273bc7a-94d1-4ed3-a357-0e4bab17ec70" />
