### PR TITLE
FIX: prevent invite links from deleting unrelated email invites

### DIFF
--- a/app/models/invite_redeemer.rb
+++ b/app/models/invite_redeemer.rb
@@ -300,7 +300,7 @@ class InviteRedeemer
 
   def delete_duplicate_invites
     # Should not happen because of ensure_email_is_present!, but better to cover bases.
-    return if email.blank?
+    return if email.blank? || invite.is_invite_link?
 
     Invite
       .where("invites.max_redemptions_allowed = 1")

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -1432,6 +1432,30 @@ RSpec.describe InvitesController do
         expect(EmailToken.hash_token(job_args["email_token"])).to eq(tokens.first.token_hash)
       end
 
+      it "redeems pending email invites after email confirmation" do
+        pending_email_invite =
+          Fabricate(:invite, invited_by: Fabricate(:user), email: "target@example.com")
+
+        put "/invites/show/#{invite.invite_key}.json",
+            params: {
+              email: pending_email_invite.email,
+              password: "verystrongpassword",
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["message"]).to eq(I18n.t("invite.confirm_email"))
+        expect(invite.reload.redemption_count).to eq(1)
+        invited_user = User.find_by_email(pending_email_invite.email)
+        expect(invited_user).to be_present
+        expect(Invite.exists?(pending_email_invite.id)).to eq(true)
+
+        email_token = Jobs::CriticalUserEmail.jobs.first["args"].first["email_token"]
+        EmailToken.confirm(email_token, scope: EmailToken.scopes[:signup])
+
+        expect(pending_email_invite.reload).to be_redeemed
+        expect(pending_email_invite.invited_users.first.user).to eq(invited_user)
+      end
+
       it "does not automatically log in the user if their email matches an existing user's and shows an error" do
         Fabricate(:user, email: "test@example.com")
         put "/invites/show/#{invite.invite_key}.json",


### PR DESCRIPTION
Previously, redeeming an invite link with an unverified email could delete unrelated pending single-use invites for that address.

This change skips duplicate-invite cleanup for invite links while preserving email-scoped invite cleanup after signup email confirmation.