### PR TITLE
UX: Don't make collapsed GH PR onebox body scrollable on mobile

### DIFF
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -592,6 +592,10 @@ pre.onebox code ol.lines li.selected {
     line-height: calc((13 + 4) / 13);
     box-sizing: border-box;
 
+    @include viewport.until(sm) {
+      max-height: 50vh;
+    }
+
     .show-more {
       font-family: var(--font-family);
 


### PR DESCRIPTION
This one bugged me for quite some time… (don't check who might have introduced this)

<img width="378" height="301" alt="Screenshot 2026-05-15 at 21 15 57" src="https://github.com/user-attachments/assets/4d5b3d73-9ffd-4aef-bbfc-05d4c7d1c68d" />
