### PR TITLE
FEATURE: Show bounce rate and session duration on admin dashboard

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -436,6 +436,9 @@ module ApplicationHelper
     if SiteSetting.use_beacon_for_browser_page_views
       tags << tag.meta(name: "discourse-beacon-pageview-enabled", content: "true")
     end
+    if SiteSetting.persist_browser_pageview_events
+      tags << tag.meta(name: "discourse-engagement-ping-enabled", content: "true")
+    end
     tags.html_safe
   end
 

--- a/app/jobs/scheduled/clean_up_browser_pageview_events.rb
+++ b/app/jobs/scheduled/clean_up_browser_pageview_events.rb
@@ -11,6 +11,7 @@ module Jobs
         .where("created_at < ?", BrowserPageviewEvent.retention_cutoff)
         .in_batches(of: 10_000) do |browser_pageview_events|
           BrowserPageviewEventScore.where(event_id: browser_pageview_events.select(:id)).delete_all
+          BrowserPageviewEngagement.where(event_id: browser_pageview_events.select(:id)).delete_all
           browser_pageview_events.delete_all
         end
     end

--- a/app/jobs/scheduled/maintain_browser_pageview_session_rollups.rb
+++ b/app/jobs/scheduled/maintain_browser_pageview_session_rollups.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Jobs
+  # Separate from MaintainBrowserPageviewRollups so the most expensive
+  # aggregate (window functions over a multi-day scan) never delays the
+  # country/referrer rollups or the referrer backfill that share that job's
+  # cluster-serialized slot.
+  class MaintainBrowserPageviewSessionRollups < ::Jobs::Scheduled
+    every 10.minutes
+
+    cluster_concurrency 1
+
+    # Exit pings only exist from the moment the engagements migration ran on
+    # this site. Days before that cannot evaluate the bounce and duration
+    # definitions, so aggregating them would permanently misclassify every
+    # pre-instrumentation single-pageview visit as a zero-duration bounce.
+    # Writing no row for those days is honest; writing an inflated one is not.
+    ENGAGEMENTS_MIGRATION_VERSION = "20260610025606"
+    private_constant :ENGAGEMENTS_MIGRATION_VERSION
+
+    def execute(_args)
+      return if !SiteSetting.persist_browser_pageview_events
+
+      start_date, end_date = aggregation_window
+      return if start_date.nil? || start_date > end_date
+
+      BrowserPageviewSessionDailyRollup.aggregate(start_date: start_date, end_date: end_date)
+    end
+
+    private
+
+    def aggregation_window
+      cutoff = instrumented_on
+      return nil, nil if cutoff.nil?
+
+      end_date = Time.zone.today
+      start_date = BrowserPageviewSessionDailyRollup.none? ? cutoff : 1.day.ago.to_date
+
+      [[start_date, cutoff].max, end_date]
+    end
+
+    def instrumented_on
+      DB
+        .query_single(
+          "SELECT created_at FROM schema_migration_details WHERE version = :version",
+          version: ENGAGEMENTS_MIGRATION_VERSION,
+        )
+        .first
+        &.to_date
+    end
+  end
+end

--- a/app/models/browser_pageview_engagement.rb
+++ b/app/models/browser_pageview_engagement.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class BrowserPageviewEngagement < ActiveRecord::Base
+  belongs_to :event, class_name: "BrowserPageviewEvent"
+
+  # A ping that races the deferred pageview insert resolves to no event and
+  # is dropped: a later ping heals the loss, a stored orphan never would.
+  def self.record(session_id:, url:, occurred_at:)
+    event_id =
+      BrowserPageviewEvent
+        .where(session_id: session_id, url: url)
+        .where(created_at: ..occurred_at)
+        .order(created_at: :desc, id: :desc)
+        .pick(:id)
+
+    create!(event_id: event_id, created_at: occurred_at) if event_id
+  end
+end
+
+# == Schema Information
+#
+# Table name: browser_pageview_engagements
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  event_id   :bigint           not null
+#
+# Indexes
+#
+#  index_browser_pageview_engagements_on_event_id_and_created_at  (event_id,created_at)
+#

--- a/app/models/browser_pageview_session_daily_rollup.rb
+++ b/app/models/browser_pageview_session_daily_rollup.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+class BrowserPageviewSessionDailyRollup < ActiveRecord::Base
+  # A browser tab keeps one session_id for its whole lifetime, which can be
+  # days for a parked tab, so the tab id is only a correlation key. A logical
+  # visit ends after this much inactivity: a later pageview in the same tab
+  # starts a new visit, and an exit ping can extend a visit's final page by
+  # at most this long.
+  VISIT_INACTIVITY_SECONDS = 30.minutes.to_i
+
+  BOUNCE_THRESHOLD_SECONDS = 10
+
+  # Visits can span midnight: scanning starts a day before the requested
+  # range so a visit attributed to the range's first day still sees the
+  # pageviews it accrued after midnight on the previous aggregation run.
+  SCAN_LOOKBACK = 1.day
+
+  private_constant :VISIT_INACTIVITY_SECONDS, :BOUNCE_THRESHOLD_SECONDS, :SCAN_LOOKBACK
+
+  # Durations are bounded elapsed time, not active engagement time. A page
+  # backgrounded after 5 seconds and revisited 25 minutes later is charged
+  # the full gap, because pageview timestamps and exit ping receipts are the
+  # only signals: nothing records when the page lost or regained visibility
+  # in between. Measuring true foreground time requires the client to report
+  # visible/hidden intervals, which this deliberately avoids so durations
+  # never depend on a client-computed value.
+  #
+  # Pings landing after the visit's inactivity window are evidence the page
+  # outlived the visit (a parked tab focused hours later), not engagement
+  # inside it: they credit the final page with at most the inactivity cap
+  # and only when no in-window ping pinned an earlier departure. Without
+  # this, a 5-second bounce whose tab is touched the next day would
+  # retroactively become a 30-minute non-bounce.
+  # Gaps and visit boundaries both come from one pass over the tab's
+  # pageviews in (created_at, id) order: a row whose gap to the next pageview
+  # is NULL or beyond the inactivity timeout is its visit's final pageview,
+  # and the remaining gaps are by definition the in-visit ones. This keeps
+  # the whole aggregation on a single sort, which is where most of its time
+  # goes at production volume.
+  def self.aggregate(start_date:, end_date:)
+    DB.exec(
+      <<~SQL,
+        WITH tab_events AS (
+          SELECT
+            session_id,
+            id,
+            created_at,
+            user_id,
+            CASE
+              WHEN LAG(created_at) OVER tab_order IS NULL THEN 1
+              WHEN EXTRACT(EPOCH FROM (created_at - LAG(created_at) OVER tab_order)) >
+                :inactivity_seconds THEN 1
+              ELSE 0
+            END AS starts_new_visit,
+            EXTRACT(EPOCH FROM (LEAD(created_at) OVER tab_order - created_at)) AS gap_seconds
+          FROM browser_pageview_events
+          WHERE created_at >= :scan_start AND created_at < :scan_end
+          WINDOW tab_order AS (PARTITION BY session_id ORDER BY created_at, id)
+        ),
+        visit_events AS (
+          SELECT
+            *,
+            SUM(starts_new_visit) OVER (
+              PARTITION BY session_id
+              ORDER BY created_at, id
+            ) AS visit_number
+          FROM tab_events
+        ),
+        visits AS (
+          SELECT
+            session_id,
+            visit_number,
+            MIN(created_at) AS first_pageview_at,
+            MAX(created_at) AS last_pageview_at,
+            MAX(id) FILTER (
+              WHERE gap_seconds IS NULL OR gap_seconds > :inactivity_seconds
+            ) AS last_pageview_id,
+            COUNT(*) AS pageviews_count,
+            BOOL_OR(user_id IS NOT NULL) AS logged_in,
+            COALESCE(
+              SUM(gap_seconds) FILTER (WHERE gap_seconds <= :inactivity_seconds),
+              0
+            ) AS gaps_seconds
+          FROM visit_events
+          GROUP BY session_id, visit_number
+        ),
+        measured_visits AS (
+          SELECT
+            visits.*,
+            visits.gaps_seconds + CASE
+              WHEN pings.last_ping_within_visit_at IS NOT NULL THEN LEAST(
+                GREATEST(
+                  EXTRACT(EPOCH FROM (pings.last_ping_within_visit_at - visits.last_pageview_at)),
+                  0
+                ),
+                :inactivity_seconds
+              )
+              WHEN pings.pinged_after_visit THEN :inactivity_seconds
+              ELSE 0
+            END AS duration_seconds
+          FROM visits
+          LEFT JOIN LATERAL (
+            SELECT
+              MAX(created_at) FILTER (
+                WHERE created_at <= visits.last_pageview_at + make_interval(secs => :inactivity_seconds)
+              ) AS last_ping_within_visit_at,
+              COUNT(*) FILTER (
+                WHERE created_at > visits.last_pageview_at + make_interval(secs => :inactivity_seconds)
+              ) > 0 AS pinged_after_visit
+            FROM browser_pageview_engagements
+            WHERE event_id = visits.last_pageview_id
+          ) pings ON true
+        )
+        INSERT INTO browser_pageview_session_daily_rollups
+          (date, logged_in, sessions_count, bounced_count, total_duration_seconds)
+        SELECT
+          first_pageview_at::date AS date,
+          logged_in,
+          COUNT(*) AS sessions_count,
+          COUNT(*) FILTER (
+            WHERE pageviews_count = 1 AND duration_seconds < :bounce_threshold
+          ) AS bounced_count,
+          COALESCE(SUM(duration_seconds), 0)::bigint AS total_duration_seconds
+        FROM measured_visits
+        WHERE first_pageview_at >= :start_date AND first_pageview_at < :scan_end
+        GROUP BY 1, 2
+        ON CONFLICT (date, logged_in) DO UPDATE
+        SET sessions_count = EXCLUDED.sessions_count,
+            bounced_count = EXCLUDED.bounced_count,
+            total_duration_seconds = EXCLUDED.total_duration_seconds
+      SQL
+      start_date: start_date.to_date,
+      scan_start: start_date.to_date - SCAN_LOOKBACK,
+      scan_end: end_date.to_date + 1,
+      inactivity_seconds: VISIT_INACTIVITY_SECONDS,
+      bounce_threshold: BOUNCE_THRESHOLD_SECONDS,
+    )
+  end
+end
+
+# == Schema Information
+#
+# Table name: browser_pageview_session_daily_rollups
+#
+#  id                     :bigint           not null, primary key
+#  bounced_count          :bigint           not null
+#  date                   :date             not null
+#  logged_in              :boolean          not null
+#  sessions_count         :bigint           not null
+#  total_duration_seconds :bigint           not null
+#
+# Indexes
+#
+#  idx_bpsd_rollups_date_logged_in_unique  (date,logged_in) UNIQUE
+#

