### PR TITLE
DEV: Check featured topic visibility in `CurrentUserSerializer`

### DIFF
--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -354,6 +354,10 @@ class CurrentUserSerializer < BasicUserSerializer
     object.totp_enabled? || object.security_keys_enabled?
   end
 
+  def include_featured_topic?
+    scope.can_see_topic?(object.user_profile.featured_topic)
+  end
+
   def featured_topic
     BasicTopicSerializer.new(object.user_profile.featured_topic, scope: scope, root: false).as_json
   end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -2997,6 +2997,17 @@ RSpec.describe SessionController do
         expect(json["current_user"]).to be_present
         expect(json["current_user"]["id"]).to eq(user.id)
       end
+
+      it "does not include a featured topic the user cannot see" do
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+        featured_topic = Fabricate(:topic, category: private_category)
+        user.user_profile.update!(featured_topic_id: featured_topic.id)
+
+        get "/session/current.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["current_user"]).not_to have_key("featured_topic")
+      end
     end
 
     context "when logged in as an anonymous shadow user" do


### PR DESCRIPTION
Follow-up to #40549, which added a `can_see_topic?` guard to `UserCardSerializer` 

`CurrentUserSerializer` inherits from `BasicUserSerializer` directly, so it kept its own unguarded `featured_topic` – this PR fixes that


relates to patch/1278