### PR TITLE
FIX: allow custom email sender name via translation overrides

### DIFF
--- a/app/mailers/group_smtp_mailer.rb
+++ b/app/mailers/group_smtp_mailer.rb
@@ -49,7 +49,7 @@ class GroupSmtpMailer < ActionMailer::Base
       locale: SiteSetting.default_locale,
       delivery_method_options: delivery_options,
       from: from_group.smtp_from_address,
-      from_alias: group_name,
+      from_alias: I18n.t("email_from_group", group_name: group_name, site_name: Email.site_title),
       html_override: html_override(post),
       cc: cc_addresses,
       bcc: bcc_addresses,

--- a/app/mailers/user_notifications.rb
+++ b/app/mailers/user_notifications.rb
@@ -573,7 +573,7 @@ class UserNotifications < ActionMailer::Base
       title: topic_title,
       post: post,
       username: original_username,
-      from_alias: user_name,
+      from_alias: I18n.t("email_from", user_name: user_name, site_name: Email.site_title),
       allow_reply_by_email: allow_reply_by_email,
       use_site_subject: opts[:use_site_subject],
       add_re_to_subject: opts[:add_re_to_subject],

--- a/app/models/translation_override.rb
+++ b/app/models/translation_override.rb
@@ -38,6 +38,7 @@ class TranslationOverride < ActiveRecord::Base
     ],
     %w[system_messages.welcome_user] => %w[username name name_or_username],
     %w[js.welcome_banner.header] => %w[site_name],
+    %w[email_from] => %w[site_name],
   }
 
   include HasSanitizableFields

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4351,6 +4351,9 @@ en:
   subject_re: "Re: "
   subject_pm: "[PM] "
 
+  email_from: "%{user_name}"
+  email_from_group: "%{group_name}"
+
   user_notifications:
     previous_discussion: "Previous Replies"
     reached_limit:

--- a/spec/mailers/group_smtp_mailer_spec.rb
+++ b/spec/mailers/group_smtp_mailer_spec.rb
@@ -109,6 +109,18 @@ RSpec.describe GroupSmtpMailer do
     )
   end
 
+  it "lets admins add the site name to the sender name via the email_from_group override" do
+    TranslationOverride.upsert!(
+      SiteSetting.default_locale,
+      "email_from_group",
+      "%{group_name} via %{site_name}",
+    )
+
+    mail = GroupSmtpMailer.send_mail(group, user.email, Fabricate(:post))
+
+    expect(mail[:from].display_names).to eql(["Testers Group via #{Email.site_title}"])
+  end
+
   it "uses the login SMTP authentication method for office365" do
     group.update!(smtp_server: "smtp.office365.com")
     mail = GroupSmtpMailer.send_mail(group, user.email, Fabricate(:post))

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -541,6 +541,24 @@ RSpec.describe UserNotifications do
     let(:user) { Fabricate(:user) }
     let(:notification) { Fabricate(:replied_notification, user: user, post: response) }
 
+    it "lets admins add the site name to the sender name via the email_from override" do
+      TranslationOverride.upsert!(
+        SiteSetting.default_locale,
+        "email_from",
+        "%{user_name} via %{site_name}",
+      )
+
+      mail =
+        UserNotifications.user_replied(
+          user,
+          post: response,
+          notification_type: notification.notification_type,
+          notification_data_hash: notification.data_hash,
+        )
+
+      expect(mail[:from].display_names).to eql(["John Doe via #{Email.site_title}"])
+    end
+
     it "generates a correct email" do
       SiteSetting.default_email_in_reply_to = true
 


### PR DESCRIPTION
The translation key for email_from was mistakenly removed in #36974 as it was thought to be redundant since we were dropping the "via site name" text from notification emails. However we should still allow sites to override this.

This change restores the translation key for `email_from` and adds a new `email_from_group` to allow overriding these values.

Both keys also whitelist `site_name` for interpolation, despite omitting it from the default translation.