### PR TITLE
FIX: restore post event allowed custom fields

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -555,8 +555,7 @@ export default class PostEventBuilder extends Component {
   }
 
   @action
-  setCustomField(field, value, { set }) {
-    set(`customFields.${field}`, value);
+  setCustomField(field, value) {
     this.event.customFields[field] = value;
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, fn, get } from "@ember/helper";
-import { on } from "@ember/modifier";
+import { concat, fn } from "@ember/helper";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
 import Form from "discourse/components/form";
@@ -119,6 +118,8 @@ export default class PostEventBuilder extends Component {
       timezone: this.event.timezone ?? null,
       // clone so the form draft owns its own reminders
       reminders: (this.event.reminders ?? []).map((r) => ({ ...r })),
+      // clone so the form draft owns the custom fields
+      customFields: { ...(this.event.customFields ?? {}) },
     };
   }
 
@@ -554,8 +555,9 @@ export default class PostEventBuilder extends Component {
   }
 
   @action
-  setCustomField(field, e) {
-    this.event.customFields[field] = e.target.value;
+  setCustomField(field, value, { set }) {
+    set(`customFields.${field}`, value);
+    this.event.customFields[field] = value;
   }
 
   @action
@@ -1223,26 +1225,24 @@ export default class PostEventBuilder extends Component {
                     }}
                     @format="full"
                   >
