### PR TITLE
PERF: Avoid re-compiling system themes during db:seed

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -87,13 +87,15 @@ class RemoteTheme < ActiveRecord::Base
   def self.import_theme_from_directory(
     directory,
     theme_id: nil,
-    allow_out_of_sequence_migration: false
+    allow_out_of_sequence_migration: false,
+    before_save: nil
   )
     update_theme(
       ThemeStore::DirectoryImporter.new(directory),
       update_components: "none",
       theme_id: theme_id,
       allow_out_of_sequence_migration: allow_out_of_sequence_migration,
+      before_save: before_save,
     )
   end
 
@@ -103,7 +105,8 @@ class RemoteTheme < ActiveRecord::Base
     theme_id: nil,
     update_components: nil,
     run_migrations: true,
-    allow_out_of_sequence_migration: false
+    allow_out_of_sequence_migration: false,
+    before_save: nil
   )
     importer.import!
 
@@ -139,6 +142,7 @@ class RemoteTheme < ActiveRecord::Base
         already_in_transaction: true,
         run_migrations:,
         allow_out_of_sequence_migration:,
+        before_save: before_save,
       )
 
       if existing && update_components.present? && update_components != "none"
@@ -244,7 +248,8 @@ class RemoteTheme < ActiveRecord::Base
     raise_if_theme_save_fails: true,
     already_in_transaction: false,
     run_migrations: true,
-    allow_out_of_sequence_migration: false
+    allow_out_of_sequence_migration: false,
+    before_save: nil
   )
     cleanup = false
 
@@ -389,6 +394,8 @@ class RemoteTheme < ActiveRecord::Base
       update_theme_color_schemes(theme, theme_info["color_schemes"]) unless theme.component
 
       self.save!
+
+      before_save&.call(theme)
 
       if raise_if_theme_save_fails
         theme.save!

--- a/lib/system_themes_manager.rb
+++ b/lib/system_themes_manager.rb
@@ -13,21 +13,20 @@ class SystemThemesManager
 
     is_initial_install = !Theme.exists?(id: theme_id)
 
+    before_save =
+      if is_initial_install && theme_id == Theme::CORE_THEMES["horizon"]
+        ->(t) { t.dark_color_scheme = t.color_schemes.find { |s| s.name == "Horizon Dark" } }
+      end
+
     theme =
       RemoteTheme.import_theme_from_directory(
         theme_dir,
         theme_id: theme_id,
         allow_out_of_sequence_migration: !is_initial_install,
+        before_save: before_save,
       )
-    theme.update_column(:enabled, true)
 
-    if is_initial_install
-      if theme_id == Theme::CORE_THEMES["horizon"]
-        theme.update!(dark_color_scheme: theme.color_schemes.find_by(name: "Horizon Dark"))
-      end
-    end
-
-    theme.save!
+    theme.update_column(:enabled, true) unless theme.enabled?
 
     Stylesheet::Manager.clear_theme_cache!
   end


### PR DESCRIPTION
Themes were being saved/compiled three times on the first call to `SystemThemesManager.sync_theme!`

- Once as part of the `RemoteTheme.import...` call

- A second time when the dark_color_scheme id was updated

- A third time when `theme.save!` was called

The color-scheme-related one is replaced with a new `before_save` hook on the importer. This way, the custom logic can be performed before the first `.save`.

The separate `theme.save!` was unnecessary, so it's removed.

In local tests, this drops clean-slate `SystemThemesManager.sync!` runtime from ~4s to ~2.5s (~37%)