### PR TITLE
DEV: Capture destination url and redirect when required user fields are present

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -872,6 +872,8 @@ class ApplicationController < ActionController::Base
       return
     end
 
+    cookies[:destination_url] = destination_url.presence
+
     redirect_path = path("/u/#{current_user.encoded_username}/preferences/profile")
     second_factor_path = path("/u/#{current_user.encoded_username}/preferences/second-factor")
     allowed_paths = [redirect_path, second_factor_path, path("/admin"), path("/safe-mode")]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -872,12 +872,12 @@ class ApplicationController < ActionController::Base
       return
     end
 
-    cookies[:destination_url] = destination_url.presence
-
     redirect_path = path("/u/#{current_user.encoded_username}/preferences/profile")
     second_factor_path = path("/u/#{current_user.encoded_username}/preferences/second-factor")
     allowed_paths = [redirect_path, second_factor_path, path("/admin"), path("/safe-mode")]
     if allowed_paths.none? { |p| request.fullpath.start_with?(p) }
+      cookies[:destination_url] = destination_url.presence
+
       rate_limiter = RateLimiter.new(current_user, "redirect_to_required_fields_log", 1, 24.hours)
 
       if rate_limiter.performed!(raise_error: false)

--- a/frontend/discourse/app/controllers/preferences/profile.js
+++ b/frontend/discourse/app/controllers/preferences/profile.js
@@ -5,6 +5,7 @@ import { compare, isEmpty } from "@ember/utils";
 import FeatureTopicOnProfileModal from "discourse/components/modal/feature-topic-on-profile";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import cookie, { removeCookie } from "discourse/lib/cookie";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import { i18n } from "discourse-i18n";
 
@@ -183,6 +184,12 @@ export default class ProfileController extends Controller {
         this.model.set("bio_cooked", user.bio_cooked);
         this.currentUser.set("needs_required_fields_check", false);
         this.set("saved", true);
+
+        const destinationUrl = cookie("destination_url");
+        if (destinationUrl) {
+          removeCookie("destination_url", { path: "/" });
+          window.location.href = destinationUrl;
+        }
       })
       .catch(popupAjaxError);
   }

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -126,5 +126,17 @@ describe "User preferences | Profile" do
 
       expect(page).to have_current_path("/u/#{user.username}/preferences/profile")
     end
+
+    it "redirects back to the original destination after filling required fields" do
+      visit("/hot")
+
+      expect(page).to have_current_path("/u/#{user.username}/preferences/profile")
+
+      find(".user-field-favourite-pokemon input").fill_in(with: "Mudkip")
+      find(".user-field-updated-terms input").check
+      find(".save-button .btn-primary").click
+
+      expect(page).to have_current_path("/hot")
+    end
   end
 end

--- a/spec/system/user_page/user_preferences_profile_spec.rb
+++ b/spec/system/user_page/user_preferences_profile_spec.rb
@@ -128,7 +128,8 @@ describe "User preferences | Profile" do
     end
 
     it "redirects back to the original destination after filling required fields" do
-      visit("/hot")
+      category = Fabricate(:category)
+      visit("/new-topic?category_id=#{category.id}")
 
       expect(page).to have_current_path("/u/#{user.username}/preferences/profile")
 
@@ -136,7 +137,7 @@ describe "User preferences | Profile" do
       find(".user-field-updated-terms input").check
       find(".save-button .btn-primary").click
 
-      expect(page).to have_current_path("/hot")
+      expect(page).to have_current_path("/new-topic?category_id=#{category.id}")
     end
   end
 end


### PR DESCRIPTION
When required user fields are present, the user is not allowed to visit other pages on the site until they fill out the user fields. This means they're redirected to the profile page, but then once they save the fields they stay on the profile page which can be confusing.

This stores the destination url in the "destination_url" cookie, then retrieves that and redirects after the required user fields have been filled out and validated.

Mirrors the logic in our login/auth flows.

Requested in meta /t/403313/ and also mentioned previously on dev at /t/133792/