### PR TITLE
UX: Add correct wording when replying to a message

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3365,6 +3365,10 @@ en:
           label: Reply to topic
           trigger: Topic
           desc: Reply to the topic, not any specific post
+        reply_to_message:
+          label: Reply to message
+          trigger: Message
+          desc: Reply to the message, not any specific post
         toggle_whisper:
           label: Toggle whisper
           desc: Whispers are only visible to allowed groups

--- a/frontend/discourse/app/components/composer-actions-new.gjs
+++ b/frontend/discourse/app/components/composer-actions-new.gjs
@@ -119,6 +119,12 @@ export default class ComposerActions extends Component {
     return this.topic?.slow_mode_seconds > 0;
   }
 
+  get isPrivateMessage() {
+    return Boolean(
+      this.composerModel?.privateMessage || this.topic?.isPrivateMessage
+    );
+  }
+
   @cached
   get templateData() {
     const { action: currentAction, isInSlowMode, isEditing } = this;
@@ -191,7 +197,9 @@ export default class ComposerActions extends Component {
       if (isReplyingToPost) {
         return this._postDisplayName(this.post);
       }
-      return i18n("composer.composer_actions.reply_to_topic.trigger");
+      return this.isPrivateMessage
+        ? i18n("composer.composer_actions.reply_to_message.trigger")
+        : i18n("composer.composer_actions.reply_to_topic.trigger");
     }
 
     return i18n("composer.composer_actions.create_topic.label");
@@ -320,7 +328,9 @@ export default class ComposerActions extends Component {
         postNumber: this.post.post_number,
       });
     }
-    return i18n("composer.composer_actions.reply_to_topic.label");
+    return this.isPrivateMessage
+      ? i18n("composer.composer_actions.reply_to_message.label")
+      : i18n("composer.composer_actions.reply_to_topic.label");
   }
 
   @action

--- a/frontend/discourse/app/lib/composer/action-items.js
+++ b/frontend/discourse/app/lib/composer/action-items.js
@@ -102,6 +102,14 @@ export class ComposerActionItemBuilder {
     return prioritizeNameFallback(post.name, post.username) || fallback;
   }
 
+  // Replying to the whole topic reads as "reply to the private message" when
+  // the target is a PM, otherwise "reply to topic".
+  #replyToTopicKeyPrefix(topic) {
+    return topic?.isPrivateMessage
+      ? "composer.composer_actions.reply_to_message"
+      : "composer.composer_actions.reply_to_topic";
+  }
+
   #replyAsNewTopic() {
     if (
       this.action === REPLY &&
@@ -177,9 +185,12 @@ export class ComposerActionItemBuilder {
             this.replyOptions?.topicLink))) ||
       (this.action === PRIVATE_MESSAGE && this.snapshotTopic)
     ) {
+      const keyPrefix = this.#replyToTopicKeyPrefix(
+        this.topic ?? this.snapshotTopic
+      );
       return {
-        name: i18n("composer.composer_actions.reply_to_topic.label"),
-        description: i18n("composer.composer_actions.reply_to_topic.desc"),
+        name: i18n(`${keyPrefix}.label`),
+        description: i18n(`${keyPrefix}.desc`),
         icon: "share",
         id: "reply_to_topic",
       };
