### PR TITLE
DEV: Add `limit_admin_personal_messages_per_day` site setting

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -522,7 +522,17 @@ class Topic < ActiveRecord::Base
   def limit_private_messages_per_day
     return unless private_message?
     return if subtype == TopicSubtype.notify_moderators
-    apply_per_day_rate_limit_for("pms", :max_personal_messages_per_day)
+    if user&.admin? && SiteSetting.limit_admin_personal_messages_per_day > 0
+      RateLimiter.new(
+        user,
+        "pms-per-day",
+        SiteSetting.limit_admin_personal_messages_per_day,
+        1.day.to_i,
+        apply_limit_to_staff: true,
+      )
+    else
+      apply_per_day_rate_limit_for("pms", :max_personal_messages_per_day)
+    end
   end
 
   def self.fancy_title(title)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2189,6 +2189,7 @@ en:
     max_edits_per_day: "Maximum number of edits per user per day."
     max_topics_per_day: "Maximum number of topics a user can create per day."
     max_personal_messages_per_day: "Maximum number of new personal message topics a user can create per day."
+    limit_admin_personal_messages_per_day: "Maximum number of new personal message topics an admin can create per day. Set to 0 for no limit."
     max_invites_per_day: "Maximum number of invites a user can send per day."
     max_topic_invitations_per_day: "Maximum number of topic invitations a user can send per day."
     max_topic_invitations_per_minute: "Maximum number of topic invitations a user can send per minute."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3160,6 +3160,10 @@ rate_limits:
     default: 30
   max_topics_per_day: 20
   max_personal_messages_per_day: 20
+  limit_admin_personal_messages_per_day:
+    default: 0
+    min: 0
+    hidden: true
   max_likes_per_day: 50
   max_bookmarks_per_day: 20
   max_flags_per_day:

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2972,6 +2972,37 @@ RSpec.describe Topic do
         )
       }.to raise_error(RateLimiter::LimitExceeded)
     end
+
+    context "with limit_admin_personal_messages_per_day" do
+      it "does not rate limit admins when set to 0" do
+        SiteSetting.limit_admin_personal_messages_per_day = 0
+
+        2.times do
+          create_post(
+            user: admin,
+            archetype: "private_message",
+            target_usernames: [user1.username, user2.username],
+          )
+        end
+      end
+
+      it "rate limits admins when set to a non-zero value" do
+        SiteSetting.limit_admin_personal_messages_per_day = 1
+
+        create_post(
+          user: admin,
+          archetype: "private_message",
+          target_usernames: [user1.username, user2.username],
+        )
+        expect {
+          create_post(
+            user: admin,
+            archetype: "private_message",
+            target_usernames: [user1.username, user2.username],
+          )
+        }.to raise_error(RateLimiter::LimitExceeded)
+      end
+    end
   end
 
   describe ".count_exceeds_minimum?" do


### PR DESCRIPTION
Set to 0 by default, no limit. But can be overridden by plugins. 