### PR TITLE
FIX: Approve users stuck with a non-pending `ReviewableUser`

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -390,10 +390,10 @@ class Reviewable < ActiveRecord::Base
     result
   end
 
-  # Override this in specific reviewable type to include scores for
-  # non-pending reviewables
+  # Includes pending scores plus disagreed ones, so re-approving a previously
+  # rejected reviewable correctly flips those scores back to "agreed".
   def updatable_reviewable_scores
-    reviewable_scores.pending
+    reviewable_scores.pending.or(reviewable_scores.disagreed)
   end
 
   def transition_to(status_symbol, performed_by)

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -31,12 +31,6 @@ class ReviewableQueuedPost < Reviewable
     }
   end
 
-  def updatable_reviewable_scores
-    # Approvals are possible for already rejected queued posts. We need the
-    # scores to be updated when this happens.
-    reviewable_scores.pending.or(reviewable_scores.disagreed)
-  end
-
   def build_combined_actions(actions, guardian, args)
     unless approved?
       if topic&.closed?

--- a/app/models/reviewable_user.rb
+++ b/app/models/reviewable_user.rb
@@ -12,36 +12,39 @@ class ReviewableUser < Reviewable
   end
 
   def build_combined_actions(actions, guardian, args)
-    if status == "rejected" && !payload["scrubbed_by"]
+    if status == "rejected" && !payload&.dig("scrubbed_by")
       build_action(actions, :scrub, client_action: "scrub")
     end
-    if status == "pending"
-      if is_a_suspect_user?
-        confirm_spam_bundle =
-          actions.add_bundle(
-            "#{id}-confirm-spam",
-            icon: "user-xmark",
-            label: "reviewables.actions.confirm_spam.title",
-          )
-        delete_user_actions(actions, confirm_spam_bundle, require_reject_reason: false)
 
-        if guardian.can_approve?(target)
-          actions.add(:approve_user, bundle: nil) do |a|
-            a.icon = "user-plus"
-            a.label = "reviewables.actions.not_spam.title"
-            a.description = "reviewables.actions.not_spam.description"
-            a.completed_message = "reviewables.actions.approve_user.complete"
-          end
+    suspect_pending = status == "pending" && is_a_suspect_user?
+
+    # For suspect users the destructive "confirm spam" bundle must be added
+    # before the approve action so it renders first in the queue UI.
+    if suspect_pending
+      bundle =
+        actions.add_bundle(
+          "#{id}-confirm-spam",
+          icon: "user-xmark",
+          label: "reviewables.actions.confirm_spam.title",
+        )
+      delete_user_actions(actions, bundle, require_reject_reason: false)
+    end
+
+    if guardian.can_approve?(target)
+      actions.add(:approve_user, bundle: nil) do |a|
+        a.icon = "user-plus"
+        a.completed_message = "reviewables.actions.approve_user.complete"
+        if suspect_pending
+          a.label = "reviewables.actions.not_spam.title"
+          a.description = "reviewables.actions.not_spam.description"
+        else
+          a.label = "reviewables.actions.approve_user.title"
         end
-      else
-        if guardian.can_approve?(target)
-          actions.add(:approve_user, bundle: nil) do |a|
-            a.icon = "user-plus"
-            a.label = "reviewables.actions.approve_user.title"
-          end
-        end
-        delete_user_actions(actions, require_reject_reason: true)
       end
+    end
+
+    if status == "pending" && !suspect_pending
+      delete_user_actions(actions, nil, require_reject_reason: true)
     end
   end
 

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -4,11 +4,13 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   Category.clear_subcategory_ids if name === :max_category_nesting
 
   # Enabling `must_approve_users` on an existing site is odd, so we assume that the
-  # existing users are approved.
+  # existing users are approved unless they currently have a pending reviewable.
   if name == :must_approve_users && new_value == true
     User
       .where(approved: false)
-      .joins("LEFT JOIN reviewables r ON r.target_id = users.id")
+      .joins(
+        "LEFT JOIN reviewables r ON r.target_id = users.id AND r.status = #{Reviewable.statuses[:pending]}",
+      )
       .where(r: { id: nil })
       .update_all(approved: true)
   end

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -9,7 +9,7 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
     User
       .where(approved: false)
       .joins(
-        "LEFT JOIN reviewables r ON r.target_id = users.id AND r.status = #{Reviewable.statuses[:pending]}",
+        "LEFT JOIN reviewables r ON r.target_id = users.id AND r.target_type = 'User' AND r.status = #{Reviewable.statuses[:pending]}",
       )
       .where(r: { id: nil })
       .update_all(approved: true)

--- a/spec/initializers/track_setting_changes_spec.rb
+++ b/spec/initializers/track_setting_changes_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe "Setting changes" do
 
       expect(non_approved_user.reload.approved?).to eq(true)
     end
+
+    it "approves a user whose id collides with a non-user reviewable's target_id" do
+      user = Fabricate(:user, approved: false)
+      Fabricate(:reviewable, type: "ReviewableFlaggedPost", target_id: user.id, target_type: "Post")
+
+      SiteSetting.must_approve_users = true
+
+      expect(user.reload.approved?).to eq(true)
+    end
   end
 
   describe "#reviewable_low_priority_threshold" do

