### PR TITLE
FEATURE: Add subcategory option to stale topic workflow trigger

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
@@ -436,7 +436,7 @@ function matchesRule(expected, value) {
 }
 
 function matchesCondition(condition, value) {
-  const operator = condition?._cnd;
+  const operator = condition?.condition;
   if (!operator) {
     return condition === value;
   }

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -485,6 +485,7 @@ en:
         description: "Fires when a topic has had no replies for the specified number of hours"
         category_id: "Category"
         category_id_description: "Only consider topics in this category"
+        include_subcategories: "Include subcategories"
         tag_names: "Tags"
         tag_names_description: "Only consider topics that have at least one of these tags"
       topic_closed:

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_data.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_data.rb
@@ -136,7 +136,7 @@ module DiscourseWorkflows
     end
 
     def matches_display_condition?(condition, value)
-      operator = condition.is_a?(Hash) ? condition["_cnd"] : nil
+      operator = condition.is_a?(Hash) ? condition["condition"] : nil
       return condition == value if operator.blank?
 
       return value != operator["not"] if operator.key?("not")

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_issues.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_issues.rb
@@ -118,7 +118,7 @@ module DiscourseWorkflows
       end
 
       def matches_condition?(condition, value)
-        operator = condition.is_a?(Hash) ? condition[:_cnd] || condition["_cnd"] : nil
+        operator = condition.is_a?(Hash) ? condition[:condition] || condition["condition"] : nil
         return condition == value if operator.blank?
 
         if operator.key?(:not) || operator.key?("not")

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
@@ -59,7 +59,7 @@ module DiscourseWorkflows
               },
               display_options: {
                 show: {
-                  category_id: [{ _cnd: { exists: true } }],
+                  category_id: [{ condition: { exists: true } }],
                 },
               },
             },

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
@@ -26,6 +26,19 @@ module DiscourseWorkflows
                 control: :category,
               },
             },
+            include_subcategories: {
+              type: :boolean,
+              required: false,
+              default: true,
+              ui: {
+                control: :checkbox,
+              },
+              display_options: {
+                show: {
+                  category_id: [{ condition: { exists: true } }],
+                },
+              },
+            },
             tag_names: {
               type: :string,
               required: false,
@@ -44,17 +57,25 @@ module DiscourseWorkflows
         def self.trigger_data_for(trigger_ctx)
           hours = trigger_ctx.get_node_parameter("hours", 24)
           category_id = trigger_ctx.get_node_parameter("category_id").presence&.to_i
+          include_subcategories = trigger_ctx.get_node_parameter("include_subcategories", true)
           tag_names = normalize_tag_names(trigger_ctx.get_node_parameter("tag_names"))
 
           stale_topics(
             hours: hours,
             category_id: category_id,
+            include_subcategories: include_subcategories,
             tag_names: tag_names,
             limit: MAX_TOPICS_PER_RUN,
           ).map { |topic| { topic: topic_data(topic) } }
         end
 
-        def self.stale_topics(hours:, category_id: nil, tag_names: [], limit:)
+        def self.stale_topics(
+          hours:,
+          category_id: nil,
+          include_subcategories: true,
+          tag_names: [],
+          limit:
+        )
           threshold = hours.to_i.clamp(1..).hours.ago
 
           scope =
@@ -64,7 +85,12 @@ module DiscourseWorkflows
               .where("topics.archetype = ?", Archetype.default)
               .includes(first_post: :user)
 
-          scope = scope.where(category_id: category_id) if category_id
+          if category_id
+            category_ids =
+              include_subcategories == false ? category_id : ::Category.subcategory_ids(category_id)
+            scope = scope.where(category_id: category_ids)
+          end
+
           scope = scope.joins(:tags).where(tags: { name: tag_names }).distinct if tag_names.any?
 
           scope.limit(limit).to_a

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
@@ -59,7 +59,7 @@ module DiscourseWorkflows
               },
               display_options: {
                 show: {
-                  category_id: [{ _cnd: { exists: true } }],
+                  category_id: [{ condition: { exists: true } }],
                 },
               },
             },

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/stale_topic_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/stale_topic_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe DiscourseWorkflows::Nodes::StaleTopic::V1 do
 
     context "with category filter" do
       fab!(:category)
