### PR TITLE
UX: Streaming placeholder and polish bot docked composer

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -72,16 +72,15 @@ export default class AiBotDockedComposer extends Component {
       return;
     }
 
-    const scrollFraction = (window.scrollY + window.innerHeight) / scrollH;
-    const below = scrollFraction < 0.85;
-    if (below !== this.hasContentBelow) {
-      this.hasContentBelow = below;
+    const distFromBottom = scrollH - window.scrollY - window.innerHeight;
+    const hasContentBelow = distFromBottom > 100;
+    if (hasContentBelow !== this.hasContentBelow) {
+      this.hasContentBelow = hasContentBelow;
     }
 
     // Two thresholds (show at 60px, hide at 140px) prevent the disclaimer
     // from toggling itself: appearing adds height, which shifts the scroll
     // position and would immediately hide it again in a loop on Firefox.
-    const distFromBottom = scrollH - window.scrollY - window.innerHeight;
     const nearBottom = this.atAbsoluteBottom
       ? distFromBottom <= 140
       : distFromBottom <= 60;
@@ -112,6 +111,11 @@ export default class AiBotDockedComposer extends Component {
       this.#placeholderEl?.style.setProperty(
         "--docked-composer-content-offset",
         `${offset}px`
+      );
+    } else {
+      composerEl.style.removeProperty("--docked-composer-content-offset");
+      this.#placeholderEl?.style.removeProperty(
+        "--docked-composer-content-offset"
       );
     }
   };
@@ -366,7 +370,9 @@ export default class AiBotDockedComposer extends Component {
       this.#pendingBotReplyTimeout = setTimeout(() => {
         this.pendingBotReply = false;
       }, 10000);
