### PR TITLE
DEV: Fix a chat search spec flake

### DIFF
--- a/plugins/chat/spec/system/page_objects/pages/chat_search.rb
+++ b/plugins/chat/spec/system/page_objects/pages/chat_search.rb
@@ -55,13 +55,6 @@ module PageObjects
 
       def scroll_to_bottom
         page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
-        wait_for_loading
-        self
-      end
-
-      def wait_for_loading
-        has_selector?(".chat-search-loading .spinner")
-        has_no_selector?(".chat-search-loading .spinner")
         self
       end
 


### PR DESCRIPTION
The loading spinner could disappear before `has_selector?(".chat-search-loading .spinner")` assertion, which resulted in awaiting for the full timeout duration.

`scroll_to_bottom` is only used in one place and the assertion after it will wait for the correct state anyway.