### PR TITLE
FEATURE: Support oidc groups claim from id_token

### DIFF
--- a/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
+++ b/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
@@ -210,6 +210,7 @@ module OmniAuth
         hash = {}
         hash[:raw_info] = options.use_userinfo ? userinfo_response : id_token_info
         hash[:id_token] = access_token["id_token"]
+        hash[:id_token_info] = id_token_info
         prune! hash
       end
 

--- a/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
+++ b/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
@@ -42,8 +42,7 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
       claim = SiteSetting.openid_connect_groups_claim
       result.associated_groups = []
       groups =
-        auth_token.extra&.dig(:raw_info, claim) ||
-          auth_token.extra&.dig(:id_token_info, claim)
+        auth_token.extra&.dig(:raw_info, claim) || auth_token.extra&.dig(:id_token_info, claim)
 
       if groups.is_a?(Array)
         result.associated_groups = groups.map { |group_name| { id: group_name, name: group_name } }

--- a/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
+++ b/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
@@ -41,7 +41,9 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
     if provides_groups?
       claim = SiteSetting.openid_connect_groups_claim
       result.associated_groups = []
-      groups = auth_token.extra&.dig(:raw_info, claim)
+      groups =
+        auth_token.extra&.dig(:raw_info, claim) ||
+          auth_token.extra&.dig(:id_token_info, claim)
 
       if groups.is_a?(Array)
         result.associated_groups = groups.map { |group_name| { id: group_name, name: group_name } }

--- a/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
@@ -250,6 +250,12 @@ describe OmniAuth::Strategies::OpenIDConnect do
           )
           expect(@app_called).to eq(false)
         end
+
+        it "exposes id_token_info alongside the userinfo raw_info" do
+          expect(strategy.callback_phase[0]).to eq(200)
+          expect(strategy.extra[:raw_info]["email"]).to eq("userinfoemail@example.com")
+          expect(strategy.extra[:id_token_info]["email"]).to eq("tokenemail@example.com")
+        end
       end
     end
   end

--- a/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
@@ -119,6 +119,21 @@ describe OpenIDConnectAuthenticator do
         result = authenticator.after_authenticate(hash)
         expect(result.associated_groups).to eq([])
       end
+
+      it "falls back to the id_token when the claim is missing from raw_info" do
+        hash[:extra][:id_token_info] = { "groups" => %w[group1 group2] }
+        result = authenticator.after_authenticate(hash)
+        expect(result.associated_groups).to eq(
+          [{ id: "group1", name: "group1" }, { id: "group2", name: "group2" }],
+        )
+      end
+
+      it "prefers raw_info over the id_token when both contain the claim" do
+        hash[:extra][:raw_info][:groups] = %w[from_userinfo]
+        hash[:extra][:id_token_info] = { "groups" => %w[from_id_token] }
+        result = authenticator.after_authenticate(hash)
+        expect(result.associated_groups).to eq([{ id: "from_userinfo", name: "from_userinfo" }])
+      end
     end
 
     context "with a custom claim name" do


### PR DESCRIPTION
Automatically falls back to checking the id_token for the specified claim, in case it is not included in the userinfo response