### PR TITLE
UX: calendar day hover should cover whole container

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
@@ -52,12 +52,6 @@
 }
 
 .fc-daygrid-day-frame {
-  cursor: pointer;
-
-  &:hover {
-    background-color: var(--tertiary-50);
-  }
-
   .fc-daygrid-day-top {
     justify-content: center;
 
@@ -65,6 +59,14 @@
       font-size: var(--font-down-2);
       color: var(--primary);
     }
+  }
+}
+
+.fc-daygrid-day {
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--tertiary-50);
   }
 }
 


### PR DESCRIPTION
Minor fix following 28baea9 so that when hovering a day on the calendar the entire background highlights 


Before:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/095e7c88-a4d9-4e50-a289-3f394001c555" />



After:
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/c353ffe5-569d-4dd6-b1e9-e2d433ac894b" />
