### PR TITLE
MT: Import `archived` state for topics in generic bulk importer

### DIFF
--- a/script/bulk_import/base.rb
+++ b/script/bulk_import/base.rb
@@ -723,6 +723,7 @@ class BulkImport::Base
     category_id
     visible
     closed
+    archived
     pinned_at
     pinned_until
     pinned_globally

--- a/script/bulk_import/generic_bulk.rb
+++ b/script/bulk_import/generic_bulk.rb
@@ -853,6 +853,7 @@ class BulkImport::Generic < BulkImport::Base
         created_at: to_datetime(row["created_at"]),
         category_id: category_id,
         closed: to_boolean(row["closed"]),
+        archived: to_boolean(row["archived"]),
         views: row["views"],
         subtype: row["subtype"],
         pinned_at: to_datetime(row["pinned_at"]),


### PR DESCRIPTION
The intermediate database's `topics.archived` column was being ignored, so all imported topics ended up unarchived regardless of source state.