### PR TITLE
FIX: Emoji deny list with regex metacharacters crashes cooking

### DIFF
--- a/frontend/discourse-markdown-it/src/features/emoji.js
+++ b/frontend/discourse-markdown-it/src/features/emoji.js
@@ -228,9 +228,9 @@ function applyEmoji(
   // prevent denied emoji and aliases from being rendered
   if (content && emojiDenyList?.length > 0) {
     emojiDenyList.forEach((emoji) => {
-      if (content.match(emoji)) {
-        const regex = new RegExp(`:${emoji}:`, "g");
-        content = content.replace(regex, "");
+      const token = `:${emoji}:`;
+      if (content.includes(token)) {
+        content = content.replaceAll(token, "");
       }
     });
   }

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1630,6 +1630,13 @@ RSpec.describe PrettyText do
       expect(PrettyText.cook("💣")).to match(/\:bomb\:/)
     end
 
+    it "renders a denied emoji name as plain text when the name contains regex metacharacters" do
+      SiteSetting.emoji_deny_list = "+1"
+      Emoji.clear_cache
+
+      expect(PrettyText.cook(":+1: hello")).to eq("<p>:+1: hello</p>")
+    end
+
     it "does not replace left right arrow" do
       expect(PrettyText.cook("&harr;")).to eq("<p>↔</p>")
     end


### PR DESCRIPTION
Cooking any post raises `MiniRacer::RuntimeError: SyntaxError: Invalid regular expression: /+1/: Nothing to repeat` whenever the `emoji_deny_list` site setting contains a name with a regex metacharacter such as `+1` or `-1`. Every page that renders cooked content then 500s. The names are real Unicode emoji aliases admins must be able to deny, so validating them away is not an option.

The deny-list block in `applyEmoji` used `content.match(emoji)` which coerces the raw emoji name into a regex via `new RegExp(...)`, and `+1` does not compile as a regex.

This commit switches that block to literal-string `includes` and `replaceAll` against the `:name:` token. Deny-list semantics for plain names are unchanged: the denied emoji is still stripped from `content` before token generation, so no `<img class="emoji">` is rendered.
