### PR TITLE
DEV: Link to Docker CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Here are just a few of the incredible communities using Discourse:
 
 To get your environment set up, follow one of the setup guides:
 
-- [Docker / Dev Container](https://meta.discourse.org/t/336366)
+- Docker
+    - [Dev Container in VS Code](https://meta.discourse.org/t/336366) (recommended)
+    - [CLI](https://meta.discourse.org/t/102009)
 - [macOS](https://meta.discourse.org/t/15772)
 - [Ubuntu/Debian](https://meta.discourse.org/t/14727)
 - [Windows](https://meta.discourse.org/t/75149)


### PR DESCRIPTION
The Dev Container documentation requires VS Code to enable port forwarding (at least on macOS). Devs who don't want to use VS Code should use `boot_dev` instead.