### PR TITLE
FEATURE: Add support for group-scoped flairs 

### DIFF
--- a/app/serializers/concerns/user_primary_group_mixin.rb
+++ b/app/serializers/concerns/user_primary_group_mixin.rb
@@ -26,7 +26,7 @@ module UserPrimaryGroupMixin
   end
 
   def include_flair_name?
-    object&.flair_group.present?
+    object&.flair_group.present? && can_see_flair?
   end
 
   def flair_url
@@ -34,7 +34,7 @@ module UserPrimaryGroupMixin
   end
 
   def include_flair_url?
-    object&.flair_group&.flair_url.present?
+    object&.flair_group&.flair_url.present? && can_see_flair?
   end
 
   def flair_bg_color
@@ -42,7 +42,7 @@ module UserPrimaryGroupMixin
   end
 
   def include_flair_bg_color?
-    object&.flair_group&.flair_bg_color.present?
+    object&.flair_group&.flair_bg_color.present? && can_see_flair?
   end
 
   def flair_group_id
@@ -50,7 +50,7 @@ module UserPrimaryGroupMixin
   end
 
   def include_flair_group_id?
-    object&.flair_group_id.present?
+    object&.flair_group_id.present? && can_see_flair?
   end
 
   def flair_color
@@ -58,7 +58,7 @@ module UserPrimaryGroupMixin
   end
 
   def include_flair_color?
-    object&.flair_group&.flair_color.present?
+    object&.flair_group&.flair_color.present? && can_see_flair?
   end
 
   def include_admin?
@@ -75,5 +75,14 @@ module UserPrimaryGroupMixin
 
   def moderator
     true
+  end
+
+  private
+
+  # Flair visibility is gated by the viewer's group membership. When no scope is
+  # present (e.g. serializing without a guardian), fall back to an anonymous
+  # guardian so the flair_visible_groups setting is still honoured.
+  def can_see_flair?
+    (scope || Guardian.new).can_see_flair?
   end
 end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -251,6 +251,14 @@ class PostSerializer < BasicPostSerializer
     object.user&.flair_group_id
   end
 
+  def include_flair_name?
+    (scope || Guardian.new).can_see_flair?
+  end
+  alias_method :include_flair_url?, :include_flair_name?
+  alias_method :include_flair_bg_color?, :include_flair_name?
+  alias_method :include_flair_color?, :include_flair_name?
+  alias_method :include_flair_group_id?, :include_flair_name?
+
   def badges_granted
     return [] unless SiteSetting.enable_badges && SiteSetting.show_badges_in_post_header
 

--- a/app/serializers/topic_post_count_serializer.rb
+++ b/app/serializers/topic_post_count_serializer.rb
@@ -49,6 +49,14 @@ class TopicPostCountSerializer < BasicUserSerializer
     object[:user]&.flair_group_id
   end
 
+  def include_flair_name?
+    (scope || Guardian.new).can_see_flair?
+  end
+  alias_method :include_flair_url?, :include_flair_name?
+  alias_method :include_flair_bg_color?, :include_flair_name?
+  alias_method :include_flair_color?, :include_flair_name?
+  alias_method :include_flair_group_id?, :include_flair_name?
+
   def include_admin?
     object[:user].admin
   end

--- a/app/serializers/topic_poster_serializer.rb
+++ b/app/serializers/topic_poster_serializer.rb
@@ -6,4 +6,8 @@ class TopicPosterSerializer < ApplicationSerializer
   has_one :user, serializer: PosterSerializer
   has_one :primary_group, serializer: PrimaryGroupSerializer
   has_one :flair_group, serializer: FlairGroupSerializer
+
+  def include_flair_group?
+    (scope || Guardian.new).can_see_flair?
+  end
 end

--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -223,6 +223,14 @@ class UserCardSerializer < BasicUserSerializer
     object.flair_group&.flair_color
   end
 
+  def include_flair_name?
+    (scope || Guardian.new).can_see_flair?
+  end
+  alias_method :include_flair_url?, :include_flair_name?
+  alias_method :include_flair_bg_color?, :include_flair_name?
+  alias_method :include_flair_color?, :include_flair_name?
+  alias_method :include_flair_group_id?, :include_flair_name?
+
   def include_featured_topic?
     scope.can_see_topic?(object.user_profile.featured_topic)
   end

