### PR TITLE
FIX: Use optionalRequire for chat imports in calendar livestream code

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/livestream/embeddable-chat-channel.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/livestream/embeddable-chat-channel.gjs
@@ -4,9 +4,10 @@ import { array } from "@ember/helper";
 import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import { bind } from "discourse/lib/decorators";
+import { optionalRequire } from "discourse/lib/utilities";
+import { and } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
-import ChatChannel from "discourse/plugins/chat/discourse/components/chat-channel";
 
 export default class EmbedableChatChannel extends Component {
   @service chatChannelsManager;
@@ -15,6 +16,13 @@ export default class EmbedableChatChannel extends Component {
   @service messageBus;
 
   @tracked activeChannel;
+
+  // Resolved at runtime rather than statically imported: cross-plugin static
+  // imports aren't resolvable in the compiled plugin bundle and break the whole
+  // bundle load.
+  chatChannelComponent = optionalRequire(
+    "discourse/plugins/chat/discourse/components/chat-channel"
+  );
 
   updateChannel = modifier(async () => {
     if (this.args.chatChannelId === this.activeChannel?.id) {
@@ -72,9 +80,9 @@ export default class EmbedableChatChannel extends Component {
         </div>
       {{/unless}}
       <div class="chat-drawer">
-        {{#if this.activeChannel}}
+        {{#if (and this.activeChannel this.chatChannelComponent)}}
           {{#each (array this.activeChannel) as |channel|}}
-            <ChatChannel @channel={{channel}} />
+            <this.chatChannelComponent @channel={{channel}} />
           {{/each}}
         {{/if}}
       </div>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -1,17 +1,21 @@
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import { service } from "@ember/service";
-import Chat from "discourse/plugins/chat/discourse/services/chat";
+import Service, { service } from "@ember/service";
 
 export const LIVESTREAM_TAG_NAME = "livestream";
 
-export default class EmbeddableChat extends Chat {
+export default class EmbeddableChat extends Service {
   @service siteSettings;
   @service router;
   @service currentUser;
   @service capabilities;
+  @service chat;
 
   @tracked isMobileChatVisible = false;
+
+  get userCanChat() {
+    return this.chat.userCanChat;
+  }
 
   canRenderChatChannel(topicController, mobileViewAllowed = false) {
     this.topicController = topicController;


### PR DESCRIPTION
The livestream code incorporated into discourse-calendar in 35520fffa55d2774c49da21888196f37157cc1af
statically imported chat plugin modules (`import Chat from "discourse/plugins/chat/..."` in
embeddable-chat.gjs and embeddable-chat-channel.gjs). Static cross-plugin ES
imports aren't resolvable in the compiled plugin bundle (the browser importmap
only carries core + the plugin's own modules), so they threw at module-eval
time and broke the entire discourse-calendar bundle load. In the plugins
frontend CI job this left the browser with no calendar tests to run, hanging
the step until it timed out.

Switch to the `optionalRequire` pattern already used elsewhere in this plugin,
which resolves cross-plugin modules at runtime via the AMD registry:

- `embeddable-chat.gjs` no longer `extends Chat`, it now includes `@service chat`
  and calls `this.chat.userCanChat`
- `embeddable-chat-channel.gjs` resolves `ChatChannel` via `optionalRequire` and
  guards its render.

This bug existed identically in the standalone discourse-livestream plugin but
never surfaced because livestream isn't in config/official_plugins.json, so core's
plugins frontend job never checked it out, and its standalone-plugin build
resolved the import via the AMD registry rather than the importmap. Bundling
the code into an official plugin removed both shields.
