### PR TITLE
FIX: Whisper messages should not create calendar events

### DIFF
--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -100,6 +100,7 @@ en:
     calendar_must_be_in_first_post: "Calendar tag can only be used in first post of a topic."
     more_than_one_calendar: "You can’t have more than one calendar in a post."
     more_than_two_dates: "A post of a calendar topic can’t contain more than two dates."
+    whisper_not_allowed: "Whispers can’t be used to create calendar events."
     event_expired: "Event expired"
     holiday_status:
       description: "On holiday"

--- a/plugins/discourse-calendar/lib/event_validator.rb
+++ b/plugins/discourse-calendar/lib/event_validator.rb
@@ -11,6 +11,11 @@ module DiscourseCalendar
       dates_count = count_dates(@post)
       calendar_type = @first_post.custom_fields[DiscourseCalendar::CALENDAR_CUSTOM_FIELD]
 
+      if @post.whisper? && dates_count > 0
+        @post.errors.add(:base, I18n.t("discourse_calendar.whisper_not_allowed"))
+        return false
+      end
+
       if calendar_type == "dynamic" && dates_count > 2
         @post.errors.add(:base, I18n.t("discourse_calendar.more_than_two_dates"))
         return false

--- a/plugins/discourse-calendar/spec/models/calendar_event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/calendar_event_spec.rb
@@ -63,6 +63,43 @@ describe CalendarEvent do
     expect(post).to be_valid
   end
 
+  it "does not allow whispers to create events in calendar topics" do
+    SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+    admin = Fabricate(:admin)
+
+    expect {
+      create_post(
+        user: admin,
+        topic: calendar_post.topic,
+        raw: %{Staff-only [date="2018-06-05" time="10:20:00"]},
+        post_type: Post.types[:whisper],
+      )
+    }.to raise_error(StandardError, /Whispers can.t be used to create calendar events/)
+
+    expect(CalendarEvent.where(topic_id: calendar_post.topic_id)).to be_empty
+  end
+
+  it "does not allow whispers to be edited into calendar events" do
+    SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+    admin = Fabricate(:admin)
+    whisper_post =
+      create_post(
+        user: admin,
+        topic: calendar_post.topic,
+        raw: "Staff-only",
+        post_type: Post.types[:whisper],
+      )
+
+    expect {
+      whisper_post.update!(raw: %{Staff-only [date="2018-06-05" time="10:20:00"]})
+    }.to raise_error(
+      ActiveRecord::RecordInvalid,
+      /Whispers can.t be used to create calendar events/,
+    )
+
+    expect(CalendarEvent.where(topic_id: calendar_post.topic_id)).to be_empty
+  end
+
   it "does not work if topic was deleted" do
     raw = %{Rome [date="2018-06-05" time="10:20:00"]}
     post = create_post(raw: raw, topic: calendar_post.topic)


### PR DESCRIPTION
Before, staff could create a whisper with a local date in a calendar topic, which created a visible calendar event from a staff-only post.

This change rejects whispered calendar events, so whispers no longer create visible calendar entries.

Relates to /patch-triage/993