### PR TITLE
FIX: Stop admin dashboard report charts stuttering stale data on date change

### DIFF
--- a/frontend/discourse/admin/components/dashboard/report-cards/core-report.gjs
+++ b/frontend/discourse/admin/components/dashboard/report-cards/core-report.gjs
@@ -1,4 +1,3 @@
-import { hash } from "@ember/helper";
 import AdminReport from "discourse/admin/components/admin-report";
 
 <template>
@@ -6,6 +5,5 @@ import AdminReport from "discourse/admin/components/admin-report";
     @dataSourceName={{@item.identifier}}
     @preloadedData={{@payload}}
     @showHeader={{false}}
-    @filters={{hash startDate=@filters.startDate endDate=@filters.endDate}}
   />
 </template>


### PR DESCRIPTION
In the new dashboard's Reports section, changing the date range made each core-report chart briefly redraw with the old range's data before the new data arrived.

The card renders through `AdminReport` in preloaded mode, where `AdminReportNew` re-runs `fetchOrRender` on `@filters.startDate`/`endDate` changes. The filters change as soon as the dashboard payload resolves, but the chart payload arrives one bulk request later — so the filter change redrew the chart with stale `preloadedData` (the stutter), then the new payload redrew it again.

In preloaded mode the chart renders entirely from `preloadedData` and the filter dates are unused. Dropping them from the `@filters` passed to `AdminReport` makes the chart redraw only when `preloadedData` changes.