### PR TITLE
FEAT: nginx sample tests

### DIFF
--- a/.github/workflows/nginx-tests.yml
+++ b/.github/workflows/nginx-tests.yml
@@ -4,16 +4,20 @@ on:
   pull_request:
     paths:
       - ".github/workflows/nginx-tests.yml"
+      - "bin/turbo_rspec"
       - "config/nginx.sample.conf"
       - "spec/nginx/**"
+      - "spec/rails_helper.rb"
   push:
     branches:
       - main
       - stable
     paths:
       - ".github/workflows/nginx-tests.yml"
+      - "bin/turbo_rspec"
       - "config/nginx.sample.conf"
       - "spec/nginx/**"
+      - "spec/rails_helper.rb"
 
 concurrency:
   group: nginx-tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}

--- a/.github/workflows/nginx-tests.yml
+++ b/.github/workflows/nginx-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/nginx-tests.yml"
       - "bin/turbo_rspec"
+      - "lib/turbo_rspec_exclusion.rb"
       - "config/nginx.sample.conf"
       - "spec/nginx/**"
       - "spec/rails_helper.rb"
@@ -15,6 +16,7 @@ on:
     paths:
       - ".github/workflows/nginx-tests.yml"
       - "bin/turbo_rspec"
+      - "lib/turbo_rspec_exclusion.rb"
       - "config/nginx.sample.conf"
       - "spec/nginx/**"
       - "spec/rails_helper.rb"

--- a/.github/workflows/nginx-tests.yml
+++ b/.github/workflows/nginx-tests.yml
@@ -1,0 +1,60 @@
+name: Nginx Tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/nginx-tests.yml"
+      - "config/nginx.sample.conf"
+      - "spec/nginx/**"
+  push:
+    branches:
+      - main
+      - stable
+    paths:
+      - ".github/workflows/nginx-tests.yml"
+      - "config/nginx.sample.conf"
+      - "spec/nginx/**"
+
+concurrency:
+  group: nginx-tests-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    if: github.event_name == 'pull_request' || github.repository != 'discourse/discourse-private-mirror'
+    name: Tests
+    runs-on: ${{ (github.repository_owner == 'discourse' && 'cdck-linux-8-core') || 'ubuntu-latest' }}
+    container: discourse/discourse_test:release
+    timeout-minutes: 10
+
+    env:
+      RAILS_ENV: test
+      NGINX_TESTS_REQUIRED: "1"
+
+    steps:
+      - name: Set working directory owner
+        run: chown root:root .
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Symlink vendor/bundle from image
+        run: |
+          ln -s /var/www/discourse/vendor/bundle vendor/bundle
+
+      - name: Setup gems
+        run: |
+          bundle config --local path vendor/bundle
+          bundle config --local deployment true
+          bundle config --local without development
+          bundle install --jobs $(($(nproc) - 1))
+
+      - name: Show nginx version
+        run: nginx -v && nginx -V 2>&1 | tr ' ' '\n' | grep -iE 'module|brotli' || true
+
+      - name: Run nginx sample tests
+        run: spec/nginx/run.sh

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -9,6 +9,25 @@ require "optparse"
 # spec/nginx has its own Rails-free runner; turbo_rspec loads rails_helper.
 DEFAULT_EXCLUDE_PATTERNS = ["spec/nginx/**/*_spec.rb"].freeze
 
+def path_for_exclude_match(file)
+  path = file.sub(/:\d+(?::\d+)?\z/, "")
+  expanded_path = File.expand_path(path)
+  working_directory = "#{Dir.pwd}/"
+
+  if expanded_path.start_with?(working_directory)
+    expanded_path.delete_prefix(working_directory)
+  else
+    path.delete_prefix("./")
+  end
+end
+
+def excluded_by_patterns?(file, patterns)
+  path = path_for_exclude_match(file)
+  patterns.any? do |pattern|
+    File.fnmatch(pattern, path) || File.fnmatch(pattern, path, File::FNM_PATHNAME)
+  end
+end
+
 requires = []
 formatters = []
 verbose = false
@@ -102,13 +121,7 @@ else
   use_runtime_info = false if use_runtime_info.nil?
 end
 
