### PR TITLE
FIX: Use bundled quotes for discobot instead of dead external API

### DIFF
--- a/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/quote_generator.rb
+++ b/plugins/discourse-narrative-bot/lib/discourse_narrative_bot/quote_generator.rb
@@ -2,27 +2,15 @@
 
 module DiscourseNarrativeBot
   class QuoteGenerator
-    API_ENDPOINT = "http://api.forismatic.com/api/1.0/"
-
     def self.format_quote(quote, author)
-      I18n.t("discourse_narrative_bot.quote.results", quote: quote, author: author)
+      I18n.t("discourse_narrative_bot.quote.results", quote:, author:)
     end
 
     def self.generate(user)
-      quote, author =
-        if !user.effective_locale.start_with?("en")
-          translation_key = "discourse_narrative_bot.quote.#{rand(1..10)}"
-
-          [I18n.t("#{translation_key}.quote"), I18n.t("#{translation_key}.author")]
-        else
-          connection = Excon.new("#{API_ENDPOINT}?lang=en&format=json&method=getQuote")
-          response = connection.request(expects: [200, 201], method: :Get)
-
-          response_body = JSON.parse(response.body)
-          [response_body["quoteText"].strip, response_body["quoteAuthor"].strip]
-        end
-
-      format_quote(quote, author)
+      I18n.with_locale(user.effective_locale) do
+        quote = I18n.t("discourse_narrative_bot.quote").values.select { |v| v.is_a?(Hash) }.sample
+        format_quote(quote[:quote], quote[:author])
+      end
     end
   end
 end

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/quote_generator_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/quote_generator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseNarrativeBot::QuoteGenerator do
+  fab!(:user)
+
+  def bundled_quotes(locale)
+    I18n.with_locale(locale) do
+      I18n
+        .t("discourse_narrative_bot.quote")
+        .values
+        .select { |v| v.is_a?(Hash) }
+        .map { |q| described_class.format_quote(q[:quote], q[:author]) }
+    end
+  end
+
+  describe ".generate" do
+    it "returns a bundled quote without contacting any external service" do
+      expect(bundled_quotes("en")).to include(described_class.generate(user))
+    end
+
+    it "localizes the quote to the user's effective locale" do
+      SiteSetting.allow_user_locale = true
+      user.update!(locale: "fr")
+
+      expect(bundled_quotes("fr")).to include(described_class.generate(user))
+    end
+  end
+end

--- a/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/track_selector_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/discourse_narrative_bot/track_selector_spec.rb
@@ -15,15 +15,13 @@ RSpec.describe DiscourseNarrativeBot::TrackSelector do
     )
   end
 
+  let(:quote_sample) do
+    DiscourseNarrativeBot::QuoteGenerator.format_quote("Be Like Water", "Bruce Lee")
+  end
+
   before do
     stub_image_size
-    stub_request(
-      :get,
-      "http://api.forismatic.com/api/1.0/?format=json&lang=en&method=getQuote",
-    ).to_return(
-      status: 200,
-      body: "{\"quoteText\":\"Be Like Water\",\"quoteAuthor\":\"Bruce Lee\"}",
-    )
+    DiscourseNarrativeBot::QuoteGenerator.stubs(:generate).returns(quote_sample)
 
     SiteSetting.discourse_narrative_bot_enabled = true
   end
@@ -46,8 +44,7 @@ RSpec.describe DiscourseNarrativeBot::TrackSelector do
         discobot_username: discobot_username,
         dice_trigger: described_class.dice_trigger,
         quote_trigger: described_class.quote_trigger,
-        quote_sample:
-          DiscourseNarrativeBot::QuoteGenerator.format_quote("Be Like Water", "Bruce Lee"),
+        quote_sample:,
         magic_8_ball_trigger: described_class.magic_8_ball_trigger,
       )
     }
@@ -673,13 +670,7 @@ RSpec.describe DiscourseNarrativeBot::TrackSelector do
             described_class.new(:reply, user, post_id: post.id).select
             new_post = Post.last
 
