### PR TITLE
UX: dashboard > redesign who is posting

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -349,6 +349,7 @@
     color: var(--primary);
     font-weight: bold;
     font-size: var(--font-down-1-rem);
+    white-space: nowrap;
 
     &:hover,
     &:focus,
@@ -496,6 +497,15 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  container-type: inline-size;
+  container-name: db-whos-posting;
+
+  .db-section__row-block-header {
+    @container db-whos-posting (width < 22rem) {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
 
   &__filter {
     display: flex;
@@ -503,6 +513,15 @@
     align-items: flex-end;
     gap: var(--space-1);
     flex-grow: 1;
+    min-width: 0;
+
+    @container db-whos-posting (width < 22rem) {
+      width: 100%;
+
+      .select-kit.combo-box.category-chooser {
+        max-width: none;
+      }
+    }
   }
 
   &__subcategories {
@@ -514,18 +533,47 @@
     cursor: pointer;
   }
 
-  &__bar {
-    display: flex;
-    width: 100%;
-    height: 12px;
-    border-radius: 6px;
-    overflow: hidden;
+  &__bars {
+    display: grid;
+    grid-template-columns: minmax(0, auto) minmax(200px, 1fr) 2.5rem;
+    gap: var(--space-2);
+
+    @container db-whos-posting (width < 22rem) {
+      grid-template-columns: 1fr;
+      gap: var(--space-3);
+    }
+  }
+
+  &__bar-row {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    align-items: center;
+
+    @container db-whos-posting (width < 22rem) {
+      grid-template-columns: 1fr auto;
+      gap: 0 var(--space-2);
+    }
+  }
+
+  &__bar-label {
+    @include ellipsis;
+
+    @container db-whos-posting (width < 22rem) {
+      grid-column: 1 / -1;
+    }
+  }
+
+  &__bar-track {
+    height: var(--space-3);
+    border-radius: 1em;
     background: var(--primary-low);
   }
 
-  &__segment {
+  &__bar-fill {
     display: block;
     height: 100%;
+    border-radius: 1em;
 
     &.--new-members {
       background: var(--tertiary);
@@ -540,49 +588,11 @@
     }
   }
 
-  &__legend {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-
-  &__legend-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    font-size: var(--font-down-1-rem);
-  }
-
-  &__legend-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex: 0 0 auto;
-
-    &.--new-members {
-      background: var(--tertiary);
-    }
-
-    &.--returning {
-      background: var(--tertiary-medium);
-    }
-
-    &.--staff {
-      background: var(--primary-medium);
-    }
-  }
-
-  &__legend-label {
-    flex: 1 1 auto;
-    color: var(--primary);
-  }
-
-  &__legend-share {
+  &__bar-share {
     color: var(--primary-medium);
     font-variant-numeric: tabular-nums;
+    text-align: right;
+    line-height: 1;
   }
 
   &__empty {
@@ -624,7 +634,6 @@
   }
 
   &__name {
-    font-weight: bold;
     color: var(--primary);
   }
 

--- a/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
@@ -53,7 +53,7 @@ export default class WhosPosting extends Component {
   get rows() {
     const rows = this.posters?.rows ?? [];
     const byType = Object.fromEntries(rows.map((r) => [r.type, r]));
-    return ROW_ORDER.map((type, index) => {
+    return ROW_ORDER.map((type) => {
       const row = byType[type] ?? { type, count: 0, share: 0 };
       return {
         type,
@@ -62,7 +62,6 @@ export default class WhosPosting extends Component {
         shareFormatted: `${Math.round(row.share)}%`,
         segmentStyle: trustHTML(`width: ${row.share}%`),
         segmentClass: `--${type.replace("_", "-")}`,
-        legendIndex: index,
       };
     });
   }
@@ -170,34 +169,25 @@ export default class WhosPosting extends Component {
 
       {{#if this.hasData}}
         <div
-          class="db-whos-posting__bar"
+          class="db-whos-posting__bars"
           role="img"
           aria-label={{this.ariaLabel}}
         >
           {{#each this.rows as |row|}}
-            {{#if row.share}}
+            <div class="db-whos-posting__bar-row">
+              <span class="db-whos-posting__bar-label">{{row.label}}</span>
+              <span class="db-whos-posting__bar-track">
+                <span
+                  class="db-whos-posting__bar-fill {{row.segmentClass}}"
+                  style={{row.segmentStyle}}
+                ></span>
+              </span>
               <span
-                class="db-whos-posting__segment {{row.segmentClass}}"
-                style={{row.segmentStyle}}
-              ></span>
-            {{/if}}
+                class="db-whos-posting__bar-share"
+              >{{row.shareFormatted}}</span>
+            </div>
           {{/each}}
         </div>
-
-        <ul class="db-whos-posting__legend">
-          {{#each this.rows as |row|}}
-            <li class="db-whos-posting__legend-item">
-              <span
-                class="db-whos-posting__legend-dot {{row.segmentClass}}"
-                aria-hidden="true"
-              ></span>
-              <span class="db-whos-posting__legend-label">{{row.label}}</span>
-              <span
-                class="db-whos-posting__legend-share"
-              >{{row.shareFormatted}}</span>
-            </li>
-          {{/each}}
-        </ul>
       {{else}}
         <p class="db-whos-posting__empty">
           {{i18n "admin.dashboard.sections.engagement.whos_posting.empty"}}

--- a/frontend/discourse/tests/integration/components/dashboard/whos-posting-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/whos-posting-test.gjs
@@ -18,7 +18,7 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
     ],
   };
 
-  test("renders the stacked bar segments and legend rows", async function (assert) {
+  test("renders a bar row with label, fill and share for each bucket", async function (assert) {
     await render(
       <template>
         <WhosPosting
@@ -29,18 +29,14 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
       </template>
     );
 
-    assert.dom(".db-whos-posting__bar").exists();
-    assert.dom(".db-whos-posting__segment").exists({ count: 3 });
-    assert.dom(".db-whos-posting__legend-item").exists({ count: 3 });
+    assert.dom(".db-whos-posting__bars").exists();
+    assert.dom(".db-whos-posting__bar-row").exists({ count: 3 });
+    assert.dom(".db-whos-posting__bar-fill").exists({ count: 3 });
     assert
-      .dom(
-        ".db-whos-posting__legend-item:nth-child(1) .db-whos-posting__legend-label"
-      )
+      .dom(".db-whos-posting__bar-row:nth-child(1) .db-whos-posting__bar-label")
       .hasText("New members");
     assert
-      .dom(
-        ".db-whos-posting__legend-item:nth-child(2) .db-whos-posting__legend-share"
-      )
+      .dom(".db-whos-posting__bar-row:nth-child(2) .db-whos-posting__bar-share")
       .hasText("51%");
   });
 
@@ -71,12 +67,11 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
       </template>
     );
 
-    assert.dom(".db-whos-posting__bar").doesNotExist();
-    assert.dom(".db-whos-posting__legend").doesNotExist();
+    assert.dom(".db-whos-posting__bars").doesNotExist();
     assert.dom(".db-whos-posting__empty").exists();
   });
 
-  test("omits the bar segment for a bucket with zero share", async function (assert) {
+  test("renders a zero-share bucket with a 0% share", async function (assert) {
     const noStaff = {
       total: 85,
       rows: [
@@ -96,7 +91,9 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
       </template>
     );
 
-    assert.dom(".db-whos-posting__segment").exists({ count: 2 });
-    assert.dom(".db-whos-posting__legend-item").exists({ count: 3 });
+    assert.dom(".db-whos-posting__bar-row").exists({ count: 3 });
+    assert
+      .dom(".db-whos-posting__bar-row:nth-child(3) .db-whos-posting__bar-share")
+      .hasText("0%");
   });
 });


### PR DESCRIPTION
* Changed the `who-is-posting` section to a stacked layout instead
* Use container queries for responsive styling

| Size | BC | AC |
|-------|--------|--------|
| Large | <img width="840" height="595" alt="CleanShot 2026-06-08 at 14 43 15" src="https://github.com/user-attachments/assets/905d0e66-0e13-41e9-a890-6482896dc835" /> | <img width="993" height="580" alt="CleanShot 2026-06-08 at 14 38 26" src="https://github.com/user-attachments/assets/adcd5569-978a-4c9f-a9e8-156f54a48858" /> | 
| Small | Same | <img width="845" height="602" alt="CleanShot 2026-06-08 at 14 39 12" src="https://github.com/user-attachments/assets/ed8ac094-f9ff-4b34-98dc-3514661b4a0c" /> | 