### PR TITLE
PERF: Batch `BrowserPageviewEvent` inserts through Redis

### DIFF
--- a/app/jobs/scheduled/flush_browser_pageview_events.rb
+++ b/app/jobs/scheduled/flush_browser_pageview_events.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Jobs
+  class FlushBrowserPageviewEvents < ::Jobs::Scheduled
+    every 1.minute
+
+    MAX_FLUSH_SECONDS = 50
+
+    def execute(args)
+      return if !SiteSetting.persist_browser_pageview_events
+
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + MAX_FLUSH_SECONDS
+
+      loop do
+        return if BrowserPageviewEvent.queued_count == 0
+
+        processed = BrowserPageviewEvent.flush_queued!
+        return if processed < BrowserPageviewEvent::REDIS_FLUSH_BATCH_SIZE
+        return if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+      end
+    end
+  end
+end

--- a/app/jobs/scheduled/flush_browser_pageview_events.rb
+++ b/app/jobs/scheduled/flush_browser_pageview_events.rb
@@ -2,12 +2,13 @@
 
 module Jobs
   class FlushBrowserPageviewEvents < ::Jobs::Scheduled
-    every 1.minute
+    every 5.minutes
 
     MAX_FLUSH_SECONDS = 50
 
     def execute(args)
       return if !SiteSetting.persist_browser_pageview_events
+      return if Discourse.pg_readonly_mode?
 
       deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + MAX_FLUSH_SECONDS
 

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -7,6 +7,174 @@ class BrowserPageviewEvent < ActiveRecord::Base
   MAX_USER_AGENT_LENGTH = 1000
   MAX_NORMALIZED_REFERRER_LENGTH = 2000
   RETENTION_PERIOD = 3.months
