### PR TITLE
FIX: reactions shouldn't be visible to users without see_hidden_post permission if a post is hidden

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions-button.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions-button.gjs
@@ -1,12 +1,26 @@
+import Component from "@glimmer/component";
+import { applyValueTransformer } from "discourse/lib/transformer";
+import { reactionsHiddenForUser } from "../lib/hidden-post";
 import DiscourseReactionsActions from "./discourse-reactions-actions";
 
-const ReactionsActionButton = <template>
-  <div class="discourse-reactions-actions-button-shim">
-    <DiscourseReactionsActions
-      @post={{@post}}
-      @showLogin={{@buttonActions.showLogin}}
-    />
-  </div>
-</template>;
+export default class ReactionsActionButton extends Component {
+  static shouldRender(args) {
+    if (reactionsHiddenForUser(args.post)) {
+      return false;
+    }
 
-export default ReactionsActionButton;
+    const show = args.post.showLike || args.post.likeCount > 0;
+    return applyValueTransformer("like-button-render-decision", show, {
+      post: args.post,
+    });
+  }
+
+  <template>
+    <div class="discourse-reactions-actions-button-shim">
+      <DiscourseReactionsActions
+        @post={{@post}}
+        @showLogin={{@buttonActions.showLogin}}
+      />
+    </div>
+  </template>
+}

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions-summary.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions-summary.gjs
@@ -13,6 +13,10 @@ export default class ReactionsActionSummary extends Component {
       return false;
     }
 
