### PR TITLE
FIX: Allow staff to view deleted topics in nested replies

### DIFF
--- a/lib/nested_replies/tree_loader.rb
+++ b/lib/nested_replies/tree_loader.rb
@@ -33,7 +33,7 @@ module NestedReplies
     end
 
     def op_post
-      @op_post ||= load_posts_for_tree(topic.posts.where(post_number: 1)).first
+      @op_post ||= load_posts_for_tree(apply_visibility(topic.posts.where(post_number: 1))).first
     end
 
     def root_posts_scope(sort)

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -455,6 +455,28 @@ RSpec.describe NestedTopicsController, type: :request do
         expect(root_json["cooked"]).to be_present
         expect(root_json["cooked"]).not_to eq("")
       end
+
+      it "lets staff view a fully-deleted topic so they can recover it" do
+        PostDestroyer.new(admin, op).destroy
+        topic.reload
+        expect(topic.deleted_at).to be_present
+        sign_in(admin)
+
+        get show_url(topic)
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["op_post"]).to be_present
+        expect(json["op_post"]["deleted_post_placeholder"]).to eq(true)
+      end
+
+      it "returns 404 for non-staff on a fully-deleted topic" do
+        PostDestroyer.new(admin, op).destroy
+        topic.reload
+        sign_in(user)
+
+        get show_url(topic)
+        expect(response.status).to eq(404)
+      end
     end
 
     describe "pinned replies" do
@@ -1169,6 +1191,20 @@ RSpec.describe NestedTopicsController, type: :request do
         expect(ancestor["deleted_post_placeholder"]).to eq(true)
         expect(ancestor["cooked"]).to be_present
         expect(ancestor["cooked"]).not_to eq("")
+      end
+
+      it "lets staff load the context view of a fully-deleted topic" do
+        reply = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+        PostDestroyer.new(admin, op).destroy
+        topic.reload
+        expect(topic.deleted_at).to be_present
+        sign_in(admin)
+
+        get context_url(topic, reply.post_number)
+        expect(response.status).to eq(200)
+        json = response.parsed_body
+        expect(json["op_post"]).to be_present
+        expect(json["op_post"]["deleted_post_placeholder"]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
## Summary

`NestedReplies::TreeLoader#op_post` loaded the OP via `topic.posts`, whose default scope (from `Trashable`) excludes rows with `deleted_at` set. When a topic is trashed its OP is trashed too, so the lookup returned `nil` and the `/n/...` request crashed in `PostPreloader#prepare` with `undefined method 'user_id' for nil` — preventing staff from reaching the page to recover the topic.

Fix: apply the existing visibility helper (which already unscopes `deleted_at`) on the OP query. The serializer's `deleted_post_placeholder` path preserves content for staff and hides it for everyone else, matching the flat topic view.

- non-staff still 404 via the earlier guardian check on the topic itself, so this does not change their visibility
- both the `show` and `context` endpoints share the same loader, so both paths are fixed

## Test plan

- [x] `bin/rspec spec/requests/nested_topics_controller_spec.rb` (100 examples, 0 failures), with new cases for staff `show`, staff `context`, and non-staff 404 on a fully-deleted topic
- [x] `bin/rspec spec/lib/nested_replies/ spec/services/nested_topic/` (127 examples, 0 failures)
- [ ] Manually: as admin, delete a topic that uses nested replies, then navigate to `/n/<slug>/<id>` — page renders with the deleted OP placeholder and the admin menu's Recover Topic action works