### PR TITLE
FIX: Horizon high-context cards show bump time instead of last-reply

### DIFF
--- a/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
@@ -11,7 +11,6 @@ import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import { shortDateNoYear } from "discourse/lib/formatter";
-import { and, or } from "discourse/truth-helpers";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import { categoryLinkHTML } from "discourse/ui-kit/helpers/d-category-link";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -20,6 +19,7 @@ import dFormatDate from "discourse/ui-kit/helpers/d-format-date";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import { i18n } from "discourse-i18n";
+import { topicWasUpdatedAfterLastPost } from "../../lib/topic-activity";
 import { getTopicStatusBadge } from "../../lib/topic-status-badge";
 
 export default class HighContextTopicCard extends Component {
@@ -101,28 +101,15 @@ export default class HighContextTopicCard extends Component {
     return this.args.topic.creator;
   }
 
+  get hasLastReplyContext() {
+    return this.hasReplies && !topicWasUpdatedAfterLastPost(this.args.topic);
+  }
+
+  get hasContext() {
+    return this.hasLastReplyContext || this.hasAssigned;
+  }
+
   get lastPoster() {
-    // When the topic was bumped > 1 day after the last actual post, the
-    // bump came from an edit or wiki conversion rather than a reply.
-    // Returning null hides the "X replied {time}" line in the template,
-    // matching how TopicActivityColumn handles the same case.
-    const bumpedLastPostedDaysDiff = moment
-      .duration(
-        moment(this.args.topic.bumped_at).diff(
-          moment(this.args.topic.last_posted_at)
-        )
-      )
-      .asDays();
-
-    if (
-      moment(this.args.topic.bumped_at).isAfter(
-        this.args.topic.last_posted_at
-      ) &&
-      bumpedLastPostedDaysDiff > 1
-    ) {
-      return null;
-    }
-
     return {
       user: this.args.topic.lastPosterUser,
       username: this.args.topic.last_poster_username,
@@ -230,9 +217,9 @@ export default class HighContextTopicCard extends Component {
         {{/if}}
       </div>
 
-      {{#if (or this.hasReplies this.hasAssigned)}}
+      {{#if this.hasContext}}
         <div class="hc-topic-card__context">
-          {{#if (and this.hasReplies this.lastPoster)}}
+          {{#if this.hasLastReplyContext}}
             <div class="hc-topic-card__last-reply">
               {{dAvatar this.lastPoster.user imageSize="tiny"}}
               <span

--- a/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
@@ -11,7 +11,7 @@ import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import { shortDateNoYear } from "discourse/lib/formatter";
-import { or } from "discourse/truth-helpers";
+import { and, or } from "discourse/truth-helpers";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import { categoryLinkHTML } from "discourse/ui-kit/helpers/d-category-link";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -102,6 +102,27 @@ export default class HighContextTopicCard extends Component {
   }
 
   get lastPoster() {
+    // When the topic was bumped > 1 day after the last actual post, the
+    // bump came from an edit or wiki conversion rather than a reply.
+    // Returning null hides the "X replied {time}" line in the template,
+    // matching how TopicActivityColumn handles the same case.
+    const bumpedLastPostedDaysDiff = moment
+      .duration(
+        moment(this.args.topic.bumped_at).diff(
+          moment(this.args.topic.last_posted_at)
+        )
+      )
+      .asDays();
+
+    if (
+      moment(this.args.topic.bumped_at).isAfter(
+        this.args.topic.last_posted_at
+      ) &&
+      bumpedLastPostedDaysDiff > 1
+    ) {
+      return null;
+    }
+
     return {
       user: this.args.topic.lastPosterUser,
       username: this.args.topic.last_poster_username,
@@ -211,7 +232,7 @@ export default class HighContextTopicCard extends Component {
 
       {{#if (or this.hasReplies this.hasAssigned)}}
         <div class="hc-topic-card__context">
-          {{#if this.hasReplies}}
+          {{#if (and this.hasReplies this.lastPoster)}}
             <div class="hc-topic-card__last-reply">
               {{dAvatar this.lastPoster.user imageSize="tiny"}}
               <span
@@ -219,7 +240,7 @@ export default class HighContextTopicCard extends Component {
               >{{this.lastPoster.username}}</span>
               <span>{{i18n (themePrefix "replied")}}</span>
               <span class="hc-topic-card__time">
-                {{dFormatDate @topic.bumpedAt leaveAgo="true"}}
+                {{dFormatDate @topic.last_posted_at leaveAgo="true"}}
               </span>
             </div>
           {{/if}}

--- a/themes/horizon/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -1,30 +1,11 @@
 import Component from "@glimmer/component";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dFormatDate from "discourse/ui-kit/helpers/d-format-date";
+import { topicWasUpdatedAfterLastPost } from "../../lib/topic-activity";
 
 export default class TopicActivityColumn extends Component {
   get topicUser() {
-    const bumpedLastPostedDaysDiff = moment
-      .duration(
-        moment(this.args.topic.bumped_at).diff(
-          moment(this.args.topic.last_posted_at)
-        )
-      )
-      .asDays();
-
-    // If the bumped + last posted at are close together,
-    // then we assume someone is editing shortly after posting,
-    // in which case we should just show the last poster/first poster
-    // as normal.
-    //
-    // In other cases, it's likely an edit or a topic bump that happened
-    // a while after the last post, so we show no user.
-    if (
-      moment(this.args.topic.bumped_at).isAfter(
-        this.args.topic.last_posted_at
-      ) &&
-      bumpedLastPostedDaysDiff > 1
-    ) {
+    if (topicWasUpdatedAfterLastPost(this.args.topic)) {
       return {
         username: undefined,
         class: "--updated",

--- a/themes/horizon/javascripts/discourse/lib/topic-activity.js
+++ b/themes/horizon/javascripts/discourse/lib/topic-activity.js
@@ -1,0 +1,14 @@
+const UPDATED_AFTER_LAST_POST_THRESHOLD_DAYS = 1;
+
+export function topicWasUpdatedAfterLastPost(topic) {
+  const bumpedAt = moment(topic.bumped_at);
+  const lastPostedAt = moment(topic.last_posted_at);
+  const bumpedLastPostedDaysDiff = moment
+    .duration(bumpedAt.diff(lastPostedAt))
+    .asDays();
+
+  return (
+    bumpedAt.isAfter(lastPostedAt) &&
+    bumpedLastPostedDaysDiff > UPDATED_AFTER_LAST_POST_THRESHOLD_DAYS
+  );
+}

--- a/themes/horizon/test/acceptance/high-context-topic-card-test.gjs
+++ b/themes/horizon/test/acceptance/high-context-topic-card-test.gjs
@@ -4,44 +4,72 @@ import Topic from "discourse/models/topic";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import HighContextTopicCard from "../../discourse/components/card/high-context-topic-card";
 
+function topicFor(attrs = {}) {
+  return Topic.create({
+    id: 1,
+    title: "How do cards work?",
+    fancy_title: "How do cards work?",
+    created_at: "2024-06-01T08:00:00Z",
+    bumped_at: "2024-06-01T18:00:00Z",
+    last_posted_at: "2024-06-01T12:00:00Z",
+    last_poster_username: "alice",
+    posts_count: 3,
+    like_count: 0,
+    tags: [],
+    posters: [
+      {
+        extras: "latest single",
+        user: {
+          id: 1,
+          username: "alice",
+          name: "Alice",
+          avatar_template: "/letter_avatar_proxy/v4/letter/a/{size}.png",
+        },
+      },
+    ],
+    ...attrs,
+  });
+}
+
 module(
   "Horizon | Integration | Component | Card | HighContextTopicCard",
   function (hooks) {
     setupRenderingTest(hooks);
 
     test("shows the last reply line with the actual reply time when a reply is recent", async function (assert) {
-      const topic = Topic.create({
-        id: 1,
-        bumped_at: "2024-06-01T12:00:00Z",
-        last_posted_at: "2024-06-01T12:00:00Z",
-        last_poster_username: "alice",
-        posts_count: 3,
-        reply_count: 2,
+      const lastPostedAt = "2024-06-01T12:00:00Z";
+      const topic = topicFor({
+        bumped_at: "2024-06-01T18:00:00Z",
+        last_posted_at: lastPostedAt,
       });
+
       await render(
-        <template><HighContextTopicCard @topic={{topic}} /></template>
+        <template>
+          <HighContextTopicCard @topic={{topic}} @hideCategory={{true}} />
+        </template>
       );
+
       assert.dom(".hc-topic-card__last-reply").exists();
       assert.dom(".hc-topic-card__last-reply-name").hasText("alice");
+      assert
+        .dom(".hc-topic-card__time .relative-date")
+        .hasAttribute("data-time", String(new Date(lastPostedAt).getTime()));
     });
 
     test("hides the last reply line when the topic was bumped more than a day after the last post", async function (assert) {
-      // This case represents an OP edit (or wiki conversion) bumping the
-      // topic well after the last actual reply. The card used to show
-      // "{last_poster} replied {bumped_at}" which read as "replied just
-      // now" when the real reply was days earlier.
-      const topic = Topic.create({
-        id: 1,
+      const topic = topicFor({
         bumped_at: "2024-06-10T12:00:00Z",
         last_posted_at: "2024-06-01T12:00:00Z",
-        last_poster_username: "alice",
-        posts_count: 3,
-        reply_count: 2,
       });
+
       await render(
-        <template><HighContextTopicCard @topic={{topic}} /></template>
+        <template>
+          <HighContextTopicCard @topic={{topic}} @hideCategory={{true}} />
+        </template>
       );
+
       assert.dom(".hc-topic-card__last-reply").doesNotExist();
+      assert.dom(".hc-topic-card__context").doesNotExist();
     });
   }
 );

--- a/themes/horizon/test/acceptance/high-context-topic-card-test.gjs
+++ b/themes/horizon/test/acceptance/high-context-topic-card-test.gjs
@@ -1,0 +1,47 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import Topic from "discourse/models/topic";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import HighContextTopicCard from "../../discourse/components/card/high-context-topic-card";
+
+module(
+  "Horizon | Integration | Component | Card | HighContextTopicCard",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("shows the last reply line with the actual reply time when a reply is recent", async function (assert) {
+      const topic = Topic.create({
+        id: 1,
+        bumped_at: "2024-06-01T12:00:00Z",
+        last_posted_at: "2024-06-01T12:00:00Z",
+        last_poster_username: "alice",
+        posts_count: 3,
+        reply_count: 2,
+      });
+      await render(
+        <template><HighContextTopicCard @topic={{topic}} /></template>
+      );
+      assert.dom(".hc-topic-card__last-reply").exists();
+      assert.dom(".hc-topic-card__last-reply-name").hasText("alice");
+    });
+
+    test("hides the last reply line when the topic was bumped more than a day after the last post", async function (assert) {
+      // This case represents an OP edit (or wiki conversion) bumping the
+      // topic well after the last actual reply. The card used to show
+      // "{last_poster} replied {bumped_at}" which read as "replied just
+      // now" when the real reply was days earlier.
+      const topic = Topic.create({
+        id: 1,
+        bumped_at: "2024-06-10T12:00:00Z",
+        last_posted_at: "2024-06-01T12:00:00Z",
+        last_poster_username: "alice",
+        posts_count: 3,
+        reply_count: 2,
+      });
+      await render(
+        <template><HighContextTopicCard @topic={{topic}} /></template>
+      );
+      assert.dom(".hc-topic-card__last-reply").doesNotExist();
+    });
+  }
+);


### PR DESCRIPTION
The high-context topic card template paired `topic.last_poster_username` with `topic.bumpedAt`, displayed as "X replied {time}". When the topic bumped because of an OP edit or wiki conversion rather than a real reply, the timestamp moved but the attributed user did not. The card then claimed the last poster had replied minutes ago when their actual reply was days earlier.

Mirror the logic `TopicActivityColumn` already uses for the same case: when `bumped_at` is more than a day after `last_posted_at`, the bump is treated as an edit and the reply line is hidden. The template now displays the reply time as `last_posted_at`, so the remaining case is always honest about when the reply happened.