### PR TITLE
FIX: uses first item for output of previous nodes

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
@@ -11,7 +11,7 @@ import {
   inputConnectionsForNode,
   inputIndexForConnection,
   inputSummaryForNode,
-  nodeItemJsonPath,
+  nodeOutputJsonPath,
   outputIndexForConnection,
   previousNodeForConnection,
   schemaFieldsForNodeInput,
@@ -95,7 +95,10 @@ export default class ExpressionInput extends Component {
           fields: schemaFieldsForNodeOutput(runData, ancestor.node.name, {
             outputIndex: ancestor.outputIndex,
             node: ancestor.node,
-            prefix: nodeItemJsonPath(ancestor.node.name),
+            prefix: nodeOutputJsonPath(runData, ancestor.node.name, {
+              outputIndex: ancestor.outputIndex,
+              node: ancestor.node,
+            }),
           }),
         }))
       : [];

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/context/input.gjs
@@ -10,7 +10,7 @@ import {
   inputFieldPrefixForConnection,
   inputIndexForConnection,
   inputSummaryForNode,
-  nodeItemJsonPath,
+  nodeOutputJsonPath,
   outputIndexForConnection,
   outputSummaryForNode,
   previousNodeForConnection,
@@ -218,7 +218,10 @@ export default class InputContext extends Component {
           {
             outputIndex: ancestor.outputIndex,
             node: ancestor.node,
-            prefix: nodeItemJsonPath(ancestor.node.name),
+            prefix: nodeOutputJsonPath(this.runData, ancestor.node.name, {
+              outputIndex: ancestor.outputIndex,
+              node: ancestor.node,
+            }),
           }
         );
         return {

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/data-schema.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/data-schema.js
@@ -44,8 +44,29 @@ function propertySegment(key) {
     : `[${JSON.stringify(key)}]`;
 }
 
-export function nodeItemJsonPath(nodeName) {
+export function nodeOutputFirstJsonPath(nodeName, { outputIndex = 0 } = {}) {
+  const branchArg = outputIndex === 0 ? "" : outputIndex;
+  return `$(${JSON.stringify(nodeName)}).first(${branchArg}).json`;
+}
+
+export function nodeOutputLinkedItemJsonPath(nodeName) {
   return `$(${JSON.stringify(nodeName)}).item.json`;
+}
+
+export function nodeOutputJsonPath(
+  runData,
+  nodeName,
+  { outputIndex = 0, node } = {}
+) {
+  const run = latestRunWithOutput(runData, nodeName, { node });
+  const output = outputForRun(run, outputIndex);
+  const itemCount = output?.item_count ?? output?.items?.length ?? 0;
+
+  if (itemCount === 1) {
+    return nodeOutputFirstJsonPath(nodeName, { outputIndex });
+  }
+
+  return nodeOutputLinkedItemJsonPath(nodeName);
 }
 
 export function nodeOutputItemJsonPath(

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/context-input-test.gjs
@@ -755,6 +755,23 @@ module(
         sectionTitles.some((t) => t.includes("First Step")),
         "shows ancestor node as section"
       );
+
+      const resultField = [
+        ...this.element.querySelectorAll(".workflows-schema-field__key"),
+      ].find((el) => el.textContent.trim() === "result");
+      const dragged = {};
+      const dataTransfer = {
+        setData(type, value) {
+          dragged[type] = value;
+        },
+      };
+
+      await triggerEvent(resultField, "dragstart", { dataTransfer });
+
+      assert.strictEqual(
+        JSON.parse(dragged[WORKFLOW_VARIABLE_MIME]).id,
+        '$("First Step").first().json.result'
+      );
     });
 
     test("environment fields match schema symbols", async function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-data-schema-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-data-schema-test.js
@@ -6,8 +6,10 @@ import {
   inputFieldPrefixForConnection,
   inputForRun,
   inputSummaryForNode,
-  nodeItemJsonPath,
+  nodeOutputFirstJsonPath,
   nodeOutputItemJsonPath,
+  nodeOutputJsonPath,
+  nodeOutputLinkedItemJsonPath,
   outputForRun,
   outputSchemaForNode,
   outputSummaryForNode,
@@ -349,10 +351,59 @@ module("Unit | lib | discourse-workflows | data-schema", function () {
     );
   });
 
-  test("nodeItemJsonPath escapes node names for expressions", function (assert) {
+  test("nodeOutputFirstJsonPath escapes node names and output indexes for expressions", function (assert) {
     assert.strictEqual(
-      nodeItemJsonPath('Fetch "quoted" \\ data'),
+      nodeOutputFirstJsonPath('Fetch "quoted" \\ data', { outputIndex: 1 }),
+      '$("Fetch \\"quoted\\" \\\\ data").first(1).json'
+    );
+    assert.strictEqual(
+      nodeOutputFirstJsonPath("Fetch data"),
+      '$("Fetch data").first().json'
+    );
+  });
+
+  test("nodeOutputLinkedItemJsonPath escapes node names for expressions", function (assert) {
+    assert.strictEqual(
+      nodeOutputLinkedItemJsonPath('Fetch "quoted" \\ data'),
       '$("Fetch \\"quoted\\" \\\\ data").item.json'
+    );
+  });
+
+  test("nodeOutputJsonPath uses the simplest safe output expression", function (assert) {
+    const runData = {
+      Aggregate: [
+        {
+          status: "success",
+          outputs: [
+            {
+              index: 0,
+              items: [{ json: { markdown: "summary" } }],
+              item_count: 1,
+            },
+          ],
+        },
+      ],
+      "Per item": [
+        {
+          status: "success",
+          outputs: [
+            {
+              index: 0,
+              items: [{ json: { name: "Ada" } }, { json: { name: "Grace" } }],
+              item_count: 2,
+            },
+          ],
+        },
+      ],
+    };
+
+    assert.strictEqual(
+      nodeOutputJsonPath(runData, "Aggregate"),
+      '$("Aggregate").first().json'
+    );
+    assert.strictEqual(
+      nodeOutputJsonPath(runData, "Per item"),
+      '$("Per item").item.json'
     );
   });
 


### PR DESCRIPTION
Previously when referencing an output of a previous node, the drag and drop code would generate the single item syntax, which can be incorrect for aggregates (eg: data-explorer query). We will now correctly generate the right syntax for aggregates: `{{ $("flags-handled").first().json.markdown }}`