### PR TITLE
FIX: Don't lose focus when pressing key up and -down in composer emoji picker

### DIFF
--- a/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/prosemirror-editor.gjs
@@ -40,7 +40,7 @@ import placeholder from "../extensions/placeholder";
 import * as utils from "../lib/plugin-utils";
 import TextManipulation from "../lib/text-manipulation";
 
-const AUTOCOMPLETE_KEY_DOWN_SUPPRESS = ["Enter", "Tab"];
+const AUTOCOMPLETE_KEY_DOWN_SUPPRESS = ["Enter", "Tab", "ArrowDown", "ArrowUp"];
 
 /**
  * @typedef ProsemirrorEditorArgs
@@ -251,7 +251,7 @@ export default class ProsemirrorEditor extends Component {
         },
       },
       handleKeyDown: (view, event) => {
-        // suppress if Enter/Tab and the autocomplete is open
+        // suppress if the autocomplete is open
         return (
           AUTOCOMPLETE_KEY_DOWN_SUPPRESS.includes(event.key) &&
           !!document.querySelector(".autocomplete")

--- a/spec/system/composer/prosemirror_autocomplete_spec.rb
+++ b/spec/system/composer/prosemirror_autocomplete_spec.rb
@@ -34,11 +34,15 @@ describe "Composer - ProseMirror - Autocomplete" do
     composer.send_keys(:up, :up)
     composer.type_content(" :smi")
 
-    expect(composer).to have_emoji_autocomplete
+    expect(composer).to have_emoji_autocomplete_selected(1)
 
     composer.send_keys(:down)
 
-    expect(composer).to have_emoji_autocomplete
+    expect(composer).to have_emoji_autocomplete_selected(2)
+
+    composer.send_keys(:up)
+
+    expect(composer).to have_emoji_autocomplete_selected(1)
   end
 
   it "strips partially written emoji when using 'more' emoji modal" do

--- a/spec/system/composer/prosemirror_autocomplete_spec.rb
+++ b/spec/system/composer/prosemirror_autocomplete_spec.rb
@@ -24,6 +24,23 @@ describe "Composer - ProseMirror - Autocomplete" do
     expect(composer).to have_emoji_autocomplete
   end
 
+  it "keeps emoji autocomplete open when pressing arrow down near a horizontal rule" do
+    open_composer
+
+    composer.send_keys(:enter, "---", :enter)
+
+    expect(rich).to have_css("hr")
+
+    composer.send_keys(:up, :up)
+    composer.type_content(" :smi")
+
+    expect(composer).to have_emoji_autocomplete
+
+    composer.send_keys(:down)
+
+    expect(composer).to have_emoji_autocomplete
+  end
+
   it "strips partially written emoji when using 'more' emoji modal" do
     open_composer
 

--- a/spec/system/page_objects/components/composer.rb
+++ b/spec/system/page_objects/components/composer.rb
@@ -215,6 +215,10 @@ module PageObjects
         has_no_css?(AUTOCOMPLETE_MENU)
       end
 
+      def has_emoji_autocomplete_selected?(index)
+        has_css?("#{AUTOCOMPLETE_MENU} ul li:nth-child(#{index}) a.selected")
+      end
+
       EMOJI_SUGGESTION_SELECTOR = "#{AUTOCOMPLETE_MENU} .emoji-shortname"
 
       def has_emoji_suggestion?(emoji)


### PR DESCRIPTION
## What is the problem?

When pressing <kbd>↑</kbd> or <kbd>↓</kbd> in the emoji picker and the cursor is on a line preceding a horizontal rule, the horizontal rule steals focus and closes the emoji picker.

<img width="370" height="213" alt="horizontal-rule-focus-stealing" src="https://github.com/user-attachments/assets/8d4189f2-3cb4-4b49-8ca6-82c3613a075a" />

## How does this solve it?

Add `ArrowUp` and `ArrowDown` to auto-complete suppressed keys.