### PR TITLE
DEV: runs manual executions in a job

### DIFF
--- a/plugins/discourse-workflows/app/jobs/regular/discourse_workflows/execute_manual_workflow.rb
+++ b/plugins/discourse-workflows/app/jobs/regular/discourse_workflows/execute_manual_workflow.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Jobs
+  module DiscourseWorkflows
+    class ExecuteManualWorkflow < ::Jobs::Base
+      def execute(args)
+        execution =
+          ::DiscourseWorkflows::Execution.includes(:execution_data, :workflow).find_by(
+            id: args[:execution_id],
+          )
+        return if !execution&.pending?
+
+        if !SiteSetting.discourse_workflows_enabled
+          execution.update!(status: :skipped, finished_at: Time.current)
+          return
+        end
+
+        execution = ::DiscourseWorkflows::Execution.claim_pending(execution)
+        return if execution.nil?
+
+        workflow_snapshot = workflow_snapshot_for(execution)
+        return if workflow_snapshot.nil?
+
+        user = User.find_by(id: args[:user_id])
+        options =
+          ::DiscourseWorkflows::Executor::ExecutionOptions.new(
+            user: user,
+            execution_mode: :manual,
+            workflow_snapshot: workflow_snapshot,
+            existing_execution: execution,
+          )
+
+        ::DiscourseWorkflows::Executor.new(
+          execution.workflow,
+          execution.trigger_node_id,
+          execution.trigger_data || {},
+          options,
+        ).run
+      end
+
+      private
+
+      def workflow_snapshot_for(execution)
+        workflow_data = execution.execution_data&.workflow_data
+        if workflow_data.blank?
+          execution.update!(
+            status: :error,
+            error: "Workflow snapshot missing",
+            finished_at: Time.current,
+          )
+          return
+        end
+
+        ::DiscourseWorkflows::WorkflowSnapshot.new(workflow_data)
+      end
+    end
+  end
+end

--- a/plugins/discourse-workflows/app/models/discourse_workflows/execution.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/execution.rb
@@ -26,6 +26,24 @@ module DiscourseWorkflows
     TERMINAL_STATUSES_FOR_PURGE = %i[success error rate_limited skipped].freeze
     PURGE_BATCH_SIZE = 5_000
 
+    def self.create_pending_manual!(workflow:, trigger_node_id:, trigger_data:)
+      transaction do
+        create!(
+          workflow: workflow,
+          workflow_version_id: workflow.version_id,
+          trigger_node_id: trigger_node_id,
+          trigger_data: trigger_data,
+          status: :pending,
+          execution_mode: :manual,
+        ).tap do |execution|
+          ExecutionData.create!(
+            execution: execution,
+            workflow_data: WorkflowSnapshot.from_workflow(workflow, published: false).to_h,
+          )
+        end
+      end
+    end
+
     def self.purge_old
       retention_days = SiteSetting.workflow_executions_retention_days
       return if retention_days <= 0
@@ -55,6 +73,22 @@ module DiscourseWorkflows
       return nil if affected.zero?
 
       execution.status = :running
+      execution.updated_at = now
+      execution
+    end
+
+    def self.claim_pending(execution)
+      now = Time.current
+      affected =
+        where(id: execution.id, status: :pending).update_all(
+          status: statuses[:running],
+          started_at: now,
+          updated_at: now,
+        )
+      return nil if affected.zero?
+
+      execution.status = :running
+      execution.started_at = now
       execution.updated_at = now
       execution
     end

--- a/plugins/discourse-workflows/app/models/discourse_workflows/execution_data.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/execution_data.rb
@@ -5,6 +5,11 @@ module DiscourseWorkflows
     self.table_name = "discourse_workflows_execution_data"
     self.primary_key = "execution_id"
 
+    attribute :data,
+              default: -> do
+                { "entries" => {}, "context" => {}, "node_contexts" => {}, "run_data" => {} }
+              end
+
     belongs_to :execution, class_name: "DiscourseWorkflows::Execution", foreign_key: "execution_id"
 
     def entries

