### PR TITLE
PERF: Rewrite DAU/MAU rolling count as a non-correlated sweep

### DIFF
--- a/app/models/user_visit.rb
+++ b/app/models/user_visit.rb
@@ -16,21 +16,48 @@ class UserVisit < ActiveRecord::Base
 
   def self.count_by_active_users(start_date, end_date)
     sql = <<~SQL
-      WITH dau AS (
-        SELECT date_trunc('day', user_visits.visited_at)::DATE AS date,
-               count(distinct user_visits.user_id) AS dau
+      WITH visits AS (
+        SELECT DISTINCT user_id, visited_at::DATE AS d
         FROM user_visits
-        WHERE user_visits.visited_at::DATE >= :start_date::DATE AND user_visits.visited_at <= :end_date::DATE
-        GROUP BY date_trunc('day', user_visits.visited_at)::DATE
-        ORDER BY date_trunc('day', user_visits.visited_at)::DATE
+        WHERE visited_at::DATE >= :start_date::DATE - 29 AND visited_at::DATE <= :end_date::DATE
+      ),
+      marked AS (
+        SELECT user_id, d,
+          CASE
+            WHEN lag(d) OVER (PARTITION BY user_id ORDER BY d) >= d - 30 THEN 0
+            ELSE 1
+          END AS new_island
+        FROM visits
+      ),
+      islands AS (
+        SELECT user_id, d, sum(new_island) OVER (PARTITION BY user_id ORDER BY d) AS grp
+        FROM marked
+      ),
+      coverage AS (
+        SELECT min(d) AS start_d, max(d) + 29 AS end_d
+        FROM islands
+        GROUP BY user_id, grp
+      ),
+      events AS (
+        SELECT start_d AS day, 1 AS delta FROM coverage
+        UNION ALL
+        SELECT end_d + 1 AS day, -1 AS delta FROM coverage
+      ),
+      running AS (
+        SELECT day, sum(sum(delta)) OVER (ORDER BY day) AS mau
+        FROM events
+        GROUP BY day
+      ),
+      dau AS (
+        SELECT visited_at::DATE AS date, count(distinct user_id) AS dau
+        FROM user_visits
+        WHERE visited_at::DATE >= :start_date::DATE AND visited_at <= :end_date::DATE
+        GROUP BY visited_at::DATE
       )
-
-      SELECT date, dau,
-        (SELECT count(distinct user_visits.user_id)
-          FROM user_visits
-          WHERE user_visits.visited_at::DATE BETWEEN dau.date - 29 AND dau.date
-        ) AS mau
+      SELECT dau.date, dau.dau,
+        (SELECT mau FROM running WHERE running.day <= dau.date ORDER BY day DESC LIMIT 1) AS mau
       FROM dau
+      ORDER BY date
     SQL
 
     DB.query_hash(sql, start_date: start_date, end_date: end_date)

--- a/app/models/user_visit.rb
+++ b/app/models/user_visit.rb
@@ -17,7 +17,7 @@ class UserVisit < ActiveRecord::Base
   def self.count_by_active_users(start_date, end_date)
     sql = <<~SQL
       WITH visits AS (
-        SELECT DISTINCT user_id, visited_at::DATE AS d
+        SELECT user_id, visited_at::DATE AS d
         FROM user_visits
         WHERE visited_at::DATE >= :start_date::DATE - 29 AND visited_at::DATE <= :end_date::DATE
       ),

--- a/app/models/user_visit.rb
+++ b/app/models/user_visit.rb
@@ -17,9 +17,10 @@ class UserVisit < ActiveRecord::Base
   def self.count_by_active_users(start_date, end_date)
     sql = <<~SQL
       WITH visits AS (
-        SELECT user_id, visited_at::DATE AS d
+        SELECT user_id, visited_at AS d
         FROM user_visits
-        WHERE visited_at::DATE >= :start_date::DATE - 29 AND visited_at::DATE <= :end_date::DATE
+        WHERE visited_at >= :start_date::DATE - 29
+          AND visited_at <= :end_date::DATE
       ),
       marked AS (
         SELECT user_id, d,
@@ -43,21 +44,35 @@ class UserVisit < ActiveRecord::Base
         UNION ALL
         SELECT end_d + 1 AS day, -1 AS delta FROM coverage
       ),
-      running AS (
-        SELECT day, sum(sum(delta)) OVER (ORDER BY day) AS mau
+      event_totals AS (
+        SELECT day, sum(delta) AS delta
         FROM events
         GROUP BY day
       ),
+      calendar AS (
+        SELECT generate_series(
+          (SELECT min(day) FROM event_totals),
+          :end_date::DATE,
+          INTERVAL '1 day'
+        )::DATE AS day
+      ),
+      running AS (
+        SELECT calendar.day,
+          sum(coalesce(event_totals.delta, 0)) OVER (ORDER BY calendar.day) AS mau
+        FROM calendar
+        LEFT JOIN event_totals ON event_totals.day = calendar.day
+      ),
       dau AS (
-        SELECT visited_at::DATE AS date, count(distinct user_id) AS dau
+        SELECT visited_at AS date, count(distinct user_id) AS dau
         FROM user_visits
-        WHERE visited_at::DATE >= :start_date::DATE AND visited_at <= :end_date::DATE
-        GROUP BY visited_at::DATE
+        WHERE visited_at >= :start_date::DATE
+          AND visited_at <= :end_date::DATE
+        GROUP BY visited_at
       )
-      SELECT dau.date, dau.dau,
-        (SELECT mau FROM running WHERE running.day <= dau.date ORDER BY day DESC LIMIT 1) AS mau
+      SELECT dau.date, dau.dau, running.mau
       FROM dau
-      ORDER BY date
+      JOIN running ON running.day = dau.date
+      ORDER BY dau.date
     SQL
 
     DB.query_hash(sql, start_date: start_date, end_date: end_date)

--- a/app/models/user_visit.rb
+++ b/app/models/user_visit.rb
@@ -16,62 +16,62 @@ class UserVisit < ActiveRecord::Base
 
   def self.count_by_active_users(start_date, end_date)
     sql = <<~SQL
-      WITH visits AS (
+      WITH visits_in_mau_range AS (
         SELECT user_id, visited_at AS d
         FROM user_visits
         WHERE visited_at >= :start_date::DATE - 29
           AND visited_at <= :end_date::DATE
       ),
-      marked AS (
+      visit_island_starts AS (
         SELECT user_id, d,
           CASE
             WHEN lag(d) OVER (PARTITION BY user_id ORDER BY d) >= d - 30 THEN 0
             ELSE 1
           END AS new_island
-        FROM visits
+        FROM visits_in_mau_range
       ),
-      islands AS (
+      visit_islands AS (
         SELECT user_id, d, sum(new_island) OVER (PARTITION BY user_id ORDER BY d) AS grp
-        FROM marked
+        FROM visit_island_starts
       ),
-      coverage AS (
+      active_ranges AS (
         SELECT min(d) AS start_d, max(d) + 29 AS end_d
-        FROM islands
+        FROM visit_islands
         GROUP BY user_id, grp
       ),
-      events AS (
-        SELECT start_d AS day, 1 AS delta FROM coverage
+      active_range_events AS (
+        SELECT start_d AS day, 1 AS delta FROM active_ranges
         UNION ALL
-        SELECT end_d + 1 AS day, -1 AS delta FROM coverage
+        SELECT end_d + 1 AS day, -1 AS delta FROM active_ranges
       ),
-      event_totals AS (
+      daily_active_deltas AS (
         SELECT day, sum(delta) AS delta
-        FROM events
+        FROM active_range_events
         GROUP BY day
       ),
-      calendar AS (
+      days AS (
         SELECT generate_series(
-          (SELECT min(day) FROM event_totals),
+          (SELECT min(day) FROM daily_active_deltas),
           :end_date::DATE,
           INTERVAL '1 day'
         )::DATE AS day
       ),
-      running AS (
-        SELECT calendar.day,
-          sum(coalesce(event_totals.delta, 0)) OVER (ORDER BY calendar.day) AS mau
-        FROM calendar
-        LEFT JOIN event_totals ON event_totals.day = calendar.day
+      rolling_mau AS (
+        SELECT days.day,
+          sum(coalesce(daily_active_deltas.delta, 0)) OVER (ORDER BY days.day) AS mau
+        FROM days
+        LEFT JOIN daily_active_deltas ON daily_active_deltas.day = days.day
       ),
       dau AS (
-        SELECT visited_at AS date, count(distinct user_id) AS dau
+        SELECT visited_at AS date, count(*) AS dau
         FROM user_visits
         WHERE visited_at >= :start_date::DATE
           AND visited_at <= :end_date::DATE
         GROUP BY visited_at
       )
-      SELECT dau.date, dau.dau, running.mau
+      SELECT dau.date, dau.dau, rolling_mau.mau
       FROM dau
-      JOIN running ON running.day = dau.date
+      JOIN rolling_mau ON rolling_mau.day = dau.date
       ORDER BY dau.date
     SQL
 

--- a/spec/models/user_visit_spec.rb
+++ b/spec/models/user_visit_spec.rb
@@ -39,4 +39,85 @@ RSpec.describe UserVisit do
       expect(UserVisit.by_day(2.days.ago, Time.zone.now)).not_to include(4.days.ago.to_date => 1)
     end
   end
+
+  describe ".count_by_active_users" do
+    fab!(:user_a, :user)
+    fab!(:user_b, :user)
+    fab!(:user_c, :user)
+
+    # base day; all visits are placed relative to it so the 30-day rolling
+    # window (visited_at BETWEEN day - 29 AND day) can be pinned exactly.
+    let(:base) { Date.new(2026, 6, 1) }
+
+    def visit(user, day)
+      user.user_visits.create!(visited_at: day)
+    end
+
+    def mau_on(rows, day)
+      rows.find { |r| r["date"] == day }&.fetch("mau")
+    end
+
+    def dau_on(rows, day)
+      rows.find { |r| r["date"] == day }&.fetch("dau")
+    end
+
+    it "reports DAU and a 30-day rolling distinct MAU per active day" do
+      visit(user_a, base)
+      visit(user_b, base)
+      visit(user_a, base + 24) # within 30 days of base -> same MAU coverage
+      visit(user_c, base + 60) # far later -> its own window
+
+      rows = UserVisit.count_by_active_users(base, base + 60)
+
+      # base: a, b visited today and in window -> dau 2, mau 2
+      expect(dau_on(rows, base)).to eq(2)
+      expect(mau_on(rows, base)).to eq(2)
+
+      # base+24: only a visited today; window [base-5, base+24] still sees a & b -> mau 2
+      expect(dau_on(rows, base + 24)).to eq(1)
+      expect(mau_on(rows, base + 24)).to eq(2)
+
+      # base+60: window [base+31, base+60] sees only c -> dau 1, mau 1
+      expect(dau_on(rows, base + 60)).to eq(1)
+      expect(mau_on(rows, base + 60)).to eq(1)
+    end
+
+    it "treats the rolling window as 29-days-inclusive / 30-days-exclusive" do
+      visit(user_a, base)
+      visit(user_b, base)
+      visit(user_c, base + 29) # probe day exactly 29 days after a/b
+      visit(user_a, base + 30) # probe day exactly 30 days after a/b's first visit
+
+      rows = UserVisit.count_by_active_users(base, base + 30)
+
+      # day base+29: window [base, base+29] still includes a & b (29 inclusive) plus c
+      expect(mau_on(rows, base + 29)).to eq(3)
+
+      # day base+30: window [base+1, base+30] excludes b's only visit (base, now 30 days out);
+      # a is back today, c is still in range -> a & c only
+      expect(mau_on(rows, base + 30)).to eq(2)
+    end
+
+    it "counts a user once across overlapping visits and separately across a >30-day gap" do
+      visit(user_a, base)
+      visit(user_a, base + 10) # overlaps -> still one user in coverage
+      visit(user_a, base + 100) # gap > 30 days -> new island, but still the same single user
+      visit(user_b, base + 100)
+
+      rows = UserVisit.count_by_active_users(base, base + 100)
+
+      expect(mau_on(rows, base)).to eq(1)
+      expect(mau_on(rows, base + 10)).to eq(1)
+      expect(mau_on(rows, base + 100)).to eq(2)
+    end
+
+    it "only emits rows for days that had at least one visit" do
+      visit(user_a, base)
+      visit(user_b, base + 5)
+
+      rows = UserVisit.count_by_active_users(base, base + 10)
+
+      expect(rows.map { |r| r["date"] }).to contain_exactly(base, base + 5)
+    end
+  end
 end


### PR DESCRIPTION
`UserVisit.count_by_active_users` computed the 30-day rolling MAU with a correlated subquery that re-scanned user_visits once per day in the range (O(days * window)). So a one-year range this spends several seconds of SQL time on large sites. 💥 

The PR avoids repeatedly recalculating overlapping 30-day MAU windows. 

On meta, the 30-day dashboard range improved from `0.173s` to `0.044s`, and the 365-day report range improved from `1.312s` to `0.296s`, while preserving identical output. (details in table)

benchmark run manually, md table generated by AI.
| Range | Previous query | PR query | Improvement |
| --- | ---: | ---: | ---: |
| 7 days | 0.113s | 0.025s | 78% faster |
| 14 days | 0.125s | 0.030s | 76% faster |
| 30 days | 0.173s | 0.044s | 75% faster |
| 45 days | 0.209s | 0.057s | 73% faster |
| 60 days | 0.260s | 0.068s | 74% faster |
| 75 days | 0.311s | 0.084s | 73% faster |
| 90 days | 0.360s | 0.097s | 73% faster |
| 180 days | 0.658s | 0.174s | 74% faster |
| 365 days | 1.312s | 0.296s | 77% faster |
