### PR TITLE
DEV: Fix a race-condition in request tracker specs

### DIFF
--- a/spec/support/discourse_event_helper.rb
+++ b/spec/support/discourse_event_helper.rb
@@ -12,7 +12,7 @@ module DiscourseEvent::TestHelper
 
   def track_events(event_name = nil, args: nil)
     @events_trigger = events_trigger = []
-    yield
+    yield events_trigger
     @events_trigger = nil
 
     if event_name

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -378,7 +378,8 @@ describe "Request tracking" do
             end
           end
 
-        beacon_event = all_events.find { |e| e[:event_name] == :beacon_browser_pageview }[:params].last
+        beacon_event =
+          all_events.find { |e| e[:event_name] == :beacon_browser_pageview }[:params].last
         non_beacon_event = all_events.find { |e| e[:event_name] == :browser_pageview }[:params].last
 
         [beacon_event, non_beacon_event].each do |event|
@@ -463,7 +464,8 @@ describe "Request tracking" do
             end
           end
 
-        beacon_event = all_events.find { |e| e[:event_name] == :beacon_browser_pageview }[:params].last
+        beacon_event =
+          all_events.find { |e| e[:event_name] == :beacon_browser_pageview }[:params].last
         non_beacon_event = all_events.find { |e| e[:event_name] == :browser_pageview }[:params].last
 
         [beacon_event, non_beacon_event].each do |event|

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -354,7 +354,7 @@ describe "Request tracking" do
 
       it "tracks an anonymous visit correctly" do
         all_events =
-          DiscourseEvent.track_events do
+          DiscourseEvent.track_events do |captured|
             visit "/"
             try_until_success do
               CachedCounting.flush
@@ -373,17 +373,13 @@ describe "Request tracking" do
                 "page_view_logged_in_total" => 0,
                 "page_view_crawler_total" => 0,
               )
+              expect(captured.count { |e| e[:event_name] == :beacon_browser_pageview }).to eq(1)
+              expect(captured.count { |e| e[:event_name] == :browser_pageview }).to eq(1)
             end
           end
 
-        beacon_events = all_events.select { |e| e[:event_name] == :beacon_browser_pageview }
-        non_beacon_events = all_events.select { |e| e[:event_name] == :browser_pageview }
-
-        expect(beacon_events.size).to eq(1)
-        expect(non_beacon_events.size).to eq(1)
-
-        beacon_event = beacon_events[0][:params].last
-        non_beacon_event = non_beacon_events[0][:params].last
+        beacon_event = all_events.find { |e| e[:event_name] == :beacon_browser_pageview }[:params].last
+        non_beacon_event = all_events.find { |e| e[:event_name] == :browser_pageview }[:params].last
 
         [beacon_event, non_beacon_event].each do |event|
           expect(event[:user_id]).to be_nil
@@ -440,7 +436,7 @@ describe "Request tracking" do
         sign_in user
 
         all_events =
-          DiscourseEvent.track_events do
+          DiscourseEvent.track_events do |captured|
             visit "/"
 
             try_until_success do
@@ -462,17 +458,13 @@ describe "Request tracking" do
                 "page_view_logged_in_browser_beacon_total" => 1,
                 "page_view_crawler_total" => 0,
               )
+              expect(captured.count { |e| e[:event_name] == :beacon_browser_pageview }).to eq(1)
+              expect(captured.count { |e| e[:event_name] == :browser_pageview }).to eq(1)
             end
           end
 
-        beacon_events = all_events.select { |e| e[:event_name] == :beacon_browser_pageview }
-        non_beacon_events = all_events.select { |e| e[:event_name] == :browser_pageview }
-
-        expect(beacon_events.size).to eq(1)
-        expect(non_beacon_events.size).to eq(1)
-
-        beacon_event = beacon_events[0][:params].last
-        non_beacon_event = non_beacon_events[0][:params].last
+        beacon_event = all_events.find { |e| e[:event_name] == :beacon_browser_pageview }[:params].last
+        non_beacon_event = all_events.find { |e| e[:event_name] == :browser_pageview }[:params].last
 
         [beacon_event, non_beacon_event].each do |event|
           expect(event[:user_id]).to eq(user.id)


### PR DESCRIPTION
beacon events could arrive after `try_until_success` loop. this moves the assertion into the loop itself