### PR TITLE
FEATURE: Add top countries and top referrers cards to the admin dashboard

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -447,6 +447,7 @@ h1 {
 }
 
 .db-traffic {
+  --db-traffic-card-min-height: 12rem;
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -489,38 +490,86 @@ h1 {
   }
 
   &__list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
+    display: grid;
+    grid-template-columns: 1fr auto;
+    column-gap: var(--space-4);
+    row-gap: var(--space-2);
     list-style: none;
     margin: 0;
     padding: 0;
-  }
-
-  &__list-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-4);
     font-size: var(--font-down-1-rem);
   }
 
-  &__name {
-    overflow: hidden;
-    color: var(--primary-high);
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  &__list-row {
+    display: contents;
   }
 
-  &__value {
-    flex: 0 0 auto;
+  &__metric {
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    justify-self: end;
+  }
+
+  &__name,
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  &__name {
+    color: var(--primary-high);
+  }
+
+  &__link {
+    color: inherit;
+    text-decoration: none;
+
+    &:visited {
+      color: inherit;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--tertiary);
+      outline-offset: 2px;
+    }
+  }
+
+  &__list-shell {
+    height: var(--db-traffic-card-min-height);
+    border-radius: var(--d-border-radius-large);
+    background: linear-gradient(
+      135deg,
+      var(--primary-very-low),
+      var(--primary-low)
+    );
+  }
+
+  &__percent {
     color: var(--primary);
-    font-weight: 600;
   }
 
   &__count {
     color: var(--primary-medium);
-    font-weight: 400;
+  }
+
+  &__list-empty {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1-rem);
+  }
+
+  &__list-error {
+    color: var(--danger);
+    font-size: var(--font-down-1-rem);
   }
 }
 

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -5,6 +5,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
   MAX_URL_LENGTH = 2000
   MAX_REFERRER_LENGTH = 2000
   MAX_USER_AGENT_LENGTH = 1000
+  MAX_NORMALIZED_REFERRER_LENGTH = 2000
 
   has_one :browser_pageview_event_score, foreign_key: :event_id, dependent: :delete
 
@@ -17,6 +18,9 @@ class BrowserPageviewEvent < ActiveRecord::Base
     self.referrer = referrer.slice(0, MAX_REFERRER_LENGTH) if referrer.present?
     self.user_agent = user_agent.slice(0, MAX_USER_AGENT_LENGTH) if user_agent.present?
     self.session_id = session_id.slice(0, MAX_SESSION_ID_LENGTH) if session_id.present?
+    if normalized_referrer.present?
+      self.normalized_referrer = normalized_referrer.slice(0, MAX_NORMALIZED_REFERRER_LENGTH)
+    end
   end
 end
 
@@ -24,21 +28,24 @@ end
 #
 # Table name: browser_pageview_events
 #
-#  id           :bigint           not null, primary key
-#  asn          :integer
-#  country_code :string(2)
-#  ip_address   :inet             not null
-#  referrer     :string(2000)
-#  score        :integer
-#  url          :string(2000)     not null
-#  user_agent   :string(1000)     not null
-#  created_at   :datetime         not null
-#  session_id   :string(32)       not null
-#  topic_id     :integer
-#  user_id      :integer
+#  id                  :bigint           not null, primary key
+#  asn                 :integer
+#  country_code        :string(2)
+#  ip_address          :inet             not null
+#  normalized_referrer :string(2000)
+#  referrer            :string(2000)
+#  score               :integer
+#  url                 :string(2000)     not null
+#  user_agent          :string(1000)     not null
+#  created_at          :datetime         not null
+#  session_id          :string(32)       not null
+#  topic_id            :integer
+#  user_id             :integer
 #
 # Indexes
 #
+#  idx_bpe_created_at_country_code              (created_at,country_code)
+#  idx_bpe_created_at_normalized_referrer       (created_at,normalized_referrer)
 #  idx_bpe_ip_ua_created_at                     (ip_address,user_agent,created_at)
 #  idx_bpe_session_created_at                   (session_id,created_at)
 #  index_browser_pageview_events_on_created_at  (created_at) USING brin

--- a/app/models/concerns/reports/top_countries_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_countries_by_browser_pageviews.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Reports::TopCountriesByBrowserPageviews
+  extend ActiveSupport::Concern
+
+  EXCLUDED_COUNTRY_CODES = %w[ZZ T1 A1 A2 O1 XX EU AP].freeze
+
+  class_methods do
+    def report_top_countries_by_browser_pageviews(report)
+      report.modes = [Report::MODES[:table]]
+
+      report.labels = [
+        {
+          property: :country_code,
+          type: :text,
+          title: I18n.t("reports.top_countries_by_browser_pageviews.labels.country_code"),
+        },
+        {
+          property: :count,
+          type: :number,
+          title: I18n.t("reports.top_countries_by_browser_pageviews.labels.count"),
+        },
+      ]
+
+      user_filter_sql = SiteSetting.login_required ? "AND user_id IS NOT NULL" : ""
+      end_date_exclusive = report.end_date.to_date + 1
+
+      sql = <<~SQL
+        WITH ranked AS (
+          SELECT
+            country_code,
+            COUNT(*) AS count,
+            SUM(COUNT(*)) OVER () AS total
+          FROM browser_pageview_events
+          WHERE created_at >= :start_date
+            AND created_at < :end_date_exclusive
+            #{user_filter_sql}
+          GROUP BY country_code
+        )
+        SELECT country_code, count,
+               CASE WHEN total = 0 THEN 0
+                    ELSE ROUND((count::numeric / total) * 100)::integer END AS percent
+        FROM ranked
+        WHERE country_code IS NOT NULL
+          AND country_code NOT IN (:excluded_codes)
+        ORDER BY count DESC, country_code ASC
+        LIMIT :limit
+      SQL
+
+      report.data =
+        DB
+          .query(
+            sql,
+            start_date: report.start_date,
+            end_date_exclusive: end_date_exclusive,
+            excluded_codes: EXCLUDED_COUNTRY_CODES,
+            limit: report.limit || 50,
+          )
+          .map { |row| { country_code: row.country_code, count: row.count, percent: row.percent } }
+    end
+  end
+end

