### PR TITLE
FIX: Disagreeing with a flag fails to restore posts by demoted users

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -242,6 +242,7 @@ class ReviewableFlaggedPost < Reviewable
     # Undo hide/silence if applicable
     if post&.hidden?
       notify_poster(performed_by)
+      post.acting_user = performed_by
       post.unhide!
       UserSilencer.unsilence(post.user) if UserSilencer.was_silenced_for?(post)
     end

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -496,6 +496,27 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
     end
   end
 
+  describe "#perform_disagree" do
+    it "restores a hidden post even when the author would no longer pass post validations" do
+      SiteSetting.newuser_max_embedded_media = 1
+
+      author = Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true)
+      flagged_post =
+        create_post(
+          user: author,
+          raw: "![one](http://example.com/one.png)\n![two](http://example.com/two.png)",
+        )
+      reviewable = PostActionCreator.spam(user, flagged_post).reviewable
+      flagged_post.hide!(PostActionType.types[:spam])
+
+      author.update!(trust_level: TrustLevel[0])
+
+      expect { reviewable.perform(moderator, :disagree) }.not_to raise_error
+      expect(flagged_post.reload.hidden).to eq(false)
+      expect(flagged_post.topic.reload.visible).to eq(true)
+    end
+  end
+
   describe "#perform_disagree_and_restore" do
     it "notifies the user about the flagged post being restored" do
       reviewable = Fabricate(:reviewable_flagged_post)


### PR DESCRIPTION
When a moderator disagreed with a flag on a hidden post, `Post#unhide!` re-ran `PostValidator` against `acting_user`, which defaults to the post's author. If the author had since lost trust (e.g. demoted to TL0) and the post's content exceeded new-user limits (embedded media, links, mentions, host spam), the update failed with `ActiveRecord::RecordInvalid` and the post stayed hidden.

Every other internal caller of `Post#unhide!` already sets `acting_user` to whoever is performing the action so validations run against the staff member, not the original poster — `PostsController#unhide`, `ReviewablePost#perform_approve_and_unhide`, `ReviewableActionBuilder#perform_unhide_post`, and `PostActionDestroyer`. `ReviewableFlaggedPost#perform_disagree` was the lone exception.

Set `post.acting_user = performed_by` before calling `post.unhide!` to follow the established convention. The post content and ownership are untouched; this only affects which user the validator inspects during the update.

https://meta.discourse.org/t/401900