### PR TITLE
DEV: backport fix, clicking calendar day fires composer discard modal 

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -143,9 +143,6 @@ export default class FullCalendar extends Component {
           });
         }
       },
-      dateClick: async (info) => {
-        await this.args.onDateClick?.(info);
-      },
       eventClick: async ({ el, event, jsEvent }) => {
         const { postNumber, postUrl, postEvent } = event.extendedProps;
 
@@ -179,8 +176,8 @@ export default class FullCalendar extends Component {
       },
       allDayContent: () =>
         i18n("discourse_post_event.upcoming_events_list.all_day"),
-      select: (info) => {
-        this.args.onDateClick?.(info);
+      select: async (info) => {
+        await this.args.onDateClick?.(info);
       },
     });
 

--- a/plugins/discourse-calendar/test/javascripts/acceptance/calendar-click-to-create-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/calendar-click-to-create-test.js
@@ -92,6 +92,10 @@ acceptance(
       await waitFor(".d-editor-input");
 
       assert
+        .dom(".discard-draft-modal")
+        .doesNotExist("discard modal does not appear on a single click");
+
+      assert
         .dom(".d-editor-input")
         .hasValue(
           new RegExp(
@@ -170,6 +174,10 @@ acceptance(
 
       await click(".fc-day-today");
       await waitFor(".d-editor-input");
+
+      assert
+        .dom(".discard-draft-modal")
+        .doesNotExist("discard modal does not appear on a single click");
 
       assert
         .dom(".d-editor-input")


### PR DESCRIPTION
Fixes a regression introduced in #40251.

With `selectable: true`, FullCalendar fires both `dateClick` and `select`
for a single click. Both callbacks called the same `onDateClick` handler,
so `composer.openNewTopic()` ran twice - the second call saw a dirty composer and immediately showed the "Discard draft?" modal before the user had typed anything.

Remove the redundant `dateClick` callback. With `selectable: true`, `select` fires for every user gesture including single clicks (a click produces a 1-day range in dayGrid), so `dateClick` is a strict subset and can be dropped entirely. Regression assertions are added to the existing acceptance tests.

(cherry picked from commit a8b9219b11243d2c2708694a35c1500649077f93)