### PR TITLE
FIX: Keep full days in browser pageview cleanup

### DIFF
--- a/app/jobs/scheduled/clean_up_browser_pageview_events.rb
+++ b/app/jobs/scheduled/clean_up_browser_pageview_events.rb
@@ -10,7 +10,7 @@ module Jobs
       return if !SiteSetting.clean_up_browser_pageview_events
 
       BrowserPageviewEvent
-        .where("created_at < ?", RETENTION_PERIOD.ago)
+        .where("created_at < ?", RETENTION_PERIOD.ago.beginning_of_day)
         .in_batches(of: 10_000)
         .delete_all
     end

--- a/spec/jobs/clean_up_browser_pageview_events_spec.rb
+++ b/spec/jobs/clean_up_browser_pageview_events_spec.rb
@@ -1,36 +1,40 @@
 # frozen_string_literal: true
 
 RSpec.describe Jobs::CleanUpBrowserPageviewEvents do
-  fab!(:fresh_event) do
-    BrowserPageviewEvent.create!(
-      url: "/t/topic/1",
-      ip_address: "1.2.3.4",
-      user_agent: "Firefox",
-      session_id: "abc",
-      created_at: 1.month.ago,
-    )
-  end
-
-  fab!(:old_event) do
-    BrowserPageviewEvent.create!(
-      url: "/t/topic/2",
-      ip_address: "1.2.3.4",
-      user_agent: "Firefox",
-      session_id: "def",
-      created_at: 4.months.ago,
-    )
-  end
-
   it "does nothing when the site setting is disabled" do
     SiteSetting.clean_up_browser_pageview_events = false
+    Fabricate(:browser_pageview_event, created_at: 4.months.ago)
+    Fabricate(:browser_pageview_event, created_at: 1.month.ago)
 
     expect { described_class.new.execute({}) }.not_to change { BrowserPageviewEvent.count }
   end
 
   it "deletes events older than 3 months and keeps fresher ones" do
     SiteSetting.clean_up_browser_pageview_events = true
+    fresh_event = Fabricate(:browser_pageview_event, created_at: 1.month.ago)
+    Fabricate(:browser_pageview_event, created_at: 4.months.ago)
 
     expect { described_class.new.execute({}) }.to change { BrowserPageviewEvent.count }.by(-1)
     expect(BrowserPageviewEvent.all).to contain_exactly(fresh_event)
+  end
+
+  it "keeps all events on the retention cutoff day" do
+    SiteSetting.clean_up_browser_pageview_events = true
+
+    freeze_time Time.zone.local(2026, 5, 28, 12, 30) do
+      cutoff_day_start = 3.months.ago.beginning_of_day
+      cutoff_day_end = 3.months.ago.end_of_day
+
+      Fabricate(:browser_pageview_event, created_at: cutoff_day_start - 1.second)
+      cutoff_day_first_event = Fabricate(:browser_pageview_event, created_at: cutoff_day_start)
+      cutoff_day_last_event = Fabricate(:browser_pageview_event, created_at: cutoff_day_end)
+
+      described_class.new.execute({})
+
+      expect(BrowserPageviewEvent.all).to contain_exactly(
+        cutoff_day_first_event,
+        cutoff_day_last_event,
+      )
+    end
   end
 end


### PR DESCRIPTION
Browser pageview event cleanup previously used an exact timestamp cutoff, which could delete part of the oldest retained day and leave the rest behind.

This change aligns the retention cutoff to the beginning of the cutoff day, so cleanup only removes complete days.