### PR TITLE
FEATURE: "new event" button in events categories

### DIFF
--- a/frontend/discourse/app/components/create-topic-button.gjs
+++ b/frontend/discourse/app/components/create-topic-button.gjs
@@ -6,24 +6,9 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 export default class CreateTopicButton extends Component {
   @service router;
-  @service site;
 
   get label() {
-    const label = this.args.label ?? "topic.create";
-
-    const sharedDraftsCategoryId = this.site.shared_drafts_category_id;
-    const currentCategoryId =
-      this.router.currentRoute?.attributes?.category?.id;
-
-    if (
-      label === "topic.create" &&
-      sharedDraftsCategoryId &&
-      currentCategoryId === sharedDraftsCategoryId
-    ) {
-      return "topic.create_shared_draft";
-    }
-
-    return label;
+    return this.args.label ?? "topic.create";
   }
 
   get btnId() {
@@ -72,6 +57,7 @@ export default class CreateTopicButton extends Component {
       <TopicDraftsDropdown
         @action={{@action}}
         @label={{this.label}}
+        @icon={{@icon}}
         @btnId={{this.btnId}}
         @btnClasses={{this.btnClasses}}
         @draftMenuClasses={{this.draftMenuClasses}}

--- a/frontend/discourse/app/components/d-navigation.gjs
+++ b/frontend/discourse/app/components/d-navigation.gjs
@@ -36,14 +36,37 @@ export default class DNavigation extends Component {
     return this.siteSettings.fixed_category_positions;
   }
 
+  @computed("category", "site.shared_drafts_category_id")
   get createTopicLabel() {
     const defaultKey = "topic.create";
+    let value = this.site.desktopView ? defaultKey : "";
 
-    return applyValueTransformer(
-      "create-topic-label",
-      this.site.desktopView ? defaultKey : "",
-      { site: this.site, defaultKey }
-    );
+    if (
+      value === defaultKey &&
+      this.site.shared_drafts_category_id &&
+      this.category?.id === this.site.shared_drafts_category_id
+    ) {
+      value = "topic.create_shared_draft";
+    }
+
+    return applyValueTransformer("create-topic-label", value, {
+      site: this.site,
+      defaultKey,
+      category: this.category,
+      currentUser: this.currentUser,
+    });
+  }
+
+  @computed("category")
+  get createTopicIcon() {
+    const defaultIcon = "far-pen-to-square";
+
+    return applyValueTransformer("create-topic-icon", defaultIcon, {
+      site: this.site,
+      defaultIcon,
+      category: this.category,
+      currentUser: this.currentUser,
+    });
   }
 
   get showBulkSelectInNavControls() {
@@ -335,6 +358,7 @@ export default class DNavigation extends Component {
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.clickCreateTopicButton}}
         @label={{this.createTopicLabel}}
+        @icon={{this.createTopicIcon}}
         @btnTypeClass={{if
           this.siteSettings.modernize_foundation_theme
           "btn-primary"

--- a/frontend/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/frontend/discourse/app/components/topic-drafts-dropdown.gjs
@@ -108,7 +108,7 @@ export default class TopicDraftsDropdown extends Component {
         @action={{@action}}
         @label={{@label}}
         @ariaLabel={{@label}}
-        @icon="far-pen-to-square"
+        @icon={{or @icon "far-pen-to-square"}}
         id={{@btnId}}
         class={{@btnClasses}}
       />

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -54,6 +54,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "composer-toggles-class",
   "create-topic-button-class",
   "create-topic-button-draft-menu-class",
+  "create-topic-icon",
   "create-topic-label",
   "flag-button-disabled-state",
   "flag-button-dynamic-class",

--- a/plugins/discourse-calendar/assets/javascripts/discourse/initializers/add-events-create-topic-button.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/initializers/add-events-create-topic-button.js
@@ -1,0 +1,54 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+function eventsCategoryIds(siteSettings) {
+  return (siteSettings.events_calendar_categories || "")
+    .split("|")
+    .filter(Boolean)
+    .map((id) => parseInt(id, 10));
+}
+
+function isEventsCategoryContext(context, currentUser, siteSettings) {
+  if (!currentUser?.can_create_discourse_post_event) {
+    return false;
+  }
+  const categoryId = context.category?.id;
+  if (!categoryId) {
+    return false;
+  }
+  return eventsCategoryIds(siteSettings).includes(categoryId);
+}
+
+function initializeEventsCreateTopicButton(api, siteSettings) {
+  const currentUser = api.getCurrentUser();
+
+  api.registerValueTransformer("create-topic-label", ({ value, context }) => {
+    if (value !== "topic.create") {
+      return value;
+    }
+    if (!isEventsCategoryContext(context, currentUser, siteSettings)) {
+      return value;
+    }
+    return "discourse_post_event.new_event";
+  });
+
+  api.registerValueTransformer("create-topic-icon", ({ value, context }) => {
+    if (!isEventsCategoryContext(context, currentUser, siteSettings)) {
+      return value;
+    }
+    return "far-calendar-plus";
+  });
+}
+
+export default {
+  name: "add-events-create-topic-button",
+
+  initialize(container) {
+    const siteSettings = container.lookup("service:site-settings");
+    if (!siteSettings.enable_events_category_type_setup) {
+      return;
+    }
+    withPluginApi((api) =>
+      initializeEventsCreateTopicButton(api, siteSettings)
+    );
+  },
+};

--- a/plugins/discourse-calendar/assets/javascripts/discourse/initializers/add-events-create-topic-button.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/initializers/add-events-create-topic-button.js
@@ -44,9 +44,6 @@ export default {
 
   initialize(container) {
     const siteSettings = container.lookup("service:site-settings");
-    if (!siteSettings.enable_events_category_type_setup) {
-      return;
-    }
     withPluginApi((api) =>
       initializeEventsCreateTopicButton(api, siteSettings)
     );

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -327,6 +327,7 @@ en:
       search: "Search..."
       group_availability: "%{group} availability"
     discourse_post_event:
+      new_event: "New Event"
       notifications:
         before_event_reminder: "An event is about to start"
         after_event_reminder: "An event has ended"

--- a/plugins/discourse-calendar/test/javascripts/acceptance/events-create-topic-button-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/events-create-topic-button-test.js
@@ -16,7 +16,6 @@ acceptance(
     needs.settings({
       calendar_enabled: true,
       discourse_post_event_enabled: true,
-      enable_events_category_type_setup: true,
       events_calendar_categories: "1",
     });
     needs.pretender(eventsPretender);
@@ -58,33 +57,11 @@ acceptance(
     needs.settings({
       calendar_enabled: true,
       discourse_post_event_enabled: true,
-      enable_events_category_type_setup: true,
       events_calendar_categories: "1",
     });
     needs.pretender(eventsPretender);
 
     test("keeps the default label and icon", async function (assert) {
-      await visit("/c/bug/1");
-
-      assert.dom("#create-topic").hasText(i18n("topic.create"));
-      assert.dom("#create-topic .d-icon-far-pen-to-square").exists();
-    });
-  }
-);
-
-acceptance(
-  "Events Create Topic Button - feature flag disabled",
-  function (needs) {
-    needs.user({ can_create_discourse_post_event: true });
-    needs.settings({
-      calendar_enabled: true,
-      discourse_post_event_enabled: true,
-      enable_events_category_type_setup: false,
-      events_calendar_categories: "1",
-    });
-    needs.pretender(eventsPretender);
-
-    test("keeps the default label and icon in an events category", async function (assert) {
       await visit("/c/bug/1");
 
       assert.dom("#create-topic").hasText(i18n("topic.create"));

--- a/plugins/discourse-calendar/test/javascripts/acceptance/events-create-topic-button-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/events-create-topic-button-test.js
@@ -1,0 +1,94 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
+
+const eventsPretender = (server, helper) => {
+  server.get("/discourse-post-event/events", () => {
+    return helper.response({ events: [] });
+  });
+};
+
+acceptance(
+  "Events Create Topic Button - allowed user in events category",
+  function (needs) {
+    needs.user({ can_create_discourse_post_event: true });
+    needs.settings({
+      calendar_enabled: true,
+      discourse_post_event_enabled: true,
+      enable_events_category_type_setup: true,
+      events_calendar_categories: "1",
+    });
+    needs.pretender(eventsPretender);
+
+    test("renames the button to New Event and swaps the icon", async function (assert) {
+      await visit("/c/bug/1");
+
+      assert
+        .dom("#create-topic")
+        .hasText(i18n("discourse_post_event.new_event"));
+      assert.dom("#create-topic .d-icon-far-calendar-plus").exists();
+    });
+
+    test("keeps the default label and icon outside events categories", async function (assert) {
+      await visit("/c/feature/2");
+
+      assert.dom("#create-topic").hasText(i18n("topic.create"));
+      assert.dom("#create-topic .d-icon-far-pen-to-square").exists();
+    });
+
+    test("updates label and icon when navigating between categories", async function (assert) {
+      await visit("/c/feature/2");
+      assert.dom("#create-topic").hasText(i18n("topic.create"));
+      assert.dom("#create-topic .d-icon-far-pen-to-square").exists();
+
+      await visit("/c/bug/1");
+      assert
+        .dom("#create-topic")
+        .hasText(i18n("discourse_post_event.new_event"));
+      assert.dom("#create-topic .d-icon-far-calendar-plus").exists();
+    });
+  }
+);
+
+acceptance(
+  "Events Create Topic Button - user without permission",
+  function (needs) {
+    needs.user({ can_create_discourse_post_event: false });
+    needs.settings({
+      calendar_enabled: true,
+      discourse_post_event_enabled: true,
+      enable_events_category_type_setup: true,
+      events_calendar_categories: "1",
+    });
+    needs.pretender(eventsPretender);
+
+    test("keeps the default label and icon", async function (assert) {
+      await visit("/c/bug/1");
+
+      assert.dom("#create-topic").hasText(i18n("topic.create"));
+      assert.dom("#create-topic .d-icon-far-pen-to-square").exists();
+    });
+  }
+);
+
+acceptance(
+  "Events Create Topic Button - feature flag disabled",
+  function (needs) {
+    needs.user({ can_create_discourse_post_event: true });
+    needs.settings({
+      calendar_enabled: true,
+      discourse_post_event_enabled: true,
+      enable_events_category_type_setup: false,
+      events_calendar_categories: "1",
+    });
+    needs.pretender(eventsPretender);
+
+    test("keeps the default label and icon in an events category", async function (assert) {
+      await visit("/c/bug/1");
+
+      assert.dom("#create-topic").hasText(i18n("topic.create"));
+      assert.dom("#create-topic .d-icon-far-pen-to-square").exists();
+    });
+  }
+);


### PR DESCRIPTION
In categories with the "events" type (using the upcoming change "Enable events category type setup"), users who can create events now see a "New Event" button with a calendar icon instead of the default "New Topic". 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/dfed0063-16cb-4da4-ba28-f58a1aca670c" />

Adds a new `create-topic-icon` value transformer alongside the existing `create-topic-label`, so plugins and themes can swap the create-topic button's icon.

Also moves core's hardcoded shared-drafts label override out of `CreateTopicButton` and into `DNavigation`, so we're utilizing the same transformer. 

Fixed an issue with the create-topic button label not updating when navigating between categories.