### PR TITLE
UX: overflow handling for composer title

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -266,11 +266,7 @@ html.composer-open:not(.has-full-page-chat) {
     .composer-actions-reply-target-link {
       --d-button-default-text-color: var(--primary-high);
       --d-button-flat-icon-color: var(--primary-high);
-      max-width: 30ch;
-
-      @include viewport.until(sm) {
-        max-width: 18ch;
-      }
+      overflow: hidden;
 
       &__label {
         @include ellipsis;


### PR DESCRIPTION
| BC | AC |
|--------|--------|
| <img width="792" height="789" alt="CleanShot 2026-06-10 at 13 43 53@2x" src="https://github.com/user-attachments/assets/e96287a2-89e7-40d5-87b7-e26901da888f" /> | <img width="792" height="789" alt="CleanShot 2026-06-10 at 13 45 01" src="https://github.com/user-attachments/assets/82aa09af-58fc-4442-957d-33838cff47ae" /> | 