### PR TITLE
FIX: Bulk invite group visibility bypass in `discourse-calendar`

### DIFF
--- a/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
+++ b/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
@@ -33,6 +33,7 @@ module Jobs
     private
 
     def process_invitees(invitees)
+      invitees = invitees.map(&:with_indifferent_access)
       invitees = filter_out_unavailable_groups(invitees)
 
       max_bulk_invitees = SiteSetting.discourse_post_event_max_bulk_invitees

--- a/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/bulk_invite_spec.rb
+++ b/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/bulk_invite_spec.rb
@@ -165,6 +165,34 @@ describe Jobs::DiscoursePostEventBulkInvite do
           end
         end
 
+        context "when the current user can't see the group's members" do
+          # Moderator can edit any post but is not an admin, so member-visibility
+          # checks actually apply to them.
+          let(:moderator) { Fabricate(:moderator) }
+          let(:mod_topic) { Fabricate(:topic, user: moderator) }
+          let(:mod_post) { Fabricate(:post, topic: mod_topic) }
+          let(:mod_event) { Fabricate(:event, post: mod_post, status: "private") }
+          let(:hidden_member) { Fabricate(:user) }
+          let(:hidden_group) do
+            Fabricate(:group, members_visibility_level: Group.visibility_levels[:owners]).tap do |g|
+              g.add(hidden_member)
+              g.save!
+            end
+          end
+
+          # Serialized Sidekiq args come back with string keys, which is what the
+          # group-visibility filter must handle (see filter_out_unavailable_groups).
+          it "filters out the group even when invitee args use string keys" do
+            Jobs::DiscoursePostEventBulkInvite.new.execute(
+              event_id: mod_event.id,
+              invitees: [{ "identifier" => hidden_group.name, "attendance" => "going" }],
+              current_user_id: moderator.id,
+            )
+
+            expect(DiscoursePostEvent::Invitee.where(post_id: mod_post.id)).to be_empty
+          end
+        end
+
         context "when the event is public" do
           before { post_event_1.update_with_params!(status: 1) }
 


### PR DESCRIPTION
Previously, `DiscoursePostEventBulkInvite` read invitee identifiers with symbol keys in `filter_out_unavailable_groups` but string keys when processing, so serialized job args (which come back with string keys) silently bypassed the unavailable/private group filtering.

This change normalizes invitee params to indifferent access up front, so the visibility filter runs regardless of how the job args were serialized. Adds a spec exercising the private-group filter with string-keyed job args.