### PR TITLE
UX: fix header voting background color

### DIFF
--- a/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
+++ b/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
@@ -124,6 +124,7 @@
   }
 
   .voting-wrapper__button {
+    --primary-very-low: var(--header_background);
     width: 100%;
     padding: var(--space-1);
   }


### PR DESCRIPTION
Need to override the background color on the voted state in the header

before
<img width="332" height="90" alt="image" src="https://github.com/user-attachments/assets/8fb121e1-a876-410e-877d-16a5bfafdcbd" />


after
<img width="720" height="88" alt="image" src="https://github.com/user-attachments/assets/7b0b00e5-74d8-43e3-9cfe-236b5940c4cd" />
