### PR TITLE
UX: dashboard > make metrics into links + css tweaks

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -253,6 +253,10 @@
     font-size: var(--font-down-2-rem);
     color: var(--primary-medium);
 
+    a {
+      color: inherit;
+    }
+
     @include viewport.until(sm) {
       white-space: wrap;
     }
@@ -359,44 +363,23 @@
     }
   }
 
-  &__row-block-title {
+  &__row-block-title,
+  &__row-block-title > a {
     color: var(--primary);
     font-weight: bold;
     font-size: var(--font-down-1-rem);
+
+    &:hover,
+    &:focus,
+    &:visited,
+    &:active {
+      color: var(--primary);
+    }
 
     .db-link-arrow {
       top: 0;
       inset-inline-end: calc(var(--space-6) * -1);
       margin-inline-start: var(--space-4);
-    }
-
-    // The drill-down link is either this element (a bare anchor) or a nested
-    // anchor when the title is wrapped in a heading for screen-reader semantics.
-    &:is(a),
-    a {
-      position: relative;
-      display: inline-block;
-      color: var(--primary);
-
-      &:hover,
-      &:focus,
-      &:visited,
-      &:active {
-        color: var(--primary);
-      }
-
-      &:hover .db-link-arrow {
-        opacity: 1;
-        transform: translateX(0);
-      }
-    }
-
-    &.--label {
-      font-size: var(--font-down-2-rem);
-      font-weight: 600;
-      color: var(--primary-medium);
-      text-transform: uppercase;
-      letter-spacing: 1px;
     }
   }
 
@@ -482,14 +465,10 @@
 .db-activity-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: var(--font-down-1-rem);
 
   thead th {
-    color: var(--primary-medium);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    font-size: var(--font-down-2-rem);
+    color: var(--primary-high);
+    font-size: var(--font-down-1-rem);
   }
 
   &__col-number,

--- a/frontend/discourse/admin/components/dashboard/engagement/headline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/headline.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { eq } from "discourse/truth-helpers";
 import I18n, { i18n } from "discourse-i18n";
@@ -55,11 +56,18 @@ class MetricItem extends Component {
     <div class="db-section__metric">
       <div class="db-section__metric-number">{{this.displayValue}}</div>
       <div class="db-section__metric-label">
-        {{i18n
-          (concat
-            "admin.dashboard.sections.engagement.headline.metrics." @metric.type
-          )
-        }}
+        <LinkTo
+          @route="adminReports.show"
+          @model={{@metric.report_type}}
+          @query={{@metric.report_query}}
+        >
+          {{i18n
+            (concat
+              "admin.dashboard.sections.engagement.headline.metrics."
+              @metric.type
+            )
+          }}
+        </LinkTo>
         <DTooltip
           class="db-section__info"
           @identifier={{concat "engagement-headline-" @metric.type "-tooltip"}}


### PR DESCRIPTION
Bring back the links for the headline/metrics + title/table/a-tag styling tweaks