### PR TITLE
FIX: Redirect over-range topic page URLs instead of 404

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -169,8 +169,18 @@ class TopicsController < ApplicationController
     end
 
     page = params[:page]
-    if page < 0 || page > 1 && (page - 1) * @topic_view.chunk_size >= @topic_view.topic.posts_count
-      raise Discourse::NotFound
+    raise Discourse::NotFound if page < 0
+
+    if page > 1
+      visible_posts_count = @topic_view.filtered_posts.count
+      chunk_size = @topic_view.chunk_size
+      if (page - 1) * chunk_size >= visible_posts_count
+        last_page = visible_posts_count > 0 ? ((visible_posts_count - 1) / chunk_size) + 1 : 1
+        url = @topic_view.topic.relative_url
+        url += ".json" if request.format.json?
+        url += "?page=#{last_page}" if last_page > 1
+        return redirect_to url, status: :moved_permanently
+      end
     end
 
     discourse_expires_in 1.minute

--- a/plugins/discourse-post-voting/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-post-voting/spec/requests/topics_controller_spec.rb
@@ -33,10 +33,10 @@ describe TopicsController do
       )
     end
 
-    it "does not error for topic views without any posts" do
+    it "redirects an over-range page to the last valid page" do
       get "/t/#{topic.id}.json?page=2"
 
-      expect(response.status).to eq(404)
+      expect(response).to redirect_to("/t/#{topic.slug}/#{topic.id}.json")
     end
 
     it "orders posts by date of creation when 'activity' filter is provided" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3068,29 +3068,34 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(200)
     end
 
-    it "return 404 for an invalid page" do
+    it "redirects an over-range page to the last valid page" do
       get "/t/#{topic.slug}/#{topic.id}.json", params: { page: 2 }
-      expect(response.status).to eq(404)
+      expect(response).to redirect_to("/t/#{topic.slug}/#{topic.id}.json")
     end
 
-    it "handles pagination correctly with deleted posts" do
+    it "redirects over-range pages to the last multi-page page" do
       topic_with_posts = Fabricate(:topic)
-
-      24.times do |i|
-        Fabricate(:post, topic: topic_with_posts, deleted_at: i.even? ? DateTime.now : nil)
-      end
-
+      Fabricate.times(25, :post, topic: topic_with_posts)
       Topic.reset_highest(topic_with_posts.id)
-      topic_with_posts.reload
 
-      expect(topic_with_posts.posts_count).to eq(12)
-      expect(topic_with_posts.highest_post_number).to eq(24)
+      get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}", params: { page: 5 }
+      expect(response).to redirect_to("/t/#{topic_with_posts.slug}/#{topic_with_posts.id}?page=2")
+    end
 
-      get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}.json", params: { page: 1 }
-      expect(response.status).to eq(200)
+    it "uses viewer-visible post count when deciding the last valid page (whispers)" do
+      SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+
+      topic_with_posts = Fabricate(:topic)
+      Fabricate.times(20, :post, topic: topic_with_posts)
+      Fabricate(:post, topic: topic_with_posts, post_type: Post.types[:whisper])
+      Topic.reset_highest(topic_with_posts.id)
 
       get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}.json", params: { page: 2 }
-      expect(response.status).to eq(404)
+      expect(response).to redirect_to("/t/#{topic_with_posts.slug}/#{topic_with_posts.id}.json")
+
+      sign_in(admin)
+      get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}.json", params: { page: 2 }
+      expect(response.status).to eq(200)
     end
 
     it "can find a topic given a slug in the id param" do
@@ -3781,7 +3786,7 @@ RSpec.describe TopicsController do
         expect(extract_post_stream).to eq(@post_ids[3..3])
 
         get "/t/#{topic.slug}/#{topic.id}.json", params: { page: 3 }
-        expect(response.status).to eq(404)
+        expect(response).to redirect_to("/t/#{topic.slug}/#{topic.id}.json?page=2")
 
         TopicView.stubs(:chunk_size).returns(4)
 
@@ -3790,7 +3795,7 @@ RSpec.describe TopicsController do
         expect(extract_post_stream).to eq(@post_ids[0..3])
 
         get "/t/#{topic.slug}/#{topic.id}.json", params: { page: 2 }
-        expect(response.status).to eq(404)
+        expect(response).to redirect_to("/t/#{topic.slug}/#{topic.id}.json")
       end
     end
 


### PR DESCRIPTION
Requesting `/t/slug/id?page=N` with a page number beyond the topic's last valid page raised `Discourse::NotFound` and returned 404. This produced a long-running stream of "increase in 404 errors" reports in Google Search Console, because crawlers (and our own `sitemap_recent.xml`) hold cached page URLs that become stale when a topic shrinks — most often after deleted posts or topic splits.

The 404 also masked a latent bug for staff: the original check compared the requested page against `topic.posts_count`, a cached column that excludes whispers and ignores active filters (`username_filters`, `replies_to_post_number`, etc.). A staff user navigating to `?page=N` covering whisper posts could be 404'd even though the page contained content they were entitled to see.

Replace the 404 with a 301 redirect to the last valid page (or the unparameterized topic URL if the topic fits in one page), using `@topic_view.filtered_posts.count` — the count of posts visible to the current viewer — so the math respects whispers, deletions visible to staff, and active filters. The COUNT query is gated behind `page > 1` so the common case (no `?page=` param) pays nothing extra.

Negative pages still raise 404; only the over-range case becomes a redirect.

https://meta.discourse.org/t/96337