### PR TITLE
DEV: Resolve `test.localhost` in system specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1358,10 +1358,12 @@ def apply_base_chrome_args(args = [])
     base_args << "--remote-debugging-address=" + CHROME_REMOTE_DEBUGGING_ADDRESS
   end
 
+  resolver_rules = ["MAP test.localhost:80 127.0.0.1:#{Capybara.server_port}"]
   if ENV["CI"]
     # Bypass the OS resolver for localhost lookups inside the browser.
-    base_args << "--host-resolver-rules=MAP localhost [::1],MAP *.localhost [::1]"
+    resolver_rules.push("MAP localhost [::1]", "MAP *.localhost [::1]")
   end
+  base_args << "--host-resolver-rules=#{resolver_rules.join(",")}"
 
   # A file that contains just a list of paths like so:
   #


### PR DESCRIPTION
Piggy-backing on 082dc7f657651e8a890037023f2644d96584777c, resolve `test.localhost` in system specs to the running capybara server, so that we don't get `ERR_CONNECTION_REFUSED` errors in browser logs