### PR TITLE
FIX: Preserve workflow connections on declared output ports

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/rete-editor.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/rete-editor.js
@@ -331,6 +331,10 @@ export class ReteEditorBridge {
         context.type === "connectioncreated" ||
         context.type === "connectionremoved"
       ) {
+        if (context.type === "connectioncreated") {
+          this.annotateConnectionIndexes(context.data);
+        }
+
         this.updateRendererGraphIndex();
         this.renderer.scheduleConnectionUpdate();
 
@@ -340,7 +344,8 @@ export class ReteEditorBridge {
             conn.source,
             conn.sourceOutput,
             conn.target,
-            conn.targetInput
+            conn.targetInput,
+            conn.sourceOutputIndex
           );
         }
       }
@@ -430,19 +435,17 @@ export class ReteEditorBridge {
     }
   }
 
-  connectionKeyFromClientIds(connection) {
-    return graphConnectionKey({
-      source: connection.sourceClientId,
-      sourceOutputIndex: normalizeSourceOutputIndex(connection),
-      target: connection.targetClientId,
-      targetInputIndex: normalizeTargetInputIndex(connection),
-    });
+  outputIndexFor(sourceNode, connection) {
+    return normalizeSourceOutputIndex(
+      connection,
+      Object.keys(sourceNode?.outputs || {})
+    );
   }
 
   outputKeyFor(sourceNode, connection) {
     return (
-      Object.keys(sourceNode.outputs || {})[
-        normalizeSourceOutputIndex(connection)
+      Object.keys(sourceNode?.outputs || {})[
+        this.outputIndexFor(sourceNode, connection)
       ] || normalizeSourceOutput(connection.sourceOutput)
     );
   }
@@ -453,6 +456,15 @@ export class ReteEditorBridge {
         normalizeTargetInputIndex(connection)
       ] || normalizeTargetInput(connection.targetInput)
     );
+  }
+
+  annotateConnectionIndexes(connection) {
+    const sourceNode = this.editor.getNode(
+      connection.sourceClientId || connection.source
+    );
+
+    connection.sourceOutputIndex = this.outputIndexFor(sourceNode, connection);
+    return connection;
   }
 
   buildDesiredGraphConnections(connections) {
@@ -466,7 +478,15 @@ export class ReteEditorBridge {
         continue;
       }
 
-      const key = this.connectionKeyFromClientIds(connection);
+      const sourceOutputIndex = this.outputIndexFor(sourceNode, connection);
+      const targetInputIndex = normalizeTargetInputIndex(connection);
+      const key = graphConnectionKey({
+        source: connection.sourceClientId,
+        sourceOutputIndex,
+        target: connection.targetClientId,
+        targetInputIndex,
+      });
+
       if (seen.has(key)) {
         continue;
       }
@@ -475,10 +495,10 @@ export class ReteEditorBridge {
       graphConnections.push({
         source: connection.sourceClientId,
         sourceOutput: this.outputKeyFor(sourceNode, connection),
-        sourceOutputIndex: normalizeSourceOutputIndex(connection),
+        sourceOutputIndex,
         target: connection.targetClientId,
         targetInput: this.inputKeyFor(targetNode, connection),
-        targetInputIndex: normalizeTargetInputIndex(connection),
+        targetInputIndex,
       });
     }
 
@@ -491,7 +511,9 @@ export class ReteEditorBridge {
         id: node.id,
         type: node.workflowData.type,
       })),
-      connections
+      connections.map((connection) =>
+        this.annotateConnectionIndexes(connection)
+      )
     );
   }
 
@@ -532,14 +554,18 @@ export class ReteEditorBridge {
       return;
     }
 
