### PR TITLE
DEV: Also pass configured supported locales into the prompt for language detection

### DIFF
--- a/plugins/discourse-ai/lib/agents/locale_detector.rb
+++ b/plugins/discourse-ai/lib/agents/locale_detector.rb
@@ -7,6 +7,8 @@ module DiscourseAi
         false
       end
 
+      STATIC_LANGUAGE_CODES = %w[en es fr de it pt-BR ru zh-CN ja ko].freeze
+
       def system_prompt
         <<~PROMPT.strip
           You will be given a piece of text, and your task is to detect the locale (language) of the text and return it in a specific JSON format.
@@ -29,7 +31,7 @@ module DiscourseAi
           - Simplified Chinese: zh-CN
           - Japanese: ja
           - Korean: ko
-
+          #{configured_locale_lines}
           If the language is not in this list, use the appropriate IETF language tag code.
 
           5. Avoid using `und` and prefer `en` over `en-US` or `en-GB` unless the text specifically indicates a regional variant.
@@ -52,6 +54,29 @@ module DiscourseAi
 
       def temperature
         0
+      end
+
+      private
+
+      def configured_locale_lines
+        settings =
+          SiteSetting.content_localization_supported_locales.to_s.split("|").reject(&:blank?)
+        return "" if settings.empty?
+
+        configured =
+          settings.filter_map do |locale|
+            lang =
+              LocaleSiteSetting.language_names[locale] ||
+                LocaleSiteSetting.language_names[locale.split("_").first]
+            next if lang.nil? || lang["name"].blank?
+
+            hyphenated = locale.tr("_", "-")
+            next if STATIC_LANGUAGE_CODES.include?(hyphenated)
+
+            "- #{lang["name"]}: #{hyphenated}"
+          end
+
+        configured.empty? ? "" : "#{configured.join("\n")}\n"
       end
     end
   end

--- a/plugins/discourse-ai/spec/lib/agents/locale_detector_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/locale_detector_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Agents::LocaleDetector do
+  describe "#system_prompt" do
+    let(:prompt) { described_class.new.system_prompt }
+
+    context "when content_localization_supported_locales is blank" do
+      before { SiteSetting.content_localization_supported_locales = "" }
+
+      it "leaves the static block intact with no extra entries" do
+        expect(prompt).to include(
+          "- Korean: ko\n\nIf the language is not in this list, use the appropriate IETF language tag code.",
+        )
+      end
+    end
+
+    context "with obscure codes" do
+      before { SiteSetting.content_localization_supported_locales = "nb_NO|zh_TW" }
+
+      it "appends every recognisable code in hyphenated form" do
+        expect(prompt).to include(
+          "- Korean: ko\n- Norwegian Bokmål: nb-NO\n- Chinese: zh-TW\n\nIf the language is not in this list, use the appropriate IETF language tag code.",
+        )
+        expect(prompt).to include("- Norwegian Bokmål: nb-NO")
+        expect(prompt).to include("- Chinese: zh-TW")
+      end
+    end
+
+    context "when supported locales overlap with the static list" do
+      before { SiteSetting.content_localization_supported_locales = "ja" }
+
+      it "does not duplicate codes already listed" do
+        expect(prompt.scan(/^\s*- Japanese: ja\s*$/).size).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related: https://meta.discourse.org/t/norwegian-is-identified-as-no-by-locale-detector-agent-content-localization-supported-locales-is-nb-no/402859

Norwegian posts get detected as `no` while sites set the target as `nb_NO`. In this PR we'll appending whatever's in content_localization_supported_locales (i.e. `Norwegian Bokmål: nb-NO` in this case) to the prompt.