### PR TITLE
FEATURE: Add PM whisper feedback for email sending failures

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -67,7 +67,7 @@ class ProblemCheck
   #
   CORE_PROBLEM_CHECKS = [
     ProblemCheck::BadFaviconUrl,
-    ProblemCheck::EmailDeliveryFailures,
+    ProblemCheck::EmailSendingFailures,
     ProblemCheck::EmailPollingErroredRecently,
     ProblemCheck::FacebookConfig,
     ProblemCheck::FailingEmails,

--- a/app/services/problem_check/email_sending_failures.rb
+++ b/app/services/problem_check/email_sending_failures.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProblemCheck::EmailDeliveryFailures < ProblemCheck
+class ProblemCheck::EmailSendingFailures < ProblemCheck
   self.priority = "low"
   self.perform_every = 1.hour
 
@@ -10,14 +10,14 @@ class ProblemCheck::EmailDeliveryFailures < ProblemCheck
     # De-duplicate with ProblemCheck::FailingEmails so we only show one
     # admin alert for the same SMTP incident when retry jobs are already failing.
     return no_problem if failing_email_job_count > 0
-    return no_problem if failed_delivery_count == 0
+    return no_problem if failed_send_count == 0
 
     problem
   end
 
   private
 
-  def failed_delivery_count
+  def failed_send_count
     @failed_delivery_count ||=
       SkippedEmailLog
         .where(reason_type: SkippedEmailLog.reason_types[:custom])
@@ -30,6 +30,6 @@ class ProblemCheck::EmailDeliveryFailures < ProblemCheck
   end
 
   def translation_data
-    { count: failed_delivery_count }
+    { count: failed_send_count }
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1800,9 +1800,9 @@ en:
       failing_emails: 'There are %{num_failed_jobs} email jobs that failed. Check your app.yml and ensure that the mail server settings are correct. <a href="%{base_path}/sidekiq/retries" target="_blank">See the failed jobs in Sidekiq</a>.'
       subfolder_ends_in_slash: "Your subfolder setup is incorrect; the DISCOURSE_RELATIVE_URL_ROOT ends in a slash."
       translation_overrides: "Some of your translation overrides are out of date. Please check your <a href='%{base_path}/admin/customize/site_texts?outdated=true'>text customizations</a>."
-      email_delivery_failures:
-        one: "Email delivery has failed once in the past 24 hours. Check the <a href='%{base_path}/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details."
-        other: "Email delivery has failed %{count} times in the past 24 hours. Check the <a href='%{base_path}/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details."
+      email_sending_failures:
+        one: "Email sending has failed once in the past 24 hours. Check the <a href='%{base_path}/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details."
+        other: "Email sending has failed %{count} times in the past 24 hours. Check the <a href='%{base_path}/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details."
       email_polling_errored_recently:
         one: "Email polling has generated an error in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
         other: "Email polling has generated %{count} errors in the past 24 hours. Look at <a href='%{base_path}/logs' target='_blank'>the logs</a> for more details."
@@ -4140,6 +4140,15 @@ en:
 
     email_bounced: |
       The message to %{email} bounced.
+
+      ### Details
+
+      ``` text
+      %{raw}
+      ```
+
+    email_sending_failed: |
+      Sending the message to %{email} failed.
 
       ### Details
 

--- a/lib/email/sender.rb
+++ b/lib/email/sender.rb
@@ -301,7 +301,9 @@ module Email
           email_log.smtp_transaction_response = message_response.message&.chomp
         end
       rescue *SMTP_CLIENT_ERRORS => e
-        return skip(SkippedEmailLog.reason_types[:custom], custom_reason: smtp_error_message(e))
+        error_message = smtp_error_message(e)
+        create_failed_email_whisper(topic, error_message)
+        return skip(SkippedEmailLog.reason_types[:custom], custom_reason: error_message)
       rescue Net::SMTPError => e
         response = e.try(:response)
         response = " response: #{response.try(:string) || response}" if response
@@ -511,6 +513,23 @@ module Email
 
       response_string = response.respond_to?(:string) ? response.string : response.to_s
       response_string.presence || error.message
+    end
+
+    def create_failed_email_whisper(topic, error_message)
+      return if topic.blank? || !topic.private_message?
+      return if SiteSetting.whispers_allowed_groups.blank?
+
+      PostCreator.create!(
+        Discourse.system_user,
+        topic_id: topic.id,
+        post_type: Post.types[:whisper],
+        skip_validations: true,
+        raw: I18n.t("system_messages.email_sending_failed", email: to_address, raw: error_message),
+      )
+    rescue StandardError => error
+      Rails.logger.warn(
+        "Failed to create email sending failure whisper for topic #{topic.id}: #{error.message}",
+      )
     end
 
     def merge_json_x_header(name, value)

--- a/spec/lib/email/sender_spec.rb
+++ b/spec/lib/email/sender_spec.rb
@@ -1112,5 +1112,44 @@ RSpec.describe Email::Sender do
         "552-5.7.0 This message was blocked because its content presents a potential\n552 5.7.0 issue",
       )
     end
