### PR TITLE
FIX: Sort topic tags in post_revisor

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -44,7 +44,7 @@ class PostRevisor
     def apply_tag_changes(tag_value)
       return unless guardian.can_tag_topics?
 
-      prev_tags = topic.tags.map(&:name)
+      prev_tags = topic.tags.map(&:name).sort
       return if tag_value.blank? && prev_tags.blank?
 
       success = DiscourseTagging.tag_topic(topic, guardian, tag_value)
@@ -54,8 +54,8 @@ class PostRevisor
         return
       end
 
-      new_tags = topic.tags.map(&:name)
-      return if prev_tags.sort == new_tags.sort
+      new_tags = topic.tags.map(&:name).sort
+      return if prev_tags == new_tags
 
       record_change("tags", prev_tags, new_tags)
       DB.after_commit do

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1476,7 +1476,7 @@ describe PostRevisor do
             expect(event[:params].first).to eq(post)
             expect(event[:params].second).to eq(true)
             expect(event[:params].third).to be_kind_of(PostRevisor)
-            expect(event[:params].third.topic_diff).to eq({ "tags" => [%w[super stuff], []] })
+            expect(event[:params].third.topic_diff).to eq({ "tags" => [%w[stuff super], []] })
           end
 
           context "with staff-only tags" do


### PR DESCRIPTION
…to have stable order. fixes a spec flake, and a rare bug where there would be post revisions created even though they haven't changed.