### PR TITLE
UX: improve data explorer SQL editor for small screens

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -149,7 +149,6 @@ export default class QueriesEdit extends Component {
                     dragMove=@controller.dragMove
                   }}
                 >
-                  {{dIcon "discourse-expand"}}
                 </div>
 
                 <div class="clear"></div>

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
@@ -321,18 +321,16 @@ export default class PluginsExplorerController extends Controller {
 
   @bind
   dragMove(e) {
-    if (!e.movementY && !e.movementX) {
+    if (!e.movementX) {
       return;
     }
 
     const editPane = document.querySelector(".query-editor");
     const target = editPane.querySelector(".panels-flex");
-    const grippie = editPane.querySelector(".grippie");
 
     // we need to get the initial height / width of edit pane
     // before we manipulate the size
     if (!this.initialPaneWidth && !this.originalPaneHeight) {
-      this.originalPaneWidth = target.clientWidth;
       this.originalPaneHeight = target.clientHeight;
     }
 
@@ -340,14 +338,9 @@ export default class PluginsExplorerController extends Controller {
       this.originalPaneHeight,
       target.clientHeight + e.movementY
     );
-    const newWidth = Math.max(
-      this.originalPaneWidth,
-      target.clientWidth + e.movementX
-    );
 
     target.style.height = newHeight + "px";
-    target.style.width = newWidth + "px";
-    grippie.style.width = newWidth + "px";
+
     this.appEvents.trigger("ace:resize");
   }
 

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -179,8 +179,6 @@ table.group-reports {
         border-bottom: 1px solid var(--primary-low);
 
         @include viewport.until(sm) {
-          position: sticky;
-          top: 0;
           border-top: 1px solid var(--primary-low);
         }
 

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -119,6 +119,8 @@ table.group-reports {
     flex: 1 0 50%;
 
     .ace-wrapper {
+      --min-height: unset;
+      min-height: var(--min-height);
       position: relative;
       height: 100%;
       width: 100%;
@@ -126,7 +128,7 @@ table.group-reports {
       border: none;
 
       @include viewport.until(sm) {
-        min-height: 300px;
+        --min-height: 300px;
       }
     }
 
@@ -140,12 +142,13 @@ table.group-reports {
   }
 
   .right-panel {
+    --width: 345px;
     flex-shrink: 0;
     flex-grow: 0;
-    width: 345px;
+    width: var(--width);
 
     @include viewport.until(sm) {
-      width: 100%;
+      --width: 100%;
     }
 
     .schema {
@@ -291,17 +294,10 @@ table.group-reports {
 
   .grippie {
     cursor: nwse-resize;
-    clear: both;
-    font-size: $font-down-2;
+    padding-bottom: var(--space-2);
     user-select: none;
     color: var(--primary);
     text-align: right;
-    background: var(--primary-very-low);
-    border: 1px solid var(--primary-very-low);
-
-    .d-icon {
-      transform: rotate(90deg);
-    }
   }
 }
 

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -105,16 +105,29 @@ table.group-reports {
   .panels-flex {
     display: flex;
     height: 400px;
-    border: 1px solid var(--primary-very-low);
+    border: 1px solid var(--primary-400);
+    border-radius: var(--d-border-radius);
+    overflow: hidden;
+
+    @include viewport.until(sm) {
+      flex-direction: column;
+      height: auto;
+    }
   }
 
   .editor-panel {
-    flex-grow: 1;
+    flex: 1 0 50%;
 
     .ace-wrapper {
       position: relative;
       height: 100%;
       width: 100%;
+      box-sizing: border-box;
+      border: none;
+
+      @include viewport.until(sm) {
+        min-height: 300px;
+      }
     }
 
     .ace_editor {
@@ -131,14 +144,28 @@ table.group-reports {
     flex-grow: 0;
     width: 345px;
 
+    @include viewport.until(sm) {
+      width: 100%;
+    }
+
     .schema {
-      border-left: 1px solid var(--primary-low);
       height: 100%;
       overflow-y: scroll;
       overflow-x: hidden;
       color: var(--primary-high);
       font-size: var(--font-down-1);
       position: relative;
+
+      @include viewport.until(sm) {
+        .schema-container {
+          height: 200px;
+          overflow: auto;
+        }
+      }
+
+      @include viewport.from(sm) {
+        border-left: 1px solid var(--primary-low);
+      }
 
       .schema-search {
         padding: 0.5em;
@@ -149,7 +176,13 @@ table.group-reports {
         display: flex;
         align-items: center;
         gap: 0.4em;
-        border-bottom: 1px solid var(--primary-very-low);
+        border-bottom: 1px solid var(--primary-low);
+
+        @include viewport.until(sm) {
+          position: sticky;
+          top: 0;
+          border-top: 1px solid var(--primary-low);
+        }
 
         .schema-search__icon {
           color: var(--primary-medium);


### PR DESCRIPTION
Making this layout a little more flexible, currently on mobile the table reference forces the editor to be too narrow to use... now it will stack 

before
<img width="320"  alt="image" src="https://github.com/user-attachments/assets/51f5e88c-3bcc-4564-a0ff-f24e3f29091f" />


after
<img width="320"  alt="image" src="https://github.com/user-attachments/assets/b7e8f4e2-5575-44de-8b92-5ad763fec234" />


before
<img width="800" alt="image" src="https://github.com/user-attachments/assets/0e819994-50b6-47c8-888d-1e33e96c4056" />



after
<img width="800" alt="image" src="https://github.com/user-attachments/assets/477d8ec6-596d-4716-a5c8-7dc8e3adc719" />