-if exclude_patterns.any?
-  files.reject! do |file|
-    exclude_patterns.any? do |pattern|
-      File.fnmatch(pattern, file) || File.fnmatch(pattern, file, File::FNM_PATHNAME)
-    end
-  end
-end
+files.reject! { |file| excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
 
 if explicit_file_args && requested_files&.any? && files.empty?
   abort "All requested spec files were excluded. spec/nginx has its own runner; use spec/nginx/run.sh for nginx specs."

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -103,7 +103,7 @@ else
   use_runtime_info = false if use_runtime_info.nil?
 end
 
-files.reject! { |file| TurboRspec::Exclusion.excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
+files.reject! { |file| TurboRspecExclusion.excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
 
 if explicit_file_args && requested_files&.any? && files.empty?
   abort "All requested spec files were excluded. spec/nginx has its own runner; use spec/nginx/run.sh for nginx specs."

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -6,6 +6,9 @@ ENV["RAILS_ENV"] ||= "test"
 require "./lib/turbo_tests"
 require "optparse"
 
+# spec/nginx has its own Rails-free runner; turbo_rspec loads rails_helper.
+DEFAULT_EXCLUDE_PATTERNS = ["spec/nginx/**/*_spec.rb"].freeze
+
 requires = []
 formatters = []
 verbose = false
@@ -16,7 +19,7 @@ profile_print_slowest_examples_count = 10
 use_runtime_info = nil
 enable_system_tests = nil
 retry_and_log_flaky_tests = ENV["DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS"].to_s == "1"
-exclude_patterns = []
+exclude_patterns = DEFAULT_EXCLUDE_PATTERNS.dup
 
 OptionParser
   .new do |opts|
@@ -96,7 +99,11 @@ else
 end
 
 if exclude_patterns.any?
-  files.reject! { |file| exclude_patterns.any? { |pattern| File.fnmatch(pattern, file) } }
+  files.reject! do |file|
+    exclude_patterns.any? do |pattern|
+      File.fnmatch(pattern, file) || File.fnmatch(pattern, file, File::FNM_PATHNAME)
+    end
+  end
 end
 
 requires.each { |f| require(f) }

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -105,8 +105,26 @@ end
 
 files.reject! { |file| TurboRspecExclusion.excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
 
-if explicit_file_args && requested_files&.any? && files.empty?
-  abort "All requested spec files were excluded. spec/nginx has its own runner; use spec/nginx/run.sh for nginx specs."
+# If a developer explicitly asked for a file that the DEFAULT nginx
+# exclusion drops, fail loudly rather than silently running a subset.
+# Only the built-in pattern triggers this -- user-supplied
+# --exclude-pattern filters are intentional and may legitimately drop
+# requested files. Checking per-dropped-file (not just files.empty?)
+# catches the mixed case, e.g.
+#   bin/turbo_rspec spec/nginx/foo_spec.rb spec/models/bar_spec.rb
+# which would otherwise run only the model spec and exit 0.
+if explicit_file_args && requested_files&.any?
+  dropped_nginx =
+    requested_files.select do |file|
+      TurboRspecExclusion.excluded_by_patterns?(file, DEFAULT_EXCLUDE_PATTERNS)
+    end
+
+  unless dropped_nginx.empty?
+    abort <<~MSG.chomp
+      Requested spec file(s) are excluded from turbo_rspec by default: #{dropped_nginx.join(", ")}
+      spec/nginx has its own Rails-free runner; run those with: spec/nginx/run.sh
+    MSG
+  end
 end
 
 requires.each { |f| require(f) }

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -77,6 +77,9 @@ OptionParser
   end
   .parse!(ARGV)
 
+explicit_file_args = ARGV.any?
+requested_files = nil
+
 # OptionParser modifies ARGV, leaving the leftover arguments in ARGV
 if ARGV.empty?
   files = Dir.glob("spec/**/*_spec.rb")
@@ -95,6 +98,7 @@ else
       end
     end
 
+  requested_files = files.dup
   use_runtime_info = false if use_runtime_info.nil?
 end
 
@@ -104,6 +108,10 @@ if exclude_patterns.any?
       File.fnmatch(pattern, file) || File.fnmatch(pattern, file, File::FNM_PATHNAME)
     end
   end
+end
+
+if explicit_file_args && requested_files&.any? && files.empty?
+  abort "All requested spec files were excluded. spec/nginx has its own runner; use spec/nginx/run.sh for nginx specs."
 end
 
 requires.each { |f| require(f) }

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -103,7 +103,9 @@ else
   use_runtime_info = false if use_runtime_info.nil?
 end
 
-files.reject! { |file| TurboRspecExclusion.excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
+if exclude_patterns.any?
+  files.reject! { |file| TurboRspecExclusion.excluded_by_patterns?(file, exclude_patterns) }
+end
 
 # If a developer explicitly asked for a file that the DEFAULT nginx
 # exclusion drops, fail loudly rather than silently running a subset.
@@ -119,12 +121,10 @@ if explicit_file_args && requested_files&.any?
       TurboRspecExclusion.excluded_by_patterns?(file, DEFAULT_EXCLUDE_PATTERNS)
     end
 
-  unless dropped_nginx.empty?
-    abort <<~MSG.chomp
+  abort <<~MSG.chomp unless dropped_nginx.empty?
       Requested spec file(s) are excluded from turbo_rspec by default: #{dropped_nginx.join(", ")}
       spec/nginx has its own Rails-free runner; run those with: spec/nginx/run.sh
     MSG
-  end
 end
 
 requires.each { |f| require(f) }

--- a/bin/turbo_rspec
+++ b/bin/turbo_rspec
@@ -4,29 +4,11 @@
 ENV["RAILS_ENV"] ||= "test"
 
 require "./lib/turbo_tests"
+require "./lib/turbo_rspec_exclusion"
 require "optparse"
 
 # spec/nginx has its own Rails-free runner; turbo_rspec loads rails_helper.
 DEFAULT_EXCLUDE_PATTERNS = ["spec/nginx/**/*_spec.rb"].freeze
-
-def path_for_exclude_match(file)
-  path = file.sub(/:\d+(?::\d+)?\z/, "")
-  expanded_path = File.expand_path(path)
-  working_directory = "#{Dir.pwd}/"
-
-  if expanded_path.start_with?(working_directory)
-    expanded_path.delete_prefix(working_directory)
-  else
-    path.delete_prefix("./")
-  end
-end
-
-def excluded_by_patterns?(file, patterns)
-  path = path_for_exclude_match(file)
-  patterns.any? do |pattern|
-    File.fnmatch(pattern, path) || File.fnmatch(pattern, path, File::FNM_PATHNAME)
-  end
-end
 
 requires = []
 formatters = []
@@ -121,7 +103,7 @@ else
   use_runtime_info = false if use_runtime_info.nil?
 end
 
-files.reject! { |file| excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
+files.reject! { |file| TurboRspec::Exclusion.excluded_by_patterns?(file, exclude_patterns) } if exclude_patterns.any?
 
 if explicit_file_args && requested_files&.any? && files.empty?
   abort "All requested spec files were excluded. spec/nginx has its own runner; use spec/nginx/run.sh for nginx specs."

--- a/lib/turbo_rspec_exclusion.rb
+++ b/lib/turbo_rspec_exclusion.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TurboRspec
+  module Exclusion
+    module_function
+
+    def path_for_exclude_match(file)
+      path = file.sub(/\[(?:\d+:)*\d+\]\z/, "")
+      path = path.sub(/:\d+(?::\d+)?\z/, "")
+
+      expanded_path = File.expand_path(path)
+      working_directory = "#{Dir.pwd}/"
+
+      if expanded_path.start_with?(working_directory)
+        expanded_path.delete_prefix(working_directory)
+      else
+        path.delete_prefix("./")
+      end
+    end
+
+    def excluded_by_patterns?(file, patterns)
+      path = path_for_exclude_match(file)
+      patterns.any? do |pattern|
+        File.fnmatch(pattern, path) || File.fnmatch(pattern, path, File::FNM_PATHNAME)
+      end
+    end
+  end
+end

--- a/lib/turbo_rspec_exclusion.rb
+++ b/lib/turbo_rspec_exclusion.rb
@@ -1,28 +1,26 @@
 # frozen_string_literal: true
 
-module TurboRspec
-  module Exclusion
-    module_function
+module TurboRspecExclusion
+  module_function
 
-    def path_for_exclude_match(file)
-      path = file.sub(/\[(?:\d+:)*\d+\]\z/, "")
-      path = path.sub(/:\d+(?::\d+)?\z/, "")
+  def path_for_exclude_match(file)
+    path = file.sub(/\[(?:\d+:)*\d+\]\z/, "")
+    path = path.sub(/:\d+(?::\d+)?\z/, "")
 
-      expanded_path = File.expand_path(path)
-      working_directory = "#{Dir.pwd}/"
+    expanded_path = File.expand_path(path)
+    working_directory = "#{Dir.pwd}/"
 
-      if expanded_path.start_with?(working_directory)
-        expanded_path.delete_prefix(working_directory)
-      else
-        path.delete_prefix("./")
-      end
+    if expanded_path.start_with?(working_directory)
+      expanded_path.delete_prefix(working_directory)
+    else
+      path.delete_prefix("./")
     end
+  end
 
-    def excluded_by_patterns?(file, patterns)
-      path = path_for_exclude_match(file)
-      patterns.any? do |pattern|
-        File.fnmatch(pattern, path) || File.fnmatch(pattern, path, File::FNM_PATHNAME)
-      end
+  def excluded_by_patterns?(file, patterns)
+    path = path_for_exclude_match(file)
+    patterns.any? do |pattern|
+      File.fnmatch(pattern, path) || File.fnmatch(pattern, path, File::FNM_PATHNAME)
     end
   end
 end

--- a/spec/nginx/README.md
+++ b/spec/nginx/README.md
@@ -28,7 +28,8 @@ specs are Rails-free.
   the test config and tests that specifically need those modules skip
   themselves via `Nginx::Support::ConfigRenderer.module_available?`.
 
-If nginx isn't available the suite warns and exits cleanly. Set
+If nginx isn't available, pure-Ruby support specs still run while
+integration examples that need nginx are skipped with a warning. Set
 `NGINX_TESTS_REQUIRED=1` in CI to make a missing nginx a failure
 instead.
 

--- a/spec/nginx/README.md
+++ b/spec/nginx/README.md
@@ -1,0 +1,90 @@
+# nginx sample config tests
+
+These specs exercise `config/nginx.sample.conf` by spawning a real nginx
+subprocess in front of a tiny WEBrick mock upstream, then sending HTTP
+requests through nginx and asserting on what gets forwarded.
+
+The goal is twofold: catch regressions when the sample config changes,
+and serve as executable documentation of nginx behaviors that are
+currently implicit.
+
+## Running
+
+```sh
+spec/nginx/run.sh                       # runs the whole suite
+spec/nginx/run.sh --example "basic"     # filter by name
+spec/nginx/run.sh spec/nginx/foo_spec.rb # one file
+```
+
+The runner explicitly passes `--options /dev/null` so rspec ignores the
+project's root `.rspec` (which auto-requires `rails_helper`). These
+specs are Rails-free.
+
+## Requirements
+
+- `nginx` on `$PATH`. On NixOS: `nix-shell -p nginx --run spec/nginx/run.sh`.
+- Standard nginx 1.x. Optional modules (e.g. `brotli`) are detected at
+  setup; if missing, directives that depend on them are commented out of
+  the test config and tests that specifically need those modules skip
+  themselves via `Nginx::Support::ConfigRenderer.module_available?`.
+
+If nginx isn't available the suite warns and exits cleanly. Set
+`NGINX_TESTS_REQUIRED=1` in CI to make a missing nginx a failure
+instead.
+
+## How it works
+
+Each example spins up:
+
+1. A WEBrick server on a random port that runs `MockUpstream`, a Rack
+   app that echoes the request as JSON (method, path, headers, body).
+   Tests can ask it for specific responses via `X-Mock-*` request
+   headers — see `support/mock_upstream.rb`.
+2. An nginx subprocess on another random port, configured by
+   `ConfigRenderer` to use the mock as its upstream.
+
+`ConfigRenderer` reads the real `config/nginx.sample.conf`, substitutes
+the handful of deployment-specific references (hardcoded `127.0.0.1:3000`
+upstream, `/var/nginx/cache`, `/var/log/nginx/...`, the
+`conf.d/outlets/...` includes), and writes the result plus a tiny
+events+http wrapper into a tmpdir. The point is to keep the substituted
+config as close to the actual sample as possible — every directive in
+the sample should be exercised.
+
+## Adding a test
+
+```ruby
+require "json"
+
+RSpec.describe "nginx static asset handling" do
+  let(:harness) { Nginx::Support::NginxHarness.new }
+
+  before { harness.start }
+  after { harness.stop }
+
+  it "serves files under /assets/ from disk without touching the upstream" do
+    asset = File.join(harness.tmpdir, "public/assets/foo.txt")
+    FileUtils.mkdir_p(File.dirname(asset))
+    File.write(asset, "hello")
+
+    response = harness.get("/assets/foo.txt")
+    expect(response.body).to eq("hello")
+  end
+end
+```
+
+For per-test response shaping from the mock upstream:
+
+```ruby
+response = harness.get("/some/path", headers: {
+  "X-Mock-Status" => "503",
+  "X-Mock-Header-Retry-After" => "30",
+})
+```
+
+## CI
+
+Not yet wired to CI. Phase-1 goal is local-only validation while we
+shake out the harness. CI integration is a follow-up that needs the
+infra team to either install nginx into `discourse/discourse_test:release`
+or add a dedicated job that uses an image with nginx pre-installed.

--- a/spec/nginx/README.md
+++ b/spec/nginx/README.md
@@ -84,7 +84,10 @@ response = harness.get("/some/path", headers: {
 
 ## CI
 
-Not yet wired to CI. Phase-1 goal is local-only validation while we
-shake out the harness. CI integration is a follow-up that needs the
-infra team to either install nginx into `discourse/discourse_test:release`
-or add a dedicated job that uses an image with nginx pre-installed.
+Runs as a dedicated GitHub Actions workflow
+(`.github/workflows/nginx-tests.yml`) triggered when
+`config/nginx.sample.conf`, `spec/nginx/**`, or the workflow file
+itself change. Uses the `discourse/discourse_test:release` image, so
+the nginx under test is the same build (including brotli) that ships
+to production. `NGINX_TESTS_REQUIRED=1` is set in CI so a missing nginx
+is a hard failure rather than a silent skip.

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -13,11 +13,15 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     }
   end
 
+  let(:existing_proxy_headers) do
+    { "X-Forwarded-For" => "198.51.100.7", "X-Forwarded-Proto" => "https" }
+  end
+
   before { harness.start }
   after { harness.stop }
 
   it "forwards a missing path through @discourse with the proxy headers intact" do
-    response = harness.get("/missing-path", headers: smuggled_headers)
+    response = harness.get("/missing-path", headers: smuggled_headers.merge(existing_proxy_headers))
 
     expect(response.code).to eq("200")
 
@@ -27,8 +31,8 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     expect(payload["headers"]).to include(
       "Host" => "127.0.0.1:#{harness.listen_port}",
       "X-Real-IP" => "127.0.0.1",
-      "X-Forwarded-For" => "127.0.0.1",
-      "X-Forwarded-Proto" => "http",
+      "X-Forwarded-For" => "198.51.100.7, 127.0.0.1",
+      "X-Forwarded-Proto" => "https",
     )
     expect_acceleration_headers_stripped(payload["headers"])
     expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "securerandom"
 require_relative "support/nginx_harness"
 
 RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/DescribeClass
@@ -63,6 +64,26 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     expect_acceleration_headers_stripped(payload["headers"])
     expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)
     expect(harness.nginx_access_log).to eq(access_log_before)
+  end
+
+  it "strips sensitive response headers from the cached asset route" do
+    # The cached asset location (svg-sprite/letter_avatar/user_avatar/...)
+    # proxy_hide_header's Set-Cookie, X-Discourse-Username and X-Runtime so
+    # a cached upstream response can never leak them to other clients. Ask
+    # the mock upstream to emit all three and assert nginx removes them.
+    # A unique path keeps this a fresh cache MISS so the assertion isn't
+    # masked by a previously cached response.
+    leaky_headers = {
+      "X-Mock-Header-Set-Cookie" => "_t=secret-session; path=/",
+      "X-Mock-Header-X-Discourse-Username" => "admin",
+      "X-Mock-Header-X-Runtime" => "0.123456",
+    }
+    response = harness.get("/svg-sprite/#{SecureRandom.hex(8)}.js", headers: leaky_headers)
+
+    expect(response.code).to eq("200")
+    expect(response["Set-Cookie"]).to be_nil
+    expect(response["X-Discourse-Username"]).to be_nil
+    expect(response["X-Runtime"]).to be_nil
   end
 
   def expect_acceleration_headers_stripped(headers)

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require_relative "support/nginx_harness"
 
 RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/DescribeClass
   let(:harness) { Nginx::Support::NginxHarness.new }

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -78,9 +78,14 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
       "X-Mock-Header-X-Discourse-Username" => "admin",
       "X-Mock-Header-X-Runtime" => "0.123456",
     }
-    response = harness.get("/svg-sprite/#{SecureRandom.hex(8)}.js", headers: leaky_headers)
+    path = "/svg-sprite/#{SecureRandom.hex(8)}.js"
+    response = harness.get(path, headers: leaky_headers)
 
     expect(response.code).to eq("200")
+    # Confirm the request actually reached the upstream (the mock echoes the
+    # request as JSON), so the headers below are absent because nginx hid
+    # them -- not because some other handler served this path.
+    expect(JSON.parse(response.body)["path"]).to eq(path)
     expect(response["Set-Cookie"]).to be_nil
     expect(response["X-Discourse-Username"]).to be_nil
     expect(response["X-Runtime"]).to be_nil

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -5,12 +5,19 @@ require_relative "support/nginx_harness"
 
 RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/DescribeClass
   let(:harness) { Nginx::Support::NginxHarness.new }
+  let(:smuggled_headers) do
+    {
+      "X-Sendfile-Type" => "spoofed-sendfile",
+      "X-Accel-Mapping" => "/tmp/=/downloads/",
+      "Client-Ip" => "203.0.113.10",
+    }
+  end
 
   before { harness.start }
   after { harness.stop }
 
   it "forwards a missing path through @discourse with the proxy headers intact" do
-    response = harness.get("/missing-path")
+    response = harness.get("/missing-path", headers: smuggled_headers)
 
     expect(response.code).to eq("200")
 
@@ -23,14 +30,14 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
       "X-Forwarded-For" => "127.0.0.1",
       "X-Forwarded-Proto" => "http",
     )
-    expect(payload["headers"]).not_to have_key("X-Sendfile-Type")
-    expect(payload["headers"]).not_to have_key("X-Accel-Mapping")
-    expect(payload["headers"]).not_to have_key("Client-Ip")
+    expect_acceleration_headers_stripped(payload["headers"])
     expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)
+    expect(harness.nginx_access_log).to include('"GET /missing-path HTTP/1.1"')
   end
 
   it "forwards /srv/status directly to the upstream with the proxy headers intact" do
-    response = harness.get("/srv/status")
+    access_log_before = harness.nginx_access_log
+    response = harness.get("/srv/status", headers: smuggled_headers)
 
     expect(response.code).to eq("200")
 
@@ -43,9 +50,14 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
       "X-Forwarded-For" => "127.0.0.1",
       "X-Forwarded-Proto" => "http",
     )
-    expect(payload["headers"]).not_to have_key("X-Sendfile-Type")
-    expect(payload["headers"]).not_to have_key("X-Accel-Mapping")
-    expect(payload["headers"]).not_to have_key("Client-Ip")
+    expect_acceleration_headers_stripped(payload["headers"])
     expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)
+    expect(harness.nginx_access_log).to eq(access_log_before)
+  end
+
+  def expect_acceleration_headers_stripped(headers)
+    expect(headers).not_to have_key("X-Sendfile-Type")
+    expect(headers).not_to have_key("X-Accel-Mapping")
+    expect(headers).not_to have_key("Client-Ip")
   end
 end

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
 
   it "forwards /srv/status directly to the upstream with the proxy headers intact" do
     access_log_before = harness.nginx_access_log
-    response = harness.get("/srv/status", headers: smuggled_headers)
+    response = harness.get("/srv/status", headers: smuggled_headers.merge(existing_proxy_headers))
 
     expect(response.code).to eq("200")
 
@@ -51,8 +51,8 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     expect(payload["headers"]).to include(
       "Host" => "127.0.0.1:#{harness.listen_port}",
       "X-Real-IP" => "127.0.0.1",
-      "X-Forwarded-For" => "127.0.0.1",
-      "X-Forwarded-Proto" => "http",
+      "X-Forwarded-For" => "198.51.100.7, 127.0.0.1",
+      "X-Forwarded-Proto" => "https",
     )
     expect_acceleration_headers_stripped(payload["headers"])
     expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/DescribeClass
+  let(:harness) { Nginx::Support::NginxHarness.new }
+
+  before { harness.start }
+  after { harness.stop }
+
+  it "forwards a GET / to the upstream and returns its response" do
+    response = harness.get("/")
+
+    expect(response.code).to eq("200")
+
+    payload = JSON.parse(response.body)
+    expect(payload["method"]).to eq("GET")
+    expect(payload["path"]).to eq("/")
+  end
+end

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     }
   end
 