@@ -201,9 +212,10 @@ export class ComposerActionItemBuilder {
 
   #replyToSnapshottedTopic() {
     if (this.snapshotTopic) {
+      const keyPrefix = this.#replyToTopicKeyPrefix(this.snapshotTopic);
       return {
-        name: i18n("composer.composer_actions.reply_to_topic.label"),
-        description: i18n("composer.composer_actions.reply_to_topic.desc"),
+        name: i18n(`${keyPrefix}.label`),
+        description: i18n(`${keyPrefix}.desc`),
         icon: "share",
         id: "reply_to_topic",
       };

--- a/frontend/discourse/app/lib/composer/action-items.js
+++ b/frontend/discourse/app/lib/composer/action-items.js
@@ -102,14 +102,6 @@ export class ComposerActionItemBuilder {
     return prioritizeNameFallback(post.name, post.username) || fallback;
   }
 
-  // Replying to the whole topic reads as "reply to the private message" when
-  // the target is a PM, otherwise "reply to topic".
-  #replyToTopicKeyPrefix(topic) {
-    return topic?.isPrivateMessage
-      ? "composer.composer_actions.reply_to_message"
-      : "composer.composer_actions.reply_to_topic";
-  }
-
   #replyAsNewTopic() {
     if (
       this.action === REPLY &&
@@ -185,9 +177,9 @@ export class ComposerActionItemBuilder {
             this.replyOptions?.topicLink))) ||
       (this.action === PRIVATE_MESSAGE && this.snapshotTopic)
     ) {
-      const keyPrefix = this.#replyToTopicKeyPrefix(
-        this.topic ?? this.snapshotTopic
-      );
+      const keyPrefix = (this.topic ?? this.snapshotTopic)?.isPrivateMessage
+        ? "composer.composer_actions.reply_to_message"
+        : "composer.composer_actions.reply_to_topic";
       return {
         name: i18n(`${keyPrefix}.label`),
         description: i18n(`${keyPrefix}.desc`),
@@ -212,7 +204,9 @@ export class ComposerActionItemBuilder {
 
   #replyToSnapshottedTopic() {
     if (this.snapshotTopic) {
-      const keyPrefix = this.#replyToTopicKeyPrefix(this.snapshotTopic);
+      const keyPrefix = this.snapshotTopic?.isPrivateMessage
+        ? "composer.composer_actions.reply_to_message"
+        : "composer.composer_actions.reply_to_topic";
       return {
         name: i18n(`${keyPrefix}.label`),
         description: i18n(`${keyPrefix}.desc`),

--- a/frontend/discourse/tests/acceptance/composer-actions-new-test.js
+++ b/frontend/discourse/tests/acceptance/composer-actions-new-test.js
@@ -387,6 +387,18 @@ acceptance(`Composer Actions (new composer actions)`, function (needs) {
       .includesText("codinghorror", "shows reply to post label");
   });
 
+  test("trigger shows the private message label when replying in a PM", async function (assert) {
+    await visit("/t/lorem-ipsum-dolor-sit-amet/130");
+    await click(".create.reply");
+
+    assert
+      .dom(".composer-actions-trigger")
+      .includesText(
+        i18n("composer.composer_actions.reply_to_message.trigger"),
+        "shows the private message reply label, not the topic label"
+      );
+  });
+
   test("trigger shows correct label for create topic mode", async function (assert) {
     await visit("/");
     await click("#create-topic");
@@ -619,6 +631,8 @@ acceptance(`Slow Mode (new composer actions)`, function (needs) {
   needs.pretender((server, helper) => {
     server.get("/t/130.json", () => {
       const json = cloneJSON(topicFixtures["/t/130.json"]);
+      // The 130 fixture is a PM; slow mode only applies to regular topics.
+      json.archetype = "regular";
       json.slow_mode_seconds = 600;
       json.slow_mode_enabled_until = "2040-01-01T04:00:00.000Z";
       return helper.response(json);
@@ -637,6 +651,33 @@ acceptance(`Slow Mode (new composer actions)`, function (needs) {
       .includesText(
         i18n("composer.composer_actions.reply_to_topic.trigger"),
         "falls back to the standard reply-to-topic trigger label"
+      );
+  });
+});
+
+acceptance(`Private Messages (new composer actions)`, function (needs) {
+  needs.user();
+  needs.settings({ enable_new_composer_actions: true });
+  needs.pretender((server, helper) => {
+    server.get("/t/280.json", () => {
+      const json = cloneJSON(topicFixtures["/t/280/1.json"]);
+      json.archetype = "private_message";
+      return helper.response(json);
+    });
+  });
+
+  test("dropdown reply-to-thread item uses the private message label", async function (assert) {
+    const composerActions = composerActionsDropdown();
+
+    await visit("/t/internationalization-localization/280");
+    await click("article#post_3 button.reply");
+    await composerActions.expand();
+
+    assert
+      .dom(".composer-actions-dropdown [data-action-id='reply_to_topic']")
+      .includesText(
+        i18n("composer.composer_actions.reply_to_message.label"),
+        "offers replying to the private message, not the topic"
       );
   });
 });


### PR DESCRIPTION
This PR corrects some language in the new post actions dropdown. When replying to a PM, the user will now correctly see "Message" instead of "Topic" in the action dropdown.