### PR TITLE
FIX: Apply watched words validation to usernames

### DIFF
--- a/app/models/discourse_connect.rb
+++ b/app/models/discourse_connect.rb
@@ -127,6 +127,8 @@ class DiscourseConnect < DiscourseConnectBase
       sso_record = user.single_sign_on_record
     end
 
+    user.skip_username_watched_words_validation = true
+
     # ensure it's not staged anymore
     user.unstage!
 
@@ -263,6 +265,7 @@ class DiscourseConnect < DiscourseConnectBase
         end
 
         user = User.new(user_params)
+        user.skip_username_watched_words_validation = true
 
         if SiteSetting.must_approve_users && EmailValidator.can_auto_approve_user?(email)
           ReviewableUser.set_approved_fields!(user, Discourse.system_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -252,6 +252,9 @@ class User < ActiveRecord::Base
   # Skip validating email, for example from a particular auth provider plugin
   attr_accessor :skip_email_validation
 
+  # DiscourseConnect is authoritative for usernames, so watched words must not block SSO users.
+  attr_accessor :skip_username_watched_words_validation
+
   # Whether we need to be sending a system message after creation
   attr_accessor :send_welcome_message
 
@@ -1495,7 +1498,11 @@ class User < ActiveRecord::Base
   end
 
   def username_format_validator
-    UsernameValidator.perform_validation(self, "username")
+    UsernameValidator.perform_validation(
+      self,
+      "username",
+      skip_watched_words: skip_username_watched_words_validation,
+    )
   end
 
   def email_confirmed?

--- a/app/models/username_validator.rb
+++ b/app/models/username_validator.rb
@@ -37,6 +37,7 @@ class UsernameValidator
     username_last_char_valid?
     username_no_double_special?
     username_does_not_end_with_confusing_suffix?
+    username_not_watched_word?
     username_plugin_validation
     errors.empty?
   end
@@ -148,6 +149,18 @@ class UsernameValidator
 
     if CONFUSING_EXTENSIONS.match?(username)
       errors << I18n.t(:"user.username.must_not_end_with_confusing_suffix")
+    end
+  end
+
+  def username_not_watched_word?
+    return unless errors.empty?
+
+    if matches = WordWatcher.new(username).word_matches_across_all_actions.presence
+      if matches.size == 1
+        errors << I18n.t(:"user.username.contains_blocked_word", word: matches[0])
+      else
+        errors << I18n.t(:"user.username.contains_blocked_words", words: matches.join(", "))
+      end
     end
   end
 

--- a/app/models/username_validator.rb
+++ b/app/models/username_validator.rb
@@ -15,9 +15,12 @@ class UsernameValidator
     end
   end
 
-  def initialize(username, skip_length_validation: false, object: nil)
+  WATCHED_WORD_ACTIONS = %i[block censor require_approval flag silence].freeze
+
+  def initialize(username, skip_length_validation: false, skip_watched_words: false, object: nil)
     @username = username&.unicode_normalize
     @skip_length_validation = skip_length_validation
+    @skip_watched_words = skip_watched_words
     @object = object
     @errors = []
   end
@@ -26,6 +29,7 @@ class UsernameValidator
   attr_reader :username
   attr_reader :object
   attr_reader :skip_length_validation
+  attr_reader :skip_watched_words
 
   def valid_format?
     username_present?
@@ -37,7 +41,7 @@ class UsernameValidator
     username_last_char_valid?
     username_no_double_special?
     username_does_not_end_with_confusing_suffix?
-    username_not_watched_word?
+    username_not_watched_word? if !skip_watched_words
     username_plugin_validation
     errors.empty?
   end
@@ -155,13 +159,14 @@ class UsernameValidator
   def username_not_watched_word?
     return unless errors.empty?
 
-    if matches = WordWatcher.new(username).word_matches_across_all_actions.presence
-      if matches.size == 1
-        errors << I18n.t(:"user.username.contains_blocked_word", word: matches[0])
-      else
-        errors << I18n.t(:"user.username.contains_blocked_words", words: matches.join(", "))
-      end
-    end
+    matches = WordWatcher.new(username).word_matches_across_actions(WATCHED_WORD_ACTIONS)
+    return if matches.blank?
+
+    errors << I18n.t(
+      :"user.username.contains_blocked_words",
+      count: matches.size,
+      words: matches.join(", "),
+    )
   end
 
   def username_plugin_validation

--- a/app/services/word_watcher.rb
+++ b/app/services/word_watcher.rb
@@ -242,15 +242,17 @@ class WordWatcher
     match_list
   end
 
-  def word_matches_across_all_actions
-    WatchedWord
-      .actions
-      .keys
+  def word_matches_across_actions(actions)
+    actions
       .filter_map { |action| word_matches_for_action?(action, all_matches: true) }
       .flatten
       .compact
       .uniq
       .sort
+  end
+
+  def word_matches_across_all_actions
+    word_matches_across_actions(WatchedWord.actions.keys)
   end
 
   def word_matches?(word, case_sensitive: false)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3462,8 +3462,9 @@ en:
       must_end_with_alphanumeric: "must end with a letter or a number"
       must_not_contain_two_special_chars_in_seq: "must not contain a sequence of 2 or more special chars (.-_)"
       must_not_end_with_confusing_suffix: "must not end with a confusing suffix like .json or .png etc."
-      contains_blocked_word: "contains the blocked word '%{word}'"
-      contains_blocked_words: "contains blocked words: %{words}"
+      contains_blocked_words:
+        one: "contains the blocked word '%{words}'"
+        other: "contains blocked words: %{words}"
     email:
       blank: "can't be blank."
       invalid: "is invalid."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3462,6 +3462,8 @@ en:
       must_end_with_alphanumeric: "must end with a letter or a number"
       must_not_contain_two_special_chars_in_seq: "must not contain a sequence of 2 or more special chars (.-_)"
       must_not_end_with_confusing_suffix: "must not end with a confusing suffix like .json or .png etc."
+      contains_blocked_word: "contains the blocked word '%{word}'"
+      contains_blocked_words: "contains blocked words: %{words}"
     email:
       blank: "can't be blank."
       invalid: "is invalid."

--- a/spec/models/discourse_connect_spec.rb
+++ b/spec/models/discourse_connect_spec.rb
@@ -119,6 +119,24 @@ RSpec.describe DiscourseConnect do
     expect(user.persisted?).to eq(true)
   end
 
+  it "allows users with watched-word usernames to be created and log in" do
+    WatchedWord.create!(word: "blockedword", action: WatchedWord.actions[:block])
+
+    sso = new_discourse_sso
+    sso.username = "blockedword"
+    sso.name = ""
+    sso.email = "blockedword@example.com"
+    sso.external_id = "C"
+    sso.suppress_welcome_message = true
+
+    user = sso.lookup_or_create_user(ip_address)
+    returning_user = sso.lookup_or_create_user(ip_address)
+
+    expect(user).to be_persisted
+    expect(user.username).to eq("blockedword")
+    expect(returning_user).to eq(user)
+  end
+
   it "always creates new users when using plus addressing" do
     SiteSetting.stubs(:normalize_emails).returns(true)
 

--- a/spec/models/username_validator_spec.rb
+++ b/spec/models/username_validator_spec.rb
@@ -315,4 +315,119 @@ RSpec.describe UsernameValidator do
       DiscoursePluginRegistry.unregister_modifier(plugin, modifier, &add_error_block)
     end
   end
+
+  describe "watched words validation" do
+    after { WatchedWord.destroy_all }
+
+    it "is invalid when username contains a blocked watched word" do
+      WatchedWord.create!(word: "blocked", action: WatchedWord.actions[:block])
+
+      expect_invalid(
+        "blocked",
+        error_message: I18n.t(:"user.username.contains_blocked_word", word: "blocked"),
+      )
+    end
+
+    it "is invalid when username contains a blocked watched word with wildcard" do
+      WatchedWord.create!(word: "*bad*", action: WatchedWord.actions[:block])
+
+      validator = UsernameValidator.new("bad")
+      expect(validator.valid_format?).to eq(false)
+      expect(validator.errors.first).to include("blocked word")
+
+      validator = UsernameValidator.new("bad_user")
+      expect(validator.valid_format?).to eq(false)
+      expect(validator.errors.first).to include("blocked word")
+
+      validator = UsernameValidator.new("mybadname")
+      expect(validator.valid_format?).to eq(false)
+      expect(validator.errors.first).to include("blocked word")
+    end
+
+    it "is invalid when username contains a censored watched word" do
+      WatchedWord.create!(word: "*censor*", action: WatchedWord.actions[:censor])
+
+      expect_invalid(
+        "censor_user",
+        error_message: I18n.t(:"user.username.contains_blocked_word", word: "censor_user"),
+      )
+    end
+
+    it "is invalid when username contains a flagged watched word" do
+      WatchedWord.create!(word: "*flag*", action: WatchedWord.actions[:flag])
+
+      expect_invalid(
+        "flag_user",
+        error_message: I18n.t(:"user.username.contains_blocked_word", word: "flag_user"),
+      )
+    end
+
+    it "is invalid when username contains a silenced watched word" do
+      WatchedWord.create!(word: "*silence*", action: WatchedWord.actions[:silence])
+
+      expect_invalid(
+        "silence_user",
+        error_message: I18n.t(:"user.username.contains_blocked_word", word: "silence_user"),
+      )
+    end
+
+    it "is invalid when username contains a require approval watched word" do
+      WatchedWord.create!(word: "*approve*", action: WatchedWord.actions[:require_approval])
+
+      expect_invalid(
+        "approve_user",
+        error_message: I18n.t(:"user.username.contains_blocked_word", word: "approve_user"),
+      )
+    end
+
+    it "is invalid when username contains multiple watched words" do
+      WatchedWord.create!(word: "*bad*", action: WatchedWord.actions[:block])
+      WatchedWord.create!(word: "*evil*", action: WatchedWord.actions[:block])
+
+      validator = UsernameValidator.new("bad_evil_user")
+      expect(validator.valid_format?).to eq(false)
+      expect(validator.errors.first).to include("blocked word")
+    end
+
+    it "is valid when username does not contain any watched words" do
+      WatchedWord.create!(word: "*bad*", action: WatchedWord.actions[:block])
+
+      expect_valid("gooduser", "nice_name")
+    end
+
+    it "is invalid when username matches watched word with word boundaries" do
+      WatchedWord.create!(word: "test", action: WatchedWord.actions[:block])
+
+      expect_invalid(
+        "test",
+        error_message: I18n.t(:"user.username.contains_blocked_word", word: "test"),
+      )
+    end
+
+    it "is valid when username contains watched word but not as complete word" do
+      WatchedWord.create!(word: "test", action: WatchedWord.actions[:block])
+
+      expect_valid("testing", "mytest", "protest")
+    end
+
+    it "is invalid when username contains watched word from any action type" do
+      WatchedWord.create!(word: "*block*", action: WatchedWord.actions[:block])
+      WatchedWord.create!(word: "*censor*", action: WatchedWord.actions[:censor])
+      WatchedWord.create!(word: "*flag*", action: WatchedWord.actions[:flag])
+      WatchedWord.create!(word: "*silence*", action: WatchedWord.actions[:silence])
+      WatchedWord.create!(word: "*approve*", action: WatchedWord.actions[:require_approval])
+
+      %w[
+        user_with_block
+        user_with_censor
+        user_with_flag
+        user_with_silence
+        user_with_approve
+      ].each do |username|
+        validator = UsernameValidator.new(username)
+        expect(validator.valid_format?).to eq(false), "Expected #{username} to be invalid"
+        expect(validator.errors.first).to include("blocked word")
+      end
+    end
+  end
 end

--- a/spec/models/username_validator_spec.rb
+++ b/spec/models/username_validator_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe UsernameValidator do
 
       expect_invalid(
         "blocked",
-        error_message: I18n.t(:"user.username.contains_blocked_word", word: "blocked"),
+        error_message: I18n.t(:"user.username.contains_blocked_words", count: 1, words: "blocked"),
       )
     end
 
@@ -349,7 +349,8 @@ RSpec.describe UsernameValidator do
 
       expect_invalid(
         "censor_user",
-        error_message: I18n.t(:"user.username.contains_blocked_word", word: "censor_user"),
+        error_message:
+          I18n.t(:"user.username.contains_blocked_words", count: 1, words: "censor_user"),
       )
     end
 
@@ -358,7 +359,8 @@ RSpec.describe UsernameValidator do
 
       expect_invalid(
         "flag_user",
-        error_message: I18n.t(:"user.username.contains_blocked_word", word: "flag_user"),
+        error_message:
+          I18n.t(:"user.username.contains_blocked_words", count: 1, words: "flag_user"),
       )
     end
 
@@ -367,7 +369,8 @@ RSpec.describe UsernameValidator do
 
       expect_invalid(
         "silence_user",
-        error_message: I18n.t(:"user.username.contains_blocked_word", word: "silence_user"),
+        error_message:
+          I18n.t(:"user.username.contains_blocked_words", count: 1, words: "silence_user"),
       )
     end
 
@@ -376,7 +379,8 @@ RSpec.describe UsernameValidator do
 
       expect_invalid(
         "approve_user",
-        error_message: I18n.t(:"user.username.contains_blocked_word", word: "approve_user"),
+        error_message:
+          I18n.t(:"user.username.contains_blocked_words", count: 1, words: "approve_user"),
       )
     end
 
@@ -395,12 +399,36 @@ RSpec.describe UsernameValidator do
       expect_valid("gooduser", "nice_name")
     end
 
+    it "is valid when username matches non-moderation watched word actions" do
+      Fabricate(
+        :watched_word,
+        word: "teh",
+        replacement: "the",
+        action: WatchedWord.actions[:replace],
+      )
+      Fabricate(
+        :watched_word,
+        word: "github",
+        replacement: "https://github.com",
+        action: WatchedWord.actions[:link],
+      )
+      Fabricate(:tag, name: "supporttag")
+      Fabricate(
+        :watched_word,
+        word: "support",
+        replacement: "supporttag",
+        action: WatchedWord.actions[:tag],
+      )
+
+      expect_valid("teh", "github", "support")
+    end
+
     it "is invalid when username matches watched word with word boundaries" do
       WatchedWord.create!(word: "test", action: WatchedWord.actions[:block])
 
       expect_invalid(
         "test",
-        error_message: I18n.t(:"user.username.contains_blocked_word", word: "test"),
+        error_message: I18n.t(:"user.username.contains_blocked_words", count: 1, words: "test"),
       )
     end
 
@@ -410,7 +438,7 @@ RSpec.describe UsernameValidator do
       expect_valid("testing", "mytest", "protest")
     end
 
-    it "is invalid when username contains watched word from any action type" do
+    it "is invalid when username contains a watched word from a moderation action" do
       WatchedWord.create!(word: "*block*", action: WatchedWord.actions[:block])
       WatchedWord.create!(word: "*censor*", action: WatchedWord.actions[:censor])
       WatchedWord.create!(word: "*flag*", action: WatchedWord.actions[:flag])

--- a/spec/services/word_watcher_spec.rb
+++ b/spec/services/word_watcher_spec.rb
@@ -412,6 +412,22 @@ RSpec.describe WordWatcher do
     end
   end
 
+  describe "#word_matches_across_actions" do
+    it "only returns words for the specified actions" do
+      Fabricate(:watched_word, action: WatchedWord.actions[:block], word: "blocked")
+      Fabricate(
+        :watched_word,
+        action: WatchedWord.actions[:replace],
+        word: "replaced",
+        replacement: "replacement",
+      )
+
+      watcher = described_class.new("blocked and replaced")
+
+      expect(watcher.word_matches_across_actions(%i[block flag])).to contain_exactly("blocked")
+    end
+  end
+
   describe "word replacement" do
     fab!(:censored_word) do
       Fabricate(:watched_word, word: "censored", action: WatchedWord.actions[:censor])


### PR DESCRIPTION
Usernames can now be blocked if they contain any watched words, regardless of the watched word action type (Block, Censor, Flag, Silence, or Require Approval).

This prevents users from creating or changing usernames that contain inappropriate words, even though those words are already blocked in posts and topics. Admins can use wildcards (*badword*) to match partial words or plain words for exact matches.

The validation uses the existing WordWatcher infrastructure and applies to new signups, username changes via preferences, and admin username edits.

Ref: /t/153312