### PR TITLE
DEV: make tests more robust

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -11,6 +11,7 @@ class Flag < ActiveRecord::Base
 
   before_save :set_position
   before_save :set_name_key
+  before_create :set_custom_id
   after_commit { reset_flag_settings! if !skip_reset_flag_callback }
 
   attr_accessor :skip_reset_flag_callback
@@ -68,6 +69,19 @@ class Flag < ActiveRecord::Base
   def set_name_key
     prefix = self.system? ? "" : "custom_"
     self.name_key = "#{prefix}#{self.name.squeeze(" ").gsub(" ", "_").gsub(/[^\w]/, "").downcase}"
+  end
+
+  def set_custom_id
+    return if self.id.present?
+
+    self.id = self.class.next_custom_id
+  end
+
+  def self.next_custom_id
+    loop do
+      next_id = DB.query_single("SELECT nextval('public.flags_id_seq')").first
+      return next_id if next_id > MAX_SYSTEM_FLAG_ID
+    end
   end
 end
 

--- a/db/migrate/20260518020440_set_flags_sequence_start.rb
+++ b/db/migrate/20260518020440_set_flags_sequence_start.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SetFlagsSequenceStart < ActiveRecord::Migration[8.0]
+  CUSTOM_FLAG_SEQUENCE_START = 1001
+
+  def up
+    execute <<~SQL
+      ALTER SEQUENCE public.flags_id_seq START WITH #{CUSTOM_FLAG_SEQUENCE_START};
+
+      SELECT setval(
+        'public.flags_id_seq',
+        GREATEST(
+          #{CUSTOM_FLAG_SEQUENCE_START - 1},
+          COALESCE((SELECT MAX(id) FROM public.flags), 0),
+          (SELECT last_value FROM public.flags_id_seq)
+        ),
+        true
+      );
+    SQL
+  end
+
+  def down
+    execute "ALTER SEQUENCE public.flags_id_seq START WITH 1"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4575,7 +4575,7 @@ CREATE TABLE public.flags (
 --
 
 CREATE SEQUENCE public.flags_id_seq
-    START WITH 1
+    START WITH 1001
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -20860,6 +20860,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260518020440'),
 ('20260514055648'),
 ('20260514043815'),
 ('20260513105516'),

--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -205,15 +205,26 @@ class TemporaryDb
 
   def create_user
     run_command!(
-      "createuser",
+      "psql",
       "-h",
       "localhost",
       "-p",
       pg_port.to_s,
-      "-s",
-      "-D",
+      "-d",
+      "postgres",
       "-w",
-      "discourse",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-c",
+      <<~SQL,
+        DO $$
+        BEGIN
+          IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'discourse') THEN
+            CREATE ROLE discourse SUPERUSER CREATEDB LOGIN;
+          END IF;
+        END
+        $$;
+      SQL
       error_prefix: "Failed to create temporary postgres superuser",
     )
   end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -16,6 +16,19 @@ RSpec.describe Flag, type: :model do
     flag.destroy!
   end
 
+  it "uses the custom id range when the sequence is stale" do
+    DB.exec("SELECT setval('public.flags_id_seq', 1, false)")
+
+    first_flag = Fabricate(:flag, name: "first custom flag")
+    second_flag = Fabricate(:flag, name: "second custom flag")
+
+    expect(first_flag.id).to be > Flag::MAX_SYSTEM_FLAG_ID
+    expect(second_flag.id).to eq(first_flag.id + 1)
+
+    first_flag.destroy!
+    second_flag.destroy!
+  end
+
   it "has correct name key" do
     flag = Fabricate(:flag, name: "FlAg!!!")
     expect(flag.name_key).to eq("custom_flag")


### PR DESCRIPTION
1. start sequence of custom flag  ids at 1000 -
 previously this was not reliable

This reserves a proper sequence and always sets it on create.

2. fix db structure create on systems that have a "discourse" user running

Previously this would explode trying to create a second discourse user
