### PR TITLE
UI: Don't squash everything in DE description

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/edit.gjs
@@ -85,9 +85,7 @@ export default class QueriesEdit extends Component {
               {{/unless}}
             </div>
 
-            <div class="desc">
-              {{@controller.model.description}}
-            </div>
+            <div class="desc">{{@controller.model.description}}</div>
           {{/if}}
 
           {{#unless @controller.model.destroyed}}

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -338,6 +338,7 @@ table.group-reports {
 
   &:not(.editing) .desc {
     margin: 10px 0;
+    white-space: pre-wrap;
   }
 
   .groups {


### PR DESCRIPTION
A simple one: a user who adds newlines to the DE description will not see it currently!

| before | after |
|--|--|
|  <img width="1392" height="1167" alt="Screenshot 2026-06-10 at 12 33 42 PM" src="https://github.com/user-attachments/assets/e8363cf1-6665-4a52-a423-5838e1961019" /> | <img width="1392" height="1167" alt="Screenshot 2026-06-10 at 12 53 51 PM" src="https://github.com/user-attachments/assets/a67d12ca-c931-4aef-9fce-8edd1c603d4a" /> |