--- a/spec/initializers/track_setting_changes_spec.rb
+++ b/spec/initializers/track_setting_changes_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe "Setting changes" do
       expect(user_pending_approval.reload.approved?).to eq(false)
     end
 
+    it "approves a user whose only reviewable is not pending" do
+      stuck_user = Fabricate(:reviewable_user, status: Reviewable.statuses[:rejected]).target
+
+      SiteSetting.must_approve_users = true
+
+      expect(stuck_user.reload.approved?).to eq(true)
+    end
+
     it "approves a user with no associated reviewables" do
       non_approved_user = Fabricate(:user, approved: false)
 

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe ReviewableUser, type: :model do
       expect(actions.has?(:delete_user_block)).to eq(false)
     end
 
+    it "still allows approving in the rejected state" do
+      reviewable.status = Reviewable.statuses[:rejected]
+      actions = reviewable.actions_for(Guardian.new(moderator))
+      expect(actions.has?(:approve_user)).to eq(true)
+      expect(actions.has?(:delete_user)).to eq(false)
+      expect(actions.has?(:delete_user_block)).to eq(false)
+    end
+
     it "doesn't ask for a rejection reason when deleting a user who was flagged as a possible spammer" do
       reviewable.reviewable_scores.build(user: admin, reason: "suspect_user")
 
@@ -100,6 +108,21 @@ RSpec.describe ReviewableUser, type: :model do
             reviewable_id: reviewable.id,
           ).count
         }.by(1)
+      end
+
+      it "transitions disagreed scores back to agreed when re-approving a rejected reviewable" do
+        score =
+          reviewable.reviewable_scores.create!(
+            user: admin,
+            reviewable_score_type: ReviewableScore.types[:needs_approval],
+            status: ReviewableScore.statuses[:disagreed],
+          )
+        reviewable.update!(status: Reviewable.statuses[:rejected])
+
+        reviewable.perform(moderator, :approve_user)
+
+        expect(reviewable.reload).to be_approved
+        expect(score.reload.status).to eq("agreed")
       end
     end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -287,6 +287,18 @@ RSpec.describe Admin::UsersController do
           ).count,
         ).to eq(1)
       end
+
+      it "approves a user whose previous reviewable was rejected" do
+        evil_trout.update!(active: true)
+        reviewable =
+          Fabricate(:reviewable_user, target: evil_trout, status: Reviewable.statuses[:rejected])
+
+        put "/admin/users/#{evil_trout.id}/approve.json"
+
+        expect(response.status).to eq(200)
+        expect(evil_trout.reload).to be_approved
+        expect(reviewable.reload).to be_approved
+      end
     end
 
     context "when logged in as an admin" do

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -32,6 +32,20 @@ describe "Admin User Page" do
     end
   end
 
+  context "when approving a user with a previously rejected reviewable" do
+    before { SiteSetting.must_approve_users = true }
+
+    it "approves the user from the admin profile page" do
+      stuck_user = Fabricate(:user, active: true, approved: false)
+      Fabricate(:reviewable_user, target: stuck_user, status: Reviewable.statuses[:rejected])
+
+      admin_user_page.visit(stuck_user)
+      admin_user_page.click_approve_button
+      expect(admin_user_page).to have_approve_success
+      expect(stuck_user.reload).to be_approved
+    end
+  end
+
   context "when visiting a regular user's page" do
     fab!(:user) { Fabricate(:user, ip_address: "93.123.44.90") }
     fab!(:similar_user) { Fabricate(:user, ip_address: user.ip_address) }

--- a/spec/system/page_objects/pages/admin_user.rb
+++ b/spec/system/page_objects/pages/admin_user.rb
@@ -52,6 +52,14 @@ module PageObjects
         find(".btn-danger.unsilence-user").click
       end
 
+      def click_approve_button
+        find(".display-row .controls .btn", text: I18n.t("admin_js.admin.user.approve")).click
+      end
+
+      def has_approve_success?
+        has_css?(".display-row .controls", text: I18n.t("admin_js.admin.user.approve_success"))
+      end
+
       def custom_groups_chooser
         PageObjects::Components::SelectKit.new(".admin-user__custom-groups .group-chooser")
       end


### PR DESCRIPTION
Previously, clicking Approve on a user's admin profile 500'd with `Reviewable::InvalidAction` when that user had a non-pending `ReviewableUser` (e.g., after `UserDestroyer.destroy` was rescued because the user had posts), and toggling on `must_approve_users` also skipped those users — leaving them permanently un-approvable from the admin UI.

This change gates the `:approve_user` action on `guardian.can_approve?(target)` instead of `status == "pending"`, fixes the auto-approval initializer to only skip users with a *pending* reviewable, and centralizes `updatable_reviewable_scores` so re-approval correctly flips `disagreed` scores back to `agreed`.

https://meta.discourse.org/t/403620