--- a/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Reports::TopReferrersByBrowserPageviews
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def report_top_referrers_by_browser_pageviews(report)
+      report.modes = [Report::MODES[:table]]
+
+      report.labels = [
+        {
+          property: :normalized_referrer,
+          type: :text,
+          title: I18n.t("reports.top_referrers_by_browser_pageviews.labels.normalized_referrer"),
+        },
+        {
+          property: :count,
+          type: :number,
+          title: I18n.t("reports.top_referrers_by_browser_pageviews.labels.count"),
+        },
+      ]
+
+      user_filter_sql = SiteSetting.login_required ? "AND user_id IS NOT NULL" : ""
+      end_date_exclusive = report.end_date.to_date + 1
+
+      host = BrowserPageviewReferrerInspector.normalize_host(Discourse.current_hostname)
+      escaped_host = host.gsub(/[\\_%]/) { |char| "\\#{char}" }
+
+      sql = <<~SQL
+        WITH ranked AS (
+          SELECT
+            normalized_referrer,
+            COUNT(*) AS count,
+            SUM(COUNT(*)) OVER () AS total
+          FROM browser_pageview_events
+          WHERE created_at >= :start_date
+            AND created_at < :end_date_exclusive
+            #{user_filter_sql}
+          GROUP BY normalized_referrer
+        )
+        SELECT normalized_referrer, count,
+               CASE WHEN total = 0 THEN 0
+                    ELSE ROUND((count::numeric / total) * 100)::integer END AS percent
+        FROM ranked
+        WHERE normalized_referrer IS NOT NULL
+          AND normalized_referrer <> :host_exact
+          AND normalized_referrer NOT LIKE :host_path_prefix ESCAPE '\\'
+          AND normalized_referrer NOT LIKE :host_query_prefix ESCAPE '\\'
+        ORDER BY count DESC, normalized_referrer ASC
+        LIMIT :limit
+      SQL
+
+      report.data =
+        DB
+          .query(
+            sql,
+            start_date: report.start_date,
+            end_date_exclusive: end_date_exclusive,
+            host_exact: host,
+            host_path_prefix: "#{escaped_host}/%",
+            host_query_prefix: "#{escaped_host}?%",
+            limit: report.limit || 50,
+          )
+          .map do |row|
+            { normalized_referrer: row.normalized_referrer, count: row.count, percent: row.percent }
+          end
+    end
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -38,10 +38,15 @@ class Report
 
   ADMIN_ONLY_REPORTS = %w[admin_logins top_uploads topic_view_stats]
   IP_ADDRESS_REPORTS = %w[suspicious_logins]
+  BROWSER_PAGEVIEW_REPORTS = %w[
+    top_countries_by_browser_pageviews
+    top_referrers_by_browser_pageviews
+  ]
 
   def self.hidden?(type, guardian:)
     return true if !guardian.is_admin? && ADMIN_ONLY_REPORTS.include?(type)
     return true if !guardian.is_admin? && !guardian.can_see_ip? && IP_ADDRESS_REPORTS.include?(type)
+    return true if BROWSER_PAGEVIEW_REPORTS.include?(type)
 
     hidden_reports =
       SiteSetting.use_legacy_pageviews ? HIDDEN_PAGEVIEW_REPORTS : HIDDEN_LEGACY_PAGEVIEW_REPORTS
@@ -109,9 +114,11 @@ class Report
   include Reports::SuspiciousLogins
   include Reports::SystemPrivateMessages
   include Reports::TimeToFirstResponse
+  include Reports::TopCountriesByBrowserPageviews
   include Reports::TopIgnoredUsers
   include Reports::TopReferredTopics
   include Reports::TopReferrers
+  include Reports::TopReferrersByBrowserPageviews
   include Reports::TopTrafficSources
   include Reports::TopUploads
   include Reports::TopUsersByLikesReceived

--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -31,15 +31,56 @@ class AdminDashboardSiteTraffic
     include_embedded = include_embedded_series?
     totals = build_totals(current_rows, include_embedded: include_embedded)
 
