### PR TITLE
FIX: State-changing summary generation is exposed via GET (CSRFable navigation)

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/summarization/summary_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/summarization/summary_controller.rb
@@ -13,6 +13,21 @@ module DiscourseAi
         summarization_service = DiscourseAi::TopicSummarization.for(topic, current_user)
         cached_summary = summarization_service.cached_summary
 
+        raise Discourse::NotFound if !cached_summary
+
+        if !guardian.can_see_summary?(topic, cached_summary: cached_summary)
+          raise Discourse::NotFound
+        end
+
+        render_serialized(cached_summary, AiTopicSummarySerializer)
+      end
+
+      def create
+        topic = Topic.find(params[:topic_id])
+        guardian.ensure_can_see!(topic)
+        summarization_service = DiscourseAi::TopicSummarization.for(topic, current_user)
+        cached_summary = summarization_service.cached_summary
+
         if !guardian.can_see_summary?(topic, cached_summary: cached_summary)
           raise Discourse::NotFound
         end

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/modal/ai-summary-modal.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/modal/ai-summary-modal.gjs
@@ -99,34 +99,36 @@ export default class AiSummaryModal extends Component {
 
   @action
   generateSummary() {
-    let fetchURL = this.baseSummarizationURL;
+    let ajaxOpts = {};
 
-    if (this.currentUser) {
-      fetchURL += `?stream=true`;
+    if (this.currentUser && !this.args.model.topic.has_cached_summary) {
+      ajaxOpts.type = "POST";
+      ajaxOpts.data = { stream: true };
     }
 
-    return this._requestSummary(fetchURL);
+    return this._requestSummary(this.baseSummarizationURL, ajaxOpts);
   }
 
   @action
   regenerateSummary() {
-    let fetchURL = this.baseSummarizationURL;
+    let ajaxOpts = {};
 
     if (this.currentUser) {
-      fetchURL += `?stream=true`;
+      ajaxOpts.type = "POST";
+      ajaxOpts.data = { stream: true };
 
       if (this.canRegenerate) {
-        fetchURL += "&skip_age_check=true";
+        ajaxOpts.data.skip_age_check = true;
       }
     }
 
     // ensure summary is reset before requesting a new one:
     this.resetSummary();
-    return this._requestSummary(fetchURL);
+    return this._requestSummary(this.baseSummarizationURL, ajaxOpts);
   }
 
   @action
-  _requestSummary(url) {
+  _requestSummary(url, ajaxOpts = {}) {
     if (this.loading || (this.text && !this.canRegenerate)) {
       return;
     }
@@ -134,7 +136,7 @@ export default class AiSummaryModal extends Component {
     this.loading = true;
     this.summarizedOn = null;
 
-    return ajax(url)
+    return ajax(url, ajaxOpts)
       .then((data) => {
         if (data?.ai_topic_summary?.summarized_text) {
           data.done = true;

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-topic-summary.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-topic-summary.js
@@ -53,19 +53,21 @@ export default class AiTopicSummary {
       return;
     }
 
-    let fetchURL = `/discourse-ai/summarization/t/${topicId}?`;
+    let fetchURL = `/discourse-ai/summarization/t/${topicId}`;
+    let ajaxOpts = {};
 
     if (currentUser) {
-      fetchURL += `stream=true`;
+      ajaxOpts.type = "POST";
+      ajaxOpts.data = { stream: true };
 
       if (this.canRegenerate) {
-        fetchURL += "&skip_age_check=true";
+        ajaxOpts.data.skip_age_check = true;
       }
     }
 
     this.loading = true;
 
-    return ajax(fetchURL)
+    return ajax(fetchURL, ajaxOpts)
       .then((data) => {
         if (!currentUser) {
           data.done = true;

--- a/plugins/discourse-ai/config/routes.rb
+++ b/plugins/discourse-ai/config/routes.rb
@@ -63,6 +63,7 @@ DiscourseAi::Engine.routes.draw do
 
   scope module: :summarization, path: "/summarization", defaults: { format: :json } do
     get "/t/:topic_id" => "summary#show", :constraints => { topic_id: /\d+/ }
+    post "/t/:topic_id" => "summary#create", :constraints => { topic_id: /\d+/ }
     put "/regen_gist" => "summary#regen_gist"
     put "/regen_summary" => "summary#regen_summary"
     post "/channels/:channel_id" => "chat_summary#show"

--- a/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/summarization/summary_controller_spec.rb
@@ -41,6 +41,55 @@ RSpec.describe DiscourseAi::Summarization::SummaryController do
       end
     end
 
+    describe "CSRF protection for state-changing summary requests" do
+      fab!(:user, :leader)
+
+      before do
+        sign_in(user)
+        Group.find(Group::AUTO_GROUPS[:trust_level_3]).add(user)
+      end
+
+      it "does not enqueue a streaming job via GET when no cached summary exists" do
+        expect { get "/discourse-ai/summarization/t/#{topic.id}.json?stream=true" }.not_to change {
+          Jobs::StreamTopicAiSummary.jobs.size
+        }
+
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+      end
+
+      it "does not generate a summary via GET when no cached summary exists" do
+        DiscourseAi::Completions::Llm.with_prepared_responses(["This is a summary"]) do
+          expect { get "/discourse-ai/summarization/t/#{topic.id}.json" }.not_to change {
+            AiSummary.where(target: topic).count
+          }
+        end
+
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+      end
+
+      it "enqueues a streaming job via POST" do
+        post "/discourse-ai/summarization/t/#{topic.id}.json", params: { stream: true }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+        expect(Jobs::StreamTopicAiSummary.jobs.size).to eq(1)
+      end
+
+      it "generates a summary via POST" do
+        summary_text = "This is a summary"
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([summary_text]) do
+          post "/discourse-ai/summarization/t/#{topic.id}.json"
+        end
+
+        expect(response.status).to eq(200)
+        expect(AiSummary.where(target: topic).count).to eq(1)
+        expect(response.parsed_body.dig("ai_topic_summary", "summarized_text")).to eq(summary_text)
+      end
+    end
+
     context "for anons" do
       it "returns a 404 if there is no cached summary" do
         get "/discourse-ai/summarization/t/#{topic.id}.json"
@@ -99,7 +148,7 @@ RSpec.describe DiscourseAi::Summarization::SummaryController do
         summary_text = "This is a summary"
 
         DiscourseAi::Completions::Llm.with_prepared_responses([summary_text]) do
-          get "/discourse-ai/summarization/t/#{topic.id}.json"
+          post "/discourse-ai/summarization/t/#{topic.id}.json"
 
           expect(response.status).to eq(200)
           response_summary = response.parsed_body["ai_topic_summary"]
@@ -115,7 +164,9 @@ RSpec.describe DiscourseAi::Summarization::SummaryController do
       end
 
       it "signals the summary is outdated" do
-        get "/discourse-ai/summarization/t/#{topic.id}.json"
+        DiscourseAi::Completions::Llm.with_prepared_responses(["This is a summary"]) do
+          post "/discourse-ai/summarization/t/#{topic.id}.json"
+        end
 
         Fabricate(:post, topic: topic, post_number: 3)
         topic.update!(highest_post_number: 3)

--- a/plugins/discourse-ai/test/javascripts/acceptance/topic-summary-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/topic-summary-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, visit, waitFor } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
@@ -22,12 +22,7 @@ acceptance("Topic - Summary", function (needs) {
     });
 
     server.post("/discourse-ai/summarization/t/1", () => {
-      return helper.response({
-        ai_topic_summary: {
-          summarized_text: "This a",
-        },
-        done: false,
-      });
+      return helper.response({ success: "OK" });
     });
 
     server.get("/discourse-ai/credits/status", () => {
@@ -45,12 +40,22 @@ acceptance("Topic - Summary", function (needs) {
     updateCurrentUser({ id: currentUserId });
   });
 
+  async function openStreamingSummaryModal() {
+    (await waitFor(".ai-summarization-button")).click();
+    await waitFor(".ai-summary-modal .ai-summary__container");
+  }
+
   test("displays streamed summary", async function (assert) {
     await visit("/t/-/1");
 
     const partialSummary = "This a";
 
-    await click(".ai-summarization-button");
+    await openStreamingSummaryModal();
+
+    await publishToMessageBus("/discourse-ai/summaries/topic/1", {
+      done: false,
+      ai_topic_summary: { summarized_text: partialSummary },
+    });
 
     assert
       .dom(".ai-summary-box .generated-summary p")
@@ -81,7 +86,7 @@ acceptance("Topic - Summary", function (needs) {
   test("clicking summary links", async function (assert) {
     await visit("/t/-/1");
 
-    await click(".ai-summarization-button");
+    await openStreamingSummaryModal();
 
     const finalSummaryCooked =
       "In this post,  <a href='/t/-/1/1'>bianca</a> said some stuff.";

--- a/plugins/discourse-ai/test/javascripts/acceptance/topic-summary-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/topic-summary-test.js
@@ -21,7 +21,7 @@ acceptance("Topic - Summary", function (needs) {
       return helper.response(json);
     });
 
-    server.get("/discourse-ai/summarization/t/1", () => {
+    server.post("/discourse-ai/summarization/t/1", () => {
       return helper.response({
         ai_topic_summary: {
           summarized_text: "This a",
@@ -49,10 +49,6 @@ acceptance("Topic - Summary", function (needs) {
     await visit("/t/-/1");
 
     const partialSummary = "This a";
-    await publishToMessageBus("/discourse-ai/summaries/topic/1", {
-      done: false,
-      ai_topic_summary: { summarized_text: partialSummary },
-    });
 
     await click(".ai-summarization-button");
 
@@ -85,13 +81,8 @@ acceptance("Topic - Summary", function (needs) {
   test("clicking summary links", async function (assert) {
     await visit("/t/-/1");
 
-    const partialSummary = "In this post,";
-    await publishToMessageBus("/discourse-ai/summaries/topic/1", {
-      done: false,
-      ai_topic_summary: { summarized_text: partialSummary },
-    });
-
     await click(".ai-summarization-button");
+
     const finalSummaryCooked =
       "In this post,  <a href='/t/-/1/1'>bianca</a> said some stuff.";
     const finalSummaryResult = "In this post, bianca said some stuff.";


### PR DESCRIPTION
## Summary

State-changing summary generation/streaming is exposed via GET endpoint, bypassing CSRF protection and allowing cross-site triggering of summary generation and credit consumption.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/334
- Original commit: https://github.com/discourse/discourse/blob/main/plugins/discourse-ai/app/controllers/discourse_ai/summarization/summary_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>