### PR TITLE
FIX: Use `bumped_at` instead of `updated_at` for `TopicQuery#apply_max_age_limit`

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -1338,7 +1338,7 @@ class TopicQuery
 
       # perf note, in the past we tried doing this in a subquery but performance was
       # terrible, also tried with a join and it was bad
-      results = results.where("topics.updated_at >= ?", unread_at)
+      results = results.where("topics.bumped_at >= ?", unread_at)
     end
     results
   end

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1921,8 +1921,8 @@ RSpec.describe TopicQuery do
           fully_read_archived.archived = true
           fully_read_archived.save
 
-          old_partially_read.update!(updated_at: 2.weeks.ago)
-          partially_read.update!(updated_at: Time.now)
+          old_partially_read.update!(bumped_at: 2.weeks.ago)
+          partially_read.update!(bumped_at: Time.now)
         end
 
         it "operates correctly" do


### PR DESCRIPTION
Customer reported that very old topics were leaking in suggested topics when they shouldn't. This is because updated_at can be bumped by things that aren't visible to the user. Switching to `bumped_at` should solve.