### PR TITLE
DEV: add ids method to NestedReplies::PostPreloader to resolve warning

### DIFF
--- a/lib/nested_replies/post_preloader.rb
+++ b/lib/nested_replies/post_preloader.rb
@@ -45,6 +45,10 @@ module NestedReplies
         self
       end
 
+      def ids
+        map(&:id)
+      end
+
       def pluck(*columns)
         if columns.one?
           map(&columns.first)


### PR DESCRIPTION
resolves `NestedReplies::PostsArray falling back to DB query for .ids — consider adding an explicit handler (called from /Users/markvanlan/ws/discourse/plugins/discourse-solved/plugin.rb:129:in 'block (2 levels) in Plugin::Instance#activate!')` in a safe way