### PR TITLE
FIX: Events should not lose their multiline formatting

### DIFF
--- a/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
@@ -74,9 +74,11 @@ module DiscoursePostEvent
     def self.linkify_description(text, post: nil)
       escaped = ERB::Util.html_escape(text)
       html =
-        escaped.gsub(URI::DEFAULT_PARSER.make_regexp(%w[http https])) do |url|
-          "<a href=\"#{url}\">#{url}</a>"
-        end
+        escaped
+          .gsub(URI::DEFAULT_PARSER.make_regexp(%w[http https])) do |url|
+            "<a href=\"#{url}\">#{url}</a>"
+          end
+          .gsub(/\r\n?|\n/, "<br>")
 
       doc = Nokogiri::HTML5.fragment(html)
       add_nofollow = post.nil? || post.add_nofollow?

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -59,6 +59,25 @@ module DiscoursePostEvent
         expect(event_ids).to match_array([active_event1.id, active_event2.id])
       end
 
+      it "includes linkified multiline description HTML in detailed JSON" do
+        event =
+          Fabricate(
+            :event,
+            original_starts_at: 1.day.from_now,
+            description: "Visit https://example.com\n\nBring snacks",
+          )
+
+        get "/discourse-post-event/events.json", params: { include_details: "true" }
+
+        expect(response.status).to eq(200)
+        description_html =
+          response.parsed_body["events"].find { |event_json| event_json["id"] == event.id }[
+            "description_html"
+          ]
+        expect(description_html).to include('<a href="https://example.com"')
+        expect(description_html).to include("<br>")
+      end
+
       it "should return events in ics format" do
         event1 = Fabricate(:event, original_starts_at: 1.day.from_now, name: "Test Event 1")
         event2 = Fabricate(:event, original_starts_at: 2.days.from_now, name: "Test Event 2")


### PR DESCRIPTION
## Summary

This patch fixes a regression where event descriptions lost their multiline formatting by ensuring newline characters are converted to <br> tags in the server-generated description_html. It updates the linkify_description utility to handle both URL linkification and line break preservation, ensuring the UI correctly renders multiline text.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/886
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>