### PR TITLE
DEV: Remove unnecessary TranslationOverride.delete_all in specs

### DIFF
--- a/spec/requests/admin/email_templates_controller_spec.rb
+++ b/spec/requests/admin/email_templates_controller_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe Admin::EmailTemplatesController do
   let(:original_body) { original_text("user_notifications.admin_login.text_body_template") }
   let(:headers) { { ACCEPT: "application/json" } }
 
-  after do
-    TranslationOverride.delete_all
-    I18n.reload!
-  end
+  after { I18n.reload! }
 
   describe "#index" do
     context "when logged in as an admin" do

--- a/spec/requests/admin/site_texts_controller_spec.rb
+++ b/spec/requests/admin/site_texts_controller_spec.rb
@@ -6,10 +6,7 @@ RSpec.describe Admin::SiteTextsController do
   fab!(:user)
   let(:locale) { I18n.locale }
 
-  after do
-    TranslationOverride.delete_all
-    I18n.reload!
-  end
+  after { I18n.reload! }
 
   describe "#index" do
     context "when logged in as an admin" do

--- a/spec/system/admin_site_texts_spec.rb
+++ b/spec/system/admin_site_texts_spec.rb
@@ -7,10 +7,7 @@ describe "Admin Site Texts Page" do
 
   before { sign_in(admin) }
 
-  after do
-    TranslationOverride.delete_all
-    I18n.reload!
-  end
+  after { I18n.reload! }
 
   it "can search for client text using the default locale" do
     site_texts_page.visit

--- a/spec/system/admin_welcome_banner_config_spec.rb
+++ b/spec/system/admin_welcome_banner_config_spec.rb
@@ -9,10 +9,7 @@ describe "Admin Welcome Banner Config" do
     SiteSetting.allow_user_locale = true
   end
 
-  after do
-    TranslationOverride.delete_all
-    I18n.reload!
-  end
+  after { I18n.reload! }
 
   describe "locale selector" do
     it "displays a locale selector" do

--- a/spec/system/welcome_banner_spec.rb
+++ b/spec/system/welcome_banner_spec.rb
@@ -10,10 +10,7 @@ describe "Welcome banner" do
       Fabricate(:theme_site_setting_with_service, name: "enable_welcome_banner", value: true)
     end
 
-    after do
-      TranslationOverride.delete_all
-      I18n.reload!
-    end
+    after { I18n.reload! }
 
     it "shows for logged in and anonymous users" do
       visit "/"


### PR DESCRIPTION
This possibly led to some db transaction-related flakes.