### PR TITLE
FIX: prevent empty QA Page schema in Solved

### DIFF
--- a/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/build_schema_markup.rb
@@ -39,7 +39,7 @@ class DiscourseSolved::BuildSchemaMarkup
     topic.topic_answers.filter_map do |ta|
       post = ta.post
       next unless post.present? && guardian.can_see_post?(post)
-      post if post.cooked.present? && Nokogiri::HTML5.fragment(post.cooked).text.strip.present?
+      post if DiscourseSolved::SchemaUtils.eligible_answer?(post)
     end
   end
 
@@ -51,7 +51,7 @@ class DiscourseSolved::BuildSchemaMarkup
       .where(post_type: Post.types[:regular], hidden: false)
       .order(:post_number)
       .to_a
-      .select { |p| p.cooked.present? && Nokogiri::HTML5.fragment(p.cooked).text.strip.present? }
+      .select { |post| DiscourseSolved::SchemaUtils.eligible_answer?(post) }
   end
 
   def fetch_html(topic:, accepted_answers:, suggested_answers:)

--- a/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/schema_utils.rb
@@ -7,7 +7,9 @@ module DiscourseSolved
     # Structure: QAPage > Question (mainEntity) > acceptedAnswer / suggestedAnswer
     #
     # - First post gets no schema (its content bubbles up to the Question scope)
-    # - Small action posts get an isolated itemscope to prevent leaking into Question
+    # - Ineligible replies (small actions, hidden, or textless onebox/image-only posts)
+    #   get no schema attributes; the crawler view suppresses their microdata so nothing
+    #   attaches to the surrounding Question scope
     # - The solved post is marked as acceptedAnswer, other replies as suggestedAnswer
     #
     # Spec: https://schema.org/QAPage
@@ -31,7 +33,8 @@ module DiscourseSolved
       end
       topic.instance_variable_set(
         :@qa_page_schema,
-        schema_markup_enabled?(topic) && eligible_answers(topic).exists?,
+        schema_markup_enabled?(topic) &&
+          eligible_answers(topic).any? { |post| eligible_answer?(post) },
       )
     end
 
@@ -71,17 +74,21 @@ module DiscourseSolved
         "<meta itemprop='upvoteCount' content='#{first_post&.like_count || 0}'>"
     end
 
+    # Whether a post should be treated as an answer in schema output: a visible, regular,
+    # non-first reply with real text content (excludes onebox/image/emoji-only posts).
+    # Shared by the crawler microdata path and the JSON-LD service so both agree on what
+    # counts as an answer.
+    def self.eligible_answer?(post)
+      !post.is_first_post? && post.post_type == Post.types[:regular] && !post.hidden &&
+        post.cooked.present? && Nokogiri::HTML5.fragment(post.cooked).text.strip.present?
+    end
+
     private_class_method def self.accepted_answer_visible?(topic)
       topic.solved&.answer_posts&.any? { |post| Guardian.new.can_see_post?(post) }
     end
 
     private_class_method def self.eligible_answers(topic)
       topic.posts.where.not(post_number: 1).where(post_type: Post.types[:regular], hidden: false)
-    end
-
-    private_class_method def self.eligible_answer?(post)
-      !post.is_first_post? && post.post_type == Post.types[:regular] && !post.hidden &&
-        post.cooked.present? && Nokogiri::HTML5.fragment(post.cooked).text.strip.present?
     end
   end
 end

--- a/plugins/discourse-solved/spec/lib/discourse_solved/schema_utils_spec.rb
+++ b/plugins/discourse-solved/spec/lib/discourse_solved/schema_utils_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseSolved::SchemaUtils do
+  before do
+    SiteSetting.allow_solved_on_all_topics = true
+    SiteSetting.solved_add_schema_markup = "always"
+  end
+
+  describe ".qa_page_schema?" do
+    # A fresh topic per example avoids the memoized @qa_page_schema bleeding between tests.
+
+    it "returns true when an eligible text reply exists" do
+      topic = Fabricate(:topic_with_op)
+      Fabricate(:post, topic:, raw: "This is a written answer")
+
+      expect(described_class.qa_page_schema?(topic)).to eq(true)
+    end
+
+    it "returns false when the only replies are textless onebox-only posts" do
+      topic = Fabricate(:topic_with_op)
+      Fabricate(
+        :post,
+        topic:,
+        raw: "https://www.youtube.com/watch?v=test",
+        cooked:
+          '<div class="onebox video-onebox"><iframe src="https://youtube.com/embed/test"></iframe></div>',
+      )
+
+      expect(described_class.qa_page_schema?(topic)).to eq(false)
+    end
+  end
+end

--- a/plugins/discourse-solved/spec/services/discourse_solved/build_schema_markup_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/build_schema_markup_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe DiscourseSolved::BuildSchemaMarkup do
       end
     end
 
+    context "when the accepted answer is hidden but visible to the requesting user" do
+      fab!(:admin)
+      fab!(:answer_post) { Fabricate(:post, topic:, hidden: true) }
+
+      # An admin can see hidden posts, so this isolates the eligible_answer? hidden filter
+      # from the guardian's can_see_post? check.
+      let(:guardian) { Guardian.new(admin) }
+
+      before do
+        SiteSetting.solved_add_schema_markup = "always"
+        Fabricate(:solved_topic, topic:, answer_post:)
+      end
+
+      it { is_expected.to fail_a_policy(:has_answers) }
+    end
+
     describe "with multiple solutions enabled" do
       before { SiteSetting.solved_allow_multiple_solutions = true }
 


### PR DESCRIPTION
Fixes a gap where the crawler's `qa_page_schema?` gating emits an empty QAPage on topics whose only replies had no real text.

The QAPage/answer schema in Discourse Solved now consistently excludes textless posts (onebox/image/emoji-only replies) across all paths by routing every eligibility check through a single shared `SchemaUtils.eligible_answer?`