### PR TITLE
FIX: Automatically wrap `a[href]` and `img[src]` in `getURL`

### DIFF
--- a/frontend/asset-processor/theme-rollup.js
+++ b/frontend/asset-processor/theme-rollup.js
@@ -19,6 +19,7 @@ import discourseTerser from "./rollup-plugins/discourse-terser";
 import discourseVirtualLoader from "./rollup-plugins/discourse-virtual-loader";
 import buildEmberTemplateManipulatorPlugin from "./theme-hbs-ast-transforms";
 import transformActionSyntax from "./transform-action-syntax";
+import autoGetUrl from "./transform-auto-get-url";
 import createVirtualFs from "./virtual-fs";
 
 let lastRollupResult;
@@ -92,6 +93,7 @@ async function performRollup(modules, opts) {
                 }).plugin,
                 buildEmberTemplateManipulatorPlugin(opts.themeId),
                 transformActionSyntax,
+                autoGetUrl,
               ],
             },
           ],

--- a/frontend/asset-processor/transform-auto-get-url.js
+++ b/frontend/asset-processor/transform-auto-get-url.js
@@ -1,0 +1,169 @@
+// A Glimmer AST transform that automatically wraps URL-bearing attribute values
+// on native elements in `getURL`, so the subfolder base path is preserved for
+// every rendered link/image — including for middle-click and "open in new tab",
+// which follow the raw href and bypass `DiscourseURL.routeTo`.
+//
+// Before:  <a href={{event.post.url}}>      <a href="/about">      <img src="/t/{{id}}">
+// After:   <a href={{getURL event.post.url}}>  <a href={{getURL "/about"}}>  <img src={{getURL (concat "/t/" id)}}>
+//
+// `getURL` is idempotent and a no-op on external/already-prefixed URLs, so
+// applying it here can never double-prefix or rewrite an external link. The
+// import is injected via `jsutils.bindImport`, which adds a lexical scope
+// binding that resolves in both strict-mode (.gjs) and loose-mode (.hbs)
+// templates.
+
+// Native elements and the attributes on them that carry a navigable/loadable
+// URL. We deliberately key by tag so we only ever touch real DOM URL slots and
+// never a component (which receives URLs via `@args` and prefixes them itself).
+const URL_ATTRS_BY_TAG = {
+  a: ["href"],
+  area: ["href"],
+  link: ["href"],
+  img: ["src"],
+  source: ["src"], // `srcset` is intentionally excluded (multi-URL syntax)
+  track: ["src"],
+  iframe: ["src"],
+  embed: ["src"],
+  audio: ["src"],
+  video: ["src", "poster"],
+  script: ["src"],
+  input: ["src", "formaction"],
+  button: ["formaction"],
+  form: ["action"],
+  use: ["href"], // SVG
+  image: ["href"], // SVG <image>
+};
+
+// Helper heads whose output is already base-path-aware. Skipping these keeps the
+// emitted markup clean (no redundant double wrap) even though getURL would be a
+// safe no-op anyway.
+const SAFE_MUSTACHE_HEADS = new Set([
+  "getURL",
+  "getURLWithCDN",
+  "get-url",
+  "userPath",
+  "groupPath",
+]);
+
+// A root-relative internal path is the only literal we prefix. Anything else —
+// external (`https://`), protocol-relative (`//cdn`), anchors (`#x`), schemes
+// (`mailto:`), or genuinely relative (`images/x`) — is left untouched.
+function isInternalLiteral(raw) {
+  const value = raw.trim();
+  if (!value) {
+    return false;
+  }
+  if (value.startsWith("//")) {
+    return false;
+  }
+  return value.startsWith("/");
+}
+
+module.exports = function autoGetUrl(env) {
+  const { builders: b } = env.syntax;
+  const jsutils = env.meta && env.meta.jsutils;
+
+  // Without jsutils we cannot inject the import, so we no-op rather than emit a
+  // broken reference. This keeps any build path that lacks the helper safe.
+  if (!jsutils) {
+    return { name: "auto-get-url", visitor: {} };
+  }
+
+  let boundGetURL;
+  function getURLPath(target) {
+    if (!boundGetURL) {
+      boundGetURL = jsutils.bindImport(
+        "discourse/lib/get-url",
+        "default",
+        target,
+        { nameHint: "getURL" }
+      );
+    }
+    return b.path(boundGetURL);
+  }
+
+  // `concat` is not an auto-scoped keyword in strict-mode (.gjs) templates, so
+  // when we synthesize a `(concat ...)` for a literal+binding href we must
+  // import it. bindImport also adds the binding harmlessly in loose mode.
+  let boundConcat;
+  function concatPath(target) {
+    if (!boundConcat) {
+      boundConcat = jsutils.bindImport("@ember/helper", "concat", target, {
+        nameHint: "concat",
+      });
+    }
+    return b.path(boundConcat);
+  }
+
+  // Convert a MustacheStatement (an attribute binding or a concat part) into an
+  // expression usable as a helper param: a bare path stays a path, anything with
+  // params/hash becomes a sub-expression.
+  function mustacheToExpression(node) {
+    if (node.params.length === 0 && node.hash.pairs.length === 0) {
+      return node.path;
+    }
+    return b.sexpr(node.path, node.params, node.hash);
+  }
+
+  function wrap(expression, target) {
+    return b.mustache(getURLPath(target), [expression]);
+  }
+
+  return {
+    name: "auto-get-url",
+
+    visitor: {
+      ElementNode(node, path) {
+        const attrs = URL_ATTRS_BY_TAG[node.tag.toLowerCase()];
+        if (!attrs) {
+          return;
+        }
+
+        for (const attr of node.attributes) {
+          if (!attrs.includes(attr.name)) {
+            continue;
+          }
+
+          const value = attr.value;
+
+          // href="/t/123"
+          if (value.type === "TextNode") {
+            if (isInternalLiteral(value.chars)) {
+              attr.value = wrap(b.string(value.chars), path);
+            }
+            continue;
+          }
+
+          // href={{event.post.url}} / href={{concat ...}} / href={{if ...}}
+          if (value.type === "MustacheStatement") {
+            const head = value.path.head?.name ?? value.path.original;
+            if (SAFE_MUSTACHE_HEADS.has(head)) {
+              continue;
+            }
+            attr.value = wrap(mustacheToExpression(value), path);
+            continue;
+          }
+
+          // href="/t/{{this.id}}" — a literal/binding mix parses to a concat.
+          // Only prefix when the leading literal is an internal path.
+          if (value.type === "ConcatStatement") {
+            const first = value.parts[0];
+            if (first?.type === "TextNode" && isInternalLiteral(first.chars)) {
+              const concatParams = value.parts.map((part) =>
+                part.type === "TextNode"
+                  ? b.string(part.chars)
+                  : mustacheToExpression(part)
+              );
+              attr.value = wrap(b.sexpr(concatPath(path), concatParams), path);
+            }
+          }
+        }
+      },
+    },
+  };
+};
+
+// Participate in template-compiler caching so edits to this file bust stale
+// compiled templates (mirrors transform-action-syntax.js).
+module.exports.baseDir = () => __dirname;
+module.exports.cacheKey = () => "auto-get-url";

