### PR TITLE
FIX: Exclude small actions from topic counters and unread tracking

### DIFF
--- a/app/jobs/regular/post_update_topic_tracking_state.rb
+++ b/app/jobs/regular/post_update_topic_tracking_state.rb
@@ -14,6 +14,8 @@ module Jobs
           TopicGroup.new_message_update(topic.last_poster, topic.id, post.post_number)
         end
       else
+        return if post.post_type == Post.types[:small_action]
+
         TopicTrackingState.publish_unmuted(post.topic)
         if post.post_number > 1
           TopicTrackingState.publish_muted(post.topic)

--- a/app/models/private_message_topic_tracking_state.rb
+++ b/app/models/private_message_topic_tracking_state.rb
@@ -99,6 +99,7 @@ class PrivateMessageTopicTrackingState
   def self.publish_unread(post)
     topic = post.topic
     return unless topic.private_message?
+    return if post.post_type == Post.types[:small_action]
 
     scope = TopicUser.tracking(post.topic_id).includes(user: %i[user_stat user_option])
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -883,14 +883,19 @@ class Topic < ActiveRecord::Base
         .first
         .to_i
 
-    # PM small_action posts only bump highest_staff_post_number, not
-    # highest_post_number, matching the exclusion in reset_highest.
+    excluded_from_public_counters = opts[:post_type] == Post.types[:small_action]
     staff_only = opts[:post_type] == Post.types[:whisper]
-    staff_only ||=
-      opts[:post_type] == Post.types[:small_action] &&
-        Topic.where(id: topic_id, archetype: Archetype.private_message).exists?
 
-    if staff_only
+    if excluded_from_public_counters
+      result = DB.query_single(<<~SQL, highest:, topic_id:)
+        UPDATE topics
+        SET highest_staff_post_number = highest_staff_post_number
+        WHERE id = :topic_id
+        RETURNING :highest + 1
+      SQL
+
+      result.first.to_i
+    elsif staff_only
       result = DB.query_single(<<~SQL, highest, topic_id)
         UPDATE topics
         SET highest_staff_post_number = ? + 1
@@ -924,7 +929,7 @@ class Topic < ActiveRecord::Base
         SELECT topic_id,
                COALESCE(MAX(post_number), 0) highest_post_number
         FROM posts
-        WHERE deleted_at IS NULL
+        WHERE deleted_at IS NULL AND post_type <> 3
         GROUP BY topic_id
       ),
       Y as (
@@ -933,14 +938,14 @@ class Topic < ActiveRecord::Base
                count(*) posts_count,
                max(created_at) last_posted_at
         FROM posts
-        WHERE deleted_at IS NULL AND post_type <> 4
+        WHERE deleted_at IS NULL AND post_type <> 3 AND post_type <> 4
         GROUP BY topic_id
       ),
       Z as (
         SELECT topic_id,
                SUM(COALESCE(posts.word_count, 0)) word_count
         FROM posts
-        WHERE deleted_at IS NULL AND post_type <> 4
+        WHERE deleted_at IS NULL AND post_type <> 3 AND post_type <> 4
         GROUP BY topic_id
       )
       UPDATE topics
@@ -970,7 +975,7 @@ class Topic < ActiveRecord::Base
         SELECT topic_id,
                COALESCE(MAX(post_number), 0) highest_post_number
         FROM posts
-        WHERE deleted_at IS NULL
+        WHERE deleted_at IS NULL AND post_type <> 3
         GROUP BY topic_id
       ),
       Y as (
@@ -1015,17 +1020,19 @@ class Topic < ActiveRecord::Base
   def self.reset_highest(topic_id)
     archetype = Topic.where(id: topic_id).pick(:archetype)
 
-    # ignore small_action replies for private messages
-    post_type =
-      archetype == Archetype.private_message ? " AND post_type <> #{Post.types[:small_action]}" : ""
+    post_type = " AND post_type <> #{Post.types[:small_action]}"
+    if archetype == Archetype.private_message
+      post_type << " AND post_type <> #{Post.types[:whisper]}"
+    end
 
-    result = DB.query_single(<<~SQL, topic_id:)
+    result = DB.query(<<~SQL, topic_id:)
       UPDATE topics
       SET
         highest_staff_post_number = (
           SELECT COALESCE(MAX(post_number), 0) FROM posts
           WHERE topic_id = :topic_id AND
-                deleted_at IS NULL
+                deleted_at IS NULL AND
+                post_type <> 3
         ),
         highest_post_number = (
           SELECT COALESCE(MAX(post_number), 0) FROM posts
@@ -1065,17 +1072,60 @@ class Topic < ActiveRecord::Base
           LIMIT 1
         ), last_post_user_id)
       WHERE id = :topic_id
