### PR TITLE
DEV: Don't trigger `DMenuInstance`'s `onClose` twice

### DIFF
--- a/frontend/discourse/float-kit/lib/d-menu-instance.js
+++ b/frontend/discourse/float-kit/lib/d-menu-instance.js
@@ -74,8 +74,6 @@ export default class DMenuInstance extends FloatKitInstance {
 
     await animateClosing(this.content);
 
-    await super.close(...arguments);
-
     if (this.site.mobileView && this.options.modalForMobile && this.expanded) {
       await this.modal.close();
     }
@@ -86,7 +84,7 @@ export default class DMenuInstance extends FloatKitInstance {
       this.trigger?.focus?.();
     }
 
-    await this.options.onClose?.(this);
+    await super.close(...arguments);
   }
 
   @action


### PR DESCRIPTION
`super` already does it so this one isn't needed