### PR TITLE
FIX: Dismiss buttons not showing in Horizon

### DIFF
--- a/frontend/discourse/app/components/topic-dismiss-buttons.gjs
+++ b/frontend/discourse/app/components/topic-dismiss-buttons.gjs
@@ -5,6 +5,7 @@ import DismissReadModal from "discourse/components/modal/dismiss-read";
 import DButton from "discourse/ui-kit/d-button";
 import DComboButton from "discourse/ui-kit/d-combo-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 export default class TopicDismissButtons extends Component {
@@ -128,7 +129,10 @@ export default class TopicDismissButtons extends Component {
         {{~#if @showResetNew~}}
           {{#if @showNewDismissCombo}}
             <DComboButton
-              class="--has-menu topic-dismiss-buttons__combo"
+              class={{dConcatClass
+                "topic-dismiss-buttons__combo"
+                (if this.showDismissNewMenu "--has-menu")
+              }}
               as |combo|
             >
               <combo.Button

--- a/frontend/discourse/app/components/topic-drafts-dropdown.gjs
+++ b/frontend/discourse/app/components/topic-drafts-dropdown.gjs
@@ -12,6 +12,7 @@ import { or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DComboButton from "discourse/ui-kit/d-combo-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 const DRAFTS_LIMIT = 4;
@@ -99,7 +100,10 @@ export default class TopicDraftsDropdown extends Component {
 
   <template>
     <DComboButton
-      class={{if @showDrafts "--has-menu"}}
+      class={{dConcatClass
+        "topic-create-button__combo"
+        (if @showDrafts "--has-menu")
+      }}
       aria-label={{i18n "topic.create_group"}}
       ...attributes
       as |combo|

--- a/themes/horizon/scss/hiddenstuff.scss
+++ b/themes/horizon/scss/hiddenstuff.scss
@@ -10,7 +10,7 @@
 
 @include viewport.from(md) {
   .horizon-new-topic-button-enabled {
-    .list-controls .d-combo-button {
+    .list-controls .topic-create-button__combo {
       display: none;
     }
   }


### PR DESCRIPTION
Followup 2f423165e99fe99112c75fcda93495d24f503e21

Horizon had CSS to hide _all_ combo buttons in the top of
the topic list, even though it was only trying to hide the
New Topic button. This meant the dismiss button was hidden
too.

Reveal the dismiss button in Horizon and add CSS classes
for specificity.

**Before**

<img width="1007" height="263" alt="image" src="https://github.com/user-attachments/assets/5a6ab3af-4fcb-4231-97c8-f6eda4a8636e" />


**After**

<img width="1041" height="267" alt="image" src="https://github.com/user-attachments/assets/da1b8801-75bd-4ff7-a0f9-f1092e817012" />
