### PR TITLE
UX: fix avatar flair position on /categories

### DIFF
--- a/app/assets/stylesheets/common/base/categories-topic-list.scss
+++ b/app/assets/stylesheets/common/base/categories-topic-list.scss
@@ -34,7 +34,6 @@
     .avatar-flair {
       position: absolute;
       bottom: 0;
-      right: 10px;
     }
   }
 


### PR DESCRIPTION
This CSS is no longer necessary after 40462be3b59b53c4c1b43c8a04cdcb184535914c and is causing a misalignment for image-based flair 

before
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/c5ac2cfc-ac47-469c-adb2-b51b4cebbce6" />


after 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/08b9a45e-0f4d-4848-a5a5-69899944a2a4" />

