### PR TITLE
FIX: Moderators can enable plugins when enable_category_type_setup SiteSetting is enabled

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -245,7 +245,7 @@ class CategoriesController < ApplicationController
       # Handles adding or removing category types registered by plugins
       # based on the multi-type selector in the General tab for categories.
       if UpcomingChanges.enabled_for_user?(:enable_simplified_category_creation, current_user)
-        manage_category_types(cat, pending_custom_fields || {})
+        return nil unless manage_category_types(cat, pending_custom_fields || {})
         cat.reload
       end
 
@@ -627,21 +627,19 @@ class CategoriesController < ApplicationController
           },
         ) do
           on_failed_policy(:type_is_available) do
-            return(
-              render json: {
-                       errors: [
-                         I18n.t(
-                           "category_types.not_available",
-                           type_name: category_type.capitalize,
-                         ),
-                       ],
-                     },
-                     status: :unprocessable_entity
-            )
+            render json: {
+                     errors: [
+                       I18n.t("category_types.not_available", type_name: category_type.capitalize),
+                     ],
+                   },
+                   status: :unprocessable_entity
+            return false
           end
         end
       end
     end
+
+    true
   end
 
   def topics_per_page

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -563,7 +563,12 @@ class CategoriesController < ApplicationController
     type_class = Categories::TypeRegistry.get(type_id)
 
     if type_class&.enables_plugin?
-      plugin_name = Categories::TypeRegistry.owner(type_id)&.sub(/^discourse-/, "")&.titleize
+      plugin_name =
+        Categories::TypeRegistry
+          .owner(type_id)
+          &.sub(/^discourse-/, "")
+          &.sub(/-plugin$/, "")
+          &.titleize
       I18n.t("category_types.requires_plugin", type_name: category_type.to_s.humanize, plugin_name:)
     else
       I18n.t("category_types.not_available", type_name: category_type.to_s.humanize)

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -138,7 +138,7 @@ class CategoriesController < ApplicationController
         end
 
     render json: {
-             types: Categories::TypeRegistry.list(only_visible: true),
+             types: Categories::TypeRegistry.list(only_visible: true, guardian:),
              counts: counts_by_type,
            }
   end
@@ -180,43 +180,45 @@ class CategoriesController < ApplicationController
         return render json: { errors: [e.message] }, status: :unprocessable_entity
       end
 
-    if @category.save
-      @category.move_to(position.to_i) if position
+    configure_error = nil
 
-      if category_type.present? &&
-           UpcomingChanges.enabled_for_user?(:enable_simplified_category_creation, current_user)
-        type_class = Categories::TypeRegistry.get(category_type.to_sym)
-        allowed_setting_keys = type_class&.configuration_schema_keys(:category_settings) || []
-        type_settings = params[:category_type_settings]&.slice(*allowed_setting_keys)&.permit!
+    Category.transaction do
+      if @category.save
+        @category.move_to(position.to_i) if position
 
-        Categories::Configure.call(
-          guardian:,
-          params: {
-            category_id: @category.id,
-            category_type:,
-            site_setting_configuration_values: params[:category_type_site_settings],
-            category_configuration_values: [
-              category_params[:custom_fields],
-              type_settings,
-            ].compact.reduce(:merge),
-          },
-        ) do |result|
-          on_failed_policy(:type_is_available) do
-            return(
-              render json: {
-                       errors: [
-                         I18n.t(
-                           "category_types.not_available",
-                           type_name: category_type.capitalize,
-                         ),
-                       ],
-                     },
-                     status: :unprocessable_entity
-            )
+        if category_type.present? &&
+             UpcomingChanges.enabled_for_user?(:enable_simplified_category_creation, current_user)
+          type_class = Categories::TypeRegistry.get(category_type.to_sym)
+          allowed_setting_keys = type_class&.configuration_schema_keys(:category_settings) || []
+          type_settings = params[:category_type_settings]&.slice(*allowed_setting_keys)&.permit!
+
+          Categories::Configure.call(
+            guardian:,
+            params: {
+              category_id: @category.id,
+              category_type:,
+              site_setting_configuration_values: params[:category_type_site_settings],
+              category_configuration_values: [
+                category_params[:custom_fields],
+                type_settings,
+              ].compact.reduce(:merge),
+            },
+          ) do
+            on_failed_policy(:type_is_available) do
+              configure_error =
+                I18n.t("category_types.not_available", type_name: category_type.capitalize)
+              raise ActiveRecord::Rollback
+            end
           end
         end
       end
