### PR TITLE
UX: add "remove all" button to make it easier to reset category permissions

### DIFF
--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -676,7 +676,7 @@ div.edit-category {
   }
 
   .remove-all-permissions {
-    justify-self: end;
+    margin-left: auto;
   }
 }
 

--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -667,10 +667,16 @@ div.edit-category {
 }
 
 .edit-category .add-group {
+  display: flex;
+  gap: var(--space-2);
   margin: 1em 0 2em;
 
   .group-name {
     width: 100%;
+  }
+
+  .remove-all-permissions {
+    justify-self: end;
   }
 }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5056,6 +5056,7 @@ en:
         toggle_reply: "Toggle Reply permission"
         toggle_full: "Toggle Create permission"
         inherited: 'This permission is inherited from "%{everyone_group}"'
+        remove_all: "Remove all"
       special_warning: "This is a pre-seeded category and the security settings cannot be edited. If you do not wish to use this category, delete it instead of repurposing it."
       uncategorized_security_warning: "This category is special. It is intended as holding area for topics that have no category; it cannot have security settings."
       uncategorized_general_warning: 'This category is special. It is used as the default category for new topics that do not have a category selected. If you want to prevent this behavior and force category selection, <a href="%{settingLink}">please disable the setting here</a>. If you want to change the name or description, go to <a href="%{customizeLink}">Customize / Text Content</a>.'

