### PR TITLE
UX: Show warning to admins when disabling Content-Security-Policy

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9340,6 +9340,9 @@ en:
           can_permanently_delete:
             prompt: "Enabling this allows admins to permanently destroy posts, topics, and post revisions. Permanently deleted data cannot be recovered. This may also affect data integrity and break existing links."
             confirm: "I understand"
+          content_security_policy:
+            prompt: "Disabling the content security policy removes an important layer of protection against cross-site scripting (XSS) and other content injection attacks. This will leave your site vulnerable, and should only be done for debugging/testing purposes. Are you sure you want to proceed?"
+            confirm: "Yes, disable the content security policy"
         job_status:
           completed: "Update completed"
           enqueued: "Update in progress"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9341,7 +9341,7 @@ en:
             prompt: "Enabling this allows admins to permanently destroy posts, topics, and post revisions. Permanently deleted data cannot be recovered. This may also affect data integrity and break existing links."
             confirm: "I understand"
           content_security_policy:
-            prompt: "Disabling the content security policy removes an important layer of protection against cross-site scripting (XSS) and other content injection attacks. This will leave your site vulnerable, and should only be done for debugging/testing purposes. Are you sure you want to proceed?"
+            prompt: "Disabling the content security policy removes an important layer of protection against cross-site scripting (XSS) and other content injection attacks. This will leave your site vulnerable, and should only be done for debugging/testing purposes. Disabling CSP will never help to resolve CORS issues. Are you sure you want to proceed?"
             confirm: "Yes, disable the content security policy"
         job_status:
           completed: "Update completed"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2017,7 +2017,7 @@ en:
     slow_down_crawler_user_agents: "User agents of web crawlers that should be rate limited as configured in the {{setting:slow_down_crawler_rate}} setting. Each value must be at least 3 characters long."
     slow_down_crawler_rate: "If {{setting:slow_down_crawler_user_agents}} is specified this rate will apply to all the crawlers (number of seconds delay between requests)"
     llms_txt: "Upload a text file to be served at /llms.txt for LLM crawlers. See <a href='https://llmstxt.org/' target='_blank'>llmstxt.org</a> for more information."
-    content_security_policy: "Enable Content-Security-Policy (CSP). CSP is an additional layer of security that helps to prevent certain types of attacks, including Cross Site Scripting (XSS) and data injection."
+    content_security_policy: "Enable Content-Security-Policy (CSP). CSP is an additional layer of security that helps to prevent certain types of attacks, including Cross Site Scripting (XSS) and data injection. It should only be disabled temporarily for debugging/testing purposes."
     content_security_policy_report_only: "Enable Content-Security-Policy-Report-Only (CSP)"
     content_security_policy_frame_ancestors: "Restrict who can embed this site in iframes via CSP. Control allowed hosts on <a href='%{base_path}/admin/customize/embedding'>Embedding</a>"
     content_security_policy_script_src: "Additional allowlisted script sources. The current host and CDN are included by default. See <a href='https://meta.discourse.org/t/mitigate-xss-attacks-with-content-security-policy/104243' target='_blank'>Mitigate XSS Attacks with Content Security Policy.</a> (CSP). Other host sources are ignored as strict-dynamic is enabled."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -20,8 +20,9 @@
 #                         These groups cannot be selected and will be stripped if set via API.
 #                         Only applies to group_list type settings.
 # requires_confirmation - A string that indicates if the setting requires confirmation before it can be changed.
-#                         Only valid value here is "simple" which will display a confirmation dialog when the setting
-#                         is changed.
+#                         Valid values are "simple" (always display a confirmation dialog when the setting is changed),
+#                         "simple_on_enable" (only when the setting is enabled), and "simple_on_disable" (only when
+#                         the setting is disabled).
 # themeable             - Set to true if themes can override this site setting. Generally, only client side affecting settings
 #                         that change the UI should be themeable, and try limit to simple setting types like bool, list, integer, enum.
 # upcoming_change_default_override - Allow an upcoming change to control the new default value of this setting.
