### PR TITLE
FIX: Existing DM sends bypass direct-message group restrictions

### DIFF
--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -17,7 +17,7 @@ en:
     chat_allow_uploads: "Allow uploads in public chat channels and direct message channels."
     chat_show_copy_button_on_codeblocks: "Show copy button on codeblocks in chat messages."
     chat_archive_destination_topic_status: "The status that the destination topic should be once a channel archive is completed. This only applies when the destination topic is a new topic, not an existing one."
-    direct_message_enabled_groups: "Allow users within these groups to create user-to-user Personal Chats. Note: staff can always create Personal Chats, and users will be able to reply to Personal Chats initiated by users who have permission to create them."
+    direct_message_enabled_groups: "Allow users within these groups to create and send user-to-user Personal Chats. Note: staff can always create and send Personal Chats."
     chat_message_flag_allowed_groups: "Users in these groups are allowed to flag chat messages. Note that admins and moderators can always flag chat messages."
     chat_pinning_messages_allowed_groups: "Users in these groups are allowed to pin chat messages in channels that they can access. Note that admins and moderators can always pin chat messages. Any member of a group chat or DM can pin messages there."
     max_mentions_per_chat_message: "Maximum number of @name notifications a user can use in a chat message."

--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -38,7 +38,8 @@ module Chat
     def can_send_direct_message?(channel)
       return true if is_staff? || @user.bot?
 
-      can_chat? && channel.chatable.user_can_access?(@user) && !@user.suspended?
+      can_chat? && can_direct_message? && channel.chatable.user_can_access?(@user) &&
+        !@user.suspended?
     end
 
     def allowing_direct_messages?

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -793,6 +793,14 @@ RSpec.describe Chat::GuardianExtensions do
       end
     end
 
+    context "when sender is not in direct message enabled groups" do
+      before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:staff] }
+
+      it "returns false" do
+        expect(guardian).not_to be_able_to_send_direct_message(dm_channel)
+      end
+    end
+
     context "when sender is suspended" do
       before do
         UserSuspender.new(

--- a/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
+++ b/plugins/chat/spec/queries/chat/channel_unreads_query_spec.rb
@@ -376,6 +376,8 @@ describe Chat::ChannelUnreadsQuery do
     fab!(:dm_channel) { Fabricate(:direct_message_channel, users: [current_user, other_user]) }
     let(:channel_ids) { [dm_channel.id] }
 
+    before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone] }
+
     it "counts reply messages in DM threads as unread_count" do
       first_message = Fabricate(:chat_message, chat_channel: dm_channel, user: other_user)
       dm_channel.membership_for(current_user).mark_read!(first_message.id)

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -148,6 +148,24 @@ RSpec.describe Chat::Api::ChannelMessagesController do
 
     before { sign_in(current_user) }
 
+    context "when direct message enabled groups exclude the sender" do
+      fab!(:other_user, :user)
+      fab!(:channel) { Fabricate(:direct_message_channel, users: [current_user, other_user]) }
+
+      before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:staff] }
+
+      it "does not allow sending in an existing direct message channel" do
+        expect { post "/chat/#{channel.id}.json", params: params }.not_to change {
+          Chat::Message.count
+        }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          I18n.t("chat.errors.user_cannot_send_direct_messages"),
+        )
+      end
+    end
+
     context "when force_thread param is given" do
       let!(:message) { Fabricate(:chat_message, chat_channel: channel) }
 

--- a/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
+++ b/plugins/chat/spec/services/chat/update_user_channel_last_read_spec.rb
@@ -140,6 +140,8 @@ RSpec.describe Chat::UpdateUserChannelLastRead do
             ).message_instance
           end
 
+          before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone] }
+
           it "marks DM reply thread memberships as read" do
             thread = reply_message.thread
             thread_membership = thread.membership_for(current_user)


### PR DESCRIPTION
## Summary

Applies patch from triage.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1078
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>