### PR TITLE
FEATURE: Activity by category section of the new dashboard's engagement section

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -344,6 +344,94 @@ h1 {
   }
 }
 
+.db-activity {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-4);
+  }
+
+  &__description {
+    margin: 0;
+    font-size: var(--font-down-1-rem);
+    color: var(--primary-medium);
+  }
+
+  &__empty {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1-rem);
+    margin: 0;
+  }
+}
+
+.db-activity-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-down-1-rem);
+
+  th,
+  td {
+    padding: var(--space-3) var(--space-2);
+    text-align: left;
+    vertical-align: middle;
+  }
+
+  thead th {
+    border-bottom: 1px solid var(--primary-low);
+    color: var(--primary-medium);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: var(--font-down-2-rem);
+  }
+
+  tbody tr {
+    border-bottom: 1px solid var(--primary-very-low);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__col-number,
+  &__cell-number {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__sort-button {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    text-transform: inherit;
+    letter-spacing: inherit;
+  }
+
+  &__cell-category {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--primary);
+  }
+
+  &__swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    flex: 0 0 auto;
+  }
+}
+
 .db-whos-posting {
   display: flex;
   flex-direction: column;

--- a/app/models/concerns/reports/activity_by_category.rb
+++ b/app/models/concerns/reports/activity_by_category.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+module Reports::ActivityByCategory
+  extend ActiveSupport::Concern
+
+  DEFAULT_TOP_N = 6
+  MAX_CATEGORY_IDS = 50
+
+  class_methods do
+    def report_activity_by_category(report)
+      report.modes = [Report::MODES[:table]]
+      report.labels = [
+        { property: :name, title: I18n.t("reports.activity_by_category.labels.category") },
+        {
+          property: :topics,
+          type: :number,
+          title: I18n.t("reports.activity_by_category.labels.topics"),
+        },
+        {
+          property: :posts,
+          type: :number,
+          title: I18n.t("reports.activity_by_category.labels.posts"),
+        },
+        {
+          property: :page_views,
+          type: :number,
+          title: I18n.t("reports.activity_by_category.labels.page_views"),
+        },
+        { property: :share_formatted, title: I18n.t("reports.activity_by_category.labels.share") },
+        {
+          property: :share_change_formatted,
+          title: I18n.t("reports.activity_by_category.labels.vs_prior"),
+        },
+      ]
+
+      raw_ids = report.filters[:category_ids]
+      filter_requested = raw_ids.present?
+      requested_ids =
+        if filter_requested
+          Array(raw_ids.is_a?(String) ? raw_ids.split(",") : raw_ids)
+            .map(&:to_i)
+            .reject(&:zero?)
+            .uniq
+            .first(MAX_CATEGORY_IDS)
+        else
+          nil
+        end
+      report.add_filter("category_ids", type: "category_list", default: requested_ids)
+
+      if filter_requested && (requested_ids.nil? || requested_ids.empty?)
+        report.total = 0
+        report.data = []
+        return
+      end
+
+      secure_category_ids =
+        report.current_user&.admin? ? nil : Guardian.new(report.current_user).secure_category_ids
+
+      current_period =
+        period_data(report.start_date, report.end_date, requested_ids, secure_category_ids)
+
+      prior_start = report.start_date - (report.end_date - report.start_date)
+      prior_period = period_data(prior_start, report.start_date, requested_ids, secure_category_ids)
+
+      total_current =
+        current_period.values.sum { |row| row[:topics] + row[:posts] + row[:page_views] }
+      total_prior = prior_period.values.sum { |row| row[:topics] + row[:posts] + row[:page_views] }
+
+      rows =
+        current_period.map do |category_id, current|
+          activity = current[:topics] + current[:posts] + current[:page_views]
+          share = total_current.zero? ? 0.0 : (activity.to_f / total_current * 100).round(2)
+
+          prior = prior_period[category_id]
+          prior_activity = prior ? prior[:topics] + prior[:posts] + prior[:page_views] : 0
+          prior_share = total_prior.zero? ? 0.0 : (prior_activity.to_f / total_prior * 100).round(2)
+          share_change = (share - prior_share).round(2)
+
+          {
+            category_id: category_id,
+            name: current[:name],
+            color: current[:color],
+            slug: current[:slug],
+            topics: current[:topics],
+            posts: current[:posts],
+            page_views: current[:page_views],
+            share: share,
+            share_change: share_change,
+            share_formatted: "#{share}%",
+            share_change_formatted: format_share_change(share_change),
+          }
+        end
+
+      rows = rows.sort_by { |r| -(r[:topics] + r[:posts] + r[:page_views]) }
+      rows = rows.first(DEFAULT_TOP_N) if requested_ids.nil?
+
+      report.total = total_current
+      report.data = rows
+    end
+
+    private
+
+    def format_share_change(change)
+      return "0%" if change.zero?
+      sign = change.positive? ? "+" : ""
+      "#{sign}#{change}%"
+    end
+
+    def period_data(period_start, period_end, requested_ids, secure_category_ids)
+      builder = DB.build <<~SQL
+        SELECT
+          c.id,
+          c.name,
+          c.color,
+          c.slug,
+          COALESCE(t.topics, 0) AS topics,
+          COALESCE(p.posts, 0) AS posts,
+          COALESCE(v.page_views, 0) AS page_views
+        FROM categories c
+        LEFT JOIN (
+          SELECT category_id, COUNT(*) AS topics
+          FROM topics
+          WHERE created_at >= :period_start
+            AND created_at <= :period_end
+            AND deleted_at IS NULL
+            AND archetype = 'regular'
+          GROUP BY category_id
+        ) t ON t.category_id = c.id
+        LEFT JOIN (
+          SELECT topics.category_id, COUNT(*) AS posts
+          FROM posts
+          INNER JOIN topics ON topics.id = posts.topic_id
+          WHERE posts.created_at >= :period_start
+            AND posts.created_at <= :period_end
+            AND posts.deleted_at IS NULL
+            AND posts.post_type = :regular_post_type
+            AND topics.deleted_at IS NULL
+            AND topics.archetype = 'regular'
+          GROUP BY topics.category_id
+        ) p ON p.category_id = c.id
+        LEFT JOIN (
+          SELECT topics.category_id,
+            COALESCE(SUM(tvs.anonymous_views + tvs.logged_in_views), 0) AS page_views
+          FROM topic_view_stats tvs
+          INNER JOIN topics ON topics.id = tvs.topic_id
+          WHERE tvs.viewed_at >= :period_start
+            AND tvs.viewed_at <= :period_end
+            AND topics.deleted_at IS NULL
+            AND topics.archetype = 'regular'
+          GROUP BY topics.category_id
+        ) v ON v.category_id = c.id
+        /*where*/
+      SQL
+
+      builder.where(
+        "(COALESCE(t.topics, 0) + COALESCE(p.posts, 0) + COALESCE(v.page_views, 0)) > 0",
+      )
+
+      if requested_ids.present?
+        builder.where("c.id IN (:requested_ids)", requested_ids: requested_ids)
+      end
+
+      builder.secure_category(secure_category_ids) unless secure_category_ids.nil?
+
+      result = {}
+      builder
+        .query(
+          period_start: period_start,
+          period_end: period_end,
+          regular_post_type: Post.types[:regular],
+        )
+        .each do |row|
+          result[row.id] = {
+            name: row.name,
+            color: row.color,
+            slug: row.slug,
+            topics: row.topics,
+            posts: row.posts,
+            page_views: row.page_views,
+          }
+        end
+      result
+    end
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -124,6 +124,7 @@ class Report
   include Reports::TrustLevelGrowth
   include Reports::TrustLevelPipeline
   include Reports::PostersByMemberType
+  include Reports::ActivityByCategory
   include Reports::UserFlaggingRatio
   include Reports::UserToUserPrivateMessages
   include Reports::UserToUserPrivateMessagesWithReplies

--- a/app/services/admin_dashboard_engagement.rb
+++ b/app/services/admin_dashboard_engagement.rb
@@ -26,6 +26,7 @@ class AdminDashboardEngagement
       headline: build_headline(kpis),
       trust_level_pipeline: build_trust_level_pipeline,
       posters: build_posters,
+      activity_by_category: build_activity_by_category,
     }
   end
 
