### PR TITLE
FIX: Don't auto-remove chat members from `logged_in_users` group

### DIFF
--- a/lib/guardian/tag_guardian.rb
+++ b/lib/guardian/tag_guardian.rb
@@ -28,9 +28,7 @@ module TagGuardian
     return false if !authenticated?
     return true if @user.is_system_user?
 
-    group_ids = SiteSetting.pm_tags_allowed_for_groups_map
-    group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
-      @user.group_users.exists?(group_id: group_ids)
+    @user.in_any_groups?(SiteSetting.pm_tags_allowed_for_groups_map)
   end
 
   def can_admin_tags?

--- a/lib/presence_channel.rb
+++ b/lib/presence_channel.rb
@@ -107,7 +107,12 @@ class PresenceChannel
     return true if user_id && config.allowed_user_ids&.include?(user_id)
 
     if user_id && config.allowed_group_ids.present?
-      return true if config.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
+      # `everyone` (0) and `logged_in_users` (5) are pseudogroups with no
+      # group_users rows; either one means any logged-in user may view.
+      if config.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+           config.allowed_group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
+        return true
+      end
       group_ids ||= GroupUser.where(user_id: user_id).pluck("group_id")
       return true if (group_ids & config.allowed_group_ids).present?
     end

--- a/plugins/chat/app/services/chat/auto_join_channels.rb
+++ b/plugins/chat/app/services/chat/auto_join_channels.rb
@@ -31,7 +31,9 @@ module Chat
       automatic = ::Chat::UserChatChannelMembership.join_modes[:automatic]
       group_permissions = ALLOWED_GROUP_PERMISSIONS
       group_ids = SiteSetting.chat_allowed_groups_map
-      everyone_allowed = group_ids.include?(Group::AUTO_GROUPS[:everyone])
+      everyone_allowed =
+        group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+          group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
       max_users = SiteSetting.max_chat_auto_joined_users
       now = Time.zone.now
       last_seen_at = 30.days.ago

--- a/plugins/chat/app/services/chat/auto_leave_channels.rb
+++ b/plugins/chat/app/services/chat/auto_leave_channels.rb
@@ -34,7 +34,11 @@ module Chat
       group_permissions = ALLOWED_GROUP_PERMISSIONS
       users_removed_map = Hash.new { |h, k| h[k] = [] }
 
-      if !group_ids.include?(Group::AUTO_GROUPS[:everyone])
+      everyone_allowed =
+        group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+          group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
+
+      if !everyone_allowed
         sql = <<~SQL
           -- event = #{params.event}
           DELETE FROM user_chat_channel_memberships uccm

--- a/plugins/chat/app/services/chat/publisher.rb
+++ b/plugins/chat/app/services/chat/publisher.rb
@@ -510,10 +510,11 @@ module Chat
     end
 
     def self.chat_allowed_group_ids
+      pseudo_everyone_ids = [Group::AUTO_GROUPS[:everyone], Group::AUTO_GROUPS[:logged_in_users]]
       Chat
         .allowed_group_ids
         .map do |group_id|
-          group_id == Group::AUTO_GROUPS[:everyone] ? Group::AUTO_GROUPS[:trust_level_0] : group_id
+          pseudo_everyone_ids.include?(group_id) ? Group::AUTO_GROUPS[:trust_level_0] : group_id
         end
         .uniq
     end

--- a/plugins/chat/lib/chat/mailer.rb
+++ b/plugins/chat/lib/chat/mailer.rb
@@ -28,7 +28,8 @@ module Chat
 
     def self.users_with_unreads
       groups_join_sql =
-        if Chat.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
+        if Chat.allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone]) ||
+             Chat.allowed_group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
           ""
         else
           "JOIN group_users gu ON gu.user_id = u.id AND gu.group_id IN (#{Chat.allowed_group_ids.join(",")})"

--- a/plugins/chat/spec/components/chat/mailer_spec.rb
+++ b/plugins/chat/spec/components/chat/mailer_spec.rb
@@ -68,6 +68,11 @@ describe Chat::Mailer do
         expect_enqueued
       end
 
+      it "queues a chat summary email when everyone is mapped to logged_in_users" do
+        SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+        expect_enqueued
+      end
+
       it "does not queue a chat summary when chat is globally disabled" do
         SiteSetting.chat_enabled = false
         expect_not_enqueued

--- a/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
+++ b/plugins/chat/spec/integration/auto_channel_user_removal_spec.rb
@@ -107,6 +107,22 @@ describe "Automatic user removal from channels" do
     end
   end
 
