### PR TITLE
FEATURE: Splash Screen Lifecycle API

### DIFF
--- a/app/views/common/_discourse_splash.html.erb
+++ b/app/views/common/_discourse_splash.html.erb
@@ -15,6 +15,7 @@
       }
 
       #d-splash {
+        --splash-bg-color: #<%= light_color_hex_for_name("secondary") %>;
         --dot-color: #<%= light_color_hex_for_name("tertiary") %>;
         <%- if custom_splash_screen_enabled? %>
           <%- if splash_screen_image_animated? %>
@@ -32,6 +33,7 @@
       }
 
       #d-splash {
+        --splash-bg-color: #<%= light_color_hex_for_name("secondary") %>;
         --dot-color: #<%= light_color_hex_for_name("tertiary") %>;
         <%- if custom_splash_screen_enabled? %>
           <%- if splash_screen_image_animated? %>
@@ -49,6 +51,7 @@
       }
 
       #d-splash {
+        --splash-bg-color: #<%= dark_color_hex_for_name("secondary") %>;
         --dot-color: #<%= dark_color_hex_for_name("tertiary") %>;
         <%- if custom_splash_screen_enabled? %>
           <%- if splash_screen_image_animated? %>
@@ -70,6 +73,7 @@
         }
 
         #d-splash {
+          --splash-bg-color: #<%= light_color_hex_for_name("secondary") %>;
           --dot-color: #<%= light_color_hex_for_name("tertiary") %>;
           <%- if custom_splash_screen_enabled? %>
             <%- if splash_screen_image_animated? %>
@@ -90,6 +94,7 @@
         }
 
         #d-splash {
+          --splash-bg-color: #<%= dark_color_hex_for_name("secondary") %>;
           --dot-color: #<%= dark_color_hex_for_name("tertiary") %>;
           <%- if custom_splash_screen_enabled? %>
             <%- if splash_screen_image_animated? %>
@@ -113,6 +118,7 @@
       width: 100vw;
       height: 100dvh;
       z-index: 1001;
+      background-color: var(--splash-bg-color);
     }
 
     #d-splash .preloader-image {

--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -8,7 +8,6 @@ import "./module-shims";
 import "./discourse-common-loader-shims";
 import embroiderCompatModules from "@embroider/virtual/compat-modules";
 import { registerDiscourseImplicitInjections } from "discourse/lib/implicit-injections";
-import { removeSplashScreen } from "discourse/lib/splash-screen";
 import { defineModules } from "./lib/loader-shim";
 
 // Register Discourse's standard implicit injections on common framework classes.
@@ -161,7 +160,6 @@ class Discourse extends Application {
 
   ready() {
     performance.mark("discourse-ready");
-    removeSplashScreen();
   }
 }
 

--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -8,6 +8,7 @@ import "./module-shims";
 import "./discourse-common-loader-shims";
 import embroiderCompatModules from "@embroider/virtual/compat-modules";
 import { registerDiscourseImplicitInjections } from "discourse/lib/implicit-injections";
+import { removeSplashScreen } from "discourse/lib/splash-screen";
 import { defineModules } from "./lib/loader-shim";
 
 // Register Discourse's standard implicit injections on common framework classes.
@@ -160,6 +161,7 @@ class Discourse extends Application {
 
   ready() {
     performance.mark("discourse-ready");
+    removeSplashScreen();
   }
 }
 

--- a/frontend/discourse/app/instance-initializers/remove-splash.js
+++ b/frontend/discourse/app/instance-initializers/remove-splash.js
@@ -1,9 +1,9 @@
+import { removeSplashScreen } from "discourse/lib/splash-screen";
+
 export default {
   initialize(owner) {
     owner
       .lookup("service:router")
-      .one("routeDidChange", () =>
-        document.querySelector("#d-splash")?.remove()
-      );
+      .one("routeDidChange", () => removeSplashScreen());
   },
 };

--- a/frontend/discourse/app/lib/splash-screen.js
+++ b/frontend/discourse/app/lib/splash-screen.js
@@ -1,23 +1,20 @@
-let holds = new Map();
+const waiters = new Set();
 
