### PR TITLE
FIX: Apply s3_cdn_url to chat uploads and resolve getURLWithCDN protocol mismatches

### DIFF
--- a/frontend/discourse/app/lib/get-url.js
+++ b/frontend/discourse/app/lib/get-url.js
@@ -38,8 +38,14 @@ export function getURLWithCDN(url) {
   // only relative urls
   if (cdn && /^\/[^\/]/.test(url)) {
     url = cdn + url;
-  } else if (S3CDN && url.startsWith(S3BaseUrl)) {
-    url = url.replace(S3BaseUrl, S3CDN);
+  } else if (S3CDN && S3BaseUrl) {
+    // Strip http: and https: to ensure robust domain comparison
+    const normalizedUrl = url.replace(/^https?:/i, "");
+    const normalizedBase = S3BaseUrl.replace(/^https?:/i, "");
+
+    if (normalizedUrl.startsWith(normalizedBase)) {
+      url = S3CDN + normalizedUrl.substring(normalizedBase.length);
+    }
   }
   return url;
 }

--- a/frontend/discourse/tests/unit/lib/get-url-test.js
+++ b/frontend/discourse/tests/unit/lib/get-url-test.js
@@ -183,4 +183,28 @@ module("Unit | Utility | get-url", function (hooks) {
 
     assert.strictEqual(getURLWithCDN(url), url, "at correct path");
   });
+
+  test("getURLWithCDN ignores protocol mismatch between S3BaseUrl and URL", function (assert) {
+    // Case 1: S3 base is protocol-relative, URL is HTTPS
+    setupS3CDN(
+      "//test.s3-us-west-1.amazonaws.com/site",
+      "https://awesome.cdn/site"
+    );
+    assert.strictEqual(
+      getURLWithCDN("https://test.s3-us-west-1.amazonaws.com/site/awesome.png"),
+      "https://awesome.cdn/site/awesome.png",
+      "applies CDN when URL has https but base is protocol-relative"
+    );
+
+    // Case 2: S3 base is HTTPS, URL is protocol-relative
+    setupS3CDN(
+      "https://test.s3-us-west-1.amazonaws.com/site",
+      "https://awesome.cdn/site"
+    );
+    assert.strictEqual(
+      getURLWithCDN("//test.s3-us-west-1.amazonaws.com/site/awesome.png"),
+      "https://awesome.cdn/site/awesome.png",
+      "applies CDN when URL is protocol-relative but base has https"
+    );
+  });
 });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
