### PR TITLE
FIX: add skip db and redis to env before building core assets and plugins

### DIFF
--- a/script/assemble_ember_build.rb
+++ b/script/assemble_ember_build.rb
@@ -137,7 +137,7 @@ ensure
 end
 
 build_cmd = %w[pnpm ember build]
-build_env = { "CI" => "1" }
+build_env = { "CI" => "1", "SKIP_DB_AND_REDIS" => "1" }
 
 if Etc.nprocessors > 2
   # Anything more than 2 doesn't seem to improve build times
@@ -164,7 +164,8 @@ else
   File.write(BUILD_INFO_FILE, JSON.pretty_generate(build_info))
 end
 
-system("bin/rake", "assets:precompile:build_plugins", exception: true)
+build_plugin_env = { "SKIP_DB_AND_REDIS" => "1" }
+system(build_plugin_env, "bin/rake", "assets:precompile:build_plugins", exception: true)
 
 if ARGV.include?("--compress")
   files = [*Dir.glob("#{EMBER_APP_DIR}/dist/**/*.js"), *Dir.glob("app/assets/generated/**/*.js")]


### PR DESCRIPTION
We should not rely on Redis/DB connections at build-time, to restore building batteries-included web-only images on discourse/discourse.

@davidtaylorhq for a quick sanity check here, believe this is safe enough as I don't think anything depends on the DBs in either of these builds but figure I'd run it by you