### PR TITLE
FIX: Skip incomplete `BrowserPageviewEvent` payloads

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -33,6 +33,7 @@ class Middleware::RequestTracker
   MAX_SESSION_ID_LENGTH = 32
   MAX_USER_AGENT_LENGTH = 1000
   MAX_IP_ADDRESS_LENGTH = 45
+  REQUIRED_BROWSER_PAGEVIEW_EVENT_FIELDS = %i[url ip_address user_agent session_id]
 
   # register callbacks for detailed request loggers called on every request
   # example:
@@ -721,6 +722,11 @@ class Middleware::RequestTracker
   private_class_method :trigger_browser_pageview_event
 
   def self.persist_browser_pageview_event(payload)
+    if REQUIRED_BROWSER_PAGEVIEW_EVENT_FIELDS.any? { |key| payload[key].blank? }
+      Rails.logger.debug("Discarding BrowserPageviewEvent: incomplete payload")
+      return
+    end
+
     Scheduler::Defer.later "Create BrowserPageviewEvent" do
       BrowserPageviewEvent.create!(
         url: payload[:url],

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -938,6 +938,25 @@ RSpec.describe Middleware::RequestTracker do
           expect(event.ip_address.to_s).to eq("1.2.3.4")
         end
 
+        it "skips persisted browser pageviews without a URL" do
+          session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
+
+          data =
+            Middleware::RequestTracker.get_data(
+              env(
+                "HTTP_DISCOURSE_TRACK_VIEW_DEFERRED" => "1",
+                "HTTP_DISCOURSE_TRACK_VIEW_SESSION_ID" => session_id,
+                "action_dispatch.remote_ip" => "1.2.3.4",
+              ),
+              ["204", {}],
+              0.2,
+            )
+
+          expect { Middleware::RequestTracker.log_request(data) }.not_to change {
+            BrowserPageviewEvent.count
+          }
+        end
+
         it "populates normalized_referrer via BrowserPageviewReferrerInspector" do
           session_id = "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx"
 


### PR DESCRIPTION
Persisted browser pageview events require a URL, IP address, user agent, and session ID. Stale deferred pageview requests can omit tracking metadata and previously caused PostgreSQL not-null violations in the deferred job.

This change discards incomplete payloads before scheduling the insert and adds regression coverage for deferred pageviews without URLs.