### PR TITLE
FIX: AI bot submission in safari during IME composition

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -47,6 +47,9 @@ export default class AiBotConversations extends Component {
   @tracked creditStatus = null;
   @tracked selectedLlmId = null;
   @tracked uploads = trackedArray();
+
+  justEndedComposition = false;
+
   // Don't track this directly - we'll get it from uppyUpload
 
   textarea = null;
@@ -219,11 +222,25 @@ export default class AiBotConversations extends Component {
   }
 
   @action
+  handleCompositionEnd() {
+    // Safari fires compositionend before the IME-confirming Enter keydown,
+    // so event.isComposing reads false there. Bridge the gap with a flag
+    // cleared on the next microtask.
+    this.justEndedComposition = true;
+    Promise.resolve().then(() => (this.justEndedComposition = false));
+  }
+
+  @action
   handleKeyDown(event) {
     if (event.target.tagName !== "TEXTAREA") {
       return;
     }
-    if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.isComposing &&
+      !this.justEndedComposition
+    ) {
       event.preventDefault();
       event.stopPropagation();
       this.prepareAndSubmitToBot();
@@ -412,6 +429,7 @@ export default class AiBotConversations extends Component {
             {{didInsert this.setTextArea}}
             {{on "input" this.updateInputValue}}
             {{on "keydown" this.handleKeyDown}}
+            {{on "compositionend" this.handleCompositionEnd}}
             id="ai-bot-conversations-input"
             autofocus={{unless this.isSubmitDisabled "true"}}
             placeholder={{i18n "discourse_ai.ai_bot.conversations.placeholder"}}

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -48,7 +48,7 @@ export default class AiBotConversations extends Component {
   @tracked selectedLlmId = null;
   @tracked uploads = trackedArray();
 
-  justEndedComposition = false;
+  shiftHeldOnEnter = false;
 
   // Don't track this directly - we'll get it from uppyUpload
 
@@ -222,29 +222,28 @@ export default class AiBotConversations extends Component {
   }
 
   @action
-  handleCompositionEnd() {
-    // Safari fires compositionend before the IME-confirming Enter keydown,
-    // so event.isComposing reads false there. Bridge the gap with a flag
-    // cleared on the next microtask.
-    this.justEndedComposition = true;
-    Promise.resolve().then(() => (this.justEndedComposition = false));
-  }
-
-  @action
   handleKeyDown(event) {
     if (event.target.tagName !== "TEXTAREA") {
       return;
     }
-    if (
-      event.key === "Enter" &&
-      !event.shiftKey &&
-      !event.isComposing &&
-      !this.justEndedComposition
-    ) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.prepareAndSubmitToBot();
+    if (event.key === "Enter") {
+      this.shiftHeldOnEnter = event.shiftKey;
     }
+  }
+
+  @action
+  handleBeforeInput(event) {
+    // Real Enter on a textarea inserts a line break; IME-confirming Enter
+    // inserts composition text. Reading inputType is deterministic across
+    // browsers regardless of compositionend/keydown ordering quirks.
+    const shiftHeld = this.shiftHeldOnEnter;
+    this.shiftHeldOnEnter = false;
+    if (event.inputType !== "insertLineBreak" || shiftHeld) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    this.prepareAndSubmitToBot();
   }
 
   @action
@@ -429,7 +428,7 @@ export default class AiBotConversations extends Component {
             {{didInsert this.setTextArea}}
             {{on "input" this.updateInputValue}}
             {{on "keydown" this.handleKeyDown}}
-            {{on "compositionend" this.handleCompositionEnd}}
+            {{on "beforeinput" this.handleBeforeInput}}
             id="ai-bot-conversations-input"
             autofocus={{unless this.isSubmitDisabled "true"}}
             placeholder={{i18n "discourse_ai.ai_bot.conversations.placeholder"}}

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-helper-custom-prompt.gjs
@@ -9,19 +9,19 @@ import { i18n } from "discourse-i18n";
 
 export default class AiHelperCustomPrompt extends Component {
   @action
-  sendInput(event) {
-    if (event.key !== "Enter" || event.isComposing) {
+  handleSubmit(event) {
+    event.preventDefault();
+    if (!this.args.value?.length) {
       return;
     }
-    return this.args.submit(this.args.promptArgs);
+    this.args.submit(this.args.promptArgs);
   }
 
   <template>
-    <div class="ai-custom-prompt">
+    <form class="ai-custom-prompt" {{on "submit" this.handleSubmit}}>
 
       <input
         {{on "input" (withEventValue (fn (mut @value)))}}
-        {{on "keydown" this.sendInput}}
         value={{@value}}
         placeholder={{i18n
           "discourse_ai.ai_helper.context_menu.custom_prompt.placeholder"
@@ -37,6 +37,6 @@ export default class AiHelperCustomPrompt extends Component {
         @disabled={{not @value.length}}
         class="ai-custom-prompt__submit btn-primary"
       />
-    </div>
+    </form>
   </template>
 }

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
@@ -1,6 +1,14 @@
-import { fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
+import {
+  fillIn,
+  find,
+  settled,
+  triggerEvent,
+  visit,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+const INPUT = "#ai-bot-conversations-input";
 
 acceptance("AI Bot - Conversations IME handling", function (needs) {
   let postRequests = 0;
@@ -24,12 +32,12 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
   });
 
   needs.pretender((server, helper) => {
-    server.get("/discourse-ai/ai-bot/conversations.json", () => {
-      return helper.response({
+    server.get("/discourse-ai/ai-bot/conversations.json", () =>
+      helper.response({
         conversations: [],
         meta: { has_more: false },
-      });
-    });
+      })
+    );
 
     server.post("/posts.json", () => {
       postRequests += 1;
@@ -40,21 +48,68 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
         post_url: "/t/ai-conversation/1/1",
       });
     });
+
+    server.get("/t/:slug/:id.json", () => helper.response({}));
   });
 
-  test("does not submit when Enter is pressed during IME composition", async function (assert) {
-    postRequests = 0;
+  needs.hooks.beforeEach(() => (postRequests = 0));
 
+  async function prepareDraft() {
     await visit("/discourse-ai/ai-bot/conversations");
-    await fillIn(
-      "#ai-bot-conversations-input",
-      "これはテスト入力として十分長い文章です"
+    await fillIn(INPUT, "これはテスト入力として十分長い文章です");
+  }
+
+  test("Enter submits the message", async function (assert) {
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "keydown", { key: "Enter" });
+
+    assert.strictEqual(postRequests, 1, "submitted once");
+  });
+
+  test("Shift+Enter does not submit", async function (assert) {
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "keydown", { key: "Enter", shiftKey: true });
+
+    assert.strictEqual(postRequests, 0, "did not submit");
+  });
+
+  // Chrome fires the IME-confirming keydown with isComposing=true (compositionend follows)
+  test("IME-confirming Enter does not submit (Chrome event order)", async function (assert) {
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "keydown", { key: "Enter", isComposing: true });
+    await triggerEvent(INPUT, "compositionend");
+
+    assert.strictEqual(postRequests, 0, "did not submit");
+  });
+
+  // Safari fires compositionend first, then the IME-confirming keydown in the
+  // same task. Dispatch directly so microtasks don't drain between them.
+  test("IME-confirming Enter does not submit (Safari event order)", async function (assert) {
+    await prepareDraft();
+
+    const el = find(INPUT);
+    el.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+    el.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      })
     );
+    await settled();
 
-    await triggerKeyEvent("#ai-bot-conversations-input", "keydown", "Enter", {
-      isComposing: true,
-    });
+    assert.strictEqual(postRequests, 0, "did not submit");
+  });
 
-    assert.strictEqual(postRequests, 0, "does not request /posts.json");
+  test("Enter after composition has fully settled still submits", async function (assert) {
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "compositionend");
+    await triggerEvent(INPUT, "keydown", { key: "Enter" });
+
+    assert.strictEqual(postRequests, 1, "submitted once composition is done");
   });
 });

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
@@ -1,10 +1,4 @@
-import {
-  fillIn,
-  find,
-  settled,
-  triggerEvent,
-  visit,
-} from "@ember/test-helpers";
+import { fillIn, triggerEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -63,6 +57,7 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
     await prepareDraft();
 
     await triggerEvent(INPUT, "keydown", { key: "Enter" });
+    await triggerEvent(INPUT, "beforeinput", { inputType: "insertLineBreak" });
 
     assert.strictEqual(postRequests, 1, "submitted once");
   });
@@ -71,45 +66,19 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
     await prepareDraft();
 
     await triggerEvent(INPUT, "keydown", { key: "Enter", shiftKey: true });
+    await triggerEvent(INPUT, "beforeinput", { inputType: "insertLineBreak" });
 
     assert.strictEqual(postRequests, 0, "did not submit");
   });
 
-  // Chrome fires the IME-confirming keydown with isComposing=true (compositionend follows)
-  test("IME-confirming Enter does not submit (Chrome event order)", async function (assert) {
+  test("IME-confirming Enter does not submit", async function (assert) {
     await prepareDraft();
 
-    await triggerEvent(INPUT, "keydown", { key: "Enter", isComposing: true });
-    await triggerEvent(INPUT, "compositionend");
-
-    assert.strictEqual(postRequests, 0, "did not submit");
-  });
-
-  // Safari fires compositionend first, then the IME-confirming keydown in the
-  // same task. Dispatch directly so microtasks don't drain between them.
-  test("IME-confirming Enter does not submit (Safari event order)", async function (assert) {
-    await prepareDraft();
-
-    const el = find(INPUT);
-    el.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
-    el.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        key: "Enter",
-        bubbles: true,
-        cancelable: true,
-      })
-    );
-    await settled();
-
-    assert.strictEqual(postRequests, 0, "did not submit");
-  });
-
-  test("Enter after composition has fully settled still submits", async function (assert) {
-    await prepareDraft();
-
-    await triggerEvent(INPUT, "compositionend");
     await triggerEvent(INPUT, "keydown", { key: "Enter" });
+    await triggerEvent(INPUT, "beforeinput", {
+      inputType: "insertCompositionText",
+    });
 
-    assert.strictEqual(postRequests, 1, "submitted once composition is done");
+    assert.strictEqual(postRequests, 0, "did not submit");
   });
 });

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { click, render, triggerEvent } from "@ember/test-helpers";
+import { render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AiHelperCustomPrompt from "discourse/plugins/discourse-ai/discourse/components/ai-helper-custom-prompt";
@@ -11,8 +11,9 @@ class TestState {
 module("Integration | Component | ai-helper-custom-prompt", function (hooks) {
   setupRenderingTest(hooks);
 
-  async function renderPrompt(submit) {
+  async function renderPrompt(submit, initialValue = "test") {
     const state = new TestState();
+    state.value = initialValue;
     await render(
       <template>
         <AiHelperCustomPrompt @value={{state.value}} @submit={{submit}} />
@@ -20,7 +21,7 @@ module("Integration | Component | ai-helper-custom-prompt", function (hooks) {
     );
   }
 
-  test("calls @submit when the form is submitted", async function (assert) {
+  test("submitting the form calls @submit", async function (assert) {
     let submitted = 0;
     await renderPrompt(() => (submitted += 1));
 
@@ -29,12 +30,12 @@ module("Integration | Component | ai-helper-custom-prompt", function (hooks) {
     assert.strictEqual(submitted, 1, "called @submit once");
   });
 
-  test("calls @submit when the submit button is clicked", async function (assert) {
+  test("submit is skipped when the input is empty", async function (assert) {
     let submitted = 0;
-    await renderPrompt(() => (submitted += 1));
+    await renderPrompt(() => (submitted += 1), "");
 
-    await click(".ai-custom-prompt__submit");
+    await triggerEvent(".ai-custom-prompt", "submit");
 
-    assert.strictEqual(submitted, 1, "called @submit once");
+    assert.strictEqual(submitted, 0, "did not call @submit");
   });
 });

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
@@ -1,5 +1,5 @@
 import { tracked } from "@glimmer/tracking";
-import { render, triggerKeyEvent } from "@ember/test-helpers";
+import { click, render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AiHelperCustomPrompt from "discourse/plugins/discourse-ai/discourse/components/ai-helper-custom-prompt";
@@ -11,37 +11,30 @@ class TestState {
 module("Integration | Component | ai-helper-custom-prompt", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("does not submit when Enter is pressed during IME composition", async function (assert) {
-    let submitted = false;
-    const submit = () => (submitted = true);
+  async function renderPrompt(submit) {
     const state = new TestState();
-
     await render(
       <template>
         <AiHelperCustomPrompt @value={{state.value}} @submit={{submit}} />
       </template>
     );
+  }
 
-    await triggerKeyEvent(".ai-custom-prompt__input", "keydown", "Enter", {
-      isComposing: true,
-    });
+  test("calls @submit when the form is submitted", async function (assert) {
+    let submitted = 0;
+    await renderPrompt(() => (submitted += 1));
 
-    assert.false(submitted, "does not submit during IME composition");
+    await triggerEvent(".ai-custom-prompt", "submit");
+
+    assert.strictEqual(submitted, 1, "called @submit once");
   });
 
-  test("submits when Enter is pressed outside of IME composition", async function (assert) {
-    let submitted = false;
-    const submit = () => (submitted = true);
-    const state = new TestState();
+  test("calls @submit when the submit button is clicked", async function (assert) {
+    let submitted = 0;
+    await renderPrompt(() => (submitted += 1));
 
-    await render(
-      <template>
-        <AiHelperCustomPrompt @value={{state.value}} @submit={{submit}} />
-      </template>
-    );
+    await click(".ai-custom-prompt__submit");
 
-    await triggerKeyEvent(".ai-custom-prompt__input", "keydown", "Enter");
-
-    assert.true(submitted, "submits on Enter without IME composition");
+    assert.strictEqual(submitted, 1, "called @submit once");
   });
 });


### PR DESCRIPTION
Follow up to #40167 which added `event.isComposing` on the keydown check. This works fine in Chrome but Safari has some known bugs and quirks for `isComposing` during IME text composition. In Safari, the event order for composition and key events is often out-of-order.

This change switches the approach to use `beforeinput` and check for `insertLineBreak` on the textarea. It also adds a `<form>` wrapper around the helper-prompt input, so the browser filters IME confirmation natively on both Chrome and Safari.