### PR TITLE
FEATURE: Support syncing User Field values from OAuth2 and OIDC

### DIFF
--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -22,6 +22,7 @@ class Auth::Result
     failed_reason
     failed_code
     associated_groups
+    user_field_values
     overrides_email
     overrides_username
     overrides_name
@@ -40,6 +41,7 @@ class Auth::Result
     extra_data
     skip_email_validation
     associated_groups
+    user_field_values
     overrides_email
     overrides_username
     overrides_name
@@ -122,6 +124,13 @@ class Auth::Result
 
       user.update(associated_group_ids: associated_group_ids)
       AssociatedGroup.where(id: associated_group_ids).update_all("last_used = CURRENT_TIMESTAMP")
+    end
+
+    if user && user_field_values.present?
+      user_field_values.each do |field_id, value|
+        user.custom_fields["user_field_#{field_id}"] = value
+      end
+      user.save_custom_fields
     end
 
     # refreshes automatic group membership (despite the name, it doesn't change TLs)

--- a/plugins/discourse-oauth2-basic/config/locales/server.en.yml
+++ b/plugins/discourse-oauth2-basic/config/locales/server.en.yml
@@ -21,6 +21,7 @@ en:
     oauth2_json_email_path: "Path in the OAuth2 User JSON to the user's email. eg: user.email"
     oauth2_json_email_verified_path: "Path in the OAuth2 User JSON to the user's email verification state. eg: user.email.verified. oauth2_email_verified must be disabled for this setting to have any effect"
     oauth2_json_avatar_path: "Path in the Oauth2 User JSON to the user's avatar. eg: user.avatar_url"
+    oauth2_user_field_mappings: "Map paths in the OAuth2 User JSON onto Discourse user fields. Each entry pairs a JSON path with the numeric ID of a Discourse user field."
     oauth2_email_verified: "Check this if the OAuth2 site has verified the email"
     oauth2_overrides_email: "Override the Discourse email with the remote email on every login. Works the same as the `auth_overrides_email` setting, but is specific to OAuth2 logins."
     oauth2_send_auth_header: "Send client credentials in an HTTP Authorization header"

--- a/plugins/discourse-oauth2-basic/config/settings.yml
+++ b/plugins/discourse-oauth2-basic/config/settings.yml
@@ -66,6 +66,19 @@ login:
   oauth2_json_avatar_path:
     default: ""
     area: "oauth2"
+  oauth2_user_field_mappings:
+    type: objects
+    default: []
+    area: "oauth2"
+    schema:
+      name: mapping
+      properties:
+        path:
+          type: string
+          required: true
+        user_field_id:
+          type: integer
+          required: true
   oauth2_email_verified:
     default: false
     area: "oauth2"

--- a/plugins/discourse-oauth2-basic/lib/oauth2_basic_authenticator.rb
+++ b/plugins/discourse-oauth2-basic/lib/oauth2_basic_authenticator.rb
@@ -118,6 +118,25 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     end
   end
 
+  def user_field_values_from(user_json)
+    mappings = JSON.parse(SiteSetting.oauth2_user_field_mappings.presence || "[]")
+    return {} if mappings.blank?
+
+    mappings.each_with_object({}) do |mapping, hash|
+      path = mapping["path"].to_s
+      field_id = mapping["user_field_id"]
+      next if path.blank? || field_id.blank?
+
+      expanded = path.gsub(".[].", ".").gsub(".[", "[")
+      value = walk_path(user_json, parse_segments(expanded))
+      next if value.nil?
+
+      hash[field_id.to_s] = value.is_a?(Array) ? value.join(",") : value.to_s
+    end
+  rescue JSON::ParserError
+    {}
+  end
+
   def parse_segments(path)
     segments = [+""]
     quoted = false
@@ -184,6 +203,8 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
           prop = "extra:#{detail}"
           json_walk(result, user_json, prop, custom_path: detail)
         end
+
+        result[:user_field_values] = user_field_values_from(user_json)
       end
       result
     else
@@ -252,7 +273,9 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
       end
     end
 
-    super(auth, existing_account: existing_account)
+    result = super(auth, existing_account: existing_account)
+    result.user_field_values = fetched_user_details[:user_field_values] if fetched_user_details
+    result
   end
 
   def enabled?

--- a/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
+++ b/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
@@ -123,6 +123,53 @@ describe OAuth2BasicAuthenticator do
         end
       end
 
