### PR TITLE
DEV: Set LOAD_PLUGIN=1 in bin/rspec in more cases

### DIFF
--- a/bin/rspec
+++ b/bin/rspec
@@ -14,7 +14,14 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE_
 require "rubygems"
 require "bundler/setup"
 
-if ENV["LOAD_PLUGINS"].nil? && ARGV.any? { |pattern| pattern.include?("plugins/") }
+if ENV["LOAD_PLUGINS"].nil? &&
+     ARGV.any? { |pattern|
+       pattern.include?("plugins/") ||
+         (
+           ENV.key?("DISCOURSE_REPO_BASE_DIRECTORY") &&
+             !pattern.include?(ENV["DISCOURSE_REPO_BASE_DIRECTORY"] + "/spec")
+         )
+     }
   STDERR.puts "Detected plugin spec path, setting LOAD_PLUGINS to 1"
   ENV["LOAD_PLUGINS"] = "1"
 end


### PR DESCRIPTION
We already automatically set LOAD_PLUGINS=1 when
detecting a spec run in plugins/blah inside the
discourse repo dir, but often plugins are in
different folders on the system. This is especially
annoying when you have e.g. vscode open in a
directory and it runs a spec command like
bin/rspec /absolute/path/to/repo/spec/blah_spec.rb, which doesn't trigger the
LOAD_PLUGIN=1 logic.

This change makes it so any spec path that is either in
plugins/ or not in DISCOURSE_REPO_BASE_DIRECTORY will
automaticlaly trigger LOAD_PLUGIN=1
