### PR TITLE
FIX: Reset topic tracking when an attendee leaves an event

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -22,6 +22,8 @@ module DiscoursePostEvent
     scope :open, -> { where(closed: false) }
 
     before_save :chat_channel_sync
+    # prepend so it runs before `dependent: :delete_all` wipes the invitees
+    before_destroy :reset_invitees_topic_tracking, prepend: true
     after_commit :destroy_topic_custom_field, on: %i[destroy]
     after_commit :create_or_update_event_date, on: %i[create update]
     after_save do
@@ -301,7 +303,10 @@ module DiscoursePostEvent
     end
 
     def enforce_private_invitees!
-      invitees.where.not(user_id: fetch_users.select(:id)).delete_all
+      pruned = invitees.where.not(user_id: fetch_users.select(:id))
+      pruned_user_ids = pruned.pluck(:user_id)
+      pruned.delete_all
+      Invitee.reset_topic_tracking!(user_ids: pruned_user_ids, topic_id: post.topic_id)
     end
 
     def can_user_update_attendance?(user)
@@ -517,6 +522,13 @@ module DiscoursePostEvent
     end
 
     private
+
+    def reset_invitees_topic_tracking
+      topic_id = post&.topic_id
+      return if topic_id.nil?
+
+      Invitee.reset_topic_tracking!(user_ids: invitees.pluck(:user_id), topic_id:)
+    end
 
     def dates_changed?
       saved_change_to_original_starts_at || saved_change_to_original_ends_at

--- a/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
@@ -20,6 +20,7 @@ module DiscoursePostEvent
     scope :with_status, ->(status) { where(status: Invitee.statuses[status]) }
 
     before_save :clear_recurring_unless_going
+    after_destroy :reset_topic_tracking!
     after_commit :sync_chat_channel_members
 
     def self.statuses
@@ -70,14 +71,31 @@ module DiscoursePostEvent
       )
     end
 
+    def self.reset_topic_tracking!(user_ids:, topic_id:)
+      user_ids = Array(user_ids)
+      return if user_ids.empty? || topic_id.nil?
+
+      TopicUser
+        .where(topic_id:, user_id: user_ids)
+        .where(
+          notification_level: [
+            TopicUser.notification_levels[:watching],
+            TopicUser.notification_levels[:tracking],
+          ],
+        )
+        .update_all(
+          notification_level: TopicUser.notification_levels[:regular],
+          notifications_reason_id: TopicUser.notification_reasons[:user_changed],
+          notifications_changed_at: Time.zone.now,
+        )
+    end
+
     def sync_chat_channel_members
       return if !event.chat_enabled?
       ChatChannelSync.sync(event)
     end
 
     def update_topic_tracking!
-      topic_id = event.post.topic.id
-      user_id = user.id
       tracking = :regular
 
       case status
@@ -87,14 +105,25 @@ module DiscoursePostEvent
         tracking = :tracking
       end
 
-      TopicUser.change(
-        user_id,
-        topic_id,
-        notification_level: TopicUser.notification_levels[tracking],
-      )
+      change_topic_tracking!(tracking)
+    end
+
+    def reset_topic_tracking!
+      self.class.reset_topic_tracking!(user_ids: user_id, topic_id: event&.post&.topic_id)
     end
 
     private
+
+    def change_topic_tracking!(tracking)
+      topic = event&.post&.topic
+      return if topic.nil?
+
+      TopicUser.change(
+        user_id,
+        topic.id,
+        notification_level: TopicUser.notification_levels[tracking],
+      )
+    end
 
     def clear_recurring_unless_going
       self.recurring = false unless going?

--- a/plugins/discourse-calendar/spec/integration/invitee_spec.rb
+++ b/plugins/discourse-calendar/spec/integration/invitee_spec.rb
@@ -14,6 +14,77 @@ describe DiscoursePostEvent::Invitee do
   let(:post1) { Fabricate(:post, topic: topic) }
   let(:post_event) { Fabricate(:event, post: post1) }
 
+  describe "topic tracking" do
+    before { post_event.create_invitees([{ user_id: user_1.id, status: nil }]) }
+
+    let(:invitee) { post_event.invitees.find_by(user_id: user_1.id) }
+
+    def notification_level
+      TopicUser.find_by(user: user_1, topic: topic)&.notification_level
+    end
+
+    it "resets the topic tracking to regular when the invitee is destroyed" do
+      invitee.update_attendance!(:going)
+      expect(notification_level).to eq(TopicUser.notification_levels[:watching])
+
+      invitee.destroy!
+
+      expect(notification_level).to eq(TopicUser.notification_levels[:regular])
+    end
+
+    it "does not create a topic tracking record when none exists" do
+      expect(TopicUser.exists?(user: user_1, topic: topic)).to eq(false)
+
+      invitee.destroy!
+
+      expect(TopicUser.exists?(user: user_1, topic: topic)).to eq(false)
+    end
+
+    it "leaves a muted topic untouched when the invitee is destroyed" do
+      TopicUser.change(
+        user_1.id,
+        topic.id,
+        notification_level: TopicUser.notification_levels[:muted],
+      )
+
+      invitee.destroy!
+
+      expect(notification_level).to eq(TopicUser.notification_levels[:muted])
+    end
+
+    describe ".reset_topic_tracking!" do
+      it "downgrades watching/tracking rows to regular" do
+        TopicUser.change(
+          user_1.id,
+          topic.id,
+          notification_level: TopicUser.notification_levels[:watching],
+        )
+
+        described_class.reset_topic_tracking!(user_ids: user_1.id, topic_id: topic.id)
+
+        expect(notification_level).to eq(TopicUser.notification_levels[:regular])
+      end
+
+      it "leaves muted rows untouched" do
+        TopicUser.change(
+          user_1.id,
+          topic.id,
+          notification_level: TopicUser.notification_levels[:muted],
+        )
+
+        described_class.reset_topic_tracking!(user_ids: user_1.id, topic_id: topic.id)
+
+        expect(notification_level).to eq(TopicUser.notification_levels[:muted])
+      end
+
+      it "does not create a record when none exists" do
+        described_class.reset_topic_tracking!(user_ids: user_1.id, topic_id: topic.id)
+
+        expect(TopicUser.exists?(user: user_1, topic: topic)).to eq(false)
+      end
+    end
+  end
+
   context "when a user is destroyed" do
     context "when the user is an invitee to an event" do
       before { post_event.create_invitees([{ user_id: user_1.id, status: nil }]) }

