### PR TITLE
DEV: Make `bin/lint <file>` lint the working tree, not the staged blob

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -109,6 +109,19 @@ class LefthookLinter
 
   EVERYTHING = ["ALL FILES"]
 
+  # In --staged mode we want to lint exactly what is in the index, so we use the
+  # pre-commit/fix-staged hooks (which read the staged blobs). Every other mode
+  # operates on what is currently on disk, so it routes to the lint-files/fix-files
+  # hooks: those are not named pre-commit/pre-push, so lefthook does not hide
+  # unstaged changes and the linters see the working-tree content.
+  def check_hook
+    @staged ? "pre-commit" : "lint-files"
+  end
+
+  def fix_hook
+    @staged ? "fix-staged" : "fix-files"
+  end
+
   def run
     files = determine_files
 
@@ -243,7 +256,7 @@ class LefthookLinter
     end
 
     core, external = partition_files(files)
-    run_lefthook_command("fix-staged", core) if core.any?
+    run_lefthook_command(fix_hook, core) if core.any?
     external.each do |root, fs|
       linter = ExternalLinter.new(root, fs, fix: true, verbose: @verbose)
       linter.run
@@ -264,7 +277,7 @@ class LefthookLinter
     end
 
     core, external = partition_files(files)
-    run_lefthook_command("pre-commit", core) if core.any?
+    run_lefthook_command(check_hook, core) if core.any?
     external.each do |root, fs|
       linter = ExternalLinter.new(root, fs, fix: false, verbose: @verbose)
       linter.run

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,46 +16,41 @@ pre-commit:
     - rebase
   commands:
     rubocop:
-      exclude:
+      exclude: &ruby_exclude
         - "bin/notify_file_change"
         - "bin/docker/**/*"
-      glob:
+      glob: &ruby_glob
         - "**/*.{rb,rake,thor}"
         - "bin/**/*"
         - "Gemfile"
       run: bundle exec rubocop --force-exclusion {staged_files}
     syntax_tree:
-      exclude:
-        - "bin/notify_file_change"
-        - "bin/docker/**/*"
-      glob:
-        - "**/*.{rb,rake,thor}"
-        - "bin/**/*"
-        - "Gemfile"
+      exclude: *ruby_exclude
+      glob: *ruby_glob
       run: bundle exec stree check Gemfile {staged_files}
     prettier:
-      glob:
+      glob: &prettier_glob
         - "app/assets/stylesheets/**/*.{css,scss}"
         - "frontend/**/*.{js,gjs,scss,css,cjs,mjs}"
         - "plugins/**/*.{js,gjs,scss,css,cjs,mjs}"
         - "themes/**/*.{js,gjs,scss,css,cjs,mjs}"
       run: pnpm pprettier --list-different {staged_files}
     eslint:
-      glob:
+      glob: &eslint_glob
         - "frontend/**/*.{js,gjs}"
         - "plugins/**/*.{js,gjs}"
         - "themes/**/*.{js,gjs}"
       run: pnpm eslint --max-warnings 0 {staged_files}
     yaml-syntax:
-      glob: "**/*.{yaml,yml}"
+      glob: &yaml_glob "**/*.{yaml,yml}"
       # database.yml is an erb file not a yaml file
-      exclude: "config/database.yml"
+      exclude: &yaml_exclude "config/database.yml"
       run: bundle exec yaml-lint {staged_files}
     i18n-lint:
-      glob: "**/{client,server}.en.yml"
+      glob: &i18n_glob "**/{client,server}.en.yml"
       run: bundle exec ruby script/i18n_lint.rb {staged_files}
     stylelint:
-      glob:
+      glob: &stylelint_glob
         - "app/assets/stylesheets/**/*.scss"
         - "plugins/**/assets/stylesheets/**/*.scss"
         - "themes/**/*.scss"
@@ -65,42 +60,90 @@ fix-staged:
   parallel: false
   commands:
     prettier:
-      glob:
-        - "app/assets/stylesheets/**/*.{css,scss}"
-        - "frontend/**/*.{js,gjs,scss,css,cjs,mjs}"
-        - "plugins/**/*.{js,gjs,scss,css,cjs,mjs}"
-        - "themes/**/*.{js,gjs,scss,css,cjs,mjs}"
+      glob: *prettier_glob
       run: pnpm pprettier --write {staged_files}
     eslint:
-      glob:
-        - "frontend/**/*.{js,gjs}"
-        - "plugins/**/*.{js,gjs}"
-        - "themes/**/*.{js,gjs}"
+      glob: *eslint_glob
       run: pnpm eslint --fix {staged_files}
     stylelint:
-      glob:
-        - "app/assets/stylesheets/**/*.scss"
-        - "plugins/**/assets/stylesheets/**/*.scss"
-        - "themes/**/*.scss"
+      glob: *stylelint_glob
       run: pnpm stylelint --fix {staged_files}
     rubocop:
-      exclude:
-        - "bin/notify_file_change"
-        - "bin/docker/**/*"
-      glob:
-        - "**/*.{rb,rake,thor}"
-        - "bin/**/*"
-        - "Gemfile"
+      exclude: *ruby_exclude
+      glob: *ruby_glob
       run: bundle exec rubocop --force-exclusion -A {staged_files}
     syntax_tree:
-      exclude:
-        - "bin/notify_file_change"
-        - "bin/docker/**/*"
-      glob:
-        - "**/*.{rb,rake,thor}"
-        - "bin/**/*"
-        - "Gemfile"
+      exclude: *ruby_exclude
+      glob: *ruby_glob
       run: bundle exec stree write Gemfile {staged_files}
