### PR TITLE
FIX: Sync post flag action lookups

### DIFF
--- a/frontend/discourse/app/components/modal/flag.gjs
+++ b/frontend/discourse/app/components/modal/flag.gjs
@@ -128,7 +128,9 @@ export default class Flag extends Component {
   }
 
   get notifyModeratorsFlag() {
-    return this.flagsAvailable.find((f) => f.id === NOTIFY_MODERATORS_KEY);
+    return this.flagsAvailable.find(
+      (flag) => flag.name_key === NOTIFY_MODERATORS_KEY
+    );
   }
 
   get canTakeAction() {

--- a/frontend/discourse/app/lib/flag-targets/post-flag.js
+++ b/frontend/discourse/app/lib/flag-targets/post-flag.js
@@ -45,8 +45,8 @@ export default class PostFlag extends Flag {
   }
 
   postActionFor(flagModal) {
-    return flagModal.args.model.flagModel.actions_summary.find(
-      (item) => item.id === flagModal.selected.id
-    );
+    return flagModal.args.model.flagModel.actionByName[
+      flagModal.selected.name_key
+    ];
   }
 }

--- a/frontend/discourse/app/models/post.js
+++ b/frontend/discourse/app/models/post.js
@@ -772,6 +772,7 @@ export default class Post extends RestModel {
     if (json && json.id === this.id) {
       json = Post.munge(json);
       this.set("actions_summary", json.actions_summary);
+      this.set("actionByName", json.actionByName);
     }
   }
 

--- a/spec/system/flagging_post_spec.rb
+++ b/spec/system/flagging_post_spec.rb
@@ -82,6 +82,16 @@ describe "Flagging post" do
   end
 
   describe "As send a message to user" do
+    fab!(:custom_notify_flag, :flag) do
+      Fabricate(
+        :flag,
+        name: "Needs review",
+        description: "Custom moderator flag",
+        notify_type: true,
+        require_message: true,
+      )
+    end
+
     before do
       SiteSetting.allow_user_locale = true
       current_user.update!(locale: "en_GB")
@@ -99,6 +109,18 @@ describe "Flagging post" do
       flag_modal.confirm_flag
 
       expect(page).to have_content(I18n.t("js.post.actions.by_you.notify_user"))
+
+      topic_page.expand_post_actions(first_post)
+      topic_page.click_post_action_button(first_post, :flag)
+      flag_modal.choose_type(custom_notify_flag.name_key)
+
+      flag_modal.fill_message("This needs moderator attention.")
+
+      flag_modal.confirm_flag
+
+      topic_page.click_post_action_button(first_post, :flag)
+
+      expect(flag_modal).to have_no_choice("Notify moderators")
     end
   end
 

--- a/spec/system/page_objects/modals/flag.rb
+++ b/spec/system/page_objects/modals/flag.rb
@@ -32,6 +32,10 @@ module PageObjects
       def has_choices?(*choices)
         expect(body.all(".flag-action-type-details strong").map(&:text)).to eq(choices)
       end
+
+      def has_no_choice?(choice)
+        body.has_no_css?(".flag-action-type-details strong", text: choice)
+      end
     end
   end
 end


### PR DESCRIPTION
Submitting a custom-message flag could leave stale post action lookup state in the frontend. After the server refreshed the post action summary, unavailable flag controls could remain visible because the name-keyed action lookup was not refreshed with it.

This commit keeps the name-keyed action lookup in sync when post actions are refreshed, so unavailable notify flags are removed from the flag modal after a custom notify flag is submitted. It also resolves the notify moderators fallback by its stable action name instead of comparing a numeric ID to a string.