### PR TITLE
FIX: Disable the last down-arrow in manage reports modal on mobile

### DIFF
--- a/frontend/discourse/admin/components/modal/manage-reports.gjs
+++ b/frontend/discourse/admin/components/modal/manage-reports.gjs
@@ -128,6 +128,7 @@ class ManageReportsRow extends Component {
           <DButton
             @icon="arrow-down"
             @action={{fn @onMoveDown @row}}
+            @disabled={{eq @index @lastEnabledIndex}}
             @translatedAriaLabel={{i18n
               "admin.dashboard.reports_section.modal.move_down"
               title=@row.title
@@ -233,6 +234,10 @@ export default class ManageReports extends Component {
 
   get reorderable() {
     return this.enabledOrder.length > 1;
+  }
+
+  get lastEnabledIndex() {
+    return this.filteredEnabledRows.length - 1;
   }
 
   cacheItems(items) {
@@ -452,6 +457,7 @@ export default class ManageReports extends Component {
               <ManageReportsRow
                 @row={{row}}
                 @index={{index}}
+                @lastEnabledIndex={{this.lastEnabledIndex}}
                 @reorderable={{this.reorderable}}
                 @toggleDisabled={{this.toggleDisabled row}}
                 @onToggle={{this.toggle}}

--- a/spec/system/admin_dashboard_redesign/reports_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/reports_section_spec.rb
@@ -25,6 +25,20 @@ describe "Admin Dashboard Redesign | Reports section" do
     expect(modal).to have_drag_controls
   end
 
+  it "disables the reorder arrows at the ends of the enabled list on mobile", mobile: true do
+    AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
+    AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)
+
+    page.visit("/admin")
+    dashboard.open_manage_reports_via_cog
+    expect(modal).to have_open
+
+    expect(modal).to have_disabled_move_up("core_report:signups")
+    expect(modal).to have_enabled_move_down("core_report:signups")
+    expect(modal).to have_enabled_move_up("core_report:topics")
+    expect(modal).to have_disabled_move_down("core_report:topics")
+  end
+
   it "lets admins customize the reports section via the manage-reports modal" do
     AdminDashboardReport.create!(source: "core_report", identifier: "signups", position: 0)
     AdminDashboardReport.create!(source: "core_report", identifier: "topics", position: 1)

--- a/spec/system/page_objects/components/manage_reports_modal.rb
+++ b/spec/system/page_objects/components/manage_reports_modal.rb
@@ -62,6 +62,30 @@ module PageObjects
         self
       end
 
+      def has_disabled_move_up?(identifier)
+        has_css?(
+          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow[disabled] .d-icon-arrow-up",
+        )
+      end
+
+      def has_disabled_move_down?(identifier)
+        has_css?(
+          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow[disabled] .d-icon-arrow-down",
+        )
+      end
+
+      def has_enabled_move_up?(identifier)
+        has_css?(
+          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow:not([disabled]) .d-icon-arrow-up",
+        )
+      end
+
+      def has_enabled_move_down?(identifier)
+        has_css?(
+          "#{MODAL} #{ROW}[data-identifier='#{identifier}'] button.manage-reports__arrow:not([disabled]) .d-icon-arrow-down",
+        )
+      end
+
       def has_drag_controls?
         has_css?("#{MODAL} .manage-reports__list.--reorderable")
       end


### PR DESCRIPTION
In the Manage reports modal, the mobile reorder controls left the down-arrow on the last enabled report active, even though there was nothing below it to swap with. Mirror the existing first-row up-arrow behavior by disabling the down-arrow on the last enabled row.