### PR TITLE
FIX: Preserve location hash in topic-load race condition

### DIFF
--- a/frontend/discourse/app/routes/topic.js
+++ b/frontend/discourse/app/routes/topic.js
@@ -296,7 +296,7 @@ export default class TopicRoute extends DiscourseRoute {
 
     const currentPos = document.scrollingElement.scrollTop;
     if (currentPos === this.lastScrollPos) {
-      DiscourseURL.replaceState(url);
+      DiscourseURL.replaceState(`${url}${window.location.hash}`);
       return;
     }
 


### PR DESCRIPTION
Clicking a heading anchor within 0.5s of topic loading would remove the just-added `#anchor` from the URL.