### PR TITLE
UX: combine group visibility and access configuration

### DIFF
--- a/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
+++ b/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
@@ -4,8 +4,8 @@
 }
 
 .groups-form-visibility-access {
+  .groups-form-visibility-label,
   .groups-form-members-visibility-label,
-  .groups-form-join-method,
   .group-form-public-exit-label {
     margin-top: var(--space-4);
   }
@@ -31,13 +31,5 @@
 
   .groups-form-membership-request-template {
     margin-top: var(--space-4);
-  }
-
-  .radio:has([disabled]) {
-    color: var(--primary-medium);
-
-    &:hover {
-      cursor: not-allowed;
-    }
   }
 }

--- a/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
+++ b/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
@@ -1,6 +1,6 @@
 .group-form-automatic-membership-automatic,
 .groups-form-grant-trust-level {
-  margin-bottom: 10px;
+  margin-bottom: var(--space-3);
 }
 
 .groups-form-visibility-access {
@@ -8,6 +8,10 @@
   .groups-form-join-method,
   .group-form-public-exit-label {
     margin-top: var(--space-4);
+  }
+
+  .group-form-public-exit-label {
+    margin-bottom: var(--space-5);
   }
 
   .groups-form-join-method {
@@ -26,7 +30,7 @@
   }
 
   .groups-form-membership-request-template {
-    margin-top: var(--space-2);
+    margin-top: var(--space-4);
   }
 
   .radio:has([disabled]) {

--- a/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
+++ b/app/assets/stylesheets/common/components/groups-form-membership-fields.scss
@@ -2,3 +2,38 @@
 .groups-form-grant-trust-level {
   margin-bottom: 10px;
 }
+
+.groups-form-visibility-access {
+  .groups-form-members-visibility-label,
+  .groups-form-join-method,
+  .group-form-public-exit-label {
+    margin-top: var(--space-4);
+  }
+
+  .groups-form-join-method {
+    margin-bottom: 0;
+    padding: 0;
+    border: 0;
+    min-inline-size: 0;
+
+    legend {
+      font-weight: normal;
+      font-size: var(--font-0);
+      color: var(--primary-high);
+      padding: 0;
+      margin-bottom: var(--space-2);
+    }
+  }
+
+  .groups-form-membership-request-template {
+    margin-top: var(--space-2);
+  }
+
+  .radio:has([disabled]) {
+    color: var(--primary-medium);
+
+    &:hover {
+      cursor: not-allowed;
+    }
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1347,9 +1347,9 @@ en:
           join_method_title: "How can users join?"
           join_method:
             free: "Anyone can join freely"
-            request: "Require approval to join"
+            request: "Anyone can request to join"
             invite: "Invite only"
-          join_method_visibility_hint: "Joining freely or by request requires a group that's visible to the public or to logged-in users."
+          join_method_visibility_hint: "Users need to be able to see the group to join freely or request access."
         categories:
           title: Categories
           long_title: "Category default notifications"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1343,13 +1343,12 @@ en:
             from_alias_hint: "Alias to use as the from address when sending group SMTP emails. Note this may not be supported by all mail providers, please consult your mail provider's documentation."
         membership:
           title: Membership
-          visibility_and_access: "Visibility & access"
+          visibility_and_access: "Access & visibility"
           join_method_title: "How can users join?"
           join_method:
             free: "Anyone can join freely"
             request: "Anyone can request to join"
             invite: "Invite only"
-          join_method_visibility_hint: "Users need to be able to see the group to join freely or request access."
         categories:
           title: Categories
           long_title: "Category default notifications"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1343,7 +1343,13 @@ en:
             from_alias_hint: "Alias to use as the from address when sending group SMTP emails. Note this may not be supported by all mail providers, please consult your mail provider's documentation."
         membership:
           title: Membership
-          access: Access
+          visibility_and_access: "Visibility & access"
+          join_method_title: "How can users join?"
+          join_method:
+            free: "Anyone can join freely"
+            request: "Require approval to join"
+            invite: "Invite only"
+          join_method_visibility_hint: "Joining freely or by request requires a group that's visible to the public or to logged-in users."
         categories:
           title: Categories
           long_title: "Category default notifications"
@@ -1376,7 +1382,6 @@ en:
         title: "Permissions"
         none: "There are no categories associated with this group."
         description: "Members of this group can access these categories"
-      public_admission: "Allow users to join the group freely (Requires publicly visible group)"
       public_exit: "Allow users to leave the group freely"
       empty:
         posts: "There are no posts by members of this group"
@@ -1392,7 +1397,6 @@ en:
       request: "Request"
       message: "Message"
       confirm_leave: "Are you sure you want to leave this group?"
-      allow_membership_requests: "Allow users to send membership requests to group owners (Requires publicly visible group)"
       membership_request_template: "Custom template to display to users when sending a membership request"
       membership_request:
         submit: "Submit Request"
@@ -7175,7 +7179,6 @@ en:
             incoming_email: "Custom incoming email address"
             incoming_email_placeholder: "enter email address"
             incoming_email_tooltip: "You can separate multiple email addresses with the | character."
-            visibility: Visibility
             visibility_levels:
               title: "Who can see this group?"
               public: "Everyone"

--- a/frontend/discourse/app/components/groups-form-interaction-fields.gjs
+++ b/frontend/discourse/app/components/groups-form-interaction-fields.gjs
@@ -14,31 +14,6 @@ import { i18n } from "discourse-i18n";
 
 @tagName("")
 export default class GroupsFormInteractionFields extends Component {
-  visibilityLevelOptions = [
-    {
-      name: i18n("admin.groups.manage.interaction.visibility_levels.public"),
-      value: 0,
-    },
-    {
-      name: i18n(
-        "admin.groups.manage.interaction.visibility_levels.logged_on_users"
-      ),
-      value: 1,
-    },
-    {
-      name: i18n("admin.groups.manage.interaction.visibility_levels.members"),
-      value: 2,
-    },
-    {
-      name: i18n("admin.groups.manage.interaction.visibility_levels.staff"),
-      value: 3,
-    },
-    {
-      name: i18n("admin.groups.manage.interaction.visibility_levels.owners"),
-      value: 4,
-    },
-  ];
-
   aliasLevelOptions = [
     { name: i18n("groups.alias_levels.nobody"), value: 0 },
     { name: i18n("groups.alias_levels.only_admins"), value: 1 },
@@ -49,17 +24,6 @@ export default class GroupsFormInteractionFields extends Component {
   ];
 
   watchingNotificationLevel = NotificationLevels.WATCHING;
-
-  @computed(
-    "model.members_visibility_level",
-    "visibilityLevelOptions.firstObject.value"
-  )
-  get membersVisibilityLevel() {
-    return (
-      this.model?.members_visibility_level ||
-      this.visibilityLevelOptions?.firstObject?.value
-    );
-  }
 
   @computed("model.messageable_level", "aliasLevelOptions.firstObject.value")
   get messageableLevel() {
@@ -110,68 +74,8 @@ export default class GroupsFormInteractionFields extends Component {
     );
   }
 
-  @computed("membersVisibilityLevel")
-  get membersVisibilityPrivate() {
-    return (
-      this.membersVisibilityLevel !==
-      this.visibilityLevelOptions.firstObject.value
-    );
-  }
-
   <template>
     <div ...attributes>
-      {{#if this.canAdminGroup}}
-        <div class="control-group">
-          <label class="control-label">
-            {{i18n "admin.groups.manage.interaction.visibility"}}
-          </label>
-          <label>
-            {{i18n "admin.groups.manage.interaction.visibility_levels.title"}}
-          </label>
-
-          <ComboBox
-            @name="alias"
-            @valueProperty="value"
-            @value={{this.model.visibility_level}}
-            @content={{this.visibilityLevelOptions}}
-            @onChange={{fn (mut this.model.visibility_level)}}
-            @options={{hash castInteger=true}}
-            class="groups-form-visibility-level"
-          />
-
-          <div class="control-instructions">
-            {{i18n
-              "admin.groups.manage.interaction.visibility_levels.description"
-            }}
-          </div>
-        </div>
-
-        <div class="control-group">
-          <label>
-            {{i18n
-              "admin.groups.manage.interaction.members_visibility_levels.title"
-            }}
-          </label>
-
-          <ComboBox
-            @name="alias"
-            @valueProperty="value"
-            @value={{this.membersVisibilityLevel}}
-            @content={{this.visibilityLevelOptions}}
-            @onChange={{fn (mut this.model.members_visibility_level)}}
-            class="groups-form-members-visibility-level"
-          />
-
-          {{#if this.membersVisibilityPrivate}}
-            <div class="control-instructions">
-              {{i18n
-                "admin.groups.manage.interaction.members_visibility_levels.description"
-              }}
-            </div>
-          {{/if}}
-        </div>
-      {{/if}}
-
       <div class="control-group">
         <label class="control-label">
           {{i18n "groups.manage.interaction.posting"}}

--- a/frontend/discourse/app/components/groups-form-membership-fields.gjs
+++ b/frontend/discourse/app/components/groups-form-membership-fields.gjs
@@ -6,13 +6,46 @@ import { action, computed } from "@ember/object";
 import { tagName } from "@ember-decorators/component";
 import GroupFlairInputs from "discourse/components/group-flair-inputs";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import DTooltip from "discourse/float-kit/components/d-tooltip";
 import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import AssociatedGroup from "discourse/models/associated-group";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import ListSetting from "discourse/select-kit/components/list-setting";
 import DExpandingTextArea from "discourse/ui-kit/d-expanding-text-area";
+import DRadioButton from "discourse/ui-kit/d-radio-button";
 import { i18n } from "discourse-i18n";
+
+const JoinMethodOption = <template>
+  {{#if @disabled}}
+    <DTooltip @content={{@disabledHint}}>
+      <:trigger>
+        <label class="radio">
+          <DRadioButton
+            @name="join_method"
+            @value={{@value}}
+            @selection={{@selection}}
+            @disabled={{true}}
+            class={{@class}}
+          />
+
+          {{@label}}
+        </label>
+      </:trigger>
+    </DTooltip>
+  {{else}}
+    <label class="radio">
+      <DRadioButton
+        @name="join_method"
+        @value={{@value}}
+        @selection={{@selection}}
+        @onChange={{@onChange}}
+        class={{@class}}
+      />
+      {{@label}}
+    </label>
+  {{/if}}
+</template>;
 
 @tagName("")
 export default class GroupsFormMembershipFields extends Component {
@@ -27,6 +60,31 @@ export default class GroupsFormMembershipFields extends Component {
     { name: 2, value: 2 },
     { name: 3, value: 3 },
     { name: 4, value: 4 },
+  ];
+
+  visibilityLevelOptions = [
+    {
+      name: i18n("admin.groups.manage.interaction.visibility_levels.public"),
+      value: 0,
+    },
+    {
+      name: i18n(
+        "admin.groups.manage.interaction.visibility_levels.logged_on_users"
+      ),
+      value: 1,
+    },
+    {
+      name: i18n("admin.groups.manage.interaction.visibility_levels.members"),
+      value: 2,
+    },
+    {
+      name: i18n("admin.groups.manage.interaction.visibility_levels.staff"),
+      value: 3,
+    },
+    {
+      name: i18n("admin.groups.manage.interaction.visibility_levels.owners"),
+      value: 4,
+    },
   ];
 
   init() {
@@ -47,9 +105,35 @@ export default class GroupsFormMembershipFields extends Component {
     return !this.model?.automatic;
   }
 
-  @computed("model.flair_icon", "model.flair_url")
-  get hasFlair() {
-    return this.model?.flair_icon || this.model?.flair_url;
+  @computed(
+    "model.isCreated",
+    "model.can_admin_group",
+    "currentUser.can_create_group"
+  )
+  get canAdminGroup() {
+    return (
+      (!this.model?.isCreated && this.currentUser?.can_create_group) ||
+      (this.model?.isCreated && this.model?.can_admin_group)
+    );
+  }
+
+  @computed(
+    "model.members_visibility_level",
+    "visibilityLevelOptions.firstObject.value"
+  )
+  get membersVisibilityLevel() {
+    return (
+      this.model?.members_visibility_level ||
+      this.visibilityLevelOptions?.firstObject?.value
+    );
+  }
+
+  @computed("membersVisibilityLevel")
+  get membersVisibilityPrivate() {
+    return (
+      this.membersVisibilityLevel !==
+      this.visibilityLevelOptions.firstObject.value
+    );
   }
 
   @computed("model.grant_trust_level", "trustLevelOptions")
@@ -60,33 +144,19 @@ export default class GroupsFormMembershipFields extends Component {
     );
   }
 
-  @computed("model.visibility_level", "model.public_admission")
-  get disableMembershipRequestSetting() {
-    const visibility_level = parseInt(this.model?.visibility_level, 10);
-    return this.model?.public_admission || visibility_level > 1;
+  @computed("model.public_admission", "model.allow_membership_requests")
+  get joinMethod() {
+    if (this.model?.public_admission) {
+      return "free";
+    } else if (this.model?.allow_membership_requests) {
+      return "request";
+    }
+    return "invite";
   }
 
-  @computed("model.visibility_level", "model.allow_membership_requests")
-  get disablePublicSetting() {
-    const visibility_level = parseInt(this.model?.visibility_level, 10);
-    return this.model?.allow_membership_requests || visibility_level > 1;
-  }
-
-  @computed("model.visibility_level", "model.primary_group", "hasFlair")
-  get privateGroupNameNotice() {
-    if (this.model?.visibility_level === 0) {
-      return;
-    }
-
-    if (this.model?.primary_group) {
-      return i18n("admin.groups.manage.alert.primary_group", {
-        group_name: this.model.name,
-      });
-    } else if (this.hasFlair) {
-      return i18n("admin.groups.manage.alert.flair_group", {
-        group_name: this.model.name,
-      });
-    }
+  @computed("model.visibility_level")
+  get joinMethodDisabled() {
+    return parseInt(this.model?.visibility_level, 10) > 1;
   }
 
   @computed("model.emailDomains")
@@ -99,6 +169,22 @@ export default class GroupsFormMembershipFields extends Component {
   }
 
   @action
+  setVisibilityLevel(value) {
+    this.model.set("visibility_level", value);
+
+    if (parseInt(value, 10) > 1) {
+      this.model.set("public_admission", false);
+      this.model.set("allow_membership_requests", false);
+    }
+  }
+
+  @action
+  setJoinMethod(value) {
+    this.model.set("public_admission", value === "free");
+    this.model.set("allow_membership_requests", value === "request");
+  }
+
+  @action
   onChangeEmailDomainsSetting(value) {
     this.set(
       "model.automatic_membership_email_domains",
@@ -108,23 +194,113 @@ export default class GroupsFormMembershipFields extends Component {
 
   <template>
     <div ...attributes>
-      <div class="control-group">
-        <label class="control-label">{{i18n
-            "groups.manage.membership.access"
-          }}</label>
-
-        <label>
-          <Input
-            @type="checkbox"
-            class="group-form-public-admission"
-            @checked={{this.model.public_admission}}
-            disabled={{this.disablePublicSetting}}
-          />
-
-          {{i18n "groups.public_admission"}}
+      <div class="control-group groups-form-visibility-access">
+        <label class="control-label">
+          {{i18n "groups.manage.membership.visibility_and_access"}}
         </label>
 
-        <label>
+        {{#if this.canAdminGroup}}
+          <label>
+            {{i18n "admin.groups.manage.interaction.visibility_levels.title"}}
+          </label>
+
+          <ComboBox
+            @name="alias"
+            @valueProperty="value"
+            @value={{this.model.visibility_level}}
+            @content={{this.visibilityLevelOptions}}
+            @onChange={{this.setVisibilityLevel}}
+            @options={{hash castInteger=true}}
+            class="groups-form-visibility-level"
+          />
+
+          <div class="control-instructions">
+            {{i18n
+              "admin.groups.manage.interaction.visibility_levels.description"
+            }}
+          </div>
+
+          <label class="groups-form-members-visibility-label">
+            {{i18n
+              "admin.groups.manage.interaction.members_visibility_levels.title"
+            }}
+          </label>
+
+          <ComboBox
+            @name="alias"
+            @valueProperty="value"
+            @value={{this.membersVisibilityLevel}}
+            @content={{this.visibilityLevelOptions}}
+            @onChange={{fn (mut this.model.members_visibility_level)}}
+            class="groups-form-members-visibility-level"
+          />
+
+          {{#if this.membersVisibilityPrivate}}
+            <div class="control-instructions">
+              {{i18n
+                "admin.groups.manage.interaction.members_visibility_levels.description"
+              }}
+            </div>
+          {{/if}}
+        {{/if}}
+
+        <fieldset class="groups-form-join-method">
+          <legend>{{i18n "groups.manage.membership.join_method_title"}}</legend>
+
+          <JoinMethodOption
+            @value="free"
+            @label={{i18n "groups.manage.membership.join_method.free"}}
+            @class="group-form-public-admission"
+            @selection={{this.joinMethod}}
+            @onChange={{fn this.setJoinMethod "free"}}
+            @disabled={{this.joinMethodDisabled}}
+            @disabledHint={{i18n
+              "groups.manage.membership.join_method_visibility_hint"
+            }}
+          />
+
+          <JoinMethodOption
+            @value="invite"
+            @label={{i18n "groups.manage.membership.join_method.invite"}}
+            @class="group-form-invite-only"
+            @selection={{this.joinMethod}}
+            @onChange={{fn this.setJoinMethod "invite"}}
+          />
+
+          <JoinMethodOption
+            @value="request"
+            @label={{i18n "groups.manage.membership.join_method.request"}}
+            @class="group-form-allow-membership-requests"
+            @selection={{this.joinMethod}}
+            @onChange={{fn this.setJoinMethod "request"}}
+            @disabled={{this.joinMethodDisabled}}
+            @disabledHint={{i18n
+              "groups.manage.membership.join_method_visibility_hint"
+            }}
+          />
+
+          {{#if this.model.allow_membership_requests}}
+            <div class="groups-form-membership-request-template">
+              <label for="membership-request-template">
+                {{i18n "groups.membership_request_template"}}
+              </label>
+
+              <DExpandingTextArea
+                {{on
+                  "input"
+                  (withEventValue
+                    (fn (mut this.model.membership_request_template))
+                  )
+                }}
+                value={{this.model.membership_request_template}}
+                name="membership-request-template"
+                class="group-form-membership-request-template input-xxlarge"
+              />
+            </div>
+          {{/if}}
+        </fieldset>
+
+        <label class="group-form-public-exit-label">
           <Input
             @type="checkbox"
             class="group-form-public-exit"
@@ -133,37 +309,6 @@ export default class GroupsFormMembershipFields extends Component {
 
           {{i18n "groups.public_exit"}}
         </label>
-
-        <label>
-          <Input
-            @type="checkbox"
-            class="group-form-allow-membership-requests"
-            @checked={{this.model.allow_membership_requests}}
-            disabled={{this.disableMembershipRequestSetting}}
-          />
-
-          {{i18n "groups.allow_membership_requests"}}
-        </label>
-
-        {{#if this.model.allow_membership_requests}}
-          <div>
-            <label for="membership-request-template">
-              {{i18n "groups.membership_request_template"}}
-            </label>
-
-            <DExpandingTextArea
-              {{on
-                "input"
-                (withEventValue
-                  (fn (mut this.model.membership_request_template))
-                )
-              }}
-              value={{this.model.membership_request_template}}
-              name="membership-request-template"
-              class="group-form-membership-request-template input-xxlarge"
-            />
-          </div>
-        {{/if}}
       </div>
 
       {{#if this.model.can_admin_group}}

--- a/frontend/discourse/app/components/groups-form-membership-fields.gjs
+++ b/frontend/discourse/app/components/groups-form-membership-fields.gjs
@@ -6,7 +6,6 @@ import { action, computed } from "@ember/object";
 import { tagName } from "@ember-decorators/component";
 import GroupFlairInputs from "discourse/components/group-flair-inputs";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import DTooltip from "discourse/float-kit/components/d-tooltip";
 import lazyHash from "discourse/helpers/lazy-hash";
 import withEventValue from "discourse/helpers/with-event-value";
 import AssociatedGroup from "discourse/models/associated-group";
@@ -17,34 +16,18 @@ import DRadioButton from "discourse/ui-kit/d-radio-button";
 import { i18n } from "discourse-i18n";
 
 const JoinMethodOption = <template>
-  {{#if @disabled}}
-    <DTooltip @content={{@disabledHint}}>
-      <:trigger>
-        <label class="radio">
-          <DRadioButton
-            @name="join_method"
-            @value={{@value}}
-            @selection={{@selection}}
-            @disabled={{true}}
-            class={{@class}}
-          />
+  <label class="radio">
+    <DRadioButton
+      @name="join_method"
+      @value={{@value}}
+      @selection={{@selection}}
+      @onChange={{@onChange}}
+      @disabled={{@disabled}}
+      class={{@class}}
+    />
 
-          {{@label}}
-        </label>
-      </:trigger>
-    </DTooltip>
-  {{else}}
-    <label class="radio">
-      <DRadioButton
-        @name="join_method"
-        @value={{@value}}
-        @selection={{@selection}}
-        @onChange={{@onChange}}
-        class={{@class}}
-      />
-      {{@label}}
-    </label>
-  {{/if}}
+    {{@label}}
+  </label>
 </template>;
 
 @tagName("")
@@ -219,7 +202,75 @@ export default class GroupsFormMembershipFields extends Component {
               "admin.groups.manage.interaction.visibility_levels.description"
             }}
           </div>
+        {{/if}}
 
+        <fieldset class="groups-form-join-method">
+          <legend>{{i18n "groups.manage.membership.join_method_title"}}</legend>
+
+          <JoinMethodOption
+            @value="free"
+            @label={{i18n "groups.manage.membership.join_method.free"}}
+            @class="group-form-public-admission"
+            @selection={{this.joinMethod}}
+            @onChange={{fn this.setJoinMethod "free"}}
+            @disabled={{this.joinMethodDisabled}}
+          />
+
+          <JoinMethodOption
+            @value="request"
+            @label={{i18n "groups.manage.membership.join_method.request"}}
+            @class="group-form-allow-membership-requests"
+            @selection={{this.joinMethod}}
+            @onChange={{fn this.setJoinMethod "request"}}
+            @disabled={{this.joinMethodDisabled}}
+          />
+
+          <JoinMethodOption
+            @value="invite"
+            @label={{i18n "groups.manage.membership.join_method.invite"}}
+            @class="group-form-invite-only"
+            @selection={{this.joinMethod}}
+            @onChange={{fn this.setJoinMethod "invite"}}
+          />
+
+          {{#if this.model.allow_membership_requests}}
+            <div class="groups-form-membership-request-template">
+              <label for="membership-request-template">
+                {{i18n "groups.membership_request_template"}}
+              </label>
+
+              <DExpandingTextArea
+                {{on
+                  "input"
+                  (withEventValue
+                    (fn (mut this.model.membership_request_template))
+                  )
+                }}
+                value={{this.model.membership_request_template}}
+                name="membership-request-template"
+                class="group-form-membership-request-template input-xxlarge"
+              />
+            </div>
+          {{/if}}
+
+          {{#if this.joinMethodDisabled}}
+            <div class="control-instructions">
+              {{i18n "groups.manage.membership.join_method_visibility_hint"}}
+            </div>
+          {{/if}}
+        </fieldset>
+
+        <label class="group-form-public-exit-label">
+          <Input
+            @type="checkbox"
+            class="group-form-public-exit"
+            @checked={{this.model.public_exit}}
+          />
+
+          {{i18n "groups.public_exit"}}
+        </label>
+
+        {{#if this.canAdminGroup}}
           <label class="groups-form-members-visibility-label">
             {{i18n
               "admin.groups.manage.interaction.members_visibility_levels.title"
@@ -243,72 +294,6 @@ export default class GroupsFormMembershipFields extends Component {
             </div>
           {{/if}}
         {{/if}}
-
-        <fieldset class="groups-form-join-method">
-          <legend>{{i18n "groups.manage.membership.join_method_title"}}</legend>
-
-          <JoinMethodOption
-            @value="free"
-            @label={{i18n "groups.manage.membership.join_method.free"}}
-            @class="group-form-public-admission"
-            @selection={{this.joinMethod}}
-            @onChange={{fn this.setJoinMethod "free"}}
-            @disabled={{this.joinMethodDisabled}}
-            @disabledHint={{i18n
-              "groups.manage.membership.join_method_visibility_hint"
-            }}
-          />
-
-          <JoinMethodOption
-            @value="invite"
-            @label={{i18n "groups.manage.membership.join_method.invite"}}
-            @class="group-form-invite-only"
-            @selection={{this.joinMethod}}
-            @onChange={{fn this.setJoinMethod "invite"}}
-          />
-
-          <JoinMethodOption
-            @value="request"
-            @label={{i18n "groups.manage.membership.join_method.request"}}
-            @class="group-form-allow-membership-requests"
-            @selection={{this.joinMethod}}
-            @onChange={{fn this.setJoinMethod "request"}}
-            @disabled={{this.joinMethodDisabled}}
-            @disabledHint={{i18n
-              "groups.manage.membership.join_method_visibility_hint"
-            }}
-          />
-
-          {{#if this.model.allow_membership_requests}}
-            <div class="groups-form-membership-request-template">
-              <label for="membership-request-template">
-                {{i18n "groups.membership_request_template"}}
-              </label>
-
-              <DExpandingTextArea
-                {{on
-                  "input"
-                  (withEventValue
-                    (fn (mut this.model.membership_request_template))
-                  )
-                }}
-                value={{this.model.membership_request_template}}
-                name="membership-request-template"
-                class="group-form-membership-request-template input-xxlarge"
-              />
-            </div>
-          {{/if}}
-        </fieldset>
-
-        <label class="group-form-public-exit-label">
-          <Input
-            @type="checkbox"
-            class="group-form-public-exit"
-            @checked={{this.model.public_exit}}
-          />
-
-          {{i18n "groups.public_exit"}}
-        </label>
       </div>
 
       {{#if this.model.can_admin_group}}

--- a/frontend/discourse/app/components/groups-form-membership-fields.gjs
+++ b/frontend/discourse/app/components/groups-form-membership-fields.gjs
@@ -22,7 +22,6 @@ const JoinMethodOption = <template>
       @value={{@value}}
       @selection={{@selection}}
       @onChange={{@onChange}}
-      @disabled={{@disabled}}
       class={{@class}}
     />
 
@@ -137,9 +136,29 @@ export default class GroupsFormMembershipFields extends Component {
     return "invite";
   }
 
-  @computed("model.visibility_level")
-  get joinMethodDisabled() {
-    return parseInt(this.model?.visibility_level, 10) > 1;
+  @computed("joinMethod")
+  get joinRequiresVisibility() {
+    return this.joinMethod !== "invite";
+  }
+
+  // Non-admins can't edit visibility, so when the group isn't visible the only
+  // valid join method is invite-only — hide the options that need visibility.
+  @computed("canAdminGroup", "model.visibility_level")
+  get restrictToInviteOnly() {
+    return (
+      !this.canAdminGroup && parseInt(this.model?.visibility_level, 10) > 1
+    );
+  }
+
+  // "Who can see this group?" can't be more private than the join method allows,
+  // so the restricted levels are dropped when joining doesn't require an invite.
+  @computed("joinRequiresVisibility", "visibilityLevelOptions")
+  get groupVisibilityLevelOptions() {
+    if (this.joinRequiresVisibility) {
+      return this.visibilityLevelOptions.filter((option) => option.value <= 1);
+    }
+
+    return this.visibilityLevelOptions;
   }
 
   @computed("model.emailDomains")
@@ -152,19 +171,18 @@ export default class GroupsFormMembershipFields extends Component {
   }
 
   @action
-  setVisibilityLevel(value) {
-    this.model.set("visibility_level", value);
-
-    if (parseInt(value, 10) > 1) {
-      this.model.set("public_admission", false);
-      this.model.set("allow_membership_requests", false);
-    }
-  }
-
-  @action
   setJoinMethod(value) {
     this.model.set("public_admission", value === "free");
     this.model.set("allow_membership_requests", value === "request");
+
+    // Free/request require a visible group, so open up a restricted visibility.
+    if (
+      this.canAdminGroup &&
+      value !== "invite" &&
+      parseInt(this.model?.visibility_level, 10) > 1
+    ) {
+      this.model.set("visibility_level", 0);
+    }
   }
 
   @action
@@ -182,48 +200,26 @@ export default class GroupsFormMembershipFields extends Component {
           {{i18n "groups.manage.membership.visibility_and_access"}}
         </label>
 
-        {{#if this.canAdminGroup}}
-          <label>
-            {{i18n "admin.groups.manage.interaction.visibility_levels.title"}}
-          </label>
-
-          <ComboBox
-            @name="alias"
-            @valueProperty="value"
-            @value={{this.model.visibility_level}}
-            @content={{this.visibilityLevelOptions}}
-            @onChange={{this.setVisibilityLevel}}
-            @options={{hash castInteger=true}}
-            class="groups-form-visibility-level"
-          />
-
-          <div class="control-instructions">
-            {{i18n
-              "admin.groups.manage.interaction.visibility_levels.description"
-            }}
-          </div>
-        {{/if}}
-
         <fieldset class="groups-form-join-method">
           <legend>{{i18n "groups.manage.membership.join_method_title"}}</legend>
 
-          <JoinMethodOption
-            @value="free"
-            @label={{i18n "groups.manage.membership.join_method.free"}}
-            @class="group-form-public-admission"
-            @selection={{this.joinMethod}}
-            @onChange={{fn this.setJoinMethod "free"}}
-            @disabled={{this.joinMethodDisabled}}
-          />
+          {{#unless this.restrictToInviteOnly}}
+            <JoinMethodOption
+              @value="free"
+              @label={{i18n "groups.manage.membership.join_method.free"}}
+              @class="group-form-public-admission"
+              @selection={{this.joinMethod}}
+              @onChange={{fn this.setJoinMethod "free"}}
+            />
 
-          <JoinMethodOption
-            @value="request"
-            @label={{i18n "groups.manage.membership.join_method.request"}}
-            @class="group-form-allow-membership-requests"
-            @selection={{this.joinMethod}}
-            @onChange={{fn this.setJoinMethod "request"}}
-            @disabled={{this.joinMethodDisabled}}
-          />
+            <JoinMethodOption
+              @value="request"
+              @label={{i18n "groups.manage.membership.join_method.request"}}
+              @class="group-form-allow-membership-requests"
+              @selection={{this.joinMethod}}
+              @onChange={{fn this.setJoinMethod "request"}}
+            />
+          {{/unless}}
 
           <JoinMethodOption
             @value="invite"
@@ -252,12 +248,6 @@ export default class GroupsFormMembershipFields extends Component {
               />
             </div>
           {{/if}}
-
-          {{#if this.joinMethodDisabled}}
-            <div class="control-instructions">
-              {{i18n "groups.manage.membership.join_method_visibility_hint"}}
-            </div>
-          {{/if}}
         </fieldset>
 
         <label class="group-form-public-exit-label">
@@ -271,6 +261,26 @@ export default class GroupsFormMembershipFields extends Component {
         </label>
 
         {{#if this.canAdminGroup}}
+          <label class="groups-form-visibility-label">
+            {{i18n "admin.groups.manage.interaction.visibility_levels.title"}}
+          </label>
+
+          <ComboBox
+            @name="alias"
+            @valueProperty="value"
+            @value={{this.model.visibility_level}}
+            @content={{this.groupVisibilityLevelOptions}}
+            @onChange={{fn (mut this.model.visibility_level)}}
+            @options={{hash castInteger=true}}
+            class="groups-form-visibility-level"
+          />
+
+          <div class="control-instructions">
+            {{i18n
+              "admin.groups.manage.interaction.visibility_levels.description"
+            }}
+          </div>
+
           <label class="groups-form-members-visibility-label">
             {{i18n
               "admin.groups.manage.interaction.members_visibility_levels.title"

--- a/frontend/discourse/tests/acceptance/group-manage-interaction-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-interaction-test.js
@@ -20,10 +20,6 @@ acceptance("Managing Group Interaction Settings", function (needs) {
     await visit("/g/alternative-group/manage/interaction");
 
     assert
-      .dom(".groups-form-visibility-level")
-      .exists("displays visibility level selector");
-
-    assert
       .dom(".groups-form-mentionable-level")
       .exists("displays mentionable level selector");
 
@@ -48,10 +44,6 @@ acceptance("Managing Group Interaction Settings", function (needs) {
     });
 
     await visit("/g/discourse/manage/interaction");
-
-    assert
-      .dom(".groups-form-visibility-level")
-      .doesNotExist("does not display visibility level selector");
 
     assert
       .dom(".groups-form-mentionable-level")

--- a/frontend/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-membership-test.js
@@ -8,8 +8,11 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { i18n } from "discourse-i18n";
 
 acceptance("Managing Group Membership", function (needs) {
+  let savedGroup;
+
   needs.user();
   needs.pretender((server, helper) => {
     server.get("/associated_groups", () =>
@@ -24,7 +27,14 @@ acceptance("Managing Group Membership", function (needs) {
         ],
       })
     );
+
+    server.put("/groups/57", (request) => {
+      savedGroup = helper.parsePostData(request.requestBody).group;
+      return helper.response({ success: "OK" });
+    });
   });
+
+  needs.hooks.beforeEach(() => (savedGroup = null));
 
   test("As an admin", async function (assert) {
     updateCurrentUser({ can_create_group: true });
@@ -115,6 +125,47 @@ acceptance("Managing Group Membership", function (needs) {
     assert
       .dom(".group-form-allow-membership-requests")
       .isDisabled("disables membership requests for a restricted group");
+
+    assert
+      .dom(".groups-form-join-method .control-instructions")
+      .hasText(
+        i18n("groups.manage.membership.join_method_visibility_hint"),
+        "shows a persistent hint explaining why the options are disabled"
+      );
+  });
+
+  test("each join method serializes to the matching booleans on save", async function (assert) {
+    updateCurrentUser({ admin: true });
+
+    await visit("/g/alternative-group/manage/membership");
+
+    await click(".group-form-allow-membership-requests");
+    await click(".group-manage-save");
+
+    assert.strictEqual(
+      savedGroup.public_admission,
+      "false",
+      "by request clears public_admission"
+    );
+    assert.strictEqual(
+      savedGroup.allow_membership_requests,
+      "true",
+      "by request sets allow_membership_requests"
+    );
+
+    await click(".group-form-invite-only");
+    await click(".group-manage-save");
+
+    assert.strictEqual(
+      savedGroup.public_admission,
+      "false",
+      "invite only clears public_admission"
+    );
+    assert.strictEqual(
+      savedGroup.allow_membership_requests,
+      "false",
+      "invite only clears allow_membership_requests"
+    );
   });
 
   test("As an admin on a site that can associate groups", async function (assert) {

--- a/frontend/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-membership-test.js
@@ -32,6 +32,10 @@ acceptance("Managing Group Membership", function (needs) {
     await visit("/g/alternative-group/manage/membership");
 
     assert
+      .dom(".groups-form-visibility-level")
+      .exists("displays visibility level selector");
+
+    assert
       .dom('label[for="automatic_membership"]')
       .exists("displays automatic membership label");
 
@@ -45,36 +49,37 @@ acceptance("Managing Group Membership", function (needs) {
 
     assert
       .dom(".group-form-public-admission")
-      .exists("displays group public admission input");
+      .exists("displays the join freely option");
+
+    assert
+      .dom(".group-form-public-admission")
+      .isChecked("selects join freely for this group");
+
+    assert
+      .dom(".group-form-allow-membership-requests")
+      .exists("displays the membership request option");
+
+    assert
+      .dom(".group-form-invite-only")
+      .exists("displays the invite only option");
 
     assert
       .dom(".group-form-public-exit")
       .exists("displays group public exit input");
 
-    assert
-      .dom(".group-form-allow-membership-requests")
-      .exists("displays group allow_membership_request input");
-
-    assert
-      .dom(".group-form-allow-membership-requests")
-      .isDisabled("disables group allow_membership_request input");
-
     assert.dom(".group-flair-inputs").exists("displays avatar flair inputs");
 
-    await click(".group-form-public-admission");
     await click(".group-form-allow-membership-requests");
 
     assert
-      .dom(".group-form-public-admission")
-      .isDisabled("disables group public admission input");
-
-    assert
-      .dom(".group-form-public-exit")
-      .isNotDisabled("it should not disable group public exit input");
+      .dom(".group-form-allow-membership-requests")
+      .isChecked("selects the membership request option");
 
     assert
       .dom(".group-form-membership-request-template")
-      .exists("displays the membership request template field");
+      .exists(
+        "displays the membership request template field when requests are enabled"
+      );
 
     const emailDomains = selectKit(
       ".group-form-automatic-membership-automatic"
@@ -84,6 +89,32 @@ acceptance("Managing Group Membership", function (needs) {
     await emailDomains.selectRowByValue("foo.com");
 
     assert.strictEqual(emailDomains.header().value(), "foo.com");
+  });
+
+  test("restricting visibility resets an incompatible join method", async function (assert) {
+    updateCurrentUser({ can_create_group: true });
+
+    await visit("/g/alternative-group/manage/membership");
+
+    assert
+      .dom(".group-form-public-admission")
+      .isChecked("join freely is selected for this group");
+
+    const visibility = selectKit(".select-kit.groups-form-visibility-level");
+    await visibility.expand();
+    await visibility.selectRowByValue("2");
+
+    assert
+      .dom(".group-form-invite-only")
+      .isChecked("falls back to invite only once the group is restricted");
+
+    assert
+      .dom(".group-form-public-admission")
+      .isDisabled("disables join freely for a restricted group");
+
+    assert
+      .dom(".group-form-allow-membership-requests")
+      .isDisabled("disables membership requests for a restricted group");
   });
 
   test("As an admin on a site that can associate groups", async function (assert) {
@@ -126,6 +157,10 @@ acceptance("Managing Group Membership", function (needs) {
     await visit("/g/discourse/manage/membership");
 
     assert
+      .dom(".groups-form-visibility-level")
+      .doesNotExist("does not display visibility level selector");
+
+    assert
       .dom('label[for="automatic_membership"]')
       .doesNotExist("it should not display automatic membership label");
 
@@ -151,19 +186,19 @@ acceptance("Managing Group Membership", function (needs) {
 
     assert
       .dom(".group-form-public-admission")
-      .exists("displays group public admission input");
+      .exists("displays the join freely option");
+
+    assert
+      .dom(".group-form-allow-membership-requests")
+      .exists("displays the membership request option");
+
+    assert
+      .dom(".group-form-invite-only")
+      .exists("displays the invite only option");
 
     assert
       .dom(".group-form-public-exit")
       .exists("displays group public exit input");
-
-    assert
-      .dom(".group-form-allow-membership-requests")
-      .exists("displays group allow_membership_request input");
-
-    assert
-      .dom(".group-form-allow-membership-requests")
-      .isDisabled("disables group allow_membership_request input");
   });
 });
 

--- a/frontend/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-membership-test.js
@@ -8,7 +8,6 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
-import { i18n } from "discourse-i18n";
 
 acceptance("Managing Group Membership", function (needs) {
   let savedGroup;
@@ -101,7 +100,7 @@ acceptance("Managing Group Membership", function (needs) {
     assert.strictEqual(emailDomains.header().value(), "foo.com");
   });
 
-  test("restricting visibility resets an incompatible join method", async function (assert) {
+  test("the join method constrains the group's visibility options", async function (assert) {
     updateCurrentUser({ can_create_group: true });
 
     await visit("/g/alternative-group/manage/membership");
@@ -112,26 +111,49 @@ acceptance("Managing Group Membership", function (needs) {
 
     const visibility = selectKit(".select-kit.groups-form-visibility-level");
     await visibility.expand();
+
+    assert
+      .dom(".groups-form-visibility-level .select-kit-row[data-value='2']")
+      .doesNotExist("members-only visibility is removed while anyone can join");
+    assert
+      .dom(".groups-form-visibility-level .select-kit-row[data-value='0']")
+      .exists("public visibility stays available");
+
+    await visibility.collapse();
+
+    await click(".group-form-invite-only");
+    await visibility.expand();
+
+    assert
+      .dom(".groups-form-visibility-level .select-kit-row[data-value='2']")
+      .exists("members-only visibility returns for invite-only groups");
+  });
+
+  test("choosing a join method that needs visibility reopens a restricted group", async function (assert) {
+    updateCurrentUser({ can_create_group: true });
+
+    await visit("/g/alternative-group/manage/membership");
+
+    // make it invite-only first so a restricted visibility can be picked
+    await click(".group-form-invite-only");
+
+    const visibility = selectKit(".select-kit.groups-form-visibility-level");
+    await visibility.expand();
     await visibility.selectRowByValue("2");
 
-    assert
-      .dom(".group-form-invite-only")
-      .isChecked("falls back to invite only once the group is restricted");
+    assert.strictEqual(
+      visibility.header().value(),
+      "2",
+      "members-only visibility is set while invite-only"
+    );
 
-    assert
-      .dom(".group-form-public-admission")
-      .isDisabled("disables join freely for a restricted group");
+    await click(".group-form-public-admission");
 
-    assert
-      .dom(".group-form-allow-membership-requests")
-      .isDisabled("disables membership requests for a restricted group");
-
-    assert
-      .dom(".groups-form-join-method .control-instructions")
-      .hasText(
-        i18n("groups.manage.membership.join_method_visibility_hint"),
-        "shows a persistent hint explaining why the options are disabled"
-      );
+    assert.strictEqual(
+      visibility.header().value(),
+      "0",
+      "switching to join freely resets visibility to public"
+    );
   });
 
   test("each join method serializes to the matching booleans on save", async function (assert) {
@@ -252,6 +274,45 @@ acceptance("Managing Group Membership", function (needs) {
       .exists("displays group public exit input");
   });
 });
+
+acceptance(
+  "Managing Group Membership - non-admin owner of a private group",
+  function (needs) {
+    needs.user();
+    needs.pretender((server, helper) => {
+      server.get("/groups/discourse.json", () => {
+        const cloned = cloneJSON(groupFixtures["/groups/discourse.json"]);
+        cloned.group.visibility_level = 2;
+        cloned.group.public_admission = false;
+        cloned.group.allow_membership_requests = false;
+        cloned.group.can_admin_group = false;
+        return helper.response(cloned);
+      });
+    });
+
+    test("hides the open join methods that need a visible group", async function (assert) {
+      updateCurrentUser({ admin: false, moderator: false });
+
+      await visit("/g/discourse/manage/membership");
+
+      assert
+        .dom(".group-form-invite-only")
+        .exists("invite only remains available");
+
+      assert
+        .dom(".group-form-public-admission")
+        .doesNotExist("join freely is hidden when the group isn't visible");
+
+      assert
+        .dom(".group-form-allow-membership-requests")
+        .doesNotExist("request to join is hidden when the group isn't visible");
+
+      assert
+        .dom(".groups-form-visibility-level")
+        .doesNotExist("a non-admin owner can't change visibility to fix it");
+    });
+  }
+);
 
 acceptance(
   "Automatic Group Tooltip - can_admin_group is true",

--- a/frontend/discourse/tests/acceptance/group-manage-save-button-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-save-button-test.js
@@ -11,8 +11,6 @@ acceptance("Managing Group - Save Button", function (needs) {
 
     await click(".groups-form-primary-group");
 
-    await click('a[href="/g/alternative-group/manage/interaction"]');
-
     const visibilitySelector = selectKit(
       ".select-kit.groups-form-visibility-level"
     );

--- a/spec/system/group_moderator_self_lockout_spec.rb
+++ b/spec/system/group_moderator_self_lockout_spec.rb
@@ -2,7 +2,9 @@
 
 describe "Group moderator self-lockout warning" do
   fab!(:moderator)
-  fab!(:group)
+  # Invite-only so the restrictive visibility levels remain available — a freely
+  # joinable group can't be hidden to members/staff/owners only.
+  fab!(:group) { Fabricate(:group, public_admission: false) }
 
   let(:group_page) { PageObjects::Pages::Group.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
@@ -16,17 +18,17 @@ describe "Group moderator self-lockout warning" do
 
   before { SiteSetting.moderators_manage_groups = true }
 
-  def visit_interaction_settings
+  def visit_membership_settings
     group_page.visit(group)
     group_page.click_manage
-    page.find(".user-secondary-navigation li", text: "Interaction").click
+    page.find(".user-secondary-navigation li", text: "Membership").click
   end
 
   context "when non-owner moderator changes visibility to 'Owners only'" do
     before { sign_in(moderator) }
 
     it "shows confirmation dialog for visibility_level change" do
-      visit_interaction_settings
+      visit_membership_settings
       visibility_chooser.expand
       visibility_chooser.select_row_by_value(Group.visibility_levels[:owners])
       group_page.click_save
@@ -36,7 +38,7 @@ describe "Group moderator self-lockout warning" do
     end
 
     it "shows confirmation dialog for members_visibility_level change" do
-      visit_interaction_settings
+      visit_membership_settings
       members_visibility_chooser.expand
       members_visibility_chooser.select_row_by_value(Group.visibility_levels[:owners])
       group_page.click_save
@@ -46,7 +48,7 @@ describe "Group moderator self-lockout warning" do
     end
 
     it "saves when confirmed" do
-      visit_interaction_settings
+      visit_membership_settings
       visibility_chooser.expand
       visibility_chooser.select_row_by_value(Group.visibility_levels[:owners])
       group_page.click_save
@@ -57,18 +59,18 @@ describe "Group moderator self-lockout warning" do
     end
 
     it "does not save when cancelled" do
-      visit_interaction_settings
+      visit_membership_settings
       visibility_chooser.expand
       visibility_chooser.select_row_by_value(Group.visibility_levels[:owners])
       group_page.click_save
       dialog.click_no
 
-      visit_interaction_settings
+      visit_membership_settings
       expect(visibility_chooser).to have_selected_value(Group.visibility_levels[:public])
     end
 
     it "saves without dialog for non-restrictive visibility levels" do
-      visit_interaction_settings
+      visit_membership_settings
       visibility_chooser.expand
       visibility_chooser.select_row_by_value(Group.visibility_levels[:staff])
       group_page.click_save
@@ -85,7 +87,7 @@ describe "Group moderator self-lockout warning" do
     end
 
     it "saves without showing dialog" do
-      visit_interaction_settings
+      visit_membership_settings
       visibility_chooser.expand
       visibility_chooser.select_row_by_value(Group.visibility_levels[:owners])
       group_page.click_save


### PR DESCRIPTION
Group access is tied to visibility, but these sections aren't currently grouped in the settings, which makes the relationship difficult to see. 

This change merges them into a single section on group creation and edit, so the relationship is more apparent. "Who can join?" is now first, which gives it more control over the "who can see" options. 

There was also some dead code cleaned up here.

Before:
<img width="892" height="904" alt="image" src="https://github.com/user-attachments/assets/52ba2ea1-4201-414d-b044-b5a57ac9d39d" />



After:

<img width="350"  alt="image" src="https://github.com/user-attachments/assets/7ed6b7a2-f826-43e4-8861-5e8f05f60428" />


<img width="400"  alt="image" src="https://github.com/user-attachments/assets/917d583a-3f54-4e1e-9545-5511f3eb7d37" />

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/5db59aab-6896-406b-9a71-68b60b18afda" />