-      window.scrollTo({ top: document.documentElement.scrollHeight });
+      schedule("afterRender", () => {
+        window.scrollTo({ top: document.documentElement.scrollHeight });
+      });
       if (result.post?.post_number) {
         this.appEvents.trigger("discourse-ai:post-submitted", {
           topicId: this.topicId,

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -14,6 +14,7 @@ import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import { isGPTBot } from "../lib/ai-bot-helper";
 
 const DRAFT_KEY_PREFIX = "ai-bot-docked-draft-";
 
@@ -36,22 +37,82 @@ export default class AiBotDockedComposer extends Component {
 
   @tracked showToolbar = false;
   @tracked hasContentBelow = false;
+  @tracked atAbsoluteBottom = false;
   @tracked editingPost = null;
+  @tracked pendingBotReply = false;
 
   #composerApi = null;
   #resizeObserver = null;
   #keyboardOpen = false;
   #composerEl = null;
+  #placeholderEl = null;
+  #mutationObserver = null;
+  #streamEndObserver = null;
+  #pendingBotReplyTimeout = null;
 
   #checkScroll = () => {
-    const threshold = 100;
-    const below =
-      document.documentElement.scrollHeight -
-        window.scrollY -
-        window.innerHeight >
-      threshold;
+    // Must run before any early return so the value is always current.
+    if (this.#composerEl) {
+      document.documentElement.style.setProperty(
+        "--ai-docked-composer-height",
+        `${this.#composerEl.offsetHeight}px`
+      );
+    }
+
+    const scrollH = document.documentElement.scrollHeight;
+    const totalScrollable = scrollH - window.innerHeight;
+
+    if (totalScrollable <= 0) {
+      if (this.hasContentBelow) {
+        this.hasContentBelow = false;
+      }
+      if (!this.atAbsoluteBottom) {
+        this.atAbsoluteBottom = true;
+      }
+      return;
+    }
+
+    const scrollFraction = (window.scrollY + window.innerHeight) / scrollH;
+    const below = scrollFraction < 0.85;
     if (below !== this.hasContentBelow) {
       this.hasContentBelow = below;
+    }
+
+    // Two thresholds (show at 60px, hide at 140px) prevent the disclaimer
+    // from toggling itself: appearing adds height, which shifts the scroll
+    // position and would immediately hide it again in a loop on Firefox.
+    const distFromBottom = scrollH - window.scrollY - window.innerHeight;
+    const nearBottom = this.atAbsoluteBottom
+      ? distFromBottom <= 140
+      : distFromBottom <= 60;
+    if (nearBottom !== this.atAbsoluteBottom) {
+      this.atAbsoluteBottom = nearBottom;
+    }
+  };
+
+  #alignWithPost = () => {
+    const composerEl = this.#composerEl;
+    if (!composerEl) {
+      return;
+    }
+    const postContents = document.querySelector(".topic-post .contents");
+    const inner = composerEl.querySelector(".docked-composer__inner");
+    if (postContents && inner) {
+      const offset = Math.max(
+        0,
+        Math.round(
+          postContents.getBoundingClientRect().left -
+            inner.getBoundingClientRect().left
+        )
+      );
+      composerEl.style.setProperty(
+        "--docked-composer-content-offset",
+        `${offset}px`
+      );
+      this.#placeholderEl?.style.setProperty(
+        "--docked-composer-content-offset",
+        `${offset}px`
+      );
     }
   };
 
@@ -65,6 +126,7 @@ export default class AiBotDockedComposer extends Component {
       "--docked-composer-max-resize-offset",
       `${this.maxResizeOffset}px`
     );
+    this.#alignWithPost();
 
     if (!window.visualViewport) {
       return;
@@ -139,9 +201,103 @@ export default class AiBotDockedComposer extends Component {
     return Math.floor(window.innerHeight / 2);
   }
 
+  get botUser() {
+    return this.topic?.details?.allowed_users?.find(isGPTBot) ?? null;
+  }
+
+  get showPlaceholder() {
+    return this.isBotPm && this.pendingBotReply && !!this.botUser;
+  }
+
   @action
   toggleToolbar() {
     this.showToolbar = !this.showToolbar;
+  }
+
+  #swapPlaceholderForPost(postId) {
+    // data-post-id is the database ID; the DOM id uses post_number instead.
+    const postEl = document.querySelector(`[data-post-id="${postId}"]`);
+    if (!postEl) {
+      return false;
+    }
+    postEl.classList.add("ai-bot-streaming-placeholder");
+    if (this.#placeholderEl) {
+      this.#placeholderEl.style.display = "none";
+      this.#placeholderEl = null;
+    }
+    this.pendingBotReply = false;
+    return true;
+  }
+
+  @action
+  handleBotReplyStarted({ topicId, postId }) {
+    if (topicId !== this.topicId || !postId) {
+      return;
+    }
+    clearTimeout(this.#pendingBotReplyTimeout);
+    this.#pendingBotReplyTimeout = null;
+    if (this.#swapPlaceholderForPost(postId)) {
+      return;
+    }
+    // MutationObserver fires as a microtask (before paint); rAF would fire
+    // one frame later, briefly showing both the placeholder and real post.
+    this.#mutationObserver?.disconnect();
+    this.#mutationObserver = new MutationObserver(() => {
+      if (this.#swapPlaceholderForPost(postId)) {
+        this.#mutationObserver?.disconnect();
+        this.#mutationObserver = null;
+      }
+    });
+    this.#mutationObserver.observe(
+      document.querySelector(".topic-area") ?? document.body,
+      { childList: true, subtree: true }
+    );
+  }
+
+  @action
+  handleBotReplyFinished({ topicId, postId }) {
+    if (topicId !== this.topicId || !postId) {
+      return;
+    }
+    this.#streamEndObserver?.disconnect();
+    this.#streamEndObserver = null;
+
+    const postEl = document.querySelector(`[data-post-id="${postId}"]`);
+    if (!postEl) {
+      return;
+    }
+
+    const release = () => {
+      requestAnimationFrame(() => {
+        postEl.classList.remove("ai-bot-streaming-placeholder");
+      });
+    };
+
+    // PostUpdater removes .streaming ~40ms after data.done when morphdom
+    // finishes. Releasing min-height before that causes a mid-transition
+    // height jump as the natural content height changes under the animation.
+    if (!postEl.classList.contains("streaming")) {
+      release();
+      return;
+    }
+
+    this.#streamEndObserver = new MutationObserver(() => {
+      if (!postEl.classList.contains("streaming")) {
+        this.#streamEndObserver?.disconnect();
+        this.#streamEndObserver = null;
+        release();
+      }
+    });
+    this.#streamEndObserver.observe(postEl, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  }
+
+  @action
+  registerPlaceholder(element) {
+    this.#placeholderEl = element;
+    this.#alignWithPost();
   }
 
   @action
