### PR TITLE
DEV: Switch DE agent to use tools for structure and accuracy

### DIFF
--- a/plugins/discourse-data-explorer/app/jobs/regular/generate_de_query_with_ai.rb
+++ b/plugins/discourse-data-explorer/app/jobs/regular/generate_de_query_with_ai.rb
@@ -38,16 +38,8 @@ module Jobs
           feature_name: "data_explorer_query_generation",
         )
 
-      structured_output = nil
-      result = +""
-      bot.reply(context) do |partial, _, type|
-        if type == :structured_output
-          structured_output = partial
-        elsif type.blank? && partial.is_a?(String)
-          result << partial
-        end
-      end
-      parsed = parse_structured_response(structured_output, result)
+      bot.reply(context)
+      parsed = context.feature_context[DiscourseDataExplorer::Tools::SubmitQuery::CONTEXT_KEY] || {}
 
       if parsed[:sql].blank?
         return(publish_error(user, I18n.t("discourse_data_explorer.ai.error_no_sql_returned")))
@@ -70,21 +62,6 @@ module Jobs
       if @generation_id
         Discourse.redis.del(DiscourseDataExplorer::AiQueryEnqueuer.redis_key(@generation_id))
       end
-    end
-
-    def parse_structured_response(structured_output, text)
-      if structured_output
-        {
-          sql: structured_output.read_buffered_property(:sql),
-          name: structured_output.read_buffered_property(:name),
-          description: structured_output.read_buffered_property(:description),
-        }
-      else
-        parsed = JSON.parse(text.strip).symbolize_keys
-        parsed.slice(:sql, :name, :description)
-      end
-    rescue JSON::ParserError
-      { sql: text.strip, name: nil, description: nil }
     end
 
     def publish_complete(user, sql:, name:, description:)

--- a/plugins/discourse-data-explorer/config/locales/server.en.yml
+++ b/plugins/discourse-data-explorer/config/locales/server.en.yml
@@ -10,10 +10,13 @@ en:
           description: "Generates SQL queries for Data Explorer from natural language"
       tool_help:
         run_sql: "Runs a SQL query and returns results"
+        submit_query: "Submits the final generated query"
       tool_summary:
         run_sql: "Running SQL query"
+        submit_query: "Submitting generated query"
       tool_description:
         run_sql: "Ran SQL query"
+        submit_query: "Submitted generated query %{name}"
   discourse_data_explorer:
     ai:
       error_agent_not_configured: "AI agent is not configured. Please check the AI features settings."

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_generator.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_generator.rb
@@ -3,7 +3,11 @@
 module DiscourseDataExplorer
   class AiQueryGenerator < DiscourseAi::Agents::Agent
     def tools
-      [DiscourseAi::Agents::Tools::DbSchema, DiscourseDataExplorer::Tools::RunSql]
+      [
+        DiscourseAi::Agents::Tools::DbSchema,
+        DiscourseDataExplorer::Tools::RunSql,
+        DiscourseDataExplorer::Tools::SubmitQuery,
+      ]
     end
 
     def self.execution_mode
@@ -18,14 +22,6 @@ module DiscourseDataExplorer
       0.2
     end
 
-    def response_format
-      [
-        { "key" => "name", "type" => "string" },
-        { "key" => "description", "type" => "string" },
-        { "key" => "sql", "type" => "string" },
-      ]
-    end
-
     def system_prompt
       <<~PROMPT
         You are a PostgreSQL expert that generates queries for Discourse Data Explorer.
@@ -36,9 +32,9 @@ module DiscourseDataExplorer
         3. Use RunSql to test the query
         4. If RunSql returns an error, fix the SQL and test again
         5. Repeat until the query runs successfully
-        6. Return your final response only after confirming the query works
+        6. Call submit_query with the final name, description, and verified SQL only after confirming the query works
 
