### PR TITLE
FIX: Filtered RSS feeds advertise the wrong self URL

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -242,8 +242,8 @@ class ListController < ApplicationController
     discourse_expires_in 1.minute
 
     @title = "#{SiteSetting.title} - #{I18n.t("rss_description.latest")}"
-    @link = "#{Discourse.base_url}/latest"
-    @atom_link = "#{Discourse.base_url}/latest.rss"
+    @link = filtered_topic_list_url("#{Discourse.base_url}/latest")
+    @atom_link = filtered_topic_list_url("#{Discourse.base_url}/latest.rss")
     @description = I18n.t("rss_description.latest")
     @topic_list = topic_query(nil, order: "created").list_latest
 
@@ -254,11 +254,11 @@ class ListController < ApplicationController
     discourse_expires_in 1.minute
 
     @title = "#{SiteSetting.title} - #{I18n.t("rss_description.top")}"
-    @link = "#{Discourse.base_url}/top"
-    @atom_link = "#{Discourse.base_url}/top.rss"
     @description = I18n.t("rss_description.top")
     period = params[:period] || SiteSetting.top_page_default_timeframe.to_sym
     TopTopic.validate_period(period)
+    @link = filtered_topic_list_url("#{Discourse.base_url}/top", period: period)
+    @atom_link = filtered_topic_list_url("#{Discourse.base_url}/top.rss", period: period)
 
     @topic_list = topic_query(nil).list_top_for(period)
 
@@ -269,8 +269,8 @@ class ListController < ApplicationController
     discourse_expires_in 1.minute
 
     @title = "#{SiteSetting.title} - #{I18n.t("rss_description.hot")}"
-    @link = "#{Discourse.base_url}/hot"
-    @atom_link = "#{Discourse.base_url}/hot.rss"
+    @link = filtered_topic_list_url("#{Discourse.base_url}/hot")
+    @atom_link = filtered_topic_list_url("#{Discourse.base_url}/hot.rss")
     @description = I18n.t("rss_description.hot")
 
     @topic_list = topic_query(nil).list_hot
@@ -283,8 +283,8 @@ class ListController < ApplicationController
     discourse_expires_in 1.minute
 
     @title = "#{@category.name} - #{SiteSetting.title}"
-    @link = "#{Discourse.base_url_no_prefix}#{@category.url}"
-    @atom_link = "#{Discourse.base_url_no_prefix}#{@category.url}.rss"
+    @link = filtered_topic_list_url("#{Discourse.base_url_no_prefix}#{@category.url}")
+    @atom_link = filtered_topic_list_url("#{Discourse.base_url_no_prefix}#{@category.url}.rss")
     @description =
       "#{I18n.t("topics_in_category", category: @category.name)} #{@category.description}"
     @topic_list = topic_query.list_new_in_category(@category)
@@ -299,8 +299,8 @@ class ListController < ApplicationController
 
     @title =
       "#{SiteSetting.title} - #{I18n.t("rss_description.user_topics", username: target_user.username)}"
-    @link = "#{target_user.full_url}/activity/topics"
-    @atom_link = "#{target_user.full_url}/activity/topics.rss"
+    @link = filtered_topic_list_url("#{target_user.full_url}/activity/topics")
+    @atom_link = filtered_topic_list_url("#{target_user.full_url}/activity/topics.rss")
     @description = I18n.t("rss_description.user_topics", username: target_user.username)
 
     @topic_list = topic_query(nil, order: "created").public_send("list_topics_by", target_user)
@@ -356,8 +356,8 @@ class ListController < ApplicationController
 
       @description = I18n.t("rss_description.top_#{period}")
       @title = "#{SiteSetting.title} - #{@description}"
-      @link = "#{Discourse.base_url}/top?period=#{period}"
-      @atom_link = "#{Discourse.base_url}/top.rss?period=#{period}"
+      @link = filtered_topic_list_url("#{Discourse.base_url}/top", period: period)
+      @atom_link = filtered_topic_list_url("#{Discourse.base_url}/top.rss", period: period)
       @topic_list = topic_query(nil).list_top_for(period)
 
       render "list", formats: [:rss]
@@ -383,6 +383,16 @@ class ListController < ApplicationController
 
   def topic_query(user = current_user, opts = {})
     TopicQuery.new(user, build_topic_list_options.merge(opts))
+  end
+
+  def filtered_topic_list_url(base_url, extra_params = {})
+    query_params =
+      build_topic_list_options
+        .merge(extra_params)
+        .except(:api_key, :api_username, :user_api_key)
+        .compact
+
+    query_params.present? ? "#{base_url}?#{query_params.to_query}" : base_url
   end
 
   def page_params

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -283,8 +283,10 @@ class ListController < ApplicationController
     discourse_expires_in 1.minute
 
     @title = "#{@category.name} - #{SiteSetting.title}"
