### PR TITLE
FIX: Suspicious login IPs bypass the moderator IP-visibility setting

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -15,7 +15,7 @@ class Admin::ReportsController < Admin::StaffController
         raise Discourse::NotFound unless report_type =~ /\A[a-z0-9\_]+\z/
 
         args = parse_params(report_params)
-        args[:current_user] = current_user
+        args[:guardian] = guardian
 
         report = nil
         report = Report.find_cached(report_type, args) if report_params[:cache]
@@ -52,7 +52,7 @@ class Admin::ReportsController < Admin::StaffController
     raise Discourse::NotFound if Report.hidden?(report_type, guardian: guardian)
 
     args = parse_params(params)
-    args[:current_user] = current_user
+    args[:guardian] = guardian
 
     report = nil
     report = Report.find_cached(report_type, args) if params[:cache]

--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -199,7 +199,7 @@ module Jobs
         @extra[:include_subcategories],
       ) if @extra[:include_subcategories].present?
 
-      report = Report.find(@extra[:name], @extra)
+      report = Report.find(@extra[:name], @extra.merge(current_user: @current_user))
 
       header = []
       titles = {}

--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -199,7 +199,7 @@ module Jobs
         @extra[:include_subcategories],
       ) if @extra[:include_subcategories].present?
 
-      report = Report.find(@extra[:name], @extra.merge(current_user: @current_user))
+      report = Report.find(@extra[:name], @extra.merge(guardian: @current_user&.guardian))
 
       header = []
       titles = {}

--- a/app/models/concerns/reports/suspicious_logins.rb
+++ b/app/models/concerns/reports/suspicious_logins.rb
@@ -41,6 +41,8 @@ module Reports::SuspiciousLogins
         ORDER BY t.created_at DESC
       SQL
 
+      can_see_ip = report.current_user&.guardian&.can_see_ip?
+
       DB
         .query(sql, start_date: report.start_date, end_date: report.end_date)
         .each do |row|
@@ -54,7 +56,7 @@ module Reports::SuspiciousLogins
           data[:username] = row.username
           data[:user_id] = row.user_id
           data[:avatar_template] = User.avatar_template(row.username, row.uploaded_avatar_id)
-          data[:client_ip] = row.client_ip.to_s
+          data[:client_ip] = row.client_ip.to_s if can_see_ip
           data[:location] = ipinfo[:location]
           data[:browser] = I18n.t("user_auth_tokens.browser.#{browser}")
           data[:device] = I18n.t("user_auth_tokens.device.#{device}")

--- a/app/models/concerns/reports/suspicious_logins.rb
+++ b/app/models/concerns/reports/suspicious_logins.rb
@@ -41,7 +41,7 @@ module Reports::SuspiciousLogins
         ORDER BY t.created_at DESC
       SQL
 
-      can_see_ip = report.current_user&.guardian&.can_see_ip?
+      can_see_ip = report.guardian&.can_see_ip?
 
       DB
         .query(sql, start_date: report.start_date, end_date: report.end_date)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -45,7 +45,6 @@ class Report
 
   def self.hidden?(type, guardian:)
     return true if !guardian.is_admin? && ADMIN_ONLY_REPORTS.include?(type)
-    return true if !guardian.is_admin? && !guardian.can_see_ip? && IP_ADDRESS_REPORTS.include?(type)
     return true if BROWSER_PAGEVIEW_REPORTS.include?(type)
 
     hidden_reports =
@@ -166,7 +165,8 @@ class Report
                 :legacy,
                 :default_group_by,
                 :y_axis_title,
-                :current_user
+                :current_user,
+                :guardian
 
   def self.default_days
     30
@@ -199,6 +199,8 @@ class Report
   end
 
   def self.cache_key(report)
+    guardian = report.guardian || report.current_user&.guardian
+
     [
       "reports",
       report.type,
@@ -208,7 +210,8 @@ class Report
       report.limit,
       report.filters.blank? ? nil : MultiJson.dump(report.filters),
       SCHEMA_VERSION,
-      report.current_user&.id,
+      guardian&.user&.id || report.current_user&.id,
+      guardian&.can_see_ip?,
     ].compact.map(&:to_s).join(":")
   end
 
