### PR TITLE
FEATURE: Replace "Spread the Word" onboarding step with theme picker

### DIFF
--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -61,6 +61,7 @@
 @import "table-layout";
 @import "tap-tile";
 @import "theme-card";
+@import "theme-card-preview";
 @import "time-input";
 @import "time-shortcut-picker";
 @import "topic-map";

--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -233,7 +233,12 @@
     opacity: 0;
     transition: opacity 0.15s ease;
 
-    .theme-picker-modal__screenshot:hover & {
+    .theme-picker-modal__screenshot:hover &,
+    .theme-picker-modal__screenshot:focus-within & {
+      opacity: 1;
+    }
+
+    @media (hover: none), (pointer: coarse) {
       opacity: 1;
     }
 
@@ -295,10 +300,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(0 0 0 / 0.6);
-    cursor: zoom-out;
 
     img {
+      position: relative;
+      z-index: 1;
       max-width: 90vw;
       max-height: 90vh;
       object-fit: contain;
@@ -306,8 +311,19 @@
     }
   }
 
+  &__lightbox-backdrop {
+    position: absolute;
+    inset: 0;
+    appearance: none;
+    padding: 0;
+    border: 0;
+    background: rgb(0 0 0 / 0.6);
+    cursor: zoom-out;
+  }
+
   &__lightbox-close {
     position: absolute;
+    z-index: 2;
     top: var(--space-4);
     right: var(--space-4);
     color: var(--secondary);

--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -211,65 +211,13 @@
     }
   }
 
-  &__screenshot {
-    position: relative;
-    aspect-ratio: 16 / 10;
-    overflow: hidden;
-    background: var(--primary-very-low);
-
-    img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-  }
-
-  &__screenshot-actions {
-    position: absolute;
-    bottom: var(--space-1);
-    right: var(--space-1);
-    display: flex;
-    gap: var(--space-half);
-    opacity: 0;
-    transition: opacity 0.15s ease;
-
-    .theme-picker-modal__screenshot:hover &,
-    .theme-picker-modal__screenshot:focus-within & {
-      opacity: 1;
-    }
-
-    @media (hover: none), (pointer: coarse) {
-      opacity: 1;
-    }
-
-    .btn {
-      background: rgb(var(--secondary-rgb) / 0.8);
-      border-radius: var(--d-border-radius);
-
-      &:hover {
-        background: var(--secondary);
-      }
-    }
-  }
-
-  &__info {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-3) var(--space-4) 0;
-  }
-
-  &__name {
-    font-weight: bold;
-    font-size: var(--font-up-1);
-  }
-
   &__badge {
     display: flex;
     align-items: center;
     gap: var(--space-half);
     font-size: var(--font-down-1);
     color: var(--tertiary);
+    padding: var(--space-3) var(--space-4) var(--space-4);
   }
 
   &__card > .btn {
@@ -290,47 +238,6 @@
 
     &:hover {
       color: var(--tertiary-hover);
-    }
-  }
-
-  &__lightbox {
-    position: fixed;
-    inset: 0;
-    z-index: 10000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    img {
-      position: relative;
-      z-index: 1;
-      max-width: 90vw;
-      max-height: 90vh;
-      object-fit: contain;
-      border-radius: var(--d-border-radius);
-    }
-  }
-
-  &__lightbox-backdrop {
-    position: absolute;
-    inset: 0;
-    appearance: none;
-    padding: 0;
-    border: 0;
-    background: rgb(0 0 0 / 0.6);
-    cursor: zoom-out;
-  }
-
-  &__lightbox-close {
-    position: absolute;
-    z-index: 2;
-    top: var(--space-4);
-    right: var(--space-4);
-    color: var(--secondary);
-    opacity: 0.8;
-
-    &:hover {
-      opacity: 1;
     }
   }
 }

--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -211,17 +211,18 @@
     }
   }
 
-  &__badge {
-    display: flex;
-    align-items: center;
-    gap: var(--space-half);
-    font-size: var(--font-down-1);
-    color: var(--tertiary);
-    padding: var(--space-3) var(--space-4) var(--space-4);
-  }
-
   &__card > .btn {
     margin: var(--space-3) var(--space-4) var(--space-4);
+  }
+
+  &__card .theme-picker-modal__current-btn.btn {
+    color: var(--tertiary);
+    pointer-events: none;
+    cursor: default;
+
+    .d-icon {
+      color: var(--tertiary);
+    }
   }
 
   &__browse-all,

--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -184,3 +184,137 @@
     max-width: var(--modal-max-width);
   }
 }
