### PR TITLE
FIX: Topic voting for nested replies topics

### DIFF
--- a/frontend/discourse/app/routes/nested.js
+++ b/frontend/discourse/app/routes/nested.js
@@ -1,3 +1,4 @@
+import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import Route from "@ember/routing/route";
 import { schedule } from "@ember/runloop";
@@ -136,7 +137,22 @@ export default class NestedRoute extends Route {
 
     controller.unsubscribe();
     this.screenTrack.stop();
-    this.header.clearTopic();
+  }
+
+  @action
+  willTransition(transition) {
+    transition.followRedirects().finally(() => {
+      const routeName = this.router.currentRouteName;
+
+      if (
+        !routeName?.startsWith("topic.") &&
+        !routeName?.startsWith("nested")
+      ) {
+        this.header.clearTopic();
+      }
+    });
+
+    return true;
   }
 
   _saveToCache(controller) {

--- a/frontend/discourse/app/routes/nested.js
+++ b/frontend/discourse/app/routes/nested.js
@@ -14,6 +14,7 @@ export default class NestedRoute extends Route {
   @service composer;
   @service header;
   @service nestedViewCache;
+  @service router;
   @service screenTrack;
   @service site;
   @service siteSettings;

--- a/frontend/discourse/app/routes/topic/from-params.js
+++ b/frontend/discourse/app/routes/topic/from-params.js
@@ -189,7 +189,12 @@ export default class TopicFromParams extends DiscourseRoute {
     this.controllerFor("topic").set("previousURL", document.location.pathname);
 
     transition.followRedirects().finally(() => {
-      if (!this.router.currentRouteName.startsWith("topic.")) {
+      const routeName = this.router.currentRouteName;
+
+      if (
+        !routeName?.startsWith("topic.") &&
+        !routeName?.startsWith("nested")
+      ) {
         this.header.clearTopic();
       }
     });

--- a/frontend/discourse/tests/unit/routes/topic-header-cleanup-test.js
+++ b/frontend/discourse/tests/unit/routes/topic-header-cleanup-test.js
@@ -1,6 +1,7 @@
 import Service from "@ember/service";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import sinon from "sinon";
 
 class HeaderStub extends Service {
   clearCount = 0;
@@ -8,10 +9,6 @@ class HeaderStub extends Service {
   clearTopic() {
     this.clearCount++;
   }
-}
-
-class RouterStub extends Service {
-  currentRouteName = null;
 }
 
 function completedTransition() {
@@ -27,20 +24,22 @@ async function waitForTransitionCleanup() {
   await Promise.resolve();
 }
 
+function setCurrentRouteName(route, currentRouteName) {
+  sinon.stub(route.router, "currentRouteName").value(currentRouteName);
+}
+
 module("Unit | Route | topic header cleanup", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
     this.owner.register("service:header", HeaderStub);
-    this.owner.register("service:router", RouterStub);
   });
 
   test("nested route does not clear header topic info when transitioning to flat topic route", async function (assert) {
     const route = this.owner.lookup("route:nested");
     const header = this.owner.lookup("service:header");
-    const router = this.owner.lookup("service:router");
 
-    router.currentRouteName = "topic.fromParams";
+    setCurrentRouteName(route, "topic.fromParams");
 
     route.willTransition(completedTransition());
     await waitForTransitionCleanup();
@@ -55,9 +54,8 @@ module("Unit | Route | topic header cleanup", function (hooks) {
   test("flat topic route does not clear header topic info when transitioning to nested route", async function (assert) {
     const route = this.owner.lookup("route:topic.from-params");
     const header = this.owner.lookup("service:header");
-    const router = this.owner.lookup("service:router");
 
-    router.currentRouteName = "nested";
+    setCurrentRouteName(route, "nested");
     route.controllerFor = () => ({
       set() {},
     });
@@ -75,9 +73,8 @@ module("Unit | Route | topic header cleanup", function (hooks) {
   test("nested route clears header topic info when transitioning away from topic routes", async function (assert) {
     const route = this.owner.lookup("route:nested");
     const header = this.owner.lookup("service:header");
-    const router = this.owner.lookup("service:router");
 
-    router.currentRouteName = "discovery.latest";
+    setCurrentRouteName(route, "discovery.latest");
 
     route.willTransition(completedTransition());
     await waitForTransitionCleanup();

--- a/frontend/discourse/tests/unit/routes/topic-header-cleanup-test.js
+++ b/frontend/discourse/tests/unit/routes/topic-header-cleanup-test.js
@@ -1,0 +1,91 @@
+import Service from "@ember/service";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+class HeaderStub extends Service {
+  clearCount = 0;
+
+  clearTopic() {
+    this.clearCount++;
+  }
+}
+
+class RouterStub extends Service {
+  currentRouteName = null;
+}
+
+function completedTransition() {
+  return {
+    followRedirects() {
+      return Promise.resolve();
+    },
+  };
+}
+
+async function waitForTransitionCleanup() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+module("Unit | Route | topic header cleanup", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register("service:header", HeaderStub);
+    this.owner.register("service:router", RouterStub);
+  });
+
+  test("nested route does not clear header topic info when transitioning to flat topic route", async function (assert) {
+    const route = this.owner.lookup("route:nested");
+    const header = this.owner.lookup("service:header");
+    const router = this.owner.lookup("service:router");
+
+    router.currentRouteName = "topic.fromParams";
+
+    route.willTransition(completedTransition());
+    await waitForTransitionCleanup();
+
+    assert.strictEqual(
+      header.clearCount,
+      0,
+      "topic info remains registered for the flat topic route"
+    );
+  });
+
+  test("flat topic route does not clear header topic info when transitioning to nested route", async function (assert) {
+    const route = this.owner.lookup("route:topic.from-params");
+    const header = this.owner.lookup("service:header");
+    const router = this.owner.lookup("service:router");
+
+    router.currentRouteName = "nested";
+    route.controllerFor = () => ({
+      set() {},
+    });
+
+    route.willTransition(completedTransition());
+    await waitForTransitionCleanup();
+
+    assert.strictEqual(
+      header.clearCount,
+      0,
+      "topic info remains registered for the nested topic route"
+    );
+  });
+
+  test("nested route clears header topic info when transitioning away from topic routes", async function (assert) {
+    const route = this.owner.lookup("route:nested");
+    const header = this.owner.lookup("service:header");
+    const router = this.owner.lookup("service:router");
+
+    router.currentRouteName = "discovery.latest";
+
+    route.willTransition(completedTransition());
+    await waitForTransitionCleanup();
+
+    assert.strictEqual(
+      header.clearCount,
+      1,
+      "topic info is cleared outside topic routes"
+    );
+  });
+});

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/topic-title/topic-title-voting.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/topic-title/topic-title-voting.gjs
@@ -1,13 +1,20 @@
+import { and, or } from "discourse/truth-helpers";
 import VoteBox from "../../components/vote-box";
 
 <template>
-  {{#if @outletArgs.model.can_vote}}
-    {{#if @outletArgs.model.postStream.loaded}}
-      {{#if @outletArgs.model.postStream.firstPostPresent}}
-        <div class="voting title-voting">
-          <VoteBox @topic={{@outletArgs.model}} />
-        </div>
-      {{/if}}
+  {{#let @outletArgs.model as |topic|}}
+    {{#if
+      (and
+        topic.can_vote
+        (or
+          topic.is_nested_view
+          (and topic.postStream.loaded topic.postStream.firstPostPresent)
+        )
+      )
+    }}
+      <div class="voting title-voting">
+        <VoteBox @topic={{topic}} />
+      </div>
     {{/if}}
-  {{/if}}
+  {{/let}}
 </template>

--- a/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
+++ b/plugins/discourse-topic-voting/assets/stylesheets/common/topic-voting.scss
@@ -75,7 +75,8 @@
 }
 
 // grid layout for voting in topic title
-#topic-title:has(.voting) {
+#topic-title:has(.voting),
+.nested-view__header:has(.voting) {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0 var(--topic-body-width-padding);

--- a/plugins/discourse-topic-voting/test/javascripts/integration/connectors/topic-title-voting-test.gjs
+++ b/plugins/discourse-topic-voting/test/javascripts/integration/connectors/topic-title-voting-test.gjs
@@ -1,0 +1,75 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import TopicTitleVoting from "discourse/plugins/discourse-topic-voting/discourse/connectors/topic-title/topic-title-voting";
+
+function buildTopic(overrides = {}) {
+  return {
+    id: 1,
+    can_vote: true,
+    closed: false,
+    is_nested_view: false,
+    postStream: {
+      firstPostPresent: false,
+      loaded: false,
+    },
+    user_voted: false,
+    vote_count: 0,
+    ...overrides,
+  };
+}
+
+module("Integration | Connector | TopicTitleVoting", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.siteSettings.topic_voting_show_who_voted = false;
+  });
+
+  test("renders after the first post is present in the flat topic stream", async function (assert) {
+    this.outletArgs = {
+      model: buildTopic({
+        postStream: {
+          firstPostPresent: true,
+          loaded: true,
+        },
+      }),
+    };
+
+    await render(
+      <template><TopicTitleVoting @outletArgs={{this.outletArgs}} /></template>
+    );
+
+    assert
+      .dom(".title-voting .voting-wrapper")
+      .exists("the vote box renders in the topic title");
+  });
+
+  test("does not render before the first post is present in the flat topic stream", async function (assert) {
+    this.outletArgs = {
+      model: buildTopic(),
+    };
+
+    await render(
+      <template><TopicTitleVoting @outletArgs={{this.outletArgs}} /></template>
+    );
+
+    assert
+      .dom(".title-voting .voting-wrapper")
+      .doesNotExist("the flat topic guard is preserved");
+  });
+
+  test("renders for nested topics before the flat topic stream is loaded", async function (assert) {
+    this.outletArgs = {
+      model: buildTopic({ is_nested_view: true }),
+    };
+
+    await render(
+      <template><TopicTitleVoting @outletArgs={{this.outletArgs}} /></template>
+    );
+
+    assert
+      .dom(".title-voting .voting-wrapper")
+      .exists("nested topics can render the vote box from topic metadata");
+  });
+});


### PR DESCRIPTION
This fixes topic voting to make sure the UI shows by the topic title when the topic is loaded in nested mode.

Also fixes a weird header-registeration bug so that on scroll the topic title goes in the header after nested replies is disabled for a topic.