### PR TITLE
PERF: Stop clearing report cache from browser pageview rollup job

### DIFF
--- a/app/jobs/scheduled/aggregate_browser_pageview_daily_rollups.rb
+++ b/app/jobs/scheduled/aggregate_browser_pageview_daily_rollups.rb
@@ -16,9 +16,6 @@ module Jobs
         BrowserPageviewCountryDailyRollup.aggregate(start_date: start_date, end_date: end_date)
         BrowserPageviewReferrerDailyRollup.aggregate(start_date: start_date, end_date: end_date)
       end
-
-      Report.clear_cache("top_countries_by_browser_pageviews")
-      Report.clear_cache("top_referrers_by_browser_pageviews")
     end
 
     private

--- a/spec/jobs/aggregate_browser_pageview_daily_rollups_spec.rb
+++ b/spec/jobs/aggregate_browser_pageview_daily_rollups_spec.rb
@@ -34,15 +34,6 @@ RSpec.describe Jobs::AggregateBrowserPageviewDailyRollups do
     expect(BrowserPageviewCountryDailyRollup.pluck(:country_code)).to contain_exactly("US", "GB")
   end
 
-  it "clears the report cache after running so stale empty results do not linger" do
-    SiteSetting.persist_browser_pageview_events = true
-    Fabricate(:browser_pageview_event, country_code: "US")
-    Report.expects(:clear_cache).with("top_countries_by_browser_pageviews").once
-    Report.expects(:clear_cache).with("top_referrers_by_browser_pageviews").once
-
-    described_class.new.execute({})
-  end
-
   it "only aggregates yesterday and today once historical rollups are populated" do
     SiteSetting.persist_browser_pageview_events = true
     Fabricate(:browser_pageview_event, country_code: "US", created_at: 60.days.ago)


### PR DESCRIPTION
`Report.clear_cache(type)` ultimately performs a redis SCAN over every key in the db. Calling it twice every 30 minutes in `AggregateBrowserPageviewDailyRollups` produced large numbers of SCAN commands, especially in large multisite clusters.

For now, we're dropping the reset. Reports are only cached for 35 minutes anyway, so the impact is minimal. We may followup with a more surgical solution in future.

Followup to 2cc3ac34e73b42317114d689f797a9c53152ce19