### PR TITLE
FIX: Add back `description` to calendar `Description` component for backwards compatibility

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/description.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/description.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { trustHTML } from "@ember/template";
 import { modifier } from "ember-modifier";
+import { or } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
@@ -44,7 +45,7 @@ export default class DiscoursePostEventDescription extends Component {
   }
 
   <template>
-    {{#if @descriptionHtml}}
+    {{#if (or @descriptionHtml @description)}}
       <section
         class="event__section event-description
           {{if this.clamp 'is-clamped'}}
@@ -56,7 +57,13 @@ export default class DiscoursePostEventDescription extends Component {
           class="event-description__content"
           {{(if this.clamp this.detectOverflow)}}
         >
-          <p class="event-description__text">{{trustHTML @descriptionHtml}}</p>
+          <p class="event-description__text">
+            {{#if @descriptionHtml}}
+              {{trustHTML @descriptionHtml}}
+            {{else}}
+              {{@description}}
+            {{/if}}
+          </p>
           {{#if this.showToggle}}
             <a
               href

--- a/plugins/discourse-calendar/test/javascripts/integration/components/description-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/description-test.gjs
@@ -30,4 +30,17 @@ module("Integration | Component | Description", function (hooks) {
       .hasAttribute("href", "https://example.com")
       .hasText("https://example.com");
   });
+
+  test("falls back to plain text @description when @descriptionHtml is absent", async function (assert) {
+    await render(
+      <template>
+        <Description @description="Plain text via legacy argument" />
+      </template>
+    );
+
+    assert
+      .dom(".event-description__text")
+      .hasText("Plain text via legacy argument");
+    assert.dom(".event-description__text a").doesNotExist();
+  });
 });


### PR DESCRIPTION

On https://github.com/discourse/discourse/commit/866ae39d4642f667eb75a663e672d0eaf32db595 we added `description_html` and updated `/discourse-post-event/description.gjs` to only use it, but previously we used `description` in the outlet:

https://github.com/discourse/discourse/blob/b4643f7151d37af312aaf8ce99dc5c163372d0c3/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs#L251-L256

In this pr we add back the description to the component so that it maintains backwards compatibility with plugins that use the description outlet.