### PR TITLE
UX: use header text color in impersonation notice

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -569,13 +569,11 @@ $mobile-avatar-height: 1.532em;
 
 .impersonation-notice {
   background-color: var(--header_background);
+  color: var(--header_primary);
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px;
+  padding: var(--space-2);
   text-align: center;
-
-  button {
-    margin-left: 10px;
-  }
+  gap: var(--space-2);
 }


### PR DESCRIPTION
Noticed the color was off here when the header has colors different from the page body.

I also wired up some common variables here while I was at it and switched a margin to gap. 


Before:
<img width="1120" height="270" alt="image" src="https://github.com/user-attachments/assets/9f6bda51-23ad-464c-82d4-0fceea0846c0" />


After:
<img width="1242" height="230" alt="image" src="https://github.com/user-attachments/assets/93312967-c677-4333-b8ce-47143f1f269f" />
