### PR TITLE
FIX: Preserve subfolder base path in calendar event popup link

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -7,6 +7,7 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
+import getURL from "discourse/lib/get-url";
 import DAsyncContent from "discourse/ui-kit/d-async-content";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -214,7 +215,7 @@ export default class DiscoursePostEvent extends Component {
                   <span class="name">
                     {{#if @linkToPost}}
                       <a
-                        href={{event.post.url}}
+                        href={{getURL event.post.url}}
                         rel="noopener noreferrer"
                       >{{dReplaceEmoji this.eventName}}</a>
                     {{else}}

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
@@ -76,6 +76,10 @@ module PageObjects
           self
         end
 
+        def has_title_link_href?(href)
+          has_css?(".event-info .name a[href='#{href}']")
+        end
+
         def has_location?(text)
           has_css?(".event-location", text:)
         end

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
@@ -4,8 +4,8 @@ module PageObjects
   module Pages
     module DiscourseCalendar
       class UpcomingEvents < PageObjects::Pages::Base
-        def visit
-          super("/upcoming-events")
+        def visit(prefix = "")
+          super("#{prefix}/upcoming-events")
         end
 
         def next

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -39,6 +39,8 @@ describe "Upcoming Events" do
 
     it "filters non-recurring goings out of future occurrences",
        time: Time.utc(2026, 5, 12, 12, 0) do
+      set_subfolder "/discuss"
+
       post =
         create_post(
           user: admin,
@@ -55,12 +57,13 @@ describe "Upcoming Events" do
       )
       DiscoursePostEvent::Invitee.create_attendance!(going_once_user.id, event.id, :going)
 
-      upcoming_events.visit
+      upcoming_events.visit("/discuss")
       upcoming_events.click_event_on("2026-05-14")
 
       expect(post_event_page).to have_going_count(2)
       expect(post_event_page).to have_invitee_avatar(going_recurring_user.username)
       expect(post_event_page).to have_invitee_avatar(going_once_user.username)
+      expect(post_event_page).to have_title_link_href(post.relative_url)
 
       post_event_page.close_popup
       upcoming_events.click_event_on("2026-05-21")


### PR DESCRIPTION
Fixes the calendar event popup title link generating a URL without the subfolder base path on subfolder installs.

The popup title link rendered the raw `event.post.url`, a base-path-less path like `/t/slug/123`. On a site mounted under a subfolder, the resulting `href` omitted the subfolder prefix, so the link pointed at the parent domain and returned a 404. Left-click still navigated correctly because the calendar's click handler routes through `DiscourseURL.routeTo`, which accounts for the base path. Middle-click and "open link in new tab" follow the raw `href` directly, so the broken URL only surfaced when opening an event in a new tab.

This commit wraps the `href` in `getURL`, matching how the rest of the calendar builds URLs (`formatEventForCalendar` and the `eventClick` handler). `getURL` is a no-op when no subfolder is configured, so default installs are unaffected.