### PR TITLE
FIX: post-voting topics failed to load in nested view

### DIFF
--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-answer-header.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-answer-header.gjs
@@ -14,6 +14,13 @@ export default class PostVotingAnswerHeader extends Component {
       return false;
     }
 
+    if (
+      !args.topicPageQueryParams ||
+      !args.actions?.updateTopicPageQueryParams
+    ) {
+      return false;
+    }
+
     const repliesToPostNumber =
       args.topicPageQueryParams.replies_to_post_number;
     const positionInStream =
@@ -36,7 +43,7 @@ export default class PostVotingAnswerHeader extends Component {
 
   get sortedByActivity() {
     return (
-      this.args.outletArgs.topicPageQueryParams.filter ===
+      this.args.outletArgs.topicPageQueryParams?.filter ===
       ORDER_BY_ACTIVITY_FILTER
     );
   }

--- a/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-comments-menu.gjs
+++ b/plugins/discourse-post-voting/assets/javascripts/discourse/components/post-voting-comments-menu.gjs
@@ -33,10 +33,10 @@ export default class PostVotingCommentsMenu extends Component {
     this.fetchComments().then(() => {
       schedule("afterRender", () => {
         const textArea = document.querySelector(
-          `#post_${this.args.postNumber} .post-voting-comments__composer .post-voting-comments__composer-textarea`
+          `#post_${this.args.postNumber} .post-voting-comments__composer .post-voting-comments__composer-textarea, [data-post-number="${this.args.postNumber}"] .post-voting-comments__composer .post-voting-comments__composer-textarea`
         );
-        textArea.focus();
-        textArea.select();
+        textArea?.focus();
+        textArea?.select();
       });
     });
   }

--- a/plugins/discourse-post-voting/test/javascripts/unit/components/post-voting-answer-header-test.js
+++ b/plugins/discourse-post-voting/test/javascripts/unit/components/post-voting-answer-header-test.js
@@ -1,0 +1,31 @@
+import { module, test } from "qunit";
+import PostVotingAnswerHeader from "discourse/plugins/discourse-post-voting/discourse/components/post-voting-answer-header";
+
+module("Unit | Component | post-voting-answer-header", function () {
+  test("shouldRender is false without flat topic page outlet args", function (assert) {
+    const topic = { is_post_voting: true };
+    const post = { topic };
+
+    assert.false(
+      PostVotingAnswerHeader.shouldRender({ post }),
+      "does not render in nested post outlets"
+    );
+  });
+
+  test("shouldRender is true above the first answer in flat topic view", function (assert) {
+    const topic = {
+      is_post_voting: true,
+      posts_count: 2,
+      postStream: { stream: [1, 2] },
+    };
+    const post = { id: 2, topic };
+
+    assert.true(
+      PostVotingAnswerHeader.shouldRender({
+        post,
+        actions: { updateTopicPageQueryParams() {} },
+        topicPageQueryParams: {},
+      })
+    );
+  });
+});


### PR DESCRIPTION
When posting a post-voting topic using `discourse-post-voting` plugin, and opening it in nested view, the page render failed.

In devcontainer, the page throw an unrecoverable render error.

And in production, the server returned 500 error.

This issue stems from the `shouldRender` reading `topicPageQueryParams` unguarded, in nested view, the connector failed. This commit solved this by adding a guard to that.

Also add some specs to avoid regression.

Before:

<img width="1917" height="912" alt="image" src="https://github.com/user-attachments/assets/1ebb901f-a3c6-43a5-8a72-76cb7bae13be" />

After:

<img width="1917" height="926" alt="image" src="https://github.com/user-attachments/assets/a35ef924-5481-475b-8ca1-88557fe437b6" />

Also solved an issue preventing the textarea triggered by clicking `Add a comment` button from focusing in nested view.