### PR TITLE
FEATURE: new tag info heading

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -4,6 +4,17 @@
   --category-header-logo-size: 3rem;
   --category-description-width: 760px;
   --category-header-border: 1px solid var(--content-border-color);
+  --discovery-heading-description-color: var(--primary-800);
+}
+
+// shared banner treatment used above the discovery topic list
+// .category-heading, .tag-info
+.discovery-heading {
+  gap: 0 var(--space-4);
+  margin-bottom: var(--space-6);
+  padding: var(--space-4);
+  border: var(--category-header-border);
+  border-radius: var(--d-border-radius);
 }
 
 .category-heading {
@@ -11,11 +22,6 @@
 
   &.--has-logo {
     display: flex;
-    gap: var(--space-4);
-    margin-bottom: var(--space-6);
-    border: var(--category-header-border);
-    padding: var(--space-4);
-    border-radius: var(--d-border-radius);
   }
 
   &__logo.category-logo.aspect-image {
@@ -29,7 +35,7 @@
     margin: 0;
     line-height: var(--line-height-large);
     font-size: var(--font-0);
-    color: var(--category-boxes-description-text-color);
+    color: var(--discovery-heading-description-color);
     max-width: var(--category-description-width);
   }
 

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -354,6 +354,50 @@
   }
 }
 
