### PR TITLE
UX: Pin the redesigned admin dashboard toolbar on scroll

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -9,7 +9,12 @@
 .db-toolbar {
   display: flex;
   align-items: center;
+  padding: var(--space-3) 0;
   margin-bottom: var(--space-8);
+  position: sticky;
+  top: var(--header-offset, 60px);
+  z-index: 1;
+  background: var(--d-content-background, var(--secondary));
 
   &__actions {
     display: flex;


### PR DESCRIPTION
On the redesigned admin dashboard, the period selector and Configure
menu sit at the very top of the page, so changing the period while
inspecting a section further down requires scrolling back to the top.

This commit pins the dashboard toolbar (heading, period selector,
Configure menu) under the main app header while the dashboard scrolls.

https://github.com/user-attachments/assets/65b85e8d-9d98-47d9-9374-3020803ca565

