### PR TITLE
DEV: Strip `COMMENT ON EXTENSION` from `structure.sql`

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -24,24 +24,10 @@ CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION hstore; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION hstore IS 'data type for storing sets of (key, value) pairs';
-
-
---
 -- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
 --
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
 
 
 --
@@ -52,24 +38,10 @@ CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION unaccent; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION unaccent IS 'text search dictionary that removes accents';
-
-
---
 -- Name: vector; Type: EXTENSION; Schema: -; Owner: -
 --
 
 CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public;
-
-
---
--- Name: EXTENSION vector; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION vector IS 'vector data type and ivfflat and hnsw access methods';
 
 
 --

--- a/lib/tasks/db_structure.rake
+++ b/lib/tasks/db_structure.rake
@@ -104,3 +104,18 @@ task "db:check_structure_dump:assert_no_unexpected_rows" => :environment do
       - #{unexpected.join("\n  - ")}
   MSG
 end
+
+Rake::Task["db:schema:dump"].enhance do
+  filename = ENV["SCHEMA"] || "db/structure.sql"
+  next unless File.exist?(filename)
+
+  contents = File.read(filename)
+
+  # `COMMENT ON EXTENSION` requires extension ownership, which we might not have.
+  # It's not essential - strip it out.
+  contents.gsub!(
+    /^--\n-- Name: EXTENSION [^;]+; Type: COMMENT;[^\n]*\n--\n\nCOMMENT ON EXTENSION [^\n]+\n\n\n/,
+    "",
+  )
+  File.write(filename, contents)
+end


### PR DESCRIPTION
`COMMENT ON EXTENSION` requires extension ownership, which we might not have. It's not essential, so we can strip it from the dumps.

Followup to 0a54093115779c9b9c08f8efc5c88012db34a411