### PR TITLE
DEV: Bump babel plugin in asset-processor and stub workerpool

### DIFF
--- a/frontend/asset-processor/build.js
+++ b/frontend/asset-processor/build.js
@@ -56,6 +56,8 @@ esbuild
       fs: "./noop",
       stream: "readable-stream",
       "abort-controller": "abort-controller/dist/abort-controller",
+      os: "./os-shim",
+      workerpool: "./workerpool-shim",
     },
     banner: {
       js: `var process = { "env": { "EMBER_ENV": "production" }, "cwd": () => "/" };`,

--- a/frontend/asset-processor/os-shim.js
+++ b/frontend/asset-processor/os-shim.js
@@ -1,0 +1,3 @@
+export function cpus() {
+  return [{}];
+}

--- a/frontend/asset-processor/workerpool-shim.js
+++ b/frontend/asset-processor/workerpool-shim.js
@@ -1,0 +1,8 @@
+// Stub for @rollup/plugin-babel's parallel mode (unused); the real workerpool touches worker globals that break mini-racer.
+export function pool() {
+  throw new Error("workerpool is stubbed out in the asset-processor build");
+}
+
+export function worker() {}
+
+export default { pool, worker };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 4.60.3
       '@rollup/plugin-babel':
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.29.0)(rollup@4.59.0)
+        version: 7.1.0(@babel/core@7.29.0)(rollup@4.59.0)
       abort-controller:
         specifier: ^3.0.0
         version: 3.0.0
@@ -2869,19 +2869,6 @@ packages:
 
   '@rollup/browser@4.60.3':
     resolution: {integrity: sha512-9EEq6JTs8UYuy/R+rZzyQlSEvg5IdFKY4Kt998nIULBoCE1R2pw8s4J4kN3uhrhG8U8lpypMs98bdYldFne0GQ==}
-
-  '@rollup/plugin-babel@7.0.0':
-    resolution: {integrity: sha512-NS2+P7v80N3MQqehZEjgpaFb9UyX3URNMW/zvoECKGo4PY4DvJfQusTI7BX/Ks+CPvtTfk3TqcR6S9VYBi/C+A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/babel__core': ^7.1.9
-      rollup: ^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      '@types/babel__core':
-        optional: true
-      rollup:
-        optional: true
 
   '@rollup/plugin-babel@7.1.0':
     resolution: {integrity: sha512-h9Y+xYha6p4wKO+FwdiPIkE+eIYCm8MzZPpX1iARIoFBnmKP9CnpT1p9dDf/DTFm6fyN8PmuLyRI5qZgchnitw==}
@@ -10946,16 +10933,6 @@ snapshots:
   '@rollup/browser@4.60.3':
     dependencies:
       '@types/estree': 1.0.8
-
-  '@rollup/plugin-babel@7.0.0(@babel/core@7.29.0)(rollup@4.59.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.29.7
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
-    optionalDependencies:
-      rollup: 4.59.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@rollup/plugin-babel@7.1.0(@babel/core@7.29.0)(rollup@4.59.0)':
     dependencies:


### PR DESCRIPTION
@rollup/plugin-babel 7.1.0 pulls in workerpool for an opt-in parallel mode we never enable. Alias workerpool to a local stub so it is never bundled. Also adds a shim for the `os` package, which the rollup plugin now imports.