### PR TITLE
DEV: Use admin created_at for onboarding logic

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -172,7 +172,7 @@ class CurrentUserSerializer < BasicUserSerializer
   def include_show_site_owner_onboarding?
     SiteSetting.enable_site_owner_onboarding && object.admin? &&
       User.where(admin: true).human_users.minimum(:id) == object.id &&
-      Topic.minimum(:created_at)&.after?(SiteSetting.site_owner_onboarding_max_days.days.ago)
+      object.created_at.after?(SiteSetting.site_owner_onboarding_max_days.days.ago)
   end
 
   def show_site_owner_onboarding

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -454,7 +454,8 @@ RSpec.describe CurrentUserSerializer do
 
     it "is not included when the site is older than the max days setting" do
       SiteSetting.site_owner_onboarding_max_days = 5
-      Topic.update_all(created_at: 6.days.ago)
+      admin.created_at = 6.days.ago
+      admin.save!
       payload = admin_serializer.as_json
       expect(payload).not_to have_key(:show_site_owner_onboarding)
     end

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -2,8 +2,6 @@
 
 describe "Admin Onboarding Banner" do
   fab!(:admin)
-  # ensures there is at least one topic, otherwise the topic recent date check doesn't pass
-  fab!(:topic)
 
   let(:banner) { PageObjects::Components::AdminOnboardingBanner.new }
   let(:predefined_topics_modal) { PageObjects::Modals::AdminOnboardingPredefinedTopics.new }


### PR DESCRIPTION
Previously, we checked the first topic's created_at to calculate whether to show the onboarding banner to the first admin user.

This change uses the admin's created_at, it's more resilient in sites that get pre-provisioned.