### PR TITLE
DEV: preview alternate admin dashboard via `?version=alt`

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -6,7 +6,7 @@ class Admin::DashboardController < Admin::StaffController
   before_action :ensure_dashboard_improvements_enabled, only: %i[bulk_reports]
 
   def index
-    if SiteSetting.dashboard_improvements
+    if dashboard_improvements?
       visible_ids = AdminDashboardSectionConfiguration.visible_section_ids
       data = { sections: visible_ids.map { |id| { id: id, data: section_data(id) } } }
       if current_user.admin?
@@ -139,6 +139,14 @@ class Admin::DashboardController < Admin::StaffController
   end
 
   def ensure_dashboard_improvements_enabled
-    raise Discourse::NotFound if !SiteSetting.dashboard_improvements
+    raise Discourse::NotFound if !dashboard_improvements?
+  end
+
+  def dashboard_improvements?
+    if params[:version] == "alt"
+      !SiteSetting.dashboard_improvements
+    else
+      SiteSetting.dashboard_improvements
+    end
   end
 end

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -26,12 +26,13 @@ export default class AdminDashboardController extends Controller {
   @tracked range = DEFAULT_PERIOD;
   @tracked start_date = null;
   @tracked end_date = null;
+  @tracked version = null;
   @tracked loadedSections = null;
   @tracked loadingSections = false;
   @tracked sectionsFetchError = false;
   @autoTrackedArray problems;
 
-  queryParams = ["range", "start_date", "end_date"];
+  queryParams = ["range", "start_date", "end_date", "version"];
 
   isLoading = false;
   dashboardFetchedAt = null;
@@ -112,6 +113,7 @@ export default class AdminDashboardController extends Controller {
       const model = await AdminDashboard.fetch({
         startDate,
         endDate,
+        version: this.version,
       });
 
       if (id !== this._sectionsLoadId) {
@@ -140,6 +142,13 @@ export default class AdminDashboardController extends Controller {
         this.loadingSections = false;
       }
     }
+  }
+
+  get showRedesign() {
+    if (this.version === "alt") {
+      return !this.siteSettings.dashboard_improvements;
+    }
+    return this.siteSettings.dashboard_improvements;
   }
 
   @computed("siteSettings.version_checks")
@@ -196,7 +205,7 @@ export default class AdminDashboardController extends Controller {
     ) {
       this.set("isLoading", true);
 
-      AdminDashboard.fetch()
+      AdminDashboard.fetch({ version: this.version })
         .then((model) => {
           let properties = {
             dashboardFetchedAt: new Date(),

--- a/frontend/discourse/admin/models/admin-dashboard.js
+++ b/frontend/discourse/admin/models/admin-dashboard.js
@@ -8,13 +8,16 @@ const GENERAL_ATTRIBUTES = [
 ];
 
 export default class AdminDashboard extends EmberObject {
-  static async fetch({ startDate, endDate } = {}) {
+  static async fetch({ startDate, endDate, version } = {}) {
     const data = {};
     if (startDate) {
       data.start_date = moment(startDate).format("YYYY-MM-DD");
     }
     if (endDate) {
       data.end_date = moment(endDate).format("YYYY-MM-DD");
+    }
+    if (version) {
+      data.version = version;
     }
 
     const json = await ajax("/admin/dashboard.json", { data });

--- a/frontend/discourse/admin/routes/admin/dashboard.js
+++ b/frontend/discourse/admin/routes/admin/dashboard.js
@@ -1,11 +1,8 @@
-import { service } from "@ember/service";
 import { scrollTop } from "discourse/lib/scroll-top";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
 
 export default class AdminDashboardRoute extends DiscourseRoute {
-  @service siteSettings;
-
   titleToken() {
     return i18n("admin.config.dashboard.title");
   }
@@ -17,7 +14,7 @@ export default class AdminDashboardRoute extends DiscourseRoute {
   setupController(controller) {
     super.setupController(...arguments);
 
-    if (this.siteSettings.dashboard_improvements) {
+    if (controller.showRedesign) {
       controller.fetchSections();
     } else {
       controller.fetchProblems();

--- a/frontend/discourse/admin/templates/admin/dashboard.gjs
+++ b/frontend/discourse/admin/templates/admin/dashboard.gjs
@@ -8,7 +8,7 @@ import DPageHeader from "discourse/ui-kit/d-page-header";
 import { i18n } from "discourse-i18n";
 
 export default <template>
-  {{#if @controller.siteSettings.dashboard_improvements}}
+  {{#if @controller.showRedesign}}
     <RedesignedAdminDashboard
       @requestedPeriod={{@controller.safePeriod}}
       @requestedStartDate={{@controller.startDate}}

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -257,6 +257,24 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body["configuration"]).to be_nil
       end
 
+      it "is returned when version=alt and dashboard_improvements is disabled" do
+        SiteSetting.dashboard_improvements = false
+
+        get "/admin/dashboard.json", params: { version: "alt" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["sections"]).to be_present
+        expect(response.parsed_body["configuration"]).to be_present
+      end
+
+      it "is omitted when version=alt and dashboard_improvements is enabled" do
+        get "/admin/dashboard.json", params: { version: "alt" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["sections"]).to be_nil
+        expect(response.parsed_body["configuration"]).to be_nil
+      end
+
       it "falls back to default dates when date params are malformed" do
         get "/admin/dashboard.json", params: { start_date: "garbage", end_date: "also-garbage" }
 


### PR DESCRIPTION
The `dashboard_improvements` site setting toggles between the legacy and redesigned admin dashboard. There was no way to view the other variant without flipping the setting site-wide.

Visiting `/admin?version=alt` now inverts the effective setting for that request - showing the legacy view when the setting is enabled and the redesigned view when it's disabled. The query param is forwarded to `/admin/dashboard.json` so the server returns the matching payload.

<img width="3376" height="1582" alt="Screenshot 2026-05-22 at 2 17 48 pm" src="https://github.com/user-attachments/assets/e6244fe6-245a-49b3-9ca8-96489c7d5dd6" />
