### PR TITLE
DEV: update single dash animation modifier to double dash

### DIFF
--- a/app/assets/stylesheets/admin/admin-dashboard-skeleton.scss
+++ b/app/assets/stylesheets/admin/admin-dashboard-skeleton.scss
@@ -270,7 +270,7 @@
     overflow: hidden;
   }
 
-  &.-animation {
+  &.--animation {
     *[class*="db-skeleton__"]:not(
         .db-skeleton__section,
         .db-skeleton__section-wrapper,

--- a/frontend/discourse/admin/components/dashboard/skeleton.gjs
+++ b/frontend/discourse/admin/components/dashboard/skeleton.gjs
@@ -8,7 +8,7 @@ const ENGAGEMENT_ACTIVITY_ROWS = Array.from({ length: 4 });
 
 <template>
   <div
-    class="db-skeleton -animation"
+    class="db-skeleton --animation"
     role="status"
     aria-label={{i18n "admin.dashboard.loading"}}
   >

--- a/frontend/discourse/tests/integration/components/dashboard/skeleton-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/skeleton-test.gjs
@@ -35,6 +35,6 @@ module("Integration | Component | Dashboard | Skeleton", function (hooks) {
   test("opts into the shimmer animation", async function (assert) {
     await render(<template><DashboardSkeleton /></template>);
 
-    assert.dom(".db-skeleton").hasClass("-animation");
+    assert.dom(".db-skeleton").hasClass("--animation");
   });
 });

--- a/plugins/chat/assets/javascripts/discourse/components/chat-skeleton.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-skeleton.gjs
@@ -19,7 +19,7 @@ export default class ChatSkeleton extends Component {
   }
 
   <template>
-    <div class="chat-skeleton -animation">
+    <div class="chat-skeleton --animation">
       {{#each this.placeholders as |placeholder|}}
         <div class="chat-skeleton__body">
           <div class="chat-skeleton__message">

--- a/plugins/chat/assets/stylesheets/common/chat-skeleton.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-skeleton.scss
@@ -107,7 +107,7 @@
     overflow: hidden;
   }
 
-  &.-animation {
+  &.--animation {
     position: relative;
     overflow: hidden;
 


### PR DESCRIPTION
Updates the `.-animation` modifier to our proper `.--animation` formatting, covers admin-dashboard-skeleton and chat-skeleton 