### PR TITLE
FIX: prevent stale `cook()` results from overwriting DCookText output

### DIFF
--- a/frontend/discourse/app/ui-kit/d-cook-text.gjs
+++ b/frontend/discourse/app/ui-kit/d-cook-text.gjs
@@ -20,7 +20,11 @@ export default class DCookText extends Component {
 
   @action
   async loadCookedText() {
-    const cooked = await cook(this.args.rawText);
+    const rawText = this.args.rawText;
+    const cooked = await cook(rawText);
+    if (this.args.rawText !== rawText) {
+      return;
+    }
     this.cooked = cooked;
   }
 

--- a/plugins/discourse-ai/spec/system/page_objects/components/ai_post_helper_menu.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/components/ai_post_helper_menu.rb
@@ -28,8 +28,7 @@ module PageObjects
       end
 
       def has_suggestion_value?(value)
-        # Bumped wait because of: MessageBus, typing animation, text cooking.
-        page.has_css?("#{SUGGESTION_SELECTOR}__text:not(.streaming)", text: value, wait: 10)
+        page.has_css?("#{SUGGESTION_SELECTOR}__text:not(.streaming)", text: value)
       end
 
       def suggestion_value


### PR DESCRIPTION
`loadCookedText` ran on every `@rawText` update and unconditionally assigned `this.cooked` when its `cook()` promise resolved. With rapid updates (e.g. streamed text from the AI helper), multiple `cook()` promises could be in flight at once, and whichever resolved last won — even if its rawText was no longer current. The result was a stuck DOM showing an intermediate snapshot.

Capture the rawText at call time and bail out if it has changed by the time `cook()` resolves.

The main symptom was flakiness in the AI completion system specs. We can now drop the extra waiting which was attempting to resolve that.