### PR TITLE
FIX: Clear chat unread counts when reaching the bottom

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -446,6 +446,15 @@ export default class ChatChannel extends Component {
       return;
     }
 
+    // Clear unread counts optimistically when the latest message is in view.
+    if (
+      !this.messagesLoader.canLoadMoreFuture &&
+      firstMessage.id === this.messagesManager.findLastMessage()?.id
+    ) {
+      this.args.channel.tracking.unreadCount = 0;
+      this.args.channel.tracking.mentionCount = 0;
+    }
+
     const lastReadId =
       this.args.channel.currentUserMembership?.lastReadMessageId;
     if (lastReadId >= firstMessage.id) {


### PR DESCRIPTION
Clear tracking counts optimistically instead of waiting for the server's push. This fixes channels sometimes staying stuck unread. (until new refresh or when new messages arrive and are marked as read)