### PR TITLE
UX: daterange Dmenu corrections + styling fixes

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -35,25 +35,6 @@
   }
 }
 
-.db-date-range {
-  &__trigger {
-    height: var(--space-9);
-    padding: var(--space-1) var(--space-3);
-    border-radius: var(--d-border-radius);
-    border: 1px solid var(--primary-low);
-    background: var(--secondary);
-    color: var(--primary-high);
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-
-    &:hover {
-      background: var(--primary-very-low);
-      color: var(--primary);
-    }
-  }
-}
-
 .db-delta {
   font-size: var(--font-down-2-rem);
   font-weight: bold;

--- a/frontend/discourse/admin/components/dashboard/date-range.gjs
+++ b/frontend/discourse/admin/components/dashboard/date-range.gjs
@@ -10,7 +10,6 @@ import {
   PRESET_LABEL_KEYS,
 } from "discourse/admin/lib/dashboard-date-range";
 import DMenu from "discourse/float-kit/components/d-menu";
-import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class DashboardDateRange extends Component {
@@ -49,16 +48,14 @@ export default class DashboardDateRange extends Component {
   <template>
     <DMenu
       @identifier="db-date-range-menu"
-      @triggerClass="db-date-range__trigger"
+      @triggerClass="btn-default db-date-range__trigger"
       @modalForMobile={{true}}
       @placement="bottom-end"
       @maxWidth={{800}}
       @contentClass="db-date-range__popover"
+      @icon="calendar-days"
+      @label={{this.triggerLabel}}
     >
-      <:trigger>
-        {{dIcon "calendar-days"}}
-        <span class="db-date-range__trigger-label">{{this.triggerLabel}}</span>
-      </:trigger>
       <:content as |args|>
         <DashboardDateRangePicker
           @from={{@startDate}}

--- a/frontend/discourse/tests/integration/components/dashboard/date-range-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/date-range-test.gjs
@@ -25,7 +25,9 @@ module("Integration | Component | Dashboard | DateRange", function (hooks) {
       <template><DashboardDateRange @period="last_30_days" /></template>
     );
 
-    assert.dom(".db-date-range__trigger-label").hasText("Last 30 days");
+    assert
+      .dom(".db-date-range__trigger .d-button-label")
+      .hasText("Last 30 days");
   });
 
   test("trigger label names a six-month preset rather than showing its dates", async function (assert) {
@@ -33,7 +35,9 @@ module("Integration | Component | Dashboard | DateRange", function (hooks) {
       <template><DashboardDateRange @period="last_6_months" /></template>
     );
 
-    assert.dom(".db-date-range__trigger-label").hasText("Last 6 months");
+    assert
+      .dom(".db-date-range__trigger .d-button-label")
+      .hasText("Last 6 months");
   });
 
   test("trigger label is the literal formatted range for hand-picked custom periods", async function (assert) {
@@ -50,14 +54,18 @@ module("Integration | Component | Dashboard | DateRange", function (hooks) {
       </template>
     );
 
-    assert.dom(".db-date-range__trigger-label").includesText("Mar 1");
-    assert.dom(".db-date-range__trigger-label").includesText("Apr 28");
+    assert.dom(".db-date-range__trigger .d-button-label").includesText("Mar 1");
+    assert
+      .dom(".db-date-range__trigger .d-button-label")
+      .includesText("Apr 28");
   });
 
   test("trigger label falls back to default when in custom mode with missing dates", async function (assert) {
     await render(<template><DashboardDateRange @period="custom" /></template>);
 
-    assert.dom(".db-date-range__trigger-label").hasText("Last 30 days");
+    assert
+      .dom(".db-date-range__trigger .d-button-label")
+      .hasText("Last 30 days");
   });
 
   test("trigger label reacts to @period changes", async function (assert) {
@@ -70,11 +78,15 @@ module("Integration | Component | Dashboard | DateRange", function (hooks) {
       <template><DashboardDateRange @period={{state.period}} /></template>
     );
 
-    assert.dom(".db-date-range__trigger-label").hasText("Last 30 days");
+    assert
+      .dom(".db-date-range__trigger .d-button-label")
+      .hasText("Last 30 days");
 
     state.period = "last_7_days";
     await settled();
 
-    assert.dom(".db-date-range__trigger-label").hasText("Last 7 days");
+    assert
+      .dom(".db-date-range__trigger .d-button-label")
+      .hasText("Last 7 days");
   });
 });

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -35,12 +35,12 @@ module PageObjects
         if period == "custom"
           page.current_url.include?("range=custom")
         else
-          has_css?(".db-date-range__trigger-label", text: preset_label(period))
+          has_css?(".db-date-range__trigger .d-button-label", text: preset_label(period))
         end
       end
 
       def has_custom_label?(text)
-        has_css?(".db-date-range__trigger-label", exact_text: text)
+        has_css?(".db-date-range__trigger .d-button-label", exact_text: text)
       end
 
       def date_range_picker


### PR DESCRIPTION
* Remove the custom styling of the datarange picker and add a standard `btn-default`.
* Update DMenu implementation to use existing properties and remove `:trigger` - don't think we need it here afaik?