### PR TITLE
FIX: Exclude direct visits from top referrers percent denominator

### DIFF
--- a/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
@@ -26,10 +26,6 @@ module Reports::TopReferrersByBrowserPageviews
       host = BrowserPageviewReferrerInspector.normalize_host(Discourse.current_hostname)
       escaped_host = host.gsub(/[\\_%]/) { |char| "\\#{char}" }
 
-      # The percent denominator (total) counts referred traffic only: direct
-      # visits (NULL referrer) and self-referrals are excluded so each percent
-      # reads as a referrer's share of external traffic rather than of all
-      # pageviews.
       sql = <<~SQL
         WITH ranked AS (
           SELECT

--- a/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
@@ -26,6 +26,10 @@ module Reports::TopReferrersByBrowserPageviews
       host = BrowserPageviewReferrerInspector.normalize_host(Discourse.current_hostname)
       escaped_host = host.gsub(/[\\_%]/) { |char| "\\#{char}" }
 
+      # The percent denominator (total) counts referred traffic only: direct
+      # visits (NULL referrer) and self-referrals are excluded so each percent
+      # reads as a referrer's share of external traffic rather than of all
+      # pageviews.
       sql = <<~SQL
         WITH ranked AS (
           SELECT
@@ -35,14 +39,10 @@ module Reports::TopReferrersByBrowserPageviews
           FROM browser_pageview_referrer_daily_rollups
           WHERE date >= :start_date
             AND date < :end_date_exclusive
-            AND (
-              normalized_referrer IS NULL
-              OR (
-                normalized_referrer <> :host_exact
-                AND normalized_referrer NOT LIKE :host_path_prefix ESCAPE '\\'
-                AND normalized_referrer NOT LIKE :host_query_prefix ESCAPE '\\'
-              )
-            )
+            AND normalized_referrer IS NOT NULL
+            AND normalized_referrer <> :host_exact
+            AND normalized_referrer NOT LIKE :host_path_prefix ESCAPE '\\'
+            AND normalized_referrer NOT LIKE :host_query_prefix ESCAPE '\\'
           GROUP BY normalized_referrer
           HAVING SUM(#{count_expr}) > 0
         )
@@ -50,7 +50,6 @@ module Reports::TopReferrersByBrowserPageviews
                CASE WHEN total = 0 THEN 0
                     ELSE ROUND((count::numeric / total) * 100)::integer END AS percent
         FROM ranked
-        WHERE normalized_referrer IS NOT NULL
         ORDER BY count DESC, normalized_referrer ASC
         LIMIT :limit
       SQL

--- a/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
@@ -114,8 +114,6 @@ describe Reports::TopReferrersByBrowserPageviews do
       expect(limited.data.map { |row| row[:normalized_referrer] }).to eq(
         %w[a.example.com b.example.com],
       )
-      # Denominator is all 10 external pageviews (a + b + c), not just the 8
-      # shown, so the hidden c.example.com still dilutes the percentages.
       expect(limited.data.map { |row| row[:percent] }).to eq([50, 30])
     end
   end

--- a/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
@@ -13,7 +13,7 @@ describe Reports::TopReferrersByBrowserPageviews do
       Report.find("top_referrers_by_browser_pageviews", start_date: start_date, end_date: end_date)
     end
 
-    it "ranks referrers by event count and computes percent of total browser pageviews" do
+    it "ranks referrers by event count and computes each percent as a share of referred pageviews" do
       3.times do
         Fabricate(:browser_pageview_event, normalized_referrer: "news.ycombinator.com/item?id=1")
       end
@@ -23,16 +23,16 @@ describe Reports::TopReferrersByBrowserPageviews do
       expect(data.map { |row| row[:normalized_referrer] }).to eq(
         %w[news.ycombinator.com/item?id=1 reddit.com/r/discourse],
       )
-      expect(data.first[:percent]).to eq(75)
+      expect(data.map { |row| row[:percent] }).to eq([75, 25])
     end
 
-    it "excludes NULL normalized_referrer from numerator but includes in denominator" do
+    it "excludes direct (no-referrer) pageviews from both numerator and percent denominator" do
       2.times { Fabricate(:browser_pageview_event, normalized_referrer: "google.com") }
       2.times { Fabricate(:browser_pageview_event, normalized_referrer: nil) }
 
       data = report.data
       expect(data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
-      expect(data.first[:percent]).to eq(50)
+      expect(data.first[:percent]).to eq(100)
     end
 
     it "excludes same-host bare, path-prefixed, and query-prefixed referrers from numerator and denominator" do
@@ -44,16 +44,6 @@ describe Reports::TopReferrersByBrowserPageviews do
       data = report.data
       expect(data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
       expect(data.first[:percent]).to eq(100)
-    end
-
-    it "includes direct (no-referrer) pageviews in the denominator alongside external referrers" do
-      2.times { Fabricate(:browser_pageview_event, normalized_referrer: "google.com") }
-      2.times { Fabricate(:browser_pageview_event, normalized_referrer: nil) }
-      Fabricate(:browser_pageview_event, normalized_referrer: "forum.example.com/t/topic/1")
-
-      data = report.data
-      expect(data.map { |row| row[:normalized_referrer] }).to eq(["google.com"])
-      expect(data.first[:percent]).to eq(50)
     end
 
     it "does not exclude hosts that merely share a prefix with current_hostname" do
@@ -106,12 +96,10 @@ describe Reports::TopReferrersByBrowserPageviews do
       expect(report.data).to eq([])
     end
 
-    it "respects the limit opt" do
-      6.times do |i|
-        (i + 1).times do
-          Fabricate(:browser_pageview_event, normalized_referrer: "site-#{i}.example.com")
-        end
-      end
+    it "limits displayed rows but keeps every external referrer in the percent denominator" do
+      5.times { Fabricate(:browser_pageview_event, normalized_referrer: "a.example.com") }
+      3.times { Fabricate(:browser_pageview_event, normalized_referrer: "b.example.com") }
+      2.times { Fabricate(:browser_pageview_event, normalized_referrer: "c.example.com") }
 
       BrowserPageviewReferrerDailyRollup.aggregate(start_date: start_date, end_date: end_date)
       BrowserPageviewEvent.delete_all
@@ -120,9 +108,15 @@ describe Reports::TopReferrersByBrowserPageviews do
           "top_referrers_by_browser_pageviews",
           start_date: start_date,
           end_date: end_date,
-          limit: 3,
+          limit: 2,
         )
-      expect(limited.data.size).to eq(3)
+
+      expect(limited.data.map { |row| row[:normalized_referrer] }).to eq(
+        %w[a.example.com b.example.com],
+      )
+      # Denominator is all 10 external pageviews (a + b + c), not just the 8
+      # shown, so the hidden c.example.com still dilutes the percentages.
+      expect(limited.data.map { |row| row[:percent] }).to eq([50, 30])
     end
   end
 end

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -184,8 +184,8 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
         normalized_referrer: nil,
         created_at: "2026-05-12",
       )
-      # Internal-referrer pageviews must not dilute the top referrers percent
-      # denominator (it covers direct + external referrer traffic only).
+      # Internal-referrer and direct (no-referrer) pageviews must not dilute the
+      # top referrers percent denominator (it counts external referrer traffic only).
       6.times do
         Fabricate(
           :browser_pageview_event,
@@ -216,8 +216,8 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
       )
       expect(traffic).to have_top_referrer_rows(
         [
-          { referrer: "news.ycombinator.com/item?id=42", percent: 50 },
-          { referrer: "reddit.com/r/discourse", percent: 25 },
+          { referrer: "news.ycombinator.com/item?id=42", percent: 67 },
+          { referrer: "reddit.com/r/discourse", percent: 33 },
         ],
       )
     end


### PR DESCRIPTION
On the admin dashboard's Top Referrers card, each referrer's percentage was divided by a total that included direct (no-referrer) pageviews. Direct traffic usually dominates, so every external referrer's share came out very small and was hard to compare at a glance.

This commit changes the percent denominator to count external referred pageviews only, so each percentage now reads as a referrer's share of referred traffic. Self-referrals were already excluded and the displayed rows are unchanged. The denominator spans every external referrer in the period rather than just the rows shown, so a referrer's percentage stays stable regardless of the display limit. Follow-up to 9520d10c07, which excluded internal referrers from the same denominator.