### PR TITLE
FEATURE: Trust level section on the dashboard engagement section

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -39,13 +39,17 @@ h1 {
   font-size: var(--font-down-3);
   border-radius: 6.25rem;
   padding: var(--space-half) var(--space-2);
+  background: var(--primary-low);
+  color: var(--primary-medium);
 
   &.--pos {
     background: var(--success-low);
+    color: var(--primary);
   }
 
   &.--neg {
     background: var(--danger-low);
+    color: var(--primary);
   }
 }
 
@@ -296,6 +300,14 @@ h1 {
         transform: translateX(0);
       }
     }
+
+    &.--label {
+      font-size: var(--font-down-2-rem);
+      font-weight: 600;
+      color: var(--primary-medium);
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
   }
 
   &__wrapper {
@@ -329,6 +341,119 @@ h1 {
         padding-bottom: 0;
       }
     }
+  }
+}
+
+.db-tl-pipeline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+
+  &__rows {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+
+  &__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding-bottom: var(--space-3);
+
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--primary-low);
+    }
+  }
+
+  &__label {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+  }
+
+  &__name {
+    font-weight: bold;
+    color: var(--primary);
+  }
+
+  &__count {
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-medium);
+  }
+
+  &__bars {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  &__bar-out,
+  &__bar-in {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 18px;
+  }
+
+  &__bar-out {
+    justify-content: flex-end;
+  }
+
+  &__bar-in {
+    justify-content: flex-start;
+  }
+
+  &__bar-track {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+
+    .db-tl-pipeline__bar-out & {
+      justify-content: flex-end;
+    }
+
+    .db-tl-pipeline__bar-in & {
+      justify-content: flex-start;
+    }
+  }
+
+  &__bar {
+    height: 10px;
+    border-radius: 5px;
+    flex: 0 0 auto;
+
+    &--out {
+      background: var(--danger);
+    }
+
+    &--in {
+      background: var(--success);
+    }
+  }
+
+  &__delta {
+    font-size: var(--font-down-2-rem);
+    font-weight: bold;
+    white-space: nowrap;
+
+    &--out {
+      color: var(--danger);
+    }
+
+    &--in {
+      color: var(--success);
+    }
+  }
+
+  &__divider {
+    width: 1px;
+    height: 18px;
+    background: var(--primary-low);
   }
 }
 

--- a/app/models/concerns/reports/trust_level_pipeline.rb
+++ b/app/models/concerns/reports/trust_level_pipeline.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Reports::TrustLevelPipeline
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def report_trust_level_pipeline(report)
+      report.modes = [Report::MODES[:table]]
+      report.labels = [
+        { property: :name, title: I18n.t("reports.trust_level_pipeline.labels.level") },
+        {
+          property: :count,
+          type: :number,
+          title: I18n.t("reports.trust_level_pipeline.labels.count"),
+        },
+        { property: :share_formatted, title: I18n.t("reports.trust_level_pipeline.labels.share") },
+        {
+          property: :moves_in,
+          type: :number,
+          title: I18n.t("reports.trust_level_pipeline.labels.moves_in"),
+        },
+        {
+          property: :moves_out,
+          type: :number,
+          title: I18n.t("reports.trust_level_pipeline.labels.moves_out"),
+        },
+      ]
+
+      snapshot = User.real.group(:trust_level).count
+      total_members = snapshot.values.sum
+
+      moves_in_by_tl = Hash.new(0)
+      moves_out_by_tl = Hash.new(0)
+      total_up = 0
+      total_down = 0
+
+      moves_sql = <<~SQL
+        SELECT
+          new_value::integer AS new_tl,
+          previous_value::integer AS prev_tl,
+          COUNT(*) AS move_count
+        FROM user_histories
+        WHERE action IN (:change_action, :auto_action)
+          AND created_at >= :start_date
+          AND created_at <= :end_date
+          AND previous_value ~ '^\\d+$'
+          AND new_value ~ '^\\d+$'
+          AND target_user_id IN (SELECT id FROM users WHERE id > 0)
+        GROUP BY new_value::integer, previous_value::integer
+      SQL
+
+      DB
+        .query(
+          moves_sql,
+          change_action: UserHistory.actions[:change_trust_level],
+          auto_action: UserHistory.actions[:auto_trust_level_change],
+          start_date: report.start_date,
+          end_date: report.end_date,
+        )
+        .each do |row|
+          next if row.new_tl == row.prev_tl
+          moves_in_by_tl[row.new_tl] += row.move_count
+          moves_out_by_tl[row.prev_tl] += row.move_count
+          if row.new_tl > row.prev_tl
+            total_up += row.move_count
+          else
+            total_down += row.move_count
+          end
+        end
+
+      report.data =
+        TrustLevel.valid_range.to_a.reverse.map do |tl|
+          count = snapshot.fetch(tl, 0)
+          share = total_members.zero? ? 0.0 : (count.to_f / total_members * 100).round(2)
+          {
+            trust_level: tl,
+            name: I18n.t("reports.trust_level_pipeline.levels.#{tl}"),
+            count: count,
+            share: share,
+            share_formatted: "#{share}%",
+            moves_in: moves_in_by_tl[tl],
+            moves_out: moves_out_by_tl[tl],
+          }
+        end
+
+      net = total_up - total_down
+
+      direction =
+        if net > 0
+          "climbing"
+        elsif net < 0
+          "dropping"
+        else
+          "stable"
+        end
+
+      report.total = total_members
+      report.prev_period = { direction: direction, net: net.abs }
+    end
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -122,6 +122,7 @@ class Report
   include Reports::TopicViewStats
   include Reports::TrendingSearch
   include Reports::TrustLevelGrowth