-      RETURNING highest_post_number
+      RETURNING highest_post_number, highest_staff_post_number
     SQL
 
-    highest = result.first.to_i
+    highest = result.first.highest_post_number.to_i
+    highest_staff = result.first.highest_staff_post_number.to_i
+    whisper_group_ids = SiteSetting.whispers_allowed_groups_map
 
-    DB.exec(<<~SQL, highest:, topic_id:)
-      UPDATE topic_users
-         SET last_read_post_number = :highest
-       WHERE topic_id = :topic_id
-         AND last_read_post_number > :highest
-    SQL
+    if whisper_group_ids.empty?
+      DB.exec(<<~SQL, highest:, topic_id:)
+        UPDATE topic_users
+           SET last_read_post_number = :highest
+         WHERE topic_id = :topic_id
+           AND last_read_post_number > :highest
+      SQL
+    else
+      DB.exec(<<~SQL, highest:, highest_staff:, topic_id:, whisper_group_ids:)
+        UPDATE topic_users
+           SET last_read_post_number = CASE
+             WHEN EXISTS (
+               SELECT 1
+               FROM users
+               WHERE users.id = topic_users.user_id AND (
+                 users.admin OR
+                 users.primary_group_id IN (:whisper_group_ids) OR
+                 EXISTS (
+                   SELECT 1
+                   FROM group_users
+                   WHERE group_users.user_id = users.id AND
+                     group_users.group_id IN (:whisper_group_ids)
+                 )
+               )
+             ) THEN :highest_staff
+             ELSE :highest
+           END
+         WHERE topic_id = :topic_id AND
+           last_read_post_number > CASE
+             WHEN EXISTS (
+               SELECT 1
+               FROM users
+               WHERE users.id = topic_users.user_id AND (
+                 users.admin OR
+                 users.primary_group_id IN (:whisper_group_ids) OR
+                 EXISTS (
+                   SELECT 1
+                   FROM group_users
+                   WHERE group_users.user_id = users.id AND
+                     group_users.group_id IN (:whisper_group_ids)
+                 )
+               )
+             ) THEN :highest_staff
+             ELSE :highest
+           END
+      SQL
+    end
 
     highest
   end
@@ -1399,7 +1449,8 @@ class Topic < ActiveRecord::Base
   def update_statistics!
     feature_topic_users
     update_action_counts
-    self.highest_post_number = Topic.reset_highest(id)
+    Topic.reset_highest(id)
+    reload
   end
 
   def update_action_counts

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -120,6 +120,8 @@ class TopicTrackingState
 
   def self.publish_unread(post)
     return unless post.topic.regular?
+    return if post.post_type == Post.types[:small_action]
+
     # TODO at high scale we are going to have to defer this,
     #   perhaps cut down to users that are around in the last 7 days as well
 