--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -39,6 +39,7 @@ class AdminDashboardSiteTraffic
     }
 
     if SiteSetting.persist_browser_pageview_events
+      response[:kpis].merge!(session_kpis)
       response[:top_countries] = fetch_card("top_countries_by_browser_pageviews")
       response[:top_referrers] = fetch_card("top_referrers_by_browser_pageviews")
     end
@@ -117,6 +118,41 @@ class AdminDashboardSiteTraffic
     return nil if login_required?
 
     totals[:human].positive? ? ((totals[:logged_in].to_f / totals[:human]) * 100).round : 0
+  end
+
+  def session_kpis
+    totals = session_totals(start_date.to_date, end_date.to_date)
+
+    {
+      bounce_rate: {
+        value: bounce_rate(totals),
+      },
+      avg_session_duration: {
+        value: avg_session_duration(totals),
+      },
+    }
+  end
+
+  def session_totals(range_start, range_end)
+    BrowserPageviewSessionDailyRollup.where(date: range_start..range_end).pick(
+      Arel.sql("SUM(sessions_count)"),
+      Arel.sql("SUM(bounced_count)"),
+      Arel.sql("SUM(total_duration_seconds)"),
+    ) || []
+  end
+
+  def bounce_rate(totals)
+    sessions, bounced, _duration = totals
+    return nil if sessions.to_i.zero?
+
+    ((bounced.to_f / sessions) * 100).round
+  end
+
+  def avg_session_duration(totals)
+    sessions, _bounced, duration = totals
+    return nil if sessions.to_i.zero?
+
+    (duration.to_f / sessions).round
   end
 
   def pageview_series(rows, include_embedded:)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7061,6 +7061,17 @@ en:
             logged_in_share:
               label: "Logged-in share"
               tooltip: "The share of pageviews from logged-in members."
+            bounce_rate:
+              label: "Bounce rate"
+              tooltip: "The share of visits that viewed a single page for less than 10 seconds."
+              empty_tooltip: "Shown once visits are recorded for this period."
+            avg_session_duration:
+              label: "Avg. session duration"
+              tooltip: "The average length of a visit, including bounced visits."
+              empty_tooltip: "Shown once visits are recorded for this period."
+          duration:
+            minutes_seconds: "%{minutes}m %{seconds}s"
+            seconds: "%{seconds}s"
           top_countries:
             title: "Top countries"
             empty: "No country data for this period."

--- a/db/migrate/20260610025606_create_browser_pageview_engagements.rb
+++ b/db/migrate/20260610025606_create_browser_pageview_engagements.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateBrowserPageviewEngagements < ActiveRecord::Migration[8.0]
+  def change
+    create_table :browser_pageview_engagements do |t|
+      t.bigint :event_id, null: false
+      t.datetime :created_at, null: false
+    end
+
+    add_index :browser_pageview_engagements, %i[event_id created_at]
+  end
+end

--- a/db/migrate/20260610025610_create_browser_pageview_session_daily_rollups.rb
+++ b/db/migrate/20260610025610_create_browser_pageview_session_daily_rollups.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateBrowserPageviewSessionDailyRollups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :browser_pageview_session_daily_rollups do |t|
+      t.date :date, null: false
+      t.boolean :logged_in, null: false
+      t.bigint :sessions_count, null: false
+      t.bigint :bounced_count, null: false
+      t.bigint :total_duration_seconds, null: false
+    end
+
+    add_index :browser_pageview_session_daily_rollups,
+              %i[date logged_in],
+              unique: true,
+              name: "idx_bpsd_rollups_date_logged_in_unique"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1899,6 +1899,36 @@ ALTER SEQUENCE public.browser_pageview_country_daily_rollups_id_seq OWNED BY pub
 
 
 --
+-- Name: browser_pageview_engagements; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.browser_pageview_engagements (
+    id bigint NOT NULL,
+    event_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: browser_pageview_engagements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.browser_pageview_engagements_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: browser_pageview_engagements_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.browser_pageview_engagements_id_seq OWNED BY public.browser_pageview_engagements.id;
+
+
+--
 -- Name: browser_pageview_event_scores; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2004,6 +2034,39 @@ CREATE SEQUENCE public.browser_pageview_referrer_daily_rollups_id_seq
 --
 
 ALTER SEQUENCE public.browser_pageview_referrer_daily_rollups_id_seq OWNED BY public.browser_pageview_referrer_daily_rollups.id;
+
+
+--
+-- Name: browser_pageview_session_daily_rollups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.browser_pageview_session_daily_rollups (
+    id bigint NOT NULL,
+    date date NOT NULL,
+    logged_in boolean NOT NULL,
+    sessions_count bigint NOT NULL,
+    bounced_count bigint NOT NULL,
+    total_duration_seconds bigint NOT NULL
+);
+
+
+--
+-- Name: browser_pageview_session_daily_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.browser_pageview_session_daily_rollups_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: browser_pageview_session_daily_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.browser_pageview_session_daily_rollups_id_seq OWNED BY public.browser_pageview_session_daily_rollups.id;
 
 
 --
@@ -12098,6 +12161,13 @@ ALTER TABLE ONLY public.browser_pageview_country_daily_rollups ALTER COLUMN id S
 
 
 --
+-- Name: browser_pageview_engagements id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.browser_pageview_engagements ALTER COLUMN id SET DEFAULT nextval('public.browser_pageview_engagements_id_seq'::regclass);
+
+
+--
 -- Name: browser_pageview_event_scores id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -12116,6 +12186,13 @@ ALTER TABLE ONLY public.browser_pageview_events ALTER COLUMN id SET DEFAULT next
 --
 
 ALTER TABLE ONLY public.browser_pageview_referrer_daily_rollups ALTER COLUMN id SET DEFAULT nextval('public.browser_pageview_referrer_daily_rollups_id_seq'::regclass);
+
+
+--
+-- Name: browser_pageview_session_daily_rollups id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.browser_pageview_session_daily_rollups ALTER COLUMN id SET DEFAULT nextval('public.browser_pageview_session_daily_rollups_id_seq'::regclass);
 
 
 --
@@ -14270,6 +14347,14 @@ ALTER TABLE ONLY public.browser_pageview_country_daily_rollups
 
 
 --
+-- Name: browser_pageview_engagements browser_pageview_engagements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.browser_pageview_engagements
+    ADD CONSTRAINT browser_pageview_engagements_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: browser_pageview_event_scores browser_pageview_event_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -14291,6 +14376,14 @@ ALTER TABLE ONLY public.browser_pageview_events
 
 ALTER TABLE ONLY public.browser_pageview_referrer_daily_rollups
     ADD CONSTRAINT browser_pageview_referrer_daily_rollups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: browser_pageview_session_daily_rollups browser_pageview_session_daily_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.browser_pageview_session_daily_rollups
+    ADD CONSTRAINT browser_pageview_session_daily_rollups_pkey PRIMARY KEY (id);
 
 
 --
@@ -16633,6 +16726,13 @@ CREATE UNIQUE INDEX idx_bprd_rollups_date_referrer_unique ON public.browser_page
 
 
 --
+-- Name: idx_bpsd_rollups_date_logged_in_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_bpsd_rollups_date_logged_in_unique ON public.browser_pageview_session_daily_rollups USING btree (date, logged_in);
+
+
+--
 -- Name: idx_category_posting_review_groups_unique; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -17778,6 +17878,13 @@ CREATE INDEX index_bookmarks_on_reminder_set_at ON public.bookmarks USING btree 
 --
 
 CREATE INDEX index_bookmarks_on_user_id ON public.bookmarks USING btree (user_id);
+
+
+--
+-- Name: index_browser_pageview_engagements_on_event_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_browser_pageview_engagements_on_event_id_and_created_at ON public.browser_pageview_engagements USING btree (event_id, created_at);
 
 
 --
@@ -21912,6 +22019,8 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260610025610'),
+('20260610025606'),
 ('20260609050938'),
 ('20260607161322'),
 ('20260604052235'),

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -86,13 +86,36 @@ export default class DashboardTraffic extends Component {
     });
   }
 
