### PR TITLE
DEV: Remove enable_support_category_type_setup from the codebase

### DIFF
--- a/plugins/discourse-solved/app/services/discourse_solved/categories/types/support.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/categories/types/support.rb
@@ -7,10 +7,6 @@ module DiscourseSolved
         type_id :support
 
         class << self
-          def visible?
-            SiteSetting.enable_support_category_type_setup
-          end
-
           def enable_plugin
             SiteSetting.solved_enabled = true
           end

--- a/plugins/discourse-solved/spec/requests/categories_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/categories_controller_spec.rb
@@ -4,10 +4,7 @@ RSpec.describe CategoriesController do
   fab!(:category)
   fab!(:admin)
 
-  before do
-    sign_in(admin)
-    SiteSetting.enable_support_category_type_setup = true
-  end
+  before { sign_in(admin) }
 
   describe "#update" do
     it "can add the support type to the category" do

--- a/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
+++ b/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
@@ -10,10 +10,7 @@ RSpec.describe "Support Category Type Setup" do
   let(:dialog) { PageObjects::Components::Dialog.new }
   let(:toast) { PageObjects::Components::Toasts.new }
 
-  before do
-    SiteSetting.enable_support_category_type_setup = true
-    sign_in(admin)
-  end
+  before { sign_in(admin) }
 
   it "works with correct defaults and configures site settings and category custom field automatically" do
     visit("/new-category/setup")


### PR DESCRIPTION
The setting/UC is permanent now so we can get rid
of any logic branches in the code/specs
