### PR TITLE
FIX: Repair missing direct message users

### DIFF
--- a/plugins/chat/app/services/chat/add_users_to_channel.rb
+++ b/plugins/chat/app/services/chat/add_users_to_channel.rb
@@ -55,6 +55,7 @@ module Chat
         step :create_memberships
         step :recompute_users_count
         step :notice_channel
+        step :publish_new_channel
       end
     end
 
@@ -98,6 +99,7 @@ module Chat
 
     def create_memberships(channel:, target_users:)
       always_level = ::Chat::UserChatChannelMembership::NOTIFICATION_LEVELS[:always]
+      now = Time.zone.now
 
       memberships =
         target_users.map do |user|
@@ -107,8 +109,8 @@ module Chat
             muted: false,
             following: true,
             notification_level: always_level,
-            created_at: Time.zone.now,
-            updated_at: Time.zone.now,
+            created_at: now,
+            updated_at: now,
           }
         end
 
@@ -117,26 +119,39 @@ module Chat
         return
       end
 
-      context[:added_user_ids] = ::Chat::UserChatChannelMembership
-        .insert_all(
-          memberships,
-          unique_by: %i[user_id chat_channel_id],
-          returning: Arel.sql("user_id, (xmax = '0') as inserted"),
-        )
-        .select { |row| row["inserted"] }
-        .map { |row| row["user_id"] }
+      inserted_membership_user_ids =
+        ::Chat::UserChatChannelMembership
+          .insert_all(
+            memberships,
+            unique_by: %i[user_id chat_channel_id],
+            returning: Arel.sql("user_id, (xmax = '0') as inserted"),
+          )
+          .select { |row| row["inserted"] }
+          .map { |row| row["user_id"] }
 
-      ::Chat::DirectMessageUser.insert_all(
-        context.added_user_ids.map do |id|
+      direct_message_users =
+        target_users.map do |user|
           {
-            user_id: id,
+            user_id: user.id,
             direct_message_channel_id: channel.chatable.id,
-            created_at: Time.zone.now,
-            updated_at: Time.zone.now,
+            created_at: now,
+            updated_at: now,
           }
-        end,
-        unique_by: %i[direct_message_channel_id user_id],
-      )
+        end
+
+      inserted_direct_message_user_ids =
+        ::Chat::DirectMessageUser
+          .insert_all(
+            direct_message_users,
+            unique_by: %i[direct_message_channel_id user_id],
+            returning: Arel.sql("user_id, (xmax = '0') as inserted"),
+          )
+          .select { |row| row["inserted"] }
+          .map { |row| row["user_id"] }
+
+      context[:added_user_ids] = (
+        inserted_membership_user_ids + inserted_direct_message_user_ids
+      ).uniq
     end
 
     def recompute_users_count(channel:)
@@ -166,6 +181,12 @@ module Chat
             ),
         },
       ) { on_failure { fail!(failure: "Failed to notice the channel") } }
+    end
+
+    def publish_new_channel(channel:)
+      return if context.added_user_ids.blank?
+
+      DB.after_commit { ::Chat::Publisher.publish_new_channel(channel, context.added_user_ids) }
     end
   end
 end

--- a/plugins/chat/db/post_migrate/20260604011058_backfill_missing_direct_message_users.rb
+++ b/plugins/chat/db/post_migrate/20260604011058_backfill_missing_direct_message_users.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class BackfillMissingDirectMessageUsers < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      INSERT INTO direct_message_users (user_id, direct_message_channel_id, created_at, updated_at)
+      SELECT DISTINCT
+        user_chat_channel_memberships.user_id,
+        chat_channels.chatable_id,
+        user_chat_channel_memberships.created_at,
+        user_chat_channel_memberships.updated_at
+      FROM user_chat_channel_memberships
+      INNER JOIN chat_channels
+        ON chat_channels.id = user_chat_channel_memberships.chat_channel_id
+       AND chat_channels.chatable_type = 'DirectMessage'
+      LEFT JOIN direct_message_users
+        ON direct_message_users.user_id = user_chat_channel_memberships.user_id
+       AND direct_message_users.direct_message_channel_id = chat_channels.chatable_id
+      WHERE direct_message_users.id IS NULL
+      ON CONFLICT (direct_message_channel_id, user_id) DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/chat/lib/chat/channel_membership_manager.rb
+++ b/plugins/chat/lib/chat/channel_membership_manager.rb
@@ -25,6 +25,8 @@ module Chat
           Chat::UserChatChannelMembership.new(user: user, chat_channel: channel, following: true)
 
       ActiveRecord::Base.transaction do
+        ensure_direct_message_user(user)
+
         if membership.new_record?
           membership.save!
           recalculate_user_count
@@ -56,6 +58,12 @@ module Chat
       return if Chat::Channel.exists?(id: channel.id, user_count_stale: true)
       channel.update!(user_count_stale: true)
       Jobs.enqueue_in(3.seconds, Jobs::Chat::UpdateChannelUserCount, chat_channel_id: channel.id)
+    end
+
+    def ensure_direct_message_user(user)
+      return if !channel.direct_message_channel?
+
+      Chat::DirectMessageUser.create_or_find_by!(user: user, direct_message: channel.chatable)
     end
 
     def unfollow_all_users

