### PR TITLE
FIX: Show voters for closed topics in topic-voting

### DIFF
--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_extension.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/topic_extension.rb
@@ -49,7 +49,7 @@ module DiscourseTopicVoting
     def who_voted(limit: DiscourseTopicVoting::VOTER_PREVIEW_LIMIT)
       return if !SiteSetting.topic_voting_show_who_voted
 
-      votes.active.includes(:user).order(created_at: :desc).limit(limit).filter_map(&:user)
+      votes.includes(:user).order(created_at: :desc).limit(limit).filter_map(&:user)
     end
   end
 end

--- a/plugins/discourse-topic-voting/spec/lib/topic_extension_spec.rb
+++ b/plugins/discourse-topic-voting/spec/lib/topic_extension_spec.rb
@@ -38,18 +38,18 @@ describe DiscourseTopicVoting::TopicExtension do
   end
 
   describe "#who_voted" do
-    it "returns recent active voters up to the requested limit" do
-      DiscourseTopicVoting::Vote.create!(user: user, topic: topic, created_at: 2.hours.ago)
-      DiscourseTopicVoting::Vote.create!(user: user2, topic: topic, created_at: 1.hour.ago)
-      archived_user = Fabricate(:user)
-      DiscourseTopicVoting::Vote.create!(
-        user: archived_user,
-        topic: topic,
-        archive: true,
-        created_at: Time.zone.now,
-      )
+    it "returns the most recent voters up to the limit" do
+      DiscourseTopicVoting::Vote.create!(user:, topic:, created_at: 2.hours.ago)
+      DiscourseTopicVoting::Vote.create!(user: user2, topic:, created_at: 1.hour.ago)
 
       expect(topic.who_voted(limit: 1)).to eq([user2])
+    end
+
+    it "includes voters whose votes were archived (e.g. closed topics)" do
+      archived_user = Fabricate(:user)
+      DiscourseTopicVoting::Vote.create!(user: archived_user, topic:, archive: true)
+
+      expect(topic.who_voted(limit: 10)).to eq([archived_user])
     end
   end
 

--- a/plugins/discourse-topic-voting/spec/requests/votes_controller_spec.rb
+++ b/plugins/discourse-topic-voting/spec/requests/votes_controller_spec.rb
@@ -6,7 +6,7 @@ describe DiscourseTopicVoting::VotesController do
   let(:topic) { Fabricate(:topic, category_id: category.id) }
 
   before do
-    DiscourseTopicVoting::CategorySetting.create!(category: category)
+    DiscourseTopicVoting::CategorySetting.create!(category:)
     Category.reset_voting_cache
     SiteSetting.topic_voting_show_who_voted = true
     SiteSetting.topic_voting_enabled = true
@@ -52,7 +52,7 @@ describe DiscourseTopicVoting::VotesController do
   end
 
   it "returns 403 when the user already voted" do
-    DiscourseTopicVoting::Vote.create!(user: user, topic: topic)
+    DiscourseTopicVoting::Vote.create!(user:, topic:)
 
     post "/voting/vote.json", params: { topic_id: topic.id }
 
@@ -92,7 +92,7 @@ describe DiscourseTopicVoting::VotesController do
     end
 
     it "returns nil for limit fields on unvote" do
-      DiscourseTopicVoting::Vote.create!(user: user, topic: topic)
+      DiscourseTopicVoting::Vote.create!(user:, topic:)
 
       post "/voting/unvote.json", params: { topic_id: topic.id }
       expect(response.status).to eq(200)
@@ -118,7 +118,7 @@ describe DiscourseTopicVoting::VotesController do
   end
 
   it "triggers a topic_unvote webhook when unvoting" do
-    DiscourseTopicVoting::Vote.create!(user: user, topic: topic)
+    DiscourseTopicVoting::Vote.create!(user:, topic:)
     topic.update_vote_count
 
     Fabricate(:topic_voting_web_hook)
