### PR TITLE
DEV: document unsilence behavior on disagree_and_restore for category moderators

### DIFF
--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -509,6 +509,53 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
 
       assert_pm_creation_enqueued(reviewable.post.user_id, "flags_disagreed")
     end
+
+    it "unsilences the user if they were silenced for the post" do
+      reviewable = Fabricate(:reviewable_flagged_post)
+      target_user = reviewable.post.user
+      reviewable.post.update(
+        hidden: true,
+        hidden_at: Time.zone.now,
+        hidden_reason_id: PostActionType.types[:spam],
+      )
+      UserSilencer.silence(target_user, moderator, post_id: reviewable.post.id)
+
+      expect(target_user.reload.silenced?).to eq(true)
+
+      reviewable.perform(moderator, :disagree_and_restore)
+
+      expect(target_user.reload.silenced?).to eq(false)
+    end
+
+    context "with category group moderator" do
+      fab!(:group)
+      fab!(:category_moderator) { Fabricate(:user, refresh_auto_groups: true) }
+
+      before do
+        SiteSetting.enable_category_group_moderation = true
+        group.add(category_moderator)
+      end
+
+      it "unsilences the user if they were silenced for a post in the moderated category" do
+        category = Fabricate(:category)
+        Fabricate(:category_moderation_group, category: category, group: group)
+
+        topic = Fabricate(:topic, category: category)
+        post = Fabricate(:post, topic: topic)
+        target_user = post.user
+
+        reviewable = PostActionCreator.spam(user, post).reviewable
+        post.update(hidden: true, hidden_at: Time.zone.now)
+        UserSilencer.silence(target_user, moderator, post_id: post.id)
+
+        expect(target_user.reload.silenced?).to eq(true)
+
+        reviewable.perform(category_moderator, :disagree_and_restore)
+
+        expect(post.reload.hidden?).to eq(false)
+        expect(target_user.reload.silenced?).to eq(false)
+      end
+    end
   end
 
   describe "recalculating the reviewable score" do


### PR DESCRIPTION
### Description:

This adds specs to document the expected behavior when category group moderators disagree with a flagged hidden post where the user was silenced for that post.

When a post is flagged and hidden, and the post author is silenced specifically for that post, performing `disagree_and_restore` will unsilence the user. This behavior applies to both staff and category group moderators. While category moderators cannot directly silence users through the `agree_and_silence` action (which requires staff privileges), they can unsilence users by disagreeing with flags on hidden posts in categories they moderate. This is considered expected behavior because the unsilence is scoped to silences that were applied for the specific post being reviewed, and category moderators are trusted to make content judgments within their categories that may have user-level consequences.

For more context check `t/183610` 