### PR TITLE
FIX: Hidden post excerpts can be returned by group activity serializers

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -464,17 +464,10 @@ class Group < ActiveRecord::Base
     end
 
     result = guardian.filter_allowed_categories(result)
-    result = filter_hidden_posts_for_guardian(result, guardian)
+    result = guardian.filter_hidden_posts(result)
     result = result.where("posts.id < ?", opts[:before_post_id].to_i) if opts[:before_post_id]
     result = result.where("posts.created_at < ?", opts[:before].to_datetime) if opts[:before]
     result.order("posts.created_at desc")
-  end
-
-  def filter_hidden_posts_for_guardian(result, guardian)
-    return result if guardian.can_see_all_hidden_posts?
-    return result.where(posts: { hidden: false }) if guardian.anonymous?
-
-    result.where("posts.hidden = false OR posts.user_id = ?", guardian.user.id)
   end
 
   def self.trust_group_ids

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -429,7 +429,6 @@ class Group < ActiveRecord::Base
   end
 
   def posts_for(guardian, opts = nil)
-    opts ||= {}
     result =
       Post
         .joins(:topic, user: :groups, topic: :category)
@@ -440,19 +439,10 @@ class Group < ActiveRecord::Base
         .where("topics.visible")
         .where(post_type: [Post.types[:regular], Post.types[:moderator_action]])
 
-    if opts[:category_id].present?
-      result = result.where("topics.category_id = ?", opts[:category_id].to_i)
-    end
-
-    result = guardian.filter_allowed_categories(result)
-    result = filter_hidden_posts_for_guardian(result, guardian)
-    result = result.where("posts.id < ?", opts[:before_post_id].to_i) if opts[:before_post_id]
-    result = result.where("posts.created_at < ?", opts[:before].to_datetime) if opts[:before]
-    result.order("posts.created_at desc")
+    filter_posts_for_guardian(result, guardian, opts)
   end
 
   def mentioned_posts_for(guardian, opts = nil)
-    opts ||= {}
     result =
       Post
         .joins(:group_mentions)
@@ -462,6 +452,12 @@ class Group < ActiveRecord::Base
         .where("topics.visible")
         .where(post_type: Post.types[:regular])
         .where("group_mentions.group_id = ?", id)
+
+    filter_posts_for_guardian(result, guardian, opts)
+  end
+
+  def filter_posts_for_guardian(result, guardian, opts = nil)
+    opts ||= {}
 
     if opts[:category_id].present?
       result = result.where("topics.category_id = ?", opts[:category_id].to_i)
@@ -475,14 +471,10 @@ class Group < ActiveRecord::Base
   end
 
   def filter_hidden_posts_for_guardian(result, guardian)
-    return result if SiteSetting.hidden_post_visible_groups_map.include?(AUTO_GROUPS[:everyone])
-    return result if guardian.is_staff?
+    return result if guardian.can_see_all_hidden_posts?
+    return result.where(posts: { hidden: false }) if guardian.anonymous?
 
-    user = guardian.user
-    return result.where(posts: { hidden: false }) if user.blank?
-    return result if user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
-
-    result.where("posts.hidden = false OR posts.user_id = ?", user.id)
+    result.where("posts.hidden = false OR posts.user_id = ?", guardian.user.id)
   end
 
   def self.trust_group_ids

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -445,6 +445,7 @@ class Group < ActiveRecord::Base
     end
 
     result = guardian.filter_allowed_categories(result)
+    result = filter_hidden_posts_for_guardian(result, guardian)
     result = result.where("posts.id < ?", opts[:before_post_id].to_i) if opts[:before_post_id]
     result = result.where("posts.created_at < ?", opts[:before].to_datetime) if opts[:before]
     result.order("posts.created_at desc")
@@ -467,9 +468,21 @@ class Group < ActiveRecord::Base
     end
 
     result = guardian.filter_allowed_categories(result)
+    result = filter_hidden_posts_for_guardian(result, guardian)
     result = result.where("posts.id < ?", opts[:before_post_id].to_i) if opts[:before_post_id]
     result = result.where("posts.created_at < ?", opts[:before].to_datetime) if opts[:before]
     result.order("posts.created_at desc")
