### PR TITLE
FEATURE: Add `post_moved` workflow trigger

### DIFF
--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -132,6 +132,7 @@ en:
         "trigger:topic_closed": "Topic closed"
         "trigger:post_created": "Post created"
         "trigger:post_edited": "Post edited"
+        "trigger:post_moved": "Post moved"
         "trigger:topic_created": "Topic created"
         "trigger:topic_category_changed": "Topic category changed"
         "trigger:topic_tag_changed": "Topic tag changed"
@@ -168,6 +169,7 @@ en:
         "trigger:topic_closed": "Fires when a topic is closed by a user or auto-close timer"
         "trigger:post_created": "Fires when a new post or reply is created"
         "trigger:post_edited": "Fires after the first post in a topic is edited and cooked"
+        "trigger:post_moved": "Fires when a post is moved to another topic"
         "trigger:topic_created": "Fires when a new topic is created"
         "trigger:topic_category_changed": "Fires when a topic is moved to a different category"
         "trigger:topic_tag_changed": "Fires when tags are added to or removed from a topic"
@@ -500,6 +502,11 @@ en:
         post_scope_all_posts: "All posts"
         trust_levels: "Trust levels"
         trust_levels_description: "Only trigger for posts created by users with these trust levels"
+      post_moved:
+        category_id: "Destination category"
+        category_id_description: "Only trigger for posts moved into this category"
+        tag_names: "Destination tags"
+        tag_names_description: "Only trigger for posts moved into topics that have at least one of these tags"
       topic_created:
         category_id: "Category"
         category_id_description: "Only trigger for topics in this category"

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module DiscourseWorkflows
+  module Nodes
+    module PostMoved
+      class V1 < NodeType
+        description(
+          name: "trigger:post_moved",
+          version: "1.0",
+          defaults: {
+            icon: "arrows-split-up-and-left",
+            color: "deep-orange",
+          },
+          group: "discourse_triggers",
+          events: [:post_moved],
+          properties: {
+            category_id: {
+              type: :integer,
+              required: false,
+              ui: {
+                control: :category,
+              },
+            },
+            tag_names: {
+              type: :string,
+              required: false,
+              ui: {
+                control: :tags,
+              },
+            },
+          },
+        )
+
+        def initialize(post, original_topic_id, *)
+          super(parameters: {})
+          @post = ::Post.find_by(id: post&.id)
+          @original_topic_id = original_topic_id
+        end
+
+        def valid?
+          @post.present? && destination_topic.present? && original_topic.present? &&
+            @post.post_type == ::Post.types[:regular]
+        end
+
+        def output
+          {
+            post: post_data(@post),
+            topic: topic_data(destination_topic),
+            original_topic: topic_data(original_topic),
+          }
+        end
+
+        def matches?(trigger_ctx)
+          matches_category?(trigger_ctx.get_node_parameter("category_id")) &&
+            matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
+        end
+
+        private
+
+        def post_data(post)
+          serialize_post(post)
+        end
+
+        def topic_data(topic)
+          serialize_record(topic, TopicListItemSerializer)
+        end
+
+        def destination_topic
+          @destination_topic ||= ::Topic.find_by(id: @post&.topic_id)
+        end
+
+        def original_topic
+          @original_topic ||= ::Topic.find_by(id: @original_topic_id)
+        end
+
+        def matches_category?(category_id)
+          category_id.blank? || destination_topic.category_id == category_id.to_i
+        end
+
+        def matches_tags?(tag_names)
+          tag_names.empty? || (destination_topic_tag_names & tag_names).any?
+        end
+
+        def destination_topic_tag_names
+          @destination_topic_tag_names ||= destination_topic.tags.pluck(:name)
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-workflows/spec/integration/post_moved_tags_spec.rb
+++ b/plugins/discourse-workflows/spec/integration/post_moved_tags_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe "Workflow: post moved -> topic tags" do
+  fab!(:admin)
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:source_post) { create_post(user: user, raw: "First post") }
+  fab!(:source_topic) { source_post.topic }
+  fab!(:reply) { create_post(user: user, topic: source_topic, raw: "Moved reply") }
+  fab!(:destination_topic, :topic)
+  fab!(:tag) { Fabricate(:tag, name: "moved") }
+
+  before do
+    SiteSetting.tagging_enabled = true
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.clear
+
+    graph =
+      build_workflow_graph do |g|
+        g.node "trigger-1", "trigger:post_moved"
+        g.node "action-1",
+               "action:topic_tags",
+               configuration: {
+                 "operation" => "add",
+                 "topic_id" => "={{ $trigger.topic.id }}",
+                 "tag_names" => tag.name,
+               }
+        g.chain "trigger-1", "action-1"
+      end
+
+    Fabricate(
+      :discourse_workflows_workflow,
+      created_by: admin,
+      published: true,
+      name: "Tag topics with moved posts",
+      **graph,
+    )
+  end
+
+  it "tags the destination topic when a post is moved" do
+    source_topic.move_posts(admin, [reply.id], destination_topic_id: destination_topic.id)
+
+    job_data = Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.last
+    expect(job_data).to be_present
+
+    trigger_data = job_data["args"].first["trigger_data"]
+    expect(trigger_data["post"]).to include(
+      "id" => reply.id,
+      "raw" => reply.raw,
+      "topic_id" => destination_topic.id,
+    )
+    expect(trigger_data["topic"]).to include("id" => destination_topic.id)
+    expect(trigger_data["original_topic"]).to include("id" => source_topic.id)
+
+    Jobs::DiscourseWorkflows::ExecuteWorkflow.new.execute(job_data["args"].first.symbolize_keys)
+
+    expect(destination_topic.reload.tags.map(&:name)).to include("moved")
+
+    execution = DiscourseWorkflows::Execution.last
+    expect(execution.status).to eq("success")
+  end
+end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_moved_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_moved_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Nodes::PostMoved::V1 do
+  fab!(:source_topic, :topic)
+  fab!(:destination_category, :category)
+  fab!(:destination_topic) { Fabricate(:topic, category: destination_category) }
+  fab!(:tag) { Fabricate(:tag, name: "destination-tag") }
+  fab!(:moved_post) { Fabricate(:post, topic: destination_topic, raw: "Moved reply") }
+  fab!(:small_action) do
+    Fabricate(:post, topic: destination_topic, post_type: Post.types[:small_action])
+  end
+
+  before do
+    SiteSetting.tagging_enabled = true
+    destination_topic.tags << tag
+  end
+
+  describe "#valid?" do
+    it "returns true for regular posts with source and destination topics" do
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(trigger).to be_valid
+    end
+
+    it "returns false when post is nil" do
+      trigger = described_class.new(nil, source_topic.id)
+
+      expect(trigger).not_to be_valid
+    end
+
+    it "returns false when the original topic is missing" do
+      trigger = described_class.new(moved_post, nil)
+
+      expect(trigger).not_to be_valid
+    end
+
+    it "returns false for non-regular posts" do
+      trigger = described_class.new(small_action, source_topic.id)
+
+      expect(trigger).not_to be_valid
+    end
+  end
+
+  describe "#output" do
+    it "returns moved post, destination topic, and original topic data" do
+      trigger = described_class.new(moved_post, source_topic.id)
+      output = trigger.output
+
+      expect(output[:post]).to include(
+        id: moved_post.id,
+        raw: moved_post.raw,
+        topic_id: destination_topic.id,
+        category_id: destination_category.id,
+        tags: ["destination-tag"],
+      )
+      expect(output[:topic]).to include(
+        id: destination_topic.id,
+        title: destination_topic.title,
+        category_id: destination_category.id,
+      )
+      expect(output[:original_topic]).to include(id: source_topic.id, title: source_topic.title)
+    end
+  end
+
+  describe "#matches?" do
+    it "returns true when destination category and tags are blank" do
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(trigger.matches?(trigger_context({}))).to eq(true)
+    end
+
+    it "returns true when the destination topic matches the configured category and tags" do
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(
+        trigger.matches?(
+          trigger_context("category_id" => destination_category.id.to_s, "tag_names" => [tag.name]),
+        ),
+      ).to eq(true)
+    end
+
+    it "returns false when the destination topic does not match category or tags" do
+      other_category = Fabricate(:category)
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(trigger.matches?(trigger_context("category_id" => other_category.id.to_s))).to eq(
+        false,
+      )
+      expect(trigger.matches?(trigger_context("tag_names" => ["missing"]))).to eq(false)
+    end
+  end
+
+  def trigger_context(parameters)
+    DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+  end
+end


### PR DESCRIPTION
Previously, workflows could not react directly when posts were moved between topics.

This change adds a Post moved trigger with destination category/tag filters and payload data for the moved post, destination topic, and original topic.

<img width="1432" height="337" alt="Screenshot 2026-06-03 at 10 48 34" src="https://github.com/user-attachments/assets/8a3c25ac-903e-4fc7-9716-b9059be2222f" />
<img width="276" height="271" alt="Screenshot 2026-06-03 at 10 48 29" src="https://github.com/user-attachments/assets/52e37226-acd7-49cb-9252-9d229d75ac95" />

