### PR TITLE
DEV: Drop `autosize` package

### DIFF
--- a/frontend/discourse/app/controllers/tags/index.js
+++ b/frontend/discourse/app/controllers/tags/index.js
@@ -1,10 +1,8 @@
 import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action, computed, set } from "@ember/object";
-import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
-import autosize from "autosize";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { optionalRequire } from "discourse/lib/utilities";
@@ -15,8 +13,6 @@ export default class TagsIndexController extends Controller {
   @tracked bulkTagInput = "";
   @tracked isCreatingTags = false;
   @tracked bulkCreateResults = null;
-
-  bulkTagTextarea = null;
 
   sortedByCount = true;
   sortedByName = false;
@@ -106,11 +102,6 @@ export default class TagsIndexController extends Controller {
   }
 
   @action
-  registerTextarea(element) {
-    this.bulkTagTextarea = element;
-  }
-
-  @action
   async bulkCreateTags(event) {
     event?.preventDefault();
 
@@ -138,11 +129,6 @@ export default class TagsIndexController extends Controller {
       this.bulkTagInput = "";
       this.bulkCreateResults = response;
 
-      schedule("afterRender", () => {
-        if (this.bulkTagTextarea) {
-          autosize.update(this.bulkTagTextarea);
-        }
-      });
       this.router.refresh();
     } catch (error) {
       popupAjaxError(error);

--- a/frontend/discourse/app/templates/tags/index.gjs
+++ b/frontend/discourse/app/templates/tags/index.gjs
@@ -1,6 +1,5 @@
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import DiscourseBanner from "discourse/components/discourse-banner";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TagList from "discourse/components/tag-list";
@@ -76,7 +75,6 @@ export default <template>
             {{i18n "tagging.bulk_create_inline_placeholder"}}
           </label>
           <DExpandingTextArea
-            {{didInsert @controller.registerTextarea}}
             {{on "input" (withEventValue (fn (mut @controller.bulkTagInput)))}}
             value={{@controller.bulkTagInput}}
             placeholder={{i18n "tagging.bulk_create_inline_placeholder"}}

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -110,7 +110,6 @@
     "@uppy/utils": "^7.2.0",
     "@uppy/xhr-upload": "^5.2.0",
     "a11y-dialog": "8.1.5",
-    "autosize": "^6.0.1",
     "babel-import-util": "^3.0.1",
     "babel-plugin-ember-template-compilation": "^4.0.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,9 +459,6 @@ importers:
       a11y-dialog:
         specifier: 8.1.5
         version: 8.1.5
-      autosize:
-        specifier: ^6.0.1
-        version: 6.0.1
       babel-import-util:
         specifier: ^3.0.1
         version: 3.0.1
@@ -3642,9 +3639,6 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
-
-  autosize@6.0.1:
-    resolution: {integrity: sha512-f86EjiUKE6Xvczc4ioP1JBlWG7FKrE13qe/DxBCpe8GCipCq2nFw73aO8QEBKHfSbYGDN5eB9jXWKen7tspDqQ==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -12327,8 +12321,6 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
-
-  autosize@6.0.1: {}
 
   available-typed-arrays@1.0.7:
     dependencies:


### PR DESCRIPTION
It was only used by `controllers/tags`... which was already using the shared DExpandingTextArea, so it was redundant.