### PR TITLE
DEV: move user-stream-item desktop css to common

### DIFF
--- a/app/assets/stylesheets/common/components/user-stream-item.scss
+++ b/app/assets/stylesheets/common/components/user-stream-item.scss
@@ -70,6 +70,10 @@
     font-size: var(--font-up-4);
     margin-right: 0.5rem;
     text-align: center;
+
+    @include viewport.from(sm) {
+      width: 3rem;
+    }
   }
 
   .stream-topic-title {
@@ -196,6 +200,13 @@
       width: 20px;
       height: 20px;
       margin: 0;
+    }
+  }
+
+  @include viewport.from(sm) {
+    .user-stream-item .excerpt,
+    .user-stream-item-actions {
+      margin: 0.75em 0 0 3.5em;
     }
   }
 

--- a/app/assets/stylesheets/desktop/components/_index.scss
+++ b/app/assets/stylesheets/desktop/components/_index.scss
@@ -4,4 +4,3 @@
 @import "sidebar/sidebar-section";
 @import "user-card";
 @import "user-info";
-@import "user-stream-item";

--- a/app/assets/stylesheets/desktop/components/user-stream-item.scss
+++ b/app/assets/stylesheets/desktop/components/user-stream-item.scss
@@ -1,8 +1,0 @@
-.user-stream-item .draft-icon {
-  width: 3rem;
-}
-
-.user-stream-item .excerpt,
-.user-stream-item-actions {
-  margin: 0.75em 0 0 3.5em;
-}


### PR DESCRIPTION
This moves the user-stream-item CSS into /common utilizing breakpoints and deletes the old file. There are no visual changes as a result.