### PR TITLE
FIX: Style hidden posts in nested replies

### DIFF
--- a/frontend/discourse/app/components/nested/post.gjs
+++ b/frontend/discourse/app/components/nested/post.gjs
@@ -580,6 +580,7 @@ export default class NestedPost extends Component {
         (if this.effectiveCollapsed "nested-post--collapsed")
         (if @isPinned "nested-post--pinned")
         (if @post.isWhisper "nested-post--whisper")
+        (if @post.hidden "nested-post--hidden post--hidden post-hidden")
         (if (or @post.deleted @post.user_deleted) "nested-post--deleted")
         (if this.cloakingData.active "nested-post--cloaked")
         (if this.selected "selected")

--- a/spec/system/nested_hidden_posts_spec.rb
+++ b/spec/system/nested_hidden_posts_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe "Nested view hidden posts" do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:op) { Fabricate(:post, topic: topic, user: user, post_number: 1) }
+  fab!(:hidden_reply) do
+    Fabricate(
+      :post,
+      topic: topic,
+      user: user,
+      raw: "This hidden reply should be visibly muted in nested view",
+      reply_to_post_number: nil,
+      hidden: true,
+      hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+    )
+  end
+
+  let(:nested_view) { PageObjects::Pages::NestedView.new }
+
+  before do
+    SiteSetting.nested_replies_enabled = true
+    sign_in(admin)
+  end
+
+  it "marks hidden posts with the same hidden classes used by the flat topic view" do
+    nested_view.visit_nested(topic)
+
+    hidden_post = find(".nested-post__article[data-post-number=\"#{hidden_reply.post_number}\"]")
+    hidden_post_classes = hidden_post.ancestor(".nested-post")["class"]
+
+    expect(hidden_post_classes).to include("post-hidden")
+    expect(hidden_post_classes).to include("post--hidden")
+    expect(hidden_post_classes).to include("nested-post--hidden")
+  end
+end


### PR DESCRIPTION
Adds the same hidden-post classes used in flat topic view to nested replies.

<img width="1526" height="1272" alt="Screenshot 2026-06-09 at 2 47 57 PM" src="https://github.com/user-attachments/assets/93db0242-3d41-4559-bb31-0e86a042e7cd" />
