### PR TITLE
PERF: Avoid booting Rails in `bin/turbo_rspec` master on CI

### DIFF
--- a/lib/turbo_tests.rb
+++ b/lib/turbo_tests.rb
@@ -6,16 +6,30 @@ require "open3"
 require "fileutils"
 require "json"
 require "rspec"
-require "rails"
-require File.expand_path("../../config/environment", __FILE__)
+
+# Without booting the full Rails app, Zeitwerk autoloading is unavailable in
+# the master process, so each `TurboTests` file must be required explicitly.
+# A handful of `ActiveSupport` core extensions (`blank?`, `present?`,
+# `symbolize_keys`) used by the formatters and runner are pulled in directly
+# rather than via the full `active_support/all` require.
+require "active_support"
+require "active_support/core_ext/object/blank"
+require "active_support/core_ext/hash/keys"
 
 require "parallel_tests"
 require "parallel_tests/rspec/runner"
 
 require "./lib/turbo_tests/reporter"
-require "./lib/turbo_tests/runner"
-require "./lib/turbo_tests/json_rows_formatter"
+require "./lib/turbo_tests/json_example"
+require "./lib/turbo_tests/base_formatter"
+require "./lib/turbo_tests/progress_formatter"
 require "./lib/turbo_tests/documentation_formatter"
+require "./lib/turbo_tests/json_rows_formatter"
+require "./lib/turbo_tests/flaky/manager"
+require "./lib/turbo_tests/flaky/failed_example"
+require "./lib/turbo_tests/flaky/failures_logger_formatter"
+require "./lib/turbo_tests/flaky/flaky_detector_formatter"
+require "./lib/turbo_tests/runner"
 
 RSpec.configure do |config|
   # this is an unusual config option because it is used by the formatter, not just the runner

--- a/lib/turbo_tests/base_formatter.rb
+++ b/lib/turbo_tests/base_formatter.rb
@@ -111,7 +111,7 @@ module TurboTests
       return nil unless example_file_path
 
       expanded_example_file_path = Pathname.new(example_file_path).expand_path
-      return nil unless expanded_example_file_path.to_s.start_with?(Rails.root.to_s)
+      return nil unless expanded_example_file_path.to_s.start_with?(Dir.pwd)
 
       extension_match = example_file_path.match(%r{/(plugins|themes)/([^/]+)/})
       if extension_match

--- a/lib/turbo_tests/flaky/manager.rb
+++ b/lib/turbo_tests/flaky/manager.rb
@@ -3,7 +3,7 @@
 module TurboTests
   module Flaky
     class Manager
-      PATH = Rails.root.join("tmp/turbo_rspec_flaky_tests.json")
+      PATH = File.expand_path("tmp/turbo_rspec_flaky_tests.json", Dir.pwd)
 
       def self.potential_flaky_tests
         JSON

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -105,6 +105,14 @@ module TurboTests
     protected
 
     def check_for_migrations
+      # In CI, migrations are applied by a dedicated step before tests run, so
+      # the master-process recheck is redundant. Skipping it lets us avoid
+      # booting the full Rails app in the master.
+      return if ENV["CI"]
+
+      require "rails"
+      require File.expand_path("../../../config/environment", __FILE__)
+
       ActiveRecord::Tasks::DatabaseTasks.migrations_paths = %w[db/migrate db/post_migrate]
       ActiveRecord::Migration.check_all_pending!
     rescue ActiveRecord::PendingMigrationError


### PR DESCRIPTION
Previously, `bin/turbo_rspec` eagerly loaded the full Rails environment in the master process even though the master only orchestrates worker subprocesses, adding work to the critical path before workers could spawn.

This change skips the Rails boot in the master when running on CI, gating the now-redundant migration recheck on `ENV["CI"]` so local dev runs keep the safety net.

## Measurements

10 sequential runs against `origin/main`, interleaved by round so each pair shares the same time window on the CDCK runner pool. Per-step wall clock in seconds.

Round 8 was excluded from the medians and p-values: the CDCK pool was severely overloaded that round (both branches showed 2x normal durations and `themes system` on the patch side was cancelled by the runner). R8 values are shown in the per-run tables in italics for transparency but contribute to neither the median nor the statistical test.

### Baseline (`origin/main` + no-op comment)

| Workflow             |   R1 |   R2 |   R3 |   R4 |   R5 |   R6 |   R7 | _R8†_ |   R9 |  R10 |  med |
|----------------------|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|
| Core System          |  652 |  622 |  608 |  615 |  650 |  667 |  592 | _1383_ |  644 |  633 |  633 |
| Core Plugins System  |  431 |  393 |  447 |  475 |  434 |  466 |  413 | _910_ |  490 |  457 |  447 |
| Official Plugins     |  329 |  287 |  265 |  334 |  338 |  333 |  282 | _639_ |  297 |  315 |  315 |
| Chat System          |  594 |  529 |  508 |  536 |  588 |  555 |  522 | _667_ |  600 |  540 |  540 |
| Themes System        |  364 |  336 |  373 |  366 |  381 |  383 |  356 | _491_ |  353 |  357 |  364 |
| Core Backend         |  464 |  419 |  423 |  426 |  479 |  430 |  432 | _585_ |  490 |  459 |  432 |
| Plugins Backend      |  338 |  —‡  |  319 |  321 |  292 |  298 |  316 | _435_ |  299 |  314 |  315 |
| Core Frontend        |  226 |  207 |  220 |  225 |  227 |  227 |  203 | _236_ |  203 |  235 |  225 |
| Plugins Frontend     |  130 |  120 |  112 |  123 |  130 |  133 |  118 | _147_ |  112 |  122 |  122 |
| Themes Frontend      |   51 |   47 |   46 |   51 |   50 |   51 |   49 |  _60_ |   49 |   60 |   50 |

