### PR TITLE
DEV: Use token vars for filter input and form kit inputs

### DIFF
--- a/app/assets/stylesheets/common/components/filter-input.scss
+++ b/app/assets/stylesheets/common/components/filter-input.scss
@@ -6,6 +6,7 @@
   justify-content: space-between;
   border: var(--d-input-border);
   border-radius: var(--d-input-border-radius);
+  background-color: var(--token-color-background-input);
   box-sizing: border-box;
 
   &.is-focused {

--- a/app/assets/stylesheets/common/form-kit/_default-input-mixin.scss
+++ b/app/assets/stylesheets/common/form-kit/_default-input-mixin.scss
@@ -3,7 +3,7 @@
 @mixin default-input {
   width: 100%;
   height: var(--space-9);
-  background: var(--secondary);
+  background: var(--token-color-background-input);
   border: 1px solid var(--primary-low-mid) !important;
   border-radius: var(--d-input-border-radius);
   padding: 0 0.5em !important;
@@ -23,10 +23,10 @@
   &:active {
     // these `!important` flags are another great case for having a button element without that pesky default styling
     &:not(:disabled) {
-      background-color: var(--secondary) !important;
+      background-color: var(--token-color-background-input) !important;
       color: var(--primary) !important;
-      border-color: var(--tertiary);
-      outline: 2px solid var(--tertiary);
+      border-color: var(--token-color-background-accent-bolder);
+      outline: 2px solid var(--token-color-background-accent-bolder);
       outline-offset: -2px;
 
       .d-icon {
@@ -37,9 +37,9 @@
 
   &:hover:not(:disabled) {
     .discourse-no-touch & {
-      background-color: var(--secondary);
+      background-color: var(--token-color-background-input);
       color: var(--primary);
-      border-color: var(--tertiary);
+      border-color: var(--token-color-background-accent-bolder);
 
       .d-icon {
         color: inherit;


### PR DESCRIPTION
I was working on a custom theme and noticed that these easier-to-override token variables were missing for inputs. There should be no visible changes in the default themes, each `--token` variable matches the previous value. (Except for the new filter-input background, but on the default themes, that has no effect because it matches the page background. 