### PR TITLE
PERF: Avoid scanning the Redis keyspace in `Report.clear_cache`

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -204,6 +204,7 @@ class Report
     [
       "reports",
       report.type,
+      cache_version(report.type),
       report.start_date.to_date.strftime("%Y%m%d"),
       report.end_date.to_date.strftime("%Y%m%d"),
       report.facets,
@@ -213,6 +214,12 @@ class Report
       guardian&.user&.id || report.current_user&.id,
       guardian&.can_see_ip?,
     ].compact.map(&:to_s).join(":")
+  end
+
+  def self.cache_version(type)
+    Discourse
+      .cache
+      .fetch("reports:cache_version:#{type}", expires_in: 1.day) { SecureRandom.hex(4) }
   end
 
   def add_filter(name, options = {})
@@ -238,10 +245,8 @@ class Report
     [category_id, include_subcategories]
   end
 
-  def self.clear_cache(type = nil)
-    pattern = type ? "reports:#{type}:*" : "reports:*"
-
-    Discourse.cache.keys(pattern).each { |key| Discourse.cache.redis.del(key) }
+  def self.clear_cache(type)
+    Discourse.cache.delete("reports:cache_version:#{type}")
   end
 
   def self.wrap_slow_query(timeout = 20_000)

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Report do
 
     describe "topics" do
       before do
-        Report.clear_cache
+        Report.clear_cache("topics")
         freeze_time_safe
         user = Fabricate(:user)
         topics =
@@ -1846,6 +1846,28 @@ RSpec.describe Report do
         .expects(:write)
         .with(Report.cache_key(valid_report), valid_report.as_json, expires_in: 35.minutes)
       Report.cache(valid_report)
+    end
+  end
+
+  describe ".clear_cache" do
+    let(:report) { Report.find("valid_test", wrap_exceptions_in_test: true) }
+    let(:other_report) { Report.find("other_valid_test", wrap_exceptions_in_test: true) }
+
+    before(:each) do
+      Report.stubs(:report_valid_test)
+      Report.stubs(:report_other_valid_test)
+    end
+
+    it "rotates the cache key for the given type so existing entries become unreachable" do
+      key_before = Report.cache_key(report)
+      Report.clear_cache("valid_test")
+      expect(Report.cache_key(report)).not_to eq(key_before)
+    end
+
+    it "does not rotate the cache key for unrelated types" do
+      other_key_before = Report.cache_key(other_report)
+      Report.clear_cache("valid_test")
+      expect(Report.cache_key(other_report)).to eq(other_key_before)
     end
   end
 


### PR DESCRIPTION
`Report.clear_cache` enumerated every key in Redis on each call to find entries matching `reports:*` or `reports:<type>:*`. Scanning the full keyspace is inherently unsafe on large multisite clusters and can overload Redis.

This commit introduces a per-type version key (`reports:cache_version:<type>`) holding a short random hex that is embedded in every report's `cache_key`. `Report.clear_cache(type)` deletes that pointer with a single `Discourse.cache.delete`. The next read regenerates a fresh hex, every subsequent `cache_key` derives from the new value, and all previously-written entries become unreachable. Those orphaned entries age out via the report's existing 35-minute TTL.

The no-arg form of `Report.clear_cache` is removed.