### PR TITLE
FEATURE: badge notifications link to the post that earned them

### DIFF
--- a/app/services/badge_granter.rb
+++ b/app/services/badge_granter.rb
@@ -152,7 +152,13 @@ class BadgeGranter
         skip_new_user_tips = @user.user_option.skip_new_user_tips
         unless self.class.suppress_notification?(@badge, user_badge.granted_at, skip_new_user_tips)
           notification =
-            self.class.send_notification(@user.id, @user.username, @user.effective_locale, @badge)
+            self.class.send_notification(
+              @user.id,
+              @user.username,
+              @user.effective_locale,
+              @badge,
+              post_id: user_badge.post_id,
+            )
           user_badge.update!(notification_id: notification.id)
         end
         is_favorite = @user.user_badges.where(badge: @badge, is_favorite: true).exists?
@@ -456,7 +462,7 @@ class BadgeGranter
         #{post_clause}
         /*where*/
         ON CONFLICT DO NOTHING
-        RETURNING id, user_id, granted_at
+        RETURNING id, user_id, granted_at, post_id
       )
       SELECT w.*, username, locale, (u.admin OR u.moderator) AS staff, uo.skip_new_user_tips
         FROM w
@@ -499,7 +505,8 @@ class BadgeGranter
       next if suppress_notification?(badge, row.granted_at, row.skip_new_user_tips)
       next if row.staff && badge.awarded_for_trust_level?
 
