### PR TITLE
DEV: Fix spec due to form assertion

### DIFF
--- a/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Data Explorer AI query generation" do
 
       expect(page).to have_css(".query-new")
       expect(page).to have_no_css(".query-mode-switch")
-      expect(page).to have_css(".query-new__manual-form")
+      expect(page).to have_css(".query-new [data-name='name']")
       expect(page).to have_no_css(".query-new__ai-section")
     end
   end


### PR DESCRIPTION
Build failing on 

```
rspec ./plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb:14 # Data Explorer AI query generation when ai queries setting is disabled shows only the manual form with no mode switch
```