### PR TITLE
DOCS: Bump minimum PostgreSQL version to 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To get your environment set up, follow one of the setup guides:
 - [Ubuntu/Debian](https://meta.discourse.org/t/14727)
 - [Windows](https://meta.discourse.org/t/75149)
 
-Before you get started, ensure you have the following minimum versions: [Ruby 3.4+](https://www.ruby-lang.org/en/downloads/), [PostgreSQL 13](https://www.postgresql.org/download/), [Redis 7](https://redis.io/download).
+Before you get started, ensure you have the following minimum versions: [Ruby 3.4+](https://www.ruby-lang.org/en/downloads/), [PostgreSQL 15](https://www.postgresql.org/download/), [Redis 7](https://redis.io/download).
 
 For more information, check out [the Developer Documentation](https://meta.discourse.org/c/documentation/developer-guides/56).
 


### PR DESCRIPTION
The README still advertised PostgreSQL 13 as the minimum supported version, but Discourse now requires PostgreSQL 15. Update the install prerequisites so new contributors don't set up an unsupported database.