### PR TITLE
FIX: Respect poll result visibility for ranked-choice outcomes

### DIFF
--- a/plugins/poll/app/serializers/poll_serializer.rb
+++ b/plugins/poll/app/serializers/poll_serializer.rb
@@ -79,7 +79,7 @@ class PollSerializer < ApplicationSerializer
   end
 
   def include_ranked_choice_outcome?
-    object.ranked_choice?
+    object.ranked_choice? && object.can_see_results?(scope.user)
   end
 
   def ranked_choice_outcome

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -53,6 +53,7 @@ export default class PollComponent extends Component {
   @tracked
   showResults =
     !(this.poll.results === ON_CLOSE && !this.closed) &&
+    !(this.staffOnly && !this.isStaff) &&
     (this.hasSavedVote ||
       (this.topicArchived && !this.staffOnly) ||
       (this.closed && !this.staffOnly));

--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -81,9 +81,7 @@ class DiscoursePoll::Poll
         end
       end
 
-    if serialized_poll[:type] == RANKED_CHOICE
-      serialized_poll[:ranked_choice_outcome] = DiscoursePoll::RankedChoice.outcome(poll_id)
-    else
+    if serialized_poll[:type] != RANKED_CHOICE
       # Ensure consistency here as we do not have a unique index to limit the
       # number of votes per the poll's configuration.
       is_multiple = serialized_poll[:type] == MULTIPLE
@@ -145,19 +143,9 @@ class DiscoursePoll::Poll
   end
 
   def self.remove_vote(user, post_id, poll_name)
-    poll_id = nil
-
-    serialized_poll =
-      DiscoursePoll::Poll.change_vote(user, post_id, poll_name) do |poll|
-        poll_id = poll.id
-        PollVote.where(poll: poll, user: user).delete_all
-      end
-
-    if serialized_poll[:type] == RANKED_CHOICE
-      serialized_poll[:ranked_choice_outcome] = DiscoursePoll::RankedChoice.outcome(poll_id)
+    DiscoursePoll::Poll.change_vote(user, post_id, poll_name) do |poll|
+      PollVote.where(poll: poll, user: user).delete_all
     end
-
-    serialized_poll
   end
 
   def self.toggle_status(user, post_id, poll_name, status, raise_errors = true)
@@ -207,8 +195,13 @@ class DiscoursePoll::Poll
       poll.save!
 
       serialized_poll = PollSerializer.new(poll, root: false, scope: guardian).as_json
-      payload = { post_id:, polls: [serialized_poll] }
 
+      # This payload is broadcast to every subscriber on the topic channel, so
+      # we only broadcast public data by serializing it as an anonymous user.
+      payload = {
+        post_id:,
+        polls: [PollSerializer.new(poll, root: false, scope: Guardian.new).as_json],
+      }
       post.publish_message!("/polls/#{post.topic_id}", payload)
 
       serialized_poll
@@ -530,8 +523,13 @@ class DiscoursePoll::Poll
       poll.reload
 
       serialized_poll = PollSerializer.new(poll, root: false, scope: guardian).as_json
-      payload = { post_id:, polls: [serialized_poll] }
 
+      # This payload is broadcast to every subscriber on the topic channel, so
+      # we only broadcast public data by serializing it as an anonymous user.
+      payload = {
+        post_id:,
+        polls: [PollSerializer.new(poll, root: false, scope: Guardian.new).as_json],
+      }
       post.publish_message!("/polls/#{post.topic_id}", payload)
 
       serialized_poll

--- a/plugins/poll/spec/integration/ranked_choice_result_visibility_spec.rb
+++ b/plugins/poll/spec/integration/ranked_choice_result_visibility_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+RSpec.describe "DiscoursePoll ranked choice result visibility" do
+  fab!(:voter) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:non_voter) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:author, :admin)
+
+  def create_ranked_choice_post(results:)
+    topic = Fabricate(:topic, user: author)
+
+    Fabricate(:post, user: author, topic: topic, raw: <<~RAW)
+      [poll type=ranked_choice results=#{results}]
+      - Red
+      - Blue
+      - Yellow
+      [/poll]
+    RAW
+  end
+
+  def ranked_choice_vote_options(poll)
+    {
+      "0" => {
+        digest: poll.poll_options.first.digest,
+        rank: "1",
+      },
+      "1" => {
+        digest: poll.poll_options.second.digest,
+        rank: "2",
+      },
+      "2" => {
+        digest: poll.poll_options.third.digest,
+        rank: "0",
+      },
+    }
+  end
+
+  def vote_in_ranked_choice_poll(user, post)
+    DiscoursePoll::Poll.vote(
+      user,
+      post.id,
+      DiscoursePoll::DEFAULT_POLL_NAME,
+      ranked_choice_vote_options(post.polls.first),
+    )
+  end
+
+  def topic_view_poll(post)
+    get "/t/#{post.topic.slug}/#{post.topic.id}.json"
+
+    expect(response.status).to eq(200)
+
+    response.parsed_body["post_stream"]["posts"]
+      .find { |serialized_post| serialized_post["id"] == post.id }
+      .fetch("polls")
+      .first
+  end
+
+  it "omits the outcome from vote responses when staff-only results are hidden from the voter" do
+    post = create_ranked_choice_post(results: "staff_only")
+
+    sign_in(voter)
+    put "/polls/vote.json",
+        params: {
+          post_id: post.id,
+          poll_name: DiscoursePoll::DEFAULT_POLL_NAME,
+          options: ranked_choice_vote_options(post.polls.first),
+        }
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["poll"]).not_to have_key("ranked_choice_outcome")
+
+    delete "/polls/vote.json",
+           params: {
+             post_id: post.id,
+             poll_name: DiscoursePoll::DEFAULT_POLL_NAME,
+           }
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["poll"]).not_to have_key("ranked_choice_outcome")
+  end
+
+  it "keeps a staff-visible outcome out of shared vote broadcasts" do
+    post = create_ranked_choice_post(results: "staff_only")
+
+    sign_in(author)
+    messages =
+      MessageBus.track_publish("/polls/#{post.topic.id}") do
+        put "/polls/vote.json",
+            params: {
+              post_id: post.id,
+              poll_name: DiscoursePoll::DEFAULT_POLL_NAME,
+              options: ranked_choice_vote_options(post.polls.first),
+            }
+      end
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["poll"]).to have_key("ranked_choice_outcome")
+    expect(messages.size).to eq(1)
+
+    published_poll = messages.first.data.deep_stringify_keys["polls"].first
+    expect(published_poll).not_to have_key("ranked_choice_outcome")
+  end
+
+  it "shows on-vote outcomes to voters without leaking them to non-voters" do
+    post = create_ranked_choice_post(results: "on_vote")
+
+    sign_in(voter)
+    messages =
+      MessageBus.track_publish("/polls/#{post.topic.id}") do
+        put "/polls/vote.json",
+            params: {
+              post_id: post.id,
+              poll_name: DiscoursePoll::DEFAULT_POLL_NAME,
+              options: ranked_choice_vote_options(post.polls.first),
+            }
+      end
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["poll"]).to have_key("ranked_choice_outcome")
+    expect(messages.size).to eq(1)
+
+    published_poll = messages.first.data.deep_stringify_keys["polls"].first
+    expect(published_poll).not_to have_key("ranked_choice_outcome")
+
+    sign_in(non_voter)
+    expect(topic_view_poll(post)).not_to have_key("ranked_choice_outcome")
+
+    sign_in(voter)
+    expect(topic_view_poll(post)).to have_key("ranked_choice_outcome")
+  end
+
+  it "omits on-close outcomes from anonymous topic views while the poll is open" do
+    post = create_ranked_choice_post(results: "on_close")
+
+    vote_in_ranked_choice_poll(voter, post)
+
+    expect(topic_view_poll(post)).not_to have_key("ranked_choice_outcome")
+  end
+end

