### PR TITLE
DEV: Add 2026 Singapore holidays

### DIFF
--- a/plugins/discourse-calendar/vendor/holidays/definitions/sg.yaml
+++ b/plugins/discourse-calendar/vendor/holidays/definitions/sg.yaml
@@ -16,66 +16,61 @@ months:
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
+  2:
   - name: First day of Chinese New Year
     regions: [sg]
-    mday: 29
+    mday: 17
     observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2025]
+      limited: [2026]
   - name: Second day of Chinese New Year
     regions: [sg]
-    mday: 30
+    mday: 18
     observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2025]
+      limited: [2026]
   3:
   - name: Hari Raya Puasa
     regions: [sg]
-    mday: 31
+    mday: 21
     year_ranges:
-      limited: [2025]
+      limited: [2026]
   4:
   - name: Good Friday
     regions: [sg]
-    mday: 18
+    mday: 3
     year_ranges:
-      limited: [2025]
+      limited: [2026]
   5:
   - name: Labour Day
     regions: [sg]
     mday: 1
     observed: to_weekday_if_weekend(date)
-  - name: Polling Day
-    regions: [sg]
-    mday: 3
-    year_ranges:
-      limited: [2025]
-    observed: to_weekday_if_weekend(date)
-  - name: Vesak Day
-    regions: [sg]
-    mday: 12
-    year_ranges:
-      limited: [2025]
-  6:
   - name: Hari Raya Haji
     regions: [sg]
-    mday: 7
+    mday: 27
     year_ranges:
-      limited: [2025]
+      limited: [2026]
+  - name: Vesak Day
+    regions: [sg]
+    mday: 31
+    observed: to_weekday_if_weekend(date)
+    year_ranges:
+      limited: [2026]
   8:
   - name: National Day
     regions: [sg]
     mday: 9
     observed: to_weekday_if_weekend(date)
-  10:
-  - name: Deepavali (Observed)
+  11:
+  - name: Deepavali
     regions: [sg]
-    mday: 20
+    mday: 8
+    observed: to_weekday_if_weekend(date)
     year_ranges:
-      limited: [2025]
+      limited: [2026]
   12:
   - name: Christmas Day
     regions: [sg]
     mday: 25
     observed: to_weekday_if_weekend(date)
-

--- a/plugins/discourse-calendar/vendor/holidays/lib/generated_definitions/sg.rb
+++ b/plugins/discourse-calendar/vendor/holidays/lib/generated_definitions/sg.rb
@@ -12,24 +12,23 @@ module Holidays
 
     def self.holidays_by_month
       {
-                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:sg]},
-            {:mday => 29, :year_ranges => { :limited => [2025] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "First day of Chinese New Year", :regions => [:sg]},
-            {:mday => 30, :year_ranges => { :limited => [2025] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Second day of Chinese New Year", :regions => [:sg]}],
-      3 => [{:mday => 31, :year_ranges => { :limited => [2025] },:name => "Hari Raya Puasa", :regions => [:sg]}],
-      4 => [{:mday => 18, :year_ranges => { :limited => [2025] },:name => "Good Friday", :regions => [:sg]}],
+                1 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "New Year's Day", :regions => [:sg]}],
+      2 => [{:mday => 17, :year_ranges => { :limited => [2026] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "First day of Chinese New Year", :regions => [:sg]},
+            {:mday => 18, :year_ranges => { :limited => [2026] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Second day of Chinese New Year", :regions => [:sg]}],
+      3 => [{:mday => 21, :year_ranges => { :limited => [2026] },:name => "Hari Raya Puasa", :regions => [:sg]}],
+      4 => [{:mday => 3, :year_ranges => { :limited => [2026] },:name => "Good Friday", :regions => [:sg]}],
       5 => [{:mday => 1, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Labour Day", :regions => [:sg]},
-            {:mday => 3, :year_ranges => { :limited => [2025] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Polling Day", :regions => [:sg]},
-            {:mday => 12, :year_ranges => { :limited => [2025] },:name => "Vesak Day", :regions => [:sg]}],
-      6 => [{:mday => 7, :year_ranges => { :limited => [2025] },:name => "Hari Raya Haji", :regions => [:sg]}],
+            {:mday => 27, :year_ranges => { :limited => [2026] },:name => "Hari Raya Haji", :regions => [:sg]},
+            {:mday => 31, :year_ranges => { :limited => [2026] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Vesak Day", :regions => [:sg]}],
       8 => [{:mday => 9, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "National Day", :regions => [:sg]}],
-      10 => [{:mday => 20, :year_ranges => { :limited => [2025] },:name => "Deepavali (Observed)", :regions => [:sg]}],
+      11 => [{:mday => 8, :year_ranges => { :limited => [2026] },:observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Deepavali", :regions => [:sg]}],
       12 => [{:mday => 25, :observed => "to_weekday_if_weekend(date)", :observed_arguments => [:date], :name => "Christmas Day", :regions => [:sg]}]
       }
     end
 
     def self.custom_methods
       {
-          
+
       }
     end
   end

--- a/plugins/discourse-calendar/vendor/holidays/lib/generated_definitions/sg.rb
+++ b/plugins/discourse-calendar/vendor/holidays/lib/generated_definitions/sg.rb
@@ -28,7 +28,7 @@ module Holidays
 
     def self.custom_methods
       {
-
+          
       }
     end
   end


### PR DESCRIPTION
The Singapore (`sg`) holiday definitions in the vendored `holidays` gem only included 2025 entries for lunar and Islamic calendar holidays, so dates like Hari Raya Haji (May 27) and Vesak Day (observed June 1) did not resolve for 2026.

This commit refreshes the `sg` definitions with 2026 dates for Chinese New Year, Hari Raya Puasa, Good Friday, Vesak Day, Hari Raya Haji, and Deepavali based on the [Ministry of Manpower's published list](https://www.mom.gov.sg/employment-practices/public-holidays), and drops the 2025-only Polling Day entry. Vesak Day (May 31) and Deepavali (Nov 8) fall on a Sunday in 2026, so both carry `to_weekday_if_weekend` so the gem returns the in-lieu Monday.