### PR TITLE
FIX: Horizon > Apply `create-topic-label` transformer to Horizon sidebar button

### DIFF
--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -8,12 +8,14 @@ import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import CreateTopicButton from "discourse/components/create-topic-button";
 import bodyClass from "discourse/helpers/body-class";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import { gt } from "discourse/truth-helpers";
 
 export default class SidebarNewTopicButton extends Component {
   @service composer;
   @service currentUser;
   @service siteSettings;
+  @service site;
   @service router;
   @service header;
   @service appEvents;
@@ -36,6 +38,36 @@ export default class SidebarNewTopicButton extends Component {
 
   get draftCount() {
     return this.currentUser?.get("draft_count");
+  }
+
+  get createTopicLabel() {
+    const defaultKey = "topic.create";
+    let value = defaultKey;
+
+    if (
+      this.site.shared_drafts_category_id &&
+      this.category?.id === this.site.shared_drafts_category_id
+    ) {
+      value = "topic.create_shared_draft";
+    }
+
+    return applyValueTransformer("create-topic-label", value, {
+      site: this.site,
+      defaultKey,
+      category: this.category,
+      currentUser: this.currentUser,
+    });
+  }
+
+  get createTopicIcon() {
+    const defaultIcon = "far-pen-to-square";
+
+    return applyValueTransformer("create-topic-icon", defaultIcon, {
+      site: this.site,
+      defaultIcon,
+      category: this.category,
+      currentUser: this.currentUser,
+    });
   }
 
   get createTopicTargetCategory() {
@@ -91,7 +123,8 @@ export default class SidebarNewTopicButton extends Component {
         {{willDestroy this.stopWatchingForComposer}}
         @canCreateTopic={{this.canCreateTopic}}
         @action={{this.createNewTopic}}
-        @label="topic.create"
+        @label={{this.createTopicLabel}}
+        @icon={{this.createTopicIcon}}
         @btnClass="sidebar-new-topic-button"
         @btnTypeClass="btn-primary"
         @showDrafts={{gt this.draftCount 0}}

--- a/themes/horizon/scss/sidebar.scss
+++ b/themes/horizon/scss/sidebar.scss
@@ -88,10 +88,6 @@ body.has-full-page-chat .sidebar-wrapper,
 
 .sidebar-new-topic-button__wrapper {
   margin: 0 var(--space-2) var(--space-4) var(--space-4);
-
-  .sidebar-new-topic-button .d-icon {
-    display: none;
-  }
 }
 
 // put the draft menu above the slide-out hamburger on small desktop screens


### PR DESCRIPTION
  Previously, the new topic button in the Horizon theme's sidebar hardcoded its label and icon, so plugins like
  discourse-calendar could not relabel it (e.g. to "New Event" in an events category) even though the button outside the sidebar updated correctly.
  
  This change runs the label and icon through the `create-topic-label` and `create-topic-icon` value transformers,
  matching core's `d-navigation` behaviour so plugin overrides apply in the sidebar too.

Since this button can now have two states, the icon is brought back to improve quick-glance clarity.

<img width="1519" height="807" alt="CleanShot 2026-06-10 at 12 11 12" src="https://github.com/user-attachments/assets/1c1e79fb-d509-40a7-b385-9e3efebf3d09" />

