### PR TITLE
FIX: Show connected workflow input previews

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/data-schema.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/data-schema.js
@@ -293,6 +293,49 @@ export function inputForRun(
   return input;
 }
 
+function connectedSourceOutputForInput(
+  runData,
+  nodeName,
+  { node, sourceNode, outputIndex = 0 } = {}
+) {
+  if (latestSuccessfulRun(runData, nodeName, { node }) || !sourceNode?.name) {
+    return null;
+  }
+
+  const sourceRun = latestRunWithOutput(runData, sourceNode.name, {
+    node: sourceNode,
+  });
+  return outputForRun(sourceRun, outputIndex);
+}
+
+function inputPreviewPort(
+  runData,
+  nodeName,
+  { inputIndex = 0, node, sourceNode, outputIndex = 0 } = {}
+) {
+  const run = latestRunWithInput(runData, nodeName, {
+    inputIndex,
+    node,
+    sourceNode,
+    outputIndex,
+  });
+  const input = inputForRun(run, inputIndex, { sourceNode, outputIndex });
+  if (input) {
+    return { port: input, source: "input" };
+  }
+
+  const output = connectedSourceOutputForInput(runData, nodeName, {
+    node,
+    sourceNode,
+    outputIndex,
+  });
+  if (output) {
+    return { port: output, source: "source_output" };
+  }
+
+  return { port: null, source: null };
+}
+
 export function schemaFieldsForNodeOutput(
   runData,
   nodeName,
@@ -308,14 +351,13 @@ export function schemaFieldsForNodeInput(
   nodeName,
   { inputIndex = 0, prefix = "$json", node, sourceNode, outputIndex = 0 } = {}
 ) {
-  const run = latestRunWithInput(runData, nodeName, {
+  const { port } = inputPreviewPort(runData, nodeName, {
     inputIndex,
     node,
     sourceNode,
     outputIndex,
   });
-  const input = inputForRun(run, inputIndex, { sourceNode, outputIndex });
-  return schemaFieldsForItems(input?.items || [], { prefix });
+  return schemaFieldsForItems(port?.items || [], { prefix });
 }
 
 function portSummary(port, indexKey) {
@@ -346,16 +388,17 @@ export function inputSummaryForNode(
   inputIndex = 0,
   { node, sourceNode, outputIndex = 0 } = {}
 ) {
-  const run = latestRunWithInput(runData, nodeName, {
+  const { port, source } = inputPreviewPort(runData, nodeName, {
     inputIndex,
     node,
     sourceNode,
     outputIndex,
   });
-  return portSummary(
-    inputForRun(run, inputIndex, { sourceNode, outputIndex }),
-    "inputIndex"
-  );
+  const summary = portSummary(port, "inputIndex");
+  if (summary && source === "source_output") {
+    summary.inputIndex = inputIndex;
+  }
+  return summary;
 }
 
 function combinedPortSummary(ports, itemCount) {

--- a/plugins/discourse-workflows/app/services/discourse_workflows/workflow/action/build_expression_preview_context.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/workflow/action/build_expression_preview_context.rb
@@ -77,7 +77,7 @@ module DiscourseWorkflows
       return if current_node.nil? || current_node["name"].blank?
 
       run = Array(node_runs[current_node["name"]]).last
-      return unless run
+      return input_from_connected_source(node_runs, primary_upstream_connection) unless run
 
       input_index = (primary_upstream_connection&.target_input_index || 0).to_i
       return unless input_source_matches_connection?(run, input_index, primary_upstream_connection)
@@ -86,6 +86,25 @@ module DiscourseWorkflows
       return unless items
 
       { "items" => Array(items), "input_sources" => Array(run["input_sources"]) }
+    end
+
+    def input_from_connected_source(node_runs, connection)
+      return unless connection
+
+      source_node = workflow_snapshot.source_node(connection)
+      return if source_node.blank? || source_node.name.blank?
+
+      run = Array(node_runs[source_node.name]).last
+      return unless run
+
+      output_index = connection.source_output_index.to_i
+      items = run.dig("outputs", output_index)
+      return unless items
+
+      {
+        "items" => Array(items),
+        "input_sources" => [{ "node_name" => source_node.name, "output_index" => output_index }],
+      }
     end
 
     def overlay_current_input(context, current_input)

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/workflow/action/build_expression_preview_context_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/workflow/action/build_expression_preview_context_spec.rb
@@ -127,8 +127,54 @@ RSpec.describe DiscourseWorkflows::Workflow::Action::BuildExpressionPreviewConte
           context "when the current node has no recorded input data" do
             let(:node_id) { "action-1" }
 
-            it "uses the default input context" do
-              expect(context["$json"]).to eq({})
+            it "uses the connected upstream output for input context" do
+              expect(context["$json"]).to eq({ "title" => "From past run" })
+              expect(context["__input_item"]).to eq(items.first)
+              expect(context["__input_items"]).to eq(items)
+              expect(context["__input_sources"]).to eq(
+                [{ "node_name" => "Topic created", "output_index" => 0 }],
+              )
+            end
+          end
+
+          context "when the current node only has a skipped run" do
+            let(:node_id) { "action-1" }
+
+            before do
+              execution.execution_data.update!(
+                data: {
+                  "entries" => {
+                  },
+                  "context" => {
+                  },
+                  "node_contexts" => {
+                  },
+                  "run_data" =>
+                    run_data_for(
+                      "trigger-1",
+                      node_name: "Topic created",
+                      node_type: "trigger:topic_created",
+                      items: items,
+                    ).deep_merge(
+                      run_data_for(
+                        "action-1",
+                        node_name: "Tag topic",
+                        node_type: "action:topic_tags",
+                        items: items,
+                        status: "skipped",
+                      ),
+                    ),
+                },
+              )
+            end
+
+            it "uses the connected upstream output for input context" do
+              expect(context["$json"]).to eq({ "title" => "From past run" })
+              expect(context["__input_item"]).to eq(items.first)
+              expect(context["__input_items"]).to eq(items)
+              expect(context["__input_sources"]).to eq(
+                [{ "node_name" => "Topic created", "output_index" => 0 }],
+              )
             end
           end
 

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
@@ -294,12 +294,10 @@ module(
       ].map((el) => el.textContent.trim());
 
       assert.true(firstTitle.includes("First Step"));
-      assert.false(firstTitle.includes("1 item"));
+      assert.true(firstTitle.includes("1 item"));
       assert.dom(".workflows-context-panel__item-title").doesNotExist();
-      assert.false(keys.includes("result"));
-      assert
-        .dom(".workflows-context-panel__empty")
-        .hasText("No input data yet. It will appear after the first run.");
+      assert.true(keys.includes("result"));
+      assert.dom(".workflows-context-panel__empty").doesNotExist();
     });
 
     test("shows an empty input state when the input has no JSON fields", async function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-data-schema-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-data-schema-test.js
@@ -284,6 +284,71 @@ module("Unit | lib | discourse-workflows | data-schema", function () {
     );
   });
 
+  test("schemaFieldsForNodeInput previews connected upstream output before the current node succeeds", function (assert) {
+    const currentNode = {
+      id: "create-post",
+      name: "Create post",
+      type: "action:create_post",
+    };
+    const sourceNode = {
+      id: "template",
+      name: "Template",
+      type: "action:template",
+    };
+    const runData = {
+      Template: [
+        {
+          node_id: "template",
+          node_type: "action:template",
+          status: "success",
+          outputs: [
+            {
+              index: 0,
+              items: [{ json: { template: "Rendered body" } }],
+              item_count: 1,
+            },
+          ],
+        },
+      ],
+      "Create post": [
+        {
+          node_id: "create-post",
+          node_type: "action:create_post",
+          status: "skipped",
+          inputs: [
+            {
+              index: 0,
+              items: [{ json: { template: "Rendered body" } }],
+              item_count: 1,
+              source: null,
+            },
+          ],
+        },
+      ],
+    };
+
+    assert.deepEqual(
+      schemaFieldsForNodeInput(runData, "Create post", {
+        node: currentNode,
+        sourceNode,
+        outputIndex: 0,
+      }).map((field) => field.key),
+      ["template"]
+    );
+    assert.deepEqual(
+      inputSummaryForNode(runData, "Create post", 0, {
+        node: currentNode,
+        sourceNode,
+        outputIndex: 0,
+      }),
+      {
+        inputIndex: 0,
+        itemCount: 1,
+        truncated: false,
+      }
+    );
+  });
+
   test("nodeItemJsonPath escapes node names for expressions", function (assert) {
     assert.strictEqual(
       nodeItemJsonPath('Fetch "quoted" \\ data'),


### PR DESCRIPTION
Previously, input previews could appear empty when the current node had not captured input yet, even though a connected upstream node had output.

This change falls back to the connected upstream output so fields and summaries remain visible before the node succeeds.