### PR TITLE
FEATURE: Private GitHub inline oneboxes

### DIFF
--- a/lib/onebox/engine/github_commit_onebox.rb
+++ b/lib/onebox/engine/github_commit_onebox.rb
@@ -23,6 +23,20 @@ module Onebox
         "https://api.github.com/repos/#{match[:org]}/#{match[:repository]}/commits/#{match[:sha]}"
       end
 
+      def inline_data
+        return if github_auth_header(match[:org]).blank?
+
+        result = raw(github_auth_header(match[:org]))
+        message = result["commit"]["message"].split("\n").first
+        {
+          title:
+            "#{message} - #{match[:org]}/#{match[:repository]}@#{result["sha"][0...7]} - GitHub",
+        }
+      rescue StandardError => e
+        Rails.logger.warn("Inline GitHub commit onebox error for #{@url}: #{e.message}")
+        nil
+      end
+
       private
 
       def match

--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -23,6 +23,19 @@ module Onebox
         "https://api.github.com/repos/#{m["org"]}/#{m["repo"]}/issues/#{m["item_id"]}"
       end
 
+      def inline_data
+        return if github_auth_header(match["org"]).blank?
+
+        result = raw(github_auth_header(match["org"]))
+        {
+          title:
+            "#{result["title"]} - Issue ##{match["item_id"]} - #{match["org"]}/#{match["repo"]} - GitHub",
+        }
+      rescue StandardError => e
+        Rails.logger.warn("Inline GitHub issue onebox error for #{@url}: #{e.message}")
+        nil
+      end
+
       private
 
       def match

--- a/lib/onebox/engine/github_pull_request_onebox.rb
+++ b/lib/onebox/engine/github_pull_request_onebox.rb
@@ -24,16 +24,34 @@ module Onebox
       end
 
       def inline_data
-        return unless SiteSetting.github_pr_status_enabled
+        return if github_auth_header(match[:org]).blank? && !SiteSetting.github_pr_status_enabled
+
+        if commit_sha = @url[%r{/commits?/(\h+)}, 1]
+          commit =
+            load_json(
+              "https://api.github.com/repos/#{match[:org]}/#{match[:repository]}/commits/#{commit_sha}",
+            )
+          message = commit["commit"]["message"].split("\n").first
+          return(
+            {
+              title:
+                "#{message} - #{match[:org]}/#{match[:repository]}@#{commit["sha"][0...7]} - GitHub",
+            }
+          )
+        end
 
         pr_data = raw(github_auth_header(match[:org]))
-        status = fetch_pr_status(pr_data)&.dig(:status)
-        return unless status
+        result = {
+          title:
+            "#{pr_data["title"]} - Pull Request ##{match[:number]} - #{match[:org]}/#{match[:repository]} - GitHub",
+        }
 
-        title =
-          "#{pr_data["title"]} · Pull Request ##{match[:number]} · " \
-            "#{match[:org]}/#{match[:repository]}"
-        { title: title, css_class: "--gh-status-#{status}" }
+        if SiteSetting.github_pr_status_enabled
+          status = fetch_pr_status(pr_data)&.dig(:status)
+          result[:css_class] = "--gh-status-#{status}" if status
+        end
+
+        result
       rescue StandardError => e
         Rails.logger.warn("Inline GitHub PR onebox error for #{@url}: #{e.message}")
         nil

--- a/lib/onebox/engine/github_repo_onebox.rb
+++ b/lib/onebox/engine/github_repo_onebox.rb
@@ -22,6 +22,20 @@ module Onebox
         "https://api.github.com/repos/#{match[:org]}/#{match[:repository]}"
       end
 
+      def inline_data
+        return if github_auth_header(match[:org]).blank?
+
+        result = raw(github_auth_header(match[:org]))
+        title = "GitHub - #{result["full_name"]}"
+        title += " - #{Onebox::Helpers.truncate(result["description"])}" if result[
+          "description"
+        ].present?
+        { title: title }
+      rescue StandardError => e
+        Rails.logger.warn("Inline GitHub repo onebox error for #{@url}: #{e.message}")
+        nil
+      end
+
       private
 
       def match

