### PR TITLE
FIX: Restrict policy reminder notifications by post visibility

### DIFF
--- a/plugins/discourse-policy/jobs/scheduled/check_policy.rb
+++ b/plugins/discourse-policy/jobs/scheduled/check_policy.rb
@@ -30,6 +30,8 @@ module Jobs
               post.post_policy.update(last_reminded_at: Time.zone.now)
 
               missing_users(post).find_each do |user|
+                next unless user.guardian.can_see?(post)
+
                 clear_existing_notification(user, post)
                 user.notifications.create!(
                   notification_type: Notification.types[:topic_reminder],

--- a/plugins/discourse-policy/spec/lib/check_policy_spec.rb
+++ b/plugins/discourse-policy/spec/lib/check_policy_spec.rb
@@ -265,19 +265,22 @@ describe Jobs::DiscoursePolicy::CheckPolicy do
   end
 
   context "when the policy topic is restricted" do
-    fab!(:visible_group) do
-      visibility_group = Fabricate(:group)
-      visibility_group.add(user1)
-      visibility_group
-    end
-
-    fab!(:private_category) { Fabricate(:private_category, group: visible_group) }
-
     it "creates reminders only for users who can see it" do
       freeze_time
 
+      policy_user_with_topic_access = Fabricate(:user)
+      policy_user_without_topic_access = Fabricate(:user)
+
+      policy_target_group = Fabricate(:group)
+      policy_target_group.add(policy_user_with_topic_access)
+      policy_target_group.add(policy_user_without_topic_access)
+
+      private_category_access_group = Fabricate(:group)
+      private_category_access_group.add(policy_user_with_topic_access)
+      private_category = Fabricate(:private_category, group: private_category_access_group)
+
       raw = <<~MD
-        [policy group=#{group.name} reminder=weekly]
+        [policy group=#{policy_target_group.name} reminder=weekly]
         I always open **doors**!
         [/policy]
       MD
@@ -294,7 +297,7 @@ describe Jobs::DiscoursePolicy::CheckPolicy do
           topic_id: post.topic_id,
           post_number: 1,
         ).pluck(:user_id),
-      ).to contain_exactly(user1.id)
+      ).to contain_exactly(policy_user_with_topic_access.id)
     end
   end
 

--- a/plugins/discourse-policy/spec/lib/check_policy_spec.rb
+++ b/plugins/discourse-policy/spec/lib/check_policy_spec.rb
@@ -264,6 +264,40 @@ describe Jobs::DiscoursePolicy::CheckPolicy do
     expect(user2_notifications.first.high_priority).to eq(true)
   end
 
+  context "when the policy topic is restricted" do
+    fab!(:visible_group) do
+      visibility_group = Fabricate(:group)
+      visibility_group.add(user1)
+      visibility_group
+    end
+
+    fab!(:private_category) { Fabricate(:private_category, group: visible_group) }
+
+    it "creates reminders only for users who can see it" do
+      freeze_time
+
+      raw = <<~MD
+        [policy group=#{group.name} reminder=weekly]
+        I always open **doors**!
+        [/policy]
+      MD
+
+      post = create_post(raw: raw, user: Fabricate(:admin), category: private_category)
+
+      freeze_time 2.weeks.from_now
+
+      job.execute
+
+      expect(
+        Notification.where(
+          notification_type: Notification.types[:topic_reminder],
+          topic_id: post.topic_id,
+          post_number: 1,
+        ).pluck(:user_id),
+      ).to contain_exactly(user1.id)
+    end
+  end
+
   it "will delete the existing policy reminder notification before creating a new one" do
     Jobs.run_immediately!
     freeze_time


### PR DESCRIPTION
Policy reminder jobs could create `topic_reminder` notifications for users who were in the policy group but could not see the policy post. That allowed restricted policy topics to be referenced by reminder notifications even though the topic itself remained private.

This commit fixes `Jobs::DiscoursePolicy::CheckPolicy` to check post visibility for each missing policy user before replacing the reminder notification. Users who cannot see the post are skipped, while visible policy users continue to receive the reminder.