### PR TITLE
FIX: render event recurrence correctly in posts

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
+import moment from "moment";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
@@ -13,6 +14,7 @@ import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
 import { i18n } from "discourse-i18n";
+import { recurrenceContext, recurrenceRef } from "../../lib/event-recurrence";
 import ChatChannel from "./chat-channel";
 import Creator from "./creator";
 import Dates from "./dates";
@@ -128,8 +130,10 @@ export default class DiscoursePostEvent extends Component {
     if (!this.event?.recurrence) {
       return null;
     }
+
     return i18n(
-      `discourse_post_event.builder_modal.recurrence.${this.event.recurrence}`
+      `discourse_post_event.builder_modal.recurrence.${this.event.recurrence}`,
+      recurrenceContext(recurrenceRef(this.event))
     );
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -17,6 +17,7 @@ import DDateInput from "discourse/ui-kit/d-date-input";
 import DDateTimeInput from "discourse/ui-kit/d-date-time-input";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
+import { recurrenceContext } from "../../lib/event-recurrence";
 import {
   attendanceTransition,
   buildParams,
@@ -306,16 +307,7 @@ export default class PostEventBuilder extends Component {
   }
 
   get availableRecurrences() {
-    const ref = this.startsAt || moment();
-    const weekday = ref.format("dddd");
-    const dayOfMonth = ref.date();
-    const isLast = dayOfMonth + 7 > ref.daysInMonth();
-    const ordinalKey = isLast
-      ? "last"
-      : ["first", "second", "third", "fourth"][Math.ceil(dayOfMonth / 7) - 1];
-    const ordinal = i18n(
-      `discourse_post_event.builder_modal.recurrence.ordinals.${ordinalKey}`
-    );
+    const { weekday, ordinal } = recurrenceContext(this.startsAt || moment());
 
     return [
       {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/event-recurrence.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/event-recurrence.js
@@ -1,0 +1,22 @@
+import { i18n } from "discourse-i18n";
+
+const ORDINALS = ["first", "second", "third", "fourth"];
+
+export function recurrenceRef(event) {
+  if (event.allDay) {
+    return moment(event.startsAt, "YYYY-MM-DD");
+  }
+  return moment(event.startsAt).tz(event.timezone || "UTC");
+}
+
+export function recurrenceContext(ref) {
+  const weekday = ref.format("dddd");
+  const dayOfMonth = ref.date();
+  const isLast = dayOfMonth + 7 > ref.daysInMonth();
+  const ordinalKey = isLast ? "last" : ORDINALS[Math.ceil(dayOfMonth / 7) - 1];
+  const ordinal = i18n(
+    `discourse_post_event.builder_modal.recurrence.ordinals.${ordinalKey}`
+  );
+
+  return { weekday, ordinal };
+}

--- a/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
@@ -66,16 +66,18 @@
         height: 100%;
       }
 
-      .reminder-type {
-        width: 320px;
-      }
+      @include viewport.from(sm) {
+        .reminder-type {
+          width: 320px;
+        }
 
-      .reminder-value {
-        width: 60px;
-      }
+        .reminder-value {
+          min-width: unset !important; // overrides another important
+        }
 
-      .reminder-unit {
-        width: 140px;
+        .reminder-unit {
+          width: 140px;
+        }
       }
 
       .reminder-period {

--- a/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -1,0 +1,92 @@
+import { getOwner } from "@ember/owner";
+import { render, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DiscoursePostEvent from "../../discourse/components/discourse-post-event";
+import DiscoursePostEventEvent from "../../discourse/models/discourse-post-event-event";
+
+function buildEvent(overrides = {}) {
+  return DiscoursePostEventEvent.create({
+    id: 1,
+    // 2026-06-04 is a Thursday
+    starts_at: "2026-06-04T14:00:00Z",
+    ends_at: "2026-06-04T15:00:00Z",
+    timezone: "UTC",
+    status: "public",
+    name: "Product team office hours",
+    post: { id: 1, url: "/t/foo/1", topic: { id: 1 } },
+    creator: { username: "bob", id: 5 },
+    should_display_invitees: false,
+    sample_invitees: [],
+    ...overrides,
+  });
+}
+
+module("Integration | Component | DiscoursePostEvent", function (hooks) {
+  setupRenderingTest(hooks);
+
+  function stubApi(event) {
+    getOwner(this).unregister("service:discourse-post-event-api");
+    getOwner(this).register(
+      "service:discourse-post-event-api",
+      {
+        async event() {
+          return event;
+        },
+      },
+      { instantiate: false }
+    );
+  }
+
+  test("interpolates the weekday into the recurrence label", async function (assert) {
+    stubApi.call(this, buildEvent({ recurrence: "every_week" }));
+
+    const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "Every Thursday",
+        "renders the weekday instead of a missing placeholder"
+      );
+  });
+
+  test("interpolates the ordinal and weekday into the monthly recurrence label", async function (assert) {
+    stubApi.call(this, buildEvent({ recurrence: "every_month" }));
+
+    const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "The first Thursday of every month",
+        "renders both the ordinal and weekday placeholders"
+      );
+  });
+
+  test("derives the weekday from the date for all-day events, ignoring the timezone offset", async function (assert) {
+    // Midnight UTC in a negative-offset timezone rolls back to the previous
+    // day; an all-day event's weekday must come from the date, not the offset.
+    stubApi.call(
+      this,
+      buildEvent({
+        recurrence: "every_week",
+        all_day: true,
+        timezone: "America/New_York",
+        starts_at: "2026-06-04T00:00:00Z",
+      })
+    );
+
+    const event = { id: 1, startsAt: "2026-06-04T00:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText("Every Thursday", "uses the date's weekday, not the prior day");
+  });
+});


### PR DESCRIPTION
The new formatting for recurrence in the configuration modal wasn't synced up with the rendered event in the post — this adds a new helper so they share the same source logic.

Added tests to avoid future regression.  

Also fixed some minor CSS in the modal. 


Before:
<img width="1398" height="660" alt="image" src="https://github.com/user-attachments/assets/7cd36ac1-8106-404a-92ed-e35f64a44342" />


After: 
<img width="1496" height="712" alt="image" src="https://github.com/user-attachments/assets/2c068a45-d5b0-4fc7-8ba1-980e9720c156" />
 