### PR TITLE
DEV: Fix a flake in credit_status_checker_spec

### DIFF
--- a/plugins/discourse-ai/spec/requests/ai_credits_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_credits_controller_spec.rb
@@ -64,7 +64,10 @@ RSpec.describe DiscourseAi::AiCreditsController do
             Fabricate(
               :ai_agent,
               default_llm_id: llm_model.id,
-              allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+              allowed_group_ids: [
+                Group::AUTO_GROUPS[:everyone],
+                Group::AUTO_GROUPS[:logged_in_users],
+              ],
             )
           Fabricate(:llm_credit_allocation, llm_model: llm_model, daily_credits: 1000)
 
@@ -81,7 +84,10 @@ RSpec.describe DiscourseAi::AiCreditsController do
           Fabricate(
             :ai_agent,
             default_llm_id: llm_model.id,
-            allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+            allowed_group_ids: [
+              Group::AUTO_GROUPS[:everyone],
+              Group::AUTO_GROUPS[:logged_in_users],
+            ],
           )
         end
 
@@ -150,7 +156,10 @@ RSpec.describe DiscourseAi::AiCreditsController do
           Fabricate(
             :ai_agent,
             default_llm_id: llm_model.id,
-            allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+            allowed_group_ids: [
+              Group::AUTO_GROUPS[:everyone],
+              Group::AUTO_GROUPS[:logged_in_users],
+            ],
           )
         end
 
@@ -203,7 +212,10 @@ RSpec.describe DiscourseAi::AiCreditsController do
           Fabricate(
             :ai_agent,
             default_llm_id: llm_model.id,
-            allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+            allowed_group_ids: [
+              Group::AUTO_GROUPS[:everyone],
+              Group::AUTO_GROUPS[:logged_in_users],
+            ],
           )
         end
         fab!(:llm_credit_allocation) do

--- a/plugins/discourse-ai/spec/services/discourse_ai/credit_status_checker_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/credit_status_checker_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DiscourseAi::CreditStatusChecker do
         Fabricate(
           :ai_agent,
           default_llm_id: llm_model.id,
-          allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+          allowed_group_ids: [Group::AUTO_GROUPS[:everyone], Group::AUTO_GROUPS[:logged_in_users]],
         )
       end
 
@@ -265,7 +265,7 @@ RSpec.describe DiscourseAi::CreditStatusChecker do
         Fabricate(
           :ai_agent,
           default_llm_id: llm_model.id,
-          allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+          allowed_group_ids: [Group::AUTO_GROUPS[:everyone], Group::AUTO_GROUPS[:logged_in_users]],
         )
       end
       fab!(:llm_credit_allocation) do


### PR DESCRIPTION
I believe these were missed in 475ff1b0fac46e0b0def6385faae2d4bce0eaadb.

Updated more `allowed_group_ids` to match.