-        Return a JSON response with three fields:
+        Do not write the final query as plain text. Your final action must be a submit_query tool call with three fields:
         - "name": a short descriptive name for the query (under 60 characters)
         - "description": a one-sentence description of what the query does
         - "sql": the verified SQL query

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_params.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_params.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module DiscourseDataExplorer
+  class AiQueryParams
+    def self.sample_for(query, current_user:)
+      new(query, current_user: current_user).sample
+    end
+
+    def initialize(query, current_user:)
+      @query = query
+      @current_user = current_user
+    end
+
+    def sample
+      query
+        .params
+        .each_with_object({}) do |param, params|
+          next if param.default.present? || param.internal?
+
+          value = sample_value(param)
+          params[param.identifier] = value if value.present? || !param.nullable
+        end
+    end
+
+    private
+
+    attr_reader :query, :current_user
+
+    def sample_value(param)
+      case param.type
+      when :int
+        "1"
+      when :bigint
+        "1"
+      when :boolean
+        "true"
+      when :string
+        "sample"
+      when :date
+        sample_date(param.identifier)
+      when :time
+        "00:00"
+      when :datetime
+        sample_datetime(param.identifier)
+      when :double
+        "1.0"
+      when :user_id
+        current_user.username
+      when :post_id
+        Post.where(deleted_at: nil).select(:id).first&.id.to_s
+      when :topic_id
+        Topic.where(deleted_at: nil).select(:id).first&.id.to_s
+      when :category_id
+        Category.where(read_restricted: false).select(:id).first&.id.to_s
+      when :group_id
+        Group.select(:name).first&.name.to_s
+      when :badge_id
+        Badge.select(:id).first&.id.to_s
+      when :int_list
+        "1,2"
+      when :string_list
+        "sample,example"
+      when :user_list
+        current_user.username
+      when :group_list
+        Group.select(:name).first&.name.to_s
+      end
+    end
+
+    def sample_date(identifier)
+      if identifier.match?(/\A(start|from|begin)/i)
+        30.days.ago.to_date.iso8601
+      elsif identifier.match?(/\A(end|to|until)/i)
+        Date.current.iso8601
+      else
+        Date.current.iso8601
+      end
+    end
+
+    def sample_datetime(identifier)
+      if identifier.match?(/\A(start|from|begin)/i)
+        30.days.ago.strftime("%Y-%m-%d %H:%M")
+      elsif identifier.match?(/\A(end|to|until)/i)
+        Time.zone.now.strftime("%Y-%m-%d %H:%M")
+      else
+        Time.zone.now.strftime("%Y-%m-%d %H:%M")
+      end
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_params.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/ai_query_params.rb
@@ -47,15 +47,15 @@ module DiscourseDataExplorer
       when :user_id
         current_user.username
       when :post_id
-        Post.where(deleted_at: nil).select(:id).first&.id.to_s
+        Post.where(deleted_at: nil).order(:id).pick(:id).to_s
       when :topic_id
-        Topic.where(deleted_at: nil).select(:id).first&.id.to_s
+        Topic.where(deleted_at: nil).order(:id).pick(:id).to_s
       when :category_id
-        Category.where(read_restricted: false).select(:id).first&.id.to_s
+        Category.where(read_restricted: false).order(:id).pick(:id).to_s
       when :group_id
-        Group.select(:name).first&.name.to_s
+        Group.order(:name).pick(:name).to_s
       when :badge_id
-        Badge.select(:id).first&.id.to_s
+        Badge.order(:id).pick(:id).to_s
       when :int_list
         "1,2"
       when :string_list
@@ -63,7 +63,7 @@ module DiscourseDataExplorer
       when :user_list
         current_user.username
       when :group_list
-        Group.select(:name).first&.name.to_s
+        Group.order(:name).pick(:name).to_s
       end
     end
 

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/tools/run_sql.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/tools/run_sql.rb
@@ -39,9 +39,22 @@ module DiscourseDataExplorer
         return error_response("SQL query is empty") if sql.blank?
 
         query = DiscourseDataExplorer::Query.new(name: "AI tool query", sql: sql)
-        result = DiscourseDataExplorer::DataExplorer.run_query(query, {}, limit: MAX_ROWS + 1)
+        params_error = undeclared_params_error(query)
+        return error_response(params_error) if params_error
+
+        query_params =
+          DiscourseDataExplorer::AiQueryParams.sample_for(query, current_user: context.user)
+        result =
+          DiscourseDataExplorer::DataExplorer.run_query(
+            query,
+            query_params,
+            current_user: context.user,
+            limit: MAX_ROWS + 1,
+          )
 
         return error_response(result[:error].message) if result[:error]
