### PR TITLE
DEV: System tests for resolving reviewables across review queue tabs

### DIFF
--- a/plugins/chat/spec/system/resolving_reviewables_spec.rb
+++ b/plugins/chat/spec/system/resolving_reviewables_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+describe "Resolving chat message reviewables from the review queue" do
+  fab!(:admin)
+  fab!(:performing_moderator, :moderator)
+  fab!(:channel, :chat_channel)
+
+  fab!(:kept_message) { Fabricate(:chat_message, chat_channel: channel) }
+  fab!(:deleted_message) { Fabricate(:chat_message, chat_channel: channel) }
+  fab!(:disagreed_message) { Fabricate(:chat_message, chat_channel: channel) }
+  fab!(:ignored_message) { Fabricate(:chat_message, chat_channel: channel) }
+
+  let(:review_page) { PageObjects::Pages::Review.new }
+
+  before do
+    chat_system_bootstrap(admin, [channel])
+    sign_in(admin)
+    Jobs.run_immediately!
+  end
+
+  it "shows each resolved reviewable's status in both open queues" do
+    review_queue = Chat::ReviewQueue.new
+    spam_flag = ReviewableScore.types[:spam]
+    kept_message_reviewable =
+      review_queue.flag_message(kept_message, admin.guardian, spam_flag).fetch(:reviewable)
+    deleted_message_reviewable =
+      review_queue.flag_message(deleted_message, admin.guardian, spam_flag).fetch(:reviewable)
+    disagreed_message_reviewable =
+      review_queue.flag_message(disagreed_message, admin.guardian, spam_flag).fetch(:reviewable)
+    ignored_message_reviewable =
+      review_queue.flag_message(ignored_message, admin.guardian, spam_flag).fetch(:reviewable)
+
+    using_session(:other_tab) do
+      sign_in(performing_moderator)
+      visit("/review")
+
+      expect(review_page).to have_reviewables(
+        [
+          kept_message_reviewable,
+          deleted_message_reviewable,
+          disagreed_message_reviewable,
+          ignored_message_reviewable,
+        ],
+      )
+    end
+
+    visit("/review")
+
+    expect(review_page).to have_reviewables(
+      [
+        kept_message_reviewable,
+        deleted_message_reviewable,
+        disagreed_message_reviewable,
+        ignored_message_reviewable,
+      ],
+    )
+
+    review_page.select_bundled_action(
+      kept_message_reviewable,
+      "chat_message-agree_and_keep_message",
+      bundle_index: 1,
+    )
+
+    expect(review_page).to have_reviewable_with_approved_status(kept_message_reviewable)
+
+    review_page.select_bundled_action(
+      deleted_message_reviewable,
+      "chat_message-agree_and_delete",
+      bundle_index: 1,
+    )
+
+    expect(review_page).to have_reviewable_with_approved_status(deleted_message_reviewable)
+
+    review_page.select_bundled_action(
+      disagreed_message_reviewable,
+      "chat_message-disagree",
+      bundle_index: 2,
+    )
+
+    expect(review_page).to have_reviewable_with_rejected_status(disagreed_message_reviewable)
+
+    review_page.select_bundled_action(
+      ignored_message_reviewable,
+      "chat_message-ignore",
+      bundle_index: 2,
+    )
+
+    expect(review_page).to have_reviewable_with_ignored_status(ignored_message_reviewable)
+    expect(review_page).to have_reviewables(
+      [
+        kept_message_reviewable,
+        deleted_message_reviewable,
+        disagreed_message_reviewable,
+        ignored_message_reviewable,
+      ],
+    )
+
+    using_session(:other_tab) do
+      expect(review_page).to have_reviewable_with_approved_status(kept_message_reviewable)
+      expect(review_page).to have_reviewable_with_approved_status(deleted_message_reviewable)
+      expect(review_page).to have_reviewable_with_rejected_status(disagreed_message_reviewable)
+      expect(review_page).to have_reviewable_with_ignored_status(ignored_message_reviewable)
+      expect(review_page).to have_reviewables(
+        [
+          kept_message_reviewable,
+          deleted_message_reviewable,
+          disagreed_message_reviewable,
+          ignored_message_reviewable,
+        ],
+      )
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/system/resolving_reviewables_spec.rb
+++ b/plugins/discourse-ai/spec/system/resolving_reviewables_spec.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+describe "Resolving AI reviewables from the review queue" do
+  fab!(:admin)
+  fab!(:watching_admin, :admin)
+
+  let(:review_page) { PageObjects::Pages::Review.new }
+
+  before do
+    enable_current_plugin
+    sign_in(admin)
+    Jobs.run_immediately!
+  end
+
+  context "with AI post reviewables" do
+    fab!(:agreed_reviewable) do
+      ReviewableAiPost.needs_review!(target: Fabricate(:post), created_by: Discourse.system_user)
+    end
+
+    fab!(:disagreed_reviewable) do
+      ReviewableAiPost.needs_review!(target: Fabricate(:post), created_by: Discourse.system_user)
+    end
+
+    fab!(:ignored_reviewable) do
+      ReviewableAiPost.needs_review!(target: Fabricate(:post), created_by: Discourse.system_user)
+    end
+
+    fab!(:deleted_reviewable) do
+      ReviewableAiPost.needs_review!(target: Fabricate(:post), created_by: Discourse.system_user)
+    end
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(watching_admin)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(
+          [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+        )
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables(
+        [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+      )
+
+      review_page.select_bundled_action(agreed_reviewable, "post-agree_and_keep", bundle_index: 1)
+
+      expect(review_page).to have_reviewable_with_approved_status(agreed_reviewable)
+
+      review_page.select_bundled_action(disagreed_reviewable, "post-disagree", bundle_index: 2)
+
+      expect(review_page).to have_reviewable_with_rejected_status(disagreed_reviewable)
+
+      review_page.select_bundled_action(ignored_reviewable, "post-ignore", bundle_index: 2)
+
+      expect(review_page).to have_reviewable_with_ignored_status(ignored_reviewable)
+
+      review_page.select_bundled_action(
+        deleted_reviewable,
+        "post-delete_and_agree",
+        bundle_index: 1,
+      )
+
+      expect(review_page).to have_reviewable_with_approved_status(deleted_reviewable)
+      expect(review_page).to have_reviewables(
+        [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+      )
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(agreed_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(disagreed_reviewable)
+        expect(review_page).to have_reviewable_with_ignored_status(ignored_reviewable)
+        expect(review_page).to have_reviewable_with_approved_status(deleted_reviewable)
+        expect(review_page).to have_reviewables(
+          [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+        )
+      end
+    end
+  end
+
+  context "with AI chat message reviewables" do
+    fab!(:kept_message_reviewable) do
+      ReviewableAiChatMessage.needs_review!(
+        target: Fabricate(:chat_message),
+        created_by: Discourse.system_user,
+      )
+    end
+
+    fab!(:deleted_message_reviewable) do
+      ReviewableAiChatMessage.needs_review!(
+        target: Fabricate(:chat_message),
+        created_by: Discourse.system_user,
+      )
+    end
+
+    fab!(:disagreed_message_reviewable) do
+      ReviewableAiChatMessage.needs_review!(
+        target: Fabricate(:chat_message),
+        created_by: Discourse.system_user,
+      )
+    end
+
+    fab!(:ignored_message_reviewable) do
+      ReviewableAiChatMessage.needs_review!(
+        target: Fabricate(:chat_message),
+        created_by: Discourse.system_user,
+      )
+    end
+
+    before { SiteSetting.chat_enabled = true }
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(watching_admin)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(
+          [
+            kept_message_reviewable,
+            deleted_message_reviewable,
+            disagreed_message_reviewable,
+            ignored_message_reviewable,
+          ],
+        )
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables(
+        [
+          kept_message_reviewable,
+          deleted_message_reviewable,
+          disagreed_message_reviewable,
+          ignored_message_reviewable,
+        ],
+      )
+
+      review_page.select_bundled_action(
+        kept_message_reviewable,
+        "chat_message-agree_and_keep_message",
+        bundle_index: 1,
+      )
+
+      expect(review_page).to have_reviewable_with_approved_status(kept_message_reviewable)
+
+      review_page.select_bundled_action(
+        deleted_message_reviewable,
+        "chat_message-agree_and_delete",
+        bundle_index: 1,
+      )
+
+      expect(review_page).to have_reviewable_with_approved_status(deleted_message_reviewable)
+
+      review_page.select_bundled_action(
+        disagreed_message_reviewable,
+        "chat_message-disagree",
+        bundle_index: 2,
+      )
+
+      expect(review_page).to have_reviewable_with_rejected_status(disagreed_message_reviewable)
+
+      review_page.select_bundled_action(
+        ignored_message_reviewable,
+        "chat_message-ignore",
+        bundle_index: 2,
+      )
+
+      expect(review_page).to have_reviewable_with_ignored_status(ignored_message_reviewable)
+      expect(review_page).to have_reviewables(
+        [
+          kept_message_reviewable,
+          deleted_message_reviewable,
+          disagreed_message_reviewable,
+          ignored_message_reviewable,
+        ],
+      )
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(kept_message_reviewable)
+        expect(review_page).to have_reviewable_with_approved_status(deleted_message_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(disagreed_message_reviewable)
+        expect(review_page).to have_reviewable_with_ignored_status(ignored_message_reviewable)
+        expect(review_page).to have_reviewables(
+          [
+            kept_message_reviewable,
+            deleted_message_reviewable,
+            disagreed_message_reviewable,
+            ignored_message_reviewable,
+          ],
+        )
+      end
+    end
+  end
+
+  context "with AI tool action reviewables" do
+    fab!(:ai_agent)
+
+    fab!(:approved_reviewable) do
+      tool_action =
+        AiToolAction.create!(
+          tool_name: "close_topic",
+          tool_parameters: {
+            topic_id: Fabricate(:topic).id,
+            closed: true,
+            reason: "Off-topic",
+          },
+          ai_agent: ai_agent,
+          bot_user_id: Discourse.system_user.id,
+        )
+
+      reviewable =
+        ReviewableAiToolAction.needs_review!(
+          target: tool_action,
+          created_by: Discourse.system_user,
+          reviewable_by_moderator: true,
+          payload: {
+            agent_name: ai_agent.name,
+            reason: "Off-topic",
+          },
+        )
+      reviewable.add_score(
+        Discourse.system_user,
+        ReviewableScore.types[:needs_approval],
+        force_review: true,
+      )
+      reviewable
+    end
+
+    fab!(:rejected_reviewable) do
+      tool_action =
+        AiToolAction.create!(
+          tool_name: "close_topic",
+          tool_parameters: {
+            topic_id: Fabricate(:topic).id,
+            closed: true,
+            reason: "Off-topic",
+          },
+          ai_agent: ai_agent,
+          bot_user_id: Discourse.system_user.id,
+        )
+
+      reviewable =
+        ReviewableAiToolAction.needs_review!(
+          target: tool_action,
+          created_by: Discourse.system_user,
+          reviewable_by_moderator: true,
+          payload: {
+            agent_name: ai_agent.name,
+            reason: "Off-topic",
+          },
+        )
+      reviewable.add_score(
+        Discourse.system_user,
+        ReviewableScore.types[:needs_approval],
+        force_review: true,
+      )
+      reviewable
+    end
+
+    before { SiteSetting.ai_bot_enabled = true }
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(watching_admin)
+        visit("/review")
+
+        expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+
+      review_page.select_action(approved_reviewable, "ai_tool_action-approve")
+
+      expect(review_page).to have_reviewable_with_approved_status(approved_reviewable)
+
+      review_page.select_action(rejected_reviewable, "ai_tool_action-reject")
+
+      expect(review_page).to have_reviewable_with_rejected_status(rejected_reviewable)
+      expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(approved_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(rejected_reviewable)
+        expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+      end
+    end
+  end
+end

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -387,4 +387,219 @@ describe "Reviewables" do
       expect(title_html).to include("&lt;b&gt;")
     end
   end
+
+  describe "when resolving flagged post reviewables from the queue" do
+    fab!(:performing_moderator, :moderator)
+    fab!(:agreed_reviewable, :reviewable_flagged_post)
+    fab!(:disagreed_reviewable, :reviewable_flagged_post)
+    fab!(:ignored_reviewable, :reviewable_flagged_post)
+    fab!(:deleted_reviewable, :reviewable_flagged_post)
+
+    before { Jobs.run_immediately! }
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(performing_moderator)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(
+          [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+        )
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables(
+        [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+      )
+
+      review_page.select_bundled_action(agreed_reviewable, "post-agree_and_keep", bundle_index: 1)
+
+      expect(review_page).to have_reviewable_with_approved_status(agreed_reviewable)
+
+      review_page.select_bundled_action(disagreed_reviewable, "post-disagree", bundle_index: 2)
+
+      expect(review_page).to have_reviewable_with_rejected_status(disagreed_reviewable)
+
+      review_page.select_bundled_action(
+        ignored_reviewable,
+        "post-ignore_and_do_nothing",
+        bundle_index: 2,
+      )
+
+      expect(review_page).to have_reviewable_with_ignored_status(ignored_reviewable)
+
+      review_page.select_bundled_action(
+        deleted_reviewable,
+        "post-delete_and_agree",
+        bundle_index: 1,
+      )
+
+      expect(review_page).to have_reviewable_with_approved_status(deleted_reviewable)
+      expect(review_page).to have_reviewables(
+        [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+      )
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(agreed_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(disagreed_reviewable)
+        expect(review_page).to have_reviewable_with_ignored_status(ignored_reviewable)
+        expect(review_page).to have_reviewable_with_approved_status(deleted_reviewable)
+        expect(review_page).to have_reviewables(
+          [agreed_reviewable, disagreed_reviewable, ignored_reviewable, deleted_reviewable],
+        )
+      end
+    end
+  end
+
+  describe "when resolving queued post reviewables from the queue" do
+    fab!(:performing_moderator, :moderator)
+    fab!(:approved_reviewable, :reviewable_queued_post)
+    fab!(:rejected_reviewable, :reviewable_queued_post)
+
+    before { Jobs.run_immediately! }
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(performing_moderator)
+        visit("/review")
+
+        expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+
+      review_page.select_action(approved_reviewable, "approve_post")
+
+      expect(review_page).to have_reviewable_with_approved_status(approved_reviewable)
+
+      review_page.select_bundled_action(rejected_reviewable, "reject_post")
+
+      expect(review_page).to have_reviewable_with_rejected_status(rejected_reviewable)
+      expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(approved_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(rejected_reviewable)
+        expect(review_page).to have_reviewables([approved_reviewable, rejected_reviewable])
+      end
+    end
+  end
+
+  describe "when resolving user reviewables from the queue" do
+    fab!(:performing_moderator, :moderator)
+
+    fab!(:approved_user) { Fabricate(:user, approved: false) }
+    fab!(:rejected_user) { Fabricate(:user, approved: false) }
+
+    fab!(:approved_user_reviewable) do
+      ReviewableUser.needs_review!(
+        target: approved_user,
+        created_by: Discourse.system_user,
+        reviewable_by_moderator: true,
+        payload: {
+          username: approved_user.username,
+          name: approved_user.name,
+          email: approved_user.email,
+        },
+      )
+    end
+
+    fab!(:rejected_user_reviewable) do
+      ReviewableUser.needs_review!(
+        target: rejected_user,
+        created_by: Discourse.system_user,
+        reviewable_by_moderator: true,
+        payload: {
+          username: rejected_user.username,
+          name: rejected_user.name,
+          email: rejected_user.email,
+        },
+      )
+    end
+
+    let(:rejection_reason_modal) { PageObjects::Modals::RejectReasonReviewable.new }
+
+    before do
+      SiteSetting.must_approve_users = true
+      Jobs.run_immediately!
+    end
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(performing_moderator)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(
+          [approved_user_reviewable, rejected_user_reviewable],
+        )
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables([approved_user_reviewable, rejected_user_reviewable])
+
+      review_page.select_action(approved_user_reviewable, "user-approve_user")
+
+      expect(review_page).to have_reviewable_with_approved_status(approved_user_reviewable)
+
+      review_page.select_bundled_action(rejected_user_reviewable, "user-delete_user")
+      rejection_reason_modal.fill_in_rejection_reason("user is spamming")
+      rejection_reason_modal.delete_user
+
+      expect(review_page).to have_reviewable_with_rejected_status(rejected_user_reviewable)
+      expect(review_page).to have_reviewables([approved_user_reviewable, rejected_user_reviewable])
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(approved_user_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(rejected_user_reviewable)
+        expect(review_page).to have_reviewables(
+          [approved_user_reviewable, rejected_user_reviewable],
+        )
+      end
+    end
+  end
+
+  describe "when resolving posts queued for review from the queue" do
+    fab!(:performing_moderator, :moderator)
+
+    fab!(:approved_post_reviewable) { ReviewablePost.queue_for_review(Fabricate(:post)) }
+    fab!(:rejected_post_reviewable) { ReviewablePost.queue_for_review(Fabricate(:post)) }
+
+    before { Jobs.run_immediately! }
+
+    it "shows each resolved reviewable's status in both open queues" do
+      using_session(:other_tab) do
+        sign_in(performing_moderator)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(
+          [approved_post_reviewable, rejected_post_reviewable],
+        )
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables([approved_post_reviewable, rejected_post_reviewable])
+
+      review_page.select_action(approved_post_reviewable, "post-approve")
+
+      expect(review_page).to have_reviewable_with_approved_status(approved_post_reviewable)
+
+      review_page.select_bundled_action(rejected_post_reviewable, "post-reject_and_delete")
+
+      expect(review_page).to have_reviewable_with_rejected_status(rejected_post_reviewable)
+      expect(review_page).to have_reviewables([approved_post_reviewable, rejected_post_reviewable])
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(approved_post_reviewable)
+        expect(review_page).to have_reviewable_with_rejected_status(rejected_post_reviewable)
+        expect(review_page).to have_reviewables(
+          [approved_post_reviewable, rejected_post_reviewable],
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds two-window system tests documenting how the pending review queue behaves on `main` when a staff member resolves reviewables while another staff user has the queue open in a second tab. Each test loads `/review` in both tabs, performs every resolving action for the type, and asserts what each tab shows.

### Behavior documented (current `main`)

1. The resolved reviewable **stays in the loaded list** in both tabs — nothing is removed until a reload.
2. Its **status label updates in both tabs** without any interaction: the acting tab refreshes the reviewable from the perform response, and the watching tab receives the update over the message bus.

### Coverage

| Type | Actions covered | Resulting statuses |
|---|---|---|
| `ReviewableFlaggedPost` | agree and keep, disagree, ignore, delete and agree | approved, rejected, ignored, approved |
| `ReviewableQueuedPost` | approve, reject | approved, rejected |
| `ReviewableUser` | approve, reject (delete user with rejection reason) | approved, rejected |
| `ReviewablePost` | approve, reject and delete | approved, rejected |
| `Chat::ReviewableMessage` | agree and keep, agree and delete, disagree, ignore | approved, approved, rejected, ignored |
| `ReviewableAiPost` | agree and keep, disagree, ignore, delete and agree | approved, rejected, ignored, approved |
| `ReviewableAiChatMessage` | agree and keep, agree and delete, disagree, ignore | approved, approved, rejected, ignored |
| `ReviewableAiToolAction` | approve, reject | approved, rejected |

### Key decisions

1. **One test per reviewable type, multiple reviewables per test.** Each test fabricates one pending reviewable per resolving action and walks through them in a single flow, so every action's two-tab behavior is verified with one browser setup per type.

2. **The flagged-post, queued-post, user, post, and chat tests watch as a moderator** to exercise the moderator branch of the `NotifyReviewable` broadcast; the AI tests watch as a second admin since `needs_review!` creates those reviewables with `reviewable_by_moderator: false` by default.

3. **All files reuse the `:other_tab` session name.** The second browser instance binds a fixed devtools port; introducing a different session name in the same process launches a third browser that collides on that port and times out.

4. **Reviewables are created through realistic paths** — fabricators where they exist, `Chat::ReviewQueue#flag_message`, `ReviewablePost.queue_for_review`, and `needs_review!` mirroring the `CreateUserReviewable` job and AI classifier/tool flows.

Tests only; no production code changes.

### Verification

```
bin/rspec spec/system/reviewables_spec.rb
# 24 examples, 0 failures

LOAD_PLUGINS=1 bin/rspec plugins/chat/spec/system/resolving_reviewables_spec.rb
# 1 example, 0 failures

LOAD_PLUGINS=1 bin/rspec plugins/discourse-ai/spec/system/resolving_reviewables_spec.rb
# 3 examples, 0 failures
```