### PR TITLE
UX: Remove splash screen after initial route is loaded

### DIFF
--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -160,7 +160,6 @@ class Discourse extends Application {
 
   ready() {
     performance.mark("discourse-ready");
-    document.querySelector("#d-splash")?.remove();
   }
 }
 

--- a/frontend/discourse/app/instance-initializers/remove-splash.js
+++ b/frontend/discourse/app/instance-initializers/remove-splash.js
@@ -1,0 +1,9 @@
+export default {
+  initialize(owner) {
+    owner
+      .lookup("service:router")
+      .one("routeDidChange", () =>
+        document.querySelector("#d-splash")?.remove()
+      );
+  },
+};


### PR DESCRIPTION
Previously, for routes which have async non-preloaded models() (e.g. custom homepage), we had a brief flash of emptiness between the splash screen and the content.

This commit moves the splash-screen removal to the first `routeDidChange` event. This fires after routing logic is complete, in the same runloop as the actual rendering.