### PR TITLE
DEV: Keep redesign admin dashboard sections stable during refresh

### DIFF
--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -29,21 +29,17 @@ export default class RedesignedAdminDashboard extends Component {
 
   constructor() {
     super(...arguments);
-    this.pendingSections = buildPending(this.committedSections);
-  }
-
-  get committedSections() {
-    return this.args.configuration?.sections ?? [];
-  }
-
-  get showSkeleton() {
-    return this.args.loadingSections && !this.args.sections;
+    this.pendingSections = buildPending(
+      this.args.loadedSections?.configuration?.sections
+    );
   }
 
   @action
   onMenuOpen() {
     this._opened = true;
-    this.pendingSections = buildPending(this.committedSections);
+    this.pendingSections = buildPending(
+      this.args.loadedSections?.configuration?.sections
+    );
   }
 
   @action
@@ -66,7 +62,11 @@ export default class RedesignedAdminDashboard extends Component {
     if (this._saving || !this._opened) {
       return;
     }
-    if (deepEqual(this.pendingSections, this.committedSections)) {
+
+    const committedSections =
+      this.args.loadedSections?.configuration?.sections ?? [];
+
+    if (deepEqual(this.pendingSections, committedSections)) {
       return;
     }
 
@@ -75,7 +75,9 @@ export default class RedesignedAdminDashboard extends Component {
       .updateConfiguration(this.pendingSections)
       .catch((e) => {
         popupAjaxError(e);
-        this.pendingSections = buildPending(this.committedSections);
+        this.pendingSections = buildPending(
+          this.args.loadedSections?.configuration?.sections
+        );
       })
       .finally(() => {
         this._saving = false;
@@ -88,9 +90,9 @@ export default class RedesignedAdminDashboard extends Component {
 
       <div class="db-toolbar__actions">
         <DashboardDateRange
-          @period={{@period}}
-          @startDate={{@startDate}}
-          @endDate={{@endDate}}
+          @period={{@requestedPeriod}}
+          @startDate={{@requestedStartDate}}
+          @endDate={{@requestedEndDate}}
           @setPeriod={{@setPeriod}}
           @setCustomDateRange={{@setCustomDateRange}}
         />
@@ -119,40 +121,38 @@ export default class RedesignedAdminDashboard extends Component {
     </div>
 
     <div class="db-main">
-      {{#if this.showSkeleton}}
-        <DashboardSkeleton />
-      {{else}}
-        {{#each @sections key="id" as |section|}}
+      {{#if @loadedSections}}
+        {{#each @loadedSections.sections key="id" as |section|}}
           <div class="db-main__section" data-section-id={{section.id}}>
             {{#if (eq section.id "highlights")}}
               <DashboardHighlights
                 @highlights={{section.data}}
-                @period={{@period}}
+                @period={{@loadedSections.period}}
                 @loading={{@loadingSections}}
                 @fetchError={{@sectionsFetchError}}
-                @startDate={{@startDate}}
-                @endDate={{@endDate}}
+                @startDate={{@loadedSections.startDate}}
+                @endDate={{@loadedSections.endDate}}
               />
             {{else if (eq section.id "reports")}}
               <DashboardReports
-                @startDate={{@startDate}}
-                @endDate={{@endDate}}
+                @startDate={{@loadedSections.startDate}}
+                @endDate={{@loadedSections.endDate}}
               />
             {{else if (eq section.id "traffic")}}
               <DashboardTraffic
-                @startDate={{@startDate}}
-                @endDate={{@endDate}}
+                @startDate={{@loadedSections.startDate}}
+                @endDate={{@loadedSections.endDate}}
               />
             {{else if (eq section.id "engagement")}}
               <DashboardEngagement
-                @startDate={{@startDate}}
-                @endDate={{@endDate}}
+                @startDate={{@loadedSections.startDate}}
+                @endDate={{@loadedSections.endDate}}
               />
             {{/if}}
           </div>
         {{/each}}
 
-        {{#unless @sections.length}}
+        {{#unless @loadedSections.sections.length}}
           <div class="db-main__empty" role="status" aria-live="polite">
             {{#if this.currentUser.admin}}
               {{i18n "admin.dashboard.configure.empty_state_admin"}}
@@ -161,6 +161,8 @@ export default class RedesignedAdminDashboard extends Component {
             {{/if}}
           </div>
         {{/unless}}
+      {{else if @loadingSections}}
+        <DashboardSkeleton />
       {{/if}}
     </div>
   </template>

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -18,6 +18,7 @@ const PROBLEMS_CHECK_MINUTES = 1;
 export default class AdminDashboardController extends Controller {
   @service router;
   @service siteSettings;
+  @service loadingSlider;
   @controller("exception") exceptionController;
 
   @tracked loadingProblems = false;
@@ -25,8 +26,7 @@ export default class AdminDashboardController extends Controller {
   @tracked range = DEFAULT_PERIOD;
   @tracked start_date = null;
   @tracked end_date = null;
-  @tracked sections = null;
-  @tracked configuration = null;
+  @tracked loadedSections = null;
   @tracked loadingSections = false;
   @tracked sectionsFetchError = false;
   @autoTrackedArray problems;
@@ -95,19 +95,31 @@ export default class AdminDashboardController extends Controller {
 
   async fetchSections() {
     const id = ++this._sectionsLoadId;
+    const period = this.safePeriod;
+    const startDate = this.startDate;
+    const endDate = this.endDate;
+
     this.loadingSections = true;
     this.sectionsFetchError = false;
+    this.loadingSlider.transitionStarted();
 
     try {
       const model = await AdminDashboard.fetch({
-        startDate: this.startDate,
-        endDate: this.endDate,
+        startDate,
+        endDate,
       });
+
       if (id !== this._sectionsLoadId) {
         return;
       }
-      this.sections = model.sections;
-      this.configuration = model.configuration;
+
+      this.loadedSections = {
+        period,
+        startDate,
+        endDate,
+        sections: model.sections,
+        configuration: model.configuration,
+      };
     } catch {
       if (id !== this._sectionsLoadId) {
         return;
@@ -116,6 +128,7 @@ export default class AdminDashboardController extends Controller {
     } finally {
       if (id === this._sectionsLoadId) {
         this.loadingSections = false;
+        this.loadingSlider.transitionEnded();
       }
     }
   }

--- a/frontend/discourse/admin/templates/admin/dashboard.gjs
+++ b/frontend/discourse/admin/templates/admin/dashboard.gjs
@@ -10,13 +10,12 @@ import { i18n } from "discourse-i18n";
 export default <template>
   {{#if @controller.siteSettings.dashboard_improvements}}
     <RedesignedAdminDashboard
-      @period={{@controller.safePeriod}}
-      @startDate={{@controller.startDate}}
-      @endDate={{@controller.endDate}}
+      @requestedPeriod={{@controller.safePeriod}}
+      @requestedStartDate={{@controller.startDate}}
+      @requestedEndDate={{@controller.endDate}}
       @setPeriod={{@controller.setPeriod}}
       @setCustomDateRange={{@controller.setCustomDateRange}}
-      @sections={{@controller.sections}}
-      @configuration={{@controller.configuration}}
+      @loadedSections={{@controller.loadedSections}}
       @updateConfiguration={{@controller.updateConfiguration}}
       @loadingSections={{@controller.loadingSections}}
       @sectionsFetchError={{@controller.sectionsFetchError}}


### PR DESCRIPTION
Keep redesigned dashboard sections bound to the last successful section response while a new date range request is in flight.

The date range selector updates query-param-backed state immediately, but section payloads arrive asynchronously from `/admin/dashboard.json`. Passing live requested dates and stale section data through the same component boundary lets sections briefly render a range that does not match their loaded content.

This PR groups the loaded section response, admin configuration, and the request range into one `loadedSections` snapshot. The date selector continues to reflect the requested range immediately. Rendered sections keep using the last loaded snapshot until the next response returns, and the loading slider indicates the refresh without replacing loaded sections with skeletons.