### PR TITLE
DEV: Fix qunit Chromium in devcontainer

### DIFF
--- a/.vscode/settings.json.sample
+++ b/.vscode/settings.json.sample
@@ -46,4 +46,9 @@
   "css.validate": false,
   "less.validate": false,
   "scss.validate": false
+
+  // Devcontainer: Allow QUnit Chromium in Docker
+  "terminal.integrated.env.linux": {
+    "DISCOURSE_DISABLE_BROWSER_SANDBOX": "1"
+  }
 }


### PR DESCRIPTION
Without this, all qunit tests fail with this error: "No usable sandbox!"