### PR TITLE
FIX: Staged user emails bypass moderator email visibility setting

### DIFF
--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -36,7 +36,7 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_email?
     # staff members can always see their email
-    (scope.is_staff? && (object.id == scope.user.id || object.staged?)) ||
+    (scope.is_staff? && object.id == scope.user.id) ||
       (@options[:emails_desired] && scope.can_check_emails?(object))
   end
 

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -36,9 +36,12 @@ class AdminUserListSerializer < BasicUserSerializer
 
   def include_email?
     # staff members can always see their email
-    (scope.is_staff? && object.id == scope.user.id) ||
-      (object.staged? && scope.can_check_emails?(object)) ||
-      (@options[:emails_desired] && scope.can_check_emails?(object))
+    return true if scope.is_staff? && object.id == scope.user.id
+
+    staged_or_desired = object.staged? || @options[:emails_desired]
+    return true if staged_or_desired && scope.can_check_emails?(object)
+
+    false
   end
 
   alias_method :include_secondary_emails?, :include_email?

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -37,6 +37,7 @@ class AdminUserListSerializer < BasicUserSerializer
   def include_email?
     # staff members can always see their email
     (scope.is_staff? && object.id == scope.user.id) ||
+      (object.staged? && scope.can_check_emails?(object)) ||
       (@options[:emails_desired] && scope.can_check_emails?(object))
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -73,6 +73,21 @@ RSpec.describe Admin::UsersController do
         expect(response.parsed_body).to be_present
       end
 
+      it "doesn't return staged user emails when moderators_view_emails is disabled" do
+        SiteSetting.moderators_view_emails = false
+        staged_user = Fabricate(:staged, email: "staged@example.com")
+        Fabricate(:secondary_email, user: staged_user, email: "staged-secondary@example.com")
+
+        get "/admin/users/list.json", params: { query: "staged", show_emails: "true" }
+
+        expect(response.status).to eq(200)
+        listed_user =
+          response.parsed_body.find { |listed_user| listed_user["id"] == staged_user.id }
+        expect(listed_user).to be_present
+        expect(listed_user["email"]).to eq(nil)
+        expect(listed_user["secondary_emails"]).to eq(nil)
+      end
+
       it "returns users with the same IP as a user" do
         target_user = Fabricate(:user, ip_address: "42.42.42.42")
         same_ip_user = Fabricate(:user, ip_address: "42.42.42.42")

--- a/spec/serializers/admin_user_list_serializer_spec.rb
+++ b/spec/serializers/admin_user_list_serializer_spec.rb
@@ -81,10 +81,18 @@ RSpec.describe AdminUserListSerializer do
       expect(json[:secondary_emails]).to contain_exactly("first@email.com", "second@email.com")
     end
 
-    it "returns a staged user's emails" do
-      user.staged = true
+    it "doesn't return a staged user's emails without emails_desired" do
+      user.update!(staged: true)
       fabricate_secondary_emails_for(user)
       json = serialize(user, admin)
+      expect(json[:email]).to eq(nil)
+      expect(json[:secondary_emails]).to eq(nil)
+    end
+
+    it "returns a staged user's emails for admins when emails_desired is true" do
+      user.update!(staged: true)
+      fabricate_secondary_emails_for(user)
+      json = serialize(user, admin, emails_desired: true)
       expect(json[:email]).to eq("user@email.com")
       expect(json[:secondary_emails]).to contain_exactly("first@email.com", "second@email.com")
     end

--- a/spec/serializers/admin_user_list_serializer_spec.rb
+++ b/spec/serializers/admin_user_list_serializer_spec.rb
@@ -81,10 +81,19 @@ RSpec.describe AdminUserListSerializer do
       expect(json[:secondary_emails]).to contain_exactly("first@email.com", "second@email.com")
     end
 
-    it "doesn't return a staged user's emails without emails_desired" do
+    it "returns a staged user's emails to admins" do
       user.update!(staged: true)
       fabricate_secondary_emails_for(user)
       json = serialize(user, admin)
+      expect(json[:email]).to eq("user@email.com")
+      expect(json[:secondary_emails]).to contain_exactly("first@email.com", "second@email.com")
+    end
+
+    it "doesn't return a staged user's emails to moderators when disabled" do
+      SiteSetting.moderators_view_emails = false
+      user.update!(staged: true)
+      fabricate_secondary_emails_for(user)
+      json = serialize(user, moderator)
       expect(json[:email]).to eq(nil)
       expect(json[:secondary_emails]).to eq(nil)
     end


### PR DESCRIPTION
## Summary

Applies patch from triage.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1012
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>