-  get showLoggedInShare() {
-    const loggedInShare = this.args.traffic?.kpis?.logged_in_share?.value;
-    return loggedInShare !== null && loggedInShare !== undefined;
-  }
+  get metricTiles() {
+    const kpis = this.args.traffic?.kpis;
+    const tiles = [];
 
-  get loggedInShare() {
-    return `${this.args.traffic?.kpis?.logged_in_share?.value ?? 0}%`;
+    const loggedInShare = kpis?.logged_in_share?.value;
+    if (loggedInShare !== null && loggedInShare !== undefined) {
+      tiles.push(this.#metricTile("logged_in_share", `${loggedInShare}%`));
+    }
+
+    if (kpis?.bounce_rate) {
+      const value = kpis.bounce_rate.value;
+      tiles.push(
+        this.#metricTile("bounce_rate", value == null ? "—" : `${value}%`, {
+          empty: value == null,
+        })
+      );
+    }
+
+    if (kpis?.avg_session_duration) {
+      const seconds = kpis.avg_session_duration.value;
+      tiles.push(
+        this.#metricTile(
+          "avg_session_duration",
+          seconds == null ? "—" : this.#formatDuration(seconds),
+          { empty: seconds == null }
+        )
+      );
+    }
+
+    return tiles;
   }
 
   get chartModel() {
@@ -133,6 +156,32 @@ export default class DashboardTraffic extends Component {
   formatTrendPercent(value) {
     const precision = value < 1 ? 1 : 0;
     return `${I18n.toNumber(value, { precision })}%`;
+  }
+
+  #metricTile(key, value, { empty = false } = {}) {
+    return {
+      value,
+      identifier: `site-traffic-${key.replaceAll("_", "-")}-tooltip`,
+      label: i18n(`admin.dashboard.site_traffic.kpi.${key}.label`),
+      tooltip: i18n(
+        `admin.dashboard.site_traffic.kpi.${key}.${empty ? "empty_tooltip" : "tooltip"}`
+      ),
+    };
+  }
+
+  #formatDuration(seconds) {
+    const minutes = Math.floor(seconds / 60);
+    const remainder = seconds % 60;
+    if (minutes === 0) {
+      return i18n("admin.dashboard.site_traffic.duration.seconds", {
+        seconds: remainder,
+      });
+    }
+
+    return i18n("admin.dashboard.site_traffic.duration.minutes_seconds", {
+      minutes,
+      seconds: remainder,
+    });
   }
 
   #dateFrom(value) {
@@ -224,29 +273,23 @@ export default class DashboardTraffic extends Component {
             </p> }}
           </div>
 
-          {{#if this.showLoggedInShare}}
+          {{#if this.metricTiles.length}}
             <div class="db-section__metrics">
-              <div class="db-section__metric">
-                <div
-                  class="db-section__metric-number"
-                >{{this.loggedInShare}}</div>
-                <div class="db-section__metric-label">
-                  {{i18n
-                    "admin.dashboard.site_traffic.kpi.logged_in_share.label"
-                  }}
-                  <DTooltip
-                    class="db-section__info"
-                    @identifier="site-traffic-logged-in-share-tooltip"
-                    @icon="far-circle-question"
-                  >
-                    <:content>
-                      {{i18n
-                        "admin.dashboard.site_traffic.kpi.logged_in_share.tooltip"
-                      }}
-                    </:content>
-                  </DTooltip>
+              {{#each this.metricTiles as |tile|}}
+                <div class="db-section__metric">
+                  <div class="db-section__metric-number">{{tile.value}}</div>
+                  <div class="db-section__metric-label">
+                    {{tile.label}}
+                    <DTooltip
+                      class="db-section__info"
+                      @identifier={{tile.identifier}}
+                      @icon="far-circle-question"
+                    >
+                      <:content>{{tile.tooltip}}</:content>
+                    </DTooltip>
+                  </div>
                 </div>
-              </div>
+              {{/each}}
             </div>
           {{/if}}
         </div>

--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -7,6 +7,10 @@ import {
 import { sendBeaconPageview } from "discourse/lib/beacon-pageview";
 import EmbedMode from "discourse/lib/embed-mode";
 import {
+  resetExitPingTracking,
+  trackPageForExitPing,
+} from "discourse/lib/engagement-exit-ping";
+import {
   googleTagManagerPageChanged,
   resetPageTracking,
   startPageTracking,
@@ -25,6 +29,12 @@ export default {
       "true";
     if (!isErrorPage) {
       sendDeferredPageview();
+      trackPageForExitPing({
+        sessionId: document.querySelector(
+          "meta[name=discourse-track-view-session-id]"
+        )?.content,
+        url: window.location.href,
+      });
     }
 
     // Tell our AJAX system to track a page transition
@@ -169,6 +179,7 @@ export default {
       }
       trackingUrl = new URL(path, window.location.origin).href;
       trackingReferrer = window.location.href;
+      trackPageForExitPing({ sessionId: trackingSessionId, url: trackingUrl });
     }
     trackNextAjaxAsPageview(trackingSessionId, trackingUrl, trackingReferrer);
 
@@ -183,5 +194,6 @@ export default {
   teardown() {
     resetPageTracking();
     resetAjax();
+    resetExitPingTracking();
   },
 };

--- a/frontend/discourse/app/lib/engagement-exit-ping.js
+++ b/frontend/discourse/app/lib/engagement-exit-ping.js
@@ -1,0 +1,82 @@
+import getURL from "discourse/lib/get-url";
+
+// Repeats are harmless (the server keeps the latest receipt per pageview),
+// so the throttle only bounds how fast a tab-flapper can send.
+const RESEND_THROTTLE_MS = 3000;
+
+let currentSessionId = null;
+let currentUrl = null;
+let lastSentAt = null;
+let listening = false;
+
+export function trackPageForExitPing({ sessionId, url }) {
+  if (!sessionId || !url || !pingsEnabled()) {
+    return;
+  }
+
+  currentSessionId = sessionId;
+  currentUrl = url;
+  lastSentAt = null;
+
+  if (!listening) {
+    document.addEventListener("visibilitychange", sendPingIfLeaving);
+    window.addEventListener("blur", sendPingIfLeaving);
+    window.addEventListener("pagehide", sendPing);
+    listening = true;
+  }
+}
+
+export function resetExitPingTracking() {
+  document.removeEventListener("visibilitychange", sendPingIfLeaving);
+  window.removeEventListener("blur", sendPingIfLeaving);
+  window.removeEventListener("pagehide", sendPing);
+  currentSessionId = null;
+  currentUrl = null;
+  lastSentAt = null;
+  listening = false;
+}
+
+// The server discards pings unless persist_browser_pageview_events is on,
+// so a site that only counts pageviews should not pay a request per leave.
+function pingsEnabled() {
+  return (
+    document.querySelector("meta[name=discourse-engagement-ping-enabled]")
+      ?.content === "true"
+  );
+}
+
+function sendPingIfLeaving() {
+  // Check the actual state rather than trusting the event type: focus moving
+  // into an iframe fires `blur` while the user is still engaged, and bfcache
+  // restores fire `visibilitychange` back to visible.
+  if (document.visibilityState !== "hidden" && document.hasFocus()) {
+    return;
+  }
+
+  sendPing();
+}
+
+// pagehide sends unconditionally: it is the only leave signal older iOS
+// Safari fires, and on other browsers the throttle absorbs the duplicate.
+function sendPing() {
+  if (!currentSessionId) {
+    return;
+  }
+
+  const now = Date.now();
+  if (lastSentAt && now - lastSentAt < RESEND_THROTTLE_MS) {
+    return;
+  }
+  lastSentAt = now;
+
+  fetch(getURL("/srv/pv"), {
+    method: "POST",
+    keepalive: true,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      session_id: currentSessionId,
+      url: currentUrl,
+      engagement: true,
+    }),
+  });
+}

--- a/frontend/discourse/scripts/js/pageview.js
+++ b/frontend/discourse/scripts/js/pageview.js
@@ -44,5 +44,42 @@ document.addEventListener("DOMContentLoaded", function () {
         body: JSON.stringify(body),
       });
     }
+
+    const engagementPingsEnabled =
+      document.querySelector("meta[name=discourse-engagement-ping-enabled]")
+        ?.content === "true";
+
+    if (trackViewSessionId && engagementPingsEnabled) {
+      let lastPingAt = null;
+
+      const sendPing = () => {
+        const now = Date.now();
+        if (lastPingAt && now - lastPingAt < 3000) {
+          return;
+        }
+        lastPingAt = now;
+        fetch(`${root}/srv/pv`, {
+          method: "POST",
+          keepalive: true,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            session_id: trackViewSessionId,
+            url: window.location.href,
+            engagement: true,
+          }),
+        });
+      };
+
+      const sendPingIfLeaving = () => {
+        if (document.visibilityState !== "hidden" && document.hasFocus()) {
+          return;
+        }
+        sendPing();
+      };
+
+      document.addEventListener("visibilitychange", sendPingIfLeaving);
+      window.addEventListener("blur", sendPingIfLeaving);
+      window.addEventListener("pagehide", sendPing);
+    }
   }
 });

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -350,6 +350,18 @@ class Middleware::RequestTracker
 
     env["discourse.request_tracker"] = self
 