-export function holdSplashScreen(name) {
-  const token = Symbol(name);
-  holds.set(token, name);
+export function registerSplashScreenWaiter(callback) {
+  waiters.add(callback);
 
   return function release() {
-    holds.delete(token);
-    removeSplashScreen();
+    waiters.delete(callback);
   };
 }
 
-export function removeSplashScreen() {
-  if (holds.size > 0) {
-    return;
-  }
+export async function removeSplashScreen() {
+  const promises = [...waiters].map((callback) => callback());
 
+  await Promise.allSettled(promises);
   document.querySelector("#d-splash")?.remove();
 }
 
-export function __resetHolds() {
-  holds = new Map();
+export function __resetWaiters() {
+  waiters.clear();
 }

--- a/frontend/discourse/app/lib/splash-screen.js
+++ b/frontend/discourse/app/lib/splash-screen.js
@@ -1,0 +1,23 @@
+let holds = new Map();
+
+export function holdSplashScreen(name) {
+  const token = Symbol(name);
+  holds.set(token, name);
+
+  return function release() {
+    holds.delete(token);
+    removeSplashScreen();
+  };
+}
+
+export function removeSplashScreen() {
+  if (holds.size > 0) {
+    return;
+  }
+
+  document.querySelector("#d-splash")?.remove();
+}
+
+export function __resetHolds() {
+  holds = new Map();
+}

--- a/frontend/discourse/tests/unit/lib/splash-screen-test.js
+++ b/frontend/discourse/tests/unit/lib/splash-screen-test.js
@@ -1,11 +1,23 @@
 import { module, test } from "qunit";
 import {
-  __resetHolds,
-  holdSplashScreen,
+  __resetWaiters,
+  registerSplashScreenWaiter,
   removeSplashScreen,
 } from "discourse/lib/splash-screen";
 
-module("Unit | lib | splash-screen", function (hooks) {
+module("Unit | Lib | splash-screen", function (hooks) {
+  function deferred() {
+    let resolve;
+    let reject;
+
+    const promise = new Promise((promiseResolve, promiseReject) => {
+      resolve = promiseResolve;
+      reject = promiseReject;
+    });
+
+    return { promise, resolve, reject };
+  }
+
   hooks.beforeEach(function () {
     const splash = document.createElement("div");
     splash.id = "d-splash";
@@ -14,93 +26,76 @@ module("Unit | lib | splash-screen", function (hooks) {
 
   hooks.afterEach(function () {
     document.querySelector("#d-splash")?.remove();
-    __resetHolds();
+    __resetWaiters();
   });
 
-  test("removeSplashScreen removes #d-splash when there are no holds", function (assert) {
-    removeSplashScreen();
+  test("removeSplashScreen removes #d-splash when there are no waiters", async function (assert) {
+    const waiter = deferred();
+    registerSplashScreenWaiter(() => waiter.promise);
 
-    assert.strictEqual(
-      document.querySelector("#d-splash"),
-      null,
-      "The splash screen should be removed when there are no holds"
-    );
-  });
-
-  test("removeSplashScreen does not remove #d-splash when holds are active", function (assert) {
-    const release = holdSplashScreen("test-hold");
-    removeSplashScreen();
+    const removal = removeSplashScreen();
 
     assert.notStrictEqual(
       document.querySelector("#d-splash"),
       null,
-      "The splash screen should not be removed when holds are active"
+      "The splash screen should not be removed while waiters are pending"
     );
 
-    release();
-  });
-
-  test("the splash is removed only after every hold is released", function (assert) {
-    const release1 = holdSplashScreen("hold-1");
-    const release2 = holdSplashScreen("hold-2");
-
-    release1();
-
-    assert.notStrictEqual(
-      document.querySelector("#d-splash"),
-      null,
-      "The splash screen should not be removed until all holds are released"
-    );
-
-    release2();
+    waiter.resolve();
+    await removal;
 
     assert.strictEqual(
       document.querySelector("#d-splash"),
       null,
-      "The splash screen should be removed after all holds are released"
+      "The splash screen should be removed when there are no waiters"
     );
   });
 
-  test("release functions can only release their own hold once", function (assert) {
-    const release1 = holdSplashScreen("hold-1");
-    const release2 = holdSplashScreen("hold-2");
+  test("removeSplashScreen waits for every registered waiter", async function (assert) {
+    const waiter1 = deferred();
+    const waiter2 = deferred();
 
-    release1();
-    release1();
+    registerSplashScreenWaiter(() => waiter1.promise);
+    registerSplashScreenWaiter(() => waiter2.promise);
+
+    const removal = removeSplashScreen();
+
+    waiter1.resolve();
+    await Promise.resolve();
 
     assert.notStrictEqual(
       document.querySelector("#d-splash"),
       null,
-      "The splash screen should not be removed until all holds are released"
+      "The splash screen should not be removed until all waiters are resolved"
     );
 
-    release2();
+    waiter2.resolve();
+    await removal;
 
     assert.strictEqual(
       document.querySelector("#d-splash"),
       null,
-      "The splash screen should be removed after all holds are released"
+      "The splash screen should be removed when all waiters are resolved"
     );
   });
 
-  test("holds with the same name are tracked separately", function (assert) {
-    const release1 = holdSplashScreen("same-name");
-    const release2 = holdSplashScreen("same-name");
+  test("removeSplashScreen removes #d-splash even if some waiters reject", async function (assert) {
+    const waiter1 = deferred();
+    const waiter2 = deferred();
 
-    release1();
+    registerSplashScreenWaiter(() => waiter1.promise);
+    registerSplashScreenWaiter(() => waiter2.promise);
 
-    assert.notStrictEqual(
-      document.querySelector("#d-splash"),
-      null,
-      "The splash screen should not be removed until all holds are released"
-    );
+    const removal = removeSplashScreen();
 
-    release2();
+    waiter1.reject(new Error("Something went wrong"));
+    waiter2.resolve();
+    await removal;
 
     assert.strictEqual(
       document.querySelector("#d-splash"),
       null,
-      "The splash screen should be removed after all holds are released"
+      "The splash screen should be removed even if some waiters reject"
     );
   });
 });

--- a/frontend/discourse/tests/unit/lib/splash-screen-test.js
+++ b/frontend/discourse/tests/unit/lib/splash-screen-test.js
@@ -1,0 +1,106 @@
+import { module, test } from "qunit";
+import {
+  __resetHolds,
+  holdSplashScreen,
+  removeSplashScreen,
+} from "discourse/lib/splash-screen";
+
+module("Unit | lib | splash-screen", function (hooks) {
+  hooks.beforeEach(function () {
+    const splash = document.createElement("div");
+    splash.id = "d-splash";
+    document.body.appendChild(splash);
+  });
+
+  hooks.afterEach(function () {
+    document.querySelector("#d-splash")?.remove();
+    __resetHolds();
+  });
+
+  test("removeSplashScreen removes #d-splash when there are no holds", function (assert) {
+    removeSplashScreen();
+
+    assert.strictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should be removed when there are no holds"
+    );
+  });
+
+  test("removeSplashScreen does not remove #d-splash when holds are active", function (assert) {
+    const release = holdSplashScreen("test-hold");
+    removeSplashScreen();
+
+    assert.notStrictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should not be removed when holds are active"
+    );
+
+    release();
+  });
+
+  test("the splash is removed only after every hold is released", function (assert) {
+    const release1 = holdSplashScreen("hold-1");
+    const release2 = holdSplashScreen("hold-2");
+
+    release1();
+
+    assert.notStrictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should not be removed until all holds are released"
+    );
+
+    release2();
+
+    assert.strictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should be removed after all holds are released"
+    );
+  });
+
+  test("release functions can only release their own hold once", function (assert) {
+    const release1 = holdSplashScreen("hold-1");
+    const release2 = holdSplashScreen("hold-2");
+
+    release1();
+    release1();
+
+    assert.notStrictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should not be removed until all holds are released"
+    );
+
+    release2();
+
+    assert.strictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should be removed after all holds are released"
+    );
+  });
+
+  test("holds with the same name are tracked separately", function (assert) {
+    const release1 = holdSplashScreen("same-name");
+    const release2 = holdSplashScreen("same-name");
+
+    release1();
+
+    assert.notStrictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should not be removed until all holds are released"
+    );
+
+    release2();
+
+    assert.strictEqual(
+      document.querySelector("#d-splash"),
+      null,
+      "The splash screen should be removed after all holds are released"
+    );
+  });
+});


### PR DESCRIPTION
This adds a small splash screen lifecycle API so boot-time code and plugins can temporarily hold the server-rendered splash screen and release it when its own startup or hold work is complete.

Used tokens for unique identifiers so that names won't clash and will respect multiple holds of the same name. Caller in charge of releasing the hold after work is complete.