--- a/plugins/chat/spec/db/post_migrate/backfill_missing_direct_message_users_spec.rb
+++ b/plugins/chat/spec/db/post_migrate/backfill_missing_direct_message_users_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "plugins/chat/db/post_migrate/20260604011058_backfill_missing_direct_message_users.rb",
+        )
+
+RSpec.describe BackfillMissingDirectMessageUsers do
+  before do
+    @original_verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after { ActiveRecord::Migration.verbose = @original_verbose }
+
+  it "backfills missing direct message users from direct message channel memberships" do
+    user = Fabricate(:user)
+    channel = Fabricate(:direct_message_channel)
+    membership =
+      Chat::UserChatChannelMembership.create!(
+        user: user,
+        chat_channel: channel,
+        following: true,
+        notification_level: Chat::UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+        created_at: 2.days.ago,
+        updated_at: 1.day.ago,
+      )
+
+    expect { described_class.new.up }.to change {
+      Chat::DirectMessageUser.exists?(
+        user_id: user.id,
+        direct_message_channel_id: channel.chatable_id,
+      )
+    }.from(false).to(true)
+
+    direct_message_user =
+      Chat::DirectMessageUser.find_by!(
+        user_id: user.id,
+        direct_message_channel_id: channel.chatable_id,
+      )
+    expect(direct_message_user.created_at.to_i).to eq(membership.created_at.to_i)
+    expect(direct_message_user.updated_at.to_i).to eq(membership.updated_at.to_i)
+  end
+
+  it "backfills direct message users for memberships that are not following" do
+    user = Fabricate(:user)
+    channel = Fabricate(:direct_message_channel)
+
+    Chat::UserChatChannelMembership.create!(
+      user: user,
+      chat_channel: channel,
+      following: false,
+      notification_level: Chat::UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+    )
+
+    expect { described_class.new.up }.to change {
+      Chat::DirectMessageUser.exists?(
+        user_id: user.id,
+        direct_message_channel_id: channel.chatable_id,
+      )
+    }.from(false).to(true)
+  end
+
+  it "does not create direct message users from category channel memberships" do
+    user = Fabricate(:user)
+    channel = Fabricate(:category_channel)
+
+    Chat::UserChatChannelMembership.create!(
+      user: user,
+      chat_channel: channel,
+      following: true,
+      notification_level: Chat::UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+    )
+
+    expect { described_class.new.up }.not_to change { Chat::DirectMessageUser.count }
+  end
+
+  it "does not duplicate existing direct message users" do
+    user = Fabricate(:user)
+    channel = Fabricate(:direct_message_channel)
+
+    Chat::UserChatChannelMembership.create!(
+      user: user,
+      chat_channel: channel,
+      following: true,
+      notification_level: Chat::UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+    )
+    Chat::DirectMessageUser.create!(user: user, direct_message: channel.chatable)
+
+    expect { described_class.new.up }.not_to change { Chat::DirectMessageUser.count }
+  end
+end

--- a/plugins/chat/spec/lib/chat/channel_membership_manager_spec.rb
+++ b/plugins/chat/spec/lib/chat/channel_membership_manager_spec.rb
@@ -62,6 +62,29 @@ RSpec.describe Chat::ChannelMembershipManager do
       }
       expect(membership.reload.following).to eq(true)
     end
+
+    it "creates a direct message user when following a direct message channel" do
+      channel = Fabricate(:direct_message_channel)
+
+      expect { described_class.new(channel).follow(user) }.to change {
+        Chat::DirectMessageUser.exists?(user: user, direct_message: channel.chatable)
+      }.from(false).to(true)
+    end
+
+    it "does not create a direct message user when following a category channel" do
+      expect { described_class.new(channel1).follow(user) }.not_to change {
+        Chat::DirectMessageUser.count
+      }
+    end
+
+    it "repairs a missing direct message user for an existing followed direct message membership" do
+      channel = Fabricate(:direct_message_channel)
+      Fabricate(:user_chat_channel_membership_for_dm, chat_channel: channel, user: user)
+
+      expect { described_class.new(channel).follow(user) }.to change {
+        Chat::DirectMessageUser.exists?(user: user, direct_message: channel.chatable)
+      }.from(false).to(true)
+    end
   end
 
   describe ".unfollow" do

--- a/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/add_users_to_channel_spec.rb
@@ -110,6 +110,31 @@ RSpec.describe Chat::AddUsersToChannel do
         expect { result }.to change { ::Chat::DirectMessageUser.count }.by(users.count + 1) # +1 for system user creating the notice message and added to the channel
       end
 
+      it "repairs a missing direct message user for an existing membership" do
+        broken_user = users.first
+        Chat::UserChatChannelMembership.create!(
+          user: broken_user,
+          chat_channel: channel,
+          following: true,
+          notification_level: Chat::UserChatChannelMembership::NOTIFICATION_LEVELS[:always],
+        )
+
+        expect { result }.to change {
+          Chat::DirectMessageUser.exists?(user: broken_user, direct_message: direct_message)
+        }.from(false).to(true)
+
+        expect(result.added_user_ids).to include(broken_user.id)
+        expect(
+          Chat::ChannelFetcher.structured(broken_user.guardian)[:direct_message_channels],
+        ).to include(channel)
+      end
+
+      it "publishes the channel to users added to the channel" do
+        Chat::Publisher.expects(:publish_new_channel).with(channel, includes(*users.map(&:id))).once
+
+        result
+      end
+
       it "updates users count" do
         expect { result }.to change { channel.reload.user_count }.by(users.count + 1) # +1 for system user creating the notice message and added to the channel
       end


### PR DESCRIPTION
Ensure adding or following direct message channels creates the matching direct_message_users rows, including when memberships already exist.
Backfill existing missing rows and publish newly repaired channels so affected users can see them.

Under rare conditions a user could have channel membership but still be missing
from direct_message_users (or the reverse)

This introduces transaction safety.

Situation is quite rare, happened twice in 6 months on a highly active instance
