### PR TITLE
DEV: Backport calendar and events fixes

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
+import moment from "moment";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
@@ -12,6 +13,7 @@ import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
 import { i18n } from "discourse-i18n";
+import { recurrenceContext, recurrenceRef } from "../../lib/event-recurrence";
 import ChatChannel from "./chat-channel";
 import Creator from "./creator";
 import Dates from "./dates";
@@ -127,8 +129,10 @@ export default class DiscoursePostEvent extends Component {
     if (!this.event?.recurrence) {
       return null;
     }
+
     return i18n(
-      `discourse_post_event.builder_modal.recurrence.${this.event.recurrence}`
+      `discourse_post_event.builder_modal.recurrence.${this.event.recurrence}`,
+      recurrenceContext(recurrenceRef(this.event))
     );
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -143,9 +143,6 @@ export default class FullCalendar extends Component {
           });
         }
       },
-      dateClick: async (info) => {
-        await this.args.onDateClick?.(info);
-      },
       eventClick: async ({ el, event, jsEvent }) => {
         const { postNumber, postUrl, postEvent } = event.extendedProps;
 
@@ -179,8 +176,8 @@ export default class FullCalendar extends Component {
       },
       allDayContent: () =>
         i18n("discourse_post_event.upcoming_events_list.all_day"),
-      select: (info) => {
-        this.args.onDateClick?.(info);
+      select: async (info) => {
+        await this.args.onDateClick?.(info);
       },
     });
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { concat, fn, get } from "@ember/helper";
-import { on } from "@ember/modifier";
+import { concat, fn } from "@ember/helper";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
 import Form from "discourse/components/form";
@@ -119,6 +118,8 @@ export default class PostEventBuilder extends Component {
       timezone: this.event.timezone ?? null,
       // clone so the form draft owns its own reminders
       reminders: (this.event.reminders ?? []).map((r) => ({ ...r })),
+      // clone so the form draft owns the custom fields
+      customFields: { ...(this.event.customFields ?? {}) },
     };
   }
 
@@ -554,8 +555,8 @@ export default class PostEventBuilder extends Component {
   }
 
   @action
-  setCustomField(field, e) {
-    this.event.customFields[field] = e.target.value;
+  setCustomField(field, value) {
+    this.event.customFields[field] = value;
   }
 
   @action
@@ -1223,26 +1224,24 @@ export default class PostEventBuilder extends Component {
                     }}
                     @format="full"
                   >
