### PR TITLE
FIX: Use dConcatClass in draft menu classes getter

### DIFF
--- a/frontend/discourse/app/components/create-topic-button.gjs
+++ b/frontend/discourse/app/components/create-topic-button.gjs
@@ -64,7 +64,7 @@ export default class CreateTopicButton extends Component {
       this.transformerContext
     );
 
-    return concatClass(this.btnTypeClass, ...additionalClasses);
+    return dConcatClass(this.btnTypeClass, ...additionalClasses);
   }
 
   <template>


### PR DESCRIPTION
The ui-kit consolidation (#38703) renamed concatClass to dConcatClass, but the new draftMenuClasses getter from #39888 still referenced the old name.