@@ -169,6 +170,20 @@ class AdminDashboardEngagement
     report = Report.find_cached("posters_by_member_type", args)
     if report.nil?
       report = Report.find("posters_by_member_type", args)
+      Report.cache(report) if report && report.error.blank?
+    end
+
+    return nil if report.nil? || report_error?(report)
+
+    { rows: report_data(report), total: report.is_a?(Hash) ? report[:total] : report.total }
+  end
+
+  def build_activity_by_category
+    args = { start_date: start_date, end_date: end_date, current_user: current_user }
+
+    report = Report.find_cached("activity_by_category", args)
+    if report.nil?
+      report = Report.find("activity_by_category", args)
       Report.cache(report) if report && report.error.blank?
     end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6884,6 +6884,16 @@ en:
           engagement:
             title: "Engagement"
             fetch_error: "Couldn't load engagement. Try refreshing the page."
+            activity_by_category:
+              title: "Activity by category"
+              description: "Topics, posts, and member participation per category."
+              category: "Category"
+              topics: "Topics"
+              posts: "Posts"
+              page_views: "Page views"
+              share: "Share"
+              vs_prior: "Vs Prior"
+              empty: "No activity in the selected period."
             whos_posting:
               title: "Who's posting?"
               all_categories: "All categories"
@@ -6892,8 +6902,6 @@ en:
               returning: "Returning"
               staff: "Staff"
               empty: "No posts in the selected period."
