### PR TITLE
UX: add skeleton loading state to post reactions menu

### DIFF
--- a/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
+++ b/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
@@ -15,6 +15,7 @@
 }
 
 .post-users-popup {
+  --skeleton-shimmer-rgb: #{hexToRGB($primary-50)};
   width: 250px;
   background: var(--secondary);
   color: var(--primary);
@@ -187,12 +188,70 @@
     }
   }
 
-  .loading-container {
-    display: flex;
-    justify-content: center;
+  &__skeleton-item {
+    pointer-events: none;
+  }
 
-    .spinner {
-      margin: var(--space-3);
+  &__skeleton-avatar,
+  &__skeleton-name,
+  &__skeleton-username,
+  &__skeleton-reaction {
+    background: var(--primary-low);
+    border-radius: var(--d-border-radius);
+    position: relative;
+    overflow: hidden;
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      transform: translateX(-100%);
+      background: linear-gradient(
+        90deg,
+        rgb(var(--skeleton-shimmer-rgb), 0) 0,
+        rgb(var(--skeleton-shimmer-rgb), 0.3) 50%,
+        rgb(var(--skeleton-shimmer-rgb), 0.5) 100%
+      );
+
+      @media (prefers-reduced-motion: no-preference) {
+        animation: post-users-popup-shimmer 1.25s infinite;
+      }
+    }
+  }
+
+  &__skeleton-avatar {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    @include viewport.until(sm) {
+      width: 32px;
+      height: 32px;
+    }
+  }
+
+  &__skeleton-name {
+    height: 12px;
+    width: 60%;
+  }
+
+  &__skeleton-username {
+    height: 10px;
+    width: 40%;
+    margin-top: var(--space-1);
+  }
+
+  &__skeleton-reaction {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  @keyframes post-users-popup-shimmer {
+    100% {
+      transform: translateX(100%);
     }
   }
 }

--- a/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
+++ b/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
@@ -139,6 +139,8 @@
   }
 
   .avatar {
+    background: var(--primary-low);
+
     @include viewport.until(sm) {
       width: 32px;
       height: 32px;
@@ -220,8 +222,8 @@
   }
 
   &__skeleton-avatar {
-    width: 25px;
-    height: 25px;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
     flex-shrink: 0;
 
@@ -234,19 +236,25 @@
   &__skeleton-name {
     height: 12px;
     width: 60%;
+    margin-top: 2px;
   }
 
   &__skeleton-username {
     height: 10px;
     width: 40%;
-    margin-top: var(--space-1);
+    margin-top: var(--space-2);
   }
 
   &__skeleton-reaction {
-    width: 14px;
-    height: 14px;
+    width: 1.15em;
+    height: 1.15em;
     flex-shrink: 0;
     margin-left: auto;
+
+    @include viewport.until(sm) {
+      width: 1.25em;
+      height: 1.25em;
+    }
   }
 
   @keyframes post-users-popup-shimmer {

--- a/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
@@ -39,6 +39,7 @@ export default class PostLikedUsersMenu extends Component {
     <PostUsersMenu
       @fetchUsers={{this.fetchUsers}}
       @titleText={{this.titleText}}
+      @totalUsers={{this.post.likeCount}}
     >
       <:avatar as |user|>
         <PluginOutlet

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -66,9 +66,7 @@ export default class PostUsersMenu extends Component {
 
     const remaining = this.args.totalUsers - this.users.length;
     const count =
-      Number.isFinite(remaining) && remaining > 0
-        ? Math.min(remaining, PAGE_SIZE)
-        : FALLBACK_SKELETON_ROWS;
+      remaining > 0 ? Math.min(remaining, PAGE_SIZE) : FALLBACK_SKELETON_ROWS;
     return Array.from({ length: count });
   }
 

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -12,6 +12,22 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 const PAGE_SIZE = 30;
 
+const SkeletonRow = <template>
+  <div
+    class="post-users-popup__item post-users-popup__skeleton-item"
+    aria-hidden="true"
+  >
+    <div class="post-users-popup__skeleton-avatar"></div>
+    <div class="post-users-popup__user-info">
+      <div class="post-users-popup__skeleton-name"></div>
+      {{#unless @prioritizeUsername}}
+        <div class="post-users-popup__skeleton-username"></div>
+      {{/unless}}
+    </div>
+    <div class="post-users-popup__skeleton-reaction"></div>
+  </div>
+</template>;
+
 export default class PostUsersMenu extends Component {
   @service siteSettings;
   @service site;
@@ -139,19 +155,9 @@ export default class PostUsersMenu extends Component {
             </div>
           {{/each}}
           {{#each this.skeletonRows}}
-            <div
-              class="post-users-popup__item post-users-popup__skeleton-item"
-              aria-hidden="true"
-            >
-              <div class="post-users-popup__skeleton-avatar"></div>
-              <div class="post-users-popup__user-info">
-                <div class="post-users-popup__skeleton-name"></div>
-                {{#unless this.siteSettings.prioritize_username_in_ux}}
-                  <div class="post-users-popup__skeleton-username"></div>
-                {{/unless}}
-              </div>
-              <div class="post-users-popup__skeleton-reaction"></div>
-            </div>
+            <SkeletonRow
+              @prioritizeUsername={{this.siteSettings.prioritize_username_in_ux}}
+            />
           {{/each}}
         </DLoadMore>
       </div>

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -11,6 +11,7 @@ import DUserLink from "discourse/ui-kit/d-user-link";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 const PAGE_SIZE = 30;
+const FALLBACK_SKELETON_ROWS = 3;
 
 const SkeletonRow = <template>
   <div
@@ -59,12 +60,16 @@ export default class PostUsersMenu extends Component {
   }
 
   get skeletonRows() {
-    if (!this.loading || !this.args.totalUsers) {
+    if (!this.loading) {
       return [];
     }
 
-    const count = Math.min(this.args.totalUsers - this.users.length, PAGE_SIZE);
-    return Array.from({ length: Math.max(count, 0) });
+    const remaining = this.args.totalUsers - this.users.length;
+    const count =
+      Number.isFinite(remaining) && remaining > 0
+        ? Math.min(remaining, PAGE_SIZE)
+        : FALLBACK_SKELETON_ROWS;
+    return Array.from({ length: count });
   }
 
   @action

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -5,7 +5,6 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
-import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DUserAvatar from "discourse/ui-kit/d-user-avatar";
 import DUserLink from "discourse/ui-kit/d-user-link";
@@ -41,6 +40,15 @@ export default class PostUsersMenu extends Component {
       return trustHTML(`min-height: ${this.bodyMinHeight}px`);
     }
     return null;
+  }
+
+  get skeletonRows() {
+    if (!this.loading || !this.args.totalUsers) {
+      return [];
+    }
+
+    const count = Math.min(this.args.totalUsers - this.users.length, PAGE_SIZE);
+    return Array.from({ length: Math.max(count, 0) });
   }
 
   @action
@@ -130,10 +138,21 @@ export default class PostUsersMenu extends Component {
               {{/if}}
             </div>
           {{/each}}
-          <DConditionalLoadingSpinner
-            @condition={{this.loading}}
-            @size="small"
-          />
+          {{#each this.skeletonRows}}
+            <div
+              class="post-users-popup__item post-users-popup__skeleton-item"
+              aria-hidden="true"
+            >
+              <div class="post-users-popup__skeleton-avatar"></div>
+              <div class="post-users-popup__user-info">
+                <div class="post-users-popup__skeleton-name"></div>
+                {{#unless this.siteSettings.prioritize_username_in_ux}}
+                  <div class="post-users-popup__skeleton-username"></div>
+                {{/unless}}
+              </div>
+              <div class="post-users-popup__skeleton-reaction"></div>
+            </div>
+          {{/each}}
         </DLoadMore>
       </div>
     </div>

--- a/frontend/discourse/app/components/post/menu/post-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/post-users-menu.gjs
@@ -65,8 +65,9 @@ export default class PostUsersMenu extends Component {
     }
 
     const remaining = this.args.totalUsers - this.users.length;
-    const count =
-      remaining > 0 ? Math.min(remaining, PAGE_SIZE) : FALLBACK_SKELETON_ROWS;
+    const count = Number.isFinite(remaining)
+      ? Math.min(Math.max(remaining, 0), PAGE_SIZE)
+      : FALLBACK_SKELETON_ROWS;
     return Array.from({ length: count });
   }
 

--- a/frontend/discourse/tests/integration/components/post/menu/post-users-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/menu/post-users-menu-test.gjs
@@ -1,0 +1,117 @@
+import { render, settled, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import PostUsersMenu from "discourse/components/post/menu/post-users-menu";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+function makeUsers(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    username: `u${i + 1}`,
+    name: `User ${i + 1}`,
+    avatar_template: "/user_avatar/avatar/{size}/1_1.png",
+  }));
+}
+
+function deferredFetch(response) {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  const fetchUsers = () => promise;
+  return {
+    fetchUsers,
+    resolve: () => resolve(response),
+  };
+}
+
+module("Integration | Component | post/menu/post-users-menu", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders skeleton rows while the initial fetch is pending", async function (assert) {
+    const { fetchUsers, resolve } = deferredFetch({
+      users: makeUsers(5),
+      canLoadMore: false,
+    });
+
+    const renderPromise = render(
+      <template>
+        <PostUsersMenu
+          @fetchUsers={{fetchUsers}}
+          @titleText="Likes"
+          @totalUsers={{5}}
+        />
+      </template>
+    );
+
+    await waitFor(".post-users-popup__skeleton-item");
+
+    assert
+      .dom(".post-users-popup__skeleton-item")
+      .exists(
+        { count: 5 },
+        "renders one skeleton per pending user up to PAGE_SIZE"
+      );
+
+    resolve();
+    await renderPromise;
+    await settled();
+
+    assert
+      .dom(".post-users-popup__skeleton-item")
+      .doesNotExist("skeleton rows clear once the fetch resolves");
+    assert
+      .dom(".post-users-popup__item:not(.post-users-popup__skeleton-item)")
+      .exists({ count: 5 }, "renders real user rows after load");
+  });
+
+  test("caps skeleton rows at PAGE_SIZE when totalUsers is larger", async function (assert) {
+    const { fetchUsers, resolve } = deferredFetch({
+      users: makeUsers(30),
+      canLoadMore: true,
+    });
+
+    const renderPromise = render(
+      <template>
+        <PostUsersMenu
+          @fetchUsers={{fetchUsers}}
+          @titleText="Likes"
+          @totalUsers={{200}}
+        />
+      </template>
+    );
+
+    await waitFor(".post-users-popup__skeleton-item");
+
+    assert
+      .dom(".post-users-popup__skeleton-item")
+      .exists({ count: 30 }, "skeleton count is capped at PAGE_SIZE");
+
+    resolve();
+    await renderPromise;
+    await settled();
+  });
+
+  test("falls back to a small skeleton count when totalUsers is missing", async function (assert) {
+    const { fetchUsers, resolve } = deferredFetch({
+      users: makeUsers(2),
+      canLoadMore: false,
+    });
+
+    const renderPromise = render(
+      <template>
+        <PostUsersMenu @fetchUsers={{fetchUsers}} @titleText="Likes" />
+      </template>
+    );
+
+    await waitFor(".post-users-popup__skeleton-item");
+
+    assert
+      .dom(".post-users-popup__skeleton-item")
+      .exists(
+        { count: 3 },
+        "still shows a small skeleton fallback when count is unknown"
+      );
+
+    resolve();
+    await renderPromise;
+    await settled();
+  });
+});

--- a/frontend/discourse/tests/integration/components/post/menu/post-users-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/menu/post-users-menu-test.gjs
@@ -1,7 +1,12 @@
-import { render, settled, waitFor } from "@ember/test-helpers";
+import { render, settled, waitFor, waitUntil } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import PostUsersMenu from "discourse/components/post/menu/post-users-menu";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import stubIntersectionObserver from "discourse/tests/helpers/stub-intersection-observer";
+import {
+  disableLoadMoreObserver,
+  enableLoadMoreObserver,
+} from "discourse/ui-kit/d-load-more";
 
 function makeUsers(count) {
   return Array.from({ length: count }, (_, i) => ({
@@ -24,6 +29,15 @@ function deferredFetch(response) {
 
 module("Integration | Component | post/menu/post-users-menu", function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    enableLoadMoreObserver();
+    this.observations = stubIntersectionObserver();
+  });
+
+  hooks.afterEach(function () {
+    disableLoadMoreObserver();
+  });
 
   test("renders skeleton rows while the initial fetch is pending", async function (assert) {
     const { fetchUsers, resolve } = deferredFetch({
@@ -86,6 +100,54 @@ module("Integration | Component | post/menu/post-users-menu", function (hooks) {
 
     resolve();
     await renderPromise;
+    await settled();
+  });
+
+  test("does not fall back to skeleton rows when load more starts with every known user loaded", async function (assert) {
+    let fetchCallCount = 0;
+    let resolveSecondFetch;
+    const secondFetchPromise = new Promise((resolve) => {
+      resolveSecondFetch = resolve;
+    });
+    const fetchUsers = () => {
+      fetchCallCount++;
+
+      if (fetchCallCount === 1) {
+        return Promise.resolve({
+          users: makeUsers(30),
+          canLoadMore: true,
+        });
+      }
+
+      return secondFetchPromise;
+    };
+
+    await render(
+      <template>
+        <PostUsersMenu
+          @fetchUsers={{fetchUsers}}
+          @titleText="Likes"
+          @totalUsers={{30}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".post-users-popup__item:not(.post-users-popup__skeleton-item)")
+      .exists({ count: 30 }, "renders the initially loaded full page");
+
+    const triggerPromise =
+      this.observations[this.observations.length - 1]?.trigger();
+    await waitUntil(() => fetchCallCount === 2);
+
+    assert
+      .dom(".post-users-popup__skeleton-item")
+      .doesNotExist(
+        "does not render fallback skeleton rows when totalUsers has already been reached"
+      );
+
+    resolveSecondFetch({ users: [], canLoadMore: false });
+    await triggerPromise;
     await settled();
   });
 

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -100,6 +100,7 @@ export default class DiscourseReactionsUsersMenu extends Component {
     <PostUsersMenu
       @fetchUsers={{this.fetchUsers}}
       @titleText={{this.titleText}}
+      @totalUsers={{this.post.reaction_users_count}}
     >
       <:header as |resetAndReload|>
         {{this.registerReset resetAndReload}}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -79,6 +79,13 @@ export default class DiscourseReactionsUsersMenu extends Component {
     });
   }
 
+  get activeFilterTotalUsers() {
+    if (!this.activeFilter) {
+      return this.post.reaction_users_count;
+    }
+    return this.reactions.find((r) => r.id === this.activeFilter)?.count;
+  }
+
   @action
   registerReset(resetFn) {
     this.#resetCallback = resetFn;
@@ -100,7 +107,7 @@ export default class DiscourseReactionsUsersMenu extends Component {
     <PostUsersMenu
       @fetchUsers={{this.fetchUsers}}
       @titleText={{this.titleText}}
-      @totalUsers={{this.post.reaction_users_count}}
+      @totalUsers={{this.activeFilterTotalUsers}}
     >
       <:header as |resetAndReload|>
         {{this.registerReset resetAndReload}}


### PR DESCRIPTION
This change improves the loading experience when fetching user list on slow connections by adding a skeleton shimmer effect. It also makes the initial load less jumpy due to opening panel with the correct number of reactions preloading.

### How it looks

<img width="287" height="350" alt="reaction-loading-state" src="https://github.com/user-attachments/assets/21cde76b-9e43-480c-b7a9-4bc832ea9e3c" />