+  REDIS_QUEUE_KEY = "browser_pageview_events:pending"
+  REDIS_FLUSH_LOCK_KEY = "browser_pageview_events:flush"
+  REDIS_FLUSH_BATCH_SIZE = 1000
+
+  class << self
+    def enqueue_for_later(payload)
+      Discourse.redis.rpush(REDIS_QUEUE_KEY, JSON.generate(serialize_payload(payload)))
+    rescue Redis::BaseConnectionError => e
+      Rails.logger.warn("Failed to queue BrowserPageviewEvent in Redis: #{e.message}")
+    end
+
+    def create_from_payload!(payload)
+      BrowserPageviewEvent.create!(attributes_from_payload(payload))
+    end
+
+    def flush_queued!
+      return 0 if Discourse.pg_readonly_mode?
+
+      processed = 0
+
+      DistributedMutex.synchronize(REDIS_FLUSH_LOCK_KEY, validity: 5.minutes) do
+        entries = Array(Discourse.redis.lrange(REDIS_QUEUE_KEY, 0, REDIS_FLUSH_BATCH_SIZE - 1))
+        queued_attributes = []
+
+        entries.each do |entry|
+          attributes = attributes_from_payload(deserialize_payload(entry))
+          if valid_attributes?(attributes)
+            queued_attributes << attributes
+          else
+            Rails.logger.debug("Discarding queued BrowserPageviewEvent: invalid data")
+            queued_attributes << nil
+          end
+          processed += 1
+        rescue JSON::ParserError => e
+          Rails.logger.error("Discarding queued BrowserPageviewEvent: #{e.message}")
+          queued_attributes << nil
+          processed += 1
+        end
+
+        begin
+          insert_rows!(queued_attributes)
+        rescue ActiveRecord::ReadOnlyError
+          Discourse.received_postgres_readonly!
+          return 0
+        rescue ActiveRecord::StatementInvalid => e
+          if postgres_readonly_error?(e)
+            Discourse.received_postgres_readonly!
+            return 0
+          end
+
+          return 0 if postgres_connection_error?(e)
+
+          Rails.logger.error("Failed to insert queued BrowserPageviewEvents: #{e.message}")
+          return 0
+        end
+      end
+
+      processed
+    end
+
+    def queued_count
+      Discourse.redis.llen(REDIS_QUEUE_KEY).to_i
+    end
+
+    def clear_queued!
+      Discourse.redis.del(REDIS_QUEUE_KEY)
+    end
+
+    def postgres_readonly_error?(error)
+      error.cause.is_a?(PG::ReadOnlySqlTransaction)
+    end
+
+    private
+
+    def insert_rows!(queued_attributes)
+      return if queued_attributes.blank?
+
+      rows = queued_attributes.compact
+      if rows.present?
+        BrowserPageviewEvent.transaction(requires_new: true) do
+          BrowserPageviewEvent.insert_all(rows, returning: false)
+        end
+      end
+      Discourse.redis.ltrim(REDIS_QUEUE_KEY, queued_attributes.length, -1)
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.error(
+        "Failed to insert queued BrowserPageviewEvents in bulk; retrying individually: #{e.message}",
+      )
+      insert_rows_individually!(queued_attributes)
+    end
+
+    def insert_rows_individually!(queued_attributes)
+      queued_attributes.each do |attributes|
+        if attributes
+          BrowserPageviewEvent.transaction(requires_new: true) do
+            BrowserPageviewEvent.insert_all([attributes], returning: false)
+          end
+        end
+        Discourse.redis.ltrim(REDIS_QUEUE_KEY, 1, -1)
+      rescue ActiveRecord::StatementInvalid => e
+        raise if postgres_readonly_error?(e) || postgres_connection_error?(e)
+
+        Rails.logger.error(
+          "Discarding queued BrowserPageviewEvent after insert failure: #{e.message}",
+        )
+        Discourse.redis.ltrim(REDIS_QUEUE_KEY, 1, -1)
+      end
+    end
+
+    def serialize_payload(payload)
+      payload = payload.with_indifferent_access
+
+      {
+        user_id: payload[:user_id],
+        url: payload[:url]&.slice(0, MAX_URL_LENGTH),
+        ip_address: payload[:ip_address],
+        country_code: payload[:country_code]&.slice(0, 2),
+        asn: payload[:asn],
+        referrer: payload[:referrer]&.slice(0, MAX_REFERRER_LENGTH),
+        user_agent: payload[:user_agent]&.slice(0, MAX_USER_AGENT_LENGTH),
+        session_id: payload[:session_id]&.slice(0, MAX_SESSION_ID_LENGTH),
+        topic_id: payload[:topic_id],
+        occurred_at: payload[:occurred_at],
+      }
+    end
+
+    def deserialize_payload(entry)
+      JSON.parse(entry).with_indifferent_access
+    end
+
+    def attributes_from_payload(payload)
+      normalized_referrer = BrowserPageviewReferrerInspector.normalize(payload[:referrer])
+
+      {
+        url: payload[:url]&.slice(0, MAX_URL_LENGTH),
+        ip_address: payload[:ip_address],
+        country_code: payload[:country_code]&.slice(0, 2),
+        asn: payload[:asn],
+        referrer: payload[:referrer]&.slice(0, MAX_REFERRER_LENGTH),
+        normalized_referrer: normalized_referrer&.slice(0, MAX_NORMALIZED_REFERRER_LENGTH),
+        normalized_referrer_version: BrowserPageviewReferrerInspector::VERSION,
+        user_agent: payload[:user_agent]&.slice(0, MAX_USER_AGENT_LENGTH),
+        session_id: payload[:session_id]&.slice(0, MAX_SESSION_ID_LENGTH),
+        user_id: payload[:user_id],
+        topic_id: payload[:topic_id],
+        created_at: payload[:occurred_at],
+      }
+    end
+
+    def valid_attributes?(attributes)
+      attributes[:url].present? && attributes[:ip_address].present? &&
+        attributes[:user_agent].present? && attributes[:session_id].present? &&
+        attributes[:created_at].present? && valid_ip_address?(attributes[:ip_address])
+    end
+
+    def valid_ip_address?(ip_address)
+      IPAddr.new(ip_address)
+      true
+    rescue IPAddr::InvalidAddressError
+      false
+    end
+
+    def postgres_connection_error?(error)
+      cause = error.cause
+      cause.is_a?(PG::ConnectionBad) ||
+        (defined?(PG::UnableToSend) && cause.is_a?(PG::UnableToSend))
+    end
+  end
 
   has_one :browser_pageview_event_score, foreign_key: :event_id, dependent: :delete
 

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -15,6 +15,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
 
   class << self
     def enqueue_for_later(payload)
+      return unless valid_payload?(payload)
       return if Discourse.redis.llen(REDIS_QUEUE_KEY) >= REDIS_QUEUE_MAX_SIZE
 
       Discourse.redis.multi do |transaction|
@@ -39,13 +40,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
         queued_attributes = []
 
         entries.each do |entry|
-          attributes = attributes_from_payload(deserialize_payload(entry))
-          if valid_attributes?(attributes)
-            queued_attributes << attributes
-          else
-            Rails.logger.debug("Discarding queued BrowserPageviewEvent: invalid data")
-            queued_attributes << nil
-          end
+          queued_attributes << attributes_from_payload(deserialize_payload(entry))
           processed += 1
         rescue => e
           Rails.logger.error("Discarding queued BrowserPageviewEvent: #{e.message}")
@@ -163,10 +158,10 @@ class BrowserPageviewEvent < ActiveRecord::Base
       }
     end
 
