### PR TITLE
DEV: Add a bit more logging to PostsArray for nested replies

### DIFF
--- a/lib/nested_replies/post_preloader.rb
+++ b/lib/nested_replies/post_preloader.rb
@@ -91,9 +91,10 @@ module NestedReplies
       def method_missing(name, *args, **kwargs, &block)
         relation = Post.none
         if relation.respond_to?(name)
+          caller_frame = caller_locations(1, 1)&.first
           Rails.logger.warn(
             "NestedReplies::PostsArray falling back to DB query for .#{name} — " \
-              "consider adding an explicit handler",
+              "consider adding an explicit handler (called from #{caller_frame})",
           )
           Post.where(id: map(&:id)).public_send(name, *args, **kwargs, &block)
         else


### PR DESCRIPTION
I got this error on Meta `NestedReplies::PostsArray falling back to DB query for .ids — consider adding an explicit handler` but I am not able to see what is causing it. Hopefully this change helps me diagnose.