### PR TITLE
FIX: Remove `stepSize: 1` from admin chart y-axis ticks

### DIFF
--- a/frontend/discourse/admin/components/admin-report-chart.gjs
+++ b/frontend/discourse/admin/components/admin-report-chart.gjs
@@ -176,7 +176,6 @@ export default class AdminReportChart extends Component {
               sampleSize: 5,
               maxRotation: 25,
               minRotation: 0,
-              stepSize: 1,
               precision: 0,
             },
           },

--- a/frontend/discourse/admin/components/admin-report-stacked-chart.gjs
+++ b/frontend/discourse/admin/components/admin-report-stacked-chart.gjs
@@ -216,7 +216,6 @@ export default class AdminReportStackedChart extends Component {
               sampleSize: 5,
               maxRotation: 25,
               minRotation: 0,
-              stepSize: 1,
             },
           },
           x: {


### PR DESCRIPTION
Rendering the admin dashboard's Site Traffic chart and the `/admin/reports`
line charts logs multiple console warnings like:

    scales.y.ticks.stepSize: 1 would result generating up to 90501 ticks. Limiting to 1000.

Both charts set `stepSize: 1` on the y-axis, which places a tick at every
integer in the value range. This PR removes the option and relies on
[Chart.js's default nice numbers algorithm](https://www.chartjs.org/docs/latest/axes/cartesian/linear.html#step-size) instead.

### Before

<img width="1110" height="990" alt="Screenshot 2026-06-09 at 9 00 20 AM" src="https://github.com/user-attachments/assets/f82566c0-2b7d-4c31-a43b-39e1d1cfae03" />

<img width="624" height="131" alt="Screenshot 2026-06-09 at 9 02 03 AM" src="https://github.com/user-attachments/assets/beff12f5-c8fd-405d-8b5d-dee39787f0e1" />


### After

<img width="1094" height="1065" alt="Screenshot 2026-06-09 at 9 00 40 AM" src="https://github.com/user-attachments/assets/29aef37a-a9aa-4183-9331-0f05363742b4" />
