### PR TITLE
PERF: Avoid timeout when deleting a house ad with many impressions

### DIFF
--- a/plugins/discourse-adplugin/app/models/ad_plugin/house_ad.rb
+++ b/plugins/discourse-adplugin/app/models/ad_plugin/house_ad.rb
@@ -12,11 +12,6 @@ module AdPlugin
     JAVASCRIPT_PROTOCOL_RE = /\Ajavascript:/i
     PROTOCOL_SEPARATOR_RE = /[\x00-\x20\x7f-\xa0]+/n
 
-    # delete_all (single DELETE) rather than :destroy (per-row instantiation)
-    # because AdImpression has no destroy callbacks and a single ad can
-    # accumulate hundreds of thousands of impressions. The FK already has
-    # ON DELETE CASCADE on the DB side; this just keeps the cleanup
-    # explicit on the Rails side and matches the pattern used for :routes.
     has_many :impressions,
              class_name: "AdPlugin::AdImpression",
              foreign_key: "ad_plugin_house_ad_id",

--- a/plugins/discourse-adplugin/app/models/ad_plugin/house_ad.rb
+++ b/plugins/discourse-adplugin/app/models/ad_plugin/house_ad.rb
@@ -12,10 +12,15 @@ module AdPlugin
     JAVASCRIPT_PROTOCOL_RE = /\Ajavascript:/i
     PROTOCOL_SEPARATOR_RE = /[\x00-\x20\x7f-\xa0]+/n
 
+    # delete_all (single DELETE) rather than :destroy (per-row instantiation)
+    # because AdImpression has no destroy callbacks and a single ad can
+    # accumulate hundreds of thousands of impressions. The FK already has
+    # ON DELETE CASCADE on the DB side; this just keeps the cleanup
+    # explicit on the Rails side and matches the pattern used for :routes.
     has_many :impressions,
              class_name: "AdPlugin::AdImpression",
              foreign_key: "ad_plugin_house_ad_id",
-             dependent: :destroy
+             dependent: :delete_all
 
     has_many :routes,
              class_name: "AdPlugin::HouseAdRoute",

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -357,16 +357,6 @@ describe AdPlugin::HouseAd do
   describe "destroying with associated impressions" do
     fab!(:ad, :house_ad)
 
-    it "has no impression destroy hooks that dependent: :delete_all would skip" do
-      dependent_associations =
-        AdPlugin::AdImpression.reflect_on_all_associations.select do |reflection|
-          reflection.options[:dependent].present?
-        end
-
-      expect(AdPlugin::AdImpression._destroy_callbacks.map(&:filter)).to be_empty
-      expect(dependent_associations.map(&:name)).to be_empty
-    end
-
     it "deletes impressions in a single DELETE query" do
       3.times { Fabricate(:anonymous_house_ad_impression, house_ad: ad) }
 

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -367,7 +367,7 @@ describe AdPlugin::HouseAd do
       expect(dependent_associations.map(&:name)).to be_empty
     end
 
-    it "deletes impressions in a single DELETE when the ad is destroyed" do
+    it "deletes impressions in a single DELETE query" do
       3.times { Fabricate(:anonymous_house_ad_impression, house_ad: ad) }
 
       delete_queries = nil

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -355,9 +355,9 @@ describe AdPlugin::HouseAd do
   end
 
   describe "destroying with associated impressions" do
-    let!(:ad) { AdPlugin::HouseAd.create!(valid_attrs) }
+    fab!(:ad) { AdPlugin::HouseAd.create!(valid_attrs) }
 
-    it "does not bypass impression destroy callbacks or dependent cleanup" do
+    it "has no impression destroy hooks that dependent: :delete_all would skip" do
       dependent_associations =
         AdPlugin::AdImpression.reflect_on_all_associations.select do |reflection|
           reflection.options[:dependent].present?
@@ -367,20 +367,17 @@ describe AdPlugin::HouseAd do
       expect(dependent_associations.map(&:name)).to be_empty
     end
 
