### PR TITLE
FIX: Apply embed `class_name` to `<html>` in full app mode

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -95,7 +95,9 @@ class EmbedController < ApplicationController
     if SiteSetting.embed_full_app && params[:full_app].present? && topic_id
       topic = Topic.find_by(id: topic_id)
       raise Discourse::NotFound if topic.blank? || !guardian.can_see?(topic)
-      redirect_to "#{topic.url}?embed_mode=true"
+      query = { embed_mode: true }
+      query[:class_name] = params[:class_name] if params[:class_name].present?
+      redirect_to "#{topic.url}?#{query.to_query}"
       return
     end
 

--- a/app/controllers/nested_topics_controller.rb
+++ b/app/controllers/nested_topics_controller.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class NestedTopicsController < ApplicationController
+  include EmbedModeHandler
+
   skip_before_action :check_xhr, only: %i[show context]
 
   before_action :ensure_nested_replies_enabled
   before_action :find_topic_with_topic_view, only: %i[show children context]
   before_action :find_topic, only: %i[pin toggle activity]
   before_action :ensure_not_pm
+  before_action :set_embed_class, only: %i[show context]
   after_action :track_visit, only: %i[show context]
+  after_action :allow_embed_mode, only: %i[show context]
 
   # GET /n/:slug/:topic_id (HTML + JSON)
   # HTML: preloads initial data into the Ember shell (crawlers redirect to flat view)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -34,6 +34,7 @@ class TopicsController < ApplicationController
                  ]
 
   before_action :consider_user_for_promotion, only: :show
+  before_action :set_embed_class, only: :show
   after_action :allow_embed_mode, only: :show
 
   skip_before_action :check_xhr, only: %i[show feed]
@@ -1388,11 +1389,24 @@ class TopicsController < ApplicationController
   end
 
   def allow_embed_mode
-    return if params[:embed_mode].blank?
-    return unless SiteSetting.embed_full_app
-    return unless SiteSetting.embed_any_origin? || EmbeddableHost.record_for_url(request.referer)
+    response.headers.delete("X-Frame-Options") if embed_mode_allowed?
+  end
 
-    response.headers.delete("X-Frame-Options")
+  # Applies the `class_name` passed by the embedding page (see EmbedController)
+  # to the `<html>` element of the full app, mirroring classic embed mode.
+  def set_embed_class
+    return unless embed_mode_allowed?
+    return if params[:class_name].blank?
+    return unless params[:class_name].match?(/\A[a-zA-Z0-9\-_ ]+\z/)
+
+    @embed_class = params[:class_name]
+  end
+
+  def embed_mode_allowed?
+    return false if params[:embed_mode].blank?
+    return false unless SiteSetting.embed_full_app
+
+    SiteSetting.embed_any_origin? || EmbeddableHost.record_for_url(request.referer).present?
   end
 
   def topic_params

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TopicsController < ApplicationController
+  include EmbedModeHandler
+
   requires_login only: %i[
                    timings
                    destroy_timings
@@ -199,7 +201,11 @@ class TopicsController < ApplicationController
       url = +"/n/#{@topic_view.topic.slug}/#{@topic_view.topic.id}"
       post_number = opts[:post_number].to_i
       url << "/#{post_number}" if post_number > 0
-      url << "?embed_mode=true" if params[:embed_mode] == "true"
+      if params[:embed_mode] == "true"
+        embed_query = { embed_mode: true }
+        embed_query[:class_name] = params[:class_name] if params[:class_name].present?
+        url << "?#{embed_query.to_query}"
+      end
       redirect_to url, status: :found
       return
     end
@@ -1386,27 +1392,6 @@ class TopicsController < ApplicationController
       else
         topic.tags.pluck(:name)
       end
-  end
-
-  def allow_embed_mode
-    response.headers.delete("X-Frame-Options") if embed_mode_allowed?
-  end
-
-  # Applies the `class_name` passed by the embedding page (see EmbedController)
-  # to the `<html>` element of the full app, mirroring classic embed mode.
-  def set_embed_class
-    return unless embed_mode_allowed?
-    return if params[:class_name].blank?
-    return unless params[:class_name].match?(/\A[a-zA-Z0-9\-_ ]+\z/)
-
-    @embed_class = params[:class_name]
-  end
-
-  def embed_mode_allowed?
-    return false if params[:embed_mode].blank?
-    return false unless SiteSetting.embed_full_app
-
-    SiteSetting.embed_any_origin? || EmbeddableHost.record_for_url(request.referer).present?
   end
 
   def topic_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -199,6 +199,7 @@ module ApplicationHelper
     list << "rtl" if rtl?
     list << text_size_class
     list << "anon" unless current_user
+    list << @embed_class if @embed_class.present?
     list.join(" ")
   end
 

--- a/lib/embed_mode_handler.rb
+++ b/lib/embed_mode_handler.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Shared embed-mode handling for controllers that render the full app inside an
+# embedding iframe (see EmbedController). Including controllers are expected to
+# register the filters with the appropriate actions, e.g.:
+#
+#   before_action :set_embed_class, only: :show
+#   after_action :allow_embed_mode, only: :show
+module EmbedModeHandler
+  # Drops X-Frame-Options so the page can be framed by an allowed embedding host.
+  def allow_embed_mode
+    response.headers.delete("X-Frame-Options") if embed_mode_allowed?
+  end
+
+  # Applies the `class_name` passed by the embedding page to the `<html>`
+  # element of the full app (via `html_classes`), mirroring classic embed mode.
+  def set_embed_class
+    return unless embed_mode_allowed?
+    return if params[:class_name].blank?
+    return unless params[:class_name].match?(/\A[a-zA-Z0-9\-_ ]+\z/)
+
+    @embed_class = params[:class_name]
+  end
+
+  def embed_mode_allowed?
+    return @embed_mode_allowed if defined?(@embed_mode_allowed)
+
+    @embed_mode_allowed =
+      if params[:embed_mode].blank? || !SiteSetting.embed_full_app
+        false
+      else
+        SiteSetting.embed_any_origin? || EmbeddableHost.record_for_url(request.referer).present?
+      end
+  end
+end

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -219,6 +219,20 @@ RSpec.describe EmbedController do
         expect(response).to redirect_to("#{topic.url}?embed_mode=true")
       end
 
+      it "forwards class_name to the topic URL" do
+        get "/embed/comments",
+            params: {
+              topic_id: topic.id,
+              full_app: "true",
+              class_name: "lee-af",
+            },
+            headers: {
+              "REFERER" => "http://eviltrout.com/some-page",
+            }
+
+        expect(response).to redirect_to("#{topic.url}?class_name=lee-af&embed_mode=true")
+      end
+
       it "redirects blank-slug topics to a slugless URL" do
         topic_embed = Fabricate(:topic_embed, embed_url: embed_url)
         topic_embed.topic.update_columns(title: "", slug: nil)

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -1495,4 +1495,26 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(actions.map { |a| a["action_code"] }).to include("assigned")
     end
   end
+
+  describe "embed mode" do
+    before { SiteSetting.embed_full_app = true }
+
+    it "applies class_name to the html element when embed_mode is allowed" do
+      SiteSetting.embed_any_origin = true
+      get("/n/#{topic.slug}/#{topic.id}", params: { embed_mode: "true", class_name: "lee-af" })
+      expect(response.body).to match(/<html[^>]*\bclass="[^"]*\blee-af\b/)
+    end
+
+    it "strips X-Frame-Options when embed_mode is allowed" do
+      SiteSetting.embed_any_origin = true
+      get("/n/#{topic.slug}/#{topic.id}", params: { embed_mode: "true" })
+      expect(response.headers).not_to include("X-Frame-Options")
+    end
+
+    it "ignores class_name when embed_mode is not allowed" do
+      get("/n/#{topic.slug}/#{topic.id}", params: { class_name: "lee-af" })
+      expect(response.body).not_to match(/<html[^>]*\blee-af\b/)
+      expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
+    end
+  end
 end

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3257,6 +3257,17 @@ RSpec.describe TopicsController do
       expect(response).to redirect_to("/n/#{topic.slug}/#{topic.id}?embed_mode=true")
     end
 