--- a/app/serializers/user_summary_serializer.rb
+++ b/app/serializers/user_summary_serializer.rb
@@ -58,6 +58,13 @@ class UserSummarySerializer < ApplicationSerializer
       object.flair_group&.flair_color
     end
 
+    def include_flair_name?
+      (scope || Guardian.new).can_see_flair?
+    end
+    alias_method :include_flair_url?, :include_flair_name?
+    alias_method :include_flair_bg_color?, :include_flair_name?
+    alias_method :include_flair_color?, :include_flair_name?
+
     def primary_group_name
       object.primary_group&.name
     end

--- a/app/serializers/web_hook_post_serializer.rb
+++ b/app/serializers/web_hook_post_serializer.rb
@@ -33,6 +33,17 @@ class WebHookPostSerializer < PostSerializer
     badges_granted
   ].each { |attr| define_method("include_#{attr}?") { false } }
 
+  # Webhooks deliver payloads to trusted, admin-configured endpoints rather than
+  # to a flair-gated viewer, so flair fields are emitted regardless of the
+  # flair_visible_groups setting.
+  def include_flair_name?
+    true
+  end
+
+  def include_flair_group_id?
+    true
+  end
+
   def topic_posts
     @topic_posts ||= object.topic.posts.where(user_deleted: false)
   end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2530,6 +2530,7 @@ en:
     public_user_custom_fields: "A list of user custom fields that can be retrieved with the API."
     staff_user_custom_fields: "A list of user custom fields that can be retrieved for staff members with the API."
     enable_user_directory: "Provide a directory of users for browsing"
+    flair_visible_groups: "Only allow members of these groups to see other users' avatar flairs. Defaults to everyone."
     enable_group_directory: "Provide a directory of groups for browsing"
     enable_category_group_moderation: "Allow groups to moderate content in specific categories"
     group_in_subject: "Set %%{optional_pm} in email subject to name of first group in PM, see: <a href='https://meta.discourse.org/t/customize-specific-email-templates/88323' target='_blank'>Customize subject format for standard emails</a>"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1085,6 +1085,13 @@ users:
     client: true
     default: true
     area: "users"
+  flair_visible_groups:
+    type: group_list
+    list_type: compact
+    default: "0" # auto group everyone
+    allow_any: false
+    refresh: true
+    area: "users"
   directory_hourly_refresh_max_users:
     default: 100
     hidden: true

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -6,6 +6,17 @@ module UserGuardian
     (SiteSetting.reviewable_claiming != "disabled" || automatic) && can_review_topic?(topic)
   end
 
+  # Gates visibility of other users' avatar flairs to the viewer; it does not
+  # change who may have a flair. No staff exemption.
+  def can_see_flair?
+    flair_visible_groups = SiteSetting.flair_visible_groups_map
+
+    return true if flair_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
+    return false if anonymous?
+
+    @user.in_any_groups?(flair_visible_groups)
+  end
+
   def can_pick_avatar?(user_avatar, upload)
     return false unless user
     return true if is_admin?

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -6,15 +6,11 @@ module UserGuardian
     (SiteSetting.reviewable_claiming != "disabled" || automatic) && can_review_topic?(topic)
   end
 
-  # Gates visibility of other users' avatar flairs to the viewer; it does not
-  # change who may have a flair. No staff exemption.
   def can_see_flair?
     flair_visible_groups = SiteSetting.flair_visible_groups_map
 
-    return true if flair_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
-    return false if anonymous?
-
-    @user.in_any_groups?(flair_visible_groups)
+    flair_visible_groups.include?(Group::AUTO_GROUPS[:everyone]) ||
+      @user.in_any_groups?(flair_visible_groups)
   end
 
   def can_pick_avatar?(user_avatar, upload)

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe UserGuardian do
 
       expect(admin.guardian.can_see_flair?).to eq(false)
     end
+
+    context "when granular_anonymous_and_logged_in_groups_permissions is enabled" do
+      before { SiteSetting.granular_anonymous_and_logged_in_groups_permissions = true }
+
+      it "treats the everyone group as logged-in users, excluding anonymous viewers" do
+        SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+        expect(non_member.guardian.can_see_flair?).to eq(true)
+        expect(Guardian.new.can_see_flair?).to eq(false)
+      end
+
+      it "lets anonymous viewers see flairs when the anonymous_users group is configured" do
+        SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:anonymous_users].to_s
+
+        expect(Guardian.new.can_see_flair?).to eq(true)
+      end
+    end
   end
 
   describe "#can_claim_reviewable_topic?" do

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -34,6 +34,38 @@ RSpec.describe UserGuardian do
   fab!(:trust_level_1)
   fab!(:trust_level_2)
 