--- a/plugins/discourse-workflows/app/services/discourse_workflows/workflow/manual_execute.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/workflow/manual_execute.rb
@@ -16,7 +16,7 @@ module DiscourseWorkflows
     policy :can_manage_workflows, class_name: Policy::CanManageWorkflows
     model :workflow
     model :trigger_node
-    model :execution, :run_workflow
+    model :execution, :enqueue_workflow
 
     private
 
@@ -28,20 +28,19 @@ module DiscourseWorkflows
       workflow.find_node(params.trigger_node_id)
     end
 
-    def run_workflow(workflow:, trigger_node:, params:, guardian:)
-      options =
-        DiscourseWorkflows::Executor::ExecutionOptions.new(
-          user: guardian.user,
-          execution_mode: :manual,
-          draft_execution: true,
+    def enqueue_workflow(workflow:, trigger_node:, params:, guardian:)
+      execution =
+        DiscourseWorkflows::Execution.create_pending_manual!(
+          workflow: workflow,
+          trigger_node_id: params.trigger_node_id,
+          trigger_data: trigger_data(workflow:, trigger_node:, params:, user: guardian.user),
         )
-
-      DiscourseWorkflows::Executor.new(
-        workflow,
-        params.trigger_node_id,
-        trigger_data(workflow:, trigger_node:, params:, user: guardian.user),
-        options,
-      ).run
+      Jobs.enqueue(
+        Jobs::DiscourseWorkflows::ExecuteManualWorkflow,
+        execution_id: execution.id,
+        user_id: guardian.user.id,
+      )
+      execution
     end
 
     def trigger_data(workflow:, trigger_node:, params:, user:)

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor.rb
@@ -90,6 +90,7 @@ module DiscourseWorkflows
         ExecutionOptions.new(
           user: user,
           execution_mode: execution.execution_mode.to_sym,
+          workflow_snapshot: snapshot,
           webhook_context: webhook_context,
         )
       new(workflow, trigger_node_id, execution.trigger_data, options).resume_from(
@@ -99,7 +100,8 @@ module DiscourseWorkflows
     end
 
     def run
-      unless @workflow.published? || @options.draft_execution || @options.workflow_version
+      unless @workflow.published? || @options.draft_execution || @options.workflow_version ||
+               @options.workflow_snapshot
         return @store.create_execution_with_status(:skipped)
       end
       return @store.create_rate_limited_execution unless rate_limiter.within_limits?
@@ -423,7 +425,12 @@ module DiscourseWorkflows
     def resolved_pin_data
       return {} unless @options.execution_mode == :manual
 
-      data = @workflow.respond_to?(:pin_data) ? @workflow.pin_data : nil
+      data =
+        if @options.workflow_snapshot
+          @options.workflow_snapshot.pin_data
+        elsif @workflow.respond_to?(:pin_data)
+          @workflow.pin_data
+        end
       return {} if data.blank?
 
       data.transform_keys(&:to_s)

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/execution_options.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/execution_options.rb
@@ -9,6 +9,7 @@ module DiscourseWorkflows
         :draft_execution,
         :workflow_version,
         :workflow_snapshot,
+        :existing_execution,
         :webhook_context,
       ) do
         def initialize(
@@ -17,6 +18,7 @@ module DiscourseWorkflows
           draft_execution: false,
           workflow_version: nil,
           workflow_snapshot: nil,
+          existing_execution: nil,
           webhook_context: nil
         )
           super

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/execution_store.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/execution_store.rb
@@ -76,23 +76,14 @@ module DiscourseWorkflows
           timeout_action: nil,
         )
         trigger_error_workflow(error, steps)
-        publish_execution_run_data(force: @options.draft_execution)
+        publish_execution_run_data(
+          force: @options.draft_execution || @options.workflow_snapshot.present?,
+        )
         execution
       end
 
       def create_execution_with_status(status, trigger_data: self.trigger_data)
-        now = Time.current
-
-        DiscourseWorkflows::Execution.create!(
-          workflow: workflow,
-          workflow_version_id: execution_workflow_version_id,
-          trigger_node_id: @trigger_node_id,
-          status: status,
-          trigger_data: trigger_data,
-          execution_mode: @options.execution_mode,
-          started_at: now,
-          finished_at: now,
-        )
+        persist_execution!(status: status, trigger_data: trigger_data, finished_at: Time.current)
       end
 
       def create_rate_limited_execution
