### PR TITLE
DEV: Fix prosemirror_links spec flakes

### DIFF
--- a/frontend/discourse/app/static/prosemirror/extensions/link-toolbar.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/link-toolbar.js
@@ -114,23 +114,23 @@ class LinkToolbarPluginView {
   update(view) {
     this.#view = view;
 
-    if (view.state.selection instanceof NodeSelection) {
-      this.#resetToolbar();
+    const markRange =
+      !(view.state.selection instanceof NodeSelection) &&
+      this.#utils.getMarkRange(
+        view.state.selection.$head,
+        view.state.schema.marks.link
+      );
+
+    if (markRange) {
+      this.#updateLinkState(markRange);
+      this.#displayToolbar();
       return;
     }
 
-    const markRange = this.#utils.getMarkRange(
-      view.state.selection.$head,
-      view.state.schema.marks.link
-    );
-
-    if (!markRange) {
+    // Don't tear down while a toolbar button is focused.
+    if (!this.#menuInstance?.content?.contains(document.activeElement)) {
       this.#resetToolbar();
-      return;
     }
-
-    this.#updateLinkState(markRange);
-    this.#displayToolbar();
   }
 
   #resetToolbar() {


### PR DESCRIPTION
Sometimes ProseMirror selection handler (triggered by editor's blur) placed the cursor outside the link for a split second just after the toolbar was focused. That was enough for `update()` to close the toolbar.