### PR TITLE
FEATURE: Drill-down and pagination for top referrers/countries

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -357,7 +357,6 @@ h1 {
   }
 
   &__row-block-title {
-    position: relative;
     color: var(--primary);
     margin-bottom: var(--space-2);
     font-weight: bold;
@@ -369,10 +368,22 @@ h1 {
       margin-inline-start: var(--space-4);
     }
 
-    &:is(a):hover {
+    // The drill-down link is either this element (a bare anchor) or a nested
+    // anchor when the title is wrapped in a heading for screen-reader semantics.
+    &:is(a),
+    a {
+      position: relative;
+      display: inline-block;
       color: var(--primary);
 
-      .db-link-arrow {
+      &:hover,
+      &:focus,
+      &:visited,
+      &:active {
+        color: var(--primary);
+      }
+
+      &:hover .db-link-arrow {
         opacity: 1;
         transform: translateX(0);
       }

--- a/app/models/concerns/reports/top_countries_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_countries_by_browser_pageviews.rb
@@ -4,6 +4,7 @@ module Reports::TopCountriesByBrowserPageviews
   extend ActiveSupport::Concern
 
   EXCLUDED_COUNTRY_CODES = %w[ZZ T1 A1 A2 O1 XX EU AP].freeze
+  MAX_ROWS = 200
 
   class_methods do
     def report_top_countries_by_browser_pageviews(report)
@@ -54,7 +55,7 @@ module Reports::TopCountriesByBrowserPageviews
             start_date: report.start_date,
             end_date_exclusive: end_date_exclusive,
             excluded_codes: EXCLUDED_COUNTRY_CODES,
-            limit: report.limit || 50,
+            limit: MAX_ROWS,
           )
           .map { |row| { country_code: row.country_code, count: row.count, percent: row.percent } }
     end

--- a/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
+++ b/app/models/concerns/reports/top_referrers_by_browser_pageviews.rb
@@ -3,6 +3,8 @@
 module Reports::TopReferrersByBrowserPageviews
   extend ActiveSupport::Concern
 
+  MAX_ROWS = 200
+
   class_methods do
     def report_top_referrers_by_browser_pageviews(report)
       report.modes = [Report::MODES[:table]]
@@ -59,7 +61,7 @@ module Reports::TopReferrersByBrowserPageviews
             host_exact: host,
             host_path_prefix: "#{escaped_host}/%",
             host_query_prefix: "#{escaped_host}?%",
-            limit: report.limit || 50,
+            limit: MAX_ROWS,
           )
           .map do |row|
             { normalized_referrer: row.normalized_referrer, count: row.count, percent: row.percent }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -36,7 +36,13 @@ class Report
     page_view_logged_in_reqs
   ]
 
-  ADMIN_ONLY_REPORTS = %w[admin_logins top_uploads topic_view_stats]
+  ADMIN_ONLY_REPORTS = %w[
+    admin_logins
+    top_uploads
+    topic_view_stats
+    top_referrers_by_browser_pageviews
+    top_countries_by_browser_pageviews
+  ]
   IP_ADDRESS_REPORTS = %w[suspicious_logins]
   BROWSER_PAGEVIEW_REPORTS = %w[
     top_countries_by_browser_pageviews
@@ -45,7 +51,9 @@ class Report
 
   def self.hidden?(type, guardian:)
     return true if !guardian.is_admin? && ADMIN_ONLY_REPORTS.include?(type)
-    return true if BROWSER_PAGEVIEW_REPORTS.include?(type)
+    if BROWSER_PAGEVIEW_REPORTS.include?(type) && !SiteSetting.persist_browser_pageview_events
+      return true
+    end
 
     hidden_reports =
       SiteSetting.use_legacy_pageviews ? HIDDEN_PAGEVIEW_REPORTS : HIDDEN_LEGACY_PAGEVIEW_REPORTS

--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -2,6 +2,7 @@
 
 class AdminDashboardSiteTraffic
   DEFAULT_RANGE_DAYS = 30
+  TOP_CARD_LIMIT = 5
   SERIES_LABEL_REQS = {
     logged_in: "page_view_logged_in_browser",
     anonymous: "page_view_anon_browser",
@@ -9,6 +10,7 @@ class AdminDashboardSiteTraffic
     crawlers: "page_view_crawler",
   }.freeze
   private_constant :DEFAULT_RANGE_DAYS
+  private_constant :TOP_CARD_LIMIT
   private_constant :SERIES_LABEL_REQS
 
   def self.build(start_date:, end_date:)
@@ -56,7 +58,6 @@ class AdminDashboardSiteTraffic
         login_required: SiteSetting.login_required,
         host: Discourse.current_hostname,
       },
-      limit: 5,
       wrap_exceptions_in_test: true,
     }
 
