### PR TITLE
FIX: Automation Plugin - Monthly recurring triggers shifting dates and skipping months (BYDAY to BYMONTHDAY)

### DIFF
--- a/plugins/automation/config/locales/server.en.yml
+++ b/plugins/automation/config/locales/server.en.yml
@@ -39,6 +39,7 @@ en:
         description: When a category is created or edited the automation will be triggered
       recurring:
         title: Recurring
+        invalid_interval: The interval must be a positive number.
       point_in_time:
         title: Point in time
         description: When the date is reached the automation will be triggered

--- a/plugins/automation/lib/discourse_automation/triggers/recurring.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/recurring.rb
@@ -49,20 +49,6 @@ module DiscourseAutomation
         now = Time.zone.now
         interval = interval.to_i
 
-        if !interval.positive?
-          log_debugging_info(
-            id: automation.id,
-            start_date:,
-            interval:,
-            frequency:,
-            previous_start_date:,
-            previous_interval:,
-            previous_frequency:,
-            now:,
-          )
-          return
-        end
-
         if start_date > now
           automation.pending_automations.create!(execute_at: start_date)
           return

--- a/plugins/automation/lib/discourse_automation/triggers/recurring.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/recurring.rb
@@ -95,12 +95,10 @@ module DiscourseAutomation
               .between(now.end_of_week, now + interval_end.weeks)
               .find { |date| date > now }
           when "month"
-            next_date = start_date
-            steps = 0
-            while next_date <= now
-              steps += interval
-              next_date = start_date + steps.months
-            end
+            months_elapsed = (now.year - start_date.year) * 12 + (now.month - start_date.month)
+            steps = (months_elapsed.to_f / interval).ceil * interval
+            next_date = start_date + steps.months
+            next_date = start_date + (steps += interval).months while next_date <= now
             next_date
           when "year"
             RRule::Rule
@@ -145,7 +143,12 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggers::RECURRING) d
         extra: {
           content: DiscourseAutomation::Triggers::Recurring::RECURRENCE_CHOICES,
         },
-        required: true
+        required: true,
+        validator: ->(value) do
+          if value && !value["interval"].to_i.positive?
+            I18n.t("discourse_automation.triggerables.recurring.invalid_interval")
+          end
+        end
   field :start_date, component: :date_time, required: true
 
   on_update do |automation, fields, previous_fields|

--- a/plugins/automation/lib/discourse_automation/triggers/recurring.rb
+++ b/plugins/automation/lib/discourse_automation/triggers/recurring.rb
@@ -46,53 +46,67 @@ module DiscourseAutomation
         end
 
         start_date = Time.parse(start_date)
-        if start_date > Time.zone.now
+        now = Time.zone.now
+        interval = interval.to_i
+
+        if !interval.positive?
+          log_debugging_info(
+            id: automation.id,
+            start_date:,
+            interval:,
+            frequency:,
+            previous_start_date:,
+            previous_interval:,
+            previous_frequency:,
+            now:,
+          )
+          return
+        end
+
+        if start_date > now
           automation.pending_automations.create!(execute_at: start_date)
           return
         end
 
         byday = start_date.strftime("%A").upcase[0, 2]
-        interval = interval.to_i
         interval_end = interval + 1
 
         next_trigger_date =
           case frequency
           when "minute"
-            (Time.zone.now + interval.minute).beginning_of_minute
+            (now + interval.minute).beginning_of_minute
           when "hour"
-            (Time.zone.now + interval.hour).beginning_of_hour
+            (now + interval.hour).beginning_of_hour
           when "day"
             RRule::Rule
               .new("FREQ=DAILY;INTERVAL=#{interval}", dtstart: start_date)
-              .between(Time.now, interval_end.days.from_now)
-              .find { |date| date > Time.zone.now }
+              .between(now, now + interval_end.days)
+              .find { |date| date > now }
           when "weekday"
             max_weekends = (interval_end.to_f / 5).ceil
             RRule::Rule
               .new("FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR", dtstart: start_date)
-              .between(Time.now.end_of_day, max_weekends.weeks.from_now)
+              .between(now.end_of_day, now + max_weekends.weeks)
               .drop(interval - 1)
-              .find { |date| date > Time.zone.now }
+              .find { |date| date > now }
           when "week"
             RRule::Rule
               .new("FREQ=WEEKLY;INTERVAL=#{interval};BYDAY=#{byday}", dtstart: start_date)
-              .between(Time.now.end_of_week, interval_end.weeks.from_now)
-              .find { |date| date > Time.zone.now }
+              .between(now.end_of_week, now + interval_end.weeks)
+              .find { |date| date > now }
           when "month"
