### PR TITLE
FIX: Render house ads correctly in nested replies view

### DIFF
--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -159,7 +159,7 @@ export default class Nested extends Component {
       {{/if}}
 
       <div class="nested-view__roots">
-        {{#each @rootNodes key="post.id" as |node|}}
+        {{#each @rootNodes key="post.id" as |node index|}}
           <NestedPost
             @post={{node.post}}
             @children={{node.children}}
@@ -192,6 +192,10 @@ export default class Nested extends Component {
             @cloakAbove={{this.cloakAbove}}
             @cloakBelow={{this.cloakBelow}}
             @collapseFromDepth={{if @collapseReplies 0}}
+          />
+          <PluginOutlet
+            @name="nested-roots-between"
+            @outletArgs={{lazyHash topic=@topic index=index}}
           />
         {{else}}
           <div class="nested-view__empty">

--- a/frontend/discourse/app/components/nested/op.gjs
+++ b/frontend/discourse/app/components/nested/op.gjs
@@ -94,7 +94,7 @@ export default class NestedOp extends Component {
   <template>
     {{#if @post}}
       <div class="nested-view__op">
-        {{#let (lazyHash post=@post) as |postOutletArgs|}}
+        {{#let (lazyHash post=@post nestedReplyView=true) as |postOutletArgs|}}
           <PluginOutlet @name="post-article" @outletArgs={{postOutletArgs}}>
             <article
               class="nested-view__op-article boxed"

--- a/frontend/discourse/app/components/nested/post.gjs
+++ b/frontend/discourse/app/components/nested/post.gjs
@@ -494,7 +494,10 @@ export default class NestedPost extends Component {
               </div>
             </div>
           {{else}}
-            {{#let (lazyHash post=@post) as |postOutletArgs|}}
+            {{#let
+              (lazyHash post=@post nestedReplyView=true)
+              as |postOutletArgs|
+            }}
               <PluginOutlet @name="post-article" @outletArgs={{postOutletArgs}}>
                 <article
                   class="nested-post__article boxed"

--- a/plugins/discourse-adplugin/admin/assets/javascripts/admin/components/house-ads-settings-panel.gjs
+++ b/plugins/discourse-adplugin/admin/assets/javascripts/admin/components/house-ads-settings-panel.gjs
@@ -34,6 +34,12 @@ const HouseAdsSettingsPanel = <template>
         @allAds={{@houseAds}}
         @adSettings={{@adSettings}}
       />
+      <HouseAdsListSetting
+        @name="nested_roots_between"
+        @value={{@adSettings.nested_roots_between}}
+        @allAds={{@houseAds}}
+        @adSettings={{@adSettings}}
+      />
 
       <DButton
         @label="admin.adplugin.house_ads.more_settings"

--- a/plugins/discourse-adplugin/app/models/ad_plugin/house_ad_setting.rb
+++ b/plugins/discourse-adplugin/app/models/ad_plugin/house_ad_setting.rb
@@ -8,6 +8,7 @@ module AdPlugin
       topic_above_suggested: "",
       post_bottom: "",
       topic_list_between: "",
+      nested_roots_between: "",
     }
 
     def self.all
@@ -37,6 +38,7 @@ module AdPlugin
           settings.merge(
             after_nth_post: SiteSetting.house_ads_after_nth_post,
             after_nth_topic: SiteSetting.house_ads_after_nth_topic,
+            after_nth_root: SiteSetting.house_ads_after_nth_root,
             house_ads_frequency: SiteSetting.house_ads_frequency,
           ),
         creatives:

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/ad-slot.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/ad-slot.gjs
@@ -137,10 +137,18 @@ export function slotContenders(
         indexNumber
       );
 
+    const canBePlacedInBetweenNestedRoots =
+      placeUnderscored === "nested_roots_between" &&
+      isNthTopicListItem(
+        parseInt(houseAds.settings.after_nth_root, 10),
+        indexNumber
+      );
+
     if (
       adAvailable &&
       (notPlacingBetweenTopics ||
         canBePlacedInBetweenTopics ||
+        canBePlacedInBetweenNestedRoots ||
         isNthPost(parseInt(houseAds.settings.after_nth_post, 10), postNumber))
     ) {
       types.push("house-ad");

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/house-ad.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/house-ad.gjs
@@ -11,6 +11,7 @@ const adIndex = {
   topic_above_suggested: null,
   post_bottom: null,
   topic_list_between: null,
+  nested_roots_between: null,
 };
 
 @tagName("")
@@ -40,19 +41,26 @@ export default class HouseAd extends AdComponent {
     "showToGroups",
     "showAfterPost",
     "showAfterTopicListItem",
+    "showAfterNestedRoot",
     "showOnCurrentPage"
   )
   get showAd() {
     return (
       this.showToGroups &&
-      (this.showAfterPost || this.showAfterTopicListItem) &&
+      (this.showAfterPost ||
+        this.showAfterTopicListItem ||
+        this.showAfterNestedRoot) &&
       this.showOnCurrentPage
     );
   }
 
   @computed("postNumber", "placement")
   get showAfterPost() {
-    if (!this.postNumber && this.placement !== "topic-list-between") {
+    if (
+      !this.postNumber &&
+      this.placement !== "topic-list-between" &&
+      this.placement !== "nested-roots-between"
+    ) {
       return true;
     }
 
@@ -69,6 +77,17 @@ export default class HouseAd extends AdComponent {
 
     return this.isNthTopicListItem(
       parseInt(this.site.get("house_creatives.settings.after_nth_topic"), 10)
+    );
+  }
+
+  @computed("placement")
+  get showAfterNestedRoot() {
+    if (this.placement !== "nested-roots-between") {
+      return true;
+    }
+
+    return this.isNthTopicListItem(
+      parseInt(this.site.get("house_creatives.settings.after_nth_root"), 10)
     );
   }
 

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/nested-root-ad.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/nested-root-ad.gjs
@@ -1,0 +1,11 @@
+import AdSlot from "./ad-slot";
+
+const NestedRootAd = <template>
+  <AdSlot
+    @placement="nested-roots-between"
+    @category={{@topic.category.slug}}
+    @indexNumber={{@index}}
+  />
+</template>;
+
+export default NestedRootAd;

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
@@ -1,5 +1,6 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import Site from "discourse/models/site";
+import NestedRootAd from "../components/nested-root-ad";
 import PostBottomAd from "../components/post-bottom-ad";
 
 export default {
@@ -26,8 +27,19 @@ function customizePost(api) {
   api.renderAfterWrapperOutlet(
     "post-article",
     <template>
-      <div class="ad-connector">
-        <PostBottomAd @model={{@post}} />
+      {{#unless @nestedReplyView}}
+        <div class="ad-connector">
+          <PostBottomAd @model={{@post}} />
+        </div>
+      {{/unless}}
+    </template>
+  );
+
+  api.renderInOutlet(
+    "nested-roots-between",
+    <template>
+      <div class="ad-connector ad-connector--nested-root">
+        <NestedRootAd @index={{@index}} @topic={{@topic}} />
       </div>
     </template>
   );

--- a/plugins/discourse-adplugin/config/locales/client.en.yml
+++ b/plugins/discourse-adplugin/config/locales/client.en.yml
@@ -70,3 +70,6 @@ en:
           topic_list_between:
             title: "Between topics"
             description: "Ads to show in between topics, after every N topics."
+          nested_roots_between:
+            title: "Between nested roots"
+            description: "Ads to show in between root replies in the nested replies view, after every N roots."

--- a/plugins/discourse-adplugin/config/locales/server.en.yml
+++ b/plugins/discourse-adplugin/config/locales/server.en.yml
@@ -33,6 +33,7 @@ en:
     no_ads_for_tags: "Don't show ads on topic list and topic pages belonging to these tags."
     house_ads_after_nth_topic: 'If "Between topics" house ads are defined, show an ad after every N topic, where N is this value.'
     house_ads_after_nth_post: 'If "Between posts" house ads are defined, show an ad after every N posts, where N is this value.'
+    house_ads_after_nth_root: 'If "Between nested roots" house ads are defined, show an ad after every N root replies in the nested replies view, where N is this value.'
     house_ads_frequency: "If other ad networks are configured to show in an ad slot, how often should house ads be shown, as a percentage."
     ads_txt: "Contents of your ads.txt file. More details available at <a href='https://support.google.com/adsense/answer/7532444?hl=en' target='_blank'>this Google AdSense help page</a>."
     ad_plugin_routes_enabled: "Enable route targeting for house ads"

--- a/plugins/discourse-adplugin/config/settings.yml
+++ b/plugins/discourse-adplugin/config/settings.yml
@@ -29,6 +29,11 @@ ad_plugin:
     default: 20
     min: 1
     max: 10000
+  house_ads_after_nth_root:
+    client: true
+    default: 5
+    min: 1
+    max: 10000
   house_ads_frequency:
     client: true
     default: 100


### PR DESCRIPTION
Previously, the house ads plugin attached to the `post-article` outlet on every nested post, so ads landed after randomly-positioned children in the nested replies tree based on the global `post_number` rather than the visible feed.

This change suppresses the per-post outlet in nested view and introduces a new `nested-roots-between` placement with a `house_ads_after_nth_root` setting, so admins can configure ads to appear between every N root replies.