### PR TITLE
DEV: bump devcontainer image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Discourse",
-  "image": "docker.io/discourse/discourse_dev:20260209-1300",
+  "image": "docker.io/discourse/discourse_dev:20260521-0047",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/discourse,type=bind",
   "workspaceFolder": "/workspace/discourse",
   "postStartCommand": "./.devcontainer/scripts/start.rb",


### PR DESCRIPTION
Includes new NGINX version, see
https://github.com/discourse/discourse_docker/pull/1054.