### PR TITLE
FIX: Render flat HTML for nested topic no-JS views

### DIFF
--- a/app/controllers/nested_topics_controller.rb
+++ b/app/controllers/nested_topics_controller.rb
@@ -24,7 +24,6 @@ class NestedTopicsController < ApplicationController
         return
       end
 
-      store_preloaded("nested_topic_#{@topic.id}", MultiJson.dump(list_roots_response(page: 0)))
       render_flat_topic_html
       return
     end
@@ -65,7 +64,6 @@ class NestedTopicsController < ApplicationController
         return
       end
 
-      store_preloaded("nested_topic_#{@topic.id}", MultiJson.dump(show_context_response))
       render_flat_topic_html(post_number: params[:post_number].to_i)
       return
     end
@@ -177,9 +175,6 @@ class NestedTopicsController < ApplicationController
     @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags.visible(guardian) : []
     @breadcrumbs = helpers.categories_breadcrumb(@topic_view.topic) || []
     @description_meta = @topic_view.topic.excerpt.presence || @topic_view.summary
-
-    topic_view_serializer = TopicViewSerializer.new(@topic_view, scope: guardian, root: false)
-    store_preloaded("topic_#{@topic_view.topic.id}", MultiJson.dump(topic_view_serializer))
 
     render "topics/show"
   end

--- a/app/controllers/nested_topics_controller.rb
+++ b/app/controllers/nested_topics_controller.rb
@@ -24,7 +24,9 @@ class NestedTopicsController < ApplicationController
         return
       end
 
-      render_flat_topic_html
+      response = list_roots_response(page: 0)
+      store_preloaded("nested_topic_#{@topic.id}", MultiJson.dump(response))
+      render_nested_topic_html(response)
       return
     end
 
@@ -64,7 +66,9 @@ class NestedTopicsController < ApplicationController
         return
       end
 
-      render_flat_topic_html(post_number: params[:post_number].to_i)
+      response = show_context_response
+      store_preloaded("nested_topic_#{@topic.id}", MultiJson.dump(response))
+      render_nested_topic_html(response)
       return
     end
 
@@ -161,22 +165,14 @@ class NestedTopicsController < ApplicationController
     result
   end
 
-  def render_flat_topic_html(post_number: nil)
-    opts = {}
-    opts[:post_number] = post_number if post_number.to_i > 0
+  def render_nested_topic_html(response)
+    @nested_response = response
+    @nested_topic = response[:topic]
+    @tags = SiteSetting.tagging_enabled ? @topic.tags.visible(guardian) : []
+    @breadcrumbs = helpers.categories_breadcrumb(@topic) || []
+    @description_meta = @topic.excerpt.presence || @topic_view.summary
 
-    @topic_view = TopicView.new(@topic.id, current_user, opts)
-    @topic = @topic_view.topic
-
-    if should_track_visit?
-      @topic_view.draft = Draft.get(current_user, @topic_view.draft_key, @topic_view.draft_sequence)
-    end
-
-    @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags.visible(guardian) : []
-    @breadcrumbs = helpers.categories_breadcrumb(@topic_view.topic) || []
-    @description_meta = @topic_view.topic.excerpt.presence || @topic_view.summary
-
-    render "topics/show"
+    render "nested_topics/show"
   end
 
   def show_context_response

--- a/app/controllers/nested_topics_controller.rb
+++ b/app/controllers/nested_topics_controller.rb
@@ -25,7 +25,7 @@ class NestedTopicsController < ApplicationController
       end
 
       store_preloaded("nested_topic_#{@topic.id}", MultiJson.dump(list_roots_response(page: 0)))
-      render "default/empty"
+      render_flat_topic_html
       return
     end
 
@@ -66,7 +66,7 @@ class NestedTopicsController < ApplicationController
       end
 
       store_preloaded("nested_topic_#{@topic.id}", MultiJson.dump(show_context_response))
-      render "default/empty"
+      render_flat_topic_html(post_number: params[:post_number].to_i)
       return
     end
 
@@ -161,6 +161,27 @@ class NestedTopicsController < ApplicationController
       on_failure { raise Discourse::NotFound }
     end
     result
