### PR TITLE
FIX: Watched word with invalid regex crashes markdown cook

### DIFF
--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -54,7 +54,20 @@ class WordWatcher
   end
 
   def self.regexps_for_action(action)
-    cached_words_for_action(action)&.to_h { |_, attrs| [word_to_regexp(attrs[:word]), attrs] }
+    words = cached_words_for_action(action)
+    return if words.blank?
+
+    words.each_with_object({}) do |(_, attrs), hash|
+      regexp = word_to_regexp(attrs[:word])
+      begin
+        Regexp.new(regexp)
+        hash[regexp] = attrs
+      rescue RegexpError => e
+        Rails.logger.warn(
+          "Watched word '#{attrs[:word]}' has invalid regex '#{regexp}' for #{action}: #{e.message}",
+        )
+      end
+    end
   end
 
   # This regexp is run in miniracer, and the client JS app

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -52,6 +52,34 @@ RSpec.describe WordWatcher do
     end
   end
 
+  describe ".regexps_for_action" do
+    before { SiteSetting.watched_words_regular_expressions = true }
+
+    it "maps valid words to their attrs and drops words whose regex is invalid" do
+      Fabricate(
+        :watched_word,
+        action: WatchedWord.actions[:replace],
+        word: "hello",
+        replacement: "hi",
+      )
+      Fabricate(:watched_word, action: WatchedWord.actions[:replace], word: "+1")
+
+      result = nil
+      fake_logger = track_log_messages { result = described_class.regexps_for_action(:replace) }
+
+      expect(result).to eq("(hello)" => { word: "hello", replacement: "hi", case_sensitive: false })
+      expect(fake_logger.warnings).to eq(
+        [
+          "Watched word '+1' has invalid regex '(+1)' for replace: target of repeat operator is not specified: /(+1)/",
+        ],
+      )
+    end
+
+    it "returns nil when no watched words exist for the action" do
+      expect(described_class.regexps_for_action(:replace)).to be_nil
+    end
+  end
+
   describe ".compiled_regexps_for_action" do
     let!(:word1) { Fabricate(:watched_word, action: WatchedWord.actions[:block]).word }
     let!(:word2) { Fabricate(:watched_word, action: WatchedWord.actions[:block]).word }


### PR DESCRIPTION
With the `watched_words_regular_expressions` site setting enabled, a single watched word whose pattern is an invalid regular expression (such as `+1`) caused every call to `PrettyText.cook` to raise, returning a 500 on every page that cooks markdown. `WordWatcher.regexps_for_action` handed unvalidated patterns to MiniRacer, where the JS side threw a `SyntaxError` that propagated back to Rails.

This commit validates each pattern with `Regexp.new` inside `WordWatcher.regexps_for_action` and drops entries that fail to parse, mirroring the existing guard in `WordWatcher.compiled_regexps_for_action`.