-    def valid_attributes?(attributes)
-      attributes[:url].present? && attributes[:ip_address].present? &&
-        attributes[:user_agent].present? && attributes[:session_id].present? &&
-        attributes[:created_at].present? && valid_ip_address?(attributes[:ip_address])
+    def valid_payload?(payload)
+      payload[:url].present? && payload[:ip_address].present? && payload[:user_agent].present? &&
+        payload[:session_id].present? && payload[:occurred_at].present? &&
+        valid_ip_address?(payload[:ip_address])
     end
 
     def valid_ip_address?(ip_address)
@@ -178,8 +173,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
 
     def postgres_connection_error?(error)
       cause = error.cause
-      cause.is_a?(PG::ConnectionBad) ||
-        (defined?(PG::UnableToSend) && cause.is_a?(PG::UnableToSend))
+      cause.is_a?(PG::ConnectionBad) || cause.is_a?(PG::UnableToSend)
     end
   end
 

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -10,10 +10,17 @@ class BrowserPageviewEvent < ActiveRecord::Base
   REDIS_QUEUE_KEY = "browser_pageview_events:pending"
   REDIS_FLUSH_LOCK_KEY = "browser_pageview_events:flush"
   REDIS_FLUSH_BATCH_SIZE = 1000
+  REDIS_QUEUE_MAX_SIZE = 1_000_000
+  REDIS_QUEUE_TTL = 1.day
 
   class << self
     def enqueue_for_later(payload)
-      Discourse.redis.rpush(REDIS_QUEUE_KEY, JSON.generate(serialize_payload(payload)))
+      return if Discourse.redis.llen(REDIS_QUEUE_KEY) >= REDIS_QUEUE_MAX_SIZE
+
+      Discourse.redis.multi do |transaction|
+        transaction.rpush(REDIS_QUEUE_KEY, JSON.generate(serialize_payload(payload)))
+        transaction.expire(REDIS_QUEUE_KEY, REDIS_QUEUE_TTL)
+      end
     rescue Redis::BaseConnectionError => e
       Rails.logger.warn("Failed to queue BrowserPageviewEvent in Redis: #{e.message}")
     end
@@ -40,7 +47,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
             queued_attributes << nil
           end
           processed += 1
-        rescue JSON::ParserError => e
+        rescue => e
           Rails.logger.error("Discarding queued BrowserPageviewEvent: #{e.message}")
           queued_attributes << nil
           processed += 1
@@ -165,7 +172,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
     def valid_ip_address?(ip_address)
       IPAddr.new(ip_address)
       true
-    rescue IPAddr::InvalidAddressError
+    rescue IPAddr::Error
       false
     end
 

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -724,6 +724,7 @@ class Middleware::RequestTracker
       DiscourseEvent.trigger(:browser_pageview, build_browser_pageview_event_payload(data))
     end
   end
+
   def self.persist_browser_pageview_event(payload)
     if REQUIRED_BROWSER_PAGEVIEW_EVENT_FIELDS.any? { |key| payload[key].blank? }
       Rails.logger.debug("Discarding BrowserPageviewEvent: incomplete payload")

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -143,7 +143,6 @@ class Middleware::RequestTracker
           ApplicationRequest.increment!(:page_view_anon_browser)
           ApplicationRequest.increment!(:page_view_anon_browser_mobile) if data[:is_mobile]
         end
-        trigger_browser_pageview_event(data)
       end
 
       if data[:topic_id].present? && (!data[:has_auth_cookie] || data[:current_user_id].present?) &&
@@ -422,6 +421,7 @@ class Middleware::RequestTracker
     Scheduler::Defer.later("Track view") do
       unless Discourse.pg_readonly_mode?
         self.class.log_request(data)
+        self.class.track_browser_pageview(data)
         instrument_browser_page_view(env, request, data)
       end
     rescue ActiveRecord::ReadOnlyError
@@ -712,15 +712,16 @@ class Middleware::RequestTracker
   end
   private_class_method :extract_beacon_view_tracking_data
 
-  def self.trigger_browser_pageview_event(data)
+  def self.track_browser_pageview(data)
+    return if data[:is_beacon]
+    return if !tracks_browser_page_view?(data)
+
     if SiteSetting.persist_browser_pageview_events
       persist_browser_pageview_event(build_browser_pageview_event_payload(data))
     elsif SiteSetting.trigger_browser_pageview_events
       DiscourseEvent.trigger(:browser_pageview, build_browser_pageview_event_payload(data))
     end
   end
-  private_class_method :trigger_browser_pageview_event
-
   def self.persist_browser_pageview_event(payload)
     if REQUIRED_BROWSER_PAGEVIEW_EVENT_FIELDS.any? { |key| payload[key].blank? }
       Rails.logger.debug("Discarding BrowserPageviewEvent: incomplete payload")
@@ -728,23 +729,18 @@ class Middleware::RequestTracker
     end
 
     Scheduler::Defer.later "Create BrowserPageviewEvent" do
