### PR TITLE
FIX: Form template `tag-chooser` dropping uppercase tag selections

### DIFF
--- a/frontend/discourse/app/components/form-template-field/tag-chooser.gjs
+++ b/frontend/discourse/app/components/form-template-field/tag-chooser.gjs
@@ -96,25 +96,13 @@ export default class TagChooserField extends Component {
 
   @action
   handleSelectedValues(event) {
-    const getFallbackValue = (optionValue) =>
-      optionValue.toLowerCase().replace(/\s+/g, "-");
-    let choiceMap = null;
-    const tagChoices = this.args.attributes?.tag_choices;
-
-    if (tagChoices) {
-      choiceMap = new Map(
-        Object.entries(tagChoices).map(([key, value]) => [value, key])
-      );
-    }
-
-    const selectedValues = Array.from(event.target.selectedOptions).map(
-      (option) => {
-        const mappedValue = choiceMap?.get(option.textContent.trim());
-        return mappedValue ?? getFallbackValue(option.value);
-      }
+    const nameByDisplay = new Map(
+      this.formattedChoices.map((choice) => [choice.display, choice.name])
     );
 
-    return selectedValues;
+    return Array.from(event.target.selectedOptions)
+      .map((option) => nameByDisplay.get(option.value))
+      .filter(Boolean);
   }
 
   @action

--- a/spec/system/composer/form_template_tag_chooser_spec.rb
+++ b/spec/system/composer/form_template_tag_chooser_spec.rb
@@ -47,3 +47,49 @@ describe "Composer Form Template" do
     expect(preview).to have_no_content(tag1.id.to_s)
   end
 end
+
+describe "Composer Form Template with uppercase tag names" do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:tag1) { Fabricate(:tag, name: "High") }
+  fab!(:tag2) { Fabricate(:tag, name: "Low") }
+  fab!(:tag_group) { Fabricate(:tag_group, name: "Priority", tags: [tag1, tag2]) }
+  fab!(:form_template) do
+    Fabricate(
+      :form_template,
+      name: "Issue Template",
+      template:
+        "- type: tag-chooser\n  id: priority\n  tag_group: \"Priority\"\n  attributes:\n    label: \"Priority\"\n    none_label: \"Select a priority\"\n    multiple: false\n  validations:\n    required: true\n",
+    )
+  end
+  fab!(:category) do
+    Fabricate(
+      :category,
+      name: "Issues",
+      slug: "issues",
+      topic_count: 2,
+      form_template_ids: [form_template.id],
+    )
+  end
+
+  before do
+    SiteSetting.enable_form_templates = true
+    SiteSetting.show_preview_for_form_templates = true
+    SiteSetting.tagging_enabled = true
+    SiteSetting.force_lowercase_tags = false
+    sign_in(user)
+  end
+
+  it "selects a tag whose name contains uppercase characters" do
+    visit("/")
+    find("#create-topic").click
+    find(".category-chooser").click
+    find(".category-row[data-value='#{category.id}']").click
+
+    expect(page).to have_css(".form-template-field__multi-select[name='priority']")
+
+    find(".form-template-field__multi-select[name='priority']").select("HIGH")
+
+    preview = find(".d-editor-preview")
+    expect(preview).to have_content("HIGH")
+  end
+end


### PR DESCRIPTION
When a form template `tag-chooser` field is populated from a tag group, each
`<option>` is rendered with its display value (the tag name upper-cased, or its
description). Selecting an option then has to translate that display value back
to the underlying tag name before storing it on the composer.

`handleSelectedValues` did this translation by lower-casing the option value
(`"HIGH"` -> `"high"`) and `handleInput` matched the result case-sensitively
against the real tag names. On sites with `force_lowercase_tags` disabled, tag
names keep their casing (e.g. `"High"`), so the reconstructed `"high"` never
matched, the selection was silently dropped, and the dropdown reset to its
placeholder. Lower-case tag names round-tripped fine, which is why this only
affected sites allowing mixed-case tags.

This regressed in ed8a62e2729, which switched the option value from the tag
name to the upper-cased display and reintroduced the lower-casing round-trip to
reverse it.

Instead of guessing the casing, build a map of each choice's display value back
to its exact tag name and look the selected option up in it. Selections are now
preserved regardless of tag name casing. Adds a system spec covering tag names
with uppercase characters and `force_lowercase_tags` disabled.