@@ -124,15 +115,23 @@ module DiscourseWorkflows
       private
 
       def create_execution!
-        DiscourseWorkflows::Execution.create!(
-          workflow: workflow,
+        persist_execution!(status: :running, trigger_data: trigger_data)
+      end
+
+      def persist_execution!(status:, trigger_data:, finished_at: nil)
+        @execution = @options.existing_execution || DiscourseWorkflows::Execution.new
+        @execution_context.execution = @execution if @options.existing_execution
+        @execution.update!(
+          workflow_id: workflow.id,
           workflow_version_id: execution_workflow_version_id,
           trigger_node_id: @trigger_node_id,
-          status: :running,
+          status: status,
           trigger_data: trigger_data,
           execution_mode: @execution_mode,
-          started_at: Time.current,
+          started_at: @execution.started_at || Time.current,
+          finished_at: finished_at,
         )
+        @execution
       end
 
       def execution_workflow_version_id

--- a/plugins/discourse-workflows/lib/discourse_workflows/workflow_snapshot.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/workflow_snapshot.rb
@@ -47,11 +47,12 @@ module DiscourseWorkflows
         keyword_init: true,
       )
 
-    attr_reader :nodes, :connections, :workflow_name
+    attr_reader :nodes, :connections, :pin_data, :workflow_name
 
     def initialize(workflow_data)
       data = workflow_data.deep_stringify_keys
       @workflow_name = data["name"]
+      @pin_data = data["pinData"] || {}
       @nodes =
         data
           .fetch("nodes") { [] }
@@ -183,6 +184,7 @@ module DiscourseWorkflows
             workflow_nodes,
             connections,
           ),
+        "pinData" => pin_data,
       }.compact
     end
 
@@ -190,7 +192,12 @@ module DiscourseWorkflows
       nodes = published ? workflow.published_nodes : workflow.nodes
       connections = published ? workflow.published_connections : workflow.connections
       workflow_name = published ? workflow.active_version&.name : workflow.name
-      new("name" => workflow_name || workflow.name, "nodes" => nodes, "connections" => connections)
+      new(
+        "name" => workflow_name || workflow.name,
+        "nodes" => nodes,
+        "connections" => connections,
+        "pinData" => workflow.pin_data || {},
+      )
     end
 
     def self.from_version(workflow, version)

--- a/plugins/discourse-workflows/spec/fabricators/discourse_workflows_fabricator.rb
+++ b/plugins/discourse-workflows/spec/fabricators/discourse_workflows_fabricator.rb
@@ -51,7 +51,6 @@ end
 
 Fabricator(:discourse_workflows_execution_data, class_name: "DiscourseWorkflows::ExecutionData") do
   execution { Fabricate(:discourse_workflows_execution) }
-  data { { "entries" => {}, "context" => {}, "node_contexts" => {}, "run_data" => {} } }
   workflow_data { {} }
 end
 

