### PR TITLE
DEV: Allow patch triage bot to trigger backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,10 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@discoursebot backport') &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) ||
+        github.event.comment.user.login == 'patch-triage[bot]'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
### What
Allows `patch-triage[bot]` comments to satisfy the backport workflow guard when it posts `@discoursebot backport`.

### Why
Patch triage needs to trigger the existing backport workflow, but bot comments do not have one of the allowed human `author_association` values.