### PR TITLE
DEV: Disable post voting plugin on nested replies topics

### DIFF
--- a/plugins/discourse-post-voting/extensions/topic_extension.rb
+++ b/plugins/discourse-post-voting/extensions/topic_extension.rb
@@ -13,7 +13,6 @@ module PostVoting
       @answers = nil
       @comments = nil
       @last_answerer = nil
-      @is_post_voting = nil
       super(options)
     end
 
@@ -56,7 +55,7 @@ module PostVoting
     end
 
     def is_post_voting?
-      @is_post_voting ||= SiteSetting.post_voting_enabled && subtype == Topic::POST_VOTING_SUBTYPE
+      SiteSetting.post_voting_enabled && subtype == Topic::POST_VOTING_SUBTYPE && !nested_view?
     end
 
     # class methods

--- a/plugins/discourse-post-voting/spec/models/topic_spec.rb
+++ b/plugins/discourse-post-voting/spec/models/topic_spec.rb
@@ -98,6 +98,17 @@ describe Topic do
     expect(topic.last_answerer.id).to eq(expected)
   end
 
+  describe "#is_post_voting?" do
+    before { SiteSetting.post_voting_enabled = true }
+
+    it "returns false when the topic renders as nested" do
+      SiteSetting.nested_replies_enabled = true
+      Fabricate(:nested_topic, topic: topic)
+
+      expect(topic).not_to be_is_post_voting
+    end
+  end
+
   describe ".post_voting_votes" do
     it "should return nil if user is blank" do
       expect(Topic.post_voting_votes(topic, nil)).to eq(nil)

--- a/plugins/discourse-post-voting/spec/system/post_voting_nested_topic_spec.rb
+++ b/plugins/discourse-post-voting/spec/system/post_voting_nested_topic_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe "Post voting nested topic" do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:topic) { Fabricate(:topic, subtype: Topic::POST_VOTING_SUBTYPE, user: user) }
+  fab!(:op) { Fabricate(:post, topic: topic, user: user, post_number: 1) }
+  fab!(:root_reply) { Fabricate(:post, topic: topic, raw: "Nested reply") }
+  fab!(:nested_topic) { Fabricate(:nested_topic, topic: topic) }
+
+  let(:nested_view) { PageObjects::Pages::NestedView.new }
+
+  before do
+    SiteSetting.nested_replies_enabled = true
+    SiteSetting.post_voting_enabled = true
+    sign_in(user)
+  end
+
+  it "lets the user read the topic in nested view" do
+    nested_view.visit_nested(topic)
+
+    expect(nested_view).to have_nested_view
+    expect(nested_view).to have_op_post
+    expect(nested_view).to have_root_post(root_reply)
+  end
+end


### PR DESCRIPTION
This disables the post voting plugin behavior on nested topics. We are removing some memoization here, but the memoization doesn't _really_ save us much as memoizing falsey values with `||=` has to be recomputed every time. Only saved a tiny but when the topic was indeed post voting enabled.