### PR TITLE
UX: Hide manage-reports drag controls unless more than one is enabled

### DIFF
--- a/app/assets/stylesheets/common/modal/manage-reports-modal.scss
+++ b/app/assets/stylesheets/common/modal/manage-reports-modal.scss
@@ -50,7 +50,7 @@
     color: var(--primary-low-mid);
     visibility: hidden;
 
-    .manage-reports__row.--enabled & {
+    .manage-reports__list.--reorderable .manage-reports__row.--enabled & {
       visibility: visible;
     }
   }
@@ -61,7 +61,7 @@
     gap: var(--space-2);
     visibility: hidden;
 
-    .manage-reports__row.--enabled & {
+    .manage-reports__list.--reorderable .manage-reports__row.--enabled & {
       visibility: visible;
     }
   }

--- a/frontend/discourse/admin/components/modal/manage-reports.gjs
+++ b/frontend/discourse/admin/components/modal/manage-reports.gjs
@@ -9,7 +9,7 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
-import { eq } from "discourse/truth-helpers";
+import { and, eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
 import DLoadMore from "discourse/ui-kit/d-load-more";
@@ -88,6 +88,10 @@ export default class ManageReports extends Component {
 
   get atCap() {
     return this.enabledOrder.length >= VISIBLE_CAP;
+  }
+
+  get reorderable() {
+    return this.enabledOrder.length > 1;
   }
 
   cacheItems(items) {
@@ -294,7 +298,12 @@ export default class ManageReports extends Component {
       <:body>
 
         {{#if this.visibleRows.length}}
-          <ul class="manage-reports__list">
+          <ul
+            class={{dConcatClass
+              "manage-reports__list"
+              (if this.reorderable "--reorderable")
+            }}
+          >
             {{#each this.visibleRows key="key" as |row index|}}
               <li
                 class={{dConcatClass
@@ -302,7 +311,7 @@ export default class ManageReports extends Component {
                   (if row.enabled "--enabled")
                 }}
                 data-identifier={{row.key}}
-                draggable={{row.enabled}}
+                draggable={{and row.enabled this.reorderable}}
                 {{on "dragstart" (fn this.onDragStart row)}}
                 {{on "dragover" this.onDragOver}}
                 {{on "drop" (fn this.onDrop row)}}

--- a/spec/system/admin_dashboard_redesign/reports_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/reports_section_spec.rb
@@ -13,6 +13,18 @@ describe "Admin Dashboard Redesign | Reports section" do
     sign_in(current_user)
   end
 
+  it "shows drag controls only once more than one report is enabled" do
+    AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+
+    page.visit("/admin")
+    dashboard.open_manage_reports_via_cog
+    expect(modal).to have_open
+    expect(modal).to have_no_drag_controls
+
+    modal.toggle("core_report:admin_logins")
+    expect(modal).to have_drag_controls
+  end
+
   it "lets admins customize the reports section via the manage-reports modal" do
     AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
     AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)

--- a/spec/system/page_objects/components/manage_reports_modal.rb
+++ b/spec/system/page_objects/components/manage_reports_modal.rb
@@ -62,6 +62,15 @@ module PageObjects
         self
       end
 
+      def has_drag_controls?
+        has_css?("#{MODAL} .manage-reports__list.--reorderable")
+      end
+
+      def has_no_drag_controls?
+        has_css?("#{MODAL} .manage-reports__list") &&
+          has_no_css?("#{MODAL} .manage-reports__list.--reorderable")
+      end
+
       def has_counter?(count, max)
         has_css?(
           "#{MODAL} .manage-reports__counter",


### PR DESCRIPTION
A single enabled report can't be reordered, so the grip and ↑/↓ arrows were unnecessary. Gate them on a `--reorderable` list modifier (more than one enabled), which also drops `draggable` on the lone row. The grip keeps its reserved space, so toggling between one and two enabled reports doesn't shift the layout.