### PR TITLE
DEV: Add Discourse BEM guidelines agent skill

### DIFF
--- a/.skills/discourse-bem-guidelines/SKILL.md
+++ b/.skills/discourse-bem-guidelines/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: discourse-bem-guidelines
+description: Use when applying Discourse's BEM guidelines for CSS class naming, modifiers, state classes, and selector structure in core, themes, theme components, or plugins.
+---
+
+# Discourse BEM Guidelines
+
+Use this skill when naming or reviewing CSS classes in Discourse core, bundled plugins, themes, and theme components.
+
+Before adding or changing CSS class names, read the [Discourse CSS and BEM guidelines](https://github.com/discourse/discourse/blob/main/docs/developer-guides/docs/03-code-internals/25-css-guidelines-bem.md) and apply those conventions.

--- a/.skills/discourse-bem-guidelines/SKILL.md
+++ b/.skills/discourse-bem-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discourse-bem-guidelines
-description: Use when applying Discourse's BEM guidelines for CSS class naming, modifiers, state classes, and selector structure in core, themes, theme components, or plugins.
+description: Use when adding, changing, or reviewing CSS class names and selectors in Discourse components, templates, stylesheets, themes, theme components, or plugins.
 ---
 
 # Discourse BEM Guidelines


### PR DESCRIPTION
This commit adds a focused core agent skill for applying Discourse's BEM class naming guidelines.

The skill points agents to the canonical CSS and BEM guide instead of duplicating those guidelines inline. This keeps the reusable skill lightweight while making the source of truth clear for CSS class naming, modifiers, state classes, and selector structure.