### PR TITLE
DEV: Fix asset workflow triggers

### DIFF
--- a/.github/workflows/publish-assets.yml
+++ b/.github/workflows/publish-assets.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches:
       - main
-      - stable
       - release/*
-      - precompile-asset-improvements
-    tags:
-      - beta
-      - v*
 
 concurrency:
   group: publish-assets-${{ format('{0}-{1}', github.run_number, github.job) }}
@@ -18,7 +13,7 @@ concurrency:
 jobs:
   publish-assets:
     if: github.repository == 'discourse/discourse'
-    runs-on: 'cdck-linux-8-core'
+    runs-on: "cdck-linux-8-core"
     container: discourse/discourse_test:release
     timeout-minutes: 30
 


### PR DESCRIPTION
We don't want to run multiple times for the same commit hash