+
+        context.feature_context[DiscourseDataExplorer::Tools::SubmitQuery::VALIDATED_SQL_KEY] = sql
 
         pg_result = result[:pg_result]
         columns = pg_result.fields
@@ -60,13 +73,33 @@ module DiscourseDataExplorer
             end
           end
 
-        { status: "success", columns: columns, rows: rows, row_count: total_rows }
+        {
+          status: "success",
+          columns: columns,
+          rows: rows,
+          row_count: total_rows,
+          params_used: query_params,
+        }
       end
 
       protected
 
       def description_args
         { sql: parameters[:sql].to_s.truncate(100) }
+      end
+
+      private
+
+      def undeclared_params_error(query)
+        declared_params = query.params.map(&:identifier).to_set
+        used_params = query.sql.scan(/(?<!:):([a-zA-Z][a-zA-Z0-9_]*)/).flatten.to_set
+        undeclared_params = used_params - declared_params
+
+        return if undeclared_params.blank?
+
+        formatted_params = undeclared_params.sort.map { |param| ":#{param}" }.to_sentence
+
+        "The SQL uses #{formatted_params}, but #{undeclared_params.one? ? "it is" : "they are"} not declared in a `-- [params]` block. Add parameter declarations at the top of the query before testing it again."
       end
     end
   end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/tools/submit_query.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/tools/submit_query.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module DiscourseDataExplorer
+  module Tools
+    class SubmitQuery < DiscourseAi::Agents::Tools::Tool
+      CONTEXT_KEY = :data_explorer_generated_query
+      VALIDATED_SQL_KEY = :data_explorer_validated_sql
+
+      def self.signature
+        {
+          name: name,
+          description:
+            "Submits the final verified Data Explorer query after schema lookup and SQL validation are complete.",
+          parameters: [
+            {
+              name: "name",
+              description: "a short descriptive name for the query, under 60 characters",
+              type: "string",
+              required: true,
+            },
+            {
+              name: "description",
+              description: "a one-sentence description of what the query does",
+              type: "string",
+              required: true,
+            },
+            {
+              name: "sql",
+              description: "the verified SQL query, without a trailing semicolon",
+              type: "string",
+              required: true,
+            },
+          ],
+        }
+      end
+
+      def self.custom?
+        true
+      end
+
+      def self.name
+        "submit_query"
+      end
+
+      def invoke
+        @submitted = false
+        if !validated_sql?
+          return(
+            {
+              status: "error",
+              error:
+                "Before submitting the final query, call run_sql with the exact SQL you intend to submit and fix any errors.",
+            }
+          )
+        end
+
+        context.feature_context[CONTEXT_KEY] = {
+          name: parameters[:name].to_s,
+          description: parameters[:description].to_s,
+          sql: normalized_sql(parameters[:sql]),
+        }
+        @submitted = true
+
+        { status: "success" }
+      end
+
+      def chain_next_response?
+        @submitted != true
+      end
+
+      protected
+
+      def description_args
+        { name: parameters[:name].to_s.truncate(100) }
+      end
+
+      private
+
+      def validated_sql?
+        submitted_sql = normalized_sql(parameters[:sql])
+        validated_sql = normalized_sql(context.feature_context[VALIDATED_SQL_KEY])
+
+        submitted_sql.present? && submitted_sql == validated_sql
+      end
+
+      def normalized_sql(sql)
+        sql.to_s.strip.chomp(";").strip
+      end
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/plugin.rb
+++ b/plugins/discourse-data-explorer/plugin.rb
@@ -205,7 +205,9 @@ after_initialize do
   end
 
   if defined?(DiscourseAi)
+    require_relative "lib/discourse_data_explorer/ai_query_params"
     require_relative "lib/discourse_data_explorer/tools/run_sql"
