### PR TITLE
FIX: Await channel lookups before redirecting in chat index routes

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/routes/chat/channels.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat/channels.js
@@ -10,17 +10,23 @@ export default class ChatChannelsRoute extends DiscourseRoute {
     this.chat.activeChannel = null;
   }
 
-  beforeModel() {
+  async beforeModel() {
+    if (!this.site.desktopView) {
+      return;
+    }
+
     const id = this.currentUser.custom_fields.last_chat_channel_id;
-    if (this.site.desktopView) {
-      if (id) {
-        this.chatChannelsManager.find(id).then((c) => {
-          return this.router.replaceWith("chat.channel", ...c.routeModels);
-        });
-      } else {
-        this.router.replaceWith("chat.browse.open");
+    if (id) {
+      const channel = await this.chatChannelsManager.find(id);
+      if (
+        channel?.isCategoryChannel &&
+        channel.currentUserMembership?.following
+      ) {
+        return this.router.replaceWith("chat.channel", ...channel.routeModels);
       }
     }
+
+    return this.router.replaceWith("chat.browse.open");
   }
 
   model() {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat/direct-messages.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat/direct-messages.js
@@ -10,20 +10,33 @@ export default class ChatDirectMessagesRoute extends DiscourseRoute {
     this.chat.activeChannel = null;
   }
 
-  beforeModel() {
-    if (this.site.desktopView) {
-      if (this.chatChannelsManager.directMessageChannels.length === 0) {
-        // first time browsing chat and the preferred index is dms
-        this.router.replaceWith("chat.direct-messages");
-      } else {
-        // there should be at least one dm channel
-        // we can reroute using the last channel id
-        const id = this.currentUser.custom_fields.last_chat_channel_id;
-        this.chatChannelsManager.find(id).then((c) => {
-          return this.router.replaceWith("chat.channel", ...c.routeModels);
-        });
+  async beforeModel() {
+    if (!this.site.desktopView) {
+      return;
+    }
+
+    await this.chat.loadChannels();
+
+    const dmChannels = this.chatChannelsManager.directMessageChannels;
+    if (dmChannels.length === 0) {
+      return;
+    }
+
+    const id = this.currentUser.custom_fields.last_chat_channel_id;
+    if (id) {
+      const channel = await this.chatChannelsManager.find(id);
+      if (
+        channel?.isDirectMessageChannel &&
+        channel.currentUserMembership?.following
+      ) {
+        return this.router.replaceWith("chat.channel", ...channel.routeModels);
       }
     }
+
+    return this.router.replaceWith(
+      "chat.channel",
+      ...dmChannels[0].routeModels
+    );
   }
 
   model() {

--- a/plugins/chat/spec/system/navigation_spec.rb
+++ b/plugins/chat/spec/system/navigation_spec.rb
@@ -88,12 +88,72 @@ RSpec.describe "Navigation" do
   end
 
   context "when visiting mobile only routes on desktop" do
-    it "redirects /chat/channels to browse" do
+    it "redirects /chat/channels to the last visited channel" do
       visit("/chat/channels")
 
       expect(page).to have_current_path(
         chat.channel_path(category_channel.slug, category_channel.id),
       )
+    end
+
+    context "when user has no last_chat_channel_id" do
+      before { current_user.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => nil) }
+
+      it "redirects /chat/channels to browse" do
+        visit("/chat/channels")
+
+        expect(page).to have_current_path("/chat/browse/open")
+      end
+    end
+
+    context "when last_chat_channel_id points to a DM channel" do
+      fab!(:other_user, :user)
+      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user, other_user]) }
+
+      before { current_user.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => dm_channel.id) }
+
+      it "redirects /chat/channels to browse instead of into the DM" do
+        visit("/chat/channels")
+
+        expect(page).to have_current_path("/chat/browse/open")
+      end
+    end
+
+    context "when visiting /chat/direct-messages with DM channels" do
+      fab!(:other_user, :user)
+      fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user, other_user]) }
+
+      it "redirects to the last visited DM when last_chat_channel_id is a DM" do
+        current_user.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => dm_channel.id)
+        visit("/chat/direct-messages")
+
+        expect(page).to have_current_path(%r{/chat/c/.+/#{dm_channel.id}$})
+      end
+
+      it "redirects to the first DM when last_chat_channel_id is a public channel" do
+        current_user.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => category_channel.id)
+        visit("/chat/direct-messages")
+
+        expect(page).to have_current_path(%r{/chat/c/.+/#{dm_channel.id}$})
+      end
+
+      it "redirects to the first DM when last_chat_channel_id is not set" do
+        current_user.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => nil)
+        visit("/chat/direct-messages")
+
+        expect(page).to have_current_path(%r{/chat/c/.+/#{dm_channel.id}$})
+      end
+    end
+
+    context "when visiting /chat/direct-messages with no DM channels" do
+      before { current_user.upsert_custom_fields(::Chat::LAST_CHAT_CHANNEL_ID => nil) }
+
+      it "stays on the route and renders the empty state" do
+        visit("/chat/direct-messages")
+
+        expect(page).to have_current_path("/chat/direct-messages")
+        expect(page).to have_css(".c-routes.--direct-messages")
+      end
     end
   end
 


### PR DESCRIPTION
Before we had a bug because we were using the .then pattern: the transition continued before the redirect fired. Leading to a brief flash.

Now beforeModels are using the `async/await` pattern. Specs were added to cover these changes