### PR TITLE
FIX: Respect category tag restrictions when suggesting tags

### DIFF
--- a/frontend/discourse/app/components/modal/move-to-topic.gjs
+++ b/frontend/discourse/app/components/modal/move-to-topic.gjs
@@ -433,6 +433,7 @@ export default class MoveToTopic extends Component {
                         selectedPosts=@model.selectedPosts
                         updateTags=this.updateTags
                         tags=this.tags
+                        categoryId=this.categoryId
                       }}
                     />
                   </div>

--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_helper/assistant_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_helper/assistant_controller.rb
@@ -100,10 +100,14 @@ module DiscourseAi
         if params[:topic_id]
           topic = Topic.find_by(id: params[:topic_id])
           guardian.ensure_can_see!(topic)
-          opts = { topic_id: topic.id }
+          opts = { topic_id: topic.id, category: topic.category, selected_tag_ids: topic.tag_ids }
         else
           input = get_text_param!
-          opts = { text: input }
+          opts = {
+            text: input,
+            category: suggestible_category,
+            selected_tag_ids: selected_tag_ids_param,
+          }
         end
 
         render json: DiscourseAi::AiHelper::SemanticCategorizer.new(current_user, opts).tags,
@@ -288,6 +292,15 @@ module DiscourseAi
 
       def get_post_param!
         params[:post_id].tap { |t| raise Discourse::InvalidParameters.new(:post_id) if t.blank? }
+      end
+
+      def suggestible_category
+        return if params[:category_id].blank?
+        Category.where(id: params[:category_id]).where(id: guardian.allowed_category_ids).first
+      end
+
+      def selected_tag_ids_param
+        Tag.where_name(Array(params[:selected_tags]).first(100)).pluck(:id)
       end
 
       def rate_limiter_performed!

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-split-topic-suggester.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-split-topic-suggester.gjs
@@ -11,6 +11,7 @@ import { uniqueItemsFromArray } from "discourse/lib/array-tools";
 import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dCategoryBadge from "discourse/ui-kit/helpers/d-category-badge";
