### PR TITLE
FIX: Chat back button loses starred context after drawer reopen

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-history.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-history.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import Service from "@ember/service";
+import { deepEqual } from "discourse/lib/object";
 
 export default class ChatHistory extends Service {
   @tracked history;
@@ -17,6 +18,12 @@ export default class ChatHistory extends Service {
   }
 
   visit(route) {
+    if (
+      this.currentRoute?.name === route.name &&
+      deepEqual(this.currentRoute?.params, route.params)
+    ) {
+      return;
+    }
     this.history = (this.history || []).slice(-9).concat([route]);
   }
 }

--- a/plugins/chat/spec/system/drawer/starred_channels_spec.rb
+++ b/plugins/chat/spec/system/drawer/starred_channels_spec.rb
@@ -186,5 +186,22 @@ RSpec.describe "Drawer - starred channels" do
       find(".c-navbar__back-button").click
       expect(drawer_page).to have_open_channels
     end
+
+    it "returns to starred channels even after closing and reopening the drawer" do
+      visit("/")
+      chat_page.open_from_header
+      drawer_page.open_channel_row(channel_1)
+      expect(drawer_page).to have_open_channel(channel_1)
+
+      drawer_page.close
+      expect(chat_page).to have_no_drawer
+
+      chat_page.open_from_header
+      expect(drawer_page).to have_open_channel(channel_1)
+
+      drawer_page.back
+
+      expect(drawer_page).to have_open_starred_channels
+    end
   end
 end

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -62,6 +62,11 @@ module PageObjects
         has_no_css?(".chat-skeleton")
       end
 
+      def open_channel_row(channel)
+        find("#{VISIBLE_DRAWER} .chat-channel-row[data-chat-channel-id='#{channel.id}']").click
+        has_no_css?(".chat-skeleton")
+      end
+
       def has_channel?(channel)
         channels_index.has_channel?(channel)
       end

--- a/plugins/chat/test/javascripts/unit/services/chat-history-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-history-test.js
@@ -1,0 +1,37 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Unit | Service | chat-history", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.subject = getOwner(this).lookup("service:chat-history");
+  });
+
+  test("visit dedupes consecutive identical routes", function (assert) {
+    this.subject.visit({ name: "chat.starred-channels", params: {} });
+    this.subject.visit({ name: "chat.channel", params: { channelId: "1" } });
+    this.subject.visit({ name: "chat.channel", params: { channelId: "1" } });
+
+    assert.strictEqual(
+      this.subject.history.length,
+      2,
+      "the duplicate visit is skipped"
+    );
+    assert.strictEqual(
+      this.subject.previousRoute.name,
+      "chat.starred-channels",
+      "previousRoute reflects the real prior step, not the duplicate"
+    );
+  });
+
+  test("visit treats same name with different params as distinct", function (assert) {
+    this.subject.visit({ name: "chat.channel", params: { channelId: "1" } });
+    this.subject.visit({ name: "chat.channel", params: { channelId: "2" } });
+
+    assert.strictEqual(this.subject.history.length, 2);
+    assert.strictEqual(this.subject.previousRoute.params.channelId, "1");
+    assert.strictEqual(this.subject.currentRoute.params.channelId, "2");
+  });
+});


### PR DESCRIPTION
When the chat drawer is closed and reopened on a starred channel, the back button took the user to the default channels list instead of the starred-channels list they had originally come from.

Root cause: `chatHistory.visit(route)` always appended to history. When the drawer reopens to `lastKnownChatURL` (the channel itself), the same route is appended a second time, shifting `previousRoute` off the original `chat.starred-channels` entry. The back-button fallback in `drawer-routes/channel.gjs` then routed to `chat.channels`.

Fix: dedupe consecutive identical route visits in `chatHistory.visit` by comparing name and params (via `deepEqual`). Reopening to the same URL no longer clobbers the user's real navigation context.

Adds a unit test for the dedup behavior, a system spec covering the close/reopen scenario, and a view-agnostic `open_channel_row` helper on the drawer page object (the existing `open_channel` is scoped to the channels-list view only and doesn't work from the starred view).

https://meta.discourse.org/t/403431