### PR TITLE
FIX: make composer education notice truly one-time

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -167,6 +167,7 @@ class UserHistory < ActiveRecord::Base
         upcoming_change_toggled: 122,
         change_site_setting_groups: 123,
         upcoming_change_available: 124,
+        notified_about_composer_education: 125,
       )
   end
 

--- a/frontend/discourse/app/components/composer-messages.gjs
+++ b/frontend/discourse/app/components/composer-messages.gjs
@@ -25,6 +25,10 @@ export function resetComposerMessagesCache() {
   _messagesCache = {};
 }
 
+function containsEducationMessage(messages) {
+  return messages?.content?.some((msg) => msg.id === "education");
+}
+
 @tagName("")
 export default class ComposerMessages extends Component {
   @tracked showShareModal;
@@ -111,9 +115,12 @@ export default class ComposerMessages extends Component {
       return;
     }
 
-    for (const msg of this.queuedForTyping) {
+    const queuedMessages = [...this.queuedForTyping];
+    this.queuedForTyping.length = 0;
+
+    for (const msg of queuedMessages) {
       if (this.composer.whisper && msg.hide_if_whisper) {
-        return;
+        continue;
       }
 
       this.popup(msg);
@@ -280,7 +287,10 @@ export default class ComposerMessages extends Component {
     const cacheKey = `${args.composer_action}${args.topic_id}${args.post_id}`;
 
     let messages;
-    if (_messagesCache.cacheKey === cacheKey) {
+    if (
+      _messagesCache.cacheKey === cacheKey &&
+      !containsEducationMessage(_messagesCache.messages)
+    ) {
       messages = _messagesCache.messages;
     } else {
       messages = await this.composer.store.find("composer-message", args);
@@ -288,7 +298,11 @@ export default class ComposerMessages extends Component {
         return;
       }
 
-      _messagesCache = { messages, cacheKey };
+      if (containsEducationMessage(messages)) {
+        _messagesCache = {};
+      } else {
+        _messagesCache = { messages, cacheKey };
+      }
     }
 
     // Checking composer messages on replies can give us a list of links to check for

--- a/frontend/discourse/tests/acceptance/composer-messages-test.js
+++ b/frontend/discourse/tests/acceptance/composer-messages-test.js
@@ -175,6 +175,43 @@ acceptance("Composer - Messages - Duplicate links", function (needs) {
   });
 });
 
+acceptance("Composer - Messages - Education", function (needs) {
+  needs.user();
+
+  test("shows wait_for_typing message only once", async function (assert) {
+    pretender.get("/composer_messages", () =>
+      response({
+        composer_messages: [
+          {
+            id: "education",
+            templateName: "education",
+            wait_for_typing: true,
+            body: "Education message",
+          },
+        ],
+      })
+    );
+
+    await visit("/t/internationalization-localization/280");
+    await click("button.create");
+
+    await triggerEvent("#reply-control", "transitionend", {
+      propertyName: "height",
+    });
+
+    await triggerKeyEvent(".d-editor-input", "keyup", "Space");
+    assert.dom(".composer-popup").exists("shows composer warning message");
+
+    await click(".composer-popup .close");
+    assert.dom(".composer-popup").doesNotExist("composer warning is closed");
+
+    await triggerKeyEvent(".d-editor-input", "keyup", "Space");
+    assert
+      .dom(".composer-popup")
+      .doesNotExist("composer warning does not show again");
+  });
+});
+
 acceptance("Composer - Messages - Private Messages", function (needs) {
   needs.user({
     id: 32,

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -26,11 +26,17 @@ class ComposerMessagesFinder
   # Determines whether to show the user education text
   def check_education_message
     return if @topic&.private_message?
+    return if UserHistory.exists_for_user?(@user, :notified_about_composer_education)
 
     education_key = creating_topic? ? "education.new-topic" : "education.new-reply"
     count = @user.topic_count + @user.post_count
 
     if count < SiteSetting.educate_until_posts
+      UserHistory.create!(
+        action: UserHistory.actions[:notified_about_composer_education],
+        target_user_id: @user.id,
+      )
+
       return(
         {
           id: "education",

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe ComposerMessagesFinder do
         user.expects(:topic_count).returns(2)
         expect(finder.check_education_message).to be_blank
       end
+
+      it "returns no message when the user has already been shown composer education" do
+        UserHistory.create!(
+          action: UserHistory.actions[:notified_about_composer_education],
+          target_user_id: user.id,
+        )
+
+        user.expects(:post_count).never
+        user.expects(:topic_count).never
+        expect(finder.check_education_message).to be_blank
+      end
+
+      it "records that composer education was shown" do
+        user.expects(:post_count).returns(8)
+        user.expects(:topic_count).returns(1)
+
+        finder.check_education_message
+
+        expect(UserHistory.exists_for_user?(user, :notified_about_composer_education)).to eq(true)
+      end
     end
 
     context "with private message" do


### PR DESCRIPTION
The “Thanks for contributing to SITENAME” composer education notice could keep showing even after it had already been displayed once. This happened because the backend did not persist a one-time marker for that specific notice, and the frontend could reuse stale composer message data during the same page session.

This change makes the education notice one-time per user by recording when it has been shown and skipping it on future checks. It also fixes composer-side behavior so typing-triggered messages are consumed once instead of being re-shown repeatedly after closing, and avoids reusing cached composer message responses that include the education notice. Together, these updates make the education message behavior consistent and prevent repeated prompts.