### PR TITLE
UI: Show categories in selector and icons in table for engagement in dashboard

### DIFF
--- a/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
@@ -8,8 +8,10 @@ import { trustHTML } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { number } from "discourse/lib/formatter";
+import Category from "discourse/models/category";
 import CategorySelector from "discourse/select-kit/components/category-selector";
 import { eq } from "discourse/truth-helpers";
+import dCategoryBadge from "discourse/ui-kit/helpers/d-category-badge";
 import I18n, { i18n } from "discourse-i18n";
 
 export default class ActivityByCategory extends Component {
@@ -19,6 +21,14 @@ export default class ActivityByCategory extends Component {
   @tracked sortBy = "share";
   @tracked sortDir = "desc";
 
+  constructor() {
+    super(...arguments);
+
+    this.selectedCategories = (this.args.activity?.rows ?? [])
+      .map((row) => Category.findById(row.category_id))
+      .filter(Boolean);
+  }
+
   get activity() {
     return this.overrideActivity ?? this.args.activity;
   }
@@ -27,6 +37,7 @@ export default class ActivityByCategory extends Component {
     const rows = this.activity?.rows ?? [];
     const decorated = rows.map((row) => ({
       ...row,
+      category: Category.findById(row.category_id),
       topicsFormatted: I18n.toNumber(row.topics, { precision: 0 }),
       postsFormatted: I18n.toNumber(row.posts, { precision: 0 }),
       pageViewsFormatted: number(row.page_views),
@@ -184,12 +195,16 @@ export default class ActivityByCategory extends Component {
             {{#each this.rows as |row|}}
               <tr>
                 <td class="db-activity-table__cell-category">
-                  <span
-                    class="db-activity-table__swatch"
-                    style={{row.swatchStyle}}
-                    aria-hidden="true"
-                  ></span>
-                  {{row.name}}
+                  {{#if row.category}}
+                    {{dCategoryBadge row.category}}
+                  {{else}}
+                    <span
+                      class="db-activity-table__swatch"
+                      style={{row.swatchStyle}}
+                      aria-hidden="true"
+                    ></span>
+                    {{row.name}}
+                  {{/if}}
                 </td>
                 <td
                   class="db-activity-table__cell-number"

--- a/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
@@ -2,6 +2,7 @@ import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import ActivityByCategory from "discourse/admin/components/dashboard/engagement/activity-by-category";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
   "Integration | Component | Dashboard | ActivityByCategory",
@@ -148,6 +149,40 @@ module(
       );
 
       assert.dom(".category-selector").exists();
+    });
+
+    test("prefills the selector with the categories shown by default", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert.strictEqual(
+        selectKit(".category-selector").header().value(),
+        "1,2,3"
+      );
+    });
+
+    test("renders a category badge for each row instead of a bare swatch", async function (assert) {
+      await render(
+        <template>
+          <ActivityByCategory
+            @activity={{activity}}
+            @startDate={{start}}
+            @endDate={{end}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".db-activity-table__cell-category .badge-category")
+        .exists({ count: 3 });
+      assert.dom(".db-activity-table__swatch").doesNotExist();
     });
   }
 );


### PR DESCRIPTION
A small update to categories in the engagement section:

<img width="1107" height="302" alt="Screenshot 2026-06-03 at 3 35 51 PM" src="https://github.com/user-attachments/assets/2dc9beb2-94b6-48e1-a7da-27914c86a1f0" />
