### PR TITLE
UX: don't include OP in "me too" shared issue counter

### DIFF
--- a/plugins/discourse-solved/app/models/discourse_solved/shared_issue.rb
+++ b/plugins/discourse-solved/app/models/discourse_solved/shared_issue.rb
@@ -11,7 +11,7 @@ module DiscourseSolved
     validates :user_id, presence: true
 
     def self.count_for(topic)
-      where(topic: topic).count + 1 # topic author is implicitly counted
+      where(topic: topic).count
     end
   end
 end

--- a/plugins/discourse-solved/assets/javascripts/discourse/components/solved-shared-issue-button.gjs
+++ b/plugins/discourse-solved/assets/javascripts/discourse/components/solved-shared-issue-button.gjs
@@ -22,7 +22,7 @@ export default class SolvedSharedIssueButton extends Component {
   }
 
   get count() {
-    return this.args.post.topic.shared_issue_count ?? 1;
+    return this.args.post.topic.shared_issue_count ?? 0;
   }
 
   get hasSharedIssue() {
@@ -38,6 +38,9 @@ export default class SolvedSharedIssueButton extends Component {
   }
 
   get label() {
+    if (this.count === 0) {
+      return i18n("solved.shared_issue.label_zero");
+    }
     return i18n("solved.shared_issue.label", { count: this.count });
   }
 

--- a/plugins/discourse-solved/config/locales/client.en.yml
+++ b/plugins/discourse-solved/config/locales/client.en.yml
@@ -60,6 +60,7 @@ en:
       confirm_solved_removal_cancel: "Cancel"
 
       shared_issue:
+        label_zero: "Me too"
         label:
           one: "Me too (%{count})"
           other: "Me too (%{count})"

--- a/plugins/discourse-solved/spec/requests/discourse_solved/shared_issue_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/discourse_solved/shared_issue_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe DiscourseSolved::SharedIssueController do
         }.by(1)
         expect(response.status).to eq(200)
         body = response.parsed_body
-        expect(body["count"]).to eq(2)
+        expect(body["count"]).to eq(1)
         expect(body["user_created_shared_issue"]).to eq(true)
       end
 

--- a/plugins/discourse-solved/spec/services/discourse_solved/shared_issue/toggle_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/shared_issue/toggle_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe DiscourseSolved::SharedIssue::Toggle do
       it "publishes a shared issue message indicating the user created a shared issue" do
         expect(messages).to include(
           an_object_having_attributes(
-            data: a_hash_including(type: :shared_issue, count: 2, user_created_shared_issue: true),
+            data: a_hash_including(type: :shared_issue, count: 1, user_created_shared_issue: true),
           ),
         )
       end
@@ -172,7 +172,7 @@ RSpec.describe DiscourseSolved::SharedIssue::Toggle do
       it "publishes a shared issue message indicating the user withdrew their shared issue" do
         expect(messages).to include(
           an_object_having_attributes(
-            data: a_hash_including(type: :shared_issue, count: 1, user_created_shared_issue: false),
+            data: a_hash_including(type: :shared_issue, count: 0, user_created_shared_issue: false),
           ),
         )
       end

--- a/plugins/discourse-solved/spec/system/page_objects/components/post_shared_issue_button.rb
+++ b/plugins/discourse-solved/spec/system/page_objects/components/post_shared_issue_button.rb
@@ -31,7 +31,8 @@ module PageObjects
       end
 
       def has_count?(count)
-        within_post { has_css?(SELECTOR, text: "Me too (#{count})") }
+        label = count.zero? ? "Me too" : "Me too (#{count})"
+        within_post { has_css?(SELECTOR, exact_text: label) }
       end
 
       private

--- a/plugins/discourse-solved/spec/system/shared_issue_spec.rb
+++ b/plugins/discourse-solved/spec/system/shared_issue_spec.rb
@@ -31,10 +31,10 @@ describe "Solved | Shared issue button" do
     topic_page.visit_topic(topic)
 
     expect(shared_issue_button).to have_shared_issue_button
-    expect(shared_issue_button).to have_count(1)
+    expect(shared_issue_button).to have_count(0)
 
     shared_issue_button.click
-    expect(shared_issue_button).to have_count(2)
+    expect(shared_issue_button).to have_count(1)
     expect(shared_issue_button).to have_active
 
     expect(TopicUser.get(topic, member).notification_level).to eq(
@@ -42,7 +42,7 @@ describe "Solved | Shared issue button" do
     )
 
     shared_issue_button.click
-    expect(shared_issue_button).to have_count(1)
+    expect(shared_issue_button).to have_count(0)
     expect(shared_issue_button).to have_no_css(".has-shared-issue")
   end
 
@@ -108,6 +108,6 @@ describe "Solved | Shared issue button" do
 
     expect(shared_issue_button).to have_shared_issue_button
     expect(shared_issue_button).to have_read_only
-    expect(shared_issue_button).to have_count(1)
+    expect(shared_issue_button).to have_count(0)
   end
 end


### PR DESCRIPTION
This removes the topic author from the count of the "me too" button when `Enable solved shared issues` is enabled. This is based on some feedback in https://meta.discourse.org/t/solved-improvements-allowing-members-to-indicate-theyre-experiencing-a-reported-issue/402498

Now when the topic is created the counter starts at 0. 

Before:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/cefb5a84-beb6-4637-95b7-b05d9989b98b" />


<img width="400"  alt="image" src="https://github.com/user-attachments/assets/a0154f0b-a66a-436a-aa1a-30ca1956dada" />




After: 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9b633da3-f7a9-4541-8813-d2721af5efef" />

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/24274b52-0a23-4157-b8e2-6b793ec78324" />