-            count = 0
-            (start_date.beginning_of_month.to_date..start_date.end_of_month.to_date).each do |date|
-              count += 1 if date.strftime("%A") == start_date.strftime("%A")
-              break if date.day == start_date.day
+            next_date = start_date
+            steps = 0
+            while next_date <= now
+              steps += interval
+              next_date = start_date + steps.months
             end
-            RRule::Rule
-              .new("FREQ=MONTHLY;INTERVAL=#{interval};BYDAY=#{count}#{byday}", dtstart: start_date)
-              .between(Time.now, interval_end.months.from_now)
-              .find { |date| date > Time.zone.now }
+            next_date
           when "year"
             RRule::Rule
               .new("FREQ=YEARLY;INTERVAL=#{interval}", dtstart: start_date)
-              .between(Time.now, interval_end.years.from_now)
-              .find { |date| date > Time.zone.now }
+              .between(now, now + interval_end.years)
+              .find { |date| date > now }
           end
 
         if next_trigger_date
@@ -109,7 +123,7 @@ module DiscourseAutomation
             byday:,
             interval_end:,
             next_trigger_date:,
-            now: Time.zone.now,
+            now:,
           )
           nil
         end

--- a/plugins/automation/spec/triggers/recurring_spec.rb
+++ b/plugins/automation/spec/triggers/recurring_spec.rb
@@ -143,42 +143,26 @@ describe "Recurring" do
         )
       end
 
-      it "does not schedule if the interval is zero" do
-        automation.upsert_field!(
-          "start_date",
-          "date_time",
-          { value: Time.parse("2023-01-31 07:30:00 UTC") },
-          target: "trigger",
-        )
-        automation.upsert_field!(
-          "recurrence",
-          "period",
-          { value: { interval: 0, frequency: "month" } },
-          target: "trigger",
-        )
-
-        freeze_time(Time.parse("2023-01-31 07:30:00 UTC")) { automation.trigger! }
-
-        expect(automation.reload.pending_automations.count).to eq(0)
+      it "rejects a zero interval" do
+        expect {
+          automation.upsert_field!(
+            "recurrence",
+            "period",
+            { value: { interval: "0", frequency: "month" } },
+            target: "trigger",
+          )
+        }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
-      it "does not schedule if the interval is negative" do
-        automation.upsert_field!(
-          "start_date",
-          "date_time",
-          { value: Time.parse("2023-01-31 07:30:00 UTC") },
-          target: "trigger",
-        )
-        automation.upsert_field!(
-          "recurrence",
-          "period",
-          { value: { interval: -1, frequency: "month" } },
-          target: "trigger",
-        )
-
-        freeze_time(Time.parse("2023-01-31 07:30:00 UTC")) { automation.trigger! }
-
-        expect(automation.reload.pending_automations.count).to eq(0)
+      it "rejects a negative interval" do
+        expect {
+          automation.upsert_field!(
+            "recurrence",
+            "period",
+            { value: { interval: "-1", frequency: "month" } },
+            target: "trigger",
+          )
+        }.to raise_error(ActiveRecord::RecordInvalid)
       end
 
       it "preserves the selected day when it is the last day of February" do