+  end
+
+  def render_flat_topic_html(post_number: nil)
+    opts = {}
+    opts[:post_number] = post_number if post_number.to_i > 0
+
+    @topic_view = TopicView.new(@topic.id, current_user, opts)
+    @topic = @topic_view.topic
+
+    if should_track_visit?
+      @topic_view.draft = Draft.get(current_user, @topic_view.draft_key, @topic_view.draft_sequence)
+    end
+
+    @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags.visible(guardian) : []
+    @breadcrumbs = helpers.categories_breadcrumb(@topic_view.topic) || []
+    @description_meta = @topic_view.topic.excerpt.presence || @topic_view.summary
+
+    topic_view_serializer = TopicViewSerializer.new(@topic_view, scope: guardian, root: false)
+    store_preloaded("topic_#{@topic_view.topic.id}", MultiJson.dump(topic_view_serializer))
+
+    render "topics/show"
   end
 
   def show_context_response

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1451,6 +1451,7 @@ class TopicsController < ApplicationController
           additional_allowed_query_parameters,
         ),
       )
+    opts[:flat] = "1" if !request.format.json? && params[:flat] == "1"
     opts.delete(:page) if params[:page] == 0
 
     url = topic.relative_url

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -181,7 +181,12 @@ class TopicsController < ApplicationController
         last_page = visible_posts_count > 0 ? ((visible_posts_count - 1) / chunk_size) + 1 : 1
         url = @topic_view.topic.relative_url
         url += ".json" if request.format.json?
-        url += "?page=#{last_page}" if last_page > 1
+
+        query = []
+        query << "page=#{last_page}" if last_page > 1
+        query << "flat=1" if !request.format.json? && params[:flat] == "1"
+        url += "?#{query.join("&")}" if query.present?
+
         return redirect_to url, status: :moved_permanently
       end
     end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -14,6 +14,16 @@ module TopicsHelper
     anchor.present? ? "#{path}##{anchor}" : path
   end
 
+  def nested_posts_have_unrendered_replies?(posts)
+    Array(posts).any? { |post| nested_post_has_unrendered_replies?(post) }
+  end
+
+  def nested_post_has_unrendered_replies?(post)
+    children = Array(post[:children])
+
+    post[:direct_reply_count].to_i > children.length || nested_posts_have_unrendered_replies?(children)
+  end
+
   def render_topic_title(topic)
     link_to(Emoji.gsub_emoji_to_unicode(topic.title), topic.relative_url)
   end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -3,6 +3,17 @@
 module TopicsHelper
   include ApplicationHelper
 
+  def topic_path_with_flat_param(path, force: nil, anchor: nil)
+    force = params[:flat] == "1" if force.nil?
+    path = path.to_s
+
+    if force && !path.match?(/[?&]flat=1(?:&|$)/)
+      path += path.include?("?") ? "&flat=1" : "?flat=1"
+    end
+
+    anchor.present? ? "#{path}##{anchor}" : path
+  end
+
   def render_topic_title(topic)
     link_to(Emoji.gsub_emoji_to_unicode(topic.title), topic.relative_url)
   end

