### PR TITLE
FIX: Use standard `Authorization` Bearer header for vLLM

### DIFF
--- a/plugins/discourse-ai/lib/completions/endpoints/vllm.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/vllm.rb
@@ -85,7 +85,7 @@ module DiscourseAi
           headers = { "Referer" => Discourse.base_url, "Content-Type" => "application/json" }
 
           api_key = llm_model&.api_key || SiteSetting.ai_vllm_api_key
-          headers["X-API-KEY"] = api_key if api_key.present?
+          headers["Authorization"] = "Bearer #{api_key}" if api_key.present?
 
           Net::HTTP::Post.new(model_uri, headers).tap { |r| r.body = payload }
         end


### PR DESCRIPTION
Previously, the vLLM endpoint sent its API key via a non-standard `X-API-KEY` header, which standard vLLM servers (started with `--api-key`) do not recognize.

This change sends the key as `Authorization: Bearer <key>` instead, matching the OpenAI-compatible auth that vLLM expects.