### PR TITLE
UX: Do not add a border-radius to AI Bot textarea

### DIFF
--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -303,8 +303,6 @@ body.has-ai-conversations-sidebar {
         resize: none;
         max-height: 30vh;
         min-height: var(--input-min-height);
-        border-radius: 0 var(--d-button-border-radius)
-          var(--d-button-border-radius) 0;
         border: none;
         padding-block: 0.8em;
         padding-inline: 0;


### PR DESCRIPTION
In some themes, this caused the text to look cropped bu a large circle on the top right and bottom right corners.

/t/184001