### PR TITLE
DEV: Fix isolation bugs in service framework's `each` step

### DIFF
--- a/lib/service/base/context.rb
+++ b/lib/service/base/context.rb
@@ -23,15 +23,16 @@ module Service
       end
 
       def to_h
-        store.deep_dup
+        store.dup
       end
 
       def with_isolation(persist_keys: [])
-        @isolated_store = to_h
+        isolated_stores << to_h
         yield
       ensure
-        @store.merge!(@isolated_store.slice(*persist_keys, *step_result_keys))
-        @isolated_store = nil
+        isolated_stores.pop.then do |isolated_store|
+          store.merge!(isolated_store.slice(*persist_keys, *step_result_keys(isolated_store)))
+        end
       end
 
       # @return [Boolean] returns +true+ if the context is set as successful (default)
@@ -74,11 +75,15 @@ module Service
       private
 
       def store
-        @isolated_store || @store
+        isolated_stores.last || @store
       end
 
-      def step_result_keys
-        store.keys.select { it.start_with?("result.") }
+      def isolated_stores
+        @isolated_stores ||= []
+      end
+
+      def step_result_keys(source = store)
+        source.keys.select { it.start_with?("result.") }
       end
 
       def method_missing(method_name, *args, &block)

--- a/lib/service/base/each_step.rb
+++ b/lib/service/base/each_step.rb
@@ -16,18 +16,18 @@ module Service
       end
 
       def run_step
-        context.with_isolation(persist_keys: [item_name, :index, *initializers.keys]) do
-          context.merge!(initializers.transform_values { instance.instance_exec(&it) })
-          Array
-            .wrap(context[name])
-            .tap do |collection|
-              context[result_key].merge!(total: collection.size, skipped?: collection.empty?)
-            end
-            .each_with_index do |item, index|
+        context.merge!(initializers.transform_values { instance.instance_exec(&it) })
+        Array
+          .wrap(context[name])
+          .tap do |collection|
+            context[result_key].merge!(total: collection.size, skipped?: collection.empty?)
+          end
+          .each_with_index do |item, index|
+            context.with_isolation(persist_keys: [item_name, :index, *initializers.keys]) do
               context.merge!(item_name => item, :index => index)
               steps.each { |step| step.call(instance, context) }
             end
-        end
+          end
       end
 
       private

--- a/spec/lib/service/base/each_step_spec.rb
+++ b/spec/lib/service/base/each_step_spec.rb
@@ -132,6 +132,80 @@ RSpec.describe Service::Base::EachStep do
       end
     end
 
+    context "with isolation between iterations" do
+      let(:service) do
+        Class.new do
+          include Service::Base
+
+          step :setup
+
+          each :users, persist: { observed_values: -> { [] } } do
+            step :track
+          end
+
+          private
+
+          def setup
+            context[:users] = %i[alice bob]
+          end
+
+          def track(user:, observed_values:)
+            observed_values << context[:transient]
+            context[:transient] = user
+          end
+        end
+      end
+
+      it "does not leak non-persisted variables between iterations" do
+        expect(result).to have_attributes(observed_values: [nil, nil])
+      end
+    end
+
+    context "when the outer context contains an ActiveRecord model" do
+      fab!(:user)
+
+      let(:service) do
+        Class.new do
+          include Service::Base
+
+          model :user
+          step :setup_usernames
+
+          each :usernames,
+               persist: {
+                 seen_user_ids: -> { [] },
+                 user_persisted_states: -> { [] },
+               } do
+            step :track_user
+          end
+
+          private
+
+          def fetch_user(user_id:)
+            User.find(user_id)
+          end
+
+          def setup_usernames
+            context[:usernames] = %i[alice bob]
+          end
+
+          def track_user(user:, seen_user_ids:, user_persisted_states:)
+            seen_user_ids << user.id
+            user_persisted_states << user.persisted?
+          end
+        end
+      end
+
+      let(:dependencies) { { user_id: user.id } }
+
+      it "keeps the original model available inside each iterations" do
+        expect(result).to have_attributes(
+          seen_user_ids: [user.id, user.id],
+          user_persisted_states: [true, true],
+        )
+      end
+    end
+
     context "with persist option" do
       context "with a lambda initializer" do
         let(:service) do
@@ -194,6 +268,46 @@ RSpec.describe Service::Base::EachStep do
         it "initializes by calling the method" do
           expect(result[:results]).to eq(processed: %i[alice bob], count: 2)
         end
+      end
+    end
+
+    context "when nesting each steps" do
+      let(:service) do
+        Class.new do
+          include Service::Base
+
+          model :groups
+
+          each :groups, persist: { processed: -> { [] } } do
+            each :group, as: :item, persist: { processed: -> { context[:processed] } } do
+              step :collect_item
+            end
+          end
+
+          private
+
+          def fetch_groups
+            context[:input_groups]
+          end
+
+          def collect_item(group:, item:, processed:)
+            processed << [group, item]
+          end
+        end
+      end
+      let(:dependencies) { { input_groups: [%i[alice bob], %i[charlie dave]] } }
+
+      it { is_expected.to run_successfully }
+
+      it "accumulates results across both levels of iteration" do
+        expect(result[:processed]).to eq(
+          [
+            [%i[alice bob], :alice],
+            [%i[alice bob], :bob],
+            [%i[charlie dave], :charlie],
+            [%i[charlie dave], :dave],
+          ],
+        )
       end
     end
   end


### PR DESCRIPTION
Three independent issues in `each`'s isolation, each surfacing as soon as the step is used outside the simplest shapes:

1. Nested `each` blocks crashed inside `with_isolation`'s `ensure`. The isolation kept its snapshot in a single slot that the inner call would overwrite then null, so the outer's cleanup ran against `nil`. The snapshot now lives on a stack, making isolation re-entrant.

2. ActiveRecord models in the context lost their primary key inside an `each` block. The snapshot used `deep_dup`, which recurses into AR objects via `dup` and AR's `dup` returns an unpersisted copy with `id == nil`. Basic shapes like `model :user; each :things do ... end` silently swapped the real user for a useless ghost. The deep copy was originally an attempt at mutation isolation for collections, but that contract was never documented, its supporting spec was removed before the original PR merged, and the rest of the framework already lets steps mutate what they receive. A shallow dup matches the documented "variables set inside the loop don't leak" guarantee and stops corrupting models.

3. Non-persisted state leaked between iterations. The whole loop ran inside one isolation, so iteration N could read scratch values iteration N-1 had left around. Each iteration now gets its own isolation. Steps inside the same iteration still share state freely (step 2 can act on what step 1 produced); only cross-iteration carry-over now requires `persist:`, which makes that dependency visible at the `each` declaration.