--- a/app/views/nested_topics/show.html.erb
+++ b/app/views/nested_topics/show.html.erb
@@ -1,0 +1,121 @@
+<% if @nested_response && @nested_topic %>
+  <div id="topic-title">
+    <h1><%= @nested_topic[:title] %></h1>
+
+    <% if @breadcrumbs.present? %>
+      <div class="topic-category" itemscope itemtype="http://schema.org/BreadcrumbList">
+        <% @breadcrumbs.each_with_index do |c, i| %>
+          <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            <a href="<%= c[:url] %>" class="badge-wrapper bullet" itemprop="item">
+              <span class="badge-category-bg" style="background-color: #<%= c[:color] %>"></span>
+              <span class="badge-category clear-badge">
+                <span class="category-name" itemprop="name"><%= c[:name] %></span>
+              </span>
+            </a>
+            <meta itemprop="position" content="<%= i + 1 %>" />
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if @tags.present? %>
+      <div class="topic-category">
+        <div class="discourse-tags list-tags">
+          <% @tags.each_with_index do |tag, i| %>
+            <a href="<%= "#{Discourse.base_url}/tag/#{tag.name}" %>" class="discourse-tag" rel="tag"><%= tag.name %></a><% if i < @tags.size - 1 %>, <% end %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <%= server_plugin_outlet "topic_header" %>
+
+  <% render_nested_post = lambda do |post, depth = 0| %>
+    <% next if post.blank? %>
+    <% username = post[:username] || post[:display_username] %>
+    <div id="post_<%= post[:post_number] %>" class="topic-body crawler-post nested-crawler-post nested-crawler-post-depth-<%= depth %>" data-post-number="<%= post[:post_number] %>">
+      <div class="crawler-post-meta">
+        <% if username.present? %>
+          <span class="creator">
+            <a rel="nofollow" href="<%= Discourse.base_url %>/u/<%= username %>"><span><%= username %></span></a>
+            <%= "(#{post[:name]})" if SiteSetting.display_name_on_posts && SiteSetting.enable_names? && post[:name].present? %>
+          </span>
+        <% end %>
+
+        <span class="crawler-post-infos">
+          <% if post[:created_at].present? %>
+            <time datetime="<%= post[:created_at] %>" class="post-time"><%= l Time.zone.parse(post[:created_at].to_s), format: :long %></time>
+          <% end %>
+          <span><%= post[:post_number] %></span>
+        </span>
+      </div>
+
+      <div class="post">
+        <% if post[:deleted_post_placeholder] %>
+          <%= t("post.deleted_by_author_simple").html_safe %>
+        <% elsif post[:ignored_post_placeholder] %>
+          <%= t("post.ignored").html_safe %>
+        <% else %>
+          <%= post[:cooked].to_s.html_safe %>
+        <% end %>
+      </div>
+
+      <% if post[:like_count].to_i > 0 %>
+        <div><span class="post-likes"><%= t("post.has_likes", count: post[:like_count]) %></span></div>
+      <% end %>
+    </div>
+
+    <% Array(post[:children]).each do |child| %>
+      <% render_nested_post.call(child, depth + 1) %>
+    <% end %>
+  <% end %>
+
+  <div class="nested-crawler" itemscope itemtype="http://schema.org/DiscussionForumPosting">
+    <meta itemprop="headline" content="<%= @nested_topic[:title] %>">
+    <link itemprop="url" href="<%= @topic.url %>">
+    <meta itemprop="datePublished" content="<%= @topic.created_at.to_formatted_s(:iso8601) %>">
+
+    <% render_nested_post.call(@nested_response[:op_post], 0) %>
+
+    <% if @nested_response[:ancestor_chain].present? %>
+      <% @nested_response[:ancestor_chain].each do |post| %>
+        <% render_nested_post.call(post, 0) %>
+      <% end %>
+    <% end %>
+
+    <% if @nested_response[:target_post].present? %>
+      <% render_nested_post.call(@nested_response[:target_post], 0) %>
+    <% else %>
+      <% Array(@nested_response[:roots]).each do |post| %>
+        <% render_nested_post.call(post, 0) %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% content_for :head do %>
+    <%= auto_discovery_link_tag(
+      @topic_view,
+      { controller: "topics", action: :feed, slug: @topic.slug, topic_id: @topic.id },
+      rel: "alternate nofollow",
+      title: t("rss_posts_in_topic", topic: @nested_topic[:title]),
+      type: "application/rss+xml"
+    ) %>
+    <%= raw crawlable_meta_data(
+      title: @nested_topic[:title],
+      description: @topic.excerpt.presence || @topic_view.summary(strip_images: true),
+      image: @topic_view.image_url,
+      image_width: @topic_view.image_width,
+      image_height: @topic_view.image_height,
+      image_type: @topic_view.image_type,
+      read_time: @topic_view.read_time,
+      like_count: @topic_view.like_count,
+      ignore_canonical: true,
+      published_time: @topic_view.published_time,
+      breadcrumbs: @breadcrumbs,
+      tags: @tags.map(&:name),
+    ) %>
+  <% end %>
+
+  <% content_for(:title) { @title || "#{gsub_emoji_to_unicode(@nested_topic[:title])} - #{SiteSetting.title}" } %>
+<% end %>