-            activity_by_category:
-              title: "Activity by category"
             trust_level_pipeline:
               title: "Trust level pipeline"
               trust_levels:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1377,6 +1377,16 @@ en:
       xaxis: "Day"
       yaxis: "Number of new contributors"
       description: "Number of users who made their first post during this period."
+    activity_by_category:
+      title: "Activity by category"
+      description: "Topics, posts, and member participation per category in the selected period. Share is each category's percentage of total activity across the listed categories; Vs Prior is the change in share compared with the previous period of equal length."
+      labels:
+        category: "Category"
+        topics: "Topics"
+        posts: "Posts"
+        page_views: "Page views"
+        share: "Share"
+        vs_prior: "Vs Prior"
     posters_by_member_type:
       title: "Who's posting?"
       description: "Posts authored in the selected period, bucketed by member type. \"New members\" signed up during the period, \"Returning\" signed up before it, and \"Staff\" are admins or moderators."

--- a/frontend/discourse/admin/components/dashboard/engagement.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement.gjs
@@ -1,3 +1,4 @@
+import ActivityByCategory from "discourse/admin/components/dashboard/engagement/activity-by-category";
 import EngagementHeadline from "discourse/admin/components/dashboard/engagement/headline";
 import TrustLevelPipeline from "discourse/admin/components/dashboard/engagement/trust-level-pipeline";
 import WhosPosting from "discourse/admin/components/dashboard/engagement/whos-posting";
@@ -41,17 +42,17 @@ import { i18n } from "discourse-i18n";
               />
             </div>
           </div>
