### PR TITLE
DEV: Perform release workflows as discoursebot

### DIFF
--- a/.github/actions/setup-release-environment/action.yml
+++ b/.github/actions/setup-release-environment/action.yml
@@ -23,8 +23,8 @@ runs:
     - name: Configure Git
       shell: bash
       run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "discoursebot"
+        git config --global user.email "team@discourse.org"
 
     - name: Bundler cache
       uses: actions/cache@v4

--- a/.github/workflows/dependabot-pnpm-dedupe.yml
+++ b/.github/workflows/dependabot-pnpm-dedupe.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Git push
         run: |
-          git config --global user.email "ci@ci.invalid"
-          git config --global user.name "Discourse CI"
+          git config --global user.email "team@discourse.org"
+          git config --global user.name "discoursebot"
           git add pnpm-lock.yaml
           git status
           git commit -m "pnpm dedupe [dependabot skip]" && git push || echo "done"

--- a/.github/workflows/release-branch-handler.yml
+++ b/.github/workflows/release-branch-handler.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
+          token: ${{ secrets.GH_PUSH_TOKEN }}
 
       - uses: ./.github/actions/setup-release-environment
 

--- a/.github/workflows/release-handler.yml
+++ b/.github/workflows/release-handler.yml
@@ -16,7 +16,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  actions: write
 
 jobs:
   build:
@@ -31,19 +30,13 @@ jobs:
         with:
           filter: tree:0
           fetch-depth: 0
-          
+          token: ${{ secrets.GH_PUSH_TOKEN }}
+
       - uses: ./.github/actions/setup-release-environment
 
       - name: Maybe cut branch
-        id: maybe-cut-branch
         if: github.ref == 'refs/heads/main'
         run: bin/rake release:maybe_cut_branch[${{ inputs.sha || github.sha }}]
-
-      - name: Maybe trigger prepare next version
-        if: steps.maybe-cut-branch.outputs.new_branch_name
-        run: gh workflow run release-branch-handler.yml -f branch="${{ steps.maybe-cut-branch.outputs.new_branch_name }}"
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Maybe tag release
         run: bin/rake release:maybe_tag_release[${{ inputs.sha || github.sha }}]


### PR DESCRIPTION
Pushes from GitHub actions do not trigger subsequent workflows. That means we miss CI (including asset publishing) when the release workflow cuts a new branch. We had a partial workaround using a deliberate workflow_dispatch, but it didn't trigger all CI jobs.

This commit updates the release workflows to use the discoursebot identity, which we already use for similar reasons in other github workflows.