### PR TITLE
DEV: Remove optionalRequire from data-explorer admin code

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/adapters/query.js
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/adapters/query.js
@@ -1,9 +1,3 @@
-import { optionalRequire } from "discourse/lib/utilities";
+import buildPluginAdapter from "discourse/admin/adapters/build-plugin";
 
-const buildPluginAdapter = optionalRequire(
-  "discourse/admin/adapters/build-plugin"
-);
-
-export default buildPluginAdapter
-  ? buildPluginAdapter("discourse-data-explorer").extend({})
-  : null; // Not logged in as admin, the adapter isn't needed
+export default buildPluginAdapter("discourse-data-explorer").extend({});


### PR DESCRIPTION
This code is now only loaded for admins, so we don't need the conditional