### PR TITLE
PERF: Reuse pre-installed playwright chromium in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
       EMBER_ENV: development
       LOAD_PLUGINS: ${{ (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
       QUNIT_REUSE_BUILD: 1
+      PLAYWRIGHT_BROWSERS_PATH: /home/discourse/.cache/ms-playwright
 
     strategy:
       fail-fast: false
@@ -300,10 +301,6 @@ jobs:
         with:
           name: ember-exam-execution-${{ matrix.target }}-${{ matrix.browser }}-frontend-${{ hashFiles('./frontend/discourse/test-execution-*.json') }}
           path: ./frontend/discourse/test-execution-*.json
-
-      - name: Install playwright
-        if: matrix.build_type == 'system'
-        run: pnpm playwright install --with-deps --no-shell chromium
 
       - name: Core System Tests
         if: matrix.build_type == 'system' && matrix.target == 'core'


### PR DESCRIPTION
Previously, every system test job re-downloaded ~170 MB of Chromium because playwright's `~/.cache/ms-playwright` resolved to `/github/home/.cache/ms-playwright` (CI runs as root with `HOME=/github/home`) while the `discourse_test` image installed it under the discourse user at `/home/discourse/.cache/ms-playwright`.

This change sets `PLAYWRIGHT_BROWSERS_PATH` to the image's cache so the binary is found without a download, and drops the `Install playwright` step.

