### PR TITLE
FIX: Serve inline-safe uploads inline on the local file store

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -373,9 +373,9 @@ class UploadsController < ApplicationController
       content_type: MiniMime.lookup_by_filename(upload.original_filename)&.content_type,
     }
 
-    if !FileHelper.is_inline_safe?(upload.original_filename)
+    if force_download? || !FileHelper.is_inline_safe?(upload.original_filename)
       opts[:disposition] = "attachment"
-    elsif params[:inline]
+    else
       opts[:disposition] = "inline"
     end
 

--- a/spec/lib/file_helper_spec.rb
+++ b/spec/lib/file_helper_spec.rb
@@ -227,6 +227,27 @@ RSpec.describe FileHelper do
       it "excludes SVG" do
         expect(FileHelper.inline_safe_files).not_to include("svg")
       end
+
+      it "only contains extensions that map to a non-scriptable content type" do
+        scriptable_content_types = %w[
+          text/html
+          application/xhtml+xml
+          image/svg+xml
+          application/xml
+          text/xml
+        ]
+
+        offenders =
+          FileHelper.inline_safe_files.select do |extension|
+            content_type = MiniMime.lookup_by_filename("file.#{extension}")&.content_type
+            next false if content_type.blank?
+
+            scriptable_content_types.include?(content_type) ||
+              content_type.match?(/(java|ecma)script/)
+          end
+
+        expect(offenders).to be_empty
+      end
     end
   end
 end

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe UploadsController do
       expect(response.status).to eq(200)
 
       expect(response.headers["Content-Disposition"]).to eq(
-        %Q|attachment; filename="#{upload.original_filename}"; filename*=UTF-8''#{upload.original_filename}|,
+        %Q|inline; filename="#{upload.original_filename}"; filename*=UTF-8''#{upload.original_filename}|,
       )
     end
 
@@ -422,7 +422,7 @@ RSpec.describe UploadsController do
       get "/uploads/#{site}/#{upload.sha1}.json"
       expect(response.status).to eq(200)
       expect(response.headers["Content-Disposition"]).to eq(
-        %Q|attachment; filename="#{upload.original_filename}"; filename*=UTF-8''#{upload.original_filename}|,
+        %Q|inline; filename="#{upload.original_filename}"; filename*=UTF-8''#{upload.original_filename}|,
       )
     end
 
@@ -452,12 +452,12 @@ RSpec.describe UploadsController do
   describe "#show_short" do
     it "inlines only supported image files" do
       upload = upload_file("smallest.png")
-      get upload.short_path, params: { inline: true }
+      get upload.short_path
       expect(response.header["Content-Type"]).to eq("image/png")
       expect(response.header["Content-Disposition"]).to include("inline;")
 
       upload.update!(original_filename: "test.xml")
-      get upload.short_path, params: { inline: true }
+      get upload.short_path
       expect(response.header["Content-Type"]).to eq("application/xml")
       expect(response.header["Content-Disposition"]).to include("attachment;")
     end
@@ -467,16 +467,6 @@ RSpec.describe UploadsController do
 
       it "returns the right response" do
         get image_upload.short_path
-
-        expect(response.status).to eq(200)
-
-        expect(response.headers["Content-Disposition"]).to include(
-          "attachment; filename=\"#{image_upload.original_filename}\"",
-        )
-      end
-
-      it "returns the right response when `inline` param is given" do
-        get "#{image_upload.short_path}?inline=1"
 
         expect(response.status).to eq(200)
 
@@ -505,60 +495,38 @@ RSpec.describe UploadsController do
         expect(response.status).to eq(200)
       end
 
-      it "includes CSP sandbox header for all uploads" do
+      it "serves inline-safe images inline with the sandbox CSP and nosniff" do
         get image_upload.short_path
 
         expect(response.status).to eq(200)
-        expect(response.headers["Content-Security-Policy"]).to eq("sandbox;")
-      end
-
-      it "serves PNG images inline with CSP header when inline param is given" do
-        png_upload = upload_file("smallest.png")
-        get "#{png_upload.short_path}?inline=1"
-
-        expect(response.status).to eq(200)
         expect(response.headers["Content-Disposition"]).to include("inline")
         expect(response.headers["Content-Security-Policy"]).to eq("sandbox;")
+        expect(response.headers["X-Content-Type-Options"]).to eq("nosniff")
       end
 
