### PR TITLE
FIX: render links in upcoming changes text

### DIFF
--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -11,6 +11,7 @@ import { capitalize } from "@ember/string";
 import { trustHTML } from "@ember/template";
 import { modifier } from "ember-modifier";
 import UpcomingChangeBadges from "discourse/admin/components/admin-config-areas/upcoming-change-badges";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
 import GroupSelector from "discourse/components/group-selector";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { ajax } from "discourse/lib/ajax";
@@ -303,8 +304,11 @@ export default class UpcomingChangeItem extends Component {
         </div>
 
         {{#if @change.description}}
-          <div class="d-table__overview-about upcoming-change__description">
-            {{@change.description}}
+          <div
+            class="d-table__overview-about upcoming-change__description"
+            {{linkifySettingLinks @change.description}}
+          >
+            {{trustHTML @change.description}}
 
             <div
               class="upcoming-change__description-details"

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
@@ -132,10 +132,15 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
       );
   });
 
-  test("renders HTML links in the description instead of escaping them", async function (assert) {
+  test("renders setting links in the description and rewrites their href via the modifier", async function (assert) {
+    const rewrittenURL = "/admin/config/category/settings?filter=other_setting";
+    const dataSource = this.owner.lookup("service:admin-search-data-source");
+    dataSource.urlForSetting = ({ setting }) =>
+      setting === "other_setting" ? rewrittenURL : null;
+
     const change = buildChange({
       description:
-        'Enables the thing. Note that <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=other_setting" data-setting-name="other_setting">Other setting</a> must be enabled.',
+        'Enables the thing. Note that <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=other_setting" data-setting-name="other_setting" data-setting-category="category">Other setting</a> must be enabled.',
     });
 
     await render(
@@ -149,7 +154,12 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
     assert
       .dom(".upcoming-change__description a.site-setting-link")
       .exists("renders the setting link as an anchor element")
-      .hasText("Other setting", "renders the link text");
+      .hasText("Other setting", "renders the link text")
+      .hasAttribute(
+        "href",
+        rewrittenURL,
+        "rewrites the href to the setting's config page via the modifier"
+      );
 
     assert
       .dom(".upcoming-change__description")

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
@@ -132,6 +132,33 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
       );
   });
 
+  test("renders HTML links in the description instead of escaping them", async function (assert) {
+    const change = buildChange({
+      description:
+        'Enables the thing. Note that <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=other_setting" data-setting-name="other_setting">Other setting</a> must be enabled.',
+    });
+
+    await render(
+      <template>
+        <table>
+          <tbody><UpcomingChangeItem @change={{change}} /></tbody>
+        </table>
+      </template>
+    );
+
+    assert
+      .dom(".upcoming-change__description a.site-setting-link")
+      .exists("renders the setting link as an anchor element")
+      .hasText("Other setting", "renders the link text");
+
+    assert
+      .dom(".upcoming-change__description")
+      .doesNotIncludeText(
+        "<a",
+        "does not render the link markup as escaped text"
+      );
+  });
+
   test("renders the permanent soon notice when status is stable", async function (assert) {
     const change = buildChange({
       upcoming_change: {

--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -69,7 +69,7 @@ en:
     event_participation_buttons: "List of event participation buttons users can use."
     sidebar_show_upcoming_events: "Show upcoming events link in the sidebar under 'More'."
     calendar_first_day_of_week: "Set the first day of the week for calendar display. Options are Saturday, Sunday, or Monday."
-    enable_events_category_type_setup: "Enables the Events category type option during category creation setup. Note that {{setting:enable_simplified_category_creation}} must be enabled for this to take effect."
+    enable_events_category_type_setup: "Enables the Events category type option during category creation setup."
 
   discourse_calendar:
     category_type:

--- a/plugins/discourse-solved/config/locales/server.en.yml
+++ b/plugins/discourse-solved/config/locales/server.en.yml
@@ -45,7 +45,7 @@ en:
     solved_add_schema_markup: "Add QAPage schema markup to HTML."
     enable_solved_tags: "Tags that will allow users to select solutions."
     prioritize_solved_topics_in_search: "Prioritize solved topics in search results."
-    enable_support_category_type_setup: "Enables the Support category type option during category creation setup. Note that {{setting:enable_simplified_category_creation}} must be enabled for this to take effect."
+    enable_support_category_type_setup: "Enables the Support category type option during category creation setup."
     enable_solved_shared_issues: "Adds a “Me too” button to unsolved topics in support categories, letting members signal they’re experiencing the same issue and opt in to notifications about the topic's solution. Note: You must enable the “Enable support type category setup” upcoming change to use this feature."
     show_who_marked_solved: "Show who marked the topic as solved. This is indicated in the topic's first post, and the answer post in a tooltip."
 


### PR DESCRIPTION
Renders links in the descriptions. Also removed a couple dead references now that simplified category creation is permanent. Added a test to avoid regressions. 

Before:
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/5939c1eb-b891-4bea-b529-6dfc05fb4d93" />



After:
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/539c8f39-c6c1-4aea-b40f-b40290adc155" />
