### PR TITLE
DEV: Fix a concurrency race in `defer`

### DIFF
--- a/lib/scheduler/defer.rb
+++ b/lib/scheduler/defer.rb
@@ -112,7 +112,7 @@ module Scheduler
         @reactor = MessageBus::TimerThread.new if !@reactor
         @thread =
           Thread.new do
-            @thread.abort_on_exception = true if Rails.env.test?
+            Thread.current.abort_on_exception = true if Rails.env.test?
             do_work while (!@finish || !@queue.empty?)
           end if !@thread&.alive?
       end


### PR DESCRIPTION
`@thread` might not be set yet when the thread starts running, use `Thread.current` for safety.