### PR TITLE
DEV: make sure badge images always have a size

### DIFF
--- a/app/assets/stylesheets/common/base/user-badges.scss
+++ b/app/assets/stylesheets/common/base/user-badges.scss
@@ -213,9 +213,9 @@
       }
 
       img {
-        width: 100%;
-        max-width: var(--badge-icon-size);
-        max-height: var(--badge-icon-size);
+        width: var(--badge-icon-size);
+        height: var(--badge-icon-size);
+        object-fit: contain;
       }
 
       &.badge-type-gold .fa {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/svg-bug/404832

SVGs don't always have dimensions included, and in this case when uploaded to a custom badge the image collapses to 0. 

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/083a1776-64e7-4d10-834e-15b925c57dce" />

This flips around the styles so that instead of setting everything to 100% and capping the maximum, we set everything to our desired dimensions and scale down using object-fit. 

This means that images without dimensions get them through CSS (avoids 100% of 0 being 0), and images that are too large will still shrink to fit the space. 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/9afe4379-cb8f-45c9-a0fd-2a5169844a39" />
