### PR TITLE
UX: Move admin user upcoming changes to a modal

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -602,3 +602,11 @@
     }
   }
 }
+
+.d-modal.admin-user-upcoming-changes-modal {
+  .d-modal {
+    &__container {
+      max-width: calc(var(--modal-max-width) * 2);
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8798,6 +8798,7 @@ en:
         post_edits_count: "Post Edits"
         upcoming_changes:
           title: "User upcoming changes"
+          view_modal: "View enabled changes"
           description: "To modify groups or to enable or disable upcoming changes, please visit the <a href='%{basePath}/admin/config/upcoming-changes'>upcoming changes config page</a>."
           filter_placeholder: "Filter upcoming changes by name or description"
           filter_no_results: "No upcoming changes found"

--- a/frontend/discourse/admin/components/admin-user-upcoming-changes.gjs
+++ b/frontend/discourse/admin/components/admin-user-upcoming-changes.gjs
@@ -7,12 +7,22 @@ import { bind } from "discourse/lib/decorators";
 import getUrl from "discourse/lib/get-url";
 import { escapeExpression } from "discourse/lib/utilities";
 import { and, eq } from "discourse/truth-helpers";
+import DModal from "discourse/ui-kit/d-modal";
+import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 import { i18n } from "discourse-i18n";
 
 export default class AdminUserUpcomingChanges extends Component {
   @bind
   reasonKey(reason) {
     return `user.upcoming_changes.why_reasons.${reason}`;
+  }
+
+  get description() {
+    return trustHTML(
+      i18n("admin.user.upcoming_changes.description", {
+        basePath: getUrl(""),
+      })
+    );
   }
 
   @bind
@@ -29,82 +39,98 @@ export default class AdminUserUpcomingChanges extends Component {
   }
 
   <template>
-    <AdminFilterControls
-      @array={{@user.upcoming_changes_stats}}
-      @searchableProps={{array "humanized_name" "description"}}
-      @inputPlaceholder={{i18n
-        "admin.user.upcoming_changes.filter_placeholder"
-      }}
-      @noResultsMessage={{i18n "admin.user.upcoming_changes.filter_no_results"}}
+    <DModal
+      class="admin-user-upcoming-changes-modal"
+      @closeModal={{@closeModal}}
+      @title={{i18n "admin.user.upcoming_changes.title"}}
     >
-      <:content as |filteredChanges|>
-        <table class="d-table user-upcoming-changes-table">
-          <thead class="d-table__header">
-            <th>{{i18n "user.upcoming_changes.for_user.upcoming_change"}}</th>
-            <th>{{i18n "user.upcoming_changes.for_user.enabled"}}</th>
-            <th>{{i18n "user.upcoming_changes.for_user.why"}}</th>
-          </thead>
-          <tbody class="d-table__body">
-            {{#each filteredChanges as |upcomingChange|}}
-              <tr
-                class="d-table__row"
-                data-upcoming-change-name={{upcomingChange.name}}
-              >
-                <td class="d-table__cell --overview">
-                  <div class="d-table__overview-name">
-                    {{upcomingChange.humanized_name}}
-                  </div>
-                  {{#if upcomingChange.description}}
-                    <div class="d-table__overview-about">
-                      {{upcomingChange.description}}
-                    </div>
-                  {{/if}}
-                </td>
-                <td class="d-table__cell">
-                  <div class="d-table__mobile-label">
-                    {{i18n "user.upcoming_changes.for_user.enabled"}}
-                  </div>
+      <:body>
+        <p
+          class="admin-user-upcoming-changes-modal__description"
+        >{{this.description}}</p>
 
-                  <span class="upcoming-change-enabled-status">
-                    {{if
-                      upcomingChange.enabled
-                      (i18n "yes_value")
-                      (i18n "no_value")
-                    }}
-                  </span>
-                </td>
-                <td class="d-table__cell">
-                  <div class="d-table__mobile-label">
-                    {{i18n "user.upcoming_changes.for_user.why"}}
-                  </div>
+        <AdminFilterControls
+          @array={{@model.user.upcoming_changes_stats}}
+          @searchableProps={{array "humanized_name" "description"}}
+          @inputPlaceholder={{i18n
+            "admin.user.upcoming_changes.filter_placeholder"
+          }}
+          @noResultsMessage={{i18n
+            "admin.user.upcoming_changes.filter_no_results"
+          }}
+        >
+          <:content as |filteredChanges|>
+            <table class="d-table user-upcoming-changes-table">
+              <thead class="d-table__header">
+                <th>{{i18n
+                    "user.upcoming_changes.for_user.upcoming_change"
+                  }}</th>
+                <th>{{i18n "user.upcoming_changes.for_user.enabled"}}</th>
+                <th>{{i18n "user.upcoming_changes.for_user.why"}}</th>
+              </thead>
+              <tbody class="d-table__body">
+                {{#each filteredChanges as |upcomingChange|}}
+                  <tr
+                    class="d-table__row"
+                    data-upcoming-change-name={{upcomingChange.name}}
+                  >
+                    <td class="d-table__cell --overview">
+                      <div class="d-table__overview-name">
+                        {{upcomingChange.humanized_name}}
+                      </div>
+                      {{#if upcomingChange.description}}
+                        <div class="d-table__overview-about">
+                          {{upcomingChange.description}}
+                        </div>
+                      {{/if}}
+                    </td>
+                    <td class="d-table__cell">
+                      <div class="d-table__mobile-label">
+                        {{i18n "user.upcoming_changes.for_user.enabled"}}
+                      </div>
 
-                  <span class="upcoming-change-reason">
-                    {{i18n
-                      (this.reasonKey upcomingChange.reason)
-                      username=@user.username
-                    }}
-                  </span>
-                  {{#if
-                    (and
-                      (eq
-                        upcomingChange.reason
-                        UPCOMING_CHANGES_USER_ENABLED_REASONS.in_specific_groups
-                      )
-                      upcomingChange.specific_groups.length
-                    )
-                  }}
-                    <span class="upcoming-change-groups">
-                      {{trustHTML
-                        (this.getGroupLinks upcomingChange.specific_groups)
+                      <span class="upcoming-change-enabled-status">
+                        {{#if upcomingChange.enabled}}
+                          {{dEmoji "white_check_mark"}}
+                        {{else}}
+                          {{dEmoji "cross_mark"}}
+                        {{/if}}
+                      </span>
+                    </td>
+                    <td class="d-table__cell">
+                      <div class="d-table__mobile-label">
+                        {{i18n "user.upcoming_changes.for_user.why"}}
+                      </div>
+
+                      <span class="upcoming-change-reason">
+                        {{i18n
+                          (this.reasonKey upcomingChange.reason)
+                          username=@model.user.username
+                        }}
+                      </span>
+                      {{#if
+                        (and
+                          (eq
+                            upcomingChange.reason
+                            UPCOMING_CHANGES_USER_ENABLED_REASONS.in_specific_groups
+                          )
+                          upcomingChange.specific_groups.length
+                        )
                       }}
-                    </span>
-                  {{/if}}
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      </:content>
-    </AdminFilterControls>
+                        <span class="upcoming-change-groups">
+                          {{trustHTML
+                            (this.getGroupLinks upcomingChange.specific_groups)
+                          }}
+                        </span>
+                      {{/if}}
+                    </td>
+                  </tr>
+                {{/each}}
+              </tbody>
+            </table>
+          </:content>
+        </AdminFilterControls>
+      </:body>
+    </DModal>
   </template>
 }

--- a/frontend/discourse/admin/controllers/admin-user/index.js
+++ b/frontend/discourse/admin/controllers/admin-user/index.js
@@ -4,6 +4,7 @@ import { action, computed } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
+import AdminUserUpcomingChanges from "discourse/admin/components/admin-user-upcoming-changes";
 import AdminUser from "discourse/admin/models/admin-user";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -183,6 +184,15 @@ export default class AdminUserIndexController extends Controller {
   @computed("ssoLastPayload")
   get ssoPayload() {
     return this.ssoLastPayload.split("&");
+  }
+
+  @action
+  openUserUpcomingChanges() {
+    this.modal.show(AdminUserUpcomingChanges, {
+      model: {
+        user: this.model,
+      },
+    });
   }
 
   @action

--- a/frontend/discourse/admin/templates/admin-user/index.gjs
+++ b/frontend/discourse/admin/templates/admin-user/index.gjs
@@ -3,7 +3,6 @@ import { LinkTo } from "@ember/routing";
 import { trustHTML } from "@ember/template";
 import AdminEditableField from "discourse/admin/components/admin-editable-field";
 import AdminUserExportsTable from "discourse/admin/components/admin-user-exports-table";
-import AdminUserUpcomingChanges from "discourse/admin/components/admin-user-upcoming-changes";
 import IpLookup from "discourse/admin/components/ip-lookup";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import i18nYesNo from "discourse/helpers/i18n-yes-no";
@@ -16,7 +15,6 @@ import { and, gt, not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
-import dBasePath from "discourse/ui-kit/helpers/d-base-path";
 import dFormatDate from "discourse/ui-kit/helpers/d-format-date";
 import dFormatDuration from "discourse/ui-kit/helpers/d-format-duration";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -668,6 +666,27 @@ export default <template>
       </div>
     {{/if}}
 
+    {{#if
+      (and
+        @controller.currentUser.staff @controller.model.upcoming_changes_stats
+      )
+    }}
+      <div class="display-row upcoming-changes-info">
+        <div class="field">{{i18n "admin.user.upcoming_changes.title"}}</div>
+        <div class="value">
+          <DButton
+            @action={{@controller.openUserUpcomingChanges}}
+            @icon="eye"
+            @label="admin.user.upcoming_changes.view_modal"
+            class="btn-default"
+          />
+        </div>
+        <div class="controls">
+          &nbsp;
+        </div>
+      </div>
+    {{/if}}
+
   </section>
 
   {{#if @controller.currentUser.admin}}
@@ -933,18 +952,6 @@ export default <template>
           </div>
         {{/if}}
       {{/let}}
-    </section>
-  {{/if}}
-
-  {{#if
-    (and @controller.currentUser.staff @controller.model.upcoming_changes_stats)
-  }}
-    <section class="details">
-      <h1>{{i18n "admin.user.upcoming_changes.title"}}</h1>
-      <p>{{trustHTML
-          (i18n "admin.user.upcoming_changes.description" basePath=dBasePath)
-        }}</p>
-      <AdminUserUpcomingChanges @user={{@controller.model}} />
     </section>
   {{/if}}
 

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -78,11 +78,16 @@ describe "Admin User Page" do
         )
       end
 
+      def open_upcoming_changes
+        admin_user_page.open_upcoming_changes_modal
+      end
+
       context "when the change is enabled for everyone" do
         before { SiteSetting.enable_upload_debug_mode = true }
 
         it "displays the upcoming change with enabled status and correct reason" do
           admin_user_page.visit(user)
+          open_upcoming_changes
           expect(admin_user_page).to have_upcoming_change("enable_upload_debug_mode")
           expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to be_enabled
           expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to have_reason(
@@ -99,6 +104,7 @@ describe "Admin User Page" do
 
         it "displays the upcoming change with disabled status and correct reason" do
           admin_user_page.visit(user)
+          open_upcoming_changes
           expect(admin_user_page).to have_upcoming_change("enable_upload_debug_mode")
           expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to be_disabled
           expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to have_reason(
@@ -125,6 +131,7 @@ describe "Admin User Page" do
 
           it "displays the upcoming change with enabled status, correct reason, and specific groups" do
             admin_user_page.visit(user)
+            open_upcoming_changes
             expect(admin_user_page).to have_upcoming_change("enable_upload_debug_mode")
             expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to be_enabled
             expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to have_reason(
@@ -144,6 +151,7 @@ describe "Admin User Page" do
 
           it "displays the upcoming change with all groups" do
             admin_user_page.visit(user)
+            open_upcoming_changes
             expect(admin_user_page).to have_upcoming_change("enable_upload_debug_mode")
             expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to be_enabled
             expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to have_reason(
@@ -158,6 +166,7 @@ describe "Admin User Page" do
         context "when the user does not belong to any of those groups" do
           it "displays the upcoming change with disabled status, correct reason, and no specific groups" do
             admin_user_page.visit(user)
+            open_upcoming_changes
             expect(admin_user_page).to have_upcoming_change("enable_upload_debug_mode")
             expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to be_disabled
             expect(admin_user_page.upcoming_change("enable_upload_debug_mode")).to have_reason(
@@ -189,6 +198,7 @@ describe "Admin User Page" do
         )
 
         admin_user_page.visit(user)
+        open_upcoming_changes
         expect(admin_user_page).to have_upcoming_change("enable_upload_debug_mode")
         expect(admin_user_page).to have_no_upcoming_change(
           "about_page_extra_groups_show_description",

--- a/spec/system/page_objects/pages/admin_user.rb
+++ b/spec/system/page_objects/pages/admin_user.rb
@@ -80,6 +80,10 @@ module PageObjects
         find(".penalty-similar-users .alert-warning")["innerHTML"]
       end
 
+      def open_upcoming_changes_modal
+        find(".upcoming-changes-info .btn-default").click
+      end
+
       class UpcomingChangeRow < PageObjects::Components::Base
         attr_reader :element
 
@@ -88,14 +92,14 @@ module PageObjects
         end
 
         def enabled?
-          expect(element.find(".upcoming-change-enabled-status")).to have_content(
-            I18n.t("js.yes_value"),
+          expect(element.find(".upcoming-change-enabled-status")).to have_css(
+            ".emoji[alt='white_check_mark']",
           )
         end
 
         def disabled?
-          expect(element.find(".upcoming-change-enabled-status")).to have_content(
-            I18n.t("js.no_value"),
+          expect(element.find(".upcoming-change-enabled-status")).to have_css(
+            ".emoji[alt='cross_mark']",
           )
         end
 
@@ -121,20 +125,20 @@ module PageObjects
 
       def has_upcoming_change?(change_name)
         has_css?(
-          ".user-upcoming-changes-table .d-table__row[data-upcoming-change-name='#{change_name}']",
+          ".admin-user-upcoming-changes-modal .user-upcoming-changes-table .d-table__row[data-upcoming-change-name='#{change_name}']",
         )
       end
 
       def has_no_upcoming_change?(change_name)
         has_no_css?(
-          ".user-upcoming-changes-table .d-table__row[data-upcoming-change-name='#{change_name}']",
+          ".admin-user-upcoming-changes-modal .user-upcoming-changes-table .d-table__row[data-upcoming-change-name='#{change_name}']",
         )
       end
 
       def upcoming_change(change_name)
         row =
           find(
-            ".user-upcoming-changes-table .d-table__row[data-upcoming-change-name='#{change_name}']",
+            ".admin-user-upcoming-changes-modal .user-upcoming-changes-table .d-table__row[data-upcoming-change-name='#{change_name}']",
           )
         UpcomingChangeRow.new(row)
       end


### PR DESCRIPTION
The list of upcoming changes and whether they are disabled
or enabled for a user were taking up a fair chunk of the
admin user page now that we are having more upcoming changes.

This commit moves it to a modal opened from the Permissions
section of the page to save space.

**Before**

<img width="1411" height="923" alt="image" src="https://github.com/user-attachments/assets/6d2c2244-f9ec-4987-a768-ad3e26db16e7" />


**After**

<img width="1134" height="573" alt="image" src="https://github.com/user-attachments/assets/1323755b-3998-46f3-a6d3-4e3ee870e66c" />

<img width="1305" height="829" alt="image" src="https://github.com/user-attachments/assets/6ff2c3ff-3e97-4cd1-9ab1-f4562f2dad0f" />
