### PR TITLE
UX: Keep dashboard traffic trend on one line

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -458,6 +458,10 @@ h1 {
     opacity: 0.55;
   }
 
+  &__subintro {
+    max-width: none;
+  }
+
   &__headline {
     margin: 0;
     font-size: var(--font-up-3-rem);
@@ -475,6 +479,7 @@ h1 {
     gap: var(--space-1);
     font-size: inherit;
     line-height: inherit;
+    white-space: nowrap;
 
     &.--up {
       color: var(--success);

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -177,8 +177,6 @@ h1 {
   }
 
   &__subintro {
-    max-width: 60ch;
-
     p {
       font-size: var(--font-down-1-rem);
       color: var(--primary-high);
@@ -456,10 +454,6 @@ h1 {
 
   &.is-loading {
     opacity: 0.55;
-  }
-
-  &__subintro {
-    max-width: none;
   }
 
   &__headline {

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -473,7 +473,6 @@ h1 {
     gap: var(--space-1);
     font-size: inherit;
     line-height: inherit;
-    white-space: nowrap;
 
     &.--up {
       color: var(--success);

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -190,7 +190,7 @@ export default class DashboardTraffic extends Component {
     >
       <div class="db-traffic {{if @loading 'is-loading'}}">
         <div class="db-section__subheader">
-          <div class="db-section__subintro db-traffic__subintro">
+          <div class="db-section__subintro">
             <h3 class="db-traffic__headline">
               {{this.headlineText}}
               {{#if this.trend}}

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -190,7 +190,7 @@ export default class DashboardTraffic extends Component {
     >
       <div class="db-traffic {{if @loading 'is-loading'}}">
         <div class="db-section__subheader">
-          <div class="db-section__subintro">
+          <div class="db-section__subintro db-traffic__subintro">
             <h3 class="db-traffic__headline">
               {{this.headlineText}}
               {{#if this.trend}}


### PR DESCRIPTION
### Before

<img width="956" height="826" alt="image" src="https://github.com/user-attachments/assets/a1f4a8af-ecfc-49e6-8bcb-e87411d9b0f6" />

### After
<img width="956" height="797" alt="image" src="https://github.com/user-attachments/assets/35265013-0732-431e-b120-f00ee3344a82" />