--- a/plugins/discourse-workflows/spec/jobs/regular/discourse_workflows/execute_manual_workflow_spec.rb
+++ b/plugins/discourse-workflows/spec/jobs/regular/discourse_workflows/execute_manual_workflow_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::DiscourseWorkflows::ExecuteManualWorkflow do
+  fab!(:admin)
+
+  def pending_execution(workflow:, trigger_node_id: "trigger-1", trigger_data: {})
+    DiscourseWorkflows::Execution.create_pending_manual!(
+      workflow: workflow,
+      trigger_node_id: trigger_node_id,
+      trigger_data: trigger_data,
+    )
+  end
+
+  def execute_job(execution_id, user_id: admin.id)
+    described_class.new.execute(execution_id: execution_id, user_id: user_id)
+  end
+
+  it "claims and completes a pending execution without creating a duplicate" do
+    graph =
+      build_workflow_graph do |builder|
+        builder.node "trigger-1", "trigger:manual"
+        builder.node "log-1", "action:log"
+        builder.chain "trigger-1", "log-1"
+      end
+    workflow = Fabricate(:discourse_workflows_workflow, created_by: admin, **graph)
+    execution = pending_execution(workflow: workflow)
+
+    expect do execute_job(execution.id) end.not_to change { DiscourseWorkflows::Execution.count }
+
+    execution.reload
+    expect(execution.status).to eq("success")
+    expect(execution.started_at).to be_present
+    expect(execution.execution_data.steps_array.map { |step| step["node_id"] }).to contain_exactly(
+      "trigger-1",
+      "log-1",
+    )
+  end
+
+  it "skips the execution when the plugin is disabled" do
+    SiteSetting.discourse_workflows_enabled = false
+    workflow = Fabricate(:discourse_workflows_workflow, created_by: admin)
+    execution = pending_execution(workflow: workflow)
+
+    execute_job(execution.id)
+
+    execution.reload
+    expect(execution.status).to eq("skipped")
+    expect(execution.finished_at).to be_present
+  end
+
+  it "leaves a non-pending execution untouched" do
+    workflow = Fabricate(:discourse_workflows_workflow, created_by: admin)
+    execution = pending_execution(workflow: workflow)
+    execution.update!(status: :running)
+    before_updated_at = execution.updated_at
+
+    execute_job(execution.id)
+
+    execution.reload
+    expect(execution.status).to eq("running")
+    expect(execution.updated_at).to eq_time(before_updated_at)
+  end
+
+  it "no-ops when the execution is missing" do
+    expect { execute_job(-1) }.not_to change { DiscourseWorkflows::Execution.count }
+  end
+
+  it "runs the stored draft snapshot instead of the current or published workflow" do
+    published_graph = build_workflow_graph { |builder| builder.node "trigger-1", "trigger:manual" }
+    workflow =
+      Fabricate(
+        :discourse_workflows_workflow,
+        created_by: admin,
+        published: true,
+        **published_graph,
+      )
+    draft_graph =
+      build_workflow_graph do |builder|
+        builder.node "trigger-1", "trigger:manual"
+        builder.node "draft-log", "action:log"
+        builder.chain "trigger-1", "draft-log"
+      end
+    workflow.update!(nodes: draft_graph[:nodes], connections: draft_graph[:connections])
+    execution = pending_execution(workflow: workflow)
+    workflow.update!(nodes: published_graph[:nodes], connections: published_graph[:connections])
+
+    execute_job(execution.id)
+
+    expect(execution.reload.execution_data.steps_array.map { |step| step["node_id"] }).to include(
+      "draft-log",
+    )
+  end
+
+  it "records errors on the existing execution" do
+    graph = build_workflow_graph { |builder| builder.node "trigger-1", "trigger:manual" }
+    workflow = Fabricate(:discourse_workflows_workflow, created_by: admin, **graph)
+    execution = pending_execution(workflow: workflow, trigger_node_id: "missing-trigger")
+
+    expect do execute_job(execution.id) end.not_to change { DiscourseWorkflows::Execution.count }
+
+    expect(execution.reload).to have_attributes(status: "error", error: include("missing-trigger"))
+  end
+end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor_spec.rb
@@ -42,6 +42,45 @@ RSpec.describe DiscourseWorkflows::Executor do
         }.by(1)
       end
 
+      it "uses an existing execution record when provided" do
+        graph =
+          build_workflow_graph do |g|
+            g.node "trigger-1", "trigger:manual"
+            g.node "log-1", "action:log"
+            g.chain "trigger-1", "log-1"
+          end
+        workflow = Fabricate(:discourse_workflows_workflow, created_by: user, **graph)
+        snapshot = DiscourseWorkflows::WorkflowSnapshot.from_workflow(workflow, published: false)
+        existing_execution =
+          Fabricate(
+            :discourse_workflows_execution,
+            workflow: workflow,
+            status: :running,
+            execution_mode: :manual,
+            trigger_node_id: "trigger-1",
+          )
+        Fabricate(
+          :discourse_workflows_execution_data,
+          execution: existing_execution,
+          workflow_data: snapshot.to_h,
+        )
+        options =
+          described_class::ExecutionOptions.new(
+            execution_mode: :manual,
+            workflow_snapshot: snapshot,
+            existing_execution: existing_execution,
+          )
+
+        expect { described_class.new(workflow, "trigger-1", {}, options).run }.not_to change {
+          DiscourseWorkflows::Execution.count
+        }
+
+        expect(existing_execution.reload.status).to eq("success")
+        expect(
+          existing_execution.execution_data.steps_array.map { |step| step["node_id"] },
+        ).to include("log-1")
+      end
+
       it "stores context with item arrays in the execution" do
         execution = described_class.new(workflow, "trigger-1", trigger_data).run
 