-            expect(new_post.raw).to eq(
-              I18n.t(
-                "discourse_narrative_bot.quote.results",
-                quote: "Be Like Water",
-                author: "Bruce Lee",
-              ),
-            )
+            expect(new_post.raw).to eq(quote_sample)
           end
 
           context "when quote is requested incorrectly" do
@@ -699,28 +690,6 @@ RSpec.describe DiscourseNarrativeBot::TrackSelector do
               expect { described_class.new(:reply, user, post_id: post.id).select }.to_not change {
                 Post.count
               }
-            end
-          end
-
-          context "when user requesting quote has a preferred locale" do
-            before do
-              SiteSetting.allow_user_locale = true
-              user.update!(locale: "it")
-              srand(1)
-            end
-
-            it "should create the right reply" do
-              post.update!(raw: "@discobot quote")
-              described_class.new(:reply, user, post_id: post.id).select
-              key = "discourse_narrative_bot.quote.6"
-
-              expect(Post.last.raw).to eq(
-                I18n.t(
-                  "discourse_narrative_bot.quote.results",
-                  quote: I18n.t("#{key}.quote"),
-                  author: I18n.t("#{key}.author"),
-                ),
-              )
             end
           end
         end

--- a/plugins/discourse-narrative-bot/spec/jobs/bot_input_spec.rb
+++ b/plugins/discourse-narrative-bot/spec/jobs/bot_input_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::BotInput do
+  fab!(:user)
+  fab!(:topic)
+  fab!(:post) { Fabricate(:post, topic:, user:) }
+
+  let(:discobot_user) { DiscourseNarrativeBot::Base.new.discobot_user }
+
+  before do
+    discobot_user
+    SiteSetting.discourse_narrative_bot_enabled = true
+    post.update!(raw: "@discobot quote")
+  end
+
+  it "does nothing when the user no longer exists" do
+    missing_user_id = User.maximum(:id).to_i + 100
+
+    expect do
+      described_class.new.execute(user_id: missing_user_id, post_id: post.id, input: "reply")
+    end.to_not change { Post.count }
+  end
+
+  it "runs the track selector with the given input in the user's locale" do
+    selector = mock
+    selector.expects(:select).once
+    DiscourseNarrativeBot::TrackSelector
+      .expects(:new)
+      .with(:reply, user, post_id: post.id, topic_id: nil)
+      .returns(selector)
+
+    described_class.new.execute(user_id: user.id, post_id: post.id, input: "reply")
+  end
+
+  it "replies to a quote request without contacting any external service" do
+    expect do
+      described_class.new.execute(user_id: user.id, post_id: post.id, input: "reply")
+    end.to change { Post.count }.by(1)
+
+    bundled_quotes =
+      I18n
+        .t("discourse_narrative_bot.quote")
+        .values
+        .select { |v| v.is_a?(Hash) }
+        .map { |q| DiscourseNarrativeBot::QuoteGenerator.format_quote(q[:quote], q[:author]) }
+
+    expect(Post.last.user).to eq(discobot_user)
+    expect(bundled_quotes).to include(Post.last.raw)
+  end
+
+  it "propagates errors raised while processing a track" do
+    DiscourseNarrativeBot::TrackSelector
+      .any_instance
+      .stubs(:select)
+      .raises(StandardError.new("boom"))
+
+    expect do
+      described_class.new.execute(user_id: user.id, post_id: post.id, input: "reply")
+    end.to raise_error(StandardError, "boom")
+  end
+end


### PR DESCRIPTION
The discobot `quote` and `help` commands fetched a random quote from the external `api.forismatic.com` service for English locales. That host now returns HTTP 521, so `QuoteGenerator.generate` (which calls Excon with `expects: [200, 201]`) raised and crashed the `bot_input` job, leaving users with no reply. `roll` and `fortune` kept working because they run locally, and non-English locales were unaffected because they already used bundled quotes.

This removes the external call entirely and samples from the locally bundled quotes for the user's effective locale — the same data already shipped for translations — so the commands work without any network dependency and can no longer fail silently. Sampling over every available quote also surfaces entries that the previous `rand(1..10)` never reached.

Adds a `QuoteGenerator` unit spec and a `bot_input` job spec covering the no-network reply path and error propagation.

Ref - t/184527