### PR TITLE
FEATURE: Enable scoped rollout for `dashboard_improvements`

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -166,10 +166,13 @@ class Admin::DashboardController < Admin::StaffController
   end
 
   def dashboard_improvements?
+    dashboard_improvements_enabled =
+      UpcomingChanges.enabled_for_user?(:dashboard_improvements, current_user)
+
     if params[:version] == "alt"
-      !SiteSetting.dashboard_improvements
+      !dashboard_improvements_enabled
     else
-      SiteSetting.dashboard_improvements
+      dashboard_improvements_enabled
     end
   end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2879,7 +2879,7 @@ en:
     enable_horizon_high_context_topic_cards: "Shows richer topic cards in the Horizon theme, including topic excerpts, tags, and plugin extended information."
     reporting_improvements: "Improvements to navigation, design, and usability for Discourse's admin reports."
     granular_anonymous_and_logged_in_groups_permissions: "Makes group-based site setting permissions treat 'everyone' as 'all logged-in users', and enables the new 'anonymous_users' and 'logged_in_users' pseudogroups so admins can explicitly target anonymous visitors and authenticated users."
-    dashboard_improvements: "Improvements to navigation, design, and usability for the Discourse admin dashboard."
+    dashboard_improvements: "Enables the redesigned admin dashboard that lets you pin custom reports and includes improved site traffic, engagement, and other analytics tied to community success and value."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4537,8 +4537,9 @@ experimental:
     hidden: true
     client: true
     upcoming_change:
-      status: "conceptual"
+      status: "experimental"
       impact: "feature,admins"
+      learn_more_url: "https://meta.discourse.org/t/-/404528"
   admin_dashboard_reports_seeded:
     default: false
     hidden: true

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1234,8 +1234,8 @@ class Plugin::Instance
   end
 
   # Registers a KPI tile in the admin dashboard "Highlights" section
-  # (gated by SiteSetting.dashboard_improvements). The KPI is rendered as a
-  # tile linking to /admin/reports/:report.
+  # (gated by the dashboard_improvements upcoming change). The KPI is rendered
+  # as a tile linking to /admin/reports/:report.
   #
   # @param type [Symbol] unique identifier for the KPI. Used as the i18n key
   #   (admin.dashboard.highlights.kpi.<type>.label / .tooltip) and to

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe Admin::DashboardController do
         end
       end
 
-      it "is omitted when dashboard_improvements is disabled" do
+      it "is omitted when enabled for no one" do
         SiteSetting.dashboard_improvements = false
 
         get "/admin/dashboard.json"
@@ -266,8 +266,32 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body["configuration"]).to be_nil
       end
 
-      it "is returned when version=alt and dashboard_improvements is disabled" do
-        SiteSetting.dashboard_improvements = false
+      it "is omitted when enabled for a group the admin is not in" do
+        group = Fabricate(:group)
+        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
+
+        get "/admin/dashboard.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["sections"]).to be_nil
+        expect(response.parsed_body["configuration"]).to be_nil
+      end
+
+      it "is returned when enabled for the admin's group" do
+        group = Fabricate(:group)
+        group.add(admin)
+        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
+
+        get "/admin/dashboard.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["sections"]).to be_present
+        expect(response.parsed_body["configuration"]).to be_present
+      end
+
+      it "is returned with version=alt when the admin is not included" do
+        group = Fabricate(:group)
+        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
 
         get "/admin/dashboard.json", params: { version: "alt" }
 
@@ -276,7 +300,7 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body["configuration"]).to be_present
       end
 
-      it "is omitted when version=alt and dashboard_improvements is enabled" do
+      it "is omitted with version=alt when enabled for the admin" do
         get "/admin/dashboard.json", params: { version: "alt" }
 
         expect(response.status).to eq(200)
@@ -371,7 +395,7 @@ RSpec.describe Admin::DashboardController do
         )
       end
 
-      it "omits version_check when the flag is on" do
+      it "omits version_check when enabled for the admin" do
         SiteSetting.version_checks = true
         DiscourseUpdates.expects(:check_version).never
 
@@ -381,8 +405,9 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body).not_to have_key("version_check")
       end
 
-      it "still includes version_check when the flag is off" do
-        SiteSetting.dashboard_improvements = false
+      it "includes version_check when the admin is not included" do
+        group = Fabricate(:group)
+        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
         SiteSetting.version_checks = true
 
         get "/admin/dashboard.json"
@@ -423,8 +448,9 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body).not_to have_key("configuration")
       end
 
-      it "is omitted when dashboard_improvements is disabled" do
-        SiteSetting.dashboard_improvements = false
+      it "is omitted when the admin is not included" do
+        group = Fabricate(:group)
+        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
         sign_in(admin)
 
         get "/admin/dashboard.json"


### PR DESCRIPTION
Previously, the redesigned admin dashboard's upcoming change was conceptual, and the dashboard controller treated it as a global on/off setting.

This change promotes `dashboard_improvements` to experimental and gates the redesigned dashboard through per-user upcoming-change access, allowing admins to roll it out to selected groups.