### PR TITLE
UX: fix small screen reply count padding

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -338,7 +338,10 @@
       font-weight: 700;
       color: inherit;
       display: inline-block;
-      padding: 15px 5px;
+
+      @include viewport.from(sm) {
+        padding: 15px 5px;
+      }
     }
   }
 

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -340,7 +340,7 @@
       display: inline-block;
 
       @include viewport.from(sm) {
-        padding: 15px 5px;
+        padding: var(--space-3)  var(--space);
       }
     }
   }

--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -340,7 +340,7 @@
       display: inline-block;
 
       @include viewport.from(sm) {
-        padding: var(--space-3)  var(--space);
+        padding: var(--space-3) var(--space);
       }
     }
   }


### PR DESCRIPTION
Fixes an issue where the counts have too much padding in the topic list on mobile devices

Before:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/4986d649-a562-432d-8e7e-717f4c169799" />


After:
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/06325a40-d33e-46e1-82ba-3da629176aa5" />