+    require_relative "lib/discourse_data_explorer/tools/submit_query"
     require_relative "lib/discourse_data_explorer/ai_query_generator"
 
     DiscourseAi.register_feature(

--- a/plugins/discourse-data-explorer/spec/jobs/regular/generate_de_query_with_ai_spec.rb
+++ b/plugins/discourse-data-explorer/spec/jobs/regular/generate_de_query_with_ai_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+describe Jobs::GenerateDeQueryWithAi do
+  fab!(:admin)
+
+  before do
+    SiteSetting.data_explorer_enabled = true
+    SiteSetting.data_explorer_ai_queries_enabled = true
+  end
+
+  def stub_agent
+    agent_id = DiscourseAi::Agents::Agent.external_agent_id(DiscourseDataExplorer::AiQueryGenerator)
+    agent_record = instance_double(AiAgent, class_instance: DiscourseDataExplorer::AiQueryGenerator)
+
+    allow(AiAgent).to receive(:find_by).and_call_original
+    allow(AiAgent).to receive(:find_by).with(id: agent_id).and_return(agent_record)
+  end
+
+  def stub_bot_with_submission(submission)
+    bot = instance_double(DiscourseAi::Agents::Bot)
+
+    allow(DiscourseAi::Agents::Bot).to receive(:as).and_return(bot)
+    allow(bot).to receive(:reply) do |context|
+      context.feature_context[DiscourseDataExplorer::Tools::SubmitQuery::CONTEXT_KEY] = submission
+    end
+  end
+
+  def execute_job
+    described_class.new.execute(
+      generation_id: "abc123",
+      user_id: admin.id,
+      ai_description: "show me users",
+    )
+  end
+
+  it "publishes the query submitted by the final tool" do
+    stub_agent
+    stub_bot_with_submission(
+      {
+        name: "Recent users",
+        description: "Lists recent users",
+        sql: "SELECT id AS user_id FROM users",
+      },
+    )
+
+    messages = MessageBus.track_publish("#{described_class::CHANNEL_PREFIX}/abc123") { execute_job }
+
+    expect(messages.first.data).to include(
+      status: "complete",
+      generation_id: "abc123",
+      name: "Recent users",
+      description: "Lists recent users",
+      sql: "SELECT id AS user_id FROM users",
+    )
+  end
+
+  it "publishes an error when the final tool does not submit SQL" do
+    stub_agent
+    stub_bot_with_submission({})
+
+    messages = MessageBus.track_publish("#{described_class::CHANNEL_PREFIX}/abc123") { execute_job }
+
+    expect(messages.first.data).to include(
+      status: "error",
+      generation_id: "abc123",
+      error: I18n.t("discourse_data_explorer.ai.error_no_sql_returned"),
+    )
+  end
+end

--- a/plugins/discourse-data-explorer/spec/lib/ai_query_generator_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/ai_query_generator_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe DiscourseDataExplorer::AiQueryGenerator do
+  it "uses tools for both validation and final structured submission" do
+    agent = described_class.new
+
+    expect(agent.tools).to include(
+      DiscourseAi::Agents::Tools::DbSchema,
+      DiscourseDataExplorer::Tools::RunSql,
+      DiscourseDataExplorer::Tools::SubmitQuery,
+    )
+    expect(agent.response_format).to be_nil
+    expect(agent.system_prompt).to include("submit_query")
+  end
+end

--- a/plugins/discourse-data-explorer/spec/lib/ai_query_params_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/ai_query_params_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseDataExplorer::AiQueryParams do
+  fab!(:user)
+
+  def sample_for(declaration)
+    sql = <<~SQL
+      -- [params]
+      #{declaration}
+
+      SELECT 1
+    SQL
+    query = Fabricate(:query, sql: sql)
+    described_class.sample_for(query, current_user: user)
+  end
+
+  it "returns representative static values for scalar types" do
+    result = sample_for(<<~PARAMS)
+        -- int :i
+        -- boolean :b
+        -- string :s
+      PARAMS
+
+    expect(result["i"]).to eq("1")
+    expect(result["b"]).to eq("true")
+    expect(result["s"]).to eq("sample")
+  end
+
+  it "uses the current user's username for user types" do
+    result = sample_for(<<~PARAMS)
+        -- user_id :u
+        -- user_list :ul
+      PARAMS
+
+    expect(result["u"]).to eq(user.username)
+    expect(result["ul"]).to eq(user.username)
+  end
+
+  it "samples existing records for id types" do
+    Fabricate(:post)
+    Fabricate(:category)
+    Fabricate(:group)
+
+    result = sample_for(<<~PARAMS)
+        -- post_id :p
+        -- topic_id :t
+        -- category_id :c
+        -- group_id :g
+        -- group_list :gl
+      PARAMS
+
+    expect(Post.where(deleted_at: nil).exists?(id: result["p"])).to eq(true)
+    expect(Topic.where(deleted_at: nil).exists?(id: result["t"])).to eq(true)
+    expect(Category.where(read_restricted: false).exists?(id: result["c"])).to eq(true)
+    expect(Group.exists?(name: result["g"])).to eq(true)
+    expect(Group.exists?(name: result["gl"])).to eq(true)
+  end
+
+  it "skips soft-deleted posts when sampling post_id" do
+    deleted_post = Fabricate(:post)
+    live_post = Fabricate(:post)
+    deleted_post.trash!
+
+    result = sample_for("-- post_id :p")
+
+    expect(result["p"]).to eq(live_post.id.to_s)
+    expect(result["p"]).not_to eq(deleted_post.id.to_s)
+  end
+
+  it "does not sample params that declare a default" do
+    result = sample_for("-- int :i = 5")
+
+    expect(result).not_to have_key("i")
+  end
+end

--- a/plugins/discourse-data-explorer/spec/lib/tools/run_sql_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/tools/run_sql_spec.rb
@@ -4,6 +4,8 @@ describe DiscourseDataExplorer::Tools::RunSql do
   fab!(:llm_model)
   fab!(:admin)
   fab!(:user)
+  fab!(:category)
+  fab!(:group)
 
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
@@ -14,9 +16,9 @@ describe DiscourseDataExplorer::Tools::RunSql do
     SiteSetting.ai_bot_enabled = true
   end
 
-  def invoke_with(user:)
+  def invoke_with(user:, sql: "SELECT 1 AS one")
     described_class.new(
-      { sql: "SELECT 1 AS one" },
+      { sql: sql },
       bot_user: bot_user,
       llm: llm,
       context: DiscourseAi::Agents::BotContext.new(user: user),
@@ -28,6 +30,96 @@ describe DiscourseDataExplorer::Tools::RunSql do
 
     expect(result[:status]).to eq("success")
     expect(result[:columns]).to eq(["one"])
+  end
+
+  it "passes the current user when validating current_user_id params" do
+    result = invoke_with(user: admin, sql: <<~SQL)
+          -- [params]
+          -- current_user_id :me
+          SELECT :me AS user_id
+        SQL
+
+    expect(result[:status]).to eq("success")
+    expect(result[:columns]).to eq(["user_id"])
+    expect(result[:rows]).to eq([[admin.id]])
+    expect(result[:params_used]).to eq({})
+  end
+
+  it "uses representative values for required params without defaults" do
+    result = invoke_with(user: admin, sql: <<~SQL)
+          -- [params]
+          -- category_id :category
+          -- group_id :group
+          SELECT :category AS category_id, :group AS group_name
+        SQL
+
+    expect(result[:status]).to eq("success")
+    expect(result[:params_used]["category"]).to be_present
+    expect(result[:params_used]["group"]).to be_present
+  end
+
+  it "uses representative values for list params" do
+    result = invoke_with(user: admin, sql: <<~SQL)
+          -- [params]
+          -- int_list :ids
+          SELECT 1 IN (:ids) AS has_sample
+        SQL
+
+    expect(result[:status]).to eq("success")
+    expect(result[:rows]).to eq([[true]])
+    expect(result[:params_used]).to eq({ "ids" => "1,2" })
+  end
+
+  it "keeps declared defaults for params" do
+    result = invoke_with(user: admin, sql: <<~SQL)
+          -- [params]
+          -- int :limit = 7
+          SELECT :limit AS selected_limit
+        SQL
+
+    expect(result[:status]).to eq("success")
+    expect(result[:rows]).to eq([[7]])
+    expect(result[:params_used]).to eq({})
+  end
+
+  it "uses representative values for date ranges" do
+    freeze_time DateTime.parse("2026-05-26 12:00")
+
+    result = invoke_with(user: admin, sql: <<~SQL)
+          -- [params]
+          -- date :start_date
+          -- date :end_date
+          SELECT CAST(:start_date AS date) AS start_date, CAST(:end_date AS date) AS end_date
+        SQL
+
+    expect(result[:status]).to eq("success")
+    expect(result[:params_used]).to eq({ "start_date" => "2026-04-26", "end_date" => "2026-05-26" })
+  end
+
+  it "returns an actionable error for undeclared params before running SQL" do
+    allow(DiscourseDataExplorer::DataExplorer).to receive(:run_query)
+
+    result = invoke_with(user: admin, sql: <<~SQL)
+          SELECT COUNT(*)
+          FROM topics
+          WHERE created_at >= CAST(:start_date AS date)
+            AND created_at < CAST(:end_date AS date) + INTERVAL '1 day'
+        SQL
+
+    expect(result[:status]).to eq("error")
+    expect(result[:error]).to include(":start_date")
+    expect(result[:error]).to include(":end_date")
+    expect(result[:error]).to include("-- [params]")
+    expect(DiscourseDataExplorer::DataExplorer).not_to have_received(:run_query)
+  end
+
+  it "does not treat PostgreSQL casts as undeclared params" do
+    result = invoke_with(user: admin, sql: <<~SQL)
+          SELECT '2026-01-01'::timestamp AS starts_at
+        SQL
+
+    expect(result[:status]).to eq("success")
+    expect(result[:columns]).to eq(["starts_at"])
   end
 
   it "blocks a non-admin caller without running the SQL" do

--- a/plugins/discourse-data-explorer/spec/lib/tools/submit_query_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/tools/submit_query_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+describe DiscourseDataExplorer::Tools::SubmitQuery do
+  fab!(:llm_model)
+  fab!(:admin)
+
+  let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
+  let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+  let(:context) { DiscourseAi::Agents::BotContext.new(user: admin) }
+
+  before do
+    SiteSetting.discourse_ai_enabled = true
+    SiteSetting.ai_bot_enabled = true
+  end
+
+  it "stores the generated query on the bot context and stops the tool chain" do
+    context.feature_context[described_class::VALIDATED_SQL_KEY] = "SELECT id AS user_id FROM users"
+
+    tool =
+      described_class.new(
+        {
+          name: "Recent users",
+          description: "Lists recent users",
+          sql: "SELECT id AS user_id FROM users",
+        },
+        bot_user: bot_user,
+        llm: llm,
+        context: context,
+      )
+
+    result = tool.invoke
+
+    expect(result[:status]).to eq("success")
+    expect(context.feature_context[described_class::CONTEXT_KEY]).to eq(
+      {
+        name: "Recent users",
+        description: "Lists recent users",
+        sql: "SELECT id AS user_id FROM users",
+      },
+    )
+    expect(tool.chain_next_response?).to eq(false)
+  end
+
+  it "keeps the chain going when the submitted SQL was not validated" do
+    tool =
+      described_class.new(
+        {
+          name: "Recent users",
+          description: "Lists recent users",
+          sql: "SELECT id AS user_id FROM users",
+        },
+        bot_user: bot_user,
+        llm: llm,
+        context: context,
+      )
+
+    result = tool.invoke
+
+    expect(result[:status]).to eq("error")
+    expect(context.feature_context[described_class::CONTEXT_KEY]).to be_nil
+    expect(tool.chain_next_response?).to eq(true)
+  end
+
+  it "stores the normalized SQL that matched validation" do
+    context.feature_context[described_class::VALIDATED_SQL_KEY] = "SELECT id AS user_id FROM users"
+
+    tool =
+      described_class.new(
+        {
+          name: "Recent users",
+          description: "Lists recent users",
+          sql: " SELECT id AS user_id FROM users;\n",
+        },
+        bot_user: bot_user,
+        llm: llm,
+        context: context,
+      )
+
+    result = tool.invoke
+
+    expect(result[:status]).to eq("success")
+    expect(context.feature_context[described_class::CONTEXT_KEY][:sql]).to eq(
+      "SELECT id AS user_id FROM users",
+    )
+  end
+end


### PR DESCRIPTION
Previously, Data Explorer AI query generation used structured output for
the final query payload, which conflicted with tool usage and could return
SQL that had not been validated.

This PR gets the required `name`, `description`, and `sql` through a final
`submit_query` tool, requiring the exact SQL to pass `run_sql` before it
is returned. It also gives `run_sql` representative values for declared
params, including `current_user_id`, and returns a targeted error when SQL
uses params that were not declared in a `-- [params]` block.