### PR TITLE
FIX: preserve Zendesk webhook email attribution

### DIFF
--- a/plugins/discourse-zendesk-plugin/app/controllers/discourse_zendesk_plugin/sync_controller.rb
+++ b/plugins/discourse-zendesk-plugin/app/controllers/discourse_zendesk_plugin/sync_controller.rb
@@ -25,7 +25,6 @@ module DiscourseZendeskPlugin
       raise Discourse::InvalidParameters.new(:topic_id) if topic.blank?
       return if !DiscourseZendeskPlugin::Helper.autogeneration_category?(topic.category_id)
 
-      user = User.find_by_email(params[:email]) || Discourse.system_user
       latest_comment = get_latest_comment(ticket_id)
       if latest_comment.present?
         existing_comment =
@@ -35,6 +34,7 @@ module DiscourseZendeskPlugin
           ).first
 
         if existing_comment.blank?
+          user = User.find_by_email(params[:email]) || Discourse.system_user
           post = topic.posts.create!(user: user, raw: latest_comment.body)
           update_post_custom_fields(post, latest_comment)
         end

--- a/plugins/discourse-zendesk-plugin/spec/requests/sync_controller_spec.rb
+++ b/plugins/discourse-zendesk-plugin/spec/requests/sync_controller_spec.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseZendeskPlugin::SyncController do
+  fab!(:category)
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:webhook_user, :user)
+
   describe "#webhook" do
-    let!(:token) { "secret-token" }
-    let!(:topic) { Fabricate(:topic) }
+    let(:token) { "secret-token" }
+    let(:ticket_id) { 12 }
+    let(:zendesk_url_default) { "https://your-url.zendesk.com/api/v2" }
+    let(:default_header) { { "Content-Type" => "application/json; charset=UTF-8" } }
+    let(:comment_id) { 321 }
+    let(:comment_body) { "trusted zendesk comment" }
+    let(:comment_response) do
+      { comments: [{ id: comment_id, body: comment_body, public: true }] }.to_json
+    end
 
     before do
       SiteSetting.zendesk_enabled = true
@@ -40,13 +51,37 @@ RSpec.describe DiscourseZendeskPlugin::SyncController do
 
     it "raises an error when topic is not present" do
       topic.destroy!
-      put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: 12 }
+      put "/zendesk-plugin/sync.json",
+          params: {
+            token: token,
+            topic_id: topic.id,
+            ticket_id: ticket_id,
+          }
       expect(response.status).to eq(400)
     end
 
-    it "returns 204 when the request succeeds" do
-      put "/zendesk-plugin/sync.json", params: { token: token, topic_id: topic.id, ticket_id: 12 }
+    it "attributes the synced comment to the authenticated webhook email" do
+      SiteSetting.zendesk_autogenerate_categories = category.id.to_s
+      stub_request(:get, "#{zendesk_url_default}/tickets/#{ticket_id}/comments").to_return(
+        status: 200,
+        body: comment_response,
+        headers: default_header,
+      )
+
+      expect {
+        put "/zendesk-plugin/sync.json",
+            params: {
+              token: token,
+              topic_id: topic.id,
+              ticket_id: ticket_id,
+              email: webhook_user.email,
+            }
+      }.to change { topic.reload.posts.count }.by(1)
+
       expect(response.status).to eq(204)
+      expect(response.body).to be_blank
+      expect(topic.reload.posts.last.raw).to eq(comment_body)
+      expect(topic.posts.last.user).to eq(webhook_user)
     end
   end
 end


### PR DESCRIPTION
Previously, Zendesk sync resolved the webhook `email` before checking whether the incoming comment needed to create a new post, and the intended attribution behavior was not covered by a request spec.

This change moves that lookup to the post creation path and adds coverage confirming that a valid Zendesk webhook with a matching `email` creates the synced comment as that Discourse user.