### PR TITLE
A11Y: improvements to the invite modal

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -807,6 +807,12 @@ html:not(.keyboard-visible).mobile-device {
   }
 }
 
+.create-invite-modal {
+  .edit-link-options {
+    text-align: left;
+  }
+}
+
 .wrap-attributes-modal {
   .wrap-modal__attribute-row {
     display: flex;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2414,8 +2414,10 @@ en:
           hide_advanced: "Hide Advanced Options"
 
           description: "Description"
+          description_help: "A note to help you identify this invite."
 
           restrict: "Restrict to"
+          restrict_help: "Enter an email or email domain to limit who can accept this invite."
           restrict_email: "Restrict to email"
           restrict_domain: "Restrict to domain"
           email_or_domain_placeholder: "name@example.com or example.com"
@@ -2427,6 +2429,7 @@ en:
           expires_at: "Expire at"
           expires_after: "Expire after"
           custom_message: "Custom message"
+          custom_message_help: "Included in the invitation email."
           custom_message_placeholder: "Add a personal note to your invitation"
 
           send_invite_email: "Save and Send Email"

--- a/frontend/discourse/app/components/modal/create-invite.gjs
+++ b/frontend/discourse/app/components/modal/create-invite.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import Form from "discourse/components/form";
@@ -42,6 +42,8 @@ export default class CreateInvite extends Component {
   model = this.args.model;
   invite = this.model.invite ?? Invite.create();
   sendEmail = false;
+  focusFormOnInsert = false;
+  focusLinkAfterCreate = false;
   formApi;
 
   get linkValidityMessageFormat() {
@@ -129,8 +131,12 @@ export default class CreateInvite extends Component {
     }
 
     this.saving = true;
+    const wasInviteCreated = this.inviteCreated;
     try {
       await this.invite.save(data);
+      if (!wasInviteCreated && this.inviteCreated) {
+        this.focusLinkAfterCreate = true;
+      }
       const invites = this.model?.invites;
       if (invites && !invites.some((i) => i.id === this.invite.id)) {
         invites.unshift(this.invite);
@@ -251,10 +257,25 @@ export default class CreateInvite extends Component {
   }
 
   @action
-  showAdvancedMode(event) {
+  showAdvancedMode() {
+    this.focusFormOnInsert = true;
     this.displayAdvancedOptions = true;
-    event.preventDefault();
-    event.stopPropagation();
+  }
+
+  @action
+  maybeFocusFirstField(element) {
+    if (this.focusFormOnInsert) {
+      this.focusFormOnInsert = false;
+      element.querySelector(".form-kit__control-input")?.focus();
+    }
+  }
+
+  @action
+  maybeFocusCopyButton(element) {
+    if (this.focusLinkAfterCreate) {
+      this.focusLinkAfterCreate = false;
+      element.querySelector("button")?.focus();
+    }
   }
 
   @action
@@ -307,6 +328,7 @@ export default class CreateInvite extends Component {
               this.inviteCreated
               (notEq this.flashClass "error")
             }}
+            @onLinkInsert={{this.maybeFocusCopyButton}}
           >
             {{#if this.flashText}}
               {{trustHTML this.flashText}}
@@ -324,7 +346,10 @@ export default class CreateInvite extends Component {
                 {{i18n "user.invited.invite.copy_link_and_share_it"}}
               </p>
             {{/unless}}
-            <div class="link-share-container">
+            <div
+              class="link-share-container"
+              {{didInsert this.maybeFocusCopyButton}}
+            >
               <ShareOrCopyInviteLink @invite={{this.invite}} />
             </div>
           {{else}}
@@ -334,26 +359,29 @@ export default class CreateInvite extends Component {
           {{/if}}
           <p class="link-limits-info">
             {{this.linkValidityMessageFormat}}
-            <a
+          </p>
+          <p>
+            <DButton
+              @display="link"
+              @action={{this.showAdvancedMode}}
+              @translatedLabel={{this.linkOptionsLabel}}
               class="edit-link-options"
-              role="button"
-              tabindex="0"
-              {{on "click" this.showAdvancedMode}}
-              {{on "keydown" this.showAdvancedMode}}
-            >{{this.linkOptionsLabel}}</a>
+            />
           </p>
         {{else}}
           <Form
             @data={{this.data}}
             @onSubmit={{this.onFormSubmit}}
             @onRegisterApi={{this.registerApi}}
+            {{didInsert this.maybeFocusFirstField}}
             as |form|
           >
             <form.Field
               @name="description"
               @type="input"
               @title={{i18n "user.invited.invite.description"}}
-              @format="large"
+              @description={{i18n "user.invited.invite.description_help"}}
+              @format="full"
               @validation={{this.descriptionValidation}}
               as |field|
             >
@@ -363,7 +391,8 @@ export default class CreateInvite extends Component {
               @name="restrictTo"
               @type="input"
               @title={{i18n "user.invited.invite.restrict"}}
-              @format="large"
+              @description={{i18n "user.invited.invite.restrict_help"}}
+              @format="full"
               @onSet={{this.handleRestrictToChange}}
               as |field|
             >
@@ -395,7 +424,7 @@ export default class CreateInvite extends Component {
                 @name="expiresAt"
                 @type="custom"
                 @title={{i18n "user.invited.invite.expires_at"}}
-                @format="large"
+                @format="full"
                 @validation="required"
                 as |field|
               >
@@ -413,7 +442,7 @@ export default class CreateInvite extends Component {
                 @name="expiresAfterDays"
                 @type="select"
                 @title={{i18n "user.invited.invite.expires_after"}}
-                @format="large"
+                @format="full"
                 @validation="required"
                 as |field|
               >
@@ -432,7 +461,7 @@ export default class CreateInvite extends Component {
                 @name="inviteToTopic"
                 @type="custom"
                 @title={{i18n "user.invited.invite.invite_to_topic"}}
-                @format="large"
+                @format="full"
                 as |field|
               >
                 <field.Control>
@@ -451,7 +480,7 @@ export default class CreateInvite extends Component {
                 @name="inviteToGroups"
                 @type="custom"
                 @title={{i18n "user.invited.invite.add_to_groups"}}
-                @format="large"
+                @format="full"
                 as |field|
               >
                 <field.Control>
@@ -470,6 +499,7 @@ export default class CreateInvite extends Component {
                 @name="customMessage"
                 @type="textarea"
                 @title={{i18n "user.invited.invite.custom_message"}}
+                @description={{i18n "user.invited.invite.custom_message_help"}}
                 @format="full"
                 as |field|
               >
@@ -529,13 +559,17 @@ export default class CreateInvite extends Component {
 }
 
 const InviteModalAlert = <template>
-  <div id="modal-alert" role="alert" class="alert alert-{{@alertClass}}">
+  <div
+    id="modal-alert"
+    role={{if (notEq @alertClass "error") "status" "alert"}}
+    class="alert alert-{{@alertClass}}"
+  >
     <div class="input-group invite-link">
       <label for="invite-link">
         {{yield}}
       </label>
       {{#if @showInviteLink}}
-        <div class="link-share-container">
+        <div class="link-share-container" {{didInsert @onLinkInsert}}>
           <ShareOrCopyInviteLink @invite={{@invite}} />
         </div>
       {{/if}}

--- a/frontend/discourse/app/ui-kit/d-copy-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-copy-button.gjs
@@ -10,6 +10,7 @@ import DButton from "discourse/ui-kit/d-button";
 export default class DCopyButton extends Component {
   copyIcon = "copy";
   copyClass = "btn-primary";
+  announcement = "";
 
   init() {
     super.init(...arguments);
@@ -26,6 +27,7 @@ export default class DCopyButton extends Component {
     this.set("copyIcon", "copy");
     this.set("copyClass", "btn-primary");
     this.set("copyTranslatedLabel", this.translatedLabel);
+    this.set("announcement", "");
   }
 
   @action
@@ -44,6 +46,7 @@ export default class DCopyButton extends Component {
       this.set("copyIcon", "check");
       this.set("copyClass", "btn-primary ok");
       this.set("copyTranslatedLabel", this.translatedLabelAfterCopy);
+      this.set("announcement", this.translatedLabelAfterCopy);
 
       discourseDebounce(this._restoreButton, 3000);
     } catch {}
@@ -57,5 +60,6 @@ export default class DCopyButton extends Component {
       @ariaLabel={{this.ariaLabel}}
       @translatedLabel={{this.copyTranslatedLabel}}
     />
+    <span class="sr-only" aria-live="polite">{{this.announcement}}</span>
   </template>
 }

--- a/frontend/discourse/tests/integration/components/create-invite-test.gjs
+++ b/frontend/discourse/tests/integration/components/create-invite-test.gjs
@@ -2,6 +2,7 @@ import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import CreateInvite from "discourse/components/modal/create-invite";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import formKit from "discourse/tests/helpers/form-kit-helper";
 
 module("Integration | Component | CreateInvite", function (hooks) {
@@ -190,6 +191,28 @@ module("Integration | Component | CreateInvite", function (hooks) {
       .dom("input[name='description']")
       .isFocused(
         "the description input receives focus when advanced options expand, so screen reader users land inside the form"
+      );
+  });
+
+  test("focuses the copy/share button after the invite link is created", async function (assert) {
+    const model = {};
+    pretender.post("/invites", () =>
+      response({
+        id: 42,
+        link: "https://example.com/invites/abc123",
+      })
+    );
+
+    await render(
+      <template><CreateInvite @inline={{true}} @model={{model}} /></template>
+    );
+
+    await click(".save-invite");
+
+    assert
+      .dom(".link-share-container button")
+      .isFocused(
+        "focus moves to the copy/share button after the invite is created"
       );
   });
 

--- a/frontend/discourse/tests/integration/components/create-invite-test.gjs
+++ b/frontend/discourse/tests/integration/components/create-invite-test.gjs
@@ -177,6 +177,22 @@ module("Integration | Component | CreateInvite", function (hooks) {
     );
   });
 
+  test("focuses the description field after expanding advanced options", async function (assert) {
+    const model = {};
+
+    await render(
+      <template><CreateInvite @inline={{true}} @model={{model}} /></template>
+    );
+
+    await click(".edit-link-options");
+
+    assert
+      .dom("input[name='description']")
+      .isFocused(
+        "the description input receives focus when advanced options expand, so screen reader users land inside the form"
+      );
+  });
+
   test("the expiresAfterDays field", async function (assert) {
     const model = {};
     this.siteSettings.invite_expiry_days = 3;

--- a/frontend/discourse/tests/integration/components/d-copy-button-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-copy-button-test.gjs
@@ -1,0 +1,27 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DCopyButton from "discourse/ui-kit/d-copy-button";
+
+module("Integration | Component | DCopyButton", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders a polite aria-live region so copy success can be announced", async function (assert) {
+    await render(
+      <template>
+        <input class="test-input" value="hello" readonly />
+        <DCopyButton
+          @selector="input.test-input"
+          @translatedLabel="Copy"
+          @translatedLabelAfterCopy="Copied!"
+        />
+      </template>
+    );
+
+    assert
+      .dom(".sr-only[aria-live='polite']")
+      .exists(
+        "a visually-hidden polite live region is rendered so screen readers can announce copy success"
+      );
+  });
+});


### PR DESCRIPTION
Improves screenreader and keyboard accessibility of the create invite modal based on feedback from a screenreader user.

* Focus moves to the first input when expanding "Edit link options", so screenreader users land
  inside the form instead of on detached focus.
  
* Focus moves to the copy button when the invite link is first created

* Replaces the `<a role="button" tabindex="0">` "Edit link options" trigger with a real `<button>`

* Adds help text under "Description", "Restrict to", and "Custom message" ... relying on placeholders here for additional context isn't enough. 

* Adds a visually-hidden `aria-live="polite"` region to the copy button so copy success is announced.

* Added tests for the live region presence and focus behavior 


Before/After
<img width="600" alt="image" src="https://github.com/user-attachments/assets/e45b0ee8-5f40-497c-a375-37f028015770" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f94e487d-507b-4394-8356-9f2df3f65d09" />


Before/After
<img width="600" alt="image" src="https://github.com/user-attachments/assets/f55a44a9-0abd-455c-bf04-c85a70e66654" />

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/665a870f-1005-4ec9-9508-db7890a20f50" />