+  include Reports::TrustLevelPipeline
   include Reports::UserFlaggingRatio
   include Reports::UserToUserPrivateMessages
   include Reports::UserToUserPrivateMessagesWithReplies

--- a/app/services/admin_dashboard_engagement.rb
+++ b/app/services/admin_dashboard_engagement.rb
@@ -20,7 +20,7 @@ class AdminDashboardEngagement
 
   def build
     kpis = build_kpis
-    { kpis: kpis, headline: build_headline(kpis) }
+    { kpis: kpis, headline: build_headline(kpis), trust_level_pipeline: build_trust_level_pipeline }
   end
 
   private
@@ -137,5 +137,23 @@ class AdminDashboardEngagement
   def sign_of(value)
     return 0 if value.nil? || value.zero?
     value.positive? ? 1 : -1
+  end
+
+  def build_trust_level_pipeline
+    args = { start_date: start_date, end_date: end_date }
+
+    report = Report.find_cached("trust_level_pipeline", args)
+    if report.nil?
+      report = Report.find("trust_level_pipeline", args)
+      Report.cache(report) if report && report.error.blank?
+    end
+
+    return nil if report.nil? || report_error?(report)
+
+    {
+      rows: report_data(report),
+      trend: report_prev_period(report),
+      total_members: report.is_a?(Hash) ? report[:total] : report.total,
+    }
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6884,6 +6884,33 @@ en:
           engagement:
             title: "Engagement"
             fetch_error: "Couldn't load engagement. Try refreshing the page."
+            whos_posting:
+              title: "Who's posting?"
+            activity_by_category:
+              title: "Activity by category"
+            trust_level_pipeline:
+              title: "Trust level pipeline"
+              trust_levels:
+                "0": "New"
+                "1": "Basic"
+                "2": "Member"
+                "3": "Regular"
+                "4": "Leader"
+              trend:
+                climbing:
+                  one: "+%{count} climbing"
+                  other: "+%{count} climbing"
+                dropping:
+                  one: "-%{count} dropping"
+                  other: "-%{count} dropping"
+                stable: "stable"
+              moves_in_aria:
+                one: "%{count} member moved up"
+                other: "%{count} members moved up"
+              moves_out_aria:
+                one: "%{count} member moved down"
+                other: "%{count} members moved down"
+              stable_aria: "no movement"
             headline:
               healthy_growth:
                 title: "Members are forming a habit of coming back."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1377,6 +1377,22 @@ en:
       xaxis: "Day"
       yaxis: "Number of new contributors"
       description: "Number of users who made their first post during this period."
+    trust_level_pipeline:
+      title: "Trust level pipeline"
+      description: "Member movement between trust levels for the selected period. Counts the members currently at each trust level, their share of the total membership, and the number of members who moved into or out of each trust level during the period."
+      description_link: "https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"
+      labels:
+        level: "Trust level"
+        count: "Members"
+        share: "Share"
+        moves_in: "Moves in"
+        moves_out: "Moves out"
+      levels:
+        "0": "New"
+        "1": "Basic"
+        "2": "Member"
+        "3": "Regular"
+        "4": "Leader"
     trust_level_growth:
       title: "Trust Level growth"
       xaxis:

--- a/frontend/discourse/admin/components/dashboard/engagement.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement.gjs
@@ -1,4 +1,5 @@
 import EngagementHeadline from "discourse/admin/components/dashboard/engagement/headline";
+import TrustLevelPipeline from "discourse/admin/components/dashboard/engagement/trust-level-pipeline";
 import DashboardSection from "discourse/admin/components/dashboard/section";
 import { i18n } from "discourse-i18n";
 
@@ -13,12 +14,46 @@ import { i18n } from "discourse-i18n";
         <div class="db-section__error" role="alert">
           {{i18n "admin.dashboard.sections.engagement.fetch_error"}}
         </div>
-      {{else if @engagement.headline}}
-        <EngagementHeadline
-          @headline={{@engagement.headline}}
-          @kpis={{@engagement.kpis}}
-          @period={{@period}}
-        />
+      {{else}}
+        {{#if @engagement.headline}}
+          <EngagementHeadline
+            @headline={{@engagement.headline}}
+            @kpis={{@engagement.kpis}}
+            @period={{@period}}
+          />
+        {{/if}}
+
+        <div class="db-section__row-group">
+          <div class="db-section__row">
+            <div class="db-section__row-block">
+              {{#if @engagement.trust_level_pipeline}}
+                <TrustLevelPipeline
+                  @data={{@engagement.trust_level_pipeline}}
+                />
+              {{/if}}
+            </div>
+            <div class="db-section__row-block">
+              <div class="db-section__row-block-header">
+                <h3 class="db-section__row-block-title --label">
+                  {{i18n
+                    "admin.dashboard.sections.engagement.whos_posting.title"
+                  }}
+                </h3>
+              </div>
+            </div>
+          </div>
+          <div class="db-section__row">
+            <div class="db-section__row-block">
+              <div class="db-section__row-block-header">
+                <h3 class="db-section__row-block-title">
+                  {{i18n
+                    "admin.dashboard.sections.engagement.activity_by_category.title"
+                  }}
+                </h3>
+              </div>
+            </div>
+          </div>
+        </div>
       {{/if}}
     </DashboardSection>
   </div>

--- a/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
@@ -1,0 +1,149 @@
+import Component from "@glimmer/component";
+import { concat, hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
+import { trustHTML } from "@ember/template";
+import I18n, { i18n } from "discourse-i18n";
+
+export default class TrustLevelPipeline extends Component {
+  get rows() {
+    const data = this.args.data?.rows ?? [];
+    const max = data.reduce(
+      (acc, row) => Math.max(acc, row.moves_in, row.moves_out),
+      0
+    );
+
+    return data.map((row) => {
+      const widthIn = this.#barWidth(row.moves_in, max);
+      const widthOut = this.#barWidth(row.moves_out, max);
+      return {
+        ...row,
+        label: i18n(
+          `admin.dashboard.sections.engagement.trust_level_pipeline.trust_levels.${row.trust_level}`
+        ),
+        shareFormatted: `${I18n.toNumber(row.share, { precision: 2 })}%`,
+        countFormatted: I18n.toNumber(row.count, { precision: 0 }),
+        barInStyle: trustHTML(`width: ${widthIn}%`),
+        barOutStyle: trustHTML(`width: ${widthOut}%`),
+        hasMovement: row.moves_in > 0 || row.moves_out > 0,
+      };
+    });
+  }
+
+  #barWidth(value, max) {
+    if (max === 0 || value === 0) {
+      return 0;
+    }
+    return Math.round((value / max) * 100);
+  }
+
+  get trendClass() {
+    const direction = this.args.data?.trend?.direction;
+    if (direction === "climbing") {
+      return "--pos";
+    }
+    if (direction === "dropping") {
+      return "--neg";
+    }
+    return "";
+  }
+
+  get trendText() {
+    const trend = this.args.data?.trend;
+    if (!trend) {
+      return null;
+    }
+    if (trend.direction === "stable") {
+      return i18n(
+        "admin.dashboard.sections.engagement.trust_level_pipeline.trend.stable"
+      );
+    }
+    return i18n(
+      `admin.dashboard.sections.engagement.trust_level_pipeline.trend.${trend.direction}`,
+      { count: trend.net }
+    );
+  }
+
+  <template>
+    <div class="db-tl-pipeline">
+      <div class="db-section__row-block-header">
+        <LinkTo
+          @route="adminReports.show"
+          @model="trust_level_pipeline"
+          class="db-section__row-block-title --label"
+        >
+          {{i18n
+            "admin.dashboard.sections.engagement.trust_level_pipeline.title"
+          }}
+        </LinkTo>
+        {{#if this.trendText}}
+          <span
+            class={{concat "db-pill " this.trendClass}}
+          >{{this.trendText}}</span>
+        {{/if}}
+      </div>
+
+      <ol class="db-tl-pipeline__rows">
+        {{#each this.rows as |row|}}
+          <li class="db-tl-pipeline__row">
+            <div class="db-tl-pipeline__label">
+              <span class="db-tl-pipeline__name">{{row.label}}</span>
+              <span class="db-tl-pipeline__count">
+                {{row.countFormatted}}
+                ({{row.shareFormatted}})
+              </span>
+            </div>
+            {{#if row.hasMovement}}
+              <div class="db-tl-pipeline__bars">
+                <div class="db-tl-pipeline__bar-out">
+                  {{#if row.moves_out}}
+                    <span
+                      class="db-tl-pipeline__delta db-tl-pipeline__delta--out"
+                    >↓
+                      {{row.moves_out}}</span>
+                    <div class="db-tl-pipeline__bar-track">
+                      <span
+                        class="db-tl-pipeline__bar db-tl-pipeline__bar--out"
+                        style={{row.barOutStyle}}
+                        aria-label={{i18n
+                          "admin.dashboard.sections.engagement.trust_level_pipeline.moves_out_aria"
+                          (hash count=row.moves_out)
+                        }}
+                      ></span>
+                    </div>
+                  {{else}}
+                    <span class="db-pill">{{i18n
+                        "admin.dashboard.sections.engagement.trust_level_pipeline.trend.stable"
+                      }}</span>
+                  {{/if}}
+                </div>
+                <div class="db-tl-pipeline__divider"></div>
+                <div class="db-tl-pipeline__bar-in">
+                  {{#if row.moves_in}}
+                    <div class="db-tl-pipeline__bar-track">
+                      <span
+                        class="db-tl-pipeline__bar db-tl-pipeline__bar--in"
+                        style={{row.barInStyle}}
+                        aria-label={{i18n
+                          "admin.dashboard.sections.engagement.trust_level_pipeline.moves_in_aria"
+                          (hash count=row.moves_in)
+                        }}
+                      ></span>
+                    </div>
+                    <span
+                      class="db-tl-pipeline__delta db-tl-pipeline__delta--in"
+                    >{{row.moves_in}}
+                      ↑</span>
+                  {{else}}
+                    <span class="db-pill">{{i18n
+                        "admin.dashboard.sections.engagement.trust_level_pipeline.trend.stable"
+                      }}</span>
+                  {{/if}}
+                </div>
+              </div>
+            {{/if}}
+          </li>
+        {{/each}}
+      </ol>
+    </div>
+  </template>
+}

--- a/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
@@ -1,0 +1,115 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import TrustLevelPipeline from "discourse/admin/components/dashboard/engagement/trust-level-pipeline";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module(
+  "Integration | Component | Dashboard | TrustLevelPipeline",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    const data = {
+      total_members: 105_580,
+      trend: { direction: "climbing", net: 72 },
+      rows: [
+        { trust_level: 4, count: 25, share: 0.55, moves_in: 4, moves_out: 0 },
+        { trust_level: 3, count: 48, share: 0.85, moves_in: 14, moves_out: 2 },
+        {
+          trust_level: 2,
+          count: 4_800,
+          share: 4.6,
+          moves_in: 42,
+          moves_out: 12,
+        },
+        {
+          trust_level: 1,
+          count: 30_000,
+          share: 28.5,
+          moves_in: 50,
+          moves_out: 18,
+        },
+        {
+          trust_level: 0,
+          count: 69_000,
+          share: 65.5,
+          moves_in: 0,
+          moves_out: 0,
+        },
+      ],
+    };
+
+    test("renders one row per trust level in descending order", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-tl-pipeline__row").exists({ count: 5 });
+
+      const names = [...document.querySelectorAll(".db-tl-pipeline__name")].map(
+        (el) => el.textContent.trim()
+      );
+      assert.deepEqual(names, ["Leader", "Regular", "Member", "Basic", "New"]);
+    });
+
+    test("renders the climbing trend pill with positive styling", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-pill.--pos").hasText("+72 climbing");
+    });
+
+    test("links the section title to the trust_level_pipeline report", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert
+        .dom("a.db-section__row-block-title")
+        .hasAttribute("href", /\/admin\/reports\/trust_level_pipeline/);
+    });
+
+    test("hides the bars section entirely when a row has no movement on either side", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      const newRow = [...document.querySelectorAll(".db-tl-pipeline__row")].at(
+        -1
+      );
+      assert.dom(".db-tl-pipeline__bars", newRow).doesNotExist();
+      assert.dom(".db-pill", newRow).doesNotExist();
+    });
+
+    test("shows a stable pill on the side that has no movement when the other side does", async function (assert) {
+      const oneSided = {
+        ...data,
+        rows: data.rows.map((r) =>
+          r.trust_level === 4 ? { ...r, moves_in: 4, moves_out: 0 } : r
+        ),
+      };
+
+      await render(
+        <template><TrustLevelPipeline @data={{oneSided}} /></template>
+      );
+
+      const leaderRow = document.querySelector(".db-tl-pipeline__row");
+      assert
+        .dom(".db-tl-pipeline__bar-out .db-pill", leaderRow)
+        .hasText("stable");
+      assert.dom(".db-tl-pipeline__delta--in", leaderRow).includesText("4");
+    });
+
+    test("renders moves_in and moves_out deltas with the count", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-tl-pipeline__delta--in").includesText("4");
+      assert.dom(".db-tl-pipeline__delta--out").exists();
+    });
+
+    test("renders a dropping trend pill in negative styling", async function (assert) {
+      const negative = {
+        ...data,
+        trend: { direction: "dropping", net: 24 },
+      };
+
+      await render(
+        <template><TrustLevelPipeline @data={{negative}} /></template>
+      );
+
+      assert.dom(".db-pill.--neg").hasText("-24 dropping");
+    });
+  }
+);

--- a/spec/models/concerns/reports/trust_level_pipeline_spec.rb
+++ b/spec/models/concerns/reports/trust_level_pipeline_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+describe Reports::TrustLevelPipeline do
+  before { freeze_time(Time.zone.local(2026, 4, 28, 12, 0, 0)) }
+
+  let(:start_date) { Time.zone.local(2026, 4, 1) }
+  let(:end_date) { Time.zone.local(2026, 4, 28).end_of_day }
+
+  def build
+    Report.find("trust_level_pipeline", start_date: start_date, end_date: end_date)
+  end
+
+  def row(report, tl)
+    report.data.find { |r| r[:trust_level] == tl }
+  end
+
+  def record_promotion(user, from:, to:, at:, action: :change_trust_level)
+    UserHistory.create!(
+      action: UserHistory.actions[action],
+      target_user_id: user.id,
+      previous_value: from.to_s,
+      new_value: to.to_s,
+      created_at: at,
+    )
+  end
+
+  it "snapshots the current member count and share per trust level" do
+    Fabricate(:user, trust_level: TrustLevel[1])
+    Fabricate(:user, trust_level: TrustLevel[1])
+    Fabricate(:user, trust_level: TrustLevel[2])
+    Fabricate(:user, trust_level: TrustLevel[4])
+
+    report = build
+
+    expect(row(report, 1)[:count]).to eq(2)
+    expect(row(report, 2)[:count]).to eq(1)
+    expect(row(report, 4)[:count]).to eq(1)
+    expect(report.data.sum { |r| r[:share] }).to be_within(0.1).of(100.0)
+  end
+
+  it "counts moves_in and moves_out from UserHistory within the period" do
+    user = Fabricate(:user, trust_level: TrustLevel[2])
+    record_promotion(user, from: 1, to: 2, at: start_date + 1.day)
+    record_promotion(user, from: 2, to: 3, at: start_date + 5.days)
+
+    report = build
+
+    expect(row(report, 2)[:moves_in]).to eq(1)
+    expect(row(report, 2)[:moves_out]).to eq(1)
+    expect(row(report, 3)[:moves_in]).to eq(1)
+    expect(row(report, 1)[:moves_out]).to eq(1)
+  end
+
+  it "counts auto_trust_level_change as well as manual change_trust_level" do
+    user = Fabricate(:user, trust_level: TrustLevel[2])
+    record_promotion(user, from: 1, to: 2, at: start_date + 1.day, action: :auto_trust_level_change)
+
+    report = build
+
+    expect(row(report, 2)[:moves_in]).to eq(1)
+  end
+
+  it "treats up-then-down within the period as one move_in and one move_out per TL" do
+    user = Fabricate(:user, trust_level: TrustLevel[1])
+    record_promotion(user, from: 1, to: 2, at: start_date + 2.days)
+    record_promotion(user, from: 2, to: 1, at: start_date + 8.days)
+
+    report = build
+
+    expect(row(report, 2)[:moves_in]).to eq(1)
+    expect(row(report, 2)[:moves_out]).to eq(1)
+    expect(row(report, 1)[:moves_in]).to eq(1)
+    expect(row(report, 1)[:moves_out]).to eq(1)
+  end
+
+  it "does not count new sign-ups as TL0 moves_in" do
+    Fabricate(:user, created_at: start_date + 3.days)
+    Fabricate(:user, created_at: start_date + 10.days)
+
+    report = build
+
+    expect(row(report, 0)[:moves_in]).to eq(0)
+  end
+
+  it "ignores history rows outside the period" do
+    user = Fabricate(:user, trust_level: TrustLevel[2])
+    record_promotion(user, from: 1, to: 2, at: start_date - 5.days)
+    record_promotion(user, from: 2, to: 3, at: end_date + 5.days)
+
+    report = build
+
+    expect(row(report, 2)[:moves_in]).to eq(0)
+    expect(row(report, 3)[:moves_in]).to eq(0)
+  end
+
+  it "excludes the system user and bots from the snapshot" do
+    Discourse.system_user
+    Fabricate(:user, trust_level: TrustLevel[1])
+
+    report = build
+
+    real_count = report.data.sum { |r| r[:count] }
+    expect(real_count).to eq(1)
+  end
+
+  it "reports a climbing direction when net promotions exceed net demotions" do
+    user_a = Fabricate(:user, trust_level: TrustLevel[2])
+    user_b = Fabricate(:user, trust_level: TrustLevel[2])
+    record_promotion(user_a, from: 1, to: 2, at: start_date + 1.day)
+    record_promotion(user_b, from: 1, to: 2, at: start_date + 2.days)
+
+    report = build
+
+    expect(report.prev_period[:direction]).to eq("climbing")
+    expect(report.prev_period[:net]).to be > 0
+  end
+
+  it "reports a stable direction when moves cancel out" do
+    user_up = Fabricate(:user, trust_level: TrustLevel[2])
+    user_down = Fabricate(:user, trust_level: TrustLevel[1])
+    record_promotion(user_up, from: 1, to: 2, at: start_date + 1.day)
+    record_promotion(user_down, from: 2, to: 1, at: start_date + 2.days)
+
+    report = build
+
+    expect(report.prev_period[:direction]).to eq("stable")
+    expect(report.prev_period[:net]).to eq(0)
+  end
+
+  it "ignores history rows whose values aren't integer strings" do
+    user = Fabricate(:user, trust_level: TrustLevel[2])
+    UserHistory.create!(
+      action: UserHistory.actions[:change_trust_level],
+      target_user_id: user.id,
+      previous_value: "not_a_number",
+      new_value: "2",
+      created_at: start_date + 1.day,
+    )
+
+    expect { build }.not_to raise_error
+  end
+end

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -72,6 +72,27 @@ describe AdminDashboardEngagement do
       Report.define_singleton_method(:find, &original)
     end
 
+    describe "trust_level_pipeline" do
+      it "includes per-TL rows, a trend object, and total_members" do
+        Fabricate(:user, trust_level: TrustLevel[1])
+        Fabricate(:user, trust_level: TrustLevel[2])
+
+        result = described_class.build(start_date: "2026-04-01", end_date: "2026-04-28")
+        pipeline = result[:trust_level_pipeline]
+
+        expect(pipeline[:rows].length).to eq(5)
+        expect(pipeline[:rows].first).to include(
+          :trust_level,
+          :count,
+          :share,
+          :moves_in,
+          :moves_out,
+        )
+        expect(pipeline[:trend]).to include(:direction, :net)
+        expect(pipeline[:total_members]).to be >= 2
+      end
+    end
+
     describe "headline" do
       def stub_kpis(signups:, dau: 0, engaged: 0)
         described_class


### PR DESCRIPTION
This PR adds the trust level section to the engagement section of the dashboard.

Builds on top of: https://github.com/discourse/discourse/pull/40220 (before)

### after

https://github.com/user-attachments/assets/81447c8f-582c-4a75-8bbe-da0b4cde6dfe

