### PR TITLE
UX: Move Site Traffic chart legend to the bottom

### DIFF
--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -105,7 +105,6 @@ export default class DashboardTraffic extends Component {
     return {
       hideYAxisGridLines: true,
       hiddenLabels: this.hiddenLabels,
-      legendPosition: "top",
     };
   }
 


### PR DESCRIPTION
The Site Traffic chart on the admin dashboard rendered its legend at the top, which was inconsistent with the other reports on the same page.

This commit aligns it with the other reports by rendering the legend at the bottom.