+    if self.class.is_engagement_ping_request?(request)
+      env["discourse.request_tracker.skip"] = true
+
+      if self.class.same_origin_beacon_request?(request)
+        self.class.record_engagement_ping(request)
+        result = [204, {}, []]
+      else
+        result = [403, {}, []]
+      end
+      return result
+    end
+
     if self.class.is_beacon_tracking_request?(request)
       if self.class.same_origin_beacon_request?(request)
         result = [204, {}, []]
@@ -678,15 +690,48 @@ class Middleware::RequestTracker
     request.post? && request.path == "#{Discourse.base_path}/pageview"
   end
 
-  def self.extract_beacon_view_tracking_data(env)
-    body = env["rack.input"]&.read
-    env["rack.input"]&.rewind
-    data =
-      begin
-        JSON.parse(body)
-      rescue JSON::ParserError
+  # An exit ping shares the beacon endpoint but is accepted regardless of
+  # SiteSetting.use_beacon_for_browser_page_views: exits can never piggyback
+  # on a subsequent request, so the ping must work in both transport modes.
+  def self.is_engagement_ping_request?(request)
+    request.post? && request.path == Discourse.beacon_pv_tracking_path &&
+      parsed_beacon_body(request.env)["engagement"] == true
+  end
+
+  def self.record_engagement_ping(request)
+    return if !SiteSetting.persist_browser_pageview_events
+
+    body = parsed_beacon_body(request.env)
+    session_id = body["session_id"]&.slice(0, MAX_SESSION_ID_LENGTH)
+    url = body["url"]&.slice(0, MAX_URL_LENGTH)
+    return if session_id.blank? || url.blank?
+
+    received_at = Time.zone.now
+
+    Scheduler::Defer.later "Record BrowserPageviewEngagement" do
+      BrowserPageviewEngagement.record(session_id: session_id, url: url, occurred_at: received_at)
+    end
+  end
+
+  MAX_BEACON_BODY_BYTES = 4096
+
+  def self.parsed_beacon_body(env)
+    env["discourse.parsed_beacon_body"] ||= begin
+      if env["CONTENT_LENGTH"].to_i > MAX_BEACON_BODY_BYTES
         {}
+      else
+        body = env["rack.input"]&.read(MAX_BEACON_BODY_BYTES)
+        env["rack.input"]&.rewind
+        JSON.parse(body)
       end
+    rescue JSON::ParserError, TypeError
+      {}
+    end
+  end
+  private_class_method :parsed_beacon_body
+
+  def self.extract_beacon_view_tracking_data(env)
+    data = parsed_beacon_body(env)
 
     topic_id = data["topic_id"]&.to_i
     tracking_url = data["url"]&.slice(0, MAX_URL_LENGTH)

--- a/spec/fabricators/browser_pageview_engagement_fabricator.rb
+++ b/spec/fabricators/browser_pageview_engagement_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:browser_pageview_engagement) do
+  event { Fabricate(:browser_pageview_event) }
+end

--- a/spec/fabricators/browser_pageview_engagement_fabricator.rb
+++ b/spec/fabricators/browser_pageview_engagement_fabricator.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
-Fabricator(:browser_pageview_engagement) do
-  event { Fabricate(:browser_pageview_event) }
-end
+Fabricator(:browser_pageview_engagement) { event { Fabricate(:browser_pageview_event) } }

--- a/spec/jobs/clean_up_browser_pageview_events_spec.rb
+++ b/spec/jobs/clean_up_browser_pageview_events_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe Jobs::CleanUpBrowserPageviewEvents do
     expect(BrowserPageviewEventScore.pluck(:event_id)).to contain_exactly(fresh_event.id)
   end
 
+  it "deletes engagements for deleted events" do
+    SiteSetting.clean_up_browser_pageview_events = true
+    fresh_event = Fabricate(:browser_pageview_event, created_at: 1.month.ago)
+    old_event = Fabricate(:browser_pageview_event, created_at: 4.months.ago)
+    Fabricate(:browser_pageview_engagement, event: fresh_event, created_at: 1.month.ago)
+    Fabricate(:browser_pageview_engagement, event: old_event, created_at: 4.months.ago)
+
+    described_class.new.execute({})
+
+    expect(BrowserPageviewEngagement.pluck(:event_id)).to contain_exactly(fresh_event.id)
+  end
+
   it "keeps all events on the retention cutoff day" do
     SiteSetting.clean_up_browser_pageview_events = true
 

--- a/spec/jobs/maintain_browser_pageview_rollups_spec.rb
+++ b/spec/jobs/maintain_browser_pageview_rollups_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
 
       expect(BrowserPageviewCountryDailyRollup.count).to eq(0)
       expect(BrowserPageviewReferrerDailyRollup.count).to eq(0)
+      expect(BrowserPageviewSessionDailyRollup.count).to eq(0)
       expect(event.reload.normalized_referrer_version).to be_nil
     end
 
@@ -32,6 +33,31 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
         expect(
           BrowserPageviewReferrerDailyRollup.where(normalized_referrer: "google.com").sum(:count),
         ).to eq(1)
+      end
+
+      it "aggregates session rollups (bounce and duration) from recent pageview events" do
+        today = Time.zone.now.beginning_of_day
+
+        Fabricate(:browser_pageview_event, created_at: today + 1.hour)
+
+        engaged_visit_start = Fabricate(:browser_pageview_event, created_at: today + 2.hours)
+        Fabricate(
+          :browser_pageview_event,
+          session_id: engaged_visit_start.session_id,
+          created_at: today + 2.hours + 40.seconds,
+        )
+
+        job.execute({})
+
+        expect(
+          BrowserPageviewSessionDailyRollup.pluck(
+            :date,
+            :logged_in,
+            :sessions_count,
+            :bounced_count,
+            :total_duration_seconds,
+          ),
+        ).to eq([[Date.current, false, 2, 1, 40]])
       end
 
       it "backfills from the earliest event date on the first run when rollups are empty" do

--- a/spec/jobs/maintain_browser_pageview_rollups_spec.rb
+++ b/spec/jobs/maintain_browser_pageview_rollups_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
 
       expect(BrowserPageviewCountryDailyRollup.count).to eq(0)
       expect(BrowserPageviewReferrerDailyRollup.count).to eq(0)
-      expect(BrowserPageviewSessionDailyRollup.count).to eq(0)
       expect(event.reload.normalized_referrer_version).to be_nil
     end
 
@@ -33,31 +32,6 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
         expect(
           BrowserPageviewReferrerDailyRollup.where(normalized_referrer: "google.com").sum(:count),
         ).to eq(1)
-      end
-
-      it "aggregates session rollups (bounce and duration) from recent pageview events" do
-        today = Time.zone.now.beginning_of_day
-
-        Fabricate(:browser_pageview_event, created_at: today + 1.hour)
-
-        engaged_visit_start = Fabricate(:browser_pageview_event, created_at: today + 2.hours)
-        Fabricate(
-          :browser_pageview_event,
-          session_id: engaged_visit_start.session_id,
-          created_at: today + 2.hours + 40.seconds,
-        )
-
-        job.execute({})
-
-        expect(
-          BrowserPageviewSessionDailyRollup.pluck(
-            :date,
-            :logged_in,
-            :sessions_count,
-            :bounced_count,
-            :total_duration_seconds,
-          ),
-        ).to eq([[Date.current, false, 2, 1, 40]])
       end
 
       it "backfills from the earliest event date on the first run when rollups are empty" do

