### PR TITLE
FIX: Don't require S3 ACLs to enable secure uploads

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -364,7 +364,7 @@ en:
       page_publishing_requirements: "Page publishing cannot be enabled if secure uploads is enabled."
       s3_backup_requires_s3_settings: "You cannot use S3 as backup location unless you've provided the '%{setting_name}'."
       s3_bucket_reused: "You cannot use the same bucket for 's3_upload_bucket' and 's3_backup_bucket'. Choose a different bucket or use a different path for each bucket."
-      secure_uploads_requirements: "S3 uploads and S3 ACLs must be enabled before enabling secure uploads."
+      secure_uploads_requirements: "S3 uploads must be enabled before enabling secure uploads."
       share_quote_facebook_requirements: "You must set a Facebook app id to enable quote sharing for Facebook."
       second_factor_cannot_be_enforced_with_disabled_local_login: "You cannot enforce 2FA if local logins are disabled."
       second_factor_cannot_be_enforced_with_discourse_connect_enabled: "You cannot enforce 2FA if DiscourseConnect is enabled."

--- a/lib/site_settings/validations.rb
+++ b/lib/site_settings/validations.rb
@@ -168,7 +168,7 @@ module SiteSettings::Validations
   end
 
   def validate_secure_uploads(new_val)
-    if new_val == "t" && (!SiteSetting.Upload.enable_s3_uploads || !SiteSetting.s3_use_acls)
+    if new_val == "t" && !SiteSetting.Upload.enable_s3_uploads
       validate_error :secure_uploads_requirements
     end
   end

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -248,46 +248,34 @@ RSpec.describe SiteSettings::Validations do
     end
 
     describe "#validate_secure_uploads" do
-      let(:error_message) { I18n.t("errors.site_settings.secure_uploads_requirements") }
+      it "allows enabling with ACLs and access control tags disabled" do
+        SiteSetting.enable_s3_uploads = true
+        SiteSetting.s3_use_acls = false
+        SiteSetting.s3_enable_access_control_tags = false
 
-      context "when the new secure uploads value is true" do
-        context "if site setting for enable_s3_uploads is enabled" do
-          before { SiteSetting.enable_s3_uploads = true }
+        expect { validations.validate_secure_uploads("t") }.not_to raise_error
+      end
 
-          it "should be ok" do
-            expect { validations.validate_secure_uploads("t") }.not_to raise_error
-          end
-        end
+      it "raises when S3 uploads are disabled" do
+        SiteSetting.enable_s3_uploads = false
 
-        context "if site setting for enable_s3_uploads is not enabled" do
-          before { SiteSetting.enable_s3_uploads = false }
+        expect { validations.validate_secure_uploads("t") }.to raise_error(
+          Discourse::InvalidParameters,
+          "S3 uploads must be enabled before enabling secure uploads.",
+        )
+      end
 
-          it "is not ok" do
-            expect { validations.validate_secure_uploads("t") }.to raise_error(
-              Discourse::InvalidParameters,
-              error_message,
-            )
-          end
+      it "allows enabling when S3 uploads are enabled globally" do
+        SiteSetting.enable_s3_uploads = false
+        GlobalSetting.stubs(:use_s3?).returns(true)
 
-          context "if global s3 setting is enabled" do
-            before { GlobalSetting.stubs(:use_s3?).returns(true) }
+        expect { validations.validate_secure_uploads("t") }.not_to raise_error
+      end
 
-            it "should be ok" do
-              expect { validations.validate_secure_uploads("t") }.not_to raise_error
-            end
-          end
-        end
+      it "allows disabling when S3 uploads are disabled" do
+        SiteSetting.enable_s3_uploads = false
 
-        context "if site setting for s3_use_acls is not enabled" do
-          before { SiteSetting.s3_use_acls = false }
-
-          it "is not ok" do
-            expect { validations.validate_secure_uploads("t") }.to raise_error(
-              Discourse::InvalidParameters,
-              error_message,
-            )
-          end
-        end
+        expect { validations.validate_secure_uploads("f") }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Previously, enabling the `secure_uploads` site setting required the `s3_use_acls` site setting to be enabled. Object ACLs are not the only way to keep uploads private: `FileStore::S3Store` applies S3 access control tags when the hidden `s3_enable_access_control_tags` site setting is enabled, and access control can be enforced entirely through a bucket policy Discourse never sees. Sites can also opt to disable the `s3_use_acls` site setting and manage object permissions themselves.

This PR relaxes the validation that runs when enabling the `secure_uploads` site setting so that it only requires S3 uploads to be enabled, and rewords the validation's error message accordingly.

Key technical changes:

1. Drop the `s3_use_acls` site setting check from `SiteSettings::Validations#validate_secure_uploads`, the method that validates changes to the `secure_uploads` site setting. ACL and access-control-tag site settings have no bearing on enabling secure uploads; `FileStore::S3Store#default_s3_options` applies each mechanism only when its site setting is enabled and works with both disabled.

2. Add no validation for the opposite change: disabling the `s3_use_acls` or `s3_enable_access_control_tags` site settings while the `secure_uploads` site setting is enabled remains allowed, since running with both disabled is a valid configuration when a bucket policy enforces access control.