-      notification = send_notification(row.user_id, row.username, row.locale, badge)
+      notification =
+        send_notification(row.user_id, row.username, row.locale, badge, post_id: row.post_id)
       UserBadge.trigger_user_badge_granted_event(badge.id, row.user_id)
 
       DB.exec(
@@ -550,18 +557,35 @@ class BadgeGranter
     use_default_locale ? SiteSetting.default_locale : locale
   end
 
-  def self.send_notification(user_id, username, locale, badge)
+  def self.send_notification(user_id, username, locale, badge, post_id: nil)
     I18n.with_locale(notification_locale(locale)) do
+      data = {
+        badge_id: badge.id,
+        badge_name: badge.display_name,
+        badge_slug: badge.slug,
+        badge_title: badge.allow_title,
+        username: username,
+      }
+
+      # When the badge was granted for a specific post (e.g. Thank You,
+      # Nice Reply), include enough to link the notification straight to
+      # that post. Post.find_by excludes trashed posts via the default
+      # scope; the guardian check additionally drops posts the user
+      # can't see (e.g. moved to a hidden category).
+      if post_id
+        post = Post.find_by(id: post_id)
+        if post && Guardian.new(User.find_by(id: user_id)).can_see?(post)
+          data[:post_id] = post.id
+          data[:post_number] = post.post_number
+          data[:topic_id] = post.topic_id
+          data[:topic_title] = post.topic&.title
+        end
+      end
+
       Notification.create!(
         user_id: user_id,
         notification_type: Notification.types[:granted_badge],
-        data: {
-          badge_id: badge.id,
-          badge_name: badge.display_name,
-          badge_slug: badge.slug,
-          badge_title: badge.allow_title,
-          username: username,
-        }.to_json,
+        data: data.to_json,
       )
     end
   end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3476,6 +3476,7 @@ en:
       moved_post: "<span>%{username}</span> moved %{description}"
       linked: "<span>%{username}</span> %{description}"
       granted_badge: "Earned '%{description}'"
+      granted_badge_for_post: "Earned '%{description}' for your post in %{topic}"
       topic_reminder: "<span>%{username}</span> %{description}"
       watching_first_post: "<span>New Topic</span> %{description}"
       membership_request_accepted: "Membership accepted in '%{group_name}'"

--- a/frontend/discourse/app/lib/notification-types/granted-badge.js
+++ b/frontend/discourse/app/lib/notification-types/granted-badge.js
@@ -4,6 +4,14 @@ import { i18n } from "discourse-i18n";
 
 export default class extends NotificationTypeBase {
   get linkHref() {
+    // When the badge was granted for a specific post, link straight to
+    // that post so the user can see what earned it. Otherwise fall back
+    // to the badge page.
+    const { topic_id, post_number } = this.notification.data;
+    if (topic_id && post_number) {
+      return getURL(`/t/${topic_id}/${post_number}`);
+    }
+
     const badgeId = this.notification.data.badge_id;
     if (badgeId) {
       let slug = this.notification.data.badge_slug;
@@ -21,6 +29,14 @@ export default class extends NotificationTypeBase {
   }
 
   get description() {
+    const topicTitle = this.notification.data.topic_title;
+    if (topicTitle) {
+      return i18n("notifications.granted_badge_for_post", {
+        description: this.notification.data.badge_name,
+        topic: topicTitle,
+      });
+    }
+
     return i18n("notifications.granted_badge", {
       description: this.notification.data.badge_name,
     });

--- a/frontend/discourse/tests/unit/lib/notification-types/granted-badge-test.js
+++ b/frontend/discourse/tests/unit/lib/notification-types/granted-badge-test.js
@@ -58,4 +58,39 @@ module("Unit | Notification Types | granted-badge", function (hooks) {
       "contains the right content"
     );
   });
+
+  test("linkHref points at the post when the badge was granted for one", function (assert) {
+    const notification = getNotification({
+      data: { topic_id: 123, post_number: 4 },
+    });
+    const director = createRenderDirector(
+      notification,
+      "granted_badge",
+      this.siteSettings
+    );
+    assert.strictEqual(
+      director.linkHref,
+      "/t/123/4",
+      "links to the post that earned the badge"
+    );
+  });
+
+  test("description names the topic when the badge was granted for a post", function (assert) {
+    const notification = getNotification({
+      data: { topic_id: 123, post_number: 4, topic_title: "A great topic" },
+    });
+    const director = createRenderDirector(
+      notification,
+      "granted_badge",
+      this.siteSettings
+    );
+    assert.strictEqual(
+      director.description,
+      i18n("notifications.granted_badge_for_post", {
+        description: "Badge 15",
+        topic: "A great topic",
+      }),
+      "includes the topic title"
+    );
+  });
 });

--- a/spec/services/badge_granter_spec.rb
+++ b/spec/services/badge_granter_spec.rb
@@ -475,6 +475,51 @@ RSpec.describe BadgeGranter do
       BadgeGranter.grant(badge, nil)
       expect(badge.reload.grant_count).to eq(0)
     end
+
+    context "when the badge was granted for a specific post" do
+      let(:multi_badge) { Fabricate(:badge, multiple_grant: true) }
+      fab!(:topic)
+      fab!(:post) { Fabricate(:post, topic: topic, user: user) }
+
+      it "includes post and topic context in the notification" do
+        BadgeGranter.grant(multi_badge, user, post_id: post.id)
+
+        data =
+          user
+            .notifications
+            .find_by(notification_type: Notification.types[:granted_badge])
+            .data_hash
+        expect(data["post_id"]).to eq(post.id)
+        expect(data["post_number"]).to eq(post.post_number)
+        expect(data["topic_id"]).to eq(topic.id)
+        expect(data["topic_title"]).to eq(topic.title)
+      end
+
+      it "omits post context for a non-post badge grant" do
+        BadgeGranter.grant(badge, user)
+
+        data =
+          user
+            .notifications
+            .find_by(notification_type: Notification.types[:granted_badge])
+            .data_hash
+        expect(data).not_to have_key("post_id")
+        expect(data).not_to have_key("topic_id")
+      end
+
+      it "omits post context when the post is no longer visible to the user" do
+        post.trash!
+
+        BadgeGranter.grant(multi_badge, user, post_id: post.id)
+
+        data =
+          user
+            .notifications
+            .find_by(notification_type: Notification.types[:granted_badge])
+            .data_hash
+        expect(data).not_to have_key("post_id")
+      end
+    end
   end
 
   describe "revoke" do


### PR DESCRIPTION
Per-post badges (Thank You, Nice Reply, etc.) record the triggering post in user_badges.post_id, but the granted-badge notification never carried it, so the notification only linked to the generic badge page.

Now when a badge was granted for a specific post, the notification includes post_id / post_number / topic_id / topic_title in its data, links straight to that post, and reads "Earned 'X' for your post in <topic>". Non-post badges are unchanged (still link to the badge page, same description).

- BadgeGranter.send_notification takes an optional post_id: and, when present and the post is visible to the recipient (Post.find_by skips trashed; a guardian check drops hidden-category posts), denormalizes the post/topic refs into the notification data.
- Single-grant path passes user_badge.post_id.
- Backfill path: the insert already wrote post_id; added it to the CTE RETURNING + outer SELECT so the per-row send_notification can pass row.post_id.
- granted-badge notification type: linkHref goes to the post when topic_id + post_number are present, else the badge page; description uses the new granted_badge_for_post string when a topic_title is present.

Specs: BadgeGranter includes post context on a post-grant, omits it for non-post badges, and omits it when the post isn't visible. JS: linkHref and description for the with-post case.

Note: the backfill path now does a Post + User lookup per granted post-badge for the guardian check. Acceptable for correctness; can be batched later if backfill volume makes it a concern.