### PR TITLE
DEV: Uppy's response object in errors is optional

### DIFF
--- a/frontend/discourse/app/lib/uppy/uppy-upload.js
+++ b/frontend/discourse/app/lib/uppy/uppy-upload.js
@@ -287,7 +287,7 @@ export default class UppyUpload {
     this.uppyWrapper.uppyInstance.on(
       "upload-error",
       (file, error, response) => {
-        if (response.aborted) {
+        if (response?.aborted) {
           return; // User cancelled the upload
         }
         this.#removeInProgressUpload(file.id);


### PR DESCRIPTION
yo dawg, I heard you like errors within your errors