### PR TITLE
DEV: Fix more prosemirror flakes

### DIFF
--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.js
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.js
@@ -149,15 +149,17 @@ export function registerRichEditorExtension(extension) {
   registeredExtensions.push(extension);
 }
 
-export function clearRichEditorExtensions() {
+export async function clearRichEditorExtensions() {
+  // Import it first - a lazy import later would re-register the defaults.
+  const module = await waitForPromise(
+    import("discourse/static/prosemirror/extensions/register-default")
+  );
   registeredExtensions.length = 0;
+  return module;
 }
 
 export async function resetRichEditorExtensions() {
-  const { default: extensions } = await waitForPromise(
-    import("discourse/static/prosemirror/extensions/register-default")
-  );
-  clearRichEditorExtensions();
+  const { default: extensions } = await clearRichEditorExtensions();
   extensions.forEach(registerRichEditorExtension);
 }
 


### PR DESCRIPTION
Make sure extensions are loaded before clearing them, not after.