### PR TITLE
DEV: Add stat_type to register_stat API and Stat model

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 
 class Stat
-  def initialize(name, expose_via_api: false, &block)
+  def initialize(name, expose_via_api: false, stat_type: nil, &block)
     @name = name
     @expose_via_api = expose_via_api
     @block = block
+    @stat_type = stat_type
+    validate_stat_type
   end
 
-  attr_reader :name, :expose_via_api
+  attr_reader :name, :expose_via_api, :stat_type
 
   def calculate
-    @block.call.transform_keys { |key| build_key(key) }
+    if @stat_type
+      { stat_type.to_sym => @block.call.transform_keys { |key| build_key(key) } }
+    else
+      @block.call.transform_keys { |key| build_key(key) }
+    end
   rescue StandardError => err
     Discourse.warn_exception(err, message: "Unexpected error when collecting #{@name} About stats.")
     {}
@@ -26,6 +32,16 @@ class Stat
 
   private
 
+  def validate_stat_type
+    return if !@stat_type
+    if !@stat_type.is_a?(Symbol) || !@stat_type.match?(/^[a-z0-9_]+$/) || @stat_type.length > 20
+      raise ArgumentError,
+            "Stat type (#{@stat_type}) must be a valid symbol, is all lowercase, only contains letters and numbers, and is < 20 characters"
+    end
+  end
+
+  # The key vars here are the keys in the result of the stat block,
+  # e.g. 7_days, 30_days, count
   def build_key(key)
     :"#{@name}_#{key}"
   end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1225,11 +1225,11 @@ class Plugin::Instance
   #   "chat_messages_30_days": 100,
   #   "chat_messages_count": 1000,
   # }
-  def register_stat(name, expose_via_api: false, &block)
+  def register_stat(name, expose_via_api: false, stat_type: nil, &block)
     # We do not want to register and display the same group multiple times.
     return if DiscoursePluginRegistry.stats.any? { |stat| stat.name == name }
 
-    stat = Stat.new(name, expose_via_api: expose_via_api, &block)
+    stat = Stat.new(name, expose_via_api: expose_via_api, stat_type: stat_type, &block)
     DiscoursePluginRegistry.register_stat(stat, self)
   end
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Stat do
+  describe ".all_stats" do
+    it "returns all the core and plugin stats registered" do
+      expect(Stat.all_stats.keys).to include(:topics_30_days, :likes_30_days)
+    end
+
+    context "when display_eu_visitor_stats is enabled" do
+      before { SiteSetting.display_eu_visitor_stats = true }
+
+      it "returns the eu visitor stats" do
+        expect(Stat.all_stats.keys).to include(:visitors_30_days, :eu_visitors_30_days)
+      end
+    end
+  end
+
+  describe "calculate" do
+    it "returns the result of the stat block with the stat name as a prefix" do
+      stat = Stat.new("test") { { "7_days" => 1, "30_days" => 10, "count" => 100 } }
+      expect(stat.calculate).to eq({ test_7_days: 1, test_30_days: 10, test_count: 100 })
+    end
+
+    it "returns an empty hash if the stat block raises an error" do
+      stat = Stat.new("test") { raise "Test error" }
+      expect(stat.calculate).to eq({})
+    end
+  end
+
+  context "when stat type is provided" do
+    it "returns the stat type" do
+      stat = Stat.new("test", stat_type: :test)
+      expect(stat.stat_type).to eq(:test)
+    end
+
+    it "validates the stat type is a symbol and contains no weird chars" do
+      expect { Stat.new("test", stat_type: :custom_stat_type) }.not_to raise_error
+      expect { Stat.new("test", stat_type: "Test") }.to raise_error(ArgumentError)
+      expect { Stat.new("test", stat_type: "Blah$&#*") }.to raise_error(ArgumentError)
+      expect { Stat.new("test", stat_type: "Blah" * 21) }.to raise_error(ArgumentError)
+    end
+
+    it "returns the stat type as a wrapper key in the result" do
+      stat =
+        Stat.new("test", stat_type: :test) { { "7_days" => 1, "30_days" => 10, "count" => 100 } }
+      expect(stat.calculate).to eq({ test: { test_7_days: 1, test_30_days: 10, test_count: 100 } })
+    end
+  end
+end


### PR DESCRIPTION
Allow plugins to specify a stat_type when registering a stat,
which will allow for additional categorization for analysis.
