### PR TITLE
UX: improve search context styles

### DIFF
--- a/app/assets/stylesheets/common/base/search-menu.scss
+++ b/app/assets/stylesheets/common/base/search-menu.scss
@@ -71,16 +71,6 @@
       }
     }
 
-    .btn.search-context {
-      margin-right: 0;
-      white-space: nowrap;
-      background-color: var(--primary-200);
-
-      &:hover {
-        background-color: var(--primary-medium);
-      }
-    }
-
     &:focus-within {
       @include default-focus;
     }
@@ -111,27 +101,6 @@
       top: unset;
       width: unset;
       border-radius: var(--d-border-radius);
-    }
-  }
-
-  .search-context {
-    white-space: nowrap;
-    background-color: var(--primary-200);
-
-    @include viewport.from(sm) {
-      margin-left: var(--space-1);
-      margin-right: 0;
-    }
-
-    @include viewport.until(sm) {
-      position: fixed;
-      top: calc(var(--header-offset) + var(--space-3));
-      left: var(--space-4);
-      padding: var(--space-1) var(--space-2);
-    }
-
-    &:hover {
-      background-color: var(--primary-medium);
     }
   }
 
@@ -417,6 +386,10 @@
       font-size: var(--font-0);
       margin-left: 2px;
     }
+  }
+
+  .search-context {
+    margin-left: var(--space-1);
   }
 }
 

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -114,4 +114,12 @@
     height: var(--d-control-height);
     padding-block: 0;
   }
+
+  .search-input {
+    .search-context {
+      height: calc(
+        var(--d-control-height) - var(--space-2)
+      ) !important; // overrides very specific btn selector at the top of this file
+    }
+  }
 }


### PR DESCRIPTION
We had some old unneeded styles in here, and this needed some adjustment to match button styles in the modernized foundation upcoming change


before
<img width="250" alt="image" src="https://github.com/user-attachments/assets/7ffe81bc-023a-4c1b-af37-e0c988b18483" />


after
<img width="500" alt="image" src="https://github.com/user-attachments/assets/482b7ffb-f6dd-4b1d-9d04-16f2a42f799a" />


still looks fine with modernized foundation disabled too 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b2d0416a-6121-4d0d-9657-8b7300b9ef3a" />