-    {
+    response = {
       kpis: kpis(totals, prior_rows),
       pageview_series: pageview_series(current_rows, include_embedded: include_embedded),
     }
+
+    if SiteSetting.persist_browser_pageview_events
+      response[:top_countries] = fetch_card("top_countries_by_browser_pageviews")
+      response[:top_referrers] = fetch_card("top_referrers_by_browser_pageviews")
+    end
+
+    response
   end
 
   private
 
   attr_reader :start_date, :end_date
+
+  def fetch_card(type)
+    opts = {
+      start_date: start_date,
+      end_date: end_date,
+      filters: {
+        login_required: SiteSetting.login_required,
+        host: Discourse.current_hostname,
+      },
+      limit: 5,
+      wrap_exceptions_in_test: true,
+    }
+
+    cached = Report.find_cached(type, opts)
+    return cached_to_payload(cached) if cached
+
+    report = Report.find(type, opts)
+    return { rows: [], error: "exception" } if report.nil?
+
+    # Timeouts skip the cache so the next request retries instead of being
+    # pinned to the error for the full 35-minute TTL.
+    Report.cache(report) if report.error != :timeout
+
+    return { rows: [], error: report.error.to_s } if report.error.present?
+
+    { rows: report.data, error: nil }
+  end
+
+  def cached_to_payload(cached)
+    error = cached[:error]
+    return { rows: [], error: error.to_s } if error.present?
+
+    { rows: (cached[:data] || []).map(&:symbolize_keys), error: nil }
+  end
 
   def series_ids(include_embedded:)
     series = %i[logged_in]

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6942,6 +6942,14 @@ en:
             logged_in_share:
               label: "Logged-in share"
               tooltip: "The share of pageviews from logged-in members."
+          top_countries:
+            title: "Top countries"
+            empty: "No country data for this period."
+            error: "Couldn't load top countries. Try refreshing the page."
+          top_referrers:
+            title: "Top referrers"
+            empty: "No referrer data for this period."
+            error: "Couldn't load top referrers. Try refreshing the page."
           series:
             logged_in: "Logged in"
             anonymous: "Anonymous"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1542,6 +1542,18 @@ en:
         num_clicks: "Clicks"
         num_topics: "Topics"
       description: "Users listed by number of clicks on links they have shared."
+    top_countries_by_browser_pageviews:
+      title: "Top countries"
+      description: "Countries driving the most browser pageviews to your forum in the selected period."
+      labels:
+        country_code: "Country code"
+        count: "Visits"
+    top_referrers_by_browser_pageviews:
+      title: "Top referrers"
+      description: "External sites referring the most browser pageviews to your forum in the selected period."
+      labels:
+        normalized_referrer: "Referrer"
+        count: "Visits"
     top_traffic_sources:
       title: "Top Traffic Sources"
       xaxis: "Domain"

--- a/db/migrate/20260520090937_add_normalized_referrer_to_browser_pageview_events.rb
+++ b/db/migrate/20260520090937_add_normalized_referrer_to_browser_pageview_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNormalizedReferrerToBrowserPageviewEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :browser_pageview_events, :normalized_referrer, :string, limit: 2000
+  end
+end

--- a/db/migrate/20260522043337_add_country_and_referrer_indexes_to_browser_pageview_events.rb
+++ b/db/migrate/20260522043337_add_country_and_referrer_indexes_to_browser_pageview_events.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class AddCountryAndReferrerIndexesToBrowserPageviewEvents < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  COUNTRY_INDEX = "idx_bpe_created_at_country_code"
+  REFERRER_INDEX = "idx_bpe_created_at_normalized_referrer"
+
+  def up
+    remove_index :browser_pageview_events,
+                 name: COUNTRY_INDEX,
+                 algorithm: :concurrently,
+                 if_exists: true
+    add_index :browser_pageview_events,
+              %i[created_at country_code],
+              name: COUNTRY_INDEX,
+              algorithm: :concurrently
+
+    remove_index :browser_pageview_events,
+                 name: REFERRER_INDEX,
+                 algorithm: :concurrently,
+                 if_exists: true
+    add_index :browser_pageview_events,
+              %i[created_at normalized_referrer],
+              name: REFERRER_INDEX,
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :browser_pageview_events,
+                 name: COUNTRY_INDEX,
+                 algorithm: :concurrently,
+                 if_exists: true
+    remove_index :browser_pageview_events,
+                 name: REFERRER_INDEX,
+                 algorithm: :concurrently,
+                 if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1884,7 +1884,8 @@ CREATE TABLE public.browser_pageview_events (
     country_code character varying(2),
     created_at timestamp without time zone NOT NULL,
     asn integer,
-    score integer
+    score integer,
+    normalized_referrer character varying(2000)
 );
 
 
@@ -15889,6 +15890,20 @@ CREATE UNIQUE INDEX idx_bookmarks_user_polymorphic_unique ON public.bookmarks US
 
 
 --
+-- Name: idx_bpe_created_at_country_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_bpe_created_at_country_code ON public.browser_pageview_events USING btree (created_at, country_code);
+
+
+--
+-- Name: idx_bpe_created_at_normalized_referrer; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_bpe_created_at_normalized_referrer ON public.browser_pageview_events USING btree (created_at, normalized_referrer);
+
+
+--
 -- Name: idx_bpe_ip_ua_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -20923,6 +20938,8 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260522043337'),
+('20260520090937'),
 ('20260518104900'),
 ('20260518054805'),
 ('20260514055648'),

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -2,8 +2,9 @@ import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import AdminReportStackedChart from "discourse/admin/components/admin-report-stacked-chart";
 import DashboardSection from "discourse/admin/components/dashboard/section";
+import { countryFlag, countryName } from "discourse/admin/lib/format-country";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
-import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { or } from "discourse/truth-helpers";
 import I18n, { i18n } from "discourse-i18n";
 
 const PERIOD_COPY_KEYS = {
@@ -268,83 +269,113 @@ export default class DashboardTraffic extends Component {
           </div>
         {{/if}}
 
-        <div class="db-section__row">
-          <div class="db-section__row-block">
-            <div class="db-section__row-block-header">
-              <a class="db-section__row-block-title">
-                Placeholder: Top referrers
-                <span class="db-link-arrow">{{dIcon "arrow-right"}}</span>
-              </a>
+        {{#unless @fetchError}}
+          {{#if @traffic}}
+            {{#if (or @traffic.top_countries @traffic.top_referrers)}}
+              <div class="db-section__row">
+                <div class="db-section__row-block">
+                  <h3 class="db-section__row-block-title">
+                    {{i18n "admin.dashboard.site_traffic.top_referrers.title"}}
+                  </h3>
+                  {{#if @traffic.top_referrers.error}}
+                    <p class="db-traffic__list-error" role="status">
+                      {{i18n
+                        "admin.dashboard.site_traffic.top_referrers.error"
+                      }}
+                    </p>
+                  {{else if @traffic.top_referrers.rows.length}}
+                    <ul class="db-traffic__list">
+                      {{#each @traffic.top_referrers.rows as |row|}}
+                        <li class="db-traffic__list-row">
+                          <a
+                            class="db-traffic__link"
+                            href={{concat "https://" row.normalized_referrer}}
+                            rel="noopener noreferrer nofollow ugc"
+                            target="_blank"
+                          >
+                            {{row.normalized_referrer}}
+                          </a>
+                          <span class="db-traffic__metric">
+                            <span class="db-traffic__percent">
+                              {{row.percent}}%
+                            </span>
+                            <span class="db-traffic__count">
+                              ({{this.formatHeadlineCount row.count}})
+                            </span>
+                          </span>
+                        </li>
+                      {{/each}}
+                    </ul>
+                  {{else}}
+                    <p class="db-traffic__list-empty">
+                      {{i18n
+                        "admin.dashboard.site_traffic.top_referrers.empty"
+                      }}
+                    </p>
+                  {{/if}}
+                </div>
+
+                <div class="db-section__row-block">
+                  <h3 class="db-section__row-block-title">
+                    {{i18n "admin.dashboard.site_traffic.top_countries.title"}}
+                  </h3>
+                  {{#if @traffic.top_countries.error}}
+                    <p class="db-traffic__list-error" role="status">
+                      {{i18n
+                        "admin.dashboard.site_traffic.top_countries.error"
+                      }}
+                    </p>
+                  {{else if @traffic.top_countries.rows.length}}
+                    <ul class="db-traffic__list">
+                      {{#each @traffic.top_countries.rows as |row|}}
+                        <li
+                          class="db-traffic__list-row"
+                          data-test-country-code={{row.country_code}}
+                        >
+                          <span class="db-traffic__name">
+                            <span aria-hidden="true">
+                              {{countryFlag row.country_code}}
+                            </span>
+                            {{countryName row.country_code}}
+                          </span>
+                          <span class="db-traffic__metric">
+                            <span class="db-traffic__percent">
+                              {{row.percent}}%
+                            </span>
+                            <span class="db-traffic__count">
+                              ({{this.formatHeadlineCount row.count}})
+                            </span>
+                          </span>
+                        </li>
+                      {{/each}}
+                    </ul>
+                  {{else}}
+                    <p class="db-traffic__list-empty">
+                      {{i18n
+                        "admin.dashboard.site_traffic.top_countries.empty"
+                      }}
+                    </p>
+                  {{/if}}
+                </div>
+              </div>
+            {{/if}}
+          {{else}}
+            <div class="db-section__row">
+              <div class="db-section__row-block">
+                <h3 class="db-section__row-block-title">
+                  {{i18n "admin.dashboard.site_traffic.top_referrers.title"}}
+                </h3>
+                <div class="db-traffic__list-shell"></div>
+              </div>
+              <div class="db-section__row-block">
+                <h3 class="db-section__row-block-title">
+                  {{i18n "admin.dashboard.site_traffic.top_countries.title"}}
+                </h3>
+                <div class="db-traffic__list-shell"></div>
+              </div>
             </div>
-
-            <ul class="db-traffic__list">
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">news.ycombinator.com</span>
-                <span class="db-traffic__value">
-                  41%
-                  <span class="db-traffic__count">(34.2k)</span>
-                </span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">google.com</span>
-                <span class="db-traffic__value">
-                  29%
-                  <span class="db-traffic__count">(24.5k)</span>
-                </span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">github.com</span>
-                <span class="db-traffic__value">
-                  15%
-                  <span class="db-traffic__count">(12.3k)</span>
-                </span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">reddit.com/r/selfhosted</span>
-                <span class="db-traffic__value">
-                  10%
-                  <span class="db-traffic__count">(8.0k)</span>
-                </span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">duckduckgo.com</span>
-                <span class="db-traffic__value">
-                  5%
-                  <span class="db-traffic__count">(4.8k)</span>
-                </span>
-              </li>
-            </ul>
-          </div>
-
-          <div class="db-section__row-block">
-            <h3 class="db-section__row-block-title">
-              Placeholder: Top countries
-            </h3>
-
-            <ul class="db-traffic__list">
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">🇺🇸 United States</span>
-                <span class="db-traffic__value">41%</span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">🇬🇧 United Kingdom</span>
-                <span class="db-traffic__value">12%</span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">🇩🇪 Germany</span>
-                <span class="db-traffic__value">8%</span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">🇨🇦 Canada</span>
-                <span class="db-traffic__value">7%</span>
-              </li>
-              <li class="db-traffic__list-row">
-                <span class="db-traffic__name">🇦🇺 Australia</span>
-                <span class="db-traffic__value">4%</span>
-              </li>
-            </ul>
-          </div>
-        </div>
+          {{/if}}
+        {{/unless}}
       </div>
     </DashboardSection>
   </template>

--- a/frontend/discourse/admin/lib/format-country.js
+++ b/frontend/discourse/admin/lib/format-country.js
@@ -1,0 +1,28 @@
+import I18n from "discourse-i18n";
+
+export function countryFlag(code) {
+  if (!code || code.length !== 2) {
+    return "";
+  }
+  const upper = code.toUpperCase();
+  const offset = 0x1f1e6 - "A".charCodeAt(0);
+  return (
+    String.fromCodePoint(offset + upper.charCodeAt(0)) +
+    String.fromCodePoint(offset + upper.charCodeAt(1))
+  );
+}
+
+export function countryName(code) {
+  if (!code) {
+    return "";
+  }
+  try {
+    const locale = I18n.currentBcp47Locale || "en";
+    const displayName = new Intl.DisplayNames([locale], { type: "region" }).of(
+      code
+    );
+    return displayName || code;
+  } catch {
+    return code;
+  }
+}

--- a/lib/browser_pageview_referrer_inspector.rb
+++ b/lib/browser_pageview_referrer_inspector.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Normalizes referrer URLs captured by the browser pageview middleware so the
+# same logical referrer groups consistently in the top-referrers report. It
+# strips scheme, `www.`, port, fragment, trailing slashes, and common tracking
+# query params, converts the host to lowercase punycode, and truncates the
+# result to 200 bytes.
+class BrowserPageviewReferrerInspector
+  # TODO: consider vendoring DuckDuckGo's Tracker Radar tracking-parameter list
+  # (https://github.com/duckduckgo/tracker-radar) for broader, maintained
+  # coverage instead of this hand-curated subset.
+  TRACKING_PARAMS = %w[
+    utm_source
+    utm_medium
+    utm_campaign
+    utm_term
+    utm_content
+    fbclid
+    gclid
+    mc_cid
+    mc_eid
+    ref_src
+    _hsenc
+    _hsmi
+  ].to_set.freeze
+
+  MAX_LENGTH = 2000
+
+  def self.normalize(raw)
+    return nil if raw.blank?
+
+    # Scheme is intentionally dropped: `http://example.com/x` and
+    # `https://example.com/x` collapse to the same key so the report groups
+    # cross-protocol traffic together.
+    uri = Addressable::URI.parse(raw.to_s.strip)
+    return nil if uri.nil?
+
+    host = normalize_host(uri.host)
+    return nil if host.blank?
+
+    path = uri.path.to_s.sub(%r{/+\z}, "")
+    filtered_query = filter_query(uri.query)
+    query_str = filtered_query.empty? ? "" : "?#{filtered_query}"
+
+    "#{host}#{path}#{query_str}".byteslice(0, MAX_LENGTH).scrub("")
+  rescue Addressable::URI::InvalidURIError, ArgumentError, TypeError
+    nil
+  end
+
+  def self.normalize_host(host)
+    return nil if host.blank?
+    normalized = Addressable::URI.parse("http://#{host}").normalized_host
+    return nil if normalized.blank?
+    normalized.delete_prefix("www.").delete_suffix(".")
+  rescue Addressable::URI::InvalidURIError
+    nil
+  end
+
+  # Filters the raw query string so original percent-encoding is preserved
+  # (avoids %20/+ duplicate groupings for rows pointing at the same URL).
+  def self.filter_query(query)
+    return "" if query.blank?
+
+    query
+      .split("&")
+      .reject do |pair|
+        key = pair.split("=", 2).first.to_s
+        TRACKING_PARAMS.include?(key)
+      end
+      .join("&")
+  end
+  private_class_method :filter_query
+end

--- a/lib/discourse_dev/browser_pageview_event.rb
+++ b/lib/discourse_dev/browser_pageview_event.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "discourse_dev"
+
+module DiscourseDev
+  class BrowserPageviewEvent
+    DEFAULT_COUNT = 1500
+    DEFAULT_RANGE = 3.months
+
+    COUNTRY_WEIGHTS = {
+      "US" => 40,
+      "GB" => 15,
+      "DE" => 10,
+      "FR" => 8,
+      "CA" => 8,
+      "AU" => 5,
+      "BR" => 5,
+      "JP" => 4,
+      "IN" => 3,
+      "CN" => 2,
+      nil => 5,
+    }.freeze
+
+    REFERRERS = [
+      "news.ycombinator.com/item?id=42",
+      "news.ycombinator.com/item?id=99",
+      "news.ycombinator.com",
+      "reddit.com/r/discourse",
+      "reddit.com/r/programming",
+      "twitter.com/discourse",
+      "google.com",
+      "github.com/discourse/discourse",
+      "facebook.com",
+      "m.facebook.com",
+      nil,
+      nil,
+      nil,
+    ].freeze
+
+    def initialize(count: DEFAULT_COUNT)
+      @count = count
+    end
+
+    def populate!
+      unless Discourse.allow_dev_populate?
+        raise 'To run this rake task in a production site, set the value of `ALLOW_DEV_POPULATE` environment variable to "1"'
+      end
+
+      SiteSetting.persist_browser_pageview_events = true
+
+      rows = build_rows
+      ::BrowserPageviewEvent.insert_all(rows)
+      mirror_to_application_requests(rows)
+
+      puts "Enabled persist_browser_pageview_events and inserted #{rows.size} events."
+      rows.size
+    end
+
+    def self.populate!(count: nil)
+      new(count: count || DEFAULT_COUNT).populate!
+    end
+
+    private
+
+    attr_reader :count
+
+    def build_rows
+      country_pool = COUNTRY_WEIGHTS.flat_map { |code, weight| [code] * weight }
+      user_ids = ::User.real.limit(20).pluck(:id)
+      user_id_pool = user_ids + ([nil] * [user_ids.size / 4, 1].max)
+
+      Array.new(count) do
+        normalized = REFERRERS.sample
+        {
+          url: "https://forum.example.com/t/sample-topic/#{rand(1000)}",
+          ip_address: "192.0.2.#{rand(1..254)}",
+          user_agent: "Mozilla/5.0 (X11; Linux x86_64) Chrome/123",
+          session_id: SecureRandom.hex(16),
+          country_code: country_pool.sample,
+          normalized_referrer: normalized,
+          referrer: normalized ? "https://#{normalized}" : nil,
+          user_id: user_id_pool.sample,
+          created_at: DEFAULT_RANGE.ago + rand(DEFAULT_RANGE.to_i).seconds,
+        }
+      end
+    end
+
+    def mirror_to_application_requests(rows)
+      rows
+        .group_by do |row|
+          req_type = row[:user_id] ? :page_view_logged_in_browser : :page_view_anon_browser
+          [row[:created_at].to_date, req_type]
+        end
+        .each do |(date, req_type), grouped|
+          ::ApplicationRequest.write_cache!(req_type, grouped.size, date)
+        end
+    end
+  end
+end

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -721,6 +721,7 @@ class Middleware::RequestTracker
         country_code: payload[:country_code],
         asn: payload[:asn],
         referrer: payload[:referrer],
+        normalized_referrer: BrowserPageviewReferrerInspector.normalize(payload[:referrer]),
         user_agent: payload[:user_agent],
         session_id: payload[:session_id],
         user_id: payload[:user_id],

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -69,3 +69,8 @@ desc "Populates sample data for the admin dashboard"
 task "admin_dashboard:populate" => ["db:load_config"] do |_, args|
   DiscourseDev::ApplicationRequest.populate!
 end
+
+desc "Enables persist_browser_pageview_events and seeds matching events + application_requests"
+task "browser_pageview_events:populate", [:count] => ["db:load_config"] do |_, args|
+  DiscourseDev::BrowserPageviewEvent.populate!(count: args[:count]&.to_i)
+end

--- a/spec/fabricators/browser_pageview_event_fabricator.rb
+++ b/spec/fabricators/browser_pageview_event_fabricator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Fabricator(:browser_pageview_event) do
+  url "https://example.com/"
+  ip_address "1.2.3.4"
+  user_agent "test"
+  session_id { SecureRandom.hex(16) }
+end

--- a/spec/lib/browser_pageview_referrer_inspector_spec.rb
+++ b/spec/lib/browser_pageview_referrer_inspector_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+describe BrowserPageviewReferrerInspector do
+  describe ".normalize" do
+    it "returns nil for blank input" do
+      expect(described_class.normalize(nil)).to be_nil
+      expect(described_class.normalize("")).to be_nil
+      expect(described_class.normalize("  ")).to be_nil
+    end
+
+    it "returns nil for malformed input or URLs without a host" do
+      expect(described_class.normalize("not a url")).to be_nil
+      expect(described_class.normalize("javascript:alert(1)")).to be_nil
+      expect(described_class.normalize("data:text/html,<x>")).to be_nil
+      expect(described_class.normalize("https://")).to be_nil
+      expect(described_class.normalize("file:///etc/passwd")).to be_nil
+    end
+
+    it "strips scheme, lowercases host, strips www and trailing dot" do
+      expect(described_class.normalize("https://www.Example.com/path")).to eq("example.com/path")
+      expect(described_class.normalize("HTTP://EXAMPLE.COM/Path")).to eq("example.com/Path")
+      expect(described_class.normalize("https://example.com./path")).to eq("example.com/path")
+    end
+
+    it "strips the port from any host" do
+      expect(described_class.normalize("https://example.com:3000/path")).to eq("example.com/path")
+      expect(described_class.normalize("https://example.com:443/path")).to eq("example.com/path")
+      expect(described_class.normalize("https://example.com:80")).to eq("example.com")
+    end
+
+    it "strips fragment" do
+      expect(described_class.normalize("https://example.com/path#section")).to eq(
+        "example.com/path",
+      )
+    end
+
+    it "strips trailing slash on path" do
+      expect(described_class.normalize("https://example.com/path/")).to eq("example.com/path")
+      expect(described_class.normalize("https://example.com/")).to eq("example.com")
+    end
+
+    it "strips multiple trailing slashes" do
+      expect(described_class.normalize("https://example.com/path//")).to eq("example.com/path")
+      expect(described_class.normalize("https://example.com/path///")).to eq("example.com/path")
+      expect(described_class.normalize("https://example.com///")).to eq("example.com")
+    end
+
+    it "collapses IDN and punycode forms to the same host" do
+      unicode = described_class.normalize("https://münchen.de/foo")
+      punycode = described_class.normalize("https://xn--mnchen-3ya.de/foo")
+      expect(unicode).to eq(punycode)
+      expect(unicode).to eq("xn--mnchen-3ya.de/foo")
+    end
+
+    it "drops tracking query params but keeps others" do
+      expect(described_class.normalize("https://example.com/p?utm_source=x&id=42")).to eq(
+        "example.com/p?id=42",
+      )
+      expect(
+        described_class.normalize("https://news.ycombinator.com/item?id=12345&utm_campaign=x"),
+      ).to eq("news.ycombinator.com/item?id=12345")
+      expect(described_class.normalize("https://example.com/p?utm_source=x")).to eq("example.com/p")
+      expect(described_class.normalize("https://example.com/p?fbclid=abc&gclid=def")).to eq(
+        "example.com/p",
+      )
+    end
+
+    it "preserves original query encoding (does not re-encode)" do
+      expect(described_class.normalize("https://example.com/p?q=foo%20bar")).to eq(
+        "example.com/p?q=foo%20bar",
+      )
+      expect(described_class.normalize("https://example.com/p?q=foo+bar")).to eq(
+        "example.com/p?q=foo+bar",
+      )
+    end
+
+    it "preserves query order and duplicates among kept params" do
+      expect(described_class.normalize("https://example.com/p?a=1&b=2&a=3")).to eq(
+        "example.com/p?a=1&b=2&a=3",
+      )
+    end
+
+    it "truncates to 2000 bytes and produces valid UTF-8" do
+      long_path = "x" * 2200
+      result = described_class.normalize("https://example.com/#{long_path}")
+      expect(result.bytesize).to be <= 2000
+      expect(result).to be_valid_encoding
+    end
+
+    it "scrubs invalid bytes left by mid-character truncation" do
+      multibyte = "ü" * 1100
+      result = described_class.normalize("https://example.com/#{multibyte}")
+      expect(result.bytesize).to be <= 2000
+      expect(result).to be_valid_encoding
+    end
+  end
+
+  describe ".normalize_host" do
+    it "lowercases, strips www prefix, and strips trailing dot" do
+      expect(described_class.normalize_host("Forum.Example.Com")).to eq("forum.example.com")
+      expect(described_class.normalize_host("www.example.com")).to eq("example.com")
+      expect(described_class.normalize_host("example.com.")).to eq("example.com")
+    end
+
+    it "converts Unicode hosts to punycode" do
+      expect(described_class.normalize_host("münchen.de")).to eq("xn--mnchen-3ya.de")
+      expect(described_class.normalize_host("xn--mnchen-3ya.de")).to eq("xn--mnchen-3ya.de")
+    end
+
+    it "returns nil for blank input" do
+      expect(described_class.normalize_host(nil)).to be_nil
+      expect(described_class.normalize_host("")).to be_nil
+    end
+  end
+end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -924,6 +924,50 @@ RSpec.describe Middleware::RequestTracker do
           expect(event.ip_address.to_s).to eq("1.2.3.4")
         end
 
+        it "populates normalized_referrer via BrowserPageviewReferrerInspector" do
+          session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
+                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
+                "HTTP_DISCOURSE_TRACK_VIEW_REFERRER" => "https://www.example.com/path?utm_source=x",
+                "action_dispatch.remote_ip" => "1.2.3.4",
+              ),
+              ["200", { "Content-Type" => "text/html" }],
+              0.2,
+            )
+
+          Middleware::RequestTracker.log_request(data)
+
+          event = BrowserPageviewEvent.last
+          expect(event.referrer).to eq("https://www.example.com/path?utm_source=x")
+          expect(event.normalized_referrer).to eq("example.com/path")
+        end
+
+        it "stores nil normalized_referrer when the referrer is blank" do
+          session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
+                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
+                "action_dispatch.remote_ip" => "1.2.3.4",
+              ),
+              ["200", { "Content-Type" => "text/html" }],
+              0.2,
+            )
+
+          Middleware::RequestTracker.log_request(data)
+
+          event = BrowserPageviewEvent.last
+          expect(event.normalized_referrer).to be_nil
+        end
+
         it "takes precedence even when trigger_browser_pageview_events is also true" do
           SiteSetting.trigger_browser_pageview_events = true
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe BrowserPageviewEvent do
         user_agent: "a" * (described_class::MAX_USER_AGENT_LENGTH + 1),
         ip_address: "1.2.3.4",
         session_id: "a" * (described_class::MAX_SESSION_ID_LENGTH + 1),
+        normalized_referrer: "a" * (described_class::MAX_NORMALIZED_REFERRER_LENGTH + 1),
       )
 
     expect(event.url.length).to eq(described_class::MAX_URL_LENGTH)
     expect(event.referrer.length).to eq(described_class::MAX_REFERRER_LENGTH)
     expect(event.user_agent.length).to eq(described_class::MAX_USER_AGENT_LENGTH)
     expect(event.session_id.length).to eq(described_class::MAX_SESSION_ID_LENGTH)
+    expect(event.normalized_referrer.length).to eq(described_class::MAX_NORMALIZED_REFERRER_LENGTH)
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2188,5 +2188,11 @@ RSpec.describe Report do
         end
       end
     end
+
+    it "always hides browser pageview reports" do
+      Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+        expect(Report.hidden?(report_type, guardian: admin_guardian)).to eq(true)
+      end
+    end
   end
 end

--- a/spec/models/reports/top_countries_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_countries_by_browser_pageviews_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+describe Reports::TopCountriesByBrowserPageviews do
+  describe ".report_top_countries_by_browser_pageviews" do
+    let(:start_date) { 7.days.ago.to_date }
+    let(:end_date) { Date.today }
+
+    it "ranks countries by event count and computes percent of total browser pageviews" do
+      3.times { Fabricate(:browser_pageview_event, country_code: "US") }
+      1.times { Fabricate(:browser_pageview_event, country_code: "GB") }
+
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:country_code] }).to eq(%w[US GB])
+      expect(report.data.first[:count]).to eq(3)
+      expect(report.data.first[:percent]).to eq(75)
+    end
+
+    it "excludes NULL country_code from numerator but includes in denominator" do
+      2.times { Fabricate(:browser_pageview_event, country_code: "US") }
+      2.times { Fabricate(:browser_pageview_event, country_code: nil) }
+
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:country_code] }).to eq(%w[US])
+      expect(report.data.first[:percent]).to eq(50)
+    end
+
+    it "excludes MaxMind reserved country codes" do
+      Reports::TopCountriesByBrowserPageviews::EXCLUDED_COUNTRY_CODES.each do |code|
+        Fabricate(:browser_pageview_event, country_code: code)
+      end
+      Fabricate(:browser_pageview_event, country_code: "US")
+
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:country_code] }).to eq(%w[US])
+    end
+
+    it "counts only logged-in events in both numerator and denominator when login_required is true" do
+      SiteSetting.login_required = true
+      user = Fabricate(:user)
+      Fabricate(:browser_pageview_event, country_code: "US", user_id: user.id)
+      Fabricate(:browser_pageview_event, country_code: "US") # anonymous, ignored
+      Fabricate(:browser_pageview_event, country_code: "GB", user_id: user.id)
+
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:country_code] }).to contain_exactly("US", "GB")
+      expect(report.data.first[:count]).to eq(1)
+      expect(report.data.first[:percent]).to eq(50)
+    end
+
+    it "returns empty data when no events exist in range" do
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data).to eq([])
+    end
+
+    it "treats the end_date day as fully inclusive via strict less-than on end_date + 1" do
+      end_of_day = end_date.to_time + 23.hours + 59.minutes
+      next_day = (end_date + 1.day).to_time
+      Fabricate(:browser_pageview_event, country_code: "US", created_at: end_of_day)
+      Fabricate(:browser_pageview_event, country_code: "US", created_at: next_day) # out of range
+
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.first[:count]).to eq(1)
+    end
+
+    it "respects the limit opt" do
+      %w[US GB DE FR JP CN].each_with_index do |code, idx|
+        (idx + 1).times { Fabricate(:browser_pageview_event, country_code: code) }
+      end
+
+      report =
+        Report.find(
+          "top_countries_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+          limit: 3,
+        )
+      expect(report.data.size).to eq(3)
+    end
+  end
+end

