### PR TITLE
FIX: Automatic promotion paths leave override-controlled settings stale until a refresh

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -738,6 +738,8 @@ module SiteSettingExtension
         name,
         upcoming_change_enabled: UpcomingChanges.enabled?(name),
       )
+    elsif name.to_sym == :promote_upcoming_changes_on_status
+      refresh!
     end
 
     return if current[name] == old_val
@@ -802,6 +804,8 @@ module SiteSettingExtension
 
     if UpcomingChanges.exists?(name)
       apply_upcoming_change_default_overrides_for!(name, upcoming_change_enabled: current[name])
+    elsif name.to_sym == :promote_upcoming_changes_on_status
+      refresh!
     end
 
     return if current[name] == old_val

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -2110,6 +2110,15 @@ RSpec.describe SiteSettingExtension do
       it "returns the YAML default" do
         expect(settings.suggested_topics_max_days_old).to eq(365)
       end
+
+      it "immediately applies the override default when the promotion status changes" do
+        expect(settings.suggested_topics_max_days_old).to eq(365)
+
+        settings.promote_upcoming_changes_on_status = :experimental
+
+        expect(settings.increase_suggested_topics_max_days_old_default).to eq(true)
+        expect(settings.suggested_topics_max_days_old).to eq(1000)
+      end
     end
 
     context "when the linked upcoming change is enabled via add_override!" do


### PR DESCRIPTION
## Summary

Applies patch from triage.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/893
- Original commit: 

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>