### PR TITLE
DEV: `bin/ember-cli` shim fixups

### DIFF
--- a/bin/ember-cli
+++ b/bin/ember-cli
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "webrick"
 
 ALLOWED_ARGS = %w[-u --build]
@@ -70,7 +71,7 @@ stub_server =
     begin
       WEBrick::HTTPServer.new(
         Port: stub_port,
-        BindAddress: "127.0.0.1",
+        BindAddress: "0.0.0.0",
         Logger: WEBrick::Log.new(File::NULL),
         AccessLog: [],
       )


### PR DESCRIPTION
- This shim depends on `webrick`, so we need to load up bundler to ensure it's available.

- It also now binds to `0.0.0.0` rather than loopback, matching the behaviour of the old `ember-cli` server so the deprecation page is reachable from outside containers/VMs.