### PR TITLE
UX: exclude topic voting wrapper from modernized foundation btn width

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -50,6 +50,7 @@
   .btn.no-text.btn-icon {
     &:not(
       .topic-voting-menu-trigger,
+      .voting-wrapper__button,
       .user-menu-tab,
       .user-menu-tab-active,
       .composer-actions-btn,


### PR DESCRIPTION
Fixes a minor width issue with the upcoming change "modernized foundation" 

before
<img width="218" height="118" alt="image" src="https://github.com/user-attachments/assets/c79a8e60-b834-4996-8059-315c0e992d81" />


after
<img width="258" height="118" alt="image" src="https://github.com/user-attachments/assets/81d23e58-7420-457f-b5ba-adc79863fc15" />
