### PR TITLE
DEV: Customize the dev-env rails logger

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,6 +50,9 @@ Discourse::Application.configure do
 
   config.log_level = ENV["DISCOURSE_DEV_LOG_LEVEL"] if ENV["DISCOURSE_DEV_LOG_LEVEL"]
 
+  require_relative "../../lib/dev_log_formatter"
+  config.log_formatter = DevLogFormatter.new
+
   config.active_record.logger = nil if ENV["RAILS_DISABLE_ACTIVERECORD_LOGS"] == "1" ||
     ENV["ENABLE_LOGSTASH_LOGGER"] == "1"
   config.active_record.verbose_query_logs = true if ENV["RAILS_VERBOSE_QUERY_LOGS"] == "1"

--- a/config/initializers/100-logster.rb
+++ b/config/initializers/100-logster.rb
@@ -16,7 +16,9 @@ if Rails.env.development? && !Sidekiq.server? && ENV["RAILS_LOGS_STDOUT"] == "1"
   Rails.application.config.after_initialize do
     console = ActiveSupport::Logger.new(STDOUT)
     original_logger = Rails.logger.broadcasts.first
-    console.formatter = original_logger.formatter
+    formatter = original_logger.formatter
+    console.formatter =
+      formatter.is_a?(DevLogFormatter) && ENV["NO_COLOR"].nil? ? formatter.colored : formatter
     console.level = original_logger.level
 
     unless ActiveSupport::Logger.logger_outputs_to?(original_logger, STDOUT)

--- a/config/pitchfork.conf.rb
+++ b/config/pitchfork.conf.rb
@@ -14,7 +14,16 @@ if enable_logstash_logger
            customize_event: lambda { |event| event["@timestamp"] = ::Time.now.utc },
          )
 else
-  logger Logger.new(STDOUT)
+  console_logger = Logger.new(STDOUT)
+  if ENV["RAILS_ENV"] != "production"
+    require_relative "../lib/dev_log_formatter"
+    console_logger.formatter = DevLogFormatter.new(color: ENV["NO_COLOR"].nil?)
+
+    # Drop per-worker spawn logs. Summary below covers that.
+    console_logger.level = Logger::WARN
+    STDOUT.puts "Starting Pitchfork..."
+  end
+  logger console_logger
 end
 
 worker_processes (ENV["UNICORN_WORKERS"] || 3).to_i
@@ -123,7 +132,18 @@ before_service_worker_ready do |server, service_worker|
     demon_class.start(1, logger: server.logger)
   end
 
-  Demon::PluginJsWatcher.start(verbose: true) if Rails.env.development? && !ENV["CI"]
+  if Rails.env.development? && !ENV["CI"]
+    Demon::PluginJsWatcher.start(verbose: false, logger: server.logger)
+  end
+
+  if Rails.env.development?
+    workers = server.worker_processes
+    parts = ["#{workers} worker#{"s" if workers != 1}"]
+    parts << "#{sidekiqs} sidekiq#{"s" if sidekiqs != 1}" if sidekiqs > 0
+    parts.concat(DiscoursePluginRegistry.demon_processes.map(&:prefix))
+    parts << "plugin JS watcher" if !ENV["CI"]
+    STDOUT.puts "Pitchfork ready on http://localhost:#{ENV["UNICORN_PORT"] || 3000} (#{parts.join(", ")})"
+  end
 
   Thread.new do
     while true

--- a/lib/demon/plugin_js_watcher.rb
+++ b/lib/demon/plugin_js_watcher.rb
@@ -6,7 +6,7 @@ class Demon::PluginJsWatcher < ::Demon::Base
   end
 
   def after_fork
-    log("[PluginJsWatcher] Loading PluginJsWatcher in process id #{Process.pid}")
+    log("Loading PluginJsWatcher in process id #{Process.pid}")
 
     @queue = Queue.new
 

