### PR TITLE
FIX: Carry automation recursion depth across background trigger jobs

### DIFF
--- a/plugins/automation/app/jobs/regular/discourse_automation/trigger.rb
+++ b/plugins/automation/app/jobs/regular/discourse_automation/trigger.rb
@@ -27,7 +27,14 @@ module Jobs
         context = ::DiscourseAutomation::Automation.deserialize_context(args[:context])
 
         automation.running_in_background!
-        automation.trigger!(context)
+        ::DiscourseAutomation.with_recursion_depth(args[:recursion_depth] || 0) do
+          automation.trigger!(context)
+        end
+      rescue ::DiscourseAutomation::RecursionLimitExceeded => e
+        # Stat.log already recorded the error; retrying can never succeed.
+        Rails.logger.warn(
+          "[discourse-automation] #{e.message} (automation_id: #{args[:automation_id]})",
+        )
       end
     end
   end

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -160,8 +160,6 @@ module DiscourseAutomation
       end
 
       if scriptable.background && !running_in_background
-        # The job carries the current depth and the script runs (and is
-        # counted) inside it, so don't increment around a mere enqueue.
         trigger_in_background!(context)
       else
         begin

--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -144,6 +144,7 @@ module DiscourseAutomation
         Jobs::DiscourseAutomation::Trigger,
         automation_id: id,
         context: self.class.serialize_context(context),
+        recursion_depth: DiscourseAutomation.recursion_depth,
       )
     end
 
@@ -158,18 +159,20 @@ module DiscourseAutomation
         end
       end
 
-      begin
-        DiscourseAutomation.increment_recursion_depth
-        if scriptable.background && !running_in_background
-          trigger_in_background!(context)
-        else
+      if scriptable.background && !running_in_background
+        # The job carries the current depth and the script runs (and is
+        # counted) inside it, so don't increment around a mere enqueue.
+        trigger_in_background!(context)
+      else
+        begin
+          DiscourseAutomation.increment_recursion_depth
           Stat.log(id) do
             triggerable&.on_call&.call(self, serialized_fields)
             scriptable.script.call(context, serialized_fields, self)
           end
+        ensure
+          DiscourseAutomation.decrement_recursion_depth
         end
-      ensure
-        DiscourseAutomation.decrement_recursion_depth
       end
     end
 

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -74,6 +74,20 @@ module ::DiscourseAutomation
     Thread.current[RECURSION_DEPTH_KEY] = new_depth.positive? ? new_depth : nil
   end
 
+  # Restores the recursion depth inherited from the thread that enqueued a
+  # background trigger, so the limit holds across job boundaries.
+  def self.with_recursion_depth(depth)
+    raise StandardError, "Expecting a block" if !block_given?
+
+    previous_depth = Thread.current[RECURSION_DEPTH_KEY]
+    Thread.current[RECURSION_DEPTH_KEY] = depth.to_i.positive? ? depth.to_i : nil
+    begin
+      yield
+    ensure
+      Thread.current[RECURSION_DEPTH_KEY] = previous_depth
+    end
+  end
+
   def self.suppressed_triggers_count
     Thread.current[SUPPRESSED_TRIGGERS_KEY] || 0
   end

--- a/plugins/automation/spec/jobs/regular/discourse_automation/trigger_spec.rb
+++ b/plugins/automation/spec/jobs/regular/discourse_automation/trigger_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe Jobs::DiscourseAutomation::Trigger do
+  fab!(:automation) { Fabricate(:automation, enabled: true, script: "recursion_depth_probe") }
+
+  before do
+    DiscourseAutomation::Scriptable.add("recursion_depth_probe") do
+      script { DiscourseAutomation::CapturedContext.add(DiscourseAutomation.recursion_depth) }
+    end
+  end
+
+  after { DiscourseAutomation::Scriptable.remove("recursion_depth_probe") }
+
+  it "resumes the recursion depth inherited from the enqueuing thread" do
+    list =
+      capture_contexts do
+        described_class.new.execute(automation_id: automation.id, context: {}, recursion_depth: 2)
+      end
+
+    expect(list).to eq([3])
+    expect(DiscourseAutomation.recursion_depth).to eq(0)
+  end
+
+  it "runs at depth 1 when no recursion depth is given" do
+    list =
+      capture_contexts { described_class.new.execute(automation_id: automation.id, context: {}) }
+
+    expect(list).to eq([1])
+  end
+
+  it "skips the script and logs an error when the depth limit is reached" do
+    list = nil
+
+    expect {
+      list =
+        capture_contexts do
+          described_class.new.execute(
+            automation_id: automation.id,
+            context: {
+            },
+            recursion_depth: DiscourseAutomation::MAX_RECURSION_DEPTH,
+          )
+        end
+    }.to change {
+      DiscourseAutomation::Stat.where(automation_id: automation.id).sum(:total_errors)
+    }.by(1)
+
+    expect(list).to eq([])
+  end
+end

--- a/plugins/automation/spec/lib/triggerable_spec.rb
+++ b/plugins/automation/spec/lib/triggerable_spec.rb
@@ -79,6 +79,29 @@ describe DiscourseAutomation::Triggerable do
 
       expect(DiscourseAutomation.recursion_depth).to eq(1)
     end
+
+    it "with_recursion_depth seeds the depth and restores the previous one" do
+      DiscourseAutomation.increment_recursion_depth
+
+      DiscourseAutomation.with_recursion_depth(3) do
+        expect(DiscourseAutomation.recursion_depth).to eq(3)
+      end
+
+      expect(DiscourseAutomation.recursion_depth).to eq(1)
+    end
+
+    it "with_recursion_depth restores the previous depth after errors" do
+      expect { DiscourseAutomation.with_recursion_depth(3) { raise "boom" } }.to raise_error("boom")
+
+      expect(DiscourseAutomation.recursion_depth).to eq(0)
+    end
+
+    it "with_recursion_depth requires a block" do
+      expect { DiscourseAutomation.with_recursion_depth(3) }.to raise_error(
+        StandardError,
+        "Expecting a block",
+      )
+    end
   end
 
   describe "#setting" do

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -106,6 +106,19 @@ describe DiscourseAutomation::Automation do
         Jobs::DiscourseAutomation::Trigger.jobs.size
       }.by(1)
     end
+
+    it "carries the current recursion depth into the job" do
+      DiscourseAutomation.increment_recursion_depth
+
+      begin
+        automation.trigger!({ val: "Howdy!" })
+      ensure
+        DiscourseAutomation.decrement_recursion_depth
+      end
+
+      job_args = Jobs::DiscourseAutomation::Trigger.jobs.last["args"].first
+      expect(job_args["recursion_depth"]).to eq(1)
+    end
   end
 
   describe "#remove_id_from_custom_field" do


### PR DESCRIPTION
Follow-up to #40672.

Previously, the recursion depth counter introduced in #40672 was thread-local only, so any automation script marked `run_in_background` restarted at depth 0 inside its Sidekiq job — a cycle of automations involving a background script could re-trigger each other indefinitely without ever reaching the recursion limit.

This change passes the current depth through the `Jobs::DiscourseAutomation::Trigger` job arguments and restores it in the worker thread before the script runs, so the limit holds across job boundaries; hitting the limit inside the job logs the error instead of raising, since retrying can never succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)