### PR TITLE
DEV: Tune Ruby GC for system test workers in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,25 @@ jobs:
         run: |
           echo "PARALLEL_TEST_PROCESSORS=$(($(nproc) / 2 + 2))" >> $GITHUB_ENV
 
+      # Tune Ruby GC for system test RSpec workers. Each worker eager loads a
+      # large heap at boot and sustains allocator pressure across its spec
+      # shard. Pre-allocating slots lets boot skip repeated heap-grow and GC
+      # cycles, raising the old-malloc limits makes major GCs fire roughly 4x
+      # less often, and the growth factor settings smooth out the steady-state
+      # heap growth curve. This is the same envelope Discourse ships in its
+      # production unicorn launchers.
+      - name: Set Ruby GC tuning for system tests
+        if: matrix.build_type == 'system'
+        run: |
+          echo "RUBY_GC_HEAP_INIT_SLOTS=2000000" >> $GITHUB_ENV
+          echo "RUBY_GC_HEAP_FREE_SLOTS=600000" >> $GITHUB_ENV
+          echo "RUBY_GC_HEAP_GROWTH_FACTOR=1.1" >> $GITHUB_ENV
+          echo "RUBY_GC_HEAP_GROWTH_MAX_SLOTS=300000" >> $GITHUB_ENV
+          echo "RUBY_GC_MALLOC_LIMIT=67108864" >> $GITHUB_ENV
+          echo "RUBY_GC_MALLOC_LIMIT_MAX=1073741824" >> $GITHUB_ENV
+          echo "RUBY_GC_OLDMALLOC_LIMIT=67108864" >> $GITHUB_ENV
+          echo "RUBY_GC_OLDMALLOC_LIMIT_MAX=2147483648" >> $GITHUB_ENV
+
       - name: Set QUNIT_PARALLEL for QUnit tests
         if: matrix.build_type == 'frontend'
         run: |


### PR DESCRIPTION
System test RSpec workers eager load a large heap at boot and sustain allocator pressure across their spec shard. With Ruby's default GC settings, boot pays repeated heap-grow plus GC cycles, and major GCs fire frequently during the example phase.

This change applies the same GC envelope Discourse ships in its production unicorn launchers to all system test workers:

- `RUBY_GC_HEAP_INIT_SLOTS=2000000` pre-allocates slots so boot skips the heap-grow and GC cycles
- `RUBY_GC_MALLOC_LIMIT` / `RUBY_GC_OLDMALLOC_LIMIT` raised to 64MB (with 1GB/2GB ceilings) so major GCs fire roughly 4x less often under sustained allocator pressure
- `RUBY_GC_HEAP_GROWTH_FACTOR=1.1` with a 300k slot cap smooths the steady-state heap growth curve

In isolated measurement on the `core system` job this was worth roughly 5% of the step.

## Measurements

Five marker-bump runs of this branch interleaved with five runs of unmodified `main`, strictly sequential so no two measured runs compete for the runner pool. Durations are the test step of each job, excluding job setup. Each cell is the median of 5 runs unless noted. Control rows are non-system builds where this change sets no environment variables.

| Job | `main` | this branch | Δ |
|---|---|---|---|
| core system | 612s | 636s | +3.9% |
| plugins (core) system | 462s | 447s | -3.2% |
| plugins (chat) system | 530s | 566s (n=4) | +6.7% |
| plugins (official) system | 287s | 282s | -1.7% |
| themes system | 335s | 353s | +5.4% |
| core backend (control) | 422s | 447s | +5.9% |
| plugins backend (control) | 337s | 318s | -5.6% |
| core frontend (control) | 218s | 229s | +5.0% |
| plugins frontend (control) | 128s | 130s | +1.6% |
| themes frontend (control) | 44s | 44s | 0.0% |

One chat run was excluded because the job was cancelled at the 20 minute timeout (round 2).

**Verdict: the isolated win does not reproduce at the workflow level, and two suites regress consistently.** The control rows put this protocol's noise floor at roughly 5%, so the core system delta is not distinguishable from noise. Pairing each run against the baseline run from the same round to cancel time-of-day drift, chat system was slower in 4 of 4 rounds (+4.5% to +10.0%) and themes system in 5 of 5 (+0.9% to +6.9%). That is directionally consistent rather than noise-like. The envelope was tuned against the core suite, and pre-allocating a 2M slot heap per worker looks oversized for the smaller chat and themes suites. Holding this PR pending a re-tune.

Runs measured, `main`: [1](https://github.com/discourse/discourse/actions/runs/27312583139), [2](https://github.com/discourse/discourse/actions/runs/27314613079), [3](https://github.com/discourse/discourse/actions/runs/27316760051), [4](https://github.com/discourse/discourse/actions/runs/27318495373), [5](https://github.com/discourse/discourse/actions/runs/27320210025)
Runs measured, this branch: [1](https://github.com/discourse/discourse/actions/runs/27313079969), [2](https://github.com/discourse/discourse/actions/runs/27315082240), [3](https://github.com/discourse/discourse/actions/runs/27317193955), [4](https://github.com/discourse/discourse/actions/runs/27318993320), [5](https://github.com/discourse/discourse/actions/runs/27320613341)
