### PR TITLE
UX: Show avatar when only 1 other user in chat group DM

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/channel-icon/index.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/channel-icon/index.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { trustHTML } from "@ember/template";
-import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
 import ChatUserAvatar from "discourse/plugins/chat/discourse/components/chat-user-avatar";
@@ -17,6 +16,14 @@ export default class ChatChannelIcon extends Component {
     );
   }
 
+  get groupIsDuoOnly() {
+    return (
+      this.args.channel.chatable.group &&
+      // User array does not include the current user
+      this.args.channel.chatable.users.length === 1
+    );
+  }
+
   get channelColorStyle() {
     return trustHTML(`color: #${this.args.channel.chatable.color}`);
   }
@@ -30,22 +37,26 @@ export default class ChatChannelIcon extends Component {
     return emoji ? dReplaceEmoji(`:${emoji}:`) : dIcon("d-chat");
   }
 
-  get directChannelIcon() {
-    const { emoji, membershipsCount } = this.args.channel;
-    return emoji ? dReplaceEmoji(`:${emoji}:`) : membershipsCount;
+  get channelEmojiCode() {
+    return `:${this.args.channel.emoji}:`;
   }
 
   <template>
     {{#if @channel.isDirectMessageChannel}}
       {{#if this.groupDirectMessage}}
-        <div
-          class={{dConcatClass
-            "chat-channel-icon"
-            (unless @channel.emoji "--users-count" "--emoji")
-          }}
-        >
-          {{this.directChannelIcon}}
-        </div>
+        {{#if @channel.emoji}}
+          <div class="chat-channel-icon --emoji">
+            {{dReplaceEmoji this.channelEmojiCode}}
+          </div>
+        {{else if this.groupIsDuoOnly}}
+          <div class="chat-channel-icon --avatar">
+            <ChatUserAvatar @user={{this.firstUser}} @interactive={{false}} />
+          </div>
+        {{else}}
+          <div class="chat-channel-icon --users-count">
+            {{@channel.membershipsCount}}
+          </div>
+        {{/if}}
       {{else}}
         <div class="chat-channel-icon --avatar">
           <ChatUserAvatar @user={{this.firstUser}} @interactive={{false}} />

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-sidebar.js
@@ -136,7 +136,11 @@ function createChannelLink(BaseCustomSidebarSectionLink, options = {}) {
         if (this.channel.emoji) {
           return "emoji";
         } else if (this.channel.chatable.group) {
-          return "text";
+          if (this.channel.chatable.users.length === 1) {
+            return "image";
+          } else {
+            return "text";
+          }
         } else {
           return "image";
         }
@@ -150,7 +154,14 @@ function createChannelLink(BaseCustomSidebarSectionLink, options = {}) {
         if (this.channel.emoji) {
           return this.channel.emoji;
         } else if (this.channel.chatable.group) {
-          return this.channel.membershipsCount;
+          if (this.channel.chatable.users.length === 1) {
+            return avatarUrl(
+              this.channel.chatable.users[0].avatar_template,
+              "tiny"
+            );
+          } else {
+            return this.channel.membershipsCount;
+          }
         } else {
           return avatarUrl(
             this.channel.chatable.users[0].avatar_template,
@@ -824,7 +835,11 @@ export default {
                 if (this.channel.emoji) {
                   return "emoji";
                 } else if (this.channel.chatable.group) {
-                  return "text";
+                  if (this.channel.chatable.users.length === 1) {
+                    return "image";
+                  } else {
+                    return "text";
+                  }
                 } else {
                   return "image";
                 }
@@ -834,7 +849,14 @@ export default {
                 if (this.channel.emoji) {
                   return this.channel.emoji;
                 } else if (this.channel.chatable.group) {
-                  return this.channel.membershipsCount;
+                  if (this.channel.chatable.users.length === 1) {
+                    return avatarUrl(
+                      this.channel.chatable.users[0].avatar_template,
+                      "tiny"
+                    );
+                  } else {
+                    return this.channel.membershipsCount;
+                  }
                 } else {
                   return avatarUrl(
                     this.channel.chatable.users[0].avatar_template,

--- a/plugins/chat/assets/javascripts/discourse/lib/fabricators.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/fabricators.js
@@ -84,6 +84,7 @@ export default class ChatFabricators {
       meta: { can_delete_self: true, ...(args.meta || {}) },
       archive_failed: args.archive_failed ?? false,
       memberships_count: args.memberships_count ?? 0,
+      emoji: args.emoji ?? null,
     });
 
     channel.lastMessage = this.message({ channel });

--- a/plugins/chat/test/javascripts/components/channel-icon-test.gjs
+++ b/plugins/chat/test/javascripts/components/channel-icon-test.gjs
@@ -68,18 +68,72 @@ module("Component | <ChannelIcon />", function (hooks) {
     assert.dom(`.chat-user-avatar .avatar[title="${user.username}"]`).exists();
   });
 
-  test("dm channel - multiple users", async function (assert) {
+  test("group DM channel - 2 users", async function (assert) {
+    const channel = new ChatFabricators(getOwner(this)).directMessageChannel({
+      chatable: new ChatFabricators(getOwner(this)).directMessage({
+        users: [
+          new CoreFabricators(getOwner(this)).user(),
+          new CoreFabricators(getOwner(this)).user(),
+        ],
+      }),
+      group: true,
+    });
+
+    const user = channel.chatable.users[0];
+
+    await render(<template><ChannelIcon @channel={{channel}} /></template>);
+
+    assert.dom(".chat-channel-icon.--avatar").exists();
+    assert
+      .dom(
+        `.chat-channel-icon.--avatar .chat-user-avatar__container .avatar[title="${user.username}"]`
+      )
+      .exists();
+  });
+
+  test("group DM channel - 2 users with emoji", async function (assert) {
+    const channel = new ChatFabricators(getOwner(this)).directMessageChannel({
+      users: [
+        new CoreFabricators(getOwner(this)).user(),
+        new CoreFabricators(getOwner(this)).user(),
+      ],
+      group: true,
+      emoji: "tada",
+    });
+
+    await render(<template><ChannelIcon @channel={{channel}} /></template>);
+
+    assert.dom(".chat-channel-icon.--emoji .emoji[title='tada']").exists();
+  });
+
+  test("group DM channel - 3 users", async function (assert) {
     const channel = new ChatFabricators(getOwner(this)).directMessageChannel({
       users: [
         new CoreFabricators(getOwner(this)).user(),
         new CoreFabricators(getOwner(this)).user(),
         new CoreFabricators(getOwner(this)).user(),
       ],
+      group: true,
     });
-    channel.chatable.group = true;
 
     await render(<template><ChannelIcon @channel={{channel}} /></template>);
 
-    assert.dom(".chat-channel-icon.--users-count").hasText("3");
+    assert.dom(".chat-channel-icon.--users-count").exists().hasText("3");
+  });
+
+  test("group DM channel - with emoji", async function (assert) {
+    const channel = new ChatFabricators(getOwner(this)).directMessageChannel({
+      users: [
+        new CoreFabricators(getOwner(this)).user(),
+        new CoreFabricators(getOwner(this)).user(),
+        new CoreFabricators(getOwner(this)).user(),
+      ],
+      group: true,
+      emoji: "tada",
+    });
+
+    await render(<template><ChannelIcon @channel={{channel}} /></template>);
+
+    assert.dom(".chat-channel-icon.--emoji .emoji[title='tada']").exists();
   });
 });


### PR DESCRIPTION
For chat group DMs, currently we always show the number of
other users in the group DM, even if there is only 1 other user.
This looks a little weird, and for our own use case of an AI
helper bot on new sites, it's a little unfreindly to see a
(1) instead of the avatar of the bot.

This commit modifies the ChannelIcon logic to show the avatar
of the other user in a group DM if there is only 1 other user.
If there is > 1 other user, we still show the count/emoji as
appropriate.

**Before**

<img width="241" height="44" alt="image" src="https://github.com/user-attachments/assets/727f1c85-901f-4d43-9a00-f7e16b7b4737" />

**After**

<img width="252" height="43" alt="image" src="https://github.com/user-attachments/assets/999e5dbd-d2ee-4345-8ca1-c3cd50f5e606" />
