### PR TITLE
FIX: Allow typing in modals opened from the mobile topic-footer menu

### DIFF
--- a/frontend/discourse/app/ui-kit/d-modal.gjs
+++ b/frontend/discourse/app/ui-kit/d-modal.gjs
@@ -234,12 +234,13 @@ export default class DModal extends Component {
     }
 
     // Prevent keyboard events from leaking to elements behind the modal.
-    // Allow events when focus is inside a float-kit portal (menu/tooltip)
-    // opened from this modal, since those render outside the modal DOM.
+    // Allow events when focus is inside another modal stacked above this one,
+    // or inside a float-kit portal (menu/tooltip) opened from this modal,
+    // since those render outside the modal DOM.
     if (
       !this.wrapperElement.contains(document.activeElement) &&
       !document.activeElement?.closest(
-        ".fk-d-menu, .fk-d-menu-modal, .fk-d-tooltip"
+        ".d-modal, .fk-d-menu, .fk-d-menu-modal, .fk-d-tooltip"
       )
     ) {
       event.stopPropagation();

--- a/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-modal-test.gjs
@@ -288,4 +288,32 @@ module("Integration | ui-kit | DModal", function (hooks) {
       "pressing enter inside select-kit does not trigger the default button"
     );
   });
+
+  test("does not swallow keystrokes aimed at a modal stacked above it", async function (assert) {
+    await render(
+      <template>
+        <DModal @inline={{true}} @title="Underlying modal" />
+        <DModal @inline={{true}} @title="Stacked modal">
+          <:body>
+            <input type="text" class="stacked-modal-input" />
+          </:body>
+        </DModal>
+      </template>
+    );
+
+    const inputElement = document.querySelector(".stacked-modal-input");
+    inputElement.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      bubbles: true,
+      cancelable: true,
+    });
+    inputElement.dispatchEvent(event);
+
+    assert.false(
+      event.defaultPrevented,
+      "the underlying modal does not preventDefault keystrokes aimed at the modal stacked above it"
+    );
+  });
 });


### PR DESCRIPTION
When one modal is stacked above another, typing into a text input in the upper modal did nothing. This happens on mobile, where menus such as the topic-footer menu render as a `DModal` and stay mounted underneath, so opening an action like Assign or Flag from one stacks a modal on top of a modal.

Each `DModal` installs a capture-phase `keydown` listener that `preventDefault()`s keystrokes whose focus is neither inside its own wrapper nor a float-kit portal. The underlying modal treated focus in the upper modal as content behind itself and swallowed the key. This commit adds `.d-modal` to that allowlist, so a modal leaves keystrokes alone whenever focus is inside any modal.

### Recording

https://github.com/user-attachments/assets/5f1f955f-e49d-4a08-b672-5a17fc9f8d6b

