### PR TITLE
FIX: Ignore stale workflow run data for changed node inputs

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/condition-builder.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/condition-builder.gjs
@@ -15,7 +15,6 @@ import {
   outputIndexForConnection,
   previousNodeForConnection,
   schemaFieldsForNodeInput,
-  schemaFieldsForNodeOutput,
 } from "../../../lib/workflows/data-schema";
 import { isExpression } from "../../../lib/workflows/property-engine";
 import Collection from "./collection";
@@ -170,7 +169,11 @@ export default class ConditionBuilder extends Component {
       const inputIndex = inputIndexForConnection(connection);
       const outputIndex = outputIndexForConnection(connection);
       const currentInputSummary = this.args.node
-        ? inputSummaryForNode(runData, this.args.node.name, inputIndex)
+        ? inputSummaryForNode(runData, this.args.node.name, inputIndex, {
+            node: this.args.node,
+            sourceNode: previousNode,
+            outputIndex,
+          })
         : null;
       const prefix = inputFieldPrefixForConnection(connection, previousNode, {
         primaryConnection,
@@ -178,12 +181,12 @@ export default class ConditionBuilder extends Component {
       const fields = currentInputSummary
         ? schemaFieldsForNodeInput(runData, this.args.node.name, {
             inputIndex,
-            prefix,
-          })
-        : schemaFieldsForNodeOutput(runData, previousNode.name, {
+            node: this.args.node,
+            sourceNode: previousNode,
             outputIndex,
             prefix,
-          });
+          })
+        : [];
       const labelPrefix =
         inputConnections.length > 1 ? previousNode.name || null : null;
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
@@ -69,17 +69,23 @@ export default class ExpressionInput extends Component {
       ? inputIndexForConnection(previousConnection)
       : 0;
     const currentInputSummary = node
-      ? inputSummaryForNode(runData, node.name, currentInputIndex)
+      ? inputSummaryForNode(runData, node.name, currentInputIndex, {
+          node,
+          sourceNode: previousNode,
+          outputIndex: previousConnection
+            ? outputIndexForConnection(previousConnection)
+            : 0,
+        })
       : null;
     let inputFields = [];
     if (currentInputSummary) {
       inputFields = schemaFieldsForNodeInput(runData, node.name, {
         inputIndex: currentInputIndex,
-        prefix: itemPrefix,
-      });
-    } else if (previousNode) {
-      inputFields = schemaFieldsForNodeOutput(runData, previousNode.name, {
-        outputIndex: outputIndexForConnection(previousConnection),
+        node,
+        sourceNode: previousNode,
+        outputIndex: previousConnection
+          ? outputIndexForConnection(previousConnection)
+          : 0,
         prefix: itemPrefix,
       });
     }
@@ -88,6 +94,7 @@ export default class ExpressionInput extends Component {
           node: ancestor.node,
           fields: schemaFieldsForNodeOutput(runData, ancestor.node.name, {
             outputIndex: ancestor.outputIndex,
+            node: ancestor.node,
             prefix: nodeItemJsonPath(ancestor.node.name),
           }),
         }))

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/input.gjs
@@ -153,32 +153,34 @@ export default class InputContext extends Component {
         const recordedInputSummary = inputSummaryForNode(
           this.runData,
           this.args.node.name,
-          inputIndex
+          inputIndex,
+          {
+            node: this.args.node,
+            sourceNode: previousNode,
+            outputIndex,
+          }
         );
-        const summary =
-          recordedInputSummary ||
-          outputSummaryForNode(this.runData, previousNode.name, outputIndex);
-        const fields = recordedInputSummary
-          ? schemaFieldsForNodeInput(this.runData, this.args.node.name, {
-              inputIndex,
-              prefix: inputFieldPrefixForConnection(connection, previousNode, {
-                primaryConnection: this.primaryInputConnection,
-              }),
-            })
-          : schemaFieldsForNodeOutput(this.runData, previousNode.name, {
-              outputIndex,
-              prefix: inputFieldPrefixForConnection(connection, previousNode, {
-                primaryConnection: this.primaryInputConnection,
-              }),
-            });
+        const fields = schemaFieldsForNodeInput(
+          this.runData,
+          this.args.node.name,
+          {
+            inputIndex,
+            node: this.args.node,
+            sourceNode: previousNode,
+            outputIndex,
+            prefix: inputFieldPrefixForConnection(connection, previousNode, {
+              primaryConnection: this.primaryInputConnection,
+            }),
+          }
+        );
 
         return {
           node: previousNode,
           inputIndex,
           fields: processFields(fields, this.args.node, this.graph),
-          itemCountLabel: this.itemCountLabel(summary),
+          itemCountLabel: this.itemCountLabel(recordedInputSummary),
           inputLabel: this.inputConnectionLabel(inputIndex),
-          emptyMessage: this.emptyMessage(summary),
+          emptyMessage: this.emptyMessage(recordedInputSummary),
         };
       })
       .filter(Boolean);