-  let(:existing_proxy_headers) do
+  # A client-supplied X-Forwarded-For that must NOT be trusted: the sample
+  # conf sets X-Forwarded-For to the end-user IP ($remote_addr), overwriting
+  # any inbound value, so a spoofed forwarded chain cannot get through.
+  let(:spoofed_proxy_headers) do
     { "X-Forwarded-For" => "198.51.100.7", "X-Forwarded-Proto" => "https" }
   end
 
@@ -21,7 +24,7 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
   after { harness.stop }
 
   it "forwards a missing path through @discourse with the proxy headers intact" do
-    response = harness.get("/missing-path", headers: smuggled_headers.merge(existing_proxy_headers))
+    response = harness.get("/missing-path", headers: smuggled_headers.merge(spoofed_proxy_headers))
 
     expect(response.code).to eq("200")
 
@@ -31,7 +34,9 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     expect(payload["headers"]).to include(
       "Host" => "127.0.0.1:#{harness.listen_port}",
       "X-Real-IP" => "127.0.0.1",
-      "X-Forwarded-For" => "198.51.100.7, 127.0.0.1",
+      # Spoofed inbound XFF (198.51.100.7) is overwritten with the real
+      # end-user IP, not appended to.
+      "X-Forwarded-For" => "127.0.0.1",
       "X-Forwarded-Proto" => "https",
     )
     expect_acceleration_headers_stripped(payload["headers"])
@@ -41,7 +46,7 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
 
   it "forwards /srv/status directly to the upstream with the proxy headers intact" do
     access_log_before = harness.nginx_access_log
-    response = harness.get("/srv/status", headers: smuggled_headers.merge(existing_proxy_headers))
+    response = harness.get("/srv/status", headers: smuggled_headers.merge(spoofed_proxy_headers))
 
     expect(response.code).to eq("200")
 
@@ -51,7 +56,8 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
     expect(payload["headers"]).to include(
       "Host" => "127.0.0.1:#{harness.listen_port}",
       "X-Real-IP" => "127.0.0.1",
-      "X-Forwarded-For" => "198.51.100.7, 127.0.0.1",
+      # Spoofed inbound XFF is overwritten with the real end-user IP.
+      "X-Forwarded-For" => "127.0.0.1",
       "X-Forwarded-Proto" => "https",
     )
     expect_acceleration_headers_stripped(payload["headers"])

--- a/spec/nginx/basic_proxy_spec.rb
+++ b/spec/nginx/basic_proxy_spec.rb
@@ -9,13 +9,43 @@ RSpec.describe "nginx.sample.conf basic proxying" do # rubocop:disable RSpec/Des
   before { harness.start }
   after { harness.stop }
 
-  it "forwards a GET / to the upstream and returns its response" do
-    response = harness.get("/")
+  it "forwards a missing path through @discourse with the proxy headers intact" do
+    response = harness.get("/missing-path")
 
     expect(response.code).to eq("200")
 
     payload = JSON.parse(response.body)
     expect(payload["method"]).to eq("GET")
-    expect(payload["path"]).to eq("/")
+    expect(payload["path"]).to eq("/missing-path")
+    expect(payload["headers"]).to include(
+      "Host" => "127.0.0.1:#{harness.listen_port}",
+      "X-Real-IP" => "127.0.0.1",
+      "X-Forwarded-For" => "127.0.0.1",
+      "X-Forwarded-Proto" => "http",
+    )
+    expect(payload["headers"]).not_to have_key("X-Sendfile-Type")
+    expect(payload["headers"]).not_to have_key("X-Accel-Mapping")
+    expect(payload["headers"]).not_to have_key("Client-Ip")
+    expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)
+  end
+
+  it "forwards /srv/status directly to the upstream with the proxy headers intact" do
+    response = harness.get("/srv/status")
+
+    expect(response.code).to eq("200")
+
+    payload = JSON.parse(response.body)
+    expect(payload["method"]).to eq("GET")
+    expect(payload["path"]).to eq("/srv/status")
+    expect(payload["headers"]).to include(
+      "Host" => "127.0.0.1:#{harness.listen_port}",
+      "X-Real-IP" => "127.0.0.1",
+      "X-Forwarded-For" => "127.0.0.1",
+      "X-Forwarded-Proto" => "http",
+    )
+    expect(payload["headers"]).not_to have_key("X-Sendfile-Type")
+    expect(payload["headers"]).not_to have_key("X-Accel-Mapping")
+    expect(payload["headers"]).not_to have_key("Client-Ip")
+    expect(payload["headers"]["X-Request-Start"]).to match(/\At=\d+(?:\.\d+)?\z/)
   end
 end

--- a/spec/nginx/run.sh
+++ b/spec/nginx/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run the nginx spec suite.
+#
+# Usage:
+#   spec/nginx/run.sh [extra rspec args]
+#
+# We pass --options /dev/null so rspec ignores the project's top-level
+# .rspec (which auto-requires rails_helper). The nginx specs are
+# deliberately rails-free.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+exec bundle exec rspec \
+  --options /dev/null \
+  --require ./spec/nginx/spec_helper.rb \
+  --color \
+  --format documentation \
+  "$@" \
+  spec/nginx/

--- a/spec/nginx/run.sh
+++ b/spec/nginx/run.sh
@@ -17,5 +17,5 @@ exec bundle exec rspec \
   --require ./spec/nginx/spec_helper.rb \
   --color \
   --format documentation \
-  "$@" \
-  spec/nginx/
+  --default-path spec/nginx \
+  "$@"

--- a/spec/nginx/spec_helper.rb
+++ b/spec/nginx/spec_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Minimal rspec config for the nginx test suite.
+#
+# Deliberately does NOT load rails_helper: these tests don't need Rails,
+# the database, fabricators, or any of the main spec/ infrastructure. The
+# suite spawns a real nginx subprocess plus a tiny WEBrick mock upstream
+# and asserts on what nginx forwards / serves.
+#
+# Run with:
+#   bundle exec rspec spec/nginx/
+#
+# Skips itself if nginx isn't on PATH (e.g. local dev machines without
+# nginx installed). CI is expected to provide nginx.
+
+require "rspec"
+
+$LOAD_PATH.unshift(File.expand_path("support", __dir__))
+require "nginx_harness"
+
+RSpec.configure do |config|
+  config.disable_monkey_patching!
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
+
+  nginx_available = ENV["DISABLE_NGINX_TESTS"].nil? && system("which nginx >/dev/null 2>&1")
+
+  unless nginx_available
+    raise "nginx not found on PATH but NGINX_TESTS_REQUIRED is set" if ENV["NGINX_TESTS_REQUIRED"]
+    config.before(:suite) do
+      warn "[nginx specs] skipping: nginx not found on PATH " \
+             "(set NGINX_TESTS_REQUIRED=1 to fail instead)"
+    end
+    config.filter_run_excluding(:nginx)
+    # Mark all examples in this directory as nginx specs by default
+    config.define_derived_metadata(file_path: %r{spec/nginx/}) { |meta| meta[:nginx] = true }
+  end
+end

--- a/spec/nginx/spec_helper.rb
+++ b/spec/nginx/spec_helper.rb
@@ -8,10 +8,11 @@
 # and asserts on what nginx forwards / serves.
 #
 # Run with:
-#   bundle exec rspec spec/nginx/
+#   spec/nginx/run.sh
 #
-# Skips itself if nginx isn't on PATH (e.g. local dev machines without
-# nginx installed). CI is expected to provide nginx.
+# Skips integration examples if nginx isn't on PATH (e.g. local dev machines
+# without nginx installed). Pure-Ruby support specs still run. CI is expected
+# to provide nginx.
 
 require "rspec"
 
@@ -22,6 +23,10 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.expect_with(:rspec) { |c| c.syntax = :expect }
 
+  config.define_derived_metadata(file_path: %r{spec/nginx/(?!support/)}) do |meta|
+    meta[:nginx] = true
+  end
+
   nginx_available = ENV["DISABLE_NGINX_TESTS"].nil? && system("which nginx >/dev/null 2>&1")
 
   unless nginx_available
@@ -31,7 +36,5 @@ RSpec.configure do |config|
              "(set NGINX_TESTS_REQUIRED=1 to fail instead)"
     end
     config.filter_run_excluding(:nginx)
-    # Mark all examples in this directory as nginx specs by default
-    config.define_derived_metadata(file_path: %r{spec/nginx/}) { |meta| meta[:nginx] = true }
   end
 end

--- a/spec/nginx/spec_helper.rb
+++ b/spec/nginx/spec_helper.rb
@@ -31,10 +31,17 @@ RSpec.configure do |config|
 
   unless nginx_available
     raise "nginx not found on PATH but NGINX_TESTS_REQUIRED is set" if ENV["NGINX_TESTS_REQUIRED"]
+
     config.before(:suite) do
-      warn "[nginx specs] skipping: nginx not found on PATH " \
+      warn "[nginx specs] skipping nginx integration examples: nginx not found on PATH " \
              "(set NGINX_TESTS_REQUIRED=1 to fail instead)"
     end
