### PR TITLE
FEATURE: Allow nested automation triggers up to a recursion limit

### DIFF
--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -148,22 +148,27 @@ module DiscourseAutomation
     end
 
     def trigger!(context = {})
-      if enabled
-        return if active_id = DiscourseAutomation.get_active_automation
+      return if !enabled
 
-        begin
-          DiscourseAutomation.set_active_automation(id)
-          if scriptable.background && !running_in_background
-            trigger_in_background!(context)
-          else
-            Stat.log(id) do
-              triggerable&.on_call&.call(self, serialized_fields)
-              scriptable.script.call(context, serialized_fields, self)
-            end
-          end
-        ensure
-          DiscourseAutomation.set_active_automation(nil)
+      if DiscourseAutomation.recursion_depth >= DiscourseAutomation::MAX_RECURSION_DEPTH
+        Stat.log(id) do
+          raise DiscourseAutomation::RecursionLimitExceeded,
+                "Automation recursion limit exceeded (max: #{DiscourseAutomation::MAX_RECURSION_DEPTH})"
         end
+      end
+
+      begin
+        DiscourseAutomation.increment_recursion_depth
+        if scriptable.background && !running_in_background
+          trigger_in_background!(context)
+        else
+          Stat.log(id) do
+            triggerable&.on_call&.call(self, serialized_fields)
+            scriptable.script.call(context, serialized_fields, self)
+          end
+        end
+      ensure
+        DiscourseAutomation.decrement_recursion_depth
       end
     end
 

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -149,6 +149,7 @@ module DiscourseAutomation
 
     def trigger!(context = {})
       return if !enabled
+      return if DiscourseAutomation.triggers_suppressed?
 
       if DiscourseAutomation.recursion_depth >= DiscourseAutomation::MAX_RECURSION_DEPTH
         Stat.log(id) do

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -31,12 +31,23 @@ module ::DiscourseAutomation
   USER_GROUP_MEMBERSHIP_THROUGH_BADGE_BULK_MODIFY_START_COUNT = 1000
   REMOVE_UPLOAD_MARKUP_FROM_DELETED_POSTS_BATCH_SIZE = 1000
 
-  def self.set_active_automation(id)
-    Thread.current[:active_automation_id] = id
+  MAX_RECURSION_DEPTH = 5
+  RECURSION_DEPTH_KEY = :discourse_automation_recursion_depth
+
+  class RecursionLimitExceeded < StandardError
   end
 
-  def self.get_active_automation
-    Thread.current[:active_automation_id]
+  def self.recursion_depth
+    Thread.current[RECURSION_DEPTH_KEY] || 0
+  end
+
+  def self.increment_recursion_depth
+    Thread.current[RECURSION_DEPTH_KEY] = recursion_depth + 1
+  end
+
+  def self.decrement_recursion_depth
+    new_depth = recursion_depth - 1
+    Thread.current[RECURSION_DEPTH_KEY] = new_depth.positive? ? new_depth : nil
   end
 end
 

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -33,8 +33,32 @@ module ::DiscourseAutomation
 
   MAX_RECURSION_DEPTH = 5
   RECURSION_DEPTH_KEY = :discourse_automation_recursion_depth
+  SUPPRESSED_TRIGGERS_KEY = :discourse_automation_suppressed_triggers
 
   class RecursionLimitExceeded < StandardError
+  end
+
+  def self.set_active_automation(_id)
+    deprecated_active_automation_api
+  end
+
+  def self.get_active_automation
+    deprecated_active_automation_api
+  end
+
+  def self.suppress_triggers
+    raise StandardError, "Expecting a block" if !block_given?
+
+    Thread.current[SUPPRESSED_TRIGGERS_KEY] = suppressed_triggers_count + 1
+    begin
+      yield
+    ensure
+      decrement_suppressed_triggers_count
+    end
+  end
+
+  def self.triggers_suppressed?
+    suppressed_triggers_count.positive?
   end
 
   def self.recursion_depth
@@ -49,6 +73,28 @@ module ::DiscourseAutomation
     new_depth = recursion_depth - 1
     Thread.current[RECURSION_DEPTH_KEY] = new_depth.positive? ? new_depth : nil
   end
