### PR TITLE
UX: fix overflow composer action-title

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -296,6 +296,11 @@ html.composer-open:not(.has-full-page-chat) {
       align-items: center;
       width: 100%;
       max-width: 100%;
+      overflow: hidden;
+
+      .topic-link {
+        @include ellipsis;
+      }
     }
 
     .composer-controls {


### PR DESCRIPTION
ref https://meta.discourse.org/t/long-personal-message-titles-overflow-in-composer/404508 