### PR TITLE
FEATURE: Localize local oneboxes

### DIFF
--- a/app/jobs/regular/process_localized_cooked.rb
+++ b/app/jobs/regular/process_localized_cooked.rb
@@ -13,6 +13,14 @@ module Jobs
         post = post_localization.post
         return if post.blank? || post.topic.blank?
 
+        # On rebake the stored cooked already holds rendered onebox cards, so
+        # re-cook from raw first to restore the a.onebox links the processor
+        # re-renders (now in the reader's locale). No content is re-translated.
+        if args[:recook]
+          recooked = post.post_analyzer.cook(post_localization.raw, post.cooking_options || {})
+          post_localization.update_column(:cooked, recooked) if recooked.present?
+        end
+
         processor = LocalizedCookedPostProcessor.new(post_localization, post, {})
         processor.post_process
         cooked = processor.html.strip

--- a/app/models/concerns/localizable.rb
+++ b/app/models/concerns/localizable.rb
@@ -8,12 +8,16 @@ module Localizable
   # Returns the localization for (in order of priority):
   # - the given locale,
   # - or the best match if an exact match is not found
-  # - or the site default locale if `content_localization_use_default_locale_when_unsupported` enabled
+  # - or the site default locale if `content_localization_use_default_locale_when_unsupported`
+  #   is enabled and +fallback+ is true
+  #
+  # Pass `fallback: false` when falling back to a different language would be
+  # wrong
   #
   # The query used to find the localization is optimized for performance, and assumes
   # that localizations are indexed by locale, and have been preloaded.
   # @return [Localization, nil] the localization object for the given locale, or nil if no match is found.
-  def get_localization(locale = I18n.locale)
+  def get_localization(locale = I18n.locale, fallback: true)
     locale_str = locale.to_s.sub("-", "_")
 
     # prioritise exact match
@@ -24,6 +28,8 @@ module Localizable
     if match = localizations.find { |l| LocaleNormalizer.is_same?(l.locale, locale_str) }
       return match
     end
+
+    return if !fallback
 
     if SiteSetting.content_localization_use_default_locale_when_unsupported
       default_locale = SiteSetting.default_locale.to_s.sub("-", "_")

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -878,6 +878,8 @@ class Post < ActiveRecord::Base
     TopicLink.extract_from(self)
     QuotedPost.extract_from(self)
 
+    rebake_localizations!
+
     trigger_post_process(bypass_bump: true, priority:)
 
     # Skip publishing if invalidating oneboxes - the ProcessPost job will
@@ -887,6 +889,14 @@ class Post < ActiveRecord::Base
     publish_change_to_clients!(:rebaked) if should_publish
 
     new_cooked != old_cooked
+  end
+
+  def rebake_localizations!
+    return if !SiteSetting.content_localization_enabled
+
+    localizations.find_each do |localization|
+      Jobs.enqueue(:process_localized_cooked, post_localization_id: localization.id, recook: true)
+    end
   end
 
   def set_owner(new_user, actor, skip_revision = false)

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -101,7 +101,8 @@ class PostSerializer < BasicPostSerializer
              :locale,
              :is_localized,
              :language,
-             :localization_outdated
+             :localization_outdated,
+             :localized_oneboxes
 
   def initialize(object, opts)
     super(object, opts)
@@ -275,6 +276,16 @@ class PostSerializer < BasicPostSerializer
       result[:clicks] = link[:clicks] || 0
       result
     end
+  end
+
+  def localized_oneboxes
+    @topic_view.localized_oneboxes[object.id]
+  end
+
+  def include_localized_oneboxes?
+    SiteSetting.content_localization_enabled && @topic_view.present? &&
+      !ContentLocalization.show_original?(scope) &&
+      @topic_view.localized_oneboxes[object.id].present?
   end
 
   def read

--- a/frontend/discourse/app/components/post/cooked-html.gjs
+++ b/frontend/discourse/app/components/post/cooked-html.gjs
@@ -9,6 +9,7 @@ import { bind } from "discourse/lib/decorators";
 import { isRailsTesting, isTesting } from "discourse/lib/environment";
 import { makeArray } from "discourse/lib/helpers";
 import decorateLinkCounts from "discourse/lib/post-cooked-html-decorators/link-counts";
+import decorateLocalizedOneboxes from "discourse/lib/post-cooked-html-decorators/localized-oneboxes";
 import decorateMentions from "discourse/lib/post-cooked-html-decorators/mentions";
 import decorateQuoteControls from "discourse/lib/post-cooked-html-decorators/quote-controls";
 import decorateSearchHighlight from "discourse/lib/post-cooked-html-decorators/search-highlight";