@@ -329,7 +332,10 @@ class Report
     report.average = opts[:average] if opts[:average]
     report.percent = opts[:percent] if opts[:percent]
     report.filters = opts[:filters] if opts[:filters]
+    report.guardian = opts[:guardian] if opts[:guardian]
     report.current_user = opts[:current_user] if opts[:current_user]
+    report.current_user ||= report.guardian&.user
+    report.guardian ||= report.current_user&.guardian
     report.labels = Report.default_labels
 
     report.legacy = LEGACY_REPORTS.include?(type) if SiteSetting.reporting_improvements

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -264,6 +264,46 @@ RSpec.describe Jobs::ExportCsvFile do
       expect(report.second).to contain_exactly(user.username, "Earth", "2010-01-01 00:00:00 UTC")
     end
 
+    it "exports suspicious login IP details when allowed" do
+      DiscourseIpInfo.stubs(:get).with("1.1.1.1").returns(location: "Earth")
+      user.user_auth_token_logs.create!(
+        action: "suspicious",
+        client_ip: "1.1.1.1",
+        user_agent: "Mozilla/5.0",
+        created_at: "2010-01-01 12:00:00 UTC",
+      )
+      exporter.extra["name"] = "suspicious_logins"
+
+      report = export_report
+
+      expect(report.second[0, 3]).to eq([user.username, "1.1.1.1", "Earth"])
+    end
+
+    context "when the current user cannot view IPs" do
+      fab!(:moderator_without_ip_access, :moderator)
+
+      let(:user) { moderator_without_ip_access }
+
+      it "redacts suspicious login IP address while retaining location" do
+        SiteSetting.moderators_view_ips = false
+        DiscourseIpInfo.stubs(:get).returns(location: "Earth")
+
+        moderator_without_ip_access.user_auth_token_logs.create!(
+          action: "suspicious",
+          client_ip: "1.1.1.1",
+          user_agent: "Mozilla/5.0",
+          created_at: "2010-01-01 12:00:00 UTC",
+        )
+        exporter.extra["name"] = "suspicious_logins"
+
+        report = export_report
+
+        expect(report.second[0]).to eq(moderator_without_ip_access.username)
+        expect(report.second[1]).to eq("")
+        expect(report.second[2]).to eq("Earth")
+      end
+    end
+
     it "works with topic reports" do
       freeze_time DateTime.parse("2010-01-01 6:00")
 

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2558,6 +2558,14 @@ RSpec.describe Guardian do
       expect(admin_guardian.can_export_entity?("report", nil, { name: "top_uploads" })).to be_truthy
     end
 
+    it "allows moderators to export suspicious login reports when IP viewing is disabled" do
+      SiteSetting.moderators_view_ips = false
+
+      expect(
+        moderator_guardian.can_export_entity?("report", nil, { name: "suspicious_logins" }),
+      ).to be_truthy
+    end
+
     it "does not allow anonymous to export" do
       expect(anonymous_guardian.can_export_entity?("user_archive")).to be_falsey
     end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2140,11 +2140,11 @@ RSpec.describe Report do
         end
       end
 
-      it "returns true for IP reports when IP viewing is disabled" do
+      it "returns false for IP reports when IP viewing is disabled" do
         SiteSetting.moderators_view_ips = false
 
         Report::IP_ADDRESS_REPORTS.each do |report_type|
-          expect(Report.hidden?(report_type, guardian: moderator_guardian)).to eq(true)
+          expect(Report.hidden?(report_type, guardian: moderator_guardian)).to eq(false)
         end
       end
 

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -452,6 +452,31 @@ RSpec.describe Admin::ReportsController do
         expect(response.parsed_body["report"]["total"]).to eq(1)
       end
 
+      context "when moderators cannot view IPs" do
+        before do
+          SiteSetting.moderators_view_ips = false
+          DiscourseIpInfo.stubs(:get).returns(location: "Earth")
+
+          user.user_auth_token_logs.create!(
+            action: "suspicious",
+            client_ip: "1.1.1.1",
+            user_agent: "Mozilla/5.0",
+            created_at: 1.hour.ago,
+          )
+        end
+
+        it "redacts suspicious login IP address while retaining location" do
+          get "/admin/reports/suspicious_logins.json"
+
+          expect(response.status).to eq(200)
+
+          row = response.parsed_body.dig("report", "data", 0)
+          expect(row["username"]).to eq(user.username)
+          expect(row["client_ip"]).to be_nil
+          expect(row["location"]).to eq("Earth")
+        end
+      end
+
       it "does not allow accessing admin-only reports" do
         Report::ADMIN_ONLY_REPORTS.each do |report_type|
           get "/admin/reports/#{report_type}.json"

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe Admin::ReportsController do
         )
       end
 