--- a/frontend/discourse/admin/components/upsert-category/security.gjs
+++ b/frontend/discourse/admin/components/upsert-category/security.gjs
@@ -241,17 +241,19 @@ export default class UpsertCategorySecurity extends Component {
               </div>
             {{/unless}}
             {{#if (or this.hasAvailableGroups this.canRemoveAllPermissions)}}
-              <div class="add-group">
-                {{#if this.hasAvailableGroups}}
-                  <PluginOutlet
-                    @name="category-security-permissions-add-group"
-                    @outletArgs={{lazyHash
-                      category=@category
-                      availableGroups=this.availableGroups
-                      onSelectGroup=this.onSelectGroup
-                    }}
-                    @defaultGlimmer={{true}}
-                  >
+              <PluginOutlet
+                @name="category-security-permissions-add-group"
+                @outletArgs={{lazyHash
+                  category=@category
+                  availableGroups=this.availableGroups
+                  onSelectGroup=this.onSelectGroup
+                  canRemoveAllPermissions=this.canRemoveAllPermissions
+                  onRemoveAllPermissions=this.onRemoveAllPermissions
+                }}
+                @defaultGlimmer={{true}}
+              >
+                <div class="add-group">
+                  {{#if this.hasAvailableGroups}}
                     <span class="group-name">
                       <@form.Field
                         @name="security_add_group_id"
@@ -277,16 +279,16 @@ export default class UpsertCategorySecurity extends Component {
                         </field.Control>
                       </@form.Field>
                     </span>
-                  </PluginOutlet>
-                {{/if}}
-                {{#if this.canRemoveAllPermissions}}
-                  <DButton
-                    class="btn-default remove-all-permissions"
-                    @label="category.permissions.remove_all"
-                    @action={{this.onRemoveAllPermissions}}
-                  />
-                {{/if}}
-              </div>
+                  {{/if}}
+                  {{#if this.canRemoveAllPermissions}}
+                    <DButton
+                      class="btn-default remove-all-permissions"
+                      @label="category.permissions.remove_all"
+                      @action={{this.onRemoveAllPermissions}}
+                    />
+                  {{/if}}
+                </div>
+              </PluginOutlet>
             {{/if}}
           </div>
 

--- a/frontend/discourse/admin/components/upsert-category/security.gjs
+++ b/frontend/discourse/admin/components/upsert-category/security.gjs
@@ -8,7 +8,8 @@ import lazyHash from "discourse/helpers/lazy-hash";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import Category from "discourse/models/category";
 import PermissionType from "discourse/models/permission-type";
-import { eq } from "discourse/truth-helpers";
+import { eq, or } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
@@ -102,6 +103,10 @@ export default class UpsertCategorySecurity extends Component {
     return this.everyonePermission?.permission_type ?? PermissionType.READONLY;
   }
 
+  get canRemoveAllPermissions() {
+    return (this.permissions?.length ?? 0) >= 3;
+  }
+
   #setFormPermissions(permissions) {
     this.args.form.set("permissions", permissions);
   }
@@ -135,6 +140,11 @@ export default class UpsertCategorySecurity extends Component {
       (p) => p.group_id !== groupId
     );
     this.#setFormPermissions(newPermissions);
+  }
+
+  @action
+  onRemoveAllPermissions() {
+    this.#setFormPermissions([]);
   }
 
   @action
@@ -230,43 +240,53 @@ export default class UpsertCategorySecurity extends Component {
                 {{i18n "category.permissions.no_groups_selected"}}
               </div>
             {{/unless}}
-
-            {{#if this.hasAvailableGroups}}
-              <PluginOutlet
-                @name="category-security-permissions-add-group"
-                @outletArgs={{lazyHash
-                  category=@category
-                  availableGroups=this.availableGroups
-                  onSelectGroup=this.onSelectGroup
-                }}
-                @defaultGlimmer={{true}}
-              >
-                <div class="add-group">
-                  <span class="group-name">
-                    <@form.Field
-                      @name="security_add_group_id"
-                      @title={{i18n "category.security_add_group"}}
-                      @showTitle={{false}}
-                      @format="max"
-                      @type="select"
-                      @onSet={{this.onSecurityAddGroupSet}}
-                      as |field|
-                    >
-                      <field.Control
-                        class="available-groups"
-                        @nonePlaceholder={{i18n "category.security_add_group"}}
-                        as |select|
+            {{#if (or this.hasAvailableGroups this.canRemoveAllPermissions)}}
+              <div class="add-group">
+                {{#if this.hasAvailableGroups}}
+                  <PluginOutlet
+                    @name="category-security-permissions-add-group"
+                    @outletArgs={{lazyHash
+                      category=@category
+                      availableGroups=this.availableGroups
+                      onSelectGroup=this.onSelectGroup
+                    }}
+                    @defaultGlimmer={{true}}
+                  >
+                    <span class="group-name">
+                      <@form.Field
+                        @name="security_add_group_id"
+                        @title={{i18n "category.security_add_group"}}
+                        @showTitle={{false}}
+                        @format="max"
+                        @type="select"
+                        @onSet={{this.onSecurityAddGroupSet}}
+                        as |field|
                       >
-                        {{#each this.availableGroups as |group|}}
-                          <select.Option
-                            @value={{group.id}}
-                          >{{group.name}}</select.Option>
-                        {{/each}}
-                      </field.Control>
-                    </@form.Field>
-                  </span>
-                </div>
-              </PluginOutlet>
+                        <field.Control
+                          class="available-groups"
+                          @nonePlaceholder={{i18n
+                            "category.security_add_group"
+                          }}
+                          as |select|
+                        >
+                          {{#each this.availableGroups as |group|}}
+                            <select.Option
+                              @value={{group.id}}
+                            >{{group.name}}</select.Option>
+                          {{/each}}
+                        </field.Control>
+                      </@form.Field>
+                    </span>
+                  </PluginOutlet>
+                {{/if}}
+                {{#if this.canRemoveAllPermissions}}
+                  <DButton
+                    class="btn-default remove-all-permissions"
+                    @label="category.permissions.remove_all"
+                    @action={{this.onRemoveAllPermissions}}
+                  />
+                {{/if}}
+              </div>
             {{/if}}
           </div>
 

--- a/frontend/discourse/tests/acceptance/category-edit-security-test.js
+++ b/frontend/discourse/tests/acceptance/category-edit-security-test.js
@@ -70,6 +70,36 @@ acceptance("Category Edit - Security", function (needs) {
       .exists({ count: 1 }, "adds only 'See' permission for a new row");
   });
 
+  test("remove all permissions", async function (assert) {
+    await visit("/c/bug/edit/security");
+
+    assert
+      .dom(".remove-all-permissions")
+      .doesNotExist("button is hidden below the group threshold");
+
+    await formKit().field("security_add_group_id").select("3");
+
+    assert
+      .dom(".remove-all-permissions")
+      .doesNotExist("button is still hidden with two groups");
+
+    await formKit().field("security_add_group_id").select("1");
+
+    assert
+      .dom(".remove-all-permissions")
+      .exists("button appears once three or more groups are configured");
+
+    await click(".remove-all-permissions");
+
+    assert.dom(".row-body").doesNotExist("removes every group permission");
+    assert
+      .dom(".row-empty")
+      .hasText(
+        i18n("category.permissions.no_groups_selected"),
+        "shows the empty message after removing all groups"
+      );
+  });
+
   test("editing permissions", async function (assert) {
     await visit("/c/bug/edit/security");
 


### PR DESCRIPTION
When there are 3 or more groups added to the category permissions matrix, this includes a "remove all" button to make it easier to reset them. This is especially useful when creating a new subcategory of a parent with many groups included. 

<img width="1446" height="578" alt="image" src="https://github.com/user-attachments/assets/803c1630-8769-4bd6-a2c8-16b9fa490bca" />
