### PR TITLE
UX: Rework the event bulk invite modal

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
@@ -2,8 +2,6 @@
 
 module DiscoursePostEvent
   class Invitee < ActiveRecord::Base
-    UNKNOWN_ATTENDANCE = "unknown"
-
     self.table_name = "discourse_post_event_invitees"
 
     belongs_to :event, foreign_key: :post_id

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/bulk-invite-sample-csv-file.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/bulk-invite-sample-csv-file.gjs
@@ -12,7 +12,6 @@ export default class BulkInviteSampleCsvFile extends Component {
       ["my_awesome_group", "going"],
       ["lucy", "interested"],
       ["mark", "not_going"],
-      ["sam", "unknown"],
     ];
 
     let csv = "";

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/csv-uploader.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/csv-uploader.gjs
@@ -25,8 +25,8 @@ export default class CsvUploader extends Component {
         });
       });
     },
-    uploadDone: () => {
-      this.dialog.alert(i18n(`${this.args.i18nPrefix}.success`));
+    uploadDone: (upload) => {
+      this.args.uploadDone?.(upload);
     },
     validateUploadedFilesOptions: {
       csvOnly: true,

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-bulk-invite.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-bulk-invite.gjs
@@ -1,39 +1,33 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { concat, fn, hash } from "@ember/helper";
-import EmberObject, { action } from "@ember/object";
+import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { isPresent } from "@ember/utils";
+import Form from "discourse/components/form";
 import GroupSelector from "discourse/components/group-selector";
 import { ajax } from "discourse/lib/ajax";
 import { extractError } from "discourse/lib/ajax-error";
-import { removeValueFromArray } from "discourse/lib/array-tools";
-import { autoTrackedArray } from "discourse/lib/tracked-tools";
 import Group from "discourse/models/group";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import EmailGroupUserChooser from "discourse/select-kit/components/email-group-user-chooser";
-import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
 import BulkInviteSampleCsvFile from "../bulk-invite-sample-csv-file";
 import CsvUploader from "../csv-uploader";
 
-export default class PostEventBulkInvite extends Component {
-  @service dialog;
+const DEFAULT_ATTENDANCE = "going";
 
-  @tracked bulkInviteDisabled = true;
+export default class PostEventBulkInvite extends Component {
+  @service toasts;
+
   @tracked flash = null;
-  @autoTrackedArray
-  bulkInvites = [
-    EmberObject.create({ identifier: null, attendance: "unknown" }),
-  ];
+
+  formApi;
+
+  data = { invitees: [{ identifier: null, attendance: DEFAULT_ATTENDANCE }] };
 
   get bulkInviteStatuses() {
     return [
-      {
-        label: i18n("discourse_post_event.models.invitee.status.unknown"),
-        name: "unknown",
-      },
       {
         label: i18n("discourse_post_event.models.invitee.status.going"),
         name: "going",
@@ -55,13 +49,42 @@ export default class PostEventBulkInvite extends Component {
   }
 
   @action
-  setBulkInviteDisabled() {
-    this.bulkInviteDisabled =
-      this.bulkInvites.filter((x) => isPresent(x.identifier)).length === 0;
+  registerApi(api) {
+    this.formApi = api;
   }
 
   @action
-  async sendBulkInvites() {
+  addInvite(addItemToCollection) {
+    const invitees = this.formApi?.get("invitees") ?? [];
+    const attendance = invitees.at(-1)?.attendance || DEFAULT_ATTENDANCE;
+    addItemToCollection("invitees", { identifier: null, attendance });
+  }
+
+  @action
+  async removeInvite(remove, index, addItemToCollection) {
+    await remove(index);
+
+    // always keep at least one row so the collection never collapses
+    if ((this.formApi?.get("invitees") ?? []).length === 0) {
+      await addItemToCollection("invitees", {
+        identifier: null,
+        attendance: DEFAULT_ATTENDANCE,
+      });
+    }
+  }
+
+  @action
+  setUserIdentifier(field, selected) {
+    field.set(selected[0]);
+  }
+
+  @action
+  setGroupIdentifier(field, _, groupNames) {
+    field.set(groupNames[0]);
+  }
+
+  @action
+  async sendBulkInvites(data) {
     try {
       const response = await ajax(
         `/discourse-post-event/events/${this.args.model.event.id}/bulk-invite.json`,
@@ -69,9 +92,7 @@ export default class PostEventBulkInvite extends Component {
           type: "POST",
           dataType: "json",
           contentType: "application/json",
-          data: JSON.stringify({
-            invitees: this.bulkInvites.filter((x) => isPresent(x.identifier)),
-          }),
+          data: JSON.stringify({ invitees: data.invitees }),
         }
       );
 
@@ -84,41 +105,12 @@ export default class PostEventBulkInvite extends Component {
   }
 
   @action
-  removeBulkInvite(bulkInvite) {
-    removeValueFromArray(this.bulkInvites, bulkInvite);
-
-    if (!this.bulkInvites.length) {
-      this.bulkInvites.push(
-        EmberObject.create({ identifier: null, attendance: "unknown" })
-      );
-    }
-  }
-
-  @action
-  addBulkInvite() {
-    const attendance =
-      this.bulkInvites[this.bulkInvites.length - 1]?.attendance || "unknown";
-    this.bulkInvites.push(EmberObject.create({ identifier: null, attendance }));
-  }
-
-  @action
-  async uploadDone() {
-    await this.dialog.alert(
-      i18n("discourse_post_event.bulk_invite_modal.success")
-    );
+  uploadDone() {
     this.args.closeModal();
-  }
-
-  @action
-  updateInviteIdentifier(bulkInvite, selected) {
-    bulkInvite.set("identifier", selected[0]);
-    this.setBulkInviteDisabled();
-  }
-
-  @action
-  updateBulkGroupInviteIdentifier(bulkInvite, _, groupNames) {
-    bulkInvite.set("identifier", groupNames[0]);
-    this.setBulkInviteDisabled();
+    this.toasts.success({
+      duration: "short",
+      data: { message: i18n("discourse_post_event.bulk_invite_modal.success") },
+    });
   }
 
   <template>
@@ -142,65 +134,100 @@ export default class PostEventBulkInvite extends Component {
               "discourse_post_event.bulk_invite_modal.inline_title"
             }}</h3>
 
-          <div class="bulk-invite-rows">
-            {{#each this.bulkInvites as |bulkInvite|}}
+          <Form
+            @data={{this.data}}
+            @onSubmit={{this.sendBulkInvites}}
+            @onRegisterApi={{this.registerApi}}
+            as |form|
+          >
+            <form.Collection @name="invitees" as |collection index|>
               <div class="bulk-invite-row">
-                {{#if @model.event.isPrivate}}
-                  <GroupSelector
-                    class="bulk-invite-identifier"
-                    @single={{true}}
-                    @groupFinder={{this.groupFinder}}
-                    @groupNames={{bulkInvite.identifier}}
-                    @placeholderKey="discourse_post_event.bulk_invite_modal.group_selector_placeholder"
-                    @onChangeCallback={{fn
-                      this.updateBulkGroupInviteIdentifier
-                      bulkInvite
-                    }}
-                  />
-                {{/if}}
-                {{#if @model.event.isPublic}}
-                  <EmailGroupUserChooser
-                    class="bulk-invite-identifier"
-                    @value={{bulkInvite.identifier}}
-                    @onChange={{fn this.updateInviteIdentifier bulkInvite}}
-                    @options={{hash
-                      maximum=1
-                      filterPlaceholder="discourse_post_event.bulk_invite_modal.user_selector_placeholder"
-                    }}
-                  />
-                {{/if}}
+                <collection.Field
+                  class="bulk-invite-identifier-field"
+                  @name="identifier"
+                  @title={{i18n
+                    (if
+                      @model.event.isPrivate
+                      "discourse_post_event.bulk_invite_modal.group_selector_placeholder"
+                      "discourse_post_event.bulk_invite_modal.user_selector_placeholder"
+                    )
+                  }}
+                  @showTitle={{false}}
+                  @type="custom"
+                  @validation="required"
+                  as |field|
+                >
+                  <field.Control>
+                    {{#if @model.event.isPrivate}}
+                      <GroupSelector
+                        class="bulk-invite-identifier"
+                        @single={{true}}
+                        @groupFinder={{this.groupFinder}}
+                        @groupNames={{field.value}}
+                        @placeholderKey="discourse_post_event.bulk_invite_modal.group_selector_placeholder"
+                        @onChangeCallback={{fn this.setGroupIdentifier field}}
+                      />
+                    {{/if}}
+                    {{#if @model.event.isPublic}}
+                      <EmailGroupUserChooser
+                        class="bulk-invite-identifier"
+                        @value={{field.value}}
+                        @onChange={{fn this.setUserIdentifier field}}
+                        @options={{hash
+                          maximum=1
+                          filterPlaceholder="discourse_post_event.bulk_invite_modal.user_selector_placeholder"
+                        }}
+                      />
+                    {{/if}}
+                  </field.Control>
+                </collection.Field>
 
-                <ComboBox
-                  class="bulk-invite-attendance"
-                  @value={{bulkInvite.attendance}}
-                  @content={{this.bulkInviteStatuses}}
-                  @nameProperty="name"
-                  @valueProperty="name"
-                  @onChange={{fn (mut bulkInvite.attendance)}}
-                />
+                <collection.Field
+                  @name="attendance"
+                  @title={{i18n
+                    "discourse_post_event.bulk_invite_modal.attendance_label"
+                  }}
+                  @showTitle={{false}}
+                  @type="custom"
+                  as |field|
+                >
+                  <field.Control>
+                    <ComboBox
+                      class="bulk-invite-attendance"
+                      @value={{field.value}}
+                      @content={{this.bulkInviteStatuses}}
+                      @nameProperty="name"
+                      @valueProperty="name"
+                      @onChange={{field.set}}
+                    />
+                  </field.Control>
+                </collection.Field>
 
-                <DButton
-                  @icon="trash-can"
-                  @action={{fn this.removeBulkInvite bulkInvite}}
+                <form.Button
                   class="remove-bulk-invite"
+                  @icon="trash-can"
+                  @action={{fn
+                    this.removeInvite
+                    collection.remove
+                    index
+                    form.addItemToCollection
+                  }}
                 />
               </div>
-            {{/each}}
-          </div>
+            </form.Collection>
 
-          <div class="bulk-invite-actions">
-            <DButton
-              class="send-bulk-invites btn-primary"
-              @label="discourse_post_event.bulk_invite_modal.send_bulk_invites"
-              @action={{this.sendBulkInvites}}
-              @disabled={{this.bulkInviteDisabled}}
-            />
-            <DButton
-              class="add-bulk-invite"
-              @icon="plus"
-              @action={{this.addBulkInvite}}
-            />
-          </div>
+            <form.Actions class="bulk-invite-actions">
+              <form.Submit
+                class="send-bulk-invites"
+                @label="discourse_post_event.bulk_invite_modal.send_bulk_invites"
+              />
+              <form.Button
+                class="add-bulk-invite"
+                @icon="plus"
+                @action={{fn this.addInvite form.addItemToCollection}}
+              />
+            </form.Actions>
+          </Form>
         </div>
 
         <div class="csv-bulk-invites">

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-bulk-invite-modal.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event-bulk-invite-modal.scss
@@ -3,23 +3,22 @@
     margin: 0 0 1em 0;
   }
 
-  .bulk-invite-rows {
-    margin-bottom: 1em;
-
-    .group-selector {
-      margin: 0;
-    }
-  }
-
   .bulk-invite-row {
     display: flex;
+    align-items: center;
+    gap: 0.5em;
     padding: 0.25em 0;
 
-    .bulk-invite-attendance {
-      margin: 0 0.5em;
+    .form-kit__field {
+      margin-bottom: 0;
+    }
 
-      .select-kit-header {
-        height: 100%;
+    .bulk-invite-identifier-field {
+      flex: 1 1 auto;
+
+      .bulk-invite-identifier {
+        width: 100%;
+        margin: 0;
       }
     }
 
@@ -31,12 +30,8 @@
   .bulk-invites {
     margin-bottom: 2em;
 
-    .bulk-invite-actions {
-      display: flex;
-
-      .add-bulk-invite {
-        margin-left: auto;
-      }
+    .add-bulk-invite {
+      margin-left: auto;
     }
   }
 

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -385,6 +385,7 @@ en:
         send_bulk_invites: "Send invites"
         group_selector_placeholder: "Choose a group..."
         user_selector_placeholder: "Choose user..."
+        attendance_label: "Attendance"
         inline_title: "Inline bulk invite"
         csv_title: "CSV bulk invite"
       upcoming_events:
@@ -415,7 +416,6 @@ en:
           this_and_following: "This event and all following events"
           leave_event: "Leave event"
           status:
-            unknown: "Not interested"
             going: "Going"
             not_going: "Not going"
             interested: "Interested"

--- a/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
+++ b/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
@@ -71,16 +71,26 @@ module Jobs
         return
       end
 
+      attendance = invitee["attendance"] || "going"
+      status = DiscoursePostEvent::Invitee.statuses[attendance.to_sym]
+
+      if status.nil?
+        save_log "Skipping '#{invitee["identifier"]}' due to unknown attendance: '#{attendance}'"
+        @failed += 1
+        return
+      end
+
+      post_id = @event.post.id
+
       users.each do |user_id|
         # Respect capacity: skip creating new going when full
-        attendance = invitee["attendance"] || "going"
         if attendance == "going" && @event.at_capacity?
           save_log "Skipping '#{invitee["identifier"]}' due to max attendees reached"
           @failed += 1
           next
         end
 
-        create_attendance(user_id, @event.post.id, attendance)
+        create_attendance(user_id, post_id, status)
       end
 
       @processed += 1
@@ -89,19 +99,12 @@ module Jobs
       @failed += 1
     end
 
-    def create_attendance(user_id, post_id, attendance)
-      unknown = DiscoursePostEvent::Invitee::UNKNOWN_ATTENDANCE
-
-      if attendance == unknown
-        DiscoursePostEvent::Invitee.where(user_id: user_id, post_id: post_id).destroy_all
-      else
-        status = DiscoursePostEvent::Invitee.statuses[attendance.to_sym]
-        invitee =
-          DiscoursePostEvent::Invitee.find_or_initialize_by(user_id: user_id, post_id: post_id)
-        invitee.notified = false
-        invitee.status = status
-        invitee.save!
-      end
+    def create_attendance(user_id, post_id, status)
+      invitee =
+        DiscoursePostEvent::Invitee.find_or_initialize_by(user_id: user_id, post_id: post_id)
+      invitee.notified = false
+      invitee.status = status
+      invitee.save!
     end
 
     def save_log(message)

--- a/plugins/discourse-calendar/spec/fixtures/csv/bulk_invite.csv
+++ b/plugins/discourse-calendar/spec/fixtures/csv/bulk_invite.csv
@@ -1,0 +1,2 @@
+bob,going
+alice,interested

--- a/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/bulk_invite_spec.rb
+++ b/plugins/discourse-calendar/spec/jobs/regular/discourse_post_event/bulk_invite_spec.rb
@@ -116,60 +116,6 @@ describe Jobs::DiscoursePostEventBulkInvite do
             expect(invitee_klass.find_by(user_id: invitee_4)).to eq(nil)
           end
 
-          it "removes the invitee if set to unknown" do
-            Jobs::DiscoursePostEventBulkInvite.new.execute(valid_params)
-
-            invitee_klass = DiscoursePostEvent::Invitee
-
-            expect(invitee_klass.count).to eq(2)
-            expect(invitee_klass.find_by(user_id: group_1.users[0].id).status).to be(
-              invitee_klass.statuses[:not_going],
-            )
-            expect(invitee_klass.find_by(user_id: group_1.users[1].id).status).to be(
-              invitee_klass.statuses[:not_going],
-            )
-
-            Jobs::DiscoursePostEventBulkInvite.new.execute(
-              event_id: post_event_1.id,
-              invitees: [{ "identifier" => group_1.name, "attendance" => "unknown" }],
-              current_user_id: user_1.id,
-            )
-
-            expect(invitee_klass.count).to eq(0)
-            expect(invitee_klass.find_by(user_id: group_1.users[0].id)).to be(nil)
-            expect(invitee_klass.find_by(user_id: group_1.users[1].id)).to be(nil)
-          end
-
-          it "resets topic tracking when an attendee is set to unknown" do
-            invitee_klass = DiscoursePostEvent::Invitee
-
-            Jobs::DiscoursePostEventBulkInvite.new.execute(
-              event_id: post_event_1.id,
-              invitees: [{ "identifier" => group_1.name, "attendance" => "going" }],
-              current_user_id: user_1.id,
-            )
-            # simulate the watching tracking set through the normal attendance flow
-            invitee_klass.where(post_id: post_1.id).find_each(&:update_topic_tracking!)
-            group_1.users.each do |u|
-              expect(TopicUser.find_by(user: u, topic: topic_1).notification_level).to eq(
-                TopicUser.notification_levels[:watching],
-              )
-            end
-
-            Jobs::DiscoursePostEventBulkInvite.new.execute(
-              event_id: post_event_1.id,
-              invitees: [{ "identifier" => group_1.name, "attendance" => "unknown" }],
-              current_user_id: user_1.id,
-            )
-
-            expect(invitee_klass.count).to eq(0)
-            group_1.users.each do |u|
-              expect(TopicUser.find_by(user: u, topic: topic_1).notification_level).to eq(
-                TopicUser.notification_levels[:regular],
-              )
-            end
-          end
-
           it "sets the attendance to going by default" do
             SystemMessage.expects(:create_from_system_user).with(
               user_1,
@@ -253,6 +199,31 @@ describe Jobs::DiscoursePostEventBulkInvite do
             )
             expect(invitee_klass.find_by(user_id: invitee_4.id).status).to eq(
               invitee_klass.statuses[:going],
+            )
+          end
+
+          it "skips an unrecognized attendance instead of corrupting the invitee" do
+            invitee_klass = DiscoursePostEvent::Invitee
+
+            Jobs::DiscoursePostEventBulkInvite.new.execute(
+              event_id: post_event_1.id,
+              invitees: [{ "identifier" => invitee_3.username, "attendance" => "interested" }],
+              current_user_id: user_1.id,
+            )
+            expect(invitee_klass.find_by(user_id: invitee_3.id).status).to eq(
+              invitee_klass.statuses[:interested],
+            )
+
+            # An attendance value that is not a real status (e.g. a malformed CSV
+            # row) is skipped: the existing invitee keeps its status rather than
+            # being saved with a null status.
+            Jobs::DiscoursePostEventBulkInvite.new.execute(
+              event_id: post_event_1.id,
+              invitees: [{ "identifier" => invitee_3.username, "attendance" => "bogus" }],
+              current_user_id: user_1.id,
+            )
+            expect(invitee_klass.find_by(user_id: invitee_3.id).status).to eq(
+              invitee_klass.statuses[:interested],
             )
           end
         end

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/bulk_invite_modal.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/bulk_invite_modal.rb
@@ -38,8 +38,17 @@ module PageObjects
           self
         end
 
+        def upload_csv(path)
+          find(".csv-bulk-invites input.hidden-upload-field", visible: :all).set(path)
+          self
+        end
+
         def closed?
           has_no_css?(".post-event-bulk-invite")
+        end
+
+        def has_invitee_rows?(count)
+          has_css?(".bulk-invite-row", count:)
         end
       end
     end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -499,6 +499,36 @@ describe "Post event" do
 
       expect(bulk_invite_modal_page).to be_closed
     end
+
+    it "keeps a single row when removing the last invitee" do
+      visit(post.topic.url)
+
+      post_event_page.open_bulk_invite_modal
+      bulk_invite_modal_page
+        .set_invitee_at_row(invitable_user_1.username, "going", 1)
+        .add_invitee
+        .set_invitee_at_row(invitable_user_2.username, "not_going", 2)
+        .remove_invitee_row(2)
+        .remove_invitee_row(1)
+
+      # the collection never collapses, an empty row is always available
+      expect(bulk_invite_modal_page).to have_invitee_rows(1)
+    end
+
+    it "closes the modal and shows a toast after a CSV bulk invite" do
+      visit(post.topic.url)
+
+      post_event_page.open_bulk_invite_modal
+      bulk_invite_modal_page.upload_csv(
+        "#{Rails.root.join("plugins/discourse-calendar/spec/fixtures/csv/bulk_invite.csv")}",
+      )
+      PageObjects::Components::Dialog.new.click_yes
+
+      expect(bulk_invite_modal_page).to be_closed
+      expect(PageObjects::Components::Toasts.new).to have_success(
+        I18n.t("js.discourse_post_event.bulk_invite_modal.success"),
+      )
+    end
   end
 
   context "when inviting a user or group" do


### PR DESCRIPTION
Previously, the event bulk invite modal defaulted each row to "Not interested" — the internal `unknown` attendance that the backend treated as a "remove invitee" instruction (`destroy_all`) — so sending the default silently un-invited people, and a successful CSV upload never closed the modal.

This converts the modal to FormKit, defaults new rows to "Going", drops `unknown` from both the UI and the backend (unrecognized attendances are now skipped and logged), and closes the modal with a success toast after a CSV upload.