-          <div class="db-section__row">
-            <div class="db-section__row-block">
-              <div class="db-section__row-block-header">
-                <h3 class="db-section__row-block-title">
-                  {{i18n
-                    "admin.dashboard.sections.engagement.activity_by_category.title"
-                  }}
-                </h3>
+          {{#if @engagement.activity_by_category}}
+            <div class="db-section__row">
+              <div class="db-section__row-block">
+                <ActivityByCategory
+                  @activity={{@engagement.activity_by_category}}
+                  @startDate={{@startDate}}
+                  @endDate={{@endDate}}
+                />
               </div>
             </div>
-          </div>
+          {{/if}}
         </div>
       {{/if}}
     </DashboardSection>

--- a/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
@@ -1,0 +1,223 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { LinkTo } from "@ember/routing";
+import { trustHTML } from "@ember/template";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import { number } from "discourse/lib/formatter";
+import CategorySelector from "discourse/select-kit/components/category-selector";
+import { eq } from "discourse/truth-helpers";
+import I18n, { i18n } from "discourse-i18n";
+
+export default class ActivityByCategory extends Component {
+  @tracked selectedCategories = [];
+  @tracked overrideActivity = null;
+  @tracked loading = false;
+  @tracked sortBy = "share";
+  @tracked sortDir = "desc";
+
+  get activity() {
+    return this.overrideActivity ?? this.args.activity;
+  }
+
+  get rows() {
+    const rows = this.activity?.rows ?? [];
+    const decorated = rows.map((row) => ({
+      ...row,
+      topicsFormatted: I18n.toNumber(row.topics, { precision: 0 }),
+      postsFormatted: I18n.toNumber(row.posts, { precision: 0 }),
+      pageViewsFormatted: number(row.page_views),
+      changeClass:
+        row.share_change > 0 ? "--pos" : row.share_change < 0 ? "--neg" : "",
+      swatchStyle: trustHTML(`background-color: #${this.#safeHex(row.color)}`),
+    }));
+
+    const direction = this.sortDir === "asc" ? 1 : -1;
+    return decorated.sort((a, b) => {
+      const av = a[this.sortBy] ?? 0;
+      const bv = b[this.sortBy] ?? 0;
+      return av === bv ? 0 : av > bv ? direction : -direction;
+    });
+  }
+
+  get hasData() {
+    return (this.activity?.rows ?? []).length > 0;
+  }
+
+  get shareSortIndicator() {
+    return this.sortDir === "desc" ? "↓" : "↑";
+  }
+
+  #safeHex(color) {
+    return /^[0-9a-fA-F]{6}$/.test(color) ? color : "cccccc";
+  }
+
+  @action
+  onCategoriesChange(categories) {
+    this.selectedCategories = categories;
+    this.refetch();
+  }
+
+  @action
+  onPeriodChange() {
+    if (this.selectedCategories.length === 0) {
+      this.overrideActivity = null;
+    } else {
+      this.refetch();
+    }
+  }
+
+  @action
+  toggleShareSort() {
+    if (this.sortBy === "share") {
+      this.sortDir = this.sortDir === "desc" ? "asc" : "desc";
+    } else {
+      this.sortBy = "share";
+      this.sortDir = "desc";
+    }
+  }
+
+  async refetch() {
+    this.loading = true;
+
+    const data = {
+      start_date: this.args.startDate?.toISOString().slice(0, 10),
+      end_date: this.args.endDate?.toISOString().slice(0, 10),
+    };
+    const ids = this.selectedCategories.map((c) => c.id);
+    if (ids.length > 0) {
+      data.filters = { category_ids: ids.join(",") };
+    }
+
+    try {
+      const response = await ajax("/admin/reports/activity_by_category.json", {
+        data,
+      });
+      const report = response?.report;
+      this.overrideActivity = {
+        rows: report?.data ?? [],
+        total: report?.total ?? 0,
+      };
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  <template>
+    <div
+      class="db-activity"
+      {{didUpdate this.onPeriodChange @startDate @endDate}}
+    >
+      <div class="db-activity__header">
+        <LinkTo
+          @route="adminReports.show"
+          @model="activity_by_category"
+          class="db-section__row-block-title"
+        >
+          {{i18n
+            "admin.dashboard.sections.engagement.activity_by_category.title"
+          }}
+        </LinkTo>
+        <CategorySelector
+          @categories={{this.selectedCategories}}
+          @onChange={{this.onCategoriesChange}}
+        />
+      </div>
+
+      <p class="db-activity__description">
+        {{i18n
+          "admin.dashboard.sections.engagement.activity_by_category.description"
+        }}
+      </p>
+
+      {{#if this.hasData}}
+        <table class="db-activity-table">
+          <thead>
+            <tr>
+              <th class="db-activity-table__col-category">
+                {{i18n
+                  "admin.dashboard.sections.engagement.activity_by_category.category"
+                }}
+              </th>
+              <th class="db-activity-table__col-number">
+                {{i18n
+                  "admin.dashboard.sections.engagement.activity_by_category.topics"
+                }}
+              </th>
+              <th class="db-activity-table__col-number">
+                {{i18n
+                  "admin.dashboard.sections.engagement.activity_by_category.posts"
+                }}
+              </th>
+              <th class="db-activity-table__col-number">
+                {{i18n
+                  "admin.dashboard.sections.engagement.activity_by_category.page_views"
+                }}
+              </th>
+              <th class="db-activity-table__col-number">
+                <button
+                  type="button"
+                  class="db-activity-table__sort-button"
+                  {{on "click" this.toggleShareSort}}
+                >
+                  {{i18n
+                    "admin.dashboard.sections.engagement.activity_by_category.share"
+                  }}
+                  {{#if (eq this.sortBy "share")}}
+                    <span aria-hidden="true">{{this.shareSortIndicator}}</span>
+                  {{/if}}
+                </button>
+              </th>
+              <th class="db-activity-table__col-number">
+                {{i18n
+                  "admin.dashboard.sections.engagement.activity_by_category.vs_prior"
+                }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each this.rows as |row|}}
+              <tr>
+                <td class="db-activity-table__cell-category">
+                  <span
+                    class="db-activity-table__swatch"
+                    style={{row.swatchStyle}}
+                    aria-hidden="true"
+                  ></span>
+                  {{row.name}}
+                </td>
+                <td
+                  class="db-activity-table__cell-number"
+                >{{row.topicsFormatted}}</td>
+                <td
+                  class="db-activity-table__cell-number"
+                >{{row.postsFormatted}}</td>
+                <td
+                  class="db-activity-table__cell-number"
+                >{{row.pageViewsFormatted}}</td>
+                <td
+                  class="db-activity-table__cell-number"
+                >{{row.share_formatted}}</td>
+                <td
+                  class="db-activity-table__cell-number db-delta
+                    {{row.changeClass}}"
+                >{{row.share_change_formatted}}</td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="db-activity__empty">
+          {{i18n
+            "admin.dashboard.sections.engagement.activity_by_category.empty"
+          }}
+        </p>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
@@ -1,0 +1,153 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import ActivityByCategory from "discourse/admin/components/dashboard/engagement/activity-by-category";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module(
+  "Integration | Component | Dashboard | ActivityByCategory",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    const start = new Date("2026-04-01");
+    const end = new Date("2026-04-30");
+
+    const activity = {
+      total: 100,
+      rows: [
+        {
+          category_id: 1,
+          name: "Support & Help",
+          color: "0088CC",
+          topics: 412,
+          posts: 2184,
+          page_views: 28400,
+          share: 42,
+          share_change: 12,
+          share_formatted: "42%",
+          share_change_formatted: "+12%",
+        },
+        {
+          category_id: 2,
+          name: "General",
+          color: "009C00",
+          topics: 231,
+          posts: 1196,
+          page_views: 14200,
+          share: 23,
+          share_change: 5,
+          share_formatted: "23%",
+          share_change_formatted: "+5%",
+        },
+        {
+          category_id: 3,
+          name: "Bug Reports",
+          color: "E45735",
+          topics: 61,
+          posts: 364,
+          page_views: 4600,
+          share: 7,
+          share_change: -8,
+          share_formatted: "7%",
+          share_change_formatted: "-8%",
+        },
+      ],
+    };
+
+    test("renders one row per category in the report", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert.dom(".db-activity-table tbody tr").exists({ count: 3 });
+    });
+
+    test("renders the section title as a link to the standalone report", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert
+        .dom("a.db-section__row-block-title")
+        .hasText("Activity by category")
+        .hasAttribute("href", /\/admin\/reports\/activity_by_category/);
+    });
+
+    test("renders share_change with positive class for gains and negative for losses", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert.dom(".db-delta.--pos").exists({ count: 2 });
+      assert.dom(".db-delta.--neg").exists({ count: 1 });
+      assert.dom(".db-delta.--neg").hasText("-8%");
+    });
+
+    test("formats page views with k suffix when over 1000", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      const cells = document.querySelectorAll(
+        ".db-activity-table tbody tr td:nth-child(4)"
+      );
+      assert.strictEqual(cells[0].textContent.trim(), "28.4k");
+      assert.strictEqual(cells[1].textContent.trim(), "14.2k");
+      assert.strictEqual(cells[2].textContent.trim(), "4.6k");
+    });
+
+    test("renders an empty-state message when there are no rows", async function (assert) {
+      const empty = { total: 0, rows: [] };
+
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{empty}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert.dom(".db-activity-table").doesNotExist();
+      assert.dom(".db-activity__empty").exists();
+    });
+
+    test("includes a CategorySelector for filtering", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert.dom(".category-selector").exists();
+    });
+  }
+);

--- a/spec/models/concerns/reports/activity_by_category_spec.rb
+++ b/spec/models/concerns/reports/activity_by_category_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+describe Reports::ActivityByCategory do
+  before { freeze_time(Time.zone.local(2026, 4, 28, 12, 0, 0)) }
+
+  let(:start_date) { Time.zone.local(2026, 4, 1) }
+  let(:end_date) { Time.zone.local(2026, 4, 28).end_of_day }
+
+  def build(filters: {}, current_user: nil)
+    Report.find(
+      "activity_by_category",
+      { start_date: start_date, end_date: end_date, filters: filters, current_user: current_user },
+    )
+  end
+
+  def row(report, category_id)
+    report.data.find { |r| r[:category_id] == category_id }
+  end
+
+  it "returns one row per category with non-zero activity" do
+    category = Fabricate(:category)
+    topic = Fabricate(:topic, category: category, created_at: start_date + 1.day)
+    Fabricate(:post, topic: topic, created_at: start_date + 1.day)
+
+    report = build
+
+    expect(row(report, category.id)).to be_present
+    expect(row(report, category.id)[:topics]).to eq(1)
+    expect(row(report, category.id)[:posts]).to be >= 1
+  end
+
+  it "counts topics created in the period" do
+    category = Fabricate(:category)
+    Fabricate(:topic, category: category, created_at: start_date + 2.days)
+    Fabricate(:topic, category: category, created_at: start_date + 5.days)
+    Fabricate(:topic, category: category, created_at: start_date - 30.days)
+
+    report = build
+
+    expect(row(report, category.id)[:topics]).to eq(2)
+  end
+
+  it "counts page views from topic_view_stats" do
+    category = Fabricate(:category)
+    topic = Fabricate(:topic, category: category, created_at: start_date + 1.day)
+    TopicViewStat.create!(
+      topic: topic,
+      viewed_at: start_date + 3.days,
+      anonymous_views: 7,
+      logged_in_views: 3,
+    )
+    TopicViewStat.create!(
+      topic: topic,
+      viewed_at: start_date + 4.days,
+      anonymous_views: 2,
+      logged_in_views: 1,
+    )
+
+    report = build
+
+    expect(row(report, category.id)[:page_views]).to eq(13)
+  end
+
+  it "excludes deleted topics, deleted posts, and PM archetype" do
+    cat = Fabricate(:category)
+    Fabricate(:topic, category: cat, created_at: start_date + 1.day, deleted_at: Time.now)
+    Fabricate(:private_message_topic, category: cat) # archetype: private_message
+
+    report = build
+
+    expect(report.data).to be_empty
+  end
+
+  it "computes share as percentage of activity across the listed categories" do
+    cat_a = Fabricate(:category)
+    cat_b = Fabricate(:category)
+    Fabricate(:topic, category: cat_a, created_at: start_date + 1.day)
+    Fabricate(:topic, category: cat_b, created_at: start_date + 1.day)
+    Fabricate(:topic, category: cat_b, created_at: start_date + 1.day)
+    Fabricate(:topic, category: cat_b, created_at: start_date + 1.day)
+
+    report = build(filters: { category_ids: [cat_a.id, cat_b.id] })
+
+    expect(report.data.map { |r| r[:share] }.sum).to be_within(0.5).of(100)
+    expect(row(report, cat_b.id)[:share]).to be > row(report, cat_a.id)[:share]
+  end
+
+  it "formats a positive share_change with a leading +" do
+    cat = Fabricate(:category)
+    Fabricate(:topic, category: cat, created_at: start_date + 5.days)
+
+    report = build
+
+    formatted = row(report, cat.id)[:share_change_formatted]
+    expect(formatted).to start_with("+")
+    expect(formatted).to end_with("%")
+  end
+
+  it "returns empty rows when an explicit filter resolves to no valid ids" do
+    Fabricate(:category) # noise data — should NOT be returned via top-N fallback
+    Fabricate(:topic, created_at: start_date + 1.day)
+
+    report = build(filters: { category_ids: "999999999,foo,bar" })
+
+    expect(report.data).to be_empty
+  end
+
+  it "caps the requested ids at MAX_CATEGORY_IDS" do
+    cats = Array.new(60) { Fabricate(:category) }
+    cats.first.tap { |c| Fabricate(:topic, category: c, created_at: start_date + 1.day) }
+
+    ids = cats.map(&:id).join(",")
+    report = build(filters: { category_ids: ids })
+
+    # only the first 50 are admitted as filter ids; the rest are ignored
+    expect(report.data.length).to be <= Reports::ActivityByCategory::MAX_CATEGORY_IDS
+  end
+
+  it "sorts rows by total activity descending" do
+    cat_small = Fabricate(:category)
+    cat_big = Fabricate(:category)
+    Fabricate(:topic, category: cat_small, created_at: start_date + 1.day)
+    3.times { Fabricate(:topic, category: cat_big, created_at: start_date + 1.day) }
+
+    report = build
+
+    expect(report.data.first[:category_id]).to eq(cat_big.id)
+  end
+
+  it "limits to the top N categories by activity when no filter is given" do
+    8.times do |i|
+      cat = Fabricate(:category, name: "cat#{i}")
+      Fabricate(:topic, category: cat, created_at: start_date + 1.day)
+    end
+
+    report = build
+
+    expect(report.data.length).to be <= Reports::ActivityByCategory::DEFAULT_TOP_N
+  end
+
+  it "returns only the requested categories when a filter is provided" do
+    cat_a = Fabricate(:category)
+    cat_b = Fabricate(:category)
+    cat_c = Fabricate(:category)
+    [cat_a, cat_b, cat_c].each do |c|
+      Fabricate(:topic, category: c, created_at: start_date + 1.day)
+    end
+
+    report = build(filters: { category_ids: [cat_a.id, cat_c.id] })
+
+    ids = report.data.map { |r| r[:category_id] }
+    expect(ids).to contain_exactly(cat_a.id, cat_c.id)
+  end
+
+  it "accepts comma-separated category ids string from URL filters" do
+    cat_a = Fabricate(:category)
+    cat_b = Fabricate(:category)
+    Fabricate(:topic, category: cat_a, created_at: start_date + 1.day)
+    Fabricate(:topic, category: cat_b, created_at: start_date + 1.day)
+
+    report = build(filters: { category_ids: "#{cat_a.id},#{cat_b.id}" })
+
+    expect(report.data.map { |r| r[:category_id] }).to contain_exactly(cat_a.id, cat_b.id)
+  end
+
+  describe "secured categories" do
+    fab!(:moderator)
+    fab!(:admin)
+    fab!(:private_group, :group)
+
+    it "excludes restricted categories from a moderator's results" do
+      private_cat = Fabricate(:private_category, group: private_group, read_restricted: true)
+      Fabricate(:topic, category: private_cat, created_at: start_date + 1.day)
+
+      report = build(current_user: moderator)
+
+      expect(report.data.map { |r| r[:category_id] }).not_to include(private_cat.id)
+    end
+
+    it "lets an admin see activity in restricted categories" do
+      private_cat = Fabricate(:private_category, group: private_group, read_restricted: true)
+      Fabricate(:topic, category: private_cat, created_at: start_date + 1.day)
+
+      report = build(current_user: admin)
+
+      expect(report.data.map { |r| r[:category_id] }).to include(private_cat.id)
+    end
+  end
+end

--- a/spec/queries/reports/list_query_spec.rb
+++ b/spec/queries/reports/list_query_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe Reports::ListQuery do
     end
 
     it "sorts reports by title" do
-      expect(result.map { |r| r[:title] }[0..5]).to eq(
+      expect(result.map { |r| r[:title] }[0..6]).to eq(
         [
+          I18n.t("reports.activity_by_category.title"),
           I18n.t("reports.admin_logins.title"),
           I18n.t("reports.page_view_anon_browser_reqs.title"),
           I18n.t("reports.associated_accounts_by_provider.title"),
@@ -111,8 +112,9 @@ RSpec.describe Reports::ListQuery do
       before { SiteSetting.reporting_improvements = true }
 
       it "sorts reports by title" do
-        expect(result.map { |r| r[:title] }[0..4]).to eq(
+        expect(result.map { |r| r[:title] }[0..5]).to eq(
           [
+            I18n.t("reports.activity_by_category.title"),
             I18n.t("reports.admin_logins.title"),
             I18n.t("reports.page_view_anon_browser_reqs.title"),
             I18n.t("reports.dau_by_mau.title"),

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -128,6 +128,50 @@ describe AdminDashboardEngagement do
       end
     end
 
+    describe "activity_by_category" do
+      it "includes the activity_by_category block with rows and total" do
+        result = described_class.build(start_date: "2026-04-01", end_date: "2026-04-28")
+        activity = result[:activity_by_category]
+
+        expect(activity).to have_key(:rows)
+        expect(activity).to have_key(:total)
+      end
+
+      it "honours category visibility when current_user is a moderator" do
+        moderator = Fabricate(:moderator)
+        private_group = Fabricate(:group)
+        private_cat = Fabricate(:private_category, group: private_group, read_restricted: true)
+        Fabricate(:topic, category: private_cat, created_at: Time.zone.local(2026, 4, 10))
+
+        result =
+          described_class.build(
+            start_date: "2026-04-01",
+            end_date: "2026-04-28",
+            current_user: moderator,
+          )
+
+        ids = result[:activity_by_category][:rows].map { |r| r[:category_id] }
+        expect(ids).not_to include(private_cat.id)
+      end
+
+      it "lets an admin see restricted categories" do
+        admin = Fabricate(:admin)
+        private_group = Fabricate(:group)
+        private_cat = Fabricate(:private_category, group: private_group, read_restricted: true)
+        Fabricate(:topic, category: private_cat, created_at: Time.zone.local(2026, 4, 10))
+
+        result =
+          described_class.build(
+            start_date: "2026-04-01",
+            end_date: "2026-04-28",
+            current_user: admin,
+          )
+
+        ids = result[:activity_by_category][:rows].map { |r| r[:category_id] }
+        expect(ids).to include(private_cat.id)
+      end
+    end
+
     describe "trust_level_pipeline" do
       it "includes per-TL rows, a trend object, and total_members" do
         Fabricate(:user, trust_level: TrustLevel[1])


### PR DESCRIPTION
This PR adds the "Activity by category" section to the engagement section of the new dashboard.

Builds on top of: https://github.com/discourse/discourse/pull/40225 (before)

### after


https://github.com/user-attachments/assets/966555a0-f678-461c-89ca-c8654a7fe7bb

