### PR TITLE
DEV: Fix d-workflows flakes

### DIFF
--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/expression_resolver_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/expression_resolver_spec.rb
@@ -545,6 +545,8 @@ RSpec.describe DiscourseWorkflows::ExpressionResolver do
     end
 
     it "propagates workflow budget errors from the shared sandbox" do
+      Process.stubs(:clock_gettime).returns(0.0)
+
       sandbox =
         DiscourseWorkflows::JsSandbox.new(
           {},

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/js_sandbox_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/js_sandbox_spec.rb
@@ -132,6 +132,9 @@ RSpec.describe DiscourseWorkflows::JsSandbox do
   describe "workflow budget" do
     it "shares elapsed sandbox time through workflow context" do
       budget_state = {}
+
+      Process.stubs(:clock_gettime).returns(0.0)
+
       first_sandbox =
         described_class.new(
           workflow_context,


### PR DESCRIPTION
gotta freeze the clock before setup, otherwise it might go over the timeout/budget before the workflow even begins