### PR TITLE
UX: fix modernized foundation review queue button padding

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -41,7 +41,8 @@
       .language-switcher-trigger,
       .d-multi-select-trigger__expand-btn,
       .emoji-picker-trigger,
-      .topic-list-header-tab
+      .topic-list-header-tab,
+      .reviewable-action-dropdown
     ) {
       padding-block: 0;
       height: var(--d-control-height);


### PR DESCRIPTION
the dropdowns in the review queue were picking up some extra button padding in the modernized foundation upcoming change

before:
<img width="578" height="346" alt="image" src="https://github.com/user-attachments/assets/4722d013-0ccc-4d7e-8747-0a09eb42a5bd" />


after:
<img width="580" height="332" alt="image" src="https://github.com/user-attachments/assets/6998cc01-7243-4c4c-892e-c013135ef7ce" />