--- a/spec/jobs/maintain_browser_pageview_session_rollups_spec.rb
+++ b/spec/jobs/maintain_browser_pageview_session_rollups_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::MaintainBrowserPageviewSessionRollups do
+  include BrowserPageviewSessionHelpers
+
+  subject(:job) { described_class.new }
+
+  before { SiteSetting.persist_browser_pageview_events = true }
+
+  describe "#execute" do
+    it "does nothing when persist_browser_pageview_events is disabled" do
+      SiteSetting.persist_browser_pageview_events = false
+      Fabricate(:browser_pageview_event)
+
+      job.execute({})
+
+      expect(BrowserPageviewSessionDailyRollup.count).to eq(0)
+    end
+
+    it "aggregates session rollups (bounce and duration) from recent pageview events" do
+      today = Time.zone.now.beginning_of_day
+
+      Fabricate(:browser_pageview_event, created_at: today + 1.hour)
+
+      engaged_visit_start = Fabricate(:browser_pageview_event, created_at: today + 2.hours)
+      Fabricate(
+        :browser_pageview_event,
+        session_id: engaged_visit_start.session_id,
+        created_at: today + 2.hours + 40.seconds,
+      )
+
+      job.execute({})
+
+      expect(
+        BrowserPageviewSessionDailyRollup.pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.current, false, 2, 1, 40]])
+    end
+
+    it "backfills from the instrumentation date on the first run, skipping older retained events" do
+      set_engagements_instrumented_at(2.days.ago)
+      Fabricate(:browser_pageview_event, created_at: 5.days.ago)
+      Fabricate(:browser_pageview_event, created_at: 1.day.ago)
+
+      job.execute({})
+
+      expect(BrowserPageviewSessionDailyRollup.pluck(:date)).to contain_exactly(1.day.ago.to_date)
+    end
+
+    it "never rolls up days before exit pings could have been recorded" do
+      set_engagements_instrumented_at(Time.zone.now)
+      Fabricate(:browser_pageview_event, created_at: 1.day.ago)
+      Fabricate(:browser_pageview_event, created_at: 1.hour.ago)
+
+      job.execute({})
+
+      expect(BrowserPageviewSessionDailyRollup.pluck(:date)).to contain_exactly(Date.current)
+    end
+
+    it "only aggregates yesterday and today once historical rollups are populated" do
+      set_engagements_instrumented_at(10.days.ago)
+      Fabricate(:browser_pageview_event, created_at: 5.days.ago)
+      job.execute({}) # first run backfills from the instrumentation date
+
+      Fabricate(:browser_pageview_event, created_at: 4.days.ago) # late event behind the window
+      Fabricate(:browser_pageview_event) # today
+      job.execute({}) # second run only does yesterday + today
+
+      expect(BrowserPageviewSessionDailyRollup.pluck(:date)).to contain_exactly(
+        5.days.ago.to_date,
+        Date.current,
+      )
+    end
+  end
+end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -1159,6 +1159,90 @@ RSpec.describe Middleware::RequestTracker do
       expect(ApplicationRequest.page_view_anon_browser_beacon.first.count).to eq(1)
     end
 
+    context "for engagement pings" do
+      before { SiteSetting.persist_browser_pageview_events = true }
+
+      let(:middleware) { Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] }) }
+
+      it "binds the ping to the latest pageview matching its session and url" do
+        earlier_pageview = Fabricate(:browser_pageview_event, created_at: 2.minutes.ago)
+
+        latest_pageview =
+          Fabricate(
+            :browser_pageview_event,
+            session_id: earlier_pageview.session_id,
+            url: earlier_pageview.url,
+            created_at: 1.minute.ago,
+          )
+
+        status, =
+          middleware.call(
+            beacon_env(
+              {
+                session_id: latest_pageview.session_id,
+                url: latest_pageview.url,
+                engagement: true,
+              },
+              same_origin,
+            ),
+          )
+
+        expect(status).to eq(204)
+        expect(BrowserPageviewEngagement.pluck(:event_id)).to eq([latest_pageview.id])
+      end
+
+      it "drops a ping that matches no pageview" do
+        unsaved_pageview = Fabricate.build(:browser_pageview_event)
+
+        status, =
+          middleware.call(
+            beacon_env(
+              {
+                session_id: unsaved_pageview.session_id,
+                url: unsaved_pageview.url,
+                engagement: true,
+              },
+              same_origin,
+            ),
+          )
+
+        expect(status).to eq(204)
+        expect(BrowserPageviewEngagement.count).to eq(0)
+      end
+
+      it "records pings even when beacon pageview tracking is disabled" do
+        SiteSetting.use_beacon_for_browser_page_views = false
+
+        pageview = Fabricate(:browser_pageview_event, created_at: 1.minute.ago)
+
+        status, =
+          middleware.call(
+            beacon_env(
+              { session_id: pageview.session_id, url: pageview.url, engagement: true },
+              same_origin,
+            ),
+          )
+
+        expect(status).to eq(204)
+        expect(BrowserPageviewEngagement.pluck(:event_id)).to eq([pageview.id])
+      end
+
+      it "does not record pings when persist_browser_pageview_events is off" do
+        SiteSetting.persist_browser_pageview_events = false
+
+        pageview = Fabricate(:browser_pageview_event, created_at: 1.minute.ago)
+
+        middleware.call(
+          beacon_env(
+            { session_id: pageview.session_id, url: pageview.url, engagement: true },
+            same_origin,
+          ),
+        )
+
+        expect(BrowserPageviewEngagement.count).to eq(0)
+      end
+    end
+
     it "returns 403 for cross-origin beacon requests" do
       middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
       status, = middleware.call(beacon_env({}, { "HTTP_ORIGIN" => "https://evil.example" }))

--- a/spec/models/browser_pageview_session_daily_rollup_spec.rb
+++ b/spec/models/browser_pageview_session_daily_rollup_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe BrowserPageviewSessionDailyRollup do
       ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 0]])
     end
 
-    it "caps each idle gap between pageviews at 30 minutes" do
+    it "starts a new visit when more than 30 minutes pass between pageviews in a tab" do
       first_pageview =
         Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
       Fabricate(
@@ -203,7 +203,97 @@ RSpec.describe BrowserPageviewSessionDailyRollup do
           :bounced_count,
           :total_duration_seconds,
         ),
-      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 3600]])
+      ).to eq([[Date.new(2026, 5, 5), false, 3, 3, 0]])
+    end
+
+    it "counts each day's drive-by in a parked tab as its own bounce" do
+      first_visit_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: first_visit_pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 5),
+      )
+
+      second_visit_pageview =
+        Fabricate(
+          :browser_pageview_event,
+          session_id: first_visit_pageview.session_id,
+          created_at: Time.zone.local(2026, 5, 6, 10, 0, 0),
+        )
+      Fabricate(
+        :browser_pageview_engagement,
+        event: second_visit_pageview,
+        created_at: Time.zone.local(2026, 5, 6, 10, 0, 5),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 5], [Date.new(2026, 5, 6), false, 1, 1, 5]])
+    end
+
+    it "splits a tab's pageviews a day apart into two visits even without exit pings" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 6, 10, 0, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 0], [Date.new(2026, 5, 6), false, 1, 1, 0]])
+    end
+
+    it "keeps a visit together when the user returns shortly after an exit ping" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: first_pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 5),
+      )
+
+      last_pageview =
+        Fabricate(
+          :browser_pageview_event,
+          session_id: first_pageview.session_id,
+          created_at: Time.zone.local(2026, 5, 5, 10, 2, 0),
+        )
+      Fabricate(
+        :browser_pageview_engagement,
+        event: last_pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 2, 30),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 150]])
     end
 
     it "counts a final-page ping received after midnight toward the prior day's visit" do
@@ -226,6 +316,77 @@ RSpec.describe BrowserPageviewSessionDailyRollup do
           :total_duration_seconds,
         ),
       ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 15]])
