### PR TITLE
A11Y: improve Horizon markup for screenreaders

### DIFF
--- a/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
@@ -153,7 +153,10 @@ export default class HighContextTopicCard extends Component {
         </div>
         <div class="hc-topic-card__status-tags">
           {{#if this.hasSolved}}
-            <span class="hc-topic-card__status --solved">
+            <span
+              class="hc-topic-card__status --solved"
+              aria-label={{i18n (themePrefix "solved")}}
+            >
               {{#if this.capabilities.viewport.sm}}
                 {{i18n (themePrefix "solved")}}
               {{/if}}
@@ -167,6 +170,7 @@ export default class HighContextTopicCard extends Component {
                 "hc-topic-card__status"
                 this.statusBadge.className
               }}
+              aria-label={{i18n this.statusBadge.text}}
             >
               {{dIcon this.statusBadge.icon}}
 
@@ -181,7 +185,7 @@ export default class HighContextTopicCard extends Component {
       </div>
 
       <div class="hc-topic-card__content">
-        <div class="hc-topic-card__title">
+        <div class="hc-topic-card__title" role="heading" aria-level="2">
           <TopicStatus @topic={{@topic}} @context="topic-list" />
           <TopicLink
             {{on "focus" this.onTitleFocus}}
@@ -223,6 +227,9 @@ export default class HighContextTopicCard extends Component {
             {{#if this.assignedUser}}
               <div class="hc-topic-card__assigned">
                 {{dIcon "user-plus"}}
+                <span class="sr-only">{{i18n
+                    "discourse_assign.assigned_to"
+                  }}</span>
                 <span
                   class="hc-topic-card__assigned-name"
                 >{{this.assignedUser.username}}</span>
@@ -231,6 +238,9 @@ export default class HighContextTopicCard extends Component {
             {{#each this.indirectAssignees as |assignment|}}
               <div class="hc-topic-card__assigned">
                 {{dIcon "user-plus"}}
+                <span class="sr-only">{{i18n
+                    "discourse_assign.assigned_to"
+                  }}</span>
                 <span
                   class="hc-topic-card__assigned-name"
                 >{{assignment.user.username}}</span>

--- a/themes/horizon/javascripts/discourse/components/card/topic-creator-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-creator-column.gjs
@@ -11,7 +11,7 @@ export default class TopicCreatorColumn extends Component {
 
   <template>
     <div class={{this.topicCreator.class}}>
-      {{dAvatar this.topicCreator.user}}
+      {{dAvatar this.topicCreator.user imageSize="small"}}
     </div>
   </template>
 }

--- a/themes/horizon/javascripts/discourse/components/card/topic-likes-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-likes-column.gjs
@@ -1,8 +1,13 @@
+import { themePrefix } from "virtual:theme";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
 
 const TopicLikesColumn = <template>
   {{#if @topic.like_count}}
-    <span class="topic-likes">{{dIcon "heart"}}{{@topic.like_count}}</span>
+    <span
+      class="topic-likes"
+      aria-label={{i18n (themePrefix "like_count") count=@topic.like_count}}
+    >{{dIcon "heart"}}{{@topic.like_count}}</span>
   {{/if}}
 </template>;
 

--- a/themes/horizon/javascripts/discourse/components/card/topic-replies-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-replies-column.gjs
@@ -1,11 +1,14 @@
+import { themePrefix } from "virtual:theme";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dNumber from "discourse/ui-kit/helpers/d-number";
+import { i18n } from "discourse-i18n";
 
 const TopicRepliesColumn = <template>
   {{#if @topic.replyCount}}
-    <span class="topic-replies">{{dIcon "reply"}}{{dNumber
-        @topic.replyCount
-      }}</span>
+    <span
+      class="topic-replies"
+      aria-label={{i18n (themePrefix "reply_count") count=@topic.replyCount}}
+    >{{dIcon "reply"}}{{dNumber @topic.replyCount}}</span>
   {{/if}}
 </template>;
 


### PR DESCRIPTION
This adds some accessibility improvements to the custom topic list items in Horizon: 

* by default icons are decorative and not read, so we added labels for the like and reply icons so they're not read by screenreaders as bare numbers ("5") and will instead have context ("5 likes") 

* title wrapper gets `role="heading" aria-level="2"` to match core's `topic-cell.gjs` heading
  structure, easier to navigate by heading now 

* the hot/pinned icons on small screens where the text is hidden needed some aria-labels 

* assigned needed hidden "assigned to" text so it's not just a bare username being read 

* added `imageSize="small"` to dAvatar, not accessibility but width/height were undefined otherwise and we were getting too-big images that were resized with CSS