### PR TITLE
DEV: Restrict `topic_view_stats` report to admins

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -36,7 +36,7 @@ class Report
     page_view_logged_in_reqs
   ]
 
-  ADMIN_ONLY_REPORTS = %w[admin_logins top_uploads]
+  ADMIN_ONLY_REPORTS = %w[admin_logins top_uploads topic_view_stats]
 
   def self.hidden?(type, admin:)
     return true if !admin && ADMIN_ONLY_REPORTS.include?(type)

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -227,14 +227,18 @@ RSpec.describe Admin::ReportsController do
                 top_uploads: {
                   limit: 10,
                 },
+                topic_view_stats: {
+                  limit: 10,
+                },
               },
             }
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["reports"].count).to eq(3)
+        expect(response.parsed_body["reports"].count).to eq(4)
         expect(response.parsed_body["reports"][0]["type"]).to eq("topics")
         expect(response.parsed_body["reports"][1]).to include("error" => "not_found", "data" => nil)
         expect(response.parsed_body["reports"][2]).to include("error" => "not_found", "data" => nil)
+        expect(response.parsed_body["reports"][3]).to include("error" => "not_found", "data" => nil)
       end
     end
 

--- a/spec/requests/export_csv_controller_spec.rb
+++ b/spec/requests/export_csv_controller_spec.rb
@@ -223,6 +223,20 @@ RSpec.describe ExportCsvController do
         expect(Jobs::ExportCsvFile.jobs.size).to eq(0)
       end
 
+      it "does not allow moderators to export the topic_view_stats report" do
+        post "/export_csv/export_entity.json",
+             params: {
+               entity: "report",
+               args: {
+                 name: "topic_view_stats",
+                 start_date: "2026-01-01",
+                 end_date: "2026-02-15",
+               },
+             }
+        expect(response.status).to eq(422)
+        expect(Jobs::ExportCsvFile.jobs.size).to eq(0)
+      end
+
       it "allows moderators to export non-hidden reports" do
         post "/export_csv/export_entity.json",
              params: {


### PR DESCRIPTION
Previously, the `topic_view_stats` report was available to all staff, including moderators.

This change adds `topic_view_stats` to `ADMIN_ONLY_REPORTS` so only admins can view it.