+      describe "user field mappings" do
+        fab!(:user_field)
+
+        before do
+          SiteSetting.oauth2_user_field_mappings = [
+            { "path" => "account.department", "user_field_id" => user_field.id },
+          ].to_json
+        end
+
+        it "populates user_field_values from the user JSON" do
+          body = { account: { email: "newemail@example.com", department: "Engineering" } }.to_json
+          stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(status: 200, body: body)
+
+          result = authenticator.after_authenticate(auth)
+          expect(result.user_field_values).to eq(user_field.id.to_s => "Engineering")
+        end
+
+        it "clears the field when the path resolves to an empty string" do
+          body = { account: { email: "newemail@example.com", department: "" } }.to_json
+          stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(status: 200, body: body)
+
+          result = authenticator.after_authenticate(auth)
+          expect(result.user_field_values).to eq(user_field.id.to_s => "")
+        end
+
+        it "skips the mapping when the path doesn't resolve" do
+          body = { account: { email: "newemail@example.com" } }.to_json
+          stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(status: 200, body: body)
+
+          result = authenticator.after_authenticate(auth)
+          expect(result.user_field_values).to eq({})
+        end
+
+        it "joins array values with commas" do
+          body = {
+            account: {
+              email: "newemail@example.com",
+              department: %w[Eng Ops],
+            },
+          }.to_json
+          stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(status: 200, body: body)
+
+          result = authenticator.after_authenticate(auth)
+          expect(result.user_field_values).to eq(user_field.id.to_s => "Eng,Ops")
+        end
+      end
+
       describe "required attributes" do
         after { DiscoursePluginRegistry.reset_register!(:oauth2_basic_required_json_paths) }
 

--- a/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
+++ b/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
@@ -157,12 +157,7 @@ describe OAuth2BasicAuthenticator do
         end
 
         it "joins array values with commas" do
-          body = {
-            account: {
-              email: "newemail@example.com",
-              department: %w[Eng Ops],
-            },
-          }.to_json
+          body = { account: { email: "newemail@example.com", department: %w[Eng Ops] } }.to_json
           stub_request(:get, SiteSetting.oauth2_user_json_url).to_return(status: 200, body: body)
 
           result = authenticator.after_authenticate(auth)

--- a/plugins/discourse-openid-connect/config/locales/server.en.yml
+++ b/plugins/discourse-openid-connect/config/locales/server.en.yml
@@ -16,6 +16,7 @@ en:
     openid_connect_overrides_email: "On every login, override the user's email using the openid-connect value. Works the same as the `auth_overrides_email` setting, but is specific to OpenID Connect logins."
     openid_connect_claims: "Explicitly define the claims for use with providers that don't pass data back based on scopes. (JSON)"
     openid_connect_groups_claim: "The name of the claim in the OIDC token that contains the user's groups as an array of strings. Leave blank to disable group syncing."
+    openid_connect_user_field_mappings: "Map OIDC claims onto Discourse user fields. Each entry pairs an OIDC claim name with the numeric ID of a Discourse user field."
     openid_connect_match_by_email: "Use email address to match OpenID Connect authentications to existing Discourse user accounts."
     openid_connect_use_pkce: "Enable Proof Key for Code Exchange (PKCE) for OpenID Connect authentication."
   login:

--- a/plugins/discourse-openid-connect/config/settings.yml
+++ b/plugins/discourse-openid-connect/config/settings.yml
@@ -56,6 +56,19 @@ discourse_openid_connect:
   openid_connect_groups_claim:
     default: ""
     area: "oidc"
+  openid_connect_user_field_mappings:
+    type: objects
+    default: []
+    area: "oidc"
+    schema:
+      name: mapping
+      properties:
+        claim:
+          type: string
+          required: true
+        user_field_id:
+          type: integer
+          required: true
   openid_connect_use_pkce:
     default: false
     area: "oidc"

--- a/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
+++ b/plugins/discourse-openid-connect/lib/openid_connect_authenticator.rb
@@ -53,7 +53,36 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
       end
     end
 
+    result.user_field_values = user_field_values_from(auth_token)
+
     result
