### PR TITLE
FIX: Escape LIKE wildcards in event invitee filtering

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -5,55 +5,21 @@ module DiscoursePostEvent
     requires_login except: %i[index]
 
     def index
-      event = Event.find(params[:post_id])
-      guardian.ensure_can_see!(event.post)
-
-      filter = params[:filter].downcase if params[:filter]
-
-      event_invitees = event.invitees
-      if params[:type]
-        unless Invitee.statuses.valid?(params[:type].to_sym)
-          raise Discourse::InvalidParameters.new(:type)
+      DiscoursePostEvent::ListInvitees.call(
+        params: {
+          post_id: params[:post_id],
+          filter: params[:filter],
+          type: params[:type],
+        },
+        guardian:,
+      ) do
+        on_success do |invitees:, suggested_users:|
+          render json: InviteeListSerializer.new(invitees:, suggested_users:)
         end
-        event_invitees = event_invitees.with_status(params[:type].to_sym)
+        on_failed_policy(:can_see_event) { raise Discourse::InvalidAccess }
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_failed_contract { raise Discourse::InvalidParameters }
       end
-
-      suggested_users = []
-      if filter.present? && guardian.can_act_on_discourse_post_event?(event)
-        missing_users = event.missing_users(event_invitees.select(:user_id))
-
-        if filter
-          missing_users = missing_users.where("LOWER(username) LIKE :filter", filter: "%#{filter}%")
-
-          custom_order = <<~SQL
-            CASE
-              WHEN LOWER(username) = ? THEN 0
-              ELSE 1
-            END ASC,
-            LOWER(username) ASC
-          SQL
-
-          custom_order = ActiveRecord::Base.sanitize_sql_array([custom_order, filter])
-          missing_users = missing_users.order(custom_order).limit(10)
-        else
-          missing_users = missing_users.order(:username_lower).limit(10)
-        end
-
-        suggested_users = missing_users
-      end
-
-      if filter
-        event_invitees =
-          event_invitees.joins(:user).where(
-            "LOWER(users.username) LIKE :filter",
-            filter: "%#{filter}%",
-          )
-      end
-
-      event_invitees = event_invitees.order(%i[status username_lower]).limit(200)
-
-      render json:
-               InviteeListSerializer.new(invitees: event_invitees, suggested_users: suggested_users)
     end
 
     def update

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -443,6 +443,28 @@ module DiscoursePostEvent
       end
     end
 
+    SUGGESTED_USERS_LIMIT = 10
+
+    # Users that could be invited to this event, ranked by how closely their
+    # username matches +filter+ (exact match first). Already-invited users are
+    # excluded, optionally narrowed to a given attendance +type+.
+    def suggested_users(filter, type: nil)
+      excluded = type ? invitees.with_status(type) : invitees
+
+      missing_users(excluded.select(:user_id))
+        .where(
+          "LOWER(username) LIKE :filter",
+          filter: "%#{User.sanitize_sql_like(filter.downcase)}%",
+        )
+        .order(
+          DB.sql_fragment(
+            "CASE WHEN LOWER(username) = ? THEN 0 ELSE 1 END ASC, LOWER(username) ASC",
+            filter.downcase,
+          ),
+        )
+        .limit(SUGGESTED_USERS_LIMIT)
+    end
+
     def update_with_params!(params)
       case params[:status] ? params[:status].to_i : status
       when Event.statuses[:private]

--- a/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/invitee.rb
@@ -18,6 +18,13 @@ module DiscoursePostEvent
         .where.not(users: { id: nil })
     end
     scope :with_status, ->(status) { where(status: Invitee.statuses[status]) }
+    scope :matching_username,
+          ->(filter) do
+            where(
+              "LOWER(users.username) LIKE :filter",
+              filter: "%#{sanitize_sql_like(filter.downcase)}%",
+            )
+          end
 
     before_save :clear_recurring_unless_going
     after_commit :sync_chat_channel_members