+    end
+
+    it "keeps a bounce bounced when a parked tab is touched hours later" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 5),
+      )
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 14, 0, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 5]])
+    end
+
+    it "credits a long single-page read whose only ping lands after the inactivity window" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 45, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 1800]])
+    end
+
+    it "attributes a visit straddling the range start to the day before the range" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 4, 23, 50, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 5, 0, 10, 0),
+      )
+
+      described_class.aggregate(start_date: Date.new(2026, 5, 5), end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([])
     end
 
     it "caps the final page's dwell at 30 minutes" do
@@ -359,7 +520,7 @@ RSpec.describe BrowserPageviewSessionDailyRollup do
       expect(described_class.sum(:sessions_count)).to eq(1)
     end
 
-    it "is idempotent — running twice produces the same totals" do
+    it "is idempotent, so running twice produces the same totals" do
       first_pageview =
         Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
       Fabricate(

--- a/spec/models/browser_pageview_session_daily_rollup_spec.rb
+++ b/spec/models/browser_pageview_session_daily_rollup_spec.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+RSpec.describe BrowserPageviewSessionDailyRollup do
+  before { freeze_time(Time.zone.local(2026, 5, 14, 12, 0, 0)) }
+
+  let(:start_date) { Date.new(2026, 5, 1) }
+  let(:end_date) { Date.new(2026, 5, 14) }
+
+  describe ".aggregate" do
+    it "groups events sharing a session_id into a single visit with a span-based duration" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 10),
+      )
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 30),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 30]])
+    end
+
+    it "counts a single-pageview visit with no engagement as a bounce of zero duration" do
+      Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 0]])
+    end
+
+    it "does not count a single-pageview visit as a bounce when the user stayed exactly 10s" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 10),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 10]])
+    end
+
+    it "counts a single-pageview visit that left under 10s as a bounce" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 5),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 5]])
+    end
+
+    it "adds only the final page's dwell to the visit duration" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      last_pageview =
+        Fabricate(
+          :browser_pageview_event,
+          session_id: first_pageview.session_id,
+          created_at: Time.zone.local(2026, 5, 5, 10, 0, 20),
+        )
+      Fabricate(
+        :browser_pageview_engagement,
+        event: last_pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 35),
+      )
+      # A later ping for an earlier pageview must not extend the visit — only
+      # the final pageview's pings count; earlier pages' dwell is already the
+      # timestamp gap to the next pageview.
+      Fabricate(
+        :browser_pageview_engagement,
+        event: first_pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 50),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 35]])
+    end
+
+    it "uses the latest engagement ping when a page reports more than once" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 5),
+      )
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 40),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 40]])
+    end
+
+    it "ignores an exit ping that predates the visit's last pageview" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 10))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 5),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 1, 0]])
+    end
+
+    it "caps each idle gap between pageviews at 30 minutes" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 5, 12, 0, 0),
+      )
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 5, 14, 0, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 3600]])
+    end
+
+    it "counts a final-page ping received after midnight toward the prior day's visit" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 23, 59, 50))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 6, 0, 0, 5),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 15]])
+    end
+
+    it "caps the final page's dwell at 30 minutes" do
+      pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_engagement,
+        event: pageview,
+        created_at: Time.zone.local(2026, 5, 5, 12, 0, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 1800]])
+    end
+
+    it "rolls up each day and audience separately across multiple days" do
+      member = Fabricate(:user)
+
+      # May 5: an anonymous bounce
+      Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+
+      # May 6: an anonymous two-pageview visit (20s) and a logged-in visit with a 30s ping
+      anon_first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 6, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: anon_first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 6, 10, 0, 20),
+      )
+
+      member_pageview =
+        Fabricate(
+          :browser_pageview_event,
+          user_id: member.id,
+          created_at: Time.zone.local(2026, 5, 6, 11, 0, 0),
+        )
+      Fabricate(
+        :browser_pageview_engagement,
+        event: member_pageview,
+        created_at: Time.zone.local(2026, 5, 6, 11, 0, 30),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq(
+        [
+          [Date.new(2026, 5, 5), false, 1, 1, 0],
+          [Date.new(2026, 5, 6), false, 1, 0, 20],
+          [Date.new(2026, 5, 6), true, 1, 0, 30],
+        ],
+      )
+    end
+
+    it "splits visits into separate rows for anonymous and logged-in audiences" do
+      user = Fabricate(:user)
+      Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        user_id: user.id,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(described_class.order(:logged_in).pluck(:logged_in, :sessions_count)).to eq(
+        [[false, 1], [true, 1]],
+      )
+    end
+
+    it "treats a visit where the user logged in partway through as logged-in" do
+      user = Fabricate(:user)
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        user_id: user.id,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 20),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(described_class.pluck(:logged_in, :sessions_count)).to eq([[true, 1]])
+    end
+
+    it "attributes a visit spanning midnight to the day of its first pageview" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 23, 50, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 6, 0, 10, 0),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 1200]])
+    end
+
+    it "only aggregates visits whose first pageview falls within the requested range" do
+      Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 4, 20, 10, 0, 0))
+      Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(described_class.sum(:sessions_count)).to eq(1)
+    end
+
+    it "is idempotent — running twice produces the same totals" do
+      first_pageview =
+        Fabricate(:browser_pageview_event, created_at: Time.zone.local(2026, 5, 5, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: first_pageview.session_id,
+        created_at: Time.zone.local(2026, 5, 5, 10, 0, 20),
+      )
+
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+      described_class.aggregate(start_date: start_date, end_date: end_date)
+
+      expect(
+        described_class.order(:date, :logged_in).pluck(
+          :date,
+          :logged_in,
+          :sessions_count,
+          :bounced_count,
+          :total_duration_seconds,
+        ),
+      ).to eq([[Date.new(2026, 5, 5), false, 1, 0, 20]])
+    end
+  end
+end

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -680,5 +680,110 @@ RSpec.describe AdminDashboardSiteTraffic do
         expect(second[:top_countries][:rows].first[:country_code]).to eq("US")
       end
     end
+
+    context "for bounce rate and average session duration" do
+      include BrowserPageviewSessionHelpers
+
+      before { SiteSetting.persist_browser_pageview_events = true }
+
+      it "omits both metrics when persist_browser_pageview_events is disabled" do
+        SiteSetting.persist_browser_pageview_events = false
+
+        kpis = described_class.build(start_date: nil, end_date: nil)[:kpis]
+        expect(kpis).not_to have_key(:bounce_rate)
+        expect(kpis).not_to have_key(:avg_session_duration)
+      end
+
+      it "returns the combined bounce rate and average session duration for the period" do
+        member = Fabricate(:user)
+
+        # bounced single-pageview visit (0s)
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
+
+        # two-pageview visit lasting 30s (not a bounce)
+        visit_start = record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
+        Fabricate(
+          :browser_pageview_event,
+          session_id: visit_start.session_id,
+          created_at: Time.zone.local(2026, 5, 1, 10, 0, 30),
+        )
+
+        # engaged single-pageview member visit (60s, not a bounce)
+        record_visit(at: Time.zone.local(2026, 5, 2, 10, 0, 0), user_id: member.id, engaged_for: 60)
+
+        aggregate_session_rollup
+
+        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
+        expect(kpis[:bounce_rate]).to eq(value: 33)
+        expect(kpis[:avg_session_duration]).to eq(value: 30)
+      end
+
+      it "returns a trend for the bounce rate compared with the previous period" do
+        # Previous period (Apr 28–30): 1 of 4 visits bounced = 25%
+        record_visit(at: Time.zone.local(2026, 4, 28, 10, 0, 0))
+        3.times { record_visit(at: Time.zone.local(2026, 4, 28, 10, 0, 0), engaged_for: 30) }
+
+        # Current period (May 1–3): 1 of 2 visits bounced = 50%
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), engaged_for: 30)
+
+        aggregate_session_rollup
+
+        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
+        expect(kpis[:bounce_rate]).to eq(
+          value: 50,
+          percent_change: 100,
+          comparison_period: {
+            start_date: "2026-04-28",
+            end_date: "2026-04-30",
+          },
+        )
+      end
+
+      it "omits the trend when the previous period has no visits" do
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), engaged_for: 30)
+
+        aggregate_session_rollup
+
+        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
+        expect(kpis[:bounce_rate]).to eq(value: 50)
+        expect(kpis[:avg_session_duration]).to eq(value: 15)
+      end
+
+      it "computes the metrics from the rollup after the source events are pruned" do
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), engaged_for: 30)
+
+        aggregate_session_rollup
+        BrowserPageviewEvent.delete_all
+        BrowserPageviewEngagement.delete_all
+
+        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
+        expect(kpis[:bounce_rate]).to eq(value: 50)
+        expect(kpis[:avg_session_duration]).to eq(value: 15)
+      end
+
+      it "returns nil values and no trend when no visits fall in the period" do
+        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
+        expect(kpis[:bounce_rate]).to eq(value: nil)
+        expect(kpis[:avg_session_duration]).to eq(value: nil)
+      end
+
+      it "keeps the metrics on login-required sites where logged-in share is dropped" do
+        SiteSetting.login_required = true
+        member = Fabricate(:user)
+
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), user_id: member.id)
+        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), user_id: member.id, engaged_for: 30)
+
+        aggregate_session_rollup
+
+        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
+        expect(kpis[:bounce_rate]).to eq(value: 50)
+        expect(kpis[:avg_session_duration]).to eq(value: 15)
+        expect(kpis).not_to have_key(:logged_in_share)
+      end
+    end
   end
 end

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -718,39 +718,6 @@ RSpec.describe AdminDashboardSiteTraffic do
         expect(kpis[:avg_session_duration]).to eq(value: 30)
       end
 
-      it "returns a trend for the bounce rate compared with the previous period" do
-        # Previous period (Apr 28–30): 1 of 4 visits bounced = 25%
-        record_visit(at: Time.zone.local(2026, 4, 28, 10, 0, 0))
-        3.times { record_visit(at: Time.zone.local(2026, 4, 28, 10, 0, 0), engaged_for: 30) }
-
-        # Current period (May 1–3): 1 of 2 visits bounced = 50%
-        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
-        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), engaged_for: 30)
-
-        aggregate_session_rollup
-
-        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
-        expect(kpis[:bounce_rate]).to eq(
-          value: 50,
-          percent_change: 100,
-          comparison_period: {
-            start_date: "2026-04-28",
-            end_date: "2026-04-30",
-          },
-        )
-      end
-
-      it "omits the trend when the previous period has no visits" do
-        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
-        record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), engaged_for: 30)
-
-        aggregate_session_rollup
-
-        kpis = described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]
-        expect(kpis[:bounce_rate]).to eq(value: 50)
-        expect(kpis[:avg_session_duration]).to eq(value: 15)
-      end
-
       it "computes the metrics from the rollup after the source events are pruned" do
         record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0))
         record_visit(at: Time.zone.local(2026, 5, 1, 10, 0, 0), engaged_for: 30)

--- a/spec/support/browser_pageview_session_helpers.rb
+++ b/spec/support/browser_pageview_session_helpers.rb
@@ -17,4 +17,11 @@ module BrowserPageviewSessionHelpers
       end_date: Date.current,
     )
   end
+
+  def set_engagements_instrumented_at(time)
+    DB.exec(
+      "UPDATE schema_migration_details SET created_at = :time WHERE version = '20260610025606'",
+      time: time,
+    )
+  end
 end

--- a/spec/support/browser_pageview_session_helpers.rb
+++ b/spec/support/browser_pageview_session_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BrowserPageviewSessionHelpers
+  def record_visit(at:, url: "https://example.com/", user_id: nil, engaged_for: nil)
+    pageview = Fabricate(:browser_pageview_event, url: url, user_id: user_id, created_at: at)
+
+    if engaged_for
+      Fabricate(:browser_pageview_engagement, event: pageview, created_at: at + engaged_for)
+    end
+
+    pageview
+  end
+
+  def aggregate_session_rollup
+    BrowserPageviewSessionDailyRollup.aggregate(
+      start_date: 1.year.ago.to_date,
+      end_date: Date.current,
+    )
+  end
+end

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -277,4 +277,99 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
       )
     end
   end
