### PR TITLE
UX: consistent "more emoji" icon, fix reactions styles in modernized foundation

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -39,7 +39,8 @@
       .back-button,
       .composer-actions-btn,
       .language-switcher-trigger,
-      .d-multi-select-trigger__expand-btn
+      .d-multi-select-trigger__expand-btn,
+      .emoji-picker-trigger
     ) {
       padding-block: 0;
       height: var(--d-control-height);
@@ -55,7 +56,8 @@
       .user-menu-tab-active,
       .composer-actions-btn,
       .dropdown-select-box-header,
-      .d-multi-select-trigger__expand-btn
+      .d-multi-select-trigger__expand-btn,
+      .emoji-picker-trigger
     ) {
       width: var(--d-control-height);
     }

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
@@ -184,7 +184,7 @@ export default class DiscourseReactionsPicker extends Component {
           {{#if this.siteSettings.discourse_reactions_allow_any_emoji}}
             <EmojiPicker
               ...attributes
-              @icon="far-face-smile"
+              @icon="discourse-emojis"
               @context="discourse-reactions"
               @didSelectEmoji={{this.onSelectEmoji}}
               @onShow={{this.preventCollapse}}

--- a/plugins/discourse-reactions/assets/stylesheets/common/discourse-reactions.scss
+++ b/plugins/discourse-reactions/assets/stylesheets/common/discourse-reactions.scss
@@ -286,6 +286,15 @@ html.discourse-reactions-no-select {
     display: grid;
     gap: 0.25em;
 
+    .emoji-picker-trigger {
+      gap: 0;
+
+      .d-icon {
+        width: 1.25em;
+        height: 1.25em;
+      }
+    }
+
     @for $i from 1 through 8 {
       &.col-#{$i} {
         grid-template-columns: repeat($i, 1fr);
@@ -299,7 +308,7 @@ html.discourse-reactions-no-select {
     margin: 0.25em !important;
     border: 1px solid transparent !important;
     cursor: not-allowed;
-    border-radius: 8px;
+    border-radius: var(--d-border-radius);
 
     .emoji {
       pointer-events: none;
@@ -324,7 +333,8 @@ html.discourse-reactions-no-select {
     }
 
     &.is-used {
-      border-color: var(--tertiary-low) !important;
+      border-color: var(--d-selected) !important;
+      background-color: var(--d-selected);
     }
   }
 }


### PR DESCRIPTION
In notifications and in chat we use the custom `discourse-emojis` icon to indicate "any emoji", so we should do the same thing in reactions when "allow any reaction" is enabled. 

There were also some minor style regressions from the "modernized foundation" upcoming change, and I've hooked up a d-selected color and border-radius variable for more consistency. 

Before:
<img width="245"  alt="image" src="https://github.com/user-attachments/assets/5a449018-66ef-4bad-9027-dd34d39e0d71" />


After: 
<img width="375" alt="image" src="https://github.com/user-attachments/assets/693f9469-d9a2-49d4-a3bb-1996938179c8" />
