### PR TITLE
FIX: Avoid single stat layout for nested topic maps

### DIFF
--- a/frontend/discourse/app/components/topic-map/topic-map-summary.gjs
+++ b/frontend/discourse/app/components/topic-map/topic-map-summary.gjs
@@ -98,7 +98,7 @@ export default class TopicMapSummary extends Component {
   }
 
   get loneStat() {
-    if (this.args.topic.has_summary) {
+    if (this.args.topic.has_summary || this.shouldShowReplyCount) {
       return false;
     }
     return [this.hasLikes, this.hasUsers, this.hasLinks].every((stat) => !stat);


### PR DESCRIPTION
### What

Prevents nested topic maps from using the `--single-stat` layout when the nested reply count is also shown. Reported on Meta https://meta.discourse.org/t/posts-from-the-topic-i-just-left-stay-rendered-in-the-next-topic-after-in-app-navigation/404488/4?u=markvanlan

### Why

Low-participant nested topics can show only views plus the nested reply count. Previously the map was classified as a lone stat, which rendered the views trigger horizontally while the reply count remained stacked. That made the topic map look inconsistent, e.g. `268 views` next to a stacked `1 reply`.

