### PR TITLE
FIX: Skip rejected reviewables in pending users reminder

### DIFF
--- a/app/jobs/scheduled/pending_users_reminder.rb
+++ b/app/jobs/scheduled/pending_users_reminder.rb
@@ -7,6 +7,11 @@ module Jobs
     def execute(args)
       if SiteSetting.must_approve_users && SiteSetting.pending_users_reminder_delay_minutes >= 0
         query = AdminUserIndexQuery.new(query: "pending", stats: false).find_users_query # default order is: users.created_at DESC
+        # Only count users whose ReviewableUser is still pending. Without this the
+        # reminder counts users whose reviewable has been rejected but whose row
+        # was kept (e.g. they had posts), which produces notifications pointing
+        # at an empty `/review` queue.
+        query = query.where(id: ReviewableUser.pending.select(:target_id))
         if SiteSetting.pending_users_reminder_delay_minutes > 0
           query =
             query.where(

--- a/app/jobs/scheduled/pending_users_reminder.rb
+++ b/app/jobs/scheduled/pending_users_reminder.rb
@@ -7,10 +7,6 @@ module Jobs
     def execute(args)
       if SiteSetting.must_approve_users && SiteSetting.pending_users_reminder_delay_minutes >= 0
         query = AdminUserIndexQuery.new(query: "pending", stats: false).find_users_query # default order is: users.created_at DESC
-        # Only count users whose ReviewableUser is still pending. Without this the
-        # reminder counts users whose reviewable has been rejected but whose row
-        # was kept (e.g. they had posts), which produces notifications pointing
-        # at an empty `/review` queue.
         query = query.where(id: ReviewableUser.pending.select(:target_id))
         if SiteSetting.pending_users_reminder_delay_minutes > 0
           query =

--- a/spec/jobs/pending_users_reminder_spec.rb
+++ b/spec/jobs/pending_users_reminder_spec.rb
@@ -51,12 +51,6 @@ RSpec.describe Jobs::PendingUsersReminder do
       end
     end
 
-    # https://meta.discourse.org/t/notification-claims-x-users-for-approval-but-none-are-found/262853
-    # When a ReviewableUser is rejected but the user cannot be destroyed (because
-    # they have posts or are an admin), the user record stays with approved:
-    # false, active: true. Without filtering by pending reviewables this job
-    # would still count them and send notifications pointing at an empty
-    # `/review` queue.
     context "when a pending user's reviewable has been rejected" do
       fab!(:moderator) { Fabricate(:moderator, approved: true, approved_by_id: -1) }
 

--- a/spec/jobs/pending_users_reminder_spec.rb
+++ b/spec/jobs/pending_users_reminder_spec.rb
@@ -17,33 +17,64 @@ RSpec.describe Jobs::PendingUsersReminder do
 
       it "sends a message if user was created more than pending_users_reminder_delay minutes ago" do
         SiteSetting.pending_users_reminder_delay_minutes = 8
-        Fabricate(:user, created_at: 9.minutes.ago)
+        user = Fabricate(:user, created_at: 9.minutes.ago)
+        Fabricate(:reviewable_user, target: user, created_by: Discourse.system_user)
         PostCreator.expects(:create).once
         Jobs::PendingUsersReminder.new.execute({})
       end
 
       it "doesn't send a message if user was created less than pending_users_reminder_delay minutes ago" do
         SiteSetting.pending_users_reminder_delay_minutes = 8
-        Fabricate(:user, created_at: 2.minutes.ago)
+        user = Fabricate(:user, created_at: 2.minutes.ago)
+        Fabricate(:reviewable_user, target: user, created_by: Discourse.system_user)
         PostCreator.expects(:create).never
         Jobs::PendingUsersReminder.new.execute({})
       end
 
       it "doesn't send a message if pending_users_reminder_delay is -1" do
         SiteSetting.pending_users_reminder_delay_minutes = -1
-        Fabricate(:user, created_at: 24.hours.ago)
+        user = Fabricate(:user, created_at: 24.hours.ago)
+        Fabricate(:reviewable_user, target: user, created_by: Discourse.system_user)
         PostCreator.expects(:create).never
         Jobs::PendingUsersReminder.new.execute({})
       end
 
       it "sets the correct pending user count in the notification" do
         SiteSetting.pending_users_reminder_delay_minutes = 8
-        Fabricate(:user, created_at: 9.minutes.ago)
+        user = Fabricate(:user, created_at: 9.minutes.ago)
+        Fabricate(:reviewable_user, target: user, created_by: Discourse.system_user)
         PostCreator.expects(:create).with(
           Discourse.system_user,
           has_entries(title: "1 user waiting for approval"),
         )
         Jobs::PendingUsersReminder.new.execute({})
+      end
+    end
+
+    # https://meta.discourse.org/t/notification-claims-x-users-for-approval-but-none-are-found/262853
+    # When a ReviewableUser is rejected but the user cannot be destroyed (because
+    # they have posts or are an admin), the user record stays with approved:
+    # false, active: true. Without filtering by pending reviewables this job
+    # would still count them and send notifications pointing at an empty
+    # `/review` queue.
+    context "when a pending user's reviewable has been rejected" do
+      fab!(:moderator) { Fabricate(:moderator, approved: true, approved_by_id: -1) }
+
+      it "does not send a notification" do
+        SiteSetting.pending_users_reminder_delay_minutes = 0
+        user = Fabricate(:user, active: true, approved: false)
+        Fabricate(:post, user: user)
+        reviewable = Fabricate(:reviewable_user, target: user, created_by: Discourse.system_user)
+        reviewable.perform(moderator, :delete_user, reject_reason: "spam")
+
+        expect(reviewable.reload).to be_rejected
+        expect(user.reload.approved).to eq(false)
+        expect(user.active).to eq(true)
+        expect(Reviewable.list_for(moderator, status: :pending)).to be_empty
+
+        Jobs::PendingUsersReminder.new.execute({})
+
+        expect(Topic.find_by(subtype: TopicSubtype.pending_users_reminder)).to be_nil
       end
     end
   end


### PR DESCRIPTION
Previously, the `PendingUsersReminder` job counted every user with `approved: false, active: true`, including users whose `ReviewableUser` had already been rejected but who could not be destroyed (because they had posts or were admins) — producing PMs claiming users were waiting for approval while `/review` was empty, as reported in https://meta.discourse.org/t/262853/9.

This change filters the query to only count users whose `ReviewableUser` is still pending, so the reminder's count matches the `/review` queue it links to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)