--- a/frontend/asset-processor/transform-auto-get-url.js
+++ b/frontend/asset-processor/transform-auto-get-url.js
@@ -1,53 +1,38 @@
 // A Glimmer AST transform that automatically wraps URL-bearing attribute values
-// on native elements in `getURL`, so the subfolder base path is preserved for
-// every rendered link/image — including for middle-click and "open in new tab",
-// which follow the raw href and bypass `DiscourseURL.routeTo`.
+// on native elements in `getURLForAttribute`, so the subfolder base path is
+// preserved for every rendered link — including for middle-click and "open in
+// new tab", which follow the raw href and bypass `DiscourseURL.routeTo`.
 //
-// Before:  <a href={{event.post.url}}>      <a href="/about">      <img src="/t/{{id}}">
-// After:   <a href={{getURL event.post.url}}>  <a href={{getURL "/about"}}>  <img src={{getURL (concat "/t/" id)}}>
+// Before:  <a href={{event.post.url}}>      <a href="/about">      <a href="/t/{{id}}">
+// After:   <a href={{getURL event.post.url}}>  <a href={{getURL "/about"}}>  <a href={{getURL (concat "/t/" id)}}>
 //
-// `getURL` is idempotent and a no-op on external/already-prefixed URLs, so
-// applying it here can never double-prefix or rewrite an external link. The
-// import is injected via `jsutils.bindImport`, which adds a lexical scope
-// binding that resolves in both strict-mode (.gjs) and loose-mode (.hbs)
-// templates.
+// `getURLForAttribute` delegates non-empty strings to `getURL` and preserves
+// every other value, so Glimmer's attribute-omission semantics for null and
+// undefined bindings are unchanged. `getURL` is idempotent and a no-op on
+// external or already-prefixed URLs, so the rewrite can never double-prefix or
+// rewrite an external link. The import is injected via `jsutils.bindImport`,
+// which adds a lexical scope binding that resolves in both strict-mode (.gjs)
+// and loose-mode (.hbs) templates.
+//
+// The initial scope is limited to anchor `href` attributes, which is where the
+// middle-click/new-tab 404s come from. Other URL slots (`img[src]`,
+// `form[action]`, `video[poster]`, ...) can be added to `URL_ATTRS_BY_TAG`
+// once this has proven itself in production. Keying by tag means only real DOM
+// URL slots are ever touched, never a component.
 
-// Native elements and the attributes on them that carry a navigable/loadable
-// URL. We deliberately key by tag so we only ever touch real DOM URL slots and
-// never a component (which receives URLs via `@args` and prefixes them itself).
 const URL_ATTRS_BY_TAG = {
   a: ["href"],
-  area: ["href"],
-  link: ["href"],
-  img: ["src"],
-  source: ["src"], // `srcset` is intentionally excluded (multi-URL syntax)
-  track: ["src"],
-  iframe: ["src"],
-  embed: ["src"],
-  audio: ["src"],
-  video: ["src", "poster"],
-  script: ["src"],
-  input: ["src", "formaction"],
-  button: ["formaction"],
-  form: ["action"],
-  use: ["href"], // SVG
-  image: ["href"], // SVG <image>
 };
 
-// Helper heads whose output is already base-path-aware. Skipping these keeps the
-// emitted markup clean (no redundant double wrap) even though getURL would be a
-// safe no-op anyway.
 const SAFE_MUSTACHE_HEADS = new Set([
   "getURL",
+  "getURLForAttribute",
   "getURLWithCDN",
   "get-url",
   "userPath",
   "groupPath",
 ]);
 
