### PR TITLE
FIX: Don't emit tag names/slugs in topic tracking state

### DIFF
--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -354,7 +354,7 @@ class TopicTrackingState
           #{sql}
         )
         SELECT *, (
-          SELECT JSON_AGG(JSON_BUILD_OBJECT('id', tags.id, 'name', tags.name, 'slug', tags.slug))
+          SELECT JSON_AGG(JSON_BUILD_OBJECT('id', tags.id))
           FROM topic_tags
           JOIN tags ON tags.id = topic_tags.tag_id
           WHERE topic_id = tags_included_cte.topic_id

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -761,7 +761,9 @@ RSpec.describe TopicTrackingState do
       report = TopicTrackingState.report(user)
       expect(report.length).to eq(1)
       row = report[0]
-      expect(row.tags.map { |t| t["name"] }).to contain_exactly("apples", "bananas")
+      expect(row.tags.map { |t| t["id"] }).to contain_exactly(
+        *Tag.where(name: %w[apples bananas]).pluck(:id),
+      )
     end
   end
 

--- a/spec/serializers/topic_tracking_state_item_serializer_spec.rb
+++ b/spec/serializers/topic_tracking_state_item_serializer_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe TopicTrackingStateItemSerializer do
     report = TopicTrackingState.report(user)
     serialized = described_class.new(report[0], scope: Guardian.new(user), root: false).as_json
 
-    expect(serialized[:tags].map { |t| t["name"] }).to contain_exactly("bananas", "apples")
+    expect(serialized[:tags].map { |t| t["id"] }).to contain_exactly(
+      *Tag.where(name: %w[bananas apples]).pluck(:id),
+    )
   end
 end


### PR DESCRIPTION
`TopicTrackingState.report` aggregates the tags on each tracked topic into a JSON array via [`JSON_AGG`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/app/models/topic_tracking_state.rb#L357), emitting `id`, `name`, and `slug` for every tag with no visibility filter. Topic visibility and tag visibility are independent in Discourse: a user can be allowed to see a topic while being restricted from one of its tags. [Standard topic serializers](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/app/serializers/concerns/topic_tags_mixin.rb#L57) filter via [`Topic#visible_tags`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/app/models/topic.rb#L2201-L2203) and [`guardian.hidden_tag_names`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/lib/guardian/tag_guardian.rb#L44-L49), but the tracking-state path did not, leaking hidden tag names and slugs to non-staff users for any topic that was new or unread for them.

This commit drops `name` and `slug` from the `JSON_AGG` in `tags_included_wrapped_sql`, leaving only `id`. The client only reads [`tag.id`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/frontend/discourse/app/models/topic-tracking-state.js#L614) from these payloads, and the existing MessageBus publish paths ([`publish_new`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/app/models/topic_tracking_state.rb#L54), [`publish_latest`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/app/models/topic_tracking_state.rb#L73), [`publish_unread`](https://github.com/discourse/discourse/blob/a0a86b014e6ba8a0b80cc0ecf6d4b04a17d9146b/app/models/topic_tracking_state.rb#L163)) already emit id-only tag objects. Since the names and slugs are no longer fetched from the database, they cannot be sent to the client. This avoids adding a new visibility filter on a query that runs on every authenticated page load.

The JOIN to `tags` is kept so orphaned `topic_tags` rows (the table has no DB-level foreign key, only Rails `dependent: :destroy`) do not surface in the payload.