### PR TITLE
 FIX: Move quoted post rebaking on avatar upload to a background job …

### DIFF
--- a/app/jobs/regular/rebake_quoted_posts_for_user.rb
+++ b/app/jobs/regular/rebake_quoted_posts_for_user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RebakeQuotedPostsForUser < ::Jobs::Base
+    def execute(args)
+      user_id = args[:user_id]
+      return if user_id.blank?
+
+      Post.rebake_all_quoted_posts(user_id)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1573,7 +1573,8 @@ class User < ActiveRecord::Base
     end
 
     # mark all the user's quoted posts as "needing a rebake"
-    Post.rebake_all_quoted_posts(self.id) if saved_change_to_uploaded_avatar_id?
+    # use background job to avoid blocking on large datasets
+    Jobs.enqueue(:rebake_quoted_posts_for_user, user_id: id) if saved_change_to_uploaded_avatar_id?
   end
 
   def first_post_created_at

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -693,8 +693,9 @@ RSpec.describe User do
           user.update!(name: "Sam")
           expect(post.reload.baked_version).not_to be_nil
 
-          user.update!(uploaded_avatar_id: 100)
-          expect(post.reload.baked_version).to be_nil
+          expect_enqueued_with(job: :rebake_quoted_posts_for_user, args: { user_id: user.id }) do
+            user.update!(uploaded_avatar_id: 100)
+          end
         end
       end
     end
@@ -1837,6 +1838,27 @@ RSpec.describe User do
 
       expect_enqueued_with(job: :update_gravatar, args: { user_id: user.id }) do
         user.refresh_avatar
+      end
+    end
+
+    it "enqueues rebake job instead of blocking when avatar is updated" do
+      user = Fabricate(:user)
+      upload = Fabricate(:upload)
+
+      allow(Post).to receive(:rebake_all_quoted_posts)
+
+      expect_enqueued_with(job: :rebake_quoted_posts_for_user, args: { user_id: user.id }) do
+        user.update!(uploaded_avatar_id: upload.id)
+      end
+
+      expect(Post).not_to have_received(:rebake_all_quoted_posts)
+    end
+
+    it "does not enqueue rebake job when avatar is not changed" do
+      user = Fabricate(:user)
+
+      expect_not_enqueued_with(job: :rebake_quoted_posts_for_user) do
+        user.update!(name: "New Name")
       end
     end
   end


### PR DESCRIPTION
… (#40231)

When a user uploads a new avatar, all their quoted posts are marked for rebaking in `Post.rebake_all_quoted_posts`.
If a user has thousands of quoted posts, this SQL UPDATE can cause PostgreSQL statement timeouts.

This commit moves the rebaking operation to a background job, allowing avatar uploads to complete in milliseconds. The rebaking still happens, but asynchronously in a Sidekiq worker without blocking the user.