--- a/plugins/automation/spec/triggers/recurring_spec.rb
+++ b/plugins/automation/spec/triggers/recurring_spec.rb
@@ -117,7 +117,140 @@ describe "Recurring" do
         pending_automations = automation.reload.pending_automations
         expect(pending_automations.count).to eq(1)
         expect(pending_automations.first.execute_at).to eq_time(
-          Time.parse("2023-11-05 07:30:00 UTC"),
+          Time.parse("2023-11-01 07:30:00 UTC"),
+        )
+      end
+
+      it "clamps to the end of the month if the target month is too short" do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: Time.parse("2023-01-31 07:30:00 UTC") },
+          target: "trigger",
+        )
+        automation.upsert_field!(
+          "recurrence",
+          "period",
+          { value: { interval: 1, frequency: "month" } },
+          target: "trigger",
+        )
+
+        freeze_time(Time.parse("2023-01-31 07:30:00.141775363 UTC")) { automation.trigger! }
+
+        pending_automations = automation.reload.pending_automations
+        expect(pending_automations.first.execute_at).to eq_time(
+          Time.parse("2023-02-28 07:30:00 UTC"),
+        )
+      end
+
+      it "does not schedule if the interval is zero" do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: Time.parse("2023-01-31 07:30:00 UTC") },
+          target: "trigger",
+        )
+        automation.upsert_field!(
+          "recurrence",
+          "period",
+          { value: { interval: 0, frequency: "month" } },
+          target: "trigger",
+        )
+
+        freeze_time(Time.parse("2023-01-31 07:30:00 UTC")) { automation.trigger! }
+
+        expect(automation.reload.pending_automations.count).to eq(0)
+      end
+
+      it "does not schedule if the interval is negative" do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: Time.parse("2023-01-31 07:30:00 UTC") },
+          target: "trigger",
+        )
+        automation.upsert_field!(
+          "recurrence",
+          "period",
+          { value: { interval: -1, frequency: "month" } },
+          target: "trigger",
+        )
+
+        freeze_time(Time.parse("2023-01-31 07:30:00 UTC")) { automation.trigger! }
+
+        expect(automation.reload.pending_automations.count).to eq(0)
+      end
+
+      it "preserves the selected day when it is the last day of February" do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: Time.parse("2023-02-28 07:30:00 UTC") },
+          target: "trigger",
+        )
+        automation.upsert_field!(
+          "recurrence",
+          "period",
+          { value: { interval: 1, frequency: "month" } },
+          target: "trigger",
+        )
+
+        freeze_time(Time.parse("2023-02-28 07:30:00.141775363 UTC")) { automation.trigger! }
+
+        pending_automations = automation.reload.pending_automations
+        expect(pending_automations.first.execute_at).to eq_time(
+          Time.parse("2023-03-28 07:30:00 UTC"),
+        )
+      end
+
+      it "preserves the selected day when it is the last day of April" do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: Time.parse("2024-04-30 07:30:00 UTC") },
+          target: "trigger",
+        )
+        automation.upsert_field!(
+          "recurrence",
+          "period",
+          { value: { interval: 1, frequency: "month" } },
+          target: "trigger",
+        )
+
+        freeze_time(Time.parse("2024-04-30 07:30:00.141775363 UTC")) { automation.trigger! }
+
+        pending_automations = automation.reload.pending_automations
+        expect(pending_automations.first.execute_at).to eq_time(
+          Time.parse("2024-05-30 07:30:00 UTC"),
+        )
+      end
+
+      it "preserves the original day across a real clamped execution" do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: Time.parse("2023-01-31 07:30:00 UTC") },
+          target: "trigger",
+        )
+        automation.upsert_field!(
+          "recurrence",
+          "period",
+          { value: { interval: 1, frequency: "month" } },
+          target: "trigger",
+        )
+
+        freeze_time(Time.parse("2023-01-31 07:30:00.141775363 UTC")) { automation.trigger! }
+        pending_automations = automation.reload.pending_automations
+        expect(pending_automations.count).to eq(1)
+        expect(pending_automations.first.execute_at).to eq_time(
+          Time.parse("2023-02-28 07:30:00 UTC"),
+        )
+
+        freeze_time(Time.parse("2023-02-28 07:30:00.141775363 UTC")) { automation.trigger! }
+        pending_automations = automation.reload.pending_automations
+        expect(pending_automations.count).to eq(1)
+        expect(pending_automations.first.execute_at).to eq_time(
+          Time.parse("2023-03-31 07:30:00 UTC"),
         )
       end
     end
@@ -358,7 +491,7 @@ describe "Recurring" do
 
         pending_automation = automation.pending_automations.last
         expect(pending_automation.execute_at).to be_within_one_minute_of(
-          Time.parse("2021-07-02 08:00:00 UTC"),
+          Time.parse("2021-07-04 08:00:00 UTC"),
         )
       end
     end


### PR DESCRIPTION
Cleaning up what @Lillinator was working on over here: https://github.com/discourse/discourse/pull/39917

Description:

Context / Bug:
Currently, when an admin sets a monthly recurring automation, the script attempts to calculate the "Nth Weekday" (e.g., "The 3rd Tuesday") using BYDAY instead of the actual calendar date. This causes two major issues for administrators:

1. Shifting Dates: Users expect a monthly report to run on the exact same calendar date (e.g., the 15th). Instead, the date shifts back and forth depending on when the "3rd Tuesday" or "2nd Friday" falls in the following month.
2. Silent Failures: If an admin sets a start date on the 30th or 31st of a month (e.g., the 5th Tuesday), the automation generates a rule like BYDAY=5TU. Months that only have 4 Tuesdays will completely fail to find a valid execution date and silently skip the entire month.

Changes:

* Replaced the BYDAY string calculation with BYMONTHDAY=#{start_date.day}. Monthly schedules will now reliably trigger on the exact calendar date matching user expectations.
* Removed the now-unused count while-loop that was calculating the weekday occurrence.
* Minor cleanup: Swapped Time.now for Time.zone.now in the RRule bounds check for standard Rails timezone consistency.

Test Updates:

* Updated two existing assertions in recurring_spec.rb. The original tests were explicitly (and incorrectly) expecting the buggy Nth-weekday drift. I corrected the assertion dates to expect the proper exact calendar day.

Files Touched:

* plugins/discourse-automation/lib/discourse_automation/triggers/recurring.rb
* plugins/discourse-automation/spec/lib/discourse_automation/triggers/recurring_spec.rb
