### PR TITLE
FEATURE: emit /pub/<slug> URLs in the sitemap

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -6,6 +6,7 @@ class SitemapController < ApplicationController
   before_action :check_sitemap_enabled
 
   def index
+    Sitemap.sync_published_pages_sitemap!
     @sitemaps = Sitemap.where(enabled: true).where.not(name: Sitemap::NEWS_SITEMAP_NAME)
 
     render :index
@@ -56,6 +57,20 @@ class SitemapController < ApplicationController
         end
 
     render plain: @output, content_type: "text/xml; charset=UTF-8" unless performed?
+  end
+
+  # Emits a sitemap of /pub/<slug> URLs for PublishedPage records that
+  # the PublishedPagesController would serve to anonymous visitors
+  # without a guardian check. Sitemap.publishable_pages enforces the
+  # same settings and visibility gates so the source of truth for
+  # "what's anonymously reachable" lives in one place.
+  def published_pages
+    raise Discourse::NotFound if !Sitemap.published_pages_sitemap_available?
+
+    sitemap = Sitemap.touch(Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+    @pages = sitemap.published_pages
+
+    render :published_pages, content_type: "text/xml; charset=UTF-8"
   end
 
   private

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -61,8 +61,8 @@ class SitemapController < ApplicationController
   # Emits a sitemap of /pub/<slug> URLs for PublishedPage records that
   # the PublishedPagesController would serve to anonymous visitors
   # without a guardian check. Sitemap.publishable_pages enforces the
-  # filter (public + visible + non-restricted category) so the source
-  # of truth for "what's publicly cacheable" lives in one place.
+  # same settings and visibility gates so the source of truth for
+  # "what's anonymously reachable" lives in one place.
   def published_pages
     raise Discourse::NotFound if !Sitemap.publishable_pages.exists?
     sitemap = Sitemap.touch(Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -58,6 +58,26 @@ class SitemapController < ApplicationController
     render plain: @output, content_type: "text/xml; charset=UTF-8" unless performed?
   end
 
+  # Emits a sitemap of /pub/<slug> URLs for PublishedPage records that
+  # the PublishedPagesController would serve to anonymous visitors
+  # without a guardian check. Sitemap.publishable_pages enforces the
+  # filter (public + visible + non-restricted category) so the source
+  # of truth for "what's publicly cacheable" lives in one place.
+  def published_pages
+    raise Discourse::NotFound if !Sitemap.publishable_pages.exists?
+    sitemap = Sitemap.touch(Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+
+    @output =
+      Rails
+        .cache
+        .fetch("sitemap/published_pages/#{sitemap.last_posted_at.to_i}", expires_in: 1.hour) do
+          @pages = sitemap.published_pages
+          render :published_pages, content_type: "text/xml; charset=UTF-8"
+        end
+
+    render plain: @output, content_type: "text/xml; charset=UTF-8" unless performed?
+  end
+
   private
 
   def check_sitemap_enabled

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -64,18 +64,12 @@ class SitemapController < ApplicationController
   # same settings and visibility gates so the source of truth for
   # "what's anonymously reachable" lives in one place.
   def published_pages
-    raise Discourse::NotFound if !Sitemap.publishable_pages.exists?
+    raise Discourse::NotFound if !Sitemap.published_pages_sitemap_available?
+
     sitemap = Sitemap.touch(Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+    @pages = sitemap.published_pages
 
-    @output =
-      Rails
-        .cache
-        .fetch("sitemap/published_pages/#{sitemap.last_posted_at.to_i}", expires_in: 1.hour) do
-          @pages = sitemap.published_pages
-          render :published_pages, content_type: "text/xml; charset=UTF-8"
-        end
-
-    render plain: @output, content_type: "text/xml; charset=UTF-8" unless performed?
+    render :published_pages, content_type: "text/xml; charset=UTF-8"
   end
 
   private

--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -6,6 +6,7 @@ class SitemapController < ApplicationController
   before_action :check_sitemap_enabled
 
   def index
+    Sitemap.sync_published_pages_sitemap!
     @sitemaps = Sitemap.where(enabled: true).where.not(name: Sitemap::NEWS_SITEMAP_NAME)
 
     render :index

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -11,7 +11,7 @@ class Sitemap < ActiveRecord::Base
 
       names_used.each { |name| touch(name) }
 
-      if publishable_pages.exists?
+      if published_pages_sitemap_available?
         touch(PUBLISHED_PAGES_SITEMAP_NAME)
         names_used << PUBLISHED_PAGES_SITEMAP_NAME
       end
@@ -55,6 +55,11 @@ class Sitemap < ActiveRecord::Base
         .joins(:topic)
         .where(topics: { visible: true, category_id: public_category_ids })
     end
+
+    def published_pages_sitemap_available?
+      count = publishable_pages.limit(SiteSetting.sitemap_page_size + 1).count
+      count.positive? && count <= SiteSetting.sitemap_page_size
+    end
   end
 
   def topics
@@ -71,7 +76,12 @@ class Sitemap < ActiveRecord::Base
   # [[slug, updated_at], ...]. Only meaningful when name ==
   # PUBLISHED_PAGES_SITEMAP_NAME.
   def published_pages
-    self.class.publishable_pages.pluck(:slug, "published_pages.updated_at")
+    self
+      .class
+      .publishable_pages
+      .order(:id)
+      .limit(SiteSetting.sitemap_page_size)
+      .pluck(:slug, "published_pages.updated_at")
   end
 
   def last_posted_topic

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -11,10 +11,7 @@ class Sitemap < ActiveRecord::Base
 
       names_used.each { |name| touch(name) }
 
-      if published_pages_sitemap_available?
-        touch(PUBLISHED_PAGES_SITEMAP_NAME)
-        names_used << PUBLISHED_PAGES_SITEMAP_NAME
-      end
+      names_used << PUBLISHED_PAGES_SITEMAP_NAME if sync_published_pages_sitemap!
 
       count = Category.where(read_restricted: false).sum(:topic_count)
       max_page_size = SiteSetting.sitemap_page_size
@@ -56,6 +53,15 @@ class Sitemap < ActiveRecord::Base
       count = publishable_pages.limit(SiteSetting.sitemap_page_size + 1).count
       count.positive? && count <= SiteSetting.sitemap_page_size
     end
+
+    def sync_published_pages_sitemap!
+      if published_pages_sitemap_available?
+        touch(PUBLISHED_PAGES_SITEMAP_NAME)
+      else
+        where(name: PUBLISHED_PAGES_SITEMAP_NAME).update_all(enabled: false)
+        nil
+      end
+    end
   end
 
   def topics
@@ -82,7 +88,9 @@ class Sitemap < ActiveRecord::Base
 
   def last_posted_topic
     if name == PUBLISHED_PAGES_SITEMAP_NAME
-      self.class.publishable_pages.maximum("published_pages.updated_at")
+      PublishedPage.joins(topic: :category).maximum(
+        "GREATEST(published_pages.updated_at, topics.updated_at, categories.updated_at)",
+      )
     else
       sitemap_topics.maximum(:updated_at)
     end

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -3,12 +3,18 @@
 class Sitemap < ActiveRecord::Base
   RECENT_SITEMAP_NAME = "recent"
   NEWS_SITEMAP_NAME = "news"
+  PUBLISHED_PAGES_SITEMAP_NAME = "published_pages"
 
   class << self
     def regenerate_sitemaps
       names_used = [RECENT_SITEMAP_NAME, NEWS_SITEMAP_NAME]
 
       names_used.each { |name| touch(name) }
+
+      if publishable_pages.exists?
+        touch(PUBLISHED_PAGES_SITEMAP_NAME)
+        names_used << PUBLISHED_PAGES_SITEMAP_NAME
+      end
 
       count = Category.where(read_restricted: false).sum(:topic_count)
       max_page_size = SiteSetting.sitemap_page_size
@@ -29,6 +35,21 @@ class Sitemap < ActiveRecord::Base
         sitemap.update!(last_posted_at: sitemap.last_posted_topic || 3.days.ago, enabled: true)
       end
     end
+
+    # Returns PublishedPage records that are safe to expose in a public
+    # sitemap. Mirrors PublishedPagesController#publicly_cacheable? so
+    # we never advertise a URL the controller would refuse to serve
+    # without a guardian check:
+    # - public: true (not gated behind a guardian)
+    # - topic.visible (not hidden / unlisted)
+    # - topic in a non-read_restricted category
+    def publishable_pages
+      public_category_ids = Category.where(read_restricted: false).pluck(:id)
+      PublishedPage
+        .where(public: true)
+        .joins(:topic)
+        .where(topics: { visible: true, category_id: public_category_ids })
+    end
   end
 
   def topics
@@ -41,8 +62,19 @@ class Sitemap < ActiveRecord::Base
     end
   end
 
+  # Returns the page rows used to render the published-pages sitemap:
+  # [[slug, updated_at], ...]. Only meaningful when name ==
+  # PUBLISHED_PAGES_SITEMAP_NAME.
+  def published_pages
+    self.class.publishable_pages.pluck(:slug, "published_pages.updated_at")
+  end
+
   def last_posted_topic
-    sitemap_topics.maximum(:updated_at)
+    if name == PUBLISHED_PAGES_SITEMAP_NAME
+      self.class.publishable_pages.maximum("published_pages.updated_at")
+    else
+      sitemap_topics.maximum(:updated_at)
+    end
   end
 
   def max_page_size

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -88,9 +88,10 @@ class Sitemap < ActiveRecord::Base
 
   def last_posted_topic
     if name == PUBLISHED_PAGES_SITEMAP_NAME
-      PublishedPage.joins(topic: :category).maximum(
-        "GREATEST(published_pages.updated_at, topics.updated_at, categories.updated_at)",
-      )
+      PublishedPage
+        .where(public: true)
+        .joins(topic: :category)
+        .maximum("GREATEST(published_pages.updated_at, topics.updated_at, categories.updated_at)")
     else
       sitemap_topics.maximum(:updated_at)
     end

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -41,19 +41,15 @@ class Sitemap < ActiveRecord::Base
     # we never advertise a URL the controller would refuse to serve without a
     # guardian check.
     def publishable_pages
-      if !SiteSetting.enable_page_publishing? || SiteSetting.secure_uploads
+      if !SiteSetting.enable_page_publishing? || SiteSetting.secure_uploads ||
+           SiteSetting.login_required?
         return PublishedPage.none
       end
 
-      if SiteSetting.login_required? && !SiteSetting.show_published_pages_login_required?
-        return PublishedPage.none
-      end
-
-      public_category_ids = Category.where(read_restricted: false).pluck(:id)
       PublishedPage
         .where(public: true)
-        .joins(:topic)
-        .where(topics: { visible: true, category_id: public_category_ids })
+        .joins(topic: :category)
+        .where(topics: { visible: true }, categories: { read_restricted: false })
     end
 
     def published_pages_sitemap_available?

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -37,13 +37,18 @@ class Sitemap < ActiveRecord::Base
     end
 
     # Returns PublishedPage records that are safe to expose in a public
-    # sitemap. Mirrors PublishedPagesController#publicly_cacheable? so
-    # we never advertise a URL the controller would refuse to serve
-    # without a guardian check:
-    # - public: true (not gated behind a guardian)
-    # - topic.visible (not hidden / unlisted)
-    # - topic in a non-read_restricted category
+    # sitemap. Mirrors PublishedPagesController's anonymous access gates so
+    # we never advertise a URL the controller would refuse to serve without a
+    # guardian check.
     def publishable_pages
+      if !SiteSetting.enable_page_publishing? || SiteSetting.secure_uploads
+        return PublishedPage.none
+      end
+
+      if SiteSetting.login_required? && !SiteSetting.show_published_pages_login_required?
+        return PublishedPage.none
+      end
+
       public_category_ids = Category.where(read_restricted: false).pluck(:id)
       PublishedPage
         .where(public: true)

--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -3,12 +3,15 @@
 class Sitemap < ActiveRecord::Base
   RECENT_SITEMAP_NAME = "recent"
   NEWS_SITEMAP_NAME = "news"
+  PUBLISHED_PAGES_SITEMAP_NAME = "published_pages"
 
   class << self
     def regenerate_sitemaps
       names_used = [RECENT_SITEMAP_NAME, NEWS_SITEMAP_NAME]
 
       names_used.each { |name| touch(name) }
+
+      names_used << PUBLISHED_PAGES_SITEMAP_NAME if sync_published_pages_sitemap!
 
       count = Category.where(read_restricted: false).sum(:topic_count)
       max_page_size = SiteSetting.sitemap_page_size
@@ -29,6 +32,36 @@ class Sitemap < ActiveRecord::Base
         sitemap.update!(last_posted_at: sitemap.last_posted_topic || 3.days.ago, enabled: true)
       end
     end
+
+    # Returns PublishedPage records that are safe to expose in a public
+    # sitemap. Mirrors PublishedPagesController's anonymous access gates so
+    # we never advertise a URL the controller would refuse to serve without a
+    # guardian check.
+    def publishable_pages
+      if !SiteSetting.enable_page_publishing? || SiteSetting.secure_uploads ||
+           SiteSetting.login_required?
+        return PublishedPage.none
+      end
+
+      PublishedPage
+        .where(public: true)
+        .joins(topic: :category)
+        .where(topics: { visible: true }, categories: { read_restricted: false })
+    end
+
+    def published_pages_sitemap_available?
+      count = publishable_pages.limit(SiteSetting.sitemap_page_size + 1).count
+      count.positive? && count <= SiteSetting.sitemap_page_size
+    end
+
+    def sync_published_pages_sitemap!
+      if published_pages_sitemap_available?
+        touch(PUBLISHED_PAGES_SITEMAP_NAME)
+      else
+        where(name: PUBLISHED_PAGES_SITEMAP_NAME).update_all(enabled: false)
+        nil
+      end
+    end
   end
 
   def topics
@@ -41,8 +74,32 @@ class Sitemap < ActiveRecord::Base
     end
   end
 
+  # Returns the page rows used to render the published-pages sitemap:
+  # [[slug, updated_at], ...]. Only meaningful when name ==
+  # PUBLISHED_PAGES_SITEMAP_NAME.
+  def published_pages
+    self
+      .class
+      .publishable_pages
+      .order(:id)
+      .limit(SiteSetting.sitemap_page_size)
+      .pluck(:slug, "published_pages.updated_at")
+  end
+
   def last_posted_topic
-    sitemap_topics.maximum(:updated_at)
+    if name == PUBLISHED_PAGES_SITEMAP_NAME
+      # Deliberately broader than publishable_pages: a page that was just
+      # hidden or restricted must still bump lastmod so crawlers re-fetch
+      # the list and see it gone. Pages with public: false never do, since
+      # they were never listed. GREATEST over three tables has no index,
+      # which is fine at published page scale (capped by sitemap_page_size).
+      PublishedPage
+        .where(public: true)
+        .joins(topic: :category)
+        .maximum("GREATEST(published_pages.updated_at, topics.updated_at, categories.updated_at)")
+    else
+      sitemap_topics.maximum(:updated_at)
+    end
   end
 
   def max_page_size

--- a/app/views/sitemap/published_pages.xml.erb
+++ b/app/views/sitemap/published_pages.xml.erb
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+                            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  <% @pages.each do |slug, updated_at| %>
+    <url>
+      <loc><%= "#{Discourse.base_url}/pub/#{slug}" %></loc>
+      <lastmod><%= updated_at.xmlschema %></lastmod>
+    </url>
+  <% end %>
+</urlset>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Discourse::Application.routes.draw do
       resources :sitemap, only: [:index]
       get "/sitemap_:page" => "sitemap#page", :page => /[1-9][0-9]*/
       get "/sitemap_recent" => "sitemap#recent"
+      get "/sitemap_published_pages" => "sitemap#published_pages"
       get "/news" => "sitemap#news"
     end
 

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe SitemapController do
   end
 
   describe "#index" do
+    def sitemap_index_entries
+      get "/sitemap.xml"
+
+      Nokogiri::XML::Document
+        .parse(response.body)
+        .css("sitemap")
+        .to_h { |sitemap| [sitemap.at_css("loc").text, sitemap.at_css("lastmod").text] }
+    end
+
     it "lists no sitemaps if we haven't generated them yet" do
       get "/sitemap.xml"
 
@@ -44,6 +53,61 @@ RSpec.describe SitemapController do
       sitemaps = Nokogiri::XML::Document.parse(response.body).css("loc")
 
       expect(sitemaps).to be_empty
+    end
+
+    it "removes a stale published pages sitemap entry after eligibility is lost" do
+      SiteSetting.enable_page_publishing = true
+      Fabricate(:published_page, public: true, slug: "indexed-post")
+      Sitemap.regenerate_sitemaps
+
+      expect(sitemap_index_entries.keys).to include(
+        "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml",
+      )
+
+      SiteSetting.enable_page_publishing = false
+
+      expect(sitemap_index_entries.keys).not_to include(
+        "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml",
+      )
+      expect(Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME).enabled).to eq(false)
+    end
+
+    it "updates the published pages sitemap lastmod when source topic visibility changes" do
+      SiteSetting.enable_page_publishing = true
+      newer_page = Fabricate(:published_page, public: true, slug: "newer-post")
+      older_topic = Fabricate(:topic, updated_at: 2.hours.ago)
+      older_page = Fabricate(:published_page, public: true, slug: "older-post", topic: older_topic)
+      newer_page.update!(updated_at: 1.hour.ago)
+      older_page.update!(updated_at: 2.hours.ago)
+      Sitemap.regenerate_sitemaps
+
+      loc = "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml"
+      previous_lastmod = Time.zone.parse(sitemap_index_entries.fetch(loc))
+      older_topic.update!(visible: false, updated_at: 1.minute.from_now)
+
+      expect(Time.zone.parse(sitemap_index_entries.fetch(loc))).to be > previous_lastmod
+    end
+
+    it "does not update the published pages sitemap lastmod for private page changes" do
+      SiteSetting.enable_page_publishing = true
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
+      private_page = Fabricate(:published_page, public: false, slug: "private-post")
+      public_page.update!(updated_at: 2.hours.ago)
+      private_page.update!(updated_at: 1.hour.from_now)
+      Sitemap.regenerate_sitemaps
+
+      loc = "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml"
+
+      expected_lastmod = [
+        public_page.reload.updated_at,
+        public_page.topic.updated_at,
+        public_page.topic.category.updated_at,
+      ].max
+
+      lastmod = Time.zone.parse(sitemap_index_entries.fetch(loc))
+
+      expect(lastmod.to_i).to eq(expected_lastmod.to_i)
+      expect(lastmod).to be < private_page.updated_at
     end
   end
 
@@ -134,6 +198,192 @@ RSpec.describe SitemapController do
 
       all_urls = urls.map { |u| u.at_css("loc").text }
       expect(all_urls).not_to include("#{Discourse.base_url}/t/#{old_topic.slug}/#{old_topic.id}")
+    end
+  end
+
+  describe "#published_pages" do
+    before { SiteSetting.enable_page_publishing = true }
+
+    def published_page_locs
+      get "/sitemap_published_pages.xml"
+
+      Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
+    end
+
+    it "returns 404 when no eligible published pages exist" do
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
+    end
+
+    it "lists public published pages whose source topic is in a public category" do
+      page = Fabricate(:published_page, public: true, slug: "public-post")
+
+      locs = published_page_locs
+
+      expect(response.status).to eq(200)
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{page.slug}")
+    end
+
+    it "returns 404 when login_required is enabled" do
+      Fabricate(:published_page, public: true, slug: "public-post")
+      SiteSetting.login_required = true
+      SiteSetting.show_published_pages_login_required = true
+      sign_in(Fabricate(:user))
+
+      get "/sitemap_published_pages.xml"
+
+      expect(response.status).to eq(404)
+    end
+
+    it "excludes non-public pages" do
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
+      Fabricate(:published_page, public: false, slug: "private-post")
+
+      locs = published_page_locs
+
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
+    end
+
+    it "excludes pages whose source topic is in a read-restricted category" do
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
+      restricted = Fabricate(:private_category, group: Fabricate(:group))
+      topic = Fabricate(:topic, category: restricted)
+      Fabricate(:published_page, public: true, slug: "restricted-post", topic: topic)
+
+      locs = published_page_locs
+
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
+    end
+
+    it "excludes pages whose source topic is not visible" do
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
+      hidden_topic = Fabricate(:topic, visible: false)
+      Fabricate(:published_page, public: true, slug: "hidden-post", topic: hidden_topic)
+
+      locs = published_page_locs
+
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
+    end
+
+    it "does not serve stale URLs after sitemap membership shrinks" do
+      newer_page = Fabricate(:published_page, public: true, slug: "newer-post")
+      older_topic = Fabricate(:topic)
+      older_page = Fabricate(:published_page, public: true, slug: "older-post", topic: older_topic)
+      older_page.update!(updated_at: 1.day.ago)
+      newer_page.update!(updated_at: 1.minute.ago)
+
+      expect(published_page_locs).to contain_exactly(
+        "#{Discourse.base_url}/pub/#{newer_page.slug}",
+        "#{Discourse.base_url}/pub/#{older_page.slug}",
+      )
+
+      older_topic.update!(visible: false)
+
+      expect(published_page_locs).to contain_exactly("#{Discourse.base_url}/pub/#{newer_page.slug}")
+    end
+
+    it "returns 404 when there are more published pages than a sitemap supports" do
+      SiteSetting.sitemap_page_size = 1
+      Fabricate(:published_page, public: true, slug: "first-post")
+      Fabricate(:published_page, public: true, slug: "second-post")
+
+      get "/sitemap_published_pages.xml"
+
+      expect(response.status).to eq(404)
+    end
+
+    it "returns 404 when published pages are not available to anonymous visitors" do
+      Fabricate(:published_page, public: true, slug: "public-post")
+
+      SiteSetting.enable_page_publishing = false
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
+
+      # secure_uploads has a validator that requires s3 uploads + acls
+      # to be on first, so we use setup_s3 to satisfy it. The thing
+      # we actually want to test is publishable_pages returning none
+      # when secure_uploads is on, hiding the sitemap.
+      setup_s3
+      SiteSetting.enable_page_publishing = true
+      SiteSetting.secure_uploads = true
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe ".regenerate_sitemaps and the published_pages entry" do
+    before { SiteSetting.enable_page_publishing = true }
+
+    it "adds an enabled published_pages sitemap row when eligible pages exist" do
+      Fabricate(:published_page, public: true, slug: "indexed-post")
+
+      Sitemap.regenerate_sitemaps
+
+      row = Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+      expect(row).to be_present
+      expect(row.enabled).to eq(true)
+    end
+
+    it "disables the published_pages row when no eligible pages remain" do
+      Sitemap.create!(
+        name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME,
+        enabled: true,
+        last_posted_at: 1.minute.ago,
+      )
+
+      Sitemap.regenerate_sitemaps
+
+      row = Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+      expect(row).to be_present
+      expect(row.enabled).to eq(false)
+    end
+
+    it "disables the published_pages row when there are more published pages than a sitemap supports" do
+      SiteSetting.sitemap_page_size = 1
+      Fabricate(:published_page, public: true, slug: "first-post")
+      Fabricate(:published_page, public: true, slug: "second-post")
+      row =
+        Sitemap.create!(
+          name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME,
+          enabled: true,
+          last_posted_at: 1.minute.ago,
+        )
+
+      Sitemap.regenerate_sitemaps
+
+      expect(row.reload.enabled).to eq(false)
+    end
+
+    it "disables the published_pages row when published pages are not available to anonymous visitors" do
+      Fabricate(:published_page, public: true, slug: "indexed-post")
+      row =
+        Sitemap.create!(
+          name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME,
+          enabled: true,
+          last_posted_at: 1.minute.ago,
+        )
+
+      SiteSetting.enable_page_publishing = false
+      Sitemap.regenerate_sitemaps
+      expect(row.reload.enabled).to eq(false)
+
+      # secure_uploads has a validator that requires s3 uploads + acls
+      # to be on first; setup_s3 satisfies the validator so the actual
+      # branch under test (publishable_pages returning none with
+      # secure_uploads on) is what runs.
+      setup_s3
+      SiteSetting.enable_page_publishing = true
+      SiteSetting.secure_uploads = true
+      row.update!(enabled: true)
+      Sitemap.regenerate_sitemaps
+      expect(row.reload.enabled).to eq(false)
+
+      SiteSetting.secure_uploads = false
+      SiteSetting.login_required = true
+      SiteSetting.show_published_pages_login_required = true
+      row.update!(enabled: true)
+      Sitemap.regenerate_sitemaps
+      expect(row.reload.enabled).to eq(false)
     end
   end
 end

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -136,4 +136,83 @@ RSpec.describe SitemapController do
       expect(all_urls).not_to include("#{Discourse.base_url}/t/#{old_topic.slug}/#{old_topic.id}")
     end
   end
+
+  describe "#published_pages" do
+    before { SiteSetting.enable_page_publishing = true }
+
+    it "returns 404 when no eligible published pages exist" do
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
+    end
+
+    it "lists public published pages whose source topic is in a public category" do
+      page = Fabricate(:published_page, public: true, slug: "public-post")
+      Discourse.cache.delete("sitemap/published_pages/#{Time.zone.now.to_i}")
+
+      get "/sitemap_published_pages.xml"
+
+      expect(response.status).to eq(200)
+      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
+      expect(locs).to include("#{Discourse.base_url}/pub/#{page.slug}")
+    end
+
+    it "excludes non-public pages" do
+      Fabricate(:published_page, public: true, slug: "public-post")
+      Fabricate(:published_page, public: false, slug: "private-post")
+
+      get "/sitemap_published_pages.xml"
+
+      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
+      expect(locs).not_to include(a_string_including("/pub/private-post"))
+    end
+
+    it "excludes pages whose source topic is in a read-restricted category" do
+      Fabricate(:published_page, public: true, slug: "public-post")
+      restricted = Fabricate(:private_category, group: Fabricate(:group))
+      topic = Fabricate(:topic, category: restricted)
+      Fabricate(:published_page, public: true, slug: "restricted-post", topic: topic)
+
+      get "/sitemap_published_pages.xml"
+
+      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
+      expect(locs).not_to include(a_string_including("/pub/restricted-post"))
+    end
+
+    it "excludes pages whose source topic is not visible" do
+      Fabricate(:published_page, public: true, slug: "public-post")
+      hidden_topic = Fabricate(:topic, visible: false)
+      Fabricate(:published_page, public: true, slug: "hidden-post", topic: hidden_topic)
+
+      get "/sitemap_published_pages.xml"
+
+      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
+      expect(locs).not_to include(a_string_including("/pub/hidden-post"))
+    end
+  end
+
+  describe ".regenerate_sitemaps and the published_pages entry" do
+    it "adds an enabled published_pages sitemap row when eligible pages exist" do
+      Fabricate(:published_page, public: true, slug: "indexed-post")
+
+      Sitemap.regenerate_sitemaps
+
+      row = Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+      expect(row).to be_present
+      expect(row.enabled).to eq(true)
+    end
+
+    it "disables the published_pages row when no eligible pages remain" do
+      Sitemap.create!(
+        name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME,
+        enabled: true,
+        last_posted_at: 1.minute.ago,
+      )
+
+      Sitemap.regenerate_sitemaps
+
+      row = Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+      expect(row).to be_present
+      expect(row.enabled).to eq(false)
+    end
+  end
 end

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -231,11 +231,11 @@ RSpec.describe SitemapController do
       get "/sitemap_published_pages.xml"
       expect(response.status).to eq(404)
 
-      SiteSetting.secure_uploads = false
-      SiteSetting.login_required = true
-      SiteSetting.show_published_pages_login_required = false
-      get "/sitemap_published_pages.xml"
-      expect(response.status).to eq(404)
+      # The login_required gate isn't asserted here: it short-circuits
+      # at middleware (302 to /login) before reaching the controller,
+      # so a controller spec isn't the place. Its effect on
+      # publishable_pages is covered directly in the regenerate_sitemaps
+      # spec below.
     end
   end
 

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -87,6 +87,28 @@ RSpec.describe SitemapController do
 
       expect(Time.zone.parse(sitemap_index_entries.fetch(loc))).to be > previous_lastmod
     end
+
+    it "does not update the published pages sitemap lastmod for private page changes" do
+      SiteSetting.enable_page_publishing = true
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
+      private_page = Fabricate(:published_page, public: false, slug: "private-post")
+      public_page.update!(updated_at: 2.hours.ago)
+      private_page.update!(updated_at: 1.hour.from_now)
+      Sitemap.regenerate_sitemaps
+
+      loc = "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml"
+
+      expected_lastmod = [
+        public_page.reload.updated_at,
+        public_page.topic.updated_at,
+        public_page.topic.category.updated_at,
+      ].max
+
+      lastmod = Time.zone.parse(sitemap_index_entries.fetch(loc))
+
+      expect(lastmod.to_i).to eq(expected_lastmod.to_i)
+      expect(lastmod).to be < private_page.updated_at
+    end
   end
 
   describe "#page" do

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe SitemapController do
   end
 
   describe "#index" do
+    def sitemap_index_entries
+      get "/sitemap.xml"
+
+      Nokogiri::XML::Document
+        .parse(response.body)
+        .css("sitemap")
+        .to_h { |sitemap| [sitemap.at_css("loc").text, sitemap.at_css("lastmod").text] }
+    end
+
     it "lists no sitemaps if we haven't generated them yet" do
       get "/sitemap.xml"
 
@@ -44,6 +53,39 @@ RSpec.describe SitemapController do
       sitemaps = Nokogiri::XML::Document.parse(response.body).css("loc")
 
       expect(sitemaps).to be_empty
+    end
+
+    it "removes a stale published pages sitemap entry after eligibility is lost" do
+      SiteSetting.enable_page_publishing = true
+      Fabricate(:published_page, public: true, slug: "indexed-post")
+      Sitemap.regenerate_sitemaps
+
+      expect(sitemap_index_entries.keys).to include(
+        "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml",
+      )
+
+      SiteSetting.enable_page_publishing = false
+
+      expect(sitemap_index_entries.keys).not_to include(
+        "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml",
+      )
+      expect(Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME).enabled).to eq(false)
+    end
+
+    it "updates the published pages sitemap lastmod when source topic visibility changes" do
+      SiteSetting.enable_page_publishing = true
+      newer_page = Fabricate(:published_page, public: true, slug: "newer-post")
+      older_topic = Fabricate(:topic, updated_at: 2.hours.ago)
+      older_page = Fabricate(:published_page, public: true, slug: "older-post", topic: older_topic)
+      newer_page.update!(updated_at: 1.hour.ago)
+      older_page.update!(updated_at: 2.hours.ago)
+      Sitemap.regenerate_sitemaps
+
+      loc = "#{Discourse.base_url}/sitemap_#{Sitemap::PUBLISHED_PAGES_SITEMAP_NAME}.xml"
+      previous_lastmod = Time.zone.parse(sitemap_index_entries.fetch(loc))
+      older_topic.update!(visible: false, updated_at: 1.minute.from_now)
+
+      expect(Time.zone.parse(sitemap_index_entries.fetch(loc))).to be > previous_lastmod
     end
   end
 

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -140,6 +140,19 @@ RSpec.describe SitemapController do
   describe "#published_pages" do
     before { SiteSetting.enable_page_publishing = true }
 
+    def clear_published_pages_sitemap_cache
+      sitemap = Sitemap.touch(Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
+      Discourse.cache.delete("sitemap/published_pages/#{sitemap.last_posted_at.to_i}")
+    end
+
+    def published_page_locs
+      clear_published_pages_sitemap_cache
+
+      get "/sitemap_published_pages.xml"
+
+      Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
+    end
+
     it "returns 404 when no eligible published pages exist" do
       get "/sitemap_published_pages.xml"
       expect(response.status).to eq(404)
@@ -147,50 +160,77 @@ RSpec.describe SitemapController do
 
     it "lists public published pages whose source topic is in a public category" do
       page = Fabricate(:published_page, public: true, slug: "public-post")
-      Discourse.cache.delete("sitemap/published_pages/#{Time.zone.now.to_i}")
 
-      get "/sitemap_published_pages.xml"
+      locs = published_page_locs
 
       expect(response.status).to eq(200)
-      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
-      expect(locs).to include("#{Discourse.base_url}/pub/#{page.slug}")
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{page.slug}")
+    end
+
+    it "lists pages when published pages are shown with login required" do
+      page = Fabricate(:published_page, public: true, slug: "public-post")
+      SiteSetting.login_required = true
+      SiteSetting.show_published_pages_login_required = true
+
+      locs = published_page_locs
+
+      expect(response.status).to eq(200)
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{page.slug}")
     end
 
     it "excludes non-public pages" do
-      Fabricate(:published_page, public: true, slug: "public-post")
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
       Fabricate(:published_page, public: false, slug: "private-post")
 
-      get "/sitemap_published_pages.xml"
+      locs = published_page_locs
 
-      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
-      expect(locs).not_to include(a_string_including("/pub/private-post"))
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
     end
 
     it "excludes pages whose source topic is in a read-restricted category" do
-      Fabricate(:published_page, public: true, slug: "public-post")
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
       restricted = Fabricate(:private_category, group: Fabricate(:group))
       topic = Fabricate(:topic, category: restricted)
       Fabricate(:published_page, public: true, slug: "restricted-post", topic: topic)
 
-      get "/sitemap_published_pages.xml"
+      locs = published_page_locs
 
-      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
-      expect(locs).not_to include(a_string_including("/pub/restricted-post"))
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
     end
 
     it "excludes pages whose source topic is not visible" do
-      Fabricate(:published_page, public: true, slug: "public-post")
+      public_page = Fabricate(:published_page, public: true, slug: "public-post")
       hidden_topic = Fabricate(:topic, visible: false)
       Fabricate(:published_page, public: true, slug: "hidden-post", topic: hidden_topic)
 
-      get "/sitemap_published_pages.xml"
+      locs = published_page_locs
 
-      locs = Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
-      expect(locs).not_to include(a_string_including("/pub/hidden-post"))
+      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
+    end
+
+    it "returns 404 when published pages are not available to anonymous visitors" do
+      Fabricate(:published_page, public: true, slug: "public-post")
+
+      SiteSetting.enable_page_publishing = false
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
+
+      SiteSetting.enable_page_publishing = true
+      SiteSetting.secure_uploads = true
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
+
+      SiteSetting.secure_uploads = false
+      SiteSetting.login_required = true
+      SiteSetting.show_published_pages_login_required = false
+      get "/sitemap_published_pages.xml"
+      expect(response.status).to eq(404)
     end
   end
 
   describe ".regenerate_sitemaps and the published_pages entry" do
+    before { SiteSetting.enable_page_publishing = true }
+
     it "adds an enabled published_pages sitemap row when eligible pages exist" do
       Fabricate(:published_page, public: true, slug: "indexed-post")
 
@@ -213,6 +253,33 @@ RSpec.describe SitemapController do
       row = Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
       expect(row).to be_present
       expect(row.enabled).to eq(false)
+    end
+
+    it "disables the published_pages row when published pages are not available to anonymous visitors" do
+      Fabricate(:published_page, public: true, slug: "indexed-post")
+      row =
+        Sitemap.create!(
+          name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME,
+          enabled: true,
+          last_posted_at: 1.minute.ago,
+        )
+
+      SiteSetting.enable_page_publishing = false
+      Sitemap.regenerate_sitemaps
+      expect(row.reload.enabled).to eq(false)
+
+      SiteSetting.enable_page_publishing = true
+      SiteSetting.secure_uploads = true
+      row.update!(enabled: true)
+      Sitemap.regenerate_sitemaps
+      expect(row.reload.enabled).to eq(false)
+
+      SiteSetting.secure_uploads = false
+      SiteSetting.login_required = true
+      SiteSetting.show_published_pages_login_required = false
+      row.update!(enabled: true)
+      Sitemap.regenerate_sitemaps
+      expect(row.reload.enabled).to eq(false)
     end
   end
 end

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -160,21 +160,15 @@ RSpec.describe SitemapController do
       expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{page.slug}")
     end
 
-    it "lists pages when published pages are shown with login required" do
-      page = Fabricate(:published_page, public: true, slug: "public-post")
+    it "returns 404 when login_required is enabled" do
+      Fabricate(:published_page, public: true, slug: "public-post")
       SiteSetting.login_required = true
       SiteSetting.show_published_pages_login_required = true
-
-      # The sitemap controller redirects anonymous requests to /login
-      # when login_required is on, regardless of
-      # show_published_pages_login_required. Signing in lets us assert
-      # the publishable_pages filter, which is what this test is for.
       sign_in(Fabricate(:user))
 
-      locs = published_page_locs
+      get "/sitemap_published_pages.xml"
 
-      expect(response.status).to eq(200)
-      expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{page.slug}")
+      expect(response.status).to eq(404)
     end
 
     it "excludes non-public pages" do
@@ -250,12 +244,6 @@ RSpec.describe SitemapController do
       SiteSetting.secure_uploads = true
       get "/sitemap_published_pages.xml"
       expect(response.status).to eq(404)
-
-      # The login_required gate isn't asserted here: it short-circuits
-      # at middleware (302 to /login) before reaching the controller,
-      # so a controller spec isn't the place. Its effect on
-      # publishable_pages is covered directly in the regenerate_sitemaps
-      # spec below.
     end
   end
 
@@ -328,7 +316,7 @@ RSpec.describe SitemapController do
 
       SiteSetting.secure_uploads = false
       SiteSetting.login_required = true
-      SiteSetting.show_published_pages_login_required = false
+      SiteSetting.show_published_pages_login_required = true
       row.update!(enabled: true)
       Sitemap.regenerate_sitemaps
       expect(row.reload.enabled).to eq(false)

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -172,6 +172,12 @@ RSpec.describe SitemapController do
       SiteSetting.login_required = true
       SiteSetting.show_published_pages_login_required = true
 
+      # The sitemap controller redirects anonymous requests to /login
+      # when login_required is on, regardless of
+      # show_published_pages_login_required. Signing in lets us assert
+      # the publishable_pages filter, which is what this test is for.
+      sign_in(Fabricate(:user))
+
       locs = published_page_locs
 
       expect(response.status).to eq(200)
@@ -215,6 +221,11 @@ RSpec.describe SitemapController do
       get "/sitemap_published_pages.xml"
       expect(response.status).to eq(404)
 
+      # secure_uploads has a validator that requires s3 uploads + acls
+      # to be on first, so we use setup_s3 to satisfy it. The thing
+      # we actually want to test is publishable_pages returning none
+      # when secure_uploads is on, hiding the sitemap.
+      setup_s3
       SiteSetting.enable_page_publishing = true
       SiteSetting.secure_uploads = true
       get "/sitemap_published_pages.xml"
@@ -268,6 +279,11 @@ RSpec.describe SitemapController do
       Sitemap.regenerate_sitemaps
       expect(row.reload.enabled).to eq(false)
 
+      # secure_uploads has a validator that requires s3 uploads + acls
+      # to be on first; setup_s3 satisfies the validator so the actual
+      # branch under test (publishable_pages returning none with
+      # secure_uploads on) is what runs.
+      setup_s3
       SiteSetting.enable_page_publishing = true
       SiteSetting.secure_uploads = true
       row.update!(enabled: true)

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -140,14 +140,7 @@ RSpec.describe SitemapController do
   describe "#published_pages" do
     before { SiteSetting.enable_page_publishing = true }
 
-    def clear_published_pages_sitemap_cache
-      sitemap = Sitemap.touch(Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
-      Discourse.cache.delete("sitemap/published_pages/#{sitemap.last_posted_at.to_i}")
-    end
-
     def published_page_locs
-      clear_published_pages_sitemap_cache
-
       get "/sitemap_published_pages.xml"
 
       Nokogiri::XML::Document.parse(response.body).css("loc").map(&:text)
@@ -214,6 +207,33 @@ RSpec.describe SitemapController do
       expect(locs).to contain_exactly("#{Discourse.base_url}/pub/#{public_page.slug}")
     end
 
+    it "does not serve stale URLs after sitemap membership shrinks" do
+      newer_page = Fabricate(:published_page, public: true, slug: "newer-post")
+      older_topic = Fabricate(:topic)
+      older_page = Fabricate(:published_page, public: true, slug: "older-post", topic: older_topic)
+      older_page.update!(updated_at: 1.day.ago)
+      newer_page.update!(updated_at: 1.minute.ago)
+
+      expect(published_page_locs).to contain_exactly(
+        "#{Discourse.base_url}/pub/#{newer_page.slug}",
+        "#{Discourse.base_url}/pub/#{older_page.slug}",
+      )
+
+      older_topic.update!(visible: false)
+
+      expect(published_page_locs).to contain_exactly("#{Discourse.base_url}/pub/#{newer_page.slug}")
+    end
+
+    it "returns 404 when there are more published pages than a sitemap supports" do
+      SiteSetting.sitemap_page_size = 1
+      Fabricate(:published_page, public: true, slug: "first-post")
+      Fabricate(:published_page, public: true, slug: "second-post")
+
+      get "/sitemap_published_pages.xml"
+
+      expect(response.status).to eq(404)
+    end
+
     it "returns 404 when published pages are not available to anonymous visitors" do
       Fabricate(:published_page, public: true, slug: "public-post")
 
@@ -264,6 +284,22 @@ RSpec.describe SitemapController do
       row = Sitemap.find_by(name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME)
       expect(row).to be_present
       expect(row.enabled).to eq(false)
+    end
+
+    it "disables the published_pages row when there are more published pages than a sitemap supports" do
+      SiteSetting.sitemap_page_size = 1
+      Fabricate(:published_page, public: true, slug: "first-post")
+      Fabricate(:published_page, public: true, slug: "second-post")
+      row =
+        Sitemap.create!(
+          name: Sitemap::PUBLISHED_PAGES_SITEMAP_NAME,
+          enabled: true,
+          last_posted_at: 1.minute.ago,
+        )
+
+      Sitemap.regenerate_sitemaps
+
+      expect(row.reload.enabled).to eq(false)
     end
 
     it "disables the published_pages row when published pages are not available to anonymous visitors" do


### PR DESCRIPTION
Adds /sitemap_published_pages.xml plus a row in the sitemaps table so /sitemap.xml lists it alongside the topic sitemaps.

Eligibility mirrors PublishedPagesController#publicly_cacheable? in the cache-headers PR: a published page only shows up in the sitemap if it's safe to serve to an anonymous visitor without a guardian check:

- PublishedPage.public == true
- topic.visible == true
- topic.category.read_restricted == false

This is defense in depth - we never advertise a /pub/<slug> URL the controller would refuse to publicly cache. Sitemap.publishable_pages is the single source of truth for the filter so the controller and view stay in lockstep.

Sitemap.regenerate_sitemaps adds (or removes) the published_pages row based on whether any eligible pages exist. The hourly cache is keyed on last_posted_at so updates show up within an hour without needing an explicit invalidation hook.

Spec covers: eligible page emits when public + non-restricted, 404 when no eligible pages exist, omitted when public: false, omitted when category is read_restricted, omitted when topic.visible: false, regenerate adds an enabled row when eligible pages exist and disables it when none remain.