### PR TITLE
FIX: Prevent hidden excerpts in user actions

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -405,10 +405,10 @@ class UserAction < ActiveRecord::Base
 
       current_user_id = -2
       current_user_id = guardian.user.id if guardian.user
-      builder.where(
-        "NOT COALESCE(p.hidden, false) OR p.user_id = :current_user_id",
-        current_user_id: current_user_id,
-      )
+      builder.where(<<~SQL, current_user_id: current_user_id)
+        NOT COALESCE(p.hidden, p2.hidden, false) OR
+        CASE WHEN p.id IS NULL THEN p2.user_id ELSE p.user_id END = :current_user_id
+      SQL
     end
 
     visible_post_types = Topic.visible_post_types(guardian.user)
@@ -417,7 +417,9 @@ class UserAction < ActiveRecord::Base
       visible_post_types: visible_post_types,
     )
 
-    builder.where("t.visible") if guardian.user&.id != user_id && !guardian.is_staff?
+    if !guardian.is_staff? && (guardian.user.nil? || guardian.user.id != user_id)
+      builder.where("t.visible")
+    end
 
     filter_private_messages(builder, user_id, guardian, ignore_private_messages)
     filter_categories(builder, guardian)

--- a/spec/requests/user_actions_controller_spec.rb
+++ b/spec/requests/user_actions_controller_spec.rb
@@ -207,6 +207,115 @@ RSpec.describe UserActionsController do
       )
     end
 
+    it "returns 404 when the fallback first post is hidden" do
+      UserActionManager.enable
+      hidden_text = "hidden fallback excerpt token"
+      hidden_post = create_post(user: acting_user, raw: hidden_text)
+      hidden_post.update_columns(hidden: true)
+      user_action =
+        UserAction.find_by!(
+          user_id: acting_user.id,
+          action_type: UserAction::NEW_TOPIC,
+          target_topic_id: hidden_post.topic_id,
+        )
+
+      get "/user_actions/#{user_action.id}.json"
+
+      aggregate_failures do
+        expect(response).to have_http_status :not_found
+        expect(response.body).not_to include(hidden_text)
+      end
+    end
+
+    it "returns the action when the hidden fallback first post belongs to the viewer" do
+      UserActionManager.enable
+      hidden_text = "own hidden fallback excerpt token"
+      hidden_post = create_post(user: acting_user, raw: hidden_text)
+      hidden_post.update_columns(hidden: true)
+      user_action =
+        UserAction.find_by!(
+          user_id: acting_user.id,
+          action_type: UserAction::NEW_TOPIC,
+          target_topic_id: hidden_post.topic_id,
+        )
+
+      sign_in(acting_user)
+      get "/user_actions/#{user_action.id}.json"
+
+      parsed = response.parsed_body["user_action"]
+
+      aggregate_failures do
+        expect(response).to have_http_status :ok
+        expect(parsed["excerpt"]).to include(hidden_text)
+      end
+    end
+
+    it "returns 404 when a hidden target post has no owner" do
+      hidden_text = "hidden ownerless excerpt token"
+      hidden_reply = create_post(user: Fabricate(:user), topic: target_post.topic, raw: hidden_text)
+      hidden_reply.update_columns(hidden: true, user_id: nil)
+      user_action =
+        UserAction.create!(
+          action_type: UserAction::REPLY,
+          user_id: acting_user.id,
+          acting_user_id: acting_user.id,
+          target_topic_id: hidden_reply.topic_id,
+          target_post_id: hidden_reply.id,
+        )
+
+      sign_in(acting_user)
+      get "/user_actions/#{user_action.id}.json"
+
+      aggregate_failures do
+        expect(response).to have_http_status :not_found
+        expect(response.body).not_to include(hidden_text)
+      end
+    end
+
+    it "returns the action when the hidden target post belongs to the viewer" do
+      hidden_text = "own hidden target excerpt token"
+      hidden_reply = create_post(user: acting_user, topic: target_post.topic, raw: hidden_text)
+      hidden_reply.update_columns(hidden: true)
+      user_action =
+        UserAction.create!(
+          action_type: UserAction::REPLY,
+          user_id: acting_user.id,
+          acting_user_id: acting_user.id,
+          target_topic_id: hidden_reply.topic_id,
+          target_post_id: hidden_reply.id,
+        )
+
+      sign_in(acting_user)
+      get "/user_actions/#{user_action.id}.json"
+
+      parsed = response.parsed_body["user_action"]
+
+      aggregate_failures do
+        expect(response).to have_http_status :ok
+        expect(parsed["excerpt"]).to include(hidden_text)
+      end
+    end
+
+    it "returns 404 for an unlisted topic viewed anonymously" do
+      UserActionManager.enable
+      unlisted_text = "unlisted user action excerpt token"
+      unlisted_post = create_post(user: acting_user, raw: unlisted_text)
+      unlisted_post.topic.update!(visible: false)
+      user_action =
+        UserAction.find_by!(
+          user_id: acting_user.id,
+          action_type: UserAction::NEW_TOPIC,
+          target_topic_id: unlisted_post.topic_id,
+        )
+
+      get "/user_actions/#{user_action.id}.json"
+
+      aggregate_failures do
+        expect(response).to have_http_status :not_found
+        expect(response.body).not_to include(unlisted_text)
+      end
+    end
+
     it "returns 404 for a non-existent action" do
       get "/user_actions/-1.json"
 


### PR DESCRIPTION
Previously, anonymous `UserAction` requests could include excerpts from hidden first posts through the fallback post join and skip unlisted-topic filtering.

This change applies visibility checks to the actual post used for the action excerpt and limits anonymous/non-owner viewers to listed topics.