### PR TITLE
FIX: Correctly rescue failed `embed_mode` parsing

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -620,9 +620,16 @@ class Middleware::RequestTracker
     # or a subsequent XHR from inside the embed iframe which sets the header below.
     # Use `request.GET` (query-string only) rather than `request.params` so a missing
     # or malformed request body cannot raise from here.
+    embed_mode_param =
+      begin
+        request.GET["embed_mode"]
+      rescue Rack::QueryParser::ParameterTypeError, Rack::QueryParser::InvalidParameterError
+        # malformed query string — Rails will turn this into a 400 downstream
+        nil
+      end
+
     is_embed =
-      request.GET["embed_mode"] == "true" ||
-        %w[1 true].include?(env["HTTP_DISCOURSE_TRACK_VIEW_EMBED"])
+      embed_mode_param == "true" || %w[1 true].include?(env["HTTP_DISCOURSE_TRACK_VIEW_EMBED"])
 
     {
       track_view: track_view,

--- a/spec/integration/invalid_request_spec.rb
+++ b/spec/integration/invalid_request_spec.rb
@@ -36,4 +36,10 @@ RSpec.describe "invalid requests", type: :request do
     expect(fake_logger.warnings).to be_empty
     expect(fake_logger.errors).to have_attributes(size: 1)
   end
+
+  it "handles query strings whose key types collide" do
+    get "/?foo=1&foo%5B1%5D=2"
+    expect(response.status).to eq(400)
+    expect(fake_logger.warnings).to be_empty
+  end
 end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -374,6 +374,19 @@ RSpec.describe Middleware::RequestTracker do
         }.not_to raise_error
       end
 
+      it "survives malformed query strings while detecting embed mode" do
+        data = nil
+        expect {
+          data =
+            Middleware::RequestTracker.get_data(
+              env(path: "/?foo=1&foo%5B1%5D=2"),
+              ["200", { "Content-Type" => "text/html" }],
+              0.1,
+            )
+        }.not_to raise_error
+        expect(data[:is_embed]).to eq(false)
+      end
+
       it "still counts crawlers as page_view_crawler even on embed URLs" do
         data =
           Middleware::RequestTracker.get_data(


### PR DESCRIPTION
Rails already handles this situation gracefully. However, our own parsing of the query parameter in the request_tracker middleware would not. This commit adds handling, and adds a new invalid_request_spec to verify the behavior.