### PR TITLE
DEV: Solved category custom fields lost after development reloads

### DIFF
--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -91,10 +91,12 @@ after_initialize do
     ).call
   end
 
-  Site.preloaded_category_custom_fields << DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD
-  Site.preloaded_category_custom_fields << DiscourseSolved::NOTIFY_ON_STAFF_ACCEPT_SOLVED_CUSTOM_FIELD
-  Site.preloaded_category_custom_fields << DiscourseSolved::EMPTY_BOX_ON_UNSOLVED_CUSTOM_FIELD
-  Site.preloaded_category_custom_fields << DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD
+  register_preloaded_category_custom_fields(DiscourseSolved::ENABLE_ACCEPTED_ANSWERS_CUSTOM_FIELD)
+  register_preloaded_category_custom_fields(
+    DiscourseSolved::NOTIFY_ON_STAFF_ACCEPT_SOLVED_CUSTOM_FIELD,
+  )
+  register_preloaded_category_custom_fields(DiscourseSolved::EMPTY_BOX_ON_UNSOLVED_CUSTOM_FIELD)
+  register_preloaded_category_custom_fields(DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD)
 
   add_api_key_scope(
     :solved,


### PR DESCRIPTION
In development, reloading the app re-evaluates the `Site` class, which resets `Site.preloaded_category_custom_fields` to an empty set. Fields registered through `Plugin::Instance#register_preloaded_category_custom_fields` are re-applied on each reload because the registration runs in a `reloadable_patch`, but discourse-solved appended its fields to the set directly, which only happens once at boot. After the first reload the solved fields were no longer preloaded, so serializing categories raised `HasCustomFields::NotPreloadedError` when the `enable_accepted_answers` category custom field was accessed.

This commit registers the solved category custom fields through `register_preloaded_category_custom_fields`, matching how other plugins register theirs.