+
+  def self.suppressed_triggers_count
+    Thread.current[SUPPRESSED_TRIGGERS_KEY] || 0
+  end
+
+  def self.decrement_suppressed_triggers_count
+    new_count = suppressed_triggers_count - 1
+    Thread.current[SUPPRESSED_TRIGGERS_KEY] = new_count.positive? ? new_count : nil
+  end
+
+  def self.deprecated_active_automation_api
+    Discourse.deprecate(
+      "DiscourseAutomation.set_active_automation/get_active_automation are deprecated. " \
+        "Use DiscourseAutomation.suppress_triggers instead.",
+      since: "2026.6.0-latest",
+      drop_from: "2026.8.0-latest",
+      raise_error: true,
+    )
+  end
+  private_class_method :suppressed_triggers_count,
+                       :decrement_suppressed_triggers_count,
+                       :deprecated_active_automation_api
 end
 
 require_relative "lib/discourse_automation/engine"

--- a/plugins/automation/spec/integration/infinite_loop_protection_spec.rb
+++ b/plugins/automation/spec/integration/infinite_loop_protection_spec.rb
@@ -37,9 +37,15 @@ describe "Infinite loop protection" do
     )
   end
 
-  it "prevents infinite loop of 2 auto_responder automations triggering each other" do
+  it "stops the loop after allowing limited recursive replies" do
+    expected_post_count = 1 + (2 * DiscourseAutomation::MAX_RECURSION_DEPTH)
+
     expect do
       PostCreator.create!(Fabricate(:user), raw: "post", title: "topic", skip_validations: true)
-    end.to change { Post.count }.by(3)
+    end.to change { Post.count }.by(expected_post_count).and change {
+            DiscourseAutomation::Stat.where(automation_id: [automation_1.id, automation_2.id]).sum(
+              :total_errors,
+            )
+          }.by(2)
   end
 end

--- a/plugins/automation/spec/lib/triggerable_spec.rb
+++ b/plugins/automation/spec/lib/triggerable_spec.rb
@@ -16,6 +16,53 @@ describe DiscourseAutomation::Triggerable do
 
   fab!(:automation) { Fabricate(:automation, trigger: "foo") }
 
+  describe "deprecated active automation API" do
+    it "raises a deprecation error" do
+      expect { DiscourseAutomation.set_active_automation(10) }.to raise_error(
+        Discourse::Deprecation,
+        /suppress_triggers/,
+      )
+
+      expect { DiscourseAutomation.get_active_automation }.to raise_error(
+        Discourse::Deprecation,
+        /suppress_triggers/,
+      )
+    end
+  end
+
+  describe "trigger suppression thread safety" do
+    it "ensures suppressed triggers are thread-local" do
+      DiscourseAutomation.suppress_triggers do
+        thread = Thread.new { DiscourseAutomation.triggers_suppressed? }
+        thread.join
+        expect(thread.value).to eq(false)
+
+        expect(DiscourseAutomation.triggers_suppressed?).to eq(true)
+      end
+
+      expect(DiscourseAutomation.triggers_suppressed?).to eq(false)
+    end
+
+    it "clears suppressed triggers after errors" do
+      expect { DiscourseAutomation.suppress_triggers { raise "boom" } }.to raise_error("boom")
+
+      expect(DiscourseAutomation.triggers_suppressed?).to eq(false)
+    end
+
+    it "requires a block without changing existing suppression" do
+      DiscourseAutomation.suppress_triggers do
+        expect { DiscourseAutomation.suppress_triggers }.to raise_error(
+          StandardError,
+          "Expecting a block",
+        )
+
+        expect(DiscourseAutomation.triggers_suppressed?).to eq(true)
+      end
+
+      expect(DiscourseAutomation.triggers_suppressed?).to eq(false)
+    end
+  end
+
   describe "recursion depth thread safety" do
     after do
       while DiscourseAutomation.recursion_depth.positive?

--- a/plugins/automation/spec/lib/triggerable_spec.rb
+++ b/plugins/automation/spec/lib/triggerable_spec.rb
@@ -16,17 +16,21 @@ describe DiscourseAutomation::Triggerable do
 
   fab!(:automation) { Fabricate(:automation, trigger: "foo") }
 
-  describe "active automation thread safety" do
-    after { DiscourseAutomation.set_active_automation(nil) }
+  describe "recursion depth thread safety" do
+    after do
+      while DiscourseAutomation.recursion_depth.positive?
+        DiscourseAutomation.decrement_recursion_depth
+      end
+    end
 
