### PR TITLE
DEV: Fix a chat upload spec flake

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -244,18 +244,18 @@ export default class ChatComposer extends Component {
 
     this.inProgressUploadsCount = inProgressUploadsCount || 0;
 
+    this.composer.textarea?.focus();
+    this.reportReplyingPresence();
+
+    // Only persist once uploads settle.
     if (
       typeof uploads !== "undefined" &&
-      inProgressUploadsCount !== "undefined" &&
       inProgressUploadsCount === 0 &&
       this.draft
     ) {
       this.draft.uploads = cloneJSON(uploads);
+      this.persistDraft();
     }
-
-    this.composer.textarea?.focus();
-    this.reportReplyingPresence();
-    this.persistDraft();
   }
 
   @action


### PR DESCRIPTION
…by skipping no-op draft updates (as the upload progresses) which matches the behavior of the regular composer.

(also removes a unnecessary `inProgressUploadsCount !== "undefined"` check)