### PR TITLE
UX: Tweak chat's mark-as-read conditions

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/lib/chat-constants.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-constants.js
@@ -1,6 +1,6 @@
 export const PAST = "past";
 export const FUTURE = "future";
-export const READ_INTERVAL_MS = 1000;
+export const READ_INTERVAL_MS = 500;
 export const DEFAULT_MESSAGE_PAGE_SIZE = 50;
 export const THREAD_TITLE_PROMPT_THRESHOLD = 5;
 export const FOOTER_NAV_ROUTES = [

--- a/plugins/chat/assets/javascripts/discourse/lib/check-message-visibility.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/check-message-visibility.js
@@ -1,7 +1,12 @@
+const BOTTOM_VISIBILITY_SLACK = 10;
+
 export function checkMessageBottomVisibility(list, message) {
   const distanceToTop = window.pageYOffset + list.getBoundingClientRect().top;
   const bounding = message.getBoundingClientRect();
-  return bounding.bottom - distanceToTop <= list.clientHeight + 1;
+  return (
+    bounding.bottom - distanceToTop <=
+    list.clientHeight + BOTTOM_VISIBILITY_SLACK
+  );
 }
 
 export function checkMessageTopVisibility(list, message) {


### PR DESCRIPTION
1. lower the read-time threshold from 1s to 0.5s
2. trigger read state when within 10px from the bottom (up from 1px)