+      fab!(:subcategory) { Fabricate(:category, parent_category: category) }
       fab!(:other_category, :category)
+
       fab!(:stale_topic_in_category) do
         Fabricate(
           :topic,
@@ -34,6 +36,16 @@ RSpec.describe DiscourseWorkflows::Nodes::StaleTopic::V1 do
           last_posted_at: 48.hours.ago,
         )
       end
+
+      fab!(:stale_topic_in_subcategory) do
+        Fabricate(
+          :topic,
+          category: subcategory,
+          created_at: 48.hours.ago,
+          last_posted_at: 48.hours.ago,
+        )
+      end
+
       fab!(:stale_topic_in_other_category) do
         Fabricate(
           :topic,
@@ -54,7 +66,19 @@ RSpec.describe DiscourseWorkflows::Nodes::StaleTopic::V1 do
         }
       end
 
-      it "only returns topics in the configured category" do
+      it "returns topics in the configured category and subcategories by default" do
+        items = described_class.trigger_data_for(trigger_context)
+
+        topic_ids = items.map { |item| item[:topic][:id] }
+        expect(topic_ids).to contain_exactly(
+          stale_topic_in_category.id,
+          stale_topic_in_subcategory.id,
+        )
+      end
+
+      it "only returns topics in the configured category when subcategories are excluded" do
+        trigger_node["parameters"]["include_subcategories"] = false
+
         items = described_class.trigger_data_for(trigger_context)
 
         topic_ids = items.map { |item| item[:topic][:id] }

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/property-engine-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/property-engine-test.gjs
@@ -89,7 +89,7 @@ module("Integration | Component | workflows property engine", function (hooks) {
           },
           display_options: {
             show: {
-              category_id: [{ _cnd: { exists: true } }],
+              category_id: [{ condition: { exists: true } }],
             },
           },
         },

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
@@ -275,7 +275,7 @@ module("Unit | Utility | workflows property engine", function () {
   test("supports the exists condition for empty checks", function (assert) {
     const schema = {
       type: "notice",
-      display_options: { hide: { columns: [{ _cnd: { exists: true } }] } },
+      display_options: { hide: { columns: [{ condition: { exists: true } }] } },
     };
 
     assert.true(fieldVisible(schema, {}));
@@ -286,7 +286,7 @@ module("Unit | Utility | workflows property engine", function () {
     assert.false(fieldVisible(schema, { columns: "value" }));
 
     const presentSchema = {
-      display_options: { show: { columns: [{ _cnd: { exists: true } }] } },
+      display_options: { show: { columns: [{ condition: { exists: true } }] } },
     };
     assert.false(fieldVisible(presentSchema, {}));
     assert.true(fieldVisible(presentSchema, { columns: [{ header: "A" }] }));
@@ -294,7 +294,9 @@ module("Unit | Utility | workflows property engine", function () {
 
   test("supports the not condition", function (assert) {
     const schema = {
-      display_options: { show: { operation: [{ _cnd: { not: "delete" } }] } },
+      display_options: {
+        show: { operation: [{ condition: { not: "delete" } }] },
+      },
     };
     assert.true(fieldVisible(schema, { operation: "insert" }));
     assert.true(fieldVisible(schema, {}));


### PR DESCRIPTION
Previously, stale topic workflow triggers filtered only the selected category when a category was configured.

This change adds an include subcategories option that defaults to true, so stale topic checks include child categories unless admins opt out.

This commit also took the opportunity to rename an exposed variable (_cnd) into `condition` for the public API.