### PR TITLE
FIX: Don't allow arbitrary values for user field enums on signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -718,11 +718,11 @@ class UsersController < ApplicationController
     # Handle custom fields
     user_fields = UserField.all
     if user_fields.present?
-      field_params = params[:user_fields] || {}
       fields = user.custom_fields
 
       user_fields.each do |f|
-        field_val = field_params[f.id.to_s]
+        field_val = clean_custom_field_values(f)
+        field_val = nil if field_val == "false"
         if field_val.blank?
           return fail_with("login.missing_user_field") if f.required?
         else
@@ -2106,7 +2106,7 @@ class UsersController < ApplicationController
   end
 
   def clean_custom_field_values(field)
-    field_values = params[:user_fields][field.id.to_s]
+    field_values = params.dig(:user_fields, field.id.to_s)
 
     return field_values if field_values.nil? || field_values.empty?
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1659,6 +1659,24 @@ RSpec.describe UsersController do
       include_examples "failed signup"
     end
 
+    context "when using an unknown value for an enum user field on signup" do
+      fab!(:user_field, :user_field_dropdown)
+
+      let(:create_params) do
+        {
+          name: @user.name,
+          username: @user.username,
+          password: "strongpassword",
+          email: @user.email,
+          user_fields: {
+            user_field.id.to_s => "Juice",
+          },
+        }
+      end
+
+      include_examples "failed signup"
+    end
+
     context "with custom fields" do
       fab!(:user_field)
       fab!(:another_field, :user_field)


### PR DESCRIPTION
## What is the problem?

When signing up and the sign-up form contains custom user fields of type "dropdown" or "multi-select", the client can send any value and it will be stored in the back-end.

## How does this fix it?

We are correctly guarding against this in the profile update endpoint, so this PR just lifts the protection we have there to the sign-up endpoint as well.

**Note:** The _real_ fix is probably to shift the validation logic away from the controller and into the user fields module, but this stems the bleeding for now.