-    @link = filtered_topic_list_url("#{Discourse.base_url_no_prefix}#{@category.url}")
-    @atom_link = filtered_topic_list_url("#{Discourse.base_url_no_prefix}#{@category.url}.rss")
+    @link =
+      filtered_topic_list_url("#{Discourse.base_url_no_prefix}#{@category.url}", category: nil)
+    @atom_link =
+      filtered_topic_list_url("#{Discourse.base_url_no_prefix}#{@category.url}.rss", category: nil)
     @description =
       "#{I18n.t("topics_in_category", category: @category.name)} #{@category.description}"
     @topic_list = topic_query.list_new_in_category(@category)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -718,6 +718,73 @@ RSpec.describe ListController do
       expect(response.body).to_not include("<item>")
     end
 
+    it "advertises sanitized filtered feed URLs in RSS metadata" do
+      TopTopic.create!(topic: topic, yearly_score: 1.0)
+      api_key = ApiKey.create!(user_id: user.id, created_by_id: Discourse.system_user)
+
+      get "/latest.rss",
+          params: {
+            exclude_tag: "excludeme",
+            api_key: api_key.key,
+            api_username: user.username_lower,
+          }
+
+      expect(response.status).to eq(200)
+      expect(response.media_type).to eq("application/rss+xml")
+
+      latest_doc = Nokogiri::XML::Document.parse(response.body)
+      latest_atom_link =
+        URI.parse(
+          latest_doc.at_xpath(
+            "/rss/channel/atom:link",
+            { "atom" => "http://www.w3.org/2005/Atom" },
+          )[
+            "href"
+          ],
+        )
+      latest_link = URI.parse(latest_doc.at_xpath("/rss/channel/link").text)
+
+      expect(latest_atom_link.path).to eq("/latest.rss")
+      expect(Rack::Utils.parse_nested_query(latest_atom_link.query.to_s)).to eq(
+        "exclude_tag" => "excludeme",
+      )
+      expect(latest_link.path).to eq("/latest")
+      expect(Rack::Utils.parse_nested_query(latest_link.query.to_s)).to eq(
+        "exclude_tag" => "excludeme",
+      )
+
+      get "/top.rss",
+          params: {
+            period: "yearly",
+            exclude_tag: "excludeme",
+            api_key: api_key.key,
+            api_username: user.username_lower,
+          }
+
+      expect(response.status).to eq(200)
+      expect(response.media_type).to eq("application/rss+xml")
+
+      top_doc = Nokogiri::XML::Document.parse(response.body)
+      top_atom_link =
+        URI.parse(
+          top_doc.at_xpath("/rss/channel/atom:link", { "atom" => "http://www.w3.org/2005/Atom" })[
+            "href"
+          ],
+        )
+      top_link = URI.parse(top_doc.at_xpath("/rss/channel/link").text)
+
+      expect(top_atom_link.path).to eq("/top.rss")
+      expect(Rack::Utils.parse_nested_query(top_atom_link.query.to_s)).to eq(
+        "exclude_tag" => "excludeme",
+        "period" => "yearly",
+      )
+      expect(top_link.path).to eq("/top")
+      expect(Rack::Utils.parse_nested_query(top_link.query.to_s)).to eq(
+        "exclude_tag" => "excludeme",
+        "period" => "yearly",
+      )
+    end
+
     it "renders links correctly with subfolder" do
       set_subfolder "/forum"
       _post = Fabricate(:post, topic: topic, user: user)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1036,6 +1036,29 @@ RSpec.describe ListController do
           expect(response.body).to include(untagged_topic.title)
           expect(response.body).not_to include(tagged_topic.title)
         end
+
+        it "does not advertise the route-derived category param in the self URL" do
+          get "/c/#{category.slug}/#{category.id}.rss?exclude_tag=excludeme"
+          expect(response.status).to eq(200)
+
+          doc = Nokogiri::XML::Document.parse(response.body)
+          atom_link =
+            URI.parse(
+              doc.at_xpath("/rss/channel/atom:link", { "atom" => "http://www.w3.org/2005/Atom" })[
+                "href"
+              ],
+            )
+          link = URI.parse(doc.at_xpath("/rss/channel/link").text)
+
+          expect(atom_link.path).to eq("/c/#{category.slug}/#{category.id}.rss")
+          expect(Rack::Utils.parse_nested_query(atom_link.query.to_s)).to eq(
+            "exclude_tag" => "excludeme",
+          )
+          expect(link.path).to eq("/c/#{category.slug}/#{category.id}")
+          expect(Rack::Utils.parse_nested_query(link.query.to_s)).to eq(
+            "exclude_tag" => "excludeme",
+          )
+        end
       end
 
       describe "category default views" do


### PR DESCRIPTION
## Summary

his PR fixes a bug where Discourse's RSS feeds for latest/top/hot/category/user-topics/top-by-period advertised a bare <link> and <atom:link> (e.g. `/latest.rss`) even when the request included filters like `exclude_tag=...` or `period=.... `Subscribers were effectively pointed at a
  different feed than the one they requested.
## Source

- Patch Triage:patch/891
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>


---

Low-risk  and no API change.