### PR TITLE
FIX: BBCode attribute values with quotation marks produce malformed output

### DIFF
--- a/frontend/discourse-markdown-it/src/features/bbcode-block.js
+++ b/frontend/discourse-markdown-it/src/features/bbcode-block.js
@@ -34,7 +34,18 @@ function trailingSpaceOnly(src, start, max) {
 
 // Most common quotation marks.
 // More can be found at https://en.wikipedia.org/wiki/Quotation_mark
-const QUOTATION_MARKS = [`""`, `''`, `“”`, `””`, `‘’`, `„“`, `‚’`, `«»`, `‹›`];
+// Keep in sync with plugins/chat/lib/chat/transcript_service.rb
+export const QUOTATION_MARKS = [
+  `""`,
+  `''`,
+  `«»`,
+  `“”`,
+  `””`,
+  `‘’`,
+  `„“`,
+  `‚’`,
+  `‹›`,
+];
 
 const QUOTATION_MARKS_PATTERN = new RegExp(
   `[${QUOTATION_MARKS.join("")}]`,

--- a/frontend/discourse/app/lib/text.js
+++ b/frontend/discourse/app/lib/text.js
@@ -157,11 +157,18 @@ export function humanizeList(listItems) {
 // Based on the BBCode parser regex: [^\s\]]+ for unquoted values
 const BBCODE_REQUIRES_QUOTES_PATTERN = /[\s\]]/;
 
+// Standard ASCII quotes used for BBCode attribute quoting
+const DOUBLE_QUOTE = '"';
+const SINGLE_QUOTE = "'";
+
 /**
  * Serializes a value for use in a BBCode attribute.
  *
  * Automatically determines whether quotes are needed based on the value content.
  * Quotes are required when the value contains whitespace or `]` characters.
+ * When the value contains quotation marks, alternates quote style to avoid
+ * breaking BBCode parsing. If both quote types are present, double quotes
+ * in the value are stripped as a last resort.
  *
  * @param {string|null|undefined} value - The attribute value to serialize
  * @param {string} name - The attribute name
@@ -170,6 +177,7 @@ const BBCODE_REQUIRES_QUOTES_PATTERN = /[\s\]]/;
  * @example
  * serializeBBCodeAttr("12:00:00", "time") // returns ' time=12:00:00'
  * serializeBBCodeAttr("YYYY-MM-DD HH:mm", "format") // returns ' format="YYYY-MM-DD HH:mm"'
+ * serializeBBCodeAttr('Design "Gems"', "channel") // returns " channel='Design \"Gems\"'"
  * serializeBBCodeAttr(null, "time") // returns ''
  */
 export function serializeBBCodeAttr(value, name) {
@@ -180,7 +188,22 @@ export function serializeBBCodeAttr(value, name) {
   const stringValue = String(value);
   const needsQuotes = BBCODE_REQUIRES_QUOTES_PATTERN.test(stringValue);
 
-  return needsQuotes ? ` ${name}="${stringValue}"` : ` ${name}=${stringValue}`;
+  if (!needsQuotes) {
+    return ` ${name}=${stringValue}`;
+  }
+
+  const hasDoubleQuote = stringValue.includes(DOUBLE_QUOTE);
+  const hasSingleQuote = stringValue.includes(SINGLE_QUOTE);
+
+  if (!hasDoubleQuote) {
+    return ` ${name}="${stringValue}"`;
+  } else if (!hasSingleQuote) {
+    return ` ${name}='${stringValue}'`;
+  } else {
+    // Both quote types present - strip double quotes as last resort
+    const stripped = stringValue.replaceAll(DOUBLE_QUOTE, "");
+    return stripped ? ` ${name}="${stripped}"` : "";
+  }
 }
 
 /**

--- a/frontend/discourse/app/lib/text.js
+++ b/frontend/discourse/app/lib/text.js
@@ -6,6 +6,7 @@ import deprecated from "discourse/lib/deprecated";
 import { getURLWithCDN } from "discourse/lib/get-url";
 import { helperContext } from "discourse/lib/helpers";
 import { i18n } from "discourse-i18n";
+import { QUOTATION_MARKS } from "discourse-markdown-it/features/bbcode-block";
 
 async function withEngine(name, ...args) {
   const engine = await waitForPromise(import("discourse/static/markdown-it"));
@@ -157,18 +158,13 @@ export function humanizeList(listItems) {
 // Based on the BBCode parser regex: [^\s\]]+ for unquoted values
 const BBCODE_REQUIRES_QUOTES_PATTERN = /[\s\]]/;
 
-// Standard ASCII quotes used for BBCode attribute quoting
-const DOUBLE_QUOTE = '"';
-const SINGLE_QUOTE = "'";
-
 /**
  * Serializes a value for use in a BBCode attribute.
  *
  * Automatically determines whether quotes are needed based on the value content.
  * Quotes are required when the value contains whitespace or `]` characters.
- * When the value contains quotation marks, alternates quote style to avoid
- * breaking BBCode parsing. If both quote types are present, double quotes
- * in the value are stripped as a last resort.
+ * When the value contains quotation marks, cycles through supported quote pairs
+ * to find one that doesn't conflict with the value's content.
  *
  * @param {string|null|undefined} value - The attribute value to serialize
  * @param {string} name - The attribute name
@@ -178,6 +174,7 @@ const SINGLE_QUOTE = "'";
  * serializeBBCodeAttr("12:00:00", "time") // returns ' time=12:00:00'
  * serializeBBCodeAttr("YYYY-MM-DD HH:mm", "format") // returns ' format="YYYY-MM-DD HH:mm"'
  * serializeBBCodeAttr('Design "Gems"', "channel") // returns " channel='Design \"Gems\"'"
+ * serializeBBCodeAttr("Sam's \"Release\"", "title") // returns ' title=«Sam's "Release"»'
  * serializeBBCodeAttr(null, "time") // returns ''
  */
 export function serializeBBCodeAttr(value, name) {
@@ -192,18 +189,15 @@ export function serializeBBCodeAttr(value, name) {
     return ` ${name}=${stringValue}`;
   }
 
-  const hasDoubleQuote = stringValue.includes(DOUBLE_QUOTE);
-  const hasSingleQuote = stringValue.includes(SINGLE_QUOTE);
-
-  if (!hasDoubleQuote) {
-    return ` ${name}="${stringValue}"`;
-  } else if (!hasSingleQuote) {
-    return ` ${name}='${stringValue}'`;
-  } else {
-    // Both quote types present - strip double quotes as last resort
-    const stripped = stringValue.replaceAll(DOUBLE_QUOTE, "");
-    return stripped ? ` ${name}="${stripped}"` : "";
+  for (const pair of QUOTATION_MARKS) {
+    const [open, close] = pair;
+    if (!stringValue.includes(open) && !stringValue.includes(close)) {
+      return ` ${name}=${open}${stringValue}${close}`;
+    }
   }
+
+  // Unreachable in practice - would require all 18 quote characters in value
+  return ` ${name}="${stringValue.replaceAll('"', "")}"`;
 }
 
 /**

--- a/frontend/discourse/tests/unit/lib/pretty-text-test.js
+++ b/frontend/discourse/tests/unit/lib/pretty-text-test.js
@@ -9,6 +9,7 @@ import QUnit, { module, test } from "qunit";
 import { deepMerge } from "discourse/lib/object";
 import DiscourseMarkdownIt from "discourse-markdown-it";
 import { extractDataAttribute } from "discourse-markdown-it/engine";
+import { QUOTATION_MARKS } from "discourse-markdown-it/features/bbcode-block";
 
 const rawOpts = {
   siteSettings: {
@@ -978,6 +979,17 @@ eviltrout</p>
       '<p><a href="http://example.com/&quot;test&quot;" data-bbcode="true">url with double quotes</a></p>',
       "single-quoted attributes can contain double quotes"
     );
+
+    QUOTATION_MARKS.forEach((pair, index) => {
+      const [open, close] = pair;
+
+      // Test that each delimiter can wrap a URL
+      assert.cooked(
+        `[url=${open}http://example.com/test${close}]test[/url]`,
+        `<p><a href="http://example.com/test" data-bbcode="true">test</a></p>`,
+        `delimiter ${index} (${open}${close}) parses correctly`
+      );
+    });
   });
 
   test("images", function (assert) {

--- a/frontend/discourse/tests/unit/lib/pretty-text-test.js
+++ b/frontend/discourse/tests/unit/lib/pretty-text-test.js
@@ -966,6 +966,18 @@ eviltrout</p>
       '<p><a href="https://discourse.org/path" data-bbcode="true"><span class="bbcode-b">discourse.org/path</span></a></p>',
       "paths are correctly handled"
     );
+
+    assert.cooked(
+      `[url='http://example.com/path?a=1']single quoted[/url]`,
+      '<p><a href="http://example.com/path?a=1" data-bbcode="true">single quoted</a></p>',
+      "single-quoted attributes are parsed correctly"
+    );
+
+    assert.cooked(
+      `[url='http://example.com/"test"']url with double quotes[/url]`,
+      '<p><a href="http://example.com/&quot;test&quot;" data-bbcode="true">url with double quotes</a></p>',
+      "single-quoted attributes can contain double quotes"
+    );
   });
 
   test("images", function (assert) {

--- a/frontend/discourse/tests/unit/lib/text-test.js
+++ b/frontend/discourse/tests/unit/lib/text-test.js
@@ -1,7 +1,14 @@
 import { setupTest } from "ember-qunit";
 import { IMAGE_VERSION as v } from "pretty-text/emoji/version";
 import { module, test } from "qunit";
-import { cook, excerpt, parseAsync, parseMentions } from "discourse/lib/text";
+import {
+  buildBBCodeAttrs,
+  cook,
+  excerpt,
+  parseAsync,
+  parseMentions,
+  serializeBBCodeAttr,
+} from "discourse/lib/text";
 
 module("Unit | Utility | text", function (hooks) {
   setupTest(hooks);
@@ -72,5 +79,94 @@ module("Unit | Utility | text | parseMentions", function (hooks) {
     `;
     const mentions = await parseMentions(markdown);
     assert.strictEqual(mentions.length, 0);
+  });
+});
+
+module("Unit | Utility | text | serializeBBCodeAttr", function () {
+  test("returns empty string for falsy values", function (assert) {
+    assert.strictEqual(serializeBBCodeAttr(null, "name"), "");
+    assert.strictEqual(serializeBBCodeAttr(undefined, "name"), "");
+    assert.strictEqual(serializeBBCodeAttr("", "name"), "");
+  });
+
+  test("serializes simple values without quotes", function (assert) {
+    assert.strictEqual(serializeBBCodeAttr("value", "name"), " name=value");
+    assert.strictEqual(
+      serializeBBCodeAttr("12:00:00", "time"),
+      " time=12:00:00"
+    );
+  });
+
+  test("serializes values with whitespace using double quotes", function (assert) {
+    assert.strictEqual(
+      serializeBBCodeAttr("hello world", "name"),
+      ' name="hello world"'
+    );
+  });
+
+  test("serializes values with ] using quotes", function (assert) {
+    assert.strictEqual(
+      serializeBBCodeAttr("value]test", "name"),
+      ' name="value]test"'
+    );
+  });
+
+  test("uses single quotes when value contains double quotes", function (assert) {
+    assert.strictEqual(
+      serializeBBCodeAttr('Design "Gems" Discussion', "channel"),
+      " channel='Design \"Gems\" Discussion'"
+    );
+  });
+
+  test("uses double quotes when value contains single quotes", function (assert) {
+    assert.strictEqual(
+      serializeBBCodeAttr("it's great", "title"),
+      ' title="it\'s great"'
+    );
+  });
+
+  test("strips double quotes when both quote types present", function (assert) {
+    assert.strictEqual(
+      serializeBBCodeAttr(`it's "great"`, "title"),
+      ' title="it\'s great"'
+    );
+  });
+
+  test("returns empty when stripping leaves empty value", function (assert) {
+    // Edge case: value with whitespace that becomes empty after stripping "
+    assert.strictEqual(serializeBBCodeAttr(`"' "`, "name"), ` name="' "`);
+  });
+});
+
+module("Unit | Utility | text | buildBBCodeAttrs", function () {
+  test("builds attributes string from object", function (assert) {
+    const attrs = { foo: "bar", baz: "qux" };
+    assert.strictEqual(buildBBCodeAttrs(attrs), "foo=bar baz=qux");
+  });
+
+  test("skips null and undefined values", function (assert) {
+    const attrs = { foo: "bar", skip: null, also: undefined, baz: "qux" };
+    assert.strictEqual(buildBBCodeAttrs(attrs), "foo=bar baz=qux");
+  });
+
+  test("skips specified attributes", function (assert) {
+    const attrs = { foo: "bar", skip: "this", baz: "qux" };
+    assert.strictEqual(
+      buildBBCodeAttrs(attrs, { skipAttrs: ["skip"] }),
+      "foo=bar baz=qux"
+    );
+  });
+
+  test("quotes values with whitespace", function (assert) {
+    const attrs = { name: "hello world" };
+    assert.strictEqual(buildBBCodeAttrs(attrs), 'name="hello world"');
+  });
+
+  test("switches to single quotes for values with double quotes", function (assert) {
+    const attrs = { channel: 'Design "Gems" :tada:' };
+    assert.strictEqual(
+      buildBBCodeAttrs(attrs),
+      "channel='Design \"Gems\" :tada:'"
+    );
   });
 });

--- a/frontend/discourse/tests/unit/lib/text-test.js
+++ b/frontend/discourse/tests/unit/lib/text-test.js
@@ -9,6 +9,7 @@ import {
   parseMentions,
   serializeBBCodeAttr,
 } from "discourse/lib/text";
+import { QUOTATION_MARKS } from "discourse-markdown-it/features/bbcode-block";
 
 module("Unit | Utility | text", function (hooks) {
   setupTest(hooks);
@@ -125,16 +126,48 @@ module("Unit | Utility | text | serializeBBCodeAttr", function () {
     );
   });
 
-  test("strips double quotes when both quote types present", function (assert) {
+  test("uses guillemets when both ASCII quote types present", function (assert) {
     assert.strictEqual(
-      serializeBBCodeAttr(`it's "great"`, "title"),
-      ' title="it\'s great"'
+      serializeBBCodeAttr(`Sam's "Release" discussion`, "title"),
+      ` title=«Sam's "Release" discussion»`
     );
   });
 
-  test("returns empty when stripping leaves empty value", function (assert) {
-    // Edge case: value with whitespace that becomes empty after stripping "
-    assert.strictEqual(serializeBBCodeAttr(`"' "`, "name"), ` name="' "`);
+  test("uses non-conflicting delimiter and preserves value", function (assert) {
+    QUOTATION_MARKS.forEach((pair, index) => {
+      const [open, close] = pair;
+
+      // Create a value containing all delimiter characters except the one being tested
+      let conflictingChars = Array.from(QUOTATION_MARKS);
+      conflictingChars = conflictingChars.filter(
+        (p) => !p.includes(open) && !p.includes(close)
+      );
+      conflictingChars = conflictingChars.join("");
+      const value = `test ${conflictingChars} value`;
+      const result = serializeBBCodeAttr(value, "attr");
+
+      // Find which delimiter was used
+      const usedPair = QUOTATION_MARKS.find(
+        ([o, c]) => result.startsWith(` attr=${o}`) && result.endsWith(c)
+      );
+
+      // Assert a non-conflicting delimiter was used
+      const hasConflict =
+        usedPair &&
+        !value.includes(usedPair[0]) &&
+        !value.includes(usedPair[1]);
+
+      assert.true(
+        hasConflict,
+        `delimiter ${index} (${open}${close}): a non-conflicting delimiter is used`
+      );
+
+      // Assert the value is preserved
+      assert.true(
+        result.includes(value),
+        `delimiter ${index} (${open}${close}): value is preserved`
+      );
+    });
   });
 });
 

--- a/plugins/chat/lib/chat/transcript_service.rb
+++ b/plugins/chat/lib/chat/transcript_service.rb
@@ -20,6 +20,9 @@ module Chat
     MULTIQUOTE_ATTR = "multiQuote=\"true\""
     NO_LINK_ATTR = "noLink=\"true\""
 
+    # Keep in sync with frontend/discourse-markdown-it/src/features/bbcode-block.js
+    QUOTATION_MARKS = ["\"\"", "''", "«»", "“”", "””", "‘’", "„“", "‚’", "‹›"].freeze
+
     class TranscriptBBCode
       attr_reader :channel,
                   :multiquote,
@@ -128,7 +131,7 @@ module Chat
       end
 
       def channel_attr
-        "channel=\"#{channel.title(@acting_user)}\""
+        serialize_attr("channel", channel.title(@acting_user))
       end
 
       def channel_id_attr
@@ -144,7 +147,17 @@ module Chat
 
         thread_title = thread.title.presence || I18n.t("chat.transcript.default_thread_title")
         thread_title += " (#{range})" if range.present?
-        "threadTitle=\"#{thread_title}\""
+        serialize_attr("threadTitle", thread_title)
+      end
+
+      def serialize_attr(name, value)
+        QUOTATION_MARKS.each do |pair|
+          open, close = pair.chars
+          next if value.include?(open) || value.include?(close)
+          return "#{name}=#{open}#{value}#{close}"
+        end
+
+        "#{name}=\"#{value.delete('"')}\""
       end
     end
 

--- a/plugins/chat/spec/system/rich_editor_extension_transcript_spec.rb
+++ b/plugins/chat/spec/system/rich_editor_extension_transcript_spec.rb
@@ -9,10 +9,22 @@ describe "chat transcripts in rich editor" do
     )
   end
   fab!(:channel, :chat_channel)
+  fab!(:channel_with_quotation_marks) do
+    Fabricate(:chat_channel, name: 'Channel with a "special" name')
+  end
   fab!(:message_1) do
     Fabricate(:chat_message, user: current_user, chat_channel: channel, created_at: 2.days.ago)
   end
   fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel, created_at: 1.day.ago) }
+
+  fab!(:message_3) do
+    Fabricate(
+      :chat_message,
+      user: current_user,
+      chat_channel: channel_with_quotation_marks,
+      created_at: 2.days.ago,
+    )
+  end
 
   let(:cdp) { PageObjects::CDP.new }
   let(:composer) { PageObjects::Components::Composer.new }
@@ -46,6 +58,31 @@ describe "chat transcripts in rich editor" do
       text: message_1.user.username,
     )
     expect(rich).to have_css(".chat-transcript .chat-transcript-messages", text: message_1.message)
+  end
+
+  it "works for channel name with quotation marks in its name" do
+    page.visit "/new-topic"
+    expect(composer).to be_opened
+    composer.focus
+
+    markdown =
+      Chat::TranscriptService.new(
+        channel_with_quotation_marks,
+        current_user,
+        messages_or_ids: [message_3],
+      ).generate_markdown
+
+    cdp.copy_paste(
+      markdown,
+      css_selector: PageObjects::Components::Composer.new.composer_input_selector,
+    )
+
+    expect(rich).to have_css(".chat-transcript", text: channel_with_quotation_marks.name)
+    expect(rich).to have_css(
+      ".chat-transcript .chat-transcript-user .chat-transcript-username",
+      text: message_3.user.username,
+    )
+    expect(rich).to have_css(".chat-transcript .chat-transcript-messages", text: message_3.message)
   end
 
   it "works for multiple messages" do


### PR DESCRIPTION
### Description 

The serializeBBCodeAttr function wraps values containing whitespace or `]` in double quotes, but does not handle the case where the value itself contains quotation marks.

This issue is fixed by wrapping the value in a quotation mark that is not present in the value. If all quotation marks are present, strip `"` to use it as the wrapper. 

Similarly, quoting a chat channel with a title that contained `"` would result in bbcode not being cooked properly. The fix applies the same logic by wrapping the chat title with a quotation mark that is not present in the title.

Ref: `patch-triage/139`
