### PR TITLE
DEV: Refactor nested topic model caching to be cleaner

### DIFF
--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -159,7 +159,7 @@ export default class Nested extends Component {
   }
 
   get rootScrollAnchor() {
-    return this.mobileReturnAnchor || this.args.scrollAnchor;
+    return this.args.scrollAnchor || this.mobileReturnAnchor;
   }
 
   get focusedNode() {
@@ -199,6 +199,7 @@ export default class Nested extends Component {
         returnAnchor ||
         this.findScrollAnchor() ||
         this.scrollAnchorForPath(path);
+      this.args.setFocusedPostNumber?.(null, path);
       this.args.saveScrollPosition?.(this.mobileReturnAnchor);
     }
 

--- a/frontend/discourse/app/components/nested/post-children.gjs
+++ b/frontend/discourse/app/components/nested/post-children.gjs
@@ -58,6 +58,7 @@ export default class NestedPostChildren extends Component {
         ? this.args.totalDescendantCount || this.args.directReplyCount || 0
         : this.args.directReplyCount || 0;
       this.hasMore = expectedCount > this.args.preloadedChildren.length;
+      this._reportToCache();
     } else if (this.args.directReplyCount > 0) {
       this.loadChildren();
     }

--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -8,12 +8,7 @@ import NestedActivityLog from "discourse/components/modal/nested-activity-log";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
-import {
-  NESTED_VIEW_CACHE_FORMAT_VERSION,
-  snapshotExpansionState,
-  snapshotFetchedChildrenCache,
-  snapshotNestedModelData,
-} from "discourse/lib/nested-view-cache-snapshot";
+import { buildNestedViewCacheEntry } from "discourse/lib/nested-view-cache-snapshot";
 import { headerOffset } from "discourse/lib/offset-calculator";
 import QuoteState from "discourse/lib/quote-state";
 import Composer from "discourse/models/composer";
@@ -324,8 +319,8 @@ export default class NestedController extends Controller {
   }
 
   @action
-  saveScrollPosition(scrollAnchor) {
-    this.saveToCache(scrollAnchor);
+  saveScrollPosition(scrollAnchor, focusedPath = this.initialFocusedPath) {
+    this.saveToCache(scrollAnchor, { focusedPath });
   }
 
   @action
@@ -333,7 +328,7 @@ export default class NestedController extends Controller {
     this.scrollAnchor = null;
   }
 
-  saveToCache(scrollAnchor) {
+  saveToCache(scrollAnchor, { focusedPath = this.initialFocusedPath } = {}) {
     if (!this.topic) {
       return;
     }
@@ -356,7 +351,7 @@ export default class NestedController extends Controller {
       postNumber: this.postNumber,
       contextMode: this.contextMode,
       contextChain: this.contextChain,
-      initialFocusedPath: this.initialFocusedPath,
+      initialFocusedPath: focusedPath,
       targetPostNumber: this.targetPostNumber,
       contextNoAncestors: this.contextNoAncestors,
       ancestorsTruncated: this.ancestorsTruncated,
@@ -364,15 +359,14 @@ export default class NestedController extends Controller {
       newRootPostIds: this.newRootPostIds,
     };
 
-    this.nestedViewCache.save(cacheKey, {
-      formatVersion: NESTED_VIEW_CACHE_FORMAT_VERSION,
-      modelData: snapshotNestedModelData(modelData),
-      expansionState: snapshotExpansionState(this.expansionState),
-      fetchedChildrenCache: snapshotFetchedChildrenCache(
-        this.fetchedChildrenCache
-      ),
-      scrollAnchor,
-    });
+    this.nestedViewCache.save(
+      cacheKey,
+      buildNestedViewCacheEntry(modelData, {
+        expansionState: this.expansionState,
+        fetchedChildrenCache: this.fetchedChildrenCache,
+        scrollAnchor,
+      })
+    );
   }
 
   @action

--- a/frontend/discourse/app/lib/nested-view-cache-snapshot.js
+++ b/frontend/discourse/app/lib/nested-view-cache-snapshot.js
@@ -1,6 +1,145 @@
-import { enumerateTrackedEntries } from "discourse/lib/tracked-tools";
+export const NESTED_VIEW_CACHE_FORMAT_VERSION = 4;
 
-export const NESTED_VIEW_CACHE_FORMAT_VERSION = 2;
+const TOPIC_CACHE_FIELDS = [
+  "id",
+  "slug",
+  "title",
+  "fancy_title",
+  "archetype",
+  "category_id",
+  "tags",
+  "created_at",
+  "deleted_at",
+  "deleted_by",
+  "visible",
+  "closed",
+  "archived",
+  "pinned",
+  "pinned_globally",
+  "pinned_until",
+  "unpinned",
+  "unpinned_globally",
+  "views",
+  "posts_count",
+  "reply_count",
+  "highest_post_number",
+  "last_read_post_number",
+  "last_posted_at",
+  "bumped_at",
+  "chunk_size",
+  "bookmarks",
+  "draft",
+  "draft_key",
+  "draft_sequence",
+  "details",
+  "suggested_topics",
+  "related_topics",
+  "related_messages",
+  "suggested_group_name",
+];
+
+const TOPIC_DETAILS_CACHE_FIELDS = [
+  "id",
+  "allowed_groups",
+  "allowed_users",
+  "can_create_post",
+  "can_delete",
+  "can_edit",
+  "can_edit_staff_notes",
+  "can_permanently_delete",
+  "can_publish_page",
+  "can_split_merge_topic",
+  "created_by",
+  "loaded",
+  "notification_level",
+  "notifications_reason_id",
+  "participants",
+];
+
+const POST_CACHE_FIELDS = [
+  "id",
+  "post_number",
+  "topic_id",
+  "reply_to_post_number",
+  "reply_count",
+  "direct_reply_count",
+  "total_descendant_count",
+  "username",
+  "name",
+  "user_id",
+  "user_title",
+  "avatar_template",
+  "primary_group_name",
+  "trust_level",
+  "created_at",
+  "updated_at",
+  "version",
+  "cooked",
+  "cooked_hidden",
+  "excerpt",
+  "actions_summary",
+  "action_code",
+  "action_code_path",
+  "action_code_who",
+  "admin",
+  "badges_granted",
+  "bookmarked",
+  "can_delete",
+  "can_edit",
+  "can_permanently_delete",
+  "can_recover",
+  "can_see_hidden_post",
+  "can_view_edit_history",
+  "deleted_at",
+  "deleted_by",
+  "deleted_post_placeholder",
+  "ignored_post_placeholder",
+  "group_moderator",
+  "hidden",
+  "is_auto_generated",
+  "is_localized",
+  "language",
+  "last_wiki_edit",
+  "link_counts",
+  "localization_outdated",
+  "localized_oneboxes",
+  "locked",
+  "moderator",
+  "notice",
+  "notice_created_by_user",
+  "post_localizations",
+  "post_type",
+  "quoted",
+  "read",
+  "readers_count",
+  "reply_to_user",
+  "staff",
+  "staged",
+  "title_is_group",
+  "user_custom_fields",
+  "user_deleted",
+  "user_suspended",
+  "via_email",
+  "wiki",
+  "yours",
+];
+
+const ACTION_SUMMARY_CACHE_FIELDS = [
+  "id",
+  "count",
+  "hidden",
+  "can_act",
+  "acted",
+  "can_undo",
+  "can_defer_flags",
+];
+
+const SUGGESTED_TOPIC_KEYS = [
+  "suggested_topics",
+  "related_topics",
+  "related_messages",
+  "suggested_group_name",
+];
 
 const EXCLUDED_RECORD_KEYS = new Set([
   "__munge",
@@ -9,6 +148,8 @@ const EXCLUDED_RECORD_KEYS = new Set([
   "_details",
   "actionByName",
   "actionType",
+  "children",
+  "likeAction",
   "post",
   "post_stream",
   "postStream",
@@ -16,59 +157,58 @@ const EXCLUDED_RECORD_KEYS = new Set([
   "topic",
 ]);
 
-export function snapshotNestedModelData(modelData) {
+export function buildNestedViewCacheEntry(
+  modelData,
+  { expansionState, fetchedChildrenCache, scrollAnchor } = {}
+) {
   return {
-    topic: snapshotRecord(modelData.topic, { includeDetails: true }),
-    opPost: snapshotRecord(modelData.opPost),
-    rootNodes: snapshotNodes(modelData.rootNodes),
-    page: modelData.page,
-    hasMoreRoots: modelData.hasMoreRoots,
-    sort: modelData.sort,
-    messageBusLastId: modelData.messageBusLastId,
-    pinnedPostIds: snapshotValue(modelData.pinnedPostIds),
-    postNumber: modelData.postNumber,
-    contextMode: modelData.contextMode,
-    contextChain: snapshotNode(modelData.contextChain),
-    initialFocusedPath: snapshotNodes(modelData.initialFocusedPath),
-    targetPostNumber: modelData.targetPostNumber,
-    contextNoAncestors: modelData.contextNoAncestors,
-    ancestorsTruncated: modelData.ancestorsTruncated,
-    topAncestorPostNumber: modelData.topAncestorPostNumber,
-    newRootPostIds: snapshotValue(modelData.newRootPostIds),
+    formatVersion: NESTED_VIEW_CACHE_FORMAT_VERSION,
+    payload: snapshotNestedPayload(modelData),
+    uiState: {
+      expansionState: snapshotExpansionState(expansionState),
+      fetchedChildren: snapshotFetchedChildrenCache(fetchedChildrenCache),
+      focusedPath: snapshotNodesAsPayload(modelData.initialFocusedPath),
+      scrollAnchor: snapshotValue(scrollAnchor),
+    },
   };
 }
 
-export function hydrateNestedModelData(store, snapshot) {
-  const topicSnapshot = { ...snapshot.topic };
-  const topicDetails = topicSnapshot.details;
-  delete topicSnapshot.details;
-
-  const topic = createFreshRecord(store, "topic", topicSnapshot);
-  if (topicDetails) {
-    topic.details = topicDetails;
+export function restoreNestedViewCacheEntry(entry) {
+  if (!isValidNestedViewCacheEntry(entry)) {
+    return null;
   }
-  topic.set("is_nested_view", true);
-  setFreshPostStream(store, topic);
-  topic.details.set("topic", topic);
 
   return {
-    topic,
-    opPost: hydratePost(store, topic, snapshot.opPost),
-    rootNodes: hydrateNodes(store, topic, snapshot.rootNodes),
-    page: snapshot.page,
-    hasMoreRoots: snapshot.hasMoreRoots,
-    sort: snapshot.sort,
-    messageBusLastId: snapshot.messageBusLastId,
-    pinnedPostIds: snapshotValue(snapshot.pinnedPostIds) || [],
-    postNumber: snapshot.postNumber,
-    contextMode: snapshot.contextMode,
-    contextChain: hydrateNode(store, topic, snapshot.contextChain),
-    initialFocusedPath: hydrateNodes(store, topic, snapshot.initialFocusedPath),
-    targetPostNumber: snapshot.targetPostNumber,
-    contextNoAncestors: snapshot.contextNoAncestors,
-    ancestorsTruncated: snapshot.ancestorsTruncated,
-    topAncestorPostNumber: snapshot.topAncestorPostNumber,
-    newRootPostIds: snapshotValue(snapshot.newRootPostIds) || [],
+    payload: cloneCacheValue(entry.payload),
+    expansionState: restoreExpansionState(entry.uiState?.expansionState),
+    fetchedChildren: cloneCacheValue(entry.uiState?.fetchedChildren) || [],
+    focusedPath: cloneCacheValue(entry.uiState?.focusedPath) || [],
+    scrollAnchor: cloneCacheValue(entry.uiState?.scrollAnchor),
+  };
+}
+
+export function isValidNestedViewCacheEntry(entry) {
+  return Boolean(
+    entry?.formatVersion === NESTED_VIEW_CACHE_FORMAT_VERSION &&
+    isValidNestedPayload(entry.payload) &&
+    isValidMapSnapshot(entry.uiState?.expansionState) &&
+    isValidMapSnapshot(entry.uiState?.fetchedChildren) &&
+    isValidFocusedPathSnapshot(entry.uiState?.focusedPath)
+  );
+}
+
+export function snapshotNestedPayload(modelData) {
+  if (modelData.contextMode || modelData.postNumber) {
+    return {
+      contextMode: true,
+      sort: modelData.sort,
+      response: snapshotContextResponse(modelData),
+    };
+  }
+
+  return {
+    contextMode: false,
+    response: snapshotRootResponse(modelData),
   };
 }
 
@@ -78,7 +218,7 @@ export function snapshotExpansionState(expansionState) {
   );
 }
 
-export function hydrateExpansionState(snapshot) {
+export function restoreExpansionState(snapshot) {
   return new Map(
     (snapshot || []).map(([postNumber, state]) => [
       postNumber,
@@ -92,7 +232,7 @@ export function snapshotFetchedChildrenCache(fetchedChildrenCache) {
     ([postNumber, entry]) => [
       postNumber,
       {
-        childNodes: snapshotNodes(entry.childNodes),
+        children: snapshotNodesAsPayload(entry.childNodes),
         page: entry.page,
         hasMore: entry.hasMore,
         fetchedFromServer: entry.fetchedFromServer,
@@ -101,167 +241,200 @@ export function snapshotFetchedChildrenCache(fetchedChildrenCache) {
   );
 }
 
-export function hydrateFetchedChildrenCache(store, topic, snapshot) {
-  return new Map(
-    (snapshot || []).map(([postNumber, entry]) => [
-      postNumber,
-      {
-        childNodes: hydrateNodes(store, topic, entry.childNodes),
-        page: entry.page,
-        hasMore: entry.hasMore,
-        fetchedFromServer: entry.fetchedFromServer,
-      },
-    ])
-  );
-}
-
-function snapshotNodes(nodes) {
-  return nodes?.map((node) => snapshotNode(node)).filter(Boolean) || [];
-}
-
-function snapshotNode(node) {
-  if (!node) {
-    return null;
-  }
-
-  return {
-    post: snapshotRecord(node.post),
-    children: snapshotNodes(node.children),
-    _renderKey: node._renderKey,
+function snapshotRootResponse(modelData) {
+  const response = {
+    topic: snapshotTopic(modelData.topic),
+    op_post: snapshotPost(modelData.opPost),
+    roots: snapshotNodesAsPayload(modelData.rootNodes),
+    page: modelData.page,
+    has_more_roots: modelData.hasMoreRoots,
+    sort: modelData.sort,
+    message_bus_last_id: modelData.messageBusLastId,
+    pinned_post_ids: snapshotValue(modelData.pinnedPostIds) || [],
   };
+
+  copySuggestedTopicKeys(modelData.topic, response);
+  return response;
 }
 
-function hydrateNodes(store, topic, nodes) {
+function snapshotContextResponse(modelData) {
+  const response = {
+    topic: snapshotTopic(modelData.topic),
+    op_post: snapshotPost(modelData.opPost),
+    target_post: snapshotNodeAsPayload(findTargetNode(modelData)),
+    ancestor_chain: snapshotAncestorChain(modelData),
+    ancestors_truncated: modelData.ancestorsTruncated,
+    message_bus_last_id: modelData.messageBusLastId,
+  };
+
+  copySuggestedTopicKeys(modelData.topic, response);
+  return response;
+}
+
+function copySuggestedTopicKeys(topic, response) {
+  for (const key of SUGGESTED_TOPIC_KEYS) {
+    if (topic?.[key] !== undefined) {
+      response[key] = snapshotValue(topic[key]);
+    }
+  }
+}
+
+function findTargetNode(modelData) {
+  const targetPostNumber = modelData.targetPostNumber || modelData.postNumber;
+
   return (
-    nodes?.map((node) => hydrateNode(store, topic, node)).filter(Boolean) || []
+    findNodeByPostNumber(modelData.contextChain, targetPostNumber) ||
+    findNodeByPostNumber(modelData.initialFocusedPath, targetPostNumber) ||
+    findNodeByPostNumber(modelData.rootNodes?.[0], targetPostNumber) ||
+    modelData.contextChain ||
+    modelData.rootNodes?.[0]
   );
 }
 
-function hydrateNode(store, topic, node) {
-  if (!node) {
+function findNodeByPostNumber(nodeOrNodes, postNumber) {
+  if (!nodeOrNodes || postNumber == null) {
     return null;
   }
 
-  const post = hydratePost(store, topic, node.post);
-  return {
-    post,
-    children: hydrateNodes(store, topic, node.children),
-    _renderKey: node._renderKey || post?.id,
-  };
-}
-
-function hydratePost(store, topic, snapshot) {
-  if (!snapshot) {
-    return null;
-  }
-
-  const post = createFreshRecord(store, "post", snapshot);
-  post.topic = topic;
-  return registerFreshPostInTopicPostStream(topic, post);
-}
-
-function snapshotRecord(record, { includeDetails = false } = {}) {
-  if (!record) {
-    return null;
-  }
-
-  const snapshot = {};
-  const entries = [
-    ...Object.keys(record).map((key) => [key, record[key]]),
-    ...enumerateTrackedEntries(record),
-  ];
-
-  for (const [key, value] of entries) {
-    if (
-      EXCLUDED_RECORD_KEYS.has(key) ||
-      value === undefined ||
-      typeof value === "function"
-    ) {
-      continue;
+  const nodes = Array.isArray(nodeOrNodes) ? nodeOrNodes : [nodeOrNodes];
+  for (const node of nodes) {
+    if (node?.post?.post_number === postNumber) {
+      return node;
     }
 
-    snapshot[key] = snapshotValue(value);
+    const childMatch = findNodeByPostNumber(node?.children, postNumber);
+    if (childMatch) {
+      return childMatch;
+    }
   }
 
-  if (includeDetails) {
-    snapshot.details = snapshotRecord(record.details);
+  return null;
+}
+
+function snapshotAncestorChain(modelData) {
+  const targetPostNumber = modelData.targetPostNumber || modelData.postNumber;
+  return (modelData.initialFocusedPath || [])
+    .filter((node) => node?.post?.post_number !== targetPostNumber)
+    .map((node) => snapshotPost(node.post))
+    .filter(Boolean);
+}
+
+function isValidNestedPayload(payload) {
+  return Boolean(
+    payload &&
+    typeof payload === "object" &&
+    typeof payload.contextMode === "boolean" &&
+    isValidNestedResponsePayload(payload.response, payload.contextMode)
+  );
+}
+
+function isValidNestedResponsePayload(response, contextMode) {
+  if (!response?.topic || !isPlainCacheRecord(response.topic)) {
+    return false;
+  }
+
+  if (response.op_post && !isPlainCacheRecord(response.op_post)) {
+    return false;
+  }
+
+  if (contextMode) {
+    return Boolean(
+      isValidPayloadNode(response.target_post) &&
+      Array.isArray(response.ancestor_chain || []) &&
+      (response.ancestor_chain || []).every(isPlainCacheRecord)
+    );
+  }
+
+  return (
+    Array.isArray(response.roots) && response.roots.every(isValidPayloadNode)
+  );
+}
+
+function snapshotTopic(topic) {
+  const snapshot = snapshotRecord(topic, TOPIC_CACHE_FIELDS);
+
+  if (topic?.details) {
+    snapshot.details = snapshotRecord(
+      topic.details,
+      TOPIC_DETAILS_CACHE_FIELDS
+    );
   }
 
   return snapshot;
 }
 
-export function isValidNestedViewCacheSnapshot(snapshot) {
-  return Boolean(
-    snapshot?.topic &&
-    isPlainCacheRecord(snapshot.topic) &&
-    Array.isArray(snapshot.rootNodes) &&
-    snapshot.rootNodes.every(isValidSnapshotNode)
+function snapshotPost(post) {
+  const snapshot = snapshotRecord(post, POST_CACHE_FIELDS);
+
+  if (Array.isArray(post?.actions_summary)) {
+    snapshot.actions_summary = post.actions_summary.map((summary) =>
+      snapshotRecord(summary, ACTION_SUMMARY_CACHE_FIELDS)
+    );
+  }
+
+  return snapshot;
+}
+
+function snapshotNodesAsPayload(nodes) {
+  return (
+    nodes?.map((node) => snapshotNodeAsPayload(node)).filter(Boolean) || []
   );
 }
 
-function isValidSnapshotNode(node) {
-  return Boolean(
-    node &&
-    isPlainCacheRecord(node.post) &&
-    Array.isArray(node.children) &&
-    node.children.every(isValidSnapshotNode)
-  );
-}
-
-function isPlainCacheRecord(record) {
-  return Boolean(
-    record &&
-    typeof record === "object" &&
-    !record.store &&
-    !record.__type &&
-    typeof record.get !== "function"
-  );
-}
-
-function createFreshRecord(store, type, attrs) {
-  return store._build(type, { ...attrs });
-}
-
-function setFreshPostStream(store, topic) {
-  const postStream = createFreshRecord(store, "postStream", {
-    id: topic.id,
-    topic,
-  });
-
-  Object.defineProperty(topic, "postStream", {
-    configurable: true,
-    value: postStream,
-  });
-}
-
-function registerFreshPostInTopicPostStream(topic, post) {
-  const postStream = topic?.postStream;
-  if (!postStream) {
-    return post;
+function snapshotNodeAsPayload(node) {
+  if (!node) {
+    return null;
   }
 
-  const storedPost = postStream.storePost(post);
-  if (!storedPost) {
-    return storedPost;
+  return {
+    ...snapshotPost(node.post),
+    children: snapshotNodesAsPayload(node.children),
+    _renderKey: node._renderKey,
+  };
+}
+
+function snapshotRecord(record, fields) {
+  if (!record) {
+    return null;
   }
 
-  if (postStream.posts && !postStream.posts.includes(storedPost)) {
-    postStream.posts.push(storedPost);
+  const snapshot = {};
+  const keys = new Set([...Object.keys(record), ...fields]);
+
+  for (const key of keys) {
+    if (!shouldSnapshotRecordKey(record, key)) {
+      continue;
+    }
+
+    snapshot[key] = snapshotValue(record[key]);
   }
 
-  if (
-    postStream.stream &&
-    storedPost.id != null &&
-    !postStream.stream.includes(storedPost.id)
-  ) {
-    postStream.stream.push(storedPost.id);
+  return snapshot;
+}
+
+function shouldSnapshotRecordKey(record, key) {
+  if (EXCLUDED_RECORD_KEYS.has(key) || key.startsWith("__")) {
+    return false;
   }
 
-  return storedPost;
+  const value = record[key];
+  return value !== undefined && typeof value !== "function";
+}
+
+function cloneCacheValue(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return JSON.parse(JSON.stringify(value));
 }
 
 function snapshotValue(value, seen = new WeakSet()) {
-  if (value === null || value === undefined || typeof value !== "object") {
+  if (value === undefined || typeof value === "function") {
+    return undefined;
+  }
+
+  if (value === null || typeof value !== "object") {
     return value;
   }
 
@@ -275,28 +448,52 @@ function snapshotValue(value, seen = new WeakSet()) {
   seen.add(value);
 
   if (Array.isArray(value)) {
-    return value.map((item) => snapshotValue(item, seen));
-  }
-
-  if (value instanceof Map) {
-    return [...value.entries()].map(([key, item]) => [
-      key,
-      snapshotValue(item, seen),
-    ]);
+    return value
+      .map((item) => snapshotValue(item, seen))
+      .filter((item) => item !== undefined);
   }
 
   const snapshot = {};
-  for (const [key, item] of Object.entries(value)) {
-    if (
-      EXCLUDED_RECORD_KEYS.has(key) ||
-      typeof item === "function" ||
-      item === undefined
-    ) {
+  for (const key of Object.keys(value)) {
+    if (EXCLUDED_RECORD_KEYS.has(key) || key.startsWith("__")) {
       continue;
     }
 
-    snapshot[key] = snapshotValue(item, seen);
+    const item = snapshotValue(value[key], seen);
+    if (item !== undefined) {
+      snapshot[key] = item;
+    }
   }
-
   return snapshot;
+}
+
+function isValidPayloadNode(node) {
+  return Boolean(
+    node &&
+    isPlainCacheRecord(node) &&
+    Array.isArray(node.children) &&
+    node.children.every(isValidPayloadNode)
+  );
+}
+
+function isPlainCacheRecord(record) {
+  return Boolean(
+    record &&
+    typeof record === "object" &&
+    !Array.isArray(record) &&
+    !record.store &&
+    !record.__type &&
+    typeof record.get !== "function"
+  );
+}
+
+function isValidFocusedPathSnapshot(snapshot) {
+  return (
+    snapshot === undefined ||
+    (Array.isArray(snapshot) && snapshot.every(isValidPayloadNode))
+  );
+}
+
+function isValidMapSnapshot(snapshot) {
+  return snapshot === undefined || Array.isArray(snapshot);
 }

--- a/frontend/discourse/app/routes/nested.js
+++ b/frontend/discourse/app/routes/nested.js
@@ -6,20 +6,12 @@ import { isEmpty } from "@ember/utils";
 import MoveToTopicModal from "discourse/components/modal/move-to-topic";
 import { ajax } from "discourse/lib/ajax";
 import EmbedMode from "discourse/lib/embed-mode";
-import {
-  hydrateExpansionState,
-  hydrateFetchedChildrenCache,
-  hydrateNestedModelData,
-  isValidNestedViewCacheSnapshot,
-  NESTED_VIEW_CACHE_FORMAT_VERSION,
-} from "discourse/lib/nested-view-cache-snapshot";
+import { restoreNestedViewCacheEntry } from "discourse/lib/nested-view-cache-snapshot";
 import PreloadStore from "discourse/lib/preload-store";
 import topicTitleToken from "discourse/lib/topic-title-token";
 import Draft from "discourse/models/draft";
 import DiscourseRoute from "discourse/routes/discourse";
-import processNode, {
-  registerPostInTopicPostStream,
-} from "../lib/process-node";
+import { registerPostInTopicPostStream } from "../lib/process-node";
 
 export default class NestedRoute extends DiscourseRoute {
   @service composer;
@@ -66,7 +58,7 @@ export default class NestedRoute extends DiscourseRoute {
     ) {
       const cached = this.nestedViewCache.get(cacheKey);
       if (cached) {
-        const restored = this._hydrateCachedEntry(cached);
+        const restored = this._restoreCachedEntry(cached, params, sort);
         if (restored) {
           this._restoringFromCache = restored;
           return restored.modelData;
@@ -153,6 +145,11 @@ export default class NestedRoute extends DiscourseRoute {
       });
     }
 
+    if (Number.isFinite(restoringFromCache?.scrollAnchor?.scrollY)) {
+      const scrollY = restoringFromCache.scrollAnchor.scrollY;
+      schedule("afterRender", () => this._restoreScrollY(scrollY));
+    }
+
     if (!restoringFromCache && !model.contextMode) {
       // Nested opts out of the global scroll manager for cache restoration,
       // so fresh root-topic entries need their own top reset.
@@ -170,6 +167,16 @@ export default class NestedRoute extends DiscourseRoute {
     controller.unsubscribe();
     this.screenTrack.stop();
     controller.topic = null;
+  }
+
+  _restoreScrollY(scrollY, attempt = 0) {
+    window.scrollTo(0, scrollY);
+
+    if (Math.abs(window.scrollY - scrollY) <= 250 || attempt >= 20) {
+      return;
+    }
+
+    requestAnimationFrame(() => this._restoreScrollY(scrollY, attempt + 1));
   }
 
   @action
@@ -257,37 +264,216 @@ export default class NestedRoute extends DiscourseRoute {
     return best;
   }
 
-  _hydrateCachedEntry(cached) {
-    if (
-      cached.formatVersion !== NESTED_VIEW_CACHE_FORMAT_VERSION ||
-      !isValidNestedViewCacheSnapshot(cached.modelData)
-    ) {
+  _restoreCachedEntry(cached, params, sort) {
+    const restored = restoreNestedViewCacheEntry(cached);
+    if (!restored) {
       return null;
     }
 
-    const modelData = hydrateNestedModelData(this.store, cached.modelData);
+    let payload = restored.payload;
+    if (!payload.contextMode && restored.focusedPath?.length) {
+      payload = {
+        ...payload,
+        response: this._mergeFocusedPathIntoRootResponse(
+          payload.response,
+          restored.focusedPath
+        ),
+      };
+    }
+
+    const modelData = payload.contextMode
+      ? this._processContextResponse(
+          payload.response,
+          params,
+          payload.sort || sort,
+          { freshRecords: true }
+        )
+      : this._processResponse(payload.response, params, {
+          freshRecords: true,
+        });
+
+    const expansionState = restored.expansionState;
+    if (restored.scrollAnchor?.postNumber) {
+      this._expandPathToPost(
+        modelData.rootNodes,
+        restored.scrollAnchor.postNumber,
+        expansionState
+      );
+    }
 
     return {
       modelData,
-      expansionState: hydrateExpansionState(cached.expansionState),
-      fetchedChildrenCache: hydrateFetchedChildrenCache(
-        this.store,
+      expansionState,
+      fetchedChildrenCache: this._restoreFetchedChildrenCache(
         modelData.topic,
-        cached.fetchedChildrenCache
+        restored.fetchedChildren
       ),
-      scrollAnchor: cached.scrollAnchor,
+      scrollAnchor: restored.scrollAnchor,
     };
   }
 
-  _processResponse(data, params) {
+  _mergeFocusedPathIntoRootResponse(response, focusedPath) {
+    const [focusedRoot] = focusedPath || [];
+    if (!focusedRoot) {
+      return response;
+    }
+
+    return {
+      ...response,
+      roots: (response.roots || []).map((root) =>
+        root.post_number === focusedRoot.post_number
+          ? this._mergePayloadNode(root, focusedRoot)
+          : root
+      ),
+    };
+  }
+
+  _mergePayloadNode(baseNode, focusedNode) {
+    const focusedChildren = focusedNode.children || [];
+    const baseChildren = baseNode.children || [];
+
+    if (focusedChildren.length === 0) {
+      return { ...baseNode, children: baseChildren };
+    }
+
+    const childrenByPostNumber = new Map(
+      baseChildren.map((child) => [child.post_number, child])
+    );
+
+    return {
+      ...baseNode,
+      children: focusedChildren.map((focusedChild) =>
+        this._mergePayloadNode(
+          childrenByPostNumber.get(focusedChild.post_number) || focusedChild,
+          focusedChild
+        )
+      ),
+    };
+  }
+
+  _expandPathToPost(nodes, postNumber, expansionState) {
+    if (!postNumber || !expansionState) {
+      return false;
+    }
+
+    for (const node of nodes || []) {
+      if (node.post?.post_number === postNumber) {
+        return true;
+      }
+
+      if (this._expandPathToPost(node.children, postNumber, expansionState)) {
+        expansionState.set(node.post.post_number, {
+          expanded: true,
+          collapsed: false,
+        });
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  _restoreFetchedChildrenCache(topic, fetchedChildren) {
+    return new Map(
+      (fetchedChildren || []).map(([postNumber, entry]) => [
+        postNumber,
+        {
+          childNodes: (entry.children || []).map((child) =>
+            this._processNode(topic, child, { freshRecords: true })
+          ),
+          page: entry.page,
+          hasMore: entry.hasMore,
+          fetchedFromServer: entry.fetchedFromServer,
+        },
+      ])
+    );
+  }
+
+  _createTopic(topicData, { freshRecords = false } = {}) {
+    let topicAttrs = topicData;
+    let topicDetails;
+
+    if (freshRecords) {
+      topicAttrs = { ...topicData };
+      topicDetails = topicAttrs.details;
+      delete topicAttrs.details;
+    }
+
+    const topic = this._createRecord("topic", topicAttrs, { freshRecords });
+
+    if (topicDetails) {
+      topic.details = topicDetails;
+    }
+
+    topic.set("is_nested_view", true);
+
+    if (freshRecords) {
+      this._setFreshPostStream(topic);
+    }
+
+    return topic;
+  }
+
+  _createPost(topic, postData, { freshRecords = false } = {}) {
+    const post = this._createRecord("post", postData, { freshRecords });
+    post.topic = topic;
+    return post;
+  }
+
+  _processNode(topic, nodeData, { freshRecords = false } = {}) {
+    const createdPost = this._createRecord("post", nodeData, { freshRecords });
+    const post =
+      registerPostInTopicPostStream(topic, createdPost) || createdPost;
+
+    if (post.topic !== topic) {
+      post.topic = topic;
+    }
+
+    const children = (nodeData.children || []).map((child) =>
+      this._processNode(topic, child, { freshRecords })
+    );
+
+    return {
+      post,
+      children,
+      _renderKey: freshRecords
+        ? crypto.randomUUID()
+        : nodeData._renderKey || post.id,
+    };
+  }
+
+  _createRecord(type, attrs, { freshRecords = false } = {}) {
+    if (freshRecords) {
+      // Cache restoration represents a prior rendered route tree. Do not use
+      // Store#createRecord here: records with ids go through the public
+      // identity map and can pull stale topic/post state from the previous
+      // visit into the restored cache payload.
+      return this.store._build(type, { ...attrs });
+    }
+
+    return this.store.createRecord(type, attrs);
+  }
+
+  _setFreshPostStream(topic) {
+    const postStream = this.store._build("postStream", {
+      id: topic.id,
+      topic,
+    });
+
+    Object.defineProperty(topic, "postStream", {
+      configurable: true,
+      value: postStream,
+    });
+  }
+
+  _processResponse(data, params, { freshRecords = false } = {}) {
     // Match Topic.find: seed the site category store from the topic
     // payload so lazy_load_categories installs can resolve category
     // badges on the topic itself and on piggybacked suggested/related
     // rows that only carry category_id.
     data.topic?.categories?.forEach((c) => this.site.updateCategory(c));
 
-    const topic = this.store.createRecord("topic", data.topic);
-    topic.set("is_nested_view", true);
+    const topic = this._createTopic(data.topic, { freshRecords });
 
     // Suggested/related are piggybacked at top-level on whichever
     // response has has_more_roots=false — here, a short topic that
@@ -303,16 +489,13 @@ export default class NestedRoute extends DiscourseRoute {
       }
     }
 
-    const assignTopic = (postData) => {
-      const post = this.store.createRecord("post", postData);
-      post.topic = topic;
-      return post;
-    };
+    const assignTopic = (postData) =>
+      this._createPost(topic, postData, { freshRecords });
 
     const opPost = data.op_post ? assignTopic(data.op_post) : null;
 
     const rootNodes = (data.roots || []).map((root) =>
-      processNode(this.store, topic, root)
+      this._processNode(topic, root, { freshRecords })
     );
 
     return {
@@ -337,11 +520,10 @@ export default class NestedRoute extends DiscourseRoute {
     };
   }
 
-  _processContextResponse(data, params, sort) {
+  _processContextResponse(data, params, sort, { freshRecords = false } = {}) {
     data.topic?.categories?.forEach((c) => this.site.updateCategory(c));
 
-    const topic = this.store.createRecord("topic", data.topic);
-    topic.set("is_nested_view", true);
+    const topic = this._createTopic(data.topic, { freshRecords });
 
     for (const key of [
       "suggested_topics",
@@ -354,15 +536,14 @@ export default class NestedRoute extends DiscourseRoute {
       }
     }
 
-    const assignTopic = (postData) => {
-      const post = this.store.createRecord("post", postData);
-      post.topic = topic;
-      return post;
-    };
+    const assignTopic = (postData) =>
+      this._createPost(topic, postData, { freshRecords });
 
     const opPost = data.op_post ? assignTopic(data.op_post) : null;
 
-    const targetNode = processNode(this.store, topic, data.target_post);
+    const targetNode = this._processNode(topic, data.target_post, {
+      freshRecords,
+    });
     const ancestors = (data.ancestor_chain || []).map((a) => assignTopic(a));
     const targetReplyTo = targetNode.post.reply_to_post_number;
     const hasParentContext = targetReplyTo && targetReplyTo !== 1;

--- a/frontend/discourse/app/routes/nested.js
+++ b/frontend/discourse/app/routes/nested.js
@@ -31,6 +31,8 @@ export default class NestedRoute extends DiscourseRoute {
     collapseReplies: { refreshModel: false },
   };
 
+  _renderKeySequence = 0;
+
   buildRouteInfoMetadata() {
     return { scrollOnTransition: false };
   }
@@ -437,9 +439,14 @@ export default class NestedRoute extends DiscourseRoute {
       post,
       children,
       _renderKey: freshRecords
-        ? crypto.randomUUID()
+        ? this._freshRenderKey(post)
         : nodeData._renderKey || post.id,
     };
+  }
+
+  _freshRenderKey(post) {
+    this._renderKeySequence += 1;
+    return `fresh-${post.id || post.post_number}-${this._renderKeySequence}`;
   }
 
   _createRecord(type, attrs, { freshRecords = false } = {}) {
@@ -565,7 +572,7 @@ export default class NestedRoute extends DiscourseRoute {
     // @preloadedChildren only in its constructor, so without a fresh key the
     // inner cascade keeps rendering the previous target when two context
     // views share a chain root.
-    chainTip._renderKey = crypto.randomUUID();
+    chainTip._renderKey = this._freshRenderKey(targetNode.post);
 
     return {
       topic,

--- a/frontend/discourse/tests/unit/controllers/nested-test.js
+++ b/frontend/discourse/tests/unit/controllers/nested-test.js
@@ -322,24 +322,33 @@ module("Unit | Controller | nested", function (hooks) {
       "stores the current cache snapshot format"
     );
     assert.deepEqual(
-      cached.modelData.initialFocusedPath.map((node) => node.post.post_number),
-      [2],
-      "keeps enough focused-path data to restore the mobile drill-down URL"
+      cached.payload.response.target_post.post_number,
+      2,
+      "keeps enough target-post data to restore the mobile drill-down URL"
+    );
+    assert.deepEqual(
+      cached.payload.response.ancestor_chain,
+      [],
+      "stores focused-path ancestors separately from the target payload"
     );
     assert.notStrictEqual(
-      cached.modelData.initialFocusedPath[0].post,
+      cached.payload.response.target_post,
       focusedPost,
-      "stores a post snapshot instead of the live post record"
-    );
-    assert.notStrictEqual(
-      cached.modelData.topic,
-      topic,
-      "stores a topic snapshot instead of the live topic record"
+      "stores a post payload instead of the live post record"
     );
     assert.strictEqual(
-      cached.modelData.postNumber,
-      2,
-      "stores the post URL cache entry under the focused post number"
+      cached.payload.response.target_post.store,
+      undefined,
+      "does not persist Ember record internals"
+    );
+    assert.notStrictEqual(
+      cached.payload.response.topic,
+      topic,
+      "stores a topic payload instead of the live topic record"
+    );
+    assert.true(
+      cached.payload.contextMode,
+      "stores the cache entry as a context payload for focused URLs"
     );
   });
 });

--- a/frontend/discourse/tests/unit/routes/nested-test.js
+++ b/frontend/discourse/tests/unit/routes/nested-test.js
@@ -2,10 +2,7 @@ import EmberObject from "@ember/object";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
-import {
-  hydrateNestedModelData,
-  NESTED_VIEW_CACHE_FORMAT_VERSION,
-} from "discourse/lib/nested-view-cache-snapshot";
+import { NESTED_VIEW_CACHE_FORMAT_VERSION } from "discourse/lib/nested-view-cache-snapshot";
 import PreloadStore from "discourse/lib/preload-store";
 
 module("Unit | Route | nested", function (hooks) {
@@ -87,7 +84,7 @@ module("Unit | Route | nested", function (hooks) {
     const cachedEntry = { modelData: { topic: { id: 42 } } };
     sinon.stub(route.nestedViewCache, "get").returns(cachedEntry);
     sinon
-      .stub(route, "_hydrateCachedEntry")
+      .stub(route, "_restoreCachedEntry")
       .returns({ modelData: cachedModel });
 
     const model = await route.model(
@@ -117,7 +114,7 @@ module("Unit | Route | nested", function (hooks) {
     const cachedEntry = { modelData: { topic: { id: 42 } } };
     sinon.stub(route.nestedViewCache, "get").returns(cachedEntry);
     sinon
-      .stub(route, "_hydrateCachedEntry")
+      .stub(route, "_restoreCachedEntry")
       .returns({ modelData: cachedModel });
 
     const model = await route.model(
@@ -147,7 +144,7 @@ module("Unit | Route | nested", function (hooks) {
     const cachedEntry = { modelData: { topic: { id: 42 } } };
     sinon.stub(route.nestedViewCache, "get").returns(cachedEntry);
     sinon
-      .stub(route, "_hydrateCachedEntry")
+      .stub(route, "_restoreCachedEntry")
       .returns({ modelData: cachedModel });
 
     const model = await route.model(
@@ -165,56 +162,65 @@ module("Unit | Route | nested", function (hooks) {
     assert.strictEqual(model, cachedModel, "returns the cache service result");
   });
 
-  test("hydrates cached snapshots into fresh records", function (assert) {
+  test("restores cached payload entries through the route response processor", function (assert) {
     const route = this.owner.lookup("route:nested");
     const cached = {
       formatVersion: NESTED_VIEW_CACHE_FORMAT_VERSION,
-      modelData: {
-        topic: {
-          id: 42,
-          slug: "nested-topic",
-          title: "Nested topic",
-          details: { can_create_post: true },
-        },
-        opPost: { id: 1, post_number: 1, cooked: "<p>op</p>" },
-        rootNodes: [
-          {
-            post: { id: 2, post_number: 2, cooked: "<p>root</p>" },
-            children: [],
-            _renderKey: 2,
-          },
-        ],
-        page: 0,
-        hasMoreRoots: false,
-        sort: "top",
-        pinnedPostIds: [],
-        postNumber: null,
+      payload: {
         contextMode: false,
-        initialFocusedPath: [],
-        newRootPostIds: [],
-      },
-      expansionState: [[2, { expanded: false, collapsed: true }]],
-      fetchedChildrenCache: [
-        [
-          2,
-          {
-            childNodes: [
-              {
-                post: { id: 3, post_number: 3, cooked: "<p>child</p>" },
-                children: [],
-                _renderKey: 3,
-              },
-            ],
-            page: 0,
-            hasMore: false,
-            fetchedFromServer: true,
+        response: {
+          topic: {
+            id: 42,
+            slug: "nested-topic",
+            title: "Nested topic",
+            details: { can_create_post: true },
           },
+          op_post: { id: 1, post_number: 1, cooked: "<p>op</p>" },
+          roots: [
+            {
+              id: 2,
+              post_number: 2,
+              cooked: "<p>root</p>",
+              children: [],
+              _renderKey: 2,
+            },
+          ],
+          page: 0,
+          has_more_roots: false,
+          sort: "top",
+          pinned_post_ids: [],
+        },
+      },
+      uiState: {
+        expansionState: [[2, { expanded: false, collapsed: true }]],
+        fetchedChildren: [
+          [
+            2,
+            {
+              children: [
+                {
+                  id: 3,
+                  post_number: 3,
+                  cooked: "<p>child</p>",
+                  children: [],
+                  _renderKey: 3,
+                },
+              ],
+              page: 0,
+              hasMore: false,
+              fetchedFromServer: true,
+            },
+          ],
         ],
-      ],
-      scrollAnchor: { postNumber: 2, offsetFromTop: 40 },
+        scrollAnchor: { postNumber: 2, offsetFromTop: 40 },
+      },
     };
 
-    const restored = route._hydrateCachedEntry(cached);
+    const restored = route._restoreCachedEntry(
+      cached,
+      { topic_id: 42, slug: "nested-topic" },
+      "top"
+    );
     const restoredTopic = restored.modelData.topic;
     const restoredRootPost = restored.modelData.rootNodes[0].post;
     const restoredChildPost =
@@ -222,7 +228,7 @@ module("Unit | Route | nested", function (hooks) {
 
     assert.notStrictEqual(
       restoredTopic,
-      cached.modelData.topic,
+      cached.payload.response.topic,
       "creates a fresh topic record"
     );
     assert.true(restoredTopic.is_nested_view, "marks restored topic as nested");
@@ -243,42 +249,55 @@ module("Unit | Route | nested", function (hooks) {
     );
     assert.deepEqual(
       restored.scrollAnchor,
-      cached.scrollAnchor,
+      cached.uiState.scrollAnchor,
       "restores scroll anchor"
     );
   });
 
-  test("hydrates cached snapshots without reusing stale store records", function (assert) {
+  test("hydrates cached payloads without reusing stale store records", function (assert) {
     const route = this.owner.lookup("route:nested");
     const stalePost = route.store.createRecord("post", {
       id: 2,
       post_number: 2,
       deleted_post_placeholder: true,
     });
-    const snapshot = {
-      topic: {
-        id: 42,
-        slug: "nested-topic",
-        title: "Nested topic",
-        details: { can_create_post: true },
-      },
-      opPost: { id: 1, post_number: 1, cooked: "<p>op</p>" },
-      rootNodes: [
-        {
-          post: {
-            id: 2,
-            post_number: 2,
-            cooked: "<p>restored root</p>",
-            created_at: "2026-06-08T17:00:00.000Z",
+    const cached = {
+      formatVersion: NESTED_VIEW_CACHE_FORMAT_VERSION,
+      payload: {
+        contextMode: false,
+        response: {
+          topic: {
+            id: 42,
+            slug: "nested-topic",
+            title: "Nested topic",
+            details: { can_create_post: true },
           },
-          children: [],
-          _renderKey: 2,
+          op_post: { id: 1, post_number: 1, cooked: "<p>op</p>" },
+          roots: [
+            {
+              id: 2,
+              post_number: 2,
+              cooked: "<p>restored root</p>",
+              created_at: "2026-06-08T17:00:00.000Z",
+              children: [],
+              _renderKey: 2,
+            },
+          ],
+          page: 0,
+          has_more_roots: false,
+          sort: "top",
+          pinned_post_ids: [],
         },
-      ],
+      },
+      uiState: {},
     };
 
-    const restored = hydrateNestedModelData(route.store, snapshot);
-    const restoredPost = restored.rootNodes[0].post;
+    const restored = route._restoreCachedEntry(
+      cached,
+      { topic_id: 42, slug: "nested-topic" },
+      "top"
+    );
+    const restoredPost = restored.modelData.rootNodes[0].post;
 
     assert.notStrictEqual(
       restoredPost,
@@ -293,7 +312,7 @@ module("Unit | Route | nested", function (hooks) {
     assert.strictEqual(
       restoredPost.created_at,
       "2026-06-08T17:00:00.000Z",
-      "keeps the snapshot timestamp for relative date rendering"
+      "keeps the payload timestamp for relative date rendering"
     );
   });
 

--- a/frontend/discourse/tests/unit/routes/nested-test.js
+++ b/frontend/discourse/tests/unit/routes/nested-test.js
@@ -216,11 +216,31 @@ module("Unit | Route | nested", function (hooks) {
       },
     };
 
-    const restored = route._restoreCachedEntry(
-      cached,
-      { topic_id: 42, slug: "nested-topic" },
-      "top"
+    let restored;
+    const randomUUIDDescriptor = Object.getOwnPropertyDescriptor(
+      crypto,
+      "randomUUID"
     );
+
+    Object.defineProperty(crypto, "randomUUID", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      restored = route._restoreCachedEntry(
+        cached,
+        { topic_id: 42, slug: "nested-topic" },
+        "top"
+      );
+    } finally {
+      if (randomUUIDDescriptor) {
+        Object.defineProperty(crypto, "randomUUID", randomUUIDDescriptor);
+      } else {
+        delete crypto.randomUUID;
+      }
+    }
+
     const restoredTopic = restored.modelData.topic;
     const restoredRootPost = restored.modelData.rootNodes[0].post;
     const restoredChildPost =


### PR DESCRIPTION
Reworks the nested topic frontend cache to store a versioned raw DTO payload instead of live Ember model graphs.

This removes private store hydration (store._build) and tracked-entry snapshotting from the cache path, centralizes cache build/hydrate logic, and keeps route restoration behavior intact for fast back/forward nested navigation. Also makes cache saves avoid mutating caller-owned entries.

Tests updated for the new raw cache shape.