### PR TITLE
FIX: Support status:noreplies and status:single_user on the /filter route

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3031,6 +3031,8 @@ en:
       status_unlisted: "Show unlisted (hidden) topics"
       status_deleted: "Show deleted topics (if you have permission)"
       status_public: "Show topics in public categories"
+      status_noreplies: "Show topics with no replies"
+      status_single_user: "Show topics with a single participant"
       in_pinned: "Show pinned topics"
       in_bookmarked: "Show topics you've bookmarked"
       in_watching: "Show topics you're watching"

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -168,6 +168,10 @@ class TopicsFilter
       end
     when "public"
       @scope = @scope.joins(:category).where("NOT categories.read_restricted")
+    when "noreplies"
+      @scope = @scope.where("topics.posts_count = 1")
+    when "single_user"
+      @scope = @scope.where("topics.participant_count = 1")
     else
       if custom_filter = TopicsFilter.custom_status_filters[status]
         @scope = custom_filter[:block].call(@scope) if custom_filter[:enabled].call
@@ -277,6 +281,8 @@ class TopicsFilter
       { name: "status:unlisted", description: I18n.t("filter.description.status_unlisted") },
       { name: "status:deleted", description: I18n.t("filter.description.status_deleted") },
       { name: "status:public", description: I18n.t("filter.description.status_public") },
+      { name: "status:noreplies", description: I18n.t("filter.description.status_noreplies") },
+      { name: "status:single_user", description: I18n.t("filter.description.status_single_user") },
       { name: "order:", description: I18n.t("filter.description.order"), priority: 1 },
       { name: "order:activity", description: I18n.t("filter.description.order_activity") },
       { name: "order:activity-asc", description: I18n.t("filter.description.order_activity_asc") },

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -1206,6 +1206,36 @@ RSpec.describe TopicsFilter do
           ).to contain_exactly(closed_and_unlisted_topic.id)
         end
       end
+
+      describe "when query string is `status:noreplies`" do
+        fab!(:topic_without_replies) { Fabricate(:topic, posts_count: 1) }
+        fab!(:topic_with_replies) { Fabricate(:topic, posts_count: 2) }
+
+        it "should only return topics that have no replies" do
+          expect(
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("status:noreplies")
+              .pluck(:id),
+          ).to contain_exactly(topic_without_replies.id)
+        end
+      end
+
+      describe "when query string is `status:single_user`" do
+        fab!(:single_user_topic) { Fabricate(:topic, participant_count: 1) }
+        fab!(:multi_user_topic) { Fabricate(:topic, participant_count: 2) }
+
+        it "should only return topics that have a single participant" do
+          topic_ids =
+            TopicsFilter
+              .new(guardian: Guardian.new)
+              .filter_from_query_string("status:single_user")
+              .pluck(:id)
+
+          expect(topic_ids).to include(single_user_topic.id)
+          expect(topic_ids).not_to include(multi_user_topic.id)
+        end
+      end
     end
 
     describe "when filtering by tags" do


### PR DESCRIPTION
## Summary

- `status:noreplies` and `status:single_user` were only implemented for the `/search` system (`Search#advanced_filter`) and never ported to the `/filter` route (`TopicsFilter#filter_status`).
- Because `filter_status` silently ignores unrecognised status values (it only falls back to plugin-registered custom statuses), a query like `/filter?q=status:noreplies` left the scope untouched and returned **every** topic — including topics with replies — instead of filtering. Users who carried the syntax over from `/search`, where it works, hit confusing results.
- This adds both statuses to `filter_status`, mirroring the existing `/search` definitions:
  - `status:noreplies` → `topics.posts_count = 1`
  - `status:single_user` → `topics.participant_count = 1`
- Both are registered in `option_info` (with new translations) so they appear as autocomplete tips in the `/filter` input, and are covered by specs.

## Test plan

- [x] `bin/rspec spec/lib/topics_filter_spec.rb -e "when filtering by status"` — all green, including the two new specs
- [x] Manually verified on a local instance: `/filter?q=status:noreplies` returns only reply-less topics; `/filter?q=status:single_user` returns only single-participant topics
- [x] Confirmed `status:noreplies` / `status:single_user` show up as autocomplete tips when typing `status:` in the `/filter` input