### PR TITLE
FIX: Expand number inputs in modals

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -170,7 +170,8 @@ html:not(.keyboard-visible).mobile-device {
       width: auto;
 
       &[type="text"],
-      &[type="password"] {
+      &[type="password"],
+      &[type="number"] {
         width: 100%;
       }
     }

--- a/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator-modal.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator-modal.scss
@@ -18,10 +18,6 @@
     flex: 1;
     min-height: 0;
     border-radius: var(--d-border-radius);
-
-    input {
-      width: 100%;
-    }
   }
 
   &__header {


### PR DESCRIPTION
Previously, number inputs inside modals kept the modal default `width: auto`, so full-width form fields could render with a narrow control and workflow configurators carried a broad local input override.

This change applies the existing full-width modal input rule to `input[type="number"]` and removes the workflow configurator override so number fields align with text and password fields.