-      it "excludes IP reports when IP viewing is disabled" do
+      it "includes suspicious logins when IP viewing is disabled" do
         SiteSetting.moderators_view_ips = false
 
         get "/admin/reports.json"
 
-        expect(response.parsed_body["reports"].map { |r| r["type"] }).not_to include(
-          *Report::IP_ADDRESS_REPORTS,
+        expect(response.parsed_body["reports"].map { |r| r["type"] }).to include(
+          "suspicious_logins",
         )
       end
     end
@@ -251,17 +251,27 @@ RSpec.describe Admin::ReportsController do
         expect(response.parsed_body["reports"][3]).to include("error" => "not_found", "data" => nil)
       end
 
-      it "marks IP reports as not_found when IP viewing is disabled" do
+      it "redacts suspicious login IP addresses when IP viewing is disabled" do
         SiteSetting.moderators_view_ips = false
+        DiscourseIpInfo.stubs(:get).returns(location: "Earth")
+        user.user_auth_token_logs.create!(
+          action: "suspicious",
+          client_ip: "1.1.1.1",
+          user_agent: "Mozilla/5.0",
+          created_at: 1.hour.ago,
+        )
 
-        reports = Report::IP_ADDRESS_REPORTS.index_with { { limit: 10 } }
-        get "/admin/reports/bulk.json", params: { reports: reports }
+        get "/admin/reports/bulk.json", params: { reports: { suspicious_logins: { limit: 10 } } }
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["reports"].count).to eq(Report::IP_ADDRESS_REPORTS.size)
-        response.parsed_body["reports"].each do |report|
-          expect(report).to include("error" => "not_found", "data" => nil)
-        end
+        expect(response.parsed_body["reports"].count).to eq(1)
+
+        report = response.parsed_body["reports"].first
+        row = report["data"].first
+        expect(report["type"]).to eq("suspicious_logins")
+        expect(row["username"]).to eq(user.username)
+        expect(row["client_ip"]).to be_nil
+        expect(row["location"]).to eq("Earth")
       end
     end
 
@@ -479,17 +489,6 @@ RSpec.describe Admin::ReportsController do
 
       it "does not allow accessing admin-only reports" do
         Report::ADMIN_ONLY_REPORTS.each do |report_type|
-          get "/admin/reports/#{report_type}.json"
-
-          expect(response.status).to eq(404)
-          expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
-        end
-      end
-
-      it "does not allow accessing IP reports when IP viewing is disabled" do
-        SiteSetting.moderators_view_ips = false
-
-        Report::IP_ADDRESS_REPORTS.each do |report_type|
           get "/admin/reports/#{report_type}.json"
 
           expect(response.status).to eq(404)

--- a/spec/requests/export_csv_controller_spec.rb
+++ b/spec/requests/export_csv_controller_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe ExportCsvController do
         expect(Jobs::ExportCsvFile.jobs.size).to eq(0)
       end
 
-      it "does not allow moderators to export IP reports when IP viewing is disabled" do
+      it "allows moderators to export redacted suspicious login reports when IP viewing is disabled" do
         SiteSetting.moderators_view_ips = false
 
         post "/export_csv/export_entity.json",
@@ -261,8 +261,12 @@ RSpec.describe ExportCsvController do
                },
              }
 
-        expect(response.status).to eq(422)
-        expect(Jobs::ExportCsvFile.jobs.size).to eq(0)
+        expect(response.status).to eq(200)
+        expect(Jobs::ExportCsvFile.jobs.size).to eq(1)
+
+        job_data = Jobs::ExportCsvFile.jobs.first["args"].first
+        expect(job_data["entity"]).to eq("report")
+        expect(job_data.dig("args", "name")).to eq("suspicious_logins")
       end
 
       it "allows moderators to export non-hidden reports" do


### PR DESCRIPTION
Harden implementation of suspicious login report

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>