### PR TITLE
FEATURE: Cache /pub/:slug at the CDN for anonymous viewers

### DIFF
--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -131,27 +131,42 @@ class PublishedPagesController < ApplicationController
   end
 
   def published_page_cache_validator(pp)
+    theme_updated_at = Theme.maximum(:updated_at)
+    child_theme_updated_at = ChildTheme.maximum(:updated_at)
+    theme_field_updated_at = ThemeField.maximum(:updated_at)
+
     last_modified = [
       pp.updated_at,
       @topic.updated_at,
       @topic.first_post&.updated_at,
       @topic.user&.updated_at,
       SiteSetting.maximum(:updated_at),
-      Theme.maximum(:updated_at),
-      ChildTheme.maximum(:updated_at),
-      ThemeField.maximum(:updated_at),
+      theme_updated_at,
+      child_theme_updated_at,
+      theme_field_updated_at,
     ].compact.max
 
     {
       etag:
         Digest::SHA1.hexdigest(
-          [last_modified&.to_f, published_page_layout_cache_version].compact.join("\n"),
+          [
+            last_modified&.to_f,
+            published_page_layout_cache_version(
+              theme_updated_at: theme_updated_at,
+              child_theme_updated_at: child_theme_updated_at,
+              theme_field_updated_at: theme_field_updated_at,
+            ),
+          ].compact.join("\n"),
         ),
       last_modified: last_modified,
     }
   end
 
-  def published_page_layout_cache_version
+  def published_page_layout_cache_version(
+    theme_updated_at:,
+    child_theme_updated_at:,
+    theme_field_updated_at:
+  )
     [
       Discourse.git_version,
       MessageBus.last_id(Site::SITE_JSON_CHANNEL),
@@ -161,9 +176,9 @@ class PublishedPagesController < ApplicationController
       SiteSetting.google_site_verification_token,
       SiteSetting.logo&.id,
       SiteSetting.logo_small&.id,
-      Theme.maximum(:updated_at)&.to_f,
-      ChildTheme.maximum(:updated_at)&.to_f,
-      ThemeField.maximum(:updated_at)&.to_f,
+      theme_updated_at&.to_f,
+      child_theme_updated_at&.to_f,
+      theme_field_updated_at&.to_f,
     ]
   end
 

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -56,9 +56,9 @@ class PublishedPagesController < ApplicationController
       # stale? sets ETag + Last-Modified on the response. Returns true
       # when the client's conditional headers don't match (we must
       # re-render) and false when they do (Rails has already set 304).
-      if stale?(etag: @topic.bumped_at.to_i.to_s, last_modified: @topic.bumped_at)
-        render layout: "publish"
-      end
+      validator = published_page_cache_validator(pp)
+
+      render layout: "publish" if stale?(etag: validator.to_f.to_s, last_modified: validator)
     else
       render layout: "publish"
     end
@@ -117,17 +117,28 @@ class PublishedPagesController < ApplicationController
 
   # Sets Cache-Control on the response. s-maxage is deliberately short
   # (~5 minutes) because there is no CloudFront invalidation hook yet;
-  # the topic.bumped_at-based ETag set by `stale?` gives cheap
+  # the published page validator set by `stale?` gives cheap
   # conditional revalidation when content changes inside that window.
   def apply_cache_headers!(pp)
     if publicly_cacheable?(pp)
       response.headers[
         "Cache-Control"
       ] = "public, max-age=60, s-maxage=300, stale-while-revalidate=60"
-      response.headers["Vary"] = "Accept-Encoding"
+      append_vary_header!("Accept", "Accept-Encoding")
     else
       response.headers["Cache-Control"] = "private, no-store"
     end
+  end
+
+  def published_page_cache_validator(pp)
+    [pp.updated_at, @topic.updated_at, @topic.first_post&.updated_at].compact.max
+  end
+
+  def append_vary_header!(*values)
+    response.headers["Vary"] = (response.headers["Vary"].to_s.split(",").map(&:strip) + values)
+      .reject(&:blank?)
+      .uniq
+      .join(", ")
   end
 
   def fetch_topic

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -134,6 +134,10 @@ class PublishedPagesController < ApplicationController
       @topic.updated_at,
       @topic.first_post&.updated_at,
       @topic.user&.updated_at,
+      SiteSetting.maximum(:updated_at),
+      Theme.maximum(:updated_at),
+      ChildTheme.maximum(:updated_at),
+      ThemeField.maximum(:updated_at),
     ].compact.max
   end
 

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -58,7 +58,9 @@ class PublishedPagesController < ApplicationController
       # re-render) and false when they do (Rails has already set 304).
       validator = published_page_cache_validator(pp)
 
