### PR TITLE
Corrected release notes `new_version_mailer` link format in English locale

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3421,7 +3421,7 @@ en:
 
       - Update using our easy **[one-click browser update](%{base_url}/admin/update)**
 
-      - See what's new in the [release notes](https://releases.discourse.org/changelog/%{new_version})
+      - See what's new in the [release notes](https://releases.discourse.org/changelog/v%{new_version})
 
       - Visit [meta.discourse.org](https://meta.discourse.org) for news, discussion, and support for Discourse
 
@@ -3437,7 +3437,7 @@ en:
 
       - Update using our easy **[one-click browser update](%{base_url}/admin/update)**
 
-      - See what's new in the [release notes](https://releases.discourse.org/changelog/%{new_version})
+      - See what's new in the [release notes](https://releases.discourse.org/changelog/v%{new_version})
 
       - Visit [meta.discourse.org](https://meta.discourse.org) for news, discussion, and support for Discourse
 


### PR DESCRIPTION
Added a hardcoded `v` in the `new_version_mailer` URL strings so that it it resolves the correct link to the [change log releases](https://releases.discourse.org/) -> (ie: https://releases.discourse.org/changelog/v2026.5.0 instead of `https://releases.discourse.org/changelog/2026.5.0`

see this bug topic: https://meta.discourse.org/t/-/403389