### PR TITLE
FIX: AI bot submits during IME composition

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -223,7 +223,7 @@ export default class AiBotConversations extends Component {
     if (event.target.tagName !== "TEXTAREA") {
       return;
     }
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
       this.prepareAndSubmitToBot();
     }
   }

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -224,6 +224,8 @@ export default class AiBotConversations extends Component {
       return;
     }
     if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+      event.preventDefault();
+      event.stopPropagation();
       this.prepareAndSubmitToBot();
     }
   }

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
@@ -10,7 +10,7 @@ import { i18n } from "discourse-i18n";
 export default class AiHelperCustomPrompt extends Component {
   @action
   sendInput(event) {
-    if (event.key !== "Enter") {
+    if (event.key !== "Enter" || event.isComposing) {
       return;
     }
     return this.args.submit(this.args.promptArgs);

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
@@ -1,0 +1,46 @@
+import { triggerKeyEvent, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("AI Bot - Conversations IME handling", function (needs) {
+  needs.user({
+    ai_enabled_agents: [],
+    ai_enabled_chat_bots: [
+      {
+        id: 1,
+        model_name: "gpt-4",
+        username: "gpt-4",
+        is_agent: false,
+      },
+    ],
+  });
+
+  needs.settings({
+    discourse_ai_enabled: true,
+    ai_bot_enabled: true,
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/discourse-ai/ai-bot/conversations.json", () => {
+      return helper.response({
+        conversations: [],
+        meta: { has_more: false },
+      });
+    });
+  });
+
+  test("does not submit when Enter is pressed during IME composition", async function (assert) {
+    await visit("/discourse-ai/ai-bot/conversations");
+
+    const textarea = document.querySelector("#ai-bot-conversations-input");
+    textarea.value = "テスト";
+
+    await triggerKeyEvent("#ai-bot-conversations-input", "keydown", "Enter", {
+      isComposing: true,
+    });
+
+    assert
+      .dom("#ai-bot-conversations-input")
+      .hasValue("テスト", "textarea value is preserved during IME composition");
+  });
+});

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
@@ -1,8 +1,10 @@
-import { triggerKeyEvent, visit } from "@ember/test-helpers";
+import { fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("AI Bot - Conversations IME handling", function (needs) {
+  let postRequests = 0;
+
   needs.user({
     ai_enabled_agents: [],
     ai_enabled_chat_bots: [
@@ -18,6 +20,7 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
   needs.settings({
     discourse_ai_enabled: true,
     ai_bot_enabled: true,
+    min_personal_message_post_length: 10,
   });
 
   needs.pretender((server, helper) => {
@@ -27,20 +30,31 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
         meta: { has_more: false },
       });
     });
+
+    server.post("/posts.json", () => {
+      postRequests += 1;
+      return helper.response({
+        id: 1,
+        topic_id: 1,
+        topic_slug: "ai-conversation",
+        post_url: "/t/ai-conversation/1/1",
+      });
+    });
   });
 
   test("does not submit when Enter is pressed during IME composition", async function (assert) {
-    await visit("/discourse-ai/ai-bot/conversations");
+    postRequests = 0;
 
-    const textarea = document.querySelector("#ai-bot-conversations-input");
-    textarea.value = "テスト";
+    await visit("/discourse-ai/ai-bot/conversations");
+    await fillIn(
+      "#ai-bot-conversations-input",
+      "これはテスト入力として十分長い文章です"
+    );
 
     await triggerKeyEvent("#ai-bot-conversations-input", "keydown", "Enter", {
       isComposing: true,
     });
 
-    assert
-      .dom("#ai-bot-conversations-input")
-      .hasValue("テスト", "textarea value is preserved during IME composition");
+    assert.strictEqual(postRequests, 0, "does not request /posts.json");
   });
 });

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
@@ -1,0 +1,47 @@
+import { tracked } from "@glimmer/tracking";
+import { render, triggerKeyEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import AiHelperCustomPrompt from "discourse/plugins/discourse-ai/discourse/components/ai-helper-custom-prompt";
+
+class TestState {
+  @tracked value = "test";
+}
+
+module("Integration | Component | ai-helper-custom-prompt", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("does not submit when Enter is pressed during IME composition", async function (assert) {
+    let submitted = false;
+    const submit = () => (submitted = true);
+    const state = new TestState();
+
+    await render(
+      <template>
+        <AiHelperCustomPrompt @value={{state.value}} @submit={{submit}} />
+      </template>
+    );
+
+    await triggerKeyEvent(".ai-custom-prompt__input", "keydown", "Enter", {
+      isComposing: true,
+    });
+
+    assert.false(submitted, "does not submit during IME composition");
+  });
+
+  test("submits when Enter is pressed outside of IME composition", async function (assert) {
+    let submitted = false;
+    const submit = () => (submitted = true);
+    const state = new TestState();
+
+    await render(
+      <template>
+        <AiHelperCustomPrompt @value={{state.value}} @submit={{submit}} />
+      </template>
+    );
+
+    await triggerKeyEvent(".ai-custom-prompt__input", "keydown", "Enter");
+
+    assert.true(submitted, "submits on Enter without IME composition");
+  });
+});


### PR DESCRIPTION
Previously, pressing Enter to confirm an IME character selection (e.g. when typing Japanese) in the AI bot conversations input or AI helper custom prompt would immediately submit the message, interrupting composition mid-text.

This change adds the standard `event.isComposing` guard to both keydown handlers, matching the fix already applied to Discourse Chat and the docked composer.