@@ -72,14 +73,14 @@ class AdminDashboardSiteTraffic
 
     return { rows: [], error: report.error.to_s } if report.error.present?
 
-    { rows: report.data, error: nil }
+    { rows: report.data.first(TOP_CARD_LIMIT), error: nil }
   end
 
   def cached_to_payload(cached)
     error = cached[:error]
     return { rows: [], error: error.to_s } if error.present?
 
-    { rows: (cached[:data] || []).map(&:symbolize_keys), error: nil }
+    { rows: (cached[:data] || []).map(&:symbolize_keys).first(TOP_CARD_LIMIT), error: nil }
   end
 
   def series_ids(include_embedded:)

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -294,7 +294,21 @@ export default class DashboardTraffic extends Component {
               <div class="db-section__row">
                 <div class="db-section__row-block">
                   <h3 class="db-section__row-block-title">
-                    {{i18n "admin.dashboard.site_traffic.top_referrers.title"}}
+                    <LinkTo
+                      @route="adminReports.show"
+                      @model="top_referrers_by_browser_pageviews"
+                      @query={{hash
+                        start_date=this.reportQuery.start_date
+                        end_date=this.reportQuery.end_date
+                      }}
+                    >
+                      {{i18n
+                        "admin.dashboard.site_traffic.top_referrers.title"
+                      }}
+                      <span class="db-link-arrow" aria-hidden="true">
+                        {{dIcon "arrow-right"}}
+                      </span>
+                    </LinkTo>
                   </h3>
                   {{#if @traffic.top_referrers.error}}
                     <p class="db-traffic__list-error" role="status">
@@ -336,7 +350,21 @@ export default class DashboardTraffic extends Component {
 
                 <div class="db-section__row-block">
                   <h3 class="db-section__row-block-title">
-                    {{i18n "admin.dashboard.site_traffic.top_countries.title"}}
+                    <LinkTo
+                      @route="adminReports.show"
+                      @model="top_countries_by_browser_pageviews"
+                      @query={{hash
+                        start_date=this.reportQuery.start_date
+                        end_date=this.reportQuery.end_date
+                      }}
+                    >
+                      {{i18n
+                        "admin.dashboard.site_traffic.top_countries.title"
+                      }}
+                      <span class="db-link-arrow" aria-hidden="true">
+                        {{dIcon "arrow-right"}}
+                      </span>
+                    </LinkTo>
                   </h3>
                   {{#if @traffic.top_countries.error}}
                     <p class="db-traffic__list-error" role="status">

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -2220,9 +2220,29 @@ RSpec.describe Report do
       end
     end
 
-    it "always hides browser pageview reports" do
-      Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
-        expect(Report.hidden?(report_type, guardian: admin_guardian)).to eq(true)
+    context "with browser pageview reports" do
+      it "hides them from admins when persist_browser_pageview_events is disabled" do
+        SiteSetting.persist_browser_pageview_events = false
+
+        Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+          expect(Report.hidden?(report_type, guardian: admin_guardian)).to eq(true)
+        end
+      end
+
+      it "exposes them to admins when persist_browser_pageview_events is enabled" do
+        SiteSetting.persist_browser_pageview_events = true
+
+        Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+          expect(Report.hidden?(report_type, guardian: admin_guardian)).to eq(false)
+        end
+      end
+
+      it "always hides them from moderators, even when persist_browser_pageview_events is enabled" do
+        SiteSetting.persist_browser_pageview_events = true
+
+        Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+          expect(Report.hidden?(report_type, guardian: moderator_guardian)).to eq(true)
+        end
       end
     end
   end

--- a/spec/models/reports/top_countries_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_countries_by_browser_pageviews_spec.rb
@@ -65,21 +65,12 @@ describe Reports::TopCountriesByBrowserPageviews do
       expect(report.data.first[:count]).to eq(1)
     end
 
-    it "respects the limit opt" do
-      %w[US GB DE FR JP CN].each_with_index do |code, idx|
-        (idx + 1).times { Fabricate(:browser_pageview_event, country_code: code) }
-      end
+    it "caps results at MAX_ROWS when no explicit limit is given" do
+      stub_const(Reports::TopCountriesByBrowserPageviews, "MAX_ROWS", 2) do
+        %w[US GB DE].each { |code| Fabricate(:browser_pageview_event, country_code: code) }
 
-      BrowserPageviewCountryDailyRollup.aggregate(start_date: start_date, end_date: end_date)
-      BrowserPageviewEvent.delete_all
-      limited =
-        Report.find(
-          "top_countries_by_browser_pageviews",
-          start_date: start_date,
-          end_date: end_date,
-          limit: 3,
-        )
-      expect(limited.data.size).to eq(3)
+        expect(report.data.size).to eq(2)
+      end
     end
   end
 end

--- a/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
+++ b/spec/models/reports/top_referrers_by_browser_pageviews_spec.rb
@@ -96,25 +96,17 @@ describe Reports::TopReferrersByBrowserPageviews do
       expect(report.data).to eq([])
     end
 
-    it "limits displayed rows but keeps every external referrer in the percent denominator" do
-      5.times { Fabricate(:browser_pageview_event, normalized_referrer: "a.example.com") }
-      3.times { Fabricate(:browser_pageview_event, normalized_referrer: "b.example.com") }
-      2.times { Fabricate(:browser_pageview_event, normalized_referrer: "c.example.com") }
+    it "caps displayed rows at MAX_ROWS but keeps every external referrer in the percent denominator" do
+      stub_const(Reports::TopReferrersByBrowserPageviews, "MAX_ROWS", 2) do
+        5.times { Fabricate(:browser_pageview_event, normalized_referrer: "a.example.com") }
+        3.times { Fabricate(:browser_pageview_event, normalized_referrer: "b.example.com") }
+        2.times { Fabricate(:browser_pageview_event, normalized_referrer: "c.example.com") }
 
-      BrowserPageviewReferrerDailyRollup.aggregate(start_date: start_date, end_date: end_date)
-      BrowserPageviewEvent.delete_all
-      limited =
-        Report.find(
-          "top_referrers_by_browser_pageviews",
-          start_date: start_date,
-          end_date: end_date,
-          limit: 2,
+        expect(report.data.map { |row| row[:normalized_referrer] }).to eq(
+          %w[a.example.com b.example.com],
         )
-
-      expect(limited.data.map { |row| row[:normalized_referrer] }).to eq(
-        %w[a.example.com b.example.com],
-      )
-      expect(limited.data.map { |row| row[:percent] }).to eq([50, 30])
+        expect(report.data.map { |row| row[:percent] }).to eq([50, 30])
+      end
     end
   end
 end

--- a/spec/requests/admin/reports_controller_spec.rb
+++ b/spec/requests/admin/reports_controller_spec.rb
@@ -547,5 +547,33 @@ RSpec.describe Admin::ReportsController do
         expect(response.status).to eq(200)
       end
     end
+
+    context "with browser pageview reports" do
+      it "lets an admin run them only when persist_browser_pageview_events is enabled" do
+        sign_in(admin)
+
+        SiteSetting.persist_browser_pageview_events = false
+        Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+          get "/admin/reports/#{report_type}.json"
+          expect(response.status).to eq(404)
+        end
+
+        SiteSetting.persist_browser_pageview_events = true
+        Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+          get "/admin/reports/#{report_type}.json"
+          expect(response.status).to eq(200)
+        end
+      end
+
+      it "denies a moderator even when persist_browser_pageview_events is enabled" do
+        SiteSetting.persist_browser_pageview_events = true
+        sign_in(moderator)
+
+        Report::BROWSER_PAGEVIEW_REPORTS.each do |report_type|
+          get "/admin/reports/#{report_type}.json"
+          expect(response.status).to eq(404)
+        end
+      end
+    end
   end
 end

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -558,6 +558,25 @@ RSpec.describe AdminDashboardSiteTraffic do
         expect(result[:top_referrers][:error]).to be_nil
       end
 
+      it "caps each card at the top 5 rows on both the fresh and cached paths" do
+        %w[US GB DE FR JP CA].each do |code|
+          Fabricate(
+            :browser_pageview_event,
+            country_code: code,
+            normalized_referrer: "#{code.downcase}.example.com",
+          )
+        end
+        aggregate_rollups
+
+        fresh = described_class.build(start_date: nil, end_date: nil)
+        expect(fresh[:top_countries][:rows].size).to eq(5)
+        expect(fresh[:top_referrers][:rows].size).to eq(5)
+
+        cached = described_class.build(start_date: nil, end_date: nil)
+        expect(cached[:top_countries][:rows].size).to eq(5)
+        expect(cached[:top_referrers][:rows].size).to eq(5)
+      end
+
       it "returns empty rows when no events match the date range" do
         result = described_class.build(start_date: nil, end_date: nil)
         expect(result[:top_countries]).to eq(rows: [], error: nil)

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -222,13 +222,51 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
       )
     end
 
-    it "shows an empty state in both cards when no events qualify",
+    it "shows an empty state in both cards but keeps the headers as drill-down links when no events qualify",
        time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
       dashboard.visit
       traffic = dashboard.site_traffic
 
       expect(traffic).to have_top_countries_empty_state
       expect(traffic).to have_top_referrers_empty_state
+      expect(traffic).to have_top_referrers_drilldown
+      expect(traffic).to have_top_countries_drilldown
+    end
+
+    it "drills into the full top referrers report scoped to the dashboard period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      Fabricate(
+        :browser_pageview_event,
+        normalized_referrer: "news.ycombinator.com/item?id=42",
+        created_at: "2026-05-12",
+      )
+      BrowserPageviewReferrerDailyRollup.aggregate(
+        start_date: "2026-05-01".to_date,
+        end_date: "2026-05-14".to_date,
+      )
+
+      dashboard.visit_with_query(range: "custom", start_date: "2026-05-01", end_date: "2026-05-12")
+      dashboard.site_traffic.click_top_referrers_drilldown
+
+      expect(page).to have_current_path(
+        "/admin/reports/top_referrers_by_browser_pageviews?end_date=2026-05-12&start_date=2026-05-01",
+      )
+    end
+
+    it "drills into the full top countries report scoped to the dashboard period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      Fabricate(:browser_pageview_event, country_code: "US", created_at: "2026-05-12")
+      BrowserPageviewCountryDailyRollup.aggregate(
+        start_date: "2026-05-01".to_date,
+        end_date: "2026-05-14".to_date,
+      )
+
+      dashboard.visit_with_query(range: "custom", start_date: "2026-05-01", end_date: "2026-05-12")
+      dashboard.site_traffic.click_top_countries_drilldown
+
+      expect(page).to have_current_path(
+        "/admin/reports/top_countries_by_browser_pageviews?end_date=2026-05-12&start_date=2026-05-01",
+      )
     end
   end
 end

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -108,6 +108,22 @@ module PageObjects
         has_empty_state_in?("Top referrers", "No referrer data for this period.")
       end
 
+      def click_top_referrers_drilldown
+        within_top_card("Top referrers") { find("h3.db-section__row-block-title a").click }
+      end
+
+      def click_top_countries_drilldown
+        within_top_card("Top countries") { find("h3.db-section__row-block-title a").click }
+      end
+
+      def has_top_referrers_drilldown?
+        within_top_card("Top referrers") { has_css?("h3.db-section__row-block-title a") }
+      end
+
+      def has_top_countries_drilldown?
+        within_top_card("Top countries") { has_css?("h3.db-section__row-block-title a") }
+      end
+
       private
 
       def has_no_top_card?(title)


### PR DESCRIPTION
Admins can now drill from the redesigned Site Traffic dashboard into the full Top Referrers and Top Countries reports. The dashboard panels show only the top 5, and the reports themselves were capped at 50 rows, so the long tail of where traffic comes from was hidden.

Key changes:

- **Drill-down on panel headers.** The Top Referrers and Top Countries headers are now links to their full report, scoped to the dashboard's current period.
- **Row cap raised to 200.** `top_referrers_by_browser_pageviews` and `top_countries_by_browser_pageviews` return up to 200 rows instead of 50, matching the existing `web_crawlers` report, and the existing client-side table pagination pages through them.
- **Reports reachable when pageview tracking is on.** The two browser-pageview reports are no longer unconditionally hidden from the reports API.

### Recording

https://github.com/user-attachments/assets/c9b13355-022f-4e80-93e4-9d24d361c75a

