### PR TITLE
UX: fix short chat window in composer peek-mode

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .chat-channel {
   display: flex;
   flex-direction: column;
@@ -9,6 +11,15 @@
   min-width: 250px;
 
   @include chat-height(var(--chat-header-offset, 0));
+
+  .peek-mode-active & {
+    @include viewport.from(xl) {
+      height: calc(
+        var(--composer-vh, 1vh) * 100 - var(--main-outlet-offset, 0px) -
+          1px - var(--chat-header-offset, 0)
+      );
+    }
+  }
 
   .join-channel-btn.in-float {
     position: absolute;

--- a/themes/horizon/scss/composer-peek-mode.scss
+++ b/themes/horizon/scss/composer-peek-mode.scss
@@ -1,8 +1,10 @@
+@use "lib/viewport";
+
 .peek-mode-toggle {
   display: none;
 }
 
-@media screen and (width >= 1300px) {
+@include viewport.from(xl) {
   html:not(.fullscreen-composer) {
     .peek-mode-toggle svg {
       transform: scaleX(-1);


### PR DESCRIPTION
Fixes full screen chat view when peek-mode for composer is enabled

| BC | AC |
|--------|--------|
| <img width="1426" height="965" alt="CleanShot 2026-06-05 at 13 01 40" src="https://github.com/user-attachments/assets/677261c0-ca65-44a6-90b3-e2810c3f430e" /> | <img width="1426" height="965" alt="CleanShot 2026-06-05 at 13 00 28" src="https://github.com/user-attachments/assets/32960e2f-1b26-4598-9dd1-2120f1754442" /> | 