### PR TITLE
DEV: Update licensee config & execution

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Check JS Licenses
         if: ${{ !cancelled() }}
         run: |
-          pnpm licensee --errors-only
+          script/run-licensee

--- a/.licensee.json
+++ b/.licensee.json
@@ -2,43 +2,18 @@
   "licenses": {
     "blueOak": "bronze",
     "spdx": [
-      "CC0-1.0",
       "CC-BY-3.0",
       "CC-BY-4.0",
-      "Apache-2.0 WITH LLVM-exception",
-      "ISC"
+      "Apache-2.0 WITH LLVM-exception"
     ]
   },
   "packages": {
     "@fortawesome/fontawesome-free": "*",
-    "@glimmer/compiler": "*",
-    "@glimmer/debug": "*",
-    "@glimmer/encoder": "*",
-    "@glimmer/global-context": "*",
-    "@glimmer/interfaces": "*",
-    "@glimmer/manager": "*",
-    "@glimmer/node": "*",
-    "@glimmer/opcode-compiler": "*",
-    "@glimmer/program": "*",
-    "@glimmer/syntax": "*",
-    "@glimmer/vm": "*",
     "@jspreadsheet/formula": "2.0.2",
     "cli-table": "0.3.11",
-    "component-bind": "1.0.0",
-    "component-inherit": "0.0.3",
-    "duplex": "1.0.0",
-    "ember-template-lint-plugin-discourse": "*",
-    "glob": "3.1.21",
-    "indexof": "0.0.1",
-    "inherits": "1.0.2",
     "jsonify": "0.0.1",
-    "jspreadsheet-ce": "4.13.4",
-    "line-stream": "0.0.0",
-    "messageformat": "0.1.5",
-    "regenerator-transform": "0.10.1",
-    "sourcemap-validator": "1.1.1",
-    "spawn-command": "0.0.2",
-    "taffydb": "2.6.2"
+    "jspreadsheet-ce": "5.0.4",
+    "@embroider/vite": "1.7.5"
   },
   "corrections": true,
   "ignore": [

--- a/script/run-licensee
+++ b/script/run-licensee
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+root = File.expand_path("..", __dir__)
+config = File.join(root, ".licensee.json")
+
+recursive_opts = %w[-r --parallel --filter=!./plugins/*]
+
+begin
+  system(
+    "pnpm",
+    *recursive_opts,
+    "exec",
+    "ln",
+    "-sf",
+    config,
+    ".licensee.json",
+    chdir: root,
+    exception: true,
+  )
+
+  ok =
+    system(
+      "pnpm",
+      *recursive_opts,
+      "--include-workspace-root",
+      "exec",
+      "licensee",
+      "--errors-only",
+      chdir: root,
+    )
+
+  exit(ok ? 0 : 1)
+ensure
+  system("pnpm", *recursive_opts, "--no-bail", "exec", "rm", "-f", ".licensee.json", chdir: root)
+end


### PR DESCRIPTION
- Create a script which runs licensee for all workspaces
- Remove redundant licenses (CC0-1.0 and ISC) are in the blueOak list already
- Remove redundant package exceptions. These have either fixed their license metadata, or are no longer dependencies of Discourse
- Bump version on jspreadsheet-ce exception