-// A root-relative internal path is the only literal we prefix. Anything else —
-// external (`https://`), protocol-relative (`//cdn`), anchors (`#x`), schemes
-// (`mailto:`), or genuinely relative (`images/x`) — is left untouched.
 function isInternalLiteral(raw) {
   const value = raw.trim();
   if (!value) {
@@ -63,8 +48,6 @@ module.exports = function autoGetUrl(env) {
   const { builders: b } = env.syntax;
   const jsutils = env.meta && env.meta.jsutils;
 
-  // Without jsutils we cannot inject the import, so we no-op rather than emit a
-  // broken reference. This keeps any build path that lacks the helper safe.
   if (!jsutils) {
     return { name: "auto-get-url", visitor: {} };
   }
@@ -74,17 +57,16 @@ module.exports = function autoGetUrl(env) {
     if (!boundGetURL) {
       boundGetURL = jsutils.bindImport(
         "discourse/lib/get-url",
-        "default",
+        "getURLForAttribute",
         target,
-        { nameHint: "getURL" }
+        { nameHint: "getURLForAttribute" }
       );
     }
     return b.path(boundGetURL);
   }
 
-  // `concat` is not an auto-scoped keyword in strict-mode (.gjs) templates, so
-  // when we synthesize a `(concat ...)` for a literal+binding href we must
-  // import it. bindImport also adds the binding harmlessly in loose mode.
+  // `concat` is not auto-scoped in strict-mode templates, so a synthesized
+  // `(concat ...)` needs its own import.
   let boundConcat;
   function concatPath(target) {
     if (!boundConcat) {
@@ -95,9 +77,6 @@ module.exports = function autoGetUrl(env) {
     return b.path(boundConcat);
   }
 
-  // Convert a MustacheStatement (an attribute binding or a concat part) into an
-  // expression usable as a helper param: a bare path stays a path, anything with
-  // params/hash becomes a sub-expression.
   function mustacheToExpression(node) {
     if (node.params.length === 0 && node.hash.pairs.length === 0) {
       return node.path;
@@ -126,7 +105,6 @@ module.exports = function autoGetUrl(env) {
 
           const value = attr.value;
 
-          // href="/t/123"
           if (value.type === "TextNode") {
             if (isInternalLiteral(value.chars)) {
               attr.value = wrap(b.string(value.chars), path);
@@ -134,7 +112,6 @@ module.exports = function autoGetUrl(env) {
             continue;
           }
 
-          // href={{event.post.url}} / href={{concat ...}} / href={{if ...}}
           if (value.type === "MustacheStatement") {
             const head = value.path.head?.name ?? value.path.original;
             if (SAFE_MUSTACHE_HEADS.has(head)) {
@@ -144,8 +121,6 @@ module.exports = function autoGetUrl(env) {
             continue;
           }
 
-          // href="/t/{{this.id}}" — a literal/binding mix parses to a concat.
-          // Only prefix when the leading literal is an internal path.
           if (value.type === "ConcatStatement") {
             const first = value.parts[0];
             if (first?.type === "TextNode" && isInternalLiteral(first.chars)) {
@@ -163,7 +138,5 @@ module.exports = function autoGetUrl(env) {
   };
 };
 
-// Participate in template-compiler caching so edits to this file bust stale
-// compiled templates (mirrors transform-action-syntax.js).
 module.exports.baseDir = () => __dirname;
 module.exports.cacheKey = () => "auto-get-url";

--- a/frontend/asset-processor/transform-auto-get-url.js
+++ b/frontend/asset-processor/transform-auto-get-url.js
@@ -14,14 +14,14 @@
 // which adds a lexical scope binding that resolves in both strict-mode (.gjs)
 // and loose-mode (.hbs) templates.
 //
-// The initial scope is limited to anchor `href` attributes, which is where the
-// middle-click/new-tab 404s come from. Other URL slots (`img[src]`,
-// `form[action]`, `video[poster]`, ...) can be added to `URL_ATTRS_BY_TAG`
-// once this has proven itself in production. Keying by tag means only real DOM
-// URL slots are ever touched, never a component.
+// The scope is limited to anchor `href` and image `src` attributes for now.
+// Other URL slots (`form[action]`, `video[poster]`, ...) can be added to
+// `URL_ATTRS_BY_TAG` once this has proven itself in production. Keying by tag
+// means only real DOM URL slots are ever touched, never a component.
 
 const URL_ATTRS_BY_TAG = {
   a: ["href"],
+  img: ["src"],
 };
 
 const SAFE_MUSTACHE_HEADS = new Set([

--- a/frontend/asset-processor/transform-auto-get-url.test.mjs
+++ b/frontend/asset-processor/transform-auto-get-url.test.mjs
@@ -48,6 +48,11 @@ test.each([
     "<a href={{if x a b}}>x</a>",
     "<a href={{getURLForAttribute (if x a b)}}>x</a>",
   ],
+  ["<img src={{@logoUrl}}>", "<img src={{getURLForAttribute @logoUrl}}>"],
+  [
+    '<img src="/a.png" srcset="/a-2x.png 2x">',
+    '<img src={{getURLForAttribute "/a.png"}} srcset="/a-2x.png 2x">',
+  ],
 ])("wraps %s", async (input, expected) => {
   const { template, code } = await compile(input);
   expect(template).toBe(expected);
@@ -64,8 +69,7 @@ test.each([
   ['<base href="/discuss/">'],
   ['<a href="https://x/{{id}}">x</a>'],
   ["<MyLink @href={{this.url}} />"],
-  ["<img src={{@logoUrl}}>"],
-  ['<img src="/a.png" srcset="/a-2x.png 2x">'],
+  ['<img src="https://cdn.example.com/a.png">'],
   ['<video src={{@v}} poster="/p.png"></video>'],
   ['<form action="/post">x</form>'],
 ])("leaves %s untouched", async (input) => {

--- a/frontend/asset-processor/transform-auto-get-url.test.mjs
+++ b/frontend/asset-processor/transform-auto-get-url.test.mjs
@@ -2,36 +2,31 @@ import { transformAsync } from "@babel/core";
 import { expect, test } from "vitest";
 import autoGetUrl from "./transform-auto-get-url.js";
 
-// Compile a template through the real production pipeline (babel +
-// ember-template-compilation + our transform) and return both the emitted
-// module code and the rewritten template body. `targetFormat: "hbs"` keeps the
-// template as a readable string literal in the output, which we extract and
-// unescape so we can assert on the exact rewrite.
-async function compile(templateBody) {
-  const source =
-    `import { precompileTemplate } from '@ember/template-compilation';\n` +
-    `export default precompileTemplate(${JSON.stringify(
-      templateBody
-    )}, { strictMode: true });`;
-
-  const { code } = await transformAsync(source, {
-    filename: "test.js",
-    configFile: false,
-    babelrc: false,
-    plugins: [
-      [
-        "babel-plugin-ember-template-compilation",
-        {
-          compilerPath: "ember-source/ember-template-compiler/index.js",
-          targetFormat: "hbs",
-          transforms: [autoGetUrl],
-        },
-      ],
+const BABEL_OPTIONS = {
+  configFile: false,
+  plugins: [
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        compilerPath: "ember-source/ember-template-compiler/index.js",
+        targetFormat: "hbs",
+        transforms: [autoGetUrl],
+      },
     ],
-  });
+  ],
+};
 
-  const match = code.match(/precompileTemplate\(\s*("(?:[^"\\]|\\.)*")/);
-  return { code, template: JSON.parse(match[1]) };
+// `targetFormat: "hbs"` keeps the compiled template as a readable string
+// literal, which we extract and unescape to assert on the exact rewrite.
+async function compile(templateBody) {
+  const source = `import { precompileTemplate } from '@ember/template-compilation';
+export default precompileTemplate(${JSON.stringify(templateBody)}, { strictMode: true });`;
+
+  const { code } = await transformAsync(source, BABEL_OPTIONS);
+  const template = JSON.parse(
+    code.match(/precompileTemplate\(\s*("(?:[^"\\]|\\.)*")/)[1]
+  );
+  return { code, template };
 }
 
 test.each([

--- a/frontend/asset-processor/transform-auto-get-url.test.mjs
+++ b/frontend/asset-processor/transform-auto-get-url.test.mjs
@@ -35,38 +35,43 @@ async function compile(templateBody) {
 }
 
 test.each([
-  ["<a href={{this.url}}>x</a>", "<a href={{getURL this.url}}>x</a>"],
-  ['<a href="/about">x</a>', '<a href={{getURL "/about"}}>x</a>'],
-  ["<img src={{@logoUrl}}>", "<img src={{getURL @logoUrl}}>"],
+  [
+    "<a href={{this.url}}>x</a>",
+    "<a href={{getURLForAttribute this.url}}>x</a>",
+  ],
+  ['<a href="/about">x</a>', '<a href={{getURLForAttribute "/about"}}>x</a>'],
   [
     '<a href={{concat "/t/" id}}>x</a>',
-    '<a href={{getURL (concat "/t/" id)}}>x</a>',
+    '<a href={{getURLForAttribute (concat "/t/" id)}}>x</a>',
   ],
   [
     '<a href="/t/{{this.id}}">x</a>',
-    '<a href={{getURL (concat "/t/" this.id)}}>x</a>',
+    '<a href={{getURLForAttribute (concat "/t/" this.id)}}>x</a>',
   ],
-  ["<a href={{if x a b}}>x</a>", "<a href={{getURL (if x a b)}}>x</a>"],
   [
-    '<video src={{@v}} poster="/p.png"></video>',
-    '<video src={{getURL @v}} poster={{getURL "/p.png"}}></video>',
+    "<a href={{if x a b}}>x</a>",
+    "<a href={{getURLForAttribute (if x a b)}}>x</a>",
   ],
 ])("wraps %s", async (input, expected) => {
   const { template, code } = await compile(input);
   expect(template).toBe(expected);
-  expect(code).toContain('import getURL from "discourse/lib/get-url"');
+  expect(code).toContain(
+    'import { getURLForAttribute } from "discourse/lib/get-url"'
+  );
 });
 
 test.each([
   ["<a href={{getURL this.url}}>x</a>"],
   ['<a href="https://example.com">x</a>'],
-  ['<img src="//cdn/x.png">'],
   ['<a href="#top">x</a>'],
   ['<a href="mailto:a@b.c">x</a>'],
-  ['<img src="images/x.png">'],
   ['<base href="/discuss/">'],
   ['<a href="https://x/{{id}}">x</a>'],
   ["<MyLink @href={{this.url}} />"],
+  ["<img src={{@logoUrl}}>"],
+  ['<img src="/a.png" srcset="/a-2x.png 2x">'],
+  ['<video src={{@v}} poster="/p.png"></video>'],
+  ['<form action="/post">x</form>'],
 ])("leaves %s untouched", async (input) => {
   const { template, code } = await compile(input);
   expect(template).toBe(input);
@@ -78,15 +83,8 @@ test("only wraps the url attribute, not siblings", async () => {
     "<a data-url={{this.url}} href={{this.url}}>x</a>"
   );
   expect(template).toBe(
-    "<a data-url={{this.url}} href={{getURL this.url}}>x</a>"
+    "<a data-url={{this.url}} href={{getURLForAttribute this.url}}>x</a>"
   );
-});
-
-test("does not touch srcset", async () => {
-  const { template } = await compile(
-    '<img src="/a.png" srcset="/a-2x.png 2x">'
-  );
-  expect(template).toBe('<img src={{getURL "/a.png"}} srcset="/a-2x.png 2x">');
 });
 
 test("imports concat when synthesizing one for a literal+binding href", async () => {

--- a/frontend/asset-processor/transform-auto-get-url.test.mjs
+++ b/frontend/asset-processor/transform-auto-get-url.test.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable qunit/require-expect */
 import { transformAsync } from "@babel/core";
 import { expect, test } from "vitest";
 import autoGetUrl from "./transform-auto-get-url.js";

--- a/frontend/asset-processor/transform-auto-get-url.test.mjs
+++ b/frontend/asset-processor/transform-auto-get-url.test.mjs
@@ -1,0 +1,106 @@
+import { transformAsync } from "@babel/core";
+import { expect, test } from "vitest";
+import autoGetUrl from "./transform-auto-get-url.js";
+
+// Compile a template through the real production pipeline (babel +
+// ember-template-compilation + our transform) and return both the emitted
+// module code and the rewritten template body. `targetFormat: "hbs"` keeps the
+// template as a readable string literal in the output, which we extract and
+// unescape so we can assert on the exact rewrite.
+async function compile(templateBody) {
+  const source =
+    `import { precompileTemplate } from '@ember/template-compilation';\n` +
+    `export default precompileTemplate(${JSON.stringify(
+      templateBody
+    )}, { strictMode: true });`;
+
+  const { code } = await transformAsync(source, {
+    filename: "test.js",
+    configFile: false,
+    babelrc: false,
+    plugins: [
+      [
+        "babel-plugin-ember-template-compilation",
+        {
+          compilerPath: "ember-source/ember-template-compiler/index.js",
+          targetFormat: "hbs",
+          transforms: [autoGetUrl],
+        },
+      ],
+    ],
+  });
+
+  const match = code.match(/precompileTemplate\(\s*("(?:[^"\\]|\\.)*")/);
+  return { code, template: JSON.parse(match[1]) };
+}
+
+test.each([
+  ["<a href={{this.url}}>x</a>", "<a href={{getURL this.url}}>x</a>"],
+  ['<a href="/about">x</a>', '<a href={{getURL "/about"}}>x</a>'],
+  ["<img src={{@logoUrl}}>", "<img src={{getURL @logoUrl}}>"],
+  [
+    '<a href={{concat "/t/" id}}>x</a>',
+    '<a href={{getURL (concat "/t/" id)}}>x</a>',
+  ],
+  [
+    '<a href="/t/{{this.id}}">x</a>',
+    '<a href={{getURL (concat "/t/" this.id)}}>x</a>',
+  ],
+  ["<a href={{if x a b}}>x</a>", "<a href={{getURL (if x a b)}}>x</a>"],
+  [
+    '<video src={{@v}} poster="/p.png"></video>',
+    '<video src={{getURL @v}} poster={{getURL "/p.png"}}></video>',
+  ],
+])("wraps %s", async (input, expected) => {
+  const { template, code } = await compile(input);
+  expect(template).toBe(expected);
+  expect(code).toContain('import getURL from "discourse/lib/get-url"');
+});
+
+test.each([
+  ["<a href={{getURL this.url}}>x</a>"],
+  ['<a href="https://example.com">x</a>'],
+  ['<img src="//cdn/x.png">'],
+  ['<a href="#top">x</a>'],
+  ['<a href="mailto:a@b.c">x</a>'],
+  ['<img src="images/x.png">'],
+  ['<base href="/discuss/">'],
+  ['<a href="https://x/{{id}}">x</a>'],
+  ["<MyLink @href={{this.url}} />"],
+])("leaves %s untouched", async (input) => {
+  const { template, code } = await compile(input);
+  expect(template).toBe(input);
+  expect(code).not.toContain("discourse/lib/get-url");
+});
+
+test("only wraps the url attribute, not siblings", async () => {
+  const { template } = await compile(
+    "<a data-url={{this.url}} href={{this.url}}>x</a>"
+  );
+  expect(template).toBe(
+    "<a data-url={{this.url}} href={{getURL this.url}}>x</a>"
+  );
+});
+
+test("does not touch srcset", async () => {
+  const { template } = await compile(
+    '<img src="/a.png" srcset="/a-2x.png 2x">'
+  );
+  expect(template).toBe('<img src={{getURL "/a.png"}} srcset="/a-2x.png 2x">');
+});
+
+test("imports concat when synthesizing one for a literal+binding href", async () => {
+  const { code } = await compile('<a href="/t/{{this.id}}">x</a>');
+  expect(code).toContain('import { concat } from "@ember/helper"');
+});
+
+test("emits a strict-mode scope binding for the injected helper", async () => {
+  const { code } = await compile("<a href={{this.url}}>x</a>");
+  expect(code).toContain("scope: () => ({");
+  expect(code).toContain("getURL");
+});
+
+test("no-ops without jsutils (defensive)", () => {
+  const result = autoGetUrl({ syntax: { builders: {} } });
+  expect(Object.keys(result.visitor)).toHaveLength(0);
+});

--- a/frontend/discourse/admin/components/admin-config-areas/components.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/components.gjs
@@ -17,7 +17,6 @@ import { ajax } from "discourse/lib/ajax";
 import { extractErrorInfo } from "discourse/lib/ajax-error";
 import discourseDebounce from "discourse/lib/debounce";
 import { INPUT_DELAY } from "discourse/lib/environment";
-import getURL from "discourse/lib/get-url";
 import { descriptionForRemoteUrl } from "discourse/lib/popular-themes";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
@@ -562,9 +561,7 @@ class ComponentRow extends Component {
                     rel="noopener noreferrer"
                     @label="admin.config_areas.themes_and_components.components.preview"
                     @icon="desktop"
-                    @href={{getURL
-                      (concat "/admin/themes/" @component.id "/preview")
-                    }}
+                    @href={{concat "/admin/themes/" @component.id "/preview"}}
                   />
                 </dropdown.item>
                 {{#if @component.remote_theme.is_git}}
@@ -595,10 +592,10 @@ class ComponentRow extends Component {
                     rel="noopener noreferrer"
                     @label="admin.config_areas.themes_and_components.components.export"
                     @icon="download"
-                    @href={{getURL
-                      (concat
-                        "/admin/customize/themes/" @component.id "/export"
-                      )
+                    @href={{concat
+                      "/admin/customize/themes/"
+                      @component.id
+                      "/export"
                     }}
                   />
                 </dropdown.item>

--- a/frontend/discourse/admin/components/admin-config-areas/components.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/components.gjs
@@ -1,7 +1,7 @@
 /* eslint-disable ember/no-tracked-properties-from-args */
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { array, concat, hash } from "@ember/helper";
+import { array, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
@@ -561,7 +561,7 @@ class ComponentRow extends Component {
                     rel="noopener noreferrer"
                     @label="admin.config_areas.themes_and_components.components.preview"
                     @icon="desktop"
-                    @href={{concat "/admin/themes/" @component.id "/preview"}}
+                    @href="/admin/themes/{{@component.id}}/preview"
                   />
                 </dropdown.item>
                 {{#if @component.remote_theme.is_git}}
@@ -592,11 +592,7 @@ class ComponentRow extends Component {
                     rel="noopener noreferrer"
                     @label="admin.config_areas.themes_and_components.components.export"
                     @icon="download"
-                    @href={{concat
-                      "/admin/customize/themes/"
-                      @component.id
-                      "/export"
-                    }}
+                    @href="/admin/customize/themes/{{@component.id}}/export"
                   />
                 </dropdown.item>
                 <dropdown.item>

--- a/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
+++ b/frontend/discourse/app/components/admin-onboarding/modal/theme-picker.gjs
@@ -7,7 +7,6 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import ThemeCardPreview from "discourse/components/theme-card-preview";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import getURL from "discourse/lib/get-url";
 import {
   FOUNDATION_THEME_ID,
   HORIZON_THEME_ID,
@@ -141,7 +140,7 @@ export default class ThemePickerModal extends Component {
           </div>
           <PluginOutlet @name="theme-picker-modal-below-themes">
             <p class="theme-picker-modal__browse-all">
-              <a href={{getURL "/admin/config/customize/themes"}}>
+              <a href="/admin/config/customize/themes">
                 {{i18n "admin_onboarding_banner.select_theme.browse_all"}}
               </a>
             </p>

--- a/frontend/discourse/app/components/header/icons.gjs
+++ b/frontend/discourse/app/components/header/icons.gjs
@@ -6,7 +6,6 @@ import InterfaceColorSelector from "discourse/components/interface-color-selecto
 import LanguageSwitcher from "discourse/components/language-switcher";
 import { ALL_PAGES_EXCLUDED_ROUTES } from "discourse/components/welcome-banner";
 import DAG from "discourse/lib/dag";
-import getURL from "discourse/lib/get-url";
 import { eq } from "discourse/truth-helpers";
 import Dropdown from "./dropdown";
 import UserDropdown from "./user-dropdown";
@@ -120,7 +119,6 @@ export default class Icons extends Component {
               @onClick={{@toggleSearchMenu}}
               @onWillDestroy={{fn @toggleSearchMenu null false}}
               @active={{this.search.visible}}
-              @href={{getURL "/search"}}
               class="search-dropdown"
             />
           {{/if}}

--- a/frontend/discourse/app/components/header/logo.gjs
+++ b/frontend/discourse/app/components/header/logo.gjs
@@ -23,7 +23,7 @@ export default class Logo extends Component {
         <img
           id="site-logo"
           class={{@key}}
-          src={{getURL @url}}
+          src={{@url}}
           width={{if (eq @key "logo-small") "36"}}
           alt={{@title}}
         />
@@ -32,7 +32,7 @@ export default class Logo extends Component {
       <img
         id="site-logo"
         class={{@key}}
-        src={{getURL @url}}
+        src={{@url}}
         width={{if (eq @key "logo-small") "36"}}
         alt={{@title}}
       />

--- a/frontend/discourse/app/components/post-list/item/details.gjs
+++ b/frontend/discourse/app/components/post-list/item/details.gjs
@@ -4,7 +4,6 @@ import { trustHTML } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import TopicStatus from "discourse/components/topic-status";
 import lazyHash from "discourse/helpers/lazy-hash";
-import getURL from "discourse/lib/get-url";
 import { prioritizeNameInUx } from "discourse/lib/settings";
 import { or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
@@ -69,7 +68,7 @@ export default class PostListItemDetails extends Component {
         <span class="title">
           {{#if this.url}}
             <a
-              href={{getURL this.url}}
+              href={{this.url}}
               aria-label={{this.titleAriaLabel}}
             >{{this.topicTitle}}</a>
           {{else if @isDraft}}

--- a/frontend/discourse/app/lib/get-url.js
+++ b/frontend/discourse/app/lib/get-url.js
@@ -33,6 +33,16 @@ export default function getURL(url) {
   return baseUri + url;
 }
 
+// Used by the auto-get-url build transform. Unlike `getURL`, which maps falsy
+// input to the base URI, this preserves non-string and empty values so
+// Glimmer's attribute-omission semantics are unchanged by the rewrite.
+export function getURLForAttribute(url) {
+  if (typeof url !== "string" || url === "") {
+    return url;
+  }
+  return getURL(url);
+}
+
 export function getURLWithCDN(url) {
   url = getURL(url);
   // only relative urls

--- a/frontend/discourse/app/templates/activate-account.gjs
+++ b/frontend/discourse/app/templates/activate-account.gjs
@@ -105,7 +105,7 @@ export default class extends Component {
         {{#if this.accountActivated}}
           <div class="account-activated">
             <div class="tada-image">
-              <img src={{getURL "/images/wizard/tada.svg"}} alt="tada emoji" />
+              <img src="/images/wizard/tada.svg" alt="tada emoji" />
             </div>
             {{#if this.needsApproval}}
               <p>{{i18n "user.activate_account.approval_required"}}</p>

--- a/frontend/discourse/app/ui-kit/d-breadcrumbs-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-breadcrumbs-item.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
-import getURL from "discourse/lib/get-url";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 export default class DBreadcrumbsItem extends Component {
@@ -29,7 +28,7 @@ export default class DBreadcrumbsItem extends Component {
             {{label}}
           </LinkTo>
         {{else}}
-          <a href={{getURL path}} class={{@linkClass}}>
+          <a href={{path}} class={{@linkClass}}>
             {{label}}
           </a>
         {{/if}}

--- a/frontend/discourse/app/ui-kit/d-button.gjs
+++ b/frontend/discourse/app/ui-kit/d-button.gjs
@@ -6,6 +6,7 @@ import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
+import { getURLForAttribute } from "discourse/lib/get-url";
 import { or } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 /** @type {import("discourse/ui-kit/helpers/d-element.gjs").default} */
@@ -232,7 +233,7 @@ export default class DButton extends Component {
   <template>
     {{! eslint-disable ember/template-no-pointer-down-event-binding }}
     <this.wrapperElement
-      href={{@href}}
+      href={{getURLForAttribute @href}}
       type={{unless @href (or @type "button")}}
       {{! For legacy compatibility. Prefer passing class as attributes. }}
       class={{dConcatClass

--- a/frontend/discourse/app/ui-kit/d-nav-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-nav-item.gjs
@@ -101,7 +101,7 @@ export default class DNavItem extends Component {
           @current-when={{this.active}}
         >{{this.contents}}</LinkTo>
       {{else}}
-        <a href={{getURL @path}} data-auto-route="true">{{this.contents}}</a>
+        <a href={{@path}} data-auto-route="true">{{this.contents}}</a>
       {{/if}}
     </li>
   </template>

--- a/frontend/discourse/babel.config.cjs
+++ b/frontend/discourse/babel.config.cjs
@@ -1,5 +1,7 @@
 const { buildMacros } = require("@embroider/macros/babel");
 
+const autoGetUrl = require("../asset-processor/transform-auto-get-url");
+
 const macros = buildMacros({
   configure(macrosConfig) {
     macrosConfig.setGlobalConfig(__filename, "@embroider/core", {
@@ -19,7 +21,7 @@ module.exports = {
           "ember-cli-htmlbars-inline-precompile",
           "htmlbars-inline-precompile",
         ],
-        transforms: [...macros.templateMacros],
+        transforms: [...macros.templateMacros, autoGetUrl],
       },
     ],
     [

--- a/frontend/discourse/tests/integration/lib/auto-get-url-transform-test.gjs
+++ b/frontend/discourse/tests/integration/lib/auto-get-url-transform-test.gjs
@@ -3,10 +3,9 @@ import { module, test } from "qunit";
 import getURL, { setPrefix } from "discourse/lib/get-url";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
-// These templates deliberately use RAW href/src values with no manual `getURL`.
+// These templates deliberately use raw href values with no manual `getURL`.
 // The auto-get-url build transform should wrap them so the subfolder base path
-// ("/forum" here) is present in the rendered attribute — the behaviour that
-// keeps middle-click / "open in new tab" working on subfolder sites.
+// ("/forum" here) is present in the rendered attribute.
 module("Integration | lib | auto-get-url transform", function (hooks) {
   setupRenderingTest(hooks);
 
@@ -33,12 +32,6 @@ module("Integration | lib | auto-get-url transform", function (hooks) {
     assert.dom("a").hasAttribute("href", "/forum/about");
   });
 
-  test("prefixes a raw img src binding", async function (assert) {
-    this.src = "/images/logo.png";
-    await render(<template><img src={{this.src}} alt="logo" /></template>);
-    assert.dom("img").hasAttribute("src", "/forum/images/logo.png");
-  });
-
   test("prefixes a literal+binding concat href", async function (assert) {
     this.id = 123;
     await render(
@@ -56,6 +49,26 @@ module("Integration | lib | auto-get-url transform", function (hooks) {
       </template>
     );
     assert.dom("a").hasAttribute("href", "/forum/already");
+  });
+
+  test("omits the attribute for a nullish binding", async function (assert) {
+    this.url = null;
+    await render(
+      <template>
+        <a href={{this.url}}>x</a>
+      </template>
+    );
+    assert.dom("a").doesNotHaveAttribute("href");
+  });
+
+  test("keeps an empty string binding empty", async function (assert) {
+    this.url = "";
+    await render(
+      <template>
+        <a href={{this.url}}>x</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("href", "");
   });
 
   test("leaves external urls untouched", async function (assert) {
@@ -78,10 +91,13 @@ module("Integration | lib | auto-get-url transform", function (hooks) {
     assert.dom("#mail").hasAttribute("href", "mailto:a@b.com");
   });
 
-  test("does not prefix a component @arg", async function (assert) {
-    // The value passed to a component is the component's responsibility; the
-    // transform must not touch @args. We assert the raw, unprefixed value is
-    // what the child receives by rendering it into a plain href downstream.
+  test("leaves img src untouched while the scope is a[href] only", async function (assert) {
+    this.src = "/images/logo.png";
+    await render(<template><img src={{this.src}} alt="logo" /></template>);
+    assert.dom("img").hasAttribute("src", "/images/logo.png");
+  });
+
+  test("does not prefix non-url attributes", async function (assert) {
     this.url = "/t/slug/123";
     await render(
       <template>

--- a/frontend/discourse/tests/integration/lib/auto-get-url-transform-test.gjs
+++ b/frontend/discourse/tests/integration/lib/auto-get-url-transform-test.gjs
@@ -1,0 +1,93 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import getURL, { setPrefix } from "discourse/lib/get-url";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+// These templates deliberately use RAW href/src values with no manual `getURL`.
+// The auto-get-url build transform should wrap them so the subfolder base path
+// ("/forum" here) is present in the rendered attribute — the behaviour that
+// keeps middle-click / "open in new tab" working on subfolder sites.
+module("Integration | lib | auto-get-url transform", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    setPrefix("/forum");
+  });
+
+  test("prefixes a raw href binding", async function (assert) {
+    this.url = "/t/slug/123";
+    await render(
+      <template>
+        <a href={{this.url}}>link</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("href", "/forum/t/slug/123");
+  });
+
+  test("prefixes a raw href string literal", async function (assert) {
+    await render(
+      <template>
+        <a href="/about">about</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("href", "/forum/about");
+  });
+
+  test("prefixes a raw img src binding", async function (assert) {
+    this.src = "/images/logo.png";
+    await render(<template><img src={{this.src}} alt="logo" /></template>);
+    assert.dom("img").hasAttribute("src", "/forum/images/logo.png");
+  });
+
+  test("prefixes a literal+binding concat href", async function (assert) {
+    this.id = 123;
+    await render(
+      <template>
+        <a href="/t/{{this.id}}">topic</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("href", "/forum/t/123");
+  });
+
+  test("does not double-prefix an already-wrapped href", async function (assert) {
+    await render(
+      <template>
+        <a href={{getURL "/already"}}>x</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("href", "/forum/already");
+  });
+
+  test("leaves external urls untouched", async function (assert) {
+    await render(
+      <template>
+        <a href="https://example.com/x">ext</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("href", "https://example.com/x");
+  });
+
+  test("leaves anchors and mailto untouched", async function (assert) {
+    await render(
+      <template>
+        <a id="anchor" href="#section">anchor</a>
+        <a id="mail" href="mailto:a@b.com">mail</a>
+      </template>
+    );
+    assert.dom("#anchor").hasAttribute("href", "#section");
+    assert.dom("#mail").hasAttribute("href", "mailto:a@b.com");
+  });
+
+  test("does not prefix a component @arg", async function (assert) {
+    // The value passed to a component is the component's responsibility; the
+    // transform must not touch @args. We assert the raw, unprefixed value is
+    // what the child receives by rendering it into a plain href downstream.
+    this.url = "/t/slug/123";
+    await render(
+      <template>
+        <a data-url={{this.url}}>x</a>
+      </template>
+    );
+    assert.dom("a").hasAttribute("data-url", "/t/slug/123");
+  });
+});

--- a/frontend/discourse/tests/integration/lib/auto-get-url-transform-test.gjs
+++ b/frontend/discourse/tests/integration/lib/auto-get-url-transform-test.gjs
@@ -91,10 +91,10 @@ module("Integration | lib | auto-get-url transform", function (hooks) {
     assert.dom("#mail").hasAttribute("href", "mailto:a@b.com");
   });
 
-  test("leaves img src untouched while the scope is a[href] only", async function (assert) {
+  test("prefixes a raw img src binding", async function (assert) {
     this.src = "/images/logo.png";
     await render(<template><img src={{this.src}} alt="logo" /></template>);
-    assert.dom("img").hasAttribute("src", "/images/logo.png");
+    assert.dom("img").hasAttribute("src", "/forum/images/logo.png");
   });
 
   test("does not prefix non-url attributes", async function (assert) {

--- a/frontend/discourse/tests/unit/lib/get-url-test.js
+++ b/frontend/discourse/tests/unit/lib/get-url-test.js
@@ -2,6 +2,7 @@ import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import getURL, {
   getAbsoluteURL,
+  getURLForAttribute,
   getURLWithCDN,
   isAbsoluteURL,
   setPrefix,
@@ -182,5 +183,21 @@ module("Unit | Utility | get-url", function (hooks) {
     let url = "https://awesome.cdn/site/awesome.png";
 
     assert.strictEqual(getURLWithCDN(url), url, "at correct path");
+  });
+
+  test("getURLForAttribute", function (assert) {
+    setupURL(null, "https://example.com/forum", "/forum");
+
+    assert.strictEqual(getURLForAttribute("/t/slug/1"), "/forum/t/slug/1");
+    assert.strictEqual(
+      getURLForAttribute("https://example.com/x"),
+      "https://example.com/x"
+    );
+
+    assert.strictEqual(getURLForAttribute(null), null);
+    assert.strictEqual(getURLForAttribute(undefined), undefined);
+    assert.false(getURLForAttribute(false));
+    assert.strictEqual(getURLForAttribute(""), "");
+    assert.strictEqual(getURLForAttribute(0), 0);
   });
 });

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -7,7 +7,6 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
-import getURL from "discourse/lib/get-url";
 import DAsyncContent from "discourse/ui-kit/d-async-content";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -215,7 +214,7 @@ export default class DiscoursePostEvent extends Component {
                   <span class="name">
                     {{#if @linkToPost}}
                       <a
-                        href={{getURL event.post.url}}
+                        href={{event.post.url}}
                         rel="noopener noreferrer"
                       >{{dReplaceEmoji this.eventName}}</a>
                     {{else}}

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event.rb
@@ -76,10 +76,6 @@ module PageObjects
           self
         end
 
-        def has_title_link_href?(href)
-          has_css?(".event-info .name a[href='#{href}']")
-        end
-
         def has_location?(text)
           has_css?(".event-location", text:)
         end

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/upcoming_events.rb
@@ -4,8 +4,8 @@ module PageObjects
   module Pages
     module DiscourseCalendar
       class UpcomingEvents < PageObjects::Pages::Base
-        def visit(prefix = "")
-          super("#{prefix}/upcoming-events")
+        def visit
+          super("/upcoming-events")
         end
 
         def next

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -39,8 +39,6 @@ describe "Upcoming Events" do
 
     it "filters non-recurring goings out of future occurrences",
        time: Time.utc(2026, 5, 12, 12, 0) do
-      set_subfolder "/discuss"
-
       post =
         create_post(
           user: admin,
@@ -57,13 +55,12 @@ describe "Upcoming Events" do
       )
       DiscoursePostEvent::Invitee.create_attendance!(going_once_user.id, event.id, :going)
 
-      upcoming_events.visit("/discuss")
+      upcoming_events.visit
       upcoming_events.click_event_on("2026-05-14")
 
       expect(post_event_page).to have_going_count(2)
       expect(post_event_page).to have_invitee_avatar(going_recurring_user.username)
       expect(post_event_page).to have_invitee_avatar(going_once_user.username)
-      expect(post_event_page).to have_title_link_href(post.relative_url)
 
       post_event_page.close_popup
       upcoming_events.click_event_on("2026-05-21")

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-posts.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-posts.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -43,7 +42,7 @@ export default class BestPosts extends Component {
                 <span class="best-posts__replies">
                   {{dIcon "comment"}}{{post.reply_count}}
                 </span>
-                <a href={{concat "/t/" post.topic_id "/" post.post_number}}>
+                <a href="/t/{{post.topic_id}}/{{post.post_number}}">
                   {{i18n "discourse_rewind.reports.best_posts.view_post"}}
                 </a>
               </div>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-posts.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-posts.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
-import getURL from "discourse/lib/get-url";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -44,11 +43,7 @@ export default class BestPosts extends Component {
                 <span class="best-posts__replies">
                   {{dIcon "comment"}}{{post.reply_count}}
                 </span>
-                <a
-                  href={{getURL
-                    (concat "/t/" post.topic_id "/" post.post_number)
-                  }}
-                >
+                <a href={{concat "/t/" post.topic_id "/" post.post_number}}>
                   {{i18n "discourse_rewind.reports.best_posts.view_post"}}
                 </a>
               </div>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-topics.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-topics.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
-import getURL from "discourse/lib/get-url";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
 import { i18n } from "discourse-i18n";
@@ -45,7 +44,7 @@ export default class BestTopics extends Component {
                 </span>
 
                 <div class="best-topics__metadata">
-                  <a href={{getURL (concat "/t/-/" topic.topic_id)}}>
+                  <a href={{concat "/t/-/" topic.topic_id}}>
                     {{i18n "discourse_rewind.reports.best_topics.view_topic"}}
                   </a>
                 </div>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-topics.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/best-topics.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
@@ -44,7 +43,7 @@ export default class BestTopics extends Component {
                 </span>
 
                 <div class="best-topics__metadata">
-                  <a href={{concat "/t/-/" topic.topic_id}}>
+                  <a href="/t/-/{{topic.topic_id}}">
                     {{i18n "discourse_rewind.reports.best_topics.view_topic"}}
                   </a>
                 </div>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/chat-usage.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/chat-usage.gjs
@@ -156,7 +156,7 @@ export default class ChatUsage extends Component {
                     {{#each this.favoriteChannels as |channel|}}
                       <a
                         class="chat-channel-link"
-                        href={{concat "/chat/c/-/" channel.channel_id}}
+                        href="/chat/c/-/{{channel.channel_id}}"
                       >
                         <span
                           class="chat-channel-link__name"

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/chat-usage.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/chat-usage.gjs
@@ -157,7 +157,7 @@ export default class ChatUsage extends Component {
                     {{#each this.favoriteChannels as |channel|}}
                       <a
                         class="chat-channel-link"
-                        href={{getURL (concat "/chat/c/-/" channel.channel_id)}}
+                        href={{concat "/chat/c/-/" channel.channel_id}}
                       >
                         <span
                           class="chat-channel-link__name"

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/chat-usage.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/chat-usage.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
-import getURL from "discourse/lib/get-url";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import I18n, { i18n } from "discourse-i18n";
@@ -175,9 +174,7 @@ export default class ChatUsage extends Component {
             <div class="chat-message --right">
               <UserMessage @user={{@user}} @authorText={{this.authorText}}>
                 <img
-                  src={{getURL
-                    "/plugins/discourse-rewind/images/dancing_baby.gif"
-                  }}
+                  src="/plugins/discourse-rewind/images/dancing_baby.gif"
                   alt={{i18n
                     "discourse_rewind.reports.chat_usage.dancing_baby_alt"
                   }}

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/fbff.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/fbff.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
-import getURL from "discourse/lib/get-url";
 import dBoundAvatarTemplate from "discourse/ui-kit/helpers/d-bound-avatar-template";
 import { i18nForOwner } from "discourse/plugins/discourse-rewind/discourse/lib/rewind-i18n";
 
@@ -31,7 +30,7 @@ export default class FBFF extends Component {
           <div class="fbff-gif-container">
             <img
               class="fbff-gif"
-              src={{getURL "/plugins/discourse-rewind/images/fbff.gif"}}
+              src="/plugins/discourse-rewind/images/fbff.gif"
             />
           </div>
           <div class="fbff-avatar-container">

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/invites.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/invites.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
 import dBoundAvatarTemplate from "discourse/ui-kit/helpers/d-bound-avatar-template";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import { i18n } from "discourse-i18n";
@@ -112,7 +111,7 @@ export default class Invites extends Component {
               </div>
 
               <a
-                href={{concat "/u/" this.mostActiveInvitee.username}}
+                href="/u/{{this.mostActiveInvitee.username}}"
                 class="guest-book__signature"
               >
                 {{dBoundAvatarTemplate

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/invites.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/invites.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
-import getURL from "discourse/lib/get-url";
 import dBoundAvatarTemplate from "discourse/ui-kit/helpers/d-bound-avatar-template";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import { i18n } from "discourse-i18n";
@@ -113,7 +112,7 @@ export default class Invites extends Component {
               </div>
 
               <a
-                href={{getURL (concat "/u/" this.mostActiveInvitee.username)}}
+                href={{concat "/u/" this.mostActiveInvitee.username}}
                 class="guest-book__signature"
               >
                 {{dBoundAvatarTemplate

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-categories.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-categories.gjs
@@ -3,7 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import { concat, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import getURL from "discourse/lib/get-url";
 import { eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18nForOwner } from "discourse/plugins/discourse-rewind/discourse/lib/rewind-i18n";
@@ -55,7 +54,7 @@ export default class MostViewedCategories extends Component {
                 "folder-wrapper"
                 (if (eq this.openedCategoryId data.category_id) "--opened" "")
               }}
-              href={{getURL (concat "/c/-/" data.category_id)}}
+              href={{concat "/c/-/" data.category_id}}
               {{on "click" (fn this.handleFolderClick data.category_id)}}
             >
               <span class="folder-tab"></span>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-categories.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-categories.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, fn } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { eq } from "discourse/truth-helpers";
@@ -54,7 +54,7 @@ export default class MostViewedCategories extends Component {
                 "folder-wrapper"
                 (if (eq this.openedCategoryId data.category_id) "--opened" "")
               }}
-              href={{concat "/c/-/" data.category_id}}
+              href="/c/-/{{data.category_id}}"
               {{on "click" (fn this.handleFolderClick data.category_id)}}
             >
               <span class="folder-tab"></span>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-tags.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-tags.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, fn } from "@ember/helper";
+import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { eq } from "discourse/truth-helpers";
@@ -47,7 +47,7 @@ export default class MostViewedTags extends Component {
                 "folder-wrapper"
                 (if (eq this.openedTag data.name) "--opened" "")
               }}
-              href={{concat "/tag/" data.slug "/" data.tag_id}}
+              href="/tag/{{data.slug}}/{{data.tag_id}}"
               {{on "click" (fn this.handleFolderClick data.name)}}
             >
               <span class="folder-tab"></span>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-tags.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/most-viewed-tags.gjs
@@ -3,7 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import { concat, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
-import getURL from "discourse/lib/get-url";
 import { eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18nForOwner } from "discourse/plugins/discourse-rewind/discourse/lib/rewind-i18n";
@@ -48,7 +47,7 @@ export default class MostViewedTags extends Component {
                 "folder-wrapper"
                 (if (eq this.openedTag data.name) "--opened" "")
               }}
-              href={{getURL (concat "/tag/" data.slug "/" data.tag_id)}}
+              href={{concat "/tag/" data.slug "/" data.tag_id}}
               {{on "click" (fn this.handleFolderClick data.name)}}
             >
               <span class="folder-tab"></span>

--- a/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/reading-time.gjs
+++ b/plugins/discourse-rewind/assets/javascripts/discourse/components/reports/reading-time.gjs
@@ -1,7 +1,5 @@
 import Component from "@glimmer/component";
-import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
-import getURL from "discourse/lib/get-url";
 import { i18n } from "discourse-i18n";
 import { i18nForOwner } from "discourse/plugins/discourse-rewind/discourse/lib/rewind-i18n";
 
@@ -46,13 +44,7 @@ export default class ReadingTime extends Component {
             <div class="book">
               <img
                 alt=""
-                src={{getURL
-                  (concat
-                    "/plugins/discourse-rewind/images/books/"
-                    @report.data.isbn
-                    ".jpg"
-                  )
-                }}
+                src="/plugins/discourse-rewind/images/books/{{@report.data.isbn}}.jpg"
               />
             </div>
             {{#if @report.data.series}}


### PR DESCRIPTION
On subfolder installs, a link rendered from a raw path like `href={{post.url}}` is missing the base path unless the author remembered to wrap it in `getURL`. Left-click usually still works because clicks route through `DiscourseURL.routeTo`, but middle-click and "open link in new tab" follow the raw href and 404. Each occurrence is fixed one call site at a time, and nothing prevents the next one.

This commit adds a Glimmer AST transform that wraps anchor `href` and image `src` attributes in `getURLForAttribute` at template compile time, injecting the import via `jsutils.bindImport` for both strict and loose mode templates. `DButton` applies the wrapper itself since its `href` lives on a dynamic element the transform cannot see. The manual wraps these slots carried, and the subfolder system test guarding the calendar popup link, are removed.

Notes for review:

- The attribute is the boundary where a routing path becomes a browser URL, so the prefix is applied there. Model getters must stay path-less for the Ember router.
- `getURL` is idempotent and ignores external URLs, so the rewrite cannot double-prefix or break an external link. `getURLForAttribute` additionally preserves non-string and empty values, so Glimmer still omits the attribute for null bindings.
- The scope is `a[href]` and `img[src]`. Other slots (`form[action]`, `video[poster]`, `srcset`) can be added to the tag map after this proves itself.
- Reverting means removing the transform from the two `transforms` arrays.

The trade-off is that prefixing is no longer visible in template source. We think that is worth making the bug class impossible to reintroduce.