### PR TITLE
PERF: Pre-compress WASM assets

### DIFF
--- a/frontend/discourse/rolldown.config.mjs
+++ b/frontend/discourse/rolldown.config.mjs
@@ -99,12 +99,10 @@ export function buildConfig({ devMode } = {}) {
       sourcemap: true,
       cleanDir: !devMode,
       hashCharacters: "base36",
-      assetFileNames: (asset) => {
-        if (asset.names?.some((n) => n.endsWith(".wasm"))) {
-          return "assets/wasm/[name]-[hash].digested[extname]";
-        }
-        return "assets/js/[name]-[hash].digested[extname]";
-      },
+      // All assets (including .wasm) go in assets/js/ so that the
+      // assets:precompile br/gz compression and the assets/js/ -> assets/br//gz/
+      // S3 path renames in s3.rake apply to them too.
+      assetFileNames: "assets/js/[name]-[hash].digested[extname]",
       chunkFileNames: "assets/js/[name]-[hash].digested.js",
       entryFileNames: "assets/js/[name]-[hash].digested.js",
     },

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -112,15 +112,15 @@ def log_task_duration(task_description, &task)
 end
 
 task "assets:precompile:compress_js": "environment" do
-  puts "Compressing JavaScript files"
+  puts "Compressing JavaScript and WASM files"
 
   load_path = Rails.application.assets.load_path
 
-  log_task_duration("Done compressing all JS files") do
+  log_task_duration("Done compressing all JS and WASM files") do
     concurrent? do |proc|
       load_path
         .assets
-        .select { |asset| asset.logical_path.extname == ".js" }
+        .select { |asset| %w[.js .wasm].include?(asset.logical_path.extname) }
         .each do |asset|
           digested_path = asset.digested_path.to_s
 

--- a/script/assemble_ember_build.rb
+++ b/script/assemble_ember_build.rb
@@ -166,7 +166,10 @@ build_plugin_env = { "SKIP_DB_AND_REDIS" => "1" }
 system(build_plugin_env, "bin/rake", "assets:precompile:build_plugins", exception: true)
 
 if ARGV.include?("--compress")
-  files = [*Dir.glob("#{EMBER_APP_DIR}/dist/**/*.js"), *Dir.glob("app/assets/generated/**/*.js")]
+  files = [
+    *Dir.glob("#{EMBER_APP_DIR}/dist/**/*.{js,wasm}"),
+    *Dir.glob("app/assets/generated/**/*.{js,wasm}"),
+  ]
   Parallel.map(files, in_threads: 4) do |file|
     next if File.exist?("#{file}.gz") && File.exist?("#{file}.br")
 


### PR DESCRIPTION
Emit them to assets/js/ alongside JS so they flow through the existing br/gz compression, and the assets/js/ -> assets/br|gz/ S3 path renames in s3.rake.