### PR TITLE
FIX: Chat lightbox anim starting from viewport origin

### DIFF
--- a/frontend/discourse/app/lib/lightbox.js
+++ b/frontend/discourse/app/lib/lightbox.js
@@ -327,7 +327,8 @@ async function initLightbox(elem, additionalData = {}) {
     // this ensures that cropped images (eg: grid) do not cause jittering when closing
     data.thumbCropped = true;
 
-    data.src = data.src || el.getAttribute("data-large-src");
+    data.src ||= el.getAttribute("data-large-src");
+    data.msrc ||= imgEl?.currentSrc || imgEl?.src;
     data.origSrc =
       imgEl?.getAttribute("data-orig-src") ||
       el.getAttribute("data-orig-src") ||


### PR DESCRIPTION
Photoswipe only extracts `msrc` from `<a>` elements, so chat's `<img>` elements got an empty div placeholder and skipped the pre-animation wait.