### PR TITLE
UX: Add See details link to Site Traffic dashboard panel

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -907,6 +907,14 @@ h1 {
     color: var(--danger);
     font-size: var(--font-down-1-rem);
   }
+
+  &__see-details {
+    align-self: flex-end;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--font-down-1-rem);
+  }
 }
 
 .db-reports {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7035,6 +7035,7 @@ en:
             anonymous: "Anonymous"
             embedded: "Embedded pageviews"
             crawlers: "Crawlers"
+          see_details: "See details"
         period:
           last_7_days: "Last 7 days"
           last_30_days: "Last 30 days"

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -4,7 +4,9 @@ import AdminReportStackedChart from "discourse/admin/components/admin-report-sta
 import DashboardSection from "discourse/admin/components/dashboard/section";
 import { countryFlag, countryName } from "discourse/admin/lib/format-country";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
+import getURL from "discourse/lib/get-url";
 import { or } from "discourse/truth-helpers";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
 
 const PERIOD_COPY_KEYS = {
@@ -106,6 +108,15 @@ export default class DashboardTraffic extends Component {
       hideYAxisGridLines: true,
       hiddenLabels: this.hiddenLabels,
     };
+  }
+
+  get reportUrl() {
+    const startDate = moment(this.args.startDate).format("YYYY-MM-DD");
+    const endDate = moment(this.args.endDate).format("YYYY-MM-DD");
+
+    return getURL(
+      `/admin/reports/site_traffic?start_date=${startDate}&end_date=${endDate}`
+    );
   }
 
   formatHeadlineCount(value) {
@@ -260,6 +271,10 @@ export default class DashboardTraffic extends Component {
               class="db-section__traffic-chart-canvas"
             />
           </div>
+          <a class="db-traffic__see-details" href={{this.reportUrl}}>
+            {{i18n "admin.dashboard.site_traffic.see_details"}}
+            {{dIcon "arrow-right"}}
+          </a>
         {{else}}
           <div class="db-section__traffic-chart">
             <div class="db-section__traffic-chart-shell"></div>

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -1,10 +1,10 @@
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
+import { concat, hash } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
 import AdminReportStackedChart from "discourse/admin/components/admin-report-stacked-chart";
 import DashboardSection from "discourse/admin/components/dashboard/section";
 import { countryFlag, countryName } from "discourse/admin/lib/format-country";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
-import getURL from "discourse/lib/get-url";
 import { or } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
@@ -110,13 +110,11 @@ export default class DashboardTraffic extends Component {
     };
   }
 
-  get reportUrl() {
-    const startDate = moment(this.args.startDate).format("YYYY-MM-DD");
-    const endDate = moment(this.args.endDate).format("YYYY-MM-DD");
-
-    return getURL(
-      `/admin/reports/site_traffic?start_date=${startDate}&end_date=${endDate}`
-    );
+  get reportQuery() {
+    return {
+      start_date: moment(this.args.startDate).format("YYYY-MM-DD"),
+      end_date: moment(this.args.endDate).format("YYYY-MM-DD"),
+    };
   }
 
   formatHeadlineCount(value) {
@@ -271,10 +269,18 @@ export default class DashboardTraffic extends Component {
               class="db-section__traffic-chart-canvas"
             />
           </div>
-          <a class="db-traffic__see-details" href={{this.reportUrl}}>
+          <LinkTo
+            class="db-traffic__see-details"
+            @route="adminReports.show"
+            @model="site_traffic"
+            @query={{hash
+              start_date=this.reportQuery.start_date
+              end_date=this.reportQuery.end_date
+            }}
+          >
             {{i18n "admin.dashboard.site_traffic.see_details"}}
             {{dIcon "arrow-right"}}
-          </a>
+          </LinkTo>
         {{else}}
           <div class="db-section__traffic-chart">
             <div class="db-section__traffic-chart-shell"></div>

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -128,7 +128,7 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
     expect(traffic).to have_chart
   end
 
-  it "takes staff to the full site traffic report for a custom period when they click See details",
+  it "takes staff to the full site traffic report scoped to the same period when they click See details",
      time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
     Fabricate(:logged_in_browser_application_request, date: "2026-05-05", count: 10)
 
@@ -142,22 +142,6 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
 
     expect(page).to have_current_path(
       "/admin/reports/site_traffic?end_date=2026-05-12&start_date=2026-05-01",
-    )
-  end
-
-  it "takes staff to the full site traffic report for a preset period when they click See details",
-     time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-    Fabricate(:logged_in_browser_application_request, date: "2026-05-10", count: 10)
-
-    dashboard.visit
-    traffic = dashboard.site_traffic
-
-    expect(traffic).to have_see_details_link
-
-    traffic.click_see_details
-
-    expect(page).to have_current_path(
-      "/admin/reports/site_traffic?end_date=2026-05-14&start_date=2026-04-15",
     )
   end
 

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -128,6 +128,39 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
     expect(traffic).to have_chart
   end
 
+  it "takes staff to the full site traffic report for a custom period when they click See details",
+     time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+    Fabricate(:logged_in_browser_application_request, date: "2026-05-05", count: 10)
+
+    dashboard.visit_with_query(range: "custom", start_date: "2026-05-01", end_date: "2026-05-12")
+    traffic = dashboard.site_traffic
+
+    expect(traffic).to have_chart
+    expect(traffic).to have_see_details_link
+
+    traffic.click_see_details
+
+    expect(page).to have_current_path(
+      "/admin/reports/site_traffic?end_date=2026-05-12&start_date=2026-05-01",
+    )
+  end
+
+  it "takes staff to the full site traffic report for a preset period when they click See details",
+     time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+    Fabricate(:logged_in_browser_application_request, date: "2026-05-10", count: 10)
+
+    dashboard.visit
+    traffic = dashboard.site_traffic
+
+    expect(traffic).to have_see_details_link
+
+    traffic.click_see_details
+
+    expect(page).to have_current_path(
+      "/admin/reports/site_traffic?end_date=2026-05-14&start_date=2026-04-15",
+    )
+  end
+
   context "with top countries and top referrers cards" do
     before do
       SiteSetting.persist_browser_pageview_events = true

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -36,6 +36,14 @@ module PageObjects
         has_css?(".db-section__traffic-chart canvas")
       end
 
+      def has_see_details_link?
+        has_css?("a.db-traffic__see-details")
+      end
+
+      def click_see_details
+        find("a.db-traffic__see-details").click
+      end
+
       def hover_comparison_tooltip
         find("[data-trigger][data-identifier='site-traffic-comparison-tooltip']").hover
         self


### PR DESCRIPTION
The redesigned Site Traffic dashboard panel shipped without a drill-down to the underlying report. Admins who wanted to inspect a date range more closely or export it as CSV had to navigate to `/admin/reports/site_traffic` by hand and re-pick the dates.

This commit adds a "See details" link at the bottom-right of the chart in `DashboardTraffic` that opens the full Site Traffic report scoped to the dashboard's currently selected period.

### Recording

https://github.com/user-attachments/assets/0c599906-617c-4899-9799-20446cff02a7

