### PR TITLE
FEATURE: Adds site settings for calendar category default view 

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
@@ -103,6 +103,13 @@ export default class CategoryCalendar extends Component {
     );
   }
 
+  get initialView() {
+    return (
+      this.categorySetting?.defaultView ||
+      this.siteSettings.calendar_category_default_view
+    );
+  }
+
   @action
   formattedEvents(events = []) {
     const timezone = this.currentUser?.user_option?.timezone;
@@ -120,7 +127,7 @@ export default class CategoryCalendar extends Component {
       <FullCalendar
         @onLoadEvents={{this.loadEvents}}
         @height="650px"
-        @initialView={{this.categorySetting.defaultView}}
+        @initialView={{this.initialView}}
         @weekends={{this.renderWeekends}}
         @refreshKey={{this.category.id}}
       />

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -131,6 +131,11 @@ discourse_calendar:
     enum: "CalendarUpcomingEventsDefaultView"
     default: month
     client: true
+  calendar_category_default_view:
+    type: enum
+    enum: "CalendarUpcomingEventsDefaultView"
+    default: month
+    client: true
   enable_events_category_type_setup:
     default: false
     hidden: true

--- a/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
+++ b/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
@@ -98,7 +98,8 @@ describe "Category calendar" do
 
     it "prefers category defaultView over calendar_category_default_view" do
       SiteSetting.calendar_category_default_view = "month"
-      SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
+      SiteSetting.calendar_categories =
+        "categoryId=#{category.id};defaultView=week"
 
       category_page.visit(category)
 

--- a/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
+++ b/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
@@ -98,14 +98,11 @@ describe "Category calendar" do
 
     it "prefers category defaultView over calendar_category_default_view" do
       SiteSetting.calendar_category_default_view = "month"
-      SiteSetting.calendar_categories =
-        "categoryId=#{category.id};defaultView=week"
+      SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
 
       category_page.visit(category)
 
-      expect(category_page).to have_selector(
-        "#category-events-calendar .fc-timeGridWeek-view",
-      )
+      expect(category_page).to have_selector("#category-events-calendar .fc-timeGridWeek-view")
     end
   end
 

--- a/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
+++ b/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
@@ -156,6 +156,14 @@ describe "Category calendar" do
           "rgb(46, 204, 113)",
         )
       end
+      it "prefers category defaultView over calendar_category_default_view" do
+        SiteSetting.calendar_category_default_view = "month"
+        SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
+
+        category_page.visit(category)
+
+        expect(category_page).to have_selector("#category-events-calendar .fc-timeGridWeek-view")
+      end
     end
   end
 end

--- a/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
+++ b/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
@@ -95,6 +95,15 @@ describe "Category calendar" do
       expect(page).to have_current_path("#{category.relative_url}/l/latest")
       expect(category_page).to have_selector("#category-events-calendar .fc")
     end
+    
+    it "prefers category defaultView over calendar_category_default_view" do
+        SiteSetting.calendar_category_default_view = "month"
+        SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
+
+        category_page.visit(category)
+
+        expect(category_page).to have_selector("#category-events-calendar .fc-timeGridWeek-view")
+    end
   end
 
   context "with color mapping", time: Time.utc(2026, 6, 2, 19, 00) do
@@ -155,14 +164,6 @@ describe "Category calendar" do
         expect(get_rgb_color(find(".fc-daygrid-event-dot"), "borderColor")).to eq(
           "rgb(46, 204, 113)",
         )
-      end
-      it "prefers category defaultView over calendar_category_default_view" do
-        SiteSetting.calendar_category_default_view = "month"
-        SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
-
-        category_page.visit(category)
-
-        expect(category_page).to have_selector("#category-events-calendar .fc-timeGridWeek-view")
       end
     end
   end

--- a/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
+++ b/plugins/discourse-calendar/spec/system/category_calendar_spec.rb
@@ -95,14 +95,16 @@ describe "Category calendar" do
       expect(page).to have_current_path("#{category.relative_url}/l/latest")
       expect(category_page).to have_selector("#category-events-calendar .fc")
     end
-    
+
     it "prefers category defaultView over calendar_category_default_view" do
-        SiteSetting.calendar_category_default_view = "month"
-        SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
+      SiteSetting.calendar_category_default_view = "month"
+      SiteSetting.calendar_categories = "categoryId=#{category.id};defaultView=week"
 
-        category_page.visit(category)
+      category_page.visit(category)
 
-        expect(category_page).to have_selector("#category-events-calendar .fc-timeGridWeek-view")
+      expect(category_page).to have_selector(
+        "#category-events-calendar .fc-timeGridWeek-view",
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a new `calendar_category_default_view` site setting for category calendars in the discourse-calendar plugin.

This allows admins to configure the default FullCalendar view used on category calendar pages (e.g. month/week/day/year).

Per-category `defaultView` values in calendar_categories continue to take precedence over the global default setting.

## Changes

- Added new site setting:
  - `calendar_category_default_view`
- Reused existing `CalendarUpcomingEventsDefaultView` enum
- Updated CategoryCalendar to use:
  - category `defaultView` if present
  - otherwise fallback to `calendar_category_default_view`
- Added system spec coverage for precedence behaviour

## Notes

This mirrors the existing `calendar_upcoming_events_default_view` behaviour used for `/upcoming-events`.