### PR TITLE
UX: show group ownership and status to all users

### DIFF
--- a/app/assets/stylesheets/common/base/group.scss
+++ b/app/assets/stylesheets/common/base/group.scss
@@ -161,7 +161,7 @@ table.group-manage-logs {
 }
 
 .group-members {
-  grid-template-columns: 3fr repeat(3, minmax(min-content, 1fr));
+  grid-template-columns: 3fr repeat(4, minmax(min-content, 1fr));
 
   &--can-manage {
     grid-template-columns: 3fr repeat(4, minmax(min-content, 1fr)) 3em;

--- a/frontend/discourse/app/templates/group/index.gjs
+++ b/frontend/discourse/app/templates/group/index.gjs
@@ -114,11 +114,9 @@ export default <template>
               class="directory-table__column-header--username username"
             />
 
-            {{#if @controller.canManageGroup}}
-              <div
-                class="directory-table__column-header directory-table__column-header--can-manage"
-              ></div>
-            {{/if}}
+            <div
+              class="directory-table__column-header directory-table__column-header--can-manage"
+            ></div>
 
             <PluginOutlet
               @name="group-index-table-header-after-username"
@@ -188,27 +186,25 @@ export default <template>
                   />
                 </div>
 
-                {{#if @controller.canManageGroup}}
-                  <div
-                    class="directory-table__cell directory-table__cell--can-manage group-owner"
-                  >
-                    {{#if (or m.owner m.primary)}}
-                      <span class="directory-table__label">
-                        <span>{{i18n "groups.members.status"}}</span>
-                      </span>
-                    {{/if}}
-                    <span class="directory-table__value">
-                      {{#if m.owner}}
-                        {{dIcon "shield-halved"}}
-                        {{i18n "groups.members.owner"}}<br />
-                      {{/if}}
-                      {{#if m.primary}}
-                        {{i18n "groups.members.primary"}}
-                      {{/if}}
+                <div
+                  class="directory-table__cell directory-table__cell--can-manage group-owner"
+                >
+                  {{#if (or m.owner m.primary)}}
+                    <span class="directory-table__label">
+                      <span>{{i18n "groups.members.status"}}</span>
                     </span>
+                  {{/if}}
+                  <span class="directory-table__value">
+                    {{#if m.owner}}
+                      {{dIcon "shield-halved"}}
+                      {{i18n "groups.members.owner"}}<br />
+                    {{/if}}
+                    {{#if m.primary}}
+                      {{i18n "groups.members.primary"}}
+                    {{/if}}
+                  </span>
 
-                  </div>
-                {{/if}}
+                </div>
 
                 <PluginOutlet
                   @name="group-index-table-row-after-username"

--- a/spec/system/viewing_group_members_spec.rb
+++ b/spec/system/viewing_group_members_spec.rb
@@ -13,4 +13,16 @@ RSpec.describe "Viewing group members" do
       expect(page).to have_selector(".group-member", count: 3)
     end
   end
+
+  it "shows the owner badge to viewers who can't manage the group" do
+    group.add_owner(user_in_group_1)
+    sign_in(Fabricate(:user))
+
+    visit("/g/#{group.name}/members")
+
+    expect(page).to have_css(
+      ".directory-table__cell.group-owner",
+      text: I18n.t("js.groups.members.owner"),
+    )
+  end
 end


### PR DESCRIPTION
Reported: https://meta.discourse.org/t/users-cannot-see-who-is-a-group-owner/402886

It can be useful to see who a group owner is if you want to figure out who to ask for membership or deal with other issues. 

Prior to a refactor in fac78413c81, this information was publicly available, and the data is still there but not rendered. Currently only group owners and staff can see it. 

This removes the `canManageGroup` gate so it's public again. 

<img width="2216" height="846" alt="image" src="https://github.com/user-attachments/assets/2a79aa07-89c8-4e1f-8ca2-e45b67eb0111" />



