### PR TITLE
DEV: stop counting plugin-outlet deprecation warnings from their tests

### DIFF
--- a/frontend/discourse/tests/integration/components/plugin-outlet-test.gjs
+++ b/frontend/discourse/tests/integration/components/plugin-outlet-test.gjs
@@ -1298,6 +1298,16 @@ module(
   }
 );
 
+const PLUGIN_OUTLET_DEPRECATION_TEST_IDS = [
+  "discourse.plugin-outlet.alias.old-name",
+  "discourse.plugin-outlet.alias.legacy-name",
+  "discourse.plugin-outlet.alias.deprecated-alias",
+  "discourse.plugin-outlet.alias.old-standalone-outlet",
+  "discourse.plugin-outlet.alias.old-below-outlet",
+  "discourse.plugin-outlet.deprecated.doomed-outlet",
+  "discourse.plugin-outlet.deprecated.old-outlet",
+];
+
 module(
   "Integration | Component | plugin-outlet | aliases and deprecations",
   function (hooks) {
@@ -1306,11 +1316,13 @@ module(
     hooks.beforeEach(function () {
       this.consoleWarnStub = sinon.stub(console, "warn");
       disableRaiseOnDeprecation();
+      PLUGIN_OUTLET_DEPRECATION_TEST_IDS.forEach(skipCountingDeprecation);
     });
 
     hooks.afterEach(function () {
       this.consoleWarnStub.restore();
       enableRaiseOnDeprecation();
+      PLUGIN_OUTLET_DEPRECATION_TEST_IDS.forEach(restoreCountingDeprecation);
     });
 
     test("renders connectors registered under an alias name", async function (assert) {


### PR DESCRIPTION
The `"Integration | Component | plugin-outlet | aliases and deprecations"` module in `frontend/discourse/tests/integration/components/plugin-outlet-test.gjs` intentionally renders `<PluginOutlet>` with deprecated/aliased configurations to verify that `deprecated()` warnings fire correctly. The warning IDs are auto-generated by `#emitAliasDeprecation` and `#emitOutletDeprecation` in `frontend/discourse/app/components/plugin-outlet.gjs` (e.g. `discourse.plugin-outlet.alias.<name>`, `discourse.plugin-outlet.deprecated.<name>`), and `DeprecationCounter.handleDiscourseDeprecation` was tallying them into the CI deprecation report. Those IDs exist purely as test fixtures and shouldn't count.

The affected IDs are now registered with `skipCountingDeprecation` in the module's `beforeEach` and cleared with `restoreCountingDeprecation` in `afterEach`, mirroring the pattern this same file already uses around `discourse.plugin-connector.deprecated-arg*`. `withSilencedDeprecations` was not used because it short-circuits `deprecated()` before `console.warn` runs, which would break the tests' `consoleWarnStub.calledWithMatch(...)` assertions; `skipCountingDeprecation` only excludes IDs from the counter and leaves the warning path untouched.