### PR TITLE
FIX: Do not apply topic-list-data font-size to category page elements

### DIFF
--- a/app/assets/stylesheets/common/base/category-list.scss
+++ b/app/assets/stylesheets/common/base/category-list.scss
@@ -15,7 +15,6 @@
     td,
     th {
       color: var(--d-topic-list-header-text-color);
-      font-size: var(--d-topic-list-data-font-size);
 
       &:first-of-type {
         padding-inline-start: var(--d-topic-list-data-padding-inline-start);
@@ -34,6 +33,7 @@
 
     th {
       vertical-align: middle;
+      font-size: var(--d-topic-list-data-font-size);
     }
 
     .topics .badge-notification,


### PR DESCRIPTION
This is mainly a fix for the foundation changes in order to not target text in these places.

| before | after |
| -- | -- |
|<img width="2076" height="1372" alt="CleanShot 2026-06-09 at 14 55 17@2x" src="https://github.com/user-attachments/assets/cad3fc66-38fe-404f-8c77-d7f54ff39bf3" />|<img width="2092" height="1392" alt="CleanShot 2026-06-09 at 14 54 45@2x" src="https://github.com/user-attachments/assets/f7be054b-38a8-4f14-8a22-e48483d33dd2" />| 