### PR TITLE
DEV: Linkify site setting references in descriptions

### DIFF
--- a/app/assets/stylesheets/admin/settings.scss
+++ b/app/assets/stylesheets/admin/settings.scss
@@ -62,6 +62,10 @@
           width: 100% !important; // !important overrides hard-coded mobile width of 68px
         }
       }
+
+      label a {
+        margin: 0;
+      }
     }
 
     .setting-override-warning {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1868,7 +1868,7 @@ en:
     default_composer_category: "The category used to pre-populate the category dropdown when creating a new topic."
     allow_uncategorized_topics: "Allow topics to be created without a category. WARNING: If there are any uncategorized topics, you must recategorize them before turning this off."
     allow_duplicate_topic_titles: "Allow topics with identical, duplicate titles."
-    allow_duplicate_topic_titles_category: "Allow topics with identical, duplicate titles if the category is different. allow_duplicate_topic_titles must be disabled."
+    allow_duplicate_topic_titles_category: "Allow topics with identical, duplicate titles if the category is different. {{setting:allow_duplicate_topic_titles}} must be disabled."
     unique_posts_mins: "How many minutes before a user can make a post with the same content again"
     educate_until_posts: "When the user starts typing their first (n) new posts, show the pop-up new user education panel in the composer."
     title: "The name of this site. Visible to all visitors including anonymous users. Note that changing this title may send a prompt to users of the PWA asking them to either update or uninstall the app."
@@ -1880,8 +1880,8 @@ en:
     download_remote_images_to_local: "Convert remote (hotlinked) images to local images by downloading them; This preserves content even if the images are removed from the remote site in future."
     download_remote_images_threshold: "Minimum disk space necessary to download remote images locally (in percent)"
     disabled_image_download_domains: "Remote images will never be downloaded from these domains."
-    block_hotlinked_media: "Prevent users from introducing remote (hotlinked) media in their posts. Remote media which is not downloaded via 'download_remote_images_to_local' will be replaced with a placeholder link."
-    block_hotlinked_media_exceptions: "A list of base URLs which are exempt from the block_hotlinked_media setting. Include the protocol (e.g. https://example.com)."
+    block_hotlinked_media: "Prevent users from introducing remote (hotlinked) media in their posts. Remote media which is not downloaded via {{setting:download_remote_images_to_local}} will be replaced with a placeholder link."
+    block_hotlinked_media_exceptions: "A list of base URLs which are exempt from the {{setting:block_hotlinked_media}} setting. Include the protocol (e.g. https://example.com)."
     editing_grace_period: "For (n) seconds after posting, editing will not create a new version in the post history."
     editing_grace_period_max_diff: "Maximum number of character changes allowed in editing grace period, if more changed store another post revision (trust level 0 and 1)"
     editing_grace_period_max_diff_high_trust: "Maximum number of character changes allowed in editing grace period, if more changed store another post revision (trust level 2 and up)"
@@ -1895,7 +1895,7 @@ en:
     max_image_height: "Maximum thumbnail height of images in a post. Images with a larger height will be resized and lightboxed."
     responsive_post_image_sizes: "Resize lightbox preview images to allow for high DPI screens of the following pixel ratios. Remove all values to disable responsive images."
     fixed_category_positions: "If checked, you will be able to arrange categories into a fixed order. If unchecked, categories are listed in order of activity."
-    fixed_category_positions_on_create: "If checked, category ordering will be maintained on topic creation dialog (requires fixed_category_positions)."
+    fixed_category_positions_on_create: "If checked, category ordering will be maintained on topic creation dialog (requires {{setting:fixed_category_positions}})."
     add_rel_nofollow_to_user_content: 'Add rel nofollow to all submitted user content, except for internal links (including parent domains). If you change this, you must rebake all posts with: "rake posts:rebake"'
     exclude_rel_nofollow_domains: "A list of domains where nofollow should not be added to links. example.com will automatically allow sub.example.com as well. As a minimum, you should add the domain of this site to help web crawlers find all content. If other parts of your website are at other domains, add those too."
     max_form_template_title_length: "Maximum allowed length for form template titles."
@@ -1910,7 +1910,7 @@ en:
     blocked_onebox_domains: "A list of domains that will never be oneboxed e.g. wikipedia.org\n(Wildcard symbols * ? not supported)"
     block_onebox_on_redirect: "Prevent oneboxing for URLs that lead to a redirecting page. This configuration stops the creation of a visual card (onebox) for any URL that redirects to a different destination, ensuring that direct, non-redirecting URLs are prioritized for oneboxing."
     allowed_inline_onebox_domains: "A list of domains that will be oneboxed in miniature form if linked without a title"
-    enable_inline_onebox_on_all_domains: "Ignore allowed_inline_onebox_domains site setting and allow inline onebox on all domains."
+    enable_inline_onebox_on_all_domains: "Ignore {{setting:allowed_inline_onebox_domains}} site setting and allow inline onebox on all domains."
     onebox_locale: "The locale sent to onebox providers. If left blank, the default locale will be used"
     force_custom_user_agent_hosts: "Hosts for which to use the custom onebox user agent on all requests. (Especially useful for hosts that limit access by user agent)."
     max_oneboxes_per_post: "Set the maximum number of oneboxes that can be included in a single post. Oneboxes provide a preview of linked content within the post."
@@ -1918,26 +1918,26 @@ en:
     github_onebox_access_tokens: "A mapping of a GitHub organisation or user to a GitHub access token which is used to generate GitHub oneboxes for private repos, commits, pull requests, issues, and file contents. Without this, only public GitHub URLs will be oneboxed."
     logo: "The logo image at the top left of your site. Use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the site title text will be shown."
     logo_small: "The small logo image at the top left of your site, seen when scrolling down. Use a square 120 × 120 image. If left blank, a home glyph will be shown."
-    digest_logo: "The alternate logo image used at the top of your site's email summary. Use a wide rectangle image. Don't use an SVG image. If left blank, the image from the `logo` setting will be used."
-    mobile_logo: "The logo used on the mobile version of your site. We recommend a square icon to avoid crowding the header, but you can use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the image from the logo setting will be used."
-    logo_dark: "Dark scheme alternative for the 'logo' site setting."
-    logo_small_dark: "Dark scheme alternative for the 'logo small' site setting."
-    mobile_logo_dark: "Dark scheme alternative for the 'mobile logo' site setting."
-    large_icon: "Image used as the base for other metadata icons. Should ideally be larger than 512 x 512. If left blank, logo_small will be used."
-    manifest_icon: "Image used as logo/splash image on Android. Will be automatically resized to 512 × 512. If left blank, large_icon will be used."
+    digest_logo: "The alternate logo image used at the top of your site's email summary. Use a wide rectangle image. Don't use an SVG image. If left blank, the image from the {{setting:logo}} setting will be used."
+    mobile_logo: "The logo used on the mobile version of your site. We recommend a square icon to avoid crowding the header, but you can use a wide rectangular image with a height of 120 and an aspect ratio greater than 3:1. If left blank, the image from the {{setting:logo}} setting will be used."
+    logo_dark: "Dark scheme alternative for the {{setting:logo}} site setting."
+    logo_small_dark: "Dark scheme alternative for the {{setting:logo_small}} site setting."
+    mobile_logo_dark: "Dark scheme alternative for the {{setting:mobile_logo}} site setting."
+    large_icon: "Image used as the base for other metadata icons. Should ideally be larger than 512 x 512. If left blank, {{setting:logo_small}} will be used."
+    manifest_icon: "Image used as logo/splash image on Android. Will be automatically resized to 512 × 512. If left blank, {{setting:large_icon}} will be used."
     manifest_screenshots: "Screenshots that showcase your instance features and functionality on its install prompt page. All images should be local uploads and of the same dimensions."
-    favicon: "A favicon for your site, see <a href='https://en.wikipedia.org/wiki/Favicon' target='_blank'>https://en.wikipedia.org/wiki/Favicon</a>. To work correctly over a CDN it must be a png. Will be resized to 32x32. If left blank, large_icon will be used."
-    apple_touch_icon: "Icon used for Apple touch devices. A transparent background is not recommended. Will be automatically resized to 180x180. If left blank, large_icon will be used."
-    opengraph_image: "Default opengraph image, used when the page has no other suitable image. If left blank, large_icon will be used"
-    x_summary_large_image: "Twitter card 'summary large image' (should be at least 280 in width, and at least 150 in height, cannot be .svg). If left blank, regular card metadata is generated using the opengraph_image, as long as that is not also a .svg"
+    favicon: "A favicon for your site, see <a href='https://en.wikipedia.org/wiki/Favicon' target='_blank'>https://en.wikipedia.org/wiki/Favicon</a>. To work correctly over a CDN it must be a png. Will be resized to 32x32. If left blank, {{setting:large_icon}} will be used."
+    apple_touch_icon: "Icon used for Apple touch devices. A transparent background is not recommended. Will be automatically resized to 180x180. If left blank, {{setting:large_icon}} will be used."
+    opengraph_image: "Default opengraph image, used when the page has no other suitable image. If left blank, {{setting:large_icon}} will be used"
+    x_summary_large_image: "Twitter card 'summary large image' (should be at least 280 in width, and at least 150 in height, cannot be .svg). If left blank, regular card metadata is generated using the {{setting:opengraph_image}}, as long as that is not also a .svg"
 
     notification_email: "The from: email address used when sending all essential system emails. The domain specified here must have SPF, DKIM and reverse PTR records set correctly for email to arrive."
     email_custom_headers: "A list of custom email headers"
     email_subject: "Customizable subject format for standard emails. See <a href='https://meta.discourse.org/t/customizing-specific-system-email-templates/88323' target='_blank'>Customizing specific system email templates on Meta</a>."
     simple_email_subject: "When enabled, the email subject lines will be more concise, containing only the essential information. This makes it easier for users to quickly understand the purpose of the email at a glance."
     detailed_404: "Provides more details to users about why they can’t access a particular topic. Note: This is less secure because users will know if a URL links to a valid topic."
-    enforce_second_factor: "Require users to enable two-factor authentication (2FA) before they can access the Discourse UI. This setting does not affect API or 'DiscourseConnect provider' authentication. If enforce_second_factor_on_external_auth is enabled, users will not be able to log in with external authentication providers after they set up 2FA."
-    enforce_second_factor_on_external_auth: "Require users to use two-factor authentication (2FA) at all times. When enabled, this will prevent users logging in with external authentication methods like social logins if they have 2FA enabled. When disabled, users will only need to confirm their 2FA when logging in with a username and password. Also see the `enforce_second_factor` setting."
+    enforce_second_factor: "Require users to enable two-factor authentication (2FA) before they can access the Discourse UI. This setting does not affect API or 'DiscourseConnect provider' authentication. If {{setting:enforce_second_factor_on_external_auth}} is enabled, users will not be able to log in with external authentication providers after they set up 2FA."
+    enforce_second_factor_on_external_auth: "Require users to use two-factor authentication (2FA) at all times. When enabled, this will prevent users logging in with external authentication methods like social logins if they have 2FA enabled. When disabled, users will only need to confirm their 2FA when logging in with a username and password. Also see the {{setting:enforce_second_factor}} setting."
     force_https: "Force your site to use HTTPS only. WARNING: do NOT enable this until you verify HTTPS is fully set up and working absolutely everywhere! Did you check your CDN, all social logins, and any external logos / dependencies to make sure they are all HTTPS compatible, too?"
 
     summary_score_threshold: "The minimum score required for a post to be included in 'Summarize This Topic'"
@@ -1947,7 +1947,7 @@ en:
     summary_max_results: "Maximum posts returned by 'Summarize This Topic'"
     summary_timeline_button: "Show a 'Summarize' button in the timeline"
 
-    enable_personal_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. Allow trust level 1 (configurable via min trust to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
+    enable_personal_messages: "DEPRECATED, use the {{setting:personal_message_enabled_groups}} setting instead. Allow trust level 1 (configurable via min trust to send messages) users to create messages and reply to messages. Note that staff can always send messages no matter what."
     personal_message_enabled_groups: "Allow users in these groups to CREATE personal messages. IMPORTANT: 1) all users can REPLY to messages. 2) Admins and mods can CREATE messages to any user. 3) Trust level groups include higher levels; choose trust_level_1 to allow TL1, TL2, TL3, TL4 but not allow TL0. 4) Group interaction settings override this setting for messaging specific groups."
     enable_system_message_replies: "Allows users to reply to system messages, even if personal messages are disabled"
     enable_chunked_encoding: "Enable chunked encoding responses by the server. This feature works on most setups however some proxies may buffer, causing responses to be delayed"
@@ -1975,7 +1975,7 @@ en:
     tl3_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl3 (regular) by multiplying with this number"
     tl4_additional_flags_per_day_multiplier: "Increase limit of flags per day for tl4 (leader) by multiplying with this number"
 
-    num_users_to_silence_new_user: "If a new user's posts exceed the hide_post_sensitivity setting, and has spam flags from this many different users, hide all their posts and prevent future posting. 0 to disable."
+    num_users_to_silence_new_user: "If a new user's posts exceed the {{setting:hide_post_sensitivity}} setting, and has spam flags from this many different users, hide all their posts and prevent future posting. 0 to disable."
     num_tl3_flags_to_silence_new_user: "If a new user's posts get this many flags from num_tl3_users_to_silence_new_user different trust level 3 users, hide all their posts and prevent future posting. 0 to disable."
     num_tl3_users_to_silence_new_user: "If a new user's posts get num_tl3_flags_to_silence_new_user flags from this many different trust level 3 users, hide all their posts and prevent future posting. 0 to disable."
     notify_mods_when_user_silenced: "If a user is automatically silenced, send a message to all moderators."
@@ -2017,8 +2017,8 @@ en:
     allowed_iframes: "A list of iframe src URL prefixes that Discourse can safely allow in posts. * can be used to match any number of non-/ characters."
     allowed_crawler_user_agents: "User agents of web crawlers that should be allowed to access the site. WARNING! SETTING THIS WILL DISALLOW ALL CRAWLERS NOT LISTED HERE!"
     blocked_crawler_user_agents: "Unique case insensitive word in the user agent string identifying web crawlers that should not be allowed to access the site. Does not apply if allowlist is defined."
-    slow_down_crawler_user_agents: 'User agents of web crawlers that should be rate limited as configured in the "slow down crawler rate" setting. Each value must be at least 3 characters long.'
-    slow_down_crawler_rate: "If slow_down_crawler_user_agents is specified this rate will apply to all the crawlers (number of seconds delay between requests)"
+    slow_down_crawler_user_agents: "User agents of web crawlers that should be rate limited as configured in the {{setting:slow_down_crawler_rate}} setting. Each value must be at least 3 characters long."
+    slow_down_crawler_rate: "If {{setting:slow_down_crawler_user_agents}} is specified this rate will apply to all the crawlers (number of seconds delay between requests)"
     llms_txt: "Upload a text file to be served at /llms.txt for LLM crawlers. See <a href='https://llmstxt.org/' target='_blank'>llmstxt.org</a> for more information."
     content_security_policy: "Enable Content-Security-Policy (CSP). CSP is an additional layer of security that helps to prevent certain types of attacks, including Cross Site Scripting (XSS) and data injection."
     content_security_policy_report_only: "Enable Content-Security-Policy-Report-Only (CSP)"
@@ -2046,7 +2046,7 @@ en:
     max_reply_history: "Maximum number of replies to expand when expanding in-reply-to"
     topics_per_period_in_top_summary: "Number of top topics shown in the default top topics summary."
     topics_per_period_in_top_page: "Number of top topics shown on the expanded 'Show More' top topics."
-    redirect_users_to_top_page: "Automatically redirect new and long absent users to the top page. Only applies when 'top' is present in the 'top menu' site setting."
+    redirect_users_to_top_page: "Automatically redirect new and long absent users to the top page. Only applies when 'top' is present in the {{setting:top_menu}} site setting."
     top_page_default_timeframe: "Default top page time period for anonymous users (automatically adjusts for logged in users based on their last visit)."
     moderators_view_emails: "Allow moderators to view user email addresses."
     moderators_view_ips: "Allow moderators to view user ip addresses."
@@ -2071,7 +2071,7 @@ en:
     hide_email_address_taken: "Don't inform users that an account exists with a given email address during signup or during forgot password flow. Require full email for 'forgotten password' requests."
     log_out_strict: "When logging out, log out ALL sessions for the user on all devices"
     version_checks: "Ping the Discourse Hub for version updates and show new version messages on the <a href='%{base_path}/admin' target='_blank'>/admin</a> dashboard"
-    new_version_emails: "Send an email to the contact_email address when a new version of Discourse is available."
+    new_version_emails: "Send an email to the {{setting:contact_email}} address when a new version of Discourse is available."
     include_in_discourse_discover: "Let CDCK, Inc. (“Discourse”) feature this community on the <a href='https://discover.discourse.org' target='_blank'>Discover page</a> and in Discourse marketing materials. By doing so, you will share the data required for your site to be included in the service. Please note that the promotion of communities is at Discourse’s discretion."
 
     invite_expiry_days: "How long user invitation keys are valid, in days"
@@ -2092,13 +2092,13 @@ en:
     password_unique_characters: "Minimum number of unique characters that a password must have."
     block_common_passwords: "Don't allow passwords that are in the 10,000 most common passwords."
 
-    auth_skip_create_confirm: When signing up via external auth, skip the create account popup. Best used alongside auth_overrides_email, auth_overrides_username and auth_overrides_name.
-    auth_immediately: "Automatically redirect to the external login system without user interaction. This only takes effect when login_required is true, and there is only one external authentication method"
+    auth_skip_create_confirm: "When signing up via external auth, skip the create account popup. Best used alongside {{setting:auth_overrides_email}}, {{setting:auth_overrides_username}} and {{setting:auth_overrides_name}}."
+    auth_immediately: "Automatically redirect to the external login system without user interaction. This only takes effect when {{setting:login_required}} is true, and there is only one external authentication method"
     auth_require_interaction: "Require user interaction before redirecting to an external login system via `/auth/*`. This is defense-in-depth against 'Login CSRF' attacks. Only disable this setting if you fully trust all enabled auth methods are protected against login CSRF."
 
     enable_discourse_connect: "Enable sign on via DiscourseConnect (formerly 'Discourse SSO') (WARNING: USERS' EMAIL ADDRESSES *MUST* BE VALIDATED BY THE EXTERNAL SITE!)"
     verbose_discourse_connect_logging: "Log verbose DiscourseConnect related diagnostics to <a href='%{base_path}/logs' target='_blank'>/logs</a>"
-    enable_discourse_connect_provider: "Implement DiscourseConnect (formerly 'Discourse SSO') provider protocol at the /session/sso_provider endpoint, requires discourse_connect_provider_secrets to be set"
+    enable_discourse_connect_provider: "Implement DiscourseConnect (formerly 'Discourse SSO') provider protocol at the /session/sso_provider endpoint, requires {{setting:discourse_connect_provider_secrets}} to be set"
     discourse_connect_url: "URL of DiscourseConnect endpoint (must include http:// or https://, and must not include a trailing slash)"
     discourse_connect_secret: "Secret string used to cryptographically authenticate DiscourseConnect information, be sure it is 10 characters or longer"
     discourse_connect_provider_secrets: "A list of domain-secret pairs that are using DiscourseConnect. Make sure DiscourseConnect secret is 10 characters or longer. Wildcard symbol * can be used to match any domain or only a part of it (e.g. *.example.com)."
@@ -2133,15 +2133,15 @@ en:
     google_oauth2_hd_groups_service_account_json: "JSON formatted key information for the Service Account. Will be used to fetch group information."
     google_oauth2_verbose_logging: "Log verbose Google OAuth2 related diagnostics to <a href='%{base_path}/logs' target='_blank'>/logs</a>"
 
-    enable_twitter_logins: "Enable Twitter authentication, requires twitter_consumer_key and twitter_consumer_secret. See <a href='https://meta.discourse.org/t/13395' target='_blank'>Configuring Twitter login (and rich embeds) for Discourse</a>."
+    enable_twitter_logins: "Enable Twitter authentication, requires {{setting:twitter_consumer_key}} and {{setting:twitter_consumer_secret}}. See <a href='https://meta.discourse.org/t/13395' target='_blank'>Configuring Twitter login (and rich embeds) for Discourse</a>."
     twitter_consumer_key: "Consumer key for Twitter authentication, registered at <a href='https://developer.twitter.com/apps' target='_blank'>https://developer.twitter.com/apps</a>"
     twitter_consumer_secret: "Consumer secret for Twitter authentication, registered at <a href='https://developer.twitter.com/apps' target='_blank'>https://developer.twitter.com/apps</a>"
 
-    enable_facebook_logins: "Enable Facebook authentication, requires facebook_app_id and facebook_app_secret. See <a href='https://meta.discourse.org/t/13394' target='_blank'>Configuring Facebook login for Discourse</a>."
+    enable_facebook_logins: "Enable Facebook authentication, requires {{setting:facebook_app_id}} and {{setting:facebook_app_secret}}. See <a href='https://meta.discourse.org/t/13394' target='_blank'>Configuring Facebook login for Discourse</a>."
     facebook_app_id: "App id for Facebook authentication and sharing, registered at <a href='https://developers.facebook.com/apps/' target='_blank'>https://developers.facebook.com/apps</a>"
     facebook_app_secret: "App secret for Facebook authentication, registered at <a href='https://developers.facebook.com/apps/' target='_blank'>https://developers.facebook.com/apps</a>"
 
-    enable_github_logins: "Enable GitHub authentication, requires github_client_id and github_client_secret. See <a href='https://meta.discourse.org/t/13745' target='_blank'>Configuring GitHub login for Discourse</a>."
+    enable_github_logins: "Enable GitHub authentication, requires {{setting:github_client_id}} and {{setting:github_client_secret}}. See <a href='https://meta.discourse.org/t/13745' target='_blank'>Configuring GitHub login for Discourse</a>."
     github_client_id: "Client id for GitHub authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>"
     github_client_secret: "Client secret for GitHub authentication, registered at <a href='https://github.com/settings/developers/' target='_blank'>https://github.com/settings/developers</a>"
 
@@ -2150,7 +2150,7 @@ en:
     discord_secret: "Discord Client Secret Key Used for authenticating and enabling Discord related features on the site, such as Discord logins. This secret key corresponds to the Discord application created for the website, and is necessary for securely communicating with the Discord API."
     discord_trusted_guilds: 'Only allow members of these Discord guilds to log in via Discord. Use the numeric ID for the guild. For more information, check the instructions <a href="https://meta.discourse.org/t/configuring-discord-login-for-discourse/127129">here</a>. Leave blank to allow any guild.'
 
-    enable_linkedin_oidc_logins: "Enable LinkedIn authentication, requires linkedin_client_id and linkedin_client_secret."
+    enable_linkedin_oidc_logins: "Enable LinkedIn authentication, requires {{setting:linkedin_oidc_client_id}} and {{setting:linkedin_oidc_client_secret}}."
     linkedin_oidc_client_id: "Client ID for LinkedIn authentication, registered at <a href='https://www.linkedin.com/developers/apps' target='_blank'>https://www.linkedin.com/developers/apps</a>"
     linkedin_oidc_client_secret: "Client secret for LinkedIn authentication, registered at <a href='https://www.linkedin.com/developers/apps' target='_blank'>https://www.linkedin.com/developers/apps</a>"
 
@@ -2163,7 +2163,7 @@ en:
     s3_endpoint: "The endpoint can be modified to backup to an S3 compatible service like DigitalOcean Spaces or Minio. WARNING: Leave blank if using AWS S3."
     s3_configure_tombstone_policy: "Enable automatic deletion policy for tombstone uploads. IMPORTANT: If disabled, no space will be reclaimed after uploads are deleted."
     s3_disable_cleanup: "Prevent removal of old backups from S3 when there are more backups than the maximum allowed."
-    s3_use_acls: "AWS recommends not using ACLs on S3 buckets; only uncheck this option if intend to configure permissions policies on the configured `s3_upload_bucket` and `s3_backup_bucket`."
+    s3_use_acls: "AWS recommends not using ACLs on S3 buckets; only uncheck this option if intend to configure permissions policies on the configured {{setting:s3_upload_bucket}} and {{setting:s3_backup_bucket}}."
     enable_direct_s3_uploads: 'Allows for direct multipart uploads to Amazon S3, see <a target="_blank" href="https://meta.discourse.org/t/a-new-era-for-file-uploads-in-discourse/210469">this Meta topic</a> for more details.'
     backup_time_of_day: "Time of day UTC when the backup should occur."
     backup_with_uploads: "Include uploads in scheduled backups. Disabling this will only backup the database."
@@ -2219,7 +2219,7 @@ en:
     purge_deleted_uploads_grace_period_days: "Grace period (in days) before a deleted upload is erased."
     purge_unactivated_users_grace_period_days: "Grace period (in days) before a user who has not activated their account is deleted. Set to 0 to never purge unactivated users."
     enable_s3_uploads: "Place uploads on Amazon S3 storage. IMPORTANT: requires valid S3 credentials (both access key id & secret access key)."
-    s3_use_iam_profile: 'Use an <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html">AWS EC2 instance profile</a> to grant access to the S3 bucket. NOTE: enabling this requires Discourse to be running in an appropriately-configured EC2 instance, and overrides the "s3 access key id" and "s3 secret access key" settings.'
+    s3_use_iam_profile: 'Use an <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html">AWS EC2 instance profile</a> to grant access to the S3 bucket. NOTE: enabling this requires Discourse to be running in an appropriately-configured EC2 instance, and overrides the {{setting:s3_access_key_id}} and {{setting:s3_secret_access_key}} settings.'
     s3_upload_bucket: "The Amazon S3 bucket name that files will be uploaded into. WARNING: must be lowercase, no periods, no underscores."
     s3_access_key_id: "The Amazon S3 access key id that will be used to upload images, attachments, and backups."
     s3_secret_access_key: "The Amazon S3 secret access key that will be used to upload images, attachments, and backups."
@@ -2231,13 +2231,13 @@ en:
 
     avatar_sizes: "List of automatically generated avatar sizes."
 
-    external_system_avatars_enabled: "Enables the use of an external service for generating system avatars. When this setting is enabled, user avatars, instead of being produced within the Discourse system, are generated and provided by an external service defined by the `external_system_avatars_url` setting."
+    external_system_avatars_enabled: "Enables the use of an external service for generating system avatars. When this setting is enabled, user avatars, instead of being produced within the Discourse system, are generated and provided by an external service defined by the {{setting:external_system_avatars_url}} setting."
     external_system_avatars_url: "URL of the external system avatars service. Allowed substitutions are {username} {first_letter} {color} {size}. Leave blank to disable."
     external_emoji_url: "URL of the external service for emoji images. Leave blank to disable."
     use_site_small_logo_as_system_avatar: "Use the site's small logo instead of the system user's avatar. Requires the logo to be present."
     restrict_letter_avatar_colors: "A list of 6-digit hexadecimal color values to be used for letter avatar background."
     enable_listing_suspended_users_on_search: "Enable regular users to find suspended users."
-    selectable_avatars_mode: "Allow users to select an avatar from the selectable_avatars list and limit custom avatar uploads to the selected trust level."
+    selectable_avatars_mode: "Allow users to select an avatar from the {{setting:selectable_avatars}} list and limit custom avatar uploads to the selected trust level."
     selectable_avatars: "Specify a collection of avatars from which users can select their profile picture. The choice will appear during user profile creation or when updating the profile avatar."
 
     allow_all_attachments_for_group_messages: "Allow all email attachments for group messages."
@@ -2254,7 +2254,7 @@ en:
     composer_media_optimization_image_enabled: "Enables client-side media optimization of uploaded image files."
     composer_media_optimization_image_bytes_optimization_threshold: "Minimum image file size to trigger client-side optimization"
     composer_media_optimization_image_resize_dimensions_threshold: "Minimum image width to trigger client-side resize"
-    composer_media_optimization_image_resize_width_target: "Images with widths larger than `composer_media_optimization_image_dimensions_resize_threshold` will be resized to this width. Must be >= than `composer_media_optimization_image_dimensions_resize_threshold`."
+    composer_media_optimization_image_resize_width_target: "Images with widths larger than {{setting:composer_media_optimization_image_resize_dimensions_threshold}} will be resized to this width. Must be >= than {{setting:composer_media_optimization_image_resize_dimensions_threshold}}."
     composer_media_optimization_image_encode_quality: "JPG encode quality used in the re-encode process."
     composer_media_optimization_image_convert_enabled: "Enables client-side conversion of JXL, HEIC, and animated GIF images before upload. JXL and HEIC are converted to JPEG, animated GIFs larger than the threshold are converted to animated WEBP."
     composer_media_optimization_image_wasm_decode_enabled: "Decode JPEG and PNG images in WASM inside the Web Worker instead of using browser canvas APIs. Avoids iOS canvas pixel limits and createImageBitmap flakiness, at the cost of a larger worker bundle."
@@ -2311,7 +2311,7 @@ en:
 
     self_wiki_allowed_groups: "Allow users in these groups to make their own posts wiki. Admins and moderators can always make their own posts wiki."
 
-    min_trust_to_send_messages: "DEPRECATED, use the 'personal message enabled groups' setting instead. The minimum trust level required to create new personal messages."
+    min_trust_to_send_messages: "DEPRECATED, use the {{setting:personal_message_enabled_groups}} setting instead. The minimum trust level required to create new personal messages."
     send_email_messages_allowed_groups: "Groups that are allowed to send personal messages via email. Admins and moderators can always send personal messages via email."
     flag_post_allowed_groups: "Groups that are allowed to flag posts. Admins and moderators can always flag posts."
     post_links_allowed_groups: "Groups that are allowed to include links in posts. Admins and moderators are always allowed to post links."
@@ -2331,7 +2331,7 @@ en:
     max_quotes_per_post: "Maximum number of quotes allowed in a single post. Set to 0 to disable the check."
     max_users_notified_per_group_mention: "Maximum number of users that may receive a notification if a group is mentioned (if threshold is met no notifications will be raised)"
     enable_mentions: "Permits users to tag or reference each other in their posts using the '@' symbol."
-    here_mention: "Name used for a @mention to allow privileged users to notify up to 'max_here_mentioned' people participating in the topic. Must not be an existing username."
+    here_mention: "Name used for a @mention to allow privileged users to notify up to {{setting:max_here_mentioned}} people participating in the topic. Must not be an existing username."
     max_here_mentioned: "Maximum number of mentioned people by @here."
     here_mention_allowed_groups: "Groups that are allowed to mention @here. Admins and moderators can always mention @here."
 
@@ -2360,7 +2360,7 @@ en:
     max_image_size_kb: "The maximum image upload size. This must be configured in nginx (client_max_body_size) / apache or proxy as well. Images larger than this and smaller than client_max_body_size will be resized to fit on upload."
     max_attachment_size_kb: "The maximum attachment files upload size. This must be configured in nginx (client_max_body_size) / apache or proxy as well."
     authorized_extensions: "A list of file extensions allowed for upload"
-    authorized_extensions_for_staff: "A list of file extensions allowed for upload for staff users in addition to the list defined in the `authorized_extensions` site setting."
+    authorized_extensions_for_staff: "A list of file extensions allowed for upload for staff users in addition to the list defined in the {{setting:authorized_extensions}} site setting."
     theme_authorized_extensions: "A list of file extensions allowed for theme uploads"
 
     max_image_megapixels: "Maximum number of megapixels allowed for an image. Images with a higher number of megapixels will be rejected."
@@ -2412,7 +2412,7 @@ en:
     auto_respond_to_flag_actions: "Enable automatic reply when disposing a flag."
     min_first_post_typing_time: "Minimum amount of time a user must type during first post, if threshold is not met post will automatically enter the needs approval queue. Set to 0 to disable (not recommended)"
     fast_typing_threshold: "Minimum amount of time a user must type for their first post. If the threshold is not met, the post will automatically enter the review queue. Low is 1 second, standard is 3 seconds, high is 5 seconds."
-    auto_silence_fast_typers_on_first_post: "Automatically silence users that do not meet `fast typing threshold`"
+    auto_silence_fast_typers_on_first_post: "Automatically silence users that do not meet {{setting:fast_typing_threshold}}"
     auto_silence_fast_typers_max_trust_level: "Maximum trust level to auto silence fast typers"
     auto_silence_first_post_regex: "Case insensitive regex that if passed will cause first post by user to be silenced and sent to approval queue. Example: raging|a[bc]a , will cause all posts containing raging or aba or aca to be silenced on first. Only applies to first post. DEPRECATED: Use <a href='%{base_path}/admin/customize/watched_words/action/silence'>Silence Watched Words</a> instead."
     moderator_guide_topic: "The topic that outlines how you moderate your community. Link will be visible on the review queue for moderators and admins."
@@ -2421,10 +2421,10 @@ en:
     reviewable_default_visibility: "Don't show reviewable items unless they meet this priority"
     reviewable_low_priority_threshold: "The priority filter hides reviewable items that don't meet this score unless the '(any)' filter is used."
     high_trust_flaggers_auto_hide_posts: "New user posts are automatically hidden after being flagged as spam by a TL3+ user"
-    allow_all_users_to_flag_illegal_content: "Anonymous users will see information that they have to e-mail administrators to report illegal content. This setting takes precedence over 'flag post allowed groups'."
+    allow_all_users_to_flag_illegal_content: "Anonymous users will see information that they have to e-mail administrators to report illegal content. This setting takes precedence over {{setting:flag_post_allowed_groups}}."
     email_address_to_report_illegal_content: "If left blank the default site admin email will be used."
     cooldown_hours_until_reflag: "How much time users will have to wait until they are able to reflag a post"
-    slow_mode_prevents_editing: "Does 'Slow mode' prevent editing, after 'editing grace period'?"
+    slow_mode_prevents_editing: "Does 'Slow mode' prevent editing, after {{setting:editing_grace_period}}?"
 
     reply_by_email_enabled: "Activate the feature that permits users to respond to topics directly through email, instead of requiring them to log into the website. See <a href='https://meta.discourse.org/t/set-up-reply-by-email-with-pop3-polling/14003' target='_blank'>the guide on Meta</a> for more information."
     reply_by_email_address: "Template for reply by email incoming email address, for example: %%{reply_key}@reply.example.com or replies+%%{reply_key}@example.com"
@@ -2496,8 +2496,8 @@ en:
 
     enable_smtp: "Enable SMTP for sending notifications for group messages."
 
-    email_prefix: "The [label] used in the subject of emails. It will default to 'title' if not set."
-    email_site_title: "The title of the site used as the sender of emails from the site. Default to 'title' if not set. If your 'title' contains characters that are not allowed in email sender strings, use this setting."
+    email_prefix: "The [label] used in the subject of emails. It will default to {{setting:title}} if not set."
+    email_site_title: "The title of the site used as the sender of emails from the site. Default to {{setting:title}} if not set. If your {{setting:title}} contains characters that are not allowed in email sender strings, use this setting."
 
     find_related_post_with_key: "Only use the 'reply key' to find the replied-to post. WARNING: disabling this allows user impersonation based on email address."
 
@@ -2536,13 +2536,13 @@ en:
     enable_group_directory: "Provide a directory of groups for browsing"
     enable_category_group_moderation: "Allow groups to moderate content in specific categories"
     group_in_subject: "Set %%{optional_pm} in email subject to name of first group in PM, see: <a href='https://meta.discourse.org/t/customize-specific-email-templates/88323' target='_blank'>Customize subject format for standard emails</a>"
-    allow_anonymous_mode: "Enable the option for users to switch to anonymous mode for posting. When activated, users can opt for their identities to be hidden when creating posts or topics throughout the site. See also `allow anonymous likes`."
-    allow_likes_in_anonymous_mode: "Enable this setting to allow users who are browsing your site anonymously to like posts. When activated, users can opt for their identities to be hidden when liking posts or topics throughout the site. This setting requires the `allow anonymous mode` setting to be enabled."
-    anonymous_posting_allowed_groups: "Groups that are allowed to enable anonymous posting. This setting requires the `allow anonymous mode` setting to be enabled."
+    allow_anonymous_mode: "Enable the option for users to switch to anonymous mode for posting. When activated, users can opt for their identities to be hidden when creating posts or topics throughout the site. See also {{setting:allow_likes_in_anonymous_mode}}."
+    allow_likes_in_anonymous_mode: "Enable this setting to allow users who are browsing your site anonymously to like posts. When activated, users can opt for their identities to be hidden when liking posts or topics throughout the site. This setting requires the {{setting:allow_anonymous_mode}} setting to be enabled."
+    anonymous_posting_allowed_groups: "Groups that are allowed to enable anonymous posting. This setting requires the {{setting:allow_anonymous_mode}} setting to be enabled."
     anonymous_account_duration_minutes: "To protect anonymity create a new anonymous account every N minutes for each user. Example: if set to 600, as soon as 600 minutes elapse from last post AND user switches to anon, a new anonymous account is created."
 
     hide_user_profiles_from_public: "Disable user cards and user profiles for anonymous users. Aggregated stats will still be available in the user directory."
-    hide_new_user_profiles: "Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time. This feature is disabled unconditionally on must_approve_users and invite_only sites."
+    hide_new_user_profiles: "Hide trust level 1 or lower user profiles from the public and trust level 1 users until they post for the first time. This feature is disabled unconditionally on {{setting:must_approve_users}} and {{setting:invite_only}} sites."
     allow_users_to_hide_profile: "Allow users to hide their profile and presence"
     hide_user_activity_tab: "Hide the activity tab on user profiles except for Admin and self."
 
@@ -2589,7 +2589,7 @@ en:
 
     global_notice: "Display an URGENT, EMERGENCY, non-dismissible global banner notice to all visitors, change to blank to hide it (HTML allowed)."
 
-    disable_system_edit_notifications: "Disables edit notifications by the system user when 'download_remote_images_to_local' is active."
+    disable_system_edit_notifications: "Disables edit notifications by the system user when {{setting:download_remote_images_to_local}} is active."
 
     disable_category_edit_notifications: "Disable notifications for topic category edits. This includes topics which are 'published' (e.g. shared drafts)."
 
@@ -2597,9 +2597,9 @@ en:
 
     notification_consolidation_threshold: "Number of liked or membership request notifications received before the notifications are consolidated into a single one. Set to 0 to disable."
 
-    likes_notification_consolidation_window_mins: "Duration in minutes where liked notifications are consolidated into a single notification once the threshold has been reached. The threshold can be configured via `SiteSetting.notification_consolidation_threshold`."
+    likes_notification_consolidation_window_mins: "Duration in minutes where liked notifications are consolidated into a single notification once the threshold has been reached. The threshold can be configured via {{setting:notification_consolidation_threshold}}."
 
-    linked_notification_consolidation_window_mins: "Duration in minutes where linked notifications are consolidated into a single notification once the threshold has been reached. The threshold can be configured via `SiteSetting.notification_consolidation_threshold`."
+    linked_notification_consolidation_window_mins: "Duration in minutes where linked notifications are consolidated into a single notification once the threshold has been reached. The threshold can be configured via {{setting:notification_consolidation_threshold}}."
 
     automatically_unpin_topics: "Automatically unpin topics when the user reaches the bottom."
 
@@ -2630,8 +2630,8 @@ en:
     display_name_on_posts: "Show a user's full name on their posts in addition to their @username."
     show_time_gap_days: "If two posts are made this many days apart, display the time gap in the topic."
     short_progress_text_threshold: "After the number of posts in a topic goes above this number, the progress bar will only show the current post number. If you change the progress bar's width, you may need to change this value."
-    default_code_lang: "Default programming language syntax highlighting applied to markdown code blocks (auto, text, ruby, python etc.). This value must also be present in the `highlighted languages` site setting."
-    autohighlight_all_code: "Apply syntax highlighting to HTML-authored &lt;code&gt; blocks, even if they didn't specify a language. To configure markdown-authored code blocks, use the 'default code lang' setting."
+    default_code_lang: "Default programming language syntax highlighting applied to markdown code blocks (auto, text, ruby, python etc.). This value must also be present in the {{setting:highlighted_languages}} site setting."
+    autohighlight_all_code: "Apply syntax highlighting to HTML-authored &lt;code&gt; blocks, even if they didn't specify a language. To configure markdown-authored code blocks, use the {{setting:default_code_lang}} setting."
     highlighted_languages: "Included syntax highlighting rules. (Warning: including too many languages may impact performance) see: <a href='https://highlightjs.org/demo/' target='_blank'>https://highlightjs.org/demo</a> for a demo"
     show_copy_button_on_codeblocks: "Add a button to codeblocks to copy the block contents to the user's clipboard."
 
@@ -2640,12 +2640,12 @@ en:
     embed_set_canonical_url: "Set the canonical URL for embedded topics to the embedded content's URL."
     embed_truncate: "Shorten the contents of posts that are embedded from external sources. This setting ensures that only the initial part of content is displayed when a post from an external URL is embedded on your site. If you prefer to display full content from the external posts, you can disable this setting."
     embed_unlisted: "Embedded topics will be unlisted until a user replies."
-    import_embed_unlisted: "Imported embedded topics will be unlisted until a user replies (even when the `embed unlisted` site setting is unchecked)."
+    import_embed_unlisted: "Imported embedded topics will be unlisted until a user replies (even when the {{setting:embed_unlisted}} site setting is unchecked)."
     embed_support_markdown: "Support Markdown formatting for embedded posts."
     allowed_embed_selectors: "A comma separated list of CSS elements that are allowed in embeds."
     allowed_href_schemes: "Schemes allowed in links in addition to http and https."
     embed_full_app: "Enable full app mode for embedded comments. When enabled, embedded comments will load the full Discourse application in an iframe, allowing users to interact with topics directly"
-    embed_full_app_signin_flow: "When full app mode is enabled, intercept logged-out actions inside the iframe with a guided flow that opens a top-level sign-in tab that auto-closes on success. Only enable this when the embed is same-site to the host page (e.g. `forum.example.com` on `blog.example.com`) or when `same site cookies` is set to `None` — otherwise the iframe will not receive the session cookie after sign-in."
+    embed_full_app_signin_flow: "When full app mode is enabled, intercept logged-out actions inside the iframe with a guided flow that opens a top-level sign-in tab that auto-closes on success. Only enable this when the embed is same-site to the host page (e.g. `forum.example.com` on `blog.example.com`) or when {{setting:same_site_cookies}} is set to `None` — otherwise the iframe will not receive the session cookie after sign-in."
     suppress_third_party_analytics_in_embed: "Skip rendering third-party analytics scripts (Google Tag Manager, Google Analytics, Adobe Analytics) when Discourse is loaded inside a full app embed iframe. Prevents duplicate pageviews and tag firing when the host page already loads the same scripts."
     embed_post_limit: "Maximum number of posts to embed."
     embed_username_required: "The username for topic creation is required."
@@ -2656,8 +2656,8 @@ en:
 
     prevent_anons_from_downloading_files: "Prevent anonymous users from downloading attachments."
     secure_uploads: 'Limits access to ALL uploads (images, video, audio, text, pdfs, zips, and others). If "login required” is enabled, only logged-in users can access uploads. Otherwise, access will be limited only for media uploads in personal messages and private categories. WARNING: This setting is complex and requires deep administrative understanding. See <a target="_blank" href="https://meta.discourse.org/t/-/140017">the secure uploads topic on Meta</a> for details.'
-    secure_uploads_allow_embed_images_in_emails: "Allows embedding secure images that would normally be redacted in emails, if their size is smaller than the 'secure uploads max email embed image size kb' setting."
-    secure_uploads_max_email_embed_image_size_kb: "The size cutoff for secure images that will be embedded in emails if the 'secure uploads allow embed in emails' setting is enabled. Without that setting enabled, this setting has no effect."
+    secure_uploads_allow_embed_images_in_emails: "Allows embedding secure images that would normally be redacted in emails, if their size is smaller than the {{setting:secure_uploads_max_email_embed_image_size_kb}} setting."
+    secure_uploads_max_email_embed_image_size_kb: "The size cutoff for secure images that will be embedded in emails if the {{setting:secure_uploads_allow_embed_images_in_emails}} setting is enabled. Without that setting enabled, this setting has no effect."
     slug_generation_method: "Choose a slug generation method. 'encoded' will generate percent encoding string. 'none' will disable slug at all."
 
     enable_emoji: "Enable the display and use of emojis in your Discourse instance. If disabled, emojis will not be rendered and users will not be able to access or use them in text fields."
@@ -2676,7 +2676,7 @@ en:
     reviewable_revision_reasons: "List of reasons that can be selected when rejecting a reviewable queued post with a revision. Other is always available as well, which allows for a custom reason to be entered."
     auto_close_messages_post_count: "Maximum number of posts allowed in a message before it is automatically closed (0 to disable)"
     auto_close_topics_post_count: "Maximum number of posts allowed in a topic before it is automatically closed (0 to disable)"
-    auto_close_topics_create_linked_topic: "Create a new linked topic when a topic is auto-closed based on 'auto close topics post count' setting"
+    auto_close_topics_create_linked_topic: "Create a new linked topic when a topic is auto-closed based on {{setting:auto_close_topics_post_count}} setting"
 
     code_formatting_style: "Code button in composer will default to this code formatting style"
 
@@ -2730,7 +2730,7 @@ en:
     default_categories_tracking: "List of categories that are tracked by default."
     default_categories_muted: "List of categories that are muted by default."
     default_categories_watching_first_post: "List of categories in which first post in each new topic will be watched by default."
-    default_categories_normal: "List of categories that are not muted by default. Useful when `mute_all_categories_by_default` site setting is enabled."
+    default_categories_normal: "List of categories that are not muted by default. Useful when {{setting:mute_all_categories_by_default}} site setting is enabled."
     mute_all_categories_by_default: "Set the default notification level of all the categories to muted. Require users opt-in to categories for them to appear in 'latest' and 'categories' pages. If you wish to amend the defaults for anonymous users set 'default_categories_' settings."
 
     default_tags_watching: "List of tags that are watched by default."
@@ -2766,7 +2766,7 @@ en:
     create_tag_allowed_groups: "Groups that are allowed to create tags. Admins and moderators can always create tags."
     edit_tags_allowed_groups: "Groups that are allowed to edit tags, tag descriptions, and tag synonyms."
     max_tags_per_topic: "The maximum tags that can be applied to a topic."
-    enable_max_tags_per_email_subject: "Use max_tags_per_email_subject when generating the subject of an email"
+    enable_max_tags_per_email_subject: "Use {{setting:max_tags_per_email_subject}} when generating the subject of an email"
     max_tags_per_email_subject: "The maximum tags that can be in the subject of an email"
     max_tag_length: "The maximum amount of characters that can be used in a tag."
     max_tag_search_results: "When searching for tags, the maximum number of results to show."
@@ -2814,7 +2814,7 @@ en:
     gravatar_enabled: "Use the <a href='https://gravatar.com/'>Gravatar</a> service for user avatars. Disabling this will prevent users from switching to Gravatar for their avatars, but will not impact users who already use it."
     gravatar_name: "Specify the name of the Gravatar service provider. This name is typically used to identify the source providing Gravatar avatars to the site."
     gravatar_base_url: "Specify the URL for accessing the Gravatar provider's API. This setting is critical for converting email addresses into Gravatar URLs where avatar images are stored."
-    gravatar_login_url: "URL relative to `gravatar_base_url`, which provides the user with the login to the Gravatar service."
+    gravatar_login_url: "URL relative to {{setting:gravatar_base_url}}, which provides the user with the login to the Gravatar service."
 
     share_quote_buttons: "Determine which items appear in the quote sharing widget, and in what order."
     share_quote_visibility: "Determine when to show quote sharing buttons: never, to anonymous users only or all users. "
@@ -2833,7 +2833,7 @@ en:
     welcome_banner_image: "Set an image to display in the background of the welcome banner."
     welcome_banner_location: "Determines where on the page the welcome banner will appear."
     welcome_banner_page_visibility: "Determines on which pages the welcome banner will appear."
-    welcome_banner_text_color: "When the 'Welcome banner image' setting has been configured, use this setting to change the banner text color to ensure it remains readable. When left blank or when no image has been uploaded, the active theme controls the color."
+    welcome_banner_text_color: "When the {{setting:welcome_banner_image}} setting has been configured, use this setting to change the banner text color to ensure it remains readable. When left blank or when no image has been uploaded, the active theme controls the color."
 
     splash_screen_image: "An SVG image to display on the splash screen while the site loads. Animated SVGs should only use CSS transform or opacity animations. Use unique names for CSS classes and keyframes. You can use var(--primary), var(--secondary), and var(--tertiary) to reference theme colors."
     navigation_menu: "Specify sidebar or header dropdown as the main navigation menu for your site. Sidebar is recommended."
@@ -2859,11 +2859,11 @@ en:
     rich_editor: "Enable the rich editor for the composer so all users can switch between the current Markdown mode and the new rich text editor for more intuitive and user-friendly composition."
     default_composition_mode: "Set the default mode for your community's composer. Rich text mode provides a more modern, familiar writing experience for most users, while Markdown mode may be suitable for more technical audiences. Members can use a toggle in the composer toolbar to switch between modes."
     reviewable_ui_refresh: "Groups that can use the experimental new UI in the review queue."
-    content_localization_enabled: "Displays localized content for users based on their browser or user language preferences. Such content may include categories, tags, posts, and topics. Supported locales are set in 'content localization supported locales'."
-    content_localization_supported_locales: "List of supported locales that user content can be translated to. The site's default locale is always included. Requires 'content localization enabled'."
-    content_localization_allowed_groups: "Groups allowed to update localized content. Requires 'content localization enabled'."
-    content_localization_language_switcher: "Show a language switcher in the header, allowing visitors to switch between translated versions of Discourse and user-contributed content. Uses languages defined in 'content localization supported locales'"
-    content_localization_crawler_param: "Serve localized content to web crawlers when 'content localization enabled' and 'set locale from param' is enabled. The list of supported locales is defined in 'content localization supported locales'."
+    content_localization_enabled: "Displays localized content for users based on their browser or user language preferences. Such content may include categories, tags, posts, and topics. Supported locales are set in {{setting:content_localization_supported_locales}}."
+    content_localization_supported_locales: "List of supported locales that user content can be translated to. The site's default locale is always included. Requires {{setting:content_localization_enabled}}."
+    content_localization_allowed_groups: "Groups allowed to update localized content. Requires {{setting:content_localization_enabled}}."
+    content_localization_language_switcher: "Show a language switcher in the header, allowing visitors to switch between translated versions of Discourse and user-contributed content. Uses languages defined in {{setting:content_localization_supported_locales}}"
+    content_localization_crawler_param: "Serve localized content to web crawlers when {{setting:content_localization_enabled}} and {{setting:set_locale_from_param}} is enabled. The list of supported locales is defined in {{setting:content_localization_supported_locales}}."
     content_localization_use_default_locale_when_unsupported: "Serve localized content in the site's default locale to users whose preferred language is not listed in 'content localization supported locales'."
     content_localization_allow_author_localization: "Allow authors update localizations of their own topics and posts via the post menu."
     nested_replies_enabled: "Enable the nested replies view for topics."
@@ -2875,7 +2875,7 @@ en:
     fake_upcoming_change: "This is a fake upcoming change for testing purposes. No need to translate this string."
     enable_new_defaults_for_trust_level_3_requirements: "We have updated the TL3 default requirements so they’re more reasonable for members of large, active communities. If you have previously overridden these settings, this upcoming change will have no effect."
     floating_dismiss_topics_on_mobile: "Shows a floating 'Dismiss...' button on mobile for the topic list for easier access and to free up space in the top of the topic list"
-    rename_faq_to_guidelines: "This change renames the FAQ page to Guidelines. The FAQ page will still be available at /faq. The 'faq url' setting works as before."
+    rename_faq_to_guidelines: "This change renames the FAQ page to Guidelines. The FAQ page will still be available at /faq. The {{setting:faq_url}} setting works as before."
     enable_simplified_category_creation: "Enables a simplified category creation flow with fewer options and a cleaner interface."
     modernize_foundation_theme: "This change introduces design modifcations to the Foundation theme in Discourse."
     enable_horizon_high_context_topic_cards: "Shows richer topic cards in the Horizon theme, including topic excerpts, tags, and plugin extended information."

--- a/frontend/discourse/admin/components/site-settings/bool.gjs
+++ b/frontend/discourse/admin/components/site-settings/bool.gjs
@@ -3,6 +3,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { trustHTML } from "@ember/template";
 import { isSettingValueTrue } from "discourse/admin/models/site-setting";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
 
 export default class Bool extends Component {
   get enabled() {
@@ -26,7 +27,9 @@ export default class Bool extends Component {
         checked={{this.enabled}}
         disabled={{@disabled}}
       />
-      <span>{{trustHTML @setting.description}}</span>
+      <span {{linkifySettingLinks @setting.description}}>{{trustHTML
+          @setting.description
+        }}</span>
     </label>
   </template>
 }

--- a/frontend/discourse/admin/components/site-settings/description.gjs
+++ b/frontend/discourse/admin/components/site-settings/description.gjs
@@ -1,5 +1,8 @@
 import { trustHTML } from "@ember/template";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
 
 <template>
-  <div class="desc">{{trustHTML @description}}</div>
+  <div class="desc" {{linkifySettingLinks @description}}>{{trustHTML
+      @description
+    }}</div>
 </template>

--- a/frontend/discourse/admin/modifiers/linkify-setting-links.js
+++ b/frontend/discourse/admin/modifiers/linkify-setting-links.js
@@ -1,0 +1,32 @@
+import { service } from "@ember/service";
+import Modifier from "ember-modifier";
+
+// Rewrites the href of server-rendered `{{setting:foo}}` links so they point at
+// the setting's actual config page instead of the generic all-settings page.
+// The server can only emit the fallback URL because the area/category -> page
+// mapping lives in the client nav map; the metadata it knows is passed through
+// data attributes on the anchor.
+export default class LinkifySettingLinks extends Modifier {
+  @service adminSearchDataSource;
+
+  modify(element, [description]) {
+    if (!description) {
+      return;
+    }
+
+    element
+      .querySelectorAll("a.site-setting-link[data-setting-name]")
+      .forEach((anchor) => {
+        const url = this.adminSearchDataSource.urlForSetting({
+          setting: anchor.dataset.settingName,
+          primaryArea: anchor.dataset.settingArea,
+          category: anchor.dataset.settingCategory,
+          plugin: anchor.dataset.settingPlugin,
+        });
+
+        if (url) {
+          anchor.setAttribute("href", url);
+        }
+      });
+  }
+}

--- a/frontend/discourse/admin/services/admin-search-data-source.js
+++ b/frontend/discourse/admin/services/admin-search-data-source.js
@@ -53,17 +53,19 @@ export class PageLinkFormatter {
     this.parentLabel = parentLabel;
   }
 
-  format() {
-    let url;
+  url() {
     if (this.link.route) {
       if (this.link.routeModels) {
-        url = this.router.urlFor(this.link.route, ...this.link.routeModels);
-      } else {
-        url = this.router.urlFor(this.link.route);
+        return this.router.urlFor(this.link.route, ...this.link.routeModels);
       }
+      return this.router.urlFor(this.link.route);
     } else if (this.link.href) {
-      url = getURL(this.link.href);
+      return getURL(this.link.href);
     }
+  }
+
+  format() {
+    const url = this.url();
 
     const sectionLabel = labelOrText(this.navMapSection);
     const linkLabel = labelOrText(this.link);
@@ -111,17 +113,13 @@ export class SettingLinkFormatter {
     this.setting = setting;
     this.plugins = plugins;
     this.settingPageMap = settingPageMap;
-    this.settingPluginNames = {};
+  }
+
+  get dasherizedPluginName() {
+    return this.setting.plugin?.replaceAll("_", "-");
   }
 
   format() {
-    if (this.setting.plugin) {
-      if (!this.settingPluginNames[this.setting.plugin]) {
-        this.settingPluginNames[this.setting.plugin] =
-          this.setting.plugin.replaceAll("_", "-");
-      }
-    }
-
     const [rootLabel, fullLabel] = this.buildLabel();
     const url = this.buildURL();
 
@@ -145,7 +143,7 @@ export class SettingLinkFormatter {
     let rootLabel;
 
     if (this.setting.plugin) {
-      const plugin = this.plugins[this.settingPluginNames[this.setting.plugin]];
+      const plugin = this.plugins[this.dasherizedPluginName];
       if (plugin) {
         rootLabel = plugin.admin_route?.label
           ? i18n(plugin.admin_route?.label)
@@ -174,7 +172,7 @@ export class SettingLinkFormatter {
     // to focus/highlight on a specific element on the page, for now though the filter is fine.
     let url;
     if (this.setting.plugin) {
-      const plugin = this.plugins[this.settingPluginNames[this.setting.plugin]];
+      const plugin = this.plugins[this.dasherizedPluginName];
       const settingPluginCategoryName = this.setting.plugin.replace(/-/g, "_");
 
       if (plugin && plugin.admin_route.use_new_show_route) {
@@ -245,6 +243,7 @@ export default class AdminSearchDataSource extends Service {
     categories: {},
     areas: {},
   };
+  #settingLinkDataCached = false;
   @tracked _mapCached = false;
 
   async buildMap() {
@@ -375,20 +374,7 @@ export default class AdminSearchDataSource extends Service {
 
     // Cache the setting area + category URLs for later use
     // when building the setting list via #processSettings.
-    if (link.settings_area && !this.settingPageMap.areas[link.settings_area]) {
-      this.settingPageMap.areas[link.settings_area] = link.multi_tabbed
-        ? `${formattedPageLink.url}/settings`
-        : formattedPageLink.url;
-    }
-
-    if (
-      link.settings_category &&
-      !this.settingPageMap.categories[link.settings_category]
-    ) {
-      this.settingPageMap.categories[link.settings_category] = link.multi_tabbed
-        ? `${formattedPageLink.url}/settings`
-        : formattedPageLink.url;
-    }
+    this.#cacheSettingPageURL(link, formattedPageLink.url);
 
     this.pageDataSourceItems.push({
       label: formattedPageLink.label,
@@ -400,6 +386,64 @@ export default class AdminSearchDataSource extends Service {
     });
 
     return formattedPageLink.label;
+  }
+
+  urlForSetting({ setting, primaryArea, category, plugin }) {
+    this.#ensureSettingLinkData();
+
+    return new SettingLinkFormatter(
+      this.router,
+      { setting, plugin, primary_area: primaryArea, category },
+      this.plugins,
+      this.settingPageMap
+    ).buildURL();
+  }
+
+  // Builds just the data needed to resolve a setting's config page URL (the
+  // area/category -> page map and the plugins map) without the network request
+  // that buildMap performs for the full admin search index.
+  #ensureSettingLinkData() {
+    if (this._mapCached || this.#settingLinkDataCached) {
+      return;
+    }
+
+    this.adminNavManager.filteredNavMap.forEach((navMapSection) => {
+      navMapSection.links.forEach((link) => {
+        this.#cacheSettingPageURLFromLink(link);
+        link.links?.forEach((subLink) =>
+          this.#cacheSettingPageURLFromLink(subLink)
+        );
+      });
+    });
+
+    this.plugins = this.buildPluginsMap();
+    this.#settingLinkDataCached = true;
+  }
+
+  #cacheSettingPageURLFromLink(link) {
+    if (!link.settings_area && !link.settings_category) {
+      return;
+    }
+
+    this.#cacheSettingPageURL(
+      link,
+      new PageLinkFormatter(this.router, null, link).url()
+    );
+  }
+
+  #cacheSettingPageURL(link, url) {
+    const pageURL = link.multi_tabbed ? `${url}/settings` : url;
+
+    if (link.settings_area && !this.settingPageMap.areas[link.settings_area]) {
+      this.settingPageMap.areas[link.settings_area] = pageURL;
+    }
+
+    if (
+      link.settings_category &&
+      !this.settingPageMap.categories[link.settings_category]
+    ) {
+      this.settingPageMap.categories[link.settings_category] = pageURL;
+    }
   }
 
   #processSettings(settings) {

--- a/frontend/discourse/tests/integration/modifiers/linkify-setting-links-test.gjs
+++ b/frontend/discourse/tests/integration/modifiers/linkify-setting-links-test.gjs
@@ -1,0 +1,52 @@
+import { getOwner } from "@ember/owner";
+import { trustHTML } from "@ember/template";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  logIn,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+
+module("Integration | Modifier | linkify-setting-links", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    logIn(getOwner(this));
+    updateCurrentUser({ admin: true });
+  });
+
+  test("rewrites a setting link's href to its config page", async function (assert) {
+    const description =
+      '<a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=title" data-setting-name="title" data-setting-area="about" data-setting-category="required">Title</a>';
+
+    await render(
+      <template>
+        <div {{linkifySettingLinks description}}>{{trustHTML description}}</div>
+      </template>
+    );
+
+    assert
+      .dom("a.site-setting-link")
+      .hasAttribute("href", "/admin/config/about?filter=title");
+  });
+
+  test("leaves an unmapped setting link pointing at the all-settings page", async function (assert) {
+    const description =
+      '<a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=foo" data-setting-name="foo">Foo</a>';
+
+    await render(
+      <template>
+        <div {{linkifySettingLinks description}}>{{trustHTML description}}</div>
+      </template>
+    );
+
+    assert
+      .dom("a.site-setting-link")
+      .hasAttribute(
+        "href",
+        "/admin/site_settings/category/all_results?filter=foo"
+      );
+  });
+});

--- a/frontend/discourse/tests/unit/services/admin-search-data-source-test.js
+++ b/frontend/discourse/tests/unit/services/admin-search-data-source-test.js
@@ -251,6 +251,59 @@ module("Unit | Service | AdminSearchDataSource", function (hooks) {
     let results = this.subject.search("exact      setting");
     assert.deepEqual(results[0].label, "Page about whatever");
   });
+
+  test("urlForSetting - resolves a setting's primary area to its config page", function (assert) {
+    assert.strictEqual(
+      this.subject.urlForSetting({ setting: "title", primaryArea: "about" }),
+      "/admin/config/about?filter=title"
+    );
+  });
+
+  test("urlForSetting - appends /settings for multi-tabbed area pages", function (assert) {
+    assert.strictEqual(
+      this.subject.urlForSetting({
+        setting: "allow_flagging",
+        primaryArea: "flags",
+      }),
+      "/admin/config/flags/settings?filter=allow_flagging"
+    );
+  });
+
+  test("urlForSetting - resolves a setting's category when it has no area", function (assert) {
+    assert.strictEqual(
+      this.subject.urlForSetting({
+        setting: "min_post_length",
+        category: "security",
+      }),
+      "/admin/config/security?filter=min_post_length"
+    );
+  });
+
+  test("urlForSetting - prefers the area over the category", function (assert) {
+    assert.strictEqual(
+      this.subject.urlForSetting({
+        setting: "title",
+        primaryArea: "about",
+        category: "security",
+      }),
+      "/admin/config/about?filter=title"
+    );
+  });
+
+  test("urlForSetting - falls back to the all-settings page when nothing matches", function (assert) {
+    assert.strictEqual(
+      this.subject.urlForSetting({ setting: "some_unmapped_setting" }),
+      "/admin/site_settings/category/all_results?filter=some_unmapped_setting"
+    );
+  });
+
+  test("urlForSetting - works without buildMap having been called", function (assert) {
+    assert.false(this.subject._mapCached);
+    assert.strictEqual(
+      this.subject.urlForSetting({ setting: "title", primaryArea: "about" }),
+      "/admin/config/about?filter=title"
+    );
+  });
 });
 
 module(

--- a/lib/site_settings/label_formatter.rb
+++ b/lib/site_settings/label_formatter.rb
@@ -129,9 +129,47 @@ module SiteSettings
     HUMANIZED_MIXED_CASE_REGEX =
       HUMANIZED_MIXED_CASE.map { |key, value| [/\b#{Regexp.escape(key)}\b/i, value] }.freeze
 
+    SETTING_LINK_PATTERN = /\{\{setting:([a-z][a-z0-9_]*)\}\}/
+
     class << self
       def description(setting)
-        I18n.t("site_settings.#{setting}", base_path: Discourse.base_path, default: "")
+        desc = I18n.t("site_settings.#{setting}", base_path: Discourse.base_path, default: "")
+        expand_setting_links(desc)
+      end
+
+      def linkify(setting)
+        setting = setting.to_sym
+
+        # The href points at the generic "all settings" page as a fallback that
+        # works without JavaScript. In the admin UI the linkify-setting-links
+        # modifier rewrites it to the setting's actual config page, using the
+        # data attributes below so it doesn't have to look the metadata up.
+        attributes = {
+          "class" => "site-setting-link",
+          "href" =>
+            "#{Discourse.base_path}/admin/site_settings/category/all_results?filter=#{CGI.escape(setting.to_s)}",
+          "data-setting-name" => setting,
+        }
+
+        if (area = SiteSetting.areas[setting]&.first)
+          attributes["data-setting-area"] = area
+        end
+        if (category = SiteSetting.categories[setting])
+          attributes["data-setting-category"] = category
+        end
+        if (plugin = SiteSetting.plugins[setting])
+          attributes["data-setting-plugin"] = plugin
+        end
+
+        attribute_string =
+          attributes.map { |name, value| %(#{name}="#{CGI.escapeHTML(value.to_s)}") }.join(" ")
+
+        %(<a #{attribute_string}>#{CGI.escapeHTML(humanized_name(setting))}</a>).html_safe
+      end
+
+      def expand_setting_links(text)
+        return text if text.blank? || !text.include?("{{setting:")
+        text.gsub(SETTING_LINK_PATTERN) { linkify(Regexp.last_match(1)) }.html_safe
       end
 
       def humanized_name(setting)

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -27,7 +27,7 @@ en:
     chat_editing_grace_period_max_diff_low_trust: "Maximum number of character changes allowed in chat editing grace period, if more changed display the (edited) tag by the chat message (trust level 0 and 1)."
     chat_editing_grace_period_max_diff_high_trust: "Maximum number of character changes allowed in chat editing grace period, if more changed display the (edited) tag by the chat message (trust level 2 and up)."
     chat_preferred_index: "Preferred tab when loading /chat."
-    allow_chat_in_anonymous_mode: "Enable this setting to allow users who are browsing your site anonymously to use chat. This setting requires the `allow anonymous mode` setting to be enabled."
+    allow_chat_in_anonymous_mode: "Enable this setting to allow users who are browsing your site anonymously to use chat. This setting requires the {{setting:allow_anonymous_mode}} setting to be enabled."
     chat_search_enabled: "Enable this setting to allow users to search chat messages."
     errors:
       chat_default_channel: "The default chat channel must be a public channel."

--- a/plugins/discourse-adplugin/config/locales/server.en.yml
+++ b/plugins/discourse-adplugin/config/locales/server.en.yml
@@ -38,7 +38,7 @@ en:
     ads_txt: "Contents of your ads.txt file. More details available at <a href='https://support.google.com/adsense/answer/7532444?hl=en' target='_blank'>this Google AdSense help page</a>."
     ad_plugin_routes_enabled: "Enable route targeting for house ads"
 
-    dfp_publisher_id: "Input your Google Ad Manager (formerly called DFP) network code, which is found in your network settings. NOTE: You will need to update the 'content security policy script src' setting. See <a href='https://meta.discourse.org/t/33734' target='_blank'>this topic</a> for the latest instructions."
+    dfp_publisher_id: "Input your Google Ad Manager (formerly called DFP) network code, which is found in your network settings. NOTE: You will need to update the {{setting:content_security_policy_script_src}} setting. See <a href='https://meta.discourse.org/t/33734' target='_blank'>this topic</a> for the latest instructions."
     dfp_publisher_id_mobile: "(Optional) If you want to use a different Ad Manager publisher id for the mobile version of the site, enter it here. Leave blank to use dfp_publisher_id on mobile."
     dfp_through_trust_level: "Show your ads to users based on trust levels. Users with trust level higher than this value will not see ads."
     dfp_exclude_groups: "Ads will not be shown to members of these groups"
@@ -72,7 +72,7 @@ en:
     dfp_target_post_bottom_key_code: "Input custom targeting keys - inventory Level"
     dfp_target_post_bottom_value_code: "Input custom targeting values - inventory Level"
 
-    adsense_publisher_code: "Your publisher ID. Enter only the number, excluding 'pub-'. NOTE: You will need to update the 'content security policy script src' setting. See <a href='https://meta.discourse.org/t/33734' target='_blank'>this topic</a> for the latest instructions."
+    adsense_publisher_code: "Your publisher ID. Enter only the number, excluding 'pub-'. NOTE: You will need to update the {{setting:content_security_policy_script_src}} setting. See <a href='https://meta.discourse.org/t/33734' target='_blank'>this topic</a> for the latest instructions."
     adsense_through_trust_level: "Show your ads to users based on trust levels. Users with trust level higher than this value will not see ads."
     adsense_exclude_groups: "Ads will not be shown to members of these groups"
     adsense_topic_list_top_code: "Enter code of the ad unit to display at topic list top location. This is the number assigned to the ad unit, not the JavaScript code."
@@ -128,7 +128,7 @@ en:
     carbonads_topic_list_top_enabled: "Show an ad above the topic list"
     carbonads_above_post_stream_enabled: "Show an ad above the post stream"
 
-    adbutler_publisher_id: "AdButler Publisher ID. NOTE: You may need to update the 'content security policy script src' setting. See <a href='https://meta.discourse.org/t/33734' target='_blank'>this topic</a> for the latest instructions."
+    adbutler_publisher_id: "AdButler Publisher ID. NOTE: You may need to update the {{setting:content_security_policy_script_src}} setting. See <a href='https://meta.discourse.org/t/33734' target='_blank'>this topic</a> for the latest instructions."
     adbutler_mobile_topic_list_top_zone_id: "Zone ID for mobile topic list top location"
     adbutler_mobile_topic_above_post_stream_zone_id: "Zone ID for mobile topic above post stream location"
     adbutler_mobile_post_bottom_zone_id: "Zone ID for mobile post bottom location"

--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -43,7 +43,7 @@ en:
     map_events_to_color: "Assign a color to each tag or category."
     map_events_title: "Overwrites 'Events' in the 'Upcoming Events' sidebar title per category."
     calendar_enabled: "Enable the discourse-calendar plugin. This will add support for a [calendar][/calendar] tag in the first post of a topic."
-    discourse_post_event_enabled: "Enables the Event features. Note: also needs `calendar enabled` to be enabled."
+    discourse_post_event_enabled: "Enables the Event features. Note: also needs {{setting:calendar_enabled}} to be enabled."
     displayed_invitees_limit: "Limits the numbers of invitees displayed on an event."
     display_post_event_date_on_topic_title: "Displays the date of the event after the topic title."
     use_local_event_date: "Use local date after topic title instead of relative time."
@@ -69,7 +69,7 @@ en:
     event_participation_buttons: "List of event participation buttons users can use."
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
     calendar_first_day_of_week: "Set the first day of the week for calendar display. Options are Saturday, Sunday, or Monday."
-    enable_events_category_type_setup: "Enables the Events category type option during category creation setup. Note that 'enable simplified category creation' must be enabled for this to take effect."
+    enable_events_category_type_setup: "Enables the Events category type option during category creation setup. Note that {{setting:enable_simplified_category_creation}} must be enabled for this to take effect."
 
   discourse_calendar:
     category_type:

--- a/plugins/discourse-login-with-amazon/config/locales/server.en.yml
+++ b/plugins/discourse-login-with-amazon/config/locales/server.en.yml
@@ -1,6 +1,6 @@
 en:
   site_settings:
-    enable_login_with_amazon: "Enable Login with Amazon authentication, requires `login with amazon client id` and `login with amazon client secret`."
+    enable_login_with_amazon: "Enable Login with Amazon authentication, requires {{setting:login_with_amazon_client_id}} and {{setting:login_with_amazon_client_secret}}."
     login_with_amazon_client_id: "Login with Amazon client ID"
     login_with_amazon_client_secret: "Login with Amazon client secret"
     login_with_amazon_scope: "Login with Amazon OAuth2 scopes (space separated)"

--- a/plugins/discourse-oauth2-basic/config/locales/server.en.yml
+++ b/plugins/discourse-oauth2-basic/config/locales/server.en.yml
@@ -24,7 +24,7 @@ en:
     oauth2_json_groups_path: "Path in the OAuth2 User JSON to an array of group names the user belongs to. Leave blank to disable group syncing."
     oauth2_user_field_mappings: "Map paths in the OAuth2 User JSON onto Discourse user fields. Each entry pairs a JSON path with the numeric ID of a Discourse user field."
     oauth2_email_verified: "Check this if the OAuth2 site has verified the email"
-    oauth2_overrides_email: "Override the Discourse email with the remote email on every login. Works the same as the `auth_overrides_email` setting, but is specific to OAuth2 logins."
+    oauth2_overrides_email: "Override the Discourse email with the remote email on every login. Works the same as the {{setting:auth_overrides_email}} setting, but is specific to OAuth2 logins."
     oauth2_send_auth_header: "Send client credentials in an HTTP Authorization header"
     oauth2_send_auth_body: "Send client credentials in the request body"
     oauth2_debug_auth: "Include rich debugging information in your logs"

--- a/plugins/discourse-openid-connect/config/locales/server.en.yml
+++ b/plugins/discourse-openid-connect/config/locales/server.en.yml
@@ -13,7 +13,7 @@ en:
     openid_connect_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the OpenID Connect provider"
     openid_connect_verbose_logging: "Log detailed openid-connect authentication information to `/logs`. Keep this disabled during normal use."
     openid_connect_authorize_parameters: "URL parameters which will be included in the redirect from /auth/oidc to the IDP's authorize endpoint"
-    openid_connect_overrides_email: "On every login, override the user's email using the openid-connect value. Works the same as the `auth_overrides_email` setting, but is specific to OpenID Connect logins."
+    openid_connect_overrides_email: "On every login, override the user's email using the openid-connect value. Works the same as the {{setting:auth_overrides_email}} setting, but is specific to OpenID Connect logins."
     openid_connect_claims: "Explicitly define the claims for use with providers that don't pass data back based on scopes. (JSON)"
     openid_connect_groups_claim: "The name of the claim in the OIDC token that contains the user's groups as an array of strings. Leave blank to disable group syncing."
     openid_connect_user_field_mappings: "Map OIDC claims onto Discourse user fields. Each entry pairs an OIDC claim name with the numeric ID of a Discourse user field."

--- a/plugins/discourse-reactions/config/locales/server.en.yml
+++ b/plugins/discourse-reactions/config/locales/server.en.yml
@@ -7,9 +7,9 @@ en:
     discourse_reactions_enabled_reactions: "Defines a list of enabled reactions, any emoji is allowed here."
     discourse_reactions_desaturated_reaction_panel: "Reduces visual noise of reactions by displaying them desaturated until hover."
     discourse_reactions_excluded_from_like: "Reactions that do not count as a Like. Any reactions that are not on this list will count as a Like for badges, reporting, and other purposes."
-    discourse_reactions_like_sync_enabled: "If this is enabled, historical reactions will have their matching Like records created, except those reactions defined in `discourse_reactions_excluded_from_like`. This sync will happen on a regular basis in the background, and also when you change `discourse_reactions_excluded_from_like`."
-    discourse_reactions_allow_any_emoji: "If this is enabled, will add a button allowing users to select any emoji in the reactions picker. Members will be allowed to choose any emoji, including custom emoji, for reactions. To limit available reactions, use the `emoji_deny_list` site setting."
-    enable_discourse_reactions_by_default: "Changes the default value for the `discourse_reactions_enabled` setting from disabled to enabled when this upcoming change is enabled."
+    discourse_reactions_like_sync_enabled: "If this is enabled, historical reactions will have their matching Like records created, except those reactions defined in {{setting:discourse_reactions_excluded_from_like}}. This sync will happen on a regular basis in the background, and also when you change {{setting:discourse_reactions_excluded_from_like}}."
+    discourse_reactions_allow_any_emoji: "If this is enabled, will add a button allowing users to select any emoji in the reactions picker. Members will be allowed to choose any emoji, including custom emoji, for reactions. To limit available reactions, use the {{setting:emoji_deny_list}} site setting."
+    enable_discourse_reactions_by_default: "Changes the default value for the {{setting:discourse_reactions_enabled}} setting from disabled to enabled when this upcoming change is enabled."
     errors:
       invalid_excluded_emoji: "You cannot exclude emojis that are not in 'discourse reactions enabled reactions' (except built-in default exclusions), and you cannot exclude the emoji used for 'discourse reactions reaction for like'."
   badges:

--- a/plugins/discourse-solved/config/locales/server.en.yml
+++ b/plugins/discourse-solved/config/locales/server.en.yml
@@ -39,7 +39,7 @@ en:
     solved_add_schema_markup: "Add QAPage schema markup to HTML."
     enable_solved_tags: "Tags that will allow users to select solutions."
     prioritize_solved_topics_in_search: "Prioritize solved topics in search results."
-    enable_support_category_type_setup: "Enables the Support category type option during category creation setup. Note that 'enable simplified category creation' must be enabled for this to take effect."
+    enable_support_category_type_setup: "Enables the Support category type option during category creation setup. Note that {{setting:enable_simplified_category_creation}} must be enabled for this to take effect."
     enable_solved_shared_issues: "Adds a “Me too” button to unsolved topics in support categories, letting members signal they’re experiencing the same issue and opt into notifications about the topic's solution. Note: You must enable the “Enable support type category setup” upcoming change to use this feature."
     show_who_marked_solved: "Show who marked the topic as solved. This is indicated in the topic's first post, and the answer post in a tooltip."
 

--- a/plugins/discourse-topic-voting/config/locales/server.en.yml
+++ b/plugins/discourse-topic-voting/config/locales/server.en.yml
@@ -6,7 +6,7 @@ en:
       description: "Where members can submit ideas and vote on the ones they want most."
 
   site_settings:
-    enable_ideas_category_type_setup: "Enables the Ideas category type option during category creation setup. Note that 'enable simplified category creation' must be enabled for this to take effect."
+    enable_ideas_category_type_setup: "Enables the Ideas category type option during category creation setup."
     topic_voting_enabled: 'Allow users to vote on topics?'
     topic_voting_enable_vote_limits: 'Limit the number of votes per user based on trust level'
     topic_voting_tl0_vote_limit: 'How many active votes are TL0 users allowed?'

--- a/script/i18n_lint.rb
+++ b/script/i18n_lint.rb
@@ -111,9 +111,9 @@ class LocaleFileValidator
 
       @errors[:invalid_relative_image_sources] << key if value.match?(%r{src\s*=\s*["']/[^/]}i)
 
-      if value.match?(/{{.+?}}/) && !key.end_with?("_MF") &&
-           !EXEMPTED_DOUBLE_CURLY_BRACKET_KEYS.include?(key)
-        @errors[:invalid_interpolation_key_format] << key
+      if value.match?(/{{(?!setting:).+?}}/)
+        exempt = key.end_with?("_MF") || EXEMPTED_DOUBLE_CURLY_BRACKET_KEYS.include?(key)
+        @errors[:invalid_interpolation_key_format] << key unless exempt
       end
 
       BANNED_PHRASES.keys.each do |banned|

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1866,6 +1866,78 @@ RSpec.describe SiteSettingExtension do
     end
   end
 
+  describe "linkify" do
+    it "returns an html_safe anchor with the humanized name as the label and the setting's area/category as data attributes" do
+      result = SiteSettings::LabelFormatter.linkify(:enable_linkedin_oidc_logins)
+      expect(result).to eq(
+        '<a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=enable_linkedin_oidc_logins" data-setting-name="enable_linkedin_oidc_logins" data-setting-area="authenticators" data-setting-category="login">Enable LinkedIn OIDC logins</a>',
+      )
+      expect(result).to be_html_safe
+    end
+
+    it "accepts a string and omits the area attribute when the setting has none" do
+      expect(SiteSettings::LabelFormatter.linkify("opengraph_image")).to eq(
+        '<a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=opengraph_image" data-setting-name="opengraph_image" data-setting-category="branding">OpenGraph image</a>',
+      )
+    end
+
+    it "omits the metadata attributes for an unknown setting" do
+      expect(SiteSettings::LabelFormatter.linkify(:not_a_real_setting)).to eq(
+        '<a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=not_a_real_setting" data-setting-name="not_a_real_setting">Not a real setting</a>',
+      )
+    end
+
+    it "honors the configured base path" do
+      Discourse.stubs(:base_path).returns("/forum")
+      expect(SiteSettings::LabelFormatter.linkify(:title)).to eq(
+        '<a class="site-setting-link" href="/forum/admin/site_settings/category/all_results?filter=title" data-setting-name="title" data-setting-area="about" data-setting-category="required">Title</a>',
+      )
+    end
+  end
+
+  describe "expand_setting_links" do
+    it "expands {{setting:foo}} markers into linkified HTML" do
+      expanded =
+        SiteSettings::LabelFormatter.expand_setting_links(
+          "Configure {{setting:title}} before enabling.",
+        )
+      expect(expanded).to eq(
+        'Configure <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=title" data-setting-name="title" data-setting-area="about" data-setting-category="required">Title</a> before enabling.',
+      )
+      expect(expanded).to be_html_safe
+    end
+
+    it "expands multiple markers in the same string" do
+      expanded =
+        SiteSettings::LabelFormatter.expand_setting_links(
+          "Use {{setting:title}} and {{setting:logo}}.",
+        )
+      expect(expanded).to include('data-setting-name="title"')
+      expect(expanded).to include(">Title</a>")
+      expect(expanded).to include('data-setting-name="logo"')
+      expect(expanded).to include(">Logo</a>")
+    end
+
+    it "returns input unchanged when no markers are present" do
+      expect(SiteSettings::LabelFormatter.expand_setting_links("nothing to expand")).to eq(
+        "nothing to expand",
+      )
+    end
+
+    it "handles blank input safely" do
+      expect(SiteSettings::LabelFormatter.expand_setting_links("")).to eq("")
+      expect(SiteSettings::LabelFormatter.expand_setting_links(nil)).to be_nil
+    end
+  end
+
+  describe "description" do
+    it "expands {{setting:foo}} markers in the translated description" do
+      expect(SiteSetting.description(:logo_dark)).to eq(
+        'Dark scheme alternative for the <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=logo" data-setting-name="logo" data-setting-category="branding">Logo</a> site setting.',
+      )
+    end
+  end
+
   describe "logging Site Settings via the Rails Console" do
     around do |example|
       # Ensure Rails::Console is defined for the duration of each example.


### PR DESCRIPTION
Site setting descriptions frequently mention other settings, but the YAML had no consistent convention. The same reference appeared in at least four styles -- `foo` in backticks, 'foo' in single quotes, 'humanized name' in single quotes, or just `bare_snake_case` -- and none of them rendered as a link the admin could click to jump to the referenced setting.

Introduce a compact marker, `{{setting:foo}}`, and expand it in `SiteSettings::LabelFormatter.description`. The marker resolves to a linkified anchor pointing at
`/admin/site_settings/category/all_results?filter=foo`, with the humanized setting name as the visible label. Wiring the expansion at the description seam (rather than in the I18n freedom patch) keeps the change surgical: no impact on `I18n.t` for unrelated translations, no `html_safe` plumbing changes in the JSON error pipeline.

Migrate ~67 references in `config/locales/server.en.yml` to the new marker, covering every flavour of inconsistency found by two sweeps (snake_case identifiers and quoted humanized names). The sweep also turned up a stale reference: `enable_linkedin_oidc_logins` described `linkedin_client_id`/`linkedin_client_secret`, which were renamed to `linkedin_oidc_client_id`/`linkedin_oidc_client_secret` years ago.

Teach `script/i18n_lint.rb` to whitelist the new marker -- previously any `{{...}}` was flagged as an accidental Handlebars-style mistake. Reset the `label a` margin inherited from `discourse.scss` inside `.setting-value`, so the linkified anchors sit flush against surrounding text in checkbox-label descriptions.

Ref - t/148687

**BEFORE**

<img width="1594" height="1279" alt="2026-05-27 @ 14 27 33" src="https://github.com/user-attachments/assets/aeaf2ee3-ce8c-484c-805d-cec9298f068b" />

**AFTER**

<img width="1594" height="1279" alt="2026-05-27 @ 14 25 32" src="https://github.com/user-attachments/assets/bbead088-6f80-4903-b320-31b87d821428" />