--- a/lib/dev_log_formatter.rb
+++ b/lib/dev_log_formatter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Compact dev log formatter: drops timestamp and pid.
+# Prefixes a severity label for file log, drops the prefix
+# applies color to the whole message instead.
+class DevLogFormatter < ::Logger::Formatter
+  SEVERITY_COLORS = {
+    "DEBUG" => "\e[90m",
+    "WARN" => "\e[33m",
+    "ERROR" => "\e[31m",
+    "FATAL" => "\e[1;31m",
+    "UNKNOWN" => "\e[35m",
+  }.freeze
+  RESET = "\e[0m"
+
+  attr_reader :color
+
+  def initialize(color: false)
+    super()
+    @color = color
+  end
+
+  def colored
+    clone.tap { |f| f.instance_variable_set(:@color, true) }
+  end
+
+  def call(severity, _time, _progname, msg)
+    message = msg2str(msg)
+    if @color
+      code = SEVERITY_COLORS[severity]
+      code ? "#{code}#{message}#{RESET}\n" : "#{message}\n"
+    else
+      "#{severity.ljust(5)}  #{message}\n"
+    end
+  end
+end

--- a/lib/plugin/js_manager.rb
+++ b/lib/plugin/js_manager.rb
@@ -47,7 +47,7 @@ module Plugin
       start = Time.now
 
       if !GlobalSetting.mini_racer_single_threaded && AssetProcessor.booted?
-        raise "[Plugin::JSManager] Cannot fork for parallel compilation because AssetProcessor is already booted."
+        raise "Cannot fork Plugin::JsManager for parallel compilation because AssetProcessor is already booted."
       end
 
       parallel_count = [Etc.nprocessors, 4].min
@@ -209,7 +209,7 @@ module Plugin
     end
 
     def log(message)
-      STDERR.puts "[Plugin::JsManager] #{message}"
+      STDERR.puts message
     end
 
     private_class_method def self.maybe_cache(key, &blk)


### PR DESCRIPTION
A minimal format + suppression of noisy logs.

```
❯ bin/ember-cli -u
Ember CLI running on PID: 72251
Starting Pitchfork...
Starting CSS change watcher
[ember-cli] Proxying to http://127.0.0.1:3000
[ember-cli] building...
Pitchfork ready on http://localhost:3000 (3 workers, 1 sidekiq, plugin JS watcher)
Compiling 43 plugins...
Finished initial compilation of plugins in 2.5s
...
```

<details><summary>Previously</summary><pre>
Ember CLI running on PID: 73296
Starting CSS change watcher
I, [2026-05-13T18:44:58.017891 #73297]  INFO -- : listening on addr=127.0.0.1:3000 fd=19
[ember-cli] Proxying to http://127.0.0.1:3000
[ember-cli] building...
I, [2026-05-13T18:45:05.459057 #73297]  INFO -- : monitor pid=73297 ready
I, [2026-05-13T18:45:05.459338 #73297]  INFO -- : monitor process ready
I, [2026-05-13T18:45:05.459501 #73297]  INFO -- : service gen=0 spawning...
I, [2026-05-13T18:45:05.486370 #73297]  INFO -- : worker=0 gen=0 spawning...
I, [2026-05-13T18:45:05.501127 #73297]  INFO -- : worker=1 gen=0 spawning...
I, [2026-05-13T18:45:05.504624 #73452]  INFO -- : starting 1 supervised sidekiqs
I, [2026-05-13T18:45:05.517574 #73297]  INFO -- : worker=2 gen=0 spawning...
I, [2026-05-13T18:45:05.527786 #73453]  INFO -- : worker=0 gen=0 pid=73453 ready
I, [2026-05-13T18:45:05.542901 #73454]  INFO -- : worker=1 gen=0 pid=73454 ready
I, [2026-05-13T18:45:05.546845 #73297]  INFO -- : service gen=0 pid=73452 spawned
I, [2026-05-13T18:45:05.547308 #73297]  INFO -- : worker=0 gen=0 pid=73453 registered
I, [2026-05-13T18:45:05.547502 #73297]  INFO -- : worker=1 gen=0 pid=73454 registered
I, [2026-05-13T18:45:05.568697 #73297]  INFO -- : worker=2 gen=0 pid=73455 registered
I, [2026-05-13T18:45:05.574660 #73455]  INFO -- : worker=2 gen=0 pid=73455 ready
I, [2026-05-13T18:45:05.868738 #73456]  INFO -- : Loading Sidekiq in process id 73456
writing pid file /Users/cvx/discourse/discourse/tmp/pids/plugin_js_watcher_0.pid for 73464
I, [2026-05-13T18:45:06.229162 #73464]  INFO -- : [PluginJsWatcher] Loading PluginJsWatcher in process id 73464
[Plugin::JsManager] Compiling 43 plugins...
[Plugin::JsManager] Finished initial compilation of plugins in 1.95s
...
</pre></details> 