--- a/app/views/nested_topics/show.html.erb
+++ b/app/views/nested_topics/show.html.erb
@@ -73,8 +73,23 @@
 
   <div class="nested-crawler" itemscope itemtype="http://schema.org/DiscussionForumPosting">
     <meta itemprop="headline" content="<%= @nested_topic[:title] %>">
-    <link itemprop="url" href="<%= @topic.url %>">
+    <link itemprop="url" href="<%= @topic_view.absolute_url %>">
     <meta itemprop="datePublished" content="<%= @topic.created_at.to_formatted_s(:iso8601) %>">
+
+    <% if @nested_response[:target_post].present? %>
+      <% target_post_number = @nested_response[:target_post][:post_number] %>
+      <noscript>
+        <div class="nested-topic-no-js-notice topic-body crawler-post">
+          <%= link_to t(:show_post_in_topic), topic_path_with_flat_param("#{@topic.url}/#{target_post_number}", force: true) %>
+        </div>
+      </noscript>
+    <% elsif @nested_response[:has_more_roots] %>
+      <noscript>
+        <div class="nested-topic-no-js-notice topic-body crawler-post">
+          <%= link_to t(:read_full_topic), topic_path_with_flat_param(@topic.url, force: true) %>
+        </div>
+      </noscript>
+    <% end %>
 
     <% render_nested_post.call(@nested_response[:op_post], 0) %>
 

--- a/app/views/nested_topics/show.html.erb
+++ b/app/views/nested_topics/show.html.erb
@@ -83,7 +83,7 @@
           <%= link_to t(:show_post_in_topic), topic_path_with_flat_param("#{@topic.url}/#{target_post_number}", force: true) %>
         </div>
       </noscript>
-    <% elsif @nested_response[:has_more_roots] %>
+    <% elsif @nested_response[:has_more_roots] || nested_posts_have_unrendered_replies?(@nested_response[:roots]) %>
       <noscript>
         <div class="nested-topic-no-js-notice topic-body crawler-post">
           <%= link_to t(:read_full_topic), topic_path_with_flat_param(@topic.url, force: true) %>

--- a/app/views/topics/plain.html.erb
+++ b/app/views/topics/plain.html.erb
@@ -15,10 +15,10 @@
     published_time: @topic_view.published_time,
   ) %>
   <% if @topic_view.prev_page %>
-    <link rel="prev" href="<%= @topic_view.prev_page_path -%>">
+    <link rel="prev" href="<%= topic_path_with_flat_param(@topic_view.prev_page_path) -%>">
   <% end %>
   <% if @topic_view.next_page %>
-    <link rel="next" href="<%= @topic_view.next_page_path -%>">
+    <link rel="next" href="<%= topic_path_with_flat_param(@topic_view.next_page_path) -%>">
   <% end %>
 </head>
 <body>
@@ -39,10 +39,10 @@
 <% end %>
 <p>
   <% if @topic_view.prev_page %>
-    <%= link_to t(:prev_page), @topic_view.prev_page_path, rel: 'prev' %>
+    <%= link_to t(:prev_page), topic_path_with_flat_param(@topic_view.prev_page_path), rel: 'prev' %>
   <% end %>
   <% if @topic_view.next_page %>
-    <b><%= link_to t(:next_page), @topic_view.next_page_path, rel: 'next' %></b>
+    <b><%= link_to t(:next_page), topic_path_with_flat_param(@topic_view.next_page_path), rel: 'next' %></b>
   <% end %>
 </p>
 </body>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -167,7 +167,13 @@
   <% end %>
 
   <% content_for :head do %>