+    it "preserves class_name alongside embed_mode when redirecting to nested view" do
+      SiteSetting.nested_replies_enabled = true
+      SiteSetting.nested_replies_default = true
+
+      get "/t/#{topic.slug}/#{topic.id}", params: { embed_mode: "true", class_name: "lee-af" }
+
+      expect(response).to redirect_to(
+        "/n/#{topic.slug}/#{topic.id}?class_name=lee-af&embed_mode=true",
+      )
+    end
+
     it "returns 404 when an invalid slug is given and no id" do
       get "/t/nope-nope.json"
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7625,6 +7625,29 @@ RSpec.describe TopicsController do
       )
       expect(response.headers["X-Frame-Options"]).to eq("SAMEORIGIN")
     end
+
+    it "applies class_name to the html element when embed_mode is allowed" do
+      SiteSetting.embed_any_origin = true
+      get("/t/#{topic.slug}/#{topic.id}", params: { embed_mode: "true", class_name: "lee-af" })
+      expect(response.body).to match(/<html[^>]*\bclass="[^"]*\blee-af\b/)
+    end
+
+    it "ignores class_name when embed_mode is not allowed" do
+      get("/t/#{topic.slug}/#{topic.id}", params: { class_name: "lee-af" })
+      expect(response.body).not_to match(/<html[^>]*\blee-af\b/)
+    end
+
+    it "ignores class_name with invalid characters" do
+      SiteSetting.embed_any_origin = true
+      get(
+        "/t/#{topic.slug}/#{topic.id}",
+        params: {
+          embed_mode: "true",
+          class_name: "lee\" onload=alert(1)",
+        },
+      )
+      expect(response.body).not_to include("onload=alert(1)")
+    end
   end
 
   describe "third-party analytics in embed mode" do


### PR DESCRIPTION
Previously, the `className` passed via `DiscourseEmbed` was applied to the iframe document's `<html>` element in classic embed mode but silently ignored in full app mode — the param was dropped during the `/embed/comments` redirect and the full app's layout never applied it.

This change forwards `class_name` through the redirect and applies it to `html_classes` when embed mode is allowed, validated against `/\A[a-zA-Z0-9\-_ ]+\z/` to prevent attribute injection, matching classic embed behaviour.