### PR TITLE
UX: Use theme color for the event date month label

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/composer-event-node-view.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/composer-event-node-view.scss
@@ -99,7 +99,7 @@
 
     .composer-event__month {
       text-align: center;
-      color: red;
+      color: var(--primary);
       font-size: var(--font-down-2);
       font-weight: 400;
       text-transform: uppercase;

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -148,7 +148,7 @@ $show-interested: inherit;
 
     .month {
       text-align: center;
-      color: red;
+      color: var(--primary);
       font-size: var(--font-down-2);
       font-weight: 400;
       text-transform: uppercase;


### PR DESCRIPTION
Previously, the month label in the event date badge was hardcoded to `color: red`, rendering a bright-red month abbreviation on every event in topics and the composer preview.

This change uses `var(--primary)` so the month matches the day and the themed badge in the upcoming events list, across light and dark modes.