--- a/db/post_migrate/20260526045813_recalculate_topic_counters_without_small_actions.rb
+++ b/db/post_migrate/20260526045813_recalculate_topic_counters_without_small_actions.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+class RecalculateTopicCountersWithoutSmallActions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 10_000
+
+  def up
+    last_post_id = 0
+    whisper_group_ids =
+      DB.query_single(<<~SQL).first.to_s.split("|").map(&:to_i).select(&:positive?)
+      SELECT value
+      FROM site_settings
+      WHERE name = 'whispers_allowed_groups'
+    SQL
+
+    loop do
+      rows = DB.query(<<~SQL, last_post_id:, batch_size: BATCH_SIZE)
+        SELECT id, topic_id
+        FROM posts
+        WHERE id > :last_post_id AND post_type = 3
+        ORDER BY id
+        LIMIT :batch_size
+      SQL
+
+      break if rows.empty?
+
+      topic_ids = rows.map(&:topic_id).uniq
+
+      DB.exec(<<~SQL, topic_ids:)
+        WITH stats AS (
+          SELECT
+            posts.topic_id,
+            COALESCE(
+              MAX(posts.post_number) FILTER (
+                WHERE posts.deleted_at IS NULL AND posts.post_type <> 3
+              ),
+              0
+            ) AS highest_staff_post_number,
+            COALESCE(
+              MAX(posts.post_number) FILTER (
+                WHERE posts.deleted_at IS NULL AND posts.post_type NOT IN (3, 4)
+              ),
+              0
+            ) AS highest_post_number,
+            COUNT(*) FILTER (
+              WHERE posts.deleted_at IS NULL AND posts.post_type NOT IN (3, 4)
+            ) AS posts_count,
+            COALESCE(
+              SUM(COALESCE(posts.word_count, 0)) FILTER (
+                WHERE posts.deleted_at IS NULL AND posts.post_type NOT IN (3, 4)
+              ),
+              0
+            ) AS word_count,
+            MAX(posts.created_at) FILTER (
+              WHERE posts.deleted_at IS NULL AND posts.post_type NOT IN (3, 4)
+            ) AS last_posted_at
+          FROM posts
+          WHERE posts.topic_id IN (:topic_ids)
+          GROUP BY posts.topic_id
+        ), last_posts AS (
+          SELECT DISTINCT ON (posts.topic_id)
+            posts.topic_id,
+            posts.user_id
+          FROM posts
+          WHERE posts.topic_id IN (:topic_ids) AND
+            posts.deleted_at IS NULL AND
+            posts.post_type NOT IN (3, 4)
+          ORDER BY posts.topic_id, posts.created_at DESC, posts.id DESC
+        )
+        UPDATE topics
+        SET highest_staff_post_number = stats.highest_staff_post_number,
+            highest_post_number = stats.highest_post_number,
+            posts_count = stats.posts_count,
+            word_count = stats.word_count,
+            last_posted_at = stats.last_posted_at,
+            last_post_user_id = COALESCE(last_posts.user_id, topics.last_post_user_id)
+        FROM stats
+        LEFT JOIN last_posts ON last_posts.topic_id = stats.topic_id
+        WHERE topics.id = stats.topic_id AND (
+          topics.highest_staff_post_number <> stats.highest_staff_post_number OR
+          topics.highest_post_number <> stats.highest_post_number OR
+          topics.posts_count <> stats.posts_count OR
+          topics.word_count <> stats.word_count OR
+          topics.last_posted_at IS DISTINCT FROM stats.last_posted_at OR
+          topics.last_post_user_id IS DISTINCT FROM COALESCE(last_posts.user_id, topics.last_post_user_id)
+        )
+      SQL
+
+      if whisper_group_ids.empty?
+        DB.exec(<<~SQL, topic_ids:)
+          WITH stats AS (
+            SELECT
+              posts.topic_id,
+              COALESCE(
+                MAX(posts.post_number) FILTER (
+                  WHERE posts.deleted_at IS NULL AND posts.post_type NOT IN (3, 4)
+                ),
+                0
+              ) AS highest_post_number
+            FROM posts
+            WHERE posts.topic_id IN (:topic_ids)
+            GROUP BY posts.topic_id
+          )
+          UPDATE topic_users
+          SET last_read_post_number = stats.highest_post_number
+          FROM stats
+          WHERE topic_users.topic_id = stats.topic_id AND
+            topic_users.last_read_post_number > stats.highest_post_number
+        SQL
+      else
+        DB.exec(<<~SQL, topic_ids:, whisper_group_ids:)
+          WITH stats AS (
+            SELECT
+              posts.topic_id,
+              COALESCE(
+                MAX(posts.post_number) FILTER (
+                  WHERE posts.deleted_at IS NULL AND posts.post_type <> 3
+                ),
+                0
+              ) AS highest_staff_post_number,
+              COALESCE(
+                MAX(posts.post_number) FILTER (
+                  WHERE posts.deleted_at IS NULL AND posts.post_type NOT IN (3, 4)
+                ),
+                0
+              ) AS highest_post_number
+            FROM posts
+            WHERE posts.topic_id IN (:topic_ids)
+            GROUP BY posts.topic_id
+          )
+          UPDATE topic_users
+          SET last_read_post_number = CASE
+            WHEN EXISTS (
+              SELECT 1
+              FROM users
+              WHERE users.id = topic_users.user_id AND (
+                users.admin OR
+                users.primary_group_id IN (:whisper_group_ids) OR
+                EXISTS (
+                  SELECT 1
+                  FROM group_users
+                  WHERE group_users.user_id = users.id AND
+                    group_users.group_id IN (:whisper_group_ids)
+                )
+              )
+            ) THEN stats.highest_staff_post_number
+            ELSE stats.highest_post_number
+          END
+          FROM stats
+          WHERE topic_users.topic_id = stats.topic_id AND
+            topic_users.last_read_post_number > CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM users
+                WHERE users.id = topic_users.user_id AND (
+                  users.admin OR
+                  users.primary_group_id IN (:whisper_group_ids) OR
+                  EXISTS (
+                    SELECT 1
+                    FROM group_users
+                    WHERE group_users.user_id = users.id AND
+                      group_users.group_id IN (:whisper_group_ids)
+                  )
+                )
+              ) THEN stats.highest_staff_post_number
+              ELSE stats.highest_post_number
+            END
+        SQL
+      end
+
+      last_post_id = rows.last.id
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -291,8 +291,7 @@ class PostCreator
 
     post.word_count = post.raw.scan(/[[:word:]]+/).size
 
