### PR TITLE
FIX: Cakeday title on emoji was not showing

### DIFF
--- a/frontend/discourse/app/components/post/meta-data/poster-name/icon.gjs
+++ b/frontend/discourse/app/components/post/meta-data/poster-name/icon.gjs
@@ -45,7 +45,7 @@ const Content = <template>
     {{dIcon @icon}}
   {{else if @emojis}}
     {{#each @emojis as |emojiName|}}
-      {{dEmoji emojiName skipEmojiTitle=(not @emojiTitle)}}
+      {{dEmoji emojiName skipEmojiTitle=(not @emojiTitle) title=@emojiTitle}}
     {{/each}}
   {{/if}}
   {{@text}}

--- a/frontend/discourse/tests/integration/components/post/meta-data/poster-name-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/meta-data/poster-name-test.gjs
@@ -178,11 +178,12 @@ module(
         .dom("span.poster-icon.test-smile > a")
         .exists()
         .hasAttribute("href", "/u/eviltrout");
+
       assert
-        .dom("span.poster-icon.test-smile > a > .emoji[alt='heart']")
+        .dom("span.poster-icon.test-smile > a > .emoji[title='test emojis']")
         .exists();
       assert
-        .dom("span.poster-icon.test-smile > a > .emoji[alt='smile']")
+        .dom("span.poster-icon.test-smile > a > .emoji[title='test emojis']")
         .exists();
     });
 

--- a/plugins/discourse-cakeday/assets/javascripts/discourse/initializers/cakeday.js
+++ b/plugins/discourse-cakeday/assets/javascripts/discourse/initializers/cakeday.js
@@ -26,16 +26,17 @@ function initializeCakeday(api) {
       if (cakeday(user_cakedate)) {
         let result = {};
 
-        if (emojiEnabled) {
-          result.emoji = siteSettings.cakeday_emoji;
-        } else {
-          result.icon = "cake-candles";
-        }
-
         if (user_id === currentUser?.id) {
           result.title = i18n("user.anniversary.user_title");
         } else {
           result.title = i18n("user.anniversary.title");
+        }
+
+        if (emojiEnabled) {
+          result.emoji = siteSettings.cakeday_emoji;
+          result.emojiTitle = result.title;
+        } else {
+          result.icon = "cake-candles";
         }
 
         return result;
@@ -50,16 +51,17 @@ function initializeCakeday(api) {
       if (birthday(user_birthdate)) {
         let result = {};
 
-        if (emojiEnabled) {
-          result.emoji = siteSettings.cakeday_birthday_emoji;
-        } else {
-          result.icon = "cake-candles";
-        }
-
         if (user_id === currentUser?.id) {
           result.title = i18n("user.date_of_birth.user_title");
         } else {
           result.title = i18n("user.date_of_birth.title");
+        }
+
+        if (emojiEnabled) {
+          result.emoji = siteSettings.cakeday_birthday_emoji;
+          result.emojiTitle = result.title;
+        } else {
+          result.icon = "cake-candles";
         }
 
         return result;

--- a/plugins/discourse-cakeday/test/javascripts/acceptance/cakeday-test.js
+++ b/plugins/discourse-cakeday/test/javascripts/acceptance/cakeday-test.js
@@ -3,7 +3,7 @@ import { test } from "qunit";
 import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
-acceptance(`Cakeday`, function (needs) {
+acceptance("Cakeday", function (needs) {
   needs.user();
   needs.settings({
     cakeday_enabled: true,
@@ -231,6 +231,12 @@ acceptance(`Cakeday`, function (needs) {
       .hasAttribute("title", i18n("user.date_of_birth.title"));
     assert.dom("img.emoji", posterIcons[0]).exists({ count: 1 });
     assert.dom("img.emoji", posterIcons[1]).exists({ count: 1 });
+    assert
+      .dom("img.emoji", posterIcons[0])
+      .hasAttribute("title", i18n("user.anniversary.title"));
+    assert
+      .dom("img.emoji", posterIcons[1])
+      .hasAttribute("title", i18n("user.date_of_birth.title"));
 
     await click(".trigger-user-card a[data-user-card]");
 


### PR DESCRIPTION
When hovering the anniversary/birthday cakeday emoji,
the emoji title string was just the emoji shortcode
on hover (e.g. tada) instead of the I18n string that
is on the wrapping element title.

This fix passes down the title to the emoji so it's
rendered properly too.
