### PR TITLE
DEV: Fix a admin tag list spec flake

### DIFF
--- a/spec/system/admin_site_setting_tag_list_spec.rb
+++ b/spec/system/admin_site_setting_tag_list_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Admin tag list site setting" do
     tag_chooser.select_row_by_name(tag_1.name)
     tag_chooser.search(tag_2.name)
     tag_chooser.select_row_by_name(tag_2.name)
+    tag_chooser.collapse
 
     expect(settings_page).to have_tags_in_setting("digest_suppress_tags", [tag_1, tag_2])
 


### PR DESCRIPTION
tag chooser doesn't close automatically, so it sometimes could prevent interacting with other UI (which happened to be underneath)