--- a/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+describe Reports::TopReferrersByBrowserPageviews do
+  describe ".report_top_referrers_by_browser_pageviews" do
+    let(:start_date) { 7.days.ago.to_date }
+    let(:end_date) { Date.today }
+
+    before { Discourse.stubs(:current_hostname).returns("forum.example.com") }
+
+    it "ranks referrers by event count and computes percent of total browser pageviews" do
+      3.times do
+        Fabricate(:browser_pageview_event, normalized_referrer: "news.ycombinator.com/item?id=1")
+      end
+      1.times { Fabricate(:browser_pageview_event, normalized_referrer: "reddit.com/r/discourse") }
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(
+        %w[news.ycombinator.com/item?id=1 reddit.com/r/discourse],
+      )
+      expect(report.data.first[:percent]).to eq(75)
+    end
+
+    it "excludes NULL normalized_referrer from numerator but includes in denominator" do
+      2.times { Fabricate(:browser_pageview_event, normalized_referrer: "google.com") }
+      2.times { Fabricate(:browser_pageview_event, normalized_referrer: nil) }
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
+      expect(report.data.first[:percent]).to eq(50)
+    end
+
+    it "excludes same-host bare, path-prefixed, and query-prefixed referrers" do
+      Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com")
+      Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com/t/topic/1")
+      Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com?ref=email")
+      Fabricate(:browser_pageview_event, normalized_referrer: "google.com")
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
+    end
+
+    it "does not exclude hosts that merely share a prefix with current_hostname" do
+      Fabricate(:browser_pageview_event, normalized_referrer: "evilforum.example.com/x")
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["evilforum.example.com/x"])
+    end
+
+    it "handles current_hostname capitalization and www prefix consistently with the normalizer" do
+      Discourse.stubs(:current_hostname).returns("Forum.Example.Com")
+      Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com")
+      Fabricate(:browser_pageview_event, normalized_referrer: "google.com")
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
+    end
+
+    it "excludes same-host referrers when current_hostname is an IDN" do
+      Discourse.stubs(:current_hostname).returns("münchen.de")
+      Fabricate(:browser_pageview_event, normalized_referrer: "xn--mnchen-3ya.de/blog")
+      Fabricate(:browser_pageview_event, normalized_referrer: "google.com")
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
+    end
+
+    it "escapes LIKE wildcards in current_hostname so other hosts do not over-match" do
+      Discourse.stubs(:current_hostname).returns("my_blog.example.com")
+      # `_` is a single-char wildcard in LIKE; without escaping, the pattern
+      # `my_blog.example.com/%` would match `my-blog.example.com/x` too.
+      Fabricate(:browser_pageview_event, normalized_referrer: "my-blog.example.com/x")
+      Fabricate(:browser_pageview_event, normalized_referrer: "google.com")
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to contain_exactly(
+        "my-blog.example.com/x",
+        "google.com",
+      )
+    end
+
+    it "counts only logged-in events in both numerator and denominator when login_required is true" do
+      SiteSetting.login_required = true
+      user = Fabricate(:user)
+      Fabricate(:browser_pageview_event, normalized_referrer: "google.com", user_id: user.id)
+      Fabricate(:browser_pageview_event, normalized_referrer: "google.com") # anonymous, ignored
+      Fabricate(:browser_pageview_event, normalized_referrer: "reddit.com", user_id: user.id)
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.first[:count]).to eq(1)
+    end
+
+    it "returns empty data when no qualifying events exist" do
+      Fabricate(:browser_pageview_event, normalized_referrer: nil)
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data).to eq([])
+    end
+
+    it "respects the limit opt" do
+      6.times do |i|
+        (i + 1).times do
+          Fabricate(:browser_pageview_event, normalized_referrer: "site-#{i}.example.com")
+        end
+      end
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+          limit: 3,
+        )
+      expect(report.data.size).to eq(3)
+    end
+  end
+end

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -524,5 +524,128 @@ RSpec.describe AdminDashboardSiteTraffic do
         ],
       )
     end
