### PR TITLE
FIX: Publish new DM channel after transaction commits

### DIFF
--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -83,9 +83,9 @@ module Chat
       step :create_webhook_event
       step :update_channel_last_message
       step :update_membership_last_read
-      step :process_direct_message_channel
     end
 
+    step :process_direct_message_channel
     step :publish_new_thread
     step :process
     step :publish_user_tracking_state

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -182,6 +182,16 @@ RSpec.describe Chat::CreateMessage do
         )
         result
       end
+
+      it "processes the direct message channel outside of the service transaction" do
+        initial_depth = ActiveRecord::Base.connection.open_transactions
+        transaction_depth_when_called = nil
+        Chat::Action::PublishAndFollowDirectMessageChannel
+          .expects(:call)
+          .with { transaction_depth_when_called = ActiveRecord::Base.connection.open_transactions }
+        result
+        expect(transaction_depth_when_called).to eq(initial_depth)
+      end
     end
 
     shared_examples "a message in a thread" do


### PR DESCRIPTION
MessageBus was notifying the UI about new DM channels while still
inside the transaction, before the channel was visible to other
connections. This caused ocassional 404 errors when the UI tried
to fetch the channel immediately after receiving the notification.
