### PR TITLE
FIX: Delete `BrowserPageviewEventScore` rows during cleanup

### DIFF
--- a/app/jobs/scheduled/clean_up_browser_pageview_events.rb
+++ b/app/jobs/scheduled/clean_up_browser_pageview_events.rb
@@ -11,8 +11,10 @@ module Jobs
 
       BrowserPageviewEvent
         .where("created_at < ?", RETENTION_PERIOD.ago.beginning_of_day)
-        .in_batches(of: 10_000)
-        .delete_all
+        .in_batches(of: 10_000) do |browser_pageview_events|
+          BrowserPageviewEventScore.where(event_id: browser_pageview_events.select(:id)).delete_all
+          browser_pageview_events.delete_all
+        end
     end
   end
 end

--- a/spec/jobs/clean_up_browser_pageview_events_spec.rb
+++ b/spec/jobs/clean_up_browser_pageview_events_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Jobs::CleanUpBrowserPageviewEvents do
     expect(BrowserPageviewEvent.all).to contain_exactly(fresh_event)
   end
 
+  it "deletes scores for deleted events" do
+    SiteSetting.clean_up_browser_pageview_events = true
+    fresh_event = Fabricate(:browser_pageview_event, created_at: 1.month.ago)
+    old_event = Fabricate(:browser_pageview_event, created_at: 4.months.ago)
+    BrowserPageviewEventScore.create!(event: fresh_event)
+    BrowserPageviewEventScore.create!(event: old_event)
+
+    described_class.new.execute({})
+
+    expect(BrowserPageviewEventScore.pluck(:event_id)).to contain_exactly(fresh_event.id)
+  end
+
   it "keeps all events on the retention cutoff day" do
     SiteSetting.clean_up_browser_pageview_events = true
 


### PR DESCRIPTION
Previously, the browser pageview cleanup job deleted old events with `delete_all`, which bypassed association cleanup and could leave orphaned score rows.

This change deletes score rows for each cleanup batch before removing the old pageview events.