+    if (args.post.hidden && !args.post.can_see_hidden_post) {
+      return false;
+    }
+
     const siteSettings = owner?.lookup("service:site-settings");
     if (siteSettings?.enable_new_post_reactions_menu) {
       return true;

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions-summary.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-actions-summary.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { reactionsHiddenForUser } from "../lib/hidden-post";
 import DiscourseReactionsActions from "./discourse-reactions-actions";
 
 export default class ReactionsActionSummary extends Component {
@@ -13,7 +14,7 @@ export default class ReactionsActionSummary extends Component {
       return false;
     }
 
-    if (args.post.hidden && !args.post.can_see_hidden_post) {
+    if (reactionsHiddenForUser(args.post)) {
       return false;
     }
 

--- a/plugins/discourse-reactions/assets/javascripts/discourse/lib/hidden-post.js
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/lib/hidden-post.js
@@ -1,0 +1,6 @@
+// When a post is hidden and the viewer lacks permission to see
+// it, the reaction affordances (counter and button) must be suppressed, otherwise
+// interacting with them hits a 403 with no way to recover.
+export function reactionsHiddenForUser(post) {
+  return post.hidden && !post.can_see_hidden_post;
+}

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
@@ -94,3 +94,60 @@ acceptance("Post", function (needs) {
       .doesNotExist("doesn’t allow to toggle the reaction");
   });
 });
+
+acceptance("Post - hidden reactions", function (needs) {
+  needs.user();
+
+  needs.settings({
+    discourse_reactions_enabled: true,
+    discourse_reactions_enabled_reactions: "otter|open_mouth",
+    discourse_reactions_reaction_for_like: "heart",
+    discourse_reactions_like_icon: "heart",
+    enable_new_post_reactions_menu: true,
+  });
+
+  needs.pretender((server, helper) => {
+    const topic = structuredClone(ReactionsTopics["/t/374.json"]);
+    topic.post_stream.posts[0].hidden = true;
+    topic.post_stream.posts[0].cooked_hidden = true;
+    topic.post_stream.posts[0].can_see_hidden_post = false;
+
+    server.get("/t/374.json", () => helper.response(topic));
+  });
+
+  test("does not show the reactions counter for hidden posts", async function (assert) {
+    await visit("/t/topic_with_reactions_and_likes/374");
+
+    assert
+      .dom("#post_1 .discourse-reactions-counter")
+      .doesNotExist("hides the counter to prevent opening the reactions list");
+  });
+});
+
+acceptance("Post - hidden reactions with hidden-post access", function (needs) {
+  needs.user();
+
+  needs.settings({
+    discourse_reactions_enabled: true,
+    discourse_reactions_enabled_reactions: "otter|open_mouth",
+    discourse_reactions_reaction_for_like: "heart",
+    discourse_reactions_like_icon: "heart",
+    enable_new_post_reactions_menu: true,
+  });
+
+  needs.pretender((server, helper) => {
+    const topic = structuredClone(ReactionsTopics["/t/374.json"]);
+    topic.post_stream.posts[0].hidden = true;
+    topic.post_stream.posts[0].can_see_hidden_post = true;
+
+    server.get("/t/374.json", () => helper.response(topic));
+  });
+
+  test("shows the reactions counter for hidden posts", async function (assert) {
+    await visit("/t/topic_with_reactions_and_likes/374");
+
+    assert
+      .dom("#post_1 .discourse-reactions-counter .reactions-counter")
+      .hasText("209", "allows the reactions list to be opened");
+  });
+});

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
@@ -108,19 +108,31 @@ acceptance("Post - hidden reactions", function (needs) {
 
   needs.pretender((server, helper) => {
     const topic = structuredClone(ReactionsTopics["/t/374.json"]);
-    topic.post_stream.posts[0].hidden = true;
-    topic.post_stream.posts[0].cooked_hidden = true;
-    topic.post_stream.posts[0].can_see_hidden_post = false;
+    const post = topic.post_stream.posts[0];
+    // A staff member or the author can always see a hidden post, so the denied
+    // case is only reachable for a non-owner, non-staff viewer.
+    post.yours = false;
+    post.admin = false;
+    post.staff = false;
+    post.moderator = false;
+    post.user_id = 999;
+    post.hidden = true;
+    post.cooked_hidden = true;
+    post.can_see_hidden_post = false;
 
     server.get("/t/374.json", () => helper.response(topic));
   });
 
-  test("does not show the reactions counter for hidden posts", async function (assert) {
+  test("hides reaction affordances for hidden posts", async function (assert) {
     await visit("/t/topic_with_reactions_and_likes/374");
 
     assert
       .dom("#post_1 .discourse-reactions-counter")
       .doesNotExist("hides the counter to prevent opening the reactions list");
+
+    assert
+      .dom("#post_1 .discourse-reactions-reaction-button")
+      .doesNotExist("hides the reaction button that would hit a 403");
   });
 });
 
@@ -137,17 +149,27 @@ acceptance("Post - hidden reactions with hidden-post access", function (needs) {
 
   needs.pretender((server, helper) => {
     const topic = structuredClone(ReactionsTopics["/t/374.json"]);
-    topic.post_stream.posts[0].hidden = true;
-    topic.post_stream.posts[0].can_see_hidden_post = true;
+    const post = topic.post_stream.posts[0];
+    post.yours = false;
+    post.admin = false;
+    post.staff = false;
+    post.moderator = false;
+    post.user_id = 999;
+    post.hidden = true;
+    post.can_see_hidden_post = true;
 
     server.get("/t/374.json", () => helper.response(topic));
   });
 
-  test("shows the reactions counter for hidden posts", async function (assert) {
+  test("keeps reaction affordances for hidden posts", async function (assert) {
     await visit("/t/topic_with_reactions_and_likes/374");
 
     assert
       .dom("#post_1 .discourse-reactions-counter .reactions-counter")
       .hasText("209", "allows the reactions list to be opened");
+
+    assert
+      .dom("#post_1 .discourse-reactions-reaction-button")
+      .exists("keeps the reaction button for viewers who can see the post");
   });
 });


### PR DESCRIPTION


The backend `/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb` uses `guardian.ensure_can_see!(post)` to restrict users without permission from loading the reactions when a post is hidden.

 However, the frontend still renders the reaction affordances. When a user without `see_hidden_post` permission clicks the reaction counter of a hidden post, there's an infinite loading state with a 403 forbidden on
 `/discourse-reactions/posts/xxx/reactions-users-list.json`. The reaction/like button has the same problem — toggling a reaction there hits the same 403 boundary.
 
 This adds a matching guard on the frontend, hiding both the reaction counter and the reaction button when `post.hidden && !post.can_see_hidden_post`. The check is extracted into a shared helper used by both entry points, and the button keeps its `shouldRender` in sync with the core like button's decision so it still behaves correctly in the cases it replaces (e.g. deleted posts).



Before:
<img width="1918" height="917" alt="image" src="https://github.com/user-attachments/assets/cf5ed458-b9ab-4365-a9ea-43d2a4737df8" />

<img width="1917" height="922" alt="image" src="https://github.com/user-attachments/assets/87c39f7f-5b8b-4555-a877-fe74714e16ca" />

After:
<img width="1918" height="921" alt="image" src="https://github.com/user-attachments/assets/ed6765b6-091a-45b0-af1b-a5b749d08fe1" />