--- a/plugins/poll/test/javascripts/component/poll-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-test.gjs
@@ -236,6 +236,51 @@ module("Component | Poll", function (hooks) {
     assert.dom("ul.results").doesNotExist("results are not shown");
   });
 
+  test("does not render an empty ranked choice outcome to a non-staff voter on staff_only polls", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+        polls_votes: {
+          poll: [
+            { digest: "1f972d1df351de3ce35a787c89faad29", rank: 1 },
+            { digest: "d7ebc3a9beea2e680815a1e4f57d6db6", rank: 2 },
+          ],
+        },
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "ranked_choice",
+        status: "open",
+        results: "staff_only",
+        options: [
+          { id: "1f972d1df351de3ce35a787c89faad29", html: "this", rank: 1 },
+          { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "that", rank: 2 },
+        ],
+        voters: 1,
+        chart_type: "bar",
+        // no ranked_choice_outcome — the server withholds it from non-staff
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert
+      .dom("table.poll-results-ranked-choice")
+      .doesNotExist("the empty outcome table is not rendered");
+    assert
+      .dom(".results-staff-only")
+      .exists("the staff-only results notice is shown instead");
+    assert
+      .dom(".ranked-choice-poll-option")
+      .exists("the ballot options are shown to the voter");
+  });
+
   test("can vote", async function (assert) {
     this.setProperties({
       post: EmberObject.create({


### PR DESCRIPTION
Ranked-choice polls always serialized `ranked_choice_outcome` (the computed winner and round-by-round activity) regardless of the poll's `results` setting, unlike vote counts and voter lists, which are gated by `Poll#can_see_results?`. 


The outcome was therefore displayed to users who should not yet see results on `on_vote`, `on_close`, and `staff_only` polls — through the topic view, the vote/remove-vote responses, and the MessageBus broadcast.

- Gate `ranked_choice_outcome` in `PollSerializer` behind `can_see_results?`, matching the other result fields.
- Stop manually re-appending the outcome in `vote`/`remove_vote` so the serializer's gating is authoritative.
- Serialize the MessageBus payload as an anonymous user so the topic-wide broadcast only carries data any viewer may see, matching `PollsUpdater.publish_changes`.
- Don't render an empty results panel to a non-staff voter on a `staff_only` poll; show the ballot and the staff-only notice instead.



Relates to /t/-/185090
And Patch 998