+  describe "#can_see_flair?" do
+    fab!(:allowed_group, :group)
+    fab!(:member) { Fabricate(:user, groups: [allowed_group]) }
+    fab!(:non_member, :user)
+
+    it "is true for everyone, including anonymous viewers, when the everyone group is configured" do
+      SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+      expect(Guardian.new.can_see_flair?).to eq(true)
+      expect(non_member.guardian.can_see_flair?).to eq(true)
+    end
+
+    it "is true only for members of the configured groups when restricted" do
+      SiteSetting.flair_visible_groups = allowed_group.id.to_s
+
+      expect(member.guardian.can_see_flair?).to eq(true)
+      expect(non_member.guardian.can_see_flair?).to eq(false)
+    end
+
+    it "is false for anonymous viewers when the everyone group is not configured" do
+      SiteSetting.flair_visible_groups = allowed_group.id.to_s
+
+      expect(Guardian.new.can_see_flair?).to eq(false)
+    end
+
+    it "does not exempt staff who are not in a configured group" do
+      SiteSetting.flair_visible_groups = allowed_group.id.to_s
+
+      expect(admin.guardian.can_see_flair?).to eq(false)
+    end
+  end
+
   describe "#can_claim_reviewable_topic?" do
     fab!(:topic)
     context "with anon user" do

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -3,6 +3,38 @@
 RSpec.describe PostSerializer do
   fab!(:post)
 
+  describe "flair fields" do
+    fab!(:flair_group) do
+      Fabricate(:group, flair_bg_color: "#111111", flair_color: "#999999", flair_icon: "icon")
+    end
+    fab!(:flair_author) { Fabricate(:user, flair_group: flair_group) }
+    fab!(:flair_post) { Fabricate(:post, user: flair_author) }
+    fab!(:allowed_group, :group)
+    fab!(:viewer) { Fabricate(:user, groups: [allowed_group]) }
+
+    let(:flair_keys) { %i[flair_name flair_url flair_bg_color flair_color flair_group_id] }
+
+    def flair_present_for?(scope)
+      json = described_class.new(flair_post, scope: scope, root: false).as_json
+      flair_keys.any? { |key| json.key?(key) }
+    end
+
+    it "includes flair for any viewer when the everyone group is configured" do
+      SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+      expect(flair_present_for?(Guardian.new)).to eq(true)
+      expect(flair_present_for?(Guardian.new(viewer))).to eq(true)
+    end
+
+    it "omits flair for non-members and anonymous viewers when restricted" do
+      SiteSetting.flair_visible_groups = allowed_group.id.to_s
+
+      expect(flair_present_for?(Guardian.new(viewer))).to eq(true)
+      expect(flair_present_for?(Guardian.new(Fabricate(:user)))).to eq(false)
+      expect(flair_present_for?(Guardian.new)).to eq(false)
+    end
+  end
+
   context "with a post with lots of actions" do
     fab!(:actor) { Fabricate(:user, refresh_auto_groups: true) }
     fab!(:admin)

--- a/spec/serializers/topic_post_count_serializer_spec.rb
+++ b/spec/serializers/topic_post_count_serializer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe TopicPostCountSerializer do
+  fab!(:flair_group) do
+    Fabricate(:group, flair_bg_color: "#111111", flair_color: "#999999", flair_icon: "icon")
+  end
+  fab!(:flair_user) { Fabricate(:user, flair_group: flair_group) }
+  fab!(:allowed_group, :group)
+
+  let(:flair_keys) { %i[flair_name flair_url flair_bg_color flair_color flair_group_id] }
+
+  def flair_present_for?(scope)
+    json =
+      described_class.new({ user: flair_user, post_count: 1 }, scope: scope, root: false).as_json
+    flair_keys.any? { |key| json.key?(key) }
+  end
+
+  it "includes flair for any viewer when the everyone group is configured" do
+    SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+    expect(flair_present_for?(Guardian.new)).to eq(true)
+  end
+
+  it "omits flair for non-members and anonymous viewers when restricted" do
+    SiteSetting.flair_visible_groups = allowed_group.id.to_s
+    member = Fabricate(:user, groups: [allowed_group])
+
+    expect(flair_present_for?(Guardian.new(member))).to eq(true)
+    expect(flair_present_for?(Guardian.new(Fabricate(:user)))).to eq(false)
+    expect(flair_present_for?(Guardian.new)).to eq(false)
+  end
+end

