### PR TITLE
DEV: Fix (again again) the chat upload spec

### DIFF
--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -257,7 +257,8 @@ RSpec.describe "Chat composer" do
       chat_page.visit_channel(channel_1)
 
       file_path = file_from_fixtures("logo.png", "images").path
-      cdp.with_slow_upload do
+      # Hold the upload request in-flight, without throttling everything.
+      cdp.with_pending_requests(%r{/uploads\.json}) do
         attach_file("channel-file-uploader", file_path, make_visible: true)
         expect(page).to have_css(".chat-composer-upload--in-progress")
         expect(page).to have_css(".chat-composer.is-send-disabled")

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -152,5 +152,15 @@ module PageObjects
         )
       end
     end
+
+    # Holds matching requests in-flight for the duration of the block.
+    def with_pending_requests(pattern)
+      page.driver.with_playwright_page do |pw_page|
+        pw_page.route(pattern, ->(_route, _request) {})
+        yield
+      ensure
+        pw_page.unroute(pattern)
+      end
+    end
   end
 end


### PR DESCRIPTION
`with_slow_upload` actually is "with all slow requests", so the spec was sometimes timing out on a non-upload request.