### PR TITLE
FIX: Skip discovery search when header search is scoped to PMs

### DIFF
--- a/frontend/discourse/app/components/search-menu.gjs
+++ b/frontend/discourse/app/components/search-menu.gjs
@@ -22,6 +22,7 @@ import getURL from "discourse/lib/get-url";
 import {
   isValidSearchTerm,
   searchForTerm,
+  searchTermScopesToPMs,
   updateRecentSearches,
 } from "discourse/lib/search";
 import DiscourseURL from "discourse/lib/url";
@@ -123,11 +124,9 @@ export default class SearchMenu extends Component {
   }
 
   get isPMOnly() {
-    // Check if search is filtered to private messages only
-    const searchTerm = this.search.activeGlobalSearchTerm || "";
     return (
       this.inPMInboxContext ||
-      /\bin:(personal|messages|personal-direct|all-pms)\b/i.test(searchTerm)
+      searchTermScopesToPMs(this.search.activeGlobalSearchTerm)
     );
   }
 

--- a/frontend/discourse/app/controllers/full-page-search.js
+++ b/frontend/discourse/app/controllers/full-page-search.js
@@ -20,6 +20,7 @@ import {
   logSearchLinkClick,
   reciprocallyRankedList,
   searchContextDescription,
+  searchTermScopesToPMs,
   translateResults,
   updateRecentSearches,
 } from "discourse/lib/search";
@@ -305,11 +306,7 @@ export default class FullPageSearchController extends Controller {
 
   @computed("q")
   get isPMOnly() {
-    // Check if search is filtered to private messages only
-    return (
-      this.q &&
-      /\bin:(personal|messages|personal-direct|all-pms)\b/i.test(this.q)
-    );
+    return searchTermScopesToPMs(this.q);
   }
 
   @computed("resultCount", "noSortQ")

--- a/frontend/discourse/app/lib/search.js
+++ b/frontend/discourse/app/lib/search.js
@@ -229,6 +229,15 @@ export function getSearchKey(args) {
 const MIN_LENGTH_BYPASS_PATTERN =
   /^(l|r)$|order:|category:|categories:|tags?:|before:|after:|status:|user:|group:|badge:|in:|with:|#|@/i;
 
+// Filters that scope the search to private messages. Mirrors the server-side
+// set in lib/search.rb (`in:personal`, `in:messages`, `in:personal-direct`,
+// `in:all-pms` — all of which set @search_pms = true).
+const PM_FILTER_PATTERN = /\bin:(personal|messages|personal-direct|all-pms)\b/i;
+
+export function searchTermScopesToPMs(searchTerm) {
+  return PM_FILTER_PATTERN.test(searchTerm || "");
+}
+
 export function isValidSearchTerm(searchTerm, siteSettings) {
   if (!searchTerm) {
     return false;

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/search-discoveries-context.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/search-discoveries-context.js
@@ -1,8 +1,17 @@
-// Mirrors SearchMenu#searchContext: only topic and PM contexts actually scope
-// the search request. Category and tag pages set search.searchContext but the
-// menu still searches globally there, so discoveries should still trigger.
+import { searchTermScopesToPMs } from "discourse/lib/search";
+
+// Mirrors SearchMenu#searchContext and #isPMOnly: only topic and PM contexts
+// (whether from the UI or an `in:` filter in the term) actually scope the
+// search request. Category and tag pages set search.searchContext but the menu
+// still searches globally there, so discoveries should still trigger.
 export function isScopedSearch(search) {
+  if (!search) {
+    return false;
+  }
+
   return (
-    search?.inTopicContext || search?.searchContext?.type === "private_messages"
+    search.inTopicContext ||
+    search.searchContext?.type === "private_messages" ||
+    searchTermScopesToPMs(search.activeGlobalSearchTerm)
   );
 }

--- a/plugins/discourse-ai/test/javascripts/unit/lib/search-discoveries-context-test.js
+++ b/plugins/discourse-ai/test/javascripts/unit/lib/search-discoveries-context-test.js
@@ -41,4 +41,29 @@ module("Unit | Lib | search-discoveries-context", function () {
       isScopedSearch({ searchContext: { type: "private_messages" } })
     );
   });
+
+  test("returns true when the term filters to PMs", function (assert) {
+    ["in:messages", "in:personal", "in:personal-direct", "in:all-pms"].forEach(
+      (filter) => {
+        assert.true(
+          isScopedSearch({ activeGlobalSearchTerm: `keyword ${filter}` }),
+          `${filter} scopes the search to PMs`
+        );
+      }
+    );
+
+    assert.true(
+      isScopedSearch({ activeGlobalSearchTerm: "keyword IN:Messages" }),
+      "PM filter detection is case-insensitive"
+    );
+  });
+
+  test("returns false for non-PM `in:` filters", function (assert) {
+    assert.false(
+      isScopedSearch({ activeGlobalSearchTerm: "keyword in:title" })
+    );
+    assert.false(
+      isScopedSearch({ activeGlobalSearchTerm: "keyword in:bookmarks" })
+    );
+  });
 });


### PR DESCRIPTION
Previously, the AI discovery (semantic) search still triggered from the header search when the user narrowed their query to private messages with an `in:messages` / `in:personal` / `in:personal-direct` / `in:all-pms` filter.

This change extends `isScopedSearch` to detect PM filters in the search term via a new shared `searchTermScopesToPMs` helper in `discourse/lib/search`, which also replaces the duplicated regex in `SearchMenu#isPMOnly` and `FullPageSearch#isPMOnly`.