### PR TITLE
DEV: Fix dashboard date picker spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -549,7 +549,19 @@ RSpec.configure do |config|
       if example.metadata[:time]
         freeze_time(example.metadata[:time])
         page.driver.with_playwright_page do |pw_page|
-          pw_page.clock.set_fixed_time(example.metadata[:time])
+          # Install the clock at the desired time and immediately resume it so
+          # the browser starts at `example.metadata[:time]` but `Date.now()`
+          # keeps advancing with the wall clock.
+          #
+          # `set_fixed_time` pins `Date.now()` forever, which breaks Ember's runloop: `next()`/`later()`
+          # schedule timers via `Date.now() + wait` and only fire them once
+          # `Date.now()` has advanced past that, so any action deferred through
+          # the runloop (e.g. DButton, which uses `next()` to optimise INP)
+          # would silently never run.
+          #
+          # Playwright warns about this "stuck page" behaviour for pinned clocks too.
+          pw_page.clock.install(time: example.metadata[:time])
+          pw_page.clock.resume
         end
       end
     end

--- a/spec/system/admin_dashboard_redesign_spec.rb
+++ b/spec/system/admin_dashboard_redesign_spec.rb
@@ -68,76 +68,70 @@ describe "Admin Dashboard Redesign" do
       expect(dashboard).to have_custom_label_text(today.strftime("%b %-d, %Y"))
     end
 
-    it "hand-picking a range applies after clicking Apply" do
-      freeze_time(Time.utc(2026, 5, 26, 12, 0, 0)) do
-        dashboard.visit
-        dashboard.open_custom_date_range
-        dashboard.pick_calendar_day("2026-05-01")
-        dashboard.pick_calendar_day("2026-05-20")
-        dashboard.apply_custom_range
+    it "hand-picking a range applies after clicking Apply", time: Time.utc(2026, 5, 26, 12, 0, 0) do
+      dashboard.visit
+      dashboard.open_custom_date_range
+      dashboard.pick_calendar_day("2026-05-01")
+      dashboard.pick_calendar_day("2026-05-20")
+      dashboard.apply_custom_range
 
-        expect(dashboard).to have_active_period("custom")
-        expect(page).to have_current_path(
-          "/admin?end_date=2026-05-20&range=custom&start_date=2026-05-01",
-        )
-        expect(dashboard).to have_custom_label_text("May 1")
-        expect(dashboard).to have_custom_label_text("May 20")
-      end
+      expect(dashboard).to have_active_period("custom")
+      expect(page).to have_current_path(
+        "/admin?end_date=2026-05-20&range=custom&start_date=2026-05-01",
+      )
+      expect(dashboard).to have_custom_label_text("May 1")
+      expect(dashboard).to have_custom_label_text("May 20")
     end
 
-    it "Cancel closes the popover and leaves the active range unchanged" do
-      freeze_time(Time.utc(2026, 5, 26, 12, 0, 0)) do
-        dashboard.visit
-        dashboard.open_custom_date_range
-        dashboard.pick_calendar_day("2026-05-01")
-        dashboard.cancel_custom_range
+    it "Cancel closes the popover and leaves the active range unchanged",
+       time: Time.utc(2026, 5, 26, 12, 0, 0) do
+      dashboard.visit
+      dashboard.open_custom_date_range
+      dashboard.pick_calendar_day("2026-05-01")
+      dashboard.cancel_custom_range
 
-        expect(dashboard).to have_no_picker_open
-        expect(dashboard).to have_active_period("last_30_days")
-      end
+      expect(dashboard).to have_no_picker_open
+      expect(dashboard).to have_active_period("last_30_days")
     end
 
-    it "Esc closes the popover and leaves the active range unchanged" do
-      freeze_time(Time.utc(2026, 5, 26, 12, 0, 0)) do
-        dashboard.visit
-        dashboard.open_custom_date_range
-        dashboard.pick_calendar_day("2026-05-01")
-        dashboard.dismiss_picker_via_escape
+    it "Esc closes the popover and leaves the active range unchanged",
+       time: Time.utc(2026, 5, 26, 12, 0, 0) do
+      dashboard.visit
+      dashboard.open_custom_date_range
+      dashboard.pick_calendar_day("2026-05-01")
+      dashboard.dismiss_picker_via_escape
 
-        expect(dashboard).to have_no_picker_open
-        expect(dashboard).to have_active_period("last_30_days")
-      end
+      expect(dashboard).to have_no_picker_open
+      expect(dashboard).to have_active_period("last_30_days")
     end
 
-    it "reopening the popover after dismissal starts in committed state with the active range" do
-      freeze_time(Time.utc(2026, 5, 26, 12, 0, 0)) do
-        dashboard.visit
-        dashboard.open_custom_date_range
-        dashboard.pick_calendar_day("2026-05-01")
-        dashboard.cancel_custom_range
-        dashboard.open_custom_date_range
+    it "reopening the popover after dismissal starts in committed state with the active range",
+       time: Time.utc(2026, 5, 26, 12, 0, 0) do
+      dashboard.visit
+      dashboard.open_custom_date_range
+      dashboard.pick_calendar_day("2026-05-01")
+      dashboard.cancel_custom_range
+      dashboard.open_custom_date_range
 
-        # Apply is disabled when no pending selection differs from the active range,
-        # which confirms the picker reopened in committed state.
-        expect(page).to have_css(".d-date-range-picker__apply[disabled]")
-        expect(page).to have_css(".d-date-range-picker__day.--end")
-      end
+      # Apply is disabled when no pending selection differs from the active range,
+      # which confirms the picker reopened in committed state.
+      expect(page).to have_css(".d-date-range-picker__apply[disabled]")
+      expect(page).to have_css(".d-date-range-picker__day.--end")
     end
 
     context "when on mobile", mobile: true do
-      it "renders as a bottom sheet and Cancel dismisses without applying" do
-        freeze_time(Time.utc(2026, 5, 26, 12, 0, 0)) do
-          dashboard.visit
-          dashboard.open_custom_date_range
+      it "renders as a bottom sheet and Cancel dismisses without applying",
+         time: Time.utc(2026, 5, 26, 12, 0, 0) do
+        dashboard.visit
+        dashboard.open_custom_date_range
 
-          expect(page).to have_css(".fk-d-menu-modal .d-date-range-picker")
+        expect(page).to have_css(".fk-d-menu-modal .d-date-range-picker")
 
-          dashboard.pick_calendar_day("2026-05-01")
-          dashboard.cancel_custom_range
+        dashboard.pick_calendar_day("2026-05-01")
+        dashboard.cancel_custom_range
 
-          expect(dashboard).to have_no_picker_open
-          expect(dashboard).to have_active_period("last_30_days")
-        end
+        expect(dashboard).to have_no_picker_open
+        expect(dashboard).to have_active_period("last_30_days")
       end
 
       it "applies a sidebar-only preset and closes the bottom sheet" do


### PR DESCRIPTION
Was using freeze_time which only freezes server time,
need to use `time:` metadata in system specs to also
freeze the browser time.

Also fixes the `time:` metadata for system specs.
We were using `playwright_page.set_fixed_time`, 
which pins `Date.now()` forever, which breaks Ember's runloop...
`next()`/`later()` schedule timers via `Date.now() + wait` and only fire them once
`Date.now()` has advanced past that, so any action deferred through
the runloop (e.g. DButton, which uses `next()` to optimise INP)
would silently never run.

We can use `playwright_pageclock.install(time: example.metadata[:time])`
and `playwright_page.resume` to start the browser at the
required time and then keep the time running.