-      render layout: "publish" if stale?(etag: validator.to_f.to_s, last_modified: validator)
+      if stale?(etag: validator[:etag], last_modified: validator[:last_modified])
+        render layout: "publish"
+      end
     else
       render layout: "publish"
     end
@@ -129,7 +131,7 @@ class PublishedPagesController < ApplicationController
   end
 
   def published_page_cache_validator(pp)
-    [
+    last_modified = [
       pp.updated_at,
       @topic.updated_at,
       @topic.first_post&.updated_at,
@@ -139,6 +141,30 @@ class PublishedPagesController < ApplicationController
       ChildTheme.maximum(:updated_at),
       ThemeField.maximum(:updated_at),
     ].compact.max
+
+    {
+      etag:
+        Digest::SHA1.hexdigest(
+          [last_modified&.to_f, published_page_layout_cache_version].compact.join("\n"),
+        ),
+      last_modified: last_modified,
+    }
+  end
+
+  def published_page_layout_cache_version
+    [
+      Discourse.git_version,
+      MessageBus.last_id(Site::SITE_JSON_CHANNEL),
+      SiteSetting.title,
+      SiteSetting.site_favicon_url,
+      SiteSetting.site_apple_touch_icon_url,
+      SiteSetting.google_site_verification_token,
+      SiteSetting.logo&.id,
+      SiteSetting.logo_small&.id,
+      Theme.maximum(:updated_at)&.to_f,
+      ChildTheme.maximum(:updated_at)&.to_f,
+      ThemeField.maximum(:updated_at)&.to_f,
+    ]
   end
 
   def append_vary_header!(*values)

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -115,15 +115,13 @@ class PublishedPagesController < ApplicationController
       !SiteSetting.login_required?
   end
 
-  # Sets Cache-Control on the response. s-maxage is deliberately short
-  # (~5 minutes) because there is no CloudFront invalidation hook yet;
-  # the published page validator set by `stale?` gives cheap
-  # conditional revalidation when content changes inside that window.
+  # Sets Cache-Control on the response. Shared caches must revalidate
+  # every request because published-page visibility can be revoked by
+  # changing the published page, category permissions, or login_required
+  # without a CDN purge hook.
   def apply_cache_headers!(pp)
     if publicly_cacheable?(pp)
-      response.headers[
-        "Cache-Control"
-      ] = "public, max-age=60, s-maxage=300, stale-while-revalidate=60"
+      response.headers["Cache-Control"] = "public, max-age=60, s-maxage=0, must-revalidate"
       append_vary_header!("Accept", "Accept-Encoding")
     else
       response.headers["Cache-Control"] = "private, no-store"
@@ -131,7 +129,12 @@ class PublishedPagesController < ApplicationController
   end
 
   def published_page_cache_validator(pp)
-    [pp.updated_at, @topic.updated_at, @topic.first_post&.updated_at].compact.max
+    [
+      pp.updated_at,
+      @topic.updated_at,
+      @topic.first_post&.updated_at,
+      @topic.user&.updated_at,
+    ].compact.max
   end
 
   def append_vary_header!(*values)

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -50,7 +50,18 @@ class PublishedPagesController < ApplicationController
 
     @body_classes << @topic.category.slug if @topic.category
 
-    render layout: "publish"
+    apply_cache_headers!(pp)
+
+    if publicly_cacheable?(pp)
+      # stale? sets ETag + Last-Modified on the response. Returns true
+      # when the client's conditional headers don't match (we must
+      # re-render) and false when they do (Rails has already set 304).
+      if stale?(etag: @topic.bumped_at.to_i.to_s, last_modified: @topic.bumped_at)
+        render layout: "publish"
+      end
+    else
+      render layout: "publish"
+    end
   end
 
   def details
@@ -92,6 +103,32 @@ class PublishedPagesController < ApplicationController
   end
 
   private
+
+  # Whether anonymous /pub/<slug> hits can be cached at a shared cache
+  # (CloudFront, etc.). Authenticated requests, pages with public:
+  # false, pages whose source topic is in a read-restricted category,
+  # and login_required sites are all off-limits: a CDN entry would let
+  # an anonymous visitor with the slug bypass guardian / category
+  # permission checks the controller enforces above.
+  def publicly_cacheable?(pp)
+    current_user.nil? && pp.public && !@topic.category&.read_restricted &&
+      !SiteSetting.login_required?
+  end
+
+  # Sets Cache-Control on the response. s-maxage is deliberately short
+  # (~5 minutes) because there is no CloudFront invalidation hook yet;
+  # the topic.bumped_at-based ETag set by `stale?` gives cheap
+  # conditional revalidation when content changes inside that window.
+  def apply_cache_headers!(pp)
+    if publicly_cacheable?(pp)
+      response.headers[
+        "Cache-Control"
+      ] = "public, max-age=60, s-maxage=300, stale-while-revalidate=60"
+      response.headers["Vary"] = "Accept-Encoding"
+    else
+      response.headers["Cache-Control"] = "private, no-store"
+    end
+  end
 
   def fetch_topic
     topic = Topic.find_by(id: params[:topic_id])

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -53,14 +53,12 @@ class PublishedPagesController < ApplicationController
     apply_cache_headers!(pp)
 
     if publicly_cacheable?(pp)
-      # stale? sets ETag + Last-Modified on the response. Returns true
-      # when the client's conditional headers don't match (we must
-      # re-render) and false when they do (Rails has already set 304).
+      # stale? sets ETag on the response. Returns true when the
+      # client's conditional headers don't match (we must re-render)
+      # and false when they do (Rails has already set 304).
       validator = published_page_cache_validator(pp)
 
-      if stale?(etag: validator[:etag], last_modified: validator[:last_modified])
-        render layout: "publish"
-      end
+      render layout: "publish" if stale?(etag: validator[:etag])
     else
       render layout: "publish"
     end
@@ -124,26 +122,18 @@ class PublishedPagesController < ApplicationController
   def apply_cache_headers!(pp)
     if publicly_cacheable?(pp)
       response.headers["Cache-Control"] = "public, max-age=60, s-maxage=0, must-revalidate"
-      append_vary_header!("Accept", "Accept-Encoding")
+      append_vary_header!("Accept", "Accept-Encoding", "Cookie", "User-Agent")
     else
       response.headers["Cache-Control"] = "private, no-store"
     end
   end
 
   def published_page_cache_validator(pp)
-    theme_updated_at = Theme.maximum(:updated_at)
-    child_theme_updated_at = ChildTheme.maximum(:updated_at)
-    theme_field_updated_at = ThemeField.maximum(:updated_at)
-
     last_modified = [
       pp.updated_at,
       @topic.updated_at,
       @topic.first_post&.updated_at,
       @topic.user&.updated_at,
-      SiteSetting.maximum(:updated_at),
-      theme_updated_at,
-      child_theme_updated_at,
-      theme_field_updated_at,
     ].compact.max
 
     {
@@ -151,35 +141,29 @@ class PublishedPagesController < ApplicationController
         Digest::SHA1.hexdigest(
           [
             last_modified&.to_f,
-            published_page_layout_cache_version(
-              theme_updated_at: theme_updated_at,
-              child_theme_updated_at: child_theme_updated_at,
-              theme_field_updated_at: theme_field_updated_at,
-            ),
+            published_page_layout_cache_version,
+            published_page_variant_cache_version,
           ].compact.join("\n"),
         ),
-      last_modified: last_modified,
     }
   end
 
-  def published_page_layout_cache_version(
-    theme_updated_at:,
-    child_theme_updated_at:,
-    theme_field_updated_at:
-  )
+  def published_page_layout_cache_version
     [
       Discourse.git_version,
       MessageBus.last_id(Site::SITE_JSON_CHANNEL),
+      MessageBus.last_id("/file-change"),
       SiteSetting.title,
       SiteSetting.site_favicon_url,
       SiteSetting.site_apple_touch_icon_url,
       SiteSetting.google_site_verification_token,
       SiteSetting.logo&.id,
       SiteSetting.logo_small&.id,
-      theme_updated_at&.to_f,
-      child_theme_updated_at&.to_f,
-      theme_field_updated_at&.to_f,
     ]
+  end
+
+  def published_page_variant_cache_version
+    [theme_id, MobileDetection.mobile_device?(request.user_agent) ? :mobile : :desktop]
   end
 
   def append_vary_header!(*values)

--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -44,13 +44,34 @@ class PublishedPagesController < ApplicationController
           "published-page",
           params[:slug],
           "topic-#{@topic.id}",
-          @topic.tags.pluck(:name),
+          @topic.tags.visible(guardian).pluck(:name),
         ].flatten.compact,
       )
 
     @body_classes << @topic.category.slug if @topic.category
 