-    <%= auto_discovery_link_tag(@topic_view, {action: :feed, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id}, rel: 'alternate nofollow', title: t('rss_posts_in_topic', topic: @topic_view.title), type: 'application/rss+xml') %>
+    <%= auto_discovery_link_tag(
+      @topic_view,
+      { controller: "topics", action: :feed, slug: @topic_view.topic.slug, topic_id: @topic_view.topic.id },
+      rel: 'alternate nofollow',
+      title: t('rss_posts_in_topic', topic: @topic_view.title),
+      type: 'application/rss+xml'
+    ) %>
     <%= raw crawlable_meta_data(
       title: @topic_view.title,
       description: @topic_view.summary(strip_images: true),

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -148,14 +148,14 @@
       <div role='navigation' itemscope itemtype='http://schema.org/SiteNavigationElement' class="topic-body crawler-post">
         <% if @topic_view.single_post_request? %>
           <span itemprop='name'>
-            <%= link_to t(:show_post_in_topic), "#{@topic_view.current_page_path}#post_#{@topic_view.crawler_posts.first&.post_number}", itemprop: 'url' %>
+            <%= link_to t(:show_post_in_topic), topic_path_with_flat_param(@topic_view.current_page_path, anchor: "post_#{@topic_view.crawler_posts.first&.post_number}"), itemprop: 'url' %>
           </span>
         <% else %>
           <% if @topic_view.prev_page %>
-            <span itemprop='name'><%= link_to t(:prev_page), @topic_view.prev_page_path, rel: 'prev', itemprop: 'url' %></span>
+            <span itemprop='name'><%= link_to t(:prev_page), topic_path_with_flat_param(@topic_view.prev_page_path), rel: 'prev', itemprop: 'url' %></span>
           <% end %>
           <% if @topic_view.next_page %>
-            <span itemprop='name'><b><%= link_to t(:next_page), @topic_view.next_page_path, rel: 'next', itemprop: 'url' %></b></span>
+            <span itemprop='name'><b><%= link_to t(:next_page), topic_path_with_flat_param(@topic_view.next_page_path), rel: 'next', itemprop: 'url' %></b></span>
           <% end %>
         <% end %>
       </div>
@@ -191,10 +191,10 @@
 
     <% if !@topic_view.single_post_request? && (@topic_view.prev_page || @topic_view.next_page)  %>
       <% if @topic_view.prev_page %>
-        <link rel="prev" href="<%= @topic_view.prev_page_path -%>">
+        <link rel="prev" href="<%= topic_path_with_flat_param(@topic_view.prev_page_path) -%>">
       <% end %>
       <% if @topic_view.next_page %>
-        <link rel="next" href="<%= @topic_view.next_page_path -%>">
+        <link rel="next" href="<%= topic_path_with_flat_param(@topic_view.next_page_path) -%>">
       <% end %>
     <% end %>
   <% end %>

--- a/spec/helpers/topics_helper_spec.rb
+++ b/spec/helpers/topics_helper_spec.rb
@@ -1,6 +1,62 @@
 # frozen_string_literal: true
 
 RSpec.describe TopicsHelper do
+  describe "#topic_path_with_flat_param" do
+    it "adds flat=1 to paths without a query string" do
+      expect(helper.topic_path_with_flat_param("/t/topic/1", force: true)).to eq("/t/topic/1?flat=1")
+    end
+
+    it "adds flat=1 to paths with an existing query string" do
+      expect(helper.topic_path_with_flat_param("/t/topic/1?page=2", force: true)).to eq(
+        "/t/topic/1?page=2&flat=1",
+      )
+    end
+
+    it "does not duplicate an existing flat=1 parameter" do
+      expect(helper.topic_path_with_flat_param("/t/topic/1?page=2&flat=1", force: true)).to eq(
+        "/t/topic/1?page=2&flat=1",
+      )
+    end
+
+    it "appends anchors after the query string" do
+      expect(helper.topic_path_with_flat_param("/t/topic/1", force: true, anchor: "post_2")).to eq(
+        "/t/topic/1?flat=1#post_2",
+      )
+    end
+  end
+
+  describe "#nested_posts_have_unrendered_replies?" do
+    it "is true when a rendered post has fewer children than its direct reply count" do
+      expect(
+        helper.nested_posts_have_unrendered_replies?([
+          { direct_reply_count: 2, children: [{ direct_reply_count: 0, children: [] }] },
+        ]),
+      ).to eq(true)
+    end
+
+    it "is true when a descendant has unrendered replies" do
+      expect(
+        helper.nested_posts_have_unrendered_replies?([
+          {
+            direct_reply_count: 1,
+            children: [{ direct_reply_count: 1, children: [] }],
+          },
+        ]),
+      ).to eq(true)
+    end
+
+    it "is false when all direct replies are rendered" do
+      expect(
+        helper.nested_posts_have_unrendered_replies?([
+          {
+            direct_reply_count: 1,
+            children: [{ direct_reply_count: 0, children: [] }],
+          },
+        ]),
+      ).to eq(false)
+    end
+  end
+
   describe "#categories_breadcrumb" do
     let(:user) { Fabricate(:user) }
 

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.status).to eq(200)
       expect(response.body).to include(topic.title)
       expect(response.body).to include(post.cooked)