-    await this.editor.addConnection(
-      new this.ClassicPreset.Connection(
-        sourceNode,
-        this.outputKeyFor(sourceNode, { sourceOutput, sourceOutputIndex }),
-        targetNode,
-        this.inputKeyFor(targetNode, { targetInput, targetInputIndex })
-      )
+    const connection = new this.ClassicPreset.Connection(
+      sourceNode,
+      this.outputKeyFor(sourceNode, { sourceOutput, sourceOutputIndex }),
+      targetNode,
+      this.inputKeyFor(targetNode, { targetInput, targetInputIndex })
     );
+    connection.sourceOutputIndex = this.outputIndexFor(sourceNode, {
+      sourceOutput,
+      sourceOutputIndex,
+    });
+
+    await this.editor.addConnection(connection);
   }
 
   async syncState(nodes, connections) {
@@ -612,13 +638,17 @@ export class ReteEditorBridge {
       this.updateRendererGraphIndex(desiredGraphConnections);
 
       const desiredConnectionKeys = new Set(
-        connections.map((c) => this.connectionKeyFromClientIds(c))
+        desiredGraphConnections.map((connection) =>
+          graphConnectionKey(connection)
+        )
       );
       const existingConnections = this.editor.getConnections();
       const existingConnectionKeys = new Map();
 
       for (const connection of existingConnections) {
-        const key = graphConnectionKey(connection);
+        const key = graphConnectionKey(
+          this.annotateConnectionIndexes(connection)
+        );
 
         if (!desiredConnectionKeys.has(key)) {
           await this.editor.removeConnection(connection.id);
@@ -628,20 +658,20 @@ export class ReteEditorBridge {
         existingConnectionKeys.set(key, connection.id);
       }
 
-      for (const connection of connections) {
-        const key = this.connectionKeyFromClientIds(connection);
+      for (const connection of desiredGraphConnections) {
+        const key = graphConnectionKey(connection);
 
         if (existingConnectionKeys.has(key)) {
           continue;
         }
 
         await this.addConnection(
-          connection.sourceClientId,
-          normalizeSourceOutput(connection.sourceOutput),
-          connection.targetClientId,
-          normalizeTargetInput(connection.targetInput),
-          normalizeSourceOutputIndex(connection),
-          normalizeTargetInputIndex(connection)
+          connection.source,
+          connection.sourceOutput,
+          connection.target,
+          connection.targetInput,
+          connection.sourceOutputIndex,
+          connection.targetInputIndex
         );
         existingConnectionKeys.set(key, true);
       }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/editor/index.gjs
@@ -15,6 +15,7 @@ import {
 } from "../../../lib/workflows/graph-constants";
 import {
   nodeTypeLabel,
+  nodeTypeOutputKeys,
   nodeTypePrimaryOutputKey,
   nodeTypeVersion,
   resolveNodeTypeVersion,
@@ -453,6 +454,22 @@ export default class WorkflowsEditor extends Component {
     );
   }
 
+  #sourceOutputIndexFor(
+    sourceClientId,
+    sourceOutput,
+    nodes = this.formApi.get("nodes")
+  ) {
+    const sourceNode = nodes?.find((node) => node.clientId === sourceClientId);
+    const sourceNodeType =
+      this.workflowsNodeTypes.findNodeType(sourceNode?.type) ||
+      sourceNode?.type;
+
+    return portIndexFromKey(
+      sourceOutput,
+      nodeTypeOutputKeys(sourceNodeType, sourceNode)
+    );
+  }
+
   #addNewNode(nodeType, position, configOverrides, wireConnections) {
     const existingNodes = this.formApi.get("nodes");
     if (existingNodes.length >= MAX_NODES) {
@@ -503,11 +520,14 @@ export default class WorkflowsEditor extends Component {
       configOverrides,
       (connections, newNode) => {
         if (sourceClientId) {
+          const sourceOutputIndex = this.#sourceOutputIndexFor(
+            sourceClientId,
+            sourceOutput
+          );
           const existingIdx = connections.findIndex(
             (connection) =>
               connection.sourceClientId === sourceClientId &&
-              normalizeSourceOutputIndex(connection) ===
-                portIndexFromKey(sourceOutput)
+              normalizeSourceOutputIndex(connection) === sourceOutputIndex
           );
 
           if (existingIdx >= 0) {
@@ -517,17 +537,21 @@ export default class WorkflowsEditor extends Component {
               sourceClientId,
               targetClientId: newNode.clientId,
               sourceOutput,
+              sourceOutputIndex,
             });
             connections.push({
               sourceClientId: newNode.clientId,
               targetClientId: existing.targetClientId,
               sourceOutput: nodeTypePrimaryOutputKey(nodeType),
+              targetInput: existing.targetInput,
+              targetInputIndex: existing.targetInputIndex,
             });
           } else {
             connections.push({
               sourceClientId,
               targetClientId: newNode.clientId,
               sourceOutput,
+              sourceOutputIndex,
             });
           }
         }
@@ -554,6 +578,10 @@ export default class WorkflowsEditor extends Component {
             sourceClientId,
             targetClientId: newNode.clientId,
             sourceOutput,
+            sourceOutputIndex: this.#sourceOutputIndexFor(
+              sourceClientId,
+              sourceOutput
+            ),
           });
         }
         return false;
@@ -602,6 +630,11 @@ export default class WorkflowsEditor extends Component {
           sourceClientId,
           targetClientId: newNode.clientId,
           sourceOutput,
+          sourceOutputIndex: this.#sourceOutputIndexFor(
+            sourceClientId,
+            sourceOutput,
+            existingNodes
+          ),
           targetInput: "main",
         });
         connections.push({
@@ -691,17 +724,24 @@ export default class WorkflowsEditor extends Component {
     sourceClientId,
     sourceOutput,
     targetClientId,
-    targetInput = "main"
+    targetInput = "main",
+    sourceOutputIndex = null
   ) {
     this.#captureUndo();
     const nodes = this.formApi.get("nodes");
     const connections = [...this.formApi.get("connections")];
+    sourceOutputIndex ??= this.#sourceOutputIndexFor(
+      sourceClientId,
+      sourceOutput,
+      nodes
+    );
 
     // Don't create duplicate connections
     const exists = connections.some((connection) =>
       connectionMatchesEndpoint(connection, {
         sourceClientId,
         sourceOutput,
+        sourceOutputIndex,
         targetClientId,
         targetInput,
       })
@@ -714,6 +754,7 @@ export default class WorkflowsEditor extends Component {
       sourceClientId,
       targetClientId,
       sourceOutput,
+      sourceOutputIndex,
       targetInput,
     });
     this.#ensureLoopSelfConnection(
@@ -735,15 +776,22 @@ export default class WorkflowsEditor extends Component {
     sourceClientId,
     sourceOutput,
     targetClientId,
-    targetInput = "main"
+    targetInput = "main",
+    sourceOutputIndex = null
   ) {
     this.#captureUndo();
     const nodes = this.formApi.get("nodes");
     const connections = [...this.formApi.get("connections")];
+    sourceOutputIndex ??= this.#sourceOutputIndexFor(
+      sourceClientId,
+      sourceOutput,
+      nodes
+    );
     const index = connections.findIndex((connection) =>
       connectionMatchesEndpoint(connection, {
         sourceClientId,
         sourceOutput,
+        sourceOutputIndex,
         targetClientId,
         targetInput,
       })

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/editor-session.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/editor-session.js
@@ -6,6 +6,10 @@ import {
   latestRunWithOutput,
   outputForRun,
 } from "./data-schema";
+import {
+  normalizeSourceOutputIndex,
+  normalizeTargetInputIndex,
+} from "./graph-constants";
 
 function compactObject(object) {
   return Object.fromEntries(
@@ -20,36 +24,6 @@ function normalizeNodeForLoadOptions(node, identifier, typeVersion) {
     type: node?.type || identifier,
     typeVersion: node?.typeVersion || typeVersion,
   });
-}
-
-function portIndexFromKey(value) {
-  value = value?.toString();
-  if (!value || value === "main" || value === "true" || value === "done") {
-    return 0;
-  }
-
-  const inputMatch = value.match(/^input_(\d+)$/);
-  if (inputMatch) {
-    return parseInt(inputMatch[1], 10) - 1;
-  }
-
-  if (value === "false" || value === "loop") {
-    return 1;
-  }
-
-  return parseInt(value, 10) || 0;
-}
-
-function sourceOutputIndexForConnection(connection) {
-  return (
-    connection.sourceOutputIndex ?? portIndexFromKey(connection.sourceOutput)
-  );
-}
-
-function targetInputIndexForConnection(connection) {
-  return (
-    connection.targetInputIndex ?? portIndexFromKey(connection.targetInput)
-  );
 }
 
 export default class WorkflowEditorSession {
@@ -119,8 +93,8 @@ export default class WorkflowEditorSession {
     );
     const resolvedInputs = incomingConnections
       .map((connection) => {
-        const inputIndex = targetInputIndexForConnection(connection);
-        const outputIndex = sourceOutputIndexForConnection(connection);
+        const inputIndex = normalizeTargetInputIndex(connection);
+        const outputIndex = normalizeSourceOutputIndex(connection);
         const sourceNode = this.nodeForClientId(connection.sourceClientId);
         const currentInput = this.inputItemsForNode(node, inputIndex, {
           sourceNode,

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/graph-constants.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/graph-constants.js
@@ -10,9 +10,17 @@ export function normalizeTargetInput(targetInput) {
   return targetInput || "main";
 }
 
-export function portIndexFromKey(value) {
-  value = value?.toString();
-  if (!value || value === "main" || value === "true" || value === "done") {
+export function portIndexFromKey(value, orderedKeys = null) {
+  value = value?.toString() || DEFAULT_OUTPUT;
+
+  const orderedIndex = orderedKeys?.findIndex(
+    (key) => key?.toString() === value
+  );
+  if (orderedIndex >= 0) {
+    return orderedIndex;
+  }
+
+  if (value === "main" || value === "true" || value === "done") {
     return 0;
   }
 
@@ -28,9 +36,13 @@ export function portIndexFromKey(value) {
   return parseInt(value, 10) || 0;
 }
 
-export function normalizeSourceOutputIndex(connection) {
+export function normalizeSourceOutputIndex(
+  connection,
+  orderedOutputKeys = null
+) {
   return (
-    connection.sourceOutputIndex ?? portIndexFromKey(connection.sourceOutput)
+    connection.sourceOutputIndex ??
+    portIndexFromKey(connection.sourceOutput, orderedOutputKeys)
   );
 }
 
@@ -57,11 +69,18 @@ export function graphConnectionKey({
 
 export function connectionMatchesEndpoint(
   connection,
-  { sourceClientId, sourceOutput, targetClientId, targetInput = "main" }
+  {
+    sourceClientId,
+    sourceOutput,
+    sourceOutputIndex,
+    targetClientId,
+    targetInput = "main",
+  }
 ) {
   return (
     (connection.sourceClientId ?? connection.source) === sourceClientId &&
-    normalizeSourceOutputIndex(connection) === portIndexFromKey(sourceOutput) &&
+    normalizeSourceOutputIndex(connection) ===
+      (sourceOutputIndex ?? portIndexFromKey(sourceOutput)) &&
     (connection.targetClientId ?? connection.target) === targetClientId &&
     normalizeTargetInputIndex(connection) === portIndexFromKey(targetInput)
   );

--- a/plugins/discourse-workflows/test/javascripts/unit/components/workflows/canvas/canvas-bridge-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/components/workflows/canvas/canvas-bridge-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { createReteEditor } from "discourse/plugins/discourse-workflows/admin/components/workflows/canvas/rete-editor";
+import { buildConnectedOutputsIndex } from "discourse/plugins/discourse-workflows/admin/lib/workflows/graph-constants";
 
 const NODE_TYPES = [
   {
@@ -244,6 +245,97 @@ module("Unit | Canvas Bridge", function (hooks) {
     const connection = bridge.editor.getConnections()[0];
     assert.strictEqual(connection.sourceOutput, "loop");
     assert.strictEqual(connection.targetInput, "main");
+
+    bridge.destroy();
+  });
+
+  test("resolves arbitrary output keys to declared port indexes", async function (assert) {
+    const bridge = await createReteEditor(container, {
+      callbacks: noopCallbacks(),
+      nodeTypes: NODE_TYPES,
+    });
+
+    const nodes = [
+      {
+        clientId: "branch",
+        type: "action:data_table",
+        position: { x: 0, y: 0 },
+      },
+      {
+        clientId: "empty",
+        type: "action:http_request",
+        position: { x: 200, y: 0 },
+      },
+    ];
+    const connections = [
+      {
+        sourceClientId: "branch",
+        sourceOutput: "no_results",
+        targetClientId: "empty",
+      },
+    ];
+
+    await bridge.syncState(nodes, connections);
+
+    const connection = bridge.editor.getConnections()[0];
+    assert.strictEqual(connection.sourceOutput, "no_results");
+    assert.strictEqual(connection.sourceOutputIndex, 1);
+    assert.true(
+      buildConnectedOutputsIndex([connection]).get("branch").has(1),
+      "the second output is marked connected"
+    );
+
+    assert.strictEqual(
+      bridge.buildDesiredGraphConnections(connections)[0].sourceOutputIndex,
+      1
+    );
+
+    bridge.destroy();
+  });
+
+  test("connectioncreated reports the declared port index for arbitrary output keys", async function (assert) {
+    let createdConnection;
+
+    const bridge = await createReteEditor(container, {
+      callbacks: noopCallbacks({
+        onConnectionCreated(source, sourceOutput, target, targetInput, index) {
+          createdConnection = {
+            source,
+            sourceOutput,
+            target,
+            targetInput,
+            index,
+          };
+        },
+      }),
+      nodeTypes: NODE_TYPES,
+    });
+
+    await bridge.syncState(
+      [
+        {
+          clientId: "branch",
+          type: "action:data_table",
+          position: { x: 0, y: 0 },
+        },
+        {
+          clientId: "empty",
+          type: "action:http_request",
+          position: { x: 200, y: 0 },
+        },
+      ],
+      []
+    );
+
+    await bridge.addConnection("branch", "no_results", "empty");
+
+    assert.deepEqual(createdConnection, {
+      source: "branch",
+      sourceOutput: "no_results",
+      target: "empty",
+      targetInput: "main",
+      index: 1,
+    });
 
     bridge.destroy();
   });


### PR DESCRIPTION
Workflow connections are saved and executed by output index, but the editor was deriving that index from a small set of hard-coded output names. That worked for core branches like `false` and `loop`, but plugin outputs like Data Explorer's no-results branch fell back to index 0.

This change resolves output keys from the source node's declared port order, stores the resolved `sourceOutputIndex` when editor connections are created, and centralizes port index normalization so the no-results branch stays connected, reloads correctly, and runs through the intended output.