### PR TITLE
UI: Truncate DE query descriptions to one line with tooltips for the full descriptions

### DIFF
--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
@@ -141,7 +141,10 @@ export default <template>
                                   }}</span>
                               {{/if}}
                             </div>
-                            <div class="query-desc">{{query.description}}</div>
+                            <div
+                              class="query-desc"
+                              title={{query.description}}
+                            >{{query.description}}</div>
                           </LinkTo>
                         </td>
                         <td class="d-table__cell --detail query-created-by">

--- a/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
+++ b/plugins/discourse-data-explorer/assets/stylesheets/explorer.scss
@@ -915,6 +915,9 @@ table.group-reports {
     .query-desc {
       color: var(--primary-high);
       max-width: 20vw;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
 
       @include viewport.until(md) {
         max-width: 90vw;


### PR DESCRIPTION
A long data explorer query description would push the others much further down in the list because the full description is rendered.  We truncate it.

| before | after |
|--|--|
|  <img width="1280" height="720" alt="before-trunc3" src="https://github.com/user-attachments/assets/57a0863b-7b15-477b-9019-c5e5de57ea54" /> | <img width="1280" height="720" alt="after-trunc" src="https://github.com/user-attachments/assets/09ceb991-19b1-4e12-9f09-0b3abc1b2f6e" /> |