### PR TITLE
DEV: encapsulate the tag info button's appearance

### DIFF
--- a/frontend/discourse/app/components/d-navigation.gjs
+++ b/frontend/discourse/app/components/d-navigation.gjs
@@ -156,9 +156,10 @@ export default class DNavigation extends Component {
     );
   }
 
-  @computed("tag", "tag.name", "additionalTags", "category")
+  @computed("toggleTagInfo", "tag", "tag.name", "additionalTags", "category")
   get showTagInfoButton() {
     return (
+      this.toggleTagInfo &&
       this.tag &&
       this.tag.name !== "none" &&
       !this.additionalTags &&


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/where-did-the-tag-info-button-go/402436/9

When the `Navigation` component gets reused in a different context, like in the [ActivityPub plugin](https://github.com/discourse/discourse-activity-pub) we need to check for `toggleTagInfo` which lives in the `discovery/list.js` controller — otherwise it's assumed that `toggleTagInfo` is present and the tag-info button appears and does not function. 

So in core nothing will change, but in customizations that reuse the `Navigation` component, authors will have to decide to explicitly show the button. 