--- a/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/bulk_invite_spec.rb
+++ b/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/bulk_invite_spec.rb
@@ -140,6 +140,36 @@ describe Jobs::DiscoursePostEventBulkInvite do
             expect(invitee_klass.find_by(user_id: group_1.users[1].id)).to be(nil)
           end
 
+          it "resets topic tracking when an attendee is set to unknown" do
+            invitee_klass = DiscoursePostEvent::Invitee
+
+            Jobs::DiscoursePostEventBulkInvite.new.execute(
+              event_id: post_event_1.id,
+              invitees: [{ "identifier" => group_1.name, "attendance" => "going" }],
+              current_user_id: user_1.id,
+            )
+            # simulate the watching tracking set through the normal attendance flow
+            invitee_klass.where(post_id: post_1.id).find_each(&:update_topic_tracking!)
+            group_1.users.each do |u|
+              expect(TopicUser.find_by(user: u, topic: topic_1).notification_level).to eq(
+                TopicUser.notification_levels[:watching],
+              )
+            end
+
+            Jobs::DiscoursePostEventBulkInvite.new.execute(
+              event_id: post_event_1.id,
+              invitees: [{ "identifier" => group_1.name, "attendance" => "unknown" }],
+              current_user_id: user_1.id,
+            )
+
+            expect(invitee_klass.count).to eq(0)
+            group_1.users.each do |u|
+              expect(TopicUser.find_by(user: u, topic: topic_1).notification_level).to eq(
+                TopicUser.notification_levels[:regular],
+              )
+            end
+          end
+
           it "sets the attendance to going by default" do
             SystemMessage.expects(:create_from_system_user).with(
               user_1,

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -601,6 +601,47 @@ describe DiscoursePostEvent::Event do
           }
         end
       end
+
+      context "when an invitee is no longer allowed" do
+        let(:group_2) { Fabricate(:group) }
+
+        it "resets the pruned invitee's topic tracking" do
+          event_1.invitees.find_by(user_id: user_1.id).update_attendance!(:going)
+          expect(TopicUser.find_by(user: user_1, topic: post_1.topic).notification_level).to eq(
+            TopicUser.notification_levels[:watching],
+          )
+
+          event_1.update_with_params!(raw_invitees: [group_2.name])
+
+          expect(event_1.invitees.find_by(user_id: user_1.id)).to be_nil
+          expect(TopicUser.find_by(user: user_1, topic: post_1.topic).notification_level).to eq(
+            TopicUser.notification_levels[:regular],
+          )
+        end
+      end
+    end
+  end
+
+  describe "resetting topic tracking when the event is destroyed" do
+    fab!(:user_1, :user)
+    fab!(:topic_1, :topic)
+    fab!(:post_1) { Fabricate(:post, topic: topic_1) }
+    fab!(:event_1) { Fabricate(:event, post: post_1) }
+
+    before { event_1.create_invitees([{ user_id: user_1.id, status: 0 }]) }
+
+    it "resets a watching invitee back to regular, leaving the topic intact" do
+      event_1.invitees.find_by(user_id: user_1.id).update_attendance!(:going)
+      expect(TopicUser.find_by(user: user_1, topic: topic_1).notification_level).to eq(
+        TopicUser.notification_levels[:watching],
+      )
+
+      event_1.destroy!
+
+      expect(Topic.exists?(topic_1.id)).to eq(true)
+      expect(TopicUser.find_by(user: user_1, topic: topic_1).notification_level).to eq(
+        TopicUser.notification_levels[:regular],
+      )
     end
   end
 

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/destroy_invitee_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/destroy_invitee_spec.rb
@@ -113,6 +113,16 @@ RSpec.describe(DiscoursePostEvent::DestroyInvitee) do
         expect { result }.to change { DiscoursePostEvent::Invitee.count }.by(-1)
         expect(DiscoursePostEvent::Invitee.exists?(invitee.id)).to eq(false)
       end
+
+      it "resets the invitee's topic tracking to regular" do
+        invitee.update_topic_tracking!
+        topic_user = TopicUser.find_by(user: invitee_user, topic: topic)
+        expect(topic_user.notification_level).to eq(TopicUser.notification_levels[:watching])
+
+        result
+
+        expect(topic_user.reload.notification_level).to eq(TopicUser.notification_levels[:regular])
+      end
     end
 
     context "when staff destroys another user's invitee" do


### PR DESCRIPTION
Previously, leaving an event (or being removed from one) left the topic stuck at the "watching" or "tracking" notification level the attendance had set, so people kept getting notified about events they no longer attended.

This resets topic tracking back to regular when an invitee is removed, covering both the per-user paths (leaving, bulk-invite "unknown", account deletion) and the bulk `delete_all` paths (private event re-scoping, event teardown). It only downgrades watching/tracking, so muted topics and unrelated tracking choices are left alone.