### PR TITLE
FIX: filter chat interaction action payloads

### DIFF
--- a/plugins/chat/app/serializers/chat/message_interaction_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_interaction_serializer.rb
@@ -15,5 +15,9 @@ module Chat
     def message
       { id: object.message.id, text: object.message.message, user_id: object.message.user.id }
     end
+
+    def action
+      object.action.except("value")
+    end
   end
 end

--- a/plugins/chat/spec/requests/chat/api/channels_messages_interactions_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_messages_interactions_controller_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe Chat::Api::ChannelsMessagesInteractionsController do
         )
       end
 
+      it "does not expose action values in the response" do
+        post "/chat/api/channels/#{accessible_channel.id}/messages/#{accessible_message.id}/interactions",
+             params: {
+               action_id: "xxx",
+             }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("interaction", "action")).not_to have_key("value")
+      end
+
       it "returns 404 when action_id does not match any block element" do
         post "/chat/api/channels/#{accessible_channel.id}/messages/#{accessible_message.id}/interactions",
              params: {


### PR DESCRIPTION
Previously, chat interaction responses could include details that were not part of the public message representation.

This change keeps the interaction response aligned with the rendered button data and adds regression coverage.