### PR TITLE
DEV: add bare mode for dashboard reports

### DIFF
--- a/frontend/discourse/admin/components/admin-report.gjs
+++ b/frontend/discourse/admin/components/admin-report.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import EmberObject, { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { isPresent } from "@ember/utils";
@@ -30,6 +31,7 @@ import { exportEntity } from "discourse/lib/export-csv";
 import { outputExportResult } from "discourse/lib/export-result";
 import { makeArray } from "discourse/lib/helpers";
 import ReportLoader from "discourse/lib/reports-loader";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 const TABLE_OPTIONS = {
@@ -588,6 +590,30 @@ export default class AdminReport extends Component {
   }
 
   <template>
-    <AdminReportBody @report={{this}} @filters={{@filters}} />
+    {{#if @bare}}
+      {{! Renders only the report's visualization (chart/table/etc.) without
+      the surrounding report chrome — used by the dashboard report cards. }}
+      <div
+        class={{dConcatClass "admin-report" "--bare" this.reportClasses}}
+        {{didUpdate
+          this.fetchOrRender
+          @filters.startDate
+          @filters.endDate
+          this.preloadedData
+        }}
+      >
+        {{#if this.hasData}}
+          {{#if this.currentMode}}
+            {{component
+              this.modeComponent
+              model=this.model
+              options=this.options
+            }}
+          {{/if}}
+        {{/if}}
+      </div>
+    {{else}}
+      <AdminReportBody @report={{this}} @filters={{@filters}} />
+    {{/if}}
   </template>
 }

--- a/frontend/discourse/admin/components/dashboard/report-cards/core-report.gjs
+++ b/frontend/discourse/admin/components/dashboard/report-cards/core-report.gjs
@@ -5,5 +5,6 @@ import AdminReport from "discourse/admin/components/admin-report";
     @dataSourceName={{@item.identifier}}
     @preloadedData={{@payload}}
     @showHeader={{false}}
+    @bare={{true}}
   />
 </template>


### PR DESCRIPTION
Previously, embedding a report in a dashboard card rendered the full AdminReport page chrome (conditional-loading-section → chart__wrapper → chart__body), forcing a height: 100% chain down ~6 nested wrappers just to make the chart fill a fixed-height card and bloating the HTML.

This adds an opt-in @bare={{true}} arg to AdminReport that renders only the report's mode component (chart/table/etc.) — keeping the model/options/mode logic and the date-range refresh hook — so dashboard cards render essentially just the chart with far less nesting.

@bare is added to AdminReport, which is used app-wide but it's opt-in and defaults to off, so every existing caller is untouched