--- a/plugins/discourse-calendar/app/services/discourse_post_event/list_invitees.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/list_invitees.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class ListInvitees
+    include Service::Base
+
+    MAX_INVITEES = 200
+
+    params do
+      attribute :post_id, :integer
+      attribute :filter, :string
+      attribute :type, :symbol
+
+      validates :post_id, presence: true
+      validates :type, inclusion: { in: Invitee.statuses.keys }, allow_blank: true
+    end
+
+    model :event
+    policy :can_see_event
+    model :invitees, optional: true
+    model :suggested_users, optional: true
+
+    private
+
+    def fetch_event(params:)
+      Event.find_by(id: params.post_id)
+    end
+
+    def can_see_event(guardian:, event:)
+      guardian.can_see?(event.post)
+    end
+
+    def fetch_invitees(event:, params:)
+      invitees = event.invitees
+      invitees = invitees.with_status(params.type) if params.type.present?
+      invitees = invitees.matching_username(params.filter) if params.filter.present?
+      invitees.order(%i[status username_lower]).limit(MAX_INVITEES)
+    end
+
+    def fetch_suggested_users(guardian:, event:, params:)
+      return User.none if params.filter.blank?
+      return User.none unless guardian.can_act_on_discourse_post_event?(event)
+      event.suggested_users(params.filter, type: params.type)
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/list_invitees_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/list_invitees_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::ListInvitees) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:post_id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+
+    fab!(:francis) { Fabricate(:user, username: "Francis") }
+    fab!(:francisco) { Fabricate(:user, username: "Francisco") }
+    fab!(:frank) { Fabricate(:user, username: "Frank") }
+    fab!(:franchesca) { Fabricate(:user, username: "Franchesca") }
+    fab!(:franny) { Fabricate(:user, username: "Franny") }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+
+      event.create_invitees(
+        [
+          { user_id: francis.id, status: DiscoursePostEvent::Invitee.statuses[:going] },
+          { user_id: francisco.id, status: DiscoursePostEvent::Invitee.statuses[:interested] },
+          { user_id: frank.id, status: DiscoursePostEvent::Invitee.statuses[:not_going] },
+          { user_id: franchesca.id, status: DiscoursePostEvent::Invitee.statuses[:going] },
+        ],
+      )
+    end
+
+    let(:params) { { post_id: event.id } }
+    let(:dependencies) { { guardian: admin.guardian } }
+
+    context "when the contract is invalid" do
+      let(:params) { { post_id: nil } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when the type is not a valid status" do
+      let(:params) { { post_id: event.id, type: "nonexistent" } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when the event does not exist" do
+      let(:params) { { post_id: -1 } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when the user cannot see the event" do
+      fab!(:group)
+      fab!(:private_category) { Fabricate(:private_category, group:) }
+      fab!(:private_topic) { Fabricate(:topic, user: admin, category: private_category) }
+      fab!(:private_post) { Fabricate(:post, user: admin, topic: private_topic) }
+      fab!(:private_event) { Fabricate(:event, post: private_post) }
+      fab!(:outsider, :user)
+
+      let(:params) { { post_id: private_event.id } }
+      let(:dependencies) { { guardian: outsider.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_see_event) }
+    end
+
+    context "when no filter is given" do
+      it { is_expected.to run_successfully }
+
+      it "returns every invitee and no suggestions" do
+        expect(result.invitees.size).to eq(4)
+        expect(result.suggested_users).to be_blank
+      end
+    end
+
+    context "when filtering invitees by name" do
+      let(:params) { { post_id: event.id, filter: "Franc" } }
+
+      it "only returns invitees whose username matches" do
+        expect(result.invitees.map { |i| i.user.username }).to contain_exactly(
+          "Francis",
+          "Francisco",
+          "Franchesca",
+        )
+      end
+    end
+
+    context "when filtering invitees by type" do
+      let(:params) { { post_id: event.id, type: "going" } }
+
+      it "only returns invitees with that status" do
+        expect(result.invitees.map { |i| i.user.username }).to contain_exactly(
+          "Francis",
+          "Franchesca",
+        )
+      end
+    end
+
+    context "when filtering invitees by name and type" do
+      let(:params) { { post_id: event.id, filter: "Franc", type: "going" } }
+
+      it "returns invitees matching both" do
+        expect(result.invitees.map { |i| i.user.username }).to contain_exactly(
+          "Francis",
+          "Franchesca",
+        )
+      end
+    end
+
+    context "when the user can act on the event" do
+      let(:params) { { post_id: event.id, filter: "Fran", type: "going" } }
+
+      it "suggests matching users who are not yet invited" do
+        expect(result.suggested_users.map(&:username)).to contain_exactly(
+          "Francisco",
+          "Frank",
+          "Franny",
+        )
+      end
+
+      context "when the filter is blank" do
+        let(:params) { { post_id: event.id, filter: "", type: "going" } }
+
+        it "returns no suggestions" do
+          expect(result.suggested_users).to be_blank
+        end
+      end
+    end
+
+    context "when the user cannot act on the event" do
+      fab!(:lurker, :user)
+      let(:dependencies) { { guardian: lurker.guardian } }
+      let(:params) { { post_id: event.id, filter: "Fran" } }
+
+      it "returns no suggestions" do
+        expect(result.suggested_users).to be_blank
+      end
+    end
+
+    context "when the filter contains SQL LIKE wildcards" do
+      let(:params) { { post_id: event.id, filter: "fr_nk" } }
+
+      it "treats the wildcards literally instead of matching everything" do
+        expect(result.invitees).to be_empty
+        expect(result.suggested_users).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What & why

`InviteesController#index` interpolated the user-supplied `filter` straight into two `LIKE` clauses (`"%#{filter}%"`), so `%` and `_` were treated as SQL wildcards. A request like `?filter=fr_nk` would match `frank`, and `?filter=%25` would match everything. Both filters are now escaped with `sanitize_sql_like`.

### While here

To keep the fix from living in a fat controller action, the inline query/suggestion logic was extracted into a `DiscoursePostEvent::ListInvitees` service, mirroring the existing `CreateInvitee` / `UpdateInvitee` / `DestroyInvitee` siblings:

- username-matching queries moved onto `Invitee.matching_username` (scope) and `Event#suggested_users` (both do the escaping)
- dropped the dead `else` branch and the redundant `joins(:user)` (the `Invitee` default scope already joins users)
- `type` validated via the contract (`inclusion` → `400`), `:symbol` cast to match `CreateInvitee`

HTTP contract is unchanged: `404` (missing event), `403` (can't see), `400` (invalid type), `200` otherwise. Suggested users stay gated on `can_act_on_discourse_post_event?` (non-fatal — a viewer still gets a `200` with no suggestions).

### Tests

- All 26 existing `invitees_controller` request specs pass unchanged.
- New `list_invitees_spec.rb` (14 examples) covers the contract, `404`/`403`, name/type/combined filtering, suggestion gating, and — adversarially verified — that LIKE wildcards in the filter are treated literally.