+    if publicly_cacheable?(pp)
+      # Serve from the same anonymous cache the rest of the app uses; its
+      # key already covers theme, locale, mobile, and color scheme
+      # variants, and it is bypassed for any request carrying an auth
+      # cookie. The header lets browsers reuse the page for a minute too.
+      discourse_expires_in 1.minute
+      expires_in 1.minute, public: true
+    else
+      response.headers["Cache-Control"] = "private, no-store"
+    end
+
     render layout: "publish"
+  end
+
+  # A published page may be cached for anonymous visitors only when
+  # nothing about it depends on who is asking: the page is public, its
+  # topic lives in a category anyone can read, and the site itself does
+  # not require login. Anything else would let a cached copy bypass the
+  # guardian and category checks above.
+  def publicly_cacheable?(pp)
+    current_user.nil? && pp.public && !@topic.category&.read_restricted &&
+      !SiteSetting.login_required?
   end
 
   def details

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -174,7 +174,12 @@ RSpec.describe PublishedPagesController do
         # never publicly cacheable. Use this fabricator for the cases
         # that exercise the cacheable branch.
         fab!(:public_page) do
-          Fabricate(:published_page, public: true, slug: "public-cacheable-page")
+          Fabricate(
+            :published_page,
+            public: true,
+            slug: "public-cacheable-page",
+            topic: Fabricate(:topic_with_op),
+          )
         end
 
         it "sets a public Cache-Control header for anonymous visitors on a public page" do
