### PR TITLE
FIX: Assignments tab can render for groups whose member list is forbidden, leading to a guaranteed 403

### DIFF
--- a/plugins/discourse-assign/assets/javascripts/discourse/connectors/group-reports-nav-item/assigned-topic-list.gjs
+++ b/plugins/discourse-assign/assets/javascripts/discourse/connectors/group-reports-nav-item/assigned-topic-list.gjs
@@ -6,7 +6,11 @@ import GroupAssignedMenuItem from "../../components/group-assigned-menu-item";
 @tagName("")
 export default class AssignedTopicList extends Component {
   static shouldRender(args, context) {
-    return context.currentUser?.can_assign && args.group.can_show_assigned_tab;
+    return (
+      context.currentUser?.can_assign &&
+      args.group.can_show_assigned_tab &&
+      args.group.can_see_members
+    );
   }
 
   <template>

--- a/plugins/discourse-assign/test/javascripts/acceptance/group-assignments-test.js
+++ b/plugins/discourse-assign/test/javascripts/acceptance/group-assignments-test.js
@@ -1,12 +1,22 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { cloneJSON } from "discourse/lib/object";
+import GroupFixtures from "discourse/tests/fixtures/group-fixtures";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
 import AssignedTopics from "../fixtures/assigned-group-assignments-fixtures";
 import GroupMembers from "../fixtures/group-members-fixtures";
+
+let canSeeMembers = true;
 
 acceptance("GroupAssignments", function (needs) {
   needs.user();
   needs.settings({ assign_enabled: true, assigns_user_url_path: "/" });
+  needs.hooks.beforeEach(() => {
+    canSeeMembers = true;
+  });
   needs.pretender((server, helper) => {
     const groupPath = "/topics/group-topics-assigned/discourse.json";
     const memberPath = "/topics/messages-assigned/ahmedgagan6.json";
@@ -14,6 +24,12 @@ acceptance("GroupAssignments", function (needs) {
     const groupAssigns = AssignedTopics[groupPath];
     const memberAssigns = AssignedTopics[memberPath];
     const getMembers = GroupMembers[getMembersPath];
+    server.get("/groups/discourse.json", () => {
+      const response = cloneJSON(GroupFixtures["/groups/discourse.json"]);
+      response.group.can_show_assigned_tab = true;
+      response.group.can_see_members = canSeeMembers;
+      return helper.response(response);
+    });
     server.get(groupPath, () => helper.response(groupAssigns));
     server.get(memberPath, () => helper.response(memberAssigns));
     server.get(getMembersPath, () => helper.response(getMembers));
@@ -27,5 +43,14 @@ acceptance("GroupAssignments", function (needs) {
   test("Group Assignments Ahmedgagan", async function (assert) {
     await visit("/g/discourse/assigned/ahmedgagan6");
     assert.dom(".topic-list-item").exists({ count: 1 });
+  });
+
+  test("does not show the Assignments tab when group members are hidden", async function (assert) {
+    updateCurrentUser({ can_assign: true });
+    canSeeMembers = false;
+
+    await visit("/g/discourse");
+
+    assert.dom(".assigned-topic-list").doesNotExist();
   });
 });


### PR DESCRIPTION
## Summary

This patch fixes a UI inconsistency where the Group Assignments tab remained visible to users who lacked permission to view a group's members. Although the backend correctly enforced these permissions by returning a 403 error, the UI failed to hide the entry point, leading to a broken user experience.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/887
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.
