### PR TITLE
FIX: Match webhook-related messagebus audience to controller audience

### DIFF
--- a/app/jobs/scheduled/redeliver_web_hook_events.rb
+++ b/app/jobs/scheduled/redeliver_web_hook_events.rb
@@ -56,7 +56,7 @@ module Jobs
           type: type,
           web_hook_event: AdminWebHookEventSerializer.new(web_hook_event, root: false).as_json,
         },
-        group_ids: [Group::AUTO_GROUPS[:staff]],
+        group_ids: [Group::AUTO_GROUPS[:admins]],
       )
     end
   end

--- a/spec/jobs/redeliver_web_hook_events_spec.rb
+++ b/spec/jobs/redeliver_web_hook_events_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Jobs::RedeliverWebHookEvents do
     expect(messages.first.data).to include(type: "redelivered")
   end
 
-  it "restricts the redelivery MessageBus publish to the staff group" do
+  it "restricts the redelivery MessageBus publish to the admins group" do
     stub_request(:post, web_hook.payload_url).to_return(status: 200, body: "", headers: {})
 
     messages =
@@ -54,7 +54,8 @@ RSpec.describe Jobs::RedeliverWebHookEvents do
     expect(RedeliveringWebhookEvent.count).to eq(0)
     expect(messages.size).to eq(1)
     expect(messages.first.data).to include(type: "redelivered")
-    expect(messages.first.group_ids).to eq([Group::AUTO_GROUPS[:staff]])
+    expect(messages.first.data[:web_hook_event]).to include(payload: "abc")
+    expect(messages.first.group_ids).to eq([Group::AUTO_GROUPS[:admins]])
   end
 
   context "when there is a redelivering_webhook_event in process" do


### PR DESCRIPTION
Previously, messagebus payloads were published to moderators and admins.

The controller is only accessible to admins, so it makes sense to target the messagebus payload in the same way. Moderators are highly-trusted, so this isn't considered a security issue.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>