### PR TITLE
DEV: Drop `media-minmax` polyfill

### DIFF
--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -2,8 +2,8 @@
 
 <%= discourse_stylesheet_link_tag(:common, supports_rtl: true) %>
 
-<%= discourse_stylesheet_link_tag(:mobile, supports_rtl: true, media: "(max-width: 39.99999rem)") %>
-<%= discourse_stylesheet_link_tag(:desktop, supports_rtl: true, media: "(min-width: 40rem)") %>
+<%= discourse_stylesheet_link_tag(:mobile, supports_rtl: true, media: "(width < 40rem)") %>
+<%= discourse_stylesheet_link_tag(:desktop, supports_rtl: true, media: "(width >= 40rem)") %>
 
 <%- if staff? %>
   <%= discourse_stylesheet_link_tag(:admin, supports_rtl: true) %>
@@ -16,9 +16,9 @@
 <%- Discourse.find_plugin_css_assets(include_official: allow_plugins?, include_unofficial: allow_third_party_plugins?, mobile_view: true, desktop_view: true, request: request, rtl: false).each do |file| %>
   <%=
     media = if file.end_with?("_mobile")
-      "(max-width: 39.99999rem)"
+      "(width < 40rem)"
     elsif file.end_with?("_desktop")
-      "(min-width: 40rem)"
+      "(width >= 40rem)"
     else
       nil
     end
@@ -28,6 +28,6 @@
 
 <%- if theme_id.present? %>
   <%= discourse_stylesheet_link_tag(:common_theme, supports_rtl: true) %>
-  <%= discourse_stylesheet_link_tag(:mobile_theme, media: "(max-width: 39.99999rem)", supports_rtl: true) %>
-  <%= discourse_stylesheet_link_tag(:desktop_theme, media: "(min-width: 40rem)", supports_rtl: true) %>
+  <%= discourse_stylesheet_link_tag(:mobile_theme, media: "(width < 40rem)", supports_rtl: true) %>
+  <%= discourse_stylesheet_link_tag(:desktop_theme, media: "(width >= 40rem)", supports_rtl: true) %>
 <%- end %>

--- a/frontend/asset-processor/package.json
+++ b/frontend/asset-processor/package.json
@@ -33,7 +33,6 @@
     "polyfill-crypto.getrandomvalues": "^1.0.0",
     "postcss": "^8.5.15",
     "postcss-js": "^5.1.0",
-    "postcss-media-minmax": "^5.0.0",
     "postcss-nesting": "^14.0.0",
     "readable-stream": "^4.7.0",
     "source-map-js": "^1.2.1",

--- a/frontend/asset-processor/postcss.js
+++ b/frontend/asset-processor/postcss.js
@@ -2,7 +2,6 @@ import "core-js/actual/url";
 import postcssLightDark from "@csstools/postcss-light-dark-function";
 import autoprefixer from "autoprefixer";
 import postcss from "postcss";
-import minmax from "postcss-media-minmax";
 import postcssNesting from "postcss-nesting";
 import { browsers } from "../discourse/config/targets";
 import postcssVariablePrefixer from "./postcss-variable-prefixer";
@@ -11,7 +10,6 @@ const postCssProcessor = postcss([
   autoprefixer({
     overrideBrowserslist: browsers,
   }),
-  minmax(),
   postcssLightDark,
   postcssNesting, // Un-nests the native css nesting from postcssLightDark
   postcssVariablePrefixer(),

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -8,7 +8,7 @@ end
 
 class Stylesheet::Manager
   # Bump this number to invalidate all stylesheet caches (e.g. if you change something inside the compiler)
-  BASE_COMPILER_VERSION = 6
+  BASE_COMPILER_VERSION = 7
 
   # Add any dependencies here which should automatically cause a global cache invalidation.
   BASE_CACHE_KEY = "#{BASE_COMPILER_VERSION}::#{DiscourseFonts::VERSION}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       postcss-js:
         specifier: ^5.1.0
         version: 5.1.0(postcss@8.5.15)
-      postcss-media-minmax:
-        specifier: ^5.0.0
-        version: 5.0.0(postcss@8.5.15)
       postcss-nesting:
         specifier: ^14.0.0
         version: 14.0.0(postcss@8.5.15)
@@ -7426,12 +7423,6 @@ packages:
     engines: {node: ^20 || ^22 || >= 24}
     peerDependencies:
       postcss: ^8.4.21
-
-  postcss-media-minmax@5.0.0:
-    resolution: {integrity: sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      postcss: ^8.1.0
 
   postcss-media-query-parser@0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
@@ -17108,10 +17099,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss-js@5.1.0(postcss@8.5.15):
-    dependencies:
-      postcss: 8.5.15
-
-  postcss-media-minmax@5.0.0(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
 

--- a/spec/system/mobile_mode_spec.rb
+++ b/spec/system/mobile_mode_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Viewport-based mobile mode" do
     mobile_stylesheet = find("link[rel=stylesheet][href*='stylesheets/mobile']", visible: false)
     desktop_stylesheet = find("link[rel=stylesheet][href*='stylesheets/desktop']", visible: false)
 
-    expect(mobile_stylesheet["media"]).to include("max-width")
-    expect(desktop_stylesheet["media"]).to include("min-width")
+    expect(mobile_stylesheet["media"]).to include("width < 40rem")
+    expect(desktop_stylesheet["media"]).to include("width >= 40rem")
 
     expect(page).to have_css("html.desktop-view")
     expect(page).not_to have_css("html.mobile-view")


### PR DESCRIPTION
Media-query Range Syntax is supported in all our target browsers, so we can drop this polyfill, and update our manual polyfilling in `media=` attributes