### PR TITLE
FIX: Skip `BrowserPageviewEvent` writes in PostgreSQL readonly

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -729,8 +729,13 @@ class Middleware::RequestTracker
         created_at: payload[:occurred_at],
       )
     rescue ActiveRecord::StatementInvalid => e
-      raise unless e.cause.is_a?(PG::NotNullViolation) && e.cause.message.include?("ip_address")
-      Rails.logger.debug("Discarding BrowserPageviewEvent: invalid IP #{payload[:ip_address]}")
+      if e.cause.is_a?(PG::ReadOnlySqlTransaction)
+        # Skip recording browser pageviews when PostgreSQL is in read-only transaction mode.
+      elsif e.cause.is_a?(PG::NotNullViolation) && e.cause.message.include?("ip_address")
+        Rails.logger.debug("Discarding BrowserPageviewEvent: invalid IP #{payload[:ip_address]}")
+      else
+        raise
+      end
     rescue => e
       Rails.logger.error(
         "Failed to create BrowserPageviewEvent with payload #{payload}: #{e.message}",


### PR DESCRIPTION
Previously, persisted browser pageview tracking could raise when `RequestTracker` attempted to insert a `BrowserPageviewEvent` during a PostgreSQL readonly transaction.

Transaction readonly is enabled for example, here: https://github.com/discourse/discourse/blob/main/app/models/report.rb#L250