### PR TITLE
DEV: Migrate discourse-livestream setting values to core calendar settings

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21912,6 +21912,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260609050938'),
 ('20260607161322'),
 ('20260604052235'),
 ('20260603115312'),

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -142,7 +142,6 @@ discourse_calendar:
   livestream_enabled:
     default: false
     client: true
-    hidden: true
   livestream_embeddable_chat_allowed_paths:
     type: list
     default: "/t"
@@ -151,9 +150,7 @@ discourse_calendar:
   livestream_enable_modal_chat_on_mobile:
     default: true
     client: true
-    hidden: true
   livestream_chat_allowed_groups:
     default: "11" # default group trust_level_1
     client: true
     type: group_list
-    hidden: true

--- a/plugins/discourse-calendar/db/migrate/20260609050938_copy_livestream_settings_to_calendar.rb
+++ b/plugins/discourse-calendar/db/migrate/20260609050938_copy_livestream_settings_to_calendar.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class CopyLivestreamSettingsToCalendar < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      SELECT 'livestream_embeddable_chat_allowed_paths', data_type, value, created_at, updated_at
+      FROM site_settings
+      WHERE name = 'discourse_livestream_embeddable_chat_allowed_paths'
+      ON CONFLICT (name) DO NOTHING
+    SQL
+
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      SELECT 'livestream_enable_modal_chat_on_mobile', data_type, value, created_at, updated_at
+      FROM site_settings
+      WHERE name = 'discourse_livestream_enable_modal_chat_on_mobile'
+      ON CONFLICT (name) DO NOTHING
+    SQL
+
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      SELECT 'livestream_chat_allowed_groups', data_type, value, created_at, updated_at
+      FROM site_settings
+      WHERE name = 'discourse_livestream_chat_allowed_groups'
+      ON CONFLICT (name) DO NOTHING
+    SQL
+
+    livestream_plugin_enabled =
+      DB.query_single(
+        "SELECT value FROM site_settings WHERE name = 'discourse_livestream_enabled' AND value = 't'",
+      )
+    return if livestream_plugin_enabled.blank?
+
+    execute <<~SQL
+      INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+      SELECT 'livestream_enabled', 5, 't', NOW(), NOW()
+      ON CONFLICT (name) DO NOTHING
+    SQL
+
+    execute <<~SQL
+      UPDATE site_settings SET value = 'f' WHERE name = 'discourse_livestream_enabled'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Copies the existing settings in the DB from the discourse-livestream
plugin to the core calendar plugin's livestream settings. Also reveals
the calendar livestream settings in the UI.
