### PR TITLE
FIX: Match searchable custom fields when searching the user directory

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -64,8 +64,8 @@ class DirectoryItemsController < ApplicationController
 
     user_ids = nil
     if params[:name].present?
-      user_ids =
-        UserSearch.new(params[:name], { include_staged_users: true, limit: 200 }).search.pluck(:id)
+      opts = { include_staged_users: true, limit: 200, search_custom_fields: true }
+      user_ids = UserSearch.new(params[:name], opts).search.pluck(:id)
       if user_ids.present?
         # Add the current user if we have at least one other match
         user_ids << current_user.id if current_user && result.dup.where(user_id: user_ids).exists?

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -5,7 +5,8 @@ class UserSearch
 
   def initialize(term, opts = {})
     @term = term.downcase
-    @term_like = @term.gsub("_", "\\_") + "%"
+    # escape LIKE wildcards (`_`, `%`, `\`) so the term matches literally
+    @term_like = ActiveRecord::Base.sanitize_sql_like(@term) + "%"
     @topic_id = opts[:topic_id]
     @category_id = opts[:category_id]
     # prioritized_user_id is only used for ordering within the topic, it will prioritize this user
@@ -17,6 +18,7 @@ class UserSearch
     @limit = opts[:limit] || 20
     @groups = opts[:groups]
     @can_review = opts[:can_review] || false
+    @search_custom_fields = opts[:search_custom_fields] || false
 
     @topic = Topic.find(@topic_id) if @topic_id
     @category = Category.find(@category_id) if @category_id
@@ -65,15 +67,14 @@ class UserSearch
   def filtered_by_term_users
     if @term.blank?
       scoped_users
-    elsif SiteSetting.enable_names? && @term !~ /[_\.-]/
-      query = Search.ts_query(term: @term, ts_config: "simple")
-
-      scoped_users
-        .includes(:user_search_data)
-        .where("user_search_data.search_data @@ #{query}")
-        .order(DB.sql_fragment("CASE WHEN username_lower LIKE ? THEN 0 ELSE 1 END ASC", @term_like))
+    elsif @search_custom_fields
+      # Directory search: also match searchable custom field values, even with
+      # names disabled or `_`, `.`, `-` terms. See `tsvector_filtered_users`.
+      tsvector_filtered_users(weight_filter: SiteSetting.enable_names? ? nil : "AC")
+    elsif SiteSetting.enable_names? && @term !~ /[_.-]/
+      tsvector_filtered_users
     else
-      scoped_users.where("username_lower LIKE :term_like", term_like: @term_like)
+      scoped_users.where("username_lower LIKE ?", @term_like)
     end
   end
 
@@ -214,5 +215,23 @@ class UserSearch
     results = results.includes(:user_status) if SiteSetting.enable_user_status
 
     results
+  end
+
+  private
+
+  # Filters `scoped_users` by matching `@term` against the `user_search_data`
+  # tsvector (A = username, B = name, C = searchable custom fields). Pass
+  # `weight_filter: "AC"` to skip the name (B) weight when names are disabled,
+  # mirroring `Search#user_search`. Usernames match via the A weight; the
+  # `simple` config tokenises the query the same way it indexed the username, so
+  # no separate `username_lower LIKE` clause is needed (see `Search#user_search`).
+  def tsvector_filtered_users(weight_filter: nil)
+    query = Search.ts_query(term: @term, ts_config: "simple", weight_filter:)
+
+    scoped_users
+      .includes(:user_search_data)
+      .references(:user_search_data)
+      .where("user_search_data.search_data @@ #{query}")
+      .order(DB.sql_fragment("CASE WHEN username_lower LIKE ? THEN 0 ELSE 1 END ASC", @term_like))
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9161,6 +9161,7 @@ en:
           disabled: "Not shown on signup form"
         searchable:
           title: "Searchable"
+          tooltip: "When enabled, anyone can find members by this field's value and see it in search results, even if it's not shown on their profile or user card."
           enabled: "Searchable"
           disabled: "Not searchable"
 