+    end
 
+    if configure_error
+      return render json: { errors: [configure_error] }, status: :unprocessable_entity
+    end
+
+    if @category.persisted?
       Scheduler::Defer.later "Log staff action create category" do
         @staff_action_logger.log_category_creation(@category)
       end
@@ -623,7 +625,7 @@ class CategoriesController < ApplicationController
             category_id: category.id,
             category_type:,
           },
-        ) do |result|
+        ) do
           on_failed_policy(:type_is_available) do
             return(
               render json: {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -205,8 +205,7 @@ class CategoriesController < ApplicationController
             },
           ) do
             on_failed_policy(:type_is_available) do
-              configure_error =
-                I18n.t("category_types.not_available", type_name: category_type.capitalize)
+              configure_error = category_type_unavailable_error(category_type)
               raise ActiveRecord::Rollback
             end
           end
@@ -559,6 +558,18 @@ class CategoriesController < ApplicationController
     end
   end
 
+  def category_type_unavailable_error(category_type)
+    type_id = category_type.to_sym
+    type_class = Categories::TypeRegistry.get(type_id)
+
+    if type_class&.enables_plugin?
+      plugin_name = Categories::TypeRegistry.owner(type_id)&.sub(/^discourse-/, "")&.titleize
+      I18n.t("category_types.requires_plugin", type_name: category_type.to_s.humanize, plugin_name:)
+    else
+      I18n.t("category_types.not_available", type_name: category_type.to_s.humanize)
+    end
+  end
+
   def manage_category_types(category, pending_custom_fields)
     # NOTE: The code in this block is pretty similar to what we are doing in
     # configure_site_settings in Categories::Types::Base, however here we
@@ -628,9 +639,7 @@ class CategoriesController < ApplicationController
         ) do
           on_failed_policy(:type_is_available) do
             render json: {
-                     errors: [
-                       I18n.t("category_types.not_available", type_name: category_type.capitalize),
-                     ],
+                     errors: [category_type_unavailable_error(category_type)],
                    },
                    status: :unprocessable_entity
             return false

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -176,6 +176,6 @@ class CategorySerializer < SiteCategorySerializer
 
   def available_category_types
     return [] if !SiteSetting.enable_simplified_category_creation
-    Categories::TypeRegistry.list(only_visible: true)
+    Categories::TypeRegistry.list(only_visible: true, guardian: scope)
   end
 end

--- a/app/services/categories/configure.rb
+++ b/app/services/categories/configure.rb
@@ -50,8 +50,8 @@ module Categories
       Categories::TypeRegistry.get(params.category_type)
     end
 
-    def type_is_available(type_class:)
-      type_class.available?
+    def type_is_available(type_class:, guardian:)
+      type_class.available?(guardian)
     end
 
     def enable_plugin(type_class:)

--- a/app/services/categories/type_registry.rb
+++ b/app/services/categories/type_registry.rb
@@ -42,6 +42,10 @@ module Categories
         types.key?(id.to_sym)
       end
 
+      def owner(id)
+        owners[id.to_sym]
+      end
+
       def reset!
         @types = nil
         @owners = nil

--- a/app/services/categories/type_registry.rb
+++ b/app/services/categories/type_registry.rb
@@ -31,8 +31,11 @@ module Categories
         types
       end
 
-      def list(only_visible: false)
-        types.values.select { |type| only_visible ? type.visible? : true }.map(&:metadata)
+      def list(only_visible: false, guardian: nil)
+        types
+          .values
+          .select { |type| only_visible ? type.visible? : true }
+          .map { |type| type.metadata(guardian:) }
       end
 
       def valid?(id)