@@ -65,6 +104,24 @@ RSpec.describe DiscourseWorkflows::Executor do
         execution = described_class.new(workflow, "trigger-1", trigger_data).run
 
         expect(execution.status).to eq("skipped")
+      end
+
+      it "updates an existing execution when skipped before start" do
+        unpublish_workflow!(workflow)
+        existing_execution =
+          Fabricate(
+            :discourse_workflows_execution,
+            workflow: workflow,
+            status: :running,
+            trigger_node_id: "trigger-1",
+          )
+        options = described_class::ExecutionOptions.new(existing_execution: existing_execution)
+
+        expect {
+          described_class.new(workflow, "trigger-1", trigger_data, options).run
+        }.not_to change { DiscourseWorkflows::Execution.count }
+
+        expect(existing_execution.reload.status).to eq("skipped")
       end
 
       it "preloads dependencies from the active workflow snapshot" do
@@ -556,6 +613,33 @@ RSpec.describe DiscourseWorkflows::Executor do
         second_execution = described_class.new(workflow, "trigger-1", trigger_data).run
         expect(second_execution.status).to eq("rate_limited")
         expect(second_execution.trigger_data).to eq("rate_limited" => true)
+      end
+
+      it "updates an existing execution when limits are exceeded" do
+        SiteSetting.discourse_workflows_max_executions_per_minute_per_workflow = 1
+
+        graph = build_workflow_graph { |g| g.node "trigger-1", "trigger:topic_closed" }
+        workflow =
+          Fabricate(:discourse_workflows_workflow, created_by: user, published: true, **graph)
+        trigger_data = { topic_id: topic.id, tags: [] }
+        expect(described_class.new(workflow, "trigger-1", trigger_data).run.status).to eq("success")
+
+        existing_execution =
+          Fabricate(
+            :discourse_workflows_execution,
+            workflow: workflow,
+            status: :running,
+            trigger_node_id: "trigger-1",
+          )
+        options = described_class::ExecutionOptions.new(existing_execution: existing_execution)
+
+        expect {
+          described_class.new(workflow, "trigger-1", trigger_data, options).run
+        }.not_to change { DiscourseWorkflows::Execution.count }
+
+        existing_execution.reload
+        expect(existing_execution.status).to eq("rate_limited")
+        expect(existing_execution.trigger_data).to eq("rate_limited" => true)
       end
     end
 

--- a/plugins/discourse-workflows/spec/models/discourse_workflows/execution_data_spec.rb
+++ b/plugins/discourse-workflows/spec/models/discourse_workflows/execution_data_spec.rb
@@ -1,6 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseWorkflows::ExecutionData do
+  describe "#data" do
+    it "defaults to empty execution data" do
+      first_data = described_class.new
+      second_data = described_class.new
+
+      first_data.data["entries"]["node-1"] = []
+
+      expect(second_data.data).to eq(
+        "entries" => {
+        },
+        "context" => {
+        },
+        "node_contexts" => {
+        },
+        "run_data" => {
+        },
+      )
+    end
+  end
+
   describe "#node_contexts" do
     it "defaults to an empty hash when absent" do
       data = described_class.new(data: { "entries" => {}, "context" => {} })
@@ -8,20 +28,7 @@ RSpec.describe DiscourseWorkflows::ExecutionData do
     end
 
     it "returns the node_contexts key from the stored hash" do
-      data =
-        described_class.new(
-          data: {
-            "entries" => {
-            },
-            "context" => {
-            },
-            "node_contexts" => {
-              "node-1" => {
-                "k" => "v",
-              },
-            },
-          },
-        )
+      data = described_class.new(data: { "node_contexts" => { "node-1" => { "k" => "v" } } })
       expect(data.node_contexts).to eq("node-1" => { "k" => "v" })
     end
   end