+      expect(response.body).not_to include("nested_topic_#{topic.id}")
     end
 
     it "renders flat topic HTML for nested post URLs without JavaScript" do

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.body).to include(I18n.t(:read_full_topic))
     end
 
+    it "links no-JavaScript users to the forced-flat topic when nested child preloading is incomplete" do
+      parent = Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      (NestedReplies::TreeLoader::PRELOAD_CHILDREN_PER_PARENT + 1).times do
+        Fabricate(:post, topic: topic, user: user, reply_to_post_number: parent.post_number)
+      end
+
+      get "/n/#{topic.slug}/#{topic.id}"
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include("<noscript>")
+      expect(response.body).to include(%(/t/#{topic.slug}/#{topic.id}?flat=1))
+      expect(response.body).to include(I18n.t(:read_full_topic))
+    end
+
     it "renders flat topic HTML for nested post URLs without JavaScript" do
       post = Fabricate(:post, topic: topic, user: user, raw: "Context post without JavaScript")
 

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.status).to eq(301)
     end
 
+    it "renders flat topic HTML for browsers without JavaScript" do
+      post = Fabricate(:post, topic: topic, user: user, raw: "Visible without JavaScript")
+
+      get "/n/#{topic.slug}/#{topic.id}"
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include(topic.title)
+      expect(response.body).to include(post.cooked)
+    end
+
+    it "renders flat topic HTML for nested post URLs without JavaScript" do
+      post = Fabricate(:post, topic: topic, user: user, raw: "Context post without JavaScript")
+
+      get "/n/#{topic.slug}/#{topic.id}/#{post.post_number}"
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include(post.cooked)
+    end
+
     it "returns 404 for anonymous users on private topics" do
       private_category = Fabricate(:private_category, group: Fabricate(:group))
       private_topic = Fabricate(:topic, category: private_category)

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.status).to eq(301)
     end
 
-    it "renders flat topic HTML for browsers without JavaScript" do
+    it "preloads nested data and renders nested topic HTML for browsers without JavaScript" do
       post = Fabricate(:post, topic: topic, user: user, raw: "Visible without JavaScript")
 
       get "/n/#{topic.slug}/#{topic.id}"
@@ -45,7 +45,7 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.status).to eq(200)
       expect(response.body).to include(topic.title)
       expect(response.body).to include(post.cooked)
-      expect(response.body).not_to include("nested_topic_#{topic.id}")
+      expect(response.body).to include("nested_topic_#{topic.id}")
     end
 
     it "renders flat topic HTML for nested post URLs without JavaScript" do

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(response.body).to include("nested_topic_#{topic.id}")
     end
 