-      BrowserPageviewEvent.create!(
-        url: payload[:url],
-        ip_address: payload[:ip_address],
-        country_code: payload[:country_code],
-        asn: payload[:asn],
-        referrer: payload[:referrer],
-        normalized_referrer: BrowserPageviewReferrerInspector.normalize(payload[:referrer]),
-        normalized_referrer_version: BrowserPageviewReferrerInspector::VERSION,
-        user_agent: payload[:user_agent],
-        session_id: payload[:session_id],
-        user_id: payload[:user_id],
-        topic_id: payload[:topic_id],
-        created_at: payload[:occurred_at],
-      )
+      if Discourse.pg_readonly_mode?
+        queue_browser_pageview_event(payload)
+      else
+        BrowserPageviewEvent.create_from_payload!(payload)
+      end
+    rescue ActiveRecord::ReadOnlyError
+      Discourse.received_postgres_readonly!
+      queue_browser_pageview_event(payload)
     rescue ActiveRecord::StatementInvalid => e
-      if e.cause.is_a?(PG::ReadOnlySqlTransaction)
-        # Skip recording browser pageviews when PostgreSQL is in read-only transaction mode.
+      if BrowserPageviewEvent.postgres_readonly_error?(e)
+        Discourse.received_postgres_readonly!
+        queue_browser_pageview_event(payload)
       elsif e.cause.is_a?(PG::NotNullViolation) && e.cause.message.include?("ip_address")
         Rails.logger.debug("Discarding BrowserPageviewEvent: invalid IP #{payload[:ip_address]}")
       else
@@ -757,6 +753,13 @@ class Middleware::RequestTracker
     end
   end
   private_class_method :persist_browser_pageview_event
+
+  def self.queue_browser_pageview_event(payload)
+    BrowserPageviewEvent.enqueue_for_later(
+      payload.merge(occurred_at: payload[:occurred_at].iso8601(6)),
+    )
+  end
+  private_class_method :queue_browser_pageview_event
 
   def self.trigger_beacon_browser_pageview_event(data)
     if SiteSetting.trigger_browser_pageview_events

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -419,7 +419,9 @@ class Middleware::RequestTracker
 
   def log_later(data, env, request)
     Scheduler::Defer.later("Track view") do
-      unless Discourse.pg_readonly_mode?
+      if Discourse.pg_readonly_mode?
+        self.class.track_browser_pageview(data) if SiteSetting.persist_browser_pageview_events
+      else
         self.class.log_request(data)
         self.class.track_browser_pageview(data)
         instrument_browser_page_view(env, request, data)

--- a/spec/jobs/flush_browser_pageview_events_spec.rb
+++ b/spec/jobs/flush_browser_pageview_events_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::FlushBrowserPageviewEvents do
+  before do
+    BrowserPageviewEvent.clear_queued!
+    Discourse.clear_readonly!
+  end
+
+  after do
+    BrowserPageviewEvent.clear_queued!
+    Discourse.clear_readonly!
+  end
+
   let(:payload) do
     {
       url: "https://discourse.example/t/topic/1",

--- a/spec/jobs/flush_browser_pageview_events_spec.rb
+++ b/spec/jobs/flush_browser_pageview_events_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Jobs::FlushBrowserPageviewEvents do
   end
 
   def queue_payload(payload)
-    Discourse.redis.rpush(BrowserPageviewEvent::REDIS_QUEUE_KEY, JSON.generate(payload))
+    BrowserPageviewEvent.enqueue_for_later(payload)
   end
 
   def queue_payloads(payloads)

--- a/spec/jobs/flush_browser_pageview_events_spec.rb
+++ b/spec/jobs/flush_browser_pageview_events_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::FlushBrowserPageviewEvents do
+  let(:payload) do
+    {
+      url: "https://discourse.example/t/topic/1",
+      ip_address: "1.2.3.4",
+      user_agent: "Mozilla/5.0",
+      session_id: "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
+      occurred_at: Time.zone.parse("2026-05-27 10:30:00").iso8601(6),
+    }
+  end
+
+  def queue_payload(payload)
+    Discourse.redis.rpush(BrowserPageviewEvent::REDIS_QUEUE_KEY, JSON.generate(payload))
+  end
+
+  def queue_payloads(payloads)
+    payloads.each { |queued_payload| queue_payload(queued_payload) }
+  end
+
+  it "does nothing when browser pageview persistence is disabled" do
+    SiteSetting.persist_browser_pageview_events = false
+    queue_payload(payload)
+
+    expect { described_class.new.execute({}) }.not_to change { BrowserPageviewEvent.count }
+
+    expect(BrowserPageviewEvent.queued_count).to eq(1)
+  end
+
+  it "flushes queued browser pageviews" do
+    SiteSetting.persist_browser_pageview_events = true
+    queue_payload(payload)
+
+    expect { described_class.new.execute({}) }.to change { BrowserPageviewEvent.count }.by(1)
+
+    expect(BrowserPageviewEvent.queued_count).to eq(0)
+  end
+
+  it "flushes multiple batches in one run" do
+    SiteSetting.persist_browser_pageview_events = true
+
+    stub_const(BrowserPageviewEvent, "REDIS_FLUSH_BATCH_SIZE", 3) do
+      payloads = 5.times.map { |index| payload.merge(session_id: format("%032d", index)) }
+      queue_payloads(payloads)
+
+      expect { described_class.new.execute({}) }.to change { BrowserPageviewEvent.count }.by(
+        payloads.length,
+      )
+
+      expect(BrowserPageviewEvent.queued_count).to eq(0)
+    end
+  end
+end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -731,6 +731,10 @@ RSpec.describe Middleware::RequestTracker do
     end
 
     describe "browser_pageview event" do
+      def log_browser_pageview(data)
+        Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] }).log_later(data, {}, nil)
+      end
+
       context "when SiteSetting.trigger_browser_pageview_events is true" do
         before { SiteSetting.trigger_browser_pageview_events = true }
         it "triggers event for anonymous user page views when `login_required` site setting is false" do