--- a/plugins/discourse-workflows/spec/models/discourse_workflows/execution_spec.rb
+++ b/plugins/discourse-workflows/spec/models/discourse_workflows/execution_spec.rb
@@ -53,6 +53,28 @@ RSpec.describe DiscourseWorkflows::Execution do
     end
   end
 
+  describe ".claim_pending" do
+    fab!(:workflow, :discourse_workflows_workflow)
+    fab!(:execution) do
+      Fabricate(:discourse_workflows_execution, workflow: workflow, status: :pending)
+    end
+
+    it "transitions a pending execution to running and returns it" do
+      claimed = described_class.claim_pending(execution)
+
+      expect(claimed).to be_present
+      expect(claimed.status).to eq("running")
+      expect(claimed.started_at).to be_present
+      expect(execution.reload.status).to eq("running")
+    end
+
+    it "returns nil when the execution is no longer pending" do
+      execution.update!(status: :running)
+
+      expect(described_class.claim_pending(execution)).to be_nil
+    end
+  end
+
   describe "#fail_with_timeout!" do
     fab!(:workflow, :discourse_workflows_workflow)
     fab!(:execution) do

--- a/plugins/discourse-workflows/spec/plugin_helper.rb
+++ b/plugins/discourse-workflows/spec/plugin_helper.rb
@@ -11,6 +11,7 @@ module DiscourseWorkflowsSpecHelper
       SiteSetting.external_system_avatars_url = "https://example.com/avatar/{username}.png"
       DiscourseWorkflows::Registry.reset_indexes!
       Jobs::DiscourseWorkflows::ExecuteWorkflow.jobs.clear
+      Jobs::DiscourseWorkflows::ExecuteManualWorkflow.jobs.clear
       Jobs::DiscourseWorkflows::ResumeWebhookWaiting.jobs.clear
       Jobs::DiscourseWorkflows::ResumeWaitingExecution.jobs.clear
     end

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/executions_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/executions_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DiscourseWorkflows::ExecutionsController do
       Fabricate(:discourse_workflows_workflow, created_by: admin, published: true, **graph)
     end
 
-    it "creates an execution" do
+    it "returns a pending execution" do
       post "/admin/plugins/discourse-workflows/executions.json",
            params: {
              workflow_id: published_workflow.id,
@@ -35,6 +35,15 @@ RSpec.describe DiscourseWorkflows::ExecutionsController do
            }
 
       expect(response).to have_http_status(:created)
+      execution = DiscourseWorkflows::Execution.find(response.parsed_body.dig("execution", "id"))
+      expect(response.parsed_body["execution"]).to include(
+        "id" => execution.id,
+        "workflow_id" => published_workflow.id,
+      )
+      expect(execution.status).to eq("pending")
+
+      job_args = Jobs::DiscourseWorkflows::ExecuteManualWorkflow.jobs.last["args"].first
+      expect(job_args).to include("execution_id" => execution.id, "user_id" => admin.id)
     end
 
     it "returns 404 when trigger node does not exist" do
@@ -44,21 +53,6 @@ RSpec.describe DiscourseWorkflows::ExecutionsController do
              trigger_node_id: "nonexistent",
            }
       expect(response).to have_http_status(:not_found)
-    end
-
-    it "forwards the current user id in service params" do
-      DiscourseWorkflows::Workflow::ManualExecute
-        .expects(:call)
-        .with { |kwargs| kwargs.dig(:params, :user_id) == admin.id }
-        .returns(Service::Base::Context.build)
-
-      post "/admin/plugins/discourse-workflows/executions.json",
-           params: {
-             workflow_id: published_workflow.id,
-             trigger_node_id: "trigger-1",
-           }
-
-      expect(response).to have_http_status(:no_content)
     end
   end
 

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/workflow/manual_execute_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/workflow/manual_execute_spec.rb
@@ -44,15 +44,20 @@ RSpec.describe DiscourseWorkflows::Workflow::ManualExecute do
     end
 
     context "when everything is valid" do
-      it { is_expected.to run_successfully }
+      it "creates a pending manual execution and enqueues a job" do
+        expect { result }.to change { DiscourseWorkflows::Execution.count }.by(1).and change {
+                Jobs::DiscourseWorkflows::ExecuteManualWorkflow.jobs.size
+              }.by(1)
 