--- a/app/services/categories/types/base.rb
+++ b/app/services/categories/types/base.rb
@@ -339,7 +339,7 @@ module Categories
         # Used when serializing the category configuration schema to the client.
         def metadata(guardian: nil)
           name = I18n.t("category_types.#{type_id}.name", default: type_id.to_s.titleize)
-          {
+          result = {
             id: type_id,
             name: name,
             title: I18n.t("category_types.#{type_id}.title", default: name),
@@ -348,7 +348,12 @@ module Categories
             available: available?(guardian),
             visible: visible?,
             configuration_schema: resolved_configuration_schema,
-          }.merge(additional_metadata)
+          }
+          if enables_plugin?
+            plugin_name = Categories::TypeRegistry.owner(type_id)
+            result[:required_plugin] = plugin_name&.sub(/^discourse-/, "")&.titleize
+          end
+          result.merge(additional_metadata)
         end
 
         private

--- a/app/services/categories/types/base.rb
+++ b/app/services/categories/types/base.rb
@@ -124,6 +124,12 @@ module Categories
         def enable_plugin
         end
 
+        # Returns true if this type overrides enable_plugin with actual behavior.
+        # Used to determine if admin privileges are required to configure this type.
+        def enables_plugin?
+          method(:enable_plugin).owner != Categories::Types::Base.singleton_class
+        end
+
         # Configure any category-specific settings or custom fields that are
         # specific to this category type, including whatever setting or custom
         # field values make this category type unique.
@@ -251,7 +257,10 @@ module Categories
 
         # Used as an extension point to limit access to a category type
         # based on certain conditions, mostly for Discourse hosting.
-        def available?
+        # When guardian is provided, also checks if admin is required for
+        # types that enable plugins.
+        def available?(guardian = nil)
+          return false if enables_plugin? && guardian && !guardian.is_admin?
           true
         end
 
@@ -328,7 +337,7 @@ module Categories
         end
 
         # Used when serializing the category configuration schema to the client.
-        def metadata
+        def metadata(guardian: nil)
           name = I18n.t("category_types.#{type_id}.name", default: type_id.to_s.titleize)
           {
             id: type_id,
@@ -336,7 +345,7 @@ module Categories
             title: I18n.t("category_types.#{type_id}.title", default: name),
             description: I18n.t("category_types.#{type_id}.description", default: ""),
             icon:,
-            available: available?,
+            available: available?(guardian),
             visible: visible?,
             configuration_schema: resolved_configuration_schema,
           }.merge(additional_metadata)

--- a/app/services/categories/types/base.rb
+++ b/app/services/categories/types/base.rb
@@ -351,7 +351,10 @@ module Categories
           }
           if enables_plugin?
             plugin_name = Categories::TypeRegistry.owner(type_id)
-            result[:required_plugin] = plugin_name&.sub(/^discourse-/, "")&.titleize
+            result[:required_plugin] = plugin_name
+              &.sub(/^discourse-/, "")
+              &.sub(/-plugin$/, "")
+              &.titleize
           end
           result.merge(additional_metadata)
         end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4947,7 +4947,7 @@ en:
         site_settings: "Site settings"
       choose_type:
         title: "Choose category type"
-        requires_plugin: "Requires %{plugin_name}"
+        requires_plugin: "Requires %{plugin_name} plugin"
         unavailable: "Unavailable"
       create_category: "Create category"
       save: "Save category"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4947,7 +4947,8 @@ en:
         site_settings: "Site settings"
       choose_type:
         title: "Choose category type"
-        requires_plugin: "Requires plugin"
+        requires_plugin: "Requires %{plugin_name}"
+        unavailable: "Unavailable"
       create_category: "Create category"
       save: "Save category"
       unsaved_changes: "You have unsaved changes"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -910,6 +910,7 @@ en:
 
   category_types:
     not_available: "Category type '%{type_name}' is not available"
+    requires_admin: "Category type '%{type_name}' enables plugins. To continue, ask an administrator to enable the corresponding plugin or create the category."
     discussion:
       name: "Discussion"
       title: "discussion"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -910,7 +910,7 @@ en:
 
   category_types:
     not_available: "Category type '%{type_name}' is not available"
