### PR TITLE
FIX: align staff action CSV export with log visibility rules

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -353,6 +353,7 @@ module Jobs
 
     def get_staff_action_fields(staff_action)
       staff_action_array = []
+      can_see_content = staff_action_log_guardian.can_see_staff_action_log_content?(staff_action)
 
       HEADER_ATTRS_FOR["staff_action"].each do |attr|
         data =
@@ -368,6 +369,8 @@ module Jobs
             else
               "#{user.username} #{staff_action.attributes[attr]}"
             end
+          elsif %w[details context].include?(attr) && !can_see_content
+            attr == "details" ? I18n.t("staff_action_logs.redacted") : nil
           else
             staff_action.attributes[attr]
           end
@@ -427,6 +430,10 @@ module Jobs
       end
 
       screened_url_array
+    end
+
+    def staff_action_log_guardian
+      @staff_action_log_guardian ||= Guardian.new(@current_user)
     end
 
     def notify_user(upload, export_title)

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -139,6 +139,44 @@ RSpec.describe Jobs::ExportCsvFile do
           end
         end
       end
+
+      it "redacts details and context for moderators who cannot see the log content" do
+        category = Fabricate(:private_category, group: Fabricate(:group))
+        topic = Fabricate(:topic, category: category)
+        post = Fabricate(:post, topic: topic)
+        moderator = Fabricate(:moderator)
+        action_log =
+          StaffActionLogger.new(admin).log_post_edit(
+            post,
+            old_raw: "#{post.raw} old",
+            context: "secret context",
+          )
+
+        Jobs::ExportCsvFile.new.execute(user_id: moderator.id, entity: "staff_action")
+
+        row = parse_staff_action_rows(Upload.last).find { |r| r["action"] == "post_edit" }
+        expect(row).to be_present
+        expect(row["details"]).to eq(I18n.t("staff_action_logs.redacted"))
+        expect(row["context"]).to be_blank
+
+        action_log.destroy!
+      end
+
+      it "does not redact details and context for admins" do
+        post = Fabricate(:post)
+        StaffActionLogger.new(admin).log_post_edit(
+          post,
+          old_raw: "#{post.raw} old",
+          context: "visible context",
+        )
+
+        Jobs::ExportCsvFile.new.execute(user_id: admin.id, entity: "staff_action")
+
+        row = parse_staff_action_rows(Upload.last).find { |r| r["action"] == "post_edit" }
+        expect(row).to be_present
+        expect(row["details"]).to include("---")
+        expect(row["context"]).to include("visible context")
+      end
     end
   end
 
@@ -364,6 +402,17 @@ RSpec.describe Jobs::ExportCsvFile do
 
   def to_hash(row)
     Hash[*user_list_header.zip(row).flatten]
+  end
+
+  def parse_staff_action_rows(upload)
+    rows = []
+    Zip::File.open(Discourse.store.path_for(upload)) do |zip_file|
+      zip_file.each do |entry|
+        csv_rows = CSV.parse(zip_file.read(entry), headers: true)
+        rows.concat(csv_rows.map(&:to_h))
+      end
+    end
+    rows
   end
 
   it "exports secondary emails" do


### PR DESCRIPTION
Ensure staff_action CSV exports follow the same visibility behavior as the logs UI. When an entry’s content is not visible to the exporting user, export a redacted details value and omit context. Added tests for moderator and admin export behavior.