### PR TITLE
FIX: Unread count could disagree with the /unread topic list

### DIFF
--- a/lib/topic_query.rb
+++ b/lib/topic_query.rb
@@ -265,6 +265,7 @@ class TopicQuery
               topic:,
               per_page: builder.results_left,
               max_age: SiteSetting.suggested_topics_unread_max_days_old,
+              age_column: :bumped_at,
             ),
           )
         else
@@ -273,6 +274,7 @@ class TopicQuery
               topic: topic,
               per_page: builder.results_left,
               max_age: SiteSetting.suggested_topics_unread_max_days_old,
+              age_column: :bumped_at,
             ),
             :high,
           )
@@ -1338,7 +1340,11 @@ class TopicQuery
 
       # perf note, in the past we tried doing this in a subquery but performance was
       # terrible, also tried with a join and it was bad
-      results = results.where("topics.bumped_at >= ?", unread_at)
+      #
+      # Default to updated_at so the unread/new lists stay consistent with the unread
+      # count (TopicTrackingState); suggested topics opt into bumped_at via age_column.
+      age_column = options[:age_column] == :bumped_at ? "bumped_at" : "updated_at"
+      results = results.where("topics.#{age_column} >= ?", unread_at)
     end
     results
   end

--- a/spec/lib/topic_query_spec.rb
+++ b/spec/lib/topic_query_spec.rb
@@ -1275,6 +1275,24 @@ RSpec.describe TopicQuery do
       end
     end
 
+    context "with a small action at the tail of an unread topic" do
+      it "keeps the topic in the unread list" do
+        topic = create_post(raw: "the original post", title: "super amazing title").topic
+        topic.add_small_action(Discourse.system_user, "closed.enabled")
+        topic.update_columns(updated_at: Time.zone.now, bumped_at: 1.year.ago)
+
+        TopicUser.change(
+          user.id,
+          topic.id,
+          notification_level: TopicUser.notification_levels[:tracking],
+        )
+        TopicUser.update_last_read(user, topic.id, 1, 1, 1)
+        user.user_stat.update!(first_unread_at: 1.minute.ago)
+
+        expect(TopicQuery.new(user).list_unread.topics).to include(topic)
+      end
+    end
+
     context "with read data" do
       fab!(:partially_read) { Fabricate(:post, user: creator).topic }
       fab!(:fully_read) { Fabricate(:post, user: creator).topic }


### PR DESCRIPTION
The "Unread (N)" badge could count a topic that did not appear on the /unread page (and, conversely, a genuinely unread topic could be hidden from /unread). See https://meta.discourse.org/t/-/403986.

Both the count and the list bound their results by the user's "old unread" cutoff, `user_stats.first_unread_at`, which is computed from `topics.updated_at`. The count (TopicTrackingState) filters on `topics.updated_at >= first_unread_at`, but since 17555ae8798 (#40127) the /unread list (TopicQuery#apply_max_age_limit) filtered on `topics.bumped_at` instead. A small action at the tail of a topic (close, auto-close, category change, ...) moves `updated_at` but not `bumped_at`, so such a topic passed the count's filter yet failed the list's filter: it was counted but never listed.

#40127 switched to `bumped_at` for suggested topics, where bounding by last visible activity is the desired behaviour, so reverting it is not an option. Instead, `apply_max_age_limit` now takes an explicit `age_column` that defaults to `updated_at` (keeping the unread and new lists consistent with the count), and the suggested-topics callers pass `age_column: :bumped_at` to preserve their behaviour.