@@ -215,6 +217,7 @@ export default class InputContext extends Component {
           ancestor.node.name,
           {
             outputIndex: ancestor.outputIndex,
+            node: ancestor.node,
             prefix: nodeItemJsonPath(ancestor.node.name),
           }
         );
@@ -228,7 +231,8 @@ export default class InputContext extends Component {
             outputSummaryForNode(
               this.runData,
               ancestor.node.name,
-              ancestor.outputIndex
+              ancestor.outputIndex,
+              { node: ancestor.node }
             )
           ),
         };

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/output.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/output.gjs
@@ -99,7 +99,7 @@ export default class OutputContext extends Component {
     const schema = outputSchemaForNode(
       this.args.session?.lastExecutionRunData || {},
       currentNode.name,
-      { pinnedItems: this.pinnedItems }
+      { pinnedItems: this.pinnedItems, node: currentNode }
     );
 
     return {

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/data-schema.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/data-schema.js
@@ -207,9 +207,42 @@ export function exemplarFromFields(fields = []) {
   return obj;
 }
 
-function latestSuccessfulRun(runData, nodeName) {
+function nodeRunMatches(run, node) {
+  if (!node) {
+    return true;
+  }
+
+  const nodeId = node.id ?? node.clientId;
+  if (run?.node_id && nodeId && run.node_id.toString() !== nodeId.toString()) {
+    return false;
+  }
+
+  if (run?.node_type && node.type && run.node_type !== node.type) {
+    return false;
+  }
+
+  return true;
+}
+
+function portSourceMatches(port, sourceNode, outputIndex) {
+  if (!sourceNode) {
+    return true;
+  }
+
+  const source = port?.source;
+  if (!source) {
+    return false;
+  }
+
+  return (
+    source.node_name === sourceNode.name &&
+    (source.output_index ?? 0).toString() === outputIndex.toString()
+  );
+}
+
+function latestSuccessfulRun(runData, nodeName, { node } = {}) {
   const runs = (runData?.[nodeName] || []).filter(
-    (run) => run.status === "success"
+    (run) => run.status === "success" && nodeRunMatches(run, node)
   );
   if (!runs?.length) {
     return null;
@@ -218,12 +251,21 @@ function latestSuccessfulRun(runData, nodeName) {
   return runs[runs.length - 1] || null;
 }
 
-export function latestRunWithOutput(runData, nodeName) {
-  return latestSuccessfulRun(runData, nodeName);
+export function latestRunWithOutput(runData, nodeName, { node } = {}) {
+  return latestSuccessfulRun(runData, nodeName, { node });
 }
 
-export function latestRunWithInput(runData, nodeName) {
-  return latestSuccessfulRun(runData, nodeName);
+export function latestRunWithInput(
+  runData,
+  nodeName,
+  { inputIndex = 0, node, sourceNode, outputIndex = 0 } = {}
+) {
+  const run = latestSuccessfulRun(runData, nodeName, { node });
+  if (!inputForRun(run, inputIndex, { sourceNode, outputIndex })) {
+    return null;
+  }
+
+  return run;
 }
 
 function portForRun(run, portKey, portIndex = 0) {
@@ -238,16 +280,25 @@ export function outputForRun(run, outputIndex = 0) {
   return portForRun(run, "outputs", outputIndex);
 }
 
-export function inputForRun(run, inputIndex = 0) {
-  return portForRun(run, "inputs", inputIndex);
+export function inputForRun(
+  run,
+  inputIndex = 0,
+  { sourceNode, outputIndex = 0 } = {}
+) {
+  const input = portForRun(run, "inputs", inputIndex);
+  if (!input || !portSourceMatches(input, sourceNode, outputIndex)) {
+    return null;
+  }
+
+  return input;
 }
 
 export function schemaFieldsForNodeOutput(
   runData,
   nodeName,
-  { outputIndex = 0, prefix = "$json" } = {}
+  { outputIndex = 0, prefix = "$json", node } = {}
 ) {
-  const run = latestRunWithOutput(runData, nodeName, outputIndex);
+  const run = latestRunWithOutput(runData, nodeName, { node });
   const output = outputForRun(run, outputIndex);
   return schemaFieldsForItems(output?.items || [], { prefix });
 }
@@ -255,10 +306,15 @@ export function schemaFieldsForNodeOutput(
 export function schemaFieldsForNodeInput(
   runData,
   nodeName,
-  { inputIndex = 0, prefix = "$json" } = {}
+  { inputIndex = 0, prefix = "$json", node, sourceNode, outputIndex = 0 } = {}
 ) {
-  const run = latestRunWithInput(runData, nodeName, inputIndex);
-  const input = inputForRun(run, inputIndex);
+  const run = latestRunWithInput(runData, nodeName, {
+    inputIndex,
+    node,
+    sourceNode,
+    outputIndex,
+  });
+  const input = inputForRun(run, inputIndex, { sourceNode, outputIndex });
   return schemaFieldsForItems(input?.items || [], { prefix });
 }
 
@@ -274,14 +330,32 @@ function portSummary(port, indexKey) {
   };
 }
 
-export function outputSummaryForNode(runData, nodeName, outputIndex = 0) {
-  const run = latestRunWithOutput(runData, nodeName, outputIndex);
+export function outputSummaryForNode(
+  runData,
+  nodeName,
+  outputIndex = 0,
+  { node } = {}
+) {
+  const run = latestRunWithOutput(runData, nodeName, { node });
   return portSummary(outputForRun(run, outputIndex), "outputIndex");
 }
 
-export function inputSummaryForNode(runData, nodeName, inputIndex = 0) {
-  const run = latestRunWithInput(runData, nodeName, inputIndex);
-  return portSummary(inputForRun(run, inputIndex), "inputIndex");
+export function inputSummaryForNode(
+  runData,
+  nodeName,
+  inputIndex = 0,
+  { node, sourceNode, outputIndex = 0 } = {}
+) {
+  const run = latestRunWithInput(runData, nodeName, {
+    inputIndex,
+    node,
+    sourceNode,
+    outputIndex,
+  });
+  return portSummary(
+    inputForRun(run, inputIndex, { sourceNode, outputIndex }),
+    "inputIndex"
+  );
 }
 
 function combinedPortSummary(ports, itemCount) {
@@ -313,7 +387,11 @@ function outputPreviewItemCount(outputs, items) {
   return items.length ? 1 : 0;
 }
 
-export function outputSchemaForNode(runData, nodeName, { pinnedItems } = {}) {
+export function outputSchemaForNode(
+  runData,
+  nodeName,
+  { pinnedItems, node } = {}
+) {
   if (Array.isArray(pinnedItems) && pinnedItems.length > 0) {
     return {
       summary: {
@@ -325,7 +403,7 @@ export function outputSchemaForNode(runData, nodeName, { pinnedItems } = {}) {
     };
   }
 
-  const run = latestRunWithOutput(runData, nodeName);
+  const run = latestRunWithOutput(runData, nodeName, { node });
   if (!run) {
     return { summary: null, fields: [] };
   }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/editor-session.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/editor-session.js
@@ -1,5 +1,11 @@
 import { tracked } from "@glimmer/tracking";
 import { ajax } from "discourse/lib/ajax";
+import {
+  inputForRun,
+  latestRunWithInput,
+  latestRunWithOutput,
+  outputForRun,
+} from "./data-schema";
 
 function compactObject(object) {
   return Object.fromEntries(
@@ -44,22 +50,6 @@ function targetInputIndexForConnection(connection) {
   return (
     connection.targetInputIndex ?? portIndexFromKey(connection.targetInput)
   );
-}
-
-function latestPortItems(runs, portKey, portIndex) {
-  const run = [...(runs || [])]
-    .reverse()
-    .find(
-      (candidate) =>
-        candidate.status === "success" &&
-        (candidate[portKey] || []).some(
-          (port) => port.index === portIndex && Array.isArray(port.items)
-        )
-    );
-  const port = (run?.[portKey] || []).find(
-    (candidate) => candidate.index === portIndex
-  );
-  return port?.items;
 }
 
 export default class WorkflowEditorSession {
@@ -132,13 +122,15 @@ export default class WorkflowEditorSession {
         const inputIndex = targetInputIndexForConnection(connection);
         const outputIndex = sourceOutputIndexForConnection(connection);
         const sourceNode = this.nodeForClientId(connection.sourceClientId);
-        const currentInput = this.inputItemsForNode(node, inputIndex);
+        const currentInput = this.inputItemsForNode(node, inputIndex, {
+          sourceNode,
+          outputIndex,
+        });
 
         return {
           sourceNodeId: connection.sourceClientId,
           inputIndex,
-          items:
-            currentInput ?? this.outputItemsForNode(sourceNode, outputIndex),
+          items: currentInput,
         };
       })
       .filter((input) => input.items !== undefined);
@@ -149,8 +141,7 @@ export default class WorkflowEditorSession {
     if (Object.keys(sourceNodeOutputs).length === 0) {
       return {
         available: false,
-        reason:
-          "No upstream execution preview output is available for this node",
+        reason: "No input execution preview is available for this node",
       };
     }
 
@@ -290,13 +281,24 @@ export default class WorkflowEditorSession {
       }
     }
 
-    const runs = this.lastExecutionRunData?.[node?.name];
-    return latestPortItems(runs, "outputs", outputIndex);
+    const run = latestRunWithOutput(this.lastExecutionRunData, node?.name, {
+      node,
+    });
+    return outputForRun(run, outputIndex)?.items;
   }
 
-  inputItemsForNode(node, inputIndex = 0) {
-    const runs = this.lastExecutionRunData?.[node?.name];
-    return latestPortItems(runs, "inputs", inputIndex);
+  inputItemsForNode(
+    node,
+    inputIndex = 0,
+    { sourceNode, outputIndex = 0 } = {}
+  ) {
+    const run = latestRunWithInput(this.lastExecutionRunData, node?.name, {
+      inputIndex,
+      node,
+      sourceNode,
+      outputIndex,
+    });
+    return inputForRun(run, inputIndex, { sourceNode, outputIndex })?.items;
   }
 
   nodeForClientId(clientId) {

--- a/plugins/discourse-workflows/app/services/discourse_workflows/workflow/action/build_expression_preview_context.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/workflow/action/build_expression_preview_context.rb
@@ -40,9 +40,6 @@ module DiscourseWorkflows
       upstream_connections = upstream_connections_for(node_id)
       primary_upstream_connection = upstream_connections.first
       current_input = current_node_input(node_runs, primary_upstream_connection)
-      if upstream_connections.present?
-        context["__input_sources"] = input_sources_for_connections(upstream_connections)
-      end
 
       workflow.nodes.each do |node|
         next if node["name"].blank?
@@ -60,13 +57,6 @@ module DiscourseWorkflows
         end
 
         context[node["name"]] = items
-
-        if current_input.blank? &&
-             primary_upstream_connection&.source_node_id.to_s == node["id"].to_s
-          context["$json"] = first_json
-          context["__input_item"] = items.first || { "json" => {} }
-          context["__input_items"] = items
-        end
       end
 
       overlay_current_input(context, current_input) if current_input
@@ -90,6 +80,8 @@ module DiscourseWorkflows
       return unless run
 
       input_index = (primary_upstream_connection&.target_input_index || 0).to_i
+      return unless input_source_matches_connection?(run, input_index, primary_upstream_connection)
+
       items = run.dig("inputs", input_index)
       return unless items
 
@@ -115,15 +107,6 @@ module DiscourseWorkflows
       workflow_snapshot.connections_to(target_node)
     end
 
-    def input_sources_for_connections(connections)
-      connections.map do |connection|
-        {
-          "node_name" => workflow_snapshot.source_node(connection)&.name,
-          "output_index" => connection.source_output_index.to_i,
-        }
-      end
-    end
-
     def workflow_snapshot
       @workflow_snapshot ||=
         DiscourseWorkflows::WorkflowSnapshot.new(
@@ -135,16 +118,55 @@ module DiscourseWorkflows
 
     def node_runs_for_expression(run_data)
       run_data.each_with_object({}) do |(node_name, runs), result|
-        result[node_name] = Array(runs).filter_map do |run|
-          next unless run["status"] == "success"
+        node = workflow_node_by_name[node_name.to_s]
+        next unless node
 
-          {
-            "inputs" => ports_to_item_groups(run["inputs"]),
-            "outputs" => ports_to_item_groups(run["outputs"]),
-            "input_sources" => input_sources(run["inputs"]),
-          }
-        end
+        matching_runs =
+          Array(runs).filter_map do |run|
+            next unless run["status"] == "success"
+            next unless run_matches_node?(run, node)
+
+            {
+              "node_id" => run["node_id"],
+              "node_type" => run["node_type"],
+              "inputs" => ports_to_item_groups(run["inputs"]),
+              "outputs" => ports_to_item_groups(run["outputs"]),
+              "input_sources" => input_sources(run["inputs"]),
+            }
+          end
+        result[node_name] = matching_runs if matching_runs.present?
       end
+    end
+
+    def workflow_node_by_name
+      @workflow_node_by_name ||=
+        workflow
+          .nodes
+          .each_with_object({}) do |node, by_name|
+            name = node["name"].to_s
+            next if name.blank?
+
+            by_name[name] = by_name.key?(name) ? nil : node
+          end
+          .compact
+    end
+
+    def run_matches_node?(run, node)
+      return false if run["node_id"].present? && run["node_id"].to_s != node["id"].to_s
+      return false if run["node_type"].present? && run["node_type"].to_s != node["type"].to_s
+
+      true
+    end
+
+    def input_source_matches_connection?(run, input_index, connection)
+      return false unless connection
+
+      source = Array(run["input_sources"])[input_index]
+      source_node = workflow_snapshot.source_node(connection)
+      return false if source.blank? || source_node.blank?
+
+      source["node_name"].to_s == source_node.name.to_s &&
+        source["output_index"].to_i == connection.source_output_index.to_i
     end
 
     def ports_to_item_groups(ports)

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/workflow/action/build_expression_preview_context_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/workflow/action/build_expression_preview_context_spec.rb
@@ -124,12 +124,11 @@ RSpec.describe DiscourseWorkflows::Workflow::Action::BuildExpressionPreviewConte
             expect(context.dig("__node_runs", "Topic created", 0, "outputs", 0)).to eq(items)
           end
 
-          context "when node_id matches the trigger's downstream" do
+          context "when the current node has no recorded input data" do
             let(:node_id) { "action-1" }
 
-            it "uses the upstream execution output for $json" do
-              expect(context["$json"]).to eq({ "title" => "From past run" })
-              expect(context["__input_items"]).to eq(items)
+            it "uses the default input context" do
+              expect(context["$json"]).to eq({})
             end
           end
 
@@ -182,6 +181,53 @@ RSpec.describe DiscourseWorkflows::Workflow::Action::BuildExpressionPreviewConte
               expect(context["__input_sources"]).to eq(
                 [{ "node_name" => "Topic created", "output_index" => 0 }],
               )
+            end
+          end
+
+          context "when recorded input came from another source" do
+            let(:node_id) { "action-1" }
+            let(:stale_items) { [{ "json" => { "reviewable" => { "id" => 1 } } }] }
+
+            before do
+              execution.execution_data.update!(
+                data: {
+                  "entries" => {
+                  },
+                  "context" => {
+                  },
+                  "node_contexts" => {
+                  },
+                  "run_data" =>
+                    run_data_for(
+                      "trigger-1",
+                      node_name: "Topic created",
+                      node_type: "trigger:topic_created",
+                      items: items,
+                    ).deep_merge(
+                      run_data_for(
+                        "action-1",
+                        node_name: "Tag topic",
+                        node_type: "action:topic_tags",
+                        items: [],
+                        inputs: [
+                          {
+                            "index" => 0,
+                            "items" => stale_items,
+                            "item_count" => stale_items.length,
+                            "source" => {
+                              "node_name" => "Approved reviewable",
+                              "output_index" => 0,
+                            },
+                          },
+                        ],
+                      ),
+                    ),
+                },
+              )
+            end
+
+            it "uses the default input context" do
+              expect(context["$json"]).to eq({})
             end
           end
         end
@@ -238,6 +284,24 @@ RSpec.describe DiscourseWorkflows::Workflow::Action::BuildExpressionPreviewConte
                         "item_count" => rejected_items.length,
                       },
                     ],
+                  ).deep_merge(
+                    run_data_for(
+                      "action-1",
+                      node_name: "Log",
+                      node_type: "action:log",
+                      items: [],
+                      inputs: [
+                        {
+                          "index" => 0,
+                          "items" => rejected_items,
+                          "item_count" => rejected_items.length,
+                          "source" => {
+                            "node_name" => "Filter",
+                            "output_index" => 1,
+                          },
+                        },
+                      ],
+                    ),
                   ),
               },
             )

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
@@ -294,9 +294,12 @@ module(
       ].map((el) => el.textContent.trim());
 
       assert.true(firstTitle.includes("First Step"));
-      assert.true(firstTitle.includes("1 item"));
+      assert.false(firstTitle.includes("1 item"));
       assert.dom(".workflows-context-panel__item-title").doesNotExist();
-      assert.true(keys.includes("result"));
+      assert.false(keys.includes("result"));
+      assert
+        .dom(".workflows-context-panel__empty")
+        .hasText("No input data yet. It will appear after the first run.");
     });
 
     test("shows an empty input state when the input has no JSON fields", async function (assert) {
@@ -315,14 +318,15 @@ module(
         { sourceClientId: "previous-1", targetClientId: "current-1" },
       ];
       this.session.lastExecutionRunData = {
-        Previous: [
+        Current: [
           {
             status: "success",
-            outputs: [
+            inputs: [
               {
                 index: 0,
                 items: [{ json: {} }],
                 item_count: 1,
+                source: { node_name: "Previous", output_index: 0 },
               },
             ],
           },
@@ -425,6 +429,25 @@ module(
             ],
           },
         ],
+        Merge: [
+          {
+            status: "success",
+            inputs: [
+              {
+                index: 0,
+                items: [{ json: { left: true } }],
+                item_count: 1,
+                source: { node_name: "Left", output_index: 0 },
+              },
+              {
+                index: 1,
+                items: [{ json: { right: true } }],
+                item_count: 1,
+                source: { node_name: "Right", output_index: 0 },
+              },
+            ],
+          },
+        ],
       };
 
       await render(
@@ -484,7 +507,7 @@ module(
       );
     });
 
-    test("prefers the current node recorded input over the previous node output", async function (assert) {
+    test("uses current node recorded input when previous node output differs", async function (assert) {
       const logNode = {
         clientId: "log-1",
         type: "action:log",
@@ -546,6 +569,83 @@ module(
       assert.true(firstTitle.includes("1 item"));
       assert.dom(".workflows-context-panel__item-title").doesNotExist();
       assert.true(keys.includes("topic"));
+    });
+
+    test("shows no input data when recorded input source is stale", async function (assert) {
+      const postMovedNode = {
+        clientId: "post-moved",
+        type: "trigger:post_moved",
+        name: "Post moved",
+      };
+      const logNode = {
+        clientId: "log",
+        type: "action:log",
+        name: "Log",
+      };
+      const nodes = makeNodes(postMovedNode, logNode);
+      const connections = [
+        { sourceClientId: "post-moved", targetClientId: "log" },
+      ];
+      this.session.lastExecutionRunData = {
+        "Post moved": [
+          {
+            node_id: "post-moved",
+            node_type: "trigger:post_moved",
+            status: "success",
+            outputs: [
+              {
+                index: 0,
+                items: [{ json: { post: { id: 1 } } }],
+                item_count: 1,
+              },
+            ],
+          },
+        ],
+        Log: [
+          {
+            node_id: "log",
+            node_type: "action:log",
+            status: "success",
+            inputs: [
+              {
+                index: 0,
+                items: [{ json: { reviewable: { id: 1 } } }],
+                item_count: 1,
+                source: { node_name: "Approved reviewable", output_index: 0 },
+              },
+            ],
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <InputContext
+            @node={{logNode}}
+            @nodes={{nodes}}
+            @connections={{connections}}
+            @nodeTypes={{(Array)}}
+            @session={{this.session}}
+          />
+        </template>
+      );
+
+      const firstTitle = this.element
+        .querySelector(
+          ".workflows-context-panel__section .workflows-context-panel__title"
+        )
+        .textContent.trim();
+      const keys = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key-title"),
+      ].map((el) => el.textContent.trim());
+
+      assert.true(firstTitle.includes("Post moved"));
+      assert.false(firstTitle.includes("1 item"));
+      assert.false(keys.includes("post"));
+      assert.false(keys.includes("reviewable"));
+      assert
+        .dom(".workflows-context-panel__empty")
+        .hasText("No input data yet. It will appear after the first run.");
     });
 
     test("hides the input section when there is no previous node", async function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/property-engine-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/property-engine-test.gjs
@@ -194,6 +194,7 @@ module("Integration | Component | workflows property engine", function (hooks) {
       node: {
         clientId: "branch",
         type: "condition:if",
+        name: "Branch",
       },
       nodes: [
         {
@@ -260,6 +261,27 @@ module("Integration | Component | workflows property engine", function (hooks) {
               index: 0,
               items: [{ json: { secondary_status: "ok" } }],
               item_count: 1,
+            },
+          ],
+        },
+      ],
+      Branch: [
+        {
+          status: "success",
+          inputs: [
+            {
+              index: 0,
+              items: [
+                { json: { status: "ok", "topic title": { "post-count": 2 } } },
+              ],
+              item_count: 1,
+              source: { node_name: "Trigger", output_index: 0 },
+            },
+            {
+              index: 1,
+              items: [{ json: { secondary_status: "ok" } }],
+              item_count: 1,
+              source: { node_name: "Secondary", output_index: 0 },
             },
           ],
         },

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-data-schema-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-data-schema-test.js
@@ -135,6 +135,33 @@ module("Unit | lib | discourse-workflows | data-schema", function () {
     });
   });
 
+  test("schemaFieldsForNodeOutput ignores runs for another node with the same name", function (assert) {
+    const runData = {
+      Log: [
+        {
+          node_id: "old-log",
+          node_type: "action:log",
+          status: "success",
+          outputs: [
+            { index: 0, items: [{ json: { stale: true } }], item_count: 1 },
+          ],
+        },
+      ],
+    };
+    const node = { id: "new-log", name: "Log", type: "action:log" };
+
+    assert.deepEqual(
+      schemaFieldsForNodeOutput(runData, "Log", { node }),
+      [],
+      "does not expose output from a different node id"
+    );
+    assert.strictEqual(
+      outputSummaryForNode(runData, "Log", 0, { node }),
+      null,
+      "does not expose summary from a different node id"
+    );
+  });
+
   test("outputForRun keeps output indexes positional", function (assert) {
     const run = {
       outputs: [{ index: 0, items: [{ json: { primary: true } }] }],
@@ -200,6 +227,61 @@ module("Unit | lib | discourse-workflows | data-schema", function () {
       truncated: false,
     });
     assert.strictEqual(inputForRun(runData["Node 1"][0], 0), null);
+  });
+
+  test("schemaFieldsForNodeInput ignores recorded inputs from another source", function (assert) {
+    const currentNode = { id: "log", name: "Log", type: "action:log" };
+    const sourceNode = {
+      id: "post-moved",
+      name: "Post moved",
+      type: "trigger:post_moved",
+    };
+    const runData = {
+      Log: [
+        {
+          node_id: "log",
+          node_type: "action:log",
+          status: "success",
+          inputs: [
+            {
+              index: 0,
+              items: [{ json: { reviewable: { id: 1 } } }],
+              item_count: 1,
+              source: { node_name: "Approved reviewable", output_index: 0 },
+            },
+          ],
+        },
+      ],
+      "Post moved": [
+        {
+          node_id: "post-moved",
+          node_type: "trigger:post_moved",
+          status: "success",
+          outputs: [
+            { index: 0, items: [{ json: { post: { id: 1 } } }], item_count: 1 },
+          ],
+        },
+      ],
+    };
+
+    assert.deepEqual(
+      schemaFieldsForNodeInput(runData, "Log", {
+        node: currentNode,
+        sourceNode,
+        outputIndex: 0,
+      }),
+      [],
+      "does not expose input fields from a stale source"
+    );
+    assert.strictEqual(
+      inputSummaryForNode(runData, "Log", 0, {
+        node: currentNode,
+        sourceNode,
+        outputIndex: 0,
+      }),
+      null,
+      "does not expose input summary from a stale source"
+    );
   });
 
   test("nodeItemJsonPath escapes node names for expressions", function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-types-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-node-types-test.js
@@ -236,7 +236,6 @@ module("Unit | Service | workflows-node-types", function (hooks) {
       name: "Upstream",
       type: "trigger:topic",
     };
-    const upstreamOutput = [{ json: { username: "sam" } }];
     const runData = {
       Upstream: [
         {
@@ -244,8 +243,8 @@ module("Unit | Service | workflows-node-types", function (hooks) {
           outputs: [
             {
               index: 0,
-              items: upstreamOutput,
-              item_count: upstreamOutput.length,
+              items: [{ json: { username: "sam" } }],
+              item_count: 1,
             },
           ],
         },
@@ -293,17 +292,15 @@ module("Unit | Service | workflows-node-types", function (hooks) {
     assert.strictEqual(payload.workflowId, 7);
     assert.strictEqual(payload.filter, "staff");
     assert.deepEqual(payload.inputContext, {
-      available: true,
-      item: upstreamOutput[0],
-      items: upstreamOutput,
-      source_node_outputs: { "node-0": upstreamOutput },
+      available: false,
+      reason: "No input execution preview is available for this node",
     });
     assert.deepEqual(payload.executionContext, {
       last_node_outputs: runData,
     });
   });
 
-  test("input context uses source output keys when output indexes are not stored", function (assert) {
+  test("input context uses recorded input source keys when output indexes are not stored", function (assert) {
     const upstreamNode = {
       clientId: "node-0",
       name: "Branch",
@@ -315,7 +312,7 @@ module("Unit | Service | workflows-node-types", function (hooks) {
       type: "action:log",
       typeVersion: "1.0",
     };
-    const rejectedOutput = [{ json: { matched: false } }];
+    const rejectedInput = [{ json: { matched: false } }];
 
     const session = new WorkflowEditorSession({
       workflowId: 7,
@@ -331,8 +328,21 @@ module("Unit | Service | workflows-node-types", function (hooks) {
               },
               {
                 index: 1,
-                items: rejectedOutput,
+                items: rejectedInput,
                 item_count: 1,
+              },
+            ],
+          },
+        ],
+        Log: [
+          {
+            status: "success",
+            inputs: [
+              {
+                index: 0,
+                items: rejectedInput,
+                item_count: 1,
+                source: { node_name: "Branch", output_index: 1 },
               },
             ],
           },
@@ -353,13 +363,13 @@ module("Unit | Service | workflows-node-types", function (hooks) {
 
     assert.deepEqual(session.inputContextForNode(node), {
       available: true,
-      item: rejectedOutput[0],
-      items: rejectedOutput,
-      source_node_outputs: { "node-0": rejectedOutput },
+      item: rejectedInput[0],
+      items: rejectedInput,
+      source_node_outputs: { "node-0": rejectedInput },
     });
   });
 
-  test("input context prefers current node inputs over upstream outputs", function (assert) {
+  test("input context uses current node inputs when upstream output differs", function (assert) {
     const upstreamNode = {
       clientId: "node-0",
       name: "Logger",
@@ -412,6 +422,52 @@ module("Unit | Service | workflows-node-types", function (hooks) {
     });
   });
 
+  test("input context ignores recorded inputs from another source", function (assert) {
+    const upstreamNode = {
+      clientId: "post-moved",
+      name: "Post moved",
+      type: "trigger:post_moved",
+    };
+    const node = {
+      clientId: "log",
+      name: "Log",
+      type: "action:log",
+      typeVersion: "1.0",
+    };
+    const staleInput = [{ json: { reviewable: { id: 1 } } }];
+
+    const session = new WorkflowEditorSession({
+      workflowId: 7,
+      lastExecutionRunData: {
+        Log: [
+          {
+            node_id: "log",
+            node_type: "action:log",
+            status: "success",
+            inputs: [
+              {
+                index: 0,
+                items: staleInput,
+                item_count: staleInput.length,
+                source: { node_name: "Approved reviewable", output_index: 0 },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    session.setEditingContext(
+      node,
+      [upstreamNode, node],
+      [{ sourceClientId: "post-moved", targetClientId: "log" }]
+    );
+
+    assert.deepEqual(session.inputContextForNode(node), {
+      available: false,
+      reason: "No input execution preview is available for this node",
+    });
+  });
+
   test("outputItemsForNode returns the latest empty output", function (assert) {
     const node = { clientId: "node-1", name: "Node 1" };
 
@@ -433,6 +489,27 @@ module("Unit | Service | workflows-node-types", function (hooks) {
     });
 
     assert.deepEqual(session.outputItemsForNode(node), []);
+  });
+
+  test("outputItemsForNode ignores runs for another node with the same name", function (assert) {
+    const node = { clientId: "new-node", name: "Node 1", type: "action:log" };
+
+    const session = new WorkflowEditorSession({
+      lastExecutionRunData: {
+        "Node 1": [
+          {
+            node_id: "old-node",
+            node_type: "action:log",
+            status: "success",
+            outputs: [
+              { index: 0, items: [{ json: { stale: true } }], item_count: 1 },
+            ],
+          },
+        ],
+      },
+    });
+
+    assert.strictEqual(session.outputItemsForNode(node), undefined);
   });
 
   test("dynamic options use full node parameters even inside nested configurators", function (assert) {


### PR DESCRIPTION
Previously, workflow editor previews could show recorded input data from an older upstream node when a node name was reused or a connection changed.

This change validates run data against the current node and input source before using it, so missing or stale inputs are treated as no input run data.