### PR TITLE
FIX: Focus OTP input after render

### DIFF
--- a/frontend/discourse/app/ui-kit/d-otp/index.gjs
+++ b/frontend/discourse/app/ui-kit/d-otp/index.gjs
@@ -4,10 +4,10 @@ import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { trackedArray } from "@ember/reactive/collections";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { isBlank } from "@ember/utils";
 import preventScrollOnFocus from "discourse/modifiers/prevent-scroll-on-focus";
-import dAutoFocus from "discourse/ui-kit/modifiers/d-auto-focus";
 import { i18n } from "discourse-i18n";
 /** @type {import("./slot.gjs").default} */
 import Slot from "./slot";
@@ -54,6 +54,23 @@ export default class DOTP extends Component {
 
   get value() {
     return this.otp.join("");
+  }
+
+  @action
+  focusInput(element) {
+    if (!this.autoFocus) {
+      return;
+    }
+
+    element.autofocus = true;
+
+    requestAnimationFrame(() => {
+      if (!element.isConnected) {
+        return;
+      }
+
+      element.focus({ preventScroll: true });
+    });
   }
 
   /**
@@ -187,7 +204,7 @@ export default class DOTP extends Component {
           {{on "blur" this.onBlur}}
           {{on "paste" this.onPaste}}
           aria-label={{i18n "d_otp.screen_reader" count=this.slots}}
-          {{(if this.autoFocus (modifier dAutoFocus))}}
+          {{didInsert this.focusInput}}
           ...attributes
         />
       </div>

--- a/frontend/discourse/tests/acceptance/second-factor-auth-test.js
+++ b/frontend/discourse/tests/acceptance/second-factor-auth-test.js
@@ -1,4 +1,10 @@
-import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
+import {
+  click,
+  currentURL,
+  fillIn,
+  visit,
+  waitUntil,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
@@ -248,6 +254,20 @@ acceptance("Second Factor Auth Page", function (needs) {
         "This is an additional description that can be customized per action",
         "action description is rendered on the page"
       );
+  });
+
+  test("TOTP input is focused on load", async function (assert) {
+    await visit("/session/2fa?nonce=ok110111");
+
+    await waitUntil(
+      () =>
+        document.activeElement ===
+        document.querySelector("form.totp-token .d-otp-input")
+    );
+
+    assert
+      .dom("form.totp-token .d-otp-input")
+      .isFocused("focuses the TOTP input");
   });
 
   test("error when submitting 2FA form", async function (assert) {

--- a/frontend/discourse/tests/integration/ui-kit/d-otp-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-otp-test.gjs
@@ -1,5 +1,5 @@
 import { next } from "@ember/runloop";
-import { focus, render, settled } from "@ember/test-helpers";
+import { focus, render, settled, waitUntil } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DOtp from "discourse/ui-kit/d-otp";
@@ -82,6 +82,11 @@ module("Integration | ui-kit | DOtp", function (hooks) {
 
   test("@autoFocus", async function (assert) {
     await render(<template><DOtp /></template>);
+
+    await waitUntil(
+      () =>
+        document.activeElement === this.element.querySelector(".d-otp-input")
+    );
 
     assert.dom(".d-otp-input").isFocused("autofocuses the input by default");
 


### PR DESCRIPTION
When a signed DiscourseConnect provider request requires 2FA, Discourse redirects the signed-in user to `/session/2fa`. The OTP input on that standalone 2FA confirmation page renders with autofocus markup, but focus can remain on the document body instead of the OTP input. This means users must click into the field before entering their code.

This updates the OTP component to focus the underlying input after it has been inserted into the DOM, while preserving the existing iOS autofocus guard and `preventScroll` behavior.

### Before / After

<img width="1988" height="1682" alt="image" src="https://github.com/user-attachments/assets/4ed67b10-66c5-4676-ae49-76fa2be5ebcc" />