+  end
+
+  def user_field_values_from(auth_token)
+    mappings = JSON.parse(SiteSetting.openid_connect_user_field_mappings.presence || "[]")
+    return {} if mappings.blank?
+
+    raw_info = auth_token.extra&.[](:raw_info)
+    id_token_info = auth_token.extra&.[](:id_token_info)
+
+    mappings.each_with_object({}) do |mapping, hash|
+      claim = mapping["claim"].to_s
+      field_id = mapping["user_field_id"]
+      next if claim.blank? || field_id.blank?
+
+      source =
+        if raw_info&.key?(claim)
+          raw_info
+        elsif id_token_info&.key?(claim)
+          id_token_info
+        end
+      next if source.nil?
+
+      value = source[claim]
+      hash[field_id.to_s] = value.is_a?(Array) ? value.join(",") : value.to_s
+    end
+  rescue JSON::ParserError
+    {}
   end
 
   def always_update_user_email?

--- a/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/openid_connect_authenticator_spec.rb
@@ -149,6 +149,60 @@ describe OpenIDConnectAuthenticator do
     end
   end
 
+  describe "user field syncing" do
+    fab!(:user_field)
+
+    it "leaves user_field_values empty when no mappings are configured" do
+      result = authenticator.after_authenticate(hash)
+      expect(result.user_field_values).to eq({})
+    end
+
+    context "with a mapping configured" do
+      before do
+        SiteSetting.openid_connect_user_field_mappings = [
+          { "claim" => "department", "user_field_id" => user_field.id },
+        ].to_json
+      end
+
+      it "pulls the value from raw_info" do
+        hash[:extra][:raw_info][:department] = "Engineering"
+        result = authenticator.after_authenticate(hash)
+        expect(result.user_field_values).to eq(user_field.id.to_s => "Engineering")
+      end
+
+      it "falls back to id_token_info when the claim is missing from raw_info" do
+        hash[:extra][:id_token_info] = { "department" => "Engineering" }
+        result = authenticator.after_authenticate(hash)
+        expect(result.user_field_values).to eq(user_field.id.to_s => "Engineering")
+      end
+
+      it "joins array values with commas" do
+        hash[:extra][:raw_info][:department] = %w[Eng Ops]
+        result = authenticator.after_authenticate(hash)
+        expect(result.user_field_values).to eq(user_field.id.to_s => "Eng,Ops")
+      end
+
+      it "skips mappings whose claim is missing entirely" do
+        result = authenticator.after_authenticate(hash)
+        expect(result.user_field_values).to eq({})
+      end
+
+      it "clears the field when raw_info has the claim set to an empty string" do
+        hash[:extra][:raw_info][:department] = ""
+        hash[:extra][:id_token_info] = { "department" => "Engineering" }
+        result = authenticator.after_authenticate(hash)
+        expect(result.user_field_values).to eq(user_field.id.to_s => "")
+      end
+
+      it "clears the field when raw_info has the claim set to null" do
+        hash[:extra][:raw_info][:department] = nil
+        hash[:extra][:id_token_info] = { "department" => "Engineering" }
+        result = authenticator.after_authenticate(hash)
+        expect(result.user_field_values).to eq(user_field.id.to_s => "")
+      end
+    end
+  end
+
   describe "discovery document fetching" do
     let(:document_url) do
       SiteSetting.openid_connect_discovery_document =

--- a/spec/lib/auth/result_spec.rb
+++ b/spec/lib/auth/result_spec.rb
@@ -71,4 +71,27 @@ RSpec.describe Auth::Result do
 
     expect(user.email).to eq(new_email)
   end
+
+  describe "#apply_associated_attributes!" do
+    fab!(:user_field)
+
+    it "writes user_field_values to the user's custom fields" do
+      result.user_field_values = { user_field.id.to_s => "Engineering" }
+      result.apply_associated_attributes!
+
+      expect(user.reload.custom_fields["user_field_#{user_field.id}"]).to eq("Engineering")
+    end
+
+    it "is a no-op when user_field_values is blank" do
+      result.user_field_values = nil
+      expect { result.apply_associated_attributes! }.not_to raise_error
+    end
+
+    it "round-trips user_field_values through session data" do
+      result.user_field_values = { "42" => "Engineering" }
+      restored = Auth::Result.from_session_data(result.session_data, user: user)
+
+      expect(restored.user_field_values).to eq("42" => "Engineering")
+    end
+  end
 end


### PR DESCRIPTION
Introduces `*_user_field_mappings` settings to the OAuth2 and OIDC plugins. These allow syncing data from the identity provider to Discourse User Fields.

The fundamentals are implemented in core, just like other Auth::Result user information. The plugins are only responsible for the configuration, and parsing the data from their respective auth flows.

The SAML plugin already implements a very similar feature, which could be updated to use this new core logic in future.