-    config.filter_run_excluding(:nginx)
+
+    # Skip per-example rather than via filter_run_excluding(:nginx): an
+    # exclusion filter is bypassed when the developer supplies an
+    # inclusion filter (e.g. run.sh --example basic), which would let an
+    # integration example run and crash on Process.spawn("nginx"). A
+    # before-hook keyed on the :nginx tag skips regardless of selection.
+    config.before(:each, :nginx) { skip "nginx not found on PATH" }
   end
 end

--- a/spec/nginx/spec_helper.rb
+++ b/spec/nginx/spec_helper.rb
@@ -17,6 +17,7 @@
 require "rspec"
 
 $LOAD_PATH.unshift(File.expand_path("support", __dir__))
+require "nginx_executable"
 require "nginx_harness"
 
 RSpec.configure do |config|
@@ -27,7 +28,9 @@ RSpec.configure do |config|
     meta[:nginx] = true
   end
 
-  nginx_available = ENV["DISABLE_NGINX_TESTS"].nil? && system("which nginx >/dev/null 2>&1")
+  # Probe the same executable the harness will spawn (Process.spawn /
+  # execvp resolution), not a separate `which` lookup that could disagree.
+  nginx_available = ENV["DISABLE_NGINX_TESTS"].nil? && Nginx::Support::NginxExecutable.available?
 
   unless nginx_available
     raise "nginx not found on PATH but NGINX_TESTS_REQUIRED is set" if ENV["NGINX_TESTS_REQUIRED"]

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -2,6 +2,7 @@
 
 require "etc"
 require "fileutils"
+require "open3"
 require "tmpdir"
 require_relative "nginx_executable"
 
@@ -106,7 +107,16 @@ module Nginx
       end
 
       def self.nginx_build_flags
-        @nginx_build_flags ||= `#{nginx_bin} -V 2>&1`
+        # argv-style (not a shell) so an NGINX_BIN path with spaces is the
+        # same executable the spawn/module-probe paths run. nginx writes
+        # its build flags to stderr, so merge both streams.
+        @nginx_build_flags ||=
+          begin
+            stdout, stderr, _status = Open3.capture3(nginx_bin, "-V")
+            stdout + stderr
+          rescue SystemCallError
+            ""
+          end
       end
 
       def self.module_directive_usable?(name)

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -149,7 +149,6 @@ module Nginx
           source
             .gsub("server 127.0.0.1:3000;", "server 127.0.0.1:#{upstream_port};")
             .gsub("listen 80;", "listen 127.0.0.1:#{listen_port};")
-            .gsub("listen [::]:80;", "listen [::1]:#{listen_port};")
             .gsub("/var/nginx/cache", File.join(tmpdir, "cache"))
             .gsub("/var/log/nginx/access.log", File.join(tmpdir, "access.log"))
             .gsub("/var/log/nginx/error.log", File.join(tmpdir, "error.log"))

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "etc"
 require "fileutils"
 
 # Reads `config/nginx.sample.conf` and rewrites the handful of references
@@ -19,7 +20,7 @@ module Nginx
       WRAPPER_TEMPLATE = <<~CONF
         # Generated for tests — do not edit by hand.
         # Wraps nginx.sample.conf with the events+http blocks it omits.
-        worker_processes 1;
+        %<worker_user_directive>sworker_processes 1;
         daemon off;
         error_log %<error_log>s warn;
         pid %<pid_file>s;
@@ -71,6 +72,7 @@ module Nginx
             mime_types: system_mime_types,
             error_log: File.join(tmpdir, "error.log"),
             pid_file: File.join(tmpdir, "nginx.pid"),
+            worker_user_directive: worker_user_directive,
           )
         wrapper_path = File.join(tmpdir, "nginx.conf")
         File.write(wrapper_path, wrapper)
@@ -81,10 +83,24 @@ module Nginx
       # Used by tests to skip when running on a stock nginx without it.
       def self.module_available?(name)
         @module_cache ||= {}
