### PR TITLE
UX: Keep date range picker weekday labels aligned with day columns

### DIFF
--- a/app/assets/stylesheets/common/components/date-range-picker.scss
+++ b/app/assets/stylesheets/common/components/date-range-picker.scss
@@ -124,7 +124,7 @@
 
   &__weekdays {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 2px;
     color: var(--primary-medium);
     font-size: var(--font-down-2);
@@ -140,7 +140,7 @@
 
   &__week {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(7, minmax(0, 1fr));
     gap: 2px;
   }
 


### PR DESCRIPTION
#### Before
<img width="704" height="450" alt="Screenshot 2026-05-29 at 12 12 32 PM" src="https://github.com/user-attachments/assets/08e59224-31cc-4973-a8cb-983cfc6713c3" />

#### After
<img width="688" height="451" alt="Screenshot 2026-05-29 at 12 12 56 PM" src="https://github.com/user-attachments/assets/e8bf7097-abd4-42b3-8df6-db948d854ce0" />