### PR TITLE
FIX: Properly URL-encode reaction value when fetching reaction users

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/models/discourse-reactions-custom-reaction.js
@@ -104,12 +104,13 @@ export default class CustomReaction extends RestModel {
   }
 
   static findReactionUsers(postId, options = {}) {
-    let url = `/discourse-reactions/posts/${postId}/reactions-users.json`;
+    const data = {};
     if (options.reactionValue) {
-      url += `?reaction_value=${options.reactionValue}`;
+      data.reaction_value = options.reactionValue;
     }
-    return ajax(url, {
+    return ajax(`/discourse-reactions/posts/${postId}/reactions-users.json`, {
       type: "GET",
+      data,
     }).then((result) => {
       const reactionUsers = result.reaction_users.map((reactionUser) => {
         reactionUser.users = reactionUser.users.map((user) =>

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
@@ -20,7 +20,7 @@ module PageObjects
       end
 
       def reaction_list_emoji_selector(reaction)
-        "#discourse-reactions-list-emoji-#{post_id}-#{reaction}"
+        %([id="discourse-reactions-list-emoji-#{post_id}-#{reaction}"])
       end
 
       def has_reaction?(reaction)

--- a/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
+++ b/plugins/discourse-reactions/spec/system/reactions_post_spec.rb
@@ -108,4 +108,25 @@ describe "Reactions | Post reactions" do
       expect(reactions_button).to have_no_emoji_picker_emoji("middle_finger")
     end
   end
+
+  context "when hovering over a reaction whose value contains a URL-reserved character" do
+    fab!(:other_user, :user)
+
+    before do
+      DiscourseReactions::ReactionManager.new(
+        reaction_value: "+1",
+        user: other_user,
+        post: post_2,
+      ).toggle!
+    end
+
+    it "loads the reaction users in the hover popup" do
+      visit post_2.url
+      expect(reactions_list).to have_reaction("+1")
+
+      reactions_list.hover_over_reaction("+1")
+
+      expect(reactions_list).to have_users_for_reaction("+1", [other_user.username])
+    end
+  end
 end


### PR DESCRIPTION
The `findReactionUsers` model method built its query string via plain template-literal concatenation, e.g. `?reaction_value=${value}`. For reactions whose value contains URL-reserved characters — most notably the default `+1` (thumbs-up) — this produced `?reaction_value=+1`, which Rack decodes as `reaction_value=" 1"`. The controller then queried for that mangled value, returned an empty `reaction_users` array, and the hover tooltip on the small emoji in the post reactions counter rendered its loading spinner indefinitely (the `{{#each ... else}}` branch fires when the users collection stays undefined).

Switch to passing the value through ajax's `data:` option so jQuery serializes it via `$.param` (which uses `encodeURIComponent`). This matches what the sibling `fetchReactionsUsersList` (new menu) already does and means the request reaches the backend as `%2B1`.

While here, update the `PostReactionsList` page object to use `[id="..."]` instead of the bare `#id` CSS selector, so it tolerates reaction values that contain characters disallowed in unescaped ID selectors. This unlocks a regression spec that hovers over a `+1` reaction and verifies the user list populates.

Ref - t/184216