### PR TITLE
UX: remove the post reaction click for initial filter

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-counter.gjs
@@ -34,13 +34,6 @@ export default class DiscourseReactionsCounter extends Component {
     }`;
   }
 
-  get hasOpenMenuForThisPost() {
-    const menu = this.menu.getByIdentifier(MENU_IDENTIFIER);
-    return (
-      !!menu?.expanded && menu.options.data?.post?.id === this.args.post.id
-    );
-  }
-
   reactionsChanged(data) {
     uniqueItemsFromArray(data.reactions).forEach((reaction) => {
       this.getUsers(reaction);
@@ -63,17 +56,6 @@ export default class DiscourseReactionsCounter extends Component {
   @action
   mouseDown(event) {
     event.stopImmediatePropagation();
-  }
-
-  @action
-  pointerDown(event) {
-    if (!this.useNewMenu) {
-      return;
-    }
-
-    if (this.hasOpenMenuForThisPost) {
-      event.stopPropagation();
-    }
   }
 
   @action
@@ -114,17 +96,7 @@ export default class DiscourseReactionsCounter extends Component {
 
       event.stopPropagation();
       event.preventDefault();
-      const reactionEl = event.target.closest(
-        ".discourse-reactions-list-emoji[data-reaction-id]"
-      );
-      const reactionId = reactionEl?.dataset.reactionId;
-
-      if (this.hasOpenMenuForThisPost) {
-        this.#switchMenuFilter(reactionId ?? "all");
-        return;
-      }
-
-      this.#toggleMenu(event.currentTarget, reactionId);
+      this.#toggleMenu(event.currentTarget);
       return;
     }
 
@@ -250,15 +222,7 @@ export default class DiscourseReactionsCounter extends Component {
     );
   }
 
-  #switchMenuFilter(filter) {
-    document
-      .querySelector(
-        `[data-identifier="${MENU_IDENTIFIER}"] [data-reaction-filter="${filter}"]`
-      )
-      ?.click();
-  }
-
-  #toggleMenu(trigger, initialFilter = null) {
+  #toggleMenu(trigger) {
     const virtualElement = {
       getBoundingClientRect: () => trigger.getBoundingClientRect(),
     };
@@ -271,7 +235,7 @@ export default class DiscourseReactionsCounter extends Component {
       arrow: true,
       placement: "bottom",
       offset: 15,
-      data: { post: this.args.post, initialFilter },
+      data: { post: this.args.post },
     });
   }
 
@@ -286,7 +250,6 @@ export default class DiscourseReactionsCounter extends Component {
         aria-label={{this.counterAriaLabel}}
         {{on "mousedown" this.mouseDown}}
         {{on "mouseup" this.mouseUp}}
-        {{on "pointerdown" this.pointerDown}}
         {{on "click" this.click}}
         {{on "keydown" this.keyDown}}
       >

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
@@ -102,11 +102,7 @@ export default class DiscourseReactionsListEmoji extends Component {
 
   <template>
     {{#if this.useNewMenu}}
-      <div
-        class="discourse-reactions-list-emoji"
-        id={{this.elementId}}
-        data-reaction-id={{@reaction.id}}
-      >
+      <div class="discourse-reactions-list-emoji" id={{this.elementId}}>
         {{#if @reaction.count}}
           {{dEmoji
             @reaction.id

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -12,7 +12,7 @@ import { i18n } from "discourse-i18n";
 import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 export default class DiscourseReactionsUsersMenu extends Component {
-  @tracked activeFilter = this.args.data.initialFilter ?? null;
+  @tracked activeFilter = null;
 
   fetchUsers = async (page, pageSize) => {
     const filter = this.activeFilter;

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_list.rb
@@ -45,10 +45,6 @@ module PageObjects
       def click_counter
         context_component.find(".discourse-reactions-counter").click
       end
-
-      def click_counter_number
-        context_component.find(".discourse-reactions-counter .reactions-counter").click
-      end
     end
   end
 end

--- a/plugins/discourse-reactions/spec/system/page_objects/post_reactions_popup.rb
+++ b/plugins/discourse-reactions/spec/system/page_objects/post_reactions_popup.rb
@@ -17,18 +17,6 @@ module PageObjects
         find("#{SELECTOR} [data-reaction-filter=#{reaction}]").click
       end
 
-      def has_active_filter?(reaction)
-        page.has_css?(
-          "#{SELECTOR} .post-users-popup__filter[data-reaction-filter=#{reaction}].is-active",
-        )
-      end
-
-      def has_no_active_filter?(reaction)
-        page.has_no_css?(
-          "#{SELECTOR} .post-users-popup__filter[data-reaction-filter=#{reaction}].is-active",
-        )
-      end
-
       def has_user?(username)
         page.has_css?("#{SELECTOR} .post-users-popup__name[data-user-card=#{username}]")
       end

--- a/plugins/discourse-reactions/spec/system/reactions_post_list_spec.rb
+++ b/plugins/discourse-reactions/spec/system/reactions_post_list_spec.rb
@@ -72,63 +72,12 @@ describe "Reactions | Post reaction user list" do
     expect(page).to have_no_css(".post-users-popup__username")
   end
 
-  it "opens the users popup pre-filtered when clicking a specific reaction emoji" do
-    sign_in(current_user)
-    visit(post.url)
-    expect(reactions_list).to have_reaction("heart")
-
-    reactions_list.click_reaction("clap")
-
-    expect(popup).to be_open
-    expect(popup).to have_active_filter("clap")
-    expect(popup).to have_no_active_filter("heart")
-    expect(popup).to have_user(user_3.username)
-    expect(popup).to have_no_user(user_2.username)
-  end
-
-  it "opens the users popup with no filter when clicking the counter number" do
-    sign_in(current_user)
-    visit(post.url)
-    expect(reactions_list).to have_reaction("heart")
-
-    reactions_list.click_counter_number
-
-    expect(popup).to be_open
-    expect(popup).to have_active_filter("all")
-  end
-
-  it "switches the active filter without reopening the menu when another emoji is clicked" do
-    sign_in(current_user)
-    visit(post.url)
-    expect(reactions_list).to have_reaction("heart")
-
-    reactions_list.click_reaction("heart")
-    expect(popup).to have_active_filter("heart")
-
-    reactions_list.click_reaction("clap")
-    expect(popup).to have_active_filter("clap")
-    expect(popup).to have_no_active_filter("heart")
-  end
-
-  it "switches to the all filter without reopening the menu when the counter number is clicked" do
-    sign_in(current_user)
-    visit(post.url)
-    expect(reactions_list).to have_reaction("heart")
-
-    reactions_list.click_reaction("heart")
-    expect(popup).to have_active_filter("heart")
-
-    reactions_list.click_counter_number
-    expect(popup).to have_active_filter("all")
-    expect(popup).to have_no_active_filter("heart")
-  end
-
   it "filters the users popup by reaction" do
     sign_in(current_user)
     visit(post.url)
     expect(reactions_list).to have_reaction("heart")
 
-    reactions_list.click_counter_number
+    reactions_list.click_counter
     expect(popup).to be_open
 
     expect(popup).to have_user(user_2.username)


### PR DESCRIPTION
This change rolls back the initial filter on click. We were experimenting with using a shortcut approach to load a single reaction panel (by clicking on a specific emoji) but due to to the small target size it feels a bit difficult to use (especially on mobile/tablet).

Removing this in favor of loading all reactions when clicking/tapping the reactions area.