### PR TITLE
DEV: Ensure `activatedThemes` key is always available in tests

### DIFF
--- a/app/controllers/qunit_controller.rb
+++ b/app/controllers/qunit_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class QunitController < ApplicationController
-  # Same list maintained in discourse-test-load-dynamic-js.js
   ALWAYS_LOADED_PLUGINS = %w[discourse-local-dates]
 
   skip_before_action *%i[

--- a/app/helpers/qunit_helper.rb
+++ b/app/helpers/qunit_helper.rb
@@ -27,9 +27,14 @@ module QunitHelper
 
   def theme_settings_preload_data
     theme = Theme.find_by(id: request.env[:resolved_theme_id])
-    return {} if theme.blank?
 
-    activated_themes = { theme.id => { name: theme.name, settings: theme.cached_default_settings } }
+    activated_themes =
+      if theme
+        { theme.id => { name: theme.name, settings: theme.cached_default_settings } }
+      else
+        {}
+      end
+
     { "activatedThemes" => activated_themes.to_json }
   end
 


### PR DESCRIPTION
Otherwise we get an error in core/plugin qunit runs