### PR TITLE
UX: minor alignment improvement for inline post-event dates

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-core-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-core-ext.scss
@@ -21,6 +21,10 @@
 }
 
 .header-topic-title-suffix-outlet {
+  &.event-date-container {
+    vertical-align: text-bottom;
+  }
+
   .event-date {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Pull out your 🔍 

This aligns the date with the topic title slightly better, by about 1px. The "before" sits just slightly too low relative to the title. 

Before:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/969295b6-7211-405d-a161-45dbfc0bd620" />


After:
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/1f2ae38d-d635-4a54-8082-32ed99729bc2" />
