### PR TITLE
UX: remove old post controls hover transition

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -577,6 +577,11 @@ nav.post-controls {
       &.create {
         color: var(--d-post-control-create-text-color);
 
+        &:hover {
+          // overrides transition applied while hovering over post
+          transition: none;
+        }
+
         .d-icon {
           color: var(--d-post-control-create-icon-color);
         }

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -382,9 +382,7 @@ nav.post-controls {
   .fade-out {
     .discourse-no-touch & {
       opacity: 0.7;
-      transition:
-        background 0.25s,
-        opacity 0.7s ease-in-out;
+      transition: opacity 0.7s ease-in-out;
     }
 
     .discourse-touch & {
@@ -576,11 +574,6 @@ nav.post-controls {
 
       &.create {
         color: var(--d-post-control-create-text-color);
-
-        &:hover {
-          // overrides transition applied while hovering over post
-          transition: none;
-        }
 
         .d-icon {
           color: var(--d-post-control-create-icon-color);


### PR DESCRIPTION
We no longer transition the background of the post controls, so all it does is cause an unwanted hover effect when hovering the button. The opacity is still used to make the reply button darker when hovering the relevant post. 