### PR TITLE
FEATURE: Show theme d-compat/* refs in admin UI

### DIFF
--- a/app/models/remote_theme.rb
+++ b/app/models/remote_theme.rb
@@ -230,6 +230,7 @@ class RemoteTheme < ActiveRecord::Base
     else
       self.updated_at = Time.zone.now
       self.remote_version, self.commits_behind = importer.commits_since(local_version)
+      self.remote_compat_ref = importer.compatibility_resolved_ref
       self.last_error_text = nil
     ensure
       save!
@@ -377,6 +378,7 @@ class RemoteTheme < ActiveRecord::Base
       self.remote_updated_at = Time.zone.now
       self.remote_version = importer.version
       self.local_version = importer.version
+      self.local_compat_ref = self.remote_compat_ref = importer.compatibility_resolved_ref
       self.commits_behind = 0
     end
 
@@ -588,10 +590,12 @@ end
 #  commits_behind            :integer
 #  last_error_text           :text
 #  license_url               :string
+#  local_compat_ref          :string
 #  local_version             :string
 #  maximum_discourse_version :string
 #  minimum_discourse_version :string
 #  private_key               :text
+#  remote_compat_ref         :string
 #  remote_updated_at         :datetime
 #  remote_url                :string           not null
 #  remote_version            :string

--- a/app/serializers/remote_theme_serializer.rb
+++ b/app/serializers/remote_theme_serializer.rb
@@ -7,6 +7,8 @@ class RemoteThemeSerializer < ApplicationSerializer
              :local_version,
              :commits_behind,
              :branch,
+             :local_compat_ref,
+             :remote_compat_ref,
              :remote_updated_at,
              :updated_at,
              :github_diff_link,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8242,6 +8242,7 @@ en:
           updating: "Updating…"
           update_success: "%{theme} Update complete"
           up_to_date: "Theme is up-to-date, last checked:"
+          up_to_date_branch: "Theme is up-to-date with %{branch}, last checked:"
           has_overwritten_history: "Current theme version no longer exists because the Git history has been overwritten by a force push."
           change_source:
             button: "Change source"
@@ -8265,6 +8266,9 @@ en:
           commits_behind:
             one: "Theme is %{count} commit behind!"
             other: "Theme is %{count} commits behind!"
+          commits_behind_branch:
+            one: "Theme is %{count} commit behind %{branch}"
+            other: "Theme is %{count} commits behind %{branch}"
           compare_commits: "(See new commits)"
           remote_theme_edits: "If you want to edit this theme, you must <a href='%{repoURL}' target='_blank'>submit a change on its repository</a>"
           repo_unreachable: "Couldn't contact the Git repository of this theme. Error message:"

--- a/db/migrate/20260608104742_add_compatibility_refs_to_remote_themes.rb
+++ b/db/migrate/20260608104742_add_compatibility_refs_to_remote_themes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCompatibilityRefsToRemoteThemes < ActiveRecord::Migration[8.0]
+  def change
+    add_column :remote_themes, :local_compat_ref, :string
+    add_column :remote_themes, :remote_compat_ref, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7841,7 +7841,9 @@ CREATE TABLE public.remote_themes (
     authors character varying,
     theme_version character varying,
     minimum_discourse_version character varying,
-    maximum_discourse_version character varying
+    maximum_discourse_version character varying,
+    local_compat_ref character varying,
+    remote_compat_ref character varying
 );
 
 
@@ -21917,6 +21919,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260612092612'),
 ('20260610075829'),
 ('20260609050938'),
+('20260608104742'),
 ('20260607161322'),
 ('20260604052235'),
 ('20260603115312'),

--- a/frontend/discourse/admin/controllers/admin-customize-themes/show.js
+++ b/frontend/discourse/admin/controllers/admin-customize-themes/show.js
@@ -14,6 +14,25 @@ export default class AdminCustomizeThemesShowController extends Controller {
     return /^http(s)?:\/\//.test(this.model?.remote_theme?.remote_url);
   }
 
+  @computed("model.remote_theme.remote_url")
+  get prettyRemoteUrl() {
+    const remoteUrl = this.model?.remote_theme?.remote_url;
+
+    if (/^https?:\/\/github\.com\//.test(remoteUrl)) {
+      return remoteUrl.replace(/^https?:\/\//, "").replace(/\.git$/, "");
+    }
+
+    return remoteUrl;
+  }
+
+  @computed("model.remote_theme.local_compat_ref", "model.remote_theme.branch")
+  get displayBranch() {
+    return (
+      this.model?.remote_theme?.local_compat_ref ||
+      this.model?.remote_theme?.branch
+    );
+  }
+
   @computed("model.remote_theme.remote_url", "model.remote_theme.branch")
   get remoteThemeLink() {
     return this.model?.remote_theme?.branch

--- a/frontend/discourse/admin/controllers/admin-customize-themes/show/index.js
+++ b/frontend/discourse/admin/controllers/admin-customize-themes/show/index.js
@@ -36,6 +36,14 @@ export default class AdminCustomizeThemesShowIndexController extends Controller 
     return getURL(`/admin/themes/${this.model?.id}/preview`);
   }
 
+  @computed("model.remote_theme.remote_compat_ref", "model.remote_theme.branch")
+  get displayRemoteBranch() {
+    return (
+      this.model?.remote_theme?.remote_compat_ref ||
+      this.model?.remote_theme?.branch
+    );
+  }
+
   @computed("model.id", "model.locale")
   get getTranslationsUrl() {
     return getURL(

--- a/frontend/discourse/admin/templates/admin-customize-themes/show.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-themes/show.gjs
@@ -1,5 +1,4 @@
 import { LinkTo } from "@ember/routing";
-import { trustHTML } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import DButton from "discourse/ui-kit/d-button";
@@ -168,18 +167,18 @@ export default <template>
       <div class="metadata control-unit remote-theme-metadata">
         {{#if @controller.model.remote_theme}}
           {{#if @controller.model.remote_theme.remote_url}}
-            {{#if @controller.sourceIsHttp}}
-              <a class="remote-url" href={{@controller.remoteThemeLink}}>{{i18n
-                  "admin.customize.theme.source_url"
-                }}{{dIcon "link"}}</a>
-            {{else}}
-              <div class="remote-url">
-                <code>{{@controller.model.remote_theme.remote_url}}</code>
-                {{#if @controller.model.remote_theme.branch}}
-                  (<code>{{@controller.model.remote_theme.branch}}</code>)
-                {{/if}}
-              </div>
-            {{/if}}
+            <div class="remote-url">
+              {{#if @controller.sourceIsHttp}}
+                <a
+                  href={{@controller.remoteThemeLink}}
+                >{{@controller.prettyRemoteUrl}}</a>
+              {{else}}
+                {{@controller.prettyRemoteUrl}}
+              {{/if}}
+              {{#if @controller.displayBranch}}
+                (<code>{{@controller.displayBranch}}</code>)
+              {{/if}}
+            </div>
           {{/if}}
 
           {{#if @controller.model.remote_theme.about_url}}
@@ -216,25 +215,14 @@ export default <template>
                 }}</span>
               {{@controller.model.remote_theme.theme_version}}</span>{{/if}}
 
-          {{#if @controller.model.remote_theme.is_git}}
-            <div class="alert alert-info remote-theme-edits">
-              {{trustHTML
-                (i18n
-                  "admin.customize.theme.remote_theme_edits"
-                  repoURL=@controller.remoteThemeLink
-                )
-              }}
+          {{#if @controller.showRemoteError}}
+            <div class="error-message">
+              {{dIcon "triangle-exclamation"}}
+              {{i18n "admin.customize.theme.repo_unreachable"}}
             </div>
-
-            {{#if @controller.showRemoteError}}
-              <div class="error-message">
-                {{dIcon "triangle-exclamation"}}
-                {{i18n "admin.customize.theme.repo_unreachable"}}
-              </div>
-              <div class="raw-error">
-                <code>{{@controller.model.remoteError}}</code>
-              </div>
-            {{/if}}
+            <div class="raw-error">
+              <code>{{@controller.model.remoteError}}</code>
+            </div>
           {{/if}}
         {{/if}}
       </div>

--- a/frontend/discourse/admin/templates/admin-customize-themes/show/index.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-themes/show/index.gjs
@@ -15,6 +15,7 @@ import ComboBox from "discourse/select-kit/components/combo-box";
 import { and, not, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
+import DInterpolatedTranslation from "discourse/ui-kit/d-interpolated-translation";
 import DUserLink from "discourse/ui-kit/d-user-link";
 import dFormatDate from "discourse/ui-kit/helpers/d-format-date";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -56,10 +57,24 @@ export default <template>
                 {{#if @controller.hasOverwrittenHistory}}
                   {{i18n "admin.customize.theme.has_overwritten_history"}}
                 {{else}}
-                  {{i18n
-                    "admin.customize.theme.commits_behind"
-                    count=@controller.model.remote_theme.commits_behind
-                  }}
+                  {{#if @controller.displayRemoteBranch}}
+                    <DInterpolatedTranslation
+                      @key="admin.customize.theme.commits_behind_branch"
+                      @options={{hash
+                        count=@controller.model.remote_theme.commits_behind
+                      }}
+                      as |Placeholder|
+                    >
+                      <Placeholder @name="branch">
+                        <code>{{@controller.displayRemoteBranch}}</code>
+                      </Placeholder>
+                    </DInterpolatedTranslation>
+                  {{else}}
+                    {{i18n
+                      "admin.customize.theme.commits_behind"
+                      count=@controller.model.remote_theme.commits_behind
+                    }}
+                  {{/if}}
                 {{/if}}
                 {{#if @controller.model.remote_theme.github_diff_link}}
                   <a href={{@controller.model.remote_theme.github_diff_link}}>
@@ -68,7 +83,18 @@ export default <template>
                 {{/if}}
               {{else}}
                 {{#unless @controller.showRemoteError}}
-                  {{i18n "admin.customize.theme.up_to_date"}}
+                  {{#if @controller.displayRemoteBranch}}
+                    <DInterpolatedTranslation
+                      @key="admin.customize.theme.up_to_date_branch"
+                      as |Placeholder|
+                    >
+                      <Placeholder @name="branch">
+                        <code>{{@controller.displayRemoteBranch}}</code>
+                      </Placeholder>
+                    </DInterpolatedTranslation>
+                  {{else}}
+                    {{i18n "admin.customize.theme.up_to_date"}}
+                  {{/if}}
                   {{dFormatDate
                     @controller.model.remote_theme.updated_at
                     leaveAgo="true"

--- a/frontend/discourse/app/ui-kit/d-interpolated-translation.gjs
+++ b/frontend/discourse/app/ui-kit/d-interpolated-translation.gjs
@@ -59,6 +59,7 @@ export default class DInterpolatedTranslation extends Component {
     // Find all of the placeholders in the string we're looking at.
     const message = I18n.findTranslationWithFallback(this.args.key, {
       ...optionsArg,
+      needsPluralization: typeof optionsArg.count === "number",
     });
     const placeholderAppearance = I18n.findPlaceholders(message);
 

--- a/frontend/discourse/tests/acceptance/admin-customize-themes-show-test.gjs
+++ b/frontend/discourse/tests/acceptance/admin-customize-themes-show-test.gjs
@@ -75,6 +75,44 @@ acceptance("Admin - Customize - Themes - Show", function (needs) {
               },
             ],
           },
+          {
+            id: 42,
+            name: "Git theme",
+            created_at: "2025-06-11T23:50:31.187Z",
+            updated_at: "2025-06-12T03:09:26.162Z",
+            default: false,
+            component: false,
+            user_selectable: false,
+            auto_update: false,
+            remote_theme_id: 42,
+            settings: [],
+            supported: true,
+            enabled: true,
+            theme_fields: [],
+            system: false,
+            color_scheme: null,
+            user: {
+              id: -1,
+              username: "system",
+              name: "system",
+              avatar_template: "/images/discourse-logo-sketch-small.png",
+              title: null,
+            },
+            child_themes: [],
+            parent_themes: [],
+            remote_theme: {
+              id: 42,
+              remote_url: "https://github.com/example/theme.git",
+              remote_version: "def456",
+              local_version: "abc123",
+              commits_behind: 2,
+              branch: "main",
+              is_git: true,
+              local_compat_ref: "d-compat/2026.5",
+              remote_compat_ref: "d-compat/2026.5",
+            },
+            translations: [],
+          },
         ],
       });
     });
@@ -131,5 +169,19 @@ acceptance("Admin - Customize - Themes - Show", function (needs) {
         "theme:-1",
         "the theme id is exposed via outletArgs on the translation selector outlet"
       );
+  });
+
+  test("shows the compatibility-pinned ref for the pending update", async function (assert) {
+    await visit("/admin/customize/themes/42");
+
+    assert
+      .dom(".status-message")
+      .includesText(
+        "Theme is 2 commits behind d-compat/2026.5",
+        "the compat ref is interpolated into the commits-behind message"
+      );
+    assert
+      .dom(".status-message code")
+      .hasText("d-compat/2026.5", "the ref is rendered inside a code tag");
   });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-interpolated-translation-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-interpolated-translation-test.gjs
@@ -32,6 +32,10 @@ module("Integration | ui-kit | DInterpolatedTranslation", function (hooks) {
             "User %{user} commented on %{topic} at %{time}",
           mixed_placeholders:
             "Welcome %{username}! You have %{count} messages.",
+          pluralized_placeholders: {
+            one: "%{username} sent %{count} message.",
+            other: "%{username} sent %{count} messages.",
+          },
           repeated_placeholders: "Welcome %{username}! Hello %{username}!",
           user: {
             profile_possessive: "Profil de %{username}",
@@ -148,6 +152,25 @@ module("Integration | ui-kit | DInterpolatedTranslation", function (hooks) {
     );
 
     assert.dom().hasText("Welcome alice ! You have 5 messages.");
+    assert.dom("a[data-user-card='alice']").exists();
+  });
+
+  test("renders a pluralized translation with a component placeholder", async function (assert) {
+    await render(
+      <template>
+        <DInterpolatedTranslation
+          @key="pluralized_placeholders"
+          @options={{hash count=5}}
+          as |Placeholder|
+        >
+          <Placeholder @name="username">
+            <DUserLink @username="alice">alice</DUserLink>
+          </Placeholder>
+        </DInterpolatedTranslation>
+      </template>
+    );
+
+    assert.dom().hasText("alice sent 5 messages.");
     assert.dom("a[data-user-card='alice']").exists();
   });
 

--- a/lib/tasks/plugin.rake
+++ b/lib/tasks/plugin.rake
@@ -158,14 +158,14 @@ task "plugin:pull_compatible", :plugin do |t, args|
     end
   end
 
-  checkout_version = Discourse.find_compatible_git_resource(plugin_path)
+  checkout = Discourse.find_compatible_git_resource(plugin_path)
 
   # Checkout value of the version compat
-  if checkout_version
-    puts "checking out compatible #{plugin} version: #{checkout_version}"
+  if checkout
+    puts "checking out compatible #{plugin} version: #{checkout}"
     update_status =
       system(
-        "git -C '#{plugin_path}' cat-file -e #{checkout_version} || git -C '#{plugin_path}' fetch --depth 1 $(git -C '#{plugin_path}' rev-parse --symbolic-full-name @{upstream} | awk -F '/' '{print $3}') #{checkout_version}; git -C '#{plugin_path}' reset --hard #{checkout_version}",
+        "git -C '#{plugin_path}' cat-file -e #{checkout} || git -C '#{plugin_path}' fetch --depth 1 $(git -C '#{plugin_path}' rev-parse --symbolic-full-name @{upstream} | awk -F '/' '{print $3}') #{checkout}; git -C '#{plugin_path}' reset --hard #{checkout}",
       )
     abort("Unable to checkout a compatible plugin version") unless update_status
   else

--- a/lib/tasks/themes.rake
+++ b/lib/tasks/themes.rake
@@ -474,15 +474,15 @@ task "themes:pull_compatible_all" do |t|
       next unless File.directory?(theme_path + "/.git")
 
       theme_name = File.basename(theme_path)
-      checkout_version = Discourse.find_compatible_git_resource(theme_path)
+      checkout = Discourse.find_compatible_git_resource(theme_path)
 
       # Checkout value of the version compat
-      if checkout_version
-        puts "checking out compatible #{theme_name} version: #{checkout_version}"
+      if checkout
+        puts "checking out compatible #{theme_name} version: #{checkout}"
 
         update_status =
           system(
-            "git -C '#{theme_path}' cat-file -e #{checkout_version} || git -C '#{theme_path}' fetch --depth 1 $(git -C '#{theme_path}' rev-parse --symbolic-full-name @{upstream} | awk -F '/' '{print $3}') #{checkout_version}; git -C '#{theme_path}' reset --hard #{checkout_version}",
+            "git -C '#{theme_path}' cat-file -e #{checkout} || git -C '#{theme_path}' fetch --depth 1 $(git -C '#{theme_path}' rev-parse --symbolic-full-name @{upstream} | awk -F '/' '{print $3}') #{checkout}; git -C '#{theme_path}' reset --hard #{checkout}",
           )
 
         abort("Unable to checkout a compatible theme version") unless update_status

--- a/lib/theme_store/git_importer.rb
+++ b/lib/theme_store/git_importer.rb
@@ -3,7 +3,7 @@
 class ThemeStore::GitImporter < ThemeStore::BaseImporter
   COMMAND_TIMEOUT_SECONDS = 20
 
-  attr_reader :url
+  attr_reader :url, :compatibility_resolved_ref
 
   def initialize(url, private_key: nil, branch: nil)
     @url = GitUrl.normalize(url)
@@ -13,25 +13,7 @@ class ThemeStore::GitImporter < ThemeStore::BaseImporter
 
   def import!
     clone!
-
-    if version = Discourse.find_compatible_git_resource(temp_folder)
-      begin
-        execute "git", "cat-file", "-e", version
-      rescue RuntimeError
-        tracking_ref =
-          execute "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
-        remote_name = tracking_ref.split("/", 2)[0]
-        execute "git", "fetch", remote_name, "#{version}:#{version}"
-      end
-
-      begin
-        execute "git", "reset", "--hard", version
-      rescue RuntimeError
-        raise RemoteTheme::ImportError.new(
-                I18n.t("themes.import_error.git_ref_not_found", ref: version),
-              )
-      end
-    end
+    checkout_compatible_version!
   end
 
   def commits_since(hash)
@@ -53,6 +35,29 @@ class ThemeStore::GitImporter < ThemeStore::BaseImporter
   end
 
   protected
+
+  def checkout_compatible_version!
+    return unless version = Discourse.find_compatible_git_resource(temp_folder)
+
+    @compatibility_resolved_ref = version.delete_prefix("origin/")
+
+    begin
+      execute "git", "cat-file", "-e", version
+    rescue RuntimeError
+      tracking_ref =
+        execute "git", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
+      remote_name = tracking_ref.split("/", 2)[0]
+      execute "git", "fetch", remote_name, "#{version}:#{version}"
+    end
+
+    begin
+      execute "git", "reset", "--hard", version
+    rescue RuntimeError
+      raise RemoteTheme::ImportError.new(
+              I18n.t("themes.import_error.git_ref_not_found", ref: version),
+            )
+    end
+  end
 
   def redirected_uri
     first_clone_uri = @uri.dup

--- a/lib/version_compatibility.rb
+++ b/lib/version_compatibility.rb
@@ -90,7 +90,9 @@ module Discourse
     compat_branch = "d-compat/#{Discourse::VERSION::MAJOR}.#{Discourse::VERSION::MINOR}"
     remote_branch_ref = "refs/remotes/origin/#{compat_branch}"
 
-    Discourse::Utils.execute_command("git", "-C", path, "rev-parse", remote_branch_ref).strip
+    # Verify the branch exists locally; return a ref that git can resolve.
+    Discourse::Utils.execute_command("git", "-C", path, "rev-parse", remote_branch_ref)
+    "origin/#{compat_branch}"
   rescue Discourse::Utils::CommandError
   end
 
@@ -98,8 +100,8 @@ module Discourse
   def self.find_compatible_git_resource(path)
     return unless File.directory?("#{path}/.git")
 
-    if compat_branch_sha = find_compatible_git_branch(path)
-      return compat_branch_sha
+    if compatible_branch = find_compatible_git_branch(path)
+      return compatible_branch
     end
 
     tree_info =

--- a/spec/lib/version_compatibility_spec.rb
+++ b/spec/lib/version_compatibility_spec.rb
@@ -172,10 +172,13 @@ RSpec.describe Discourse do
 
       after { FileUtils.remove_entry(git_directory) }
 
-      it "returns the branch commit and ignores .discourse-compatibility" do
-        compat_branch_sha = `cd #{git_directory} && git rev-parse #{compat_branch_name}`.strip
+      it "returns the d-compat branch ref and ignores .discourse-compatibility" do
+        resource = Discourse.find_compatible_git_resource(git_directory)
 
-        expect(Discourse.find_compatible_git_resource(git_directory)).to eq(compat_branch_sha)
+        expect(resource).to eq("origin/#{compat_branch_name}")
+        expect(`cd #{git_directory} && git rev-parse #{resource}`.strip).to eq(
+          `cd #{git_directory} && git rev-parse #{compat_branch_name}`.strip,
+        )
       end
     end
 

--- a/spec/models/remote_theme_spec.rb
+++ b/spec/models/remote_theme_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe RemoteTheme do
       JSON
     end
 
+    # Adds the version-specific d-compat branch, one commit ahead of the default branch.
+    def add_compat_branch(repo)
+      branch = "d-compat/#{Discourse::VERSION::MAJOR}.#{Discourse::VERSION::MINOR}"
+      system("git -C #{repo} checkout -q -b #{branch}", exception: true)
+      add_to_git_repo(repo, "compatible.txt" => "compatible version")
+      sha = `cd #{repo} && git rev-parse HEAD`.strip
+      system("git -C #{repo} checkout -q -", exception: true)
+      [branch, sha]
+    end
+
     let :scss_data do
       "@font-face { font-family: magic; src: url($font)}; body {color: $color; content: $name;}"
     end
@@ -184,6 +194,45 @@ RSpec.describe RemoteTheme do
       expect(
         theme.theme_fields.find_by(type_id: ThemeField.types[:scss], name: "file").value,
       ).to eq(".class1{color:red}")
+    end
+
+    it "leaves the compatibility refs nil when no compatibility pinning applies" do
+      theme = RemoteTheme.import_theme(initial_repo_url)
+      remote = theme.remote_theme
+
+      expect(remote.local_compat_ref).to be_nil
+      expect(remote.remote_compat_ref).to be_nil
+    end
+
+    it "records local_compat_ref and remote_compat_ref when pinned to a d-compat branch" do
+      compat_branch, compat_sha = add_compat_branch(initial_repo)
+
+      theme = RemoteTheme.import_theme(initial_repo_url)
+      remote = theme.remote_theme
+
+      expect(remote.local_compat_ref).to eq(compat_branch)
+      expect(remote.remote_compat_ref).to eq(compat_branch)
+      expect(remote.local_version).to eq(compat_sha)
+
+      serialized = RemoteThemeSerializer.new(remote, root: false).as_json
+      expect(serialized[:local_compat_ref]).to eq(compat_branch)
+      expect(serialized[:remote_compat_ref]).to eq(compat_branch)
+    end
+
+    it "updates remote_compat_ref without touching local_compat_ref when checking for updates" do
+      theme = RemoteTheme.import_theme(initial_repo_url)
+      remote = theme.remote_theme
+      expect(remote.local_compat_ref).to be_nil
+      expect(remote.remote_compat_ref).to be_nil
+
+      compat_branch, compat_sha = add_compat_branch(initial_repo)
+
+      remote.update_remote_version
+      remote.reload
+
+      expect(remote.local_compat_ref).to be_nil
+      expect(remote.remote_compat_ref).to eq(compat_branch)
+      expect(remote.remote_version).to eq(compat_sha)
     end
 
     it "can correctly import a remote theme" do

--- a/spec/support/mock_git_importer.rb
+++ b/spec/support/mock_git_importer.rb
@@ -52,5 +52,6 @@ class MockGitImporter < ThemeStore::GitImporter
     end
 
     Discourse::Utils.execute_command("git", "clone", path, @temp_folder)
+    checkout_compatible_version!
   end
 end


### PR DESCRIPTION
When a remote theme is installed or updated from a git repository, Discourse may check out a compatibility-pinned ref (a `d-compat/YYYY.MM` branch or a `.discourse-compatibility` entry) rather than the requested branch.

Previously this wasn't obvious in the UI. This commit surfaces the currently-running compatibility reference, and the compatibility reference of any pending update.

<img width="650" height="293" alt="image" src="https://github.com/user-attachments/assets/11137fbd-e6e3-4786-8234-5799965d05c6" />