@@ -749,10 +753,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          events =
-            DiscourseEvent.track_events(:browser_pageview) do
-              Middleware::RequestTracker.log_request(data)
-            end
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
 
           expect(events.length).to eq(1)
           event = events[0][:params].first
@@ -781,10 +782,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          events =
-            DiscourseEvent.track_events(:browser_pageview) do
-              Middleware::RequestTracker.log_request(data)
-            end
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
 
           expect(events).to be_empty
         end
@@ -805,10 +803,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          events =
-            DiscourseEvent.track_events(:browser_pageview) do
-              Middleware::RequestTracker.log_request(data)
-            end
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
 
           expect(events.length).to eq(1)
           event = events[0][:params].first
@@ -843,10 +838,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          events =
-            DiscourseEvent.track_events(:browser_pageview) do
-              Middleware::RequestTracker.log_request(data)
-            end
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
 
           expect(events.length).to eq(1)
           event = events[0][:params].first
@@ -866,10 +858,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          events =
-            DiscourseEvent.track_events(:browser_pageview) do
-              Middleware::RequestTracker.log_request(data)
-            end
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
 
           expect(events.length).to eq(0)
         end
@@ -891,10 +880,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          events =
-            DiscourseEvent.track_events(:browser_pageview) do
-              Middleware::RequestTracker.log_request(data)
-            end
+          events = DiscourseEvent.track_events(:browser_pageview) { log_browser_pageview(data) }
 
           expect(events.length).to eq(0)
         end
@@ -922,9 +908,7 @@ RSpec.describe Middleware::RequestTracker do
 
           events =
             DiscourseEvent.track_events(:browser_pageview) do
-              expect { Middleware::RequestTracker.log_request(data) }.to change {
-                BrowserPageviewEvent.count
-              }.by(1)
+              expect { log_browser_pageview(data) }.to change { BrowserPageviewEvent.count }.by(1)
             end
 
           expect(events).to be_empty
@@ -973,7 +957,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          Middleware::RequestTracker.log_request(data)
+          log_browser_pageview(data)
 
           event = BrowserPageviewEvent.last
           expect(event.referrer).to eq("https://www.example.com/path?utm_source=x")
@@ -996,7 +980,7 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          Middleware::RequestTracker.log_request(data)
+          log_browser_pageview(data)
 
           event = BrowserPageviewEvent.last
           expect(event.normalized_referrer).to be_nil
@@ -1020,12 +1004,39 @@ RSpec.describe Middleware::RequestTracker do
 
           events =
             DiscourseEvent.track_events(:browser_pageview) do
-              expect { Middleware::RequestTracker.log_request(data) }.to change {
-                BrowserPageviewEvent.count
-              }.by(1)
+              expect { log_browser_pageview(data) }.to change { BrowserPageviewEvent.count }.by(1)
             end
 
           expect(events).to be_empty
+        end
+
+        it "skips browser pageviews while PostgreSQL is readonly" do
+          session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+          Discourse.enable_readonly_mode(Discourse::PG_READONLY_MODE_KEY)
+
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_DISCOURSE_TRACK_VIEW" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
+                "HTTP_DISCOURSE_TRACK_VIEW_URL" => "https://discourse.org",
+                "action_dispatch.remote_ip" => "1.2.3.4",
+              ),
+              ["200", { "Content-Type" => "text/html" }],
+              0.2,
+            )
+
+          expect {
+            Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] }).log_later(
+              data,
+              {},
+              nil,
+            )
+          }.not_to change { BrowserPageviewEvent.count }
+
+          expect(BrowserPageviewEvent.queued_count).to eq(0)
+        ensure
+          Discourse.disable_readonly_mode(Discourse::PG_READONLY_MODE_KEY)
         end
       end
     end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -887,7 +887,16 @@ RSpec.describe Middleware::RequestTracker do
       end
 
       context "when SiteSetting.persist_browser_pageview_events is true" do