--- a/frontend/discourse/admin/components/admin-user-fields-form.gjs
+++ b/frontend/discourse/admin/components/admin-user-fields-form.gjs
@@ -269,6 +269,7 @@ export default class AdminUserFieldsForm extends Component {
             @name="searchable"
             @showTitle={{false}}
             @title={{i18n "admin.user_fields.searchable.title"}}
+            @tooltip={{i18n "admin.user_fields.searchable.tooltip"}}
             @type="checkbox"
             as |field|
           >

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -308,4 +308,28 @@ RSpec.describe UserSearch do
       expect(results[2]).to eq("mrorange")
     end
   end
+
+  context "with the search_custom_fields option" do
+    fab!(:searchable_field) { Fabricate(:user_field, searchable: true, show_on_profile: true) }
+    fab!(:member) { Fabricate(:user, username: "memberx", name: "Member X") }
+
+    before do
+      member.set_user_field(searchable_field.id, "Acme-Corp")
+      member.save_custom_fields
+      SearchIndexer.index(member.reload, force: true)
+    end
+
+    it "matches a custom field value containing `_`, `.` or `-` when the option is set" do
+      expect(search_for("Acme-Corp", search_custom_fields: true)).to include("memberx")
+    end
+
+    it "matches a custom field value when the option is set and `enable_names` is disabled" do
+      SiteSetting.enable_names = false
+      expect(search_for("Acme-Corp", search_custom_fields: true)).to include("memberx")
+    end
+
+    it "does not match custom fields for `_`, `.` or `-` terms without the option" do
+      expect(search_for("Acme-Corp")).not_to include("memberx")
+    end
+  end
 end

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -490,5 +490,45 @@ RSpec.describe DirectoryItemsController do
         expect(fields[field.id.to_s]["value"]).to include("Music")
       end
     end
+
+    it "finds users by a searchable custom field value containing `_`, `.` or `-`" do
+      field = Fabricate(:user_field, searchable: true, show_on_profile: true)
+      member = Fabricate(:user)
+      UserCustomField.create!(
+        user_id: member.id,
+        name: "user_field_#{field.id}",
+        value: "Acme-Corp",
+      )
+
+      DirectoryItem.refresh!
+      SearchIndexer.with_indexing { SearchIndexer.index(member, force: true) }
+
+      get "/directory_items.json", params: { period: "all", name: "Acme-Corp" }
+
+      expect(response.status).to eq(200)
+      usernames = response.parsed_body["directory_items"].map { |item| item["user"]["username"] }
+      expect(usernames).to include(member.username)
+    end
+
+    it "finds users by a searchable custom field value when `enable_names` is disabled" do
+      SiteSetting.enable_names = false
+
+      field = Fabricate(:user_field, searchable: true, show_on_profile: true)
+      member = Fabricate(:user)
+      UserCustomField.create!(
+        user_id: member.id,
+        name: "user_field_#{field.id}",
+        value: "Cutrocket",
+      )
+
+      DirectoryItem.refresh!
+      SearchIndexer.with_indexing { SearchIndexer.index(member, force: true) }
+
+      get "/directory_items.json", params: { period: "all", name: "Cutrocket" }
+
+      expect(response.status).to eq(200)
+      usernames = response.parsed_body["directory_items"].map { |item| item["user"]["username"] }
+      expect(usernames).to include(member.username)
+    end
   end
 end


### PR DESCRIPTION
Previously, the user directory (`/u`) search only matched usernames -- it never found people by their *searchable* user custom field values (e.g. "Company" or "Member ID"), even though the quick search did. The gap appeared whenever `enable_names` was off or the term contained `_`, `.` or `-`, so member IDs, emails and phone numbers never matched.

This change lets the directory search those fields too, via an opt-in `search_custom_fields:` option on `UserSearch` that searches the `user_search_data` tsvector (mention autocomplete and chat are unchanged). It also escapes `LIKE` wildcards in the search term with `sanitize_sql_like`, and adds a tooltip warning that the "Searchable" toggle makes a field's value publicly findable in search.

Reported at https://meta.discourse.org/t/trouble-searching-user-custom-fields/404800