-                    {{#each this.allowedCustomFields as |allowedCustomField|}}
-                      <span class="label custom-field-label">
-                        {{allowedCustomField}}
-                      </span>
-                      <input
-                        type="text"
-                        class="custom-field-input"
-                        value={{get
-                          @model.event.customFields
-                          allowedCustomField
-                        }}
-                        {{on
-                          "input"
-                          (fn this.setCustomField allowedCustomField)
-                        }}
-                        placeholder={{i18n
-                          "discourse_post_event.builder_modal.custom_fields.placeholder"
-                        }}
-                      />
-                    {{/each}}
+                    <form.Object @name="customFields" as |customFields|>
+                      {{#each this.allowedCustomFields as |allowedCustomField|}}
+                        <customFields.Field
+                          @name={{allowedCustomField}}
+                          @title={{allowedCustomField}}
+                          @type="input"
+                          @format="full"
+                          @onSet={{fn this.setCustomField allowedCustomField}}
+                          as |field|
+                        >
+                          <field.Control
+                            placeholder={{i18n
+                              "discourse_post_event.builder_modal.custom_fields.placeholder"
+                            }}
+                          />
+                        </customFields.Field>
+                      {{/each}}
+                    </form.Object>
                   </form.Container>
                 {{/if}}
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -17,6 +17,7 @@ import DDateInput from "discourse/ui-kit/d-date-input";
 import DDateTimeInput from "discourse/ui-kit/d-date-time-input";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
+import { recurrenceContext } from "../../lib/event-recurrence";
 import {
   attendanceTransition,
   buildParams,
@@ -306,16 +307,7 @@ export default class PostEventBuilder extends Component {
   }
 
   get availableRecurrences() {
-    const ref = this.startsAt || moment();
-    const weekday = ref.format("dddd");
-    const dayOfMonth = ref.date();
-    const isLast = dayOfMonth + 7 > ref.daysInMonth();
-    const ordinalKey = isLast
-      ? "last"
-      : ["first", "second", "third", "fourth"][Math.ceil(dayOfMonth / 7) - 1];
-    const ordinal = i18n(
-      `discourse_post_event.builder_modal.recurrence.ordinals.${ordinalKey}`
-    );
+    const { weekday, ordinal } = recurrenceContext(this.startsAt || moment());
 
     return [
       {

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/event-recurrence.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/event-recurrence.js
@@ -1,0 +1,22 @@
+import { i18n } from "discourse-i18n";
+
+const ORDINALS = ["first", "second", "third", "fourth"];
+
+export function recurrenceRef(event) {
+  if (event.allDay) {
+    return moment(event.startsAt, "YYYY-MM-DD");
+  }
+  return moment(event.startsAt).tz(event.timezone || "UTC");
+}
+
+export function recurrenceContext(ref) {
+  const weekday = ref.format("dddd");
+  const dayOfMonth = ref.date();
+  const isLast = dayOfMonth + 7 > ref.daysInMonth();
+  const ordinalKey = isLast ? "last" : ORDINALS[Math.ceil(dayOfMonth / 7) - 1];
+  const ordinal = i18n(
+    `discourse_post_event.builder_modal.recurrence.ordinals.${ordinalKey}`
+  );
+
+  return { weekday, ordinal };
+}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
@@ -3,7 +3,11 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import { buildBBCodeAttrs } from "discourse/lib/text";
 import EventNodeView from "../components/event-node-view";
 import { buildEventPreview } from "../lib/event-preview";
-import { defaultReminderFor, reminderToBBCode } from "../lib/raw-event-helper";
+import {
+  defaultReminderFor,
+  getCustomFieldNames,
+  reminderToBBCode,
+} from "../lib/raw-event-helper";
 
 export const EVENT_ATTRIBUTES = {
   name: { default: null },
@@ -25,8 +29,8 @@ export const EVENT_ATTRIBUTES = {
   image: { default: null },
 };
 
-/** @type {RichEditorExtension} */
-const extension = {
+/** @returns {RichEditorExtension} */
+const buildExtension = (siteSettings) => ({
   nodeViews: {
     event: {
       component: EventNodeView,
@@ -35,7 +39,13 @@ const extension = {
 
   nodeSpec: {
     event: {
-      attrs: EVENT_ATTRIBUTES,
+      get attrs() {
+        const attrs = { ...EVENT_ATTRIBUTES };
+        getCustomFieldNames(siteSettings).forEach((field) => {
+          attrs[camelize(field)] = { default: null };
+        });
+        return attrs;
+      },
       group: "block",
       content: "block*",
       defining: true,
@@ -135,12 +145,13 @@ const extension = {
         : null;
     },
   }),
-};
+});
 
 export default {
   initialize() {
     withPluginApi((api) => {
-      api.registerRichEditorExtension(extension);
+      const siteSettings = api.container.lookup("service:site-settings");
+      api.registerRichEditorExtension(buildExtension(siteSettings));
     });
   },
 };

--- a/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
@@ -66,16 +66,18 @@
         height: 100%;
       }
 
-      .reminder-type {
-        width: 320px;
-      }
+      @include viewport.from(sm) {
+        .reminder-type {
+          width: 320px;
+        }
 
-      .reminder-value {
-        width: 60px;
-      }
+        .reminder-value {
+          min-width: unset !important; // overrides another important
+        }
 
-      .reminder-unit {
-        width: 140px;
+        .reminder-unit {
+          width: 140px;
+        }
       }
 
       .reminder-period {

--- a/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
@@ -96,15 +96,6 @@
     }
   }
 
-  .custom-field-label {
-    font-weight: 500;
-    margin: 0.5em 0 0.25em 0;
-  }
-
-  .custom-field-input {
-    width: 100%;
-  }
-
   .d-date-time-input {
     width: 100%;
   }

--- a/plugins/discourse-calendar/spec/system/composer/prosemirror_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/composer/prosemirror_event_spec.rb
@@ -257,5 +257,26 @@ describe "Composer - ProseMirror - Event Editor" do
 
       expect(rich).to have_css(".composer-event__more-dropdown")
     end
+
+    it "persists allowed custom fields edited through the event builder to markdown" do
+      SiteSetting.discourse_post_event_allowed_custom_fields = "fancy_field"
+
+      open_composer
+      composer.toggle_rich_editor
+      composer.fill_content(
+        "[event start=\"2025-03-21 15:41\" status=\"public\" timezone=\"Europe/Paris\"]\n[/event]",
+      )
+      composer.toggle_rich_editor
+
+      rich.find(".composer-event__more-dropdown button").click
+
+      form = PageObjects::Components::FormKit.new(".post-event-builder-modal form")
+      form.field("customFields.fancy_field").fill_in("hello world")
+      find(".post-event-builder-modal .d-modal__footer .btn-primary").click
+      expect(page).to have_no_css(".post-event-builder-modal")
+
+      composer.toggle_rich_editor
+      expect(find(".d-editor-input").value).to include("fancyField=\"hello world\"")
+    end
   end
 end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -455,7 +455,7 @@ describe "Post event" do
     find(".group-selector").click
     find(".d-multi-select__search-input").send_keys(group.name)
     find(".d-multi-select__result", text: group.name).click
-    find(".d-modal .custom-field-input").fill_in(with: "custom value")
+    form.field("customFields.custom").fill_in("custom value")
     form.field("recurrence").select("every_day")
     find(".d-modal .recurrence-until .date-picker").fill_in(with: "#{1.year.from_now.year}-12-30")
     find(".d-modal .btn-primary").click
@@ -469,7 +469,7 @@ describe "Post event" do
     form = PageObjects::Components::FormKit.new(".d-modal form")
     expect(form.field("eventType")).to have_value("private")
     expect(find(".group-selector .d-multi-select-trigger__selection")).to have_text(group.name)
-    expect(find(".d-modal .custom-field-input").value).to eq("custom value")
+    expect(form.field("customFields.custom")).to have_value("custom value")
     expect(page).to have_selector(".d-modal .recurrence-until .date-picker") do |input|
       input.value == "#{1.year.from_now.year}-12-30"
     end

--- a/plugins/discourse-calendar/test/javascripts/acceptance/calendar-click-to-create-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/calendar-click-to-create-test.js
@@ -92,6 +92,10 @@ acceptance(
       await waitFor(".d-editor-input");
 
       assert
+        .dom(".discard-draft-modal")
+        .doesNotExist("discard modal does not appear on a single click");
+
+      assert
         .dom(".d-editor-input")
         .hasValue(
           new RegExp(
@@ -170,6 +174,10 @@ acceptance(
 
       await click(".fc-day-today");
       await waitFor(".d-editor-input");
+
+      assert
+        .dom(".discard-draft-modal")
+        .doesNotExist("discard modal does not appear on a single click");
 
       assert
         .dom(".d-editor-input")

--- a/plugins/discourse-calendar/test/javascripts/acceptance/post-event-builder-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/post-event-builder-test.js
@@ -147,3 +147,53 @@ acceptance("Post event - composer", function (needs) {
     }
   });
 });
+
+acceptance("Post event - composer - custom fields", function (needs) {
+  needs.user({ admin: true, can_create_discourse_post_event: true });
+  needs.settings({
+    discourse_local_dates_enabled: true,
+    discourse_calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    discourse_post_event_allowed_on_groups: "",
+    discourse_post_event_allowed_custom_fields: "fancy_field",
+  });
+
+  test("custom fields render and save", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
+    await click(".toolbar-menu__options-trigger");
+    await click(
+      `button[title='${i18n("discourse_post_event.builder_modal.attach")}']`
+    );
+
+    await click(".d-editor-preview .composer-event__more-dropdown button");
+
+    const modal = ".post-event-builder-modal";
+
+    assert
+      .dom(`${modal} [data-name="customFields.fancy_field"] input`)
+      .exists("the allowed custom field renders as a form field");
+
+    await fillIn(`${modal} .from input[type=date]`, "2022-07-01");
+    const fromTime = selectKit(`${modal} .from .d-time-input .select-kit`);
+    await fromTime.expand();
+    await fromTime.selectRowByName("12:00 PM");
+
+    await fillIn(
+      `${modal} [data-name="customFields.fancy_field"] input`,
+      "hello world"
+    );
+
+    await click(`${modal} .d-modal__footer .btn-primary`);
+
+    assert
+      .dom(".d-editor-input")
+      .hasValue(
+        /fancyField="hello world"/,
+        "the custom field is written to the event bbcode"
+      );
+  });
+});

--- a/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -1,0 +1,92 @@
+import { getOwner } from "@ember/owner";
+import { render, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DiscoursePostEvent from "../../discourse/components/discourse-post-event";
+import DiscoursePostEventEvent from "../../discourse/models/discourse-post-event-event";
+
+function buildEvent(overrides = {}) {
+  return DiscoursePostEventEvent.create({
+    id: 1,
+    // 2026-06-04 is a Thursday
+    starts_at: "2026-06-04T14:00:00Z",
+    ends_at: "2026-06-04T15:00:00Z",
+    timezone: "UTC",
+    status: "public",
+    name: "Product team office hours",
+    post: { id: 1, url: "/t/foo/1", topic: { id: 1 } },
+    creator: { username: "bob", id: 5 },
+    should_display_invitees: false,
+    sample_invitees: [],
+    ...overrides,
+  });
+}
+
+module("Integration | Component | DiscoursePostEvent", function (hooks) {
+  setupRenderingTest(hooks);
+
+  function stubApi(event) {
+    getOwner(this).unregister("service:discourse-post-event-api");
+    getOwner(this).register(
+      "service:discourse-post-event-api",
+      {
+        async event() {
+          return event;
+        },
+      },
+      { instantiate: false }
+    );
+  }
+
+  test("interpolates the weekday into the recurrence label", async function (assert) {
+    stubApi.call(this, buildEvent({ recurrence: "every_week" }));
+
+    const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "Every Thursday",
+        "renders the weekday instead of a missing placeholder"
+      );
+  });
+
+  test("interpolates the ordinal and weekday into the monthly recurrence label", async function (assert) {
+    stubApi.call(this, buildEvent({ recurrence: "every_month" }));
+
+    const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText(
+        "The first Thursday of every month",
+        "renders both the ordinal and weekday placeholders"
+      );
+  });
+
+  test("derives the weekday from the date for all-day events, ignoring the timezone offset", async function (assert) {
+    // Midnight UTC in a negative-offset timezone rolls back to the previous
+    // day; an all-day event's weekday must come from the date, not the offset.
+    stubApi.call(
+      this,
+      buildEvent({
+        recurrence: "every_week",
+        all_day: true,
+        timezone: "America/New_York",
+        starts_at: "2026-06-04T00:00:00Z",
+      })
+    );
+
+    const event = { id: 1, startsAt: "2026-06-04T00:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-recurrence");
+
+    assert
+      .dom(".event-recurrence")
+      .hasText("Every Thursday", "uses the date's weekday, not the prior day");
+  });
+});

--- a/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -65,4 +65,19 @@ module("Integration | Component | rich-editor-extension", function (hooks) {
       });
     });
   });
+
+  test("event preserves allowed custom fields", async function (assert) {
+    this.siteSettings.rich_editor = true;
+    this.siteSettings.discourse_post_event_allowed_custom_fields =
+      "fancy_field";
+
+    await testMarkdown(
+      assert,
+      `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" fancyField="hello world"]\n[/event]\n`,
+      (a) => {
+        a.dom(".composer-event-node").exists("Event node should be rendered");
+      },
+      `[event start="2025-03-21 15:41" status=public timezone=Europe/Paris fancyField="hello world"]\n[/event]\n`
+    );
+  });
 });


### PR DESCRIPTION
This backports some Calendar and Events plugin fixes to 2026.5 for a customer, specifically: ff1f7ea, 7ac3dd2, and a8b9219b11243d2c2708694a35c1500649077f93