### PR TITLE
UX: fix topics table heading styles on /categories

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -474,7 +474,8 @@
 }
 
 .table-heading {
-  border-bottom: 3px solid var(--primary-low);
+  border-bottom: var(--d-table-border-top-height) solid
+    var(--table-border-color);
 }
 
 // This is not what we want:

--- a/app/assets/stylesheets/common/base/categories-topic-list.scss
+++ b/app/assets/stylesheets/common/base/categories-topic-list.scss
@@ -6,7 +6,8 @@
 
   .table-heading {
     padding: var(--space-2) var(--space-1);
-    color: var(--primary-med-or-secondary-high);
+    color: var(--d-topic-list-header-text-color);
+    font-size: var(--d-topic-list-data-font-size);
   }
 
   .no-topics,


### PR DESCRIPTION
We have some common variables that weren't being used here and caused inconsistent styles 

Before:
<img width="2188" height="106" alt="image" src="https://github.com/user-attachments/assets/60948a71-d102-4d24-8aa8-579b9edd3293" />


After:
<img width="2204" height="160" alt="image" src="https://github.com/user-attachments/assets/503e0852-4b17-4a5e-8932-79a56223d9c7" />