-    it "ensurese thread safety when setting automation id" do
-      DiscourseAutomation.set_active_automation(10)
+    it "ensures thread safety when setting recursion depth" do
+      DiscourseAutomation.increment_recursion_depth
 
-      thread = Thread.new { DiscourseAutomation.get_active_automation }
+      thread = Thread.new { DiscourseAutomation.recursion_depth }
       thread.join
-      expect(thread.value).to eq(nil)
+      expect(thread.value).to eq(0)
 
-      expect(DiscourseAutomation.get_active_automation).to eq(10)
+      expect(DiscourseAutomation.recursion_depth).to eq(1)
     end
   end
 

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -21,6 +21,55 @@ describe DiscourseAutomation::Automation do
         expect(list).to eq(["Howdy!"])
       end
     end
+
+    context "when recursively triggered" do
+      before do
+        DiscourseAutomation::Scriptable.add("recursive_test_scriptable") do
+          script do |context, _, automation|
+            depth = context[:depth]
+
+            DiscourseAutomation::CapturedContext.add(depth)
+
+            if depth < context[:target_depth]
+              automation.trigger!(depth: depth + 1, target_depth: context[:target_depth])
+            end
+          end
+        end
+      end
+
+      after { DiscourseAutomation::Scriptable.remove("recursive_test_scriptable") }
+
+      it "runs nested triggers up to the maximum depth" do
+        automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
+
+        list = capture_contexts { automation.trigger!(depth: 1, target_depth: 5) }
+
+        expect(list).to eq([1, 2, 3, 4, 5])
+      end
+
+      it "raises when the maximum depth is exceeded" do
+        automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
+
+        expect {
+          capture_contexts { automation.trigger!(depth: 1, target_depth: 6) }
+        }.to raise_error(
+          DiscourseAutomation::RecursionLimitExceeded,
+          /Automation recursion limit exceeded/,
+        )
+      end
+
+      it "clears recursion depth after the limit error" do
+        automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
+
+        expect { automation.trigger!(depth: 1, target_depth: 6) }.to raise_error(
+          DiscourseAutomation::RecursionLimitExceeded,
+        )
+
+        list = capture_contexts { automation.trigger!(depth: 1, target_depth: 1) }
+
+        expect(list).to eq([1])
+      end
+    end
   end
 
   describe "when a script is meant to be triggered in the background" do

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -22,6 +22,19 @@ describe DiscourseAutomation::Automation do
       end
     end
 
+    context "when triggers are suppressed" do
+      it "doesn’t run the script" do
+        automation = Fabricate(:automation, enabled: true)
+
+        list =
+          capture_contexts do
+            DiscourseAutomation.suppress_triggers { automation.trigger!("Howdy!") }
+          end
+
+        expect(list).to eq([])
+      end
+    end
+
     context "when recursively triggered" do
       before do
         DiscourseAutomation::Scriptable.add("recursive_test_scriptable") do

--- a/plugins/discourse-ai/app/models/reviewable_ai_tool_action.rb
+++ b/plugins/discourse-ai/app/models/reviewable_ai_tool_action.rb
@@ -76,12 +76,10 @@ class ReviewableAiToolAction < Reviewable
 
     # Suppress automation re-triggers caused by the tool's side effects
     # (e.g. edit_tags → topic_tags_changed → automation fires again → loop).
-    # Setting an active automation makes trigger!() return early.
-    begin
-      DiscourseAutomation.set_active_automation(id) if defined?(DiscourseAutomation)
+    if defined?(DiscourseAutomation)
+      DiscourseAutomation.suppress_triggers { tool.invoke }
+    else
       tool.invoke
-    ensure
-      DiscourseAutomation.set_active_automation(nil) if defined?(DiscourseAutomation)
     end
 
     create_result(:success, :approved)


### PR DESCRIPTION
Previously a thread-local "active automation" guard meant that as soon
as one automation was running, any nested `trigger!` call was silently
skipped. This prevented automations from triggering other automations.

This replaces that guard with a per-thread recursion depth counter.
Nested triggers are now allowed up to `MAX_RECURSION_DEPTH` (5); going
beyond that raises `RecursionLimitExceeded` (recorded via `Stat.log`)
to guard against infinite recursion.
