### PR TITLE
FIX: Don't blow up small images in chat

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-upload.gjs
@@ -38,7 +38,9 @@ export default class ChatUpload extends Component {
     const width = this.args.upload.width;
     const height = this.args.upload.height;
 
+    // Shrink to fit, never blow up small images.
     const ratio = Math.min(
+      1,
       this.siteSettings.max_image_width / width,
       this.siteSettings.max_image_height / height
     );


### PR DESCRIPTION
That led to cases where the image in the lightbox was actually smaller than the one in the message.