-        before { SiteSetting.persist_browser_pageview_events = true }
+        before do
+          SiteSetting.persist_browser_pageview_events = true
+          BrowserPageviewEvent.clear_queued!
+          Discourse.clear_readonly!
+        end
+
+        after do
+          BrowserPageviewEvent.clear_queued!
+          Discourse.clear_readonly!
+        end
 
         def flush_browser_pageview_events
           Jobs::FlushBrowserPageviewEvents.new.execute({})
@@ -912,13 +921,11 @@ RSpec.describe Middleware::RequestTracker do
 
           events =
             DiscourseEvent.track_events(:browser_pageview) do
-              expect {
-                log_browser_pageview(data)
-                flush_browser_pageview_events
-              }.to change { BrowserPageviewEvent.count }.by(1)
+              expect { log_browser_pageview(data) }.to change { BrowserPageviewEvent.count }.by(1)
             end
 
           expect(events).to be_empty
+          expect(BrowserPageviewEvent.queued_count).to eq(0)
 
           event = BrowserPageviewEvent.last
           expect(event.session_id).to eq(session_id)
@@ -965,7 +972,6 @@ RSpec.describe Middleware::RequestTracker do
             )
 
           log_browser_pageview(data)
-          flush_browser_pageview_events
 
           event = BrowserPageviewEvent.last
           expect(event.referrer).to eq("https://www.example.com/path?utm_source=x")
@@ -989,7 +995,6 @@ RSpec.describe Middleware::RequestTracker do
             )
 
           log_browser_pageview(data)
-          flush_browser_pageview_events
 
           event = BrowserPageviewEvent.last
           expect(event.normalized_referrer).to be_nil
@@ -1013,10 +1018,7 @@ RSpec.describe Middleware::RequestTracker do
 
           events =
             DiscourseEvent.track_events(:browser_pageview) do
-              expect {
-                log_browser_pageview(data)
-                flush_browser_pageview_events
-              }.to change { BrowserPageviewEvent.count }.by(1)
+              expect { log_browser_pageview(data) }.to change { BrowserPageviewEvent.count }.by(1)
             end
 
           expect(events).to be_empty
@@ -1045,8 +1047,6 @@ RSpec.describe Middleware::RequestTracker do
 
           expect { flush_browser_pageview_events }.to change { BrowserPageviewEvent.count }.by(1)
           expect(BrowserPageviewEvent.queued_count).to eq(0)
-        ensure
-          Discourse.disable_readonly_mode(Discourse::PG_READONLY_MODE_KEY)
         end
       end
     end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -889,6 +889,10 @@ RSpec.describe Middleware::RequestTracker do
       context "when SiteSetting.persist_browser_pageview_events is true" do
         before { SiteSetting.persist_browser_pageview_events = true }
 
+        def flush_browser_pageview_events
+          Jobs::FlushBrowserPageviewEvents.new.execute({})
+        end
+
         it "creates a BrowserPageviewEvent row and does not fire the :browser_pageview event" do
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
           DiscourseIpInfo.stubs(:get).returns(country_code: "AU")
@@ -908,7 +912,10 @@ RSpec.describe Middleware::RequestTracker do
 
           events =
             DiscourseEvent.track_events(:browser_pageview) do
-              expect { log_browser_pageview(data) }.to change { BrowserPageviewEvent.count }.by(1)
+              expect {
+                log_browser_pageview(data)
+                flush_browser_pageview_events
+              }.to change { BrowserPageviewEvent.count }.by(1)
             end
 
           expect(events).to be_empty
@@ -958,6 +965,7 @@ RSpec.describe Middleware::RequestTracker do
             )
 
           log_browser_pageview(data)
+          flush_browser_pageview_events
 
           event = BrowserPageviewEvent.last
           expect(event.referrer).to eq("https://www.example.com/path?utm_source=x")
@@ -981,6 +989,7 @@ RSpec.describe Middleware::RequestTracker do
             )
 
           log_browser_pageview(data)
+          flush_browser_pageview_events
 
           event = BrowserPageviewEvent.last
           expect(event.normalized_referrer).to be_nil
@@ -1004,7 +1013,10 @@ RSpec.describe Middleware::RequestTracker do
 
           events =
             DiscourseEvent.track_events(:browser_pageview) do