+    it "links no-JavaScript users to the forced-flat topic when the nested response is incomplete" do
+      (NestedReplies::TreeLoader::ROOTS_PER_PAGE + 1).times do
+        Fabricate(:post, topic: topic, user: user, reply_to_post_number: nil)
+      end
+
+      get "/n/#{topic.slug}/#{topic.id}"
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include("<noscript>")
+      expect(response.body).to include(%(/t/#{topic.slug}/#{topic.id}?flat=1))
+      expect(response.body).to include(I18n.t(:read_full_topic))
+    end
+
     it "renders flat topic HTML for nested post URLs without JavaScript" do
       post = Fabricate(:post, topic: topic, user: user, raw: "Context post without JavaScript")
 
@@ -55,6 +68,8 @@ RSpec.describe NestedTopicsController, type: :request do
 
       expect(response.status).to eq(200)
       expect(response.body).to include(post.cooked)
+      expect(response.body).to include(%(/t/#{topic.slug}/#{topic.id}/#{post.post_number}?flat=1))
+      expect(response.body).to include(I18n.t(:show_post_in_topic))
     end
 
     it "returns 404 for anonymous users on private topics" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3152,6 +3152,48 @@ RSpec.describe TopicsController do
       expect(response).to redirect_to("/t/#{topic_with_posts.slug}/#{topic_with_posts.id}?page=2")
     end
 
+    it "preserves forced-flat mode when redirecting over-range pages" do
+      SiteSetting.nested_replies_enabled = true
+      SiteSetting.nested_replies_default = true
+
+      topic_with_posts = Fabricate(:topic)
+      Fabricate.times(25, :post, topic: topic_with_posts)
+      Topic.reset_highest(topic_with_posts.id)
+
+      get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}", params: { page: 5, flat: "1" }
+
+      expect(response).to redirect_to("/t/#{topic_with_posts.slug}/#{topic_with_posts.id}?page=2&flat=1")
+    end
+
+    it "preserves forced-flat mode in topic pagination links" do
+      SiteSetting.nested_replies_enabled = true
+      SiteSetting.nested_replies_default = true
+
+      topic_with_posts = Fabricate(:topic)
+      Fabricate.times(25, :post, topic: topic_with_posts)
+      Topic.reset_highest(topic_with_posts.id)
+
+      get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}", params: { flat: "1" }
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include(%(/t/#{topic_with_posts.slug}/#{topic_with_posts.id}?page=2&amp;flat=1))
+    end
+
+    it "does not redirect forced-flat paginated topic requests back to nested view" do
+      SiteSetting.nested_replies_enabled = true
+      SiteSetting.nested_replies_default = true
+
+      topic_with_posts = Fabricate(:topic)
+      Fabricate.times(25, :post, topic: topic_with_posts)
+      Topic.reset_highest(topic_with_posts.id)
+
+      get "/t/#{topic_with_posts.slug}/#{topic_with_posts.id}", params: { page: 2, flat: "1" }
+
+      expect(response.status).to eq(200)
+      expect(response.location.to_s).not_to match(%r{/n/})
+      expect(response.body).to include(%(/t/#{topic_with_posts.slug}/#{topic_with_posts.id}?flat=1))
+    end
+
     it "uses viewer-visible post count when deciding the last valid page (whispers)" do
       SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3247,6 +3247,21 @@ RSpec.describe TopicsController do
       expect(response).to redirect_to(topic.relative_url + "/42?page=123")
     end
 
+    it "preserves forced-flat mode when redirecting to the canonical topic URL" do
+      SiteSetting.nested_replies_enabled = true
+      SiteSetting.nested_replies_default = true
+
+      get "/t/wrong-slug/#{topic.id}", params: { flat: "1" }
+
+      expect(response).to redirect_to("#{topic.relative_url}?flat=1")
+    end
+
+    it "does not preserve forced-flat mode on JSON canonical topic redirects" do
+      get "/t/wrong-slug/#{topic.id}.json", params: { flat: "1" }
+
+      expect(response).to redirect_to("#{topic.relative_url}.json")
+    end
+
     it "does not accept page params as an array" do
       get "/t/#{topic.slug}", params: { post_number: 42, page: [2] }
 


### PR DESCRIPTION
## What

Render the normal flat topic HTML as the no-JS fallback for nested topic URLs, while still preloading the nested-topic payload for the Ember app.

This covers both:

- `/n/:slug/:topic_id`
- `/n/:slug/:topic_id/:post_number`

Also makes the topic view RSS autodiscovery link explicitly target `topics#feed`, since `topics/show` can now be rendered from `NestedTopicsController`.

## Why

Nested topic HTML requests were rendering `default/empty`. That works when JavaScript boots the nested topic app, but leaves a completely empty page when JavaScript is disabled.

## Tests

```text
bin/rspec spec/requests/nested_topics_controller_spec.rb
108 examples, 0 failures
```

Ran in the `hot-nested-dv` container.
