### PR TITLE
FEATURE: Create staff action log when recovering posts

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -168,6 +168,7 @@ class UserHistory < ActiveRecord::Base
         change_site_setting_groups: 123,
         upcoming_change_available: 124,
         notified_about_composer_education: 125,
+        recover_post: 126,
       )
   end
 
@@ -222,6 +223,7 @@ class UserHistory < ActiveRecord::Base
       post_edit
       topic_published
       recover_topic
+      recover_post
       post_approved
       create_badge
       change_badge
@@ -346,6 +348,7 @@ class UserHistory < ActiveRecord::Base
       :post_staff_note_destroy,
       :delete_post,
       :delete_post_permanently,
+      :recover_post,
       :permanently_delete_post_revisions,
       # topics
       :topic_published,

--- a/app/services/staff_action_logger.rb
+++ b/app/services/staff_action_logger.rb
@@ -106,6 +106,29 @@ class StaffActionLogger
     )
   end
 
+  def log_post_recover(post)
+    raise Discourse::InvalidParameters.new(:post) unless post && post.is_a?(Post)
+
+    user = post.user ? "#{post.user.username} (#{post.user.name})" : "(deleted user)"
+    topic = post.topic || Topic.with_deleted.find_by(id: post.topic_id)
+
+    details = [
+      "id: #{post.id}",
+      "created_at: #{post.created_at}",
+      "user: #{user}",
+      "raw: #{truncate(post.raw)}",
+    ]
+
+    UserHistory.create!(
+      params.merge(
+        action: UserHistory.actions[:recover_post],
+        topic_id: topic&.id,
+        post_id: post.id,
+        details: details.join("\n"),
+      ),
+    )
+  end
+
   def log_topic_delete_recover(topic, action = "delete_topic", opts = {})
     raise Discourse::InvalidParameters.new(:topic) unless topic && topic.is_a?(Topic)
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8298,6 +8298,7 @@ en:
             delete_topic: "delete topic"
             recover_topic: "un-delete topic"
             delete_post: "delete post"
+            recover_post: "un-delete post"
             impersonate: "impersonate"
             anonymize_user: "anonymize user"
             roll_up: "roll up IP blocks"

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -136,6 +136,7 @@ class PostDestroyer
     if @post.is_first_post?
       UserActionManager.topic_created(@topic)
       DiscourseEvent.trigger(:topic_recovered, @topic, @user)
+
       if @user.id != @post.user_id
         StaffActionLogger.new(@user).log_topic_delete_recover(
           @topic,
@@ -143,9 +144,12 @@ class PostDestroyer
           @opts.slice(:context),
         )
       end
+
       if SiteSetting.tos_topic_id == @topic.id || SiteSetting.privacy_topic_id == @topic.id
         Discourse.clear_urls!
       end
+    else
+      StaffActionLogger.new(@user).log_post_recover(@post) if @user.id != @post.user_id
     end
   end
 

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -172,6 +172,25 @@ RSpec.describe PostDestroyer do
       expect(post_action).to be_present
     end
 
+    it "creates a staff log entry when recovering the first post" do
+      first_post = create_post
+      PostDestroyer.new(moderator, first_post).destroy
+
+      expect { PostDestroyer.new(moderator, first_post).recover }.to change {
+        UserHistory.where(action: UserHistory.actions[:recover_topic]).count
+      }.by(1)
+    end
+
+    it "creates a staff log entry when recovering a reply" do
+      reply = create_post(topic: post.topic)
+
+      PostDestroyer.new(moderator, reply).destroy
+
+      expect { PostDestroyer.new(moderator, reply).recover }.to change {
+        UserHistory.where(action: UserHistory.actions[:recover_post]).count
+      }.by(1)
+    end
+
     it "works with topics and posts with no user" do
       post = Fabricate(:post)
       UserDestroyer.new(Discourse.system_user).destroy(post.user, delete_posts: true)

--- a/spec/services/staff_action_logger_spec.rb
+++ b/spec/services/staff_action_logger_spec.rb
@@ -79,6 +79,30 @@ RSpec.describe StaffActionLogger do
     end
   end
 
+  describe "#log_post_recover" do
+    fab!(:topic)
+    fab!(:reply, :post)
+
+    it "raises an error when post is nil" do
+      expect { logger.log_post_recover(nil) }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "raises an error when post is not a Post" do
+      expect { logger.log_post_recover(topic) }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "creates a new UserHistory record" do
+      expect { logger.log_post_recover(reply) }.to change { UserHistory.count }.by(1)
+    end
+
+    it "truncates overly long values" do
+      long_reply = Fabricate(:post, topic: topic, skip_validation: true, raw: long_string)
+      expect { logger.log_post_recover(long_reply) }.to change { UserHistory.count }.by(1)
+      log = UserHistory.last
+      expect(log.details.size).to be_between(50_000, 110_000)
+    end
+  end
+
   describe "log_topic_delete_recover" do
     fab!(:topic)
 


### PR DESCRIPTION
## What is this change?

Discourse currently logs staff actions for:

- Deleting topics.
- Deleting posts.
- Recovering topics.

But is missing the "last" action of:

- Recovering posts.

This PR adds a new user history type "recover post" and wires that up through the post destroyer.

## Manual verification

<img width="918" height="200" alt="Screenshot 2026-05-22 at 10 34 53 AM" src="https://github.com/user-attachments/assets/829a07cf-7c84-4abe-a145-96917553d6d2" />
