### PR TITLE
DEV: Tighten featured topic serialization data

### DIFF
--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -223,6 +223,10 @@ class UserCardSerializer < BasicUserSerializer
     object.flair_group&.flair_color
   end
 
+  def include_featured_topic?
+    scope.can_see_topic?(object.user_profile.featured_topic)
+  end
+
   def featured_topic
     BasicTopicSerializer.new(object.user_profile.featured_topic, scope: scope, root: false).as_json
   end

--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -166,10 +166,26 @@
           ]
         },
         "featured_topic": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            },
+            "fancy_title": {
+              "type": "string"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "posts_count": {
+              "type": "integer"
+            }
+          },
+          "required": ["id", "title", "fancy_title", "slug", "posts_count"]
         },
         "staged": {
           "type": "boolean"

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe "users" do
         expected_response_schema = load_spec_schema("user_get_response")
         schema expected_response_schema
 
-        let(:username) { Fabricate(:user).username }
+        fab!(:featured_topic, :topic)
+        fab!(:user) { Fabricate(:user).tap { |u| u.user_profile.update!(featured_topic:) } }
+        let(:username) { user.username }
 
         it_behaves_like "a JSON endpoint", 200 do
           let(:expected_response_schema) { expected_response_schema }
@@ -73,7 +75,14 @@ RSpec.describe "users" do
         expected_response_schema = load_spec_schema("user_get_response")
         schema expected_response_schema
 
-        let(:username) { Fabricate(:user, primary_group_id: Fabricate(:group).id).username }
+        fab!(:group)
+        fab!(:featured_topic, :topic)
+        fab!(:user) do
+          Fabricate(:user, primary_group_id: group.id).tap do |u|
+            u.user_profile.update!(featured_topic:)
+          end
+        end
+        let(:username) { user.username }
 
         it_behaves_like "a JSON endpoint", 200 do
           let(:expected_response_schema) { expected_response_schema }
@@ -124,7 +133,8 @@ RSpec.describe "users" do
         expected_response_schema = load_spec_schema("user_get_response")
         schema expected_response_schema
 
-        let(:user) { Fabricate(:user) }
+        fab!(:featured_topic, :topic)
+        fab!(:user) { Fabricate(:user).tap { |u| u.user_profile.update!(featured_topic:) } }
         let(:external_id) { "1" }
 
         before do
@@ -162,7 +172,8 @@ RSpec.describe "users" do
         expected_response_schema = load_spec_schema("user_get_response")
         schema expected_response_schema
 
-        let(:user) { Fabricate(:user) }
+        fab!(:featured_topic, :topic)
+        fab!(:user) { Fabricate(:user).tap { |u| u.user_profile.update!(featured_topic:) } }
         let(:provider) { "google_oauth2" }
         let(:external_id) { "myuid" }
 

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe UserCardSerializer do
 
     before { user.user_profile.update(featured_topic_id: featured_topic.id) }
 
-    it "includes the featured topic" do
+    it "includes the featured topic when viewer can see it" do
       serializer = described_class.new(user, scope: Guardian.new(user), root: false)
       json = serializer.as_json
 
@@ -142,6 +142,34 @@ RSpec.describe UserCardSerializer do
         :slug,
         :posts_count,
       )
+    end
+
+    it "does not include the featured topic when viewer cannot see it" do
+      restricted_category = Fabricate(:category, read_restricted: true)
+      viewer = Fabricate(:user)
+
+      serializer = described_class.new(user, scope: Guardian.new(viewer), root: false)
+      json = serializer.as_json
+
+      expect(json[:featured_topic]).not_to be_nil
+
+      featured_topic.update!(category: restricted_category)
+      user.reload
+
+      serializer = described_class.new(user, scope: Guardian.new(viewer), root: false)
+      json = serializer.as_json
+
+      expect(json[:featured_topic]).to be_nil
+    end
+
+    it "does not include the featured topic for anonymous users when topic is restricted" do
+      restricted_category = Fabricate(:category, read_restricted: true)
+      featured_topic.update!(category: restricted_category)
+
+      serializer = described_class.new(user, scope: Guardian.new, root: false)
+      json = serializer.as_json
+
+      expect(json[:featured_topic]).to be_nil
     end
   end
 

--- a/spec/serializers/web_hook_user_serializer_spec.rb
+++ b/spec/serializers/web_hook_user_serializer_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe WebHookUserSerializer do
+  fab!(:featured_topic, :topic)
   let(:user) do
-    user = Fabricate(:user)
+    user = Fabricate(:user).tap { |u| u.user_profile.update!(featured_topic:) }
     SingleSignOnRecord.create!(user_id: user.id, external_id: "12345", last_payload: "")
     user
   end


### PR DESCRIPTION
The UserCardSerializer was including featured_topic metadata (id, title, slug, posts_count) without checking if the viewer had permission to see the topic. 