-              expect { log_browser_pageview(data) }.to change { BrowserPageviewEvent.count }.by(1)
+              expect {
+                log_browser_pageview(data)
+                flush_browser_pageview_events
+              }.to change { BrowserPageviewEvent.count }.by(1)
             end
 
           expect(events).to be_empty

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -1022,7 +1022,7 @@ RSpec.describe Middleware::RequestTracker do
           expect(events).to be_empty
         end
 
-        it "skips browser pageviews while PostgreSQL is readonly" do
+        it "queues browser pageviews while PostgreSQL is readonly" do
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
           Discourse.enable_readonly_mode(Discourse::PG_READONLY_MODE_KEY)
 
@@ -1038,14 +1038,12 @@ RSpec.describe Middleware::RequestTracker do
               0.2,
             )
 
-          expect {
-            Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] }).log_later(
-              data,
-              {},
-              nil,
-            )
-          }.not_to change { BrowserPageviewEvent.count }
+          expect { log_browser_pageview(data) }.not_to change { BrowserPageviewEvent.count }
+          expect(BrowserPageviewEvent.queued_count).to eq(1)
 
+          Discourse.disable_readonly_mode(Discourse::PG_READONLY_MODE_KEY)
+
+          expect { flush_browser_pageview_events }.to change { BrowserPageviewEvent.count }.by(1)
           expect(BrowserPageviewEvent.queued_count).to eq(0)
         ensure
           Discourse.disable_readonly_mode(Discourse::PG_READONLY_MODE_KEY)

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -91,22 +91,13 @@ RSpec.describe BrowserPageviewEvent do
       expect(described_class.queued_count).to eq(0)
     end
 
-    it "removes malformed queued payloads" do
+    it "removes malformed queued payloads without blocking later entries" do
       Discourse.redis.rpush(described_class::REDIS_QUEUE_KEY, "{")
-      queue_payload(payload.except(:url))
-
-      expect { described_class.flush_queued! }.not_to change { described_class.count }
-
-      expect(described_class.queued_count).to eq(0)
-    end
-
-    it "discards payloads with an unparseable IP address without blocking the flush" do
-      queue_payload(payload.merge(ip_address: "1.2.3.4/64"))
-      queue_payload(payload.merge(url: "https://discourse.example/t/topic/3"))
+      queue_payload(payload.merge(url: "https://discourse.example/t/topic/4"))
 
       expect { described_class.flush_queued! }.to change { described_class.count }.by(1)
 
-      expect(described_class.last.url).to eq("https://discourse.example/t/topic/3")
+      expect(described_class.last.url).to eq("https://discourse.example/t/topic/4")
       expect(described_class.queued_count).to eq(0)
     end
   end
@@ -120,6 +111,18 @@ RSpec.describe BrowserPageviewEvent do
         session_id: "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
         occurred_at: Time.zone.parse("2026-05-27 10:30:00").iso8601(6),
       }