+
+.theme-picker-modal {
+  &__loading {
+    display: flex;
+    justify-content: center;
+    padding: var(--space-6);
+  }
+
+  &__themes {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: var(--space-4);
+  }
+
+  &__card {
+    display: flex;
+    flex-direction: column;
+    border: 2px solid var(--content-border-color);
+    border-radius: var(--d-border-radius);
+    overflow: hidden;
+    background: var(--secondary);
+
+    &.--active {
+      border-color: var(--tertiary);
+    }
+  }
+
+  &__screenshot {
+    position: relative;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+    background: var(--primary-very-low);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  &__screenshot-actions {
+    position: absolute;
+    bottom: var(--space-1);
+    right: var(--space-1);
+    display: flex;
+    gap: var(--space-half);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+
+    .theme-picker-modal__screenshot:hover & {
+      opacity: 1;
+    }
+
+    .btn {
+      background: rgb(var(--secondary-rgb) / 0.8);
+      border-radius: var(--d-border-radius);
+
+      &:hover {
+        background: var(--secondary);
+      }
+    }
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4) 0;
+  }
+
+  &__name {
+    font-weight: bold;
+    font-size: var(--font-up-1);
+  }
+
+  &__badge {
+    display: flex;
+    align-items: center;
+    gap: var(--space-half);
+    font-size: var(--font-down-1);
+    color: var(--tertiary);
+  }
+
+  &__card > .btn {
+    margin: var(--space-3) var(--space-4) var(--space-4);
+  }
+
+  &__browse-all,
+  &__upgrade-text {
+    margin-top: var(--space-4);
+    font-size: var(--font-down-1);
+    color: var(--primary-medium);
+    text-align: center;
+  }
+
+  &__browse-all a,
+  &__upgrade-link {
+    color: var(--tertiary);
+
+    &:hover {
+      color: var(--tertiary-hover);
+    }
+  }
+
+  &__lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgb(0 0 0 / 0.6);
+    cursor: zoom-out;
+
+    img {
+      max-width: 90vw;
+      max-height: 90vh;
+      object-fit: contain;
+      border-radius: var(--d-border-radius);
+    }
+  }
+
+  &__lightbox-close {
+    position: absolute;
+    top: var(--space-4);
+    right: var(--space-4);
+    color: var(--secondary);
+    opacity: 0.8;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/app/assets/stylesheets/common/components/theme-card-preview.scss
+++ b/app/assets/stylesheets/common/components/theme-card-preview.scss
@@ -1,0 +1,56 @@
+.theme-card-preview {
+  &__image-wrapper {
+    width: 100%;
+    height: 160px;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    position: relative;
+    border-bottom: 1px solid var(--content-border-color);
+
+    svg {
+      width: 100%;
+      top: 0;
+      left: 0;
+    }
+
+    &:hover .theme-card-preview__screenshot-toggle {
+      opacity: 1;
+    }
+  }
+
+  &__image {
+    width: 100%;
+    height: 100%;
+    flex-shrink: 0;
+    object-fit: cover;
+    object-position: top left;
+  }
+
+  &__screenshot-toggle {
+    position: absolute;
+    bottom: 0.5rem;
+    right: 0.5rem;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  &__content {
+    padding-inline: 1rem;
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  &__name {
+    font-size: var(--font-up-0);
+    font-weight: 700;
+    overflow-wrap: anywhere;
+    color: var(--primary);
+  }
+
+  &__description {
+    margin: 0 0 10px 0;
+  }
+}

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -88,43 +88,6 @@
     display: flex;
   }
 
-  &__image-wrapper {
-    width: 100%;
-    height: 160px;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    position: relative;
-    border-bottom: 1px solid var(--content-border-color);
-    border-top-left-radius: var(--d-border-radius);
-    border-top-right-radius: var(--d-border-radius);
-
-    svg {
-      width: 100%;
-      top: 0;
-      left: 0;
-    }
-
-    &:hover .theme-card__screenshot-toggle {
-      opacity: 1;
-    }
-  }
-
-  &__image {
-    width: 100%;
-    flex-shrink: 0;
-    object-fit: cover;
-    object-position: top left;
-  }
-
-  &__screenshot-toggle {
-    position: absolute;
-    bottom: 0.5rem;
-    right: 0.5rem;
-    opacity: 0;
-    transition: opacity 0.2s ease-in-out;
-  }
-
   .ember-checkbox {
     margin: 0 5px 0 0;
   }
@@ -132,14 +95,6 @@
   &__checkbox-label {
     margin: 0;
     font-weight: 400;
-  }
-
-  &__content {
-    padding-inline: 1rem;
-    padding-top: 1rem;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
   }
 
   &__title {
@@ -159,10 +114,6 @@
     &:focus {
       color: var(--tertiary);
     }
-  }
-
-  &__description {
-    margin: 0 0 10px 0;
   }
 
   &__components {
@@ -272,6 +223,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 
   .admin-config-area-card__content {
     margin: 0;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -508,6 +508,15 @@ en:
     admin_onboarding_banner:
       launch_in_easy_steps: "Launch in %{step_count} easy steps"
       congrats_onboarding_complete: "Congratulations on completing the onboarding process!"
+      select_theme:
+        title: "Customize your site"
+        description: "Give your community its own look and feel"
+        action: "Select theme"
+        modal_title: "Choose a theme"
+        use_theme: "Use this theme"
+        current: "Current"
+        theme_set: "%{theme} is now your default theme"
+        browse_all: "Browse all themes"
       invite_collaborators:
         title: "Invite Collaborators"
         description: "Early members help bring your community to life"
@@ -535,12 +544,6 @@ en:
           what_is_your_favorite_food:
             title: "What is your favorite food?"
             body: "Share your favorite food with the community! I'll start: I love pizza, especially with extra cheese and pepperoni."
-
-      spread_the_word:
-        title: "Spread the Word!"
-        description: "Share a link with everyone in your network"
-        action: "Copy link"
-        copied_to_clipboard: "Link copied to clipboard!"
 
     about:
       edit: "Edit this page"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -514,7 +514,7 @@ en:
         action: "Select theme"
         modal_title: "Choose a theme"
         use_theme: "Use this theme"
-        current: "Current"
+        currently_selected: "Currently selected"
         theme_set: "%{theme} is now your default theme"
         browse_all: "Browse all themes"
         show_light_screenshot: "Show light screenshot"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -510,7 +510,7 @@ en:
       congrats_onboarding_complete: "Congratulations on completing the onboarding process!"
       select_theme:
         title: "Customize your site"
-        description: "Give your community its own look and feel"
+        description: "Choose a starting theme for your community"
         action: "Select theme"
         modal_title: "Choose a theme"
         use_theme: "Use this theme"
@@ -519,8 +519,6 @@ en:
         browse_all: "Browse all themes"
         show_light_screenshot: "Show light screenshot"
         show_dark_screenshot: "Show dark screenshot"
-        expand_preview: "Expand preview"
-        close_preview: "Close preview"
       invite_collaborators:
         title: "Invite Collaborators"
         description: "Early members help bring your community to life"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -517,6 +517,10 @@ en:
         current: "Current"
         theme_set: "%{theme} is now your default theme"
         browse_all: "Browse all themes"
+        show_light_screenshot: "Show light screenshot"
+        show_dark_screenshot: "Show dark screenshot"
+        expand_preview: "Expand preview"
+        close_preview: "Close preview"
       invite_collaborators:
         title: "Invite Collaborators"
         description: "Early members help bring your community to life"

--- a/frontend/discourse/admin/components/themes-grid-card.gjs
+++ b/frontend/discourse/admin/components/themes-grid-card.gjs
@@ -8,6 +8,7 @@ import DMenu from "discourse/float-kit/components/d-menu";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { removeValueFromArray } from "discourse/lib/array-tools";
 import getURL from "discourse/lib/get-url";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import DButton from "discourse/ui-kit/d-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -37,6 +38,20 @@ export default class ThemeCard extends Component {
       this.isUpdating ? "--updating" : "",
       dasherize(this.args.theme.name),
     ].join(" ");
+  }
+
+  get themeCardControls() {
+    return applyValueTransformer("admin-theme-card-show-full-controls", true, {
+      theme: this.args.theme,
+    });
+  }
+
+  get showControls() {
+    return this.themeCardControls !== false;
+  }
+
+  get showFullControls() {
+    return this.themeCardControls === true;
   }
 
   get themeRouteModels() {
@@ -262,98 +277,104 @@ export default class ThemeCard extends Component {
             {{/if}}
           </div>
 
-          <div class="theme-card__controls">
-            <DButton
-              @translatedLabel={{i18n "admin.customize.theme.edit"}}
-              @route="adminCustomizeThemes.show"
-              @routeModels={{this.themeRouteModels}}
-              class="btn-default theme-card__button edit"
-              @preventFocus={{true}}
-            />
+          {{#if this.showControls}}
+            <div class="theme-card__controls">
+              {{#if this.showFullControls}}
+                <DButton
+                  @translatedLabel={{i18n "admin.customize.theme.edit"}}
+                  @route="adminCustomizeThemes.show"
+                  @routeModels={{this.themeRouteModels}}
+                  class="btn-default theme-card__button edit"
+                  @preventFocus={{true}}
+                />
+              {{/if}}
 
-            <div class="theme-card__footer-actions">
-              <DMenu
-                @identifier="theme-card__footer-menu"
-                @triggerClass="theme-card__footer-menu btn-flat"
-                @onRegisterApi={{this.onRegisterApi}}
-                @modalForMobile={{true}}
-                @icon="ellipsis"
-              >
-                <:content>
-                  <DDropdownMenu as |dropdown|>
-                    {{! TODO: Jordan solutions for broken, disabled states }}
-                    <dropdown.item>
-                      <DButton
-                        @action={{this.setDefault}}
-                        @preventFocus={{true}}
-                        @icon={{if @theme.default "star" "far-star"}}
-                        class="theme-card__button set-default"
-                        @translatedLabel={{i18n
-                          (if
-                            @theme.default
-                            "admin.customize.theme.default_theme"
-                            "admin.customize.theme.set_default_theme"
-                          )
-                        }}
-                        @disabled={{@theme.default}}
-                      />
-                    </dropdown.item>
-                    {{#if @theme.isPendingUpdates}}
+              <div class="theme-card__footer-actions">
+                <DMenu
+                  @identifier="theme-card__footer-menu"
+                  @triggerClass="theme-card__footer-menu btn-flat"
+                  @onRegisterApi={{this.onRegisterApi}}
+                  @modalForMobile={{true}}
+                  @icon="ellipsis"
+                >
+                  <:content>
+                    <DDropdownMenu as |dropdown|>
+                      {{! TODO: Jordan solutions for broken, disabled states }}
                       <dropdown.item>
                         <DButton
-                          @action={{this.updateTheme}}
-                          @icon="cloud-arrow-down"
-                          class="theme-card__button update"
+                          @action={{this.setDefault}}
                           @preventFocus={{true}}
+                          @icon={{if @theme.default "star" "far-star"}}
+                          class="theme-card__button set-default"
                           @translatedLabel={{i18n
-                            "admin.customize.theme.update_to_latest"
+                            (if
+                              @theme.default
+                              "admin.customize.theme.default_theme"
+                              "admin.customize.theme.set_default_theme"
+                            )
                           }}
+                          @disabled={{@theme.default}}
                         />
                       </dropdown.item>
-                    {{/if}}
-                    <dropdown.item>
-                      <DButton
-                        @action={{this.toggleUserSelectable}}
-                        @preventFocus={{true}}
-                        @icon={{if
-                          @theme.user_selectable
-                          "user-xmark"
-                          "user-check"
-                        }}
-                        class="theme-card__button set-selectable"
-                        @translatedLabel={{i18n
-                          (if
-                            @theme.user_selectable
-                            "admin.customize.theme.user_selectable_unavailable_button_label"
-                            "admin.customize.theme.user_selectable_button_label"
-                          )
-                        }}
-                      />
-                    </dropdown.item>
-                    <dropdown.item>
-                      <a
-                        href={{this.themePreviewUrl}}
-                        title={{i18n "admin.customize.explain_preview"}}
-                        rel="noopener noreferrer"
-                        target="_blank"
-                        class="btn btn-transparent theme-card__button preview"
-                      >{{dIcon "eye"}}
-                        {{i18n "admin.customize.theme.preview"}}</a>
-                    </dropdown.item>
-                    <dropdown.item>
-                      <DButton
-                        @action={{this.destroyTheme}}
-                        @label="admin.customize.delete"
-                        @icon="trash-can"
-                        @disabled={{this.destroyDisabled}}
-                        class="theme-card__button btn-transparent --danger delete"
-                      />
-                    </dropdown.item>
-                  </DDropdownMenu>
-                </:content>
-              </DMenu>
+                      {{#if this.showFullControls}}
+                        {{#if @theme.isPendingUpdates}}
+                          <dropdown.item>
+                            <DButton
+                              @action={{this.updateTheme}}
+                              @icon="cloud-arrow-down"
+                              class="theme-card__button update"
+                              @preventFocus={{true}}
+                              @translatedLabel={{i18n
+                                "admin.customize.theme.update_to_latest"
+                              }}
+                            />
+                          </dropdown.item>
+                        {{/if}}
+                        <dropdown.item>
+                          <DButton
+                            @action={{this.toggleUserSelectable}}
+                            @preventFocus={{true}}
+                            @icon={{if
+                              @theme.user_selectable
+                              "user-xmark"
+                              "user-check"
+                            }}
+                            class="theme-card__button set-selectable"
+                            @translatedLabel={{i18n
+                              (if
+                                @theme.user_selectable
+                                "admin.customize.theme.user_selectable_unavailable_button_label"
+                                "admin.customize.theme.user_selectable_button_label"
+                              )
+                            }}
+                          />
+                        </dropdown.item>
+                        <dropdown.item>
+                          <a
+                            href={{this.themePreviewUrl}}
+                            title={{i18n "admin.customize.explain_preview"}}
+                            rel="noopener noreferrer"
+                            target="_blank"
+                            class="btn btn-transparent theme-card__button preview"
+                          >{{dIcon "eye"}}
+                            {{i18n "admin.customize.theme.preview"}}</a>
+                        </dropdown.item>
+                        <dropdown.item>
+                          <DButton
+                            @action={{this.destroyTheme}}
+                            @label="admin.customize.delete"
+                            @icon="trash-can"
+                            @disabled={{this.destroyDisabled}}
+                            class="theme-card__button btn-transparent --danger delete"
+                          />
+                        </dropdown.item>
+                      {{/if}}
+                    </DDropdownMenu>
+                  </:content>
+                </DMenu>
+              </div>
             </div>
-          </div>
+          {{/if}}
         </div>
       </:content>
     </AdminConfigAreaCard>

--- a/frontend/discourse/admin/components/themes-grid-card.gjs
+++ b/frontend/discourse/admin/components/themes-grid-card.gjs
@@ -4,6 +4,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
+import ThemeCardPreview from "discourse/components/theme-card-preview";
 import DMenu from "discourse/float-kit/components/d-menu";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { removeValueFromArray } from "discourse/lib/array-tools";
@@ -25,11 +26,8 @@ export default class ThemeCard extends Component {
   @service toasts;
   @service dialog;
   @service router;
-  @service interfaceColor;
-  @service session;
 
   @tracked isUpdating = false;
-  @tracked showingDarkScreenshot = this.#shouldShowDarkByDefault();
 
   get themeCardClasses() {
     return [
@@ -64,31 +62,6 @@ export default class ThemeCard extends Component {
 
   get destroyDisabled() {
     return this.args.theme.default || this.args.theme.system;
-  }
-
-  get currentScreenshotUrl() {
-    return this.showingDarkScreenshot
-      ? this.args.theme.screenshot_dark_url
-      : this.args.theme.screenshot_light_url;
-  }
-
-  get screenshotToggleIcon() {
-    return this.showingDarkScreenshot ? "sun" : "moon";
-  }
-
-  get hasBothScreenshots() {
-    return (
-      this.args.theme.screenshot_light_url &&
-      this.args.theme.screenshot_dark_url
-    );
-  }
-
-  #shouldShowDarkByDefault() {
-    return (
-      this.interfaceColor.colorModeIsDark ||
-      window.matchMedia("(prefers-color-scheme: dark)").matches ||
-      this.session.defaultColorSchemeIsDark
-    );
   }
 
   get editUrl() {
@@ -188,11 +161,6 @@ export default class ThemeCard extends Component {
   }
 
   @action
-  toggleScreenshot() {
-    this.showingDarkScreenshot = !this.showingDarkScreenshot;
-  }
-
-  @action
   destroyTheme() {
     return this.dialog.deleteConfirm({
       title: i18n("admin.customize.delete_confirm", {
@@ -223,159 +191,149 @@ export default class ThemeCard extends Component {
       data-theme-id={{@theme.id}}
     >
       <:content>
-        <div class="theme-card__image-wrapper">
-          {{#if this.currentScreenshotUrl}}
-            <img
-              class="theme-card__image"
-              src={{this.currentScreenshotUrl}}
-              alt={{@theme.name}}
-            />
-            {{#if this.hasBothScreenshots}}
-              <DButton
-                @action={{this.toggleScreenshot}}
-                @icon={{this.screenshotToggleIcon}}
-                @preventFocus={{true}}
-                class="btn-flat theme-card__screenshot-toggle"
-              />
-            {{/if}}
-          {{else}}
+        <ThemeCardPreview @theme={{@theme}}>
+          <:placeholder>
             <ThemesGridPlaceholder @theme={{@theme}} />
-          {{/if}}
-        </div>
-        <div class="theme-card__content">
-          <a class="theme-card__title" href={{this.editUrl}}>{{@theme.name}}</a>
-          {{#if @theme.description}}
-            <p class="theme-card__description">{{@theme.description}}</p>
-          {{/if}}
-        </div>
-        <div class="theme-card__footer">
-          <div class="theme-card__badges">
-            {{#if @theme.isPendingUpdates}}
-              <span
-                title={{i18n "admin.customize.theme.updates_available_tooltip"}}
-                class="theme-card__badge"
-              >{{dIcon "arrows-rotate"}}
-                {{i18n "admin.customize.theme.update_available"}}</span>
-            {{/if}}
+          </:placeholder>
+          <:title>
+            <a
+              class="theme-card__title"
+              href={{this.editUrl}}
+            >{{@theme.name}}</a>
+          </:title>
+          <:footer>
+            <div class="theme-card__footer">
+              <div class="theme-card__badges">
+                {{#if @theme.isPendingUpdates}}
+                  <span
+                    title={{i18n
+                      "admin.customize.theme.updates_available_tooltip"
+                    }}
+                    class="theme-card__badge"
+                  >{{dIcon "arrows-rotate"}}
+                    {{i18n "admin.customize.theme.update_available"}}</span>
+                {{/if}}
 
-            {{#if @theme.default}}
-              <span
-                class="theme-card__badge --default"
-                title={{i18n "admin.customize.theme.default_theme"}}
-              >{{dIcon "paintbrush"}}
-                {{i18n "admin.customize.theme.default"}}</span>
-            {{/if}}
+                {{#if @theme.default}}
+                  <span
+                    class="theme-card__badge --default"
+                    title={{i18n "admin.customize.theme.default_theme"}}
+                  >{{dIcon "paintbrush"}}
+                    {{i18n "admin.customize.theme.default"}}</span>
+                {{/if}}
 
-            {{#if @theme.user_selectable}}
-              <span
-                title={{i18n "admin.customize.theme.user_selectable"}}
-                class="theme-card__badge --selectable"
-              >{{dIcon "user-check"}}
-                {{i18n
-                  "admin.customize.theme.user_selectable_badge_label"
-                }}</span>
-            {{/if}}
-          </div>
+                {{#if @theme.user_selectable}}
+                  <span
+                    title={{i18n "admin.customize.theme.user_selectable"}}
+                    class="theme-card__badge --selectable"
+                  >{{dIcon "user-check"}}
+                    {{i18n
+                      "admin.customize.theme.user_selectable_badge_label"
+                    }}</span>
+                {{/if}}
+              </div>
 
-          {{#if this.showControls}}
-            <div class="theme-card__controls">
-              {{#if this.showFullControls}}
-                <DButton
-                  @translatedLabel={{i18n "admin.customize.theme.edit"}}
-                  @route="adminCustomizeThemes.show"
-                  @routeModels={{this.themeRouteModels}}
-                  class="btn-default theme-card__button edit"
-                  @preventFocus={{true}}
-                />
-              {{/if}}
+              {{#if this.showControls}}
+                <div class="theme-card__controls">
+                  {{#if this.showFullControls}}
+                    <DButton
+                      @translatedLabel={{i18n "admin.customize.theme.edit"}}
+                      @route="adminCustomizeThemes.show"
+                      @routeModels={{this.themeRouteModels}}
+                      class="btn-default theme-card__button edit"
+                      @preventFocus={{true}}
+                    />
+                  {{/if}}
 
-              <div class="theme-card__footer-actions">
-                <DMenu
-                  @identifier="theme-card__footer-menu"
-                  @triggerClass="theme-card__footer-menu btn-flat"
-                  @onRegisterApi={{this.onRegisterApi}}
-                  @modalForMobile={{true}}
-                  @icon="ellipsis"
-                >
-                  <:content>
-                    <DDropdownMenu as |dropdown|>
-                      {{! TODO: Jordan solutions for broken, disabled states }}
-                      <dropdown.item>
-                        <DButton
-                          @action={{this.setDefault}}
-                          @preventFocus={{true}}
-                          @icon={{if @theme.default "star" "far-star"}}
-                          class="theme-card__button set-default"
-                          @translatedLabel={{i18n
-                            (if
-                              @theme.default
-                              "admin.customize.theme.default_theme"
-                              "admin.customize.theme.set_default_theme"
-                            )
-                          }}
-                          @disabled={{@theme.default}}
-                        />
-                      </dropdown.item>
-                      {{#if this.showFullControls}}
-                        {{#if @theme.isPendingUpdates}}
+                  <div class="theme-card__footer-actions">
+                    <DMenu
+                      @identifier="theme-card__footer-menu"
+                      @triggerClass="theme-card__footer-menu btn-flat"
+                      @onRegisterApi={{this.onRegisterApi}}
+                      @modalForMobile={{true}}
+                      @icon="ellipsis"
+                    >
+                      <:content>
+                        <DDropdownMenu as |dropdown|>
+                          {{! TODO: Jordan solutions for broken, disabled states }}
                           <dropdown.item>
                             <DButton
-                              @action={{this.updateTheme}}
-                              @icon="cloud-arrow-down"
-                              class="theme-card__button update"
+                              @action={{this.setDefault}}
                               @preventFocus={{true}}
+                              @icon={{if @theme.default "star" "far-star"}}
+                              class="theme-card__button set-default"
                               @translatedLabel={{i18n
-                                "admin.customize.theme.update_to_latest"
+                                (if
+                                  @theme.default
+                                  "admin.customize.theme.default_theme"
+                                  "admin.customize.theme.set_default_theme"
+                                )
                               }}
+                              @disabled={{@theme.default}}
                             />
                           </dropdown.item>
-                        {{/if}}
-                        <dropdown.item>
-                          <DButton
-                            @action={{this.toggleUserSelectable}}
-                            @preventFocus={{true}}
-                            @icon={{if
-                              @theme.user_selectable
-                              "user-xmark"
-                              "user-check"
-                            }}
-                            class="theme-card__button set-selectable"
-                            @translatedLabel={{i18n
-                              (if
-                                @theme.user_selectable
-                                "admin.customize.theme.user_selectable_unavailable_button_label"
-                                "admin.customize.theme.user_selectable_button_label"
-                              )
-                            }}
-                          />
-                        </dropdown.item>
-                        <dropdown.item>
-                          <a
-                            href={{this.themePreviewUrl}}
-                            title={{i18n "admin.customize.explain_preview"}}
-                            rel="noopener noreferrer"
-                            target="_blank"
-                            class="btn btn-transparent theme-card__button preview"
-                          >{{dIcon "eye"}}
-                            {{i18n "admin.customize.theme.preview"}}</a>
-                        </dropdown.item>
-                        <dropdown.item>
-                          <DButton
-                            @action={{this.destroyTheme}}
-                            @label="admin.customize.delete"
-                            @icon="trash-can"
-                            @disabled={{this.destroyDisabled}}
-                            class="theme-card__button btn-transparent --danger delete"
-                          />
-                        </dropdown.item>
-                      {{/if}}
-                    </DDropdownMenu>
-                  </:content>
-                </DMenu>
-              </div>
+                          {{#if this.showFullControls}}
+                            {{#if @theme.isPendingUpdates}}
+                              <dropdown.item>
+                                <DButton
+                                  @action={{this.updateTheme}}
+                                  @icon="cloud-arrow-down"
+                                  class="theme-card__button update"
+                                  @preventFocus={{true}}
+                                  @translatedLabel={{i18n
+                                    "admin.customize.theme.update_to_latest"
+                                  }}
+                                />
+                              </dropdown.item>
+                            {{/if}}
+                            <dropdown.item>
+                              <DButton
+                                @action={{this.toggleUserSelectable}}
+                                @preventFocus={{true}}
+                                @icon={{if
+                                  @theme.user_selectable
+                                  "user-xmark"
+                                  "user-check"
+                                }}
+                                class="theme-card__button set-selectable"
+                                @translatedLabel={{i18n
+                                  (if
+                                    @theme.user_selectable
+                                    "admin.customize.theme.user_selectable_unavailable_button_label"
+                                    "admin.customize.theme.user_selectable_button_label"
+                                  )
+                                }}
+                              />
+                            </dropdown.item>
+                            <dropdown.item>
+                              <a
+                                href={{this.themePreviewUrl}}
+                                title={{i18n "admin.customize.explain_preview"}}
+                                rel="noopener noreferrer"
+                                target="_blank"
+                                class="btn btn-transparent theme-card__button preview"
+                              >{{dIcon "eye"}}
+                                {{i18n "admin.customize.theme.preview"}}</a>
+                            </dropdown.item>
+                            <dropdown.item>
+                              <DButton
+                                @action={{this.destroyTheme}}
+                                @label="admin.customize.delete"
+                                @icon="trash-can"
+                                @disabled={{this.destroyDisabled}}
+                                class="theme-card__button btn-transparent --danger delete"
+                              />
+                            </dropdown.item>
+                          {{/if}}
+                        </DDropdownMenu>
+                      </:content>
+                    </DMenu>
+                  </div>
+                </div>
+              {{/if}}
             </div>
-          {{/if}}
-        </div>
+          </:footer>
+        </ThemeCardPreview>
       </:content>
     </AdminConfigAreaCard>
   </template>

--- a/frontend/discourse/app/components/admin-onboarding/banner.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/banner.gjs
@@ -89,7 +89,7 @@ const STEPS = [
     }
 
     completeStep() {
-      this.markAsCompleted();
+      return this.markAsCompleted();
     }
 
     showStartPostingOptions() {
@@ -131,30 +131,11 @@ const STEPS = [
 
 export default class AdminOnboardingBanner extends Component {
   @service currentUser;
-  @service appEvents;
   @service keyValueStore;
   @service router;
   @service toasts;
 
   @tracked dismissed = false;
-
-  constructor() {
-    super(...arguments);
-    this.appEvents.on(
-      "onboarding-step:completed",
-      this,
-      this.checkIfOnboardingIsComplete
-    );
-  }
-
-  willDestroy() {
-    super.willDestroy(...arguments);
-    this.appEvents.off(
-      "onboarding-step:completed",
-      this,
-      this.checkIfOnboardingIsComplete
-    );
-  }
 
   get shouldDisplay() {
     if (this.dismissed) {
@@ -169,13 +150,14 @@ export default class AdminOnboardingBanner extends Component {
     return currentRouteName === `discovery.${defaultHomepage()}`;
   }
 
-  checkIfOnboardingIsComplete() {
+  @action
+  async checkIfOnboardingIsComplete() {
     const allStepsAreDone = STEPS.every(
       (Step) => !!this.keyValueStore.get(`onboarding_step_${Step.name}`)
     );
 
     if (allStepsAreDone) {
-      this.endOnboarding({ skipped: false });
+      await this.endOnboarding({ skipped: false });
     }
   }
 
@@ -216,7 +198,7 @@ export default class AdminOnboardingBanner extends Component {
           <div class="admin-onboarding-banner__content">
             <div class="admin-onboarding-banner__steps">
               {{#each STEPS as |Step|}}
-                <Step />
+                <Step @onCompleted={{this.checkIfOnboardingIsComplete}} />
               {{/each}}
             </div>
           </div>

--- a/frontend/discourse/app/components/admin-onboarding/banner.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/banner.gjs
@@ -7,16 +7,30 @@ import { service } from "@ember/service";
 import SiteSetting from "discourse/admin/models/site-setting";
 import PredefinedTopicsOptionsModal from "discourse/components/admin-onboarding/modal/predefined-topics-options";
 import StartPostingOptions from "discourse/components/admin-onboarding/modal/start-posting-options";
+import ThemePickerModal from "discourse/components/admin-onboarding/modal/theme-picker";
 import PredefinedTopicOption from "discourse/components/admin-onboarding/predefined-topics-option";
 import OnboardingStep from "discourse/components/admin-onboarding/step";
 import CreateInvite from "discourse/components/modal/create-invite";
-import { getAbsoluteURL } from "discourse/lib/get-url";
 import { applyValueTransformer } from "discourse/lib/transformer";
-import { clipboardCopy, defaultHomepage } from "discourse/lib/utilities";
+import { defaultHomepage } from "discourse/lib/utilities";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
 const STEPS = [
+  class SelectTheme extends OnboardingStep {
+    static name = "select_theme";
+
+    @service modal;
+
+    icon = "paintbrush";
+
+    @action
+    performAction() {
+      this.modal.show(ThemePickerModal, {
+        model: { onThemeSelected: () => this.markAsCompleted() },
+      });
+    }
+  },
   class InviteCollaborators extends OnboardingStep {
     static name = "invite_collaborators";
 
@@ -111,27 +125,6 @@ const STEPS = [
     @action
     async performAction() {
       this.showStartPostingOptions();
-    }
-  },
-  class SpreadTheWord extends OnboardingStep {
-    static name = "spread_the_word";
-    @service toasts;
-
-    @tracked icon = "copy";
-
-    @action
-    performAction() {
-      clipboardCopy(getAbsoluteURL("/"));
-
-      this.toasts.success({
-        data: {
-          message: i18n(
-            "admin_onboarding_banner.spread_the_word.copied_to_clipboard"
-          ),
-        },
-      });
-
-      this.markAsCompleted();
     }
   },
 ];

--- a/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import getURL from "discourse/lib/get-url";
 import {
   FOUNDATION_THEME_ID,
   HORIZON_THEME_ID,
@@ -28,13 +29,21 @@ class ThemeCard extends Component {
   @tracked previewExpanded = false;
 
   get currentScreenshotUrl() {
+    const { screenshot_dark_url, screenshot_light_url } = this.args.theme;
+
     return this.showingDarkScreenshot
-      ? this.args.theme.screenshot_dark_url
-      : this.args.theme.screenshot_light_url;
+      ? screenshot_dark_url || screenshot_light_url
+      : screenshot_light_url || screenshot_dark_url;
   }
 
   get screenshotToggleIcon() {
     return this.showingDarkScreenshot ? "sun" : "moon";
+  }
+
+  get screenshotToggleLabel() {
+    return this.showingDarkScreenshot
+      ? "admin_onboarding_banner.select_theme.show_light_screenshot"
+      : "admin_onboarding_banner.select_theme.show_dark_screenshot";
   }
 
   get hasBothScreenshots() {
@@ -76,15 +85,19 @@ class ThemeCard extends Component {
             {{#if this.hasBothScreenshots}}
               <DButton
                 @action={{this.toggleScreenshot}}
+                @ariaLabel={{this.screenshotToggleLabel}}
                 @icon={{this.screenshotToggleIcon}}
                 @preventFocus={{true}}
+                @title={{this.screenshotToggleLabel}}
                 class="btn-flat btn-small"
               />
             {{/if}}
             <DButton
               @action={{this.expandPreview}}
+              @ariaLabel="admin_onboarding_banner.select_theme.expand_preview"
               @icon="expand"
               @preventFocus={{true}}
+              @title="admin_onboarding_banner.select_theme.expand_preview"
               class="btn-flat btn-small"
             />
           </div>
@@ -110,17 +123,22 @@ class ThemeCard extends Component {
       {{/unless}}
     </div>
     {{#if this.previewExpanded}}
-      {{! template-lint-disable no-invalid-interactive }}
-      <div
-        class="theme-picker-modal__lightbox"
-        {{on "click" this.collapsePreview}}
-        role="button"
-        tabindex="0"
-      >
+      <div class="theme-picker-modal__lightbox">
+        <button
+          aria-label={{i18n
+            "admin_onboarding_banner.select_theme.close_preview"
+          }}
+          class="theme-picker-modal__lightbox-backdrop"
+          title={{i18n "admin_onboarding_banner.select_theme.close_preview"}}
+          type="button"
+          {{on "click" this.collapsePreview}}
+        ></button>
         <img src={{this.currentScreenshotUrl}} alt={{@theme.name}} />
         <DButton
           @action={{this.collapsePreview}}
+          @ariaLabel="admin_onboarding_banner.select_theme.close_preview"
           @icon="xmark"
+          @title="admin_onboarding_banner.select_theme.close_preview"
           class="btn-flat theme-picker-modal__lightbox-close"
         />
       </div>
@@ -177,7 +195,7 @@ export default class ThemePickerModal extends Component {
         },
       });
 
-      this.args.model.onThemeSelected?.();
+      await this.args.model?.onThemeSelected?.();
       this.args.closeModal();
       window.location.reload();
     } catch (error) {
@@ -206,7 +224,7 @@ export default class ThemePickerModal extends Component {
           </div>
           <PluginOutlet @name="theme-picker-modal-below-themes">
             <p class="theme-picker-modal__browse-all">
-              <a href="/admin/config/customize/themes">
+              <a href={{getURL "/admin/config/customize/themes"}}>
                 {{i18n "admin_onboarding_banner.select_theme.browse_all"}}
               </a>
             </p>

--- a/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
@@ -1,10 +1,10 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import ThemeCardPreview from "discourse/components/theme-card-preview";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import getURL from "discourse/lib/get-url";
@@ -21,130 +21,28 @@ import { i18n } from "discourse-i18n";
 
 const ALLOWED_THEME_IDS = [FOUNDATION_THEME_ID, HORIZON_THEME_ID];
 
-class ThemeCard extends Component {
-  @service interfaceColor;
-  @service session;
-
-  @tracked showingDarkScreenshot = this.#shouldShowDarkByDefault();
-  @tracked previewExpanded = false;
-
-  get currentScreenshotUrl() {
-    const { screenshot_dark_url, screenshot_light_url } = this.args.theme;
-
-    return this.showingDarkScreenshot
-      ? screenshot_dark_url || screenshot_light_url
-      : screenshot_light_url || screenshot_dark_url;
-  }
-
-  get screenshotToggleIcon() {
-    return this.showingDarkScreenshot ? "sun" : "moon";
-  }
-
-  get screenshotToggleLabel() {
-    return this.showingDarkScreenshot
-      ? "admin_onboarding_banner.select_theme.show_light_screenshot"
-      : "admin_onboarding_banner.select_theme.show_dark_screenshot";
-  }
-
-  get hasBothScreenshots() {
-    return (
-      this.args.theme.screenshot_light_url &&
-      this.args.theme.screenshot_dark_url
-    );
-  }
-
-  #shouldShowDarkByDefault() {
-    return (
-      this.interfaceColor?.colorModeIsDark ||
-      window.matchMedia("(prefers-color-scheme: dark)").matches ||
-      this.session?.defaultColorSchemeIsDark
-    );
-  }
-
-  @action
-  toggleScreenshot() {
-    this.showingDarkScreenshot = !this.showingDarkScreenshot;
-  }
-
-  @action
-  expandPreview() {
-    this.previewExpanded = true;
-  }
-
-  @action
-  collapsePreview() {
-    this.previewExpanded = false;
-  }
-
-  <template>
-    <div class="theme-picker-modal__card {{if @theme.default '--active'}}">
-      <div class="theme-picker-modal__screenshot">
-        {{#if this.currentScreenshotUrl}}
-          <img src={{this.currentScreenshotUrl}} alt={{@theme.name}} />
-          <div class="theme-picker-modal__screenshot-actions">
-            {{#if this.hasBothScreenshots}}
-              <DButton
-                @action={{this.toggleScreenshot}}
-                @ariaLabel={{this.screenshotToggleLabel}}
-                @icon={{this.screenshotToggleIcon}}
-                @preventFocus={{true}}
-                @title={{this.screenshotToggleLabel}}
-                class="btn-flat btn-small"
-              />
-            {{/if}}
-            <DButton
-              @action={{this.expandPreview}}
-              @ariaLabel="admin_onboarding_banner.select_theme.expand_preview"
-              @icon="expand"
-              @preventFocus={{true}}
-              @title="admin_onboarding_banner.select_theme.expand_preview"
-              class="btn-flat btn-small"
-            />
-          </div>
-        {{/if}}
-      </div>
-      <div class="theme-picker-modal__info">
-        <span class="theme-picker-modal__name">{{@theme.name}}</span>
+const ThemeCard = <template>
+  <div class="theme-picker-modal__card {{if @theme.default '--active'}}">
+    <ThemeCardPreview @theme={{@theme}}>
+      <:footer>
         {{#if @theme.default}}
           <span class="theme-picker-modal__badge">
             {{dIcon "check"}}
             {{i18n "admin_onboarding_banner.select_theme.current"}}
           </span>
+        {{else}}
+          <DButton
+            @action={{fn @onSelect @theme}}
+            @translatedLabel={{i18n
+              "admin_onboarding_banner.select_theme.use_theme"
+            }}
+            class="btn-primary"
+          />
         {{/if}}
-      </div>
-      {{#unless @theme.default}}
-        <DButton
-          @action={{fn @onSelect @theme}}
-          @translatedLabel={{i18n
-            "admin_onboarding_banner.select_theme.use_theme"
-          }}
-          class="btn-primary"
-        />
-      {{/unless}}
-    </div>
-    {{#if this.previewExpanded}}
-      <div class="theme-picker-modal__lightbox">
-        <button
-          aria-label={{i18n
-            "admin_onboarding_banner.select_theme.close_preview"
-          }}
-          class="theme-picker-modal__lightbox-backdrop"
-          title={{i18n "admin_onboarding_banner.select_theme.close_preview"}}
-          type="button"
-          {{on "click" this.collapsePreview}}
-        ></button>
-        <img src={{this.currentScreenshotUrl}} alt={{@theme.name}} />
-        <DButton
-          @action={{this.collapsePreview}}
-          @ariaLabel="admin_onboarding_banner.select_theme.close_preview"
-          @icon="xmark"
-          @title="admin_onboarding_banner.select_theme.close_preview"
-          class="btn-flat theme-picker-modal__lightbox-close"
-        />
-      </div>
-    {{/if}}
-  </template>
-}
+      </:footer>
+    </ThemeCardPreview>
+  </div>
+</template>;
 
 export default class ThemePickerModal extends Component {
   @service toasts;

--- a/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
@@ -15,7 +15,6 @@ import {
 } from "discourse/lib/theme-selector";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
-import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dLoadingSpinner from "discourse/ui-kit/helpers/d-loading-spinner";
 import { i18n } from "discourse-i18n";
 
@@ -26,10 +25,13 @@ const ThemeCard = <template>
     <ThemeCardPreview @theme={{@theme}}>
       <:footer>
         {{#if @theme.default}}
-          <span class="theme-picker-modal__badge">
-            {{dIcon "check"}}
-            {{i18n "admin_onboarding_banner.select_theme.current"}}
-          </span>
+          <DButton
+            @icon="check"
+            @translatedLabel={{i18n
+              "admin_onboarding_banner.select_theme.currently_selected"
+            }}
+            class="btn-transparent theme-picker-modal__current-btn"
+          />
         {{else}}
           <DButton
             @action={{fn @onSelect @theme}}

--- a/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
@@ -1,0 +1,218 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import {
+  FOUNDATION_THEME_ID,
+  HORIZON_THEME_ID,
+  setLocalTheme,
+} from "discourse/lib/theme-selector";
+import DButton from "discourse/ui-kit/d-button";
+import DModal from "discourse/ui-kit/d-modal";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import dLoadingSpinner from "discourse/ui-kit/helpers/d-loading-spinner";
+import { i18n } from "discourse-i18n";
+
+const ALLOWED_THEME_IDS = [FOUNDATION_THEME_ID, HORIZON_THEME_ID];
+
+class ThemeCard extends Component {
+  @service interfaceColor;
+  @service session;
+
+  @tracked showingDarkScreenshot = this.#shouldShowDarkByDefault();
+  @tracked previewExpanded = false;
+
+  get currentScreenshotUrl() {
+    return this.showingDarkScreenshot
+      ? this.args.theme.screenshot_dark_url
+      : this.args.theme.screenshot_light_url;
+  }
+
+  get screenshotToggleIcon() {
+    return this.showingDarkScreenshot ? "sun" : "moon";
+  }
+
+  get hasBothScreenshots() {
+    return (
+      this.args.theme.screenshot_light_url &&
+      this.args.theme.screenshot_dark_url
+    );
+  }
+
+  #shouldShowDarkByDefault() {
+    return (
+      this.interfaceColor?.colorModeIsDark ||
+      window.matchMedia("(prefers-color-scheme: dark)").matches ||
+      this.session?.defaultColorSchemeIsDark
+    );
+  }
+
+  @action
+  toggleScreenshot() {
+    this.showingDarkScreenshot = !this.showingDarkScreenshot;
+  }
+
+  @action
+  expandPreview() {
+    this.previewExpanded = true;
+  }
+
+  @action
+  collapsePreview() {
+    this.previewExpanded = false;
+  }
+
+  <template>
+    <div class="theme-picker-modal__card {{if @theme.default '--active'}}">
+      <div class="theme-picker-modal__screenshot">
+        {{#if this.currentScreenshotUrl}}
+          <img src={{this.currentScreenshotUrl}} alt={{@theme.name}} />
+          <div class="theme-picker-modal__screenshot-actions">
+            {{#if this.hasBothScreenshots}}
+              <DButton
+                @action={{this.toggleScreenshot}}
+                @icon={{this.screenshotToggleIcon}}
+                @preventFocus={{true}}
+                class="btn-flat btn-small"
+              />
+            {{/if}}
+            <DButton
+              @action={{this.expandPreview}}
+              @icon="expand"
+              @preventFocus={{true}}
+              class="btn-flat btn-small"
+            />
+          </div>
+        {{/if}}
+      </div>
+      <div class="theme-picker-modal__info">
+        <span class="theme-picker-modal__name">{{@theme.name}}</span>
+        {{#if @theme.default}}
+          <span class="theme-picker-modal__badge">
+            {{dIcon "check"}}
+            {{i18n "admin_onboarding_banner.select_theme.current"}}
+          </span>
+        {{/if}}
+      </div>
+      {{#unless @theme.default}}
+        <DButton
+          @action={{fn @onSelect @theme}}
+          @translatedLabel={{i18n
+            "admin_onboarding_banner.select_theme.use_theme"
+          }}
+          class="btn-primary"
+        />
+      {{/unless}}
+    </div>
+    {{#if this.previewExpanded}}
+      {{! template-lint-disable no-invalid-interactive }}
+      <div
+        class="theme-picker-modal__lightbox"
+        {{on "click" this.collapsePreview}}
+        role="button"
+        tabindex="0"
+      >
+        <img src={{this.currentScreenshotUrl}} alt={{@theme.name}} />
+        <DButton
+          @action={{this.collapsePreview}}
+          @icon="xmark"
+          class="btn-flat theme-picker-modal__lightbox-close"
+        />
+      </div>
+    {{/if}}
+  </template>
+}
+
+export default class ThemePickerModal extends Component {
+  @service toasts;
+
+  @tracked themes = [];
+  @tracked loading = true;
+  @tracked saving = false;
+
+  constructor() {
+    super(...arguments);
+    this.loadThemes();
+  }
+
+  async loadThemes() {
+    try {
+      const result = await ajax("/admin/themes.json");
+      this.themes = result.themes.filter((theme) =>
+        ALLOWED_THEME_IDS.includes(theme.id)
+      );
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  @action
+  async selectTheme(theme) {
+    if (this.saving) {
+      return;
+    }
+
+    this.saving = true;
+
+    try {
+      await ajax(`/admin/themes/${theme.id}.json`, {
+        type: "PUT",
+        data: { theme: { default: true } },
+      });
+
+      setLocalTheme([], 0);
+
+      this.toasts.success({
+        data: {
+          message: i18n("admin_onboarding_banner.select_theme.theme_set", {
+            theme: theme.name,
+          }),
+        },
+      });
+
+      this.args.model.onThemeSelected?.();
+      this.args.closeModal();
+      window.location.reload();
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  <template>
+    <DModal
+      class="theme-picker-modal"
+      @title={{i18n "admin_onboarding_banner.select_theme.modal_title"}}
+      @closeModal={{@closeModal}}
+    >
+      <:body>
+        {{#if this.loading}}
+          <div class="theme-picker-modal__loading">
+            {{dLoadingSpinner}}
+          </div>
+        {{else}}
+          <div class="theme-picker-modal__themes">
+            {{#each this.themes as |theme|}}
+              <ThemeCard @theme={{theme}} @onSelect={{this.selectTheme}} />
+            {{/each}}
+          </div>
+          <PluginOutlet @name="theme-picker-modal-below-themes">
+            <p class="theme-picker-modal__browse-all">
+              <a href="/admin/config/customize/themes">
+                {{i18n "admin_onboarding_banner.select_theme.browse_all"}}
+              </a>
+            </p>
+          </PluginOutlet>
+        {{/if}}
+      </:body>
+    </DModal>
+  </template>
+}

--- a/frontend/discourse/app/components/admin-onboarding/step.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/step.gjs
@@ -47,6 +47,8 @@ export default class OnboardingStep extends Component {
     });
     this.completed = true;
     this.appEvents.trigger(`onboarding-step:completed`, this.name);
+
+    return this.args.onCompleted?.(this.name);
   }
 
   <template>

--- a/frontend/discourse/app/components/theme-card-preview.gjs
+++ b/frontend/discourse/app/components/theme-card-preview.gjs
@@ -1,0 +1,85 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/ui-kit/d-button";
+import { i18n } from "discourse-i18n";
+
+export default class ThemeCardPreview extends Component {
+  @service interfaceColor;
+  @service session;
+
+  @tracked showingDarkScreenshot = this.#shouldShowDarkByDefault();
+
+  get currentScreenshotUrl() {
+    const { screenshot_dark_url, screenshot_light_url } = this.args.theme;
+    return this.showingDarkScreenshot
+      ? screenshot_dark_url || screenshot_light_url
+      : screenshot_light_url || screenshot_dark_url;
+  }
+
+  get hasBothScreenshots() {
+    return (
+      this.args.theme.screenshot_light_url &&
+      this.args.theme.screenshot_dark_url
+    );
+  }
+
+  get screenshotToggleIcon() {
+    return this.showingDarkScreenshot ? "sun" : "moon";
+  }
+
+  get screenshotToggleLabel() {
+    return this.showingDarkScreenshot
+      ? i18n("admin_onboarding_banner.select_theme.show_light_screenshot")
+      : i18n("admin_onboarding_banner.select_theme.show_dark_screenshot");
+  }
+
+  #shouldShowDarkByDefault() {
+    return (
+      this.interfaceColor?.colorModeIsDark ||
+      window.matchMedia("(prefers-color-scheme: dark)").matches ||
+      this.session?.defaultColorSchemeIsDark
+    );
+  }
+
+  @action
+  toggleScreenshot() {
+    this.showingDarkScreenshot = !this.showingDarkScreenshot;
+  }
+
+  <template>
+    <div class="theme-card-preview__image-wrapper">
+      {{#if this.currentScreenshotUrl}}
+        <img
+          class="theme-card-preview__image"
+          src={{this.currentScreenshotUrl}}
+          alt={{@theme.name}}
+        />
+        {{#if this.hasBothScreenshots}}
+          <DButton
+            @action={{this.toggleScreenshot}}
+            @ariaLabel={{this.screenshotToggleLabel}}
+            @icon={{this.screenshotToggleIcon}}
+            @preventFocus={{true}}
+            @title={{this.screenshotToggleLabel}}
+            class="btn-flat theme-card-preview__screenshot-toggle"
+          />
+        {{/if}}
+      {{else}}
+        {{yield to="placeholder"}}
+      {{/if}}
+    </div>
+    <div class="theme-card-preview__content">
+      {{#if (has-block "title")}}
+        {{yield to="title"}}
+      {{else}}
+        <span class="theme-card-preview__name">{{@theme.name}}</span>
+      {{/if}}
+      {{#if @theme.description}}
+        <p class="theme-card-preview__description">{{@theme.description}}</p>
+      {{/if}}
+    </div>
+    {{yield to="footer"}}
+  </template>
+}

--- a/frontend/discourse/app/components/theme-card-preview.gjs
+++ b/frontend/discourse/app/components/theme-card-preview.gjs
@@ -59,10 +59,10 @@ export default class ThemeCardPreview extends Component {
         {{#if this.hasBothScreenshots}}
           <DButton
             @action={{this.toggleScreenshot}}
-            @ariaLabel={{this.screenshotToggleLabel}}
+            @translatedAriaLabel={{this.screenshotToggleLabel}}
             @icon={{this.screenshotToggleIcon}}
             @preventFocus={{true}}
-            @title={{this.screenshotToggleLabel}}
+            @translatedTitle={{this.screenshotToggleLabel}}
             class="btn-flat theme-card-preview__screenshot-toggle"
           />
         {{/if}}

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -35,6 +35,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "admin-onboarding-start-posting-options",
   "admin-plugin-icon",
   "admin-reports-show-query-params",
+  "admin-theme-card-show-full-controls",
   "bulk-select-in-nav-controls",
   "category-available-views",
   "category-default-colors",

--- a/frontend/discourse/tests/acceptance/admin-onboarding-banner-test.gjs
+++ b/frontend/discourse/tests/acceptance/admin-onboarding-banner-test.gjs
@@ -1,8 +1,7 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { click, visit } from "@ember/test-helpers";
+import { click, settled, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import sinon from "sinon";
 import StartPostingOption from "discourse/components/admin-onboarding/start-posting-option";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -33,14 +32,34 @@ acceptance("Admin - Onboarding Banner", function (needs) {
         success: "OK",
       });
     });
-  });
 
-  needs.hooks.beforeEach(() => {
-    const mockClipboard = {
-      writeText: sinon.stub().resolves(true),
-      write: sinon.stub().resolves(true),
-    };
-    sinon.stub(window.navigator, "clipboard").get(() => mockClipboard);
+    server.get("/admin/themes.json", () => {
+      return helper.response(200, {
+        themes: [
+          {
+            id: -1,
+            name: "Foundation",
+            default: true,
+            screenshot_light_url: null,
+            screenshot_dark_url: null,
+          },
+          {
+            id: -2,
+            name: "Horizon",
+            default: false,
+            screenshot_light_url: null,
+            screenshot_dark_url: null,
+          },
+        ],
+        extras: { color_schemes: [] },
+      });
+    });
+
+    server.put("/admin/themes/-2.json", () => {
+      return helper.response(200, {
+        theme: { id: -2, name: "Horizon", default: true },
+      });
+    });
   });
 
   const withStep = (id, assert) => {
@@ -206,14 +225,19 @@ acceptance("Admin - Onboarding Banner", function (needs) {
     step.isChecked();
   });
 
-  test("it can complete `spread_the_word` step", async function (assert) {
-    const step = withStep("spread_the_word", assert);
+  test("it can complete `select_theme` step", async function (assert) {
+    const step = withStep("select_theme", assert);
 
     await visit("/");
 
     step.isNotChecked();
     await step.clickAction();
-    step.isChecked();
+    await settled();
+
+    assert.dom(".theme-picker-modal").exists("theme picker modal is shown");
+    assert
+      .dom(".theme-picker-modal__card")
+      .exists({ count: 2 }, "shows Foundation and Horizon");
   });
 });
 

--- a/frontend/discourse/tests/acceptance/admin-onboarding-banner-test.gjs
+++ b/frontend/discourse/tests/acceptance/admin-onboarding-banner-test.gjs
@@ -225,7 +225,7 @@ acceptance("Admin - Onboarding Banner", function (needs) {
     step.isChecked();
   });
 
-  test("it can complete `select_theme` step", async function (assert) {
+  test("it can open `select_theme` step", async function (assert) {
     const step = withStep("select_theme", assert);
 
     await visit("/");

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -25,9 +25,9 @@ describe "Admin Onboarding Banner" do
 
     it "shows all three onboarding steps" do
       visit("/")
-      expect(banner.step("start_posting")).to be_present
+      expect(banner.step("select_theme")).to be_present
       expect(banner.step("invite_collaborators")).to be_present
-      expect(banner.step("spread_the_word")).to be_present
+      expect(banner.step("start_posting")).to be_present
     end
 
     it "can close the banner prematurely" do
@@ -102,16 +102,29 @@ describe "Admin Onboarding Banner" do
     end
   end
 
-  describe "spread the word step" do
-    it "copies site URL to clipboard and marks step complete" do
+  describe "select theme step" do
+    it "opens the theme picker modal" do
       visit("/")
-      expect(banner.step_not_completed?("spread_the_word")).to eq(true)
+      expect(banner.step_not_completed?("select_theme")).to eq(true)
 
-      banner.click_step_action("spread_the_word")
+      banner.click_step_action("select_theme")
 
-      expect(banner.step_completed?("spread_the_word")).to eq(true)
+      expect(page).to have_css(".theme-picker-modal")
+      expect(page).to have_css(".theme-picker-modal__card", minimum: 1)
+    end
+
+    it "sets a theme as default and marks step complete" do
+      visit("/")
+      banner.click_step_action("select_theme")
+
+      expect(page).to have_css(".theme-picker-modal")
+
+      non_default_card =
+        find(".theme-picker-modal__card:not(.--active) .btn-primary", match: :first)
+      non_default_card.click
+
       expect(toasts).to have_success(
-        I18n.t("js.admin_onboarding_banner.spread_the_word.copied_to_clipboard"),
+        I18n.t("js.admin_onboarding_banner.select_theme.theme_set", theme: "Foundation"),
       )
     end
   end
@@ -120,6 +133,17 @@ describe "Admin Onboarding Banner" do
     it "disables onboarding when all steps are complete" do
       visit("/")
 
+      # Complete select_theme
+      banner.click_step_action("select_theme")
+      expect(page).to have_css(".theme-picker-modal")
+      non_default_card =
+        find(".theme-picker-modal__card:not(.--active) .btn-primary", match: :first)
+      non_default_card.click
+
+      visit("/")
+      expect(banner.step_completed?("select_theme")).to eq(true)
+
+      # Complete start_posting
       banner.click_step_action("start_posting")
       predefined_topics_modal.select_topic(0)
       composer.create
@@ -127,17 +151,13 @@ describe "Admin Onboarding Banner" do
 
       expect(banner.step_completed?("start_posting")).to eq(true)
 
+      # Complete invite_collaborators
       banner.click_step_action("invite_collaborators")
       create_invite_modal.save_button.click
       expect(create_invite_modal).to have_copy_button
       create_invite_modal.close
 
-      expect(banner.step_completed?("invite_collaborators")).to eq(true)
-
-      banner.click_step_action("spread_the_word")
-
-      # banner is hidden after all steps are complete; No need to check for `spread_the_word` step completion
-
+      # banner is hidden after all steps are complete
       expect(banner).to be_not_visible
       expect(SiteSetting.enable_site_owner_onboarding).to eq(false)
     end

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -121,11 +121,12 @@ describe "Admin Onboarding Banner" do
 
       expect(theme_picker_modal).to be_open
 
-      theme_picker_modal.select_first_selectable_theme
+      selected_name = theme_picker_modal.select_first_selectable_theme
 
       # Page reloads after theme selection; wait for it to complete
       expect(page).to have_css(".admin-onboarding-banner")
       expect(banner.step_completed?("select_theme")).to eq(true)
+      expect(Theme.find(SiteSetting.default_theme_id).name).to eq(selected_name)
     end
   end
 

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -7,12 +7,14 @@ describe "Admin Onboarding Banner" do
 
   let(:banner) { PageObjects::Components::AdminOnboardingBanner.new }
   let(:predefined_topics_modal) { PageObjects::Modals::AdminOnboardingPredefinedTopics.new }
+  let(:theme_picker_modal) { PageObjects::Modals::AdminOnboardingThemePicker.new }
   let(:create_invite_modal) { PageObjects::Modals::CreateInvite.new }
   let(:composer) { PageObjects::Components::Composer.new }
   let(:toasts) { PageObjects::Components::Toasts.new }
 
   before do
     SiteSetting.enable_site_owner_onboarding = true
+    SiteSetting.default_theme_id = Theme.foundation_theme.id
 
     sign_in(admin)
   end
@@ -109,41 +111,31 @@ describe "Admin Onboarding Banner" do
 
       banner.click_step_action("select_theme")
 
-      expect(page).to have_css(".theme-picker-modal")
-      expect(page).to have_css(".theme-picker-modal__card", minimum: 1)
+      expect(theme_picker_modal).to be_open
+      expect(theme_picker_modal).to have_theme_cards(minimum: 1)
     end
 
     it "sets a theme as default and marks step complete" do
       visit("/")
       banner.click_step_action("select_theme")
 
-      expect(page).to have_css(".theme-picker-modal")
+      expect(theme_picker_modal).to be_open
 
-      non_default_card =
-        find(".theme-picker-modal__card:not(.--active) .btn-primary", match: :first)
-      non_default_card.click
+      selected_theme_name = theme_picker_modal.select_first_selectable_theme
 
-      expect(toasts).to have_success(
-        I18n.t("js.admin_onboarding_banner.select_theme.theme_set", theme: "Foundation"),
-      )
+      expected_message =
+        I18n.t("js.admin_onboarding_banner.select_theme.theme_set", theme: selected_theme_name)
+      expect(toasts).to have_success(expected_message)
+
+      visit("/")
+      expect(banner.step_completed?("select_theme")).to eq(true)
     end
   end
 
   describe "completing all steps" do
-    it "disables onboarding when all steps are complete" do
+    it "disables onboarding when select theme is completed last" do
       visit("/")
 
-      # Complete select_theme
-      banner.click_step_action("select_theme")
-      expect(page).to have_css(".theme-picker-modal")
-      non_default_card =
-        find(".theme-picker-modal__card:not(.--active) .btn-primary", match: :first)
-      non_default_card.click
-
-      visit("/")
-      expect(banner.step_completed?("select_theme")).to eq(true)
-
-      # Complete start_posting
       banner.click_step_action("start_posting")
       predefined_topics_modal.select_topic(0)
       composer.create
@@ -151,13 +143,17 @@ describe "Admin Onboarding Banner" do
 
       expect(banner.step_completed?("start_posting")).to eq(true)
 
-      # Complete invite_collaborators
       banner.click_step_action("invite_collaborators")
       create_invite_modal.save_button.click
       expect(create_invite_modal).to have_copy_button
       create_invite_modal.close
 
-      # banner is hidden after all steps are complete
+      expect(banner.step_completed?("invite_collaborators")).to eq(true)
+
+      banner.click_step_action("select_theme")
+      expect(theme_picker_modal).to be_open
+      theme_picker_modal.select_first_selectable_theme
+
       expect(banner).to be_not_visible
       expect(SiteSetting.enable_site_owner_onboarding).to eq(false)
     end

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -121,13 +121,10 @@ describe "Admin Onboarding Banner" do
 
       expect(theme_picker_modal).to be_open
 
-      selected_theme_name = theme_picker_modal.select_first_selectable_theme
+      theme_picker_modal.select_first_selectable_theme
 
-      expected_message =
-        I18n.t("js.admin_onboarding_banner.select_theme.theme_set", theme: selected_theme_name)
-      expect(toasts).to have_success(expected_message)
-
-      visit("/")
+      # Page reloads after theme selection; wait for it to complete
+      expect(page).to have_css(".admin-onboarding-banner")
       expect(banner.step_completed?("select_theme")).to eq(true)
     end
   end
@@ -154,6 +151,7 @@ describe "Admin Onboarding Banner" do
       expect(theme_picker_modal).to be_open
       theme_picker_modal.select_first_selectable_theme
 
+      # Page reloads after theme selection; banner disappears when all steps complete
       expect(banner).to be_not_visible
       expect(SiteSetting.enable_site_owner_onboarding).to eq(false)
     end

--- a/spec/system/page_objects/modals/admin_onboarding_theme_picker.rb
+++ b/spec/system/page_objects/modals/admin_onboarding_theme_picker.rb
@@ -16,10 +16,7 @@ module PageObjects
       end
 
       def first_selectable_theme_name
-        find(
-          "#{CARD_SELECTOR}:not(.--active) #{NAME_SELECTOR}",
-          match: :first,
-        ).text
+        find("#{CARD_SELECTOR}:not(.--active) #{NAME_SELECTOR}", match: :first).text
       end
 
       def select_theme(name)

--- a/spec/system/page_objects/modals/admin_onboarding_theme_picker.rb
+++ b/spec/system/page_objects/modals/admin_onboarding_theme_picker.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class AdminOnboardingThemePicker < PageObjects::Modals::Base
+      MODAL_SELECTOR = ".theme-picker-modal"
+      CARD_SELECTOR = ".theme-picker-modal__card"
+      NAME_SELECTOR = ".theme-picker-modal__name"
+
+      def open?
+        has_css?(MODAL_SELECTOR)
+      end
+
+      def has_theme_cards?(**options)
+        has_css?(CARD_SELECTOR, **options)
+      end
+
+      def first_selectable_theme_name
+        find(
+          "#{CARD_SELECTOR}:not(.--active) #{NAME_SELECTOR}",
+          match: :first,
+        ).text
+      end
+
+      def select_theme(name)
+        find(CARD_SELECTOR, text: name).find(".btn-primary").click
+      end
+
+      def select_first_selectable_theme
+        first_selectable_theme_name.tap { |name| select_theme(name) }
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/modals/admin_onboarding_theme_picker.rb
+++ b/spec/system/page_objects/modals/admin_onboarding_theme_picker.rb
@@ -5,7 +5,7 @@ module PageObjects
     class AdminOnboardingThemePicker < PageObjects::Modals::Base
       MODAL_SELECTOR = ".theme-picker-modal"
       CARD_SELECTOR = ".theme-picker-modal__card"
-      NAME_SELECTOR = ".theme-picker-modal__name"
+      NAME_SELECTOR = ".theme-card-preview__name"
 
       def open?
         has_css?(MODAL_SELECTOR)

--- a/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes_config_area.rb
@@ -98,15 +98,15 @@ module PageObjects
       end
 
       def screenshot_toggle_button(theme)
-        find_theme_card(theme).find(".theme-card__screenshot-toggle")
+        find_theme_card(theme).find(".theme-card-preview__screenshot-toggle")
       end
 
       def has_screenshot_toggle_button?(theme)
-        find_theme_card(theme).has_css?(".theme-card__screenshot-toggle")
+        find_theme_card(theme).has_css?(".theme-card-preview__screenshot-toggle")
       end
 
       def has_no_screenshot_toggle_button?(theme)
-        find_theme_card(theme).has_no_css?(".theme-card__screenshot-toggle")
+        find_theme_card(theme).has_no_css?(".theme-card-preview__screenshot-toggle")
       end
 
       def click_screenshot_toggle(theme)
@@ -115,12 +115,14 @@ module PageObjects
       end
 
       def screenshot_image(theme)
-        find_theme_card(theme).find(".theme-card__image")
+        find_theme_card(theme).find(".theme-card-preview__image")
       end
 
       def has_screenshot_with_icon?(theme, icon_name)
         find_theme_card(theme).hover
-        find_theme_card(theme).has_css?(".theme-card__screenshot-toggle .d-icon-#{icon_name}")
+        find_theme_card(theme).has_css?(
+          ".theme-card-preview__screenshot-toggle .d-icon-#{icon_name}",
+        )
       end
     end
   end


### PR DESCRIPTION
**Previously**, the admin onboarding banner included a "Spread the Word" step that copied the site URL to clipboard.

**In this update**, replaced it with a "Select a theme" step that opens a modal allowing admins to preview and set Foundation or Horizon as their default theme, with dark/light screenshot toggle and lightbox preview.

<img width="984" height="260" alt="Screenshot 2026-05-14 at 10 00 24" src="https://github.com/user-attachments/assets/f44a53c2-18c3-4ba3-99f6-a801be7be8b3" />

<img width="634" height="543" alt="Screenshot 2026-05-14 at 10 12 59" src="https://github.com/user-attachments/assets/a7ecadcf-67a2-4d70-91d1-c310f57fb403" />

