### PR TITLE
DEV: Account for macports installs of postgres in TemporaryDB

### DIFF
--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -46,6 +46,12 @@ class TemporaryDb
       return @pg_bin_path = bin_path if File.exist?("#{bin_path}/pg_ctl")
     end
 
+    # macOS MacPorts: /opt/local/lib/postgresql{version}/bin
+    @versions.reverse_each do |v|
+      bin_path = "/opt/local/lib/postgresql#{v}/bin"
+      return @pg_bin_path = bin_path if File.exist?("#{bin_path}/pg_ctl")
+    end
+
     # Unversioned fallbacks — skipped when the caller pinned a version range.
     if @versions == VERSIONS
       bin_path = "/Applications/Postgres.app/Contents/Versions/latest/bin"


### PR DESCRIPTION
When creating the temp DB for structure.yml, we check for
postgres 15 or 16 versions. However, we were only checking
for postgres installed via the mac app, but not for postgres
installed via macports.

This commit adds the macports version check for pg_ctl