+    end
+
+    it "skips payloads missing a required field instead of queueing them" do
+      expect { described_class.enqueue_for_later(payload.except(:url)) }.not_to change {
+        described_class.queued_count
+      }
+    end
+
+    it "skips payloads with an unparseable IP address instead of queueing them" do
+      expect {
+        described_class.enqueue_for_later(payload.merge(ip_address: "1.2.3.4/64"))
+      }.not_to change { described_class.queued_count }
     end
 
     it "drops new events once the queue reaches its maximum size" do

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe BrowserPageviewEvent do
+  before do
+    described_class.clear_queued!
+    Discourse.clear_readonly!
+  end
+
+  after do
+    described_class.clear_queued!
+    Discourse.clear_readonly!
+  end
+
   it "truncates string fields before saving" do
     event =
       described_class.create!(
@@ -88,6 +98,45 @@ RSpec.describe BrowserPageviewEvent do
       expect { described_class.flush_queued! }.not_to change { described_class.count }
 
       expect(described_class.queued_count).to eq(0)
+    end
+
+    it "discards payloads with an unparseable IP address without blocking the flush" do
+      queue_payload(payload.merge(ip_address: "1.2.3.4/64"))
+      queue_payload(payload.merge(url: "https://discourse.example/t/topic/3"))
+
+      expect { described_class.flush_queued! }.to change { described_class.count }.by(1)
+
+      expect(described_class.last.url).to eq("https://discourse.example/t/topic/3")
+      expect(described_class.queued_count).to eq(0)
+    end
+  end
+
+  describe ".enqueue_for_later" do
+    let(:payload) do
+      {
+        url: "https://discourse.example/t/topic/1",
+        ip_address: "1.2.3.4",
+        user_agent: "Mozilla/5.0",
+        session_id: "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
+        occurred_at: Time.zone.parse("2026-05-27 10:30:00").iso8601(6),
+      }
+    end
+
+    it "drops new events once the queue reaches its maximum size" do
+      stub_const(described_class, "REDIS_QUEUE_MAX_SIZE", 1) do
+        described_class.enqueue_for_later(payload)
+        expect { described_class.enqueue_for_later(payload) }.not_to change {
+          described_class.queued_count
+        }
+      end
+
+      expect(described_class.queued_count).to eq(1)
+    end
+
+    it "sets an expiry on the queue so a stranded backlog self-cleans" do
+      described_class.enqueue_for_later(payload)
+
+      expect(Discourse.redis.ttl(described_class::REDIS_QUEUE_KEY)).to be > 0
     end
   end
 end

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -18,4 +18,72 @@ RSpec.describe BrowserPageviewEvent do
     expect(event.session_id.length).to eq(described_class::MAX_SESSION_ID_LENGTH)
     expect(event.normalized_referrer.length).to eq(described_class::MAX_NORMALIZED_REFERRER_LENGTH)
   end
+
+  describe ".flush_queued!" do
+    let(:occurred_at) { Time.zone.parse("2026-05-27 10:30:00") }
+
+    let(:payload) do
+      {
+        url: "https://discourse.example/t/topic/1",
+        ip_address: "1.2.3.4",
+        country_code: "AU",
+        asn: 12_345,
+        referrer: "https://www.example.com/path?utm_source=x",
+        user_agent: "Mozilla/5.0",
+        session_id: "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
+        topic_id: 123,
+        occurred_at: occurred_at.iso8601(6),
+      }
+    end
+
+    def queue_payload(payload)
+      Discourse.redis.rpush(described_class::REDIS_QUEUE_KEY, JSON.generate(payload))
+    end
+
+    it "persists queued payloads and removes them from Redis" do
+      Discourse.stubs(:pg_readonly_mode?).returns(true)
+      described_class.enqueue_for_later(payload)
+      Discourse.unstub(:pg_readonly_mode?)
+
+      expect { described_class.flush_queued! }.to change { described_class.count }.by(1)
+
+      event = described_class.last
+      expect(event.url).to eq(payload[:url])
+      expect(event.country_code).to eq("AU")
+      expect(event.asn).to eq(12_345)
+      expect(event.normalized_referrer).to eq("example.com/path")
+      expect(event.created_at).to eq_time(occurred_at)
+      expect(described_class.queued_count).to eq(0)
+    end
+
+    it "keeps queued payloads while PostgreSQL is readonly" do
+      Discourse.stubs(:pg_readonly_mode?).returns(true)
+      described_class.enqueue_for_later(payload)
+
+      expect { described_class.flush_queued! }.not_to change { described_class.count }
+
+      expect(described_class.queued_count).to eq(1)
+    end
+
+    it "discards invalid payloads without blocking later entries" do
+      invalid_payload = payload.merge(occurred_at: "not-a-date")
+      valid_payload = payload.merge(url: "https://discourse.example/t/topic/2")
+      queue_payload(invalid_payload)
+      queue_payload(valid_payload)
+
+      expect { described_class.flush_queued! }.to change { described_class.count }.by(1)
+
+      expect(described_class.last.url).to eq(valid_payload[:url])
+      expect(described_class.queued_count).to eq(0)
+    end
+
+    it "removes malformed queued payloads" do
+      Discourse.redis.rpush(described_class::REDIS_QUEUE_KEY, "{")
+      queue_payload(payload.except(:url))
+
+      expect { described_class.flush_queued! }.not_to change { described_class.count }
+
+      expect(described_class.queued_count).to eq(0)
+    end
+  end
 end

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -37,13 +37,17 @@ RSpec.describe BrowserPageviewEvent do
     end
 
     def queue_payload(payload)
-      Discourse.redis.rpush(described_class::REDIS_QUEUE_KEY, JSON.generate(payload))
+      described_class.enqueue_for_later(payload)
+    end
+
+    it "queues payloads without flushing them synchronously" do
+      expect { described_class.enqueue_for_later(payload) }.not_to change { described_class.count }
+
+      expect(described_class.queued_count).to eq(1)
     end
 
     it "persists queued payloads and removes them from Redis" do
-      Discourse.stubs(:pg_readonly_mode?).returns(true)
       described_class.enqueue_for_later(payload)
-      Discourse.unstub(:pg_readonly_mode?)
 
       expect { described_class.flush_queued! }.to change { described_class.count }.by(1)
 


### PR DESCRIPTION
Persisted browser pageview events now enqueue lightweight payloads in Redis and flush them in batches through a scheduled job, reducing per-request database writes.

The flush path preserves queued events while PostgreSQL is readonly, and request tracking skips browser pageview logging during PostgreSQL readonly mode.