### PR TITLE
A11Y: improve sidebar and header landmarks, post controls role

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3698,6 +3698,7 @@ en:
           aria_label: filter by maximum views
 
     hamburger_menu: "Navigation menu"
+    header_panel: "Header"
     new_item: "new"
     go_back: "go back"
     not_logged_in_user: "user page with summary of current activity and preferences"
@@ -4686,6 +4687,7 @@ en:
       few_likes_left: "Thanks for sharing the love! You only have a few likes left for today."
 
       controls:
+        menu_label: "Post actions"
         reply: "begin composing a reply to this post"
         like_action: "Like"
         like: "like this post"

--- a/frontend/discourse/app/components/header/contents.gjs
+++ b/frontend/discourse/app/components/header/contents.gjs
@@ -4,6 +4,7 @@ import { ALL_PAGES_EXCLUDED_ROUTES } from "discourse/components/welcome-banner";
 import deprecatedOutletArgument from "discourse/helpers/deprecated-outlet-argument";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { applyValueTransformer } from "discourse/lib/transformer";
+import { i18n } from "discourse-i18n";
 import PluginOutlet from "../plugin-outlet";
 import HeaderSearch from "./header-search";
 import HomeLogo from "./home-logo";
@@ -122,7 +123,11 @@ export default class Contents extends Component {
           }}
         />
       </div>
-      <div class="panel" role="navigation">{{yield}}</div>
+      <div
+        class="panel"
+        role="navigation"
+        aria-label={{i18n "header_panel"}}
+      >{{yield}}</div>
       <div class="after-header-panel-outlet">
         <PluginOutlet
           @name="after-header-panel"

--- a/frontend/discourse/app/components/header/sidebar-toggle.gjs
+++ b/frontend/discourse/app/components/header/sidebar-toggle.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -11,17 +12,20 @@ export default class SidebarToggle extends Component {
   @service navigationMenu;
 
   @action
-  toggleWithBlur(e) {
+  toggle() {
+    const wasHidden = !this.args.showSidebar;
+
     if (this.navigationMenu.isDesktopDropdownMode) {
       this.args.toggleNavigationMenu("sidebar");
     } else {
       this.args.toggleNavigationMenu();
     }
 
-    // remove the focus of the header dropdown button after clicking
-    e.target.tagName.toLowerCase() === "button"
-      ? e.target.blur()
-      : e.target.closest("button").blur();
+    if (wasHidden) {
+      schedule("afterRender", () => {
+        document.querySelector("#d-sidebar a, #d-sidebar button")?.focus();
+      });
+    }
   }
 
   <template>
@@ -34,7 +38,7 @@ export default class SidebarToggle extends Component {
         }}
         aria-expanded={{if @showSidebar "true" "false"}}
         aria-controls="d-sidebar"
-        {{on "click" this.toggleWithBlur}}
+        {{on "click" this.toggle}}
       >
         {{dIcon @icon}}
       </button>

--- a/frontend/discourse/app/components/post.gjs
+++ b/frontend/discourse/app/components/post.gjs
@@ -603,7 +603,11 @@ export default class Post extends Component {
                         />
                       {{/if}}
 
-                      <section class="post__menu-area post-menu-area clearfix">
+                      <section
+                        class="post__menu-area post-menu-area clearfix"
+                        role="group"
+                        aria-label={{i18n "post.controls.menu_label"}}
+                      >
                         <PostMenu
                           @post={{@post}}
                           @prevPost={{@prevPost}}

--- a/frontend/discourse/app/components/post/menu.gjs
+++ b/frontend/discourse/app/components/post/menu.gjs
@@ -636,8 +636,7 @@ export default class PostMenu extends Component {
             "replies-button-visible"
           )
         }}
-        role="group"
-        aria-label={{i18n "post.controls.menu_label"}}
+        role="none"
       >
         {{! do not include PluginOutlets here, use the PostMenu DAG API instead }}
         {{#each this.extraControls key="key" as |extraControl|}}

--- a/frontend/discourse/app/components/post/menu.gjs
+++ b/frontend/discourse/app/components/post/menu.gjs
@@ -636,6 +636,8 @@ export default class PostMenu extends Component {
             "replies-button-visible"
           )
         }}
+        role="group"
+        aria-label={{i18n "post.controls.menu_label"}}
       >
         {{! do not include PluginOutlets here, use the PostMenu DAG API instead }}
         {{#each this.extraControls key="key" as |extraControl|}}

--- a/frontend/discourse/app/components/sidebar.gjs
+++ b/frontend/discourse/app/components/sidebar.gjs
@@ -7,6 +7,7 @@ import Sections from "discourse/components/sidebar/sections";
 import SwitchPanelButtons from "discourse/components/sidebar/switch-panel-buttons";
 import bodyClass from "discourse/helpers/body-class";
 import { bind } from "discourse/lib/decorators";
+import { i18n } from "discourse-i18n";
 
 export default class Sidebar extends Component {
   @service site;
@@ -71,7 +72,11 @@ export default class Sidebar extends Component {
   <template>
     {{bodyClass "has-sidebar-page"}}
 
-    <section id="d-sidebar" class="sidebar-container">
+    <nav
+      id="d-sidebar"
+      class="sidebar-container"
+      aria-label={{i18n "sidebar.title"}}
+    >
       {{#if this.showSwitchPanelButtonsOnTop}}
         <SwitchPanelButtons @buttons={{this.switchPanelButtons}} />
       {{/if}}
@@ -98,6 +103,6 @@ export default class Sidebar extends Component {
       {{/unless}}
 
       <Footer />
-    </section>
+    </nav>
   </template>
 }

--- a/frontend/discourse/tests/acceptance/sidebar-user-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-user-test.js
@@ -228,6 +228,14 @@ acceptance(
       await visit("/");
 
       assert
+        .dom("nav#d-sidebar")
+        .hasAttribute(
+          "aria-label",
+          i18n("sidebar.title"),
+          "sidebar is exposed as a named navigation landmark"
+        );
+
+      assert
         .dom(
           ".btn-sidebar-toggle[aria-expanded='true'][aria-controls='d-sidebar']"
         )
@@ -260,6 +268,13 @@ acceptance(
           i18n("sidebar.title"),
           "has the right title attribute when sidebar is collapsed"
         );
+
+      await click(".btn-sidebar-toggle");
+
+      assert.true(
+        document.querySelector("#d-sidebar").contains(document.activeElement),
+        "focus moves into the sidebar when it is opened via the toggle"
+      );
     });
   }
 );


### PR DESCRIPTION
This makes a handful of general accessibility improvements, including: 

* Changing the sidebar from `section` -> `nav`, which will identify it as a navigation landmark 
* Adding `sidebar` and `header` labels to differentiate the sidebar and header landmarks
* Add a `group` role and "post actions" label to the post navigation buttons, because they're very repetitive and too granular as a landmark 
* When opening the sidebar, focus the first sidebar link — currently you have to navigate through the header to reach it. Also added a test to make sure this doesn't regress. The header dropdown version is already fine.