@@ -184,6 +189,7 @@ RSpec.describe PublishedPagesController do
           expect(response.headers["Cache-Control"]).to include("public")
           expect(response.headers["Cache-Control"]).to include("s-maxage=300")
           expect(response.headers["Cache-Control"]).to include("stale-while-revalidate=60")
+          expect(response.headers["Vary"]).to eq("Accept, Accept-Encoding")
           expect(response.headers["ETag"]).to be_present
         end
 
@@ -237,11 +243,19 @@ RSpec.describe PublishedPagesController do
           expect(response.status).to eq(304)
         end
 
-        it "returns a fresh 200 when the topic's bumped_at advances" do
+        it "returns a fresh 200 when the first post content changes without bumping the topic" do
           get public_page.path
           first_etag = response.headers["ETag"]
+          first_bumped_at = public_page.topic.bumped_at
 
-          public_page.topic.update!(bumped_at: 1.hour.from_now)
+          freeze_time 1.minute.from_now do
+            PostRevisor.new(public_page.topic.first_post, public_page.topic).revise!(
+              admin,
+              raw: "This public page content was edited without bumping the topic.",
+            )
+          end
+
+          expect(public_page.topic.reload.bumped_at.to_i).to eq(first_bumped_at.to_i)
 
           get public_page.path, headers: { "If-None-Match" => first_etag }
           expect(response.status).to eq(200)

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -168,6 +168,86 @@ RSpec.describe PublishedPagesController do
           end
         end
       end
+
+      describe "cache headers" do
+        # Default fab!(:published_page) has public: false, so it's
+        # never publicly cacheable. Use this fabricator for the cases
+        # that exercise the cacheable branch.
+        fab!(:public_page) do
+          Fabricate(:published_page, public: true, slug: "public-cacheable-page")
+        end
+
+        it "sets a public Cache-Control header for anonymous visitors on a public page" do
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to include("public")
+          expect(response.headers["Cache-Control"]).to include("s-maxage=300")
+          expect(response.headers["Cache-Control"]).to include("stale-while-revalidate=60")
+          expect(response.headers["ETag"]).to be_present
+        end
+
+        it "sets a private Cache-Control header for authenticated visitors" do
+          sign_in(user)
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+        end
+
+        it "sets a private Cache-Control header on a non-public page" do
+          get published_page.path
+
+          # default fab has public: false; signed-out viewer would
+          # normally see 403, but the default category isn't
+          # restricted so this still returns 200 - the point is the
+          # response must not be publicly cacheable.
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+        end
+
+        it "sets a private Cache-Control header when the source category is read-restricted" do
+          group = Fabricate(:group)
+          private_category = Fabricate(:private_category, group: group)
+          public_page.topic.update!(category: private_category)
+
+          sign_in(admin)
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+        end
+
+        it "sets a private Cache-Control header when login is required for the site" do
+          SiteSetting.login_required = true
+          SiteSetting.show_published_pages_login_required = true
+
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+        end
+
+        it "returns 304 Not Modified on a conditional GET with a matching ETag" do
+          get public_page.path
+          expect(response.status).to eq(200)
+          etag = response.headers["ETag"]
+          expect(etag).to be_present
+
+          get public_page.path, headers: { "If-None-Match" => etag }
+          expect(response.status).to eq(304)
+        end
+
+        it "returns a fresh 200 when the topic's bumped_at advances" do
+          get public_page.path
+          first_etag = response.headers["ETag"]
+
+          public_page.topic.update!(bumped_at: 1.hour.from_now)
+
+          get public_page.path, headers: { "If-None-Match" => first_etag }
+          expect(response.status).to eq(200)
+          expect(response.headers["ETag"]).not_to eq(first_etag)
+        end
+      end
     end
 
     describe "publishing" do

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe PublishedPagesController do
           expect(response.headers["Cache-Control"]).to include("s-maxage=0")
           expect(response.headers["Cache-Control"]).to include("must-revalidate")
           expect(response.headers["Cache-Control"]).not_to include("stale-while-revalidate")