@@ -72,9 +72,10 @@ export default class ChatUpload extends Component {
   get videoSourceUrl() {
     const baseUrl =
       this.args.upload.optimized_video?.url ?? this.args.upload.url;
-    const finalUrl = this.capabilities.isIOS || this.capabilities.isSafari
-      ? `${baseUrl}#t=0.001`
-      : baseUrl;
+    const finalUrl =
+      this.capabilities.isIOS || this.capabilities.isSafari
+        ? `${baseUrl}#t=0.001`
+        : baseUrl;
     return getURLWithCDN(finalUrl);
   }
 

--- a/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
@@ -4,6 +4,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+import { getURLWithCDN } from "discourse/lib/get-url";
 import { isAudio, isImage, isVideo } from "discourse/lib/uploads";
 import { eq } from "discourse/truth-helpers";
 
@@ -52,7 +53,12 @@ export default class ChatUpload extends Component {
   }
 
   get imageUrl() {
-    return this.args.upload.thumbnail?.url ?? this.args.upload.url;
+    const rawUrl = this.args.upload.thumbnail?.url ?? this.args.upload.url;
+    return getURLWithCDN(rawUrl);
+  }
+
+  get largeImageUrl() {
+    return getURLWithCDN(this.args.upload.url);
   }
 
   get imageStyle() {
@@ -66,9 +72,18 @@ export default class ChatUpload extends Component {
   get videoSourceUrl() {
     const baseUrl =
       this.args.upload.optimized_video?.url ?? this.args.upload.url;
-    return this.capabilities.isIOS || this.capabilities.isSafari
+    const finalUrl = this.capabilities.isIOS || this.capabilities.isSafari
       ? `${baseUrl}#t=0.001`
       : baseUrl;
+    return getURLWithCDN(finalUrl);
+  }
+
+  get audioSourceUrl() {
+    return getURLWithCDN(this.args.upload.url);
+  }
+
+  get attachmentUrl() {
+    return getURLWithCDN(this.args.upload.url);
   }
 
   @action
@@ -81,7 +96,7 @@ export default class ChatUpload extends Component {
       <img
         class="chat-img-upload lightbox"
         data-orig-src={{@upload.short_url}}
-        data-large-src={{@upload.url}}
+        data-large-src={{this.largeImageUrl}}
         data-download-href={{@upload.short_path}}
         height={{this.size.thumb_height}}
         width={{this.size.thumb_width}}
@@ -100,13 +115,13 @@ export default class ChatUpload extends Component {
       </video>
     {{else if (eq this.type this.AUDIO_TYPE)}}
       <audio class="chat-audio-upload" preload="metadata" controls>
-        <source src={{@upload.url}} />
+        <source src={{this.audioSourceUrl}} />
       </audio>
     {{else}}
       <a
         class="chat-other-upload"
         data-orig-href={{@upload.short_url}}
-        href={{@upload.url}}
+        href={{this.attachmentUrl}}
       >
         {{@upload.original_filename}}
       </a>

--- a/plugins/chat/test/javascripts/components/chat-upload-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-upload-test.gjs
@@ -2,6 +2,7 @@ import { tracked } from "@glimmer/tracking";
 import Service from "@ember/service";
 import { render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
+import { setupS3CDN } from "discourse/lib/get-url";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import ChatUpload from "discourse/plugins/chat/discourse/components/chat-upload";
 
@@ -137,6 +138,93 @@ module("Component | ChatUpload", function (hooks) {
     assert
       .dom("a.chat-other-upload")
       .hasAttribute("href", TXT_FIXTURE.url, "has the correct URL");
+  });
+
+  module("S3 CDN URLs", function (nestedHooks) {
+    nestedHooks.beforeEach(function () {
+      setupS3CDN(
+        "//test.s3-us-west-1.amazonaws.com/site",
+        "https://awesome.cdn/site"
+      );
+    });
+
+    test("uses the CDN for image src and data-large-src", async function (assert) {
+      this.set("upload", {
+        ...IMAGE_FIXTURE,
+        url: "https://test.s3-us-west-1.amazonaws.com/site/original.jpg",
+        thumbnail: {
+          url: "https://test.s3-us-west-1.amazonaws.com/site/thumbnail.jpg",
+        },
+      });
+
+      await render(<template><ChatUpload @upload={{this.upload}} /></template>);
+
+      assert
+        .dom("img.chat-img-upload")
+        .hasAttribute(
+          "src",
+          "https://awesome.cdn/site/thumbnail.jpg",
+          "uses the CDN for image thumbnails"
+        );
+      assert
+        .dom("img.chat-img-upload")
+        .hasAttribute(
+          "data-large-src",
+          "https://awesome.cdn/site/original.jpg",
+          "uses the CDN for the full-size image URL"
+        );
+    });
+
+    test("uses the CDN for video sources", async function (assert) {
+      this.set("upload", {
+        ...VIDEO_FIXTURE,
+        url: "https://test.s3-us-west-1.amazonaws.com/site/video.mp4",
+      });
+
+      await render(<template><ChatUpload @upload={{this.upload}} /></template>);
+
+      assert
+        .dom("video.chat-video-upload source")
+        .hasAttribute(
+          "src",
+          "https://awesome.cdn/site/video.mp4",
+          "uses the CDN for video uploads"
+        );
+    });
+
+    test("uses the CDN for audio sources", async function (assert) {
+      this.set("upload", {
+        ...AUDIO_FIXTURE,
+        url: "https://test.s3-us-west-1.amazonaws.com/site/song.mp3",
+      });
+
+      await render(<template><ChatUpload @upload={{this.upload}} /></template>);
+
+      assert
+        .dom("audio.chat-audio-upload source")
+        .hasAttribute(
+          "src",
+          "https://awesome.cdn/site/song.mp3",
+          "uses the CDN for audio uploads"
+        );
+    });
+
+    test("uses the CDN for attachment hrefs", async function (assert) {
+      this.set("upload", {
+        ...TXT_FIXTURE,
+        url: "https://test.s3-us-west-1.amazonaws.com/site/file.txt",
+      });
+
+      await render(<template><ChatUpload @upload={{this.upload}} /></template>);
+
+      assert
+        .dom("a.chat-other-upload")
+        .hasAttribute(
+          "href",
+          "https://awesome.cdn/site/file.txt",
+          "uses the CDN for attachment uploads"
+        );
+    });
   });
 
   module("video source URL", function (nestedHooks) {

--- a/plugins/chat/test/javascripts/components/chat-upload-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-upload-test.gjs
@@ -67,6 +67,11 @@ const TXT_FIXTURE = {
   human_filesize: "168 KB",
 };
 
+class MockCapabilitiesService extends Service {
+  @tracked isIOS = false;
+  @tracked isSafari = false;
+}
+
 module("Component | ChatUpload", function (hooks) {
   setupRenderingTest(hooks);
 
@@ -142,6 +147,8 @@ module("Component | ChatUpload", function (hooks) {
 
   module("S3 CDN URLs", function (nestedHooks) {
     nestedHooks.beforeEach(function () {
+      this.owner.register("service:capabilities", MockCapabilitiesService);
+
       setupS3CDN(
         "//test.s3-us-west-1.amazonaws.com/site",
         "https://awesome.cdn/site"
@@ -229,10 +236,6 @@ module("Component | ChatUpload", function (hooks) {
 
   module("video source URL", function (nestedHooks) {
     let mockCapabilities;
-
-    class MockCapabilitiesService extends Service {
-      @tracked isSafari = false;
-    }
 
     nestedHooks.beforeEach(function () {
       // Register and inject the mock service


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where Discourse Chat bypasses the configured `s3_cdn_url` and exposes raw S3 bucket URLs in the chat stream. 

It addresses two separate issues preventing the CDN from applying properly:
1. **Missing Wrappers in Chat:** The `chat-upload.gjs` component was piping raw database URLs directly into the `<img src>`, `<video>`, and `<audio>` tags. This PR imports and applies the `getURLWithCDN` utility to all upload types in the chat stream.
2. **Protocol Mismatches in `getURLWithCDN`:** The JavaScript utility relied on a strict `.startsWith()` comparison between the `url` and `S3BaseUrl`. When the server configures `S3BaseUrl` with `https://` but sends the payload `url` as protocol-relative (`//`), the match fails and the CDN is ignored. This PR normalizes both strings by stripping the protocol before comparison, mirroring how Ruby handles domain matching on the backend.

### Why is it needed?
Bypassing the CDN for chat uploads causes two major issues:
* **Broken UI for Secure Buckets:** For providers like Cloudflare R2 that block direct, unauthenticated bucket access, bypassing the CDN results in broken images (`403 Forbidden`). 
* **Bandwidth Leaks:** For standard setups (AWS, DigitalOcean), bypassing the CDN means admins are paying raw S3 egress fees for chat thumbnail traffic instead of utilizing their configured CDN. *(Note: This bug is currently visible on Meta, where chat thumbnails are serving directly from `assets-meta-cdck-prod-meta.s3.dualstack.us-west-1.amazonaws.com` instead of CloudFront).*

### How was this tested?
* Added unit tests to `get-url-test.js` to verify `getURLWithCDN` successfully applies the CDN even when protocol strings mismatch (e.g., `https://` vs `//`).
* Deployed to a cloud dev instance using Cloudflare R2. Verified that both original uploads and optimized thumbnails in the Chat stream now successfully route through the configured `s3_cdn_url` domain without breaking existing attachment functionality.

**Files Touched:**
* `frontend/discourse/app/lib/get-url.js`
* `frontend/discourse/tests/unit/lib/get-url-test.js`
* `plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs`