### PR TITLE
DEV: Automatically detect and revert translation overrides in specs

### DIFF
--- a/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
@@ -204,17 +204,6 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
         )
       end
 
-      after do
-        TranslationOverride.revert!(
-          SiteSetting.default_locale,
-          "discourse_ai.ai_bot.agents.general.name",
-        )
-        TranslationOverride.revert!(
-          SiteSetting.default_locale,
-          "discourse_ai.ai_bot.agents.general.description",
-        )
-      end
-
       it "returns localized agent names and descriptions" do
         get "/admin/plugins/discourse-ai/ai-agents.json"
 

--- a/spec/integration/email_style_spec.rb
+++ b/spec/integration/email_style_spec.rb
@@ -99,13 +99,6 @@ RSpec.describe EmailStyle do
           )
         end
 
-        after do
-          TranslationOverride.revert!(
-            SiteSetting.default_locale,
-            ["user_notifications.signup.text_body_template"],
-          )
-        end
-
         it "applies customizations when translation override exists" do
           expect(mail_html.scan('<h1 style="color:red">FOR YOU</h1>').count).to eq(1)
           expect(mail_html.scan("CLICK THAT LINK").count).to eq(1)

--- a/spec/jobs/regular/bulk_user_title_update_spec.rb
+++ b/spec/jobs/regular/bulk_user_title_update_spec.rb
@@ -48,7 +48,5 @@ RSpec.describe Jobs::BulkUserTitleUpdate do
       described_class.new.execute(granted_badge_id: badge.id, action: described_class::RESET_ACTION)
       expect(user.reload.title).to eq("Protector of the Realm")
     end
-
-    after { TranslationOverride.revert!(I18n.locale, Badge.i18n_key(badge.name)) }
   end
 end

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -724,11 +724,6 @@ RSpec.describe UserNotifications do
         expect(body).not_to include("%{optional_cat}")
         expect(body).not_to include("%{optional_pm}")
         expect(body).not_to include("%{optional_re}")
-
-        TranslationOverride.revert!(
-          I18n.locale,
-          ["user_notifications.user_replied.text_body_template"],
-        )
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3046,8 +3046,6 @@ RSpec.describe User do
         user.update!(title: customized_badge_name)
         expect(user.user_profile.reload.granted_title_badge_id).to eq(badge.id)
       end
-
-      after { TranslationOverride.revert!(I18n.locale, Badge.i18n_key(badge.name)) }
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -185,6 +185,12 @@ module TestSetup
 
     I18n.locale = SiteSettings::DefaultsProvider::DEFAULT_LOCALE
 
+    # Flush I18n cache if there were any TranslationOverrides created.
+    overrides_by_site = I18n.instance_variable_get(:@overrides_by_site)
+    if overrides_by_site&.any? { |_, by_locale| by_locale&.any? { |_, kv| kv.present? } }
+      I18n.reload!
+    end
+
     RspecErrorTracker.clear_exceptions
 
     if $test_cleanup_callbacks

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -185,11 +185,10 @@ module TestSetup
 
     I18n.locale = SiteSettings::DefaultsProvider::DEFAULT_LOCALE
 
-    # Flush I18n cache if there were any TranslationOverrides created.
-    overrides_by_site = I18n.instance_variable_get(:@overrides_by_site)
-    if overrides_by_site&.any? { |_, by_locale| by_locale&.any? { |_, kv| kv.present? } }
-      I18n.reload!
-    end
+    # Database is rolled back between specs, but I18n override cache doesn't.
+    # Flush it if there were any TranslationOverrides created.
+    overrides_by_site = I18n.instance_variable_get(:@overrides_by_site) || {}
+    I18n.reload! if overrides_by_site.values.flat_map(&:values).any?(&:any?)
 
     RspecErrorTracker.clear_exceptions
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -3485,8 +3485,6 @@ RSpec.describe UsersController do
         TranslationOverride.upsert!("en", "badges.demogorgon.name", "Boss")
       end
 
-      after { TranslationOverride.revert!("en", ["badges.demogorgon.name"]) }
-
       it "uses the badge display name as user title" do
         sign_in(user1)
 

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -527,8 +527,6 @@ RSpec.describe BadgeGranter do
         ).to be_empty
         expect(user.reload.title).to eq(nil)
       end
-
-      after { TranslationOverride.revert!(I18n.locale, Badge.i18n_key(badge.name)) }
     end
   end
 


### PR DESCRIPTION
Fixes flakes in places that did not do that manually.