### PR TITLE
UX: add missing group nav border

### DIFF
--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -37,6 +37,7 @@
     grid-row-start: 2;
     grid-row-end: 3;
     font-size: var(--font-down-1);
+    border-bottom: 1px solid var(--content-border-color);
   }
 
   .user-primary-navigation,


### PR DESCRIPTION
Just missing a border on the secondary nav here 

Before:
<img width="2208" height="192" alt="image" src="https://github.com/user-attachments/assets/214687a2-31dd-4c9c-b45d-2c8e7ba5abed" />



After:
<img width="2218" height="220" alt="image" src="https://github.com/user-attachments/assets/d97a2d76-91ad-45c5-9aa3-006dbb1a1f5d" />
