### PR TITLE
FIX: enforce published product allowlist for subscriptions

### DIFF
--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -42,6 +42,8 @@ module DiscourseSubscriptions
 
     def show
       params.require(:id)
+      return render_not_found unless published_product?(params[:id])
+
       begin
         product = ::Stripe::Product.retrieve(params[:id], stripe_request_opts)
         plans = ::Stripe::Price.list({ active: true, product: params[:id] }, stripe_request_opts)
@@ -57,13 +59,15 @@ module DiscourseSubscriptions
     def create
       params.require(%i[source plan])
       begin
+        plan = ::Stripe::Price.retrieve(params[:plan], stripe_request_opts)
+        return render_not_found unless published_price?(plan)
+
         customer =
           find_or_create_customer(
             params[:source],
             params[:cardholder_name],
             params[:cardholder_address],
           )
-        plan = ::Stripe::Price.retrieve(params[:plan], stripe_request_opts)
 
         if params[:promo].present?
           promo_code = ::Stripe::PromotionCode.list({ code: params[:promo] }, stripe_request_opts)
@@ -155,10 +159,12 @@ module DiscourseSubscriptions
       raise Discourse::InvalidAccess if pending.blank?
 
       begin
+        plan = ::Stripe::Price.retrieve(pending[:plan_id], stripe_request_opts)
+        return render_not_found unless published_price?(plan)
+
         transaction = retrieve_transaction(pending[:transaction_id])
         raise Discourse::InvalidAccess unless transaction_ok(transaction)
 
-        plan = ::Stripe::Price.retrieve(pending[:plan_id], stripe_request_opts)
         finalize_transaction(transaction, plan)
 
         server_session.delete("pending_subscription")
@@ -274,6 +280,25 @@ module DiscourseSubscriptions
 
     def metadata_user
       { user_id: current_user.id, username: current_user.username_lower }
+    end
+
+    def published_product?(product_id)
+      Product.exists?(external_id: product_id)
+    end
+
+    def published_price?(price)
+      published_product?(price_product_id(price))
+    end
+
+    def price_product_id(price)
+      product = price[:product]
+      return product if product.is_a?(String) || product.nil?
+
+      product[:id]
+    end
+
+    def render_not_found
+      render_json_error(I18n.t("not_found"), status: 404)
     end
 
     def transaction_ok(transaction)

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -42,7 +42,7 @@ module DiscourseSubscriptions
 
     def show
       params.require(:id)
-      return render_not_found unless published_product?(params[:id])
+      ensure_published_product!(params[:id])
 
       begin
         product = ::Stripe::Product.retrieve(params[:id], stripe_request_opts)
@@ -59,8 +59,7 @@ module DiscourseSubscriptions
     def create
       params.require(%i[source plan])
       begin
-        plan = ::Stripe::Price.retrieve(params[:plan], stripe_request_opts)
-        return render_not_found unless published_price?(plan)
+        plan = fetch_published_plan(params[:plan])
 
         customer =
           find_or_create_customer(
@@ -159,9 +158,7 @@ module DiscourseSubscriptions
       raise Discourse::InvalidAccess if pending.blank?
 
       begin
-        plan = ::Stripe::Price.retrieve(pending[:plan_id], stripe_request_opts)
-        return render_not_found unless published_price?(plan)
-
+        plan = fetch_published_plan(pending[:plan_id])
         transaction = retrieve_transaction(pending[:transaction_id])
         raise Discourse::InvalidAccess unless transaction_ok(transaction)
 
@@ -282,12 +279,14 @@ module DiscourseSubscriptions
       { user_id: current_user.id, username: current_user.username_lower }
     end
 
-    def published_product?(product_id)
-      Product.exists?(external_id: product_id)
+    def fetch_published_plan(plan_id)
+      plan = ::Stripe::Price.retrieve(plan_id, stripe_request_opts)
+      ensure_published_product!(price_product_id(plan))
+      plan
     end
 
-    def published_price?(price)
-      published_product?(price_product_id(price))
+    def ensure_published_product!(product_id)
+      raise Discourse::NotFound unless Product.exists?(external_id: product_id)
     end
 
     def price_product_id(price)
@@ -295,10 +294,6 @@ module DiscourseSubscriptions
       return product if product.is_a?(String) || product.nil?
 
       product[:id]
-    end
-
-    def render_not_found
-      render_json_error(I18n.t("not_found"), status: 404)
     end
 
     def transaction_ok(transaction)

--- a/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
@@ -170,6 +170,8 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
     describe "#show" do
       it "retrieves the product" do
+        Fabricate(:product, external_id: "prod_walterwhite")
+
         ::Stripe::Product
           .expects(:retrieve)
           .with("prod_walterwhite", DiscourseSubscriptions::Stripe.request_opts)
@@ -224,6 +226,15 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           },
         )
       end
+
+      it "returns 404 for a product outside the allowlist" do
+        ::Stripe::Product.expects(:retrieve).never
+        ::Stripe::Price.expects(:list).never
+
+        get "/s/prod_hidden.json"
+
+        expect(response.status).to eq(404)
+      end
     end
   end
 