-    requires_admin: "Category type '%{type_name}' enables plugins. To continue, ask an administrator to enable the corresponding plugin or create the category."
+    requires_plugin: "Category type '%{type_name}' requires the '%{plugin_name}' plugin to be enabled. Ask an administrator to enable it or create this category."
     discussion:
       name: "Discussion"
       title: "discussion"

--- a/frontend/discourse/app/components/category-type-cards.gjs
+++ b/frontend/discourse/app/components/category-type-cards.gjs
@@ -9,6 +9,15 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 import { i18n } from "discourse-i18n";
 
+function unavailableBadgeText(type) {
+  if (type.required_plugin) {
+    return i18n("category.choose_type.requires_plugin", {
+      plugin_name: type.required_plugin,
+    });
+  }
+  return i18n("category.choose_type.unavailable");
+}
+
 export default class CategoryTypeCards extends Component {
   @service categoryTypeChooser;
   @service router;
@@ -53,7 +62,7 @@ export default class CategoryTypeCards extends Component {
                 @name="category-type-card-top-right-corner"
                 @outletArgs={{lazyHash type=type}}
               >
-                {{i18n "category.choose_type.requires_plugin"}}
+                {{unavailableBadgeText type}}
               </PluginOutlet>
             </span>
           {{/unless}}

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1373,7 +1373,7 @@ RSpec.describe CategoriesController do
               I18n.t(
                 "category_types.requires_plugin",
                 type_name: "Test plugin type",
-                plugin_name: "Test Plugin",
+                plugin_name: "Test plugin",
               ),
             )
           end

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1327,6 +1327,56 @@ RSpec.describe CategoriesController do
           expect(response.status).to eq(200)
           expect(category.reload.locale).to be_nil
         end
+
+        context "when adding category_types that enable plugins" do
+          let(:test_type_class) do
+            Class.new(Categories::Types::Base) do
+              type_id :test_plugin_type
+
+              def self.enable_plugin
+              end
+
+              def self.category_matches?(category)
+                false
+              end
+
+              def self.find_matches
+                Category.none
+              end
+
+              def self.configure_category(category, guardian:, configuration_values: {})
+              end
+
+              def self.unconfigure_category(category, guardian:)
+              end
+            end
+          end
+
+          before do
+            SiteSetting.enable_simplified_category_creation = true
+            Categories::TypeRegistry.register(test_type_class)
+          end
+
+          after { Categories::TypeRegistry.reset! }
+
+          it "returns 422 when a moderator tries to add a plugin-enabling type" do
+            sign_in(Fabricate(:moderator))
+            SiteSetting.moderators_manage_categories = true
+
+            put "/categories/#{category.id}.json", params: { category_types: %w[test_plugin_type] }
+
+            expect(response.status).to eq(422)
+            expect(response.parsed_body["errors"]).to include(
+              I18n.t("category_types.not_available", type_name: "Test_plugin_type"),
+            )
+          end
+
+          it "allows an admin to add a plugin-enabling type" do
+            put "/categories/#{category.id}.json", params: { category_types: %w[test_plugin_type] }
+
+            expect(response.status).to eq(200)
+          end
+        end
       end
     end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1354,7 +1354,10 @@ RSpec.describe CategoriesController do
 
           before do
             SiteSetting.enable_simplified_category_creation = true
-            Categories::TypeRegistry.register(test_type_class)
+            Categories::TypeRegistry.register(
+              test_type_class,
+              plugin_identifier: "discourse-test-plugin",
+            )
           end
 
           after { Categories::TypeRegistry.reset! }
@@ -1367,7 +1370,11 @@ RSpec.describe CategoriesController do
 
             expect(response.status).to eq(422)
             expect(response.parsed_body["errors"]).to include(
-              I18n.t("category_types.not_available", type_name: "Test_plugin_type"),
+              I18n.t(
+                "category_types.requires_plugin",
+                type_name: "Test plugin type",
+                plugin_name: "Test Plugin",
+              ),
             )
           end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1373,7 +1373,7 @@ RSpec.describe CategoriesController do
               I18n.t(
                 "category_types.requires_plugin",
                 type_name: "Test plugin type",
-                plugin_name: "Test plugin",
+                plugin_name: "Test",
               ),
             )
           end

