### PR TITLE
UX: Make composer tag suggestions word-based with clearer reasons

### DIFF
--- a/app/services/tags/search.rb
+++ b/app/services/tags/search.rb
@@ -129,7 +129,7 @@ class Tags::Search
 
     candidate_tags =
       visible_tags(guardian)
-        .where("position(LOWER(?) IN LOWER(tags.name)) <> 0", params.term)
+        .where("tags.name ~* ?", "\\m#{Regexp.escape(params.term)}")
         .where.not(id: skip_ids)
         .limit(SiteSetting.max_tag_search_results)
         .to_a
@@ -196,7 +196,24 @@ class Tags::Search
           .where(one_per_topic: true, tag_group_memberships: { tag_id: tag.id })
           .where(id: TagGroupMembership.where(tag_id: selected_ids).select(:tag_group_id))
           .first
-      return I18n.t("tags.forbidden.one_tag_per_topic_group", tag_group_name: group.name) if group
+
+      if group
+        conflicting_tag_names =
+          Tag
+            .where(id: selected_ids)
+            .joins(:tag_group_memberships)
+            .where(tag_group_memberships: { tag_group_id: group.id })
+            .order(:name)
+            .pluck(:name)
+
+        return(
+          I18n.t(
+            "tags.forbidden.one_tag_per_topic_group",
+            tag_group_name: group.name,
+            tag_names: conflicting_tag_names.join(", "),
+          )
+        )
+      end
     end
 
     if params.filterForInput
@@ -207,6 +224,7 @@ class Tags::Search
           .where.not(parent_tag_id: [nil, *selected_ids])
           .includes(:parent_tag)
           .first
