### PR TITLE
FIX: preserve unconfigured products state in `discourse-subscriptions`

### DIFF
--- a/plugins/discourse-subscriptions/assets/javascripts/discourse/routes/admin-plugins/discourse-subscriptions/products/index.js
+++ b/plugins/discourse-subscriptions/assets/javascripts/discourse/routes/admin-plugins/discourse-subscriptions/products/index.js
@@ -1,17 +1,14 @@
 import { action } from "@ember/object";
-import { trackedArray } from "@ember/reactive/collections";
 import Route from "@ember/routing/route";
 import { service } from "@ember/service";
-import { removeValueFromArray } from "discourse/lib/array-tools";
 import { i18n } from "discourse-i18n";
 import AdminProduct from "discourse/plugins/discourse-subscriptions/discourse/models/admin-product";
 
 export default class AdminPluginsDiscourseSubscriptionsProductsIndexRoute extends Route {
   @service dialog;
 
-  async model() {
-    const products = await AdminProduct.findAll();
-    return trackedArray(products);
+  model() {
+    return AdminProduct.findAll();
   }
 
   @action
@@ -24,11 +21,16 @@ export default class AdminPluginsDiscourseSubscriptionsProductsIndexRoute extend
         return product
           .destroy()
           .then(() => {
-            const model = this.controllerFor(
+            const controller = this.controllerFor(
               "adminPlugins.discourseSubscriptions.products.index"
-            ).model;
+            );
 
-            removeValueFromArray(model, product);
+            controller.set(
+              "model",
+              controller.model.filter(
+                (modelProduct) => modelProduct !== product
+              )
+            );
           })
           .catch((data) =>
             this.dialog.alert(data.jqXHR.responseJSON.errors.join("\n"))

--- a/plugins/discourse-subscriptions/test/javascripts/unit/routes/admin-plugins/discourse-subscriptions/products/index-test.js
+++ b/plugins/discourse-subscriptions/test/javascripts/unit/routes/admin-plugins/discourse-subscriptions/products/index-test.js
@@ -1,0 +1,25 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+
+module(
+  "Unit | Route | admin-plugins.discourse-subscriptions.products.index",
+  function (hooks) {
+    setupTest(hooks);
+
+    test("returns the unconfigured model from the products endpoint", async function (assert) {
+      pretender.get("/s/admin/products", () => response(null));
+
+      const route = this.owner.lookup(
+        "route:admin-plugins.discourse-subscriptions.products.index"
+      );
+      const model = await route.model();
+
+      assert.deepEqual(
+        model,
+        { unconfigured: true },
+        "the template can render the unconfigured state"
+      );
+    });
+  }
+);


### PR DESCRIPTION
Previously, the products admin route wrapped every response from `AdminProduct.findAll()` in a tracked array, which broke the unconfigured state returned when Stripe was not fully configured.

This change preserves the model returned by `AdminProduct.findAll()` and updates product deletion by replacing the product list, allowing the admin page to render its setup guidance.