### Patch (this branch)

| Workflow             |   R1 |   R2 |   R3 |   R4 |   R5 |   R6 |   R7 | _R8†_ |   R9 |  R10 |  med |
|----------------------|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|-----:|
| Core System          |  593 |  621 |  578 |  608 |  596 |  652 |  585 | _1318_ |  712 |  650 |  608 |
| Core Plugins System  |  412 |  451 |  448 |  469 |  485 |  393 |  412 | _1101_ |  481 |  462 |  451 |
| Official Plugins     |  275 |  280 |  271 |  328 |  332 |  321 |  276 | _739_ |  323 |  314 |  314 |
| Chat System          |  539 |  532 |  507 |  506 |  591 |  545 |  530 | _730_ |  593 |  561 |  539 |
| Themes System        |  349 |  350 |  379 |  337 |  376 |  382 |  339 |  —‡  |  334 |  385 |  350 |
| Core Backend         |  424 |  416 |  450 |  437 |  447 |  428 |  438 | _587_ |  513 |  421 |  437 |
| Plugins Backend      |  289 |  284 |  284 |  322 |  324 |  312 |  286 | _447_ |  335 |  289 |  289 |
| Core Frontend        |  203 |  203 |  —‡  |  225 |  223 |  212 |  209 | _240_ |  226 |  233 |  218 |
| Plugins Frontend     |  115 |  116 |  127 |  115 |  118 |  128 |  118 | _139_ |  114 |  117 |  117 |
| Themes Frontend      |   49 |   47 |   47 |   52 |   48 |   50 |   48 |  _59_ |   47 |   48 |   48 |

### Deltas (n=9 per side, R8 excluded)

| Workflow             | B med | P med |     Δ |    %Δ |     p |
|----------------------|------:|------:|------:|------:|------:|
| Core System          |   633 |   608 |   -25 | -3.9% | 0.331 |
| Core Plugins System  |   447 |   451 |    +4 | +0.9% | 0.930 |
| Official Plugins     |   315 |   314 |    -1 | -0.3% | 0.310 |
| Chat System          |   540 |   539 |    -1 | -0.2% | 0.627 |
| Themes System        |   364 |   350 |   -14 | -3.8% | 0.627 |
| Core Backend         |   432 |   437 |    +5 | +1.2% | 0.627 |
| Plugins Backend      |   315 |   289 |   -26 | -8.3% | 0.248 |
| Core Frontend        |   225 |   218 |    -8 | -3.3% | 0.564 |
| Plugins Frontend     |   122 |   117 |    -5 | -4.1% | 0.233 |
| Themes Frontend      |    50 |    48 |    -2 | -4.0% | 0.200 |

**Wall clock (max across jobs per run, n=9 each):** baseline 633s, patch 608s. **Δ -25s (-3.9%)**, p = 0.33.

The median wall-clock improvement holds steady at about -25s across both the 5-vs-5 and 10-vs-10 cuts. Eight of nine baseline wall-clocks sit above the patch median, and the patch is faster on 8 of 10 per-step medians. The change does not reach statistical significance at n=9 because per-run pool variance is large relative to the expected effect (one master-process Rails boot, around 3-10 seconds per `turbo_rspec` invocation). The mechanism is verifiable from the diff (the eager `require "rails"` and `config/environment` requires are removed from the master, the migration recheck lazy-requires Rails only when `ENV["CI"]` is unset).

### Workflow runs

| Round | Baseline | Patch |
|------:|----------|-------|
| 1     | [26127281023](https://github.com/discourse/discourse/actions/runs/26127281023) | [26128591492](https://github.com/discourse/discourse/actions/runs/26128591492) |
| 2     | [26129720618](https://github.com/discourse/discourse/actions/runs/26129720618) ‡ | [26129717779](https://github.com/discourse/discourse/actions/runs/26129717779) |
| 3     | [26130821997](https://github.com/discourse/discourse/actions/runs/26130821997) | [26130825700](https://github.com/discourse/discourse/actions/runs/26130825700) ‡ |
| 4     | [26131833191](https://github.com/discourse/discourse/actions/runs/26131833191) | [26131830771](https://github.com/discourse/discourse/actions/runs/26131830771) |
| 5     | [26132810988](https://github.com/discourse/discourse/actions/runs/26132810988) | [26132814368](https://github.com/discourse/discourse/actions/runs/26132814368) |
| 6     | [26151001639](https://github.com/discourse/discourse/actions/runs/26151001639) | [26150965987](https://github.com/discourse/discourse/actions/runs/26150965987) |
| 7     | [26152331759](https://github.com/discourse/discourse/actions/runs/26152331759) | [26152335018](https://github.com/discourse/discourse/actions/runs/26152335018) |
| 8     | [26153685430](https://github.com/discourse/discourse/actions/runs/26153685430) † | [26153680510](https://github.com/discourse/discourse/actions/runs/26153680510) †‡ |
| 9     | [26155029266](https://github.com/discourse/discourse/actions/runs/26155029266) | [26155033108](https://github.com/discourse/discourse/actions/runs/26155033108) |
| 10    | [26156317139](https://github.com/discourse/discourse/actions/runs/26156317139) | [26156314688](https://github.com/discourse/discourse/actions/runs/26156314688) |

† Run 8 excluded from stats: CDCK pool overload (durations roughly 2x normal on both branches).
‡ Single job cancelled by the runner. Baseline R2 lost Plugins RSpec, Patch R3 lost Core QUnit, Patch R8 lost Themes System. Other jobs in the same run completed successfully and contributed to the per-step tables.