### PR TITLE
DEV: Fix anonymous-related spec flakes

### DIFF
--- a/plugins/discourse-calendar/spec/system/anonymous_user_rsvp_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/anonymous_user_rsvp_event_spec.rb
@@ -31,7 +31,7 @@ describe "Anonymous user RSVPing to an event" do
 
     login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-    expect(page).to have_current_path(topic.url)
+    expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
     expect(post_event_page).to have_going_status
   end
 
@@ -45,7 +45,7 @@ describe "Anonymous user RSVPing to an event" do
     expect(login_page).to be_open
     login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-    expect(page).to have_current_path(topic.url)
+    expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
     expect(post_event_page).to have_going_status
 
     invitee = DiscoursePostEvent::Invitee.find_by(user_id: user.id, post_id: event.id)

--- a/plugins/discourse-post-voting/spec/system/anonymous_user_vote_post_spec.rb
+++ b/plugins/discourse-post-voting/spec/system/anonymous_user_vote_post_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Anonymous user voting on a post" do
 
     login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-    expect(page).to have_current_path(topic.url)
+    expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
     expect(PostVotingVote.exists?(votable: answer, user: user, direction: "up")).to eq(true)
   end
 end

--- a/plugins/discourse-reactions/spec/system/anonymous_user_react_post_spec.rb
+++ b/plugins/discourse-reactions/spec/system/anonymous_user_react_post_spec.rb
@@ -22,7 +22,7 @@ describe "Anonymous user reacting to a post" do
 
       login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-      expect(page).to have_current_path(topic.url)
+      expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
       expect(post.reload.like_count).to eq(1)
     end
   end

--- a/plugins/discourse-topic-voting/spec/system/anonymous_user_vote_topic_spec.rb
+++ b/plugins/discourse-topic-voting/spec/system/anonymous_user_vote_topic_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Anonymous user voting on a topic" do
 
     login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-    expect(page).to have_current_path(topic.url)
+    expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
     expect(DiscourseTopicVoting::Vote.exists?(user: user, topic: topic)).to eq(true)
   end
 end

--- a/plugins/poll/spec/system/anonymous_user_vote_poll_spec.rb
+++ b/plugins/poll/spec/system/anonymous_user_vote_poll_spec.rb
@@ -29,7 +29,7 @@ describe "Anonymous user voting on a poll" do
 
       login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-      expect(page).to have_current_path(topic.url)
+      expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
       expect(PollVote.where(user: user).count).to eq(1)
     end
   end

--- a/spec/system/anonymous_user_like_post_spec.rb
+++ b/spec/system/anonymous_user_like_post_spec.rb
@@ -19,7 +19,7 @@ describe "Anonymous user liking a post" do
 
       login_page.fill(username: user.username, password: "supersecurepassword").click_login
 
-      expect(page).to have_current_path(topic.url)
+      expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
       expect(topic_page).to have_post_action_button(post, :like_count)
       expect(post.reload.like_count).to eq(1)
     end


### PR DESCRIPTION
Those don't care about which post they land on, just confirm the topic id part of the path.