+  context "when granular_anonymous_and_logged_in_groups_permissions is enabled" do
+    before do
+      SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+    end
+
+    it "does not remove any users on the next sweep" do
+      # Everyone (0) is mapped to the logged_in_users (5) pseudo-group.
+      expect(SiteSetting.chat_allowed_groups_map).to include(Group::AUTO_GROUPS[:logged_in_users])
+
+      expect { Chat::AutoLeaveChannels.call(params: { event: :hourly_job }) }.not_to change {
+        Chat::UserChatChannelMembership.count
+      }
+    end
+  end
+
   context "when a user is removed from a group" do
     context "when the user is no longer in any chat_allowed_groups" do
       fab!(:group)

--- a/plugins/chat/spec/services/chat/auto_join_channels_spec.rb
+++ b/plugins/chat/spec/services/chat/auto_join_channels_spec.rb
@@ -95,6 +95,15 @@ RSpec.describe Chat::AutoJoinChannels do
           expect { result }.to change { Chat::UserChatChannelMembership.count }.from(0).to(1)
         end
 
+        it "automatically joins users when everyone is mapped to logged_in_users" do
+          SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+          SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+
+          Fabricate(:user, trust_level:, last_seen_at:)
+
+          expect { result }.to change { Chat::UserChatChannelMembership.count }.from(0).to(1)
+        end
+
         it "always automatically joins moderators" do
           SiteSetting.chat_allowed_groups = Fabricate(:group).id
 

--- a/plugins/chat/spec/services/chat/publisher_spec.rb
+++ b/plugins/chat/spec/services/chat/publisher_spec.rb
@@ -282,6 +282,22 @@ describe Chat::Publisher do
           ).allowed?(messages.first),
         ).to eq(false)
       end
+
+      it "publishes to trust level 0 when everyone is mapped to logged_in_users" do
+        SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+        SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+
+        messages =
+          MessageBus.track_publish("/chat/#{channel.id}") do
+            described_class.publish_new!(channel, message_1, staged_id)
+          end
+
+        expect(messages.first.group_ids).to contain_exactly(
+          Group::AUTO_GROUPS[:admins],
+          Group::AUTO_GROUPS[:moderators],
+          Group::AUTO_GROUPS[:trust_level_0],
+        )
+      end
     end
 
     context "when the message is a thread reply" do

--- a/spec/lib/guardian/tag_guardian_spec.rb
+++ b/spec/lib/guardian/tag_guardian_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe TagGuardian do
 
       expect(Guardian.new(trust_level_1).can_tag_pms?).to be_truthy
     end
+
+    it "returns true for any user when everyone is mapped to logged_in_users" do
+      SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:everyone]
+      SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true
+
+      expect(Guardian.new(trust_level_0).can_tag_pms?).to be_truthy
+    end
   end
 
   describe "#can_admin_tags?" do

--- a/spec/lib/presence_channel_spec.rb
+++ b/spec/lib/presence_channel_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe PresenceChannel do
         PresenceChannel::Config.new(allowed_group_ids: [group.id])
       when "/test/everyonegroup"
         PresenceChannel::Config.new(allowed_group_ids: [Group::AUTO_GROUPS[:everyone]])
+      when "/test/loggedingroup"
+        PresenceChannel::Config.new(allowed_group_ids: [Group::AUTO_GROUPS[:logged_in_users]])
       when "/test/noaccess"
         PresenceChannel::Config.new
       when "/test/countonly"
@@ -219,6 +221,7 @@ RSpec.describe PresenceChannel do
     expect(PresenceChannel.new("/test/securegroup").can_view?(user_id: nil)).to eq(false)
     expect(PresenceChannel.new("/test/noaccess").can_view?(user_id: nil)).to eq(false)
     expect(PresenceChannel.new("/test/everyonegroup").can_view?(user_id: nil)).to eq(false)
+    expect(PresenceChannel.new("/test/loggedingroup").can_view?(user_id: nil)).to eq(false)
   end
 
   it "handles security correctly for a user" do
@@ -234,6 +237,7 @@ RSpec.describe PresenceChannel do
     expect(PresenceChannel.new("/test/alloweduser").can_view?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/allowedgroup").can_view?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/everyonegroup").can_view?(user_id: user.id)).to eq(true)
+    expect(PresenceChannel.new("/test/loggedingroup").can_view?(user_id: user.id)).to eq(true)
     expect(PresenceChannel.new("/test/noaccess").can_view?(user_id: user.id)).to eq(false)
   end
 


### PR DESCRIPTION
A regression caused by introducing/toggling `granular_anonymous_and_logged_in_groups_permissions` site setting.

Also fixes other `:logged_in_users` issues.