### PR TITLE
FIX: Do not render fancyTitle link in composer header

### DIFF
--- a/frontend/discourse/app/components/composer-actions-new.gjs
+++ b/frontend/discourse/app/components/composer-actions-new.gjs
@@ -292,7 +292,9 @@ export default class ComposerActions extends Component {
     if (this.isOnComposerTopic && !this.site.mobileView) {
       return null;
     }
-    return this.replyOptions?.topicLink?.anchor;
+    return (
+      this.composerModel?.topic?.title || this.replyOptions?.topicLink?.anchor
+    );
   }
 
   get showReplyTargetLink() {

--- a/frontend/discourse/tests/acceptance/composer-actions-new-test.js
+++ b/frontend/discourse/tests/acceptance/composer-actions-new-test.js
@@ -56,6 +56,13 @@ acceptance(`Composer Actions (new composer actions)`, function (needs) {
 
       return helper.response(response);
     });
+    server.get("/t/54077.json", () => {
+      const response = cloneJSON(topicFixtures["/t/54077.json"]);
+      response.fancy_title =
+        '<span dir="auto">Short topic with two posts</span>';
+
+      return helper.response(response);
+    });
   });
 
   test("replying to post", async function (assert) {
@@ -230,6 +237,21 @@ acceptance(`Composer Actions (new composer actions)`, function (needs) {
     await composerActions.expand();
 
     assert.deepEqual(composerActions.actionIds().sort(), ["create_topic"]);
+  });
+
+  test("reply target link uses plain topic title when fancy title includes HTML", async function (assert) {
+    await visit("/t/short-topic-with-two-posts/54077");
+    await click(".create.reply");
+
+    await visit("/");
+    await waitFor(".composer-actions-reply-target-link__label");
+
+    assert
+      .dom(".composer-actions-reply-target-link__label")
+      .hasText(
+        "Short topic with two posts",
+        "renders the plain topic title in the reply target link"
+      );
   });
 
   test("toggle no-bump via actions dropdown", async function (assert) {


### PR DESCRIPTION
<img width="1692" height="706" alt="CleanShot 2026-06-02 at 16 07 13@2x" src="https://github.com/user-attachments/assets/7b72f1e9-9973-4a94-83c1-7f1e289c48df" />

The new composer actions component was rendering `replyOptions.topicLink.anchor,` which comes from `topic.fancyTitle`. `fancyTitle` can include HTML like <span dir="auto">…</span>, and the new component displayed it as plain text.

I changed the new composer reply-target label to use the plain `composerModel.topic.title` instead