+
+    context "when the email is related to a PM topic" do
+      fab!(:pm_creator, :user)
+      fab!(:pm_target, :user)
+      fab!(:pm_topic) { Fabricate(:private_message_topic, user: pm_creator, recipient: pm_target) }
+      fab!(:pm_post) { Fabricate(:post, topic: pm_topic, user: pm_creator) }
+
+      before do
+        SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+        message.header["X-Discourse-Post-Id"] = pm_post.id
+        message.header["X-Discourse-Topic-Id"] = pm_topic.id
+      end
+
+      it "creates a staff whisper with the SMTP failure details" do
+        error = Net::SMTPFatalError.new("552-5.7.0 This message was blocked")
+        smtp_response =
+          Net::SMTP::Response.new(
+            "552",
+            "552-5.7.0 This message was blocked because its content presents a potential\n552 5.7.0 issue",
+          )
+        error.define_singleton_method(:response) { smtp_response }
+        message.expects(:deliver!).raises(error)
+
+        expect { email_sender.send }.to change {
+          Post.where(topic_id: pm_topic.id, post_type: Post.types[:whisper]).count
+        }.by(1)
+
+        whisper = Post.where(topic_id: pm_topic.id, post_type: Post.types[:whisper]).last
+        expect(whisper.user).to eq(Discourse.system_user)
+        expect(whisper.raw).to eq(
+          I18n.t(
+            "system_messages.email_sending_failed",
+            email: "eviltrout@test.domain",
+            raw:
+              "552-5.7.0 This message was blocked because its content presents a potential\n552 5.7.0 issue",
+          ).strip,
+        )
+      end
+    end
   end
 end

--- a/spec/services/problem_check/email_sending_failures_spec.rb
+++ b/spec/services/problem_check/email_sending_failures_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe ProblemCheck::EmailDeliveryFailures do
+RSpec.describe ProblemCheck::EmailSendingFailures do
   subject(:check) { described_class.new }
 
   describe ".call" do
@@ -34,7 +34,7 @@ RSpec.describe ProblemCheck::EmailDeliveryFailures do
       it do
         expect(check).to(
           have_a_problem.with_priority("low").with_message(
-            "Email delivery has failed once in the past 24 hours. Check the <a href='/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details.",
+            "Email sending has failed once in the past 24 hours. Check the <a href='/admin/email-logs/skipped' target='_blank'>skipped email logs</a> for SMTP error details.",
           ),
         )
       end


### PR DESCRIPTION
Follow-up to bc4d4ec0272b87368448bafe288873ba2572a882.

Add immediate staff-facing PM whisper feedback when outbound SMTP sending fails with client errors, reusing the captured SMTP response details. This aligns send failure diagnostics with existing bounce visibility in message threads.

Rename the problem check from `EmailDeliveryFailures` to `EmailSendingFailures` and update related locale keys/messages to use "sending failure" terminology for consistency.