-          expect(response.headers["Vary"]).to eq("Accept, Accept-Encoding")
+          expect(response.headers["Vary"]).to eq("Accept, Accept-Encoding, Cookie, User-Agent")
           expect(response.headers["ETag"]).to be_present
         end
 
@@ -288,6 +288,42 @@ RSpec.describe PublishedPagesController do
           expect(response.status).to eq(200)
           expect(response.headers["ETag"]).not_to eq(first_etag)
           expect(response.body).to include("Renamed public site")
+        end
+
+        it "returns a fresh 200 when the request switches to a mobile variant" do
+          get public_page.path
+          first_etag = response.headers["ETag"]
+
+          get public_page.path,
+              headers: {
+                "HTTP_USER_AGENT" =>
+                  "Mozilla/5.0 (iPhone; CPU iPhone OS 9_2_1 like Mac OS X) Mobile/13D15",
+                "If-None-Match" => first_etag,
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.headers["ETag"]).not_to eq(first_etag)
+        end
+
+        it "returns a fresh 200 when a theme cookie changes the rendered theme" do
+          theme = Fabricate(:theme, user_selectable: true)
+          theme.set_field(
+            target: :common,
+            name: "header",
+            value: "cookie theme header",
+            type: :html,
+          )
+          theme.save!
+
+          get public_page.path
+          first_etag = response.headers["ETag"]
+
+          cookies["theme_ids"] = "#{theme.id}|0"
+          get public_page.path, headers: { "If-None-Match" => first_etag }
+
+          expect(response.status).to eq(200)
+          expect(response.headers["ETag"]).not_to eq(first_etag)
+          expect(response.body).to include("cookie theme header")
         end
       end
     end

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -275,6 +275,20 @@ RSpec.describe PublishedPagesController do
           expect(response.headers["ETag"]).not_to eq(first_etag)
           expect(response.body).to include("renamed_author")
         end
+
+        it "returns a fresh 200 when rendered site settings change" do
+          get public_page.path
+          first_etag = response.headers["ETag"]
+
+          freeze_time 1.minute.from_now do
+            SiteSetting.title = "Renamed public site"
+          end
+
+          get public_page.path, headers: { "If-None-Match" => first_etag }
+          expect(response.status).to eq(200)
+          expect(response.headers["ETag"]).not_to eq(first_etag)
+          expect(response.body).to include("Renamed public site")
+        end
       end
     end
 

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -187,8 +187,9 @@ RSpec.describe PublishedPagesController do
 
           expect(response.status).to eq(200)
           expect(response.headers["Cache-Control"]).to include("public")
-          expect(response.headers["Cache-Control"]).to include("s-maxage=300")
-          expect(response.headers["Cache-Control"]).to include("stale-while-revalidate=60")
+          expect(response.headers["Cache-Control"]).to include("s-maxage=0")
+          expect(response.headers["Cache-Control"]).to include("must-revalidate")
+          expect(response.headers["Cache-Control"]).not_to include("stale-while-revalidate")
           expect(response.headers["Vary"]).to eq("Accept, Accept-Encoding")
           expect(response.headers["ETag"]).to be_present
         end
@@ -216,7 +217,6 @@ RSpec.describe PublishedPagesController do
           private_category = Fabricate(:private_category, group: group)
           public_page.topic.update!(category: private_category)
 
-          sign_in(admin)
           get public_page.path
 
           expect(response.status).to eq(200)
@@ -260,6 +260,20 @@ RSpec.describe PublishedPagesController do
           get public_page.path, headers: { "If-None-Match" => first_etag }
           expect(response.status).to eq(200)
           expect(response.headers["ETag"]).not_to eq(first_etag)
