### PR TITLE
UX: fix alignment of topic list header tab

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -40,7 +40,8 @@
       .composer-actions-btn,
       .language-switcher-trigger,
       .d-multi-select-trigger__expand-btn,
-      .emoji-picker-trigger
+      .emoji-picker-trigger,
+      .topic-list-header-tab
     ) {
       padding-block: 0;
       height: var(--d-control-height);

--- a/app/assets/stylesheets/common/components/more-topics.scss
+++ b/app/assets/stylesheets/common/components/more-topics.scss
@@ -25,7 +25,6 @@
         padding: var(--d-topic-list-header-data-padding-y) 0.8em;
         border: none;
         border-radius: 0;
-        font-size: var(--d-topic-list-data-font-size);
         line-height: var(--line-height-medium);
 
         .d-icon {

--- a/frontend/discourse/app/components/topic-list/header/topic-cell.gjs
+++ b/frontend/discourse/app/components/topic-list/header/topic-cell.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { fn } from "@ember/helper";
 import { service } from "@ember/service";
 import DButton from "discourse/ui-kit/d-button";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import SortableColumn from "./sortable-column";
 
 export default class TopicCell extends Component {
@@ -22,7 +23,10 @@ export default class TopicCell extends Component {
                 @translatedLabel={{tab.name}}
                 @translatedTitle={{tab.name}}
                 @icon={{tab.icon}}
-                class={{if (this.moreTopicsTabs.isActiveTab tab) "active"}}
+                class={{dConcatClass
+                  "topic-list-header-tab"
+                  (if (this.moreTopicsTabs.isActiveTab tab) "active")
+                }}
                 tabindex={{if (this.moreTopicsTabs.isActiveTab tab) -1 0}}
               />
             </li>


### PR DESCRIPTION
Fixes the alignment and size of these tabs when the modernized foundation upcoming change is enabled 

Before:
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/c74d9b56-8d10-48fc-ac62-8a48966fe68b" />


After: 
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/438f43dd-bef8-4327-870a-d80f8354d00e" />


Alignment is still fine with the upcoming change disabled too 

<img width="800" alt="image" src="https://github.com/user-attachments/assets/154224f4-8092-4ae5-a2a1-da5bf8532a95" />
