### PR TITLE
DEV: add plugin outlet to Horizon topic card title

### DIFF
--- a/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
+++ b/themes/horizon/javascripts/discourse/components/card/high-context-topic-card.gjs
@@ -3,12 +3,14 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { themePrefix } from "virtual:theme";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import BulkSelectCheckbox from "discourse/components/topic-list/bulk-select-checkbox";
 import TopicExcerpt from "discourse/components/topic-list/topic-excerpt";
 import TopicLink from "discourse/components/topic-list/topic-link";
 import UnreadIndicator from "discourse/components/topic-list/unread-indicator";
 import TopicPostBadges from "discourse/components/topic-post-badges";
 import TopicStatus from "discourse/components/topic-status";
+import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
 import { shortDateNoYear } from "discourse/lib/formatter";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
@@ -204,6 +206,10 @@ export default class HighContextTopicCard extends Component {
           {{~#if @topic.featured_link~}}
             &nbsp;{{topicFeaturedLink @topic}}
           {{~/if~}}
+          <PluginOutlet
+            @name="topic-list-after-title"
+            @outletArgs={{lazyHash topic=@topic}}
+          />
           <UnreadIndicator @topic={{@topic}} />
           <TopicPostBadges
             @unreadPosts={{@topic.unread_posts}}

--- a/themes/horizon/scss/topic-cards.scss
+++ b/themes/horizon/scss/topic-cards.scss
@@ -396,17 +396,6 @@
     }
   }
 
-  .link-top-line .event-date {
-    margin-left: 0.5em;
-    font-size: var(--font-down-3);
-    white-space: nowrap;
-  }
-
-  .link-top-line .event-date-container {
-    top: -0.15rem;
-    line-height: normal;
-  }
-
   .topic-list-data {
     padding: 0;
   }
@@ -641,13 +630,25 @@
   }
 }
 
+// for both types of context cards
+.topic-list.--d-topic-cards {
+  .event-date {
+    margin-left: var(--space-2);
+    font-size: var(--font-down-3);
+    white-space: nowrap;
+    font-weight: normal;
+  }
+
+  .event-date-container {
+    display: inline-flex;
+    position: relative;
+    top: -0.15rem;
+    line-height: normal;
+  }
+}
+
 // bulk-select overrule for j/k nav
 .topic-list tr.selected td:first-of-type,
 .topic-list-item.selected td:first-of-type {
   box-shadow: none;
-}
-
-.event-date-container {
-  display: inline-flex;
-  position: relative;
 }


### PR DESCRIPTION
Previously, since Horizon high-context topic card rendered its own copy of the title markup, it omitted the `topic-list-after-title` plugin outlet, so discourse-calendar event dates appeared in simple cards but were missing from high-context cards.

This change adds the `topic-list-after-title` outlet to the card title.

This also means other uses of this outlet will show up in Horizon, but that seems fine by me.