@@ -24,6 +25,7 @@ const detachedDocument = document.implementation.createHTMLDocument("detached");
 
 const POST_COOKED_DECORATORS = [
   decorateStatefulHtmlElements,
+  decorateLocalizedOneboxes,
   decorateQuoteControls,
   decorateLinkCounts,
   decorateSearchHighlight,

--- a/frontend/discourse/app/lib/post-cooked-html-decorators/localized-oneboxes.js
+++ b/frontend/discourse/app/lib/post-cooked-html-decorators/localized-oneboxes.js
@@ -1,0 +1,40 @@
+// Swaps the title and preview of internal topic onebox cards with the reader's
+// language when the post is shown in its original form (see PostSerializer
+// #localized_oneboxes). Same-topic inline quotes carry a data-username and are
+// left untouched. Runs before quote-controls so the rendered quote component
+// picks up the already-localized text.
+//
+// title and excerpt are server-rendered, sanitized HTML (HTML-escaped text with
+// emoji <img> tags), matching the baked onebox card, so both are assigned via
+// innerHTML — textContent would show emoji markup as literal text.
+export default function decorateLocalizedOneboxes(element, context) {
+  const { post } = context;
+
+  const localized = post.localized_oneboxes;
+  if (!localized?.length) {
+    return;
+  }
+
+  for (const { topic_id, post_number, title, excerpt } of localized) {
+    const selector = `aside.quote[data-topic="${topic_id}"][data-post="${post_number}"]:not([data-username])`;
+
+    element.querySelectorAll(selector).forEach((aside) => {
+      if (title) {
+        // the title link, not the category badge that also lives in .title
+        const titleLink =
+          aside.querySelector(".quote-title__text-content a[href]") ??
+          aside.querySelector(".title a[href]");
+        if (titleLink) {
+          titleLink.innerHTML = title;
+        }
+      }
+
+      if (excerpt) {
+        const blockquote = aside.querySelector("blockquote");
+        if (blockquote) {
+          blockquote.innerHTML = excerpt;
+        }
+      }
+    });
+  }
+}

--- a/frontend/discourse/app/models/post.js
+++ b/frontend/discourse/app/models/post.js
@@ -169,6 +169,7 @@ export default class Post extends RestModel {
   @tracked likeAction;
   @tracked link_counts;
   @tracked localization_outdated;
+  @tracked localized_oneboxes;
   @tracked locked;
   @tracked moderator;
   @tracked name;

--- a/frontend/discourse/tests/integration/components/post/cooked-html-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/cooked-html-test.gjs
@@ -44,6 +44,72 @@ module("Integration | Component | Post | PostCookedHtml", function (hooks) {
     assert.dom("blockquote").hasText("abcd");
   });
 
+  test("localizes internal onebox cards using localized_oneboxes", async function (assert) {
+    this.post.cooked = `<aside class="quote" data-post="2" data-topic="55">
+      <div class="title">
+        <div class="quote-controls"></div>
+        <div class="quote-title__text-content"><a href="/t/sun/55/2">Original Title</a></div>
+      </div>
+      <blockquote>Original preview</blockquote>
+    </aside>`;
+    this.post.localized_oneboxes = [
+      {
+        topic_id: 55,
+        post_number: 2,
+        title: "孫子の兵法",
+        excerpt: "戦わずして勝つ",
+      },
+    ];
+
+    await renderComponent(this.post);
+
+    assert
+      .dom("aside.quote .title")
+      .includesText("孫子の兵法")
+      .doesNotIncludeText("Original Title");
+    assert.dom("aside.quote blockquote").includesText("戦わずして勝つ");
+  });
+
+  test("swaps only the title when no excerpt is provided", async function (assert) {
+    this.post.cooked = `<aside class="quote" data-post="1" data-topic="55">
+      <div class="title">
+        <div class="quote-controls"></div>
+        <div class="quote-title__text-content"><a href="/t/sun/55/1">Original Title</a></div>
+      </div>
+      <blockquote>Original preview</blockquote>
+    </aside>`;
+    this.post.localized_oneboxes = [
+      { topic_id: 55, post_number: 1, title: "孫子の兵法" },
+    ];
+
+    await renderComponent(this.post);
+
+    assert.dom("aside.quote .title").includesText("孫子の兵法");
+    assert.dom("aside.quote blockquote").includesText("Original preview");
+  });
+
+  test("leaves same-topic inline quotes (with data-username) untouched", async function (assert) {
+    this.post.cooked = `<aside class="quote" data-username="sun" data-post="2" data-topic="55">
+      <div class="title"><div class="quote-controls"></div>sun:</div>
+      <blockquote>Original preview</blockquote>
+    </aside>`;
+    this.post.localized_oneboxes = [
+      {
+        topic_id: 55,
+        post_number: 2,
+        title: "孫子の兵法",
+        excerpt: "戦わずして勝つ",
+      },
+    ];
+
+    await renderComponent(this.post);
+
+    assert
+      .dom("aside.quote blockquote")
+      .includesText("Original preview")
+      .doesNotIncludeText("戦わずして勝つ");
+  });
+
   test("it keeps the opened state of the `details` tag between renders", async function (assert) {
     this.post.cooked = `<details><summary>Quote Summary</summary><p>Quote Content</p></details>`;
 

--- a/lib/content_localization/onebox_localizer.rb
+++ b/lib/content_localization/onebox_localizer.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+class ContentLocalization
+  # Builds, per post, the localized title/preview for internal topic oneboxes
+  # whose linked topic or post has a translation in the reader's locale and that
+  # the reader is allowed to see. The frontend swaps this text into the onebox
+  # card for original posts the reader sees in their own language (see the
+  # localized-oneboxes cooked decorator). Posts shown translated already carry
+  # localized cards baked into their cooked HTML (see LocalizedCookedPostProcessor),
+  # so they are skipped here.
+  #
+  # Returns { post_id => [{ topic_id:, post_number:, title:, excerpt: }, ...] }.
+  # title and excerpt are each present only when that part has a translation, so
+  # a translated title can sit above an untranslated preview.
+  #
+  # NOTE: this deliberately does not honour the "show original" preference — the
+  # guardian passed in (from TopicView) has no request, so it cannot read the
+  # anonymous show-original cookie. PostSerializer#include_localized_oneboxes? is
+  # the authoritative gate for that (it has the request-aware scope). Any new
+  # caller must apply the same gate.
+  class OneboxLocalizer
+    def self.build(...)
+      new(...).build
+    end
+
+    # @param posts [Array<Post>] the posts on the page
+    # @param guardian [Guardian] the reader's guardian (visibility only)
+    # @param category [Category, nil] the category of the topic being viewed
+    # @param locale the reader's locale
+    def initialize(posts:, guardian:, category:, locale: I18n.locale)
+      @posts = posts
+      @guardian = guardian
+      @category = category
+      @locale = locale
+    end
+
+    def build
+      # Skip only posts actually rendered with their translated cooked (which
+      # already carries Path-1-localized cards) — i.e. the same condition as
+      # PostSerializer#is_localized. A post that is eligible for translation but
+      # has none is still served with its original cooked (BasicPostSerializer
+      # falls back), so its oneboxes still need localizing here.
+      source_posts =
+        @posts.reject do |post|
+          ContentLocalization.show_translated_post?(post, @guardian) &&
+            post.has_localization?(@locale)
+        end
+      return {} if source_posts.empty?
+
+      # Internal links the reader's post points at, excluding inbound reflections.
+      # We deliberately do not filter on the `quote` flag: an internal onebox
+      # card is only `quote: true` once it has been re-extracted from the baked
+      # cooked, so a freshly rebaked post can carry `quote: false` for a real
+      # card. The frontend decorator is the authority — it only swaps actual
+      # `aside.quote` cards — so any extra inline-link rows here are harmless.
+      links =
+        TopicLink
+          .where(post_id: source_posts.map(&:id), internal: true, reflection: false)
+          .where.not(link_topic_id: nil)
+          .pluck(:post_id, :link_topic_id, :link_post_id)
+          .uniq
+      return {} if links.empty?
+
+      topic_ids = links.map { |l| l[1] }.uniq
+      topics_by_id =
+        Topic
+          .where(id: topic_ids, archetype: Archetype.default, deleted_at: nil)
+          .includes(:category)
+          .index_by(&:id)
+
+      linked_posts = linked_posts_for(links)
+      visible_topic_ids = topics_by_id.values.select { |topic| visible?(topic) }.map(&:id).to_set
+      titles = localized_titles(topic_ids)
+      cooked = localized_cooked(linked_posts.values.map(&:id).uniq)
+
+      result = {}
+
+      links.each do |source_post_id, link_topic_id, link_post_id|
+        topic = topics_by_id[link_topic_id]
+        next if topic.nil? || !visible_topic_ids.include?(topic.id)
+
+        linked_post = linked_posts[link_post_id || [:first, link_topic_id]]
+        next if linked_post.nil? || linked_post.topic_id != topic.id
+
+        title =
+          if ContentLocalization.show_translated_topic?(topic, @guardian)
+            titles[topic.id].presence
+          end
+
+        excerpt_cooked =
+          if ContentLocalization.show_translated_post?(linked_post, @guardian)
+            cooked[linked_post.id].presence
+          end
+
+        next if title.blank? && excerpt_cooked.blank?
+
+        entry = { topic_id: topic.id, post_number: linked_post.post_number }
+        # escape + emoji like the baked card; the frontend assigns this via innerHTML
+        entry[:title] = PrettyText.unescape_emoji(CGI.escapeHTML(title)) if title.present?
+        entry[:excerpt] = excerpt_for(linked_post, excerpt_cooked) if excerpt_cooked.present?
+
+        (result[source_post_id] ||= []) << entry
+      end
+
+      result
+    end
+
+    private
+
+    # Resolves each link's target post. A null link_post_id is a normal shape for
+    # topic-level/legacy links (see TopicLink.apply_link_visibility_filters); we
+    # fall back to the topic's first post, matching how the card itself renders.
+    # The frontend matches on post_number, so this never mis-swaps a card that
+    # points at a now-deleted specific post.
+    def linked_posts_for(links)
+      by_post_id =
+        Post.where(
+          id: links.filter_map { |l| l[2] }.uniq,
+          post_type: Oneboxer.allowed_post_types,
+          hidden: false,
+          deleted_at: nil,
+        ).index_by(&:id)
+
+      nil_topic_ids = links.select { |l| l[2].nil? }.map { |l| l[1] }.uniq
+      if nil_topic_ids.present?
+        Post
+          .where(
+            topic_id: nil_topic_ids,
+            post_type: Oneboxer.allowed_post_types,
+            hidden: false,
+            deleted_at: nil,
+          )
+          .select("DISTINCT ON (topic_id) *")
+          .order(:topic_id, :post_number)
+          .each { |post| by_post_id[[:first, post.topic_id]] = post }
+      end
+
+      by_post_id
+    end
+
+    def visible?(topic)
+      same_category = @category&.id.present? && @category.id == topic.category_id
+      (same_category ? @guardian : anon_guardian).can_see_topic?(topic)
+    end
+
+    def anon_guardian
+      @anon_guardian ||= Guardian.new
+    end
+
+    def localized_titles(topic_ids)
+      prefer_exact(
+        TopicLocalization
+          .where(topic_id: topic_ids)
+          .matching_locale(@locale)
+          .pluck(:topic_id, :locale, :title),
+      )
+    end
+
+    def localized_cooked(post_ids)
+      prefer_exact(
+        PostLocalization
+          .where(post_id: post_ids)
+          .matching_locale(@locale)
+          .pluck(:post_id, :locale, :cooked),
+      )
+    end
+
+    # matching_locale is a language-prefix match (no site-default fallback — fall
+    # back to the original, never another language). When both an exact and a
+    # regional row match (e.g. ja and ja_JP for a ja reader), prefer the exact.
+    def prefer_exact(rows)
+      locale_str = @locale.to_s.sub("-", "_")
+      rows.each_with_object({}) do |(id, row_locale, value), acc|
+        acc[id] = value if acc[id].nil? || row_locale == locale_str
+      end
+    end
+
+    def excerpt_for(post, cooked)
+      PrettyText.unescape_emoji(
+        Post.excerpt(cooked, SiteSetting.post_onebox_maxlength, keep_svg: true, post: post),
+      )
+    end
+  end
+end

--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -36,6 +36,7 @@ module CookedProcessorMixin
             invalidate_oneboxes: !!@opts[:invalidate_oneboxes],
             user_id: @model&.user_id,
             category_id: @category_id,
+            locale: @opts[:locale],
           )
 
         @has_oneboxes = true if onebox.present?

--- a/lib/localized_cooked_post_processor.rb
+++ b/lib/localized_cooked_post_processor.rb
@@ -6,7 +6,7 @@ class LocalizedCookedPostProcessor
   def initialize(post_localization, post, opts = {})
     @post_localization = post_localization
     @post = post
-    @opts = opts
+    @opts = (opts || {}).merge(locale: post_localization.locale)
     @doc = Loofah.html5_fragment(@post_localization.cooked)
     @cooking_options = @post.cooking_options || {}
     @cooking_options[:topic_id] = @post.topic_id

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -410,22 +410,49 @@ module Oneboxer
 
       PrettyText.cook(quote)
     else
+      title, excerpt = localized_topic_onebox_content(topic, post, opts[:locale])
+
       args = {
         topic_id: topic.id,
         post_number: post.post_number,
         avatar: PrettyText.avatar_img(post.user.avatar_template_url, "tiny"),
         original_url: url,
-        title: PrettyText.unescape_emoji(CGI.escapeHTML(topic.title)),
+        title: PrettyText.unescape_emoji(CGI.escapeHTML(title)),
         category_html: CategoryBadge.html_for(topic.category),
-        quote:
-          PrettyText.unescape_emoji(
-            post.excerpt(SiteSetting.post_onebox_maxlength, keep_svg: true),
-          ),
+        quote: PrettyText.unescape_emoji(excerpt),
       }
 
       template = template("discourse_topic_onebox")
       Mustache.render(template, args)
     end
+  end
+
+  # Returns the [title, excerpt] for an internal topic onebox card, localized to
+  # +locale+ when a translation exists. The title and excerpt fall back to the
+  # original independently, so a translated title can sit above an untranslated
+  # preview. Used while cooking a translated post (see LocalizedCookedPostProcessor).
+  def self.localized_topic_onebox_content(topic, post, locale)
+    title = topic.title
+    excerpt = post.excerpt(SiteSetting.post_onebox_maxlength, keep_svg: true)
+
+    return title, excerpt if locale.blank? || !SiteSetting.content_localization_enabled
+
+    if (topic_localization = topic.get_localization(locale, fallback: false))
+      title = topic_localization.title.presence || title
+    end
+
+    if (post_localization = post.get_localization(locale, fallback: false)) &&
+         post_localization.cooked.present?
+      excerpt =
+        Post.excerpt(
+          post_localization.cooked,
+          SiteSetting.post_onebox_maxlength,
+          keep_svg: true,
+          post: post,
+        )
+    end
+
+    [title, excerpt]
   end
 
   def self.local_user_html(url, route)

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -758,6 +758,25 @@ class TopicView
     link_counts[post.id]&.select { |l| l[:reflection] && l[:title].present? }
   end
 
+  # Per-post localized title/preview for internal topic oneboxes the reader sees
+  # in their own language. See ContentLocalization::OneboxLocalizer for the full
+  # contract (including why "show original" is gated in the serializer, not here).
+  def localized_oneboxes
+    return @localized_oneboxes if defined?(@localized_oneboxes)
+
+    @localized_oneboxes =
+      if SiteSetting.content_localization_enabled
+        ContentLocalization::OneboxLocalizer.build(
+          posts:,
+          guardian: @guardian,
+          category:,
+          locale: I18n.locale,
+        )
+      else
+        {}
+      end
+  end
+
   def pm_params
     @pm_params ||= TopicQuery.new(@user).get_pm_params(topic)
   end

--- a/spec/jobs/process_localized_cooked_spec.rb
+++ b/spec/jobs/process_localized_cooked_spec.rb
@@ -92,6 +92,26 @@ describe Jobs::ProcessLocalizedCooked do
     expect(post_localization.cooked).to include("onebox")
   end
 
+  describe "recook" do
+    it "re-cooks the localization from its raw before processing when recook is true" do
+      post_localization.update!(raw: "新しい本文です。", cooked: "<p>古いHTML</p>")
+
+      job.execute(post_localization_id: post_localization.id, recook: true)
+
+      post_localization.reload
+      expect(post_localization.cooked).to include("新しい本文です。")
+      expect(post_localization.cooked).not_to include("古いHTML")
+    end
+
+    it "uses the stored cooked when recook is not set" do
+      post_localization.update!(raw: "新しい本文です。", cooked: "<p>古いHTML</p>")
+
+      job.execute(post_localization_id: post_localization.id)
+
+      expect(post_localization.reload.cooked).to include("古いHTML")
+    end
+  end
+
   describe "topic localization excerpt" do
     fab!(:topic)
     fab!(:first_post) { Fabricate(:post, topic: topic, post_number: 1) }

--- a/spec/lib/content_localization/onebox_localizer_spec.rb
+++ b/spec/lib/content_localization/onebox_localizer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe ContentLocalization::OneboxLocalizer do
+  fab!(:reader) { Fabricate(:user, locale: "ja") }
+  fab!(:source_topic, :topic)
+  fab!(:source_post) do
+    Fabricate(:post, topic: source_topic, post_number: 1, locale: "ja", raw: "見てください")
+  end
+
+  before { SiteSetting.content_localization_enabled = true }
+
+  def add_localized_onebox(index)
+    topic = Fabricate(:topic, title: "Linked topic number #{index} goes here", locale: "en")
+    post = Fabricate(:post, topic: topic, post_number: 1, locale: "en", raw: "body number #{index}")
+    Fabricate(:topic_localization, topic: topic, locale: "ja", title: "翻訳タイトル#{index}")
+    Fabricate(:post_localization, post: post, locale: "ja", cooked: "<p>翻訳本文#{index}</p>")
+    TopicLink.create!(
+      topic: source_topic,
+      post: source_post,
+      user: source_post.user,
+      url: post.url,
+      domain: Discourse.current_hostname,
+      internal: true,
+      quote: true,
+      reflection: false,
+      link_topic_id: topic.id,
+      link_post_id: post.id,
+    )
+  end
+
+  def build
+    I18n.with_locale(:ja) do
+      described_class.build(
+        posts: [source_post],
+        guardian: Guardian.new(reader),
+        category: source_topic.category,
+        locale: :ja,
+      )
+    end
+  end
+
+  it "batches its lookups into one query each regardless of onebox count (no N+1)" do
+    add_localized_onebox(1)
+    add_localized_onebox(2)
+    add_localized_onebox(3)
+
+    queries = track_sql_queries { build }
+
+    expect(queries.count { |q| q =~ /FROM "?topic_links"?/ }).to eq(1)
+    expect(queries.count { |q| q =~ /FROM "?topics"?/ }).to eq(1)
+    expect(queries.count { |q| q =~ /FROM "?posts"?/ }).to eq(1)
+    expect(queries.count { |q| q =~ /FROM "?topic_localizations"?/ }).to eq(1)
+    expect(queries.count { |q| q =~ /FROM "?post_localizations"?/ }).to eq(1)
+  end
+end

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1208,6 +1208,7 @@ RSpec.describe CookedPostProcessor do
           invalidate_oneboxes: true,
           user_id: nil,
           category_id: post.topic.category_id,
+          locale: nil,
         )
         .returns("<div>GANGNAM STYLE</div>")
 
@@ -1445,6 +1446,7 @@ RSpec.describe CookedPostProcessor do
           invalidate_oneboxes: true,
           user_id: nil,
           category_id: post.topic.category_id,
+          locale: nil,
         )
         .returns(
           '<aside class="onebox"><a href="https://www.youtube.com/watch?v=9bZkp7q19f0" rel="noopener nofollow ugc">GANGNAM STYLE</a></aside>',
@@ -1476,6 +1478,7 @@ RSpec.describe CookedPostProcessor do
           invalidate_oneboxes: true,
           user_id: nil,
           category_id: post.topic.category_id,
+          locale: nil,
         )
         .returns(
           '<aside class="onebox"><a href="https://www.youtube.com/watch?v=9bZkp7q19f0" rel="noopener nofollow ugc">GANGNAM STYLE</a></aside>',
@@ -1503,6 +1506,7 @@ RSpec.describe CookedPostProcessor do
           invalidate_oneboxes: true,
           user_id: nil,
           category_id: post.topic.category_id,
+          locale: nil,
         )
         .returns(
           "<aside class='onebox'><div class='scale-images'><img src='/img.jpg' width='400' height='500'/></div></div>",
@@ -1523,6 +1527,7 @@ RSpec.describe CookedPostProcessor do
           invalidate_oneboxes: true,
           user_id: nil,
           category_id: post.topic.category_id,
+          locale: nil,
         )
         .returns(
           "<aside class='onebox'><div class='scale-images'><a href='https://example.com'><img src='/img.jpg' width='400' height='500'/></a></div></div>",

--- a/spec/lib/localized_cooked_post_processor_spec.rb
+++ b/spec/lib/localized_cooked_post_processor_spec.rb
@@ -68,6 +68,47 @@ RSpec.describe LocalizedCookedPostProcessor do
       end
     end
 
+    context "with an internal topic onebox" do
+      fab!(:linked_topic) { Fabricate(:topic, title: "Sun Tzu's strategies", locale: "en") }
+      fab!(:linked_post) do
+        Fabricate(
+          :post,
+          topic: linked_topic,
+          post_number: 1,
+          locale: "en",
+          raw: "Subdue the enemy without fighting.",
+        )
+      end
+
+      let(:onebox_localization) do
+        raw = linked_topic.url
+        Fabricate(
+          :post_localization,
+          post: post,
+          locale: "ja",
+          raw: raw,
+          cooked: PrettyText.cook(raw),
+        )
+      end
+
+      before do
+        SiteSetting.content_localization_enabled = true
+        Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+        Fabricate(:post_localization, post: linked_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      end
+
+      it "renders the onebox card in the localization's locale" do
+        processor = LocalizedCookedPostProcessor.new(onebox_localization, post)
+        processor.post_process_oneboxes
+
+        html = processor.html
+        expect(html).to include("孫子の兵法")
+        expect(html).to include("戦わずして勝つ")
+        expect(html).not_to include("Sun Tzu")
+        expect(html).not_to include("Subdue the enemy")
+      end
+    end
+
     context "when secure uploads is enabled" do
       before do
         setup_s3

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -237,6 +237,125 @@ RSpec.describe Oneboxer do
     end
   end
 
+  describe "localized internal topic oneboxes" do
+    fab!(:viewer, :user)
+    fab!(:category)
+    fab!(:linked_topic) do
+      Fabricate(:topic, title: "Sun Tzu's strategies", category: category, locale: "en")
+    end
+    fab!(:first_post) do
+      Fabricate(
+        :post,
+        topic: linked_topic,
+        post_number: 1,
+        locale: "en",
+        raw: "The supreme art of war is to subdue the enemy without fighting.",
+      )
+    end
+    fab!(:second_post) do
+      Fabricate(
+        :post,
+        topic: linked_topic,
+        post_number: 2,
+        locale: "en",
+        raw: "Every battle is won before it is ever fought.",
+      )
+    end
+
+    before { SiteSetting.content_localization_enabled = true }
+
+    def card(url, locale: nil)
+      Oneboxer.onebox(
+        "#{Discourse.base_url}#{url}",
+        user_id: viewer.id,
+        category_id: category.id,
+        locale: locale,
+      ).to_s
+    end
+
+    it "shows the topic title and first-post preview in the target locale" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+
+      html = card(linked_topic.relative_url, locale: "ja")
+
+      expect(html).to include("孫子の兵法")
+      expect(html).to include("戦わずして勝つ")
+      expect(html).not_to include("Sun Tzu")
+      expect(html).not_to include("subdue the enemy")
+    end
+
+    it "shows the linked post's own translation, not another post's" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      Fabricate(:post_localization, post: second_post, locale: "ja", cooked: "<p>戦う前に勝つ</p>")
+
+      html = card(second_post.url, locale: "ja")
+
+      expect(html).to include(%{data-post="2"})
+      expect(html).to include("戦う前に勝つ")
+      expect(html).not_to include("戦わずして勝つ")
+    end
+
+    it "keeps the preview original when only the title is translated" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+
+      html = card(linked_topic.relative_url, locale: "ja")
+
+      expect(html).to include("孫子の兵法")
+      expect(html).to include("subdue the enemy")
+    end
+
+    it "falls back to the original when no translation exists" do
+      html = card(linked_topic.relative_url, locale: "ja")
+
+      expect(html).to include("Sun Tzu")
+      expect(html).to include("subdue the enemy")
+    end
+
+    it "keeps the original when the linked topic is already in the target locale" do
+      # topic is authored in ja and only carries an en translation; a ja reader
+      # must see the original ja, never the en default-locale fallback.
+      SiteSetting.content_localization_use_default_locale_when_unsupported = true
+      ja_topic = Fabricate(:topic, title: "孫子の兵法に関する詳細な考察と議論", category: category, locale: "ja")
+      ja_post = Fabricate(:post, topic: ja_topic, post_number: 1, locale: "ja", raw: "戦わずして勝つのが最善")
+      Fabricate(:topic_localization, topic: ja_topic, locale: "en", title: "The Art of War")
+      Fabricate(
+        :post_localization,
+        post: ja_post,
+        locale: "en",
+        cooked: "<p>Win without fighting</p>",
+      )
+
+      html = card(ja_topic.relative_url, locale: "ja")
+
+      expect(html).to include("孫子の兵法に関する詳細な考察と議論")
+      expect(html).not_to include("The Art of War")
+      expect(html).not_to include("Win without fighting")
+    end
+
+    it "leaves the card original when no locale is requested" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+
+      html = card(linked_topic.relative_url, locale: nil)
+
+      expect(html).to include("Sun Tzu")
+      expect(html).not_to include("孫子の兵法")
+    end
+
+    it "leaves the card original when content localization is disabled" do
+      SiteSetting.content_localization_enabled = false
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+
+      html = card(linked_topic.relative_url, locale: "ja")
+
+      expect(html).to include("Sun Tzu")
+      expect(html).not_to include("孫子の兵法")
+    end
+  end
+
   describe ".onebox_raw" do
     it "should escape the onebox URL before processing" do
       post = Fabricate(:post, raw: Discourse.base_url + "/new?'class=black")

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -1281,4 +1281,260 @@ RSpec.describe TopicView do
       end
     end
   end
+
+  describe "#localized_oneboxes" do
+    fab!(:reader) { Fabricate(:user, locale: "ja") }
+    fab!(:source_topic, :topic)
+    fab!(:source_post) do
+      Fabricate(:post, topic: source_topic, post_number: 1, locale: "ja", raw: "見てください")
+    end
+
+    fab!(:linked_topic) { Fabricate(:topic, title: "Sun Tzu's strategies", locale: "en") }
+    fab!(:linked_first_post) do
+      Fabricate(
+        :post,
+        topic: linked_topic,
+        post_number: 1,
+        locale: "en",
+        raw: "Subdue the enemy without fighting.",
+      )
+    end
+    fab!(:linked_second_post) do
+      Fabricate(
+        :post,
+        topic: linked_topic,
+        post_number: 2,
+        locale: "en",
+        raw: "Every battle is won before it is fought.",
+      )
+    end
+
+    def link_to(post, **overrides)
+      TopicLink.create!(
+        {
+          topic: source_topic,
+          post: source_post,
+          user: source_post.user,
+          url: post.url,
+          domain: Discourse.current_hostname,
+          internal: true,
+          # onebox cards are extracted as quote links (aside.quote)
+          quote: true,
+          reflection: false,
+          link_topic_id: post.topic_id,
+          link_post_id: post.id,
+        }.merge(overrides),
+      )
+    end
+
+    def localized_oneboxes_for(post, viewer: reader)
+      I18n.with_locale(:ja) { TopicView.new(post.topic_id, viewer).localized_oneboxes[post.id] }
+    end
+
+    before { SiteSetting.content_localization_enabled = true }
+
+    it "returns the translated title and preview for an internal onebox" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: linked_first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      link_to(linked_first_post)
+
+      entries = localized_oneboxes_for(source_post)
+
+      expect(entries.size).to eq(1)
+      expect(entries.first[:topic_id]).to eq(linked_topic.id)
+      expect(entries.first[:post_number]).to eq(1)
+      expect(entries.first[:title]).to eq("孫子の兵法")
+      expect(entries.first[:excerpt]).to include("戦わずして勝つ")
+    end
+
+    it "produces a sanitized excerpt (no script/event-handler markup)" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(
+        :post_localization,
+        post: linked_first_post,
+        locale: "ja",
+        cooked: "<p>安全な要約<script>alert(1)</script><img src=x onerror=alert(2)></p>",
+      )
+      link_to(linked_first_post)
+
+      excerpt = localized_oneboxes_for(source_post).first[:excerpt]
+
+      expect(excerpt).to include("安全な要約")
+      expect(excerpt).not_to include("<script")
+      expect(excerpt).not_to include("onerror")
+    end
+
+    it "uses the linked post's own translation, not another post's" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: linked_first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      Fabricate(:post_localization, post: linked_second_post, locale: "ja", cooked: "<p>戦う前に勝つ</p>")
+      link_to(linked_second_post)
+
+      entry = localized_oneboxes_for(source_post).first
+
+      expect(entry[:post_number]).to eq(2)
+      expect(entry[:excerpt]).to include("戦う前に勝つ")
+      expect(entry[:excerpt]).not_to include("戦わずして勝つ")
+    end
+
+    it "localizes a topic-level onebox whose link_post_id was never recorded" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: linked_first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      link_to(linked_first_post, link_post_id: nil)
+
+      entry = localized_oneboxes_for(source_post).first
+
+      expect(entry[:post_number]).to eq(1)
+      expect(entry[:title]).to eq("孫子の兵法")
+      expect(entry[:excerpt]).to include("戦わずして勝つ")
+    end
+
+    it "prefers the exact locale over a regional variant" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "正確な日本語タイトル")
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja_JP", title: "地域別の日本語タイトル")
+      link_to(linked_first_post)
+
+      entry = localized_oneboxes_for(source_post).first
+
+      expect(entry[:title]).to eq("正確な日本語タイトル")
+    end
+
+    it "sends only the title when the linked post has no translation" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      link_to(linked_first_post)
+
+      entry = localized_oneboxes_for(source_post).first
+
+      expect(entry[:title]).to eq("孫子の兵法")
+      expect(entry).not_to have_key(:excerpt)
+    end
+
+    it "returns nothing when there is no translation" do
+      link_to(linked_first_post)
+
+      expect(localized_oneboxes_for(source_post)).to be_blank
+    end
+
+    it "returns nothing when the linked topic is already in the reader's language" do
+      linked_topic.update!(locale: "ja")
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      link_to(linked_first_post)
+
+      expect(localized_oneboxes_for(source_post)).to be_blank
+    end
+
+    it "returns nothing when content localization is disabled" do
+      SiteSetting.content_localization_enabled = false
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      link_to(linked_first_post)
+
+      expect(localized_oneboxes_for(source_post)).to be_blank
+    end
+
+    it "skips posts the reader sees translated (their cards are localized at cook time)" do
+      source_post.update!(locale: "en")
+      Fabricate(:post_localization, post: source_post, locale: "ja", raw: "翻訳", cooked: "<p>翻訳</p>")
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      link_to(linked_first_post)
+
+      expect(localized_oneboxes_for(source_post)).to be_blank
+    end
+
+    it "localizes oneboxes in an untranslated post viewed in a foreign language" do
+      # source post is English with no Japanese translation, so the reader sees
+      # its original cooked — its oneboxes should still be localized.
+      source_post.update!(locale: "en")
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: linked_first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      link_to(linked_first_post)
+
+      entry = localized_oneboxes_for(source_post).first
+
+      expect(entry[:title]).to eq("孫子の兵法")
+      expect(entry[:excerpt]).to include("戦わずして勝つ")
+    end
+
+    context "with visibility restrictions" do
+      it "does not expose a topic the reader cannot see" do
+        secured_category = Fabricate(:category)
+        secured_category.set_permissions(staff: :full)
+        secured_category.save!
+        linked_topic.update!(category: secured_category)
+        Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+        link_to(linked_first_post)
+
+        expect(localized_oneboxes_for(source_post)).to be_blank
+      end
+
+      it "does not expose a private message" do
+        pm = Fabricate(:private_message_topic, title: "Secret plans")
+        pm_post = Fabricate(:post, topic: pm, post_number: 1, locale: "en")
+        Fabricate(:topic_localization, topic: pm, locale: "ja", title: "秘密")
+        link_to(pm_post)
+
+        expect(localized_oneboxes_for(source_post)).to be_blank
+      end
+
+      it "does not expose a deleted linked post" do
+        Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+        Fabricate(
+          :post_localization,
+          post: linked_first_post,
+          locale: "ja",
+          cooked: "<p>戦わずして勝つ</p>",
+        )
+        link_to(linked_first_post)
+        linked_first_post.trash!
+
+        expect(localized_oneboxes_for(source_post)).to be_blank
+      end
+
+      it "does not expose a hidden linked post" do
+        Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+        Fabricate(
+          :post_localization,
+          post: linked_first_post,
+          locale: "ja",
+          cooked: "<p>戦わずして勝つ</p>",
+        )
+        link_to(linked_first_post)
+        linked_first_post.update!(hidden: true)
+
+        expect(localized_oneboxes_for(source_post)).to be_blank
+      end
+
+      it "requires anonymous visibility for a cross-category linked topic" do
+        # mirrors Oneboxer.local_topic: a card to a different category is only
+        # baked when anonymous can see it, so we must not emit swap data for a
+        # staff-only topic even to a staff reader.
+        secured_category = Fabricate(:category)
+        secured_category.set_permissions(staff: :full)
+        secured_category.save!
+        linked_topic.update!(category: secured_category)
+        Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+        link_to(linked_first_post)
+
+        admin = Fabricate(:admin, locale: "ja")
+        expect(localized_oneboxes_for(source_post, viewer: admin)).to be_blank
+      end
+    end
+
+    it "localizes an internal onebox link regardless of the quote flag" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: linked_first_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      link_to(linked_first_post, quote: false)
+
+      entry = localized_oneboxes_for(source_post).first
+
+      expect(entry[:title]).to eq("孫子の兵法")
+      expect(entry[:excerpt]).to include("戦わずして勝つ")
+    end
+
+    it "ignores inbound reflection links" do
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      link_to(linked_first_post, reflection: true)
+
+      expect(localized_oneboxes_for(source_post)).to be_blank
+    end
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1392,6 +1392,47 @@ RSpec.describe Post do
       post.rebake!(invalidate_oneboxes: true)
     end
 
+    context "with content localization enabled" do
+      before { SiteSetting.content_localization_enabled = true }
+
+      it "enqueues a recook of each translation" do
+        post = create_post
+        localization =
+          Fabricate(:post_localization, post: post, locale: "ja", raw: "孫子", cooked: "stale")
+
+        expect_enqueued_with(
+          job: :process_localized_cooked,
+          args: {
+            post_localization_id: localization.id,
+            recook: true,
+          },
+        ) { post.rebake! }
+      end
+
+      it "refreshes the translation's cooked HTML from its raw" do
+        Jobs.run_immediately!
+        post = create_post
+        localization =
+          Fabricate(:post_localization, post: post, locale: "ja", raw: "孫子", cooked: "stale")
+
+        post.rebake!
+
+        expect(localization.reload.cooked).to include("孫子")
+        expect(localization.cooked).not_to eq("stale")
+      end
+
+      it "does not re-translate the localization raw" do
+        Jobs.run_immediately!
+        post = create_post
+        localization =
+          Fabricate(:post_localization, post: post, locale: "ja", raw: "孫子", cooked: "stale")
+
+        post.rebake!
+
+        expect(localization.reload.raw).to eq("孫子")
+      end
+    end
+
     it "does not publish to clients when skip_publish_rebaked_changes is true" do
       post = create_post
       post.expects(:publish_change_to_clients!).never

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3376,6 +3376,58 @@ RSpec.describe TopicsController do
         queries = queries.filter { |q| q =~ /FROM "?post_localizations"?/ }
         expect(queries.size).to eq(1)
       end
+
+      context "with an internal topic onebox" do
+        fab!(:reader) { Fabricate(:user, locale: "ja") }
+        fab!(:onebox_topic) { Fabricate(:topic, title: "Sun Tzu's strategies", locale: "en") }
+        fab!(:onebox_post) do
+          Fabricate(:post, topic: onebox_topic, post_number: 1, locale: "en", raw: "Subdue them.")
+        end
+        fab!(:host_topic) { Fabricate(:topic, locale: "ja") }
+        fab!(:host_post) do
+          Fabricate(:post, topic: host_topic, post_number: 1, locale: "ja", raw: "見てください")
+        end
+
+        before do
+          SiteSetting.allow_user_locale = true
+          SiteSetting.content_localization_supported_locales = "en|ja"
+          Fabricate(:topic_localization, topic: onebox_topic, locale: "ja", title: "孫子の兵法")
+          Fabricate(:post_localization, post: onebox_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+          TopicLink.create!(
+            topic: host_topic,
+            post: host_post,
+            user: host_post.user,
+            url: onebox_post.url,
+            domain: Discourse.current_hostname,
+            internal: true,
+            quote: true,
+            reflection: false,
+            link_topic_id: onebox_topic.id,
+            link_post_id: onebox_post.id,
+          )
+        end
+
+        def host_post_json
+          get "/t/#{host_topic.id}.json"
+          expect(response.status).to eq(200)
+          response.parsed_body["post_stream"]["posts"].find { |p| p["id"] == host_post.id }
+        end
+
+        it "returns localized onebox data for a reader in their own language" do
+          sign_in(reader)
+
+          entry = host_post_json["localized_oneboxes"].first
+          expect(entry["title"]).to eq("孫子の兵法")
+          expect(entry["excerpt"]).to include("戦わずして勝つ")
+        end
+
+        it "omits localized onebox data when the reader chose to see original content" do
+          reader.user_option.update!(show_original_content: true)
+          sign_in(reader)
+
+          expect(host_post_json.key?("localized_oneboxes")).to eq(false)
+        end
+      end
     end
 
     context "with serialize_post_user_badges" do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -1020,4 +1020,72 @@ RSpec.describe PostSerializer do
       expect(json.key?(:post_localizations_count)).to eq(false)
     end
   end
+
+  describe "#localized_oneboxes" do
+    fab!(:reader) { Fabricate(:user, locale: "ja") }
+    fab!(:source_topic, :topic)
+    fab!(:source_post) do
+      Fabricate(:post, topic: source_topic, post_number: 1, locale: "ja", raw: "見てください")
+    end
+    fab!(:linked_topic) { Fabricate(:topic, title: "Sun Tzu's strategies", locale: "en") }
+    fab!(:linked_post) do
+      Fabricate(:post, topic: linked_topic, post_number: 1, locale: "en", raw: "Subdue the enemy.")
+    end
+
+    before do
+      SiteSetting.content_localization_enabled = true
+      Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+      Fabricate(:post_localization, post: linked_post, locale: "ja", cooked: "<p>戦わずして勝つ</p>")
+      TopicLink.create!(
+        topic: source_topic,
+        post: source_post,
+        user: source_post.user,
+        url: linked_post.url,
+        domain: Discourse.current_hostname,
+        internal: true,
+        quote: true,
+        reflection: false,
+        link_topic_id: linked_topic.id,
+        link_post_id: linked_post.id,
+      )
+    end
+
+    def json_for(viewer, scope: nil)
+      I18n.with_locale(:ja) do
+        serializer =
+          PostSerializer.new(source_post, scope: scope || Guardian.new(viewer), root: false)
+        serializer.topic_view = TopicView.new(source_topic.id, viewer)
+        serializer.as_json
+      end
+    end
+
+    it "includes the localized title and preview for the reader" do
+      entry = json_for(reader)[:localized_oneboxes].first
+      expect(entry[:title]).to eq("孫子の兵法")
+      expect(entry[:excerpt]).to include("戦わずして勝つ")
+    end
+
+    it "is omitted when the reader chose to see original content" do
+      reader.user_option.update!(show_original_content: true)
+      expect(json_for(reader).key?(:localized_oneboxes)).to eq(false)
+    end
+
+    it "is omitted for an anonymous reader with the show-original cookie" do
+      env = create_request_env.merge("HTTP_COOKIE" => ContentLocalization::SHOW_ORIGINAL_COOKIE)
+      anon_scope = Guardian.new(nil, ActionDispatch::Request.new(env))
+
+      expect(json_for(nil, scope: anon_scope).key?(:localized_oneboxes)).to eq(false)
+    end
+
+    it "is included for an anonymous reader without the show-original cookie" do
+      anon_scope = Guardian.new(nil, ActionDispatch::Request.new(create_request_env))
+
+      expect(json_for(nil, scope: anon_scope)[:localized_oneboxes].first[:title]).to eq("孫子の兵法")
+    end
+
+    it "is omitted when content localization is disabled" do
+      SiteSetting.content_localization_enabled = false
+      expect(json_for(reader).key?(:localized_oneboxes)).to eq(false)
+    end
+  end
 end

--- a/spec/system/localized_internal_oneboxes_spec.rb
+++ b/spec/system/localized_internal_oneboxes_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+describe "Localized internal oneboxes" do
+  fab!(:japanese_user) { Fabricate(:user, locale: "ja", refresh_auto_groups: true) }
+
+  fab!(:linked_topic) { Fabricate(:topic, title: "Sun Tzu's strategies", locale: "en") }
+  fab!(:linked_post) do
+    Fabricate(
+      :post,
+      topic: linked_topic,
+      post_number: 1,
+      locale: "en",
+      raw: "Subdue the enemy without fighting.",
+    )
+  end
+
+  fab!(:host_topic) { Fabricate(:topic, locale: "ja", title: "ホストトピックのタイトルですよ皆さんこんにちは") }
+  fab!(:host_post) do
+    Fabricate(:post, topic: host_topic, post_number: 1, locale: "ja", raw: "見てください")
+  end
+
+  let(:host_post_obj) { PageObjects::Components::Post.new(1) }
+
+  before do
+    SiteSetting.allow_user_locale = true
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_supported_locales = "en|ja"
+    SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:everyone]
+
+    Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
+    Fabricate(:post_localization, post: linked_post, locale: "ja", cooked: "<p>戦わずして勝つのが最善である</p>")
+
+    # bake an internal onebox card (in its original English) into the host post,
+    # matching what CookedPostProcessor would render for a same-site topic link
+    host_post.update!(cooked: <<~HTML)
+      <p>見てください</p>
+      <aside class="quote" data-post="1" data-topic="#{linked_topic.id}">
+        <div class="title">
+          <div class="quote-controls"></div>
+          <div class="quote-title__text-content"><a href="#{linked_topic.relative_url}">Sun Tzu's strategies</a></div>
+        </div>
+        <blockquote>Subdue the enemy without fighting.</blockquote>
+      </aside>
+    HTML
+
+    TopicLink.create!(
+      topic: host_topic,
+      post: host_post,
+      user: host_post.user,
+      url: "#{Discourse.base_url}#{linked_topic.relative_url}",
+      domain: Discourse.current_hostname,
+      internal: true,
+      quote: true,
+      reflection: false,
+      link_topic_id: linked_topic.id,
+      link_post_id: linked_post.id,
+    )
+  end
+
+  it "shows the onebox title and preview in the reader's language" do
+    sign_in(japanese_user)
+    visit("/t/#{host_topic.id}")
+
+    expect(host_post_obj).to have_cooked_content("孫子の兵法")
+    expect(host_post_obj).to have_cooked_content("戦わずして勝つ")
+  end
+
+  it "leaves the onebox in its original language when 'Show Original' is on" do
+    japanese_user.user_option.update!(show_original_content: true)
+    sign_in(japanese_user)
+    visit("/t/#{host_topic.id}")
+
+    expect(host_post_obj).to have_cooked_content("Sun Tzu's strategies")
+  end
+end


### PR DESCRIPTION
We currently see unlocalized oneboxes even when `content_localization_enabled`. An internal topic onebox stored the linked topic's title and excerpt in its original language, so a reader using content localization saw it untranslated even when a translation existed.

| before | after |
|---|---|
| <img width="801" height="470" alt="before" src="https://github.com/user-attachments/assets/f686fd36-1198-4bc2-ab6f-575fa4b387bb"/> | <img width="794" height="489" alt="after" src="https://github.com/user-attachments/assets/32378d75-ec5a-4c07-bd13-4fe8c599e810"/> |

This shows internal topic oneboxes in the reader's language via two purpose-built paths (no rewriting cooked HTML at request time):

- For translated posts, `LocalizedCookedPostProcessor` bakes the card in the localization's locale at cook time; the original cooked is untouched.
- For "original posts", the serializer adds a `localized_oneboxes` map (built once per page from `topic_links`, scoped to onebox links + the reader's locale family), and a post-cooked decorator swaps the title/excerpt into the rendered card.

Falls back to the original when no translation exists, respects "show original", and never exposes a title/preview the reader couldn't already see. "Rebuild HTML" now refreshes localizations too, without re-translating.
