### PR TITLE
FIX: Enforce group PM visibility checks on new/unread list routes

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -196,9 +196,13 @@ class ListController < ApplicationController
       )
 
     case action
-    when :private_messages_unread, :private_messages_new, :private_messages_group_new,
-         :private_messages_group_unread
+    when :private_messages_unread, :private_messages_new
       raise Discourse::NotFound if target_user.id != current_user.id
+    when :private_messages_group_new, :private_messages_group_unread
+      raise Discourse::NotFound if target_user.id != current_user.id
+      group = Group.find_by("LOWER(name) = ?", params[:group_name].downcase)
+      raise Discourse::NotFound if !group
+      raise Discourse::NotFound unless guardian.can_see_group_messages?(group)
     when :private_messages_tag
       raise Discourse::NotFound if target_user.id != current_user.id
       raise Discourse::NotFound if !guardian.can_tag_pms?

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -480,6 +480,23 @@ RSpec.describe ListController do
   end
 
   describe "#private_messages_group" do
+    describe "#private_messages_group_new and #private_messages_group_unread" do
+      before do
+        group.add(user)
+        sign_in(user)
+      end
+
+      it "enforces can_see_group_messages? when personal messages are disabled for the user" do
+        SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:staff]
+
+        get "/topics/private-messages-group/#{user.username}/#{group.name}/new.json"
+        expect(response.status).to eq(404)
+
+        get "/topics/private-messages-group/#{user.username}/#{group.name}/unread.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
     describe "when user not in personal_message_enabled_groups group" do
       let!(:topic) { Fabricate(:private_message_topic, allowed_groups: [group]) }
 


### PR DESCRIPTION
Apply the same group authorization used by group inbox/archive routes to `private_messages_group_new` and `private_messages_group_unread` in `ListController#message_route`.

Previously, these two endpoints only validated `target_user == current_user`, which allowed members blocked by `can_see_group_messages?` (for example via `personal_message_enabled_groups`) to access group PM metadata through `/new` and `/unread`.