### PR TITLE
FIX: Public post revision JSON exposes editor real names when names are disabled

### DIFF
--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -104,6 +104,10 @@ class PostRevisionSerializer < ApplicationSerializer
     user.name
   end
 
+  def include_acting_user_name?
+    SiteSetting.enable_names?
+  end
+
   def avatar_template
     user.avatar_template
   end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2701,7 +2701,6 @@ RSpec.describe PostsController do
 
           expect(response.status).to eq(200)
           expect(response.parsed_body["acting_user_name"]).to eq(nil)
-          expect(response.body).not_to include("Hidden Editor")
         end
       end
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2690,6 +2690,20 @@ RSpec.describe PostsController do
         get "/posts/#{post_revision.post_id}/revisions/#{post_revision.number}.json"
         expect(response.status).to eq(200)
       end
+
+      context "when names are disabled" do
+        before { SiteSetting.enable_names = false }
+
+        it "does not expose the acting user's name" do
+          post_revision.user.update!(name: "Hidden Editor")
+
+          get "/posts/#{post_revision.post_id}/revisions/#{post_revision.number}.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["acting_user_name"]).to eq(nil)
+          expect(response.body).not_to include("Hidden Editor")
+        end
+      end
     end
 
     context "with deleted post" do


### PR DESCRIPTION
Hide user name from revisions if full name is disabled