### PR TITLE
DEV: Fix `PG::ReadOnlySqlTransaction` flakes

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -253,12 +253,10 @@ class Report
   end
 
   def self.wrap_slow_query(timeout = 20_000)
-    # Only set read-only when we own the transaction, otherwise (e.g. in specs, with
-    # transactional fixtures) we'd break concurrent writes on the shared connection.
-    already_in_transaction = ActiveRecord::Base.connection.transaction_open?
     ActiveRecord::Base.connection.transaction do
-      # Allows only read only transactions
-      DB.exec "SET TRANSACTION READ ONLY" if !already_in_transaction
+      # Allows only read only transactions. Skipped in tests, where threads
+      # share one connection and read-only would break concurrent writes.
+      DB.exec "SET TRANSACTION READ ONLY" if !Rails.env.test?
       # Set a statement timeout so we can't tie up the server
       DB.exec "SET LOCAL statement_timeout = #{timeout}"
       yield

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -253,9 +253,12 @@ class Report
   end
 
   def self.wrap_slow_query(timeout = 20_000)
+    # Only set read-only when we own the transaction, otherwise (e.g. in specs, with
+    # transactional fixtures) we'd break concurrent writes on the shared connection.
+    already_in_transaction = ActiveRecord::Base.connection.transaction_open?
     ActiveRecord::Base.connection.transaction do
       # Allows only read only transactions
-      DB.exec "SET TRANSACTION READ ONLY"
+      DB.exec "SET TRANSACTION READ ONLY" if !already_in_transaction
       # Set a statement timeout so we can't tie up the server
       DB.exec "SET LOCAL statement_timeout = #{timeout}"
       yield


### PR DESCRIPTION
`Report.wrap_slow_query` sets the shared test connection to `READ ONLY` and any concurrent write requests that happen during it was exploding with `PG::ReadOnlySqlTransaction`.