### PR TITLE
DEV: Ungate Reports section endpoints from dashboard_improvements

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,8 +3,6 @@
 class Admin::DashboardController < Admin::StaffController
   BULK_REPORTS_FILTER_KEYS = %i[start_date end_date].freeze
 
-  before_action :ensure_dashboard_improvements_enabled,
-                only: %i[bulk_reports available_reports update_reports_section]
   before_action :ensure_admin,
                 only: %i[available_reports update_reports_section update_configuration]
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -806,8 +806,6 @@ RSpec.describe Admin::DashboardController do
   end
 
   describe "#bulk_reports" do
-    before { SiteSetting.dashboard_improvements = true }
-
     let(:fake_provider) do
       Class.new(AdminDashboard::Reports::SourceProvider) do
         def self.source_name = "fake_source"
@@ -845,12 +843,6 @@ RSpec.describe Admin::DashboardController do
 
     context "when signed in as an admin" do
       before { sign_in(admin) }
-
-      it "returns 404 when the dashboard_improvements feature flag is off" do
-        SiteSetting.dashboard_improvements = false
-        post "/admin/dashboard/reports/bulk.json", params: { items: [] }
-        expect(response.status).to eq(404)
-      end
 
       it "returns items in the order they were requested" do
         DiscoursePluginRegistry.register_admin_dashboard_report_source(fake_provider, plugin)
@@ -938,10 +930,7 @@ RSpec.describe Admin::DashboardController do
   end
 
   describe "#available_reports" do
-    before do
-      SiteSetting.dashboard_improvements = true
-      AdminDashboardReport.delete_all
-    end
+    before { AdminDashboardReport.delete_all }
 
     let(:fake_provider) do
       Class.new(AdminDashboard::Reports::SourceProvider) do
@@ -1024,10 +1013,7 @@ RSpec.describe Admin::DashboardController do
     end
 
     context "when signed in as a moderator" do
-      before do
-        SiteSetting.dashboard_improvements = true
-        sign_in(Fabricate(:moderator))
-      end
+      before { sign_in(Fabricate(:moderator)) }
 
       it "denies access" do
         get "/admin/dashboard/reports/available.json"
@@ -1037,12 +1023,6 @@ RSpec.describe Admin::DashboardController do
 
     context "when signed in as an admin" do
       before { sign_in(admin) }
-
-      it "returns 404 when dashboard_improvements is off" do
-        SiteSetting.dashboard_improvements = false
-        get "/admin/dashboard/reports/available.json"
-        expect(response.status).to eq(404)
-      end
 
       it "returns enabled, available, and providers" do
         DiscoursePluginRegistry.register_admin_dashboard_report_source(fake_provider, plugin)
@@ -1140,10 +1120,7 @@ RSpec.describe Admin::DashboardController do
   end
 
   describe "#update_reports_section" do
-    before do
-      SiteSetting.dashboard_improvements = true
-      AdminDashboardReport.delete_all
-    end
+    before { AdminDashboardReport.delete_all }
 
     let(:fake_provider) do
       Class.new(AdminDashboard::Reports::SourceProvider) do
@@ -1171,10 +1148,7 @@ RSpec.describe Admin::DashboardController do
     end
 
     context "when signed in as a moderator" do
-      before do
-        SiteSetting.dashboard_improvements = true
-        sign_in(Fabricate(:moderator))
-      end
+      before { sign_in(Fabricate(:moderator)) }
 
       it "denies access" do
         put "/admin/dashboard/reports/layout.json", params: { items: [] }
@@ -1184,12 +1158,6 @@ RSpec.describe Admin::DashboardController do
 
     context "when signed in as an admin" do
       before { sign_in(admin) }
-
-      it "returns 404 when dashboard_improvements is off" do
-        SiteSetting.dashboard_improvements = false
-        put "/admin/dashboard/reports/layout.json", params: { items: [] }
-        expect(response.status).to eq(404)
-      end
 
       it "replaces the current layout with the supplied items in order" do
         DiscoursePluginRegistry.register_admin_dashboard_report_source(fake_provider, plugin)


### PR DESCRIPTION
`Admin::DashboardController#index` now also serves the new dashboard when `?version=alt` is passed, regardless of `SiteSetting.dashboard_improvements`, so the full feature set has to work even when the flag is off. Removes the `ensure_dashboard_improvements_enabled` before_action from `bulk_reports`, `available_reports`, and `update_reports_section`, along with the request specs that exercised the gate.