### PR TITLE
DEV: Fix `bin/qunit` file path filtering for relative test modules

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -297,14 +297,14 @@ class QunitRunner
     end
 
     if path.include?("/frontend/discourse/tests/")
-      return path.split("/frontend/discourse/").last
+      return path.split("/frontend/discourse/tests/").last
     elsif path.include?("/tests/")
-      return path.split("/tests/").last.prepend("tests/")
+      return path.split("/tests/").last
     end
 
     parts = path.split("/")
     if idx = parts.index("tests")
-      return parts[idx..-1].join("/")
+      return parts[(idx + 1)..-1].join("/")
     end
 
     file_path


### PR DESCRIPTION
Running `bin/qunit` against a specific test file or directory matched no tests and failed with "No tests matched with the filter". The file path filter passed to `ember exam` was prefixed with `tests/`, but core test modules are now registered relative to the tests directory (e.g. `./unit/foo-test`), so the substring match never hit.

This commit changes `convert_to_ember_relative_path` to emit the path relative to the tests directory, dropping the `tests/` prefix so the filter matches against the relative module names again.


### Before

```
bin/qunit frontend/discourse/tests/unit/deprecation-workflow-test.js

Running tests against Rails on localhost:3000
  Using existing build in frontend/discourse/dist
  Filtered by file path
  Load plugins: false

Randomizing tests with seed: ZfaDTIE5
[log] [warn] DEPRECATION NOTICE: The array["[]"] getter is a deprecated Ember native array extension. Use native array methods or a TrackedArray instead. [deprecated since Discourse 3.6.0.beta1-dev] [deprecation id: discourse.native-array-extensions.[]]
# Launcher: Chrome 148.0
not ok 1 Chrome 148.0 - [undefined ms] - Global error: Error: No tests matched with the filter: tests/unit/deprecation-workflow-test.js. at http://localhost:7357/2078241447000/tests?hidepassed&target=core&testem=1&filePath=tests%2Funit%2Fdeprecation-workflow-test.js&seed=ZfaDTIE5, line 0
    ---
        browser log: |
            {"type":"warn","text":"DEPRECATION NOTICE: The array[\"[]\"] getter is a deprecated Ember native array extension. Use native array methods or a TrackedArray instead. [deprecated since Discourse 3.6.0.beta1-dev] [deprecation id: discourse.native-array-extensions.[]]"}
            {"type":"error","text":"Error: No tests matched with the filter: tests/unit/deprecation-workflow-test.js. at http://localhost:7357/2078241447000/tests?hidepassed&target=core&testem=1&filePath=tests%2Funit%2Fdeprecation-workflow-test.js&seed=ZfaDTIE5, line 0\n","testContext":{}}
    ...
[log] [error] Error: No tests matched with the filter: tests/unit/deprecation-workflow-test.js. at http://localhost:7357/2078241447000/tests?hidepassed&target=core&testem=1&filePath=tests%2Funit%2Fdeprecation-workflow-test.js&seed=ZfaDTIE5:0

1..1
# tests 1
# pass  0
# skip  0
# todo  0
# fail  1

[Deprecation Counter] No deprecations logged


Failures:

not ok 1 Chrome 148.0 - [undefined ms] - Global error: Error: No tests matched with the filter: tests/unit/deprecation-workflow-test.js. at http://localhost:7357/2078241447000/tests?hidepassed&target=core&testem=1&filePath=tests%2Funit%2Fdeprecation-workflow-test.js&seed=ZfaDTIE5, line 0
    ---
        browser log: |
            {"type":"warn","text":"DEPRECATION NOTICE: The array[\"[]\"] getter is a deprecated Ember native array extension. Use native array methods or a TrackedArray instead. [deprecated since Discourse 3.6.0.beta1-dev] [deprecation id: discourse.native-array-extensions.[]]"}
            {"type":"error","text":"Error: No tests matched with the filter: tests/unit/deprecation-workflow-test.js. at http://localhost:7357/2078241447000/tests?hidepassed&target=core&testem=1&filePath=tests%2Funit%2Fdeprecation-workflow-test.js&seed=ZfaDTIE5, line 0\n","testContext":{"state":"complete"}}
    ...
Testem finished with non-zero exit code. Tests failed.
```

### After

```
bin/qunit frontend/discourse/tests/unit/deprecation-workflow-test.js

Running tests against Rails on localhost:3000
  Using existing build in frontend/discourse/dist
  Filtered by file path
  Load plugins: false

Randomizing tests with seed: a4jZKaVP
[log] [warn] DEPRECATION NOTICE: The array["[]"] getter is a deprecated Ember native array extension. Use native array methods or a TrackedArray instead. [deprecated since Discourse 3.6.0.beta1-dev] [deprecation id: discourse.native-array-extensions.[]]
# Launcher: Chrome 148.0
ok 1 [35 ms] - Unit | deprecation-workflow > constructor validations: validates matchId types
    ---
        browser log: |
            {"type":"warn","text":"DEPRECATION NOTICE: The array[\"[]\"] getter is a deprecated Ember native array extension. Use native array methods or a TrackedArray instead. [deprecated since Discourse 3.6.0.beta1-dev] [deprecation id: discourse.native-array-extensions.[]]"}
    ...
ok 2 [15 ms] - Unit | deprecation-workflow > constructor validations: normalizes env and validates allowed values
ok 3 [23 ms] - Unit | deprecation-workflow > environment activation: active workflows when environment is not set
ok 4 [21 ms] - Unit | deprecation-workflow > environment activation: active workflows in production
ok 5 [22 ms] - Unit | deprecation-workflow > environment activation: setEnvironment updates active workflows
ok 6 [22 ms] - Unit | deprecation-workflow > behavior helpers: shouldSilence reflects presence of silence handler
ok 7 [22 ms] - Unit | deprecation-workflow > environment activation: active workflows in development-like env
ok 8 [21 ms] - Unit | deprecation-workflow > behavior helpers: shouldThrow respects dont-throw handler
ok 9 [21 ms] - Unit | deprecation-workflow > behavior helpers: shouldLog respects workflow presence and handlers
ok 10 [21 ms] - Unit | deprecation-workflow > constructor validations: normalizes handler array and validates allowed handlers and combinations
ok 11 [22 ms] - Unit | deprecation-workflow > behavior helpers: shouldCount respects dont-count handler
ok 12 [20 ms] - Unit | deprecation-workflow > environment activation: active workflows in qunit/test environment
ok 13 [21 ms] - Unit | deprecation-workflow > behavior helpers: shouldCount defaults to true and is true with count even if silenced
ok 14 [20 ms] - Unit | deprecation-workflow > environment activation: active workflows in rails test environment
ok 15 [21 ms] - Unit | deprecation-workflow: emberWorkflowList flattens handlers and filters to Ember CLI-compatible ones
ok 16 [21 ms] - Unit | deprecation-workflow > behavior helpers: shouldThrow handles throw and includeUnsilenced
ok 17 [3 ms] - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly
ok 18 [21 ms] - Unit | deprecation-workflow > behavior helpers: helpers work with exact match and regex match
ok 19 [21 ms] - Unit | deprecation-workflow > behavior helpers: shouldNotifyAdmin reflects presence of notify-admin handler
Out of requested 1 browser(s), 1 browser(s) was launched & completed.
All browsers to exited.

1..19
# tests 19
# pass  19
# skip  0
# todo  0
# fail  0

# ok

[Deprecation Counter] No deprecations logged
```