### PR TITLE
FIX: Average daily engaged users KPI instead of summing the period

### DIFF
--- a/app/models/concerns/reports/daily_engaged_users.rb
+++ b/app/models/concerns/reports/daily_engaged_users.rb
@@ -23,9 +23,8 @@ module Reports::DailyEngagedUsers
         prev_data =
           UserAction.count_daily_engaged_users(report.prev_start_date, report.prev_end_date)
 
-        prev = prev_data.sum { |k, v| v }
-        prev = prev / ((report.end_date - report.start_date) / 1.day) if prev > 0
-        report.prev_period = prev
+        prev = prev_data.values.sum
+        report.prev_period = prev.zero? ? prev : (prev.to_f / prev_data.size).round(1)
       end
 
       data.each { |key, value| report.data << { x: key, y: value } }

--- a/app/services/admin_dashboard_engagement.rb
+++ b/app/services/admin_dashboard_engagement.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdminDashboardEngagement
+  include AdminDashboardKpis
+
   DEFAULT_RANGE_DAYS = 30
 
   KPI_REPORTS = {
@@ -43,66 +45,6 @@ class AdminDashboardEngagement
 
   def build_kpis
     KPI_REPORTS.filter_map { |type, report| build_kpi(type, report) }
-  end
-
-  def build_kpi(type, report_name)
-    args = { start_date: start_date, end_date: end_date, facets: %i[prev_period] }
-
-    report = Report.find_cached(report_name, args)
-    if report.nil?
-      report = Report.find(report_name, args)
-      Report.cache(report) if report && report.error.blank?
-    end
-
-    return nil if report.nil? || report_error?(report) || report_data(report).nil?
-
-    current = period_value(type, report_data(report))
-    previous = report_prev_period(report)
-
-    {
-      type: type,
-      value: current,
-      previous_value: previous,
-      percent_change: compute_percent_change(current, previous),
-      report_type: report_name,
-      report_query: {
-        start_date: start_date.to_date.iso8601,
-        end_date: end_date.to_date.iso8601,
-      },
-    }
-  end
-
-  def report_error?(report_or_hash)
-    report_or_hash.is_a?(Hash) ? report_or_hash[:error].present? : report_or_hash.error.present?
-  end
-
-  def report_data(report_or_hash)
-    report_or_hash.is_a?(Hash) ? report_or_hash[:data] : report_or_hash.data
-  end
-
-  def report_prev_period(report_or_hash)
-    if report_or_hash.is_a?(Hash)
-      report_or_hash[:prev_period]
-    else
-      report_or_hash.prev_period
-    end
-  end
-
-  def period_value(type, data)
-    return nil if data.empty?
-
-    ys = data.map { |point| point[:y] }
-
-    if type == :dau_mau
-      (ys.sum(&:to_f) / ys.size).round(1)
-    else
-      ys.sum(&:to_i)
-    end
-  end
-
-  def compute_percent_change(current, previous)
-    return nil if previous.blank? || previous.zero? || current.blank?
-    ((current.to_f - previous) / previous * 100).round(2)
   end
 
   HEADLINE_KEYS = {

--- a/app/services/admin_dashboard_highlights.rb
+++ b/app/services/admin_dashboard_highlights.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AdminDashboardHighlights
+  include AdminDashboardKpis
+
   DEFAULT_RANGE_DAYS = 30
 
   KPI_REPORTS = {
@@ -41,68 +43,5 @@ class AdminDashboardHighlights
       next if kpi[:enabled].respond_to?(:call) && !kpi[:enabled].call
       build_kpi(kpi[:type], kpi[:report])
     end
-  end
-
-  def build_kpi(type, report_name)
-    args = { start_date: start_date, end_date: end_date, facets: %i[prev_period] }
-
-    report = Report.find_cached(report_name, args)
-    if report.nil?
-      report = Report.find(report_name, args)
-      Report.cache(report) if report && report.error.blank?
-    end
-
-    return nil if report.nil? || report_error?(report) || report_data(report).nil?
-
-    current = period_value(type, report_data(report))
-    previous = report_prev_period(report)
-
-    {
-      type: type,
-      value: current,
-      previous_value: previous,
-      percent_change: compute_percent_change(current, previous),
-      report_type: report_name,
-      report_query: {
-        start_date: start_date.to_date.iso8601,
-        end_date: end_date.to_date.iso8601,
-      },
-    }
-  end
-
-  # Report.find returns a Report object
-  # Report.find_cached returns the as_json hash (symbol-keyed).
-  # The accessors below cope with either
-  def report_error?(report_or_hash)
-    report_or_hash.is_a?(Hash) ? report_or_hash[:error].present? : report_or_hash.error.present?
-  end
-
-  def report_data(report_or_hash)
-    report_or_hash.is_a?(Hash) ? report_or_hash[:data] : report_or_hash.data
-  end
-
-  def report_prev_period(report_or_hash)
-    if report_or_hash.is_a?(Hash)
-      report_or_hash[:prev_period]
-    else
-      report_or_hash.prev_period
-    end
-  end
-
-  def period_value(type, data)
-    return nil if data.empty?
-
-    ys = data.map { |point| point[:y] }
-
-    if type == :dau_mau
-      (ys.sum(&:to_f) / ys.size).round(1)
-    else
-      ys.sum(&:to_i)
-    end
-  end
-
-  def compute_percent_change(current, previous)
-    return nil if previous.blank? || previous.zero? || current.blank?
-    ((current.to_f - previous) / previous * 100).round(2)
   end
 end

--- a/app/services/concerns/admin_dashboard_kpis.rb
+++ b/app/services/concerns/admin_dashboard_kpis.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Including classes must expose `start_date` and `end_date`.
+module AdminDashboardKpis
+  private
+
+  def build_kpi(type, report_name)
+    args = { start_date: start_date, end_date: end_date, facets: %i[prev_period] }
+
+    report = Report.find_cached(report_name, args)
+    if report.nil?
+      report = Report.find(report_name, args)
+      Report.cache(report) if report && report.error.blank?
+    end
+
+    return nil if report.nil? || report_error?(report) || report_data(report).nil?
+
+    current = period_value(report_data(report), average: report_average?(report))
+    previous = report_prev_period(report)
+
+    {
+      type: type,
+      value: current,
+      previous_value: previous,
+      percent_change: compute_percent_change(current, previous),
+      report_type: report_name,
+      report_query: {
+        start_date: start_date.to_date.iso8601,
+        end_date: end_date.to_date.iso8601,
+      },
+    }
+  end
+
+  # Report.find returns a Report object; Report.find_cached returns the as_json
+  # hash (symbol-keyed). The accessors below cope with either.
+  def report_error?(report_or_hash)
+    report_or_hash.is_a?(Hash) ? report_or_hash[:error].present? : report_or_hash.error.present?
+  end
+
+  def report_data(report_or_hash)
+    report_or_hash.is_a?(Hash) ? report_or_hash[:data] : report_or_hash.data
+  end
+
+  def report_prev_period(report_or_hash)
+    report_or_hash.is_a?(Hash) ? report_or_hash[:prev_period] : report_or_hash.prev_period
+  end
+
+  def report_average?(report_or_hash)
+    report_or_hash.is_a?(Hash) ? report_or_hash[:average] : report_or_hash.average
+  end
+
+  def period_value(data, average:)
+    return nil if data.empty?
+
+    ys = data.map { |point| point[:y] }
+    return (ys.sum(&:to_f) / ys.size).round(1) if average
+
+    ys.sum(&:to_i)
+  end
+
+  def compute_percent_change(current, previous)
+    return nil if previous.blank? || previous.zero? || current.blank?
+    ((current.to_f - previous) / previous * 100).round(2)
+  end
+end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -719,6 +719,37 @@ RSpec.describe Report do
         expect(report.data.last[:y]).to eq(2)
       end
     end
+
+    it "averages the previous period over the days that had engagement" do
+      freeze_time(Time.zone.local(2026, 4, 28, 12, 0, 0))
+
+      two_on_first_day = [Fabricate(:user), Fabricate(:user)]
+      one_on_second_day = Fabricate(:user)
+      two_on_first_day.each do |engaged_user|
+        Fabricate(
+          :user_action,
+          user: engaged_user,
+          action_type: UserAction::LIKE,
+          created_at: Time.zone.local(2026, 4, 16, 12),
+        )
+      end
+      Fabricate(
+        :user_action,
+        user: one_on_second_day,
+        action_type: UserAction::LIKE,
+        created_at: Time.zone.local(2026, 4, 17, 12),
+      )
+
+      report =
+        Report.find(
+          "daily_engaged_users",
+          start_date: Time.zone.local(2026, 4, 22).beginning_of_day,
+          end_date: Time.zone.local(2026, 4, 28).end_of_day,
+          facets: [:prev_period],
+        )
+
+      expect(report.prev_period).to eq(1.5)
+    end
   end
 
   describe "posts counts" do

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -36,6 +36,46 @@ describe AdminDashboardEngagement do
       expect(engaged[:report_query]).to eq(start_date: "2026-04-01", end_date: "2026-04-28")
     end
 
+    it "averages daily_engaged_users and reports a decline when daily engagement falls" do
+      engaged_now = Fabricate(:user, created_at: Time.zone.local(2026, 1, 1))
+      Fabricate(
+        :user_action,
+        user: engaged_now,
+        action_type: UserAction::LIKE,
+        created_at: Time.zone.local(2026, 4, 23, 12),
+      )
+      Fabricate(
+        :user_action,
+        user: engaged_now,
+        action_type: UserAction::LIKE,
+        created_at: Time.zone.local(2026, 4, 24, 12),
+      )
+
+      4.times do
+        engaged_before = Fabricate(:user, created_at: Time.zone.local(2026, 1, 1))
+        Fabricate(
+          :user_action,
+          user: engaged_before,
+          action_type: UserAction::LIKE,
+          created_at: Time.zone.local(2026, 4, 16, 12),
+        )
+        Fabricate(
+          :user_action,
+          user: engaged_before,
+          action_type: UserAction::LIKE,
+          created_at: Time.zone.local(2026, 4, 17, 12),
+        )
+      end
+
+      result = described_class.build(start_date: "2026-04-22", end_date: "2026-04-28")
+      engaged = result[:kpis].find { |k| k[:type] == :daily_engaged_users }
+
+      expect(engaged[:value]).to eq(1.0)
+      expect(engaged[:previous_value]).to eq(4.0)
+      expect(engaged[:percent_change]).to eq(-75.0)
+      expect(result[:headline][:key]).not_to end_with("healthy_growth")
+    end
+
     it "falls back to a default 30-day window when params are blank" do
       result = described_class.build(start_date: nil, end_date: nil)
       expect(result[:kpis]).to be_an(Array)

--- a/spec/services/admin_dashboard_highlights_spec.rb
+++ b/spec/services/admin_dashboard_highlights_spec.rb
@@ -79,6 +79,30 @@ describe AdminDashboardHighlights do
         result = described_class.build(start_date: "2026-04-01", end_date: "2026-04-28")
         expect(result[:kpis].map { |k| k[:type] }).not_to include(:extra_kpi)
       end
+
+      it "averages a registered KPI backed by an average report instead of summing it" do
+        DiscoursePluginRegistry.stubs(:admin_dashboard_highlight_kpis).returns(
+          [{ type: :plugin_engaged, report: "daily_engaged_users" }],
+        )
+        engaged_user = Fabricate(:user, created_at: Time.zone.local(2026, 1, 1))
+        Fabricate(
+          :user_action,
+          user: engaged_user,
+          action_type: UserAction::LIKE,
+          created_at: Time.zone.local(2026, 4, 23, 12),
+        )
+        Fabricate(
+          :user_action,
+          user: engaged_user,
+          action_type: UserAction::LIKE,
+          created_at: Time.zone.local(2026, 4, 24, 12),
+        )
+
+        result = described_class.build(start_date: "2026-04-22", end_date: "2026-04-28")
+        kpi = result[:kpis].find { |k| k[:type] == :plugin_engaged }
+
+        expect(kpi[:value]).to eq(1.0) # daily average, not the two-day sum of 2
+      end
     end
 
     it "skips a KPI when its report errors out" do
@@ -173,7 +197,7 @@ describe AdminDashboardHighlights do
         Report
           .expects(:find)
           .at_least_once
-          .returns(stub(type: "signups", error: nil, data: [], prev_period: 0))
+          .returns(stub(type: "signups", error: nil, data: [], prev_period: 0, average: false))
         Report.stubs(:cache)
         described_class.build(start_date: "2026-03-01", end_date: "2026-03-31")
       end


### PR DESCRIPTION
The "Daily engaged" KPI on the admin dashboard could show an upward trend while engagement was actually falling, because the current period was summed while the previous period it compared against was a daily average.

This commit drives the average-versus-sum choice off each report's `average` flag instead of a hardcoded check, so average reports like `daily_engaged_users` average both periods while cumulative reports keep summing both. 