+
       if group&.parent_tag && tag_visible?(group.parent_tag_id, guardian)
         return(
           I18n.t(

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5753,16 +5753,16 @@ en:
       invalid:
         one: "The tag you selected cannot be used"
         other: "None of the tags you selected can be used"
-      in_this_category: '"%{tag_name}" cannot be used in this category'
-      not_allowed: '"%{tag_name}" cannot be used'
+      in_this_category: "Can't be used in this category"
+      not_allowed: "Can't be used"
       restricted_to:
-        one: '"%{tag_name}" is restricted to the "%{category_names}" category'
-        other: '"%{tag_name}" is restricted to the following categories: %{category_names}'
-      restricted_to_truncated: '"%{tag_name}" is restricted to the following categories: %{category_names}, and %{more_count} more'
-      synonym: 'This is a synonym for "%{tag_name}". Use "%{tag_name}" instead.'
+        one: 'Only available in the "%{category_names}" category'
+        other: "Only available in: %{category_names}"
+      restricted_to_truncated: "Only available in: %{category_names}, and %{more_count} more"
+      synonym: 'Please use "%{tag_name}" instead'
       has_synonyms: '"%{tag_name}" cannot be used because it has synonyms.'
-      one_tag_per_topic_group: 'Only one tag from the "%{tag_group_name}" group is allowed per topic'
-      missing_parent_tag: 'Requires the "%{parent_tag_name}" tag to use tags from the "%{tag_group_name}" group'
+      one_tag_per_topic_group: 'Conflicts with "%{tag_names}" (only one allowed per topic)'
+      missing_parent_tag: 'Available after adding the "%{parent_tag_name}" tag'
       restricted_tags_cannot_be_used_in_category:
         one: 'The "%{tags}" tag cannot be used in the "%{category}" category. Please remove it.'
         other: 'The following tags cannot be used in the "%{category}" category: %{tags}. Please remove them.'

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1753,7 +1753,7 @@ RSpec.describe TagsController do
           expect(result).to be_present
           expect(result["disabled"]).to eq(true)
           expect(result["title"]).to eq(
-            I18n.t("tags.forbidden.one_tag_per_topic_group", tag_group_name: "Workflow"),
+            I18n.t("tags.forbidden.one_tag_per_topic_group", tag_names: "todo"),
           )
         end
 
@@ -1761,6 +1761,20 @@ RSpec.describe TagsController do
           get "/tags/filter/search.json",
               params: {
                 q: "ready",
+                filterForInput: true,
+                selected_tag_ids: [workflow_tag1.id],
+              }
+
+          expect(response.status).to eq(200)
+          result = response.parsed_body["results"].find { |t| t["name"] == "ready-to-deploy" }
+          expect(result).to be_present
+          expect(result["disabled"]).to eq(true)
+        end
+
+        it "returns sibling tag as disabled when the term matches a later word" do
+          get "/tags/filter/search.json",
+              params: {
+                q: "deploy",
                 filterForInput: true,
                 selected_tag_ids: [workflow_tag1.id],
               }

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -107,9 +107,11 @@ RSpec.describe(Tags::Search) do
         expect(disabled.map { |t| t[:name] }).to include("gamma")
       end
 
-      it "includes the one_per_topic reason" do
+      it "names the conflicting tag in the one_per_topic reason" do
         disabled = result[:tags].find { |t| t[:name] == "gamma" && t[:disabled] }
-        expect(disabled[:title]).to include("Exclusive Group")
+        expect(disabled[:title]).to eq(
+          I18n.t("tags.forbidden.one_tag_per_topic_group", tag_names: "alpha"),
+        )
       end
     end
 
@@ -132,6 +134,12 @@ RSpec.describe(Tags::Search) do
       it "includes the missing parent tag reason" do
         disabled = result[:tags].find { |t| t[:name] == "childtag" && t[:disabled] }
         expect(disabled[:title]).to include("parent")
+      end
+
+      it "does not surface the tag when the term only matches mid-word" do
+        result =
+          described_class.call(params: { q: "hildtag", filterForInput: true }, **dependencies)
+        expect(result[:tags].map { |t| t[:name] }).not_to include("childtag")
       end
     end
 


### PR DESCRIPTION
When typing in the composer's tag field, the autocomplete also surfaces tags that match the term but can't currently be used, shown greyed-out with an explanation of why. Two things made these suggestions confusing — e.g. typing "know" surfaced "chat-v-unknown" with a baffling reason.

Why:
- Matching was done on substrings, so "know" matched the "know" inside "unknown" and dragged in unrelated tags. It now matches only at a word boundary, so "know" still finds "knowledge-base" but no longer "chat-v-unknown" — the balance between showing too much and too little.
- The reasons assumed familiarity with "tag groups", which users often don't have (or can't even see). They are reworded to be self-explanatory and actionable, and the one-per-topic conflict now names the conflicting tag(s) instead of an opaque group.

How:
- `Tags::Search#append_disabled_tags` matches candidates with `tags.name ~* '\m<term>'` (Postgres word-start anchor) instead of a `position(...)` substring match.
- `Tags::Search#explain_exclusion` resolves the already-selected sibling tag(s) for one-per-topic conflicts and passes them to the message.
- English strings are reworded below; the Ruby still passes the previous interpolation variables so untranslated locales keep rendering until they are updated.
- Specs updated for the new wording, with added regression coverage for word-boundary vs mid-word matching.

Reworded reasons (`tags.forbidden.*` in `config/locales/server.en.yml`):

  missing_parent_tag
    before: Requires the "%{parent_tag_name}" tag to use tags from the "%{tag_group_name}" group
    after:  Available after adding the "%{parent_tag_name}" tag

  one_tag_per_topic_group
    before: Only one tag from the "%{tag_group_name}" group is allowed per topic
    after:  Conflicts with "%{tag_names}" (only one allowed per topic)

  in_this_category
    before: "%{tag_name}" cannot be used in this category
    after:  Can't be used in this category

  not_allowed
    before: "%{tag_name}" cannot be used
    after:  Can't be used

  restricted_to.one
    before: "%{tag_name}" is restricted to the "%{category_names}" category
    after:  Only available in the "%{category_names}" category

  restricted_to.other
    before: "%{tag_name}" is restricted to the following categories: %{category_names}
    after:  Only available in: %{category_names}

  restricted_to_truncated
    before: "%{tag_name}" is restricted to the following categories: %{category_names}, and %{more_count} more
    after:  Only available in: %{category_names}, and %{more_count} more

  synonym
    before: This is a synonym for "%{tag_name}". Use "%{tag_name}" instead.
    after:  Please use "%{tag_name}" instead

Ref - t/184946