+import { tagSuggestionParams } from "../lib/ai-helper-suggestions";
 
 export default class AiSplitTopicSuggester extends Component {
   @service site;
@@ -40,9 +41,18 @@ export default class AiSplitTopicSuggester extends Component {
 
     this.loading = true;
 
+    const data = { text: this.input };
+
+    if (this.args.mode === this.SUGGESTION_TYPES.tag) {
+      Object.assign(
+        data,
+        tagSuggestionParams(this.args.categoryId, this.args.currentValue)
+      );
+    }
+
     ajax(`/discourse-ai/ai-helper/${this.args.mode}`, {
       method: "POST",
-      data: { text: this.input },
+      data,
     })
       .then((result) => {
         if (this.args.mode === this.SUGGESTION_TYPES.title) {

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/suggestion-menus/ai-tag-suggester.gjs
@@ -14,6 +14,7 @@ import { i18n } from "discourse-i18n";
 import {
   MIN_CHARACTER_COUNT,
   showSuggestionsError,
+  tagSuggestionParams,
 } from "../../lib/ai-helper-suggestions";
 
 export default class AiTagSuggester extends Component {
@@ -71,6 +72,10 @@ export default class AiTagSuggester extends Component {
 
     if (this.content) {
       data.text = this.content;
+      Object.assign(
+        data,
+        tagSuggestionParams(this.model?.categoryId, this.model?.get("tags"))
+      );
     } else {
       data.topic_id = this.args.buffered.content.id;
     }

--- a/plugins/discourse-ai/assets/javascripts/discourse/connectors/split-new-topic-tag-after/ai-tag-suggestion.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/connectors/split-new-topic-tag-after/ai-tag-suggestion.gjs
@@ -17,6 +17,7 @@ export default class AiTagSuggestion extends Component {
         @mode="suggest_tags"
         @updateAction={{@outletArgs.updateTags}}
         @currentValue={{@outletArgs.tags}}
+        @categoryId={{@outletArgs.categoryId}}
       />
     {{/if}}
   </template>

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-helper-suggestions.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-helper-suggestions.js
@@ -4,6 +4,27 @@ import { i18n } from "discourse-i18n";
 
 export const MIN_CHARACTER_COUNT = 40;
 
+function tagNames(tags) {
+  return (tags ?? [])
+    .map((tag) => (typeof tag === "string" ? tag : tag?.name))
+    .filter(Boolean);
+}
+
+export function tagSuggestionParams(categoryId, tags) {
+  const params = {};
+
+  if (categoryId) {
+    params.category_id = categoryId;
+  }
+
+  const selectedTags = tagNames(tags);
+  if (selectedTags.length) {
+    params.selected_tags = selectedTags;
+  }
+
+  return params;
+}
+
 export function showSuggestionsError(context, reloadFn) {
   const toasts = getOwner(context).lookup("service:toasts");
 

--- a/plugins/discourse-ai/lib/ai_helper/semantic_categorizer.rb
+++ b/plugins/discourse-ai/lib/ai_helper/semantic_categorizer.rb
@@ -8,6 +8,8 @@ module DiscourseAi
         @vector = DiscourseAi::Embeddings::Vector.instance
         @schema = DiscourseAi::Embeddings::Schema.for(Topic)
         @topic_id = opts[:topic_id]
+        @category = opts[:category]
+        @selected_tag_ids = opts[:selected_tag_ids]
       end
 
       def categories
@@ -87,6 +89,7 @@ module DiscourseAi
           .group_by { |c| c[:name] }
           .map { |name, scores| { name: name, score: scores.sum { |s| s[:score] } } }
           .sort_by { |c| -c[:score] }
+          .then { reject_tags_disallowed_in_category(it) }
           .take(7)
           .then do |tags|
             models = Tag.where(name: tags.map { it[:name] }).index_by(&:name)
@@ -101,6 +104,25 @@ module DiscourseAi
       end
 
       private
+
+      def reject_tags_disallowed_in_category(candidates)
+        return candidates if candidates.empty?
+
+        allowed_names =
+          DiscourseTagging
+            .filter_allowed_tags(
+              @user.guardian,
+              category: @category,
+              selected_tag_ids: @selected_tag_ids,
+              for_topic: true,
+              only_tag_names: candidates.map { |c| c[:name] },
+              limit: nil,
+            )
+            .map(&:name)
+            .to_set
+
+        candidates.select { |c| allowed_names.include?(c[:name]) }
+      end
 
       def nearest_neighbors(limit: 50)
         if @topic_id

--- a/plugins/discourse-ai/spec/lib/modules/ai_helper/semantic_categorizer_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_helper/semantic_categorizer_spec.rb
@@ -56,4 +56,67 @@ RSpec.describe DiscourseAi::AiHelper::SemanticCategorizer do
     categorizer.tags
     expect(inner_vector.vdef.pg_function).to eq("<=>")
   end
+
+  def seed_candidate_tagged_with(tag)
+    topic = Fabricate(:topic)
+    Fabricate(:topic_tag, topic:, tag:)
+    vector.generate_representation_from(topic)
+  end
+
+  describe "category tag restrictions" do
+    fab!(:restricted_tag, :tag)
+    fab!(:allowed_tag, :tag)
+
+    fab!(:restricted_category) { Fabricate(:category, allowed_tags: [allowed_tag.name]) }
+
+    before do
+      seed_candidate_tagged_with(restricted_tag)
+      seed_candidate_tagged_with(allowed_tag)
+    end
+
+    it "does not suggest a tag the selected category disallows" do
+      suggested =
+        described_class
+          .new(user, { text: "hello", category: restricted_category })
+          .tags
+          .map { |t| t[:name] }
+
+      expect(suggested).to include(allowed_tag.name)
+      expect(suggested).not_to include(restricted_tag.name)
+    end
+
+    it "suggests the tag in a category that allows it" do
+      permissive_category = Fabricate(:category, allow_global_tags: true)
+
+      suggested =
+        described_class
+          .new(user, { text: "hello", category: permissive_category })
+          .tags
+          .map { |t| t[:name] }
+
+      expect(suggested).to include(restricted_tag.name)
+    end
+  end
+
+  describe "one tag per group restrictions" do
+    fab!(:selected_tag, :tag)
+    fab!(:sibling_tag, :tag)
+    fab!(:tag_group) do
+      Fabricate(:tag_group, tags: [selected_tag, sibling_tag], one_per_topic: true)
+    end
+
+    before { seed_candidate_tagged_with(sibling_tag) }
+
+    it "excludes a one-per-topic group sibling once a member is selected" do
+      without_selection = described_class.new(user, { text: "hello" }).tags.map { |t| t[:name] }
+      expect(without_selection).to include(sibling_tag.name)
+
+      with_selection =
+        described_class
+          .new(user, { text: "hello", selected_tag_ids: [selected_tag.id] })
+          .tags
+          .map { |t| t[:name] }
+      expect(with_selection).not_to include(sibling_tag.name)
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/requests/ai_helper/assistant_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_helper/assistant_controller_spec.rb
@@ -874,6 +874,39 @@ RSpec.describe DiscourseAi::AiHelper::AssistantController do
           expect(response.status).to eq(403)
         end
       end
+
+      context "when the selected category restricts tags" do
+        fab!(:allowed_tag, :tag)
+        fab!(:restricted_tag, :tag)
+        fab!(:restricted_category) { Fabricate(:category, allowed_tags: [allowed_tag.name]) }
+        fab!(:topic)
+
+        before do
+          Fabricate(:topic_tag, topic:, tag: allowed_tag)
+          Fabricate(:topic_tag, topic:, tag: restricted_tag)
+
+          WebMock.stub_request(:post, embedding_definition.url).to_return(
+            status: 200,
+            body: JSON.dump([[0.0038493] * embedding_definition.dimensions]),
+          )
+
+          DiscourseAi::Embeddings::Vector.instance.generate_representation_from(topic)
+        end
+
+        it "does not suggest tags the category disallows" do
+          post "/discourse-ai/ai-helper/suggest_tags",
+               params: {
+                 text: "hello",
+                 category_id: restricted_category.id,
+               }
+
+          expect(response.status).to eq(200)
+
+          suggested = response.parsed_body["assistant"].map { |t| t["name"] }
+          expect(suggested).to include(allowed_tag.name)
+          expect(suggested).not_to include(restricted_tag.name)
+        end
+      end
     end
 
     describe "#semantic_categories" do


### PR DESCRIPTION
Previously, the AI helper's tag suggester could recommend tags the selected category doesn't allow — it filtered candidates only by tag visibility and was never told the composer's category, so a user could pick a suggestion they then couldn't submit (while adding the same tag manually was correctly blocked).

This change routes the suggested tags through the same `DiscourseTagging.filter_allowed_tags` rules the tag chooser and topic-save validation use, scoped to the selected category and already-selected tags, so only submittable tags are suggested.

Meta: https://meta.discourse.org/t/ai-helper-can-suggest-tags-not-allowed-in-category/404423
