### PR TITLE
UI: AI mode on DE edit page (step 4/n)

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -6,6 +6,7 @@ import AceEditor from "discourse/components/ace-editor";
 import BackButton from "discourse/components/back-button";
 import DSegmentedControl from "discourse/components/d-segmented-control";
 import MultiSelect from "discourse/select-kit/components/multi-select";
+import { and, eq, notEq, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DTextField from "discourse/ui-kit/d-text-field";
@@ -16,6 +17,8 @@ import { i18n } from "discourse-i18n";
 import CodeView from "discourse/plugins/discourse-data-explorer/discourse/components/code-view";
 import ExplorerSchema from "discourse/plugins/discourse-data-explorer/discourse/components/explorer-schema";
 import ParamInputForm from "discourse/plugins/discourse-data-explorer/discourse/components/param-input-form";
+import QueryAiPrompt from "discourse/plugins/discourse-data-explorer/discourse/components/query-ai-prompt";
+import QueryModeSwitch from "discourse/plugins/discourse-data-explorer/discourse/components/query-mode-switch";
 import QueryResultDownloadButtons from "discourse/plugins/discourse-data-explorer/discourse/components/query-result-download-buttons";
 import QueryResultsWrapper from "discourse/plugins/discourse-data-explorer/discourse/components/query-results-wrapper";
 import QueryRunSplitButton from "discourse/plugins/discourse-data-explorer/discourse/components/query-run-split-button";
@@ -30,10 +33,20 @@ export default class QueriesEdit extends Component {
       {{#if @controller.disallow}}
         <h1>{{i18n "explorer.admins_only"}}</h1>
       {{else}}
-        <BackButton
-          @route="adminPlugins.show.explorer.index"
-          @label="explorer.queries"
-        />
+        <div class="query-edit__top-bar">
+          <BackButton
+            @route="adminPlugins.show.explorer.index"
+            @label="explorer.queries"
+          />
+
+          {{#if @controller.aiQueriesEnabled}}
+            <QueryModeSwitch
+              @value={{@controller.mode}}
+              @onChange={{@controller.setMode}}
+              @editDisabled={{@controller.editDisabled}}
+            />
+          {{/if}}
+        </div>
 
         <div class="query-edit {{if @controller.editingName 'editing'}}">
           {{#if @controller.editingName}}
@@ -93,6 +106,145 @@ export default class QueriesEdit extends Component {
 
           <div class="clear"></div>
 
+          {{#if (eq @controller.mode "ai")}}
+            <QueryAiPrompt
+              @value={{@controller.aiPrompt}}
+              @onChange={{@controller.updateAiPrompt}}
+              @onRegenerate={{@controller.regenerate}}
+              @regenerateDisabled={{@controller.regenerateDisabled}}
+              @generating={{@controller.aiGenerating}}
+              @disabled={{@controller.aiGenerating}}
+            />
+          {{else}}
+            <div class="query-editor">
+              <div class="query-editor__header">
+                <h3 class="query-editor__label">{{i18n
+                    "explorer.sql_label"
+                  }}</h3>
+              </div>
+
+              {{#if @controller.editingQuery}}
+                <div class="panels-flex">
+                  <div class="editor-panel">
+                    <AceEditor
+                      @content={{@controller.model.sql}}
+                      @onChange={{@controller.updateSql}}
+                      @mode="sql"
+                      @disabled={{@controller.editorDisabled}}
+                      @save={{@controller.save}}
+                      @submit={{@controller.run}}
+                    />
+                  </div>
+
+                  <div class="right-panel">
+                    <ExplorerSchema @schema={{@controller.schema}} />
+                  </div>
+                </div>
+
+                <div
+                  class="grippie"
+                  {{dDraggable
+                    didStartDrag=@controller.didStartDrag
+                    didEndDrag=@controller.didEndDrag
+                    dragMove=@controller.dragMove
+                  }}
+                >
+                  {{dIcon "discourse-expand"}}
+                </div>
+
+                <div class="clear"></div>
+              {{else}}
+                <div class="sql">
+                  <CodeView
+                    @value={{@controller.model.sql}}
+                    @codeClass="sql"
+                    @setDirty={{@controller.setDirty}}
+                  />
+                </div>
+              {{/if}}
+            </div>
+          {{/if}}
+
+          {{#if @controller.model.is_default}}
+            <div class="default-query-notice alert alert-info">{{i18n
+                "explorer.default_query_notice"
+              }}</div>
+          {{/if}}
+        </div>
+
+        {{#if @controller.model.hasParams}}
+          <form class="query-params-block" {{on "submit" @controller.run}}>
+            <ParamInputForm
+              @initialValues={{@controller.parsedParams}}
+              @paramInfo={{@controller.model.param_info}}
+              @onRegisterApi={{@controller.onRegisterApi}}
+            />
+          </form>
+        {{/if}}
+
+        <div class="query-action-bar">
+          <div class="query-action-bar__left">
+            <QueryRunSplitButton
+              @onRun={{@controller.run}}
+              @disabled={{@controller.runDisabled}}
+              @label={{@controller.runButtonLabel}}
+            />
+            {{#if @controller.editingQuery}}
+              <DButton
+                @action={{@controller.discard}}
+                @icon="arrow-rotate-left"
+                @label="explorer.undo"
+                @disabled={{@controller.saveDisabled}}
+                class="btn-discard-query"
+              />
+              <DButton
+                @action={{@controller.showHelpModal}}
+                @label="explorer.help.label"
+                @icon="circle-question"
+                class="btn-transparent query-action-bar__help"
+              />
+            {{/if}}
+          </div>
+
+          <div class="query-action-bar__right">
+            {{#if (or @controller.hasResults (eq @controller.mode "ai"))}}
+              <DSegmentedControl
+                @name="query-result-view"
+                @value={{@controller.view}}
+                @items={{@controller.viewItems}}
+                @onSelect={{@controller.setView}}
+                @translatedLabel={{i18n "explorer.view.label"}}
+                class="query-results-modes"
+              />
+            {{/if}}
+            <QueryResultDownloadButtons
+              @query={{@controller.model}}
+              @content={{@controller.results}}
+              @includeQueryExport={{true}}
+            />
+
+            {{#if @controller.model.destroyed}}
+              <DButton
+                @action={{@controller.recover}}
+                @icon="arrow-rotate-left"
+                @label="explorer.recover"
+              />
+            {{else if this.showDestroyQuery}}
+              <DButton
+                @action={{@controller.destroyQuery}}
+                @icon="trash-can"
+                @label="explorer.delete"
+                class="btn-danger"
+              />
+            {{/if}}
+          </div>
+        </div>
+
+        <div hidden {{didInsert @controller.runOnLoad}}></div>
+
+        <DConditionalLoadingSpinner @condition={{@controller.loading}} />
+
+        {{#if (and (eq @controller.mode "ai") (eq @controller.view "sql"))}}
           <div class="query-editor">
             <div class="query-editor__header">
               <h3 class="query-editor__label">{{i18n "explorer.sql_label"}}</h3>
@@ -138,98 +290,20 @@ export default class QueriesEdit extends Component {
               </div>
             {{/if}}
           </div>
-
-          <div class="clear"></div>
-
-          {{#if @controller.model.is_default}}
-            <div class="default-query-notice alert alert-info">{{i18n
-                "explorer.default_query_notice"
-              }}</div>
-          {{/if}}
-        </div>
-
-        {{#if @controller.model.hasParams}}
-          <form class="query-params-block" {{on "submit" @controller.run}}>
-            <ParamInputForm
-              @initialValues={{@controller.parsedParams}}
-              @paramInfo={{@controller.model.param_info}}
-              @onRegisterApi={{@controller.onRegisterApi}}
-            />
-          </form>
         {{/if}}
 
-        <div class="query-action-bar">
-          <div class="query-action-bar__left">
-            <QueryRunSplitButton
-              @onRun={{@controller.run}}
-              @disabled={{@controller.runDisabled}}
-              @label={{@controller.runButtonLabel}}
-            />
-            {{#if @controller.editingQuery}}
-              <DButton
-                @action={{@controller.discard}}
-                @icon="arrow-rotate-left"
-                @label="explorer.undo"
-                @disabled={{@controller.saveDisabled}}
-                class="btn-discard-query"
-              />
-              <DButton
-                @action={{@controller.showHelpModal}}
-                @label="explorer.help.label"
-                @icon="circle-question"
-                class="btn-transparent query-action-bar__help"
-              />
-            {{/if}}
-          </div>
-
-          <div class="query-action-bar__right">
-            {{#if @controller.hasResults}}
-              <DSegmentedControl
-                @name="query-result-view"
-                @value={{@controller.view}}
-                @items={{@controller.viewItems}}
-                @onSelect={{@controller.setView}}
-                @translatedLabel={{i18n "explorer.view.label"}}
-                class="query-results-modes"
-              />
-            {{/if}}
-            <QueryResultDownloadButtons
-              @query={{@controller.model}}
-              @content={{@controller.results}}
-              @includeQueryExport={{true}}
-            />
-
-            {{#if @controller.model.destroyed}}
-              <DButton
-                @action={{@controller.recover}}
-                @icon="arrow-rotate-left"
-                @label="explorer.recover"
-              />
-            {{else if this.showDestroyQuery}}
-              <DButton
-                @action={{@controller.destroyQuery}}
-                @icon="trash-can"
-                @label="explorer.delete"
-                class="btn-danger"
-              />
-            {{/if}}
-          </div>
-        </div>
-
-        <div hidden {{didInsert @controller.runOnLoad}}></div>
-
-        <DConditionalLoadingSpinner @condition={{@controller.loading}} />
-
-        <QueryResultsWrapper
-          @results={{@controller.results}}
-          @showResults={{@controller.showResults}}
-          @query={{@controller.model}}
-          @content={{@controller.results}}
-          @cachedAt={{@controller.cachedAt}}
-          @view={{@controller.view}}
-          @onSetView={{@controller.setView}}
-          @hideHeaderActions={{true}}
-        />
+        {{#if (notEq @controller.view "sql")}}
+          <QueryResultsWrapper
+            @results={{@controller.results}}
+            @showResults={{@controller.showResults}}
+            @query={{@controller.model}}
+            @content={{@controller.results}}
+            @cachedAt={{@controller.cachedAt}}
+            @view={{@controller.view}}
+            @onSetView={{@controller.setView}}
+            @hideHeaderActions={{true}}
+          />
+        {{/if}}
 
       {{/if}}
     </div>

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-ai-prompt.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-ai-prompt.gjs
@@ -1,0 +1,42 @@
+import { on } from "@ember/modifier";
+import DButton from "discourse/ui-kit/d-button";
+import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
+import DTextarea from "discourse/ui-kit/d-textarea";
+import { i18n } from "discourse-i18n";
+
+const QueryAiPrompt = <template>
+  <div class="query-ai-prompt">
+    <label class="query-ai-prompt__label" for="query-ai-prompt-input">
+      {{i18n "explorer.ai.prompt_label"}}
+    </label>
+    <DTextarea
+      @value={{@value}}
+      {{on "input" @onChange}}
+      placeholder={{i18n "explorer.ai.regenerate_placeholder"}}
+      id="query-ai-prompt-input"
+      class="query-ai-prompt__input"
+      disabled={{@disabled}}
+    />
+    <div class="query-ai-prompt__actions">
+      <DButton
+        @action={{@onRegenerate}}
+        @icon="arrows-rotate"
+        @label="explorer.ai.regenerate"
+        @disabled={{@regenerateDisabled}}
+        class="btn-default query-ai-prompt__regenerate"
+      />
+      {{#if @generating}}
+        <span
+          class="query-ai-prompt__generating"
+          role="status"
+          aria-live="polite"
+        >
+          <DConditionalLoadingSpinner @condition={{true}} @size="small" />
+          <span>{{i18n "explorer.ai.generating"}}</span>
+        </span>
+      {{/if}}
+    </div>
+  </div>
+</template>;
+
+export default QueryAiPrompt;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-mode-switch.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-mode-switch.gjs
@@ -17,7 +17,9 @@ export default class QueryModeSwitch extends Component {
         value: "ai",
         icon: "discourse-sparkles",
         label: i18n("explorer.mode.ai"),
-        disabled: !this.siteSettings.data_explorer_ai_queries_enabled,
+        disabled:
+          !this.siteSettings.data_explorer_ai_queries_enabled ||
+          this.args.editDisabled,
       },
     ];
   }

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
@@ -8,8 +8,10 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import { bind } from "discourse/lib/decorators";
 import KeyValueStore from "discourse/lib/key-value-store";
+import { i18n } from "discourse-i18n";
 import QueryHelp from "discourse/plugins/discourse-data-explorer/discourse/components/modal/query-help";
 import { ParamValidationError } from "discourse/plugins/discourse-data-explorer/discourse/components/param-input-form";
+import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
 import { chartability } from "discourse/plugins/discourse-data-explorer/discourse/lib/chart-helpers";
 import Query from "discourse/plugins/discourse-data-explorer/discourse/models/query";
 
@@ -18,6 +20,9 @@ const viewStore = new KeyValueStore("discourse_data_explorer_");
 export default class PluginsExplorerController extends Controller {
   @service modal;
   @service appEvents;
+  @service siteSettings;
+  @service messageBus;
+  @service toasts;
 
   @tracked params;
   @tracked editingName = false;
@@ -27,12 +32,18 @@ export default class PluginsExplorerController extends Controller {
   @tracked dirty = false;
   @tracked isCachedResult = false;
   @tracked view = "table";
+  @tracked mode = "manual";
+  @tracked aiPrompt = "";
+  @tracked aiGenerating = false;
+  @tracked lastGeneratedPrompt = null;
 
   queryParams = ["params"];
   order = null;
   form = null;
   shouldAutoRun = false;
   _pristine = null;
+  _teardownAiGeneration = null;
+  _aiGenerationToken = 0;
 
   constructor() {
     super(...arguments);
@@ -122,18 +133,37 @@ export default class PluginsExplorerController extends Controller {
     return this.dirty ? "explorer.saverun" : "explorer.run";
   }
 
+  get aiQueriesEnabled() {
+    return this.siteSettings.data_explorer_ai_queries_enabled;
+  }
+
+  get regenerateDisabled() {
+    const trimmed = this.aiPrompt.trim();
+    return (
+      this.aiGenerating || !trimmed || trimmed === this.lastGeneratedPrompt
+    );
+  }
+
   get viewItems() {
-    return [
+    const items = [
       { value: "chart", icon: "signal" },
       { value: "table", icon: "table" },
     ];
+    if (this.mode === "ai") {
+      items.push({ value: "sql", icon: "code" });
+    }
+    return items;
   }
 
   initView() {
     const queryId = this.model?.id;
     const stored = queryId ? viewStore.get(`view_${queryId}`) : null;
-    if (stored === "chart" || stored === "table") {
+    const validViews =
+      this.mode === "ai" ? ["chart", "table", "sql"] : ["chart", "table"];
+    if (validViews.includes(stored)) {
       this.view = stored;
+    } else if (this.mode === "ai" && !this.hasResults) {
+      this.view = "sql";
     } else {
       this.view = chartability(this.results).chartable ? "chart" : "table";
     }
@@ -146,6 +176,101 @@ export default class PluginsExplorerController extends Controller {
     if (queryId) {
       viewStore.set({ key: `view_${queryId}`, value });
     }
+  }
+
+  @action
+  setMode(value) {
+    this.mode = value;
+    if (value !== "ai") {
+      this._teardownAi();
+      this.aiPrompt = "";
+      this.lastGeneratedPrompt = null;
+    }
+  }
+
+  @action
+  updateAiPrompt(event) {
+    this.aiPrompt = event.target.value;
+  }
+
+  @action
+  async regenerate() {
+    if (this.regenerateDisabled) {
+      return;
+    }
+
+    this._teardownAi();
+    this.aiGenerating = true;
+    const token = this._aiGenerationToken;
+
+    try {
+      const response = await ajax(
+        "/admin/plugins/discourse-data-explorer/queries/generate.json",
+        {
+          type: "POST",
+          data: {
+            ai_description: this.aiPrompt.trim(),
+            existing_sql: this.model.sql || undefined,
+          },
+        }
+      );
+
+      if (token !== this._aiGenerationToken) {
+        return;
+      }
+
+      this._teardownAiGeneration = subscribeToAiGeneration({
+        messageBus: this.messageBus,
+        generationId: response.generation_id,
+        onComplete: (data) => {
+          if (token !== this._aiGenerationToken) {
+            return;
+          }
+          this.model.set("sql", data.sql);
+          this.recomputeDirty();
+          this.lastGeneratedPrompt = this.aiPrompt.trim();
+          this.aiGenerating = false;
+          if (this.view === "chart" || this.view === "table") {
+            this.run();
+          } else {
+            this.setView("sql");
+          }
+        },
+        onError: (data) => {
+          if (token !== this._aiGenerationToken) {
+            return;
+          }
+          this.aiGenerating = false;
+          this.toasts.error({
+            data: {
+              message: data.error || i18n("explorer.ai.generation_error"),
+            },
+          });
+        },
+        onTimeout: () => {
+          if (token !== this._aiGenerationToken) {
+            return;
+          }
+          this.aiGenerating = false;
+          this.toasts.error({
+            data: { message: i18n("explorer.ai.generation_timeout") },
+          });
+        },
+      });
+    } catch (error) {
+      if (token !== this._aiGenerationToken) {
+        return;
+      }
+      this.aiGenerating = false;
+      popupAjaxError(error);
+    }
+  }
+
+  _teardownAi() {
+    this._aiGenerationToken++;
+    this._teardownAiGeneration?.();
+    this._teardownAiGeneration = null;
+    this.aiGenerating = false;
   }
 
   @action
@@ -375,7 +500,15 @@ export default class PluginsExplorerController extends Controller {
           return;
         }
         this.showResults = true;
-        this.initView();
+        // After a successful run, jump out of the SQL view so the user sees
+        // the results they just asked for.
+        if (this.view === "sql") {
+          this.setView(
+            chartability(this.results).chartable ? "chart" : "table"
+          );
+        } else {
+          this.initView();
+        }
       })
       .catch((err) => {
         this.showResults = false;

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
@@ -4,12 +4,8 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { bind } from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
-
-const AI_GENERATION_CHANNEL_PREFIX =
-  "/discourse-data-explorer/queries/ai-generation";
-const AI_GENERATION_TIMEOUT_MS = 60000;
+import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
 
 export default class AdminPluginsExplorerNew extends Controller {
   @service store;
@@ -29,9 +25,8 @@ export default class AdminPluginsExplorerNew extends Controller {
   @tracked schema = null;
   @tracked manualSql = "SELECT 1";
 
-  currentGenerationId = null;
   manualFormData = { name: "", description: "" };
-  _aiGenerationTimer = null;
+  _teardownAiGeneration = null;
 
   get aiQueriesEnabled() {
     return this.siteSettings.data_explorer_ai_queries_enabled;
@@ -86,7 +81,7 @@ export default class AdminPluginsExplorerNew extends Controller {
       return;
     }
 
-    this._teardownMessageBus();
+    this._teardownAi();
     this.aiGenerating = true;
 
     try {
@@ -101,8 +96,31 @@ export default class AdminPluginsExplorerNew extends Controller {
         }
       );
 
-      this.currentGenerationId = response.generation_id;
-      this._subscribeToGeneration(this.currentGenerationId);
+      this._teardownAiGeneration = subscribeToAiGeneration({
+        messageBus: this.messageBus,
+        generationId: response.generation_id,
+        onComplete: (data) => {
+          this.generatedSql = data.sql;
+          this.generatedName = data.name;
+          this.generatedDescription = data.description;
+          this.hasGenerated = true;
+          this.aiGenerating = false;
+        },
+        onError: (data) => {
+          this.aiGenerating = false;
+          this.toasts.error({
+            data: {
+              message: data.error || i18n("explorer.ai.generation_error"),
+            },
+          });
+        },
+        onTimeout: () => {
+          this.aiGenerating = false;
+          this.toasts.error({
+            data: { message: i18n("explorer.ai.generation_timeout") },
+          });
+        },
+      });
     } catch (error) {
       this.aiGenerating = false;
       popupAjaxError(error);
@@ -154,57 +172,13 @@ export default class AdminPluginsExplorerNew extends Controller {
     this.generatedDescription = event.target.value;
   }
 
-  _subscribeToGeneration(generationId) {
-    const channel = `${AI_GENERATION_CHANNEL_PREFIX}/${generationId}`;
-    this.messageBus.subscribe(channel, this._onAiGenerationMessage, -1);
-
-    this._aiGenerationTimer = setTimeout(() => {
-      this._teardownMessageBus();
-      this.aiGenerating = false;
-      this.toasts.error({
-        data: { message: i18n("explorer.ai.generation_timeout") },
-      });
-    }, AI_GENERATION_TIMEOUT_MS);
-  }
-
-  @bind
-  _onAiGenerationMessage(data) {
-    if (data.generation_id !== this.currentGenerationId) {
-      return;
-    }
-
-    if (data.status === "complete") {
-      this.generatedSql = data.sql;
-      this.generatedName = data.name;
-      this.generatedDescription = data.description;
-      this.hasGenerated = true;
-      this.aiGenerating = false;
-      this._teardownMessageBus();
-    } else if (data.status === "error") {
-      this.aiGenerating = false;
-      this._teardownMessageBus();
-      this.toasts.error({
-        data: {
-          message: data.error || i18n("explorer.ai.generation_error"),
-        },
-      });
-    }
-  }
-
-  _teardownMessageBus() {
-    if (this.currentGenerationId) {
-      const channel = `${AI_GENERATION_CHANNEL_PREFIX}/${this.currentGenerationId}`;
-      this.messageBus.unsubscribe(channel, this._onAiGenerationMessage);
-    }
-    if (this._aiGenerationTimer) {
-      clearTimeout(this._aiGenerationTimer);
-      this._aiGenerationTimer = null;
-    }
+  _teardownAi() {
+    this._teardownAiGeneration?.();
+    this._teardownAiGeneration = null;
   }
 
   resetState() {
-    this._teardownMessageBus();
-    this.currentGenerationId = null;
+    this._teardownAi();
     this.aiGenerating = false;
     this.hasGenerated = false;
     this.aiDescription = "";

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/ai-generation.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/ai-generation.js
@@ -1,0 +1,45 @@
+export const AI_GENERATION_CHANNEL_PREFIX =
+  "/discourse-data-explorer/queries/ai-generation";
+export const AI_GENERATION_TIMEOUT_MS = 60000;
+
+export function subscribeToAiGeneration({
+  messageBus,
+  generationId,
+  onComplete,
+  onError,
+  onTimeout,
+}) {
+  const channel = `${AI_GENERATION_CHANNEL_PREFIX}/${generationId}`;
+  let timerId = null;
+  let torndown = false;
+
+  const teardown = () => {
+    if (torndown) {
+      return;
+    }
+    torndown = true;
+    messageBus.unsubscribe(channel, handler);
+    clearTimeout(timerId);
+  };
+
+  const handler = (data) => {
+    if (data.generation_id !== generationId) {
+      return;
+    }
+    if (data.status === "complete") {
+      teardown();
+      onComplete?.(data);
+    } else if (data.status === "error") {
+      teardown();
+      onError?.(data);
+    }
+  };
+
+  messageBus.subscribe(channel, handler, -1);
+  timerId = setTimeout(() => {
+    teardown();
+    onTimeout?.();
+  }, AI_GENERATION_TIMEOUT_MS);
+
+  return teardown;
+}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
@@ -1,7 +1,10 @@
+import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
+  @service siteSettings;
+
   queryParams = {
     autoRun: {
       as: "run",
@@ -54,9 +57,16 @@ export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
   }
 
   setupController(controller, model, transition) {
+    controller._teardownAi();
+
     const cachedResult = model.model.cached_result;
     const shouldAutoRun = !!transition.to.queryParams.run;
     const showCachedResult = !!cachedResult && !shouldAutoRun;
+    const defaultMode =
+      this.siteSettings.data_explorer_ai_queries_enabled &&
+      !model.model.is_default
+        ? "ai"
+        : "manual";
 
     controller.setProperties({
       ...model,
@@ -64,8 +74,17 @@ export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
       showResults: showCachedResult,
       isCachedResult: showCachedResult,
       shouldAutoRun,
+      mode: defaultMode,
+      aiPrompt: "",
+      lastGeneratedPrompt: null,
     });
     controller.snapshotPristine();
     controller.initView();
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller._teardownAi();
+    }
   }
 }

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -417,7 +417,8 @@ table.group-reports {
   margin-bottom: 2em;
 }
 
-.query-new__top-bar {
+.query-new__top-bar,
+.query-edit__top-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -426,6 +427,36 @@ table.group-reports {
 
   .back-button {
     margin: 0;
+  }
+}
+
+.query-ai-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  margin: 1em 0;
+
+  &__label {
+    font-weight: 700;
+  }
+
+  &__input {
+    width: 100%;
+    min-height: 4em;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+  }
+
+  &__generating {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
   }
 }
 

--- a/plugins/discourse-data-explorer/config/locales/client.en.yml
+++ b/plugins/discourse-data-explorer/config/locales/client.en.yml
@@ -35,6 +35,8 @@ en:
         description_title: "Generate with AI"
         description_hint: "Describe what you want in plain language. We'll generate the SQL, name, and description for you."
         description_placeholder: "e.g. Show me signups across time"
+        regenerate_placeholder: "e.g. Update the query to limit to 50 results"
+        prompt_label: "Prompt"
         generate: "Generate"
         regenerate: "Re-generate"
         generating: "Generating query with AI..."

--- a/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
@@ -45,4 +45,73 @@ RSpec.describe "Data Explorer AI query generation" do
       expect(page).to have_no_css(".query-new__manual-form")
     end
   end
+
+  context "when on the edit page" do
+    fab!(:query) { Fabricate(:query, name: "Existing query", sql: "SELECT 1", user: admin) }
+
+    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+
+    it "shows the AI prompt and view segmented control (with SQL option) by default in AI mode" do
+      visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+
+      expect(page).to have_css(".query-ai-prompt")
+      expect(page).to have_css(".query-results-modes input[value='sql']", visible: :all)
+
+      find(".query-mode-switch .d-segmented-control__label", text: "Write SQL").click
+
+      expect(page).to have_no_css(".query-ai-prompt")
+      expect(page).to have_no_css(".query-results-modes input[value='sql']", visible: :all)
+    end
+
+    it "keeps Re-generate disabled until the prompt is non-empty" do
+      visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+
+      expect(page).to have_css(".query-ai-prompt__regenerate[disabled]")
+
+      fill_in("query-ai-prompt-input", with: "show me popular topics")
+
+      expect(page).to have_no_css(".query-ai-prompt__regenerate[disabled]")
+    end
+
+    it "switches between SQL, chart, and table views via the segmented control" do
+      visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+
+      # Default in AI mode is SQL — editor visible, results hidden
+      expect(page).to have_css(".query-editor")
+      expect(page).to have_no_css(".query-results")
+
+      page.execute_script(
+        "document.querySelector(\".query-results-modes input[value='table']\").closest('label').click()",
+      )
+      expect(page).to have_no_css(".query-editor")
+      expect(page).to have_no_css(".sql")
+
+      page.execute_script(
+        "document.querySelector(\".query-results-modes input[value='sql']\").closest('label').click()",
+      )
+      expect(page).to have_css(".query-editor")
+    end
+
+    it "clears the prompt when switching back to manual mode" do
+      visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+      fill_in("query-ai-prompt-input", with: "hello")
+
+      find(".query-mode-switch .d-segmented-control__label", text: "Write SQL").click
+      find(".query-mode-switch .d-segmented-control__label", text: "Generate with AI").click
+
+      expect(page).to have_field("query-ai-prompt-input", with: "")
+    end
+  end
+
+  context "when on the edit page for a default query" do
+    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+
+    it "disables the AI option in the mode switch" do
+      visit("/admin/plugins/discourse-data-explorer/queries/-1")
+
+      expect(page).to have_css(".query-mode-switch input[value='manual']:checked", visible: :all)
+      expect(page).to have_css(".query-mode-switch input[value='ai'][disabled]", visible: :all)
+      expect(page).to have_no_css(".query-ai-prompt")
+    end
+  end
 end

--- a/plugins/discourse-data-explorer/spec/system/query_runner_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/query_runner_spec.rb
@@ -12,6 +12,25 @@ RSpec.describe "Data explorer query runner" do
     sign_in admin
   end
 
+  context "with the mode switch in the header" do
+    fab!(:query) { Fabricate(:query, name: "Query", sql: "SELECT 1", user: admin) }
+
+    it "hides the switch when AI queries are disabled" do
+      SiteSetting.data_explorer_ai_queries_enabled = false
+      visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+      expect(page).to have_no_css(".query-mode-switch")
+    end
+
+    it "shows the switch defaulted to AI and toggles to manual" do
+      SiteSetting.data_explorer_ai_queries_enabled = true
+      visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
+      expect(page).to have_css(".query-mode-switch input[value='ai']:checked", visible: :all)
+
+      find(".query-mode-switch .d-segmented-control__label", text: "Write SQL").click
+      expect(page).to have_css(".query-mode-switch input[value='manual']:checked", visible: :all)
+    end
+  end
+
   context "when navigating between queries" do
     fab!(:query_a) do
       Fabricate(:query, name: "Query A", sql: "SELECT * FROM users LIMIT 1", user: admin)


### PR DESCRIPTION
 On `/queries/:id` when AI queries are enabled:
- mode switch top-right (defaults to AI; locked to manual for default queries)
- AI prompt + Re-generate above tabs (Results | SQL)
- generation subscribe/teardown extracted to a shared lib for reuse with `/queries/new`

### before 
**_No AI_** 
<img width="1207" height="1191" alt="Screenshot 2026-05-21 at 3 08 53 PM" src="https://github.com/user-attachments/assets/3d1cff3d-9b46-46f4-83e3-b430149a0fcb" />

### after

https://github.com/user-attachments/assets/378080d7-3515-44c7-a122-b526b043e107