-      it "serves PDFs inline with CSP header when inline param is given" do
-        SiteSetting.authorized_extensions = "pdf|png"
-        pdf_upload = upload_file("smallest.png")
-        pdf_upload.update!(original_filename: "document.pdf", extension: "pdf")
-        get "#{pdf_upload.short_path}?inline=1"
+      {
+        "document.pdf" => "inline",
+        "clip.mp4" => "inline",
+        "page.html" => "attachment",
+        "data.xml" => "attachment",
+        "image.svg" => "attachment",
+      }.each do |filename, disposition|
+        it "serves #{filename} with #{disposition} disposition and the sandbox CSP" do
+          extension = File.extname(filename).delete_prefix(".")
+          SiteSetting.authorized_extensions = "#{extension}|png"
+          upload = upload_file("smallest.png")
+          upload.update!(original_filename: filename, extension: extension)
 
-        expect(response.status).to eq(200)
-        expect(response.headers["Content-Disposition"]).to include("inline")
-        expect(response.headers["Content-Security-Policy"]).to eq("sandbox;")
+          get upload.short_path
+
+          expect(response.status).to eq(200)
+          expect(response.headers["Content-Disposition"]).to include(disposition)
+          expect(response.headers["Content-Security-Policy"]).to eq("sandbox;")
+        end
       end
 
-      it "forces attachment disposition for HTML files with CSP header" do
-        SiteSetting.authorized_extensions = "html|png"
-        html_upload = upload_file("smallest.png")
-        html_upload.update!(original_filename: "page.html", extension: "html")
-        get "#{html_upload.short_path}?inline=1"
-
-        expect(response.status).to eq(200)
-        expect(response.headers["Content-Disposition"]).to include("attachment")
-        expect(response.headers["Content-Security-Policy"]).to eq("sandbox;")
-      end
-
-      it "forces attachment disposition for XML files with CSP header" do
-        SiteSetting.authorized_extensions = "xml|png"
-        xml_upload = upload_file("smallest.png")
-        xml_upload.update!(original_filename: "data.xml", extension: "xml")
-        get "#{xml_upload.short_path}?inline=1"
-
-        expect(response.status).to eq(200)
-        expect(response.headers["Content-Disposition"]).to include("attachment")
-        expect(response.headers["Content-Security-Policy"]).to eq("sandbox;")
-      end
-
-      it "forces attachment disposition for SVG files with CSP header" do
-        SiteSetting.authorized_extensions = "svg|png"
-        svg_upload = upload_file("smallest.png")
-        svg_upload.update!(original_filename: "image.svg", extension: "svg")
-        get "#{svg_upload.short_path}?inline=1"
+      it "forces an attachment download with a sandbox CSP when the dl param is given" do
+        get "#{image_upload.short_path}?dl=1"
 
         expect(response.status).to eq(200)
         expect(response.headers["Content-Disposition"]).to include("attachment")


### PR DESCRIPTION
Inline-safe uploads (images, PDFs, audio and video) served from the local
file store were sent with `Content-Disposition: attachment`, so clicking a
PDF link downloaded the file instead of opening it in the browser. This was
inconsistent with the S3 store, which already serves these files inline, and
it left simple self-hosted (single-container, no S3/CDN) sites unable to open
PDFs inline.

`UploadsController#send_file_local_upload` only set the disposition to
`attachment` for unsafe types, and to `inline` when `?inline=1` was passed,
leaving it unset otherwise. Rails' `send_file` defaults an unset disposition
to `attachment`, so inline-safe files fell through to a download.

Inline-safe files are now served with `Content-Disposition: inline` by
default, mirroring the S3 store, while unsafe types (HTML, SVG, XML, ...) and
explicit downloads (`?dl=1`) keep the `attachment` disposition. The redundant
`params[:inline]` branch is removed, since inline-safe files are now inline by
default.

The `Content-Security-Policy: sandbox;` header stays on **every** response as
defense-in-depth: if the `is_inline_safe?` allowlist is ever wrong, the
sandbox forces an opaque origin and disables script execution so a
misclassified file cannot run as a document in our origin. It does not
interfere with inline viewing — `sandbox` sandboxes scripts *inside* the
served file, not the browser's native rendering of it. Chrome's built-in PDF
viewer and Firefox's pdf.js both render sandboxed PDFs identically to
unsandboxed ones, and images/audio/video decode natively regardless.

A spec locks the allowlist invariant by asserting no inline-safe extension
maps to a script-capable content type, so re-adding something like SVG or XML
to the allowlist fails CI instead of becoming a stored XSS.
