### PR TITLE
DEV: Bump system test PARALLEL_TEST_PROCESSORS to nproc/2 + 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set PARALLEL_TEST_PROCESSORS for system tests
         if: matrix.build_type == 'system'
         run: |
-          echo "PARALLEL_TEST_PROCESSORS=$(($(nproc) / 2))" >> $GITHUB_ENV
+          echo "PARALLEL_TEST_PROCESSORS=$(($(nproc) / 2 + 2))" >> $GITHUB_ENV
 
       - name: Set QUNIT_PARALLEL for QUnit tests
         if: matrix.build_type == 'frontend'


### PR DESCRIPTION
Previously, system tests ran with `PARALLEL_TEST_PROCESSORS = nproc / 2` (8 workers on the 16-core runners, 4 on the 8-core ones).

This change bumps it to `nproc / 2 + 2` (10 on 16-core, 6 on 8-core), shortening every system test variant by 13-29%. `core system` is the slowest variant and gates the system test workflow wall time, so total CI wall drops by roughly 21% at the median (~717s to ~567s).

## Measurements

Five sequential runs of `main` against five sequential runs of this branch. Full workflow matrix, all 10 jobs in parallel per run. Each header column links to the workflow run.

### Before, `nproc / 2`

| Job | [Run 1](https://github.com/discourse/discourse/actions/runs/25839410729) | [Run 2](https://github.com/discourse/discourse/actions/runs/25840073966) | [Run 3](https://github.com/discourse/discourse/actions/runs/25840720619) | [Run 4](https://github.com/discourse/discourse/actions/runs/25841377434) | [Run 5](https://github.com/discourse/discourse/actions/runs/25842032524) | Median |
|---|---:|---:|---:|---:|---:|---:|
| core system | 612 | 798 | 616 | 717 | 773 | **717s** |
| plugins (core) system | 435 | 557 | 437 | 459 | 546 | **459s** |
| plugins (official) system | 287 | 305 | 281 | 321 | 360 | **305s** |
| plugins (chat) system | 590 | 701 | 596 | 673 | 790 | **673s** |
| themes system | 470 | 497 | 466 | 527 | 643 | **497s** |

### After, `nproc / 2 + 2`

| Job | [Run 1](https://github.com/discourse/discourse/actions/runs/25842714879) | [Run 2](https://github.com/discourse/discourse/actions/runs/25843404929) | [Run 3](https://github.com/discourse/discourse/actions/runs/25844126953) | [Run 4](https://github.com/discourse/discourse/actions/runs/25844848908) | [Run 5](https://github.com/discourse/discourse/actions/runs/25845605625) | Median |
|---|---:|---:|---:|---:|---:|---:|
| core system | 652 | 567 | 557 | 559 | 659 | **567s** |
| plugins (core) system | 415 | 389 | 386 | 390 | 488 | **390s** |
| plugins (official) system | 319 | 259 | 262 | 265 | 281 | **265s** |
| plugins (chat) system | 592 | 511 | 530 | 527 | 550 | **530s** |
| themes system | 385 | 353 | 347 | 344 | 370 | **353s** |

### Δ

| Job | Before | After | Δ | Δ% |
|---|---:|---:|---:|---:|
| **core system** | 717s | **567s** | -150s | **-20.9%** |
| plugins (core) system | 459s | 390s | -69s | -15.0% |
| plugins (official) system | 305s | 265s | -40s | -13.1% |
| plugins (chat) system | 673s | 530s | -143s | -21.2% |
| themes system | 497s | 353s | -144s | -29.0% |