-    increase_posts_count =
-      !post.topic&.private_message? || post.post_type != Post.types[:small_action]
+    increase_posts_count = post.post_type != Post.types[:small_action]
     post.post_number ||=
       Topic.next_post_number(
         post.topic_id,
@@ -521,12 +520,16 @@ class PostCreator
   def update_topic_stats
     attrs = { updated_at: Time.now }
 
-    if @post.post_type != Post.types[:whisper] && !@opts[:silent]
+    if ![Post.types[:whisper], Post.types[:small_action]].include?(@post.post_type) &&
+         !@opts[:silent]
       attrs[:last_posted_at] = @post.created_at
       attrs[:last_post_user_id] = @post.user_id
       attrs[:word_count] = (@topic.word_count || 0) + @post.word_count
       attrs[:excerpt] = @post.excerpt_for_topic if new_topic?
-      attrs[:bumped_at] = @post.created_at unless @post.no_bump
+    end
+
+    if @post.post_type != Post.types[:whisper] && !@opts[:silent] && !@post.no_bump
+      attrs[:bumped_at] = @post.created_at
     end
 
     @topic.update_columns(attrs)
@@ -621,7 +624,8 @@ class PostCreator
 
     UserStatCountUpdater.increment!(@post) if !@post.hidden || @post.topic.visible
 
-    if !@topic.private_message? && @post.post_type != Post.types[:whisper]
+    if !@topic.private_message? &&
+         ![Post.types[:whisper], Post.types[:small_action]].include?(@post.post_type)
       @user.update(last_posted_at: @post.created_at)
     end
   end
@@ -656,6 +660,11 @@ class PostCreator
   def track_topic
     return if @opts[:import_mode] || @opts[:auto_track] == false
 
+    if @post.post_type == Post.types[:small_action]
+      track_small_action_topic
+      return
+    end
+
     TopicUser.change(
       @post.user_id,
       @topic.id,
@@ -679,6 +688,28 @@ class PostCreator
         TopicUser.notification_reasons[:auto_watch],
       )
     elsif !@topic.private_message?
+      notification_level =
+        @user.user_option.notification_level_when_replying ||
+          NotificationLevels.topic_levels[:tracking]
+      TopicUser.auto_notification(
+        @user.id,
+        @topic.id,
+        TopicUser.notification_reasons[:created_post],
+        notification_level,
+      )
+    end
+  end
+
+  def track_small_action_topic
+    return if @topic.private_message?
+
+    if @user.staged
+      TopicUser.auto_notification_for_staging(
+        @user.id,
+        @topic.id,
+        TopicUser.notification_reasons[:auto_watch],
+      )
+    else
       notification_level =
         @user.user_option.notification_level_when_replying ||
           NotificationLevels.topic_levels[:tracking]

--- a/spec/jobs/post_update_topic_tracking_state_spec.rb
+++ b/spec/jobs/post_update_topic_tracking_state_spec.rb
@@ -16,6 +16,21 @@ RSpec.describe Jobs::PostUpdateTopicTrackingState do
     expect(messages.size).to eq(0)
   end
 
+  it "does not publish messages for small actions in regular topics" do
+    reader = Fabricate(:user)
+    TopicUser.change(
+      reader.id,
+      post.topic_id,
+      notification_level: TopicUser.notification_levels[:tracking],
+      last_read_post_number: post.post_number,
+    )
+    small_action = post.topic.add_small_action(Fabricate(:moderator), "closed.enabled")
+
+    messages = MessageBus.track_publish { job.execute({ post_id: small_action.id }) }
+
+    expect(messages).to be_empty
+  end
+
   it "should not update topic groups for small_action posts in private messages" do
     user = Fabricate(:user, refresh_auto_groups: true)
     recipient = Fabricate(:user)

--- a/spec/migrations/recalculate_topic_counters_without_small_actions_spec.rb
+++ b/spec/migrations/recalculate_topic_counters_without_small_actions_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "db/post_migrate/20260526045813_recalculate_topic_counters_without_small_actions.rb",
+        )
+
+RSpec.describe RecalculateTopicCountersWithoutSmallActions do
+  before do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after { ActiveRecord::Migration.verbose = @original_verbose }
+
+  it "recalculates counters without small actions" do
+    SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+    DB.exec(<<~SQL, value: Group::AUTO_GROUPS[:staff].to_s, now: Time.zone.now)
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES ('whispers_allowed_groups', 20, :value, :now, :now)
+      ON CONFLICT (name) DO UPDATE SET value = :value, updated_at = :now
+    SQL
+    user = Fabricate(:admin)
+    moderator = Fabricate(:moderator)
+    reader = Fabricate(:user)
+    post = create_post(user: user)
+    topic = post.topic
+    whisper = create_post(topic: topic, user: moderator, post_type: Post.types[:whisper])
+    small_action = topic.add_small_action(moderator, "closed.enabled")
+
+    topic.update!(
+      highest_post_number: small_action.post_number,
+      highest_staff_post_number: small_action.post_number,
+      posts_count: 3,
+      last_posted_at: small_action.created_at,
+      last_post_user_id: small_action.user_id,
+      word_count: 999,
+    )
+    [user, reader].each do |topic_user|
+      TopicUser.change(
+        topic_user.id,
+        topic.id,
+        last_read_post_number: small_action.post_number,
+        notification_level: TopicUser.notification_levels[:tracking],
+      )
+    end
+
+    described_class.new.up
+
+    topic.reload
+    admin_topic_user = TopicUser.find_by!(topic: topic, user: user)
+    reader_topic_user = TopicUser.find_by!(topic: topic, user: reader)
+    expect(topic.highest_post_number).to eq(post.post_number)
+    expect(topic.highest_staff_post_number).to eq(whisper.post_number)
+    expect(topic.posts_count).to eq(1)
+    expect(topic.last_posted_at).to eq_time(post.created_at)
+    expect(topic.last_post_user_id).to eq(post.user_id)
+    expect(topic.word_count).to eq(post.word_count)
+    expect(admin_topic_user.last_read_post_number).to eq(whisper.post_number)
+    expect(reader_topic_user.last_read_post_number).to eq(post.post_number)
+  end
+end

