### PR TITLE
FIX: Changing theme source URL not working correctly

### DIFF
--- a/frontend/discourse/admin/components/modal/change-theme-source.gjs
+++ b/frontend/discourse/admin/components/modal/change-theme-source.gjs
@@ -16,6 +16,7 @@ export default class ChangeThemeSourceModal extends Component {
   @tracked loading = false;
   @tracked generateNewKey = false;
   @tracked remoteUrl = this.args.model.theme.remote_theme?.remote_url || "";
+  @tracked formApi = null;
 
   @cached
   get data() {
@@ -40,8 +41,9 @@ export default class ChangeThemeSourceModal extends Component {
   }
 
   @action
-  onRemoteUrlChange(value) {
+  onRemoteUrlChange(value, { set, name }) {
     this.remoteUrl = value;
+    set(name, value);
   }
 
   @action

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -305,12 +305,14 @@ describe "Admin Customize Themes" do
       theme
     end
 
-    it "shows the change source button for git themes" do
-      theme_page.visit(git_theme)
-      expect(page).to have_button(I18n.t("admin_js.admin.customize.theme.change_source.button"))
-    end
+    it "opens the change source modal with pre-filled values, and allows submitting" do
+      # Stub the git fetch so the update succeeds without hitting a real remote.
+      allow_any_instance_of(RemoteTheme).to receive(:update_from_remote) do |remote_theme|
+        remote_theme.save!
+      end
 
-    it "opens the change source modal with pre-filled values" do
+      new_url = "https://github.com/discourse/some-other-theme.git"
+
       theme_page.visit(git_theme)
       find("button", text: I18n.t("admin_js.admin.customize.theme.change_source.button")).click
 
@@ -319,6 +321,12 @@ describe "Admin Customize Themes" do
         "https://github.com/discourse/example-theme.git",
       )
       expect(find(".admin-change-theme-source-modal input.branch").value).to eq("main")
+
+      find(".admin-change-theme-source-modal input.repo-url").fill_in(with: new_url)
+      find(".admin-change-theme-source-modal button.btn-primary").click
+
+      expect(page).to have_no_css(".admin-change-theme-source-modal")
+      expect(git_theme.reload.remote_theme.remote_url).to eq(new_url)
     end
 
     it "does not show the change source button for local themes" do


### PR DESCRIPTION
Previously, the "Change Source" modal for theme components had two bugs:

1.  The form always submitted the original repository URL regardless of what the user typed. For example, changing the URL from https://github.com/denvergeeks/discourse-breadcrumb-links to https://github.com/jlzlt/discourse-breadcrumb-links and clicking Update would silently submit the old URL. As a side effect, if the user typed a new URL and then clicked into the Branch field and started typing, the URL field would visually revert back to the original URL, making the bug visible.

2. After fixing the first bug, a second issue was discovered: if a user entered an incorrect repository/branch combination, received an error, then corrected it and clicked Update again without closing the modal, the form would ignore the correction and keep submitting the incorrect values.

Bug 1 was caused by the @onSet handler on the URL field not calling FormKit's internal set(name, value), which meant the form's internal state always held the original URL regardless of what the user typed. This was fixed by updating the handler to also call set(name, value).

Bug 2 had a separate cause: every time a submission fails, DConditionalLoadingSection destroys and recreates the form component. Because formApi was not @tracked (meaning the UI does not automatically update when it changes), the submit button in the footer never updated its reference to the new form instance and kept submitting data from the old destroyed one. This was fixed by marking formApi as @tracked.

Both bugs were introduced in #38169 which added this feature - just wanted to flag it in case it's useful context!