### PR TITLE
FIX: Closed topics no longer expose the existing unvote path

### DIFF
--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-button.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/components/vote-button.gjs
@@ -23,6 +23,10 @@ export default class VoteBox extends Component {
     return this.args.topic;
   }
 
+  get showClosedTooltip() {
+    return this.topic.closed && !this.topic.user_voted;
+  }
+
   get buttonIcon() {
     return this.topic.user_voted ? "vote-up-filled" : "vote-up";
   }
@@ -52,7 +56,7 @@ export default class VoteBox extends Component {
   }
 
   get ariaLabel() {
-    if (this.topic.closed) {
+    if (this.showClosedTooltip) {
       return i18n("topic_voting.voting_closed_description");
     }
     if (this.currentUser?.vote_limit === 0) {
@@ -151,7 +155,7 @@ export default class VoteBox extends Component {
   }
 
   <template>
-    {{#if this.topic.closed}}
+    {{#if this.showClosedTooltip}}
       <DTooltip @identifier="vote-closed-tooltip" @placement="right">
         <:trigger>
           <DButton

--- a/plugins/discourse-topic-voting/test/javascripts/integration/components/vote-button-test.gjs
+++ b/plugins/discourse-topic-voting/test/javascripts/integration/components/vote-button-test.gjs
@@ -1,0 +1,80 @@
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import VoteButton from "discourse/plugins/discourse-topic-voting/discourse/components/vote-button";
+
+module(
+  "Discourse Topic Voting | Integration | Component | vote-button",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    function configureCurrentUser(context) {
+      context.currentUser.setProperties({
+        vote_limit: 10,
+        votes_exceeded: false,
+        votes_left: 9,
+      });
+    }
+
+    test("closed topics without a vote render the closed tooltip instead of the voting menu", async function (assert) {
+      configureCurrentUser(this);
+      this.topic = { closed: true, user_voted: false };
+      this.addVote = () => assert.step("addVote");
+      this.removeVote = () => assert.step("removeVote");
+
+      await render(
+        <template>
+          <VoteButton
+            @topic={{this.topic}}
+            @addVote={{this.addVote}}
+            @removeVote={{this.removeVote}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".fk-d-tooltip__trigger[data-identifier='vote-closed-tooltip']")
+        .exists();
+      assert
+        .dom(".fk-d-tooltip__trigger button.voting-wrapper__button")
+        .isDisabled();
+      assert
+        .dom(".fk-d-menu__trigger[data-identifier='topic-voting-menu']")
+        .doesNotExist();
+      assert.verifySteps([]);
+    });
+
+    test("closed topics with an existing vote keep the remove vote path", async function (assert) {
+      configureCurrentUser(this);
+      this.topic = { closed: true, user_voted: true };
+      this.removeVoteCalls = 0;
+      this.addVote = () => {};
+      this.removeVote = () => this.removeVoteCalls++;
+
+      await render(
+        <template>
+          <VoteButton
+            @topic={{this.topic}}
+            @addVote={{this.addVote}}
+            @removeVote={{this.removeVote}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".fk-d-tooltip__trigger[data-identifier='vote-closed-tooltip']")
+        .doesNotExist();
+      assert
+        .dom(".fk-d-menu__trigger[data-identifier='topic-voting-menu']")
+        .exists();
+
+      await click(".fk-d-menu__trigger[data-identifier='topic-voting-menu']");
+
+      assert.dom("button.remove-vote").exists();
+
+      await click("button.remove-vote");
+
+      assert.strictEqual(this.removeVoteCalls, 1);
+    });
+  }
+);


### PR DESCRIPTION
## Summary

The patch fixes a logic bug where users were unable to remove their votes on closed topics because the voting button was replaced by a disabled tooltip. The component now only displays the disabled state for closed topics if the user has not yet voted, ensuring that existing votes remain manageable through the standard menu.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/915
- Original commit: https://github.com/discourse/discourse/commit/f5a29c690567d8f82eac4a1fe1aa0e0cd1427415

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>