### PR TITLE
DEV: Let plugins exclude reports from the customisable dashboard

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -320,13 +320,21 @@ class Report
     end
   end
 
-  def Report.add_report(name, &block)
+  def Report.add_report(name, exclude_from_dashboard: false, &block)
     singleton_class.instance_eval { define_method("report_#{name}", &block) }
+    dashboard_excluded_report_types << name.to_s if exclude_from_dashboard
   end
 
   # Only used for testing.
   def Report.remove_report(name)
     singleton_class.instance_eval { remove_method("report_#{name}") }
+    dashboard_excluded_report_types.delete(name.to_s)
+  end
+
+  # Report types a plugin has marked as not mountable on the customisable
+  # admin dashboard. They remain available on the regular reports page.
+  def Report.dashboard_excluded_report_types
+    @dashboard_excluded_report_types ||= Set.new
   end
 
   def self._get(type, opts = nil)

--- a/lib/admin_dashboard/reports/core_report_provider.rb
+++ b/lib/admin_dashboard/reports/core_report_provider.rb
@@ -20,10 +20,7 @@ module AdminDashboard
         return {} if guardian.nil?
 
         index =
-          ::Reports::ListQuery
-            .call(guardian: guardian)
-            .map { |entry| build_resolved(entry) }
-            .index_by(&:identifier)
+          dashboard_entries(guardian).map { |entry| build_resolved(entry) }.index_by(&:identifier)
         identifiers.each_with_object({}) do |identifier, hash|
           key = identifier.to_s
           resolved = index[key]
@@ -59,10 +56,17 @@ module AdminDashboard
       private_class_method :with_empty_flag
 
       def self.list_all(search: nil, after: nil, limit: nil)
-        entries = ::Reports::ListQuery.call(guardian: Guardian.new(Discourse.system_user))
+        entries = dashboard_entries(Guardian.new(Discourse.system_user))
         entries = filter_by_search(entries, search) if search.present?
         seek(entries.map { |entry| build_resolved(entry) }, after: after, limit: limit)
       end
+
+      def self.dashboard_entries(guardian)
+        ::Reports::ListQuery
+          .call(guardian: guardian)
+          .reject { |entry| ::Report.dashboard_excluded_report_types.include?(entry[:type]) }
+      end
+      private_class_method :dashboard_entries
 
       def self.build_resolved(entry)
         AdminDashboard::Reports::ResolvedReport.new(

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -250,8 +250,8 @@ class Plugin::Instance
   end
 
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?
-  def add_report(name, &block)
-    reloadable_patch { |plugin| Report.add_report(name, &block) }
+  def add_report(name, exclude_from_dashboard: false, &block)
+    reloadable_patch { |plugin| Report.add_report(name, exclude_from_dashboard:, &block) }
   end
 
   # Applies to all sites in a multisite environment. Ignores plugin.enabled?

--- a/plugins/discourse-ai/lib/sentiment/emotion_dashboard_report.rb
+++ b/plugins/discourse-ai/lib/sentiment/emotion_dashboard_report.rb
@@ -5,7 +5,7 @@ module DiscourseAi
     class EmotionDashboardReport
       def self.register!(plugin)
         Emotions::LIST.each do |emotion|
-          plugin.add_report("emotion_#{emotion}") do |report|
+          plugin.add_report("emotion_#{emotion}", exclude_from_dashboard: true) do |report|
             query_results = DiscourseAi::Sentiment::EmotionDashboardReport.fetch_data(report)
             report.data = query_results.map { |row| { x: row.day, y: row.send(emotion) } }
             if report.facets.include?(:prev_period) && query_results.length > 30

--- a/plugins/discourse-ai/spec/lib/modules/sentiment/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/sentiment/entry_point_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe DiscourseAi::Sentiment::EntryPoint do
 
   before { enable_current_plugin }
 
+  describe "admin dashboard report registration" do
+    it "excludes the per-emotion reports while keeping the sentiment summaries" do
+      DiscourseAi::Sentiment::Emotions::LIST.each do |emotion|
+        expect(Report.dashboard_excluded_report_types).to include("emotion_#{emotion}")
+      end
+
+      expect(Report.dashboard_excluded_report_types).not_to include(
+        "overall_sentiment",
+        "sentiment_analysis",
+      )
+    end
+  end
+
   describe "registering event callbacks" do
     context "when editing a post" do
       fab!(:post) { Fabricate(:post, user: user) }

--- a/spec/lib/admin_dashboard/reports/core_report_provider_spec.rb
+++ b/spec/lib/admin_dashboard/reports/core_report_provider_spec.rb
@@ -82,6 +82,17 @@ RSpec.describe AdminDashboard::Reports::CoreReportProvider do
     end
   end
 
+  describe "reports excluded from the dashboard" do
+    after { Report.dashboard_excluded_report_types.delete("signups") }
+
+    it "omits them from both list_all and resolve_many" do
+      Report.dashboard_excluded_report_types << "signups"
+
+      expect(described_class.list_all.map(&:identifier)).not_to include("signups")
+      expect(described_class.resolve_many(%w[signups], guardian: guardian)).to be_empty
+    end
+  end
+
   describe ".fetch_many" do
     it "returns report payloads keyed by identifier" do
       result = described_class.fetch_many(%w[signups], guardian: guardian, filters: {})

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe Report do
+  describe ".add_report" do
+    after { Report.remove_report("my_custom_report") }
+
+    it "records report types flagged as excluded from the dashboard" do
+      Report.add_report("my_custom_report", exclude_from_dashboard: true) { |report| }
+      expect(Report.dashboard_excluded_report_types).to include("my_custom_report")
+    end
+
+    it "does not record report types by default" do
+      Report.add_report("my_custom_report") { |report| }
+      expect(Report.dashboard_excluded_report_types).not_to include("my_custom_report")
+    end
+  end
+
   let(:user) { Fabricate(:user) }
   let(:category_1) { Fabricate(:category, user: user) }
   let(:category_2) { Fabricate(:category, parent_category: category_1, user: user) } # id: 2


### PR DESCRIPTION
`add_report` now accepts `exclude_from_dashboard: true`, which keeps a report on the regular reports page but hides it from the new dashboard's "add report" list and enabled cards. Data Explorer's per-emotion sentiment reports use it, since the ~28 emotion reports were swamping the picker; the overall sentiment and sentiment analysis summaries stay.