### PR TITLE
FEATURE: Add "Sign Up" link to mobile hamburger menu

### DIFF
--- a/frontend/discourse/app/components/header.gjs
+++ b/frontend/discourse/app/components/header.gjs
@@ -282,6 +282,7 @@ export default class GlimmerHeader extends Component {
             />
           {{else if this.header.hamburgerVisible}}
             <HamburgerDropdownWrapper
+              @showCreateAccount={{@showCreateAccount}}
               @toggleNavigationMenu={{this.toggleNavigationMenu}}
               @sidebarEnabled={{@sidebarEnabled}}
               {{this.handleFocus}}

--- a/frontend/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
+++ b/frontend/discourse/app/components/header/hamburger-dropdown-wrapper.gjs
@@ -107,6 +107,7 @@ export default class HamburgerDropdownWrapper extends Component {
     >
       <SidebarHamburgerDropdown
         @forceMainSidebarPanel={{this.forceMainSidebarPanel}}
+        @showCreateAccount={{@showCreateAccount}}
         @toggleNavigationMenu={{this.toggleNavigation}}
       />
     </div>

--- a/frontend/discourse/app/components/sidebar/hamburger-dropdown.gjs
+++ b/frontend/discourse/app/components/sidebar/hamburger-dropdown.gjs
@@ -9,6 +9,7 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import { or } from "discourse/truth-helpers";
 import ApiPanels from "./api-panels";
 import Footer from "./footer";
+import HamburgerSignupLink from "./hamburger-signup-link";
 import Sections from "./sections";
 
 export default class SidebarHamburgerDropdown extends Component {
@@ -54,6 +55,10 @@ export default class SidebarHamburgerDropdown extends Component {
                 class="sidebar-hamburger-dropdown"
                 {{didInsert this.focusFirstLink}}
               >
+                <HamburgerSignupLink
+                  @showCreateAccount={{@showCreateAccount}}
+                  @toggleNavigationMenu={{@toggleNavigationMenu}}
+                />
                 <PluginOutlet
                   @name="before-sidebar-sections"
                   @outletArgs={{lazyHash

--- a/frontend/discourse/app/components/sidebar/hamburger-signup-link.gjs
+++ b/frontend/discourse/app/components/sidebar/hamburger-signup-link.gjs
@@ -1,0 +1,33 @@
+import Component from "@glimmer/component";
+import { inject as controller } from "@ember/controller";
+import { service } from "@ember/service";
+import { i18n } from "discourse-i18n";
+import SectionLinkButton from "./section-link-button";
+
+export default class HamburgerSignupLink extends Component {
+  @service currentUser;
+  @service site;
+  @service header;
+
+  @controller application;
+
+  get shouldRender() {
+    return (
+      !this.currentUser &&
+      this.application.canSignUp &&
+      this.site.mobileView &&
+      !this.header.headerButtonsHidden.includes("signup")
+    );
+  }
+
+  <template>
+    {{#if this.shouldRender}}
+      <SectionLinkButton
+        @action={{@showCreateAccount}}
+        @icon="user"
+        @text={{i18n "sign_up"}}
+        @toggleNavigationMenu={{@toggleNavigationMenu}}
+      />
+    {{/if}}
+  </template>
+}

--- a/frontend/discourse/tests/acceptance/sidebar-anonymous-user-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-anonymous-user-test.js
@@ -1,6 +1,7 @@
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
 
 acceptance("Sidebar - Anonymous User", function (needs) {
   needs.settings({
@@ -36,6 +37,77 @@ acceptance("Sidebar - Anonymous User", function (needs) {
       );
   });
 });
+
+acceptance(
+  "Sidebar - Anonymous User - Mobile hamburger sign up",
+  function (needs) {
+    needs.mobileView();
+
+    test("shows sign up as the first item in the hamburger menu", async function (assert) {
+      await visit("/");
+      await click(".hamburger-dropdown button");
+
+      const signUpLabel = i18n("sign_up");
+
+      assert
+        .dom(
+          `.sidebar-hamburger-dropdown button[data-list-item-name="${signUpLabel}"]`
+        )
+        .exists("sign up link is shown in the hamburger menu");
+
+      await click(
+        `.sidebar-hamburger-dropdown button[data-list-item-name="${signUpLabel}"]`
+      );
+
+      assert.dom(".signup-fullpage").exists("it shows the signup page");
+    });
+  }
+);
+
+acceptance(
+  "Sidebar - Anonymous User - Desktop hamburger sign up",
+  function (needs) {
+    needs.settings({
+      navigation_menu: "header dropdown",
+    });
+
+    test("does not show sign up in the hamburger menu on desktop", async function (assert) {
+      await visit("/");
+      await click(".hamburger-dropdown button");
+
+      const signUpLabel = i18n("sign_up");
+
+      assert
+        .dom(
+          `.sidebar-hamburger-dropdown button[data-list-item-name="${signUpLabel}"]`
+        )
+        .doesNotExist("sign up link is hidden on desktop");
+    });
+  }
+);
+
+acceptance(
+  "Sidebar - Anonymous User - Invite only hamburger sign up",
+  function (needs) {
+    needs.mobileView();
+    needs.settings({
+      invite_only: true,
+    });
+
+    test("does not show sign up in the hamburger menu when invite only", async function (assert) {
+      await visit("/");
+      await click(".hamburger-dropdown button");
+
+      const signUpLabel = i18n("sign_up");
+
+      assert
+        .dom(
+          `.sidebar-hamburger-dropdown button[data-list-item-name="${signUpLabel}"]`
+        )
+        .doesNotExist("sign up link is hidden when invite only");
+    });
+  }
+);
 
 acceptance("Sidebar - Anonymous User - Login Required", function (needs) {
   needs.settings({


### PR DESCRIPTION
On mobile, the "Sign Up" button is hidden in the header; we only show the "Log In" button.

Now, in mobile view, we show the "Sign Up" button in the hamburger menu, providing a way for mobile users to find the "Sign Up" button.

<img width="576" height="361" alt="image" src="https://github.com/user-attachments/assets/b898e46c-a009-4f5e-9014-bd56e452eb67" />

I've confirmed with acceptance tests and by manual testing that the "Sign Up" button doesn't appear in the hamburger menu in desktop view; it only appears there in mobile view.