### PR TITLE
DEV: Update test module name conventions

### DIFF
--- a/.skills/discourse-writing-js-tests/SKILL.md
+++ b/.skills/discourse-writing-js-tests/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: discourse-writing-js-tests
+description: Write and structure JavaScript/QUnit tests for Discourse core, plugins, and themes. Use when creating or modifying unit tests (lib/utility/service/model), component rendering tests, integration tests, or acceptance tests. Covers module naming, setupTest/setupRenderingTest/setupApplicationTest, fixtures, the qunit-helpers toolbox, pretender, and qunit-dom assertions.
+---
+
+# Writing JavaScript (QUnit) Tests
+
+Discourse uses [QUnit](https://qunitjs.com/) with `ember-qunit` and
+[`@ember/test-helpers`](https://github.com/emberjs/ember-test-helpers). Assertions use
+[`qunit-dom`](https://github.com/mainmatter/qunit-dom/blob/master/API.md) (`assert.dom(...)`).
+
+## Testing Principles
+
+- **Test behavior, not implementation** — assert on rendered output, DOM state, and public
+  return values, not internal component state or private methods.
+- **One concept per `test`** — each `test()` verifies one behavior for clear failure diagnosis.
+- **Prefer `assert.dom(...)`** over manual DOM querying. It produces better failure messages
+  and waits-free, synchronous DOM reads. See the [qunit-dom API](https://github.com/mainmatter/qunit-dom/blob/master/API.md).
+- **Always `await` interactions** — `render`, `click`, `fillIn`, `visit`, `settled`, etc. are
+  async. Forgetting `await` causes flaky tests.
+- **Always pass a description** as the last argument to assertions — it documents intent and
+  pinpoints failures: `assert.dom(".foo").exists("the widget renders")`.
+- **Keep tests independent** — global state is reset between tests by `testCleanup` (see
+  `qunit-helpers.js`); don't rely on order or leak registrations.
+- **Don't over-stub** — stub network boundaries via pretender, not internal collaborators.
+
+## File locations & naming
+
+| Type | Location | Setup helper |
+| --- | --- | --- |
+| Unit (lib/utility/service/model) | `frontend/discourse/tests/unit/**` | `setupTest` |
+| Component rendering | `frontend/discourse/tests/integration/components/**` | `setupRenderingTest` |
+| Other integration | `frontend/discourse/tests/integration/**` | `setupRenderingTest`/`setupTest` |
+| Acceptance (full app) | `frontend/discourse/tests/acceptance/**` | `acceptance(...)` |
+| Plugin tests | `plugins/<name>/test/javascripts/**` | same helpers |
+
+Test files end in `-test.js` or `-test.gjs` (use `.gjs` when the test renders a component template).
+
+### Module naming convention
+
+The `module(...)` title is a `|`-separated hierarchy. The **last** segment is the subject.
+For **components**, the subject must be the modern **PascalCase** invocation name — matching
+how Ember invokes the component (`<PollInfo />`), not the kebab-case filename:
+
+```js
+// GOOD — component subject is PascalCase
+module("Integration | Component | PollInfo", function (hooks) { ... });
+module("Component | ChatChannelCard", function (hooks) { ... });   // plugins
+
+// nested components: each path segment is its own PascalCase pipe segment
+module("Integration | Component | SelectKit | ComboBox", ...);     // select-kit/combo-box
+module("Integration | Component | Post | Menu | PostUsersMenu", ...);
+
+// BAD — kebab-case or slash paths for components
+module("Integration | Component | poll-info", ...);
+module("Integration | Component | select-kit/combo-box", ...);
+```
+
+Non-component subjects (`Lib`, `Utility`, `Service`, `Model`, `Controller`, `Route`) stay
+**kebab-case**, matching their filenames:
+
+```js
+module("Unit | Lib | singleton", ...);
+module("Unit | Utility | user-search", ...);
+module("Unit | Service | site-settings", ...);
+module("Unit | Model | topic", ...);
+```
+
+Common prefixes: `Unit | <Kind> | <subject>`, `Integration | Component | <PascalName>`,
+acceptance tests are auto-prefixed with `Acceptance: ` by the `acceptance()` helper.
+
+## Unit tests (`setupTest`)
+
+For libs, utilities, services, models — no rendering.
+
+```js
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import singleton from "discourse/lib/singleton";
+
+module("Unit | Lib | singleton", function (hooks) {
+  setupTest(hooks);
+
+  test("current returns a memoized instance", function (assert) {
+    const current = SomeModel.current();
+    assert.strictEqual(current, SomeModel.current());
+  });
+});
+```
+
+Look services/objects up from the owner: `getOwner(this).lookup("service:site-settings")`.
+
+## Component rendering tests (`setupRenderingTest`)
+
+Import `setupRenderingTest` from **`discourse/tests/helpers/component-test`** (the Discourse
+wrapper), NOT directly from `ember-qunit`. The wrapper also sets `this.siteSettings`,
+`this.site`, `this.session`, and a logged-in `this.currentUser` for you.
+
+```js
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import BookmarkIcon from "discourse/components/bookmark-icon";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+module("Integration | Component | BookmarkIcon", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("with reminder", async function (assert) {
+    const store = this.owner.lookup("service:store");
+    const bookmark = store.createRecord("bookmark", { name: "some name" });
+
+    await render(<template><BookmarkIcon @bookmark={{bookmark}} /></template>);
+
+    assert.dom(".d-icon-discourse-bookmark-clock").exists();
+    assert.dom(".svg-icon-title").hasAttribute("title", i18n("bookmarks.created"));
+  });
+});
+```
+
+- Prefer **`.gjs`** with inline `<template>` so you can import and invoke the real component.
+- Options: `setupRenderingTest(hooks, { anonymous: true })` for an anonymous user;
+  `{ stubRouter: true }` to stub `service:router`.
+- Interact with `@ember/test-helpers`: `click`, `fillIn`, `triggerKeyEvent`, `settled`, `find`.
+- For select-kit and FormKit widgets, use `discourse/tests/helpers/select-kit-helper` and
+  `discourse/tests/helpers/form-kit-helper` rather than poking the DOM directly.
+
+## Acceptance tests (`acceptance`)
+
+Full-application tests that `visit()` routes. Use the `acceptance()` helper from
+`qunit-helpers` — it wires up `setupApplicationTest`, the default pretender, site, settings,
+and per-test cleanup. Configure the scenario through the `needs` argument.
+
+```js
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Topic Notifications button", function (needs) {
+  needs.user();                       // logged-in user (optionally pass overrides)
+  needs.settings({ enable_foo: true });
+  needs.site({ categories: [...] });
+  needs.mobileView();
+  needs.pretender((server, helper) => {
+    server.post("/t/280/notifications", () => helper.response({}));
+  });
+
+  test("updates the notification level", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    assert.dom(".topic-notifications-button").exists();
+  });
+});
+```
+
+`needs.*` options: `user(overrides)`, `pretender(fn)`, `site(changes)`, `settings(changes)`,
+`mobileView()`. The active QUnit `hooks` are available as `needs.hooks`.
+
+## Network stubbing (pretender)
+
+Discourse ships a large default [Pretender](https://github.com/pretenderjs/pretender) server
+(`frontend/discourse/tests/helpers/create-pretender.js`) that answers common endpoints. Add or
+override routes with `needs.pretender(...)` (acceptance) or `pretender`/`applyPretender`
+patterns for other types. The `helper.response(body)` / `helper.response(statusCode, body)`
+builders shape responses.
+
+## Fixtures
+
+Canned API payloads live in `frontend/discourse/tests/fixtures/**` and back the default
+pretender. Import a fixture to seed models or assertions instead of hand-building JSON:
+
+```js
+import sessionFixtures from "discourse/tests/fixtures/session-fixtures";
+import siteFixtures from "discourse/tests/fixtures/site-fixtures";
+```
+
+`currentUser()` (from `qunit-helpers`) builds a `User` from the session fixture.
+
+## The `qunit-helpers` toolbox
+
+`frontend/discourse/tests/helpers/qunit-helpers.js` exports broadly useful helpers:
+
+- **Users/session**: `acceptance`, `currentUser()`, `logIn(owner)`, `loggedInUser()`,
+  `updateCurrentUser(props)`, `resetSite(extras)`.
+- **MessageBus**: `publishToMessageBus(channel, ...args)` — drive realtime updates, then assert.
+- **Time**: `fakeTime(timeString, tz, advance)` and `withFrozenTime(timeString, tz, cb)` (sinon
+  fake timers). Remember to restore (`withFrozenTime` does it for you).
+- **Input simulation**: `createFile(name, type)`, `paste(selector, text)`,
+  `selectText(selector)`, `simulateKey(el, key)` / `simulateKeys(el, keys)`, `metaModifier`.
+- **Conditional tests**: `conditionalTest`, `chromeTest`, `firefoxTest`.
+- **Legacy DOM helpers** (jQuery-backed): `query()`, `queryAll()`, `exists()`, `count()`,
+  `visible()`, `invisible()`, `fixture()`. **Prefer `assert.dom(...)` and `find()` in new
+  tests** — reach for these only when matching existing style.
+- **Deprecated**: `discourseModule` — use QUnit's `module` instead.
+
+## Custom assertions
+
+Beyond [qunit-dom](https://github.com/mainmatter/qunit-dom/blob/master/API.md)'s `assert.dom`:
+
+- `assert.present(value, msg)` / `assert.blank(value, msg)` — Ember `isEmpty` checks.
+- `assert.containsInstance(collection, klass, msg)`.
+- Domain assertions registered at import time: `assert.form()` (FormKit, see
+  `form-kit-assertions.js`), `assert.dselect()` (`d-select-assertions.js`),
+  `assert.notificationsTracking()` (`notifications-tracking-assertions.js`).
+
+## Running tests
+
+```sh
+bin/qunit --help                       # full options
+bin/qunit path/to/some-test.gjs        # one file
+bin/qunit path/to/integration/components  # a directory
+bin/qunit -f "BookmarkIcon"            # filter by module/test name
+bin/qunit --target chat                # a specific plugin
+```
+
+Requires a running Rails server (or pass `--standalone` to spin up an isolated one).
+
+## Before committing
+
+Always lint changed test files:
+
+```sh
+bin/lint --fix --recent
+```

--- a/frontend/discourse/tests/integration/components/a11y/live-regions-test.gjs
+++ b/frontend/discourse/tests/integration/components/a11y/live-regions-test.gjs
@@ -5,7 +5,7 @@ import A11yLiveRegions from "discourse/components/a11y/live-regions";
 import { disableClearA11yAnnouncementsInTests } from "discourse/services/a11y";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | a11y/live-regions", function (hooks) {
+module("Integration | Component | A11y | LiveRegions", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders polite and assertive live regions", async function (assert) {

--- a/frontend/discourse/tests/integration/components/a11y/skip-links-test.gjs
+++ b/frontend/discourse/tests/integration/components/a11y/skip-links-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | a11y/skip-links", function (hooks) {
+module("Integration | Component | A11y | SkipLinks", function (hooks) {
   setupRenderingTest(hooks);
 
   test("skip link height does not exceed -75px offset on narrow 320px viewports", async function (assert) {

--- a/frontend/discourse/tests/integration/components/about-page-test.gjs
+++ b/frontend/discourse/tests/integration/components/about-page-test.gjs
@@ -23,7 +23,7 @@ function createModelObject({
   );
 }
 
-module("Integration | Component | about-page", function (hooks) {
+module("Integration | Component | AboutPage", function (hooks) {
   setupRenderingTest(hooks);
 
   test("custom site activities registered via the plugin API", async function (assert) {

--- a/frontend/discourse/tests/integration/components/accessible-discovery-heading-test.gjs
+++ b/frontend/discourse/tests/integration/components/accessible-discovery-heading-test.gjs
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "ember-qunit";
 import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
-module("Component | discovery/accessible-discovery-heading", function (hooks) {
+module("Component | Discovery | AccessibleDiscoveryHeading", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders the correct label for categories filter", async function (assert) {

--- a/frontend/discourse/tests/integration/components/activation-controls-test.gjs
+++ b/frontend/discourse/tests/integration/components/activation-controls-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import ActivationControls from "discourse/components/activation-controls";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | activation-controls", function (hooks) {
+module("Integration | Component | ActivationControls", function (hooks) {
   setupRenderingTest(hooks);
 
   test("hides change email button", async function (assert) {

--- a/frontend/discourse/tests/integration/components/add-category-tag-classes-test.gjs
+++ b/frontend/discourse/tests/integration/components/add-category-tag-classes-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import AddCategoryTagClasses from "discourse/components/add-category-tag-classes";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | add-category-tag-classes", function (hooks) {
+module("Integration | Component | AddCategoryTagClasses", function (hooks) {
   setupRenderingTest(hooks);
 
   test("adds category classes to body", async function (assert) {

--- a/frontend/discourse/tests/integration/components/admin-plugin-config-area-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-plugin-config-area-test.gjs
@@ -6,7 +6,7 @@ import AdminPlugin from "discourse/admin/models/admin-plugin";
 import { registerAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | admin-plugin-config-area", function (hooks) {
+module("Integration | Component | AdminPluginConfigArea", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders the nav items along the top", async function (assert) {

--- a/frontend/discourse/tests/integration/components/admin-plugins-list-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-plugins-list-item-test.gjs
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 import AdminPluginsListItem from "discourse/admin/components/admin-plugins-list-item";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | admin-plugins-list-item", function (hooks) {
+module("Integration | Component | AdminPluginsListItem", function (hooks) {
   setupRenderingTest(hooks);
 
   function pluginAttrs() {

--- a/frontend/discourse/tests/integration/components/admin-report-chart-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-report-chart-test.gjs
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { hasIncompleteData } from "discourse/admin/components/admin-report-chart";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | admin-report-chart", function (hooks) {
+module("Integration | Component | AdminReportChart", function (hooks) {
   setupRenderingTest(hooks);
 
   module("hasIncompleteData", function () {

--- a/frontend/discourse/tests/integration/components/admin-report-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-report-test.gjs
@@ -4,7 +4,7 @@ import AdminReport from "discourse/admin/components/admin-report";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
-module("Integration | Component | admin-report", function (hooks) {
+module("Integration | Component | AdminReport", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default", async function (assert) {

--- a/frontend/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
@@ -88,7 +88,7 @@ const MOVE_UP_BTN = ".schema-setting-editor__move-up-btn";
 const MOVE_DOWN_BTN = ".schema-setting-editor__move-down-btn";
 
 module(
-  "Integration | Admin | Themes | Component | schema-setting/editor",
+  "Integration | Admin | Themes | Component | SchemaSetting | Editor",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -1865,7 +1865,7 @@ module(
 );
 
 module(
-  "Integration | Admin | Plugins | Component | schema-setting/editor",
+  "Integration | Admin | Plugins | Component | SchemaSetting | Editor",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/admin-theme-settings-editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-theme-settings-editor-test.gjs
@@ -3,127 +3,110 @@ import { module, test } from "qunit";
 import ThemeSettingsEditor from "discourse/admin/components/theme-settings-editor";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module(
-  "Integration | Component | admin-theme-settings-editor",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | AdminThemeSettingsEditor", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("renders passed json model object into string in the ace editor", async function (assert) {
-      const model = {
-        model: {
-          settings: [
-            { setting: "setting1", value: "value1" },
-            { setting: "setting2", value: "value2" },
-          ],
-        },
-      };
+  test("renders passed json model object into string in the ace editor", async function (assert) {
+    const model = {
+      model: {
+        settings: [
+          { setting: "setting1", value: "value1" },
+          { setting: "setting2", value: "value2" },
+        ],
+      },
+    };
 
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
+
+    assert.dom(".ace_line").hasText("[");
+  });
+
+  test("input is valid json", async function (assert) {
+    const model = [];
+
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
+
+    await fillIn(".ace textarea", "foo");
+    await click("button#save");
+
+    assert.dom(".validation-error").hasText(/Syntax Error/);
+  });
+
+  test("'setting' key is present for each setting", async function (assert) {
+    const model = [];
+
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
+
+    await fillIn(".ace textarea", `[{ "value": "value1" }]`);
+    await click("button#save");
+
+    assert.dom(".validation-error").hasText(/Syntax Error/);
+  });
+
+  test("'value' key is present for each setting", async function (assert) {
+    const model = [];
+
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
+
+    await fillIn(".ace textarea", `[{ "setting": "setting1" }]`);
+    await click("button#save");
+
+    assert.dom(".validation-error").hasText(/Syntax Error/);
+  });
+
+  test("only 'setting' and 'value' keys are present, no others", async function (assert) {
+    const model = [];
+
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
+
+    await fillIn(".ace textarea", `[{ "other_key": "other-key-1" }]`);
+    await click("button#save");
+
+    assert.dom(".validation-error").hasText(/Syntax Error/);
+  });
+
+  test("no settings are deleted", async function (assert) {
+    const model = {
+      model: {
+        settings: [{ setting: "foo", value: "foo" }],
+      },
+    };
+
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
+
+    find(".ace").aceEditor.session.doc.setValue(
+      JSON.stringify([{ setting: "bar", value: "bar" }])
+    );
+    await click("button#save");
+
+    assert
+      .dom(".validation-error")
+      .hasText(
+        "foo: These settings were deleted. Please restore them and try again."
       );
+  });
 
-      assert.dom(".ace_line").hasText("[");
-    });
+  test("no settings are added", async function (assert) {
+    const model = {
+      model: {
+        settings: [{ setting: "bar", value: "bar" }],
+      },
+    };
 
-    test("input is valid json", async function (assert) {
-      const model = [];
+    await render(<template><ThemeSettingsEditor @model={{model}} /></template>);
 
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
+    find(".ace").aceEditor.session.doc.setValue(
+      JSON.stringify([
+        { setting: "foo", value: "foo" },
+        { setting: "bar", value: "bar" },
+      ])
+    );
+    await click("button#save");
+
+    assert
+      .dom(".validation-error")
+      .hasText(
+        "foo: These settings were added. Please remove them and try again."
       );
-
-      await fillIn(".ace textarea", "foo");
-      await click("button#save");
-
-      assert.dom(".validation-error").hasText(/Syntax Error/);
-    });
-
-    test("'setting' key is present for each setting", async function (assert) {
-      const model = [];
-
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
-      );
-
-      await fillIn(".ace textarea", `[{ "value": "value1" }]`);
-      await click("button#save");
-
-      assert.dom(".validation-error").hasText(/Syntax Error/);
-    });
-
-    test("'value' key is present for each setting", async function (assert) {
-      const model = [];
-
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
-      );
-
-      await fillIn(".ace textarea", `[{ "setting": "setting1" }]`);
-      await click("button#save");
-
-      assert.dom(".validation-error").hasText(/Syntax Error/);
-    });
-
-    test("only 'setting' and 'value' keys are present, no others", async function (assert) {
-      const model = [];
-
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
-      );
-
-      await fillIn(".ace textarea", `[{ "other_key": "other-key-1" }]`);
-      await click("button#save");
-
-      assert.dom(".validation-error").hasText(/Syntax Error/);
-    });
-
-    test("no settings are deleted", async function (assert) {
-      const model = {
-        model: {
-          settings: [{ setting: "foo", value: "foo" }],
-        },
-      };
-
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
-      );
-
-      find(".ace").aceEditor.session.doc.setValue(
-        JSON.stringify([{ setting: "bar", value: "bar" }])
-      );
-      await click("button#save");
-
-      assert
-        .dom(".validation-error")
-        .hasText(
-          "foo: These settings were deleted. Please restore them and try again."
-        );
-    });
-
-    test("no settings are added", async function (assert) {
-      const model = {
-        model: {
-          settings: [{ setting: "bar", value: "bar" }],
-        },
-      };
-
-      await render(
-        <template><ThemeSettingsEditor @model={{model}} /></template>
-      );
-
-      find(".ace").aceEditor.session.doc.setValue(
-        JSON.stringify([
-          { setting: "foo", value: "foo" },
-          { setting: "bar", value: "bar" },
-        ])
-      );
-      await click("button#save");
-
-      assert
-        .dom(".validation-error")
-        .hasText(
-          "foo: These settings were added. Please remove them and try again."
-        );
-    });
-  }
-);
+  });
+});

--- a/frontend/discourse/tests/integration/components/avatar-uploader-test.gjs
+++ b/frontend/discourse/tests/integration/components/avatar-uploader-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { createFile } from "discourse/tests/helpers/qunit-helpers";
 
-module("Integration | Component | avatar-uploader", function (hooks) {
+module("Integration | Component | AvatarUploader", function (hooks) {
   setupRenderingTest(hooks);
 
   test("uploading", async function (assert) {

--- a/frontend/discourse/tests/integration/components/badge-title-test.gjs
+++ b/frontend/discourse/tests/integration/components/badge-title-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | badge-title", function (hooks) {
+module("Integration | Component | BadgeTitle", function (hooks) {
   setupRenderingTest(hooks);
 
   test("badge title", async function (assert) {

--- a/frontend/discourse/tests/integration/components/bookmark-icon-test.gjs
+++ b/frontend/discourse/tests/integration/components/bookmark-icon-test.gjs
@@ -6,7 +6,7 @@ import { tomorrow } from "discourse/lib/time-utils";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | bookmark-icon", function (hooks) {
+module("Integration | Component | BookmarkIcon", function (hooks) {
   setupRenderingTest(hooks);
 
   test("with reminder", async function (assert) {

--- a/frontend/discourse/tests/integration/components/d-document-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-document-test.gjs
@@ -16,7 +16,7 @@ function triggerTitleUpdate(appEvents) {
   appEvents.trigger("notifications:changed", { forced: true });
 }
 
-module("Integration | Component | d-document", function (hooks) {
+module("Integration | Component | DDocument", function (hooks) {
   setupRenderingTest(hooks);
 
   test("with user menu", async function (assert) {

--- a/frontend/discourse/tests/integration/components/d-navigation-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-navigation-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import DNavigation from "discourse/components/d-navigation";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | d-navigation", function (hooks) {
+module("Integration | Component | DNavigation", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/d-section-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-section-test.gjs
@@ -4,7 +4,7 @@ import DSection from "discourse/components/d-section";
 import { withSilencedDeprecationsAsync } from "discourse/lib/deprecated";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | d-section", function (hooks) {
+module("Integration | Component | DSection", function (hooks) {
   setupRenderingTest(hooks);
 
   test("can set classes on the body element", async function (assert) {

--- a/frontend/discourse/tests/integration/components/d-segmented-control-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-segmented-control-test.gjs
@@ -4,7 +4,7 @@ import DSegmentedControl from "discourse/components/d-segmented-control";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import I18n, { i18n } from "discourse-i18n";
 
-module("Integration | Component | d-segmented-control", function (hooks) {
+module("Integration | Component | DSegmentedControl", function (hooks) {
   setupRenderingTest(hooks);
 
   const ITEMS = [

--- a/frontend/discourse/tests/integration/components/dialog-holder-test.gjs
+++ b/frontend/discourse/tests/integration/components/dialog-holder-test.gjs
@@ -14,7 +14,7 @@ import DialogHolder from "discourse/dialog-holder/components/dialog-holder";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | dialog-holder", function (hooks) {
+module("Integration | Component | DialogHolder", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/discovery/filter-navigation-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/discovery/filter-navigation-menu-test.gjs
@@ -11,7 +11,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module(
-  "Integration | Component | discovery | FilterNavigationMenu",
+  "Integration | Component | Discovery | FilterNavigationMenu",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/dismiss-new-test.gjs
+++ b/frontend/discourse/tests/integration/components/dismiss-new-test.gjs
@@ -4,7 +4,7 @@ import DismissNew from "discourse/components/modal/dismiss-new";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | modal/dismiss-new", function (hooks) {
+module("Integration | Component | Modal | DismissNew", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/docked-composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/docked-composer-test.gjs
@@ -4,7 +4,7 @@ import DockedComposer from "discourse/components/docked-composer";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
-module("Integration | Component | docked-composer", function (hooks) {
+module("Integration | Component | DockedComposer", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/emoji-picker-test.gjs
+++ b/frontend/discourse/tests/integration/components/emoji-picker-test.gjs
@@ -7,7 +7,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import emojiPicker from "discourse/tests/helpers/emoji-picker-helper";
 
-module("Integration | Component | emoji-picker-content", function (hooks) {
+module("Integration | Component | EmojiPickerContent", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/emoji-uploader-test.gjs
+++ b/frontend/discourse/tests/integration/components/emoji-uploader-test.gjs
@@ -9,7 +9,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 let requestNumber;
 
-module("Integration | Component | emoji-uploader", function (hooks) {
+module("Integration | Component | EmojiUploader", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/file-size-input-test.gjs
+++ b/frontend/discourse/tests/integration/components/file-size-input-test.gjs
@@ -4,7 +4,7 @@ import FileSizeInput from "discourse/admin/components/file-size-input";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | file-size-input", function (hooks) {
+module("Integration | Component | FileSizeInput", function (hooks) {
   setupRenderingTest(hooks);
 
   test("file size unit selector kb", async function (assert) {

--- a/frontend/discourse/tests/integration/components/float-kit/d-button-tooltip-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-button-tooltip-test.gjs
@@ -5,27 +5,24 @@ import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DButton from "discourse/ui-kit/d-button";
 
-module(
-  "Integration | Component | FloatKit | d-button-tooltip",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | FloatKit | DButtonTooltip", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("default", async function (assert) {
-      await render(
-        <template>
-          <DButtonTooltip>
-            <:button>
-              <DButton />
-            </:button>
-            <:tooltip>
-              <DTooltip />
-            </:tooltip>
-          </DButtonTooltip>
-        </template>
-      );
+  test("default", async function (assert) {
+    await render(
+      <template>
+        <DButtonTooltip>
+          <:button>
+            <DButton />
+          </:button>
+          <:tooltip>
+            <DTooltip />
+          </:tooltip>
+        </DButtonTooltip>
+      </template>
+    );
 
-      assert.dom(".btn").exists();
-      assert.dom("[data-trigger]").exists();
-    });
-  }
-);
+    assert.dom(".btn").exists();
+    assert.dom("[data-trigger]").exists();
+  });
+});

--- a/frontend/discourse/tests/integration/components/float-kit/d-default-toast-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-default-toast-test.gjs
@@ -5,128 +5,125 @@ import DToastInstance from "discourse/float-kit/lib/d-toast-instance";
 import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module(
-  "Integration | Component | FloatKit | d-default-toast",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | FloatKit | DDefaultToast", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("icon", async function (assert) {
-      this.toast = new DToastInstance(this, { data: { icon: "check" } });
+  test("icon", async function (assert) {
+    this.toast = new DToastInstance(this, { data: { icon: "check" } });
 
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
 
-      assert.dom(".fk-d-default-toast__icon-container .d-icon-check").exists();
+    assert.dom(".fk-d-default-toast__icon-container .d-icon-check").exists();
+  });
+
+  test("no icon", async function (assert) {
+    this.toast = new DToastInstance(this, {});
+
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
+
+    assert.dom(".fk-d-default-toast__icon-container").doesNotExist();
+  });
+
+  test("progress bar", async function (assert) {
+    this.toast = new DToastInstance(this, {});
+
+    await render(
+      <template>
+        <DDefaultToast
+          @data={{this.toast.options.data}}
+          @showProgressBar={{true}}
+          @onRegisterProgressBar={{(noop)}}
+        />
+      </template>
+    );
+
+    assert.dom(".fk-d-default-toast__progress-bar").exists();
+  });
+
+  test("no progress bar", async function (assert) {
+    this.toast = new DToastInstance(this, {});
+
+    await render(
+      <template>
+        <DDefaultToast
+          @data={{this.toast.options.data}}
+          @showProgressBar={{false}}
+        />
+      </template>
+    );
+
+    assert.dom(".fk-d-default-toast__progress-bar").doesNotExist();
+  });
+
+  test("title", async function (assert) {
+    this.toast = new DToastInstance(this, { data: { title: "Title" } });
+
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
+
+    assert
+      .dom(".fk-d-default-toast__title")
+      .hasText(this.toast.options.data.title);
+  });
+
+  test("no title", async function (assert) {
+    this.toast = new DToastInstance(this, {});
+
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
+
+    assert.dom(".fk-d-default-toast__title").doesNotExist();
+  });
+
+  test("message", async function (assert) {
+    this.toast = new DToastInstance(this, { data: { message: "Message" } });
+
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
+
+    assert
+      .dom(".fk-d-default-toast__message")
+      .hasText(this.toast.options.data.message);
+  });
+
+  test("no message", async function (assert) {
+    this.toast = new DToastInstance(this, {});
+
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
+
+    assert.dom(".fk-d-default-toast__message").doesNotExist();
+  });
+
+  test("actions", async function (assert) {
+    this.toast = new DToastInstance(this, {
+      data: {
+        actions: [
+          {
+            label: "cancel",
+            icon: "xmark",
+            class: "btn-danger",
+            action: () => {},
+          },
+        ],
+      },
     });
 
-    test("no icon", async function (assert) {
-      this.toast = new DToastInstance(this, {});
+    await render(
+      <template><DDefaultToast @data={{this.toast.options.data}} /></template>
+    );
 
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
-
-      assert.dom(".fk-d-default-toast__icon-container").doesNotExist();
-    });
-
-    test("progress bar", async function (assert) {
-      this.toast = new DToastInstance(this, {});
-
-      await render(
-        <template>
-          <DDefaultToast
-            @data={{this.toast.options.data}}
-            @showProgressBar={{true}}
-            @onRegisterProgressBar={{(noop)}}
-          />
-        </template>
-      );
-
-      assert.dom(".fk-d-default-toast__progress-bar").exists();
-    });
-
-    test("no progress bar", async function (assert) {
-      this.toast = new DToastInstance(this, {});
-
-      await render(
-        <template>
-          <DDefaultToast
-            @data={{this.toast.options.data}}
-            @showProgressBar={{false}}
-          />
-        </template>
-      );
-
-      assert.dom(".fk-d-default-toast__progress-bar").doesNotExist();
-    });
-
-    test("title", async function (assert) {
-      this.toast = new DToastInstance(this, { data: { title: "Title" } });
-
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
-
-      assert
-        .dom(".fk-d-default-toast__title")
-        .hasText(this.toast.options.data.title);
-    });
-
-    test("no title", async function (assert) {
-      this.toast = new DToastInstance(this, {});
-
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
-
-      assert.dom(".fk-d-default-toast__title").doesNotExist();
-    });
-
-    test("message", async function (assert) {
-      this.toast = new DToastInstance(this, { data: { message: "Message" } });
-
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
-
-      assert
-        .dom(".fk-d-default-toast__message")
-        .hasText(this.toast.options.data.message);
-    });
-
-    test("no message", async function (assert) {
-      this.toast = new DToastInstance(this, {});
-
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
-
-      assert.dom(".fk-d-default-toast__message").doesNotExist();
-    });
-
-    test("actions", async function (assert) {
-      this.toast = new DToastInstance(this, {
-        data: {
-          actions: [
-            {
-              label: "cancel",
-              icon: "xmark",
-              class: "btn-danger",
-              action: () => {},
-            },
-          ],
-        },
-      });
-
-      await render(
-        <template><DDefaultToast @data={{this.toast.options.data}} /></template>
-      );
-
-      assert
-        .dom(".fk-d-default-toast__actions .btn.btn-danger")
-        .exists()
-        .hasText("cancel");
-    });
-  }
-);
+    assert
+      .dom(".fk-d-default-toast__actions .btn.btn-danger")
+      .exists()
+      .hasText("cancel");
+  });
+});

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -18,7 +18,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DButton from "discourse/ui-kit/d-button";
 import dElement from "discourse/ui-kit/helpers/d-element";
 
-module("Integration | Component | FloatKit | d-menu", function (hooks) {
+module("Integration | Component | FloatKit | DMenu", function (hooks) {
   setupRenderingTest(hooks);
 
   async function open() {

--- a/frontend/discourse/tests/integration/components/float-kit/d-toast-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-toast-test.gjs
@@ -23,7 +23,7 @@ function createCustomToastInstance(owner, options, newClose) {
   return new CustomToastInstance(owner, options);
 }
 
-module("Integration | Component | FloatKit | d-toast", function (hooks) {
+module("Integration | Component | FloatKit | DToast", function (hooks) {
   setupRenderingTest(hooks);
 
   test("swipe up to close", async function (assert) {

--- a/frontend/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-tooltip-test.gjs
@@ -15,7 +15,7 @@ import DTooltipInstance from "discourse/float-kit/lib/d-tooltip-instance";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | FloatKit | d-tooltip", function (hooks) {
+module("Integration | Component | FloatKit | DTooltip", function (hooks) {
   setupRenderingTest(hooks);
 
   async function hover() {

--- a/frontend/discourse/tests/integration/components/form-template-field/checkbox-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/checkbox-test.gjs
@@ -5,7 +5,7 @@ import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module(
-  "Integration | Component | form-template-field | checkbox",
+  "Integration | Component | FormTemplateField | Checkbox",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -11,7 +11,7 @@ function fakeUppy() {
 }
 
 module(
-  "Integration | Component | form-template-field | composer",
+  "Integration | Component | FormTemplateField | Composer",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/dropdown-test.gjs
@@ -7,7 +7,7 @@ import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
-  "Integration | Component | form-template-field | dropdown",
+  "Integration | Component | FormTemplateField | Dropdown",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/input-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/input-test.gjs
@@ -4,83 +4,80 @@ import FormInput from "discourse/components/form-template-field/input";
 import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module(
-  "Integration | Component | form-template-field | input",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | FormTemplateField | Input", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("renders a text input", async function (assert) {
-      await render(<template><FormInput @onChange={{noop}} /></template>);
+  test("renders a text input", async function (assert) {
+    await render(<template><FormInput @onChange={{noop}} /></template>);
 
-      assert
-        .dom(".form-template-field[data-field-type='input'] input[type='text']")
-        .exists("a text input component exists");
-    });
+    assert
+      .dom(".form-template-field[data-field-type='input'] input[type='text']")
+      .exists("a text input component exists");
+  });
 
-    test("renders a text input with attributes", async function (assert) {
-      const attributes = {
-        label: "My text label",
-        placeholder: "Enter text here",
-      };
+  test("renders a text input with attributes", async function (assert) {
+    const attributes = {
+      label: "My text label",
+      placeholder: "Enter text here",
+    };
 
-      await render(
-        <template>
-          <FormInput @attributes={{attributes}} @onChange={{noop}} />
-        </template>
-      );
+    await render(
+      <template>
+        <FormInput @attributes={{attributes}} @onChange={{noop}} />
+      </template>
+    );
 
-      assert
-        .dom(".form-template-field[data-field-type='input'] input[type='text']")
-        .exists("a text input component exists");
+    assert
+      .dom(".form-template-field[data-field-type='input'] input[type='text']")
+      .exists("a text input component exists");
 
-      assert.dom(".form-template-field__label").hasText("My text label");
-      assert
-        .dom(".form-template-field__input")
-        .hasAttribute("placeholder", "Enter text here");
-    });
+    assert.dom(".form-template-field__label").hasText("My text label");
+    assert
+      .dom(".form-template-field__input")
+      .hasAttribute("placeholder", "Enter text here");
+  });
 
-    test("doesn't render a label when attribute is missing", async function (assert) {
-      const attributes = {
-        placeholder: "Enter text here",
-      };
+  test("doesn't render a label when attribute is missing", async function (assert) {
+    const attributes = {
+      placeholder: "Enter text here",
+    };
 
-      await render(
-        <template>
-          <FormInput @attributes={{attributes}} @onChange={{noop}} />
-        </template>
-      );
+    await render(
+      <template>
+        <FormInput @attributes={{attributes}} @onChange={{noop}} />
+      </template>
+    );
 
-      assert.dom(".form-template-field__label").doesNotExist();
-    });
+    assert.dom(".form-template-field__label").doesNotExist();
+  });
 
-    test("renders a description if present", async function (assert) {
-      const attributes = {
-        description: "Your full name",
-      };
+  test("renders a description if present", async function (assert) {
+    const attributes = {
+      description: "Your full name",
+    };
 
-      await render(
-        <template>
-          <FormInput @attributes={{attributes}} @onChange={{noop}} />
-        </template>
-      );
+    await render(
+      <template>
+        <FormInput @attributes={{attributes}} @onChange={{noop}} />
+      </template>
+    );
 
-      assert.dom(".form-template-field__description").hasText("Your full name");
-    });
+    assert.dom(".form-template-field__description").hasText("Your full name");
+  });
 
-    test("renders a description if present", async function (assert) {
-      const attributes = {
-        description: "Write your bio here",
-      };
+  test("renders a description if present", async function (assert) {
+    const attributes = {
+      description: "Write your bio here",
+    };
 
-      await render(
-        <template>
-          <FormInput @attributes={{attributes}} @onChange={{noop}} />
-        </template>
-      );
+    await render(
+      <template>
+        <FormInput @attributes={{attributes}} @onChange={{noop}} />
+      </template>
+    );
 
-      assert
-        .dom(".form-template-field__description")
-        .hasText("Write your bio here");
-    });
-  }
-);
+    assert
+      .dom(".form-template-field__description")
+      .hasText("Write your bio here");
+  });
+});

--- a/frontend/discourse/tests/integration/components/form-template-field/multi-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/multi-select-test.gjs
@@ -7,7 +7,7 @@ import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
-  "Integration | Component | form-template-field | multi-select",
+  "Integration | Component | FormTemplateField | MultiSelect",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/textarea-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/textarea-test.gjs
@@ -5,7 +5,7 @@ import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module(
-  "Integration | Component | form-template-field | textarea",
+  "Integration | Component | FormTemplateField | Textarea",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/upload-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/upload-test.gjs
@@ -5,7 +5,7 @@ import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module(
-  "Integration | Component | form-template-field | upload",
+  "Integration | Component | FormTemplateField | Upload",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/wrapper-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/wrapper-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module(
-  "Integration | Component | form-template-field | wrapper",
+  "Integration | Component | FormTemplateField | Wrapper",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/group-membership-button-test.gjs
+++ b/frontend/discourse/tests/integration/components/group-membership-button-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import GroupMembershipButton from "discourse/components/group-membership-button";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | group-membership-button", function (hooks) {
+module("Integration | Component | GroupMembershipButton", function (hooks) {
   setupRenderingTest(hooks);
 
   test("canJoinGroup", async function (assert) {

--- a/frontend/discourse/tests/integration/components/home-logo-test.gjs
+++ b/frontend/discourse/tests/integration/components/home-logo-test.gjs
@@ -13,7 +13,7 @@ const darkLogo = "/images/d-logo-sketch.png?dark";
 const title = "Cool Forum";
 const prefersDark = "(prefers-color-scheme: dark)";
 
-module("Integration | Component | home-logo", function (hooks) {
+module("Integration | Component | HomeLogo", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.afterEach(function () {

--- a/frontend/discourse/tests/integration/components/iframed-html-test.gjs
+++ b/frontend/discourse/tests/integration/components/iframed-html-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import IframedHtml from "discourse/components/iframed-html";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | iframed-html", function (hooks) {
+module("Integration | Component | IframedHtml", function (hooks) {
   setupRenderingTest(hooks);
 
   test("appends the html into the iframe", async function (assert) {

--- a/frontend/discourse/tests/integration/components/image-carousel-test.gjs
+++ b/frontend/discourse/tests/integration/components/image-carousel-test.gjs
@@ -3,7 +3,7 @@ import { setupRenderingTest } from "ember-qunit";
 import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 
-module("Integration | Component | image-carousel", function (hooks) {
+module("Integration | Component | ImageCarousel", function (hooks) {
   setupRenderingTest(hooks);
 
   const items = [

--- a/frontend/discourse/tests/integration/components/invite-panel-test.gjs
+++ b/frontend/discourse/tests/integration/components/invite-panel-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | invite-panel", function (hooks) {
+module("Integration | Component | InvitePanel", function (hooks) {
   setupRenderingTest(hooks);
 
   test("shows the invite link after it is generated", async function (assert) {

--- a/frontend/discourse/tests/integration/components/latest-topic-list-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/latest-topic-list-item-test.gjs
@@ -4,7 +4,7 @@ import LatestTopicListItem from "discourse/components/topic-list/latest-topic-li
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | latest-topic-list-item", function (hooks) {
+module("Integration | Component | LatestTopicListItem", function (hooks) {
   setupRenderingTest(hooks);
 
   test("latest-topic-list-item-class value transformer", async function (assert) {

--- a/frontend/discourse/tests/integration/components/navigation-bar-test.gjs
+++ b/frontend/discourse/tests/integration/components/navigation-bar-test.gjs
@@ -24,7 +24,7 @@ const navItems = [
   }),
 ];
 
-module("Integration | Component | navigation-bar", function (hooks) {
+module("Integration | Component | NavigationBar", function (hooks) {
   setupRenderingTest(hooks);
 
   test("display navigation bar items", async function (assert) {

--- a/frontend/discourse/tests/integration/components/number-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/number-field-test.gjs
@@ -4,7 +4,7 @@ import { withSilencedDeprecationsAsync } from "discourse/lib/deprecated";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DNumberField from "discourse/ui-kit/d-number-field";
 
-module("Integration | Component | number-field", function (hooks) {
+module("Integration | Component | NumberField", function (hooks) {
   setupRenderingTest(hooks);
 
   test("number field", async function (assert) {

--- a/frontend/discourse/tests/integration/components/pinned-options-test.gjs
+++ b/frontend/discourse/tests/integration/components/pinned-options-test.gjs
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 import PinnedOptions from "discourse/components/pinned-options";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | pinned-options", function (hooks) {
+module("Integration | Component | PinnedOptions", function (hooks) {
   setupRenderingTest(hooks);
 
   test("unpinning", async function (assert) {

--- a/frontend/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/frontend/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -36,7 +36,7 @@ import {
 const TEMPLATE_PREFIX = "discourse/plugins/some-plugin/templates/connectors";
 const CLASS_PREFIX = "discourse/plugins/some-plugin/connectors";
 
-module("Integration | Component | plugin-outlet", function (hooks) {
+module("Integration | Component | PluginOutlet", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
@@ -672,7 +672,7 @@ module("Integration | Component | plugin-outlet", function (hooks) {
 });
 
 module(
-  "Integration | Component | plugin-outlet | connector class definitions",
+  "Integration | Component | PluginOutlet | connector class definitions",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -1033,7 +1033,7 @@ module(
 );
 
 module(
-  "Integration | Component | plugin-outlet | gjs class definitions",
+  "Integration | Component | PluginOutlet | gjs class definitions",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -1055,7 +1055,7 @@ module(
 );
 
 module(
-  "Integration | Component | plugin-outlet | extraConnectorComponent",
+  "Integration | Component | PluginOutlet | ExtraConnectorComponent",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -1093,7 +1093,7 @@ module(
 );
 
 module(
-  "Integration | Component | plugin-outlet | legacy extraConnectorClass",
+  "Integration | Component | PluginOutlet | legacy extraConnectorClass",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -1124,7 +1124,7 @@ module(
 );
 
 module(
-  "Integration | Component | plugin-outlet | argument currying",
+  "Integration | Component | PluginOutlet | argument currying",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -1243,63 +1243,60 @@ module(
   }
 );
 
-module(
-  "Integration | Component | plugin-outlet | whitespace",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | PluginOutlet | Whitespace", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("no whitespace for unused outlet", async function (assert) {
-      await render(
-        <template>
-          <div class="test-wrapper"><PluginOutlet @name="test-name" /></div>
-        </template>
-      );
-      assert.dom(".test-wrapper").hasText(/^$/, "no whitespace"); // using regex to avoid hasText builtin strip
-    });
+  test("no whitespace for unused outlet", async function (assert) {
+    await render(
+      <template>
+        <div class="test-wrapper"><PluginOutlet @name="test-name" /></div>
+      </template>
+    );
+    assert.dom(".test-wrapper").hasText(/^$/, "no whitespace"); // using regex to avoid hasText builtin strip
+  });
 
-    test("no whitespace for used outlet", async function (assert) {
-      extraConnectorComponent("test-name", <template></template>);
+  test("no whitespace for used outlet", async function (assert) {
+    extraConnectorComponent("test-name", <template></template>);
 
-      await render(
-        <template>
-          <div class="test-wrapper"><PluginOutlet @name="test-name" /></div>
-        </template>
-      );
-      assert.dom(".test-wrapper").hasText(/^$/, "no whitespace"); // using regex to avoid hasText builtin strip
-    });
+    await render(
+      <template>
+        <div class="test-wrapper"><PluginOutlet @name="test-name" /></div>
+      </template>
+    );
+    assert.dom(".test-wrapper").hasText(/^$/, "no whitespace"); // using regex to avoid hasText builtin strip
+  });
 
-    test("no whitespace for unused wrapper outlet", async function (assert) {
-      await render(
-        <template>
-          <div class="test-wrapper"><PluginOutlet
-              @name="test-name"
-            >foo</PluginOutlet></div>
-        </template>
-      );
-      assert.dom(".test-wrapper").hasText(/^foo$/, "no whitespace"); // using regex to avoid hasText builtin strip
-    });
+  test("no whitespace for unused wrapper outlet", async function (assert) {
+    await render(
+      <template>
+        <div class="test-wrapper"><PluginOutlet
+            @name="test-name"
+          >foo</PluginOutlet></div>
+      </template>
+    );
+    assert.dom(".test-wrapper").hasText(/^foo$/, "no whitespace"); // using regex to avoid hasText builtin strip
+  });
 
-    test("no whitespace for used wrapper outlet", async function (assert) {
-      extraConnectorComponent(
-        "test-name",
-        <template>
-          {{! eslint-disable ember/template-no-yield-only }}{{yield}}
-        </template>
-      );
-      await render(
-        <template>
-          <div class="test-wrapper"><PluginOutlet
-              @name="test-name"
-            >foo</PluginOutlet></div>
-        </template>
-      );
-      assert.dom(".test-wrapper").hasText(/^foo$/, "no whitespace"); // using regex to avoid hasText builtin strip
-    });
-  }
-);
+  test("no whitespace for used wrapper outlet", async function (assert) {
+    extraConnectorComponent(
+      "test-name",
+      <template>
+        {{! eslint-disable ember/template-no-yield-only }}{{yield}}
+      </template>
+    );
+    await render(
+      <template>
+        <div class="test-wrapper"><PluginOutlet
+            @name="test-name"
+          >foo</PluginOutlet></div>
+      </template>
+    );
+    assert.dom(".test-wrapper").hasText(/^foo$/, "no whitespace"); // using regex to avoid hasText builtin strip
+  });
+});
 
 module(
-  "Integration | Component | plugin-outlet | aliases and deprecations",
+  "Integration | Component | PluginOutlet | aliases and deprecations",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/post/menu/post-users-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/menu/post-users-menu-test.gjs
@@ -41,144 +41,147 @@ function renderMenu({ fetchUsers, totalUsers, onReset = () => {} }) {
   );
 }
 
-module("Integration | Component | post/menu/post-users-menu", function (hooks) {
-  setupRenderingTest(hooks);
+module(
+  "Integration | Component | Post | Menu | PostUsersMenu",
+  function (hooks) {
+    setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    enableLoadMoreObserver();
-    this.observations = stubIntersectionObserver();
-  });
-
-  hooks.afterEach(function () {
-    disableLoadMoreObserver();
-  });
-
-  test("renders skeleton rows while the initial fetch is pending", async function (assert) {
-    const { fetchUsers, resolve } = deferredFetch({
-      users: makeUsers(5),
-      canLoadMore: false,
+    hooks.beforeEach(function () {
+      enableLoadMoreObserver();
+      this.observations = stubIntersectionObserver();
     });
 
-    const renderPromise = renderMenu({ fetchUsers, totalUsers: 5 });
-
-    await waitFor(".post-users-popup__skeleton-item");
-
-    assert
-      .dom(".post-users-popup__skeleton-item")
-      .exists(
-        { count: 5 },
-        "renders one skeleton per pending user up to PAGE_SIZE"
-      );
-
-    resolve();
-    await renderPromise;
-    await settled();
-
-    assert
-      .dom(".post-users-popup__skeleton-item")
-      .doesNotExist("skeleton rows clear once the fetch resolves");
-    assert
-      .dom(".post-users-popup__item:not(.post-users-popup__skeleton-item)")
-      .exists({ count: 5 }, "renders real user rows after load");
-  });
-
-  test("caps skeleton rows at PAGE_SIZE when totalUsers is larger", async function (assert) {
-    const { fetchUsers, resolve } = deferredFetch({
-      users: makeUsers(30),
-      canLoadMore: true,
+    hooks.afterEach(function () {
+      disableLoadMoreObserver();
     });
 
-    const renderPromise = renderMenu({ fetchUsers, totalUsers: 200 });
+    test("renders skeleton rows while the initial fetch is pending", async function (assert) {
+      const { fetchUsers, resolve } = deferredFetch({
+        users: makeUsers(5),
+        canLoadMore: false,
+      });
 
-    await waitFor(".post-users-popup__skeleton-item");
+      const renderPromise = renderMenu({ fetchUsers, totalUsers: 5 });
 
-    assert
-      .dom(".post-users-popup__skeleton-item")
-      .exists({ count: 30 }, "skeleton count is capped at PAGE_SIZE");
+      await waitFor(".post-users-popup__skeleton-item");
 
-    resolve();
-    await renderPromise;
-    await settled();
-  });
+      assert
+        .dom(".post-users-popup__skeleton-item")
+        .exists(
+          { count: 5 },
+          "renders one skeleton per pending user up to PAGE_SIZE"
+        );
 
-  test("does not fall back to skeleton rows when load more starts with every known user loaded", async function (assert) {
-    let fetchCallCount = 0;
-    let resolveSecondFetch;
-    const secondFetchPromise = new Promise((resolve) => {
-      resolveSecondFetch = resolve;
-    });
-    const fetchUsers = () => {
-      fetchCallCount++;
+      resolve();
+      await renderPromise;
+      await settled();
 
-      if (fetchCallCount === 1) {
-        return Promise.resolve({
-          users: makeUsers(30),
-          canLoadMore: true,
-        });
-      }
-
-      return secondFetchPromise;
-    };
-
-    await renderMenu({ fetchUsers, totalUsers: 30 });
-
-    assert
-      .dom(".post-users-popup__item:not(.post-users-popup__skeleton-item)")
-      .exists({ count: 30 }, "renders the initially loaded full page");
-
-    const triggerPromise =
-      this.observations[this.observations.length - 1]?.trigger();
-    await waitUntil(() => fetchCallCount === 2);
-
-    assert
-      .dom(".post-users-popup__skeleton-item")
-      .doesNotExist(
-        "does not render fallback skeleton rows when totalUsers has already been reached"
-      );
-
-    resolveSecondFetch({ users: [], canLoadMore: false });
-    await triggerPromise;
-    await settled();
-  });
-
-  test("resets scroll position when the user list is reloaded", async function (assert) {
-    const fetchUsers = () =>
-      Promise.resolve({ users: makeUsers(3), canLoadMore: false });
-
-    let resetAndReload;
-    await renderMenu({
-      fetchUsers,
-      onReset: (fn) => (resetAndReload = fn),
+      assert
+        .dom(".post-users-popup__skeleton-item")
+        .doesNotExist("skeleton rows clear once the fetch resolves");
+      assert
+        .dom(".post-users-popup__item:not(.post-users-popup__skeleton-item)")
+        .exists({ count: 5 }, "renders real user rows after load");
     });
 
-    const body = document.querySelector(".post-users-popup__body");
-    body.style.cssText = "max-height: 20px; overflow-y: auto";
-    body.scrollTop = 50;
+    test("caps skeleton rows at PAGE_SIZE when totalUsers is larger", async function (assert) {
+      const { fetchUsers, resolve } = deferredFetch({
+        users: makeUsers(30),
+        canLoadMore: true,
+      });
 
-    await resetAndReload();
+      const renderPromise = renderMenu({ fetchUsers, totalUsers: 200 });
 
-    assert.strictEqual(body.scrollTop, 0, "scrollTop is reset after reload");
-  });
+      await waitFor(".post-users-popup__skeleton-item");
 
-  test("falls back to a small skeleton count when totalUsers is missing", async function (assert) {
-    const { fetchUsers, resolve } = deferredFetch({
-      users: makeUsers(2),
-      canLoadMore: false,
+      assert
+        .dom(".post-users-popup__skeleton-item")
+        .exists({ count: 30 }, "skeleton count is capped at PAGE_SIZE");
+
+      resolve();
+      await renderPromise;
+      await settled();
     });
 
-    const renderPromise = renderMenu({ fetchUsers });
+    test("does not fall back to skeleton rows when load more starts with every known user loaded", async function (assert) {
+      let fetchCallCount = 0;
+      let resolveSecondFetch;
+      const secondFetchPromise = new Promise((resolve) => {
+        resolveSecondFetch = resolve;
+      });
+      const fetchUsers = () => {
+        fetchCallCount++;
 
-    await waitFor(".post-users-popup__skeleton-item");
+        if (fetchCallCount === 1) {
+          return Promise.resolve({
+            users: makeUsers(30),
+            canLoadMore: true,
+          });
+        }
 
-    assert
-      .dom(".post-users-popup__skeleton-item")
-      .exists(
-        { count: 3 },
-        "still shows a small skeleton fallback when count is unknown"
-      );
+        return secondFetchPromise;
+      };
 
-    resolve();
-    await renderPromise;
-    await settled();
-  });
-});
+      await renderMenu({ fetchUsers, totalUsers: 30 });
+
+      assert
+        .dom(".post-users-popup__item:not(.post-users-popup__skeleton-item)")
+        .exists({ count: 30 }, "renders the initially loaded full page");
+
+      const triggerPromise =
+        this.observations[this.observations.length - 1]?.trigger();
+      await waitUntil(() => fetchCallCount === 2);
+
+      assert
+        .dom(".post-users-popup__skeleton-item")
+        .doesNotExist(
+          "does not render fallback skeleton rows when totalUsers has already been reached"
+        );
+
+      resolveSecondFetch({ users: [], canLoadMore: false });
+      await triggerPromise;
+      await settled();
+    });
+
+    test("resets scroll position when the user list is reloaded", async function (assert) {
+      const fetchUsers = () =>
+        Promise.resolve({ users: makeUsers(3), canLoadMore: false });
+
+      let resetAndReload;
+      await renderMenu({
+        fetchUsers,
+        onReset: (fn) => (resetAndReload = fn),
+      });
+
+      const body = document.querySelector(".post-users-popup__body");
+      body.style.cssText = "max-height: 20px; overflow-y: auto";
+      body.scrollTop = 50;
+
+      await resetAndReload();
+
+      assert.strictEqual(body.scrollTop, 0, "scrollTop is reset after reload");
+    });
+
+    test("falls back to a small skeleton count when totalUsers is missing", async function (assert) {
+      const { fetchUsers, resolve } = deferredFetch({
+        users: makeUsers(2),
+        canLoadMore: false,
+      });
+
+      const renderPromise = renderMenu({ fetchUsers });
+
+      await waitFor(".post-users-popup__skeleton-item");
+
+      assert
+        .dom(".post-users-popup__skeleton-item")
+        .exists(
+          { count: 3 },
+          "still shows a small skeleton fallback when count is unknown"
+        );
+
+      resolve();
+      await renderPromise;
+      await settled();
+    });
+  }
+);

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-editor-test.gjs
@@ -9,7 +9,7 @@ import ProsemirrorEditor from "discourse/static/prosemirror/components/prosemirr
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
 
-module("Integration | Component | prosemirror-editor", function (hooks) {
+module("Integration | Component | ProsemirrorEditor", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(() => clearRichEditorExtensions());

--- a/frontend/discourse/tests/integration/components/relative-time-picker-test.gjs
+++ b/frontend/discourse/tests/integration/components/relative-time-picker-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import DRelativeTimePicker from "discourse/ui-kit/d-relative-time-picker";
 
-module("Integration | Component | relative-time-picker", function (hooks) {
+module("Integration | Component | RelativeTimePicker", function (hooks) {
   setupRenderingTest(hooks);
 
   test("calls the onChange arg", async function (assert) {

--- a/frontend/discourse/tests/integration/components/request-group-membership-form-test.gjs
+++ b/frontend/discourse/tests/integration/components/request-group-membership-form-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module(
-  "Integration | Component | request-group-membership-form",
+  "Integration | Component | RequestGroupMembershipForm",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/reviewable/created-by-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/created-by-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import CreatedBy from "discourse/components/reviewable/created-by";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | reviewable | created-by", function (hooks) {
+module("Integration | Component | Reviewable | CreatedBy", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders user avatar and name when user is provided", async function (assert) {

--- a/frontend/discourse/tests/integration/components/reviewable/flag-reason-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/flag-reason-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import ReviewableFlagReason from "discourse/components/reviewable/flag-reason";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | reviewable | flag-reason", function (hooks) {
+module("Integration | Component | Reviewable | FlagReason", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders with basic arguments", async function (assert) {

--- a/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import ReviewableItem from "discourse/components/reviewable/item";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | reviewable | item", function (hooks) {
+module("Integration | Component | Reviewable | Item", function (hooks) {
   setupRenderingTest(hooks);
 
   const reviewable = {

--- a/frontend/discourse/tests/integration/components/reviewable/topic-link-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/topic-link-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import ReviewableTopicLink from "discourse/components/reviewable/topic-link";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | reviewable | topic-link", function (hooks) {
+module("Integration | Component | Reviewable | TopicLink", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders topic information when topic exists", async function (assert) {

--- a/frontend/discourse/tests/integration/components/search-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/search-menu-test.gjs
@@ -17,7 +17,7 @@ import { i18n } from "discourse-i18n";
 // Note this isn't a full-fledge test of the search menu. Those tests are in
 // acceptance/search-test.js. This is simply about the rendering of the
 // menu panel separate from the search input.
-module("Integration | Component | search-menu", function (hooks) {
+module("Integration | Component | SearchMenu", function (hooks) {
   setupRenderingTest(hooks);
 
   test("rendering standalone", async function (assert) {

--- a/frontend/discourse/tests/integration/components/search-menu/results/assistant-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/search-menu/results/assistant-item-test.gjs
@@ -8,7 +8,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | search-menu/results/assistant-item",
+  "Integration | Component | SearchMenu | Results | AssistantItem",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
+++ b/frontend/discourse/tests/integration/components/search-menu/results/type/topic-test.gjs
@@ -6,7 +6,7 @@ import TopicResultComponent from "discourse/components/search-menu/results/type/
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module(
-  "Integration | Component | search-menu/results/type/topic",
+  "Integration | Component | SearchMenu | Results | Type | Topic",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/secret-value-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/secret-value-list-test.gjs
@@ -4,7 +4,7 @@ import SecretValueList from "discourse/admin/components/secret-value-list";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | secret-value-list", function (hooks) {
+module("Integration | Component | SecretValueList", function (hooks) {
   setupRenderingTest(hooks);
 
   test("adding a value", async function (assert) {

--- a/frontend/discourse/tests/integration/components/select-kit/api-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/api-test.gjs
@@ -10,7 +10,7 @@ import selectKit, {
   setDefaultState,
 } from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | select-kit/api", function (hooks) {
+module("Integration | Component | SelectKit | Api", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/category-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/category-chooser-test.gjs
@@ -8,7 +8,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import I18n from "discourse-i18n";
 
 module(
-  "Integration | Component | select-kit/category-chooser",
+  "Integration | Component | SelectKit | CategoryChooser",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/category-drop-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/category-drop-test.gjs
@@ -34,7 +34,7 @@ function initCategoriesWithParentCategory(context) {
   });
 }
 
-module("Integration | Component | select-kit/category-drop", function (hooks) {
+module("Integration | Component | SelectKit | CategoryDrop", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/category-selector-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/category-selector-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
-  "Integration | Component | select-kit/category-selector",
+  "Integration | Component | SelectKit | CategorySelector",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/color-palette-picker-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/color-palette-picker-test.gjs
@@ -76,7 +76,7 @@ const setDefaultState = (ctx, options = {}) => {
 };
 
 module(
-  "Integration | Component | select-kit/color-palette-picker",
+  "Integration | Component | SelectKit | ColorPalettePicker",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/combo-box-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/combo-box-test.gjs
@@ -24,7 +24,7 @@ const setDefaultState = (ctx, options = {}) => {
   ctx.setProperties(properties);
 };
 
-module("Integration | Component | select-kit/combo-box", function (hooks) {
+module("Integration | Component | SelectKit | ComboBox", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/dropdown-select-box-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/dropdown-select-box-test.gjs
@@ -28,7 +28,7 @@ const setDefaultState = (ctx, options) => {
 };
 
 module(
-  "Integration | Component | select-kit/dropdown-select-box",
+  "Integration | Component | SelectKit | DropdownSelectBox",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/email-group-user-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/email-group-user-chooser-test.gjs
@@ -8,7 +8,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import pretender, { response } from "../../../helpers/create-pretender";
 
 module(
-  "Integration | Component | select-kit/email-group-user-chooser",
+  "Integration | Component | SelectKit | EmailGroupUserChooser",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/form-template-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/form-template-chooser-test.gjs
@@ -6,7 +6,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
-  "Integration | Component | select-kit/form-template-chooser",
+  "Integration | Component | SelectKit | FormTemplateChooser",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/future-date-input-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/future-date-input-test.gjs
@@ -16,7 +16,7 @@ function getOptions() {
 }
 
 module(
-  "Integration | Component | select-kit/future-date-input",
+  "Integration | Component | SelectKit | FutureDateInput",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/group-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/group-chooser-test.gjs
@@ -5,7 +5,7 @@ import GroupChooser from "discourse/select-kit/components/group-chooser";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | select-kit/group-chooser", function (hooks) {
+module("Integration | Component | SelectKit | GroupChooser", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/list-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/list-setting-test.gjs
@@ -4,7 +4,7 @@ import ListSetting from "discourse/select-kit/components/list-setting";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | select-kit/list-setting", function (hooks) {
+module("Integration | Component | SelectKit | ListSetting", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.gjs
@@ -8,7 +8,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | select-kit/mini-tag-chooser",
+  "Integration | Component | SelectKit | MiniTagChooser",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/multi-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/multi-select-test.gjs
@@ -23,7 +23,7 @@ const setDefaultState = (ctx, options) => {
   ctx.setProperties(properties);
 };
 
-module("Integration | Component | select-kit/multi-select", function (hooks) {
+module("Integration | Component | SelectKit | MultiSelect", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/notifications-button-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/notifications-button-test.gjs
@@ -8,7 +8,7 @@ import selectKit, {
 } from "discourse/tests/helpers/select-kit-helper";
 
 module(
-  "Integration | Component | select-kit/notifications-button",
+  "Integration | Component | SelectKit | NotificationsButton",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/single-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/single-select-test.gjs
@@ -31,7 +31,7 @@ const setDefaultState = (ctx, options) => {
   ctx.setProperties(properties);
 };
 
-module("Integration | Component | select-kit/single-select", function (hooks) {
+module("Integration | Component | SelectKit | SingleSelect", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/tag-drop-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/tag-drop-test.gjs
@@ -7,7 +7,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | select-kit/tag-drop", function (hooks) {
+module("Integration | Component | SelectKit | TagDrop", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/timezone-input-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/timezone-input-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | select-kit/timezone-input", function (hooks) {
+module("Integration | Component | SelectKit | TimezoneInput", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/select-kit/topic-notifications-button-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/topic-notifications-button-test.gjs
@@ -28,7 +28,7 @@ const originalTranslation =
   I18n.translations.en.js.topic.notifications.tracking_pm.title;
 
 module(
-  "Integration | Component | select-kit/topic-notifications-button",
+  "Integration | Component | SelectKit | TopicNotificationsButton",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/select-kit/user-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/user-chooser-test.gjs
@@ -4,7 +4,7 @@ import UserChooser from "discourse/select-kit/components/user-chooser";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | select-kit/user-chooser", function (hooks) {
+module("Integration | Component | SelectKit | UserChooser", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import SectionLink from "discourse/components/sidebar/section-link";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | sidebar | section-link", function (hooks) {
+module("Integration | Component | Sidebar | SectionLink", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default class attribute for link", async function (assert) {

--- a/frontend/discourse/tests/integration/components/sidebar/section-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar/section-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import Section from "discourse/components/sidebar/section";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | sidebar | section", function (hooks) {
+module("Integration | Component | Sidebar | Section", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default displaySection value for section", async function (assert) {

--- a/frontend/discourse/tests/integration/components/simple-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/simple-list-test.gjs
@@ -11,7 +11,7 @@ import { module, test } from "qunit";
 import SimpleList from "discourse/admin/components/simple-list";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | simple-list", function (hooks) {
+module("Integration | Component | SimpleList", function (hooks) {
   setupRenderingTest(hooks);
 
   test("adding a value", async function (assert) {

--- a/frontend/discourse/tests/integration/components/site-settings/tag-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-settings/tag-list-test.gjs
@@ -4,7 +4,7 @@ import TagList from "discourse/admin/components/site-settings/tag-list";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | site-settings/tag-list", function (hooks) {
+module("Integration | Component | SiteSettings | TagList", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/site-settings/upload-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-settings/upload-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import SiteSettingUpload from "discourse/admin/components/site-settings/upload";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | site-settings/upload", function (hooks) {
+module("Integration | Component | SiteSettings | Upload", function (hooks) {
   setupRenderingTest(hooks);
 
   test("with image file shows preview and lightbox", async function (assert) {

--- a/frontend/discourse/tests/integration/components/slow-mode-info-test.gjs
+++ b/frontend/discourse/tests/integration/components/slow-mode-info-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import SlowModeInfo from "discourse/components/slow-mode-info";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | slow-mode-info", function (hooks) {
+module("Integration | Component | SlowModeInfo", function (hooks) {
   setupRenderingTest(hooks);
 
   test("doesn't render if the topic is closed", async function (assert) {

--- a/frontend/discourse/tests/integration/components/software-update-prompt-test.gjs
+++ b/frontend/discourse/tests/integration/components/software-update-prompt-test.gjs
@@ -4,7 +4,7 @@ import SoftwareUpdatePrompt from "discourse/components/software-update-prompt";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
 
-module("Integration | Component | software-update-prompt", function (hooks) {
+module("Integration | Component | SoftwareUpdatePrompt", function (hooks) {
   setupRenderingTest(hooks);
 
   test("software-update-prompt gets correct CSS class after messageBus message", async function (assert) {

--- a/frontend/discourse/tests/integration/components/tag-info-test.gjs
+++ b/frontend/discourse/tests/integration/components/tag-info-test.gjs
@@ -4,7 +4,7 @@ import TagInfo from "discourse/components/tag-info";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | tag-info", function (hooks) {
+module("Integration | Component | TagInfo", function (hooks) {
   setupRenderingTest(hooks);
 
   function buildTagInfo(store, attrs = {}) {

--- a/frontend/discourse/tests/integration/components/text-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/text-field-test.gjs
@@ -4,7 +4,7 @@ import { resetSiteDirForTesting } from "discourse/lib/text-direction";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DTextField from "discourse/ui-kit/d-text-field";
 
-module("Integration | Component | text-field", function (hooks) {
+module("Integration | Component | TextField", function (hooks) {
   setupRenderingTest(hooks);
 
   let originalHtmlDir;

--- a/frontend/discourse/tests/integration/components/themes-list-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/themes-list-item-test.gjs
@@ -5,7 +5,7 @@ import Theme from "discourse/admin/models/theme";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | themes-list-item", function (hooks) {
+module("Integration | Component | ThemesListItem", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default theme", async function (assert) {

--- a/frontend/discourse/tests/integration/components/toolbar-popup-menu-options-test.gjs
+++ b/frontend/discourse/tests/integration/components/toolbar-popup-menu-options-test.gjs
@@ -14,55 +14,52 @@ function generateOptions(count) {
   }));
 }
 
-module(
-  "Integration | Component | toolbar-popup-menu-options",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | ToolbarPopupMenuOptions", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("adds scroll classes when content overflows", async function (assert) {
-      const content = generateOptions(30);
+  test("adds scroll classes when content overflows", async function (assert) {
+    const content = generateOptions(30);
 
-      await render(
-        <template>
-          <div style="height: 200px;">
-            <ToolbarPopupMenuOptions
-              @content={{content}}
-              @class="options-content"
-              @icon="cog"
-              @onChange={{fn (mut this.value)}}
-            />
-          </div>
-        </template>
-      );
+    await render(
+      <template>
+        <div style="height: 200px;">
+          <ToolbarPopupMenuOptions
+            @content={{content}}
+            @class="options-content"
+            @icon="cog"
+            @onChange={{fn (mut this.value)}}
+          />
+        </div>
+      </template>
+    );
 
-      await click(".fk-d-menu__trigger");
+    await click(".fk-d-menu__trigger");
 
-      const menu = document.querySelector(".fk-d-menu[class*='toolbar-menu']");
-      assert.false(menu.classList.contains("--scroll-top"));
-      assert.true(menu.classList.contains("--scroll-bottom"));
-    });
+    const menu = document.querySelector(".fk-d-menu[class*='toolbar-menu']");
+    assert.false(menu.classList.contains("--scroll-top"));
+    assert.true(menu.classList.contains("--scroll-bottom"));
+  });
 
-    test("does not add scroll classes when content fits", async function (assert) {
-      const content = generateOptions(2);
+  test("does not add scroll classes when content fits", async function (assert) {
+    const content = generateOptions(2);
 
-      await render(
-        <template>
-          <div>
-            <ToolbarPopupMenuOptions
-              @content={{content}}
-              @class="options-content"
-              @icon="cog"
-              @onChange={{fn (mut this.value)}}
-            />
-          </div>
-        </template>
-      );
+    await render(
+      <template>
+        <div>
+          <ToolbarPopupMenuOptions
+            @content={{content}}
+            @class="options-content"
+            @icon="cog"
+            @onChange={{fn (mut this.value)}}
+          />
+        </div>
+      </template>
+    );
 
-      await click(".fk-d-menu__trigger");
+    await click(".fk-d-menu__trigger");
 
-      const menu = document.querySelector(".fk-d-menu[class*='toolbar-menu']");
-      assert.false(menu.classList.contains("--scroll-top"));
-      assert.false(menu.classList.contains("--scroll-bottom"));
-    });
-  }
-);
+    const menu = document.querySelector(".fk-d-menu[class*='toolbar-menu']");
+    assert.false(menu.classList.contains("--scroll-top"));
+    assert.false(menu.classList.contains("--scroll-bottom"));
+  });
+});

--- a/frontend/discourse/tests/integration/components/topic-dismiss-buttons-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-dismiss-buttons-test.gjs
@@ -4,7 +4,7 @@ import TopicDismissButtons from "discourse/components/topic-dismiss-buttons";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | topic-dismiss-buttons", function (hooks) {
+module("Integration | Component | TopicDismissButtons", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/topic-list-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-list-item-test.gjs
@@ -5,7 +5,7 @@ import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | topic-list-item", function (hooks) {
+module("Integration | Component | TopicListItem", function (hooks) {
   setupRenderingTest(hooks);
 
   test("checkbox is rendered checked if topic is in selected array", async function (assert) {

--- a/frontend/discourse/tests/integration/components/topic-list-post-count-or-badges-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-list-post-count-or-badges-test.gjs
@@ -4,7 +4,7 @@ import PostCountOrBadges from "discourse/components/topic-list/post-count-or-bad
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module(
-  "Integration | Component | topic-list/post-count-or-badges",
+  "Integration | Component | TopicList | PostCountOrBadges",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/topic-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-list-test.gjs
@@ -6,7 +6,7 @@ import BulkSelectHelper from "discourse/lib/bulk-select-helper";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | topic-list", function (hooks) {
+module("Integration | Component | TopicList", function (hooks) {
   setupRenderingTest(hooks);
 
   test("bulk select", async function (assert) {

--- a/frontend/discourse/tests/integration/components/topic-localized-content-toggle-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-localized-content-toggle-test.gjs
@@ -6,7 +6,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | topic-localized-content-toggle",
+  "Integration | Component | TopicLocalizedContentToggle",
   function (hooks) {
     setupRenderingTest(hooks, { stubRouter: true });
 

--- a/frontend/discourse/tests/integration/components/topic-participant-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-participant-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import TopicParticipant from "discourse/components/topic-map/topic-participant";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | topic-participant", function (hooks) {
+module("Integration | Component | TopicParticipant", function (hooks) {
   setupRenderingTest(hooks);
 
   test("one post", async function (assert) {

--- a/frontend/discourse/tests/integration/components/topic-timer-info-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-timer-info-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import TopicTimerInfo from "discourse/components/topic-timer-info";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | topic-timer-info", function (hooks) {
+module("Integration | Component | TopicTimerInfo", function (hooks) {
   setupRenderingTest(hooks);
 
   test("does not crash when category does not exist in client cache", async function (assert) {

--- a/frontend/discourse/tests/integration/components/uppy-image-uploader-test.gjs
+++ b/frontend/discourse/tests/integration/components/uppy-image-uploader-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import UppyImageUploader from "discourse/components/uppy-image-uploader";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | uppy-image-uploader", function (hooks) {
+module("Integration | Component | UppyImageUploader", function (hooks) {
   setupRenderingTest(hooks);
 
   test("with image", async function (assert) {

--- a/frontend/discourse/tests/integration/components/user-menu/bookmarks-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/bookmarks-list-test.gjs
@@ -7,80 +7,77 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
-module(
-  "Integration | Component | user-menu | bookmarks-list",
-  function (hooks) {
-    setupRenderingTest(hooks);
+module("Integration | Component | UserMenu | BookmarksList", function (hooks) {
+  setupRenderingTest(hooks);
 
-    test("renders notifications on top and bookmarks on bottom", async function (assert) {
-      await render(<template><BookmarksList /></template>);
-      const items = queryAll("ul li");
+  test("renders notifications on top and bookmarks on bottom", async function (assert) {
+    await render(<template><BookmarksList /></template>);
+    const items = queryAll("ul li");
 
-      assert.strictEqual(items.length, 2);
+    assert.strictEqual(items.length, 2);
 
-      assert.dom(items[0]).hasClass("notification");
-      assert.dom(items[0]).hasClass("unread");
-      assert.dom(items[0]).hasClass("bookmark-reminder");
+    assert.dom(items[0]).hasClass("notification");
+    assert.dom(items[0]).hasClass("unread");
+    assert.dom(items[0]).hasClass("bookmark-reminder");
 
-      assert.dom(items[1]).hasClass("bookmark");
+    assert.dom(items[1]).hasClass("bookmark");
+  });
+
+  test("show all button for bookmark notifications", async function (assert) {
+    await render(<template><BookmarksList /></template>);
+    assert
+      .dom(".panel-body-bottom .show-all")
+      .hasAttribute(
+        "title",
+        i18n("user_menu.view_all_bookmarks"),
+        "has the correct title"
+      );
+  });
+
+  test("dismiss button", async function (assert) {
+    this.currentUser.set("grouped_unread_notifications", {
+      [NOTIFICATION_TYPES.bookmark_reminder]: 72,
     });
+    await render(<template><BookmarksList /></template>);
+    assert
+      .dom(".panel-body-bottom .notifications-dismiss")
+      .exists(
+        "dismiss button is shown if the user has unread bookmark_reminder notifications"
+      );
+    assert
+      .dom(".panel-body-bottom .notifications-dismiss")
+      .hasAttribute(
+        "title",
+        i18n("user.dismiss_bookmarks_tooltip"),
+        "dismiss button has a title"
+      );
 
-    test("show all button for bookmark notifications", async function (assert) {
-      await render(<template><BookmarksList /></template>);
-      assert
-        .dom(".panel-body-bottom .show-all")
-        .hasAttribute(
-          "title",
-          i18n("user_menu.view_all_bookmarks"),
-          "has the correct title"
-        );
+    this.currentUser.set("grouped_unread_notifications", {});
+    await settled();
+
+    assert
+      .dom(".panel-body-bottom .notifications-dismiss")
+      .doesNotExist(
+        "dismiss button is not shown if the user no unread bookmark_reminder notifications"
+      );
+  });
+
+  test("empty state (aka blank page syndrome)", async function (assert) {
+    pretender.get("/u/eviltrout/user-menu-bookmarks", () => {
+      return response({ notifications: [], bookmarks: [] });
     });
-
-    test("dismiss button", async function (assert) {
-      this.currentUser.set("grouped_unread_notifications", {
-        [NOTIFICATION_TYPES.bookmark_reminder]: 72,
-      });
-      await render(<template><BookmarksList /></template>);
-      assert
-        .dom(".panel-body-bottom .notifications-dismiss")
-        .exists(
-          "dismiss button is shown if the user has unread bookmark_reminder notifications"
-        );
-      assert
-        .dom(".panel-body-bottom .notifications-dismiss")
-        .hasAttribute(
-          "title",
-          i18n("user.dismiss_bookmarks_tooltip"),
-          "dismiss button has a title"
-        );
-
-      this.currentUser.set("grouped_unread_notifications", {});
-      await settled();
-
-      assert
-        .dom(".panel-body-bottom .notifications-dismiss")
-        .doesNotExist(
-          "dismiss button is not shown if the user no unread bookmark_reminder notifications"
-        );
-    });
-
-    test("empty state (aka blank page syndrome)", async function (assert) {
-      pretender.get("/u/eviltrout/user-menu-bookmarks", () => {
-        return response({ notifications: [], bookmarks: [] });
-      });
-      await render(<template><BookmarksList /></template>);
-      assert
-        .dom(".empty-state__title")
-        .hasText(i18n("user.no_bookmarks_title"), "empty state title is shown");
-      assert
-        .dom(".empty-state__body")
-        .hasText(
-          i18n("user.no_bookmarks_body", { icon: "" }),
-          "empty state body is shown"
-        );
-      assert
-        .dom(".empty-state__body svg.d-icon-bookmark")
-        .exists("icon is correctly rendered in the empty state body");
-    });
-  }
-);
+    await render(<template><BookmarksList /></template>);
+    assert
+      .dom(".empty-state__title")
+      .hasText(i18n("user.no_bookmarks_title"), "empty state title is shown");
+    assert
+      .dom(".empty-state__body")
+      .hasText(
+        i18n("user.no_bookmarks_body", { icon: "" }),
+        "empty state body is shown"
+      );
+    assert
+      .dom(".empty-state__body svg.d-icon-bookmark")
+      .exists("icon is correctly rendered in the empty state body");
+  });
+});

--- a/frontend/discourse/tests/integration/components/user-menu/likes-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/likes-list-test.gjs
@@ -6,7 +6,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | user-menu | likes-notifications-list",
+  "Integration | Component | UserMenu | LikesNotificationsList",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/user-menu/menu-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/menu-item-test.gjs
@@ -48,7 +48,7 @@ function getNotification(currentUser, siteSettings, site, overrides = {}) {
 }
 
 module(
-  "Integration | Component | user-menu | menu-item | with notification items",
+  "Integration | Component | UserMenu | MenuItem | with notification items",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -437,7 +437,7 @@ function getMessage(overrides = {}, siteSettings, site) {
 }
 
 module(
-  "Integration | Component | user-menu | menu-item | with message items",
+  "Integration | Component | UserMenu | MenuItem | with message items",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -506,7 +506,7 @@ function getBookmark(overrides = {}, siteSettings, site) {
 }
 
 module(
-  "Integration | Component | user-menu | menu-item | with bookmark items",
+  "Integration | Component | UserMenu | MenuItem | with bookmark items",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -566,7 +566,7 @@ function getReviewable(currentUser, siteSettings, site, overrides = {}) {
 }
 
 module(
-  "Integration | Component | user-menu | menu-item | with reviewable items",
+  "Integration | Component | UserMenu | MenuItem | with reviewable items",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/user-menu/menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/menu-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
 import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
-module("Integration | Component | user-menu", function (hooks) {
+module("Integration | Component | UserMenu", function (hooks) {
   setupRenderingTest(hooks);
 
   test("default tab is all notifications", async function (assert) {

--- a/frontend/discourse/tests/integration/components/user-menu/messages-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/messages-list-test.gjs
@@ -89,7 +89,7 @@ function getGroupMessageSummaryNotification(overrides = {}) {
   );
 }
 
-module("Integration | Component | user-menu | messages-list", function (hooks) {
+module("Integration | Component | UserMenu | MessagesList", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders unread PM notifications first followed by messages and read group_message_summary notifications", async function (assert) {

--- a/frontend/discourse/tests/integration/components/user-menu/notifications-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/notifications-list-test.gjs
@@ -14,7 +14,7 @@ function getNotificationsData() {
 }
 
 module(
-  "Integration | Component | user-menu | notifications-list",
+  "Integration | Component | UserMenu | NotificationsList",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/user-menu/other-notifications-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/other-notifications-list-test.gjs
@@ -6,7 +6,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | user-menu | other-notifications-list",
+  "Integration | Component | UserMenu | OtherNotificationsList",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/user-menu/replies-notifications-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/replies-notifications-list-test.gjs
@@ -6,7 +6,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | user-menu | replies-notifications-list",
+  "Integration | Component | UserMenu | RepliesNotificationsList",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/user-menu/reviewables-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/reviewables-list-test.gjs
@@ -6,7 +6,7 @@ import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 module(
-  "Integration | Component | user-menu | reviewables-list",
+  "Integration | Component | UserMenu | ReviewablesList",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/frontend/discourse/tests/integration/components/user-status-picker-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-status-picker-test.gjs
@@ -5,7 +5,7 @@ import UserStatusPicker from "discourse/components/user-status-picker";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
-module("Integration | Component | user-status-picker", function (hooks) {
+module("Integration | Component | UserStatusPicker", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/value-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/value-list-test.gjs
@@ -4,7 +4,7 @@ import ValueList from "discourse/admin/components/value-list";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
-module("Integration | Component | value-list", function (hooks) {
+module("Integration | Component | ValueList", function (hooks) {
   setupRenderingTest(hooks);
 
   test("adding a value", async function (assert) {

--- a/frontend/discourse/tests/integration/components/watched-word-uploader-test.gjs
+++ b/frontend/discourse/tests/integration/components/watched-word-uploader-test.gjs
@@ -8,7 +8,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { createFile } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
-module("Integration | Component | watched-word-uploader", function (hooks) {
+module("Integration | Component | WatchedWordUploader", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/frontend/discourse/tests/integration/components/webhook-status-test.gjs
+++ b/frontend/discourse/tests/integration/components/webhook-status-test.gjs
@@ -5,7 +5,7 @@ import WebhookStatus from "discourse/admin/components/webhook-status";
 import CoreFabricators from "discourse/lib/fabricators";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Integration | Component | webhook-status", function (hooks) {
+module("Integration | Component | WebhookStatus", function (hooks) {
   setupRenderingTest(hooks);
 
   const DELIVERY_STATUSES = [

--- a/frontend/discourse/tests/unit/components/post-menu-test.gjs
+++ b/frontend/discourse/tests/unit/components/post-menu-test.gjs
@@ -5,7 +5,7 @@ import PostMenu from "discourse/components/post/menu";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-module("Unit | Component | post-menu", function (hooks) {
+module("Unit | Component | PostMenu", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-boolean-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-boolean-field-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-boolean-field", function (hooks) {
+module("Integration | Component | DaBooleanField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-categories-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-categories-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-categories-field", function (hooks) {
+module("Integration | Component | DaCategoriesField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-category-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-category-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-category-field", function (hooks) {
+module("Integration | Component | DaCategoryField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-category-notification-level-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-category-notification-level-field-test.gjs
@@ -7,7 +7,7 @@ import AutomationField from "discourse/plugins/automation/admin/components/autom
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
 module(
-  "Integration | Component | da-category-notification-level-field",
+  "Integration | Component | DaCategoryNotificationLevelField",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/automation/test/javascripts/integration/components/da-choices-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-choices-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-choices-field", function (hooks) {
+module("Integration | Component | DaChoicesField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-custom-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-custom-field-test.gjs
@@ -7,7 +7,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-custom-field", function (hooks) {
+module("Integration | Component | DaCustomField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-date-time-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-date-time-field-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-date-time-field", function (hooks) {
+module("Integration | Component | DaDateTimeField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-email-group-user-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-email-group-user-field-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DaEmailGroupUserField from "discourse/plugins/automation/admin/components/fields/da-email-group-user-field";
 
-module("Integration | Component | email-group-user-field", function (hooks) {
+module("Integration | Component | EmailGroupUserField", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Email group user field uses email-group-user-chooser component", async function (assert) {

--- a/plugins/automation/test/javascripts/integration/components/da-group-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-group-field-test.gjs
@@ -7,7 +7,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-group-field", function (hooks) {
+module("Integration | Component | DaGroupField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-groups-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-groups-field-test.gjs
@@ -7,7 +7,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-groups-field", function (hooks) {
+module("Integration | Component | DaGroupsField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-message-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-message-field-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-message-field", function (hooks) {
+module("Integration | Component | DaMessageField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-pms-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-pms-field-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-pms-field", function (hooks) {
+module("Integration | Component | DaPmsField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-post-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-post-field-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-post-field", function (hooks) {
+module("Integration | Component | DaPostField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-relative-time-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-relative-time-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-relative_time-field", function (hooks) {
+module("Integration | Component | DaRelativeTimeField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-tags-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-tags-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-tags-field", function (hooks) {
+module("Integration | Component | DaTagsField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-text-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-text-field-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-text-field", function (hooks) {
+module("Integration | Component | DaTextField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-text-list-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-text-list-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-text-list-field", function (hooks) {
+module("Integration | Component | DaTextListField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-trust-levels-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-trust-levels-field-test.gjs
@@ -6,7 +6,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-trust-levels-field", function (hooks) {
+module("Integration | Component | DaTrustLevelsField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-user-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-user-field-test.gjs
@@ -7,7 +7,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-user-field", function (hooks) {
+module("Integration | Component | DaUserField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/automation/test/javascripts/integration/components/da-users-field-test.gjs
+++ b/plugins/automation/test/javascripts/integration/components/da-users-field-test.gjs
@@ -7,7 +7,7 @@ import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AutomationField from "discourse/plugins/automation/admin/components/automation-field";
 import AutomationFabricators from "discourse/plugins/automation/admin/lib/fabricators";
 
-module("Integration | Component | da-users-field", function (hooks) {
+module("Integration | Component | DaUsersField", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/chat/test/javascripts/components/chat-channel-card-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-card-test.gjs
@@ -6,7 +6,7 @@ import { i18n } from "discourse-i18n";
 import ChatChannelCard from "discourse/plugins/chat/discourse/components/chat-channel-card";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-channel-card", function (hooks) {
+module("Component | ChatChannelCard", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/chat/test/javascripts/components/chat-channel-leave-btn-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-leave-btn-test.gjs
@@ -8,7 +8,7 @@ import { i18n } from "discourse-i18n";
 import ChatChannelLeaveBtn from "discourse/plugins/chat/discourse/components/chat-channel-leave-btn";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-channel-leave-btn", function (hooks) {
+module("Component | ChatChannelLeaveBtn", function (hooks) {
   setupRenderingTest(hooks);
 
   test("accepts an optional onLeaveChannel callback", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-channel-metadata-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-metadata-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatChannelMetadata from "discourse/plugins/chat/discourse/components/chat-channel-metadata";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-channel-metadata", function (hooks) {
+module("Component | ChatChannelMetadata", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displays created at placeholder for empty chat", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-channel-preview-card-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-preview-card-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatChannelPreviewCard from "discourse/plugins/chat/discourse/components/chat-channel-preview-card";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-channel-preview-card", function (hooks) {
+module("Component | ChatChannelPreviewCard", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-row-test.gjs
@@ -8,7 +8,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatChannelRow from "discourse/plugins/chat/discourse/components/chat-channel-row";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-channel-row", function (hooks) {
+module("Component | ChatChannelRow", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/chat/test/javascripts/components/chat-channel-status-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-status-test.gjs
@@ -10,7 +10,7 @@ import {
   channelStatusIcon,
 } from "discourse/plugins/chat/discourse/models/chat-channel";
 
-module("Component | chat-channel-status", function (hooks) {
+module("Component | ChatChannelStatus", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders nothing when channel is opened", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-channel-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.gjs
@@ -8,7 +8,7 @@ import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
 import ChatChannel from "discourse/plugins/chat/discourse/components/chat-channel";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-channel | status on mentions", function (hooks) {
+module("Component | ChatChannel | status on mentions", function (hooks) {
   setupRenderingTest(hooks);
 
   const channelId = 1;

--- a/plugins/chat/test/javascripts/components/chat-composer-dropdown-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-composer-dropdown-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatComposerDropdown from "discourse/plugins/chat/discourse/components/chat-composer-dropdown";
 
-module("Component | chat-composer-dropdown", function (hooks) {
+module("Component | ChatComposerDropdown", function (hooks) {
   setupRenderingTest(hooks);
 
   test("buttons", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-composer-message-details-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-composer-message-details-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatComposerMessageDetails from "discourse/plugins/chat/discourse/components/chat-composer-message-details";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-composer-message-details", function (hooks) {
+module("Component | ChatComposerMessageDetails", function (hooks) {
   setupRenderingTest(hooks);
 
   test("data-id attribute", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-composer-upload-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-composer-upload-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import ChatComposerUpload from "discourse/plugins/chat/discourse/components/chat-composer-upload";
 
-module("Component | chat-composer-upload", function (hooks) {
+module("Component | ChatComposerUpload", function (hooks) {
   setupRenderingTest(hooks);
 
   test("file - uploading in progress", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-composer-uploads-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-composer-uploads-test.gjs
@@ -41,7 +41,7 @@ function setupUploadPretender() {
   );
 }
 
-module("Component | chat-composer-uploads", function (hooks) {
+module("Component | ChatComposerUploads", function (hooks) {
   setupRenderingTest(hooks);
 
   test("loading uploads from an outside source (e.g. draft or editing message)", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-emoji-avatar-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-emoji-avatar-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatEmojiAvatar from "discourse/plugins/chat/discourse/components/chat-emoji-avatar";
 
-module("Component | chat-emoji-avatar", function (hooks) {
+module("Component | ChatEmojiAvatar", function (hooks) {
   setupRenderingTest(hooks);
 
   test("uses an emoji as avatar", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-header-icon-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-header-icon-test.gjs
@@ -8,7 +8,7 @@ import { i18n } from "discourse-i18n";
 import Icon from "discourse/plugins/chat/discourse/components/chat/header/icon";
 import { HEADER_INDICATOR_PREFERENCE_ALL_NEW } from "discourse/plugins/chat/discourse/lib/chat-constants";
 
-module("Component | chat-header-icon", function (hooks) {
+module("Component | ChatHeaderIcon", function (hooks) {
   setupRenderingTest(hooks);
 
   test("full page - never separated sidebar mode", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-message-avatar-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-avatar-test.gjs
@@ -6,7 +6,7 @@ import Avatar from "discourse/plugins/chat/discourse/components/chat/message/ava
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 
-module("Component | chat-message-avatar", function (hooks) {
+module("Component | ChatMessageAvatar", function (hooks) {
   setupRenderingTest(hooks);
 
   test("chat_webhook_event", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-message-info-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-info-test.gjs
@@ -8,7 +8,7 @@ import Info from "discourse/plugins/chat/discourse/components/chat/message/info"
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
 
-module("Component | chat-message-info", function (hooks) {
+module("Component | ChatMessageInfo", function (hooks) {
   setupRenderingTest(hooks);
 
   test("chat_webhook_event", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-message-reaction-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-reaction-test.gjs
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatMessageReaction from "discourse/plugins/chat/discourse/components/chat-message-reaction";
 
-module("Component | chat-message-reaction", function (hooks) {
+module("Component | ChatMessageReaction", function (hooks) {
   setupRenderingTest(hooks);
 
   test("adds reacted class when user reacted", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-message-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatMessage from "discourse/plugins/chat/discourse/components/chat-message";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-message", function (hooks) {
+module("Component | ChatMessage", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Message with edits", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-message-text-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-text-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatMessageText from "discourse/plugins/chat/discourse/components/chat-message-text";
 
-module("Component | chat-message-text", function (hooks) {
+module("Component | ChatMessageText", function (hooks) {
   setupRenderingTest(hooks);
 
   test("yields", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-notices-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-notices-test.gjs
@@ -8,7 +8,7 @@ import { i18n } from "discourse-i18n";
 import ChatNotices from "discourse/plugins/chat/discourse/components/chat-notices";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-notice", function (hooks) {
+module("Component | ChatNotice", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displays all notices for a channel", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-replying-indicator-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-replying-indicator-test.gjs
@@ -23,7 +23,7 @@ async function removeUser(id, channelName = "/chat-reply/1") {
   });
 }
 
-module("Component | chat-replying-indicator", function (hooks) {
+module("Component | ChatReplyingIndicator", function (hooks) {
   setupRenderingTest(hooks);
 
   test("not displayed when no one is replying", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-retention-reminder-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-retention-reminder-test.gjs
@@ -5,7 +5,7 @@ import { i18n } from "discourse-i18n";
 import ChatRetentionReminder from "discourse/plugins/chat/discourse/components/chat-retention-reminder";
 import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 
-module("Component | chat-retention-reminder", function (hooks) {
+module("Component | ChatRetentionReminder", function (hooks) {
   setupRenderingTest(hooks);
 
   test("display retention info", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-retention-reminder-text-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-retention-reminder-text-test.gjs
@@ -6,7 +6,7 @@ import { i18n } from "discourse-i18n";
 import ChatRetentionReminderText from "discourse/plugins/chat/discourse/components/chat-retention-reminder-text";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-retention-reminder-text", function (hooks) {
+module("Component | ChatRetentionReminderText", function (hooks) {
   setupRenderingTest(hooks);
 
   test("when setting is set on 0", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-sidebar-indicators-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-sidebar-indicators-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatSidebarIndicators from "discourse/plugins/chat/discourse/components/chat-sidebar-indicators";
 
-module("Component | chat-sidebar-indicators", function (hooks) {
+module("Component | ChatSidebarIndicators", function (hooks) {
   setupRenderingTest(hooks);
 
   test("shows indicator when unreadCount > 0", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-thread-header-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-thread-header-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import Header from "discourse/plugins/chat/discourse/components/chat/thread/header";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-thread-header", function (hooks) {
+module("Component | ChatThreadHeader", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it safely renders title", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-thread-heading-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-thread-heading-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatThreadHeading from "discourse/plugins/chat/discourse/components/chat-thread-heading";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-thread-heading", function (hooks) {
+module("Component | ChatThreadHeading", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders the title", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-thread-list-item-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-thread-list-item-test.gjs
@@ -5,7 +5,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import Item from "discourse/plugins/chat/discourse/components/chat/thread-list/item";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
 
-module("Component | chat-thread-list-item", function (hooks) {
+module("Component | ChatThreadListItem", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it safely renders title", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-upload-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-upload-test.gjs
@@ -66,7 +66,7 @@ const TXT_FIXTURE = {
   human_filesize: "168 KB",
 };
 
-module("Component | chat-upload", function (hooks) {
+module("Component | ChatUpload", function (hooks) {
   setupRenderingTest(hooks);
 
   test("with an image", async function (assert) {

--- a/plugins/chat/test/javascripts/components/chat-user-display-name-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-user-display-name-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatUserDisplayName from "discourse/plugins/chat/discourse/components/chat-user-display-name";
 
 module(
-  "Component | chat-user-display-name | prioritize username in UX",
+  "Component | ChatUserDisplayName | prioritize username in UX",
   function (hooks) {
     setupRenderingTest(hooks);
 
@@ -33,7 +33,7 @@ module(
 );
 
 module(
-  "Component | chat-user-display-name | prioritize name in UX",
+  "Component | ChatUserDisplayName | prioritize name in UX",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/chat/test/javascripts/components/chat-user-info-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-user-info-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatUserInfo from "discourse/plugins/chat/discourse/components/chat-user-info";
 
-module("Component | chat-user-info", function (hooks) {
+module("Component | ChatUserInfo", function (hooks) {
   setupRenderingTest(hooks);
 
   test("avatar and name", async function (assert) {

--- a/plugins/chat/test/javascripts/components/collapser-test.gjs
+++ b/plugins/chat/test/javascripts/components/collapser-test.gjs
@@ -4,7 +4,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import Collapser from "discourse/plugins/chat/discourse/components/collapser";
 
-module("Component | collapser", function (hooks) {
+module("Component | Collapser", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders header", async function (assert) {

--- a/plugins/chat/test/javascripts/integration/components/user-menu/chat-notifications-list-test.gjs
+++ b/plugins/chat/test/javascripts/integration/components/user-menu/chat-notifications-list-test.gjs
@@ -6,7 +6,7 @@ import { i18n } from "discourse-i18n";
 import ChatNotificationsList from "discourse/plugins/chat/discourse/components/user-menu/chat-notifications-list";
 
 module(
-  "Integration | Component | user-menu | chat-notifications-list",
+  "Integration | Component | UserMenu | ChatNotificationsList",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-default-llm-selector-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-default-llm-selector-test.gjs
@@ -5,7 +5,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import AiDefaultLlmSelector from "discourse/plugins/discourse-ai/discourse/components/ai-default-llm-selector";
 
-module("Integration | Component | ai-default-llm-selector", function (hooks) {
+module("Integration | Component | AiDefaultLlmSelector", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-features-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-features-test.gjs
@@ -30,7 +30,7 @@ function aiFeaturesPayload(llmModel) {
   };
 }
 
-module("Integration | Component | ai-features", function (hooks) {
+module("Integration | Component | AiFeatures", function (hooks) {
   setupRenderingTest(hooks, { stubRouter: true });
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-helper-custom-prompt-test.gjs
@@ -8,7 +8,7 @@ class TestState {
   @tracked value = "test";
 }
 
-module("Integration | Component | ai-helper-custom-prompt", function (hooks) {
+module("Integration | Component | AiHelperCustomPrompt", function (hooks) {
   setupRenderingTest(hooks);
 
   async function renderPrompt(submit, initialValue = "test") {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-indicator-wave-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-indicator-wave-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AiIndicatorWave from "discourse/plugins/discourse-ai/discourse/components/ai-indicator-wave";
 
-module("Integration | Component | ai-indicator-wave", function (hooks) {
+module("Integration | Component | AiIndicatorWave", function (hooks) {
   setupRenderingTest(hooks);
 
   test("it renders an indicator wave", async function (assert) {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-mcp-server-editor-form-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-mcp-server-editor-form-test.gjs
@@ -9,7 +9,7 @@ class ToastsStub extends Service {
   success() {}
 }
 
-module("Integration | Component | ai-mcp-server-editor-form", function (hooks) {
+module("Integration | Component | AiMcpServerEditorForm", function (hooks) {
   setupRenderingTest(hooks, { stubRouter: true });
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-search-discoveries-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-search-discoveries-test.gjs
@@ -8,7 +8,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
 import AiSearchDiscoveries from "discourse/plugins/discourse-ai/discourse/components/ai-search-discoveries";
 
-module("Integration | Component | ai-search-discoveries", function (hooks) {
+module("Integration | Component | AiSearchDiscoveries", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-tool-list-editor-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-tool-list-editor-test.gjs
@@ -18,7 +18,7 @@ class ModalStub extends Service {
   }
 }
 
-module("Integration | Component | ai-tool-list-editor", function (hooks) {
+module("Integration | Component | AiToolListEditor", function (hooks) {
   setupRenderingTest(hooks, { stubRouter: true });
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-topic-gist-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-topic-gist-test.gjs
@@ -9,7 +9,7 @@ import {
   TABLE_LAYOUT,
 } from "discourse/plugins/discourse-ai/discourse/services/gists";
 
-module("Integration | Component | ai-topic-gist", function (hooks) {
+module("Integration | Component | AiTopicGist", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-ai/test/javascripts/unit/components/ai-quick-search-test.js
+++ b/plugins/discourse-ai/test/javascripts/unit/components/ai-quick-search-test.js
@@ -1,7 +1,7 @@
 import { module, test } from "qunit";
 import AiQuickSearch from "discourse/plugins/discourse-ai/discourse/connectors/search-menu-results-bottom/ai-quick-search";
 
-module("Unit | Component | ai-quick-search", function () {
+module("Unit | Component | AiQuickSearch", function () {
   module("shouldRender", function () {
     test("returns true when site setting is enabled", function (assert) {
       const siteSettings = {

--- a/plugins/discourse-assign/test/javascripts/integration/components/group-assigned-filter-test.gjs
+++ b/plugins/discourse-assign/test/javascripts/integration/components/group-assigned-filter-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import GroupAssignedFilter from "discourse/plugins/discourse-assign/discourse/components/group-assigned-filter";
 
-module("Integration | Component | group-assigned-filter", function (hooks) {
+module("Integration | Component | GroupAssignedFilter", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displays username and name", async function (assert) {

--- a/plugins/discourse-calendar/test/javascripts/integration/components/admin-holidays-list-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/admin-holidays-list-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AdminHolidaysList from "discourse/plugins/discourse-calendar/discourse/components/admin-holidays-list";
 
-module("Integration | Component | admin-holidays-list", function (hooks) {
+module("Integration | Component | AdminHolidaysList", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displaying a list of the provided holidays", async function (assert) {

--- a/plugins/discourse-calendar/test/javascripts/integration/components/region-input-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/region-input-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import RegionInput from "discourse/plugins/discourse-calendar/discourse/components/region-input";
 
-module("Integration | Component | region-input", function (hooks) {
+module("Integration | Component | RegionInput", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displaying the 'None' region option", async function (assert) {

--- a/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -2,7 +2,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { testMarkdown } from "discourse/tests/helpers/rich-editor-helper";
 
-module("Integration | Component | rich-editor-extension", function (hooks) {
+module("Integration | Component | RichEditorExtension", function (hooks) {
   setupRenderingTest(hooks);
 
   const testCases = {

--- a/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -30,7 +30,7 @@ const ongoingEnd = "2100-02-09T00:00:00";
 const pastStart = "2100-01-01T00:00:00";
 const pastEnd = "2100-01-15T00:00:00";
 
-module("Integration | Component | upcoming-events-list", function (hooks) {
+module("Integration | Component | UpcomingEventsList", function (hooks) {
   setupRenderingTest(hooks, { stubRouter: true });
 
   hooks.beforeEach(function () {

--- a/plugins/discourse-data-explorer/test/javascripts/components/explorer-schema-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/components/explorer-schema-test.gjs
@@ -36,7 +36,7 @@ const schema = {
   ],
 };
 
-module("Component | explorer-schema", function (hooks) {
+module("Component | ExplorerSchema", function (hooks) {
   setupRenderingTest(hooks);
 
   test("will automatically convert to lowercase", async function (assert) {

--- a/plugins/discourse-data-explorer/test/javascripts/components/param-input-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/components/param-input-test.gjs
@@ -149,7 +149,7 @@ const InputTestCases = [
   },
 ];
 
-module("Component | param-input", function (hooks) {
+module("Component | ParamInput", function (hooks) {
   setupRenderingTest(hooks);
 
   for (const testcase of InputTestCases) {

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/data-explorer-chart-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/data-explorer-chart-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DataExplorerChart from "../../discourse/components/data-explorer-chart";
 
-module("Integration | Component | data-explorer-chart", function (hooks) {
+module("Integration | Component | DataExplorerChart", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders a bar chart with a single dataset", async function (assert) {

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import QueryResult from "../../discourse/components/query-result";
 
-module("Integration | Component | query-result", function (hooks) {
+module("Integration | Component | QueryResult", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders query results", async function (assert) {
@@ -135,7 +135,7 @@ module("Integration | Component | query-result", function (hooks) {
   });
 });
 
-module("Integration | Component | query-result | chart", function (hooks) {
+module("Integration | Component | QueryResult | Chart", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders the chart by default and the toggle for chartable results", async function (assert) {

--- a/plugins/discourse-gamification/test/javascripts/components/gamification-leaderboard-row-test.gjs
+++ b/plugins/discourse-gamification/test/javascripts/components/gamification-leaderboard-row-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import GamificationLeaderboardRow from "../discourse/components/gamification-leaderboard-row";
 
 module(
-  "Discourse Gamification | Component | gamification-leaderboard-row",
+  "Discourse Gamification | Component | GamificationLeaderboardRow",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-gamification/test/javascripts/components/gamification-leaderboard-test.gjs
+++ b/plugins/discourse-gamification/test/javascripts/components/gamification-leaderboard-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import GamificationLeaderboard from "../discourse/components/gamification-leaderboard";
 
 module(
-  "Discourse Gamification | Component | gamification-leaderboard",
+  "Discourse Gamification | Component | GamificationLeaderboard",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-gamification/test/javascripts/components/gamification-score-test.gjs
+++ b/plugins/discourse-gamification/test/javascripts/components/gamification-score-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import GamificationScore from "../discourse/components/gamification-score";
 
 module(
-  "Discourse Gamification | Component | gamification-score",
+  "Discourse Gamification | Component | GamificationScore",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-gamification/test/javascripts/components/minimal-gamification-leaderboard-row-test.gjs
+++ b/plugins/discourse-gamification/test/javascripts/components/minimal-gamification-leaderboard-row-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import MinimalGamificationLeaderboardRow from "../discourse/components/minimal-gamification-leaderboard-row";
 
 module(
-  "Discourse Gamification | Component | minimal-gamification-leaderboard-row",
+  "Discourse Gamification | Component | MinimalGamificationLeaderboardRow",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-gamification/test/javascripts/components/minimal-gamification-leaderboard-test.gjs
+++ b/plugins/discourse-gamification/test/javascripts/components/minimal-gamification-leaderboard-test.gjs
@@ -5,7 +5,7 @@ import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import MinimalGamificationLeaderboard from "../discourse/components/minimal-gamification-leaderboard";
 
 module(
-  "Discourse Gamification | Component | minimal-gamification-leaderboard",
+  "Discourse Gamification | Component | MinimalGamificationLeaderboard",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-gamification/test/javascripts/integration/components/admin-edit-leaderboard-test.gjs
+++ b/plugins/discourse-gamification/test/javascripts/integration/components/admin-edit-leaderboard-test.gjs
@@ -6,7 +6,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import AdminEditLeaderboard from "discourse/plugins/discourse-gamification/admin/components/admin-edit-leaderboard";
 
 module(
-  "Discourse Gamification | Integration | Component | admin-edit-leaderboard",
+  "Discourse Gamification | Integration | Component | AdminEditLeaderboard",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-lazy-videos/test/javascripts/components/lazy-video-test.gjs
+++ b/plugins/discourse-lazy-videos/test/javascripts/components/lazy-video-test.gjs
@@ -3,7 +3,7 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import LazyVideo from "../discourse/components/lazy-video";
 
-module("Component | lazy-video", function (hooks) {
+module("Component | LazyVideo", function (hooks) {
   setupRenderingTest(hooks);
 
   this.attributes = {

--- a/plugins/discourse-policy/test/javascripts/integration/components/policy-builder-form-test.gjs
+++ b/plugins/discourse-policy/test/javascripts/integration/components/policy-builder-form-test.gjs
@@ -7,7 +7,7 @@ import { i18n } from "discourse-i18n";
 import PolicyBuilderForm from "discourse/plugins/discourse-policy/discourse/components/policy-builder-form";
 
 module(
-  "Discourse Policy | Integration | Component | policy-builder-form",
+  "Discourse Policy | Integration | Component | PolicyBuilderForm",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-policy/test/javascripts/integration/components/post-policy-test.gjs
+++ b/plugins/discourse-policy/test/javascripts/integration/components/post-policy-test.gjs
@@ -18,7 +18,7 @@ function fabricatePolicy(options = {}) {
 }
 
 module(
-  "Discourse Policy | Integration | Component | post-policy",
+  "Discourse Policy | Integration | Component | PostPolicy",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows-form-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows-form-test.gjs
@@ -6,7 +6,7 @@ import formKit from "discourse/tests/helpers/form-kit-helper";
 import { i18n } from "discourse-i18n";
 import WorkflowsForm from "discourse/plugins/discourse-workflows/discourse/components/workflows-form";
 
-module("Integration | Component | workflows-form", function (hooks) {
+module("Integration | Component | WorkflowsForm", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders backend form schema with FormKit controls", async function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
@@ -56,644 +56,652 @@ function makeNodes(...nodes) {
   return nodes;
 }
 
-module("Integration | Component | workflows/context/input", function (hooks) {
-  setupRenderingTest(hooks);
+module(
+  "Integration | Component | Workflows | Context | Input",
+  function (hooks) {
+    setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    const service = this.owner.lookup("service:workflows-node-types");
-    service.nodeTypes = [];
-    service.credentialTypes = [];
-    service.expressionContext = EXPRESSION_CONTEXT;
-    this.session = new WorkflowEditorSession({ lastExecutionRunData: {} });
-  });
+    hooks.beforeEach(function () {
+      const service = this.owner.lookup("service:workflows-node-types");
+      service.nodeTypes = [];
+      service.credentialTypes = [];
+      service.expressionContext = EXPRESSION_CONTEXT;
+      this.session = new WorkflowEditorSession({ lastExecutionRunData: {} });
+    });
 
-  hooks.afterEach(function () {
-    this.owner.lookup("service:workflows-node-types").clear();
-  });
+    hooks.afterEach(function () {
+      this.owner.lookup("service:workflows-node-types").clear();
+    });
 
-  test("renders environment fields", async function (assert) {
-    const node = {
-      clientId: "n1",
-      type: "action:http_request",
-      name: "HTTP",
-    };
-    const nodes = makeNodes(node);
+    test("renders environment fields", async function (assert) {
+      const node = {
+        clientId: "n1",
+        type: "action:http_request",
+        name: "HTTP",
+      };
+      const nodes = makeNodes(node);
 
-    await render(
-      <template>
-        <InputContext
-          @node={{node}}
-          @nodes={{nodes}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await render(
+        <template>
+          <InputContext
+            @node={{node}}
+            @nodes={{nodes}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
 
-    const sections = this.element.querySelectorAll(
-      ".workflows-context-panel__section"
-    );
-    const envSection = sections[0];
-    const fieldKeys = [
-      ...envSection.querySelectorAll(".workflows-schema-field__key"),
-    ].map((el) => el.textContent.trim());
+      const sections = this.element.querySelectorAll(
+        ".workflows-context-panel__section"
+      );
+      const envSection = sections[0];
+      const fieldKeys = [
+        ...envSection.querySelectorAll(".workflows-schema-field__key"),
+      ].map((el) => el.textContent.trim());
 
-    assert.true(fieldKeys.includes("site_settings"));
-    assert.true(fieldKeys.includes("vars"));
-    assert.true(fieldKeys.includes("current_user"));
-    assert.true(fieldKeys.includes("execution"));
-  });
+      assert.true(fieldKeys.includes("site_settings"));
+      assert.true(fieldKeys.includes("vars"));
+      assert.true(fieldKeys.includes("current_user"));
+      assert.true(fieldKeys.includes("execution"));
+    });
 
-  test("execution fields include resume_url when webhook wait node exists", async function (assert) {
-    const waitNode = {
-      clientId: "w1",
-      type: "flow:wait",
-      name: "Wait",
-      configuration: { resume: "webhook" },
-    };
-    const actionNode = {
-      clientId: "a1",
-      type: "action:http_request",
-      name: "HTTP",
-    };
-    const nodes = makeNodes(waitNode, actionNode);
+    test("execution fields include resume_url when webhook wait node exists", async function (assert) {
+      const waitNode = {
+        clientId: "w1",
+        type: "flow:wait",
+        name: "Wait",
+        configuration: { resume: "webhook" },
+      };
+      const actionNode = {
+        clientId: "a1",
+        type: "action:http_request",
+        name: "HTTP",
+      };
+      const nodes = makeNodes(waitNode, actionNode);
 
-    await render(
-      <template>
-        <InputContext
-          @node={{actionNode}}
-          @nodes={{nodes}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await render(
+        <template>
+          <InputContext
+            @node={{actionNode}}
+            @nodes={{nodes}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
 
-    const executionFields = this.element.querySelectorAll(
-      ".workflows-schema-field"
-    );
-    const executionField = [...executionFields].find(
-      (el) =>
-        el.querySelector(".workflows-schema-field__key")?.textContent.trim() ===
-        "execution"
-    );
+      const executionFields = this.element.querySelectorAll(
+        ".workflows-schema-field"
+      );
+      const executionField = [...executionFields].find(
+        (el) =>
+          el
+            .querySelector(".workflows-schema-field__key")
+            ?.textContent.trim() === "execution"
+      );
 
-    await click(executionField.querySelector(".workflows-schema-field__row"));
+      await click(executionField.querySelector(".workflows-schema-field__row"));
 
-    const allKeys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key"),
-    ].map((el) => el.textContent.trim());
+      const allKeys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key"),
+      ].map((el) => el.textContent.trim());
 
-    assert.true(allKeys.includes("resume_url"));
-  });
+      assert.true(allKeys.includes("resume_url"));
+    });
 
-  test("execution fields exclude resume_url when no webhook wait node", async function (assert) {
-    const node = {
-      clientId: "n1",
-      type: "action:http_request",
-      name: "HTTP",
-    };
-    const nodes = makeNodes(node);
+    test("execution fields exclude resume_url when no webhook wait node", async function (assert) {
+      const node = {
+        clientId: "n1",
+        type: "action:http_request",
+        name: "HTTP",
+      };
+      const nodes = makeNodes(node);
 
-    await render(
-      <template>
-        <InputContext
-          @node={{node}}
-          @nodes={{nodes}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await render(
+        <template>
+          <InputContext
+            @node={{node}}
+            @nodes={{nodes}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
 
-    const executionFields = this.element.querySelectorAll(
-      ".workflows-schema-field"
-    );
-    const executionField = [...executionFields].find(
-      (el) =>
-        el.querySelector(".workflows-schema-field__key")?.textContent.trim() ===
-        "execution"
-    );
+      const executionFields = this.element.querySelectorAll(
+        ".workflows-schema-field"
+      );
+      const executionField = [...executionFields].find(
+        (el) =>
+          el
+            .querySelector(".workflows-schema-field__key")
+            ?.textContent.trim() === "execution"
+      );
 
-    await click(executionField.querySelector(".workflows-schema-field__row"));
+      await click(executionField.querySelector(".workflows-schema-field__row"));
 
-    const allKeys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key"),
-    ].map((el) => el.textContent.trim());
+      const allKeys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key"),
+      ].map((el) => el.textContent.trim());
 
-    assert.false(allKeys.includes("resume_url"));
-  });
+      assert.false(allKeys.includes("resume_url"));
+    });
 
-  test("execution fields include resumeFormUrl when a form page node exists", async function (assert) {
-    const formNode = {
-      clientId: "f1",
-      type: "action:form",
-      name: "Form",
-      configuration: { page_type: "page" },
-    };
-    const actionNode = {
-      clientId: "a1",
-      type: "action:http_request",
-      name: "HTTP",
-    };
-    const nodes = makeNodes(formNode, actionNode);
+    test("execution fields include resumeFormUrl when a form page node exists", async function (assert) {
+      const formNode = {
+        clientId: "f1",
+        type: "action:form",
+        name: "Form",
+        configuration: { page_type: "page" },
+      };
+      const actionNode = {
+        clientId: "a1",
+        type: "action:http_request",
+        name: "HTTP",
+      };
+      const nodes = makeNodes(formNode, actionNode);
 
-    await render(
-      <template>
-        <InputContext
-          @node={{actionNode}}
-          @nodes={{nodes}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await render(
+        <template>
+          <InputContext
+            @node={{actionNode}}
+            @nodes={{nodes}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
 
-    const executionFields = this.element.querySelectorAll(
-      ".workflows-schema-field"
-    );
-    const executionField = [...executionFields].find(
-      (el) =>
-        el.querySelector(".workflows-schema-field__key")?.textContent.trim() ===
-        "execution"
-    );
+      const executionFields = this.element.querySelectorAll(
+        ".workflows-schema-field"
+      );
+      const executionField = [...executionFields].find(
+        (el) =>
+          el
+            .querySelector(".workflows-schema-field__key")
+            ?.textContent.trim() === "execution"
+      );
 
-    await click(executionField.querySelector(".workflows-schema-field__row"));
+      await click(executionField.querySelector(".workflows-schema-field__row"));
 
-    const allKeys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key"),
-    ].map((el) => el.textContent.trim());
+      const allKeys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key"),
+      ].map((el) => el.textContent.trim());
 
-    assert.true(allKeys.includes("resumeFormUrl"));
-  });
+      assert.true(allKeys.includes("resumeFormUrl"));
+    });
 
-  test("uses previous node name as the input heading", async function (assert) {
-    const triggerNode = {
-      clientId: "t1",
-      type: "trigger:webhook",
-      name: "Webhook",
-    };
-    const step1 = {
-      clientId: "s1",
-      type: "action:http_request",
-      name: "First Step",
-    };
-    const currentNode = {
-      clientId: "c1",
-      type: "action:http_request",
-      name: "Current",
-    };
-    const nodes = makeNodes(triggerNode, step1, currentNode);
-    const connections = [
-      { sourceClientId: "t1", targetClientId: "s1" },
-      { sourceClientId: "s1", targetClientId: "c1" },
-    ];
-    this.session.lastExecutionRunData = {
-      "First Step": [
+    test("uses previous node name as the input heading", async function (assert) {
+      const triggerNode = {
+        clientId: "t1",
+        type: "trigger:webhook",
+        name: "Webhook",
+      };
+      const step1 = {
+        clientId: "s1",
+        type: "action:http_request",
+        name: "First Step",
+      };
+      const currentNode = {
+        clientId: "c1",
+        type: "action:http_request",
+        name: "Current",
+      };
+      const nodes = makeNodes(triggerNode, step1, currentNode);
+      const connections = [
+        { sourceClientId: "t1", targetClientId: "s1" },
+        { sourceClientId: "s1", targetClientId: "c1" },
+      ];
+      this.session.lastExecutionRunData = {
+        "First Step": [
+          {
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: { result: "ok" } }],
+                item_count: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <InputContext
+            @node={{currentNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const firstTitle = this.element
+        .querySelector(
+          ".workflows-context-panel__section .workflows-context-panel__title"
+        )
+        .textContent.trim();
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
+
+      assert.true(firstTitle.includes("First Step"));
+      assert.true(firstTitle.includes("1 item"));
+      assert.dom(".workflows-context-panel__item-title").doesNotExist();
+      assert.true(keys.includes("result"));
+    });
+
+    test("shows an empty input state when the input has no JSON fields", async function (assert) {
+      const previousNode = {
+        clientId: "previous-1",
+        type: "action:http_request",
+        name: "Previous",
+      };
+      const currentNode = {
+        clientId: "current-1",
+        type: "action:http_request",
+        name: "Current",
+      };
+      const nodes = makeNodes(previousNode, currentNode);
+      const connections = [
+        { sourceClientId: "previous-1", targetClientId: "current-1" },
+      ];
+      this.session.lastExecutionRunData = {
+        Previous: [
+          {
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: {} }],
+                item_count: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <InputContext
+            @node={{currentNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      assert.dom(".workflows-context-panel__item-title").doesNotExist();
+      assert.dom(".workflows-context-panel__title-meta").hasText("1 item");
+      assert.dom(".workflows-context-panel__empty").hasText("No input fields");
+    });
+
+    test("shows an empty input state before the input has run", async function (assert) {
+      const previousNode = {
+        clientId: "previous-1",
+        type: "action:http_request",
+        name: "Previous",
+      };
+      const currentNode = {
+        clientId: "current-1",
+        type: "action:http_request",
+        name: "Current",
+      };
+      const nodes = makeNodes(previousNode, currentNode);
+      const connections = [
+        { sourceClientId: "previous-1", targetClientId: "current-1" },
+      ];
+
+      await render(
+        <template>
+          <InputContext
+            @node={{currentNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".workflows-context-panel__empty")
+        .hasText("No input data yet. It will appear after the first run.");
+    });
+
+    test("renders each direct input source for multi-input nodes", async function (assert) {
+      const leftNode = {
+        clientId: "left-1",
+        type: "action:http_request",
+        name: "Left",
+      };
+      const rightNode = {
+        clientId: "right-1",
+        type: "action:http_request",
+        name: "Right",
+      };
+      const currentNode = {
+        clientId: "merge-1",
+        type: "action:merge",
+        name: "Merge",
+      };
+      const nodes = makeNodes(leftNode, rightNode, currentNode);
+      const connections = [
         {
-          status: "success",
-          outputs: [
-            {
-              index: 0,
-              items: [{ json: { result: "ok" } }],
-              item_count: 1,
-            },
-          ],
+          sourceClientId: "right-1",
+          targetClientId: "merge-1",
+          targetInputIndex: 1,
         },
-      ],
-    };
-
-    await render(
-      <template>
-        <InputContext
-          @node={{currentNode}}
-          @nodes={{nodes}}
-          @connections={{connections}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    const firstTitle = this.element
-      .querySelector(
-        ".workflows-context-panel__section .workflows-context-panel__title"
-      )
-      .textContent.trim();
-    const keys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
-    ].map((el) => el.textContent.trim());
-
-    assert.true(firstTitle.includes("First Step"));
-    assert.true(firstTitle.includes("1 item"));
-    assert.dom(".workflows-context-panel__item-title").doesNotExist();
-    assert.true(keys.includes("result"));
-  });
-
-  test("shows an empty input state when the input has no JSON fields", async function (assert) {
-    const previousNode = {
-      clientId: "previous-1",
-      type: "action:http_request",
-      name: "Previous",
-    };
-    const currentNode = {
-      clientId: "current-1",
-      type: "action:http_request",
-      name: "Current",
-    };
-    const nodes = makeNodes(previousNode, currentNode);
-    const connections = [
-      { sourceClientId: "previous-1", targetClientId: "current-1" },
-    ];
-    this.session.lastExecutionRunData = {
-      Previous: [
         {
-          status: "success",
-          outputs: [
-            {
-              index: 0,
-              items: [{ json: {} }],
-              item_count: 1,
-            },
-          ],
+          sourceClientId: "left-1",
+          targetClientId: "merge-1",
+          targetInputIndex: 0,
         },
-      ],
-    };
+      ];
+      this.session.lastExecutionRunData = {
+        Left: [
+          {
+            status: "success",
+            outputs: [
+              { index: 0, items: [{ json: { left: true } }], item_count: 1 },
+            ],
+          },
+        ],
+        Right: [
+          {
+            status: "success",
+            outputs: [
+              { index: 0, items: [{ json: { right: true } }], item_count: 1 },
+            ],
+          },
+        ],
+      };
 
-    await render(
-      <template>
-        <InputContext
-          @node={{currentNode}}
-          @nodes={{nodes}}
-          @connections={{connections}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await render(
+        <template>
+          <InputContext
+            @node={{currentNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
 
-    assert.dom(".workflows-context-panel__item-title").doesNotExist();
-    assert.dom(".workflows-context-panel__title-meta").hasText("1 item");
-    assert.dom(".workflows-context-panel__empty").hasText("No input fields");
-  });
+      const sectionTitles = [
+        ...this.element.querySelectorAll(".workflows-context-panel__title"),
+      ].map((el) => el.textContent.trim());
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
 
-  test("shows an empty input state before the input has run", async function (assert) {
-    const previousNode = {
-      clientId: "previous-1",
-      type: "action:http_request",
-      name: "Previous",
-    };
-    const currentNode = {
-      clientId: "current-1",
-      type: "action:http_request",
-      name: "Current",
-    };
-    const nodes = makeNodes(previousNode, currentNode);
-    const connections = [
-      { sourceClientId: "previous-1", targetClientId: "current-1" },
-    ];
+      assert.true(sectionTitles[0].includes("Left"));
+      assert.true(sectionTitles[0].includes("Input 1"));
+      assert.true(sectionTitles[0].includes("1 item"));
+      assert.true(sectionTitles[1].includes("Right"));
+      assert.true(sectionTitles[1].includes("Input 2"));
+      assert.true(sectionTitles[1].includes("1 item"));
+      assert.true(keys.includes("left"));
+      assert.true(keys.includes("right"));
 
-    await render(
-      <template>
-        <InputContext
-          @node={{currentNode}}
-          @nodes={{nodes}}
-          @connections={{connections}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    assert
-      .dom(".workflows-context-panel__empty")
-      .hasText("No input data yet. It will appear after the first run.");
-  });
-
-  test("renders each direct input source for multi-input nodes", async function (assert) {
-    const leftNode = {
-      clientId: "left-1",
-      type: "action:http_request",
-      name: "Left",
-    };
-    const rightNode = {
-      clientId: "right-1",
-      type: "action:http_request",
-      name: "Right",
-    };
-    const currentNode = {
-      clientId: "merge-1",
-      type: "action:merge",
-      name: "Merge",
-    };
-    const nodes = makeNodes(leftNode, rightNode, currentNode);
-    const connections = [
-      {
-        sourceClientId: "right-1",
-        targetClientId: "merge-1",
-        targetInputIndex: 1,
-      },
-      {
-        sourceClientId: "left-1",
-        targetClientId: "merge-1",
-        targetInputIndex: 0,
-      },
-    ];
-    this.session.lastExecutionRunData = {
-      Left: [
-        {
-          status: "success",
-          outputs: [
-            { index: 0, items: [{ json: { left: true } }], item_count: 1 },
-          ],
+      const fieldRows = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key"),
+      ];
+      const leftField = fieldRows.find(
+        (el) => el.textContent.trim() === "left"
+      );
+      const rightField = fieldRows.find(
+        (el) => el.textContent.trim() === "right"
+      );
+      const dragged = {};
+      const dataTransfer = {
+        setData(type, value) {
+          dragged[type] = value;
         },
-      ],
-      Right: [
-        {
-          status: "success",
-          outputs: [
-            { index: 0, items: [{ json: { right: true } }], item_count: 1 },
-          ],
-        },
-      ],
-    };
+      };
 
-    await render(
-      <template>
-        <InputContext
-          @node={{currentNode}}
-          @nodes={{nodes}}
-          @connections={{connections}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await triggerEvent(leftField, "dragstart", { dataTransfer });
+      assert.strictEqual(
+        JSON.parse(dragged[WORKFLOW_VARIABLE_MIME]).id,
+        "$json.left"
+      );
 
-    const sectionTitles = [
-      ...this.element.querySelectorAll(".workflows-context-panel__title"),
-    ].map((el) => el.textContent.trim());
-    const keys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
-    ].map((el) => el.textContent.trim());
-
-    assert.true(sectionTitles[0].includes("Left"));
-    assert.true(sectionTitles[0].includes("Input 1"));
-    assert.true(sectionTitles[0].includes("1 item"));
-    assert.true(sectionTitles[1].includes("Right"));
-    assert.true(sectionTitles[1].includes("Input 2"));
-    assert.true(sectionTitles[1].includes("1 item"));
-    assert.true(keys.includes("left"));
-    assert.true(keys.includes("right"));
-
-    const fieldRows = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key"),
-    ];
-    const leftField = fieldRows.find((el) => el.textContent.trim() === "left");
-    const rightField = fieldRows.find(
-      (el) => el.textContent.trim() === "right"
-    );
-    const dragged = {};
-    const dataTransfer = {
-      setData(type, value) {
-        dragged[type] = value;
-      },
-    };
-
-    await triggerEvent(leftField, "dragstart", { dataTransfer });
-    assert.strictEqual(
-      JSON.parse(dragged[WORKFLOW_VARIABLE_MIME]).id,
-      "$json.left"
-    );
-
-    await triggerEvent(rightField, "dragstart", { dataTransfer });
-    assert.strictEqual(
-      JSON.parse(dragged[WORKFLOW_VARIABLE_MIME]).id,
-      '$("Right").all(0)[$itemIndex].json.right'
-    );
-  });
-
-  test("prefers the current node recorded input over the previous node output", async function (assert) {
-    const logNode = {
-      clientId: "log-1",
-      type: "action:log",
-      name: "Log",
-    };
-    const currentNode = {
-      clientId: "current-1",
-      type: "action:http_request",
-      name: "Current",
-    };
-    const nodes = makeNodes(logNode, currentNode);
-    const connections = [
-      { sourceClientId: "log-1", targetClientId: "current-1" },
-    ];
-    this.session.lastExecutionRunData = {
-      Log: [
-        {
-          status: "success",
-          outputs: [{ index: 0, items: [], item_count: 0 }],
-        },
-      ],
-      Current: [
-        {
-          status: "success",
-          inputs: [
-            {
-              index: 0,
-              items: [{ json: { topic: { id: 1, title: "Runtime topic" } } }],
-              item_count: 1,
-              source: { node_name: "Log", output_index: 0 },
-            },
-          ],
-        },
-      ],
-    };
-
-    await render(
-      <template>
-        <InputContext
-          @node={{currentNode}}
-          @nodes={{nodes}}
-          @connections={{connections}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    const firstTitle = this.element
-      .querySelector(
-        ".workflows-context-panel__section .workflows-context-panel__title"
-      )
-      .textContent.trim();
-    const keys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
-    ].map((el) => el.textContent.trim());
-
-    assert.true(firstTitle.includes("Log"));
-    assert.true(firstTitle.includes("1 item"));
-    assert.dom(".workflows-context-panel__item-title").doesNotExist();
-    assert.true(keys.includes("topic"));
-  });
-
-  test("hides the input section when there is no previous node", async function (assert) {
-    const node = {
-      clientId: "n1",
-      type: "action:http_request",
-      name: "HTTP",
-    };
-    const nodes = makeNodes(node);
-
-    await render(
-      <template>
-        <InputContext
-          @node={{node}}
-          @nodes={{nodes}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    const firstTitle = this.element
-      .querySelector(
-        ".workflows-context-panel__section .workflows-context-panel__title"
-      )
-      .textContent.trim();
-
-    assert.strictEqual(
-      firstTitle,
-      "Environment",
-      "first section is Environment, input section is hidden"
-    );
-  });
-
-  test("renders ancestor nodes with $() expression format", async function (assert) {
-    const triggerNode = {
-      clientId: "t1",
-      type: "trigger:webhook",
-      name: "Webhook",
-    };
-    const step1 = {
-      clientId: "s1",
-      type: "action:http_request",
-      name: "First Step",
-    };
-    const step2 = {
-      clientId: "s2",
-      type: "action:http_request",
-      name: "Second Step",
-    };
-    const currentNode = {
-      clientId: "c1",
-      type: "action:http_request",
-      name: "Current",
-    };
-    const nodes = makeNodes(triggerNode, step1, step2, currentNode);
-    const connections = [
-      { sourceClientId: "t1", targetClientId: "s1" },
-      { sourceClientId: "s1", targetClientId: "s2" },
-      { sourceClientId: "s2", targetClientId: "c1" },
-    ];
-
-    const nodeTypes = [];
-    this.session.lastExecutionRunData = {
-      "First Step": [
-        {
-          status: "success",
-          outputs: [
-            {
-              index: 0,
-              items: [{ json: { result: "ok" } }],
-              item_count: 1,
-            },
-          ],
-        },
-      ],
-      "Second Step": [
-        {
-          status: "success",
-          outputs: [
-            {
-              index: 0,
-              items: [{ json: { data: { id: 1 } } }],
-              item_count: 1,
-            },
-          ],
-        },
-      ],
-    };
-
-    await render(
-      <template>
-        <InputContext
-          @node={{currentNode}}
-          @nodes={{nodes}}
-          @connections={{connections}}
-          @nodeTypes={{nodeTypes}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    const sectionTitles = [
-      ...this.element.querySelectorAll(".workflows-context-panel__title"),
-    ].map((el) => el.textContent.trim());
-
-    assert.true(
-      sectionTitles.some((t) => t.includes("First Step")),
-      "shows ancestor node as section"
-    );
-  });
-
-  test("environment fields match schema symbols", async function (assert) {
-    const node = {
-      clientId: "n1",
-      type: "action:http_request",
-      name: "HTTP",
-    };
-
-    await render(
-      <template>
-        <InputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    const service = this.owner.lookup("service:workflows-node-types");
-    const expectedSymbols = Object.keys(
-      service.expressionContext.environment || {}
-    );
-
-    const sections = this.element.querySelectorAll(
-      ".workflows-context-panel__section"
-    );
-    const envSection = sections[0];
-    const fieldKeys = [
-      ...envSection.querySelectorAll(
-        ":scope > .workflows-schema-field-list > .workflows-schema-field"
-      ),
-    ].map((el) =>
-      el.querySelector(".workflows-schema-field__key")?.textContent.trim()
-    );
-
-    expectedSymbols.forEach((symbol) => {
-      const displayKey = symbol.replace(/^\$/, "");
-      assert.true(
-        fieldKeys.includes(displayKey),
-        `expected environment field "${displayKey}" (from schema symbol "${symbol}") to be rendered`
+      await triggerEvent(rightField, "dragstart", { dataTransfer });
+      assert.strictEqual(
+        JSON.parse(dragged[WORKFLOW_VARIABLE_MIME]).id,
+        '$("Right").all(0)[$itemIndex].json.right'
       );
     });
-  });
-});
+
+    test("prefers the current node recorded input over the previous node output", async function (assert) {
+      const logNode = {
+        clientId: "log-1",
+        type: "action:log",
+        name: "Log",
+      };
+      const currentNode = {
+        clientId: "current-1",
+        type: "action:http_request",
+        name: "Current",
+      };
+      const nodes = makeNodes(logNode, currentNode);
+      const connections = [
+        { sourceClientId: "log-1", targetClientId: "current-1" },
+      ];
+      this.session.lastExecutionRunData = {
+        Log: [
+          {
+            status: "success",
+            outputs: [{ index: 0, items: [], item_count: 0 }],
+          },
+        ],
+        Current: [
+          {
+            status: "success",
+            inputs: [
+              {
+                index: 0,
+                items: [{ json: { topic: { id: 1, title: "Runtime topic" } } }],
+                item_count: 1,
+                source: { node_name: "Log", output_index: 0 },
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <InputContext
+            @node={{currentNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const firstTitle = this.element
+        .querySelector(
+          ".workflows-context-panel__section .workflows-context-panel__title"
+        )
+        .textContent.trim();
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
+
+      assert.true(firstTitle.includes("Log"));
+      assert.true(firstTitle.includes("1 item"));
+      assert.dom(".workflows-context-panel__item-title").doesNotExist();
+      assert.true(keys.includes("topic"));
+    });
+
+    test("hides the input section when there is no previous node", async function (assert) {
+      const node = {
+        clientId: "n1",
+        type: "action:http_request",
+        name: "HTTP",
+      };
+      const nodes = makeNodes(node);
+
+      await render(
+        <template>
+          <InputContext
+            @node={{node}}
+            @nodes={{nodes}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const firstTitle = this.element
+        .querySelector(
+          ".workflows-context-panel__section .workflows-context-panel__title"
+        )
+        .textContent.trim();
+
+      assert.strictEqual(
+        firstTitle,
+        "Environment",
+        "first section is Environment, input section is hidden"
+      );
+    });
+
+    test("renders ancestor nodes with $() expression format", async function (assert) {
+      const triggerNode = {
+        clientId: "t1",
+        type: "trigger:webhook",
+        name: "Webhook",
+      };
+      const step1 = {
+        clientId: "s1",
+        type: "action:http_request",
+        name: "First Step",
+      };
+      const step2 = {
+        clientId: "s2",
+        type: "action:http_request",
+        name: "Second Step",
+      };
+      const currentNode = {
+        clientId: "c1",
+        type: "action:http_request",
+        name: "Current",
+      };
+      const nodes = makeNodes(triggerNode, step1, step2, currentNode);
+      const connections = [
+        { sourceClientId: "t1", targetClientId: "s1" },
+        { sourceClientId: "s1", targetClientId: "s2" },
+        { sourceClientId: "s2", targetClientId: "c1" },
+      ];
+
+      const nodeTypes = [];
+      this.session.lastExecutionRunData = {
+        "First Step": [
+          {
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: { result: "ok" } }],
+                item_count: 1,
+              },
+            ],
+          },
+        ],
+        "Second Step": [
+          {
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: { data: { id: 1 } } }],
+                item_count: 1,
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <InputContext
+            @node={{currentNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{nodeTypes}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const sectionTitles = [
+        ...this.element.querySelectorAll(".workflows-context-panel__title"),
+      ].map((el) => el.textContent.trim());
+
+      assert.true(
+        sectionTitles.some((t) => t.includes("First Step")),
+        "shows ancestor node as section"
+      );
+    });
+
+    test("environment fields match schema symbols", async function (assert) {
+      const node = {
+        clientId: "n1",
+        type: "action:http_request",
+        name: "HTTP",
+      };
+
+      await render(
+        <template>
+          <InputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const service = this.owner.lookup("service:workflows-node-types");
+      const expectedSymbols = Object.keys(
+        service.expressionContext.environment || {}
+      );
+
+      const sections = this.element.querySelectorAll(
+        ".workflows-context-panel__section"
+      );
+      const envSection = sections[0];
+      const fieldKeys = [
+        ...envSection.querySelectorAll(
+          ":scope > .workflows-schema-field-list > .workflows-schema-field"
+        ),
+      ].map((el) =>
+        el.querySelector(".workflows-schema-field__key")?.textContent.trim()
+      );
+
+      expectedSymbols.forEach((symbol) => {
+        const displayKey = symbol.replace(/^\$/, "");
+        assert.true(
+          fieldKeys.includes(displayKey),
+          `expected environment field "${displayKey}" (from schema symbol "${symbol}") to be rendered`
+        );
+      });
+    });
+  }
+);

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-output-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-output-test.gjs
@@ -4,349 +4,354 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import OutputContext from "discourse/plugins/discourse-workflows/admin/components/workflows/context/output";
 import WorkflowEditorSession from "discourse/plugins/discourse-workflows/admin/lib/workflows/editor-session";
 
-module("Integration | Component | workflows/context/output", function (hooks) {
-  setupRenderingTest(hooks);
+module(
+  "Integration | Component | Workflows | Context | Output",
+  function (hooks) {
+    setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    this.session = new WorkflowEditorSession({ lastExecutionRunData: {} });
-  });
+    hooks.beforeEach(function () {
+      this.session = new WorkflowEditorSession({ lastExecutionRunData: {} });
+    });
 
-  hooks.afterEach(function () {
-    this.owner.lookup("service:workflows-node-types").clear();
-  });
+    hooks.afterEach(function () {
+      this.owner.lookup("service:workflows-node-types").clear();
+    });
 
-  test("renders output fields from execution run data", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:http_request",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    const nodes = [node];
-    this.session.lastExecutionRunData = {
-      Sample: [
-        {
-          status: "success",
-          outputs: [
-            {
-              index: 0,
-              items: [
-                { json: { body: { ok: true }, status: 200 } },
-                { json: { body: { ok: false }, status: 500 } },
-              ],
-              item_count: 2,
-            },
-          ],
-        },
-      ],
-    };
-
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{nodes}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    assert.dom(".workflows-context-panel__title-meta").hasText("2 items");
-    assert
-      .dom(".workflows-context-panel__hint")
-      .hasText(
-        "Tip Now that you have output data for this node, you can pin it and use it when executing this trigger manually with the green play button."
-      );
-    assert.dom(".workflows-context-panel__item-title").doesNotExist();
-    const keys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
-    ].map((el) => el.textContent.trim());
-    assert.deepEqual(keys, ["body", "status"]);
-  });
-
-  test("asks the user to run the workflow when no execution output is available", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:http_request",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    assert
-      .dom(".workflows-context-panel__empty-state-title")
-      .hasText("No output yet");
-    assert.dom(".workflows-context-panel__hint").doesNotExist();
-    assert
-      .dom(".workflows-context-panel__empty-state-btn")
-      .hasText(/Add sample data/);
-  });
-
-  test("does not show the pin tip when output data is already pinned", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:http_request",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    const session = new WorkflowEditorSession({
-      lastExecutionRunData: {
+    test("renders output fields from execution run data", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:http_request",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      const nodes = [node];
+      this.session.lastExecutionRunData = {
         Sample: [
           {
             status: "success",
             outputs: [
               {
                 index: 0,
-                items: [{ json: { body: { ok: true }, status: 200 } }],
-                item_count: 1,
+                items: [
+                  { json: { body: { ok: true }, status: 200 } },
+                  { json: { body: { ok: false }, status: 500 } },
+                ],
+                item_count: 2,
               },
             ],
           },
         ],
-      },
-      pinData: {
-        Sample: [{ json: { body: { pinned: true }, status: 200 } }],
-      },
+      };
+
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{nodes}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      assert.dom(".workflows-context-panel__title-meta").hasText("2 items");
+      assert
+        .dom(".workflows-context-panel__hint")
+        .hasText(
+          "Tip Now that you have output data for this node, you can pin it and use it when executing this trigger manually with the green play button."
+        );
+      assert.dom(".workflows-context-panel__item-title").doesNotExist();
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
+      assert.deepEqual(keys, ["body", "status"]);
     });
 
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{session}}
-        />
-      </template>
-    );
+    test("asks the user to run the workflow when no execution output is available", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:http_request",
+        typeVersion: "1.0",
+        configuration: {},
+      };
 
-    assert.dom(".workflows-context-panel__pin-banner").exists();
-    assert.dom(".workflows-context-panel__hint").doesNotExist();
-  });
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
 
-  test("shows an empty output state when the node executed with zero items", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:log",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    this.session.lastExecutionRunData = {
-      Sample: [
-        {
-          status: "success",
-          outputs: [{ index: 0, items: [], item_count: 0 }],
-        },
-      ],
-    };
+      assert
+        .dom(".workflows-context-panel__empty-state-title")
+        .hasText("No output yet");
+      assert.dom(".workflows-context-panel__hint").doesNotExist();
+      assert
+        .dom(".workflows-context-panel__empty-state-btn")
+        .hasText(/Add sample data/);
+    });
 
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    assert.dom(".workflows-context-panel__title-meta").doesNotExist();
-    assert.dom(".workflows-context-panel__empty").hasText("No output data");
-  });
-
-  test("shows item count and field-empty state for real empty output items", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:http_request",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    this.session.lastExecutionRunData = {
-      Sample: [
-        {
-          status: "success",
-          outputs: [{ index: 0, items: [{ json: {} }], item_count: 1 }],
-        },
-      ],
-    };
-
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    assert.dom(".workflows-context-panel__title-meta").hasText("1 item");
-    assert.dom(".workflows-context-panel__empty").hasText("No output fields");
-  });
-
-  test("does not show stale fields after a later zero-item output", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:log",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    this.session.lastExecutionRunData = {
-      Sample: [
-        {
-          status: "success",
-          outputs: [
-            { index: 0, items: [{ json: { stale: true } }], item_count: 1 },
-          ],
-        },
-        {
-          status: "success",
-          outputs: [{ index: 0, items: [], item_count: 0 }],
-        },
-      ],
-    };
-
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    assert.dom(".workflows-schema-field__key-title").doesNotExist();
-    assert.dom(".workflows-context-panel__empty").hasText("No output data");
-  });
-
-  test("merges fields across output items without rendering item rows", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "action:http_request",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    this.session.lastExecutionRunData = {
-      Sample: [
-        {
-          status: "success",
-          outputs: [
+    test("does not show the pin tip when output data is already pinned", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:http_request",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      const session = new WorkflowEditorSession({
+        lastExecutionRunData: {
+          Sample: [
             {
-              index: 0,
-              items: [{ json: {} }, { json: { result: "ok" } }],
-              item_count: 2,
+              status: "success",
+              outputs: [
+                {
+                  index: 0,
+                  items: [{ json: { body: { ok: true }, status: 200 } }],
+                  item_count: 1,
+                },
+              ],
             },
           ],
         },
-      ],
-    };
-
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
-
-    const itemTitles = [
-      ...this.element.querySelectorAll(".workflows-context-panel__item-title"),
-    ].map((el) => el.textContent.trim());
-    const keys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
-    ].map((el) => el.textContent.trim());
-
-    assert.deepEqual(itemTitles, []);
-    assert.dom(".workflows-context-panel__title-meta").hasText("2 items");
-    assert.deepEqual(keys, ["result"]);
-  });
-
-  test("combines output indexes into one output schema", async function (assert) {
-    const node = {
-      clientId: "n1",
-      name: "Sample",
-      type: "condition:if",
-      typeVersion: "1.0",
-      configuration: {},
-    };
-    this.session.lastExecutionRunData = {
-      Sample: [
-        {
-          status: "success",
-          outputs: [
-            {
-              index: 0,
-              items: [{ json: { topic: { id: 1 } } }],
-              item_count: 1,
-            },
-            {
-              index: 1,
-              items: [],
-              item_count: 0,
-            },
-          ],
+        pinData: {
+          Sample: [{ json: { body: { pinned: true }, status: 200 } }],
         },
-      ],
-    };
+      });
 
-    await render(
-      <template>
-        <OutputContext
-          @node={{node}}
-          @nodes={{Array node}}
-          @connections={{(Array)}}
-          @nodeTypes={{(Array)}}
-          @session={{this.session}}
-        />
-      </template>
-    );
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{session}}
+          />
+        </template>
+      );
 
-    const subtitles = [
-      ...this.element.querySelectorAll(".workflows-context-panel__subtitle"),
-    ].map((el) => el.textContent.replace(/\s+/g, " ").trim());
-    const keys = [
-      ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
-    ].map((el) => el.textContent.trim());
+      assert.dom(".workflows-context-panel__pin-banner").exists();
+      assert.dom(".workflows-context-panel__hint").doesNotExist();
+    });
 
-    assert.deepEqual(subtitles, []);
-    assert
-      .dom(
-        ".workflows-context-panel__header .workflows-context-panel__title-meta"
-      )
-      .hasText("1 item");
-    assert.dom(".workflows-context-panel__empty").doesNotExist();
-    assert.deepEqual(keys, ["topic"]);
-  });
-});
+    test("shows an empty output state when the node executed with zero items", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:log",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      this.session.lastExecutionRunData = {
+        Sample: [
+          {
+            status: "success",
+            outputs: [{ index: 0, items: [], item_count: 0 }],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      assert.dom(".workflows-context-panel__title-meta").doesNotExist();
+      assert.dom(".workflows-context-panel__empty").hasText("No output data");
+    });
+
+    test("shows item count and field-empty state for real empty output items", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:http_request",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      this.session.lastExecutionRunData = {
+        Sample: [
+          {
+            status: "success",
+            outputs: [{ index: 0, items: [{ json: {} }], item_count: 1 }],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      assert.dom(".workflows-context-panel__title-meta").hasText("1 item");
+      assert.dom(".workflows-context-panel__empty").hasText("No output fields");
+    });
+
+    test("does not show stale fields after a later zero-item output", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:log",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      this.session.lastExecutionRunData = {
+        Sample: [
+          {
+            status: "success",
+            outputs: [
+              { index: 0, items: [{ json: { stale: true } }], item_count: 1 },
+            ],
+          },
+          {
+            status: "success",
+            outputs: [{ index: 0, items: [], item_count: 0 }],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      assert.dom(".workflows-schema-field__key-title").doesNotExist();
+      assert.dom(".workflows-context-panel__empty").hasText("No output data");
+    });
+
+    test("merges fields across output items without rendering item rows", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "action:http_request",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      this.session.lastExecutionRunData = {
+        Sample: [
+          {
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: {} }, { json: { result: "ok" } }],
+                item_count: 2,
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const itemTitles = [
+        ...this.element.querySelectorAll(
+          ".workflows-context-panel__item-title"
+        ),
+      ].map((el) => el.textContent.trim());
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
+
+      assert.deepEqual(itemTitles, []);
+      assert.dom(".workflows-context-panel__title-meta").hasText("2 items");
+      assert.deepEqual(keys, ["result"]);
+    });
+
+    test("combines output indexes into one output schema", async function (assert) {
+      const node = {
+        clientId: "n1",
+        name: "Sample",
+        type: "condition:if",
+        typeVersion: "1.0",
+        configuration: {},
+      };
+      this.session.lastExecutionRunData = {
+        Sample: [
+          {
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: { topic: { id: 1 } } }],
+                item_count: 1,
+              },
+              {
+                index: 1,
+                items: [],
+                item_count: 0,
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <OutputContext
+            @node={{node}}
+            @nodes={{Array node}}
+            @connections={{(Array)}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const subtitles = [
+        ...this.element.querySelectorAll(".workflows-context-panel__subtitle"),
+      ].map((el) => el.textContent.replace(/\s+/g, " ").trim());
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
+
+      assert.deepEqual(subtitles, []);
+      assert
+        .dom(
+          ".workflows-context-panel__header .workflows-context-panel__title-meta"
+        )
+        .hasText("1 item");
+      assert.dom(".workflows-context-panel__empty").doesNotExist();
+      assert.deepEqual(keys, ["topic"]);
+    });
+  }
+);

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/pin-data-editor-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/pin-data-editor-test.gjs
@@ -23,7 +23,7 @@ async function setBuffer(element, value) {
 }
 
 module(
-  "Integration | Component | workflows/context/pin-data-editor",
+  "Integration | Component | Workflows | Context | PinDataEditor",
   function (hooks) {
     setupRenderingTest(hooks);
 

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/variable-input-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/variable-input-test.gjs
@@ -8,75 +8,86 @@ function editorText(element) {
   return element.querySelector(".cm-content")?.textContent ?? "";
 }
 
-module("Integration | Component | workflows/variable/input", function (hooks) {
-  setupRenderingTest(hooks);
+module(
+  "Integration | Component | Workflows | Variable | Input",
+  function (hooks) {
+    setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    pretender.get("/admin/plugins/discourse-workflows/variables.json", () =>
-      response(200, { variables: [] })
-    );
-  });
+    hooks.beforeEach(function () {
+      pretender.get("/admin/plugins/discourse-workflows/variables.json", () =>
+        response(200, { variables: [] })
+      );
+    });
 
-  test("renders CodeMirror editor", async function (assert) {
-    await render(<template><VariableInput @value="" /></template>);
-    await waitFor(".cm-editor");
+    test("renders CodeMirror editor", async function (assert) {
+      await render(<template><VariableInput @value="" /></template>);
+      await waitFor(".cm-editor");
 
-    assert.dom(".workflows-variable-input").exists();
-    assert.dom(".cm-editor").exists();
-    assert.dom(".cm-content").exists();
-  });
+      assert.dom(".workflows-variable-input").exists();
+      assert.dom(".cm-editor").exists();
+      assert.dom(".cm-content").exists();
+    });
 
-  test("displays expression value as text", async function (assert) {
-    const value = "Hello {{ $current_user.username }}!";
+    test("displays expression value as text", async function (assert) {
+      const value = "Hello {{ $current_user.username }}!";
 
-    await render(<template><VariableInput @value={{value}} /></template>);
-    await waitFor(".cm-editor");
+      await render(<template><VariableInput @value={{value}} /></template>);
+      await waitFor(".cm-editor");
 
-    const text = editorText(this.element);
-    assert.true(
-      text.includes("$current_user.username"),
-      "editor displays the expression variable"
-    );
-  });
+      const text = editorText(this.element);
+      assert.true(
+        text.includes("$current_user.username"),
+        "editor displays the expression variable"
+      );
+    });
 
-  test("displays multiple expressions", async function (assert) {
-    const value = "{{ $execution.id }} - {{ $json.title }}";
+    test("displays multiple expressions", async function (assert) {
+      const value = "{{ $execution.id }} - {{ $json.title }}";
 
-    await render(<template><VariableInput @value={{value}} /></template>);
-    await waitFor(".cm-editor");
+      await render(<template><VariableInput @value={{value}} /></template>);
+      await waitFor(".cm-editor");
 
-    const text = editorText(this.element);
-    assert.true(text.includes("$execution.id"), "contains first expression");
-    assert.true(text.includes("$json.title"), "contains second expression");
-  });
+      const text = editorText(this.element);
+      assert.true(text.includes("$execution.id"), "contains first expression");
+      assert.true(text.includes("$json.title"), "contains second expression");
+    });
 
-  test("preserves value through render cycle", async function (assert) {
-    const value = "prefix {{ $vars.API_URL }} suffix";
+    test("preserves value through render cycle", async function (assert) {
+      const value = "prefix {{ $vars.API_URL }} suffix";
 
-    await render(<template><VariableInput @value={{value}} /></template>);
-    await waitFor(".cm-editor");
+      await render(<template><VariableInput @value={{value}} /></template>);
+      await waitFor(".cm-editor");
 
-    const text = editorText(this.element);
-    assert.true(text.includes("$vars.API_URL"), "expression is preserved");
-    assert.true(text.includes("prefix"), "prefix text is preserved");
-    assert.true(text.includes("suffix"), "suffix text is preserved");
-  });
+      const text = editorText(this.element);
+      assert.true(text.includes("$vars.API_URL"), "expression is preserved");
+      assert.true(text.includes("prefix"), "prefix text is preserved");
+      assert.true(text.includes("suffix"), "suffix text is preserved");
+    });
 
-  test("fires onChange when user types", async function (assert) {
-    let captured = null;
-    let editorView = null;
-    const onChange = (val) => (captured = val);
-    const onSetup = (view) => (editorView = view);
+    test("fires onChange when user types", async function (assert) {
+      let captured = null;
+      let editorView = null;
+      const onChange = (val) => (captured = val);
+      const onSetup = (view) => (editorView = view);
 
-    await render(
-      <template>
-        <VariableInput @value="" @onChange={{onChange}} @onSetup={{onSetup}} />
-      </template>
-    );
-    await waitFor(".cm-editor");
+      await render(
+        <template>
+          <VariableInput
+            @value=""
+            @onChange={{onChange}}
+            @onSetup={{onSetup}}
+          />
+        </template>
+      );
+      await waitFor(".cm-editor");
 
-    editorView.dispatch({ changes: { from: 0, insert: "hello" } });
+      editorView.dispatch({ changes: { from: 0, insert: "hello" } });
 
-    assert.strictEqual(captured, "hello", "onChange was called with the value");
-  });
-});
+      assert.strictEqual(
+        captured,
+        "hello",
+        "onChange was called with the value"
+      );
+    });
+  }
+);

--- a/plugins/discourse-workflows/test/javascripts/unit/components/workflows/workflow-node-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/unit/components/workflows/workflow-node-test.gjs
@@ -4,7 +4,7 @@ import {
   shouldShowManualTrigger,
 } from "discourse/plugins/discourse-workflows/admin/components/workflows/canvas/workflow-node";
 
-module("Unit | Component | workflows/canvas/workflow-node", function () {
+module("Unit | Component | Workflows | Canvas | WorkflowNode", function () {
   test("shows manual trigger for trigger nodes", function (assert) {
     assert.true(
       shouldShowManualTrigger({

--- a/plugins/poll/test/javascripts/component/poll-buttons-dropdown-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-buttons-dropdown-test.gjs
@@ -4,7 +4,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import { i18n } from "discourse-i18n";
 import PollButtonsDropdown from "discourse/plugins/poll/discourse/components/poll-buttons-dropdown";
 
-module("Component | poll-buttons-dropdown", function (hooks) {
+module("Component | PollButtonsDropdown", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Renders a clickable dropdown menu with a close option", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-info-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-info-test.gjs
@@ -10,7 +10,7 @@ const OPTIONS = [
   { id: "6c986ebcde3d5822a6e91a695c388094", html: "Other", votes: 5, rank: 0 },
 ];
 
-module("Component | poll-info", function (hooks) {
+module("Component | PollInfo", function (hooks) {
   setupRenderingTest(hooks);
 
   test("public multiple poll with results anytime", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-options-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-options-test.gjs
@@ -25,7 +25,7 @@ const IMAGE_OPTIONS = [
   },
 ];
 
-module("Component | poll-options", function (hooks) {
+module("Component | PollOptions", function (hooks) {
   setupRenderingTest(hooks);
 
   test("single, not selected", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-results-pie-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-results-pie-test.gjs
@@ -11,7 +11,7 @@ const OPTIONS = [
 
 const ID = "23";
 
-module("Component | poll-results-pie", function (hooks) {
+module("Component | PollResultsPie", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Renders the pie chart Component correctly", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-results-ranked-choice-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-results-ranked-choice-test.gjs
@@ -30,7 +30,7 @@ const RANKED_CHOICE_OUTCOME = {
   ],
 };
 
-module("Component | poll-results-ranked-choice", function (hooks) {
+module("Component | PollResultsRankedChoice", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Renders the ranked choice results component correctly", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-results-standard-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-results-standard-test.gjs
@@ -34,7 +34,7 @@ const PRELOADEDVOTERS = {
   ],
 };
 
-module("Component | poll-results-standard", function (hooks) {
+module("Component | PollResultsStandard", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Renders the standard results Component correctly", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-results-tabs-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-results-tabs-test.gjs
@@ -55,7 +55,7 @@ const PRELOADEDVOTERS = {
   ],
 };
 
-module("Component | poll-results-tabs", function (hooks) {
+module("Component | PollResultsTabs", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Renders one tab for non-ranked-choice poll", async function (assert) {

--- a/plugins/poll/test/javascripts/component/poll-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-test.gjs
@@ -9,7 +9,7 @@ import Poll from "discourse/plugins/poll/discourse/components/poll";
 
 let requests = 0;
 
-module("Component | poll", function (hooks) {
+module("Component | Poll", function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/plugins/poll/test/javascripts/component/poll-ui-builder-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-ui-builder-test.gjs
@@ -20,7 +20,7 @@ async function setupBuilder() {
   return results;
 }
 
-module("Component | poll-ui-builder", function (hooks) {
+module("Component | PollUiBuilder", function (hooks) {
   setupRenderingTest(hooks);
 
   test("Can switch poll type", async function (assert) {


### PR DESCRIPTION
Currently, most of the JS test modules follow this
convention:

```
module("Integration | Component | topic-dismiss-buttons"
```

Which is a legacy from when ember components etc were
rendered in templates like this:

```
{{d-button title="foo"}}
```

Instead, this commit updates all of them to follow this
PascalCase convention:

```
module("Integration | Component | TopicDismissButtons", function (hooks) {
```

No linting is added to enforce this, we suspect that it's
mostly a result of cargo culting, and people will add new
tests following PascalCase convention.