+  end
+
+  def filter_hidden_posts_for_guardian(result, guardian)
+    return result if SiteSetting.hidden_post_visible_groups_map.include?(AUTO_GROUPS[:everyone])
+    return result if guardian.is_staff?
+
+    user = guardian.user
+    return result.where(posts: { hidden: false }) if user.blank?
+    return result if user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
+
+    result.where("posts.hidden = false OR posts.user_id = ?", user.id)
   end
 
   def self.trust_group_ids

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -326,15 +326,21 @@ module PostGuardian
     post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4])
   end
 
-  def can_see_hidden_post?(post)
-    if SiteSetting.hidden_post_visible_groups_map.include?(Group::AUTO_GROUPS[:everyone])
-      return true
-    end
+  def can_see_all_hidden_posts?
+    hidden_post_visible_groups = SiteSetting.hidden_post_visible_groups_map
+
+    return true if hidden_post_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
     return false if anonymous?
     return true if is_staff?
-    return true if is_my_own?(post)
 
-    @user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
+    @user.in_any_groups?(hidden_post_visible_groups)
+  end
+
+  def can_see_hidden_post?(post)
+    return true if can_see_all_hidden_posts?
+    return false if anonymous?
+
+    is_my_own?(post)
   end
 
   def can_view_edit_history?(post)

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -326,12 +326,28 @@ module PostGuardian
     post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4])
   end
 
-  def can_see_all_hidden_posts?
+  def filter_hidden_posts(records, category: nil, category_id_column: "topics.category_id")
+    return records if can_see_all_hidden_posts?(category)
+    return records.where(posts: { hidden: false }) if anonymous?
+
+    conditions = ["posts.hidden = false", "posts.user_id = :user_id"]
+    params = { user_id: user.id }
+
+    if category.nil? && category_group_moderation_allowed?
+      conditions << "#{category_id_column} IN (:moderated_category_ids)"
+      params[:moderated_category_ids] = category_group_moderator_scope.select(:id)
+    end
+
+    records.where(conditions.join(" OR "), params)
+  end
+
+  def can_see_all_hidden_posts?(category = nil)
     hidden_post_visible_groups = SiteSetting.hidden_post_visible_groups_map
 
     return true if hidden_post_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
     return false if anonymous?
     return true if is_staff?
+    return true if is_category_group_moderator?(category)
 
     @user.in_any_groups?(hidden_post_visible_groups)
   end

--- a/lib/nested_replies/post_tree_serializer.rb
+++ b/lib/nested_replies/post_tree_serializer.rb
@@ -95,8 +95,7 @@ module NestedReplies
       post_types << Post.types[:whisper] if @guardian.user&.whisperer?
 
       scope = @topic.posts.where(post_type: post_types).where.not(action_code: [nil, ""])
-      scope = scope.where(hidden: false) unless @guardian.can_see_all_hidden_posts?
-      scope.exists?
+      @guardian.filter_hidden_posts(scope, category: @topic.category).exists?
     end
   end
 end

--- a/lib/nested_replies/post_tree_serializer.rb
+++ b/lib/nested_replies/post_tree_serializer.rb
@@ -95,17 +95,8 @@ module NestedReplies
       post_types << Post.types[:whisper] if @guardian.user&.whisperer?
 
       scope = @topic.posts.where(post_type: post_types).where.not(action_code: [nil, ""])
-      scope = scope.where(hidden: false) unless can_see_hidden_posts?
+      scope = scope.where(hidden: false) unless @guardian.can_see_all_hidden_posts?
       scope.exists?
-    end
-
-    def can_see_hidden_posts?
-      return true if @guardian.is_staff?
-      if SiteSetting.hidden_post_visible_groups_map.include?(Group::AUTO_GROUPS[:everyone])
-        return true
-      end
-      return false if @guardian.anonymous?
-      @guardian.user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
     end
   end
 end

--- a/spec/lib/guardian/post_guardian_spec.rb
+++ b/spec/lib/guardian/post_guardian_spec.rb
@@ -1156,6 +1156,77 @@ RSpec.describe PostGuardian do
     end
   end
 
