### PR TITLE
UX: remove old margin from shortcuts

### DIFF
--- a/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
+++ b/app/assets/stylesheets/common/components/keyboard_shortcuts.scss
@@ -116,7 +116,6 @@
     span {
       border-radius: 3px;
       display: inline-flex;
-      margin: 0 6px;
       padding: 2px 1px 4px;
     }
 


### PR DESCRIPTION
Tiny one for

https://meta.discourse.org/t/shortcuts-in-keyboard-shortcut-modal-are-not-aligned/404060