--- a/spec/serializers/user_card_serializer_spec.rb
+++ b/spec/serializers/user_card_serializer_spec.rb
@@ -1,6 +1,37 @@
 # frozen_string_literal: true
 
 RSpec.describe UserCardSerializer do
+  describe "flair fields" do
+    fab!(:flair_group) do
+      Fabricate(:group, flair_bg_color: "#111111", flair_color: "#999999", flair_icon: "icon")
+    end
+    fab!(:flair_user) { Fabricate(:user, flair_group: flair_group) }
+    fab!(:allowed_group, :group)
+    fab!(:viewer) { Fabricate(:user, groups: [allowed_group]) }
+
+    let(:flair_keys) { %i[flair_name flair_url flair_bg_color flair_color flair_group_id] }
+
+    def flair_present_for?(scope)
+      json = described_class.new(flair_user, scope: scope, root: false).as_json
+      flair_keys.any? { |key| json.key?(key) }
+    end
+
+    it "includes flair for any viewer when the everyone group is configured" do
+      SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+      expect(flair_present_for?(Guardian.new)).to eq(true)
+      expect(flair_present_for?(Guardian.new(viewer))).to eq(true)
+    end
+
+    it "omits flair for non-members and anonymous viewers when restricted" do
+      SiteSetting.flair_visible_groups = allowed_group.id.to_s
+
+      expect(flair_present_for?(Guardian.new(viewer))).to eq(true)
+      expect(flair_present_for?(Guardian.new(Fabricate(:user)))).to eq(false)
+      expect(flair_present_for?(Guardian.new)).to eq(false)
+    end
+  end
+
   context "with a TL0 user seen as anonymous" do
     let(:user) { Fabricate(:user, trust_level: 0) }
     let(:serializer) { described_class.new(user, scope: Guardian.new, root: false) }

--- a/spec/serializers/user_summary_serializer_spec.rb
+++ b/spec/serializers/user_summary_serializer_spec.rb
@@ -31,6 +31,38 @@ RSpec.describe UserSummarySerializer do
     expect(serializer.as_json[:most_liked_users][0][:name]).to eq(nil)
   end
 
+  describe "flair fields in interaction lists" do
+    fab!(:flair_group) do
+      Fabricate(:group, flair_bg_color: "#111111", flair_color: "#999999", flair_icon: "icon")
+    end
+    fab!(:allowed_group, :group)
+
+    def most_liked_user_json(viewer)
+      UserActionManager.enable
+      liked_user = Fabricate(:user, flair_group: flair_group, refresh_auto_groups: true)
+      liked_post = create_post(user: liked_user)
+      PostActionCreator.like(user, liked_post)
+
+      guardian = Guardian.new(viewer)
+      summary = UserSummary.new(user, guardian)
+      UserSummarySerializer.new(summary, scope: guardian, root: false).as_json[:most_liked_users][0]
+    end
+
+    it "includes flair when the everyone group is configured" do
+      SiteSetting.flair_visible_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+      expect(most_liked_user_json(another_user).key?(:flair_name)).to eq(true)
+    end
+
+    it "omits flair for viewers outside the configured groups" do
+      SiteSetting.flair_visible_groups = allowed_group.id.to_s
+      member = Fabricate(:user, groups: [allowed_group])
+
+      expect(most_liked_user_json(member).key?(:flair_name)).to eq(true)
+      expect(most_liked_user_json(another_user).key?(:flair_name)).to eq(false)
+    end
+  end
+
   it "respects hide_user_activity_tab setting" do
     SiteSetting.hide_user_activity_tab = true
     guardian = Guardian.new(another_user)


### PR DESCRIPTION
With this PR, we can now define in `flair_visible_groups` site setting which groups can see user flairs.

This is useful for sites that want to see some user flairs without having it to make it visible to everyone.

This will not change the default behavior of user flairs, so if `flair_visible_groups` is empty/default, then all users will see user flairs as before.


See demo: 

https://github.com/user-attachments/assets/d0f0ebc1-d019-4896-ac93-6ac4de8c5b09