@@ -134,13 +134,13 @@ describe DiscourseTopicVoting::VotesController do
   end
 
   it "does not remove an archived vote when unvoting" do
-    DiscourseTopicVoting::Vote.create!(user: user, topic: topic, archive: true)
+    DiscourseTopicVoting::Vote.create!(user:, topic:, archive: true)
     topic.update_vote_count
 
     post "/voting/unvote.json", params: { topic_id: topic.id }
 
     expect(response.status).to eq(200)
-    expect(DiscourseTopicVoting::Vote.where(user: user, topic: topic, archive: true).count).to eq(1)
+    expect(DiscourseTopicVoting::Vote.where(user:, topic:, archive: true).count).to eq(1)
     expect(topic.reload.vote_count).to eq(1)
   end
 
@@ -155,7 +155,7 @@ describe DiscourseTopicVoting::VotesController do
     stub_const(DiscourseTopicVoting, "VOTER_PREVIEW_LIMIT", 10) do
       Fabricate
         .times(11, :user)
-        .each { |voter| DiscourseTopicVoting::Vote.create!(user: voter, topic: topic) }
+        .each { |voter| DiscourseTopicVoting::Vote.create!(user: voter, topic:) }
 
       get "/voting/who.json", params: { topic_id: topic.id }
 
@@ -164,16 +164,30 @@ describe DiscourseTopicVoting::VotesController do
     end
   end
 
-  it "excludes archived votes and honors a smaller who-voted limit" do
+  it "still returns voters after the topic has been closed" do
+    voter = Fabricate(:user)
+    DiscourseTopicVoting::Vote.create!(user: voter, topic:)
+    topic.update_vote_count
+
+    Jobs.run_immediately!
+    topic.update_status("closed", true, Discourse.system_user)
+
+    get "/voting/who.json", params: { topic_id: topic.id }
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body.pluck("id")).to eq([voter.id])
+  end
+
+  it "includes archived votes and honors a smaller who-voted limit" do
     older_voter = Fabricate(:user)
     newer_voter = Fabricate(:user)
     archived_voter = Fabricate(:user)
 
-    DiscourseTopicVoting::Vote.create!(user: older_voter, topic: topic, created_at: 2.hours.ago)
-    DiscourseTopicVoting::Vote.create!(user: newer_voter, topic: topic, created_at: 1.hour.ago)
+    DiscourseTopicVoting::Vote.create!(user: older_voter, topic:, created_at: 2.hours.ago)
+    DiscourseTopicVoting::Vote.create!(user: newer_voter, topic:, created_at: 1.hour.ago)
     DiscourseTopicVoting::Vote.create!(
       user: archived_voter,
-      topic: topic,
+      topic:,
       archive: true,
       created_at: Time.zone.now,
     )
@@ -181,6 +195,6 @@ describe DiscourseTopicVoting::VotesController do
     get "/voting/who.json", params: { topic_id: topic.id, limit: 1 }
 
     expect(response.status).to eq(200)
-    expect(response.parsed_body.pluck("id")).to eq([newer_voter.id])
+    expect(response.parsed_body.pluck("id")).to eq([archived_voter.id])
   end
 end


### PR DESCRIPTION
Previously, opening the "who voted" popup on a closed topic returned an empty list even though the vote count still showed the correct total. The same was true for any topic whose votes had been archived (e.g. moved out of a voting category, or trashed).

This was a regression from #39394, which added `votes.active` to `Topic#who_voted` alongside the same filter applied to "my votes" and `/topics/voted-by/:username`. That filter is correct for those per-user listings — you don't want closed-topic votes polluting "your votes" — but the `who_voted` popup is about historical participation on a specific topic, not per-user vote accounting.

This change drops `.active` from `Topic#who_voted` so archived votes are included, restoring the pre-regression behaviour. The accounting filters in `Votes::Remove`, `User#topics_with_active_vote`, the voted-topics query, and the `current_user_voted` flag are unchanged.

https://meta.discourse.org/t/403286