### PR TITLE
FIX: use user timezone for upcoming-events redirect date

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/routes/discourse-post-event-upcoming-events/default-index.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/routes/discourse-post-event-upcoming-events/default-index.js
@@ -3,11 +3,14 @@ import moment from "moment";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class PostEventUpcomingEventsDefaultIndexRoute extends DiscourseRoute {
+  @service currentUser;
   @service router;
   @service siteSettings;
 
   beforeModel() {
-    const today = moment();
+    // Use the user's TZ so the redirect date matches what the calendar will render.
+    const tz = this.currentUser?.user_option?.timezone;
+    const today = tz ? moment.tz(tz) : moment();
     const year = today.year();
     const month = today.month() + 1; // moment months are 0-indexed, but URLs use 1-indexed
     const day = today.date();

--- a/plugins/discourse-calendar/assets/javascripts/discourse/routes/discourse-post-event-upcoming-events/default-mine.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/routes/discourse-post-event-upcoming-events/default-mine.js
@@ -3,10 +3,13 @@ import moment from "moment";
 import DiscourseRoute from "discourse/routes/discourse";
 
 export default class PostEventUpcomingEventsDefaultMineRoute extends DiscourseRoute {
+  @service currentUser;
   @service router;
 
   beforeModel() {
-    const today = moment();
+    // Use the user's TZ so the redirect date matches what the calendar will render.
+    const tz = this.currentUser?.user_option?.timezone;
+    const today = tz ? moment.tz(tz) : moment();
     const year = today.year();
     const month = today.month() + 1; // moment months are 0-indexed, but URLs use 1-indexed
     const day = today.date();


### PR DESCRIPTION
The upcoming-events default routes computed today via `moment()` (browser local TZ) for the redirect URL, but the calendar renders in `user_option.timezone`. When those days disagreed (e.g. a UTC browser with an Australia/Brisbane user during the ~10h overlap each day), the URL landed on yesterday, so the timegrid day view showed a `fc-day-past` column with no `.fc-day-today`, breaking the click-to-create day-view test.