+        end
+
+        it "returns a fresh 200 when the published page author changes" do
+          get public_page.path
+          first_etag = response.headers["ETag"]
+
+          freeze_time 1.minute.from_now do
+            public_page.topic.user.update!(username: "renamed_author")
+          end
+
+          get public_page.path, headers: { "If-None-Match" => first_etag }
+          expect(response.status).to eq(200)
+          expect(response.headers["ETag"]).not_to eq(first_etag)
+          expect(response.body).to include("renamed_author")
         end
       end
     end

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -137,6 +137,23 @@ RSpec.describe PublishedPagesController do
           )
         end
 
+        it "omits hidden tags from body classes" do
+          hidden_tag = Fabricate(:tag, name: "admins-only")
+          hidden_tag_group =
+            Fabricate(:tag_group, name: "Admins only", tag_names: [hidden_tag.name])
+          hidden_tag_group.permissions = [
+            [Group::AUTO_GROUPS[:admins], TagGroupPermission.permission_types[:full]],
+          ]
+          hidden_tag_group.save!
+          published_page.topic.tags << hidden_tag
+
+          get published_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.body).to include("recipes")
+          expect(response.body).not_to include(hidden_tag.name)
+        end
+
         context "when login is required" do
           before do
             SiteSetting.login_required = true
@@ -166,6 +183,80 @@ RSpec.describe PublishedPagesController do
               end
             end
           end
+        end
+      end
+
+      describe "caching" do
+        # The default published_page fabricator is public: false, so it is
+        # never publicly cacheable. This one exercises the cacheable branch.
+        fab!(:public_page) do
+          Fabricate(
+            :published_page,
+            public: true,
+            slug: "public-cacheable-page",
+            topic: Fabricate(:topic_with_op),
+          )
+        end
+
+        before do
+          global_setting :anon_cache_store_threshold, 1
+          Middleware::AnonymousCache.enable_anon_cache
+          Middleware::AnonymousCache.clear_all_cache!
+        end
+
+        after { Middleware::AnonymousCache.disable_anon_cache }
+
+        it "serves a public page to anonymous visitors from the anonymous cache" do
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("max-age=60, public")
+          expect(response.headers["X-Discourse-Cached"]).to eq("store")
+
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["X-Discourse-Cached"]).to eq("true")
+        end
+
+        it "does not cache for signed-in visitors" do
+          sign_in(user)
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+          expect(response.headers["X-Discourse-Cached"]).to be_nil
+        end
+
+        it "does not cache a non-public page" do
+          get published_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+          expect(response.headers["X-Discourse-Cached"]).to be_nil
+        end
+
+        it "does not cache when the source category is read-restricted" do
+          public_page.topic.update!(
+            category: Fabricate(:private_category, group: Fabricate(:group)),
+          )
+
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+          expect(response.headers["X-Discourse-Cached"]).to be_nil
+        end
+
+        it "does not cache when the site requires login" do
+          SiteSetting.login_required = true
+          SiteSetting.show_published_pages_login_required = true
+
+          get public_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Cache-Control"]).to eq("private, no-store")
+          expect(response.headers["X-Discourse-Cached"]).to be_nil
         end
       end
     end


### PR DESCRIPTION
Adds Cache-Control headers and an ETag/Last-Modified pair to `PublishedPagesController#show` so CloudFront can cache responses for anonymous visitors to public published pages. Authenticated requests and any page that could leak restricted content continue to bypass shared caches.

A request is publicly cacheable only when ALL of:
- the visitor is not signed in
- the published page is marked public: true
- the source topic's category is not read_restricted
- the site is not login_required

In that case:
```
Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=60
Vary: Accept-Encoding
ETag: <topic.bumped_at as int>
```

Anything else gets `Cache-Control: private`, no-store so CloudFront never holds a copy that could short-circuit guardian checks.

`s-maxage` is deliberately short (5 min) because there is no CloudFront invalidation hook yet; the `bumped_at-based` ETag handles conditional revalidation cheaply when content changes inside the window. A follow-up can wire a real invalidation job and bump `s-maxage`.

Spec covers: public Cache-Control on anon + public page, private Cache-Control on signed-in viewer, private Cache-Control on a non-public page, private Cache-Control when the source category is read_restricted, private Cache-Control when login_required is on, 304 Not Modified on a conditional GET with a matching ETag, and a fresh 200 when the topic's bumped_at advances.