### PR TITLE
UX: rename new icons to generic names

### DIFF
--- a/frontend/discourse/app/components/nested-replies-expand-button.gjs
+++ b/frontend/discourse/app/components/nested-replies-expand-button.gjs
@@ -14,7 +14,7 @@ export default class NestedRepliesExpandButton extends Component {
       class="nested-post__expand-replies btn-flat"
       ...attributes
       @action={{@onClick}}
-      @icon="nested-circle-plus"
+      @icon="discourse-circle-plus"
       @translatedLabel={{this.label}}
     />
   </template>

--- a/frontend/discourse/app/components/nested/post.gjs
+++ b/frontend/discourse/app/components/nested/post.gjs
@@ -401,7 +401,7 @@ export default class NestedPost extends Component {
             >
               {{#if this.expanded}}
                 <span class="nested-post__depth-line-icon">
-                  {{dIcon "nested-circle-minus"}}
+                  {{dIcon "discourse-circle-minus"}}
                 </span>
               {{/if}}
             </button>
@@ -415,7 +415,7 @@ export default class NestedPost extends Component {
               data-post-number={{@post.post_number}}
               {{on "click" this.toggleExpanded}}
             >
-              {{dIcon "nested-circle-plus"}}
+              {{dIcon "discourse-circle-plus"}}
               {{#if this.isDeletedPlaceholder}}
                 <span class="nested-post__collapsed-username">{{i18n
                     "nested_replies.deleted_post_placeholder"

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -88,6 +88,8 @@ module SvgSprite
         discourse-bookmark-clock
         discourse-chevron-collapse
         discourse-chevron-expand
+        discourse-circle-minus
+        discourse-circle-plus
         discourse-compress
         discourse-dnd
         discourse-emojis
@@ -215,8 +217,6 @@ module SvgSprite
         minus
         mobile-screen-button
         moon
-        nested-circle-minus
-        nested-circle-plus
         nested-thread
         paintbrush
         palette

--- a/vendor/assets/svg-icons/nested-replies-icons.svg
+++ b/vendor/assets/svg-icons/nested-replies-icons.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
-  <symbol id="nested-circle-plus" viewBox="0 0 20 20">
+  <symbol id="discourse-circle-plus" viewBox="0 0 20 20">
     <path fill-rule="evenodd" d="M10 1A9 9 0 0 1 10 19A9 9 0 0 1 10 1ZM10 3A7 7 0 0 1 10 17A7 7 0 0 1 10 3Z"/>
     <path d="M6 9h8v2H6zM9 6h2v8H9z"/>
   </symbol>
-  <symbol id="nested-circle-minus" viewBox="0 0 20 20">
+  <symbol id="discourse-circle-minus" viewBox="0 0 20 20">
     <path fill-rule="evenodd" d="M10 1A9 9 0 0 1 10 19A9 9 0 0 1 10 1ZM10 3A7 7 0 0 1 10 17A7 7 0 0 1 10 3Z"/>
     <path d="M6 9h8v2H6z"/>
   </symbol>


### PR DESCRIPTION
Naming `nested-circle-plus` and `nested-circle-minus` is too scoped to the nested-replies feature even though the shapes themselves are generic UI primitives.
                                                                                                                        
This change renames them to `discourse-circle-plus` and `discourse-circle-minus` (matching the existing `discourse-*`icon convention) so they can be reused anywhere a plain plus/minus-in-a-circle is needed without a nested-replies-specific name.    