### PR TITLE
DEV: Add chat message workflow trigger

### DIFF
--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -842,9 +842,14 @@ en:
       nodes:
         "action:send_chat_message": "Send chat message"
         "action:chat_approval": "Chat approval"
+        "trigger:chat_message_created": "Chat message created"
       node_descriptions:
         "action:send_chat_message": "Send a message to a chat channel"
         "action:chat_approval": "Send an approval request to a chat channel and wait for a response"
+        "trigger:chat_message_created": "Fires when a new chat message is created"
+      chat_message_created:
+        channel_id: "Channel"
+        channel_id_description: "Leave blank to trigger for all chat channels."
       send_chat_message:
         channel_id: "Channel"
         message: "Message"

--- a/plugins/chat/lib/discourse_workflows/nodes/chat_message_created/v1.rb
+++ b/plugins/chat/lib/discourse_workflows/nodes/chat_message_created/v1.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+if defined?(DiscourseWorkflows)
+  module DiscourseWorkflows
+    module Nodes
+      module ChatMessageCreated
+        class V1 < NodeType
+          include ChatChannelSelection
+
+          description(
+            name: "trigger:chat_message_created",
+            version: "1.0",
+            defaults: {
+              icon: "comments",
+              color: "teal",
+            },
+            group: "discourse_triggers",
+            available: -> { SiteSetting.chat_enabled },
+            unavailable_reason_key: "discourse_workflows.node_unavailable.requires_chat",
+            properties: {
+              channel_id: {
+                type: :integer,
+                required: false,
+                type_options: {
+                  load_options_method: "chat_channels",
+                },
+                no_data_expression: true,
+                ui: {
+                  control: :combo_box,
+                },
+                control_options: {
+                  filterable: true,
+                  value_property: :id,
+                  name_property: :name,
+                  set_from_option: {
+                    channel_name: "name",
+                  },
+                },
+              },
+              channel_name: {
+                type: :string,
+                ui: {
+                  hidden: true,
+                },
+              },
+            },
+          )
+
+          def initialize(message, channel, user)
+            super(parameters: {})
+            @message = message
+            @channel = channel
+            @user = user
+          end
+
+          def self.load_options_context(context)
+            case context.method_name
+            when "chat_channels"
+              ChatChannelSelection.load_options(context)
+            end
+          end
+
+          def valid?
+            @message.present? && @channel.present?
+          end
+
+          def matches?(trigger_ctx)
+            return false if selectable_chat_channel(@channel.id).blank?
+
+            channel_id = trigger_ctx.get_node_parameter("channel_id").presence
+            channel_id.blank? || channel_id.to_i == @channel.id
+          end
+
+          def output
+            {
+              message: {
+                id: @message.id,
+                message: @message.message,
+                cooked: @message.cooked,
+                excerpt: @message.excerpt || @message.build_excerpt,
+                created_at: @message.created_at.iso8601,
+                thread_id: @message.thread_id,
+                chat_channel_id: @message.chat_channel_id,
+              },
+              channel: {
+                id: @channel.id,
+                title: @channel.title(@user),
+                slug: @channel.slug,
+                chatable_type: @channel.chatable_type,
+                chatable_id: @channel.chatable_id,
+              },
+              user: user_data,
+            }
+          end
+
+          private
+
+          def user_data
+            return {} if @user.blank?
+
+            serialize_record(@user, BasicUserSerializer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -106,6 +106,21 @@ after_initialize do
       [DiscourseWorkflows::Nodes::SendChatMessage::V1, DiscourseWorkflows::Nodes::ChatApproval::V1]
     end
 
+    require_relative "lib/discourse_workflows/nodes/chat_message_created/v1"
+    DiscoursePluginRegistry.register_discourse_workflows_node(
+      DiscourseWorkflows::Nodes::ChatMessageCreated::V1,
+      self,
+    )
+
+    on(:chat_message_created) do |message, channel, user|
+      DiscourseWorkflows::EventListener.handle(
+        DiscourseWorkflows::Nodes::ChatMessageCreated::V1,
+        message,
+        channel,
+        user,
+      )
+    end
+
     on(:chat_message_interaction) do |interaction|
       next unless SiteSetting.discourse_workflows_enabled
 

--- a/plugins/chat/spec/integration/workflows_chat_message_created_spec.rb
+++ b/plugins/chat/spec/integration/workflows_chat_message_created_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chat message created workflow trigger" do
+  fab!(:user)
+  fab!(:channel, :chat_channel)
+  fab!(:other_channel, :chat_channel)
+
+  before do
+    SiteSetting.chat_enabled = true
+    SiteSetting.discourse_workflows_enabled = true
+  end
+
+  it "enqueues matching workflows when a chat message is created" do
+    all_channels_workflow =
+      Fabricate(
+        :discourse_workflows_workflow,
+        created_by: user,
+        published: true,
+        **build_workflow_graph { |g| g.node "trigger-all", "trigger:chat_message_created" },
+      )
+    matching_channel_workflow =
+      Fabricate(
+        :discourse_workflows_workflow,
+        created_by: user,
+        published: true,
+        **build_workflow_graph do |g|
+          g.node "trigger-matching",
+                 "trigger:chat_message_created",
+                 configuration: {
+                   "channel_id" => channel.id.to_s,
+                 }
+        end,
+      )
+    Fabricate(
+      :discourse_workflows_workflow,
+      created_by: user,
+      published: true,
+      **build_workflow_graph do |g|
+        g.node "trigger-other",
+               "trigger:chat_message_created",
+               configuration: {
+                 "channel_id" => other_channel.id.to_s,
+               }
+      end,
+    )
+
+    message = Fabricate(:chat_message, chat_channel: channel, user: user)
+    DiscourseEvent.trigger(:chat_message_created, message, channel, user)
+
+    jobs =
+      Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.select do |job|
+        job["args"].first["trigger_node_id"].in?(%w[trigger-all trigger-matching trigger-other])
+      end
+
+    expect(jobs.map { |job| job["args"].first["workflow_id"] }).to contain_exactly(
+      all_channels_workflow.id,
+      matching_channel_workflow.id,
+    )
+    expect(jobs.map { |job| job["args"].first["trigger_data"] }).to all(
+      include("message" => include("id" => message.id), "channel" => include("id" => channel.id)),
+    )
+  end
+end

--- a/plugins/chat/spec/lib/discourse_workflows/nodes/chat_message_created_spec.rb
+++ b/plugins/chat/spec/lib/discourse_workflows/nodes/chat_message_created_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Nodes::ChatMessageCreated::V1 do
+  fab!(:user)
+  fab!(:channel, :chat_channel)
+  fab!(:other_channel, :chat_channel)
+  fab!(:direct_message_channel, :direct_message_channel)
+  fab!(:message) { Fabricate(:chat_message, chat_channel: channel, user: user) }
+  fab!(:direct_message) do
+    Fabricate(:chat_message, chat_channel: direct_message_channel, user: user)
+  end
+
+  before { SiteSetting.chat_enabled = true }
+
+  it "returns the correct identifier" do
+    expect(described_class.identifier).to eq("trigger:chat_message_created")
+  end
+
+  describe ".load_options_context" do
+    fab!(:other_channel) { Fabricate(:chat_channel, name: "Announcements") }
+    fab!(:closed_channel) { Fabricate(:chat_channel, name: "Closed", status: :closed) }
+    fab!(:dm_channel, :direct_message_channel)
+
+    def load_options(filter: nil)
+      context =
+        DiscourseWorkflows::LoadOptionsContext.new(
+          method_name: "chat_channels",
+          filter: filter,
+          node_class: described_class,
+        )
+
+      described_class.load_options_context(context)
+    end
+
+    it "returns open public channels with id and name" do
+      ids = load_options.map { |option| option[:id] }
+
+      expect(ids).to include(channel.id, other_channel.id)
+      expect(ids).not_to include(closed_channel.id, dm_channel.id)
+    end
+
+    it "filters channels by the filter term" do
+      expect(load_options(filter: "announce")).to contain_exactly(
+        { id: other_channel.id, name: other_channel.name },
+      )
+    end
+  end
+
+  it "serializes the message, channel, and user" do
+    output = described_class.new(message, channel, user).output
+
+    expect(output[:message]).to include(
+      id: message.id,
+      message: message.message,
+      chat_channel_id: channel.id,
+    )
+    expect(output[:channel]).to include(id: channel.id, slug: channel.slug)
+    expect(output[:user]).to include(
+      id: user.id,
+      username: user.username,
+      avatar_template: user.avatar_template,
+    )
+  end
+
+  it "matches nodes with no channel filter or the same channel" do
+    trigger = described_class.new(message, channel, user)
+
+    expect(trigger.matches?(trigger_context({}))).to eq(true)
+    expect(trigger.matches?(trigger_context("channel_id" => channel.id.to_s))).to eq(true)
+    expect(trigger.matches?(trigger_context("channel_id" => other_channel.id.to_s))).to eq(false)
+  end
+
+  it "does not match direct message channels" do
+    trigger = described_class.new(direct_message, direct_message_channel, user)
+
+    expect(trigger.matches?(trigger_context({}))).to eq(false)
+  end
+
+  def trigger_context(parameters)
+    DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+  end
+end


### PR DESCRIPTION
Adds a `trigger:chat_message_created` workflow node from the chat plugin. The trigger includes an optional chat channel filter using the workflow chat channel chooser, and emits message, channel, and user data.

<img width="1595" height="906" alt="Screenshot 2026-06-12 at 16 34 06" src="https://github.com/user-attachments/assets/2756a20b-1106-4bca-8295-2c37644c105a" />
<img width="244" height="193" alt="Screenshot 2026-06-12 at 16 34 03" src="https://github.com/user-attachments/assets/ac64f007-e8ec-40f8-b797-43a36ac8eba2" />

