### PR TITLE
DEV: Add prev period specs for dashboard highlight reports

### DIFF
--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -801,37 +801,6 @@ RSpec.describe Report do
       end
     end
 
-    it "averages the previous period over the days that had engagement" do
-      freeze_time(Time.zone.local(2026, 4, 28, 12, 0, 0))
-
-      two_on_first_day = [Fabricate(:user), Fabricate(:user)]
-      one_on_second_day = Fabricate(:user)
-      two_on_first_day.each do |engaged_user|
-        Fabricate(
-          :user_action,
-          user: engaged_user,
-          action_type: UserAction::LIKE,
-          created_at: Time.zone.local(2026, 4, 16, 12),
-        )
-      end
-      Fabricate(
-        :user_action,
-        user: one_on_second_day,
-        action_type: UserAction::LIKE,
-        created_at: Time.zone.local(2026, 4, 17, 12),
-      )
-
-      report =
-        Report.find(
-          "daily_engaged_users",
-          start_date: Time.zone.local(2026, 4, 22).beginning_of_day,
-          end_date: Time.zone.local(2026, 4, 28).end_of_day,
-          facets: [:prev_period],
-        )
-
-      expect(report.prev_period).to eq(1.5)
-    end
-
     it "returns the current data and previous period average" do
       current_user = Fabricate(:user)
       previous_users = [Fabricate(:user), Fabricate(:user)]

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -590,6 +590,25 @@ RSpec.describe Report do
     end
   end
 
+  describe "signups report" do
+    it "returns the current data and previous period count" do
+      Fabricate(:user, created_at: Time.zone.local(2026, 4, 1, 12))
+      Fabricate(:user, created_at: Time.zone.local(2026, 4, 2, 12))
+      Fabricate(:user, created_at: Time.zone.local(2026, 3, 31, 12))
+
+      report =
+        Report.find(
+          "signups",
+          start_date: Time.zone.local(2026, 4, 1).beginning_of_day,
+          end_date: Time.zone.local(2026, 4, 2).end_of_day,
+          facets: [:prev_period],
+        )
+
+      expect(report.data.sum { |point| point[:y] }).to eq(2)
+      expect(report.prev_period).to eq(1)
+    end
+  end
+
   describe "new contributors report" do
     let(:report) { Report.find("new_contributors") }
 
@@ -613,6 +632,35 @@ RSpec.describe Report do
         expect(report.data[0][:y]).to eq 2
         expect(report.data[1][:y]).to eq 1
       end
+    end
+
+    it "returns the current data and previous period count" do
+      current_contributor = Fabricate(:user)
+      current_contributor.user_stat.update!(
+        new_since: Time.zone.local(2026, 4, 1, 12),
+        first_post_created_at: Time.zone.local(2026, 4, 1, 12),
+      )
+      another_current_contributor = Fabricate(:user)
+      another_current_contributor.user_stat.update!(
+        new_since: Time.zone.local(2026, 4, 2, 12),
+        first_post_created_at: Time.zone.local(2026, 4, 2, 12),
+      )
+      previous_contributor = Fabricate(:user)
+      previous_contributor.user_stat.update!(
+        new_since: Time.zone.local(2026, 3, 31, 12),
+        first_post_created_at: Time.zone.local(2026, 3, 31, 12),
+      )
+
+      report =
+        Report.find(
+          "new_contributors",
+          start_date: Time.zone.local(2026, 4, 1).beginning_of_day,
+          end_date: Time.zone.local(2026, 4, 2).end_of_day,
+          facets: [:prev_period],
+        )
+
+      expect(report.data.sum { |point| point[:y] }).to eq(2)
+      expect(report.prev_period).to eq(1)
     end
   end
 
@@ -706,6 +754,25 @@ RSpec.describe Report do
         expect(report.prev30Days).to eq(75)
       end
     end
+
+    it "returns the current data and previous period average" do
+      current_visitor = Fabricate(:user)
+      previous_visitor = Fabricate(:user)
+
+      current_visitor.user_visits.create!(visited_at: Time.zone.local(2026, 4, 11).to_date)
+      previous_visitor.user_visits.create!(visited_at: Time.zone.local(2026, 4, 9).to_date)
+
+      report =
+        Report.find(
+          "dau_by_mau",
+          start_date: Time.zone.local(2026, 4, 10).beginning_of_day,
+          end_date: Time.zone.local(2026, 4, 11).end_of_day,
+          facets: [:prev_period],
+        )
+
+      expect(report.data.map { |point| point[:x] }).to eq([Date.new(2026, 4, 11)])
+      expect(report.prev_period).to eq(100)
+    end
   end
 
   describe "Daily engaged users" do
@@ -763,6 +830,37 @@ RSpec.describe Report do
         )
 
       expect(report.prev_period).to eq(1.5)
+    end
+
+    it "returns the current data and previous period average" do
+      current_user = Fabricate(:user)
+      previous_users = [Fabricate(:user), Fabricate(:user)]
+
+      Fabricate(
+        :user_action,
+        user: current_user,
+        action_type: UserAction::LIKE,
+        created_at: Time.zone.local(2026, 4, 23, 12),
+      )
+      previous_users.each do |previous_user|
+        Fabricate(
+          :user_action,
+          user: previous_user,
+          action_type: UserAction::LIKE,
+          created_at: Time.zone.local(2026, 4, 16, 12),
+        )
+      end
+
+      report =
+        Report.find(
+          "daily_engaged_users",
+          start_date: Time.zone.local(2026, 4, 22).beginning_of_day,
+          end_date: Time.zone.local(2026, 4, 28).end_of_day,
+          facets: [:prev_period],
+        )
+
+      expect(report.data).to eq([{ x: Date.new(2026, 4, 23), y: 1 }])
+      expect(report.prev_period).to eq(2.0)
     end
   end
 


### PR DESCRIPTION
Add report-level coverage for current and previous period values used by dashboard KPIs.