### PR TITLE
FIX: Suppress composer mention warning for AI bot users

### DIFF
--- a/app/controllers/composer_controller.rb
+++ b/app/controllers/composer_controller.rb
@@ -96,7 +96,7 @@ class ComposerController < ApplicationController
     # Non-staff users can see only basic information why the users cannot see the topic.
     reason = nil if !guardian.is_staff? && reason != :private && reason != :category
 
-    reason
+    DiscoursePluginRegistry.apply_modifier(:composer_mention_user_reason, reason, user)
   end
 
   def group_reason(group)

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -142,6 +142,11 @@ after_initialize do
     Post.prepend DiscourseAi::PostExtensions
   end
 
+  # AI bots reply via `skip_guardian: true`, so the reachability warning is misleading.
+  register_modifier(:composer_mention_user_reason) do |reason, user|
+    DiscourseAi::AiBot::EntryPoint.all_bot_ids.include?(user.id) ? nil : reason
+  end
+
   register_modifier(:post_should_secure_uploads?) do |_, _, topic|
     if topic.private_message? && SharedAiConversation.exists?(target: topic)
       false

--- a/plugins/discourse-ai/spec/requests/composer_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/composer_controller_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe ComposerController do
+  fab!(:admin)
+  fab!(:ai_agent)
+  fab!(:private_category) { Fabricate(:private_category, group: Group[:staff]) }
+  fab!(:restricted_topic) { Fabricate(:topic, category: private_category) }
+
+  before do
+    enable_current_plugin
+    sign_in(admin)
+  end
+
+  describe "#mentions" do
+    it "suppresses the reachability warning when mentioning an AI bot user" do
+      agent_user = ai_agent.create_user!
+
+      get "/composer/mentions.json",
+          params: {
+            names: [agent_user.username.upcase],
+            topic_id: restricted_topic.id,
+          }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["users"]).to contain_exactly(agent_user.username_lower)
+      expect(response.parsed_body["user_reasons"]).to eq({})
+    end
+  end
+end

--- a/spec/requests/composer_controller_spec.rb
+++ b/spec/requests/composer_controller_spec.rb
@@ -329,6 +329,56 @@ RSpec.describe ComposerController do
       end
     end
 
+    context "with the composer_mention_user_reason modifier" do
+      fab!(:modified_user) { Fabricate(:user, username: "ModifiedReason") }
+      fab!(:private_category) { Fabricate(:private_category, group: Group[:staff]) }
+      fab!(:restricted_topic) { Fabricate(:topic, category: private_category) }
+
+      before { sign_in(Fabricate(:admin)) }
+
+      it "lets a plugin clear the reachability reason" do
+        target_id = modified_user.id
+        modifier = Proc.new { |reason, user| user.id == target_id ? nil : reason }
+        plugin_instance = Plugin::Instance.new
+        DiscoursePluginRegistry.register_modifier(
+          plugin_instance,
+          :composer_mention_user_reason,
+          &modifier
+        )
+
+        begin
+          get "/composer/mentions.json",
+              params: {
+                names: [modified_user.username],
+                topic_id: restricted_topic.id,
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["users"]).to contain_exactly(modified_user.username.downcase)
+          expect(response.parsed_body["user_reasons"]).to eq({})
+        ensure
+          DiscoursePluginRegistry.unregister_modifier(
+            plugin_instance,
+            :composer_mention_user_reason,
+            &modifier
+          )
+        end
+      end
+
+      it "still returns the reachability reason without the modifier" do
+        get "/composer/mentions.json",
+            params: {
+              names: [modified_user.username],
+              topic_id: restricted_topic.id,
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["user_reasons"]).to eq(
+          modified_user.username.downcase => "category",
+        )
+      end
+    end
+
     context "with an invalid topic" do
       it "returns an error" do
         get "/composer/mentions.json", params: { names: base_names, topic_id: -1 }


### PR DESCRIPTION
Mentioning an AI bot (e.g. `@Forum_Research_Assis`) in a topic the bot's User record can't see — like a category restricted to a group the bot isn't part of — surfaced the "this user cannot see this mention" warning popup in the composer. The warning is misleading: AI bots reply via `PostCreator.create!(... skip_guardian: true)` (`playground.rb`), so they respond regardless of whether their User can `Guardian#can_see?` the topic.

The previous case-insensitive fix (9a4cca29) exposed this latent behavior. Pre-fix, mixed-case names hit a case-sensitive hash miss in `ComposerController#mentions` and silently returned an empty `user_reasons`. Post-fix, the lookup hits correctly and the reachability check — which was always there — now fires for AI bot users that genuinely can't see the topic.

Adds a `:composer_mention_user_reason` plugin modifier, applied after the standard reason is computed in `user_reason`, so plugins can clear or transform it. The AI plugin registers against the modifier and returns `nil` for any user in `DiscourseAi::AiBot::EntryPoint.all_bot_ids` (covering both AI agent users and chat-bot-enabled LLM model users).

discobot and the system user are intentionally unaffected: discobot's `PostCreator.create!` does not skip the guardian, so the reachability warning remains accurate for it.

https://meta.discourse.org/t/401292