### PR TITLE
DEV: Fix (again) admin_customize_themes spec flake

### DIFF
--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -382,13 +382,13 @@ describe "Admin Customize Themes" do
       visit("/")
       expect(banner).to be_visible
 
-      # Wait for the `/client_settings` subscription's first poll finish.
+      # Wait for the `/client_settings` subscription's first poll to finish.
       try_until_success do
         expect(
           page.evaluate_script(
-            "window.MessageBus.callbacks.find(c => c.channel === '/client_settings')?.last_id",
+            "window.MessageBus.callbacks.find((c) => c.channel === '/client_settings')?.last_id ?? -1",
           ),
-        ).not_to eq(-1)
+        ).to be >= 0
       end
 
       using_session(:admin) do


### PR DESCRIPTION
A followup to f2d8a4e. In some states last_id is nil, which was in fact `not eq(-1)` 🙃