### PR TITLE
DEV: Refresh all plugin stylesheet targets on change

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -2,6 +2,9 @@
 #  A class that handles interaction between a plugin and the Discourse App.
 #
 class DiscoursePluginRegistry
+  # Non-default plugin stylesheet targets, each rendered as its own <link> tag.
+  STYLESHEET_TARGETS = %i[desktop mobile admin]
+
   @@register_names = Set.new
 
   # Plugins often need to be able to register additional handlers, data, or
@@ -217,16 +220,8 @@ class DiscoursePluginRegistry
   end
 
   def self.stylesheets_exists?(plugin_directory_name, target = nil)
-    case target
-    when :desktop
-      desktop_stylesheets[plugin_directory_name].present?
-    when :mobile
-      mobile_stylesheets[plugin_directory_name].present?
-    when :admin
-      admin_stylesheets[plugin_directory_name].present?
-    else
-      stylesheets[plugin_directory_name].present?
-    end
+    register = target.in?(STYLESHEET_TARGETS) ? "#{target}_stylesheets" : "stylesheets"
+    public_send(register)[plugin_directory_name].present?
   end
 
   def self.register_seed_data(key, value)

--- a/lib/stylesheet/watcher.rb
+++ b/lib/stylesheet/watcher.rb
@@ -102,19 +102,21 @@ module Stylesheet
       MessageBus.publish "/file-change", message
     end
 
-    def plugin_assets_refresh(plugin_name, target)
+    def plugin_assets_refresh(plugin_name)
       Stylesheet::Manager.clear_plugin_cache!(plugin_name)
+
+      # A changed file can't be mapped back to a single target (it may be a
+      # shared partial), so refresh every target the plugin defines.
       targets = []
-      if target.present?
-        if DiscoursePluginRegistry.stylesheets_exists?(plugin_name, target.to_sym)
-          targets.push("#{plugin_name}_#{target}")
+      targets << plugin_name if DiscoursePluginRegistry.stylesheets_exists?(plugin_name)
+      DiscoursePluginRegistry::STYLESHEET_TARGETS.each do |target|
+        if DiscoursePluginRegistry.stylesheets_exists?(plugin_name, target)
+          targets << "#{plugin_name}_#{target}"
         end
-      else
-        targets.push(plugin_name)
       end
-      message =
-        targets.map! { |name| Stylesheet::Manager.new.stylesheet_data(name.to_sym) }.flatten!
-      MessageBus.publish "/file-change", message
+
+      message = targets.flat_map { |name| Stylesheet::Manager.new.stylesheet_data(name.to_sym) }
+      MessageBus.publish "/file-change", message if message.present?
     end
 
     def worker_loop
@@ -123,7 +125,7 @@ module Stylesheet
       @queue.pop while @queue.length > 0
 
       if path[:plugin_name]
-        plugin_assets_refresh(path[:plugin_name], path[:target])
+        plugin_assets_refresh(path[:plugin_name])
       else
         core_assets_refresh(path[:target])
       end


### PR DESCRIPTION
We were previously looking for path segments like `/admin/` and `/mobile/` to deduce the 'target' of plugin CSS files. In reality, the file path provides no guarantee about the configured target.

The easy fix is to rebuild all known targets whenever any plugin css changes. In general, plugins only have one or two targets, and only have a small number of css files, so this shouldn't be a perf concern.