+
+  context "with bounce rate and average session duration metrics" do
+    include BrowserPageviewSessionHelpers
+
+    before { SiteSetting.persist_browser_pageview_events = true }
+
+    it "shows staff the bounce rate and average session duration for the period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      # 3 visits across 3 days: one bounce (0s), one 120s, one 150s -> bounce 33%, avg 90s = "1m 30s"
+      record_visit(at: Time.zone.local(2026, 5, 10, 10, 0, 0))
+
+      visit_start = record_visit(at: Time.zone.local(2026, 5, 11, 10, 0, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: visit_start.session_id,
+        created_at: Time.zone.local(2026, 5, 11, 10, 2, 0),
+      )
+
+      record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0), engaged_for: 150)
+
+      aggregate_session_rollup
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_bounce_rate("33%")
+      expect(traffic).to have_avg_session_duration("1m 30s")
+    end
+
+    it "does not show the metrics when persist_browser_pageview_events is off",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      SiteSetting.persist_browser_pageview_events = false
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_no_bounce_rate
+      expect(traffic).to have_no_avg_session_duration
+    end
+
+    it "shows a falling bounce rate and a rising session duration as positive trends",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      # Previous period (Apr 1): bounce 75%, low duration
+      3.times { record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0)) }
+      record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0), engaged_for: 30)
+
+      # Current period (May 12): bounce 25%, high duration
+      3.times { record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0), engaged_for: 200) }
+      record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0))
+
+      aggregate_session_rollup
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_positive_bounce_rate_trend
+      expect(traffic).to have_positive_avg_session_duration_trend
+    end
+
+    it "shows a rising bounce rate and a falling session duration as negative trends",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      # Previous period (Apr 1): bounce 25%, high duration
+      record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0))
+      3.times { record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0), engaged_for: 200) }
+
+      # Current period (May 12): bounce 75%, low duration
+      3.times { record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0)) }
+      record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0), engaged_for: 30)
+
+      aggregate_session_rollup
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_negative_bounce_rate_trend
+      expect(traffic).to have_negative_avg_session_duration_trend
+    end
+
+    it "shows a neutral placeholder for each metric when no visits fall in the period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_empty_bounce_rate
+      expect(traffic).to have_empty_avg_session_duration
+
+      traffic.hover_bounce_rate_tooltip
+      expect(traffic).to have_bounce_rate_tooltip("Shown once visits are recorded for this period.")
+
+      traffic.hover_avg_session_duration_tooltip
+      expect(traffic).to have_avg_session_duration_tooltip(
+        "Shown once visits are recorded for this period.",
+      )
+    end
+  end
 end

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -317,44 +317,6 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
       expect(traffic).to have_no_avg_session_duration
     end
 
-    it "shows a falling bounce rate and a rising session duration as positive trends",
-       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-      # Previous period (Apr 1): bounce 75%, low duration
-      3.times { record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0)) }
-      record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0), engaged_for: 30)
-
-      # Current period (May 12): bounce 25%, high duration
-      3.times { record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0), engaged_for: 200) }
-      record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0))
-
-      aggregate_session_rollup
-
-      dashboard.visit
-      traffic = dashboard.site_traffic
-
-      expect(traffic).to have_positive_bounce_rate_trend
-      expect(traffic).to have_positive_avg_session_duration_trend
-    end
-
-    it "shows a rising bounce rate and a falling session duration as negative trends",
-       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-      # Previous period (Apr 1): bounce 25%, high duration
-      record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0))
-      3.times { record_visit(at: Time.zone.local(2026, 4, 1, 10, 0, 0), engaged_for: 200) }
-
-      # Current period (May 12): bounce 75%, low duration
-      3.times { record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0)) }
-      record_visit(at: Time.zone.local(2026, 5, 12, 10, 0, 0), engaged_for: 30)
-
-      aggregate_session_rollup
-
-      dashboard.visit
-      traffic = dashboard.site_traffic
-
-      expect(traffic).to have_negative_bounce_rate_trend
-      expect(traffic).to have_negative_avg_session_duration_trend
-    end
-
     it "shows a neutral placeholder for each metric when no visits fall in the period",
        time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
       dashboard.visit

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -32,6 +32,46 @@ module PageObjects
         has_no_css?(".db-section__metric", text: label)
       end
 
+      def has_bounce_rate?(value)
+        has_metric?("Bounce rate", value)
+      end
+
+      def has_no_bounce_rate?
+        has_no_metric?("Bounce rate")
+      end
+
+      def has_empty_bounce_rate?
+        has_metric?("Bounce rate", "—")
+      end
+
+      def has_positive_bounce_rate_trend?
+        has_metric_trend?("Bounce rate", "good")
+      end
+
+      def has_negative_bounce_rate_trend?
+        has_metric_trend?("Bounce rate", "bad")
+      end
+
+      def has_avg_session_duration?(value)
+        has_metric?("Avg. session duration", value)
+      end
+
+      def has_no_avg_session_duration?
+        has_no_metric?("Avg. session duration")
+      end
+
+      def has_empty_avg_session_duration?
+        has_metric?("Avg. session duration", "—")
+      end
+
+      def has_positive_avg_session_duration_trend?
+        has_metric_trend?("Avg. session duration", "good")
+      end
+
+      def has_negative_avg_session_duration_trend?
+        has_metric_trend?("Avg. session duration", "bad")
+      end
+
       def has_chart?
         has_css?(".db-section__traffic-chart canvas")
       end
@@ -64,6 +104,24 @@ module PageObjects
 
       def has_logged_in_share_tooltip?(text)
         Tooltips.new("site-traffic-logged-in-share-tooltip").present?(text: text)
+      end
+
+      def hover_bounce_rate_tooltip
+        find("[data-trigger][data-identifier='site-traffic-bounce-rate-tooltip']").hover
+        self
+      end
+
+      def has_bounce_rate_tooltip?(text)
+        Tooltips.new("site-traffic-bounce-rate-tooltip").present?(text: text)
+      end
+
+      def hover_avg_session_duration_tooltip
+        find("[data-trigger][data-identifier='site-traffic-avg-session-duration-tooltip']").hover
+        self
+      end
+
+      def has_avg_session_duration_tooltip?(text)
+        Tooltips.new("site-traffic-avg-session-duration-tooltip").present?(text: text)
       end
 
       def has_no_top_countries_card?
@@ -125,6 +183,12 @@ module PageObjects
       end
 
       private
+
+      def has_metric_trend?(label, quality)
+        within(".db-section__metric", text: label) do
+          has_css?(".db-section__metric-trend.--#{quality}")
+        end
+      end
 
       def has_no_top_card?(title)
         has_no_css?(".db-section__row-block", text: title)

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -44,14 +44,6 @@ module PageObjects
         has_metric?("Bounce rate", "—")
       end
 
-      def has_positive_bounce_rate_trend?
-        has_metric_trend?("Bounce rate", "good")
-      end
-
-      def has_negative_bounce_rate_trend?
-        has_metric_trend?("Bounce rate", "bad")
-      end
-
       def has_avg_session_duration?(value)
         has_metric?("Avg. session duration", value)
       end
@@ -62,14 +54,6 @@ module PageObjects
 
       def has_empty_avg_session_duration?
         has_metric?("Avg. session duration", "—")
-      end
-
-      def has_positive_avg_session_duration_trend?
-        has_metric_trend?("Avg. session duration", "good")
-      end
-
-      def has_negative_avg_session_duration_trend?
-        has_metric_trend?("Avg. session duration", "bad")
       end
 
       def has_chart?
@@ -183,12 +167,6 @@ module PageObjects
       end
 
       private
-
-      def has_metric_trend?(label, quality)
-        within(".db-section__metric", text: label) do
-          has_css?(".db-section__metric-trend.--#{quality}")
-        end
-      end
 
       def has_no_top_card?(title)
         has_no_css?(".db-section__row-block", text: title)

--- a/spec/system/page_objects/pages/pageview_tracking.rb
+++ b/spec/system/page_objects/pages/pageview_tracking.rb
@@ -6,6 +6,45 @@ module PageObjects
       def session_id
         find("meta[name='discourse-track-view-session-id']", visible: :all)[:content]
       end
+
+      # Simulates the user switching to another application. A new tab takes
+      # the browser's real focus, then ending Chrome's focus emulation lets
+      # the original page notice: the browser itself fires `blur` and reports
+      # `document.hasFocus() == false`, the same focus-loss path a real
+      # app-switch takes. Headless Chrome has no window manager, so this is
+      # the only real leave action available to system tests.
+      def switch_to_another_application
+        remember_app_page
+        page.switch_to_window(page.open_new_window(:tab))
+        set_focus_emulation(enabled: false)
+      end
+
+      def return_to_page
+        page.switch_to_window(@app_window)
+        set_focus_emulation(enabled: true)
+      end
+
+      # Jumps the page's Date.now() past the exit ping resend throttle using
+      # the Playwright clock installed by the `time:` metadata, so tests
+      # never wait in real time.
+      def skip_past_resend_throttle
+        remember_app_page
+        @app_pw_page.clock.fast_forward(5_000)
+      end
+
+      private
+
+      def remember_app_page
+        return if @app_pw_page
+
+        @app_window = page.current_window
+        page.driver.with_playwright_page { |pw_page| @app_pw_page = pw_page }
+      end
+
+      def set_focus_emulation(enabled:)
+        cdp_session = @app_pw_page.context.new_cdp_session(@app_pw_page)
+        cdp_session.send_message("Emulation.setFocusEmulationEnabled", params: { enabled: enabled })
+      end
     end
   end
 end

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -561,17 +561,61 @@ describe "Request tracking" do
         visit "/"
         session_id = pageview_tracking.session_id
 