-    it "deletes impressions when the ad is destroyed" do
-      Fabricate(:anonymous_house_ad_impression, house_ad: ad)
-      Fabricate(:anonymous_house_ad_impression, house_ad: ad)
-
-      expect { ad.destroy }.to change { AdPlugin::AdImpression.count }.by(-2)
-    end
-
-    it "deletes impressions in a single DELETE rather than per-row" do
+    it "deletes impressions in a single DELETE when the ad is destroyed" do
       3.times { Fabricate(:anonymous_house_ad_impression, house_ad: ad) }
 
-      delete_queries =
-        track_sql_queries { ad.destroy }.select do |sql|
-          sql.match?(/DELETE FROM ["']?ad_plugin_impressions["']?/i)
-        end
+      delete_queries = nil
+
+      expect do
+        delete_queries =
+          track_sql_queries { ad.destroy }.select do |sql|
+            sql.match?(/DELETE FROM ["']?ad_plugin_impressions["']?/i)
+          end
+      end.to change { AdPlugin::AdImpression.count }.by(-3)
 
       expect(delete_queries.size).to eq(1)
     end

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -353,4 +353,26 @@ describe AdPlugin::HouseAd do
       expect { ad.destroy }.to change { AdPlugin::HouseAdRoute.count }.by(-1)
     end
   end
+
+  describe "destroying with associated impressions" do
+    let!(:ad) { AdPlugin::HouseAd.create!(valid_attrs) }
+
+    it "deletes impressions when the ad is destroyed" do
+      Fabricate(:anonymous_house_ad_impression, house_ad: ad)
+      Fabricate(:anonymous_house_ad_impression, house_ad: ad)
+
+      expect { ad.destroy }.to change { AdPlugin::AdImpression.count }.by(-2)
+    end
+
+    it "deletes impressions in a single DELETE rather than per-row" do
+      3.times { Fabricate(:anonymous_house_ad_impression, house_ad: ad) }
+
+      delete_queries =
+        track_sql_queries { ad.destroy }.select do |sql|
+          sql.match?(/DELETE FROM ["']?ad_plugin_impressions["']?/i)
+        end
+
+      expect(delete_queries.size).to eq(1)
+    end
+  end
 end

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -357,6 +357,16 @@ describe AdPlugin::HouseAd do
   describe "destroying with associated impressions" do
     let!(:ad) { AdPlugin::HouseAd.create!(valid_attrs) }
 
+    it "does not bypass impression destroy callbacks or dependent cleanup" do
+      dependent_associations =
+        AdPlugin::AdImpression.reflect_on_all_associations.select do |reflection|
+          reflection.options[:dependent].present?
+        end
+
+      expect(AdPlugin::AdImpression._destroy_callbacks.map(&:filter)).to be_empty
+      expect(dependent_associations.map(&:name)).to be_empty
+    end
+
     it "deletes impressions when the ad is destroyed" do
       Fabricate(:anonymous_house_ad_impression, house_ad: ad)
       Fabricate(:anonymous_house_ad_impression, house_ad: ad)

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -355,7 +355,7 @@ describe AdPlugin::HouseAd do
   end
 
   describe "destroying with associated impressions" do
-    fab!(:ad) { AdPlugin::HouseAd.create!(valid_attrs) }
+    fab!(:ad, :house_ad)
 
     it "has no impression destroy hooks that dependent: :delete_all would skip" do
       dependent_associations =

--- a/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/models/house_ad_spec.rb
@@ -374,7 +374,7 @@ describe AdPlugin::HouseAd do
 
       expect do
         delete_queries =
-          track_sql_queries { ad.destroy }.select do |sql|
+          track_sql_queries { ad.destroy! }.select do |sql|
             sql.match?(/DELETE FROM ["']?ad_plugin_impressions["']?/i)
           end
       end.to change { AdPlugin::AdImpression.count }.by(-3)


### PR DESCRIPTION
Deleting a house ad loaded every associated impression into memory and issued a separate DELETE per row, because the impressions association used dependent: :destroy. A customer with ~299k impressions on a single ad could not complete the request before the worker timed out.

AdImpression has no destroy callbacks, no further dependent associations, and no observers, so :destroy and :delete_all produce identical results for this model. The FK already has ON DELETE CASCADE on the DB side, so referential integrity is preserved either way. The sibling :routes association on the same model already uses :delete_all.

Switch to dependent: :delete_all so deletion is a single DELETE statement regardless of impression count.