### PR TITLE
DEV: Add descriptive error message when creating requestable group with no owner

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -16,6 +16,13 @@ class Admin::GroupsController < Admin::StaffController
     ) do |result|
       on_success { |group:| render_serialized(group, BasicGroupSerializer) }
       on_failed_policy(:can_create_group) { |policy| raise Discourse::InvalidAccess }
+      on_failed_policy(:can_request_access) do
+        render json:
+                 failed_json.merge(
+                   errors: [I18n.t("groups.errors.cant_allow_membership_requests")],
+                 ),
+               status: :unprocessable_entity
+      end
       on_failure { render(json: failed_json, status: :unprocessable_entity) }
     end
   end

--- a/app/services/groups/create.rb
+++ b/app/services/groups/create.rb
@@ -108,6 +108,7 @@ class Groups::Create
   end
 
   policy :can_create_group
+  policy :can_request_access
   model :user_attributes, :build_user_attributes, optional: true
   model :group, :instantiate_group
   only_if(:should_associate_groups) { step :associate_groups }
@@ -121,6 +122,10 @@ class Groups::Create
 
   def can_create_group(guardian:)
     guardian.can_create_group?
+  end
+
+  def can_request_access(params:)
+    params.owner_ids.present? || !params.allow_membership_requests
   end
 
   def build_user_attributes(params:)

--- a/spec/services/groups/create_spec.rb
+++ b/spec/services/groups/create_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe Groups::Create do
       it { is_expected.to fail_a_policy(:can_create_group) }
     end
 
+    context "when creating a group with access requests and no owner" do
+      let(:params) { { name: "requestable", allow_membership_requests: true, owner_usernames: [] } }
+
+      it { is_expected.to fail_a_policy(:can_request_access) }
+    end
+
     context "when data is invalid" do
       let(:params) { { name: nil } }
 


### PR DESCRIPTION
### What is this change?

The back-end validates that groups where users can request access from owners has at least one owner. Currently this results in a `FAILED` error message. After this PR, it shows a helpful error instead.

The translation already exists, so it's likely this was once there, but lost when converting to a service object.

**Before:**

<img width="603" height="168" alt="Screenshot 2026-05-29 at 10 37 03 AM" src="https://github.com/user-attachments/assets/d10c363f-ec23-4bab-9857-9558eb590178" />

**After:**

<img width="724" height="167" alt="Screenshot 2026-05-29 at 10 36 27 AM" src="https://github.com/user-attachments/assets/46cb76af-4936-4a42-b058-da20fb59cf23" />