### PR TITLE
DEV: Persist flags_id_seq start value in structure.sql

### DIFF
--- a/db/migrate/20260518054805_fix_flags_id_seq_start.rb
+++ b/db/migrate/20260518054805_fix_flags_id_seq_start.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FixFlagsIdSeqStart < ActiveRecord::Migration[8.0]
+  MAX_SYSTEM_FLAG_ID = 1000
+
+  def up
+    execute "ALTER SEQUENCE flags_id_seq START WITH #{MAX_SYSTEM_FLAG_ID + 1}"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4575,7 +4575,7 @@ CREATE TABLE public.flags (
 --
 
 CREATE SEQUENCE public.flags_id_seq
-    START WITH 1
+    START WITH 1001
     INCREMENT BY 1
     NO MINVALUE
     NO MAXVALUE
@@ -20860,6 +20860,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260518054805'),
 ('20260514055648'),
 ('20260514043815'),
 ('20260513105516'),


### PR DESCRIPTION
The original `CreateFlags` migration bumped `flags_id_seq` to 1001 via `setval` so non-system flags get IDs >= 1001, reserving 1-999 for system flags.

`pg_dump --schema-only` (which Rails uses to generate `structure.sql`) captures the sequence's `seqstart` metadata but omits runtime `setval` calls. As a result, fresh installs provisioned from `structure.sql` saw the sequence start at 1 instead of 1001.

This migration uses `ALTER SEQUENCE ... START WITH` to update the sequence's metadata so the value is preserved in subsequent `structure.sql` dumps. `RESTART` is intentionally omitted: existing sites may already have `last_value` well past 1001, and rewinding would cause id collisions on the next insert.