+
+    context "for top countries and top referrers" do
+      before { SiteSetting.persist_browser_pageview_events = true }
+
+      it "omits top_countries and top_referrers when persist_browser_pageview_events is disabled" do
+        SiteSetting.persist_browser_pageview_events = false
+
+        result = described_class.build(start_date: nil, end_date: nil)
+        expect(result).not_to have_key(:top_countries)
+        expect(result).not_to have_key(:top_referrers)
+      end
+
+      it "returns top_countries and top_referrers with rows and no error when matching events exist" do
+        6.times do
+          Fabricate(:browser_pageview_event, country_code: "US", normalized_referrer: "google.com")
+        end
+
+        result = described_class.build(start_date: nil, end_date: nil)
+
+        expect(result[:top_countries][:rows].first[:country_code]).to eq("US")
+        expect(result[:top_countries][:error]).to be_nil
+
+        expect(result[:top_referrers][:rows].first[:normalized_referrer]).to eq("google.com")
+        expect(result[:top_referrers][:error]).to be_nil
+      end
+
+      it "returns empty rows when no events match the date range" do
+        result = described_class.build(start_date: nil, end_date: nil)
+        expect(result[:top_countries]).to eq(rows: [], error: nil)
+        expect(result[:top_referrers]).to eq(rows: [], error: nil)
+      end
+
+      it "returns an exception error payload when the underlying report cannot be built" do
+        allow(Report).to receive(:find).and_return(nil)
+
+        result = described_class.build(start_date: nil, end_date: nil)
+        expect(result[:top_countries]).to eq(rows: [], error: "exception")
+        expect(result[:top_referrers]).to eq(rows: [], error: "exception")
+      end
+
+      it "serves the cached payload on subsequent calls within the cache window" do
+        4.times do
+          Fabricate(:browser_pageview_event, country_code: "US", normalized_referrer: "google.com")
+        end
+
+        first = described_class.build(start_date: nil, end_date: nil)
+        expect(first[:top_countries][:rows].first[:country_code]).to eq("US")
+
+        BrowserPageviewEvent.delete_all
+
+        second = described_class.build(start_date: nil, end_date: nil)
+        expect(second[:top_countries][:rows].first[:country_code]).to eq("US")
+        expect(second[:top_countries][:rows].first.keys).to all(be_a(Symbol))
+      end
+
+      it "invalidates the cached payload when login_required is toggled" do
+        4.times do
+          Fabricate(:browser_pageview_event, country_code: "US", normalized_referrer: "google.com")
+        end
+
+        SiteSetting.login_required = false
+        first = described_class.build(start_date: nil, end_date: nil)
+        expect(first[:top_countries][:rows].first[:country_code]).to eq("US")
+
+        SiteSetting.login_required = true
+        second = described_class.build(start_date: nil, end_date: nil)
+        expect(second[:top_countries][:rows]).to be_empty
+      end
+
+      it "invalidates the cached payload when current_hostname changes" do
+        Discourse.stubs(:current_hostname).returns("forum-a.example.com")
+        Fabricate(:browser_pageview_event, normalized_referrer: "forum-b.example.com/path")
+
+        first = described_class.build(start_date: nil, end_date: nil)
+        expect(first[:top_referrers][:rows].first[:normalized_referrer]).to eq(
+          "forum-b.example.com/path",
+        )
+
+        Discourse.stubs(:current_hostname).returns("forum-b.example.com")
+        second = described_class.build(start_date: nil, end_date: nil)
+        expect(second[:top_referrers][:rows]).to be_empty
+      end
+
+      it "serves the cached error payload on subsequent calls" do
+        allow(Report).to receive(:find) do |type, opts|
+          Report
+            ._get(type, opts)
+            .tap do |report|
+              report.error = :exception
+              report.data = []
+            end
+        end
+
+        first = described_class.build(start_date: nil, end_date: nil)
+        expect(first[:top_countries]).to eq(rows: [], error: "exception")
+
+        allow(Report).to receive(:find).and_call_original
+
+        second = described_class.build(start_date: nil, end_date: nil)
+        expect(second[:top_countries]).to eq(rows: [], error: "exception")
+      end
+
+      it "returns a timeout error payload and retries the report on a subsequent call" do
+        allow(Report).to receive(:find) do |type, _opts|
+          Report
+            .new(type)
+            .tap do |report|
+              report.error = :timeout
+              report.data = []
+            end
+        end
+
+        first = described_class.build(start_date: nil, end_date: nil)
+        expect(first[:top_countries]).to eq(rows: [], error: "timeout")
+        expect(first[:top_referrers]).to eq(rows: [], error: "timeout")
+
+        allow(Report).to receive(:find).and_call_original
+        Fabricate(:browser_pageview_event, country_code: "US", normalized_referrer: "google.com")
+
+        second = described_class.build(start_date: nil, end_date: nil)
+        expect(second[:top_countries][:rows].first[:country_code]).to eq("US")
+      end
+    end
   end
 end

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -127,4 +127,69 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
     expect(traffic).to have_no_comparison_tooltip
     expect(traffic).to have_chart
   end