@@ -2979,6 +2980,7 @@ security:
     max_file_size_kb: 512
   content_security_policy:
     default: true
+    requires_confirmation: "simple_on_disable"
   content_security_policy_report_only:
     default: false
   content_security_policy_frame_ancestors:

--- a/frontend/discourse/admin/lib/constants.js
+++ b/frontend/discourse/admin/lib/constants.js
@@ -13,6 +13,7 @@ export const ADMIN_SEARCH_RESULT_TYPES = [
 export const SITE_SETTING_REQUIRES_CONFIRMATION_TYPES = {
   simple: "simple",
   simple_on_enable: "simple_on_enable",
+  simple_on_disable: "simple_on_disable",
   user_option: "user_option",
 };
 

--- a/frontend/discourse/admin/models/site-setting.js
+++ b/frontend/discourse/admin/models/site-setting.js
@@ -161,6 +161,10 @@ export default class SiteSetting extends EmberObject {
         const val = this.buffered?.get("value");
         return isSettingValueTrue(val);
       }
+      case SITE_SETTING_REQUIRES_CONFIRMATION_TYPES.simple_on_disable: {
+        const val = this.buffered?.get("value");
+        return !isSettingValueTrue(val);
+      }
       default:
         return false;
     }

--- a/lib/site_settings/type_supervisor.rb
+++ b/lib/site_settings/type_supervisor.rb
@@ -36,6 +36,7 @@ class SiteSettings::TypeSupervisor
   REQUIRES_CONFIRMATION_TYPES = {
     simple: "simple",
     simple_on_enable: "simple_on_enable",
+    simple_on_disable: "simple_on_disable",
     user_option: "user_option",
   }.freeze
 

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1434,6 +1434,14 @@ RSpec.describe SiteSettingExtension do
       ).to eq("simple")
     end
 
+    it "returns 'simple_on_disable' for settings that require confirmation with 'simple_on_disable' type" do
+      expect(
+        SiteSetting.all_settings.find { |s| s[:setting] == :content_security_policy }[
+          :requires_confirmation
+        ],
+      ).to eq("simple_on_disable")
+    end
+
     it "returns nil for settings that do not require confirmation" do
       expect(
         SiteSetting.all_settings.find { |s| s[:setting] == :display_local_time_in_user_card }[

--- a/spec/system/admin_site_setting_requires_confirmation_spec.rb
+++ b/spec/system/admin_site_setting_requires_confirmation_spec.rb
@@ -57,4 +57,24 @@ describe "Admin Site Setting Requires Confirmation" do
       expect(dialog).to be_closed
     end
   end
+
+  context "with simple_on_disable confirmation type" do
+    it "shows confirmation when disabling the setting but not when enabling it" do
+      settings_page.visit("content_security_policy")
+      settings_page.toggle_bool_setting("content_security_policy")
+      expect(dialog).to be_open
+      expect(dialog).to have_content(
+        I18n.t(
+          "admin_js.admin.site_settings.requires_confirmation_messages.content_security_policy.prompt",
+        ),
+      )
+      dialog.click_yes
+      expect(dialog).to be_closed
+      expect(settings_page).to have_overridden_setting("content_security_policy")
+
+      settings_page.toggle_bool_setting("content_security_policy")
+      expect(dialog).to be_closed
+      expect(settings_page).to have_no_overridden_setting("content_security_policy")
+    end
+  end
 end


### PR DESCRIPTION
Having CSP enabled is an important layer of security for Discourse sites, and should not be disabled except for debugging purposes. We're keeping the setting visible so that admins have visibility of the current state and can re-enable if they've disabled it in the past.

<img width="876" height="243" alt="image" src="https://github.com/user-attachments/assets/c464e5fc-0264-4e3d-b417-b8a881fd5b0f" />
