### PR TITLE
DEV: Adds a check for the Arch AUR legacy postgresql packages bin path to temporary_db script

### DIFF
--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -58,6 +58,12 @@ class TemporaryDb
       return @pg_bin_path = bin_path if File.exist?("#{bin_path}/pg_ctl")
     end
 
+    # Arch AUR packages: /opt/postgresql{version}/bin
+    @versions.reverse_each do |v|
+      bin_path = "/opt/postgresql#{v}/bin"
+      return @pg_bin_path = bin_path if File.exist?("#{bin_path}/pg_ctl")
+    end
+
     # Unversioned fallbacks — skipped when the caller pinned a version range.
     if @versions == VERSIONS
       bin_path = "/Applications/Postgres.app/Contents/Versions/latest/bin"


### PR DESCRIPTION
AUR postgresql15 and postgresql16 packages use /opt/postgresql{version}/bin