### PR TITLE
FIX: Add reverse DNS timeout to DiscourseIpInfo

### DIFF
--- a/lib/discourse_ip_info.rb
+++ b/lib/discourse_ip_info.rb
@@ -6,6 +6,8 @@ require "resolv"
 class DiscourseIpInfo
   include Singleton
 
+  HOSTNAME_LOOKUP_TIMEOUT_SECONDS = 1
+
   def initialize
     open_db(DiscourseIpInfo.path)
   end
@@ -141,13 +143,14 @@ class DiscourseIpInfo
       end
     end
 
-    # this can block for quite a while
-    # only use it explicitly when needed
     if resolve_hostname
       begin
-        result = Resolv::DNS.new.getname(ip)
+        dns = Resolv::DNS.new
+        dns.timeouts = HOSTNAME_LOOKUP_TIMEOUT_SECONDS
+
+        result = dns.getname(ip)
         ret[:hostname] = result&.to_s
-      rescue Resolv::ResolvError
+      rescue Resolv::ResolvError, Timeout::Error
       end
     end
 

--- a/spec/lib/discourse_ip_info_spec.rb
+++ b/spec/lib/discourse_ip_info_spec.rb
@@ -1,6 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseIpInfo do
+  describe ".get" do
+    let(:ip) { "81.2.69.142" }
+    let(:expected_ip_info) do
+      {
+        city: "London",
+        country: "United Kingdom",
+        country_code: "GB",
+        geoname_ids: [6_255_148, 2_635_167, 2_643_743, 6_269_131],
+        location: "London, England, United Kingdom",
+        region: "England",
+        latitude: 51.5142,
+        longitude: -0.0931,
+      }
+    end
+
+    before { described_class.open_db(Rails.root.join("spec/fixtures/mmdb").to_s) }
+
+    it "returns IP info without hostname when reverse DNS is interrupted" do
+      Resolv::DNS.any_instance.stubs(:getname).with(ip).raises(Timeout::Error)
+
+      result = described_class.get(ip, resolve_hostname: true)
+
+      expect(result).to eq(expected_ip_info)
+    end
+
+    it "sets a timeout for reverse DNS" do
+      resolver = Resolv::DNS.new
+      resolver
+        .expects(:timeouts=)
+        .with { |timeouts| Array(timeouts).present? && Array(timeouts).sum <= 5 }
+      resolver.stubs(:getname).with(ip).raises(Resolv::ResolvError)
+
+      Resolv::DNS.stubs(:new).returns(resolver)
+
+      result = described_class.get(ip, resolve_hostname: true)
+
+      expect(result).to eq(expected_ip_info)
+    end
+  end
+
   describe ".mmdb_download" do
     before { Discourse::Utils.stubs(:execute_command) }
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -2242,6 +2242,27 @@ RSpec.describe Admin::UsersController do
       before { sign_in(admin) }
 
       include_examples "IP info retrieval possible"
+
+      it "returns IP info without hostname when reverse DNS is interrupted" do
+        ip = "81.2.69.142"
+
+        DiscourseIpInfo.open_db(Rails.root.join("spec/fixtures/mmdb").to_s)
+        Resolv::DNS.any_instance.stubs(:getname).with(ip).raises(Timeout::Error)
+
+        get "/admin/users/ip-info.json", params: { ip: ip }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.symbolize_keys).to eq(
+          city: "London",
+          country: "United Kingdom",
+          country_code: "GB",
+          geoname_ids: [6_255_148, 2_635_167, 2_643_743, 6_269_131],
+          location: "London, England, United Kingdom",
+          region: "England",
+          latitude: 51.5142,
+          longitude: -0.0931,
+        )
+      end
     end
 
     context "when logged in as a moderator" do


### PR DESCRIPTION
`DiscourseIpInfo#get` returns MaxMind IP data by default. The admin IP info endpoint asks for a hostname with `resolve_hostname: true`, which makes `DiscourseIpInfo` run a reverse DNS PTR lookup through `Resolv::DNS#getname` and add `hostname` when that lookup succeeds.

That resolver call did not configure `Resolv::DNS#timeouts`, so Ruby used its default retry schedule. Ruby 3.4's [`Resolv::DNS::Config#generate_timeouts`](https://github.com/ruby/ruby/blob/v3_4_0/lib/resolv.rb#L1133-L1140) starts at 5 seconds and derives the later attempts from the configured nameserver count. With one configured nameserver, that generates `[5, 10, 20, 40]`. A reverse DNS server that does not answer can therefore keep the request busy long enough to hit Discourse's production [Pitchfork timeout of 30 seconds](https://github.com/discourse/discourse/blob/main/config/pitchfork.conf.rb#L34-L36). When that happens, the whole `/admin/users/ip-info.json` request can fail even though the MaxMind location data has already been collected.

This PR bounds the reverse DNS part of IP info lookups. The hostname is useful context, but it is less critical than the IP location data, so it is fine to leave it out when reverse DNS fails.

Key technical changes:

1. Add `HOSTNAME_LOOKUP_TIMEOUT_SECONDS` to `DiscourseIpInfo` and set it to 1 second. The hostname lookup gets a short budget before Discourse returns the location data without `hostname`.

2. Apply that timeout to the `Resolv::DNS` instance before requesting the hostname. This keeps the timeout decision at the shared IP info boundary instead of making individual callers handle DNS behavior.

3. Treat `Resolv::ResolvError` and `Timeout::Error` as a missing hostname. Reverse DNS failures no longer discard the location fields that were already populated from MaxMind.

4. Keep the existing API shape for `/admin/users/ip-info.json`. Successful hostname lookups still include `hostname`, failed or interrupted hostname lookups omit it, and the existing staff permission behavior is unchanged.