### PR TITLE
FIX: Cap the number of [quote] tags allowed per post

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -550,6 +550,9 @@ en:
   too_many_links:
     one: "Sorry, new users can only put one link in a post."
     other: "Sorry, new users can only put %{count} links in a post."
+  too_many_quotes:
+    one: "Sorry, you can only include one quote in a post."
+    other: "Sorry, you can only include %{count} quotes in a post."
   contains_blocked_word: "Sorry, you can't post the word '%{word}'; it's not allowed."
   contains_blocked_words: "Sorry, you can't post that. Not allowed: %{words}."
 
@@ -2323,6 +2326,7 @@ en:
     newuser_max_mentions_per_post: "Maximum number of @name notifications a new user can use in a post."
     newuser_max_replies_per_topic: "Maximum number of replies a new user can make in a single topic until someone replies to them."
     max_mentions_per_post: "Maximum number of @name notifications anyone can use in a post."
+    max_quotes_per_post: "Maximum number of quotes allowed in a single post. Set to 0 to disable the check."
     max_users_notified_per_group_mention: "Maximum number of users that may receive a notification if a group is mentioned (if threshold is met no notifications will be raised)"
     enable_mentions: "Permits users to tag or reference each other in their posts using the '@' symbol."
     here_mention: "Name used for a @mention to allow privileged users to notify up to 'max_here_mentioned' people participating in the topic. Must not be an existing username."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1480,6 +1480,10 @@ posting:
   max_mentions_per_post:
     default: 10
     area: "notifications"
+  max_quotes_per_post:
+    default: 50
+    min: 0
+    area: "posts_and_topics"
   max_users_notified_per_group_mention:
     default: 100
     client: true

--- a/lib/validators/post_validator.rb
+++ b/lib/validators/post_validator.rb
@@ -18,6 +18,7 @@ class PostValidator < ActiveModel::Validator
       max_embedded_media_validator(record)
       max_attachments_validator(record)
       max_links_validator(record)
+      max_quotes_validator(record)
       force_edit_last_validator(record)
     end
   end
@@ -148,6 +149,14 @@ class PostValidator < ActiveModel::Validator
     end
 
     post.errors.add(:base, I18n.t(:links_require_trust))
+  end
+
+  def max_quotes_validator(post)
+    max = SiteSetting.max_quotes_per_post
+    return if max <= 0
+
+    count = post.raw.to_s.scan(/\[quote[=\]]/i).size
+    post.errors.add(:base, I18n.t(:too_many_quotes, count: max)) if count > max
   end
 
   def force_edit_last_validator(post)

--- a/spec/lib/validators/post_validator_spec.rb
+++ b/spec/lib/validators/post_validator_spec.rb
@@ -299,6 +299,47 @@ RSpec.describe PostValidator do
     end
   end
 
+  describe "max_quotes_validator" do
+    before { SiteSetting.max_quotes_per_post = 3 }
+
+    it "is invalid when the post has more quote openers than the limit" do
+      post.raw = ([%([quote="user, post:1, topic:1"]), "[/quote]"] * 4).join("\n")
+      validator.max_quotes_validator(post)
+      expect(post.errors[:base]).to be_present
+    end
+
+    it "is valid when the post has quote openers at or below the limit" do
+      post.raw = ([%([quote="user, post:1, topic:1"]), "[/quote]"] * 3).join("\n")
+      validator.max_quotes_validator(post)
+      expect(post.errors[:base]).to be_blank
+    end
+
+    it "counts unbalanced openers, not balanced quote pairs" do
+      post.raw = %([quote="a, post:1, topic:1"]\n) * 4
+      validator.max_quotes_validator(post)
+      expect(post.errors[:base]).to be_present
+    end
+
+    it "counts plain [quote] openers too" do
+      post.raw = "[quote]\n" * 4
+      validator.max_quotes_validator(post)
+      expect(post.errors[:base]).to be_present
+    end
+
+    it "is case-insensitive" do
+      post.raw = "[QUOTE=foo]\n" * 4
+      validator.max_quotes_validator(post)
+      expect(post.errors[:base]).to be_present
+    end
+
+    it "is disabled when max_quotes_per_post is 0" do
+      SiteSetting.max_quotes_per_post = 0
+      post.raw = %([quote="a, post:1, topic:1"]\n) * 50
+      validator.max_quotes_validator(post)
+      expect(post.errors[:base]).to be_blank
+    end
+  end
+
   describe "max_embedded_media_validator" do
     fab!(:new_user) { Fabricate(:newuser, refresh_auto_groups: true) }
 


### PR DESCRIPTION
## Summary

Reports have surfaced of posts that lock up or crash browsers when their topic loads, even though the raw is well within `max_post_length`. The trigger is many `[quote=...]` BBCode openers per post — typically unbalanced with the matching `[/quote]` closers. When the BBCode block rule can't pair them up, each opener falls through to inline parsing and cooks into its own `<p>[quote=...]</p>` paragraph. Posts with hundreds to thousands of these paragraphs are cheap to author but expensive to render: thousands of DOM nodes, per-post decoration passes (quote-back links, MutationObservers, oneboxer, etc.) running once per fragment, and post-level event handlers all compound.

Examples in the wild have raws of 11–47 KB containing 220–880 `[quote=` openers, cooking into 25–100 KB of near-identical paragraphs. None of these come close to `max_post_length`, so the existing length validator never fires.

This adds a `max_quotes_per_post` site setting (default `50`, set to `0` to disable). `PostValidator` rejects any post whose raw contains more `[quote=` / `[quote]` openers than the limit.

## Notes

- The default of 50 is well above any realistic legitimate use (deeply nested quote-replies in practice top out around 5–10 levels). The four observed offender posts contain 220, 220, 660, and 880 `[quote=` openers — all rejected at the default.
- Counts openers only (`[quote=` and `[quote]`, case-insensitive), not balanced pairs. The DoS comes from openers; closers are cheap.
- Existing offending posts on affected sites still need to be deleted/rebaked manually — this only stops new ones.

## Test plan

- [x] `bin/rspec spec/lib/validators/post_validator_spec.rb` — all 53 examples pass, including 6 new cases covering: over-limit, at-limit, unbalanced openers, plain `[quote]`, case-insensitivity, and disable-via-zero.
- [ ] Manually try to submit a post with 51+ `[quote=...]` lines via the composer and confirm the error message.
- [ ] Try the same via the API.
- [ ] Confirm legitimate "Quote Reply" workflows (a handful of nested quotes) still work.