### PR TITLE
FIX: Don't cache `can_act_on_discourse_post_event?` result across events

### DIFF
--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -211,14 +211,10 @@ after_initialize do
   end
 
   add_to_class(:user, :can_act_on_discourse_post_event?) do |event|
-    return @can_act_on_discourse_post_event if defined?(@can_act_on_discourse_post_event)
-    @can_act_on_discourse_post_event =
-      begin
-        return true if staff?
-        can_create_discourse_post_event? && Guardian.new(self).can_edit_post?(event.post)
-      rescue StandardError
-        false
-      end
+    return true if staff?
+    can_create_discourse_post_event? && Guardian.new(self).can_edit_post?(event.post)
+  rescue StandardError
+    false
   end
 
   add_to_class(:guardian, :can_act_on_discourse_post_event?) do |event|

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/user_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/user_spec.rb
@@ -82,6 +82,28 @@ describe User do
             expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)
           end
         end
+
+        context "with multiple events in the same request" do
+          let(:user_2) { Fabricate(:user) }
+
+          let(:own_topic) { Fabricate(:topic, user: user_1) }
+          let(:own_post) { Fabricate(:post, topic: own_topic, user: user_1) }
+          let(:own_event) { Fabricate(:event, post: own_post) }
+
+          let(:other_topic) { Fabricate(:topic, user: user_2) }
+          let(:other_post) { Fabricate(:post, topic: other_topic, user: user_2) }
+          let(:other_event) { Fabricate(:event, post: other_post) }
+
+          it "does not leak the answer from one event to another" do
+            expect(user_1.can_act_on_discourse_post_event?(own_event)).to eq(true)
+            expect(user_1.can_act_on_discourse_post_event?(other_event)).to eq(false)
+          end
+
+          it "does not leak a negative answer either" do
+            expect(user_1.can_act_on_discourse_post_event?(other_event)).to eq(false)
+            expect(user_1.can_act_on_discourse_post_event?(own_event)).to eq(true)
+          end
+        end
       end
 
       context "when user is not in list of allowed groups" do


### PR DESCRIPTION
Previously, `User#can_act_on_discourse_post_event?` memoized its result in an instance variable without keying it by the `event` argument, so within a single request the first event's answer leaked to later permission checks on different events (most visibly when a serializer renders a list of events under one scope).

This change removes the memoization so the permission is computed fresh per event. The cheap per-event `can_edit_post?` check now runs on each call, while the expensive parameterless `can_create_discourse_post_event?` group lookup stays memoized.

A multi-event spec was added that exercises the leak in both directions (positive→negative and negative→positive); it fails against the old memoized code and passes with the fix.