### PR TITLE
UX: Always show options in bookmark modal

### DIFF
--- a/app/assets/stylesheets/common/components/bookmark-modal.scss
+++ b/app/assets/stylesheets/common/components/bookmark-modal.scss
@@ -31,31 +31,11 @@
     }
   }
 
-  .bookmark-name-wrap {
-    display: inline-flex;
-    width: 100%;
-    align-items: end;
-  }
-
-  .bookmark-options-button {
-    margin-left: 0.5em;
-    margin-bottom: 0.5em;
-  }
-
   .bookmark-options-panel {
     margin-bottom: 18px;
 
     .select-kit {
       width: 100%;
-    }
-
-    label {
-      display: flex;
-
-      span {
-        display: block;
-        flex: 1;
-      }
     }
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4842,7 +4842,6 @@ en:
         name_placeholder: "What is this bookmark for?"
         name_input_label: "Bookmark name"
         set_reminder: "Remind me"
-        options: "Options"
         actions:
           delete_bookmark:
             name: "Delete bookmark"

--- a/frontend/discourse/app/components/modal/bookmark.gjs
+++ b/frontend/discourse/app/components/modal/bookmark.gjs
@@ -48,7 +48,6 @@ export default class BookmarkModal extends Component {
   @tracked postDetectedLocalTimezone = null;
   @tracked prefilledDatetime = null;
   @tracked flash = null;
-  @tracked showOptions = this.args.model.bookmark.id ? true : false;
 
   @tracked _closeWithoutSaving = false;
   @tracked _savingBookmarkManually = false;
@@ -194,11 +193,6 @@ export default class BookmarkModal extends Component {
       .finally(() => {
         this._saving = false;
       });
-  }
-
-  @action
-  toggleShowOptions() {
-    this.showOptions = !this.showOptions;
   }
 
   @action
@@ -384,7 +378,7 @@ export default class BookmarkModal extends Component {
       </:headerPrimaryAction>
 
       <:body>
-        <div class="control-group bookmark-name-wrap">
+        <div class="control-group">
           <Input
             id="bookmark-name"
             @value={{this.bookmark.name}}
@@ -393,30 +387,21 @@ export default class BookmarkModal extends Component {
             placeholder={{i18n "post.bookmarks.name_placeholder"}}
             aria-label={{i18n "post.bookmarks.name_input_label"}}
           />
-          <DButton
-            @icon="gear"
-            @action={{this.toggleShowOptions}}
-            @ariaLabel="post.bookmarks.options"
-            @title="post.bookmarks.options"
-            class="bookmark-options-button"
-          />
         </div>
 
-        {{#if this.showOptions}}
-          <div class="bookmark-options-panel">
-            <label
-              class="control-label"
-              for="bookmark_auto_delete_preference"
-            >{{i18n "bookmarks.auto_delete_preference.label"}}</label>
-            <ComboBox
-              @content={{this.autoDeletePreferences}}
-              @value={{this.bookmark.autoDeletePreference}}
-              @id="bookmark-auto-delete-preference"
-              @onChange={{fn (mut this.bookmark.autoDeletePreference)}}
-              class="bookmark-option-selector"
-            />
-          </div>
-        {{/if}}
+        <div class="bookmark-options-panel">
+          <label
+            class="control-label"
+            for="bookmark_auto_delete_preference"
+          >{{i18n "bookmarks.auto_delete_preference.label"}}</label>
+          <ComboBox
+            @content={{this.autoDeletePreferences}}
+            @value={{this.bookmark.autoDeletePreference}}
+            @id="bookmark-auto-delete-preference"
+            @onChange={{fn (mut this.bookmark.autoDeletePreference)}}
+            class="bookmark-option-selector"
+          />
+        </div>
 
         {{#if this.showExistingReminderAt}}
           <div class="alert alert-info existing-reminder-at-alert">

--- a/spec/system/bookmarks_spec.rb
+++ b/spec/system/bookmarks_spec.rb
@@ -67,10 +67,6 @@ describe "Bookmarking posts and topics" do
     bookmark_menu.click_menu_option("custom")
     expect(bookmark_modal).to be_open
 
-    # NOTE: (martin) Not sure why, but I need to click this twice for the panel to open :/
-    bookmark_modal.open_options_panel
-    bookmark_modal.open_options_panel
-
     expect(bookmark_modal).to have_auto_delete_preference(
       Bookmark.auto_delete_preferences[:on_owner_reply],
     )
@@ -79,7 +75,6 @@ describe "Bookmarking posts and topics" do
     expect(topic_page).to have_post_bookmarked(post_2, with_reminder: false)
     topic_page.click_post_action_button(post_2, :bookmark)
     bookmark_menu.click_menu_option("edit")
-    expect(bookmark_modal).to have_open_options_panel
     expect(bookmark_modal).to have_auto_delete_preference(
       Bookmark.auto_delete_preferences[:clear_reminder],
     )
@@ -231,7 +226,6 @@ describe "Bookmarking posts and topics" do
     it "prefills the name of the bookmark and the custom reminder date and time" do
       visit_topic_and_open_bookmark_menu(post_2, expand_actions: false)
       bookmark_menu.click_menu_option("edit")
-      expect(bookmark_modal).to have_open_options_panel
       expect(bookmark_modal.name.value).to eq("test name")
       expect(bookmark_modal.existing_reminder_alert).to have_content(
         bookmark_modal.existing_reminder_alert_message(bookmark),

--- a/spec/system/page_objects/modals/bookmark.rb
+++ b/spec/system/page_objects/modals/bookmark.rb
@@ -32,14 +32,6 @@ module PageObjects
         has_css?(".bookmark-reminder-modal[data-bookmark-id='#{bookmark_id}']")
       end
 
-      def open_options_panel
-        find(".bookmark-options-button").click
-      end
-
-      def has_open_options_panel?
-        has_css?(".bookmark-options-panel")
-      end
-
       def select_relative_time_duration(duration)
         find("#bookmark-relative-time-picker").fill_in(with: duration)
       end


### PR DESCRIPTION

Previously, the bookmark modal hid the auto-delete preference behind a gear-icon toggle, even though that toggle revealed only that one control.

This change removes the toggle and renders the auto-delete preference inline alongside the name and reminder fields.

| BC | AC |
|--------|--------|
| <img width="1234" height="1134" alt="CleanShot 2026-05-15 at 17 12 49@2x" src="https://github.com/user-attachments/assets/9deeb527-6ae6-429c-93c5-355b445df279" /> | <img width="1234" height="1134" alt="CleanShot 2026-05-15 at 17 11 13@2x" src="https://github.com/user-attachments/assets/eaa65188-aead-4be3-8d7d-8b5d6ca032f6" /> | 

[Meta](https://meta.discourse.org/t/superfluous-button-in-edit-bookmark-dialog/403018?u=chapoi)