### PR TITLE
FIX: Trap mousedown and touchend in float-kit body to keep tooltip content clickable

### DIFF
--- a/frontend/discourse/float-kit/components/d-float-body.gjs
+++ b/frontend/discourse/float-kit/components/d-float-body.gjs
@@ -26,7 +26,7 @@ export default class DFloatBody extends Component {
     };
   });
 
-  trapPointerEvents = modifierFn((element) => {
+  trapInteractionPropagation = modifierFn((element) => {
     const handler = (event) => {
       event.stopPropagation();
     };
@@ -90,7 +90,7 @@ export default class DFloatBody extends Component {
         aria-expanded={{if @instance.expanded "true" "false"}}
         role={{@role}}
         {{FloatKitApplyFloatingUi this.trigger this.options @instance}}
-        {{this.trapPointerEvents}}
+        {{this.trapInteractionPropagation}}
         {{(if @trapTab (modifier dTrapTab autofocus=this.options.autofocus))}}
         {{(if
           (and @instance.expanded this.supportsCloseOnClickOutside)

--- a/frontend/discourse/float-kit/components/d-float-body.gjs
+++ b/frontend/discourse/float-kit/components/d-float-body.gjs
@@ -26,15 +26,16 @@ export default class DFloatBody extends Component {
     };
   });
 
-  trapPointerDown = modifierFn((element) => {
+  trapPointerEvents = modifierFn((element) => {
     const handler = (event) => {
       event.stopPropagation();
     };
 
-    element.addEventListener("pointerdown", handler);
+    const events = ["pointerdown", "mousedown", "touchend"];
+    events.forEach((name) => element.addEventListener(name, handler));
 
     return () => {
-      element.removeEventListener("pointerdown", handler);
+      events.forEach((name) => element.removeEventListener(name, handler));
     };
   });
 
@@ -89,7 +90,7 @@ export default class DFloatBody extends Component {
         aria-expanded={{if @instance.expanded "true" "false"}}
         role={{@role}}
         {{FloatKitApplyFloatingUi this.trigger this.options @instance}}
-        {{this.trapPointerDown}}
+        {{this.trapPointerEvents}}
         {{(if @trapTab (modifier dTrapTab autofocus=this.options.autofocus))}}
         {{(if
           (and @instance.expanded this.supportsCloseOnClickOutside)

--- a/frontend/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
@@ -1,4 +1,5 @@
 import { hash } from "@ember/helper";
+import { on } from "@ember/modifier";
 import { getOwner } from "@ember/owner";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import {
@@ -353,6 +354,63 @@ module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
     await leave();
 
     assert.dom(".fk-d-tooltip__content").doesNotExist();
+  });
+
+  test("traps pointerdown, mousedown, and touchend inside the tooltip body", async function (assert) {
+    const received = { pointerdown: 0, mousedown: 0, touchend: 0 };
+    const listeners = {};
+    for (const name of Object.keys(received)) {
+      listeners[name] = () => received[name]++;
+      document.addEventListener(name, listeners[name]);
+    }
+
+    let innerClicked = false;
+    const handleInnerClick = () => (innerClicked = true);
+
+    try {
+      await render(
+        <template>
+          <DTooltip @inline={{true}} @label="trigger">
+            <:content>
+              <button
+                type="button"
+                class="inner-link"
+                {{on "click" handleInnerClick}}
+              >link</button>
+            </:content>
+          </DTooltip>
+        </template>
+      );
+
+      await hover();
+
+      await triggerEvent(".inner-link", "pointerdown");
+      await triggerEvent(".inner-link", "mousedown");
+      await triggerEvent(".inner-link", "touchend");
+
+      assert.strictEqual(
+        received.pointerdown,
+        0,
+        "pointerdown does not bubble out of the tooltip body"
+      );
+      assert.strictEqual(
+        received.mousedown,
+        0,
+        "mousedown does not bubble out of the tooltip body"
+      );
+      assert.strictEqual(
+        received.touchend,
+        0,
+        "touchend does not bubble out of the tooltip body"
+      );
+
+      await click(".inner-link");
+      assert.true(innerClicked, "the inner control still receives its click");
+    } finally {
+      for (const name of Object.keys(received)) {
+        document.removeEventListener(name, listeners[name]);
+      }
+    }
   });
 
   test("@portalOutletElement", async function (assert) {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/ai/403201

We were only catching pointerdown, but parents like the search menu listen for mousedown and/or touchend so the trap ends up missing these and you can't click a link in a nested situation like this... on attempt all the menus just close and the link doesn't work. 



<img width="600" alt="image" src="https://github.com/user-attachments/assets/4a60fda9-bb89-4bbc-ab63-800232a2d65a" />