--- a/plugins/discourse-github/spec/lib/github_pr_onebox_status_spec.rb
+++ b/plugins/discourse-github/spec/lib/github_pr_onebox_status_spec.rb
@@ -222,9 +222,39 @@ RSpec.describe Onebox::Engine::GithubPullRequestOnebox do
   describe "#inline_data" do
     let(:onebox) { Onebox::Engine::GithubPullRequestOnebox.new(gh_link) }
 
-    it "returns nil when github_pr_status_enabled is false" do
+    it "returns nil when no token is configured and github_pr_status_enabled is false" do
       SiteSetting.github_pr_status_enabled = false
       expect(onebox.inline_data).to be_nil
+    end
+
+    it "returns the title for a private repo when a token is configured and status is disabled" do
+      SiteSetting.github_pr_status_enabled = false
+      SiteSetting.github_onebox_access_tokens = "discourse|github_pat_1234"
+      stub_request(:get, api_uri).to_return(status: 200, body: MultiJson.dump(open_pr_response))
+
+      expect(onebox.inline_data).to eq(
+        title: "Add audio onebox - Pull Request #1253 - discourse/discourse - GitHub",
+      )
+    end
+
+    it "returns the commit title when the URL links to a specific commit in the PR" do
+      SiteSetting.github_onebox_access_tokens = "discourse|github_pat_1234"
+      sha = "803d023e2307309f8b776ab3b8b7e38ba91c0919"
+      commit_onebox =
+        Onebox::Engine::GithubPullRequestOnebox.new(
+          "https://github.com/discourse/discourse/pull/1253/commits/#{sha}",
+        )
+      stub_request(
+        :get,
+        "https://api.github.com/repos/discourse/discourse/commits/#{sha}",
+      ).to_return(
+        status: 200,
+        body: MultiJson.dump("sha" => sha, "commit" => { "message" => "Add audio onebox" }),
+      )
+
+      expect(commit_onebox.inline_data).to eq(
+        title: "Add audio onebox - discourse/discourse@803d023 - GitHub",
+      )
     end
 
     context "when github_pr_status_enabled is true" do
@@ -235,16 +265,18 @@ RSpec.describe Onebox::Engine::GithubPullRequestOnebox do
         stub_request(:get, reviews_api_uri).to_return(status: 200, body: "[]")
 
         expect(onebox.inline_data).to eq(
-          title: "#{open_pr_response["title"]} · Pull Request #1253 · discourse/discourse",
+          title: "Add audio onebox - Pull Request #1253 - discourse/discourse - GitHub",
           css_class: "--gh-status-open",
         )
       end
 
-      it "returns nil when the status fetch fails" do
+      it "returns the title without a status css class when the status fetch fails" do
         stub_request(:get, api_uri).to_return(status: 200, body: MultiJson.dump(open_pr_response))
         stub_request(:get, reviews_api_uri).to_return(status: 500, body: "error")
 
-        expect(onebox.inline_data).to be_nil
+        expect(onebox.inline_data).to eq(
+          title: "Add audio onebox - Pull Request #1253 - discourse/discourse - GitHub",
+        )
       end
     end
   end

--- a/spec/lib/inline_oneboxer_spec.rb
+++ b/spec/lib/inline_oneboxer_spec.rb
@@ -508,4 +508,40 @@ RSpec.describe InlineOneboxer do
       expect(Oneboxer).not_to have_received(:inline_data_for)
     end
   end