-      it "creates a new execution record" do
-        expect { result }.to change { DiscourseWorkflows::Execution.count }.by(1)
-      end
-
-      it "records a manual execution mode" do
-        result
-        expect(result[:execution]).to be_manual
+        expect(result).to run_successfully
+        execution = result[:execution]
+        job_args = Jobs::DiscourseWorkflows::ExecuteManualWorkflow.jobs.last["args"].first
+        expect(execution).to have_attributes(status: "pending", execution_mode: "manual")
+        expect(execution.started_at).to be_nil
+        expect(
+          execution.execution_data.workflow_data["nodes"].map { |node| node["id"] },
+        ).to contain_exactly("trigger-1")
+        expect(job_args).to include("execution_id" => execution.id, "user_id" => admin.id)
       end
 
       context "when the trigger has pinned data" do
@@ -68,12 +73,11 @@ RSpec.describe DiscourseWorkflows::Workflow::ManualExecute do
           )
         end
 
-        it { is_expected.to run_successfully }
-
-        it "uses pinned items as the trigger output" do
+        it "stores pinned items in the execution snapshot" do
+          expect(result).to run_successfully
           execution = result[:execution]
-          trigger_run = execution.execution_data.run_data["Trigger-1"].first
-          expect(trigger_run["outputs"].first["items"]).to include(
+          expect(execution.trigger_data).to eq({})
+          expect(execution.execution_data.workflow_data["pinData"]["Trigger-1"]).to include(
             hash_including("json" => hash_including("post" => hash_including("id" => 42))),
           )
         end
@@ -85,9 +89,8 @@ RSpec.describe DiscourseWorkflows::Workflow::ManualExecute do
           Fabricate(:discourse_workflows_workflow, created_by: admin, published: true, **graph)
         end
 
-        it { is_expected.to run_successfully }
-
         it "runs with empty trigger data" do
+          expect(result).to run_successfully
           expect(result[:execution].trigger_data).to eq({})
         end
       end
@@ -101,23 +104,21 @@ RSpec.describe DiscourseWorkflows::Workflow::ManualExecute do
           Fabricate(:discourse_workflows_workflow, created_by: admin, published: true, **graph)
         end
 
-        fab!(:stale_topic_1) do
+        fab!(:first_stale_topic) do
           Fabricate(:topic, created_at: 48.hours.ago, last_posted_at: 48.hours.ago)
         end
-        fab!(:stale_topic_2) do
+        fab!(:second_stale_topic) do
           Fabricate(:topic, created_at: 48.hours.ago, last_posted_at: 48.hours.ago)
         end
 
-        it { is_expected.to run_successfully }
-
-        it "creates one execution carrying every stale topic as an item" do
+        it "creates one execution carrying every stale topic as trigger data" do
           expect { result }.to change { DiscourseWorkflows::Execution.count }.by(1)
 
+          expect(result).to run_successfully
           execution = result[:execution]
-          trigger_run = execution.execution_data.run_data["Trigger-1"].first
           topic_ids =
-            trigger_run["outputs"].first["items"].map { |item| item.dig("json", "topic", "id") }
-          expect(topic_ids).to match_array([stale_topic_1.id, stale_topic_2.id])
+            execution.trigger_data.map { |item| item.dig("topic", "id") || item.dig(:topic, :id) }
+          expect(topic_ids).to match_array([first_stale_topic.id, second_stale_topic.id])
         end
       end
 
@@ -139,8 +140,7 @@ RSpec.describe DiscourseWorkflows::Workflow::ManualExecute do
         it "uses the schedule trigger's manual output" do
           freeze_time Time.utc(2026, 3, 18, 9, 0)
 
-          result
-
+          expect(result).to run_successfully
           expect(result[:execution].trigger_data).to include(
             "timestamp" => "2026-03-18T09:00:00.000Z",
             "hour" => "09",


### PR DESCRIPTION
Prior to this change manual executions were run synchronously, this was causing issues for long running tasks (AI for example) which would timeout. This change will create an execution with the current draft data and then start a job to  claim that pending execution and run it inside the job.