### PR TITLE
FIX: Emoji autocomplete with Unicode characters

### DIFF
--- a/frontend/discourse/app/lib/textarea-text-manipulation.js
+++ b/frontend/discourse/app/lib/textarea-text-manipulation.js
@@ -739,7 +739,7 @@ export default class TextareaTextManipulation {
   @bind
   emojiSelected(code) {
     let selected = this.getSelected();
-    const captures = selected.pre.match(/\B:(\w*)$/);
+    const captures = selected.pre.match(/\B:([\p{L}\p{N}_]*)$/u);
 
     if (isEmpty(captures)) {
       if (selected.pre.match(/\S$/)) {

--- a/frontend/discourse/app/static/prosemirror/lib/text-manipulation.js
+++ b/frontend/discourse/app/static/prosemirror/lib/text-manipulation.js
@@ -339,7 +339,7 @@ export default class ProsemirrorTextManipulation {
     let index = 0;
 
     const value = this.autocompleteHandler.getValue();
-    const match = value.match(/\B:(\w*)$/);
+    const match = value.match(/\B:([\p{L}\p{N}_]*)$/u);
     if (match) {
       index = value.length - match.index;
     }

--- a/frontend/discourse/tests/unit/lib/text-area-manipulaton-test.js
+++ b/frontend/discourse/tests/unit/lib/text-area-manipulaton-test.js
@@ -51,4 +51,46 @@ module("Unit | Utility | text-area-manipulation", function (hooks) {
     manipulation.applySurroundSelection("**", "**", "example");
     assert.strictEqual(textarea.value, "****Hello World**");
   });
+
+  test("emojiSelected - replaces ASCII partial term", async function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.value = ":trau";
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    manipulation.emojiSelected("disappointed");
+
+    assert.strictEqual(textarea.value, ":disappointed:");
+  });
+
+  test("emojiSelected - replaces partial term containing Unicode letters", async function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.value = ":glücklich";
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    manipulation.emojiSelected("smile");
+
+    assert.strictEqual(textarea.value, ":smile:");
+  });
+
+  test("emojiSelected - appends emoji when no partial term is present", async function (assert) {
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    const manipulation = new TextareaTextManipulation(getOwner(this), {
+      textarea,
+    });
+
+    textarea.value = "hello";
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    manipulation.emojiSelected("smile");
+
+    assert.strictEqual(textarea.value, "hello :smile:");
+  });
 });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -440,7 +440,7 @@ export default class ChatComposer extends Component {
   onSelectEmoji(emoji, context = {}) {
     const textareaInteractor = this.composer.textarea;
 
-    if (context.emojiTermStart && context.emojiTermStart) {
+    if (context?.emojiTermStart != null) {
       const value = textareaInteractor.textarea.value;
       const valueUpToCursor = `${value.substring(0, context.emojiTermStart)}:${emoji}: `;
       const valueAfterCursor = value.substring(context.emojiTermEnd + 1);
@@ -580,7 +580,8 @@ export default class ChatComposer extends Component {
 
           if (currentValue && currentCaretPos !== undefined) {
             const textBeforeCursor = currentValue.substring(0, currentCaretPos);
-            const incompleteMatch = textBeforeCursor.match(/(:[\w-]+)$/);
+            const incompleteMatch =
+              textBeforeCursor.match(/(:[\p{L}\p{N}_-]+)$/u);
 
             if (incompleteMatch) {
               emojiContext = {

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -87,6 +87,25 @@ RSpec.describe "Chat composer" do
 
       expect(channel_page.composer).to have_value("hey :grimacing: ")
     end
+
+    it "replaces a partially typed term containing Unicode letters" do
+      chat_page.visit_channel(channel_1)
+      input = find(".chat-composer__input")
+      input.send_keys(":gri")
+      # Inject a Unicode character into the partial term while the autocomplete
+      # is open, so the captured term spans non-ASCII letters too.
+      page.execute_script(<<~JS)
+        const el = document.querySelector(".chat-composer__input");
+        el.focus();
+        el.setSelectionRange(el.value.length, el.value.length);
+        document.execCommand("insertText", false, "ü");
+      JS
+
+      click_link(I18n.t("js.composer.more_emoji"))
+      find(".emoji-picker [data-emoji='grimacing']").click
+
+      expect(channel_page.composer).to have_value(":grimacing: ")
+    end
   end
 
   context "when typing on keyboard" do


### PR DESCRIPTION
The term-capture regex used `\w`, which is ASCII-only in JavaScript, so partial terms like `:glücklich` weren't replaced when picking from the emoji picker. Switch to `[\p{L}\p{N}_]` with the `u` flag.

Also fix a null-context crash and a duplicate-condition typo in the chat composer's `onSelectEmoji`.