+
+  describe "private GitHub repo" do
+    let(:repo_url) { "https://github.com/discourse/discourse" }
+    let(:api_uri) { "https://api.github.com/repos/discourse/discourse" }
+
+    before do
+      stub_request(:get, api_uri).to_return(status: 200, body: onebox_response("githubrepo"))
+    end
+
+    it "resolves the title via the authenticated GitHub API when a token is configured" do
+      SiteSetting.github_onebox_access_tokens = "discourse|github_pat_1234"
+
+      expect(InlineOneboxer.lookup(repo_url, skip_cache: true)).to eq(
+        url: repo_url,
+        title: "GitHub - discourse/discourse - A platform for community discussion. Free, open,...",
+      )
+      expect(WebMock).to have_requested(:get, api_uri).with(
+        headers: {
+          "Authorization" => "Bearer github_pat_1234",
+        },
+      )
+    end
+
+    it "falls back to HTML title scraping and does not call the GitHub API when no token is configured" do
+      stub_request(:get, repo_url).to_return(
+        status: 200,
+        body: "<html><head><title>GitHub - discourse/discourse</title></head></html>",
+      )
+
+      expect(InlineOneboxer.lookup(repo_url, skip_cache: true)).to eq(
+        url: repo_url,
+        title: "GitHub - discourse/discourse",
+      )
+      expect(WebMock).not_to have_requested(:get, api_uri)
+    end
+  end
 end

--- a/spec/lib/onebox/engine/github_commit_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_commit_onebox_spec.rb
@@ -134,6 +134,31 @@ RSpec.describe Onebox::Engine::GithubCommitOnebox do
     end
   end
 
+  describe "#inline_data" do
+    let(:link) do
+      "https://github.com/discourse/discourse/commit/803d023e2307309f8b776ab3b8b7e38ba91c0919"
+    end
+
+    before do
+      stub_request(
+        :get,
+        "https://api.github.com/repos/discourse/discourse/commits/803d023e2307309f8b776ab3b8b7e38ba91c0919",
+      ).to_return(status: 200, body: onebox_response("githubcommit"))
+    end
+
+    it "returns nil when no access token is configured" do
+      expect(described_class.new(link).inline_data).to be_nil
+    end
+
+    it "returns the commit title from the API when an access token is configured" do
+      SiteSetting.github_onebox_access_tokens = "discourse|github_pat_1234"
+      expect(described_class.new(link).inline_data).to eq(
+        title:
+          "Fixed GitHub auth, GitHub can provide us with a valid email - so automatically log in for those cases - discourse/discourse@803d023 - GitHub",
+      )
+    end
+  end
+
   describe ".===" do
     it "matches valid GitHub commit URL" do
       valid_url =

--- a/spec/lib/onebox/engine/github_issue_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_issue_onebox_spec.rb
@@ -54,4 +54,19 @@ RSpec.describe Onebox::Engine::GithubIssueOnebox do
       end
     end
   end
+
+  describe "#inline_data" do
+    let(:link) { "https://github.com/discourse/discourse/issues/1" }
+
+    it "returns nil when no access token is configured" do
+      expect(described_class.new(link).inline_data).to be_nil
+    end
+
+    it "returns the issue title from the API when an access token is configured" do
+      SiteSetting.github_onebox_access_tokens = "discourse|github_pat_1234"
+      expect(described_class.new(link).inline_data).to eq(
+        title: "Test issue #2 - Issue #1 - discourse/discourse - GitHub",
+      )
+    end
+  end
 end

--- a/spec/lib/onebox/engine/github_repo_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_repo_onebox_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe Onebox::Engine::GithubRepoOnebox do
     end
   end
 
+  describe "#inline_data" do
+    it "returns nil when no access token is configured" do
+      expect(described_class.new(gh_link).inline_data).to be_nil
+    end
+
+    it "returns the repo title from the API when an access token is configured" do
+      SiteSetting.github_onebox_access_tokens = "discourse|github_pat_1234"
+      expect(described_class.new(gh_link).inline_data).to eq(
+        title: "GitHub - discourse/discourse - A platform for community discussion. Free, open,...",
+      )
+    end
+  end
+
   describe ".===" do
     it "matches valid GitHub repository URL" do
       valid_url = URI("https://github.com/username/repository/")


### PR DESCRIPTION
Followup https://github.com/discourse/hosted-site/pull/1270

Adds the ability to inline onebox private GitHub repos,
using the same auth method as block oneboxes, using the
`github_onebox_access_tokens` site setting.

**Examples:**

<img width="788" height="208" alt="image" src="https://github.com/user-attachments/assets/5130d6ec-585c-41c3-99c4-2bef8e9bba73" />