+
+# Working-tree counterparts of pre-commit/fix-staged. Deliberately NOT named
+# pre-commit/pre-push so lefthook does not hide unstaged changes: the linters
+# read the files exactly as they are on disk, not their staged blobs. bin/lint
+# routes explicit-path, --recent, --unstaged and --wip runs here. The {files}
+# template is overridden by the --file flag bin/lint passes; the files command
+# is only the fallback when no --file is given and lists tracked plus untracked
+# (but not ignored) paths.
+lint-files:
+  parallel: true
+  commands:
+    rubocop:
+      files: &working_tree_files git ls-files --cached --others --exclude-standard
+      exclude: *ruby_exclude
+      glob: *ruby_glob
+      run: bundle exec rubocop --force-exclusion {files}
+    syntax_tree:
+      files: *working_tree_files
+      exclude: *ruby_exclude
+      glob: *ruby_glob
+      run: bundle exec stree check Gemfile {files}
+    prettier:
+      files: *working_tree_files
+      glob: *prettier_glob
+      run: pnpm pprettier --list-different {files}
+    eslint:
+      files: *working_tree_files
+      glob: *eslint_glob
+      run: pnpm eslint --max-warnings 0 {files}
+    yaml-syntax:
+      files: *working_tree_files
+      glob: *yaml_glob
+      exclude: *yaml_exclude
+      run: bundle exec yaml-lint {files}
+    i18n-lint:
+      files: *working_tree_files
+      glob: *i18n_glob
+      run: bundle exec ruby script/i18n_lint.rb {files}
+    stylelint:
+      files: *working_tree_files
+      glob: *stylelint_glob
+      run: pnpm stylelint {files}
+
+fix-files:
+  parallel: false
+  commands:
+    prettier:
+      files: *working_tree_files
+      glob: *prettier_glob
+      run: pnpm pprettier --write {files}
+    eslint:
+      files: *working_tree_files
+      glob: *eslint_glob
+      run: pnpm eslint --fix {files}
+    stylelint:
+      files: *working_tree_files
+      glob: *stylelint_glob
+      run: pnpm stylelint --fix {files}
+    rubocop:
+      files: *working_tree_files
+      exclude: *ruby_exclude
+      glob: *ruby_glob
+      run: bundle exec rubocop --force-exclusion -A {files}
+    syntax_tree:
+      files: *working_tree_files
+      exclude: *ruby_exclude
+      glob: *ruby_glob
+      run: bundle exec stree write Gemfile {files}
 
 fix-all:
   parallel: false
@@ -114,32 +157,19 @@ fix-all:
     rubocop:
       run: bundle exec rubocop --force-exclusion -A
     syntax_tree:
-      exclude:
-        - "bin/notify_file_change"
-        - "bin/docker/**/*"
-      glob:
-        - "**/*.{rb,rake,thor}"
-        - "bin/**/*"
-        - "Gemfile"
+      exclude: *ruby_exclude
+      glob: *ruby_glob
       run: bundle exec stree write Gemfile {all_files}
 
 lints:
   parallel: true
   commands:
     rubocop:
-      glob:
-        - "**/*.{rb,rake,thor}"
-        - "bin/**/*"
-        - "Gemfile"
+      glob: *ruby_glob
       run: bundle exec rubocop
     syntax_tree:
-      exclude:
-        - "bin/notify_file_change"
-        - "bin/docker/**/*"
-      glob:
-        - "**/*.{rb,rake,thor}"
-        - "bin/**/*"
-        - "Gemfile"
+      exclude: *ruby_exclude
+      glob: *ruby_glob
       run: bundle exec stree check Gemfile {all_files}
     prettier:
       run: pnpm lint:prettier
@@ -148,12 +178,12 @@ lints:
     stylelint:
       run: pnpm lint:css
     yaml-syntax:
-      glob: "**/*.{yaml,yml}"
+      glob: *yaml_glob
       # database.yml is an erb file not a yaml file
-      exclude: "config/database.yml"
+      exclude: *yaml_exclude
       run: bundle exec yaml-lint {all_files}
     i18n-lint:
-      glob: "**/{client,server}.en.yml"
+      glob: *i18n_glob
       run: bundle exec ruby script/i18n_lint.rb {all_files}
     glint:
       run: pnpm lint:types


### PR DESCRIPTION
Running `bin/lint <file>` checked the git-staged version of a file rather than its current working-tree content, so an edit was not reflected until it was `git add`-ed. The cause is that `bin/lint` routed every mode through lefthook's `pre-commit` hook, and lefthook deliberately hides unstaged changes for hooks named `pre-commit`/`pre-push` so that a commit is linted against exactly what it will contain. That is correct for a commit, but surprising when linting on demand.

This adds two working-tree counterparts, `lint-files` and `fix-files`, that mirror the command sets of `pre-commit` and `fix-staged` but are not named `pre-commit`/`pre-push`, so lefthook leaves unstaged changes in place and the linters see the files as they are on disk. `bin/lint` now sends explicit paths and the `--recent`, `--unstaged`, and `--wip` modes to these hooks. `--staged` continues to use `pre-commit`/`fix-staged`, and the installed `pre-commit` git hook is unchanged, so commit-time linting still runs against the staged content.

The shared `glob`/`exclude` blocks in `lefthook.yml` are now defined once as YAML anchors and reused across the hooks to keep the command sets from drifting apart.