### PR TITLE
FIX: Include parent route params in page tracking URLs

### DIFF
--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -15,6 +15,35 @@ import { sendDeferredPageview } from "./message-bus";
 
 let _preNavigationUrl = null;
 
+function routeInfoUrlForArgs(transition) {
+  const routeInfos = [];
+  const contexts = [...(transition.intent?.contexts || [])];
+  const params = [];
+  let routeInfo = transition.to;
+
+  while (routeInfo) {
+    routeInfos.unshift(routeInfo);
+    routeInfo = routeInfo.parent;
+  }
+
+  routeInfos.forEach((info) => {
+    const routeParams = info.params || {};
+    const paramNames = info.paramNames || Object.keys(routeParams);
+
+    if (!paramNames.length) {
+      return;
+    }
+
+    if (paramNames.some((paramName) => routeParams[paramName] === undefined)) {
+      params.push(contexts.shift());
+    } else {
+      paramNames.forEach((paramName) => params.push(routeParams[paramName]));
+    }
+  });
+
+  return params;
+}
+
 export default {
   after: "inject-objects",
   before: "message-bus",
@@ -157,7 +186,7 @@ export default {
         try {
           path = router.urlFor(
             transition.to.name,
-            ...Object.values(transition.to.params)
+            ...routeInfoUrlForArgs(transition)
           );
         } catch {}
       }

--- a/spec/system/page_objects/components/navigation_menu/sidebar.rb
+++ b/spec/system/page_objects/components/navigation_menu/sidebar.rb
@@ -90,6 +90,10 @@ module PageObjects
           page.has_css?(my_messages_link_css, text:)
         end
 
+        def click_my_messages_link
+          find(my_messages_link_css).click
+        end
+
         def has_no_my_messages_link?(text = my_messages)
           page.has_no_css?(my_messages_link_css, text:)
         end

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -17,6 +17,7 @@ describe "Request tracking" do
   end
 
   let(:pageview_tracking) { PageObjects::Pages::PageviewTracking.new }
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
 
   describe "pageviews" do
     it "tracks an anonymous visit correctly" do
@@ -176,6 +177,45 @@ describe "Request tracking" do
       expect(event_2[:ip_address]).to eq("::1")
       expect(event_2[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
       expect(event_2[:session_id]).to eq(event[:session_id])
+    end
+
+    it "tracks a logged-in user opening My messages from the sidebar" do
+      SiteSetting.navigation_menu = "sidebar"
+      user = Fabricate(:admin, refresh_auto_groups: true)
+      sign_in(user)
+
+      visit "/"
+      expect(sidebar).to have_my_messages_link
+      CachedCounting.flush
+      initial_browser_pageviews = ApplicationRequest.stats["page_view_logged_in_browser_total"]
+
+      events =
+        DiscourseEvent.track_events(:browser_pageview) do
+          sidebar.click_my_messages_link
+
+          expect(page).to have_current_path("/u/#{user.username}/messages")
+
+          try_until_success do
+            CachedCounting.flush
+            expect(ApplicationRequest.stats["page_view_logged_in_browser_total"]).to eq(
+              initial_browser_pageviews + 1,
+            )
+          end
+        end
+
+      event =
+        events.find do |tracked_event|
+          tracked_event[:params].last[:url] ==
+            "#{Discourse.base_url_no_prefix}/u/#{user.username}/messages"
+        end
+      expect(event).to be_present
+
+      event_params = event[:params].last
+      expect(event_params[:user_id]).to eq(user.id)
+      expect(event_params[:ip_address]).to eq("::1")
+      expect(event_params[:referrer]).to eq("#{Discourse.base_url_no_prefix}/")
+      expect(event_params[:session_id]).to be_present
+      expect(event_params[:topic_id]).to be_blank
     end
 
     it "tracks normal error pages correctly" do


### PR DESCRIPTION
Previously, page tracking rebuilt fallback URLs from only the leaf route params, so named transitions like chat channel routes could miss parent dynamic segments such as `channelTitle`.

This change builds fallback URLs from the full `RouteInfo` chain in route param order, ensuring tracked pageview URLs are generated correctly.