### PR TITLE
UX: penalty modal increase size + fixes

### DIFF
--- a/app/assets/stylesheets/admin/penalty.scss
+++ b/app/assets/stylesheets/admin/penalty.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .silence-user-modal,
 .suspend-user-modal {
   .penalty-duration,
@@ -26,6 +28,12 @@
       align-items: end;
       display: flex;
       justify-content: space-between;
+
+      @include viewport.until(sm) {
+        flex-direction: column;
+        gap: var(--space-2);
+        align-items: stretch;
+      }
 
       input {
         height: 34px;
@@ -86,27 +94,5 @@
         padding: 8px 0;
       }
     }
-  }
-
-  .penalty-history {
-    position: sticky;
-    bottom: 0;
-    background-color: var(--secondary);
-    padding: 0 0 1em 0;
-  }
-
-  .penalty-history::before {
-    position: absolute;
-    content: "";
-    display: block;
-    height: 1.5em;
-    top: -1.5em;
-    width: 100%;
-    pointer-events: none;
-    background: linear-gradient(
-      to bottom,
-      rgb(var(--secondary-rgb), 0),
-      rgb(var(--secondary-rgb), 1)
-    );
   }
 }

--- a/frontend/discourse/admin/components/modal/penalize-user.gjs
+++ b/frontend/discourse/admin/components/modal/penalize-user.gjs
@@ -156,7 +156,7 @@ export default class PenalizeUser extends Component {
 
   <template>
     <DModal
-      class="{{@model.penaltyType}}-user-modal"
+      class="{{@model.penaltyType}}-user-modal --large"
       @title={{i18n this.modalTitle}}
       @closeModal={{this.warnBeforeClosing}}
       @flash={{this.flash}}
@@ -220,9 +220,9 @@ export default class PenalizeUser extends Component {
             <div class="cant-silence">{{i18n "admin.user.cant_silence"}}</div>
           {{/if}}
         {{/if}}
+        <div class="penalty-history">{{trustHTML this.penaltyHistory}}</div>
       </:body>
       <:footer>
-        <div class="penalty-history">{{trustHTML this.penaltyHistory}}</div>
         <DButton
           class="btn-danger perform-penalize"
           @action={{this.penalizeUser}}


### PR DESCRIPTION
| BC | AC |
|--------|--------|
| <img width="613" height="603" alt="CleanShot 2026-06-05 at 12 20 01" src="https://github.com/user-attachments/assets/a52eb2f2-140c-49f1-b334-28fb6ebe378c" /> | <img width="867" height="569" alt="CleanShot 2026-06-05 at 12 19 10" src="https://github.com/user-attachments/assets/b64ac90d-c09e-4ea3-a953-f404f43819eb" /> |
| <img width="410" height="886" alt="CleanShot 2026-06-05 at 12 19 51" src="https://github.com/user-attachments/assets/76cc2987-c2f6-42f7-8ae2-79dd8c0ec09a" /> | <img width="410" height="886" alt="CleanShot 2026-06-05 at 12 19 37" src="https://github.com/user-attachments/assets/279b1be0-70aa-4c68-972d-66bb868b3352" /> | 