+
+  context "with top countries and top referrers cards" do
+    before do
+      SiteSetting.persist_browser_pageview_events = true
+      Discourse.stubs(:current_hostname).returns("test.localhost")
+      Discourse.cache.clear
+    end
+
+    it "does not show the cards when persist_browser_pageview_events is off" do
+      SiteSetting.persist_browser_pageview_events = false
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_no_top_countries_card
+      expect(traffic).to have_no_top_referrers_card
+    end
+
+    it "shows ranked top countries and top referrers when events exist in the period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      2.times do
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "US",
+          normalized_referrer: "news.ycombinator.com/item?id=42",
+          created_at: "2026-05-12",
+        )
+      end
+      Fabricate(
+        :browser_pageview_event,
+        country_code: "GB",
+        normalized_referrer: "reddit.com/r/discourse",
+        created_at: "2026-05-12",
+      )
+      Fabricate(
+        :browser_pageview_event,
+        country_code: "DE",
+        normalized_referrer: nil,
+        created_at: "2026-05-12",
+      )
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_top_country_rows(
+        [
+          { country: "US", percent: 50 },
+          { country: "DE", percent: 25 },
+          { country: "GB", percent: 25 },
+        ],
+      )
+      expect(traffic).to have_top_referrer_rows(
+        [{ referrer: "news.ycombinator.com/item?id=42" }, { referrer: "reddit.com/r/discourse" }],
+      )
+    end
+
+    it "shows an empty state in both cards when no events qualify",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_top_countries_empty_state
+      expect(traffic).to have_top_referrers_empty_state
+    end
+  end
 end

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -57,6 +57,59 @@ module PageObjects
       def has_logged_in_share_tooltip?(text)
         Tooltips.new("site-traffic-logged-in-share-tooltip").present?(text: text)
       end
