### PR TITLE
DEV: Remove dead `events#create` route from discourse-post-event

### DIFF
--- a/plugins/discourse-calendar/config/routes.rb
+++ b/plugins/discourse-calendar/config/routes.rb
@@ -10,7 +10,6 @@ DiscoursePostEvent::Engine.routes.draw do
       }
   get "/discourse-post-event/events/:id" => "events#show"
   delete "/discourse-post-event/events/:id" => "events#destroy"
-  post "/discourse-post-event/events" => "events#create"
   post "/discourse-post-event/events/:id/csv-bulk-invite" => "events#csv_bulk_invite"
   post "/discourse-post-event/events/:id/bulk-invite" => "events#bulk_invite", :format => :json
   post "/discourse-post-event/events/:id/invite" => "events#invite"


### PR DESCRIPTION
Previously, `routes.rb` mapped `POST /discourse-post-event/events` to a non-existent `EventsController#create` action, so any request to it raised `ActionNotFound`.

This change removes the dead route, since events are created exclusively by parsing post raw via `Event.update_from_raw` on `post_created`/`post_edited` — there is no controller action and no frontend caller (the only hit on that path is the `GET` `index`).
