### PR TITLE
DEV: add guardian.can_boost_post? and fix issue where we could boost archived posts.

### DIFF
--- a/app/services/discourse_boosts/boost/create.rb
+++ b/app/services/discourse_boosts/boost/create.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module DiscourseBoosts
+  class Boost::Create
+    include Service::Base
+
+    params do
+      attribute :post_id, :integer
+      attribute :raw, :string
+
+      before_validation { self.raw = raw.to_s.strip }
+
+      validates :post_id, presence: true
+      validates :raw, presence: true
+    end
+
+    model :post
+    policy :can_boost_post
+    policy :user_has_not_boosted_post
+    policy :within_post_boost_limit
+    policy :not_blocked_by_watched_words
+    model :processed_raw
+    model :boost, :create_boost
+
+    step :publish_change
+    only_if(:notify_post_author?) { step :create_notification }
+
+    private
+
+    def fetch_post(params:)
+      Post.find_by(id: params.post_id)
+    end
+
+    def can_boost_post(guardian:, post:)
+      guardian.can_boost_post?(post)
+    end
+
+    def user_has_not_boosted_post(guardian:, post:)
+      !DiscourseBoosts::Boost.exists?(
+        post_id: post.id,
+        user_id: guardian.user.id
+      )
+    end
+
+    def within_post_boost_limit(post:)
+      DiscourseBoosts::Boost.where(post_id: post.id).count <
+        SiteSetting.discourse_boosts_max_per_post
+    end
+
+    def not_blocked_by_watched_words(params:)
+      !WordWatcher.new(params.raw).should_block?
+    end
+
+    def fetch_processed_raw(params:)
+      WordWatcher.apply_to_text(params.raw)
+    end
+
+    def create_boost(processed_raw:, guardian:, post:)
+      DiscourseBoosts::Boost.create(
+        post:,
+        user: guardian.user,
+        raw: processed_raw
+      )
+    end
+
+    def publish_change(post:, boost:)
+      DiscourseBoosts::Boost.publish_add(post, boost)
+    end
+
+    def notify_post_author?(post:, guardian:)
+      return false if post.user.ignored_user_ids.include?(guardian.user.id)
+      post.user.user_option.boost_notifications_level != 2
+    end
+
+    def create_notification(boost:)
+      Notification.consolidate_or_create!(
+        user_id: boost.post.user_id,
+        notification_type: Notification.types[:boost],
+        topic_id: boost.post.topic_id,
+        post_number: boost.post.post_number,
+        data: {
+          display_username: boost.user.username,
+          display_name: boost.user.name,
+          boost_raw: boost.raw,
+          topic_title: boost.post.topic.title
+        }.to_json
+      )
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+# name: discourse-boosts
+# about: Allows users to add freeform micro-reactions (boosts) to posts.
+# version: 0.1
+# authors: discourse
+# url: https://github.com/discourse/discourse-boosts
+
+enabled_site_setting :discourse_boosts_enabled
+
+register_asset "stylesheets/common/discourse-boosts.scss"
+
+register_svg_icon "rocket"
+register_svg_icon "trash-can"
+register_svg_icon "flag"
+
+module ::DiscourseBoosts
+  PLUGIN_NAME = "discourse-boosts"
+end
+
+require_relative "lib/discourse_boosts/engine"
+
+after_initialize do
+  reloadable_patch do |plugin|
+    Post.prepend DiscourseBoosts::PostExtension
+    UserOption.prepend DiscourseBoosts::UserOptionExtension
+    Reviewable.prepend DiscourseBoosts::ReviewableExtension
+    TopicView.prepend DiscourseBoosts::TopicViewExtension
+  end
+
+  Discourse::Application.routes.append do
+    mount DiscourseBoosts::Engine, at: "/"
+  end
+
+  add_to_class(:guardian, :can_boost_post?) do |post|
+    authenticated? && post && can_see_post?(post) && !user.silenced? &&
+      !post.topic&.archived? && !post.trashed? && post.user_id.present? &&
+      !is_my_own?(post)
+  end
+
+  TopicView.on_preload do |topic_view|
+    if SiteSetting.discourse_boosts_enabled
+      topic_view.instance_variable_set(
+        :@posts,
+        topic_view.posts.includes(boosts: :user)
+      )
+
+      topic_view.boosts_available_flags =
+        Flag
+          .enabled
+          .where("'DiscourseBoosts::Boost' = ANY(applies_to)")
+          .pluck(:name_key)
+    end
+  end
+
+  add_to_serializer(
+    :post,
+    :boosts,
+    include_condition: -> do
+      SiteSetting.discourse_boosts_enabled &&
+        object.association(:boosts).loaded?
+    end
+  ) do
+    boosts = object.boosts
+
+    if scope.user
+      ignored_user_ids = scope.user.ignored_user_ids
+      if ignored_user_ids.present?
+        boosts =
+          boosts.reject do |b|
+            ignored_user_ids.include?(b.user_id) && !b.user&.staff?
+          end
+      end
+    end
+
+    reviewables_by_target =
+      if scope.user && @topic_view
+        @topic_view.boosts_reviewables_by_target ||=
+          begin
+            all_boost_ids =
+              @topic_view.posts.flat_map do |p|
+                p.association(:boosts).loaded? ? p.boosts.map(&:id) : []
+              end
+            if all_boost_ids.present?
+              Reviewable
+                .includes(:reviewable_scores)
+                .where(
+                  target_type: "DiscourseBoosts::Boost",
+                  target_id: all_boost_ids
+                )
+                .index_by(&:target_id)
+            else
+              {}
+            end
+          end
+      else
+        {}
+      end
+
+    available_flags =
+      @topic_view&.boosts_available_flags ||
+        Flag
+          .enabled
+          .where("'DiscourseBoosts::Boost' = ANY(applies_to)")
+          .pluck(:name_key)
+
+    boosts.map do |boost|
+      DiscourseBoosts::BoostSerializer.new(
+        boost,
+        scope: scope,
+        root: false,
+        reviewables_by_target: reviewables_by_target,
+        available_flags: available_flags
+      ).as_json
+    end
+  end
+
+  add_to_serializer(
+    :post,
+    :can_boost,
+    include_condition: -> do
+      SiteSetting.discourse_boosts_enabled &&
+        object.association(:boosts).loaded?
+    end
+  ) do
+    scope.can_boost_post?(object) &&
+      object.boosts.none? { |b| b.user_id == scope.user.id } &&
+      object.boosts.size < SiteSetting.discourse_boosts_max_per_post
+  end
+
+  UserUpdater::OPTION_ATTR.push(:boost_notifications_level)
+
+  add_to_serializer(:user_option, :boost_notifications_level) do
+    object.boost_notifications_level
+  end
+
+  register_reviewable_type DiscourseBoosts::ReviewableBoost
+  DiscoursePluginRegistry.register_flag_applies_to_type(
+    "DiscourseBoosts::Boost",
+    self
+  )
+  register_seedfu_fixtures(
+    Rails.root.join("plugins/discourse-boosts/db/fixtures")
+  )
+
+  register_notification_consolidation_plan(
+    DiscourseBoosts::NotificationConsolidation.boosted_by_multiple_users_plan
+  )
+end