+  describe "#filter_hidden_posts" do
+    before { SiteSetting.hidden_post_visible_groups = "" }
+
+    it "returns only visible posts for anonymous users" do
+      records = Post.where(id: [post.id, hidden_post.id])
+
+      expect(Guardian.new.filter_hidden_posts(records)).to contain_exactly(post)
+    end
+
+    it "returns visible posts and the user's hidden posts for regular users" do
+      own_hidden_post = Fabricate(:post, topic: topic, user: user, hidden: true)
+      records = Post.where(id: [post.id, hidden_post.id, own_hidden_post.id])
+
+      expect(Guardian.new(user).filter_hidden_posts(records)).to contain_exactly(
+        post,
+        own_hidden_post,
+      )
+    end
+
+    it "returns hidden posts for staff users" do
+      records = Post.where(id: [post.id, hidden_post.id])
+
+      expect(Guardian.new(moderator).filter_hidden_posts(records)).to contain_exactly(
+        post,
+        hidden_post,
+      )
+    end
+
+    it "returns hidden posts for members of hidden_post_visible_groups" do
+      SiteSetting.hidden_post_visible_groups = group.id.to_s
+      records = Post.where(id: [post.id, hidden_post.id])
+
+      expect(Guardian.new(user).filter_hidden_posts(records)).to contain_exactly(post, hidden_post)
+    end
+
+    it "returns hidden posts for everyone when configured" do
+      SiteSetting.hidden_post_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+      records = Post.where(id: [post.id, hidden_post.id])
+
+      expect(Guardian.new.filter_hidden_posts(records)).to contain_exactly(post, hidden_post)
+    end
+
+    it "returns hidden posts from moderated categories for category group moderators" do
+      SiteSetting.enable_category_group_moderation = true
+      Fabricate(:category_moderation_group, category: category, group: group)
+      unmoderated_visible_post = Fabricate(:post)
+      unmoderated_hidden_post =
+        Fabricate(:post, topic: unmoderated_visible_post.topic, hidden: true)
+      records =
+        Post.joins(:topic).where(
+          id: [post.id, hidden_post.id, unmoderated_visible_post.id, unmoderated_hidden_post.id],
+        )
+
+      expect(Guardian.new(user).filter_hidden_posts(records)).to contain_exactly(
+        post,
+        hidden_post,
+        unmoderated_visible_post,
+      )
+    end
+
+    it "returns hidden posts in the category for category group moderators" do
+      SiteSetting.enable_category_group_moderation = true
+      Fabricate(:category_moderation_group, category: category, group: group)
+      records = Post.where(id: [post.id, hidden_post.id])
+
+      expect(
+        Guardian.new(user).filter_hidden_posts(records, category: category),
+      ).to contain_exactly(post, hidden_post)
+    end
+  end
+
   describe "#can_see_hidden_post?" do
     context "when the hidden_post_visible_groups contains everyone" do
       before { SiteSetting.hidden_post_visible_groups = "#{Group::AUTO_GROUPS[:everyone]}" }

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -602,6 +602,37 @@ RSpec.describe GroupsController do
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
+    it "does not return hidden posts from group activity endpoints" do
+      visible_post = Fabricate(:post, user: user, raw: "visible group activity post")
+      hidden_post =
+        Fabricate(
+          :post,
+          user: user,
+          raw: "private hidden group activity post should not leak",
+          hidden: true,
+        )
+      GroupMention.create!(post: visible_post, group: group)
+      GroupMention.create!(post: hidden_post, group: group)
+
+      sign_in(user2)
+
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
+        visible_post.id,
+      )
+      expect(response.body).not_to include("private hidden group activity post should not leak")
+
+      get "/groups/#{group.name}/mentions.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
+        visible_post.id,
+      )
+      expect(response.body).not_to include("private hidden group activity post should not leak")
+    end
+
     it "supports pagination using before (date)" do
       post = Fabricate(:post)
       GroupMention.create!(post: post, group: group)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -602,35 +602,20 @@ RSpec.describe GroupsController do
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
-    it "does not return hidden posts from group activity endpoints" do
-      visible_post = Fabricate(:post, user: user, raw: "visible group activity post")
-      hidden_post =
-        Fabricate(
-          :post,
-          user: user,
-          raw: "private hidden group activity post should not leak",
-          hidden: true,
-        )
+    it "returns only visible mentions for another user" do
+      visible_post = Fabricate(:post, user: user, raw: "visible group mention")
+      hidden_post = Fabricate(:post, user: user, raw: "private hidden group mention", hidden: true)
       GroupMention.create!(post: visible_post, group: group)
       GroupMention.create!(post: hidden_post, group: group)
 
       sign_in(user2)
-
-      get "/groups/#{group.name}/posts.json"
-
-      expect(response.status).to eq(200)
-      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
-        visible_post.id,
-      )
-      expect(response.body).not_to include("private hidden group activity post should not leak")
-
       get "/groups/#{group.name}/mentions.json"
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
         visible_post.id,
       )
