### PR TITLE
DEV: Migrate google-dfp-ad to GPT setConfig API

### DIFF
--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/google-dfp-ad.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/google-dfp-ad.gjs
@@ -45,13 +45,15 @@ function keyParse(word) {
   return key;
 }
 
-// This should call adslot.setTargeting(key for that location, value for that location)
-function custom_targeting(key_array, value_array, adSlot) {
+// This builds the targeting map for that location, for slot.setConfig({ targeting })
+function custom_targeting(key_array, value_array) {
+  const targeting = {};
   for (let i = 0; i < key_array.length; i++) {
     if (key_array[i]) {
-      adSlot.setTargeting(key_array[i], valueParse(value_array[i]));
+      targeting[key_array[i]] = valueParse(value_array[i]);
     }
   }
+  return targeting;
 }
 
 const DESKTOP_SETTINGS = {
@@ -177,15 +179,16 @@ function defineSlot(
     divId
   );
 
-  custom_targeting(
+  const targeting = custom_targeting(
     keyParse(settings[config.targeting_keys]),
-    keyParse(settings[config.targeting_values]),
-    ad
+    keyParse(settings[config.targeting_values])
   );
 
   if (categoryTarget) {
-    ad.setTargeting("discourse-category", categoryTarget);
+    targeting["discourse-category"] = categoryTarget;
   }
+
+  ad.setConfig({ targeting });
 
   ad.addService(window.googletag.pubads());
 
@@ -226,14 +229,16 @@ function loadGoogle() {
     }
 
     window.googletag.cmd.push(function () {
-      // Infinite scroll requires SRA:
-      window.googletag.pubads().enableSingleRequest();
+      window.googletag.setConfig({
+        // Infinite scroll requires SRA:
+        singleRequest: true,
 
-      // we always use refresh() to fetch the ads:
-      window.googletag.pubads().disableInitialLoad();
+        // we always use refresh() to fetch the ads:
+        disableInitialLoad: true,
 
-      // Improve CSP compatibility (https://developers.google.com/publisher-tag/guides/content-security-policy)
-      window.googletag.pubads().setForceSafeFrame(true);
+        // Improve CSP compatibility (https://developers.google.com/publisher-tag/guides/content-security-policy)
+        safeFrame: { forceSafeFrame: true },
+      });
 
       window.googletag.enableServices();
     });
@@ -386,7 +391,9 @@ export default class GoogleDfpAd extends AdComponent {
     if (this.get("loadedGoogletag")) {
       this.set("lastAdRefresh", new Date());
       window.googletag.cmd.push(() => {
-        ad.setTargeting("discourse-category", categorySlug || "0");
+        ad.setConfig({
+          targeting: { "discourse-category": categorySlug || "0" },
+        });
         window.googletag.pubads().refresh([ad]);
       });
     }


### PR DESCRIPTION
Fixes deprecation warnings from Google Publisher Tag.

- replaces `pubads().enableSingleRequest()`, `disableInitialLoad()` and `setForceSafeFrame()` with `googletag.setConfig()`
- replaces `slot.setTargeting()` with `slot.setConfig({ targeting })`

See https://developers.google.com/publisher-tag/reference and https://goo.gle/gpt-message#170