@@ -238,12 +249,14 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
     end
 
     context "when authenticated" do
+      fab!(:published_product) { Fabricate(:product, external_id: "product_12345") }
+
       before { sign_in(user) }
 
       describe "#create" do
         before do
           ::Stripe::Customer
-            .expects(:create)
+            .stubs(:create)
             .with(anything, DiscourseSubscriptions::Stripe.request_opts)
             .returns(id: "cus_1234")
         end
@@ -322,6 +335,28 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           expect {
             post "/s/create.json", params: { plan: "plan_1234", source: "tok_1234" }
           }.to change { DiscourseSubscriptions::Customer.count }
+        end
+
+        it "rejects a plan outside the allowlist" do
+          ::Stripe::Price
+            .expects(:retrieve)
+            .with("price_hidden", DiscourseSubscriptions::Stripe.request_opts)
+            .returns(
+              type: "recurring",
+              product: "prod_hidden",
+              metadata: {
+                group_name: "awesome",
+                trial_period_days: 0,
+              },
+            )
+          ::Stripe::Customer.expects(:create).never
+          ::Stripe::Subscription.expects(:create).never
+
+          expect {
+            post "/s/create.json", params: { plan: "price_hidden", source: "tok_1234" }
+          }.not_to change { DiscourseSubscriptions::Customer.count }
+
+          expect(response.status).to eq(404)
         end
 
         it "returns 422 on a one time payment subscription error" do
@@ -468,7 +503,7 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           ::Stripe::Price
             .expects(:retrieve)
             .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-            .returns(type: "recurring", metadata: {})
+            .returns(type: "recurring", product: "product_12345", metadata: {})
             .twice
           ::Stripe::Subscription
             .expects(:create)
@@ -494,7 +529,7 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             ::Stripe::Price
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-              .returns(type: "recurring", metadata: {})
+              .returns(type: "recurring", product: "product_12345", metadata: {})
             ::Stripe::Subscription
               .expects(:create)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
@@ -666,7 +701,7 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             ::Stripe::Price
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-              .returns(id: "plan_1234", product: "prod_1234", metadata: {})
+              .returns(id: "plan_1234", product: "product_12345", metadata: {})
             ::Stripe::Subscription
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
@@ -685,7 +720,7 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             ::Stripe::Price
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-              .returns(id: "plan_1234", product: "prod_1234", metadata: {})
+              .returns(id: "plan_1234", product: "product_12345", metadata: {})
             ::Stripe::Invoice
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
@@ -708,7 +743,7 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
           ::Stripe::Price
             .expects(:retrieve)
             .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-            .returns(id: "plan_1234", product: "prod_1234", metadata: {})
+            .returns(id: "plan_1234", product: "product_12345", metadata: {})
           ::Stripe::Subscription
             .expects(:retrieve)
             .with(anything, DiscourseSubscriptions::Stripe.request_opts)
@@ -719,6 +754,24 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
           post "/s/finalize.json"
           expect(response.status).to eq(403)
+        end
+
+        it "rejects a pending plan outside the allowlist" do
+          server_session["pending_subscription"] = {
+            transaction_id: "sub_123",
+            plan_id: "price_hidden",
+          }
+          ::Stripe::Price
+            .expects(:retrieve)
+            .with("price_hidden", DiscourseSubscriptions::Stripe.request_opts)
+            .returns(id: "price_hidden", product: "prod_hidden", metadata: {})
+          ::Stripe::Subscription.expects(:retrieve).never
+
+          expect { post "/s/finalize.json" }.not_to change {
+            DiscourseSubscriptions::Customer.count
+          }
+
+          expect(response.status).to eq(404)
         end
       end
 
@@ -742,7 +795,13 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             ::Stripe::Price
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-              .returns(type: "recurring", metadata: { group_name: "admins" })
+              .returns(
+                type: "recurring",
+                product: "product_12345",
+                metadata: {
+                  group_name: "admins",
+                },
+              )
             post "/s/create.json", params: { plan: "plan_1234", source: "tok_1234" }
             expect(user.admin).to eq false
           end
@@ -751,7 +810,13 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             ::Stripe::Price
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-              .returns(type: "recurring", metadata: { group_name: "other" })
+              .returns(
+                type: "recurring",
+                product: "product_12345",
+                metadata: {
+                  group_name: "other",
+                },
+              )
             post "/s/create.json", params: { plan: "plan_1234", source: "tok_1234" }
             expect(user.groups).to be_empty
           end
@@ -766,7 +831,13 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
             ::Stripe::Price
               .expects(:retrieve)
               .with(anything, DiscourseSubscriptions::Stripe.request_opts)
-              .returns(type: "recurring", metadata: { group_name: group_name })
+              .returns(
+                type: "recurring",
+                product: "product_12345",
+                metadata: {
+                  group_name: group_name,
+                },
+              )
           end
 
           it "does not add the user to the group when subscription fails" do


### PR DESCRIPTION
Previously, subscription detail and checkout paths could accept Stripe products or prices that were not published in Discourse.

This change checks the local product list before showing products, creating purchases, or finalizing pending purchases, keeping checkout behavior consistent with the public catalog.