### PR TITLE
FIX: Improve email delivery failure visibility and skipped SMTP error display

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -67,6 +67,7 @@ class ProblemCheck
   #
   CORE_PROBLEM_CHECKS = [
     ProblemCheck::BadFaviconUrl,
+    ProblemCheck::EmailDeliveryFailures,
     ProblemCheck::EmailPollingErroredRecently,
     ProblemCheck::FacebookConfig,
     ProblemCheck::FailingEmails,

--- a/app/services/problem_check/email_delivery_failures.rb
+++ b/app/services/problem_check/email_delivery_failures.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ProblemCheck::EmailDeliveryFailures < ProblemCheck
+  self.priority = "low"
+  self.perform_every = 1.hour
+
+  LOOKBACK_WINDOW = 24.hours
+
+  def call
+    # De-duplicate with ProblemCheck::FailingEmails so we only show one
+    # admin alert for the same SMTP incident when retry jobs are already failing.
+    return no_problem if failing_email_job_count > 0
+    return no_problem if failed_delivery_count == 0
+
+    problem
+  end
+
+  private
+
+  def failed_delivery_count
+    @failed_delivery_count ||=
+      SkippedEmailLog
+        .where(reason_type: SkippedEmailLog.reason_types[:custom])
+        .where("created_at >= ?", LOOKBACK_WINDOW.ago)
+        .count
+  end
+
+  def failing_email_job_count
+    @failing_email_job_count ||= Jobs.num_email_retry_jobs.to_i
+  end
+
+  def translation_data
+    { count: failed_delivery_count }
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1751,6 +1751,9 @@ en:
       failing_emails: 'There are %{num_failed_jobs} email jobs that failed. Check your app.yml and ensure that the mail server settings are correct. <a href="%{base_path}/sidekiq/retries" target="_blank">See the failed jobs in Sidekiq</a>.'
       subfolder_ends_in_slash: "Your subfolder setup is incorrect; the DISCOURSE_RELATIVE_URL_ROOT ends in a slash."
       translation_overrides: "Some of your translation overrides are out of date. Please check your <a href='%{base_path}/admin/customize/site_texts?outdated=true'>text customizations</a>."
+      email_delivery_failures:
+        one: "Email delivery has failed once in the past 24 hours. Check the <a href='%{base_path}/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details."
+        other: "Email delivery has failed %{count} times in the past 24 hours. Check the <a href='%{base_path}/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details."
       email_polling_errored_recently:
         one: "Email polling has generated an error in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
         other: "Email polling has generated %{count} errors in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."

--- a/frontend/discourse/admin/templates/admin-email-logs/skipped.gjs
+++ b/frontend/discourse/admin/templates/admin-email-logs/skipped.gjs
@@ -54,7 +54,11 @@ export default <template>
           <a href="mailto:{{emailLog.to_address}}">{{emailLog.to_address}}</a>
         </td>
         <td>{{emailLog.email_type}}</td>
-        <td>{{emailLog.skipped_reason}}</td>
+        <td>
+          <div class="overflow-ellipsis" title={{emailLog.skipped_reason}}>
+            {{emailLog.skipped_reason}}
+          </div>
+        </td>
       </tr>
     </:default>
   </EmailLogsList>

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -301,7 +301,7 @@ module Email
           email_log.smtp_transaction_response = message_response.message&.chomp
         end
       rescue *SMTP_CLIENT_ERRORS => e
-        return skip(SkippedEmailLog.reason_types[:custom], custom_reason: e.message)
+        return skip(SkippedEmailLog.reason_types[:custom], custom_reason: smtp_error_message(e))
       rescue Net::SMTPError => e
         response = e.try(:response)
         response = " response: #{response.try(:string) || response}" if response
@@ -503,6 +503,14 @@ module Email
 
       attributes[:custom_reason] = custom_reason if custom_reason
       SkippedEmailLog.create!(attributes)
+    end
+
+    def smtp_error_message(error)
+      response = error.try(:response)
+      return error.message if response.blank?
+
+      response_string = response.respond_to?(:string) ? response.string : response.to_s
+      response_string.presence || error.message
     end
 
     def merge_json_x_header(name, value)

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -1089,4 +1089,28 @@ RSpec.describe Email::Sender do
       expect { email_sender.send }.to raise_error(Net::SMTPUnknownError)
     end
   end
+
+  context "with Net::SMTPFatalError" do
+    let(:message) { Mail::Message.new(to: "eviltrout@test.domain", body: "test body") }
+    let(:email_sender) { Email::Sender.new(message, :valid_type) }
+
+    it "stores the SMTP response string as custom reason" do
+      error = Net::SMTPFatalError.new("552-5.7.0 This message was blocked")
+      smtp_response =
+        Net::SMTP::Response.new(
+          "552",
+          "552-5.7.0 This message was blocked because its content presents a potential\n552 5.7.0 issue",
+        )
+      error.define_singleton_method(:response) { smtp_response }
+      message.expects(:deliver!).raises(error)
+
+      expect { email_sender.send }.to change(SkippedEmailLog, :count).by(1)
+
+      skipped_email_log = SkippedEmailLog.last
+      expect(skipped_email_log.reason_type).to eq(SkippedEmailLog.reason_types[:custom])
+      expect(skipped_email_log.custom_reason).to eq(
+        "552-5.7.0 This message was blocked because its content presents a potential\n552 5.7.0 issue",
+      )
+    end
+  end
 end

--- a/spec/services/problem_check/email_delivery_failures_spec.rb
+++ b/spec/services/problem_check/email_delivery_failures_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::EmailDeliveryFailures do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    before { Jobs.stubs(num_email_retry_jobs: retry_jobs) }
+
+    let(:retry_jobs) { 0 }
+
+    context "when there are no recent custom skipped email logs" do
+      fab!(:old_failure) do
+        Fabricate(
+          :skipped_email_log,
+          reason_type: SkippedEmailLog.reason_types[:custom],
+          custom_reason: "smtp failed",
+          created_at: 25.hours.ago,
+        )
+      end
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when there is a recent custom skipped email log" do
+      fab!(:recent_failure) do
+        Fabricate(
+          :skipped_email_log,
+          reason_type: SkippedEmailLog.reason_types[:custom],
+          custom_reason: "smtp failed",
+          created_at: 1.hour.ago,
+        )
+      end
+
+      it do
+        expect(check).to(
+          have_a_problem.with_priority("low").with_message(
+            "Email delivery has failed once in the past 24 hours. Check the <a href='/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details.",
+          ),
+        )
+      end
+    end
+
+    context "when email retry jobs are failing" do
+      let(:retry_jobs) { 2 }
+
+      fab!(:recent_failure) do
+        Fabricate(
+          :skipped_email_log,
+          reason_type: SkippedEmailLog.reason_types[:custom],
+          custom_reason: "smtp failed",
+          created_at: 1.hour.ago,
+        )
+      end
+
+      it { expect(check).to be_chill_about_it }
+    end
+  end
+end


### PR DESCRIPTION
Add a dedicated `email_delivery_failures` problem check to surface recent custom skipped email delivery failures, de-duplicated against `failing_emails`, and scheduled hourly at low priority. Improve SMTP client error capture to store full server response text in `SkippedEmailLog.custom_reason` for better diagnostics. Update skipped email logs UI to follow existing admin table truncation patterns with `overflow-ellipsis` plus full-text tooltip, so long reasons no longer overwhelm layout while remaining inspectable.