### PR TITLE
FIX: Prevent tag page render crash on invalid numeric tag id routes

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -163,6 +163,7 @@ class TagsController < ::ApplicationController
   Discourse.filters.each do |filter|
     define_method("show_#{filter}") do
       fetch_tag(raise_not_found: false)
+      raise Discourse::NotFound if params[:tag_id].present? && @tag.blank?
 
       if @tag
         if @tag.target_tag_id.present? && @tag.target_tag_id != @tag.id

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -569,6 +569,11 @@ RSpec.describe TagsController do
       expect(response.body).not_to include("ActionView::Template::Error")
     end
 
+    it "returns 404 for missing numeric /tag/:tag_id routes" do
+      get "/tag/9999999"
+      expect(response.status).to eq(404)
+    end
+
     it "redirects slug routes for numeric tag names to the canonical slug/id URL" do
       numeric_tag_name = (Tag.maximum(:id).to_i + 10_000).to_s
       numeric_tag = Fabricate(:tag, name: numeric_tag_name)


### PR DESCRIPTION
When a browser requests /tag/:tag_id with a numeric value that does not match an existing tag id or numeric tag name, the tag show action could continue into HTML rendering with no resolved tag. During list/list render, the RSS alternate link helper then tried to build a tag_feed route using only tag_id, which has no matching RSS route and raised ActionView::Template::Error (No route matches { action: "tag_feed", controller: "tags", tag_id: ... }). Return 404 early for unresolved numeric tag_id requests in tag show filters so we do not render the list template in this invalid state.