### PR TITLE
FIX: Use anonymous permissions for hashtag lookup when cooking without a valid user

### DIFF
--- a/lib/pretty_text/helpers.rb
+++ b/lib/pretty_text/helpers.rb
@@ -104,14 +104,9 @@ module PrettyText
     end
 
     def hashtag_lookup(slug, cooking_user_id, types_in_priority_order)
-      # NOTE: This is _somewhat_ expected since we need to be able to cook posts
-      # etc. without a user sometimes, but it is still an edge case.
-      #
-      # The Discourse.system_user is usually an admin with access to _all_
-      # categories, however if the suppress_secured_categories_from_admin
-      # site setting is activated then this user will not be able to access
-      # secure categories, so hashtags that are secure will not render.
-      cooking_user = User.find_by(id: cooking_user_id) || Discourse.system_user
+      # Missing or invalid user IDs cook with anonymous permissions. Callers that
+      # need wider access must pass an explicit trusted user_id.
+      cooking_user = User.find_by(id: cooking_user_id)
 
       types_in_priority_order =
         types_in_priority_order.select do |type|

--- a/spec/lib/pretty_text/helpers_spec.rb
+++ b/spec/lib/pretty_text/helpers_spec.rb
@@ -161,31 +161,31 @@ RSpec.describe PrettyText::Helpers do
       expect(PrettyText::Helpers.hashtag_lookup("blah", user.id, %w[category tag])).to eq(nil)
     end
 
-    it "uses the system user if the cooking_user is nil" do
-      guardian_system = Guardian.new(Discourse.system_user)
-      Guardian.expects(:new).with(Discourse.system_user).returns(guardian_system)
-      PrettyText::Helpers.hashtag_lookup("somecooltag", nil, %w[category tag])
+    it "does not expose private category hashtags when cooking without a user" do
+      group = Fabricate(:group)
+      private_category =
+        Fabricate(:private_category, slug: "secretcategory", name: "Manager Hideout", group: group)
+
+      cooked = PrettyText.cook(" #secretcategory")
+
+      expect(cooked).to have_tag("span", text: "#secretcategory", with: { class: "hashtag-raw" })
+      expect(cooked).not_to include(private_category.url)
     end
 
-    it "falls back to system user when cooking_user is deleted" do
+    it "uses anonymous permissions if the cooking user is nil" do
+      group = Fabricate(:group)
+      Fabricate(:private_category, slug: "secretcategory", name: "Manager Hideout", group: group)
+
+      expect(PrettyText::Helpers.hashtag_lookup("secretcategory", nil, %w[category tag])).to eq(nil)
+    end
+
+    it "uses anonymous permissions when the cooking user is deleted" do
+      group = Fabricate(:group)
+      Fabricate(:private_category, slug: "secretcategory", name: "Manager Hideout", group: group)
       user.destroy
 
-      expect(
-        PrettyText::Helpers.hashtag_lookup("somecooltag::tag", user.id, %w[category tag]),
-      ).to eq(
-        {
-          relative_url: tag.url,
-          text: "somecooltag",
-          description: "Coolest things ever",
-          colors: nil,
-          emoji: nil,
-          icon: "tag",
-          style_type: "icon",
-          id: tag.id,
-          slug: "somecooltag",
-          ref: "somecooltag::tag",
-          type: "tag",
-        },
+      expect(PrettyText::Helpers.hashtag_lookup("secretcategory", user.id, %w[category tag])).to eq(
+        nil,
       )
     end
   end


### PR DESCRIPTION
## Summary

This PR updates `PrettyText::Helpers.hashtag_lookup` in `lib/pretty_text/helpers.rb` so hashtag resolution no longer falls back to `Discourse.system_user` when `cooking_user_id` is nil, invalid, or belongs to a deleted user. In those cases, lookup now uses anonymous permissions instead, preventing private category hashtags from being resolved in cooked content.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1070
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.