@@ -198,12 +354,27 @@ export default class AiBotDockedComposer extends Component {
     if (this.editingPost) {
       return this.#submitEdit(raw);
     }
-    return this.aiBotDockedSubmit.submitReply({
+    const result = await this.aiBotDockedSubmit.submitReply({
       topicId: this.topicId,
       raw,
       uploads,
       inProgressUploadsCount,
     });
+    if (result) {
+      this.pendingBotReply = true;
+      clearTimeout(this.#pendingBotReplyTimeout);
+      this.#pendingBotReplyTimeout = setTimeout(() => {
+        this.pendingBotReply = false;
+      }, 10000);
+      window.scrollTo({ top: document.documentElement.scrollHeight });
+      if (result.post?.post_number) {
+        this.appEvents.trigger("discourse-ai:post-submitted", {
+          topicId: this.topicId,
+          userPostNumber: result.post.post_number,
+        });
+      }
+    }
+    return result;
   }
 
   async #submitEdit(raw) {
@@ -235,12 +406,24 @@ export default class AiBotDockedComposer extends Component {
     window.addEventListener("scroll", this.#checkScroll, { passive: true });
     this.#resizeObserver = new ResizeObserver(this.#checkScroll);
     this.#resizeObserver.observe(document.body);
+    this.#resizeObserver.observe(element);
     this.#checkScroll();
+    this.#alignWithPost();
     window.visualViewport?.addEventListener("resize", this.#onViewportChange);
     window.visualViewport?.addEventListener("scroll", this.#onViewportChange);
     window.addEventListener("resize", this.#onViewportChange);
     this.appEvents.on("topic:edit-post", this, this.handleEditPost);
     this.appEvents.on("topic:quote-post", this, this.handleQuotePost);
+    this.appEvents.on(
+      "discourse-ai:bot-reply-started",
+      this,
+      this.handleBotReplyStarted
+    );
+    this.appEvents.on(
+      "discourse-ai:bot-reply-finished",
+      this,
+      this.handleBotReplyFinished
+    );
   }
 
   @action
@@ -258,8 +441,28 @@ export default class AiBotDockedComposer extends Component {
       this.#onViewportChange
     );
     window.removeEventListener("resize", this.#onViewportChange);
+    document.documentElement.style.removeProperty(
+      "--ai-docked-composer-height"
+    );
     this.appEvents.off("topic:edit-post", this, this.handleEditPost);
     this.appEvents.off("topic:quote-post", this, this.handleQuotePost);
+    this.appEvents.off(
+      "discourse-ai:bot-reply-started",
+      this,
+      this.handleBotReplyStarted
+    );
+    this.appEvents.off(
+      "discourse-ai:bot-reply-finished",
+      this,
+      this.handleBotReplyFinished
+    );
+    this.#mutationObserver?.disconnect();
+    this.#mutationObserver = null;
+    this.#streamEndObserver?.disconnect();
+    this.#streamEndObserver = null;
+    this.#placeholderEl = null;
+    clearTimeout(this.#pendingBotReplyTimeout);
+    this.#pendingBotReplyTimeout = null;
   }
 
   @action
@@ -271,6 +474,23 @@ export default class AiBotDockedComposer extends Component {
   }
 
   <template>
+    {{#if this.showPlaceholder}}
+      <div
+        class="ai-bot-reply-placeholder"
+        {{didInsert this.registerPlaceholder}}
+      >
+        <div class="ai-bot-reply-placeholder__row">
+          <div class="ai-bot-reply-placeholder__avatar">
+            {{dAvatar this.botUser imageSize="large"}}
+          </div>
+          <div class="ai-bot-reply-placeholder__body">
+            <span
+              class="ai-bot-reply-placeholder__username"
+            >{{this.botUser.username}}</span>
+          </div>
+        </div>
+      </div>
+    {{/if}}
     <DockedComposer
       @show={{this.isBotPm}}
       @class={{this.composerClass}}
@@ -362,9 +582,11 @@ export default class AiBotDockedComposer extends Component {
             {{/if}}
           </button>
         {{/if}}
-        <p class="ai-bot-docked-composer__disclaimer">
-          {{i18n "discourse_ai.ai_bot.conversations.disclaimer"}}
-        </p>
+        {{#if this.atAbsoluteBottom}}
+          <p class="ai-bot-docked-composer__disclaimer">
+            {{i18n "discourse_ai.ai_bot.conversations.disclaimer"}}
+          </p>
+        {{/if}}
       </:default>
     </DockedComposer>
   </template>

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
@@ -38,6 +38,33 @@ function attachHeaderIcon(api) {
 
 function initializeAIBotReplies(api) {
   const siteSettings = api.container.lookup("service:site-settings");
+  const appEvents = api.container.lookup("service:app-events");
+
+  function scrollUserPostToTopWhenReady(userPostNumber) {
+    let cancelled = false;
+    const cancel = () => {
+      cancelled = true;
+    };
+    appEvents.on("page:changed", cancel);
+
+    let attempts = 0;
+    function tryScroll() {
+      if (cancelled) {
+        return;
+      }
+      const el = document.querySelector(`#post_${userPostNumber}`);
+      if (el) {
+        appEvents.off("page:changed", cancel);
+        const top = el.getBoundingClientRect().top + window.scrollY - 10;
+        window.scrollTo({ top: Math.max(0, top) });
+      } else if (++attempts < 60) {
+        requestAnimationFrame(tryScroll);
+      } else {
+        appEvents.off("page:changed", cancel);
+      }
+    }
+    requestAnimationFrame(tryScroll);
+  }
 
   initializePauseButton(api);
 
@@ -76,8 +103,21 @@ function initializeAIBotReplies(api) {
 
       if (data?.done) {
         streamingState?.markFinishedAfterRender(topicId, data?.post_id);
+        if (siteSettings.ai_bot_enable_docked_composer) {
+          appEvents.trigger("discourse-ai:bot-reply-finished", {
+            topicId,
+            postId: data?.post_id,
+          });
+        }
       } else {
+        const isNewStream = !streamingState?.isStreamingForTopic(topicId);
         streamingState?.markStarted(topicId, data?.post_id);
+        if (isNewStream && siteSettings.ai_bot_enable_docked_composer) {
+          appEvents.trigger("discourse-ai:bot-reply-started", {
+            topicId,
+            postId: data?.post_id,
+          });
+        }
       }
 
       streamPostText(this.model.postStream, data);
@@ -121,6 +161,12 @@ function initializeAIBotReplies(api) {
       this.messageBus.unsubscribe("discourse-ai/ai-bot/topic/*");
       this._super();
     },
+  });
+
+  api.onAppEvent("discourse-ai:post-submitted", ({ userPostNumber }) => {
+    if (siteSettings.ai_bot_enable_docked_composer) {
+      scrollUserPostToTopWhenReady(userPostNumber);
+    }
   });
 
   // When a user triggers a reply on a bot PM (via the `r` shortcut, the

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
@@ -44,6 +44,7 @@ function initializeAIBotReplies(api) {
     let cancelled = false;
     const cancel = () => {
       cancelled = true;
+      appEvents.off("page:changed", cancel);
     };
     appEvents.on("page:changed", cancel);
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
@@ -1,6 +1,8 @@
 @use "lib/viewport";
 
 body.has-ai-bot-docked-composer {
+  --ai-bot-placeholder-height: 60vh;
+
   // hide the floating composer on bot PMs — the docked composer has
   // replaced it (including edits). Scoped to the body class, which is
   // only present while the DockedComposer component is rendered (cleared
@@ -23,6 +25,14 @@ body.has-ai-bot-docked-composer {
   .more-topics__container {
     display: none;
   }
+
+  // Lift the sticky topic-progress above the docked composer. No-op on
+  // desktop where .with-topic-progress is absent (timeline panel instead).
+  .with-topic-progress {
+    bottom: calc(
+      var(--ai-docked-composer-height, 0px) + env(safe-area-inset-bottom)
+    );
+  }
 }
 
 // AI-bot variant of the docked composer: align with the PM post body's
@@ -42,14 +52,12 @@ body.has-ai-bot-docked-composer {
 
   // ~4 lines tall by default; still expands further with content
   --docked-composer-input-min-height: 7em;
-
-  // Remove the spacing above the composer
-  padding-top: 0;
+  background: transparent;
+  padding: 0.75em 0 max(env(safe-area-inset-bottom), 0.5em);
   margin-top: 0;
 
-  // Hide the fade when already at the bottom — nothing is being obscured
-  // above the composer so the gradient adds no information.
-  &.docked-composer--at-bottom::before {
+  // Suppress the core ::before gradient.
+  &::before {
     display: none;
   }
 
@@ -97,7 +105,6 @@ body.has-ai-bot-docked-composer {
 .docked-composer.ai-bot-docked-composer .d-editor-textarea-wrapper {
   display: flex;
   flex-direction: column-reverse;
-  padding-top: 1em;
   border: var(--d-input-border);
   border-color: var(--content-border-color);
   border-radius: var(--d-input-border-radius);
@@ -134,7 +141,6 @@ body.has-ai-bot-docked-composer {
   max-height: 4em;
   opacity: 1;
   margin: 0;
-  padding-bottom: var(--space-3);
   padding-right: 3em;
   border-top: 1px solid var(--primary-low);
   border-radius: 0 0 var(--d-input-border-radius) var(--d-input-border-radius);
@@ -182,9 +188,13 @@ body.has-ai-bot-docked-composer {
   }
 }
 
-// Send button: vertically centered with toolbar icons.
+// Send button: smaller icon than core default (font-up-1 → font-down-1).
 .docked-composer.ai-bot-docked-composer .docked-composer__submit-btn.btn {
   bottom: var(--space-2);
+
+  .d-icon {
+    font-size: var(--font-down-1) !important;
+  }
 }
 
 .docked-composer.ai-bot-docked-composer .ai-bot-docked-composer__editing {
@@ -280,6 +290,59 @@ body.has-ai-bot-docked-composer {
   30% {
     transform: translateY(-4px);
     opacity: 1;
+  }
+}
+
+body.has-ai-bot-docked-composer
+  [data-user-id^="-"].ai-bot-streaming-placeholder {
+  animation: ai-bot-fade-in 0.3s ease-out;
+
+  .cooked {
+    min-height: var(--ai-bot-placeholder-height);
+  }
+}
+
+body.has-ai-bot-docked-composer [data-user-id^="-"] .cooked {
+  transition: min-height 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ai-bot-reply-placeholder {
+  --docked-composer-content-offset: 0px;
+  padding-left: var(--docked-composer-content-offset);
+  padding-bottom: 1em;
+  animation: ai-bot-fade-in 0.2s ease-out;
+
+  &__row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--topic-avatar-width, 45px);
+  }
+
+  &__avatar {
+    flex-shrink: 0;
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    min-height: var(--ai-bot-placeholder-height);
+    padding-top: 0.25em;
+  }
+
+  &__username {
+    font-weight: bold;
+    color: var(--primary-high);
+  }
+}
+
+@keyframes ai-bot-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
Previously, sending a message to an AI bot in a PM would leave a jarring gap before the bot's streamed reply appeared, and the docked composer had several small layout issues (wrong submit icon size, overlap with the native topic progress bar on mobile, stale content offset on viewport resize).

This change introduces a fake bot-post placeholder that appears immediately after submit (dismissed seamlessly when the real streaming post enters the DOM via `MutationObserver`), adds a smooth min-height collapse at end-of-stream, lifts the native topic-progress bar above the docked composer using a measured `--ai-docked-composer-height` CSS variable, and fixes the content-offset alignment resetting correctly across viewport sizes.


https://github.com/user-attachments/assets/de034f1b-0c7e-4938-99d5-5135840ad12b


