### PR TITLE
UX: Improve theme picker modal and fix more card spacing

### DIFF
--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -199,6 +199,7 @@
   }
 
   &__card {
+    position: relative;
     display: flex;
     flex-direction: column;
     border: 2px solid var(--content-border-color);
@@ -215,14 +216,20 @@
     margin: var(--space-3) var(--space-4) var(--space-4);
   }
 
-  &__card .theme-picker-modal__current-btn.btn {
-    color: var(--tertiary);
-    pointer-events: none;
-    cursor: default;
-
-    .d-icon {
-      color: var(--tertiary);
-    }
+  &__enabled-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--font-down-2);
+    font-weight: 700;
+    color: var(--secondary);
+    background: var(--tertiary);
+    padding: var(--space-1) var(--space-2);
+    border-radius: 0 0 0 var(--d-border-radius);
+    z-index: 1;
   }
 
   &__browse-all,

--- a/app/assets/stylesheets/common/components/theme-card.scss
+++ b/app/assets/stylesheets/common/components/theme-card.scss
@@ -116,6 +116,18 @@
     }
   }
 
+  &__content {
+    padding-inline: 1rem;
+    padding-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+
+  &__description {
+    margin: 0 0 10px 0;
+  }
+
   &__components {
     display: -webkit-box;
     font-size: var(--font-down-1);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -514,9 +514,9 @@ en:
         action: "Select theme"
         modal_title: "Choose a theme"
         use_theme: "Use this theme"
-        currently_selected: "Currently selected"
+        enabled: "Enabled"
         theme_set: "%{theme} is now your default theme"
-        browse_all: "Browse all themes"
+        browse_all: "Manage themes"
         show_light_screenshot: "Show light screenshot"
         show_dark_screenshot: "Show dark screenshot"
       invite_collaborators:

--- a/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
@@ -15,6 +15,7 @@ import {
 } from "discourse/lib/theme-selector";
 import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dLoadingSpinner from "discourse/ui-kit/helpers/d-loading-spinner";
 import { i18n } from "discourse-i18n";
 
@@ -22,25 +23,21 @@ const ALLOWED_THEME_IDS = [FOUNDATION_THEME_ID, HORIZON_THEME_ID];
 
 const ThemeCard = <template>
   <div class="theme-picker-modal__card {{if @theme.default '--active'}}">
+    {{#if @theme.default}}
+      <span class="theme-picker-modal__enabled-badge">
+        {{dIcon "check"}}
+        {{i18n "admin_onboarding_banner.select_theme.enabled"}}
+      </span>
+    {{/if}}
     <ThemeCardPreview @theme={{@theme}}>
       <:footer>
-        {{#if @theme.default}}
-          <DButton
-            @icon="check"
-            @translatedLabel={{i18n
-              "admin_onboarding_banner.select_theme.currently_selected"
-            }}
-            class="btn-transparent theme-picker-modal__current-btn"
-          />
-        {{else}}
-          <DButton
-            @action={{fn @onSelect @theme}}
-            @translatedLabel={{i18n
-              "admin_onboarding_banner.select_theme.use_theme"
-            }}
-            class="btn-primary"
-          />
-        {{/if}}
+        <DButton
+          @action={{fn @onSelect @theme}}
+          @translatedLabel={{i18n
+            "admin_onboarding_banner.select_theme.use_theme"
+          }}
+          class="btn-primary"
+        />
       </:footer>
     </ThemeCardPreview>
   </div>


### PR DESCRIPTION
**Previously**, the theme picker modal showed a non-clickable "Currently selected" label on the default theme, the "Install more themes" card lost its content/description spacing after the `ThemeCardPreview` extraction, and the modal link text said "Browse all themes".

**In this update**, both theme cards show a "Use this theme" button (allowing the current theme to be re-selected to complete onboarding), the active card gets an "Enabled" badge in the top-right corner, the install-more card spacing is restored, and the link text is renamed to "Manage themes".

<img width="1057" height="748" alt="Screenshot 2026-05-15 at 10 53 42" src="https://github.com/user-attachments/assets/a1ca56cf-59fe-4c53-9160-a79f2424e386" />
<img width="643" height="531" alt="Screenshot 2026-05-15 at 10 53 25" src="https://github.com/user-attachments/assets/d124f1fc-9206-4e0f-aa71-47f9a202a5ba" />