+
+      def has_no_top_countries_card?
+        has_no_top_card?("Top countries")
+      end
+
+      def has_no_top_referrers_card?
+        has_no_top_card?("Top referrers")
+      end
+
+      def has_top_country_rows?(rows)
+        within_top_card("Top countries") do
+          next false unless has_css?(".db-traffic__list-row", count: rows.size)
+
+          rows.each_with_index.all? do |row, index|
+            nth =
+              ".db-traffic__list-row:nth-child(#{index + 1})[data-test-country-code='#{row[:country]}']"
+            has_css?(nth) && has_css?("#{nth} .db-traffic__percent", text: "#{row[:percent]}%")
+          end
+        end
+      end
+
+      def has_top_referrer_rows?(rows)
+        within_top_card("Top referrers") do
+          next false unless has_css?(".db-traffic__list-row", count: rows.size)
+
+          rows.each_with_index.all? do |row, index|
+            nth = ".db-traffic__list-row:nth-child(#{index + 1})"
+            has_css?("#{nth} a.db-traffic__link", text: row[:referrer])
+          end
+        end
+      end
+
+      def has_top_countries_empty_state?
+        has_empty_state_in?("Top countries", "No country data for this period.")
+      end
+
+      def has_top_referrers_empty_state?
+        has_empty_state_in?("Top referrers", "No referrer data for this period.")
+      end
+
+      private
+
+      def has_no_top_card?(title)
+        has_no_css?(".db-section__row-block", text: title)
+      end
+
+      def within_top_card(title, &block)
+        within(".db-section__row-block", text: title, &block)
+      end
+
+      def has_empty_state_in?(title, message)
+        within_top_card(title) { has_css?(".db-traffic__list-empty", text: message) }
+      end
     end
   end
 end