-        @module_cache[name] ||= !`nginx -V 2>&1`.split.grep(/#{Regexp.escape(name)}/i).empty?
+        @module_cache.fetch(name) do
+          @module_cache[name] = nginx_build_flags.split.grep(/#{Regexp.escape(name)}/i).any?
+        end
+      end
+
+      def self.nginx_build_flags
+        @nginx_build_flags ||= `nginx -V 2>&1`
       end
 
       private
+
+      def worker_user_directive
+        return "" if Process.euid.nonzero?
+
+        user = Etc.getpwuid(Process.euid).name
+        group = Etc.getgrgid(Process.egid).name
+        "user #{user} #{group};\n"
+      end
 
       def rewrite_sample(source)
         source =
@@ -125,7 +141,7 @@ module Nginx
       def system_mime_types
         # nginx ships its own mime.types; locate it via `nginx -V`'s
         # configured --prefix or fall back to /etc/nginx/mime.types.
-        prefix = `nginx -V 2>&1`[/--prefix=(\S+)/, 1]
+        prefix = ConfigRenderer.nginx_build_flags[/--prefix=(\S+)/, 1]
         candidates = [
           prefix && File.join(prefix, "conf/mime.types"),
           "/etc/nginx/mime.types",

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -140,10 +140,13 @@ module Nginx
 
       def system_mime_types
         # nginx ships its own mime.types; locate it via `nginx -V`'s
-        # configured --prefix or fall back to /etc/nginx/mime.types.
-        prefix = ConfigRenderer.nginx_build_flags[/--prefix=(\S+)/, 1]
+        # configured --prefix/--conf-path or fall back to /etc/nginx/mime.types.
+        build_flags = ConfigRenderer.nginx_build_flags
+        prefix = build_flags[/--prefix=(\S+)/, 1]
+        conf_path = build_flags[/--conf-path=(\S+)/, 1]
         candidates = [
           prefix && File.join(prefix, "conf/mime.types"),
+          conf_path && File.join(File.dirname(conf_path), "mime.types"),
           "/etc/nginx/mime.types",
         ].compact
         candidates.find { |p| File.exist?(p) } || candidates.first

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -3,6 +3,7 @@
 require "etc"
 require "fileutils"
 require "tmpdir"
+require_relative "nginx_executable"
 
 # Reads `config/nginx.sample.conf` and rewrites the handful of references
 # that don't work outside a deployed Discourse environment: hardcoded
@@ -100,8 +101,12 @@ module Nginx
         @module_cache.fetch(name) { @module_cache[name] = module_directive_usable?(name) }
       end
 
+      def self.nginx_bin
+        NginxExecutable.path || "nginx"
+      end
+
       def self.nginx_build_flags
-        @nginx_build_flags ||= `nginx -V 2>&1`
+        @nginx_build_flags ||= `#{nginx_bin} -V 2>&1`
       end
 
       def self.module_directive_usable?(name)
@@ -109,7 +114,16 @@ module Nginx
           config_path = File.join(tmpdir, "nginx.conf")
           File.write(config_path, module_probe_config(tmpdir, name))
 
-          !!system("nginx", "-t", "-c", config_path, "-p", tmpdir, out: File::NULL, err: File::NULL)
+          !!system(
+            nginx_bin,
+            "-t",
+            "-c",
+            config_path,
+            "-p",
+            tmpdir,
+            out: File::NULL,
+            err: File::NULL,
+          )
         end
       rescue SystemCallError
         false

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -2,6 +2,7 @@
 
 require "etc"
 require "fileutils"
+require "tmpdir"
 
 # Reads `config/nginx.sample.conf` and rewrites the handful of references
 # that don't work outside a deployed Discourse environment: hardcoded
@@ -11,12 +12,23 @@ require "fileutils"
 # invoke `nginx -c <wrapper> -p <tmpdir>`.
 #
 # Optional nginx modules (brotli today; potentially others later) that
-# the system's nginx wasn't built with get commented out so the test
-# suite runs against a stock nginx. Tests that need a stripped directive
-# should skip themselves when `module_available?` reports it missing.
+# the system's nginx cannot use in this generated wrapper get commented
+# out so the test suite runs against a stock nginx. Tests that need a
+# stripped directive should skip themselves when `module_available?`
+# reports it missing.
 module Nginx
   module Support
     class ConfigRenderer
+      MODULE_PROBES = {
+        "brotli" => [
+          "brotli on;",
+          "brotli_min_length 1000;",
+          "brotli_comp_level 4;",
+          "brotli_types text/plain;",
+          "brotli_static on;",
+        ],
+      }.freeze
+
       WRAPPER_TEMPLATE = <<~CONF
         # Generated for tests — do not edit by hand.
         # Wraps nginx.sample.conf with the events+http blocks it omits.
@@ -79,18 +91,48 @@ module Nginx
         wrapper_path
       end
 
-      # Whether the system's nginx supports the given add-on module.
-      # Used by tests to skip when running on a stock nginx without it.
+      # Whether the system's nginx can use this module's directives in the
+      # generated test wrapper. Dynamic modules can appear in `nginx -V` output
+      # but still be unavailable unless a separate `load_module` directive runs,
+      # so probe a tiny standalone config instead of trusting build flags.
       def self.module_available?(name)
         @module_cache ||= {}
-        @module_cache.fetch(name) do
-          @module_cache[name] = nginx_build_flags.split.grep(/#{Regexp.escape(name)}/i).any?
-        end
+        @module_cache.fetch(name) { @module_cache[name] = module_directive_usable?(name) }
       end
 
       def self.nginx_build_flags
         @nginx_build_flags ||= `nginx -V 2>&1`
       end
+
+      def self.module_directive_usable?(name)
+        Dir.mktmpdir("nginx-module-probe-") do |tmpdir|
+          config_path = File.join(tmpdir, "nginx.conf")
+          File.write(config_path, module_probe_config(tmpdir, name))
+
+          !!system("nginx", "-t", "-c", config_path, "-p", tmpdir, out: File::NULL, err: File::NULL)
+        end
+      rescue SystemCallError
+        false
+      end
+
+      def self.module_probe_config(tmpdir, name)
+        directives = MODULE_PROBES.fetch(name) { ["#{name} on;"] }
+
+        [
+          "worker_processes 1;",
+          "error_log #{File.join(tmpdir, "error.log")} warn;",
+          "pid #{File.join(tmpdir, "nginx.pid")};",
+          "",
+          "events {",
+          "  worker_connections 16;",
+          "}",
+          "",
+          "http {",
+          *directives.map { |directive| "  #{directive}" },
+          "}",
+        ].join("\n") + "\n"
+      end
+      private_class_method :module_directive_usable?, :module_probe_config
 
       private
 
@@ -114,10 +156,9 @@ module Nginx
             .gsub("/var/www/discourse/public", File.join(tmpdir, "public"))
             .gsub("conf.d/outlets/", File.join(tmpdir, "outlets/"))
 
-        # Comment out directives belonging to nginx modules that the system
-        # nginx wasn't built with. We do this with a regex rather than
-        # listing every directive name so future additions (e.g. ngx_pagespeed)
-        # work too.
+        # Comment out directives belonging to nginx modules that the generated
+        # wrapper cannot use. We do this with a regex rather than listing every
+        # directive name so future additions (e.g. ngx_pagespeed) work too.
         unless ConfigRenderer.module_available?("brotli")
           source = comment_directives(source, /\bbrotli(_[a-z_]+)?\b/)
         end

--- a/spec/nginx/support/config_renderer.rb
+++ b/spec/nginx/support/config_renderer.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+# Reads `config/nginx.sample.conf` and rewrites the handful of references
+# that don't work outside a deployed Discourse environment: hardcoded
+# upstream port, log/cache filesystem paths, and the `conf.d/outlets/...`
+# customization-hook includes. Writes the result plus a tiny wrapper
+# (`events { ... }` + `http { include ...; }`) into a tmpdir so we can
+# invoke `nginx -c <wrapper> -p <tmpdir>`.
+#
+# Optional nginx modules (brotli today; potentially others later) that
+# the system's nginx wasn't built with get commented out so the test
+# suite runs against a stock nginx. Tests that need a stripped directive
+# should skip themselves when `module_available?` reports it missing.
+module Nginx
+  module Support
+    class ConfigRenderer
+      WRAPPER_TEMPLATE = <<~CONF
+        # Generated for tests — do not edit by hand.
+        # Wraps nginx.sample.conf with the events+http blocks it omits.
+        worker_processes 1;
+        daemon off;
+        error_log %<error_log>s warn;
+        pid %<pid_file>s;
+
+        events {
+          worker_connections 256;
+        }
+
+        http {
+          include %<mime_types>s;
+          default_type application/octet-stream;
+          client_body_temp_path %<tmpdir>s/client_body_temp;
+          proxy_temp_path %<tmpdir>s/proxy_temp;
+          fastcgi_temp_path %<tmpdir>s/fastcgi_temp;
+          uwsgi_temp_path %<tmpdir>s/uwsgi_temp;
+          scgi_temp_path %<tmpdir>s/scgi_temp;
+
+          include %<sample>s;
+        }
+      CONF
+
+      attr_reader :tmpdir, :sample_path, :upstream_port, :listen_port
+
+      def initialize(tmpdir:, sample_path:, upstream_port:, listen_port:)
+        @tmpdir = tmpdir
+        @sample_path = sample_path
+        @upstream_port = upstream_port
+        @listen_port = listen_port
+      end
+
+      # Returns the path to the wrapper nginx.conf the harness should pass
+      # to `nginx -c`.
+      def render
+        FileUtils.mkdir_p(File.join(tmpdir, "cache"))
+        FileUtils.mkdir_p(File.join(tmpdir, "logs"))
+        FileUtils.mkdir_p(File.join(tmpdir, "public"))
+        FileUtils.mkdir_p(File.join(tmpdir, "outlets/before-server"))
+        FileUtils.mkdir_p(File.join(tmpdir, "outlets/server"))
+
+        rewritten = rewrite_sample(File.read(sample_path))
+        sample_out = File.join(tmpdir, "discourse.conf")
+        File.write(sample_out, rewritten)
+
+        wrapper =
+          format(
+            WRAPPER_TEMPLATE,
+            tmpdir: tmpdir,
+            sample: sample_out,
+            mime_types: system_mime_types,
+            error_log: File.join(tmpdir, "error.log"),
+            pid_file: File.join(tmpdir, "nginx.pid"),
+          )
+        wrapper_path = File.join(tmpdir, "nginx.conf")
+        File.write(wrapper_path, wrapper)
+        wrapper_path
+      end
+
+      # Whether the system's nginx supports the given add-on module.
+      # Used by tests to skip when running on a stock nginx without it.
+      def self.module_available?(name)
+        @module_cache ||= {}
+        @module_cache[name] ||= !`nginx -V 2>&1`.split.grep(/#{Regexp.escape(name)}/i).empty?
+      end
+
+      private
+
+      def rewrite_sample(source)
+        source =
+          source
+            .gsub("server 127.0.0.1:3000;", "server 127.0.0.1:#{upstream_port};")
+            .gsub("listen 80;", "listen 127.0.0.1:#{listen_port};")
+            .gsub("listen [::]:80;", "listen [::1]:#{listen_port};")
+            .gsub("/var/nginx/cache", File.join(tmpdir, "cache"))
+            .gsub("/var/log/nginx/access.log", File.join(tmpdir, "access.log"))
+            .gsub("/var/log/nginx/error.log", File.join(tmpdir, "error.log"))
+            .gsub("/var/www/discourse/public", File.join(tmpdir, "public"))
+            .gsub("conf.d/outlets/", File.join(tmpdir, "outlets/"))
+
+        # Comment out directives belonging to nginx modules that the system
+        # nginx wasn't built with. We do this with a regex rather than
+        # listing every directive name so future additions (e.g. ngx_pagespeed)
+        # work too.
+        unless ConfigRenderer.module_available?("brotli")
+          source = comment_directives(source, /\bbrotli(_[a-z_]+)?\b/)
+        end
+
+        source
+      end
+
+      def comment_directives(source, prefix_regex)
+        source
+          .lines
+          .map do |line|
+            if line =~ /^\s*#{prefix_regex.source}/
+              "# [test-harness disabled] #{line}"
+            else
+              line
+            end
+          end
+          .join
+      end
+
+      def system_mime_types
+        # nginx ships its own mime.types; locate it via `nginx -V`'s
+        # configured --prefix or fall back to /etc/nginx/mime.types.
+        prefix = `nginx -V 2>&1`[/--prefix=(\S+)/, 1]
+        candidates = [
+          prefix && File.join(prefix, "conf/mime.types"),
+          "/etc/nginx/mime.types",
+        ].compact
+        candidates.find { |p| File.exist?(p) } || candidates.first
+      end
+    end
+  end
+end

--- a/spec/nginx/support/config_renderer_spec.rb
+++ b/spec/nginx/support/config_renderer_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "config_renderer"
+
+RSpec.describe Nginx::Support::ConfigRenderer do
+  describe "#render" do
+    it "runs nginx workers as the test process user when root spawns nginx" do
+      Dir.mktmpdir do |tmpdir|
+        name_entry = Struct.new(:name)
+        sample_path = File.join(tmpdir, "nginx.sample.conf")
+        File.write(sample_path, "")
+
+        allow(Process).to receive(:euid).and_return(0)
+        allow(Process).to receive(:egid).and_return(0)
+        allow(Etc).to receive(:getpwuid).with(0).and_return(name_entry.new("root"))
+        allow(Etc).to receive(:getgrgid).with(0).and_return(name_entry.new("root"))
+        allow(described_class).to receive(:module_available?).with("brotli").and_return(true)
+        allow(described_class).to receive(:nginx_build_flags).and_return("")
+
+        renderer =
+          described_class.new(
+            tmpdir: tmpdir,
+            sample_path: sample_path,
+            upstream_port: 3001,
+            listen_port: 3002,
+          )
+
+        expect(File.read(renderer.render)).to include("user root root;\nworker_processes 1;")
+      end
+    end
+  end
+
+  describe ".module_available?" do
+    before do
+      described_class.instance_variable_set(:@module_cache, {})
+      described_class.remove_instance_variable(:@nginx_build_flags) if build_flags_cached?
+    end
+
+    after do
+      described_class.remove_instance_variable(:@module_cache) if module_cache_exists?
+      described_class.remove_instance_variable(:@nginx_build_flags) if build_flags_cached?
+    end
+
+    it "memoizes missing modules" do
+      allow(described_class).to receive(:nginx_build_flags).once.and_return("")
+
+      expect(described_class.module_available?("brotli")).to eq(false)
+      expect(described_class.module_available?("brotli")).to eq(false)
+    end
+
+    def module_cache_exists?
+      described_class.instance_variable_defined?(:@module_cache)
+    end
+
+    def build_flags_cached?
+      described_class.instance_variable_defined?(:@nginx_build_flags)
+    end
+  end
+end

--- a/spec/nginx/support/config_renderer_spec.rb
+++ b/spec/nginx/support/config_renderer_spec.rb
@@ -5,6 +5,32 @@ require_relative "config_renderer"
 
 RSpec.describe Nginx::Support::ConfigRenderer do
   describe "#render" do
+    it "uses mime.types next to nginx --conf-path when the prefix candidate is absent" do
+      Dir.mktmpdir do |tmpdir|
+        conf_dir = File.join(tmpdir, "etc/nginx")
+        FileUtils.mkdir_p(conf_dir)
+        mime_types = File.join(conf_dir, "mime.types")
+        File.write(mime_types, "types {}\n")
+        sample_path = File.join(tmpdir, "nginx.sample.conf")
+        File.write(sample_path, "")
+
+        allow(described_class).to receive(:module_available?).with("brotli").and_return(true)
+        allow(described_class).to receive(:nginx_build_flags).and_return(
+          "--prefix=#{File.join(tmpdir, "prefix")} --conf-path=#{File.join(conf_dir, "nginx.conf")}",
+        )
+
+        renderer =
+          described_class.new(
+            tmpdir: tmpdir,
+            sample_path: sample_path,
+            upstream_port: 3001,
+            listen_port: 3002,
+          )
+
+        expect(File.read(renderer.render)).to include("include #{mime_types};")
+      end
+    end
+
     it "runs nginx workers as the test process user when root spawns nginx" do
       Dir.mktmpdir do |tmpdir|
         name_entry = Struct.new(:name)

--- a/spec/nginx/support/config_renderer_spec.rb
+++ b/spec/nginx/support/config_renderer_spec.rb
@@ -55,6 +55,52 @@ RSpec.describe Nginx::Support::ConfigRenderer do
         expect(File.read(renderer.render)).to include("user root root;\nworker_processes 1;")
       end
     end
+
+    it "rewrites the sample's upstream port, listen port, and filesystem paths" do
+      Dir.mktmpdir do |tmpdir|
+        sample_path = File.join(tmpdir, "nginx.sample.conf")
+        File.write(sample_path, <<~CONF)
+          server 127.0.0.1:3000;
+          listen 80;
+          proxy_cache_path /var/nginx/cache keys_zone=one:10m;
+          access_log /var/log/nginx/access.log;
+          error_log /var/log/nginx/error.log;
+          root /var/www/discourse/public;
+          include conf.d/outlets/discourse/*.conf;
+        CONF
+
+        allow(described_class).to receive(:module_available?).with("brotli").and_return(true)
+        allow(described_class).to receive(:nginx_build_flags).and_return("")
+
+        renderer =
+          described_class.new(
+            tmpdir: tmpdir,
+            sample_path: sample_path,
+            upstream_port: 3001,
+            listen_port: 3002,
+          )
+
+        renderer.render
+        rendered = File.read(File.join(tmpdir, "discourse.conf"))
+
+        expect(rendered).to include("server 127.0.0.1:3001;")
+        expect(rendered).to include("listen 127.0.0.1:3002;")
+        expect(rendered).to include("#{tmpdir}/cache")
+        expect(rendered).to include("#{tmpdir}/access.log")
+        expect(rendered).to include("#{tmpdir}/error.log")
+        expect(rendered).to include("#{tmpdir}/public")
+        expect(rendered).to include("include #{tmpdir}/outlets/discourse/*.conf;")
+
+        # The pre-substitution values must be gone, or a typo'd gsub would
+        # pass this test while leaking production paths into the rendered conf.
+        expect(rendered).not_to include("127.0.0.1:3000")
+        expect(rendered).not_to include("listen 80;")
+        expect(rendered).not_to include("/var/nginx/cache")
+        expect(rendered).not_to include("/var/log/nginx/")
+        expect(rendered).not_to include("/var/www/discourse/public")
+        expect(rendered).not_to include("conf.d/outlets/")
+      end
+    end
   end
 
   describe ".module_available?" do

--- a/spec/nginx/support/config_renderer_spec.rb
+++ b/spec/nginx/support/config_renderer_spec.rb
@@ -58,18 +58,28 @@ RSpec.describe Nginx::Support::ConfigRenderer do
   end
 
   describe ".module_available?" do
-    before do
-      described_class.instance_variable_set(:@module_cache, {})
-      described_class.remove_instance_variable(:@nginx_build_flags) if build_flags_cached?
+    before { described_class.instance_variable_set(:@module_cache, {}) }
+
+    after { described_class.remove_instance_variable(:@module_cache) if module_cache_exists? }
+
+    it "does not trust build flags when nginx rejects the directive probe" do
+      allow(described_class).to receive(:nginx_build_flags).and_return(
+        "--add-dynamic-module=/tmp/ngx_brotli",
+      )
+      allow(described_class).to receive(:system).and_return(false)
+
+      expect(described_class.module_available?("brotli")).to eq(false)
+      expect(described_class).not_to have_received(:nginx_build_flags)
     end
 
-    after do
-      described_class.remove_instance_variable(:@module_cache) if module_cache_exists?
-      described_class.remove_instance_variable(:@nginx_build_flags) if build_flags_cached?
+    it "returns true when nginx accepts the directive probe" do
+      allow(described_class).to receive(:system).and_return(true)
+
+      expect(described_class.module_available?("brotli")).to eq(true)
     end
 
-    it "memoizes missing modules" do
-      allow(described_class).to receive(:nginx_build_flags).once.and_return("")
+    it "memoizes rejected module probes" do
+      allow(described_class).to receive(:system).once.and_return(false)
 
       expect(described_class.module_available?("brotli")).to eq(false)
       expect(described_class.module_available?("brotli")).to eq(false)
@@ -77,10 +87,6 @@ RSpec.describe Nginx::Support::ConfigRenderer do
 
     def module_cache_exists?
       described_class.instance_variable_defined?(:@module_cache)
-    end
-
-    def build_flags_cached?
-      described_class.instance_variable_defined?(:@nginx_build_flags)
     end
   end
 end

--- a/spec/nginx/support/mock_upstream.rb
+++ b/spec/nginx/support/mock_upstream.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "json"
+
+# Rack app that echoes every request back as a JSON response. Tests use it
+# to assert on what nginx forwards upstream: method, path, query string,
+# request headers, body.
+#
+# Per-request response shaping is available via request headers prefixed
+# with `X-Mock-`:
+#
+#   X-Mock-Status: 503     -> respond with the given status code
+#   X-Mock-Body: <text>    -> respond with the given body instead of the echo
+#   X-Mock-Header-Foo: bar -> add `Foo: bar` to the response headers
+#
+# These let individual tests provoke specific upstream behavior without
+# adding a new Rack route every time.
+module Nginx
+  module Support
+    class MockUpstream
+      ECHO_HEADER_PREFIX = "HTTP_"
+      MOCK_HEADER_PREFIX = "HTTP_X_MOCK_"
+      MOCK_RESPONSE_HEADER_PREFIX = "HTTP_X_MOCK_HEADER_"
+
+      def call(env)
+        status = mock_status(env)
+        headers = { "Content-Type" => "application/json" }
+        merge_mock_headers!(headers, env)
+
+        body =
+          if env["HTTP_X_MOCK_BODY"]
+            env["HTTP_X_MOCK_BODY"]
+          else
+            JSON.dump(echo_payload(env))
+          end
+
+        [status, headers, [body]]
+      end
+
+      private
+
+      def mock_status(env)
+        env["HTTP_X_MOCK_STATUS"]&.to_i || 200
+      end
+
+      def merge_mock_headers!(headers, env)
+        env.each do |key, value|
+          next unless key.start_with?(MOCK_RESPONSE_HEADER_PREFIX)
+          header_name =
+            key.sub(MOCK_RESPONSE_HEADER_PREFIX, "").split("_").map(&:capitalize).join("-")
+          headers[header_name] = value
+        end
+      end
+
+      def echo_payload(env)
+        request_headers = {}
+        env.each do |key, value|
+          next unless key.start_with?(ECHO_HEADER_PREFIX)
+          # Skip Mock-* control headers — they aren't part of what nginx forwarded
+          next if key.start_with?(MOCK_HEADER_PREFIX)
+          name = key.sub(ECHO_HEADER_PREFIX, "").split("_").map(&:capitalize).join("-")
+          request_headers[name] = value
+        end
+
+        body = env["rack.input"]&.read || ""
+        env["rack.input"]&.rewind
+
+        {
+          method: env["REQUEST_METHOD"],
+          path: env["PATH_INFO"],
+          query: env["QUERY_STRING"],
+          headers: request_headers,
+          body: body,
+        }
+      end
+    end
+  end
+end

--- a/spec/nginx/support/mock_upstream.rb
+++ b/spec/nginx/support/mock_upstream.rb
@@ -21,6 +21,22 @@ module Nginx
       ECHO_HEADER_PREFIX = "HTTP_"
       MOCK_HEADER_PREFIX = "HTTP_X_MOCK_"
       MOCK_RESPONSE_HEADER_PREFIX = "HTTP_X_MOCK_HEADER_"
+      ORIGINAL_HEADER_NAMES_ENV = "nginx.mock_upstream.original_header_names"
+      HEADER_WORDS = {
+        "CDN" => "CDN",
+        "DNT" => "DNT",
+        "ETAG" => "ETag",
+        "HTTP" => "HTTP",
+        "HTTPS" => "HTTPS",
+        "ID" => "ID",
+        "IP" => "IP",
+        "MD5" => "MD5",
+        "SSL" => "SSL",
+        "TLS" => "TLS",
+        "URI" => "URI",
+        "URL" => "URL",
+        "WWW" => "WWW",
+      }.freeze
 
       def call(env)
         status = mock_status(env)
@@ -46,19 +62,18 @@ module Nginx
       def merge_mock_headers!(headers, env)
         env.each do |key, value|
           next unless key.start_with?(MOCK_RESPONSE_HEADER_PREFIX)
-          header_name =
-            key.sub(MOCK_RESPONSE_HEADER_PREFIX, "").split("_").map(&:capitalize).join("-")
-          headers[header_name] = value
+          headers[header_name_from_env_key(key, MOCK_RESPONSE_HEADER_PREFIX)] = value
         end
       end
 
       def echo_payload(env)
         request_headers = {}
+        original_header_names = env[ORIGINAL_HEADER_NAMES_ENV] || {}
         env.each do |key, value|
           next unless key.start_with?(ECHO_HEADER_PREFIX)
           # Skip Mock-* control headers — they aren't part of what nginx forwarded
           next if key.start_with?(MOCK_HEADER_PREFIX)
-          name = key.sub(ECHO_HEADER_PREFIX, "").split("_").map(&:capitalize).join("-")
+          name = original_header_names[key] || header_name_from_env_key(key, ECHO_HEADER_PREFIX)
           request_headers[name] = value
         end
 
@@ -72,6 +87,14 @@ module Nginx
           headers: request_headers,
           body: body,
         }
+      end
+
+      def header_name_from_env_key(key, prefix)
+        key
+          .delete_prefix(prefix)
+          .split("_")
+          .map { |part| HEADER_WORDS.fetch(part, part.capitalize) }
+          .join("-")
       end
     end
   end

--- a/spec/nginx/support/mock_upstream_spec.rb
+++ b/spec/nginx/support/mock_upstream_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require_relative "mock_upstream"
+
+RSpec.describe Nginx::Support::MockUpstream do
+  subject(:upstream) { described_class.new }
+
+  it "echoes Rack headers with stable casing for common acronyms" do
+    _status, _headers, body =
+      upstream.call(
+        request_env(
+          "HTTP_ETAG" => "tag",
+          "HTTP_X_REAL_IP" => "127.0.0.1",
+          "HTTP_X_REQUEST_ID" => "request-id",
+        ),
+      )
+
+    payload = JSON.parse(body.join)
+
+    expect(payload["headers"]).to include(
+      "ETag" => "tag",
+      "X-Real-IP" => "127.0.0.1",
+      "X-Request-ID" => "request-id",
+    )
+    expect(payload["headers"]).not_to have_key("X-Real-Ip")
+    expect(payload["headers"]).not_to have_key("X-Request-Id")
+  end
+
+  it "preserves original header names captured before Rack env conversion" do
+    _status, _headers, body =
+      upstream.call(
+        request_env(
+          described_class::ORIGINAL_HEADER_NAMES_ENV => {
+            "HTTP_X_REQUEST_ID" => "x-request-id",
+          },
+          "HTTP_X_REQUEST_ID" => "request-id",
+        ),
+      )
+
+    payload = JSON.parse(body.join)
+
+    expect(payload["headers"]).to include("x-request-id" => "request-id")
+    expect(payload["headers"]).not_to have_key("X-Request-ID")
+  end
+
+  it "uses the same header casing for shaped response headers" do
+    _status, headers, _body = upstream.call(request_env("HTTP_X_MOCK_HEADER_ETAG" => "tag"))
+
+    expect(headers["ETag"]).to eq("tag")
+    expect(headers).not_to have_key("Etag")
+  end
+
+  def request_env(headers = {})
+    {
+      "REQUEST_METHOD" => "GET",
+      "PATH_INFO" => "/",
+      "QUERY_STRING" => "",
+      "rack.input" => StringIO.new(""),
+    }.merge(headers)
+  end
+end

--- a/spec/nginx/support/nginx_executable.rb
+++ b/spec/nginx/support/nginx_executable.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Nginx
+  module Support
+    # Resolves the nginx executable the suite will actually run, the same
+    # way Process.spawn("nginx") / execvp does: first match for a file
+    # named "nginx" that is executable, walking ENV["PATH"] in order.
+    #
+    # The availability probe and the spawn must agree on the same binary,
+    # so both go through here rather than the probe shelling out to
+    # `which` (which can resolve differently, or be missing entirely on a
+    # minimal system, giving a false "not available").
+    module NginxExecutable
+      module_function
+
+      def path
+        # An explicit override wins, mirroring how an operator would point
+        # the suite at a specific build.
+        if (override = ENV["NGINX_BIN"]) && !override.empty?
+          return File.executable?(override) ? override : nil
+        end
+
+        ENV["PATH"]
+          .to_s
+          .split(File::PATH_SEPARATOR)
+          .each do |dir|
+            next if dir.empty?
+
+            candidate = File.join(dir, "nginx")
+            return candidate if File.file?(candidate) && File.executable?(candidate)
+          end
+
+        nil
+      end
+
+      def available?
+        !path.nil?
+      end
+    end
+  end
+end

--- a/spec/nginx/support/nginx_executable_spec.rb
+++ b/spec/nginx/support/nginx_executable_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require_relative "nginx_executable"
+
+RSpec.describe Nginx::Support::NginxExecutable do
+  around do |example|
+    original_path = ENV["PATH"]
+    original_bin = ENV["NGINX_BIN"]
+    example.run
+  ensure
+    ENV["PATH"] = original_path
+    ENV["NGINX_BIN"] = original_bin
+  end
+
+  def write_executable(dir, name)
+    path = File.join(dir, name)
+    File.write(path, "#!/bin/sh\n")
+    File.chmod(0o755, path)
+    path
+  end
+
+  describe ".path" do
+    it "returns the first executable nginx found walking PATH in order" do
+      Dir.mktmpdir do |root|
+        first = File.join(root, "a")
+        second = File.join(root, "b")
+        FileUtils.mkdir_p(first)
+        FileUtils.mkdir_p(second)
+        write_executable(first, "nginx")
+        write_executable(second, "nginx")
+
+        ENV.delete("NGINX_BIN")
+        ENV["PATH"] = [first, second].join(File::PATH_SEPARATOR)
+
+        expect(described_class.path).to eq(File.join(first, "nginx"))
+      end
+    end
+
+    it "skips a non-executable file named nginx and keeps walking PATH" do
+      Dir.mktmpdir do |root|
+        first = File.join(root, "a")
+        second = File.join(root, "b")
+        FileUtils.mkdir_p(first)
+        FileUtils.mkdir_p(second)
+        non_exec = File.join(first, "nginx")
+        File.write(non_exec, "not executable")
+        File.chmod(0o644, non_exec)
+        real = write_executable(second, "nginx")
+
+        ENV.delete("NGINX_BIN")
+        ENV["PATH"] = [first, second].join(File::PATH_SEPARATOR)
+
+        expect(described_class.path).to eq(real)
+      end
+    end
+
+    it "returns nil when nginx is not on PATH" do
+      Dir.mktmpdir do |root|
+        ENV.delete("NGINX_BIN")
+        ENV["PATH"] = root
+
+        expect(described_class.path).to be_nil
+      end
+    end
+
+    it "honors NGINX_BIN when it points at an executable" do
+      Dir.mktmpdir do |root|
+        bin = write_executable(root, "my-nginx")
+        ENV["NGINX_BIN"] = bin
+        ENV["PATH"] = ""
+
+        expect(described_class.path).to eq(bin)
+      end
+    end
+
+    it "returns nil when NGINX_BIN points at a non-executable" do
+      Dir.mktmpdir do |root|
+        bogus = File.join(root, "nope")
+        File.write(bogus, "x")
+        File.chmod(0o644, bogus)
+        ENV["NGINX_BIN"] = bogus
+        ENV["PATH"] = root
+
+        expect(described_class.path).to be_nil
+      end
+    end
+  end
+
+  describe ".available?" do
+    it "is false when nothing resolves" do
+      Dir.mktmpdir do |root|
+        ENV.delete("NGINX_BIN")
+        ENV["PATH"] = root
+        expect(described_class.available?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/nginx/support/nginx_harness.rb
+++ b/spec/nginx/support/nginx_harness.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "net/http"
+require "socket"
+require "stringio"
+require "tmpdir"
+require "webrick"
+require_relative "config_renderer"
+require_relative "mock_upstream"
+
+module Nginx
+  module Support
+    # Owns the lifecycle of one (mock upstream, nginx subprocess) pair.
+    # `start` brings both up; `stop` tears both down. `get` / `request`
+    # send HTTP to nginx and return the response.
+    class NginxHarness
+      attr_reader :listen_port, :upstream_port, :tmpdir
+
+      def initialize(sample_path: default_sample_path)
+        @sample_path = sample_path
+        @tmpdir = nil
+        @nginx_pid = nil
+        @upstream_thread = nil
+        @upstream_server = nil
+        @listen_port = nil
+        @upstream_port = nil
+      end
+
+      def start
+        @tmpdir = Dir.mktmpdir("nginx-spec-")
+        @upstream_port = allocate_port
+        @listen_port = allocate_port
+
+        start_upstream
+        render_and_spawn_nginx
+        wait_for_port(@listen_port, "nginx") or
+          raise_with_logs("nginx never bound to port #{@listen_port}")
+      end
+
+      def stop
+        stop_nginx
+        stop_upstream
+      ensure
+        FileUtils.remove_entry(@tmpdir) if @tmpdir && File.exist?(@tmpdir)
+      end
+
+      # Convenience: `harness.get("/", headers: {...})` returns
+      # Net::HTTPResponse. Body and headers are inspectable on the result.
+      def get(path, headers: {})
+        request(:get, path, headers: headers)
+      end
+
+      def request(method, path, headers: {}, body: nil)
+        uri = URI("http://127.0.0.1:#{@listen_port}#{path}")
+        req_class =
+          case method.to_s.downcase
+          when "get"
+            Net::HTTP::Get
+          when "post"
+            Net::HTTP::Post
+          when "head"
+            Net::HTTP::Head
+          when "put"
+            Net::HTTP::Put
+          when "delete"
+            Net::HTTP::Delete
+          else
+            raise ArgumentError, "unsupported method #{method.inspect}"
+          end
+        req = req_class.new(uri)
+        headers.each { |k, v| req[k] = v }
+        req.body = body if body
+        Net::HTTP.start(uri.host, uri.port) { |http| http.request(req) }
+      end
+
+      private
+
+      def start_upstream
+        # WEBrick's log is noisy on stderr; redirect to a file under tmpdir
+        # so test output stays clean but we keep it for failure forensics.
+        log = WEBrick::Log.new(File.join(@tmpdir, "upstream.log"), WEBrick::Log::WARN)
+        access = [
+          [
+            File.open(File.join(@tmpdir, "upstream-access.log"), "w"),
+            WEBrick::AccessLog::COMMON_LOG_FORMAT,
+          ],
+        ]
+        @upstream_server =
+          WEBrick::HTTPServer.new(
+            BindAddress: "127.0.0.1",
+            Port: @upstream_port,
+            Logger: log,
+            AccessLog: access,
+          )
+        @upstream_server.mount_proc("/") do |req, res|
+          rack_env = build_rack_env(req)
+          status, headers, body = MockUpstream.new.call(rack_env)
+          res.status = status
+          headers.each { |k, v| res[k] = v }
+          res.body = body.join
+        end
+        @upstream_thread = Thread.new { @upstream_server.start }
+        wait_for_port(@upstream_port, "mock upstream") or
+          raise_with_logs("mock upstream never bound to port #{@upstream_port}")
+      end
+
+      def stop_upstream
+        @upstream_server&.shutdown
+        @upstream_thread&.join(5)
+      end
+
+      def render_and_spawn_nginx
+        renderer =
+          ConfigRenderer.new(
+            tmpdir: @tmpdir,
+            sample_path: @sample_path,
+            upstream_port: @upstream_port,
+            listen_port: @listen_port,
+          )
+        wrapper_path = renderer.render
+
+        @nginx_pid =
+          Process.spawn(
+            "nginx",
+            "-c",
+            wrapper_path,
+            "-p",
+            @tmpdir,
+            out: File.join(@tmpdir, "nginx-stdout.log"),
+            err: File.join(@tmpdir, "nginx-stderr.log"),
+          )
+      end
+
+      def stop_nginx
+        return unless @nginx_pid
+        Process.kill("TERM", @nginx_pid)
+        deadline = Time.now + 5
+        loop do
+          break if Process.waitpid(@nginx_pid, Process::WNOHANG)
+          if Time.now > deadline
+            begin
+              Process.kill("KILL", @nginx_pid)
+            rescue StandardError
+              nil
+            end
+            begin
+              Process.waitpid(@nginx_pid, Process::WNOHANG)
+            rescue StandardError
+              nil
+            end
+            break
+          end
+          sleep 0.05
+        end
+      rescue Errno::ECHILD, Errno::ESRCH
+        # Already reaped or never started — fine.
+      end
+
+      def allocate_port
+        # Bind to port 0, read what the kernel assigned, immediately close.
+        # Brief race window before we re-bind, but adequate for tests.
+        server = TCPServer.new("127.0.0.1", 0)
+        port = server.addr[1]
+        server.close
+        port
+      end
+
+      def wait_for_port(port, label, timeout: 5)
+        deadline = Time.now + timeout
+        loop do
+          return true if port_open?(port)
+          return false if Time.now > deadline
+          sleep 0.05
+        end
+      end
+
+      def port_open?(port)
+        TCPSocket.new("127.0.0.1", port).tap(&:close)
+        true
+      rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
+        false
+      end
+
+      def raise_with_logs(message)
+        details = []
+        %w[nginx-stderr.log nginx-stdout.log error.log].each do |name|
+          path = File.join(@tmpdir, name)
+          next unless File.exist?(path)
+          details << "--- #{name} ---\n#{File.read(path)}"
+        end
+        raise "#{message}\n#{details.join("\n")}"
+      end
+
+      def build_rack_env(webrick_req)
+        env = {
+          "REQUEST_METHOD" => webrick_req.request_method,
+          "PATH_INFO" => webrick_req.path,
+          "QUERY_STRING" => webrick_req.query_string || "",
+          "rack.input" => StringIO.new(webrick_req.body || ""),
+        }
+        webrick_req.header.each do |name, values|
+          # WEBrick gives header values as arrays; join with comma per RFC.
+          rack_key = "HTTP_" + name.upcase.tr("-", "_")
+          env[rack_key] = Array(values).join(", ")
+        end
+        env
+      end
+
+      def default_sample_path
+        File.expand_path("../../../config/nginx.sample.conf", __dir__)
+      end
+    end
+  end
+end

--- a/spec/nginx/support/nginx_harness.rb
+++ b/spec/nginx/support/nginx_harness.rb
@@ -86,8 +86,10 @@ module Nginx
       end
 
       def nginx_access_log
+        return "" if @tmpdir.nil?
+
         path = File.join(@tmpdir, "access.log")
-        return "" if @tmpdir.nil? || !File.exist?(path)
+        return "" unless File.exist?(path)
 
         File.read(path)
       end
@@ -202,7 +204,13 @@ module Nginx
 
       def raise_with_logs(message)
         details = []
-        %w[nginx-stderr.log nginx-stdout.log error.log].each do |name|
+        %w[
+          nginx-stderr.log
+          nginx-stdout.log
+          error.log
+          upstream.log
+          upstream-access.log
+        ].each do |name|
           path = File.join(@tmpdir, name)
           next unless File.exist?(path)
           details << "--- #{name} ---\n#{File.read(path)}"

--- a/spec/nginx/support/nginx_harness.rb
+++ b/spec/nginx/support/nginx_harness.rb
@@ -8,6 +8,7 @@ require "tmpdir"
 require "webrick"
 require_relative "config_renderer"
 require_relative "mock_upstream"
+require_relative "nginx_executable"
 
 module Nginx
   module Support
@@ -142,7 +143,7 @@ module Nginx
 
         @nginx_pid =
           Process.spawn(
-            "nginx",
+            NginxExecutable.path || "nginx",
             "-c",
             wrapper_path,
             "-p",

--- a/spec/nginx/support/nginx_harness.rb
+++ b/spec/nginx/support/nginx_harness.rb
@@ -74,6 +74,13 @@ module Nginx
         Net::HTTP.start(uri.host, uri.port) { |http| http.request(req) }
       end
 
+      def nginx_access_log
+        path = File.join(@tmpdir, "access.log")
+        return "" if @tmpdir.nil? || !File.exist?(path)
+
+        File.read(path)
+      end
+
       private
 
       def start_upstream

--- a/spec/nginx/support/nginx_harness.rb
+++ b/spec/nginx/support/nginx_harness.rb
@@ -15,6 +15,8 @@ module Nginx
     # `start` brings both up; `stop` tears both down. `get` / `request`
     # send HTTP to nginx and return the response.
     class NginxHarness
+      HTTP_TIMEOUT_SECONDS = 5
+
       attr_reader :listen_port, :upstream_port, :tmpdir
 
       def initialize(sample_path: default_sample_path)
@@ -30,9 +32,9 @@ module Nginx
       def start
         @tmpdir = Dir.mktmpdir("nginx-spec-")
         @upstream_port = allocate_port
-        @listen_port = allocate_port
-
         start_upstream
+
+        @listen_port = allocate_port
         render_and_spawn_nginx
         wait_for_port(@listen_port, "nginx") or
           raise_with_logs("nginx never bound to port #{@listen_port}")
@@ -71,7 +73,16 @@ module Nginx
         req = req_class.new(uri)
         headers.each { |k, v| req[k] = v }
         req.body = body if body
-        Net::HTTP.start(uri.host, uri.port) { |http| http.request(req) }
+        Net::HTTP.start(
+          uri.host,
+          uri.port,
+          open_timeout: HTTP_TIMEOUT_SECONDS,
+          read_timeout: HTTP_TIMEOUT_SECONDS,
+        ) { |http| http.request(req) }
+      rescue Net::OpenTimeout, Net::ReadTimeout => e
+        raise_with_logs(
+          "#{method.to_s.upcase} #{path} timed out after #{HTTP_TIMEOUT_SECONDS}s (#{e.class}: #{e.message})",
+        )
       end
 
       def nginx_access_log

--- a/spec/nginx/support/nginx_harness.rb
+++ b/spec/nginx/support/nginx_harness.rb
@@ -198,6 +198,7 @@ module Nginx
           "PATH_INFO" => webrick_req.path,
           "QUERY_STRING" => webrick_req.query_string || "",
           "rack.input" => StringIO.new(webrick_req.body || ""),
+          MockUpstream::ORIGINAL_HEADER_NAMES_ENV => original_header_names(webrick_req),
         }
         webrick_req.header.each do |name, values|
           # WEBrick gives header values as arrays; join with comma per RFC.
@@ -205,6 +206,15 @@ module Nginx
           env[rack_key] = Array(values).join(", ")
         end
         env
+      end
+
+      def original_header_names(webrick_req)
+        Array(webrick_req.raw_header).each_with_object({}) do |line, names|
+          next unless (raw_name = line[/\A([^:\s]+):/, 1])
+
+          rack_key = "HTTP_" + raw_name.upcase.tr("-", "_")
+          names[rack_key] ||= raw_name
+        end
       end
 
       def default_sample_path

--- a/spec/nginx/support/nginx_harness_spec.rb
+++ b/spec/nginx/support/nginx_harness_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "nginx_harness"
+
+RSpec.describe Nginx::Support::NginxHarness do
+  describe "#start" do
+    it "binds the upstream before choosing the nginx listen port" do
+      harness_class =
+        Class.new(described_class) do
+          attr_reader :events
+
+          def initialize
+            super(sample_path: "/tmp/unused-nginx-sample.conf")
+            @events = []
+            @next_port = 30_000
+          end
+
+          private
+
+          def allocate_port
+            @events << :allocate_port
+            @next_port += 1
+          end
+
+          def start_upstream
+            @events << :start_upstream
+          end
+
+          def render_and_spawn_nginx
+            @events << :render_and_spawn_nginx
+          end
+
+          def wait_for_port(port, label, _timeout: 5)
+            @events << [:wait_for_port, port, label]
+            true
+          end
+        end
+      harness = harness_class.new
+
+      begin
+        harness.start
+
+        expect(harness.events).to eq(
+          [
+            :allocate_port,
+            :start_upstream,
+            :allocate_port,
+            :render_and_spawn_nginx,
+            [:wait_for_port, 30_002, "nginx"],
+          ],
+        )
+      ensure
+        harness.stop
+      end
+    end
+  end
+
+  describe "#request" do
+    it "uses short HTTP open and read timeouts" do
+      harness = described_class.new
+      harness.instance_variable_set(:@listen_port, 30_000)
+      http = instance_double(Net::HTTP)
+      response = instance_double(Net::HTTPResponse)
+
+      allow(Net::HTTP).to receive(:start) { |_host, _port, **_options, &block| block.call(http) }
+      allow(http).to receive(:request).and_return(response)
+
+      expect(harness.get("/")).to eq(response)
+      expect(Net::HTTP).to have_received(:start).with(
+        "127.0.0.1",
+        30_000,
+        open_timeout: described_class::HTTP_TIMEOUT_SECONDS,
+        read_timeout: described_class::HTTP_TIMEOUT_SECONDS,
+      )
+      expect(http).to have_received(:request).with(instance_of(Net::HTTP::Get))
+    end
+
+    it "raises with nginx logs when a request times out" do
+      harness_class =
+        Class.new(described_class) do
+          attr_reader :log_message
+
+          private
+
+          def raise_with_logs(message)
+            @log_message = message
+            raise "logs included"
+          end
+        end
+      harness = harness_class.new
+      harness.instance_variable_set(:@listen_port, 30_000)
+
+      allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout)
+
+      expect { harness.get("/slow") }.to raise_error(RuntimeError, "logs included")
+      expect(harness.log_message).to include("GET /slow timed out")
+      expect(harness.log_message).to include("Net::ReadTimeout")
+    end
+  end
+end

--- a/spec/nginx/support/nginx_harness_spec.rb
+++ b/spec/nginx/support/nginx_harness_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe Nginx::Support::NginxHarness do
     end
   end
 
+  describe "#nginx_access_log" do
+    it "returns an empty log before start creates a tmpdir" do
+      expect(described_class.new.nginx_access_log).to eq("")
+    end
+  end
+
   describe "#request" do
     it "uses short HTTP open and read timeouts" do
       harness = described_class.new
@@ -75,26 +81,25 @@ RSpec.describe Nginx::Support::NginxHarness do
       expect(http).to have_received(:request).with(instance_of(Net::HTTP::Get))
     end
 
-    it "raises with nginx logs when a request times out" do
-      harness_class =
-        Class.new(described_class) do
-          attr_reader :log_message
+    it "raises with nginx and upstream logs when a request times out" do
+      Dir.mktmpdir do |tmpdir|
+        harness = described_class.new
+        harness.instance_variable_set(:@listen_port, 30_000)
+        harness.instance_variable_set(:@tmpdir, tmpdir)
+        File.write(File.join(tmpdir, "nginx-stderr.log"), "nginx stderr\n")
+        File.write(File.join(tmpdir, "upstream.log"), "upstream log\n")
+        File.write(File.join(tmpdir, "upstream-access.log"), "upstream access\n")
 
-          private
+        allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout)
 
-          def raise_with_logs(message)
-            @log_message = message
-            raise "logs included"
-          end
+        expect { harness.get("/slow") }.to raise_error(RuntimeError) do |error|
+          expect(error.message).to include("GET /slow timed out")
+          expect(error.message).to include("Net::ReadTimeout")
+          expect(error.message).to include("--- nginx-stderr.log ---\nnginx stderr")
+          expect(error.message).to include("--- upstream.log ---\nupstream log")
+          expect(error.message).to include("--- upstream-access.log ---\nupstream access")
         end
-      harness = harness_class.new
-      harness.instance_variable_set(:@listen_port, 30_000)
-
-      allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout)
-
-      expect { harness.get("/slow") }.to raise_error(RuntimeError, "logs included")
-      expect(harness.log_message).to include("GET /slow timed out")
-      expect(harness.log_message).to include("Net::ReadTimeout")
+      end
     end
   end
 end

--- a/spec/nginx/support/nginx_harness_spec.rb
+++ b/spec/nginx/support/nginx_harness_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Nginx::Support::NginxHarness do
             @events << :render_and_spawn_nginx
           end
 
-          def wait_for_port(port, label, _timeout: 5)
+          def wait_for_port(port, label, timeout: 5)
             @events << [:wait_for_port, port, label]
             true
           end

--- a/spec/nginx/support/turbo_rspec_exclusion_spec.rb
+++ b/spec/nginx/support/turbo_rspec_exclusion_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../../lib/turbo_rspec_exclusion"
 
-RSpec.describe TurboRspec::Exclusion do
+RSpec.describe TurboRspecExclusion do
   describe ".path_for_exclude_match" do
     it "strips bracketed RSpec example ids" do
       expect(described_class.path_for_exclude_match("spec/nginx/basic_proxy_spec.rb[1:1]")).to eq(

--- a/spec/nginx/support/turbo_rspec_exclusion_spec.rb
+++ b/spec/nginx/support/turbo_rspec_exclusion_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "../../../lib/turbo_rspec_exclusion"
+
+RSpec.describe TurboRspec::Exclusion do
+  describe ".path_for_exclude_match" do
+    it "strips bracketed RSpec example ids" do
+      expect(described_class.path_for_exclude_match("spec/nginx/basic_proxy_spec.rb[1:1]")).to eq(
+        "spec/nginx/basic_proxy_spec.rb",
+      )
+    end
+
+    it "strips line and bracketed example ids together" do
+      expect(
+        described_class.path_for_exclude_match("spec/nginx/basic_proxy_spec.rb:42[1:1]"),
+      ).to eq("spec/nginx/basic_proxy_spec.rb")
+    end
+  end
+
+  describe ".excluded_by_patterns?" do
+    it "matches bracketed example ids against the nginx exclusion pattern" do
+      expect(
+        described_class.excluded_by_patterns?(
+          "spec/nginx/basic_proxy_spec.rb[1:1]",
+          ["spec/nginx/**/*_spec.rb"],
+        ),
+      ).to eq(true)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,12 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  # spec/nginx/ has its own Rails-free harness (spawns a real nginx subprocess
+  # in front of a mock upstream) and its own runner at spec/nginx/run.sh.
+  # Exclude it from the main rspec invocation, which would otherwise load the
+  # specs without their support files and fail with NameError on the harness.
+  config.exclude_pattern = "spec/nginx/**/*_spec.rb"
+
   # Default is :fork, but this causes problems if any miniracer context have started
   config.bisect_runner = :shell
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,8 +73,8 @@ RSpec.configure do |config|
 
   # spec/nginx/ has its own Rails-free harness (spawns a real nginx subprocess
   # in front of a mock upstream) and its own runner at spec/nginx/run.sh.
-  # Exclude it from the main rspec invocation, which would otherwise load the
-  # specs without their support files and fail with NameError on the harness.
+  # Exclude it from direct RSpec discovery here; bin/turbo_rspec has a matching
+  # default exclusion before it passes explicit file paths to Rails-loaded workers.
   config.exclude_pattern = "spec/nginx/**/*_spec.rb"
 
   # Default is :fork, but this causes problems if any miniracer context have started


### PR DESCRIPTION
### Why

`config/nginx.sample.conf` ships as Discourse's reference nginx config but carries a lot of implied behaviors (proxy header forwarding, `/srv/status` routing, request-start timing, fallback through `@discourse`, response-header sanitization) with no executable documentation or regression coverage. Proposed changes to the file are hard to validate without running a forum behind it.

### What this adds

A Rails-free spec harness under `spec/nginx/` that:

1. Reads the real `config/nginx.sample.conf` and substitutes only the values that can't work in a test environment — ports, log/cache paths, customization-hook includes. Every other directive in the sample runs exactly as shipped.
2. Spawns a real nginx subprocess in front of a tiny WEBrick mock upstream that echoes each request back as JSON.
3. Lets tests assert on what nginx forwarded by inspecting the echo (`response["headers"]["X-Real-IP"]`, etc.) or shape mock behavior via `X-Mock-*` request headers.

### What's covered

`basic_proxy_spec.rb` exercises two real paths:

- Missing path falls through `@discourse` with `Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`, and `X-Request-Start` set; and with `X-Sendfile-Type`, `X-Accel-Mapping`, `Client-Ip` *not* set (the sample strips these to prevent header smuggling from the upstream).
- **`/srv/status` routes directly** to the upstream with the same header guarantees.

Plus unit-level coverage for the support modules themselves (`config_renderer_spec.rb`, `mock_upstream_spec.rb`).

The "tests as documentation" framing means subsequent behavioral coverage grows organically as people touch directives: static asset bypass via `try_files`, gzip / brotli content-type matching, websocket upgrade for `/message-bus/`, 502 on upstream down, cache rules, rate limiting.

### CI

Dedicated workflow (`.github/workflows/nginx-tests.yml`) triggered only when `config/nginx.sample.conf`, `spec/nginx/**`, or the workflow file itself change. Doesn't slow down any other PR. Uses `discourse/discourse_test:release` so the nginx under test is the production build (including brotli), not stock apt nginx.

Excluded from the main rspec invocation via `config.exclude_pattern` in `spec/rails_helper.rb`, so the `core backend` job doesn't accidentally load these Rails-free specs and blow up on undefined constants.

### How to run locally

```sh
spec/nginx/run.sh                       # whole suite
spec/nginx/run.sh --example "basic"     # filter
spec/nginx/run.sh spec/nginx/foo_spec.rb # one file
```

Requires `nginx` on `$PATH`.

Refs: /t/148738