+section.tag-info {
+  display: flex;
+  flex-direction: column;
+  color: var(--discovery-heading-description-color);
+  transition: opacity 0.15s ease-out;
+
+  &.--loading {
+    opacity: 0.5;
+  }
+
+  .tag-name-wrapper {
+    display: flex;
+    font-size: var(--font-up-3);
+    align-items: baseline;
+
+    .discourse-tag {
+      &,
+      &:visited,
+      &:hover {
+        color: var(--primary);
+        font-weight: bold;
+      }
+    }
+  }
+
+  .tag-description-wrapper {
+    display: flex;
+    font-size: var(--font-0);
+    line-height: var(--line-height-large);
+  }
+
+  .tag-associations .badge-category__wrapper {
+    font-size: var(--font-0);
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+}
+
+#show-tag-info[aria-pressed="true"] .d-icon {
+  color: var(--tertiary);
+}
+
 .tag-navigation {
   .mini-tag-chooser.tags-intersection-chooser {
     margin: 0 0.5em 0 0;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5631,18 +5631,20 @@ en:
       staff_info: "To add restrictions, put this tag in a <a href=%{basePath}/tag_groups>tag group</a>."
       category_restricted: "This tag is restricted to categories you don't have permission to access."
       synonyms: "Synonyms"
-      synonyms_description: "When the following tags are used, they will be replaced with <b>%{base_tag_name}</b>."
+      synonyms_description:
+        one: "The synonym %{synonyms} will be replaced with %{base_tag_name}."
+        other: "The synonyms %{synonyms} will be replaced with %{base_tag_name}."
       synonyms_inline: "These synonyms will be replaced with %{base_tag_name}:"
       save: "Save name and description of the tag"
       tag_groups_info:
-        one: 'This tag belongs to the group "%{tag_groups}".'
-        other: "This tag belongs to these groups: %{tag_groups}."
+        one: 'This tag belongs to the tag group "%{tag_groups}".'
+        other: "This tag belongs to these tag groups: %{tag_groups}."
       tag_groups_info_prefix:
-        one: "This tag belongs to the group "
-        other: "This tag belongs to these groups: "
+        one: "This tag belongs to the tag group "
+        other: "This tag belongs to these tag groups: "
       category_restrictions:
-        one: "It can only be used in this category:"
-        other: "It can only be used in these categories:"
+        one: "It can only be used in the %{categories} category."
+        other: "It can only be used in these categories: %{categories}."
       restricted_to: "Restricted to"
       no_synonyms: "This tag has no synonyms."
       edit_synonyms: "Edit Synonyms"

--- a/frontend/discourse/app/components/d-navigation.gjs
+++ b/frontend/discourse/app/components/d-navigation.gjs
@@ -133,6 +133,16 @@ export default class DNavigation extends Component {
     );
   }
 
+  @computed("tag", "tag.name", "additionalTags", "category")
+  get showTagInfoButton() {
+    return (
+      this.tag &&
+      this.tag.name !== "none" &&
+      !this.additionalTags &&
+      !this.category
+    );
+  }
+
   @computed(
     "category.can_edit",
     "tag",
@@ -232,6 +242,16 @@ export default class DNavigation extends Component {
     this.createTopic();
   }
 
+  @action
+  editTag() {
+    this.router.transitionTo(
+      "tag.edit.tab",
+      this.tag.slug,
+      this.tag.id,
+      "general"
+    );
+  }
+
   <template>
     <BreadCrumbs
       @categories={{this.categories}}
@@ -315,8 +335,23 @@ export default class DNavigation extends Component {
         {{/if}}
 
         {{#if this.showTagEdit}}
-          <TagInfoButton @tag={{this.tag}} @currentUser={{this.currentUser}} />
+          <DButton
+            @action={{this.editTag}}
+            @icon="wrench"
+            @ariaLabel="tagging.edit"
+            @title="tagging.edit"
+            id="edit-tag"
+            class="btn-default"
+          />
         {{/if}}
+      {{/if}}
+
+      {{#if this.showTagInfoButton}}
+        <TagInfoButton
+          @toggleInfo={{@toggleTagInfo}}
+          @active={{@showTagInfo}}
+          @loading={{@loadingTagInfo}}
+        />
       {{/if}}
 
       <PluginOutlet

--- a/frontend/discourse/app/components/discovery/layout.gjs
+++ b/frontend/discourse/app/components/discovery/layout.gjs
@@ -40,6 +40,15 @@ export default class Layout extends Component {
         {{/if}}
       </ConditionalWrap>
 
+      {{#if (has-block "aboveNavigation")}}
+        <ConditionalWrap
+          @when={{this.hasSidebarLayout}}
+          @class="discovery-layout__above-navigation"
+        >
+          {{yield to="aboveNavigation"}}
+        </ConditionalWrap>
+      {{/if}}
+
       <ConditionalWrap
         @when={{this.hasSidebarLayout}}
         @class="discovery-layout__navigation"
@@ -47,7 +56,11 @@ export default class Layout extends Component {
         <PluginOutlet
           @name="discovery-list-controls-above"
           @connectorTagName="div"
-          @outletArgs={{lazyHash category=@model.category tag=@model.tag}}
+          @outletArgs={{lazyHash
+            category=@model.category
+            tag=@model.tag
+            toggleTagInfo=@toggleTagInfo
+          }}
         />
         <div class="list-controls">
           <PluginOutlet

--- a/frontend/discourse/app/components/discovery/navigation.gjs
+++ b/frontend/discourse/app/components/discovery/navigation.gjs
@@ -75,7 +75,9 @@ export default class DiscoveryNavigation extends Component {
   get headingClasses() {
     return dConcatClass(
       "category-heading",
-      this.args.category?.uploaded_logo?.url ? "--has-logo" : null
+      this.args.category?.uploaded_logo?.url
+        ? "--has-logo discovery-heading"
+        : null
     );
   }
 
@@ -149,6 +151,9 @@ export default class DiscoveryNavigation extends Component {
         @canBulkSelect={{@canBulkSelect}}
         @bulkSelectHelper={{@bulkSelectHelper}}
         @skipCategoriesNavItem={{this.skipCategoriesNavItem}}
+        @toggleTagInfo={{@toggleTagInfo}}
+        @showTagInfo={{@showTagInfo}}
+        @loadingTagInfo={{@loadingTagInfo}}
         @tagNotification={{@tagNotification}}
         @model={{@model}}
         @showDismissRead={{@showDismissRead}}

--- a/frontend/discourse/app/components/tag-info-button.gjs
+++ b/frontend/discourse/app/components/tag-info-button.gjs
@@ -1,35 +1,16 @@
-import Component from "@glimmer/component";
-import { action } from "@ember/object";
-import { service } from "@ember/service";
 import DButton from "discourse/ui-kit/d-button";
 
-export default class TagInfoButton extends Component {
-  @service router;
+const TagInfoButton = <template>
+  <DButton
+    @icon="circle-info"
+    @ariaLabel="tagging.info"
+    @title="tagging.info"
+    @action={{@toggleInfo}}
+    @ariaPressed={{if @active true false}}
+    @isLoading={{@loading}}
+    id="show-tag-info"
+    class="btn-default"
+  />
+</template>;
 
-  get canEditTags() {
-    return this.args.currentUser?.canEditTags;
-  }
-
-  @action
-  handleClick() {
-    this.router.transitionTo(
-      "tag.edit.tab",
-      this.args.tag.slug,
-      this.args.tag.id,
-      "general"
-    );
-  }
-
-  <template>
-    {{#if this.canEditTags}}
-      <DButton
-        @icon="wrench"
-        @ariaLabel="tagging.edit"
-        @title="tagging.edit"
-        @action={{this.handleClick}}
-        id="show-tag-info"
-        class="btn-default"
-      />
-    {{/if}}
-  </template>
-}
+export default TagInfoButton;

--- a/frontend/discourse/app/components/tag-info.gjs
+++ b/frontend/discourse/app/components/tag-info.gjs
@@ -1,0 +1,93 @@
+import { trustHTML } from "@ember/template";
+import { isEmpty } from "@ember/utils";
+import PluginOutlet from "discourse/components/plugin-outlet";
+import lazyHash from "discourse/helpers/lazy-hash";
+import renderTags from "discourse/lib/render-tags";
+import dBasePath from "discourse/ui-kit/helpers/d-base-path";
+import { categoryBadgeHTML } from "discourse/ui-kit/helpers/d-category-link";
+import dDiscourseTag from "discourse/ui-kit/helpers/d-discourse-tag";
+import { i18n } from "discourse-i18n";
+
+function tagGroupsInfo(tagInfo) {
+  return i18n("tagging.tag_groups_info", {
+    count: tagInfo?.tag_group_names?.length,
+    tag_groups: tagInfo?.tag_group_names?.join(", "),
+  });
+}
+
+function categoriesInfo(tagInfo) {
+  const categories = tagInfo?.categories || [];
+  return i18n("tagging.category_restrictions", {
+    count: categories.length,
+    categories: categories.map((c) => categoryBadgeHTML(c)).join(" "),
+  });
+}
+
+function synonymsDescription(tagInfo) {
+  const synonyms = tagInfo?.synonyms || [];
+  return i18n("tagging.synonyms_description", {
+    count: synonyms.length,
+    base_tag_name: renderTags(null, { tags: [tagInfo] }),
+    synonyms: renderTags(null, { tags: synonyms }),
+  });
+}
+
+function nothingToShow(tagInfo) {
+  return (
+    isEmpty(tagInfo?.tag_group_names) &&
+    isEmpty(tagInfo?.categories) &&
+    isEmpty(tagInfo?.synonyms)
+  );
+}
+
+const TagInfo = <template>
+  {{#if @tagInfo}}
+    <section class="tag-info discovery-heading {{if @loading '--loading'}}">
+      <div class="tag-name">
+        <div class="tag-name-wrapper">
+          {{dDiscourseTag @tagInfo}}
+        </div>
+        {{#if @tagInfo.description}}
+          <div class="tag-description-wrapper">
+            <span>{{trustHTML @tagInfo.description}}</span>
+          </div>
+        {{/if}}
+      </div>
+
+      <p class="tag-associations">
+        {{#if @tagInfo.tag_group_names}}
+          <span>{{tagGroupsInfo @tagInfo}}</span>
+        {{/if}}
+        {{#if @tagInfo.categories}}
+          <span>{{trustHTML (categoriesInfo @tagInfo)}}</span>
+        {{/if}}
+        {{#if (nothingToShow @tagInfo)}}
+          {{#if @tagInfo.category_restricted}}
+            {{i18n "tagging.category_restricted"}}
+          {{else}}
+            {{trustHTML (i18n "tagging.default_info")}}
+            {{#if @currentUser.staff}}
+              {{trustHTML (i18n "tagging.staff_info" basePath=(dBasePath))}}
+            {{/if}}
+          {{/if}}
+        {{/if}}
+      </p>
+
+      {{#if @tagInfo.synonyms}}
+        <div class="synonyms-list">{{trustHTML
+            (synonymsDescription @tagInfo)
+          }}</div>
+      {{/if}}
+
+      {{#if @currentUser.canEditTags}}
+        <PluginOutlet
+          @name="tag-custom-settings"
+          @outletArgs={{lazyHash tag=@tagInfo}}
+          @connectorTagName="section"
+        />
+      {{/if}}
+    </section>
+  {{/if}}
+</template>;
+
+export default TagInfo;

--- a/frontend/discourse/app/components/tag-info.gjs
+++ b/frontend/discourse/app/components/tag-info.gjs
@@ -36,7 +36,8 @@ function nothingToShow(tagInfo) {
   return (
     isEmpty(tagInfo?.tag_group_names) &&
     isEmpty(tagInfo?.categories) &&
-    isEmpty(tagInfo?.synonyms)
+    isEmpty(tagInfo?.synonyms) &&
+    !tagInfo?.category_restricted
   );
 }
 
@@ -60,15 +61,13 @@ const TagInfo = <template>
         {{/if}}
         {{#if @tagInfo.categories}}
           <span>{{trustHTML (categoriesInfo @tagInfo)}}</span>
+        {{else if @tagInfo.category_restricted}}
+          <span>{{i18n "tagging.category_restricted"}}</span>
         {{/if}}
         {{#if (nothingToShow @tagInfo)}}
-          {{#if @tagInfo.category_restricted}}
-            {{i18n "tagging.category_restricted"}}
-          {{else}}
-            {{trustHTML (i18n "tagging.default_info")}}
-            {{#if @currentUser.staff}}
-              {{trustHTML (i18n "tagging.staff_info" basePath=(dBasePath))}}
-            {{/if}}
+          {{trustHTML (i18n "tagging.default_info")}}
+          {{#if @currentUser.staff}}
+            {{trustHTML (i18n "tagging.staff_info" basePath=(dBasePath))}}
           {{/if}}
         {{/if}}
       </p>

--- a/frontend/discourse/app/components/tag-settings.gjs
+++ b/frontend/discourse/app/components/tag-settings.gjs
@@ -23,6 +23,7 @@ export default class TagSettings extends Component {
   @service toasts;
   @service siteSettings;
   @service store;
+  @service appEvents;
 
   @tracked form = null;
   @tracked tags = [];
@@ -157,6 +158,8 @@ export default class TagSettings extends Component {
             this.args.selectedTab
           );
         }
+
+        this.appEvents.trigger("tag-info:updated", result.tag_settings.id);
       }
 
       this.toasts.success({

--- a/frontend/discourse/app/controllers/discovery/list.js
+++ b/frontend/discourse/app/controllers/discovery/list.js
@@ -64,6 +64,7 @@ export default class DiscoveryListController extends Controller {
   queryParams = Object.keys(queryParams);
   bulkSelectHelper = new BulkSelectHelper(this);
   #loadedTagId = null;
+  #tagInfoFetchToken = 0;
 
   constructor() {
     super(...arguments);
@@ -223,14 +224,21 @@ export default class DiscoveryListController extends Controller {
     this.model.list.updateNewListSubsetParam(subset);
   }
 
+  #resetTagInfo() {
+    this.tagInfo = null;
+    this.#loadedTagId = null;
+    this.#tagInfoFetchToken++;
+    this.loadingTagInfo = false;
+  }
+
   async #fetchTagInfo(tagKey) {
+    const token = ++this.#tagInfoFetchToken;
     this.loadingTagInfo = true;
     try {
       const result = await this.store.find("tag-info", tagKey);
 
-      // discard if a newer tag became current while this fetch was in flight
-      const currentTagKey = this.model.tag?.id || this.model.tag?.name;
-      if (currentTagKey !== tagKey) {
+      // discard if a newer fetch superseded this one
+      if (token !== this.#tagInfoFetchToken) {
         return;
       }
 
@@ -240,10 +248,15 @@ export default class DiscoveryListController extends Controller {
       this.tagInfo = result;
       this.#loadedTagId = tagKey;
     } catch (e) {
+      if (token !== this.#tagInfoFetchToken) {
+        return;
+      }
       popupAjaxError(e);
       throw e;
     } finally {
-      this.loadingTagInfo = false;
+      if (token === this.#tagInfoFetchToken) {
+        this.loadingTagInfo = false;
+      }
     }
   }
 
@@ -278,33 +291,40 @@ export default class DiscoveryListController extends Controller {
 
     if (this.showTagInfo) {
       this.#fetchTagInfo(tagId).catch(() => {
-        this.tagInfo = null;
-        this.#loadedTagId = null;
+        this.#resetTagInfo();
         this.showTagInfo = false;
       });
     } else {
-      this.tagInfo = null;
-      this.#loadedTagId = null;
+      this.#resetTagInfo();
     }
+  }
+
+  get canShowTagInfo() {
+    const { tag, category, additionalTags } = this.model;
+    return tag && tag.name !== "none" && !additionalTags && !category;
   }
 
   @action
   syncTagInfo() {
-    const tagKey = this.model.tag?.id || this.model.tag?.name;
+    if (!this.canShowTagInfo) {
+      this.showTagInfo = false;
+      this.#resetTagInfo();
+      return;
+    }
 
-    if (!this.model.tag || this.#loadedTagId === tagKey) {
+    const tagKey = this.model.tag.id || this.model.tag.name;
+
+    if (this.#loadedTagId === tagKey) {
       return;
     }
 
     if (this.showTagInfo) {
       this.#fetchTagInfo(tagKey).catch(() => {
-        this.tagInfo = null;
-        this.#loadedTagId = null;
+        this.#resetTagInfo();
         this.showTagInfo = false;
       });
     } else {
-      this.tagInfo = null;
-      this.#loadedTagId = null;
+      this.#resetTagInfo();
     }
   }
 

--- a/frontend/discourse/app/controllers/discovery/list.js
+++ b/frontend/discourse/app/controllers/discovery/list.js
@@ -3,6 +3,7 @@ import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DismissNew from "discourse/components/modal/dismiss-new";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { filterTypeForMode } from "discourse/lib/filter-mode";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
@@ -47,18 +48,22 @@ export function addDiscoveryQueryParam(p, opts) {
 
 @disableImplicitInjections
 export default class DiscoveryListController extends Controller {
+  @service appEvents;
   @service composer;
   @service siteSettings;
   @service currentUser;
   @service router;
+  @service store;
   @service topicTrackingState;
   @service modal;
 
   @tracked model;
-
+  @tracked showTagInfo = false;
+  @tracked tagInfo = null;
+  @tracked loadingTagInfo = false;
   queryParams = Object.keys(queryParams);
-
   bulkSelectHelper = new BulkSelectHelper(this);
+  #loadedTagId = null;
 
   constructor() {
     super(...arguments);
@@ -67,6 +72,12 @@ export default class DiscoveryListController extends Controller {
     }
 
     this.bulkSelectHelper.onResetNew = () => this.resetNew();
+    this.appEvents.on("tag-info:updated", this, this.onTagInfoUpdated);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.appEvents.off("tag-info:updated", this, this.onTagInfoUpdated);
   }
 
   // NOTE: (martin) Please keep this in tact for now, will remove once we have
@@ -210,6 +221,91 @@ export default class DiscoveryListController extends Controller {
   changeNewListSubset(subset) {
     this.subset = subset;
     this.model.list.updateNewListSubsetParam(subset);
+  }
+
+  async #fetchTagInfo(tagKey) {
+    this.loadingTagInfo = true;
+    try {
+      const result = await this.store.find("tag-info", tagKey);
+
+      // discard if a newer tag became current while this fetch was in flight
+      const currentTagKey = this.model.tag?.id || this.model.tag?.name;
+      if (currentTagKey !== tagKey) {
+        return;
+      }
+
+      result.synonyms = result.synonyms.map((s) =>
+        this.store.createRecord("tag", s)
+      );
+      this.tagInfo = result;
+      this.#loadedTagId = tagKey;
+    } catch (e) {
+      popupAjaxError(e);
+      throw e;
+    } finally {
+      this.loadingTagInfo = false;
+    }
+  }
+
+  @action
+  async toggleTagInfo() {
+    if (this.showTagInfo) {
+      this.showTagInfo = false;
+      return;
+    }
+
+    const tagKey = this.model.tag?.id || this.model.tag?.name;
+    if (!tagKey) {
+      return;
+    }
+
+    if (!this.tagInfo || this.#loadedTagId !== tagKey) {
+      try {
+        await this.#fetchTagInfo(tagKey);
+      } catch {
+        return;
+      }
+    }
+
+    this.showTagInfo = true;
+  }
+
+  @action
+  onTagInfoUpdated(tagId) {
+    if (this.#loadedTagId !== tagId) {
+      return;
+    }
+
+    if (this.showTagInfo) {
+      this.#fetchTagInfo(tagId).catch(() => {
+        this.tagInfo = null;
+        this.#loadedTagId = null;
+        this.showTagInfo = false;
+      });
+    } else {
+      this.tagInfo = null;
+      this.#loadedTagId = null;
+    }
+  }
+
+  @action
+  syncTagInfo() {
+    const tagKey = this.model.tag?.id || this.model.tag?.name;
+
+    if (!this.model.tag || this.#loadedTagId === tagKey) {
+      return;
+    }
+
+    if (this.showTagInfo) {
+      this.#fetchTagInfo(tagKey).catch(() => {
+        this.tagInfo = null;
+        this.#loadedTagId = null;
+        this.showTagInfo = false;
+      });
+    } else {
+      this.tagInfo = null;
+      this.#loadedTagId = null;
+    }
   }
 
   @action

--- a/frontend/discourse/app/routes/tag/show.js
+++ b/frontend/discourse/app/routes/tag/show.js
@@ -244,6 +244,7 @@ export default class TagShowRoute extends DiscourseRoute {
   setupController(controller, model) {
     super.setupController(...arguments);
     controller.bulkSelectHelper.clear();
+    controller.syncTagInfo();
     setTopicList(model.list);
 
     if (model.category || model.additionalTags) {

--- a/frontend/discourse/app/templates/discovery/list.gjs
+++ b/frontend/discourse/app/templates/discovery/list.gjs
@@ -2,14 +2,27 @@ import CategoriesDisplay from "discourse/components/discovery/categories-display
 import Layout from "discourse/components/discovery/layout";
 import Navigation from "discourse/components/discovery/navigation";
 import Topics from "discourse/components/discovery/topics";
+import TagInfo from "discourse/components/tag-info";
+import { and } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 export default <template>
   <Layout
     @model={{@controller.model}}
     @createTopicDisabled={{@controller.createTopicDisabled}}
+    @toggleTagInfo={{@controller.toggleTagInfo}}
     @listClass="--topic-list"
   >
+    <:aboveNavigation>
+      {{#if (and @controller.model.tag @controller.showTagInfo)}}
+        <TagInfo
+          @tagInfo={{@controller.tagInfo}}
+          @currentUser={{@controller.currentUser}}
+          @loading={{@controller.loadingTagInfo}}
+        />
+      {{/if}}
+    </:aboveNavigation>
+
     <:navigation>
       <Navigation
         @category={{@controller.model.category}}
@@ -22,6 +35,9 @@ export default <template>
         @createTopic={{@controller.createTopic}}
         @createTopicDisabled={{@controller.createTopicDisabled}}
         @canCreateTopicOnTag={{@controller.model.canCreateTopicOnTag}}
+        @toggleTagInfo={{@controller.toggleTagInfo}}
+        @showTagInfo={{@controller.showTagInfo}}
+        @loadingTagInfo={{@controller.loadingTagInfo}}
         @tagNotification={{@controller.model.tagNotification}}
         @model={{@controller.model.list}}
         @showDismissRead={{@controller.showDismissRead}}

--- a/frontend/discourse/float-kit/components/d-float-body.gjs
+++ b/frontend/discourse/float-kit/components/d-float-body.gjs
@@ -26,15 +26,16 @@ export default class DFloatBody extends Component {
     };
   });
 
-  trapPointerDown = modifierFn((element) => {
+  trapPointerEvents = modifierFn((element) => {
     const handler = (event) => {
       event.stopPropagation();
     };
 
-    element.addEventListener("pointerdown", handler);
+    const events = ["pointerdown", "mousedown", "touchend"];
+    events.forEach((name) => element.addEventListener(name, handler));
 
     return () => {
-      element.removeEventListener("pointerdown", handler);
+      events.forEach((name) => element.removeEventListener(name, handler));
     };
   });
 
@@ -89,7 +90,7 @@ export default class DFloatBody extends Component {
         aria-expanded={{if @instance.expanded "true" "false"}}
         role={{@role}}
         {{FloatKitApplyFloatingUi this.trigger this.options @instance}}
-        {{this.trapPointerDown}}
+        {{this.trapPointerEvents}}
         {{(if @trapTab (modifier dTrapTab autofocus=this.options.autofocus))}}
         {{(if
           (and @instance.expanded this.supportsCloseOnClickOutside)

--- a/frontend/discourse/float-kit/components/d-float-body.gjs
+++ b/frontend/discourse/float-kit/components/d-float-body.gjs
@@ -26,16 +26,15 @@ export default class DFloatBody extends Component {
     };
   });
 
-  trapPointerEvents = modifierFn((element) => {
+  trapPointerDown = modifierFn((element) => {
     const handler = (event) => {
       event.stopPropagation();
     };
 
-    const events = ["pointerdown", "mousedown", "touchend"];
-    events.forEach((name) => element.addEventListener(name, handler));
+    element.addEventListener("pointerdown", handler);
 
     return () => {
-      events.forEach((name) => element.removeEventListener(name, handler));
+      element.removeEventListener("pointerdown", handler);
     };
   });
 
@@ -90,7 +89,7 @@ export default class DFloatBody extends Component {
         aria-expanded={{if @instance.expanded "true" "false"}}
         role={{@role}}
         {{FloatKitApplyFloatingUi this.trigger this.options @instance}}
-        {{this.trapPointerEvents}}
+        {{this.trapPointerDown}}
         {{(if @trapTab (modifier dTrapTab autofocus=this.options.autofocus))}}
         {{(if
           (and @instance.expanded this.supportsCloseOnClickOutside)

--- a/frontend/discourse/tests/acceptance/tags-test.js
+++ b/frontend/discourse/tests/acceptance/tags-test.js
@@ -517,6 +517,20 @@ acceptance("Tag info", function (needs) {
     assert.dom(".tag-info").doesNotExist("panel is gone outside tag routes");
   });
 
+  test("tag info panel is hidden on a tag+category route", async function (assert) {
+    await visit("/tag/planters/12");
+    await click("#show-tag-info");
+    assert.dom(".tag-info").exists();
+
+    await visit("/tags/c/feature/2/planters/12");
+    assert
+      .dom("#show-tag-info")
+      .doesNotExist("info button is hidden on tag+category route");
+    assert
+      .dom(".tag-info")
+      .doesNotExist("panel is hidden on tag+category route");
+  });
+
   test("can filter tags page by category", async function (assert) {
     await visit("/tag/planters/12");
 

--- a/frontend/discourse/tests/acceptance/tags-test.js
+++ b/frontend/discourse/tests/acceptance/tags-test.js
@@ -471,6 +471,52 @@ acceptance("Tag info", function (needs) {
     );
   });
 
+  test("tag info button toggles a read-only info panel for non-editors", async function (assert) {
+    updateCurrentUser({ moderator: false, admin: false, can_edit_tags: false });
+
+    await visit("/tag/planters/12");
+    assert.dom("#show-tag-info").exists("info button is shown to everyone");
+    assert.dom("#edit-tag").doesNotExist("non-editors don't see the wrench");
+    assert
+      .dom("#show-tag-info")
+      .hasAttribute("aria-pressed", "false", "button starts unpressed");
+
+    await click("#show-tag-info");
+    assert.dom(".tag-info .tag-name").exists("panel renders the tag");
+    assert
+      .dom(".tag-info .tag-associations")
+      .includesText("Gardening", "panel lists tag groups");
+    assert
+      .dom('.tag-info .synonyms-list [data-tag-name="containers"]')
+      .exists("first synonym is rendered");
+    assert
+      .dom('.tag-info .synonyms-list [data-tag-name="planter"]')
+      .exists("second synonym is rendered");
+    assert.dom(".tag-info .badge-category").exists("panel lists categories");
+    assert
+      .dom("#show-tag-info")
+      .hasAttribute("aria-pressed", "true", "button is pressed when open");
+
+    await click("#show-tag-info");
+    assert.dom(".tag-info").doesNotExist("clicking again hides the panel");
+    assert
+      .dom("#show-tag-info")
+      .hasAttribute(
+        "aria-pressed",
+        "false",
+        "button returns to unpressed state"
+      );
+  });
+
+  test("tag info panel is hidden when not on a tag page", async function (assert) {
+    await visit("/tag/planters/12");
+    await click("#show-tag-info");
+    assert.dom(".tag-info").exists();
+
+    await visit("/latest");
+    assert.dom(".tag-info").doesNotExist("panel is gone outside tag routes");
+  });
+
   test("can filter tags page by category", async function (assert) {
     await visit("/tag/planters/12");
 
@@ -847,11 +893,11 @@ acceptance("Tag settings page", function (needs) {
     );
   });
 
-  test("clicking tag info button navigates to settings page", async function (assert) {
+  test("clicking edit tag button navigates to settings page", async function (assert) {
     updateCurrentUser({ moderator: false, admin: true, can_edit_tags: true });
 
     await visit("/tag/test-tag/100");
-    await click("#show-tag-info");
+    await click("#edit-tag");
 
     assert.strictEqual(
       currentURL(),

--- a/frontend/discourse/tests/integration/components/tag-info-test.gjs
+++ b/frontend/discourse/tests/integration/components/tag-info-test.gjs
@@ -1,0 +1,87 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import TagInfo from "discourse/components/tag-info";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+module("Integration | Component | tag-info", function (hooks) {
+  setupRenderingTest(hooks);
+
+  function buildTagInfo(store, attrs = {}) {
+    const { synonyms = [], ...rest } = attrs;
+    return store.createRecord("tag-info", {
+      id: 12,
+      name: "planters",
+      slug: "planters",
+      tag_group_names: [],
+      categories: [],
+      category_restricted: false,
+      ...rest,
+      synonyms: synonyms.map((s) => store.createRecord("tag", s)),
+    });
+  }
+
+  test("shows category_restricted message when restricted with no visible categories", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const tagInfo = buildTagInfo(store, {
+      tag_group_names: ["Gardening"],
+      categories: [],
+      category_restricted: true,
+    });
+
+    await render(<template><TagInfo @tagInfo={{tagInfo}} /></template>);
+
+    assert
+      .dom(".tag-associations")
+      .includesText("Gardening", "tag group is still shown");
+    assert
+      .dom(".tag-associations")
+      .includesText(
+        i18n("tagging.category_restricted"),
+        "restricted message renders alongside the tag group"
+      );
+    assert
+      .dom(".tag-associations")
+      .doesNotIncludeText(
+        i18n("tagging.default_info"),
+        "default fallback is suppressed when restricted"
+      );
+  });
+
+  test("hides category_restricted message when categories are visible", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const tagInfo = buildTagInfo(store, {
+      categories: [
+        {
+          id: 7,
+          name: "Outdoors",
+          color: "000",
+          text_color: "FFFFFF",
+          slug: "outdoors",
+        },
+      ],
+      category_restricted: true,
+    });
+
+    await render(<template><TagInfo @tagInfo={{tagInfo}} /></template>);
+
+    assert.dom(".tag-associations .badge-category").exists();
+    assert
+      .dom(".tag-associations")
+      .doesNotIncludeText(
+        i18n("tagging.category_restricted"),
+        "restricted message is not duplicated when categories render"
+      );
+  });
+
+  test("shows default_info when there is nothing else to show", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const tagInfo = buildTagInfo(store);
+
+    await render(<template><TagInfo @tagInfo={{tagInfo}} /></template>);
+
+    assert
+      .dom(".tag-associations")
+      .includesText(i18n("tagging.default_info").replace(/<[^>]+>/g, ""));
+  });
+});

--- a/spec/system/page_objects/pages/tag.rb
+++ b/spec/system/page_objects/pages/tag.rb
@@ -20,6 +20,18 @@ module PageObjects
         has_no_css?("#show-tag-info")
       end
 
+      def edit_tag_btn
+        find("#edit-tag")
+      end
+
+      def has_edit_tag_btn?
+        has_css?("#edit-tag")
+      end
+
+      def has_no_edit_tag_btn?
+        has_no_css?("#edit-tag")
+      end
+
       def has_no_tag?(name)
         has_no_css?(".tag-box", text: name)
       end

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -24,7 +24,7 @@ describe "Tag Settings" do
       sign_in(admin)
 
       tags_page.visit_tag(tag_1)
-      tags_page.tag_info_btn.click
+      tags_page.edit_tag_btn.click
 
       expect(tag_settings_page).to have_tag_settings_page
       expect(page).to have_current_path("/tag/#{tag_1.id}-tag/#{tag_1.id}/edit/general")
@@ -36,18 +36,18 @@ describe "Tag Settings" do
       sign_in(admin)
 
       tags_page.visit_tag(tag_1)
-      tags_page.tag_info_btn.click
+      tags_page.edit_tag_btn.click
       expect(page).to have_current_path("/tag/#{tag_1.slug}/#{tag_1.id}/edit/general")
 
       sign_in(trust_level_4)
       tags_page.visit_tag(tag_1)
-      tags_page.tag_info_btn.click
+      tags_page.edit_tag_btn.click
       expect(page).to have_current_path("/tag/#{tag_1.slug}/#{tag_1.id}/edit/general")
 
       sign_in(user)
       tags_page.visit_tag(tag_1)
 
-      expect(tags_page).to have_no_tag_info_btn
+      expect(tags_page).to have_no_edit_tag_btn
       visit("/tag/#{tag_1.slug}/#{tag_1.id}/edit/general")
       expect(page).to have_current_path("/tag/#{tag_1.slug}/#{tag_1.id}")
     end
@@ -55,7 +55,7 @@ describe "Tag Settings" do
     it "allows privileged users to edit tag, admin to delete tag" do
       sign_in(trust_level_4)
       tags_page.visit_tag(tag_1)
-      tags_page.tag_info_btn.click
+      tags_page.edit_tag_btn.click
 
       expect(page).to have_no_css(".d-page-header__actions .btn-danger")
       expect(tag_settings_page).to have_name_value(tag_1.name)
@@ -80,14 +80,14 @@ describe "Tag Settings" do
 
       sign_in(admin)
       tags_page.visit_tag(tag_2)
-      tags_page.tag_info_btn.click
+      tags_page.edit_tag_btn.click
       expect(page).to have_css(".d-page-header__actions .btn-danger")
       tag_settings_page.click_delete
       dialog.click_danger
       expect(page).to have_current_path("/tags")
 
       tags_page.visit_tag(tag_1)
-      tags_page.tag_info_btn.click
+      tags_page.edit_tag_btn.click
       tag_settings_page.click_back
       expect(page).to have_current_path("/tag/custom-slug/#{tag_1.id}")
     end


### PR DESCRIPTION
In 5f0d95e1f11 we added a dedicated tag settings page, but removed some information for tags that was available to regular visitors. This PR adds an info button back to the UI and revamps that tag information so it's better aligned with our category heading styles. 

The ℹ️ button also now reflects the state (blue icon = active) and it can persist while navigating between tag routes. 

There are now some shared styles between the two banners with a new `.discovery-heading` class. 

<img width="2188" height="502" alt="image" src="https://github.com/user-attachments/assets/b430a694-1f7a-4891-bdde-40276b526aad" />


and the existing category banner, for comparison 

<img width="2194" height="602" alt="image" src="https://github.com/user-attachments/assets/a3fcc6df-78a8-42d0-acc2-a48e69eae6f1" />