-      expect(response.body).not_to include("private hidden group activity post should not leak")
+      expect(response.body).not_to include(hidden_post.raw)
     end
 
     it "supports pagination using before (date)" do
@@ -707,6 +692,20 @@ RSpec.describe GroupsController do
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
+    end
+
+    it "returns only visible posts for another user" do
+      visible_post = Fabricate(:post, user: user, raw: "visible group post")
+      hidden_post = Fabricate(:post, user: user, raw: "private hidden group post", hidden: true)
+
+      sign_in(user2)
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
+        visible_post.id,
+      )
+      expect(response.body).not_to include(hidden_post.raw)
     end
 
     it "does not include names when names are disabled" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -602,7 +602,7 @@ RSpec.describe GroupsController do
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
-    it "returns only visible mentions for another user" do
+    it "omits hidden mentions from other users", :aggregate_failures do
       visible_post = Fabricate(:post, user: user, raw: "visible group mention")
       hidden_post = Fabricate(:post, user: user, raw: "private hidden group mention", hidden: true)
       GroupMention.create!(post: visible_post, group: group)
@@ -611,11 +611,26 @@ RSpec.describe GroupsController do
       sign_in(user2)
       get "/groups/#{group.name}/mentions.json"
 
+      post_ids = response.parsed_body["posts"].map { |post| post["id"] }
+
+      expect(response.status).to eq(200)
+      expect(post_ids).to contain_exactly(visible_post.id)
+      expect(response.body).not_to include(hidden_post.raw)
+    end
+
+    it "returns hidden mentions to the author", :aggregate_failures do
+      hidden_post =
+        Fabricate(:post, user: user, raw: "author visible hidden group mention", hidden: true)
+      GroupMention.create!(post: hidden_post, group: group)
+
+      sign_in(user)
+      get "/groups/#{group.name}/mentions.json"
+
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
-        visible_post.id,
+        hidden_post.id,
       )
-      expect(response.body).not_to include(hidden_post.raw)
+      expect(response.body).to include(hidden_post.raw)
     end
 
     it "supports pagination using before (date)" do
@@ -694,18 +709,58 @@ RSpec.describe GroupsController do
       expect(response.parsed_body["posts"].first["id"]).to eq(post.id)
     end
 
-    it "returns only visible posts for another user" do
+    it "omits hidden posts from other users", :aggregate_failures do
       visible_post = Fabricate(:post, user: user, raw: "visible group post")
       hidden_post = Fabricate(:post, user: user, raw: "private hidden group post", hidden: true)
 
       sign_in(user2)
       get "/groups/#{group.name}/posts.json"
 
+      post_ids = response.parsed_body["posts"].map { |post| post["id"] }
+
+      expect(response.status).to eq(200)
+      expect(post_ids).to contain_exactly(visible_post.id)
+      expect(response.body).not_to include(hidden_post.raw)
+    end
+
+    it "returns hidden posts to staff", :aggregate_failures do
+      hidden_post =
+        Fabricate(:post, user: user, raw: "staff visible hidden group post", hidden: true)
+
+      sign_in(moderator)
+      get "/groups/#{group.name}/posts.json"
+
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
-        visible_post.id,
+        hidden_post.id,
       )
-      expect(response.body).not_to include(hidden_post.raw)
+      expect(response.body).to include(hidden_post.raw)
+    end
+
+    it "returns hidden posts to category moderators", :aggregate_failures do
+      SiteSetting.enable_category_group_moderation = true
+      moderated_category = Fabricate(:category)
+      moderation_group = Fabricate(:group)
+      category_moderator = Fabricate(:user)
+      moderation_group.add(category_moderator)
+      Fabricate(:category_moderation_group, category: moderated_category, group: moderation_group)
+      hidden_post =
+        Fabricate(
+          :post,
+          user: user,
+          topic: Fabricate(:topic, category: moderated_category),
+          raw: "category moderator visible hidden group post",
+          hidden: true,
+        )
+
+      sign_in(category_moderator)
+      get "/groups/#{group.name}/posts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts"].map { |post| post["id"] }).to contain_exactly(
+        hidden_post.id,
+      )
+      expect(response.body).to include(hidden_post.raw)
     end
 
     it "does not include names when names are disabled" do


### PR DESCRIPTION
Some spam posts that are hidden may be exposes in group listings

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>