### PR TITLE
UX: Drop obsolete setup note from solved shared issues description

### DIFF
--- a/plugins/discourse-solved/config/locales/server.en.yml
+++ b/plugins/discourse-solved/config/locales/server.en.yml
@@ -46,7 +46,7 @@ en:
     enable_solved_tags: "Tags that will allow users to select solutions."
     prioritize_solved_topics_in_search: "Prioritize solved topics in search results."
     enable_support_category_type_setup: "Enables the Support category type option during category creation setup."
-    enable_solved_shared_issues: "Adds a “Me too” button to unsolved topics in support categories, letting members signal they’re experiencing the same issue and opt in to notifications about the topic's solution. Note: You must enable the “Enable support type category setup” upcoming change to use this feature."
+    enable_solved_shared_issues: "Adds a “Me too” button to unsolved topics in support categories, letting members signal they’re experiencing the same issue and opt-in to notifications about the topic's solution."
     show_who_marked_solved: "Show who marked the topic as solved. This is indicated in the topic's first post, and the answer post in a tooltip."
 
     keywords:


### PR DESCRIPTION
Previously, the `enable_solved_shared_issues` upcoming change description instructed admins to first enable the "Enable support category type setup" change — which has since been made `permanent`, making that instruction obsolete.

This change removes the stale note (and tweaks "opt in" → "opt-in").