--- a/spec/services/categories/configure_spec.rb
+++ b/spec/services/categories/configure_spec.rb
@@ -46,6 +46,62 @@ RSpec.describe Categories::Configure do
       it { is_expected.to fail_a_policy(:type_is_available) }
     end
 
+    context "when type does not enable a plugin (Discussion)" do
+      context "when user is a moderator" do
+        fab!(:moderator)
+
+        let(:dependencies) { { guardian: moderator.guardian } }
+
+        before { SiteSetting.moderators_manage_categories = true }
+
+        it { is_expected.to run_successfully }
+      end
+    end
+
+    context "when type enables a plugin" do
+      let(:test_type_class) do
+        Class.new(Categories::Types::Base) do
+          type_id :test_plugin_type
+
+          def self.enable_plugin
+          end
+
+          def self.category_matches?(category)
+            false
+          end
+
+          def self.find_matches
+            Category.none
+          end
+
+          def self.configure_category(category, guardian:, configuration_values: {})
+          end
+
+          def self.unconfigure_category(category, guardian:)
+          end
+        end
+      end
+
+      let(:params) { { category_id: category.id, category_type: "test_plugin_type" } }
+
+      before { Categories::TypeRegistry.register(test_type_class) }
+      after { Categories::TypeRegistry.reset! }
+
+      context "when user is a moderator" do
+        fab!(:moderator)
+
+        let(:dependencies) { { guardian: moderator.guardian } }
+
+        before { SiteSetting.moderators_manage_categories = true }
+
+        it { is_expected.to fail_a_policy(:type_is_available) }
+      end
+
+      context "when user is an admin" do
+        it { is_expected.to run_successfully }
+      end
+    end
+
     context "when everything's ok" do
       it { is_expected.to run_successfully }
 

--- a/spec/services/categories/types/base_spec.rb
+++ b/spec/services/categories/types/base_spec.rb
@@ -13,6 +13,26 @@ RSpec.describe Categories::Types::Base do
     end
   end
 
+  describe ".enables_plugin?" do
+    it "returns false when enable_plugin is not overridden" do
+      test_type = Class.new(described_class) { type_id :no_plugin }
+
+      expect(test_type.enables_plugin?).to eq(false)
+    end
+
+    it "returns true when enable_plugin is overridden" do
+      test_type =
+        Class.new(described_class) do
+          type_id :with_plugin
+
+          def self.enable_plugin
+          end
+        end
+
+      expect(test_type.enables_plugin?).to eq(true)
+    end
+  end
+
   describe ".metadata" do
     it "returns type information including configuration_schema" do
       expect(described_class.metadata).to include(


### PR DESCRIPTION
When `moderators_manage_categories` is enabled, moderators could create "support" or "ideas" category types, which would enable the Solved or Topic Voting plugins site-wide - bypassing admin-only site setting protections. Likewise, this also applies to any plugin that implements other category types. 

  This fix:
  - Adds `enables_plugin?` to detect if a category type overrides `enable_plugin`
  - Updates `available?` to return `false` for non-admins when the type enables plugins
  - Wraps category creation in a transaction so the category is rolled back if the type is unavailable
  - Threads guardian through `TypeRegistry.list` and metadata so the UI grays out unavailable types

Moderators can still create Discussion categories (which don't enable plugins). Types that enable plugins now show as unavailable in the UI for non-admins and are blocked server-side.


When a moderator creates a category: 

**Before** 
<img width="900" height="600" alt="image" src="https://github.com/user-attachments/assets/9e451e0f-89a4-469b-89c8-3d27de3aac68" />


**After**
<img width="888" height="588" alt="image" src="https://github.com/user-attachments/assets/40c08684-5904-4b59-af10-a6e76e650096" />

Ref: `patch-triage/810`