### PR TITLE
DEV: Persist browser pageview events by default

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -610,7 +610,7 @@ basic:
     hidden: true
     client: true
   persist_browser_pageview_events:
-    default: false
+    default: true
     hidden: true
   clean_up_browser_pageview_events:
     default: false

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Middleware::RequestTracker do
     ApplicationRequest.enable
     CachedCounting.reset
     CachedCounting.enable
+    SiteSetting.persist_browser_pageview_events = false
   end
 
   after do

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -169,6 +169,8 @@ RSpec.describe Admin::DashboardController do
       end
 
       context "with traffic_data" do
+        before { SiteSetting.persist_browser_pageview_events = false }
+
         let(:traffic_data) { section_payloads["traffic"]&.dig("data") }
 
         it "returns the site traffic payload for the selected dates" do

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe AdminDashboardSiteTraffic do
   before do
     freeze_time(Time.zone.local(2026, 5, 14, 12, 0, 0))
     SiteSetting.use_legacy_pageviews = false
+    SiteSetting.persist_browser_pageview_events = false
   end
 
   def traffic_point(date, count)

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -7,6 +7,7 @@ describe "Request tracking" do
     CachedCounting.reset
     CachedCounting.enable
     SiteSetting.trigger_browser_pageview_events = true
+    SiteSetting.persist_browser_pageview_events = false
   end
 
   after do


### PR DESCRIPTION
Flips the hidden `persist_browser_pageview_events` site setting on by default so the request tracker writes browser pageview events to the database out of the box. These events power the site traffic section of the redesigned admin dashboard.