### PR TITLE
FIX: all-day event end date off by one day when created from calendar

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/open-event-composer.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/open-event-composer.js
@@ -40,7 +40,14 @@ export default async function openEventComposer({
   let end;
   if (info.endStr) {
     end = moment.parseZone(info.endStr);
+    if (info.allDay) {
+      end.subtract(1, "day");
+    }
   } else {
+    end = start.clone().add(1, "hour");
+  }
+
+  if (end.isSameOrBefore(start)) {
     end = start.clone().add(1, "hour");
   }
 

--- a/plugins/discourse-calendar/test/javascripts/acceptance/calendar-click-to-create-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/calendar-click-to-create-test.js
@@ -86,7 +86,6 @@ acceptance(
       await waitFor(".fc-day-today");
 
       const date = todayCellDate();
-      const nextDate = moment(date).add(1, "day").format("YYYY-MM-DD");
 
       await click(".fc-day-today");
       await waitFor(".d-editor-input");
@@ -99,7 +98,7 @@ acceptance(
         .dom(".d-editor-input")
         .hasValue(
           new RegExp(
-            `^\\[event start="${date} 09:00" status="public" timezone="[^"]+" end="${nextDate} 00:00" allDay=true\\]\\n\\[/event\\]\\n$`
+            `^\\[event start="${date} 09:00" status="public" timezone="[^"]+" end="${date} 10:00" allDay=true\\]\\n\\[/event\\]\\n$`
           ),
           "composer opens with an all-day event defaulting to 9am for the clicked day"
         );
@@ -111,8 +110,6 @@ acceptance(
 
       const startDate = todayCellDate();
       const lastDate = moment(startDate).add(2, "days").format("YYYY-MM-DD");
-      // the selection end is exclusive, so a 3-day selection ends on the 4th day
-      const endDate = moment(startDate).add(3, "days").format("YYYY-MM-DD");
 
       await dragSelect(cellFor(startDate), cellFor(lastDate));
       await waitFor(".d-editor-input");
@@ -121,7 +118,7 @@ acceptance(
         .dom(".d-editor-input")
         .hasValue(
           new RegExp(
-            `^\\[event start="${startDate} 09:00" status="public" timezone="[^"]+" end="${endDate} 00:00" allDay=true\\]\\n\\[/event\\]\\n$`
+            `^\\[event start="${startDate} 09:00" status="public" timezone="[^"]+" end="${lastDate} 00:00" allDay=true\\]\\n\\[/event\\]\\n$`
           ),
           "composer opens with an all-day event spanning the dragged range"
         );
@@ -170,7 +167,6 @@ acceptance(
       await waitFor(".fc-day-today");
 
       const date = todayCellDate();
-      const nextDate = moment(date).add(1, "day").format("YYYY-MM-DD");
 
       await click(".fc-day-today");
       await waitFor(".d-editor-input");
@@ -183,7 +179,7 @@ acceptance(
         .dom(".d-editor-input")
         .hasValue(
           new RegExp(
-            `^\\[event start="${date} 09:00" status="public" timezone="[^"]+" end="${nextDate} 00:00" allDay=true\\]\\n\\[/event\\]\\n$`
+            `^\\[event start="${date} 09:00" status="public" timezone="[^"]+" end="${date} 10:00" allDay=true\\]\\n\\[/event\\]\\n$`
           ),
           "composer opens with an all-day event for the clicked day"
         );

--- a/plugins/discourse-calendar/test/javascripts/lib/open-event-composer-test.js
+++ b/plugins/discourse-calendar/test/javascripts/lib/open-event-composer-test.js
@@ -153,8 +153,8 @@ module("Unit | Lib | open-event-composer", function (hooks) {
     );
     assert.strictEqual(
       params.end,
-      "2026-05-25 00:00",
-      "uses the exclusive end of the all-day selection"
+      "2026-05-24 00:00",
+      "converts FC's exclusive end to an inclusive end date"
     );
     assert.strictEqual(params.allDay, "true", "emits the allDay flag");
   });


### PR DESCRIPTION
Introduced in #40251.

All-day events created by clicking or dragging on the calendar had their end date off by one day. Clicking June 14 produced a 2-day event; dragging June 14–15 produced a 3-day event.

FullCalendar's `select` callback uses an exclusive end date (clicking June 14 -> endStr="June 15"), but Discourse Post Event treats end as inclusive. openEventComposer was passing FC's end through without conversion.

Subtract one day from FC's exclusive end for all-day selections to get the inclusive end Discourse Post Event expects. For single-day clicks the subtracted end lands at midnight, before the 9am start - in that case fall back to start + 1 hour. Time-range selections are unaffected.