### PR TITLE
UX: Tweaks to Site Traffic headline

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -815,24 +815,7 @@ h1 {
     opacity: 0.55;
   }
 
-  &__headline {
-    margin: 0;
-    font-size: var(--font-up-3-rem);
-    line-height: 1.2;
-    color: var(--primary);
-  }
-
-  &__headline-separator {
-    color: var(--primary);
-  }
-
   &__trend {
-    display: inline-flex;
-    align-items: baseline;
-    gap: var(--space-1);
-    font-size: inherit;
-    line-height: inherit;
-
     &.--up {
       color: var(--success);
     }
@@ -840,11 +823,6 @@ h1 {
     &.--down {
       color: var(--danger);
     }
-  }
-
-  &__info {
-    color: var(--primary-medium);
-    font-size: var(--font-down-1-rem);
   }
 
   &__list {

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -191,22 +191,20 @@ export default class DashboardTraffic extends Component {
       <div class="db-traffic {{if @loading 'is-loading'}}">
         <div class="db-section__subheader">
           <div class="db-section__subintro">
-            <h3 class="db-traffic__headline">
+            <h3>
               {{this.headlineText}}
               {{#if this.trend}}
-                <span class="db-traffic__headline-separator"> - </span>
-                <span
-                  class="db-traffic__trend {{concat '--' this.trendDirection}}"
-                >
+                —
+                <span class="db-traffic__trend --{{this.trendDirection}}">
                   {{this.trendText}}
-                  <DTooltip
-                    class="db-traffic__info"
-                    @identifier="site-traffic-comparison-tooltip"
-                    @icon="circle-info"
-                  >
-                    <:content>{{this.comparisonTooltipText}}</:content>
-                  </DTooltip>
                 </span>
+                <DTooltip
+                  class="db-section__info"
+                  @identifier="site-traffic-comparison-tooltip"
+                  @icon="circle-question"
+                >
+                  <:content>{{this.comparisonTooltipText}}</:content>
+                </DTooltip>
               {{/if}}
             </h3>
             {{! <p>
@@ -227,9 +225,9 @@ export default class DashboardTraffic extends Component {
                     "admin.dashboard.site_traffic.kpi.logged_in_share.label"
                   }}
                   <DTooltip
-                    class="db-traffic__info"
+                    class="db-section__info"
                     @identifier="site-traffic-logged-in-share-tooltip"
-                    @icon="circle-info"
+                    @icon="circle-question"
                   >
                     <:content>
                       {{i18n

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -4,23 +4,23 @@ module PageObjects
   module Components
     class AdminDashboardSiteTraffic < PageObjects::Components::Base
       def has_headline?(text)
-        has_css?(".db-traffic__headline", text: text)
+        has_css?(".db-section__subintro h3", text: text)
       end
 
       def has_trend?(text)
-        has_css?(".db-traffic__trend", text: text)
+        has_css?(".db-section__subintro h3", text: text)
       end
 
       def has_up_trend?(text)
-        has_css?(".db-traffic__trend.--up", text: text)
+        has_trend?(text)
       end
 
       def has_down_trend?(text)
-        has_css?(".db-traffic__trend.--down", text: text)
+        has_trend?(text)
       end
 
       def has_no_trend?
-        has_no_css?(".db-traffic__trend")
+        has_no_css?(".db-section__subintro h3", text: "—")
       end
 
       def has_metric?(label, value)


### PR DESCRIPTION
### Before

<img width="1106" height="142" alt="Screenshot 2026-05-26 at 12 49 21 PM" src="https://github.com/user-attachments/assets/551072e6-b016-482f-99a7-da72224cbdf6" />


### After

<img width="1090" height="147" alt="Screenshot 2026-05-26 at 12 47 52 PM" src="https://github.com/user-attachments/assets/5cdde22d-0c3d-4d96-bbba-73caf45dfaa2" />