-                    {{#each this.allowedCustomFields as |allowedCustomField|}}
-                      <span class="label custom-field-label">
-                        {{allowedCustomField}}
-                      </span>
-                      <input
-                        type="text"
-                        class="custom-field-input"
-                        value={{get
-                          @model.event.customFields
-                          allowedCustomField
-                        }}
-                        {{on
-                          "input"
-                          (fn this.setCustomField allowedCustomField)
-                        }}
-                        placeholder={{i18n
-                          "discourse_post_event.builder_modal.custom_fields.placeholder"
-                        }}
-                      />
-                    {{/each}}
+                    <form.Object @name="customFields" as |customFields|>
+                      {{#each this.allowedCustomFields as |allowedCustomField|}}
+                        <customFields.Field
+                          @name={{allowedCustomField}}
+                          @title={{allowedCustomField}}
+                          @type="input"
+                          @format="full"
+                          @onSet={{fn this.setCustomField allowedCustomField}}
+                          as |field|
+                        >
+                          <field.Control
+                            placeholder={{i18n
+                              "discourse_post_event.builder_modal.custom_fields.placeholder"
+                            }}
+                          />
+                        </customFields.Field>
+                      {{/each}}
+                    </form.Object>
                   </form.Container>
                 {{/if}}
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
@@ -3,7 +3,10 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { buildBBCodeAttrs } from "discourse/lib/text";
 import EventNodeView from "../components/event-node-view";
 import { buildEventPreview } from "../lib/event-preview";
-import { buildEventSkeleton } from "../lib/raw-event-helper";
+import {
+  buildEventSkeleton,
+  getCustomFieldNames,
+} from "../lib/raw-event-helper";
 
 export const EVENT_ATTRIBUTES = {
   name: { default: null },
@@ -25,8 +28,8 @@ export const EVENT_ATTRIBUTES = {
   image: { default: null },
 };
 
-/** @type {RichEditorExtension} */
-const extension = {
+/** @returns {RichEditorExtension} */
+const buildExtension = (siteSettings) => ({
   nodeViews: {
     event: {
       component: EventNodeView,
@@ -35,7 +38,13 @@ const extension = {
 
   nodeSpec: {
     event: {
-      attrs: EVENT_ATTRIBUTES,
+      get attrs() {
+        const attrs = { ...EVENT_ATTRIBUTES };
+        getCustomFieldNames(siteSettings).forEach((field) => {
+          attrs[camelize(field)] = { default: null };
+        });
+        return attrs;
+      },
       group: "block",
       content: "block*",
       defining: true,
@@ -117,12 +126,13 @@ const extension = {
         : null;
     },
   }),
-};
+});
 
 export default {
   initialize() {
     withPluginApi((api) => {
-      api.registerRichEditorExtension(extension);
+      const siteSettings = api.container.lookup("service:site-settings");
+      api.registerRichEditorExtension(buildExtension(siteSettings));
     });
   },
 };

--- a/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
@@ -96,15 +96,6 @@
     }
   }
 
-  .custom-field-label {
-    font-weight: 500;
-    margin: 0.5em 0 0.25em 0;
-  }
-
-  .custom-field-input {
-    width: 100%;
-  }
-
   .d-date-time-input {
     width: 100%;
   }

--- a/plugins/discourse-calendar/spec/system/composer/prosemirror_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/composer/prosemirror_event_spec.rb
@@ -257,5 +257,26 @@ describe "Composer - ProseMirror - Event Editor" do
 
       expect(rich).to have_css(".composer-event__more-dropdown")
     end
+
+    it "persists allowed custom fields edited through the event builder to markdown" do
+      SiteSetting.discourse_post_event_allowed_custom_fields = "fancy_field"
+
+      open_composer
+      composer.toggle_rich_editor
+      composer.fill_content(
+        "[event start=\"2025-03-21 15:41\" status=\"public\" timezone=\"Europe/Paris\"]\n[/event]",
+      )
+      composer.toggle_rich_editor
+
+      rich.find(".composer-event__more-dropdown button").click
+
+      form = PageObjects::Components::FormKit.new(".post-event-builder-modal form")
+      form.field("customFields.fancy_field").fill_in("hello world")
+      find(".post-event-builder-modal .d-modal__footer .btn-primary").click
+      expect(page).to have_no_css(".post-event-builder-modal")
+
+      composer.toggle_rich_editor
+      expect(find(".d-editor-input").value).to include("fancyField=\"hello world\"")
+    end
   end
 end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -455,7 +455,7 @@ describe "Post event" do
     find(".group-selector").click
     find(".d-multi-select__search-input").send_keys(group.name)
     find(".d-multi-select__result", text: group.name).click
-    find(".d-modal .custom-field-input").fill_in(with: "custom value")
+    form.field("customFields.custom").fill_in("custom value")
     form.field("recurrence").select("every_day")
     find(".d-modal .recurrence-until .date-picker").fill_in(with: "#{1.year.from_now.year}-12-30")
     find(".d-modal .btn-primary").click
@@ -469,7 +469,7 @@ describe "Post event" do
     form = PageObjects::Components::FormKit.new(".d-modal form")
     expect(form.field("eventType")).to have_value("private")
     expect(find(".group-selector .d-multi-select-trigger__selection")).to have_text(group.name)
-    expect(find(".d-modal .custom-field-input").value).to eq("custom value")
+    expect(form.field("customFields.custom")).to have_value("custom value")
     expect(page).to have_selector(".d-modal .recurrence-until .date-picker") do |input|
       input.value == "#{1.year.from_now.year}-12-30"
     end

--- a/plugins/discourse-calendar/test/javascripts/acceptance/post-event-builder-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/post-event-builder-test.js
@@ -147,3 +147,53 @@ acceptance("Post event - composer", function (needs) {
     }
   });
 });
+
+acceptance("Post event - composer - custom fields", function (needs) {
+  needs.user({ admin: true, can_create_discourse_post_event: true });
+  needs.settings({
+    discourse_local_dates_enabled: true,
+    discourse_calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    discourse_post_event_allowed_on_groups: "",
+    discourse_post_event_allowed_custom_fields: "fancy_field",
+  });
+
+  test("custom fields render and save", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
+    await click(".toolbar-menu__options-trigger");
+    await click(
+      `button[title='${i18n("discourse_post_event.builder_modal.attach")}']`
+    );
+
+    await click(".d-editor-preview .composer-event__more-dropdown button");
+
+    const modal = ".post-event-builder-modal";
+
+    assert
+      .dom(`${modal} [data-name="customFields.fancy_field"] input`)
+      .exists("the allowed custom field renders as a form field");
+
+    await fillIn(`${modal} .from input[type=date]`, "2022-07-01");
+    const fromTime = selectKit(`${modal} .from .d-time-input .select-kit`);
+    await fromTime.expand();
+    await fromTime.selectRowByName("12:00 PM");
+
+    await fillIn(
+      `${modal} [data-name="customFields.fancy_field"] input`,
+      "hello world"
+    );
+
+    await click(`${modal} .d-modal__footer .btn-primary`);
+
+    assert
+      .dom(".d-editor-input")
+      .hasValue(
+        /fancyField="hello world"/,
+        "the custom field is written to the event bbcode"
+      );
+  });
+});

--- a/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -65,4 +65,19 @@ module("Integration | Component | RichEditorExtension", function (hooks) {
       });
     });
   });
+
+  test("event preserves allowed custom fields", async function (assert) {
+    this.siteSettings.rich_editor = true;
+    this.siteSettings.discourse_post_event_allowed_custom_fields =
+      "fancy_field";
+
+    await testMarkdown(
+      assert,
+      `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" fancyField="hello world"]\n[/event]\n`,
+      (a) => {
+        a.dom(".composer-event-node").exists("Event node should be rendered");
+      },
+      `[event start="2025-03-21 15:41" status=public timezone=Europe/Paris fancyField="hello world"]\n[/event]\n`
+    );
+  });
 });


### PR DESCRIPTION
These were broken in #39835 because I didn't know `Discourse post event allowed custom fields` existed! This wires them up properly in the new event creation flow, fixes the styling in the advanced settings modal, and adds some tests to avoid regression. 

<img width="626" height="707" alt="image" src="https://github.com/user-attachments/assets/33591abf-2177-40d5-956c-71bea70d1efc" />
