### PR TITLE
FIX: Sideload `discourse-workflows` node option metadata

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/combo-box.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/combo-box.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
@@ -36,14 +35,6 @@ export default class ComboBoxField extends Component {
   @service router;
   @service workflowsNodeTypes;
 
-  @tracked _remoteOptions = [];
-  _remoteOptionsRequestKey = null;
-
-  constructor(owner, args) {
-    super(owner, args);
-    this.ensureRemoteOptions();
-  }
-
   get methodName() {
     return this.args.schema?.type_options?.load_options_method;
   }
@@ -65,8 +56,21 @@ export default class ComboBoxField extends Component {
     );
   }
 
+  get hasLoadOptionsDependencies() {
+    const dependencies =
+      this.args.schema?.type_options?.load_options_depends_on;
+
+    return Array.isArray(dependencies)
+      ? dependencies.length > 0
+      : Boolean(dependencies);
+  }
+
   get usesRemoteOptions() {
-    return Boolean(this.methodName && this.identifier && !this.localOptions);
+    return Boolean(
+      this.methodName &&
+      this.identifier &&
+      (!this.localOptions || this.hasLoadOptionsDependencies)
+    );
   }
 
   get metadataOptions() {
@@ -76,8 +80,7 @@ export default class ComboBoxField extends Component {
     if (this.localOptions) {
       return this.localOptions;
     }
-    this.ensureRemoteOptions();
-    return this._remoteOptions;
+    return [];
   }
 
   get controlOptions() {
@@ -179,49 +182,10 @@ export default class ComboBoxField extends Component {
     return this.args.session?.nodeParameterOptionsContext(context) || context;
   }
 
-  remoteOptionsRequestKey(filter = null) {
-    return JSON.stringify({
-      methodName: this.methodName,
-      identifier: this.identifier,
-      typeVersion: this.typeVersion,
-      context: this.remoteOptionsContext(filter),
-    });
-  }
-
-  ensureRemoteOptions(filter = null) {
-    if (!this.usesRemoteOptions) {
-      return;
-    }
-
-    const requestKey = this.remoteOptionsRequestKey(filter);
-    if (this._remoteOptionsRequestKey === requestKey) {
-      return;
-    }
-
-    this._remoteOptionsRequestKey = requestKey;
-    this.workflowsNodeTypes
-      .loadNodeParameterOptions(
-        this.identifier,
-        this.methodName,
-        this.typeVersion,
-        this.remoteOptionsContext(filter)
-      )
-      .then((options) => {
-        if (this._remoteOptionsRequestKey === requestKey) {
-          this._remoteOptions = options;
-        }
-      });
-  }
-
   @action
   async loadRemoteOptions(filter = null) {
     if (!this.usesRemoteOptions) {
       return null;
-    }
-
-    // Mutating _remoteOptions here loops via the ComboBox didReceiveAttrs hook.
-    if (!filter) {
-      return this.formatOptions(this._remoteOptions);
     }
 
     const options = await this.workflowsNodeTypes.loadNodeParameterOptions(

--- a/plugins/discourse-workflows/app/services/discourse_workflows/node_type/list.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/node_type/list.rb
@@ -12,7 +12,7 @@ module DiscourseWorkflows
 
     private
 
-    def fetch_node_types
+    def fetch_node_types(guardian:)
       DiscourseWorkflows::Registry
         .nodes
         .uniq(&:identifier)
@@ -23,6 +23,7 @@ module DiscourseWorkflows
           NodeTypeSerializer.new(
             identifier: identifier,
             available_versions: Registry.available_versions(identifier),
+            guardian: guardian,
           ).to_h
         end
     end

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type_serializer.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type_serializer.rb
@@ -2,10 +2,11 @@
 
 module DiscourseWorkflows
   class NodeTypeSerializer
-    def initialize(identifier:, available_versions:)
+    def initialize(identifier:, available_versions:, guardian: nil)
       @identifier = identifier
       @available_versions = available_versions
       @latest_version = available_versions.last
+      @guardian = guardian
     end
 
     def to_h
@@ -33,6 +34,7 @@ module DiscourseWorkflows
     def serializable_version(klass, version)
       properties = klass.property_schema
       webhooks = serializable_webhooks(klass)
+      metadata = load_options_metadata(klass, properties)
       description =
         klass.description.merge(
           displayName: klass.label_key,
@@ -64,11 +66,53 @@ module DiscourseWorkflows
         operations: klass.operations,
         available: klass.available?,
         unavailable_reason_key: (klass.unavailable_reason_key unless klass.available?),
+        metadata: metadata.presence,
       }.compact
     end
 
     def serializable_webhooks(klass)
       klass.webhooks.map { |webhook| webhook.except(:handler) }
+    end
+
+    def load_options_metadata(klass, properties)
+      return {} unless klass.respond_to?(:load_options_context)
+
+      load_options_methods(properties)
+        .index_with do |method_name|
+          context =
+            LoadOptionsContext.new(
+              method_name: method_name,
+              node_class: klass,
+              guardian: @guardian,
+              user: @guardian&.user,
+            )
+          klass.load_options_context(context)
+        end
+        .compact
+    end
+
+    def load_options_methods(properties)
+      properties.values.flat_map { |definition| load_options_methods_for_field(definition) }.uniq
+    end
+
+    def load_options_methods_for_field(definition)
+      return [] unless definition.is_a?(Hash)
+
+      methods = Array(definition.dig(:type_options, :load_options_method)).compact
+
+      nested_definitions = schema_field_definitions(definition[:item_schema])
+      nested_definitions += schema_field_definitions(definition[:extra_item_schema])
+
+      nested_definitions +=
+        Array(definition[:options]).flat_map do |option|
+          option.is_a?(Hash) && option[:values].is_a?(Hash) ? option[:values].values : []
+        end
+
+      methods + nested_definitions.flat_map { |field| load_options_methods_for_field(field) }
+    end
+
+    def schema_field_definitions(schema)
+      schema.is_a?(Hash) ? schema.values : []
     end
   end
 end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/group/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/group/v1.rb
@@ -44,6 +44,7 @@ module DiscourseWorkflows
               required: true,
               type_options: {
                 load_options_method: "groups",
+                load_options_depends_on: %w[operation],
               },
               ui: {
                 control: :group_select,

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe DiscourseWorkflows::NodeTypesController do
       expect(properties["advanced_filter"]["ui"]).to include("hidden" => true)
     end
 
-    it "does not include metadata key in node type response" do
+    it "includes load options metadata in node type response" do
       get "/admin/plugins/discourse-workflows/node-types.json"
 
       badge_node =
         response.parsed_body["node_types"].find { |nt| nt["identifier"] == "action:badge" }
-      expect(badge_node).not_to have_key("metadata")
+      expect(badge_node.dig("metadata", "badges")).to all(include("id", "name"))
     end
 
     it "returns descriptor fields used by the admin client" do

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/node_type/list_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/node_type/list_spec.rb
@@ -78,13 +78,13 @@ RSpec.describe DiscourseWorkflows::NodeType::List do
         expect(webhook.dig(:properties, :url_preview, :ui, :control)).to eq(:url_preview)
       end
 
-      it "declares load options methods for dynamic combo box fields" do
+      it "sideloads options metadata for dynamic combo box fields" do
         award_badge = result[:node_types].find { |nt| nt[:identifier] == "action:badge" }
 
         expect(award_badge.dig(:properties, :badge_id, :type_options)).to include(
           load_options_method: "badges",
         )
-        expect(award_badge).not_to have_key(:metadata)
+        expect(award_badge.dig(:metadata, "badges")).to include(id: badge.id, name: badge.name)
       end
 
       it "includes branching for condition nodes" do


### PR DESCRIPTION
Previously, workflow combo boxes loaded remote options during render, causing textarea edits to repeatedly call `/dynamic-node-parameters/options.json` and selected dynamic values to display raw ids.

This change sideloads option metadata through node type serialization and keeps dynamic option requests scoped to dropdown open/search interactions.