--- a/spec/models/private_message_topic_tracking_state_spec.rb
+++ b/spec/models/private_message_topic_tracking_state_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe PrivateMessageTopicTrackingState do
       expect(messages).to eq([])
     end
 
-    it "publishes small_action posts only to staff users" do
+    it "does not publish small_action posts" do
       staff = Fabricate(:moderator, refresh_auto_groups: true)
       private_message.topic_allowed_users.create!(user_id: staff.id)
       TopicUser.change(
@@ -187,9 +187,7 @@ RSpec.describe PrivateMessageTopicTrackingState do
 
       messages = MessageBus.track_publish { described_class.publish_unread(small_action) }
 
-      published_user_ids = messages.flat_map(&:user_ids)
-      expect(published_user_ids).to include(staff.id)
-      expect(published_user_ids).not_to include(user_2.id)
+      expect(messages).to be_empty
     end
   end
 

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -1483,6 +1483,54 @@ RSpec.describe Topic do
       expect(topic.reload.moderator_posts_count).to eq(1)
     end
 
+    it "does not count small actions as replies" do
+      post = create_post(topic: topic, user: topic.user)
+      topic.reload
+
+      small_action = topic.add_small_action(moderator, "closed.enabled")
+
+      expect(small_action.post_number).to eq(post.post_number + 1)
+      expect(topic.reload.highest_post_number).to eq(post.post_number)
+      expect(topic.highest_staff_post_number).to eq(post.post_number)
+      expect(topic.posts_count).to eq(1)
+      expect(topic.last_posted_at).to eq_time(post.created_at)
+    end
+
+    it "does not let small actions advance staff-only progress" do
+      SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+      post = create_post(topic: topic, user: topic.user)
+      whisper = create_post(topic: topic, user: moderator, post_type: Post.types[:whisper])
+      topic.reload
+
+      topic.add_small_action(moderator, "closed.enabled")
+
+      expect(topic.reload.highest_post_number).to eq(post.post_number)
+      expect(topic.highest_staff_post_number).to eq(whisper.post_number)
+    end
+
+    it "caps read progress by whisper access when resetting highest" do
+      SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+      reader = Fabricate(:user)
+      post = create_post(topic: topic, user: topic.user)
+      whisper = create_post(topic: topic, user: moderator, post_type: Post.types[:whisper])
+      small_action = topic.add_small_action(moderator, "closed.enabled")
+      [moderator, reader].each do |topic_user|
+        TopicUser.change(
+          topic_user.id,
+          topic.id,
+          last_read_post_number: small_action.post_number,
+          notification_level: TopicUser.notification_levels[:tracking],
+        )
+      end
+
+      expect(Topic.reset_highest(topic.id)).to eq(post.post_number)
+
+      staff_topic_user = TopicUser.find_by!(topic: topic, user: moderator)
+      reader_topic_user = TopicUser.find_by!(topic: topic, user: reader)
+      expect(staff_topic_user.last_read_post_number).to eq(whisper.post_number)
+      expect(reader_topic_user.last_read_post_number).to eq(post.post_number)
+    end
+
     context "when moderator post fails to be created" do
       before { user.update_column(:silenced_till, 1.year.from_now) }
 

--- a/spec/models/topic_tracking_state_spec.rb
+++ b/spec/models/topic_tracking_state_spec.rb
@@ -816,6 +816,19 @@ RSpec.describe TopicTrackingState do
   end
 
   describe ".report" do
+    it "does not report topics with only unread small actions" do
+      TopicUser.change(
+        user.id,
+        topic.id,
+        notification_level: TopicUser.notification_levels[:tracking],
+        last_read_post_number: post.post_number,
+      )
+
+      topic.add_small_action(Fabricate(:moderator), "closed.enabled")
+
+      expect(described_class.report(user)).to be_empty
+    end
+
     it "correctly reports topics with staff posts" do
       SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
       create_post(raw: "this is a test post", topic: topic, user: post.user)


### PR DESCRIPTION
Small action posts (closed, archived, pinned, etc.) were inflating
public topic counters and triggering unread notifications for regular
topics. Previously the exclusion only applied to private messages.

- Treat small actions like whispers when updating highest_post_number,
  posts_count, last_posted_at and word_count, so they no longer count
  as replies in regular topics.
- Stop publishing unread MessageBus updates for small action posts in
  both regular topics and private messages.
- When resetting highest, cap topic_users.last_read_post_number by
  whisper access so staff retain progress against staff-only posts
  while non-staff are clamped to the public highest.
- Track watchers/staged users on the topic when a small action is
  created without bumping the poster's last_posted_at.
- Add a post-migration to recalculate counters and read state for
  topics already affected by historical small actions.
