### PR TITLE
FIX: Honor `house_ads_after_nth_root` in the nested replies view

### DIFF
--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/house-ad.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/house-ad.gjs
@@ -37,58 +37,34 @@ export default class HouseAd extends AdComponent {
     return this.showAd ? `house-${this.placement}` : "";
   }
 
-  @computed(
-    "showToGroups",
-    "showAfterPost",
-    "showAfterTopicListItem",
-    "showAfterNestedRoot",
-    "showOnCurrentPage"
-  )
+  @computed("showToGroups", "showAfterPlacement", "showOnCurrentPage")
   get showAd() {
     return (
-      this.showToGroups &&
-      (this.showAfterPost ||
-        this.showAfterTopicListItem ||
-        this.showAfterNestedRoot) &&
-      this.showOnCurrentPage
+      this.showToGroups && this.showAfterPlacement && this.showOnCurrentPage
     );
   }
 
-  @computed("postNumber", "placement")
-  get showAfterPost() {
-    if (
-      !this.postNumber &&
-      this.placement !== "topic-list-between" &&
-      this.placement !== "nested-roots-between"
-    ) {
-      return true;
+  @computed("placement", "postNumber", "indexNumber")
+  get showAfterPlacement() {
+    if (this.placement === "topic-list-between") {
+      return this.isNthTopicListItem(
+        parseInt(this.site.get("house_creatives.settings.after_nth_topic"), 10)
+      );
     }
 
-    return this.isNthPost(
-      parseInt(this.site.get("house_creatives.settings.after_nth_post"), 10)
-    );
-  }
-
-  @computed("placement")
-  get showAfterTopicListItem() {
-    if (this.placement !== "topic-list-between") {
-      return true;
+    if (this.placement === "nested-roots-between") {
+      return this.isNthTopicListItem(
+        parseInt(this.site.get("house_creatives.settings.after_nth_root"), 10)
+      );
     }
 
-    return this.isNthTopicListItem(
-      parseInt(this.site.get("house_creatives.settings.after_nth_topic"), 10)
-    );
-  }
-
-  @computed("placement")
-  get showAfterNestedRoot() {
-    if (this.placement !== "nested-roots-between") {
-      return true;
+    if (this.postNumber) {
+      return this.isNthPost(
+        parseInt(this.site.get("house_creatives.settings.after_nth_post"), 10)
+      );
     }
 
-    return this.isNthTopicListItem(
-      parseInt(this.site.get("house_creatives.settings.after_nth_root"), 10)
-    );
+    return true;
   }
 
   chooseAdHtml() {

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/nested-root-ad.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/nested-root-ad.gjs
@@ -1,11 +1,26 @@
-import AdSlot from "./ad-slot";
+import Component from "@glimmer/component";
+import AdSlot, { slotContenders } from "./ad-slot";
 
-const NestedRootAd = <template>
-  <AdSlot
-    @placement="nested-roots-between"
-    @category={{@topic.category.slug}}
-    @indexNumber={{@index}}
-  />
-</template>;
+export default class NestedRootAd extends Component {
+  static shouldRender(args, context) {
+    return (
+      args.index &&
+      slotContenders(
+        context.site,
+        context.siteSettings,
+        "nested-roots-between",
+        args.index
+      ).length > 0
+    );
+  }
 
-export default NestedRootAd;
+  <template>
+    <div class="ad-connector ad-connector--nested-root">
+      <AdSlot
+        @placement="nested-roots-between"
+        @category={{@topic.category.slug}}
+        @indexNumber={{@index}}
+      />
+    </div>
+  </template>
+}

--- a/plugins/discourse-adplugin/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/initializers/initialize-ad-plugin.gjs
@@ -35,12 +35,5 @@ function customizePost(api) {
     </template>
   );
 
-  api.renderInOutlet(
-    "nested-roots-between",
-    <template>
-      <div class="ad-connector ad-connector--nested-root">
-        <NestedRootAd @index={{@index}} @topic={{@topic}} />
-      </div>
-    </template>
-  );
+  api.renderInOutlet("nested-roots-between", NestedRootAd);
 }

--- a/plugins/discourse-adplugin/spec/system/house_ads_nested_view_spec.rb
+++ b/plugins/discourse-adplugin/spec/system/house_ads_nested_view_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe "House ads in nested replies view" do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:topic)
+  fab!(:op) { Fabricate(:post, topic: topic) }
+  fab!(:root_replies) { Fabricate.times(7, :post, topic: topic) }
+  fab!(:house_ad)
+
+  let(:nested_view) { PageObjects::Pages::NestedView.new }
+  let(:nested_root_ads) { PageObjects::Components::NestedRootAds.new }
+
+  before do
+    enable_current_plugin
+    SiteSetting.nested_replies_enabled = true
+    SiteSetting.nested_replies_default_sort = "old"
+    SiteSetting.house_ads_after_nth_root = 3
+    SiteSetting.house_ads_after_nth_post = 2
+
+    PluginStoreRow.create!(
+      plugin_name: "discourse-adplugin",
+      key: "ad-setting:nested_roots_between",
+      type_name: "JSON",
+      value: house_ad.name,
+    )
+
+    PluginStoreRow.create!(
+      plugin_name: "discourse-adplugin",
+      key: "ad-setting:post_bottom",
+      type_name: "JSON",
+      value: house_ad.name,
+    )
+
+    sign_in(user)
+  end
+
+  it "shows the user an ad after every nth root reply and no post-bottom ads" do
+    nested_view.visit_nested(topic)
+
+    expect(nested_view).to have_root_post(root_replies.first)
+    expect(nested_root_ads).to have_ads(count: 2)
+    expect(nested_root_ads).to have_ad_after(root_replies[2])
+    expect(nested_root_ads).to have_ad_after(root_replies[5])
+    expect(nested_root_ads).to have_no_ad_after(root_replies[0])
+    expect(nested_root_ads).to have_no_post_bottom_ads
+  end
+end

--- a/plugins/discourse-adplugin/spec/system/page_objects/components/nested_root_ads.rb
+++ b/plugins/discourse-adplugin/spec/system/page_objects/components/nested_root_ads.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class NestedRootAds < PageObjects::Components::Base
+      def has_ads?(count:)
+        has_css?(
+          ".ad-connector--nested-root .house-creative.house-nested-roots-between",
+          count: count,
+        )
+      end
+
+      def has_ad_after?(post)
+        has_css?(ad_after_selector(post))
+      end
+
+      def has_no_ad_after?(post)
+        has_no_css?(ad_after_selector(post))
+      end
+
+      def has_no_post_bottom_ads?
+        has_no_css?(".house-creative.house-post-bottom")
+      end
+
+      private
+
+      def ad_after_selector(post)
+        ".nested-post:has([data-post-number='#{post.post_number}']) + .ad-connector--nested-root"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, the `nested-roots-between` ad connector rendered an empty `.ad-connector` div after every root reply, and a house ad always appeared after the first root regardless of `house_ads_after_nth_root`, because the slot-selection logic treats index 0 as a non-between placement and the OR'd placement guards in `house-ad` defeated the nth-root check added in #40198.

This change gates the connector with `shouldRender` (mirroring the `after-topic-list-item` connector) and replaces the OR'd guards with a single placement-aware check, so house ads only render after every nth root reply.

Follow-up to #40198.