### PR DESCRIPTION
This commit adds two new cards to the redesigned admin dashboard's Site Traffic section: top countries and top referrers, both sourced from `browser_pageview_events`.

Key technical decisions:

1. Gate the cards on the `persist_browser_pageview_events` site setting. The cards have no data source unless browser pageview events are being persisted, so they are omitted from the dashboard. 

2. Normalize referrers at write time. A new `normalized_referrer` column on `browser_pageview_events` is populated by `BrowserPageviewReferrerInspector`, which strips scheme, `www.`, port, fragment, trailing slashes, and common tracking query params. Doing this at insert time avoids per-row string operations at query time.

3. Count browser pageviews by country and by referrer in two new report concerns. `Reports::TopCountriesByBrowserPageviews` groups by `country_code` and `Reports::TopReferrersByBrowserPageviews` groups by `normalized_referrer`. Both compute share of total browser pageviews and rank the top 5 in SQL. The country report drops MaxMind reserved codes (unknown, anonymous proxy, satellite). The referrer report drops same-host referrals. Both also exclude anonymous browser pageviews (`user_id IS NULL`) when the `login_required` site setting is enabled, since only logged-in browser pageviews are meaningful on a closed forum.

4. Fetch each report through the existing dashboard service. `AdminDashboardSiteTraffic#build` returns one entry per card with a `{ rows:, error: }` shape, e.g.:

   ```ruby
   {
     top_countries: {
       rows: [
         { country_code: "US", count: 142, percent: 35 },
         { country_code: "GB", count: 89, percent: 22 }
       ],
       error: nil
     },
     top_referrers: {
       rows: [
         { normalized_referrer: "news.ycombinator.com/item?id=1", count: 47, percent: 12 },
         { normalized_referrer: "reddit.com/r/discourse", count: 31, percent: 8 }
       ],
       error: nil
     }
   }
   ```

   On report failure, `rows: []` and `error: :timeout` (or another symbol). This lets the UI render rows, error, or empty state independently. Healthy responses are cached via `Report.find_cached`. `SiteSetting.login_required` and `Discourse.current_hostname` flow into `opts[:filters]` so toggling either invalidates the cache. Timeouts skip the cache so the next request retries.

5. Use `Intl.DisplayNames` for country names instead of locale files. `Intl.DisplayNames` is a built-in browser API that returns a localized country name for an ISO 3166-1 alpha-2 code, avoiding ~250 translation strings per locale.

#### Recording

https://github.com/user-attachments/assets/5de12b37-1594-4de1-9b05-7df7d86133e6

#### Empty state

<img width="1090" height="718" alt="Screenshot 2026-05-22 at 9 34 22 AM" src="https://github.com/user-attachments/assets/89a32aa9-1dfc-4fc0-b3f8-88c0667d027f" />

