### PR TITLE
FIX: Apply embed mode to nested replies view

### DIFF
--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -19,6 +19,8 @@ body.embed-mode {
   .suggested-topics,
   .more-topics__container,
   #topic-title,
+  .nested-view__header,
+  .nested-view__topic-map,
   .topic-above-footer-buttons-outlet.presence,
   .above-main-container-outlet,
   .topic-footer-main-buttons__actions .toggle-admin-menu,
@@ -165,12 +167,20 @@ body.embed-mode {
 
   // Hide OP
   // Use visibility hidden to prevent issues with jumpy behavior
-  .post-stream .topic-post.topic-owner:first-child {
+  .post-stream .topic-post.topic-owner:first-child,
+  .nested-view__op {
     opacity: 0;
     height: 0;
     visibility: hidden;
     position: absolute;
     pointer-events: none;
+  }
+
+  // Drop the nested-view's outer framing so it sits flush in the iframe
+  .nested-view {
+    padding: 0;
+    background: transparent;
+    border-radius: 0;
   }
 
   .embed-mode-composer {

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -185,9 +185,10 @@ class TopicsController < ApplicationController
          !@topic_view.topic.private_message? &&
          (@topic_view.topic.nested_topic.present? || SiteSetting.nested_replies_default) &&
          params[:flat] != "1"
-      url = "/n/#{@topic_view.topic.slug}/#{@topic_view.topic.id}"
+      url = +"/n/#{@topic_view.topic.slug}/#{@topic_view.topic.id}"
       post_number = opts[:post_number].to_i
       url << "/#{post_number}" if post_number > 0
+      url << "?embed_mode=true" if params[:embed_mode] == "true"
       redirect_to url, status: :found
       return
     end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3063,6 +3063,15 @@ RSpec.describe TopicsController do
       expect(response).not_to redirect_to("/n/#{pm.slug}/#{pm.id}")
     end
 
+    it "preserves embed_mode when redirecting to nested view" do
+      SiteSetting.nested_replies_enabled = true
+      SiteSetting.nested_replies_default = true
+
+      get "/t/#{topic.slug}/#{topic.id}", params: { embed_mode: "true" }
+
+      expect(response).to redirect_to("/n/#{topic.slug}/#{topic.id}?embed_mode=true")
+    end
+
     it "returns 404 when an invalid slug is given and no id" do
       get "/t/nope-nope.json"
 


### PR DESCRIPTION
Previously, embedding a topic with nested replies via `embed_full_app` did not work correctly: the redirect from `/t/...` to `/n/...` dropped the `embed_mode=true` query param, and even if preserved the nested view's title, OP, and topic map were not hidden because they use a different DOM than the flat view.

This change preserves `embed_mode` across the nested redirect and extends `embed-mode.scss` to hide the `.nested-view` header/OP/topic-map and drop its outer framing, so the embed renders flush and focused on replies.