-        switch_to_window(open_new_window(:tab))
+        try_until_success do
+          expect(BrowserPageviewEvent.exists?(session_id: session_id)).to eq(true)
+        end
+
+        pageview_tracking.switch_to_another_application
 
         try_until_success do
           expect(
-            BrowserPageviewEngagement.joins(:event).where(
-              browser_pageview_events: {
-                session_id: session_id,
-                url: "#{Discourse.base_url_no_prefix}/",
-              },
-            ).count,
+            BrowserPageviewEngagement
+              .joins(:event)
+              .where(
+                browser_pageview_events: {
+                  session_id: session_id,
+                  url: "#{Discourse.base_url_no_prefix}/",
+                },
+              )
+              .count,
           ).to eq(1)
+        end
+      end
+
+      it "records another ping when the user returns and leaves again",
+         time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+        SiteSetting.persist_browser_pageview_events = true
+
+        visit "/"
+        session_id = pageview_tracking.session_id
+
+        try_until_success do
+          expect(BrowserPageviewEvent.exists?(session_id: session_id)).to eq(true)
+        end
+
+        pageview_tracking.switch_to_another_application
+
+        try_until_success do
+          expect(
+            BrowserPageviewEngagement
+              .joins(:event)
+              .where(browser_pageview_events: { session_id: session_id })
+              .count,
+          ).to eq(1)
+        end
+
+        pageview_tracking.skip_past_resend_throttle
+        pageview_tracking.return_to_page
+        pageview_tracking.skip_past_resend_throttle
+        pageview_tracking.switch_to_another_application
+
+        try_until_success do
+          expect(
+            BrowserPageviewEngagement
+              .joins(:event)
+              .where(browser_pageview_events: { session_id: session_id })
+              .count,
+          ).to eq(2)
         end
       end
 
@@ -584,15 +628,23 @@ describe "Request tracking" do
         find(".nav-item_categories a").click
         expect(page).to have_current_path("/categories")
 
-        switch_to_window(open_new_window(:tab))
+        try_until_success do
+          expect(
+            BrowserPageviewEvent.exists?(
+              session_id: session_id,
+              url: "#{Discourse.base_url_no_prefix}/categories",
+            ),
+          ).to eq(true)
+        end
+
+        pageview_tracking.switch_to_another_application
 
         try_until_success do
           expect(
-            BrowserPageviewEngagement.joins(:event).where(
-              browser_pageview_events: {
-                session_id: session_id,
-              },
-            ).pluck("browser_pageview_events.url"),
+            BrowserPageviewEngagement
+              .joins(:event)
+              .where(browser_pageview_events: { session_id: session_id })
+              .pluck("browser_pageview_events.url"),
           ).to eq(["#{Discourse.base_url_no_prefix}/categories"])
         end
       end

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -554,6 +554,48 @@ describe "Request tracking" do
         expect(beacon_events).to be_blank
         expect(non_beacon_events).to be_blank
       end
+
+      it "records an engagement ping when the user switches away from the page" do
+        SiteSetting.persist_browser_pageview_events = true
+
+        visit "/"
+        session_id = pageview_tracking.session_id
+
+        switch_to_window(open_new_window(:tab))
+
+        try_until_success do
+          expect(
+            BrowserPageviewEngagement.joins(:event).where(
+              browser_pageview_events: {
+                session_id: session_id,
+                url: "#{Discourse.base_url_no_prefix}/",
+              },
+            ).count,
+          ).to eq(1)
+        end
+      end
+
+      it "binds the engagement ping to the last page viewed when the user leaves after browsing multiple pages" do
+        SiteSetting.persist_browser_pageview_events = true
+
+        visit "/"
+        session_id = pageview_tracking.session_id
+
+        find(".nav-item_categories a").click
+        expect(page).to have_current_path("/categories")
+
+        switch_to_window(open_new_window(:tab))
+
+        try_until_success do
+          expect(
+            BrowserPageviewEngagement.joins(:event).where(
+              browser_pageview_events: {
+                session_id: session_id,
+              },
+            ).pluck("browser_pageview_events.url"),
+          ).to eq(["#{Discourse.base_url_no_prefix}/categories"])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds two new numbers to the Traffic section of the redesigned admin dashboard. Bounce rate is the percentage of visits where someone viewed a single page for less than 10 seconds and left. Average session duration is how long a typical visit lasts.

Discourse already saves a row in the browser_pageview_events table every time someone views a page, and every pageview from the same browser tab shares a session id. A visit is a run of pageviews from the same tab with no gap longer than 30 minutes, and the time someone spent on a page is the gap between that pageview's timestamp and the next one's. That works for every page except the last one: when someone reads the final page and closes the tab, there is no next pageview to measure against. The server never hears from them again, and solving that gap is most of this PR.

Key technical changes:

1. The browser now sends an "I'm leaving" signal. When the page is hidden, the window loses focus, or the page unloads, the client sends a keepalive POST to /srv/pv, the same endpoint the pageview beacon uses, with the body { session_id, url, engagement: true }. The engagement flag is how the server tells this request apart from a pageview beacon. The request contains no measurements. The server records when it arrived, and time on the last page is that arrival time minus the last pageview's timestamp. Keeping all timekeeping on the server means we never have to trust a number computed inside the visitor's browser. Clients only arm the signal when the persist_browser_pageview_events site setting is on (a dedicated meta tag), so sites that merely count pageviews pay no extra requests, and pages outside the Ember app (published pages, safe mode) send the same signal.

2. Each signal is stored as a row in the new browser_pageview_engagements table:

    ```
    create_table :browser_pageview_engagements do |t|
      t.bigint :event_id, null: false     # the browser_pageview_events row the signal belongs to
      t.datetime :created_at, null: false # server arrival time
    end
    add_index :browser_pageview_engagements, %i[event_id created_at]
    ```

    On arrival the server resolves the signal's (session_id, url) to the latest matching pageview created at or before the arrival time and stores only that pageview's id. If no matching pageview exists yet (the signal can occasionally arrive before the pageview finishes saving), the signal is discarded, and a later signal makes up for it. Rows in this table are only ever inserted, never updated, because updating rows on busy tables is far more expensive in Postgres than inserting new ones. Jobs::CleanUpBrowserPageviewEvents deletes a pageview's engagement rows in the same batch that deletes the pageview itself, so this table follows the same three month retention as its parent.

3. A tab's session id is treated as a correlation key, not as the visit itself. A browser tab keeps one session id for its whole lifetime, which can be days for a pinned tab. The rollup therefore derives logical visits: a pageview arriving more than 30 minutes after the previous one in the same tab starts a new visit. Someone who glances at their pinned tab for 5 seconds each morning produces a separate small bounce each day, instead of one ever-growing visit that can never bounce. Signals arriving after a visit's 30 minute inactivity window cannot retroactively turn a bounce into a long visit: a signal inside the window pins the departure time, and a visit whose only signals came later is credited with at most the 30 minute cap.

4. Visits are summarized once a day into the new browser_pageview_session_daily_rollups table, split by logged in versus anonymous visitors:

    ```
    create_table :browser_pageview_session_daily_rollups do |t|
      t.date :date, null: false
      t.boolean :logged_in, null: false
      t.bigint :sessions_count, null: false
      t.bigint :bounced_count, null: false
      t.bigint :total_duration_seconds, null: false
    end
    add_index :browser_pageview_session_daily_rollups, %i[date logged_in],
              unique: true, name: "idx_bpsd_rollups_date_logged_in_unique"
    ```

    The raw pageview rows are deleted after three months to save space, so the dashboard reads from this summary, which is tiny and permanent. The dedicated job Jobs::MaintainBrowserPageviewSessionRollups keeps it current every 10 minutes. It is separate from the existing rollup job so the most expensive aggregate never delays the country and referrer rollups, and the aggregation derives visit boundaries, gaps, and each visit's final pageview from a single sorted pass per run. The job never aggregates days from before this feature was deployed to the site. Visits from those days have no exit signals, so rolling them up would permanently misclassify every single-pageview visit as a zero-duration bounce; the cutoff is the day the engagements table was created, read from schema_migration_details.

5. The "I'm leaving" signal repeats safely. A visitor can leave and come back many times, and nobody knows which leave is the last one. The browser therefore sends the signal on every leave (at most one per 3 seconds) and the server keeps the latest arrival inside the visit's window. If the final signal is lost, for example when the browser is force-closed, the previous one still captures most of the visit.

6. The KPI tiles are not rendered at all when the persist_browser_pageview_events site setting is disabled, the same switch that controls the existing Top countries and Top referrers cards. When the setting is enabled but no visits are recorded yet, each tile shows a dash with a tooltip explaining the number will appear once visits are recorded, instead of a misleading 0%.