### PR TITLE
FIX: Exclude internal referrers from top referrers percent denominator

### DIFF
--- a/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
@@ -36,6 +36,14 @@ module Reports::TopReferrersByBrowserPageviews
           WHERE created_at >= :start_date
             AND created_at < :end_date_exclusive
             #{user_filter_sql}
+            AND (
+              normalized_referrer IS NULL
+              OR (
+                normalized_referrer <> :host_exact
+                AND normalized_referrer NOT LIKE :host_path_prefix ESCAPE '\\'
+                AND normalized_referrer NOT LIKE :host_query_prefix ESCAPE '\\'
+              )
+            )
           GROUP BY normalized_referrer
         )
         SELECT normalized_referrer, count,
@@ -43,9 +51,6 @@ module Reports::TopReferrersByBrowserPageviews
                     ELSE ROUND((count::numeric / total) * 100)::integer END AS percent
         FROM ranked
         WHERE normalized_referrer IS NOT NULL
-          AND normalized_referrer <> :host_exact
-          AND normalized_referrer NOT LIKE :host_path_prefix ESCAPE '\\'
-          AND normalized_referrer NOT LIKE :host_query_prefix ESCAPE '\\'
         ORDER BY count DESC, normalized_referrer ASC
         LIMIT :limit
       SQL

--- a/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
@@ -39,7 +39,7 @@ describe Reports::TopReferrersByBrowserPageviews do
       expect(report.data.first[:percent]).to eq(50)
     end
 
-    it "excludes same-host bare, path-prefixed, and query-prefixed referrers" do
+    it "excludes same-host bare, path-prefixed, and query-prefixed referrers from numerator and denominator" do
       Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com")
       Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com/t/topic/1")
       Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com?ref=email")
@@ -52,6 +52,22 @@ describe Reports::TopReferrersByBrowserPageviews do
           end_date: end_date,
         )
       expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
+      expect(report.data.first[:percent]).to eq(100)
+    end
+
+    it "includes direct (no-referrer) pageviews in the denominator alongside external referrers" do
+      2.times { Fabricate(:browser_pageview_event, normalized_referrer: "google.com") }
+      2.times { Fabricate(:browser_pageview_event, normalized_referrer: nil) }
+      Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com/t/topic/1")
+
+      report =
+        Report.find(
+          "top_referrers_by_browser_pageviews",
+          start_date: start_date,
+          end_date: end_date,
+        )
+      expect(report.data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
+      expect(report.data.first[:percent]).to eq(50)
     end
 
     it "does not exclude hosts that merely share a prefix with current_hostname" do

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -167,19 +167,32 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
         normalized_referrer: nil,
         created_at: "2026-05-12",
       )
+      # Internal-referrer pageviews must not dilute the top referrers percent
+      # denominator (it covers direct + external referrer traffic only).
+      6.times do
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "DE",
+          normalized_referrer: "test.localhost/t/topic/1",
+          created_at: "2026-05-12",
+        )
+      end
 
       dashboard.visit
       traffic = dashboard.site_traffic
 
       expect(traffic).to have_top_country_rows(
         [
-          { country: "US", percent: 50 },
-          { country: "DE", percent: 25 },
-          { country: "GB", percent: 25 },
+          { country: "DE", percent: 70 },
+          { country: "US", percent: 20 },
+          { country: "GB", percent: 10 },
         ],
       )
       expect(traffic).to have_top_referrer_rows(
-        [{ referrer: "news.ycombinator.com/item?id=42" }, { referrer: "reddit.com/r/discourse" }],
+        [
+          { referrer: "news.ycombinator.com/item?id=42", percent: 50 },
+          { referrer: "reddit.com/r/discourse", percent: 25 },
+        ],
       )
     end
 

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -84,7 +84,10 @@ module PageObjects
 
           rows.each_with_index.all? do |row, index|
             nth = ".db-traffic__list-row:nth-child(#{index + 1})"
-            has_css?("#{nth} a.db-traffic__link", text: row[:referrer])
+            next false unless has_css?("#{nth} a.db-traffic__link", text: row[:referrer])
+            next true unless row.key?(:percent)
+
+            has_css?("#{nth} .db-traffic__percent", text: "#{row[:percent]}%")
           end
         end
       end


### PR DESCRIPTION
On the redesigned admin dashboard's "Top referrers" card, the percent next to each referrer was computed against the total of all browser pageviews, including internal navigation. This diluted each external referrer's share, so admins could not tell how much of their off-site traffic each source actually drove.

This commit narrows the percent denominator to direct visits and external-referrer pageviews only, leaving the displayed rows and existing host-matching rules unchanged.