--- a/spec/requests/boosts_controller_spec.rb
+++ b/spec/requests/boosts_controller_spec.rb
@@ -1,0 +1,467 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require_relative "../support/api_schema_matcher"
+
+RSpec.describe DiscourseBoosts::BoostsController do
+  fab!(:current_user, :user)
+  fab!(:post_author, :user)
+  fab!(:category)
+  fab!(:topic) { Fabricate(:topic, category: category) }
+  fab!(:target_post, :post) do
+    Fabricate(:post, topic: topic, user: post_author)
+  end
+
+  before { SiteSetting.discourse_boosts_enabled = true }
+
+  describe "#create" do
+    context "when plugin is disabled" do
+      before do
+        SiteSetting.discourse_boosts_enabled = false
+        sign_in(current_user)
+      end
+
+      it "returns a 404" do
+        post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+             params: {
+               raw: "🎉"
+             }
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when not logged in" do
+      it "returns a 403" do
+        post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+             params: {
+               raw: "🎉"
+             }
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when logged in" do
+      before { sign_in(current_user) }
+
+      it "works" do
+        post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+             params: {
+               raw: "🎉"
+             }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["cooked"]).to include("tada")
+        expect(response.parsed_body["user"]["id"]).to eq(current_user.id)
+      end
+
+      context "when params are invalid" do
+        it "returns a 400" do
+          post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+               params: {
+                 raw: ""
+               }
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context "when post doesn't exist" do
+        it "returns a 404" do
+          post "/discourse-boosts/posts/-1/boosts.json", params: { raw: "🎉" }
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when boosting own post" do
+        fab!(:current_user) { post_author }
+
+        it "returns a 403" do
+          post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+               params: {
+                 raw: "🎉"
+               }
+          expect(response.status).to eq(403)
+        end
+      end
+
+      context "when the topic is archived" do
+        before { topic.update!(archived: true) }
+
+        it "returns a 403 without creating a boost, publishing a message, or notifying" do
+          notification_count =
+            Notification.where(
+              user: post_author,
+              notification_type: Notification.types[:boost]
+            ).count
+          messages = nil
+
+          expect do
+            messages =
+              MessageBus.track_publish("/topic/#{topic.id}") do
+                post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+                     params: {
+                       raw: "🎉"
+                     }
+              end
+          end.not_to change { DiscourseBoosts::Boost.count }
+
+          expect(response.status).to eq(403)
+          expect(response.parsed_body["errors"]).to be_present
+          expect(messages).to be_empty
+          expect(
+            Notification.where(
+              user: post_author,
+              notification_type: Notification.types[:boost]
+            ).count
+          ).to eq(notification_count)
+        end
+      end
+
+      context "when user has already boosted the post" do
+        before { Fabricate(:boost, post: target_post, user: current_user) }
+
+        it "returns a 422" do
+          post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+               params: {
+                 raw: "🎉"
+               }
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "when the post has reached the max boosts limit" do
+        before { SiteSetting.discourse_boosts_max_per_post = 1 }
+
+        fab!(:other_user, :user)
+        fab!(:existing_boost) do
+          Fabricate(:boost, post: target_post, user: other_user)
+        end
+
+        it "returns a 422" do
+          post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+               params: {
+                 raw: "🎉"
+               }
+
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"].first).to eq(
+            I18n.t("discourse_boosts.post_boost_limit_reached")
+          )
+        end
+      end
+
+      context "when rate limit is exceeded" do
+        fab!(:other_posts) do
+          Array.new(6) { Fabricate(:post, topic: topic, user: post_author) }
+        end
+
+        before { RateLimiter.enable }
+
+        it "returns a 429" do
+          other_posts.each do |other_post|
+            post "/discourse-boosts/posts/#{other_post.id}/boosts.json",
+                 params: {
+                   raw: "🎉"
+                 }
+          end
+
+          expect(response.status).to eq(429)
+        end
+      end
+
+      context "when a duplicate key error occurs while creating the boost" do
+        before do
+          allow(DiscourseBoosts::Boost).to receive(:create).and_raise(
+            ActiveRecord::RecordNotUnique.new(
+              "duplicate key value violates unique constraint"
+            )
+          )
+        end
+
+        it "returns a 422" do
+          post "/discourse-boosts/posts/#{target_post.id}/boosts.json",
+               params: {
+                 raw: "🎉"
+               }
+          expect(response.status).to eq(422)
+        end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    fab!(:boost) { Fabricate(:boost, post: target_post, user: current_user) }
+
+    context "when plugin is disabled" do
+      before do
+        SiteSetting.discourse_boosts_enabled = false
+        sign_in(current_user)
+      end
+
+      it "returns a 404" do
+        delete "/discourse-boosts/boosts/#{boost.id}.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when not logged in" do
+      it "returns a 403" do
+        delete "/discourse-boosts/boosts/#{boost.id}.json"
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when logged in" do
+      before { sign_in(current_user) }
+
+      it "works" do
+        delete "/discourse-boosts/boosts/#{boost.id}.json"
+
+        expect(response.status).to eq(204)
+        expect(DiscourseBoosts::Boost.exists?(boost.id)).to eq(false)
+      end
+
+      context "when boost doesn't exist" do
+        it "returns a 404" do
+          delete "/discourse-boosts/boosts/-1.json"
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when user is not the author" do
+        fab!(:boost) { Fabricate(:boost, post: target_post, user: post_author) }
+
+        it "returns a 403" do
+          delete "/discourse-boosts/boosts/#{boost.id}.json"
+          expect(response.status).to eq(403)
+        end
+      end
+
+      context "when user is an admin" do
+        fab!(:current_user, :admin)
+        fab!(:boost) { Fabricate(:boost, post: target_post, user: post_author) }
+
+        it "works" do
+          delete "/discourse-boosts/boosts/#{boost.id}.json"
+          expect(response.status).to eq(204)
+        end
+      end
+
+      context "when rate limit is exceeded" do
+        fab!(:other_posts) do
+          Array.new(6) { Fabricate(:post, topic: topic, user: post_author) }
+        end
+        fab!(:boosts) do
+          other_posts.map { |p| Fabricate(:boost, post: p, user: current_user) }
+        end
+
+        before { RateLimiter.enable }
+
+        it "returns a 429" do
+          boosts.each { |b| delete "/discourse-boosts/boosts/#{b.id}.json" }
+
+          expect(response.status).to eq(429)
+        end
+      end
+    end
+  end
+
+  describe "#flag" do
+    fab!(:boost_author, :user)
+    fab!(:boost) { Fabricate(:boost, post: target_post, user: boost_author) }
+
+    context "when not logged in" do
+      it "returns a 403" do
+        post "/discourse-boosts/boosts/#{boost.id}/flags.json",
+             params: {
+               flag_type_id: ReviewableScore.types[:spam]
+             }
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when logged in" do
+      before { sign_in(current_user) }
+
+      it "works" do
+        post "/discourse-boosts/boosts/#{boost.id}/flags.json",
+             params: {
+               flag_type_id: ReviewableScore.types[:spam]
+             }
+        expect(response.status).to eq(200)
+      end
+
+      context "when boost doesn't exist" do
+        it "returns a 404" do
+          post "/discourse-boosts/boosts/-1/flags.json",
+               params: {
+                 flag_type_id: ReviewableScore.types[:spam]
+               }
+          expect(response.status).to eq(404)
+        end
+      end
+
+      context "when flagging own boost" do
+        fab!(:boost) do
+          Fabricate(:boost, post: target_post, user: current_user)
+        end
+
+        it "returns a 403" do
+          post "/discourse-boosts/boosts/#{boost.id}/flags.json",
+               params: {
+                 flag_type_id: ReviewableScore.types[:spam]
+               }
+          expect(response.status).to eq(403)
+        end
+      end
+
+      context "when rate limit is exceeded" do
+        before { RateLimiter.enable }
+
+        it "returns a 429" do
+          5.times do
+            post "/discourse-boosts/boosts/#{boost.id}/flags.json",
+                 params: {
+                   flag_type_id: ReviewableScore.types[:spam]
+                 }
+          end
+          expect(response.status).to eq(429)
+        end
+      end
+    end
+  end
+
+  describe "#boosts_given" do
+    fab!(:boost) { Fabricate(:boost, post: target_post, user: current_user) }
+
+    before { SiteSetting.hide_new_user_profiles = false }
+
+    context "when plugin is disabled" do
+      before { SiteSetting.discourse_boosts_enabled = false }
+
+      it "returns a 404" do
+        get "/discourse-boosts/users/#{current_user.username}/boosts-given.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when not logged in" do
+      it "returns boosts given by the user" do
+        get "/discourse-boosts/users/#{current_user.username}/boosts-given.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["boosts"].length).to eq(1)
+      end
+    end
+
+    context "when logged in" do
+      before { sign_in(current_user) }
+
+      it "returns boosts given by the user matching the expected schema" do
+        get "/discourse-boosts/users/#{current_user.username}/boosts-given.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to match_response_schema("boost_list")
+        expect(response.parsed_body["boosts"].length).to eq(1)
+      end
+
+      context "with before_boost_id pagination" do
+        fab!(:another_post, :post) do
+          Fabricate(:post, topic: topic, user: post_author)
+        end
+        fab!(:newer_boost) do
+          Fabricate(:boost, post: another_post, user: current_user)
+        end
+
+        it "returns only boosts before the given id" do
+          get "/discourse-boosts/users/#{current_user.username}/boosts-given.json",
+              params: {
+                before_boost_id: newer_boost.id
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["boosts"].map { |b| b["id"] }).to eq(
+            [boost.id]
+          )
+        end
+      end
+
+      context "when user doesn't exist" do
+        it "returns a 404" do
+          get "/discourse-boosts/users/nonexistent_user/boosts-given.json"
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
+
+  describe "#boosts_received" do
+    fab!(:boost) { Fabricate(:boost, post: target_post, user: current_user) }
+
+    context "when plugin is disabled" do
+      before do
+        SiteSetting.discourse_boosts_enabled = false
+        sign_in(post_author)
+      end
+
+      it "returns a 404" do
+        get "/discourse-boosts/users/#{post_author.username}/boosts-received.json"
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "when logged in as the target user" do
+      before { sign_in(post_author) }
+
+      it "returns boosts received on the user's posts" do
+        get "/discourse-boosts/users/#{post_author.username}/boosts-received.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["boosts"].length).to eq(1)
+      end
+
+      it "returns boosts matching the expected schema" do
+        get "/discourse-boosts/users/#{post_author.username}/boosts-received.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to match_response_schema("boost_list")
+      end
+
+      context "with before_boost_id pagination" do
+        fab!(:other_user, :user)
+        fab!(:newer_boost) do
+          Fabricate(:boost, post: target_post, user: other_user)
+        end
+
+        it "returns only boosts before the given id" do
+          get "/discourse-boosts/users/#{post_author.username}/boosts-received.json",
+              params: {
+                before_boost_id: newer_boost.id
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["boosts"].map { |b| b["id"] }).to eq(
+            [boost.id]
+          )
+        end
+      end
+    end
+
+    context "when logged in as another user" do
+      fab!(:other_user, :user)
+
+      before { sign_in(other_user) }
+
+      it "returns a 403" do
+        get "/discourse-boosts/users/#{post_author.username}/boosts-received.json"
+        expect(response.status).to eq(403)
+      end
+    end
+
+    context "when not logged in" do
+      it "returns a 403" do
+        get "/discourse-boosts/users/#{post_author.username}/boosts-received.json"
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Applies patch from triage, here we do a small code refactor, add a `can_boost_post` guardian, and apply it throughout the code, also fixing this issue were a user could boost an archived post  

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1207
- Affected file: https://github.com/discourse/discourse-boosts/blob/main/app/services/discourse_boosts/boost/create.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>