### PR TITLE
FIX: Surface upsell upcoming changes from non-configurable plugins

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -380,7 +380,16 @@ module SiteSettingExtension
       .all(default_locale)
       .reject do |setting_name, _|
         plugin_name = plugins[setting_name]
-        plugin_name && !Discourse.plugins_by_name[plugin_name].configurable?
+        next false if !plugin_name
+        next false if Discourse.plugins_by_name[plugin_name].configurable?
+
+        # Non-configurable plugin. Surface an upcoming change only when a
+        # :hidden_site_settings modifier has explicitly un-hidden it.
+        if only_upcoming_changes && UpcomingChanges.exists?(setting_name)
+          current_hidden_settings.include?(setting_name)
+        else
+          true
+        end
       end
       .select do |setting_name, _|
         is_hidden = current_hidden_settings.include?(setting_name)

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1065,7 +1065,7 @@ RSpec.describe SiteSettingExtension do
   end
 
   describe ".all_settings" do
-    describe "non-configurable plugin exclusion" do
+    describe "non-configurable plugin filtering" do
       it "includes plugin site settings when the plugin is configurable" do
         SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(true)
 
@@ -1076,6 +1076,36 @@ RSpec.describe SiteSettingExtension do
         SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
 
         expect(SiteSetting.all_settings.map { |s| s[:setting] }).not_to include(:plugin_setting)
+      end
+
+      context "with only_upcoming_changes" do
+        it "excludes a non-configurable plugin's upcoming change when no upsell has un-hidden it" do
+          SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+
+          settings =
+            SiteSetting
+              .all_settings(only_upcoming_changes: true, include_hidden: true)
+              .map { |s| s[:setting] }
+          expect(settings).not_to include(:enable_experimental_sample_plugin_feature)
+        end
+
+        it "surfaces a non-configurable plugin's upcoming change when the :hidden_site_settings modifier removes it from hidden (upsell pattern)" do
+          SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+
+          plugin = Plugin::Instance.new
+          modifier = ->(hidden) { hidden - [:enable_experimental_sample_plugin_feature] }
+          plugin.register_modifier(:hidden_site_settings, &modifier)
+
+          begin
+            settings =
+              SiteSetting
+                .all_settings(only_upcoming_changes: true, include_hidden: true)
+                .map { |s| s[:setting] }
+            expect(settings).to include(:enable_experimental_sample_plugin_feature)
+          ensure
+            DiscoursePluginRegistry.unregister_modifier(plugin, :hidden_site_settings, &modifier)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The `configurable?` reject in `all_settings` was dropping upcoming-change rows owned by plan-gated plugins. Narrow it so an upcoming change still surfaces when a `:hidden_site_settings` modifier has un-hidden it.