### PR TITLE
DEV: Prune unconsumed test instrumentation in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,11 @@ jobs:
         run: |
           echo "PARALLEL_TEST_PROCESSORS=$(($(nproc) / 2 + 2))" >> $GITHUB_ENV
 
+      - name: Prune test instrumentation for system tests
+        if: matrix.build_type == 'system'
+        run: |
+          echo "DISCOURSE_PRUNE_TEST_INSTRUMENTATION=1" >> $GITHUB_ENV
+
       - name: Set QUNIT_PARALLEL for QUnit tests
         if: matrix.build_type == 'frontend'
         run: |

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,11 +30,14 @@ ENV["ENABLE_LOGSTASH_LOGGER"] ||= "1"
 require File.expand_path("../../config/environment", __FILE__)
 Discourse.singleton_class.prepend(RspecWarnExceptionCapture)
 
-# In CI, prune instrumentation whose output is unreachable under
-# `RAILS_TEST_LOG_LEVEL=error` but whose compute cost is paid on every
-# query or request. Set DISCOURSE_KEEP_TEST_INSTRUMENTATION=1 to restore
-# everything for debugging.
-if ENV["CI"] && !ENV["DISCOURSE_KEEP_TEST_INSTRUMENTATION"]
+# In CI system test builds, prune instrumentation whose output is unreachable
+# under `RAILS_TEST_LOG_LEVEL=error` but whose compute cost is paid on every
+# query or request. The backend suite must keep full instrumentation because
+# it contains specs that exercise it directly (method_profiler_spec,
+# hijack_spec, request_tracker_spec), so the workflow only sets this variable
+# when `matrix.build_type == 'system'`. Unset it to restore everything for
+# debugging.
+if ENV["DISCOURSE_PRUNE_TEST_INSTRUMENTATION"] == "1"
   # `config/environments/test.rb` enables query log tags and verbose query
   # logs. Their output never surfaces at the error log level, but every AR
   # query still runs the `request_path` / `Thread.current.object_id` lambdas

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,106 @@ ENV["RAILS_ENV"] ||= "test"
 ENV["ENABLE_LOGSTASH_LOGGER"] ||= "1"
 require File.expand_path("../../config/environment", __FILE__)
 Discourse.singleton_class.prepend(RspecWarnExceptionCapture)
+
+# In CI, prune instrumentation whose output is unreachable under
+# `RAILS_TEST_LOG_LEVEL=error` but whose compute cost is paid on every
+# query or request. Set DISCOURSE_KEEP_TEST_INSTRUMENTATION=1 to restore
+# everything for debugging.
+if ENV["CI"] && !ENV["DISCOURSE_KEEP_TEST_INSTRUMENTATION"]
+  # `config/environments/test.rb` enables query log tags and verbose query
+  # logs. Their output never surfaces at the error log level, but every AR
+  # query still runs the `request_path` / `Thread.current.object_id` lambdas
+  # and builds an SQL comment, and `verbose_query_logs` walks the Ruby stack
+  # via caller_locations on every log emit. Override `QueryLogs.comment` to a
+  # constant nil so the prepended `call(sql, connection)` exits in one branch
+  # without iterating handlers or touching the execution context.
+  ActiveRecord.verbose_query_logs = false
+
+  if defined?(ActiveRecord::QueryLogs)
+    ActiveRecord::QueryLogs.tags = []
+    ActiveRecord::QueryLogs.singleton_class.define_method(:comment) { |_connection| nil }
+  end
+
+  # Mirror the production-only optimization from
+  # `config/initializers/300-perf.rb` into CI test runs. Every AR query
+  # passes through `ActiveSupport::Notifications.instrument("sql.active_record")`.
+  # With AR's LogSubscriber attached, that path allocates a notification
+  # Event and dispatches start/finish across all subscribers, only for
+  # `ActiveRecord::LogSubscriber#sql` to immediately exit because
+  # `RAILS_TEST_LOG_LEVEL=error` keeps the logger level above the
+  # subscriber's `:debug` threshold. With no subscribers, the `instrument`
+  # call short-circuits via `listening?` and just yields the block.
+  # `spec/support/helpers.rb#track_sql_queries` attaches a transient
+  # subscriber via `Notifications.subscribed { ... }` for the duration of a
+  # block, so query-counting tests still work unchanged.
+  ActiveSupport::Notifications.notifier.unsubscribe("sql.active_record")
+
+  # Same idea for the MiniSql path. Every `DB.query`/`DB.exec` flows through
+  # `MiniSqlMultisiteConnection#run`, which builds the `sql.mini_sql`
+  # notification payload eagerly. The `sql:` value runs
+  # `ActiveRecord::Base.sanitize_sql_array` (regex parameter interpolation)
+  # on every parameterized query before `instrument` even checks for
+  # listeners. Unlike AR's path there is no LogSubscriber to unsubscribe
+  # (MiniSql ships none), so gate the whole instrument behind `listening?`.
+  # `track_sql_queries` attaches a transient `sql.mini_sql` subscriber, so
+  # query-counting blocks still measure correctly.
+  MiniSqlMultisiteConnection.class_eval do
+    def run(sql, params)
+      if ActiveSupport::Notifications.notifier.listening?("sql.mini_sql")
+        ActiveSupport::Notifications.instrument(
+          "sql.mini_sql",
+          sql: sql_fragment(sql, *params),
+          name: "MiniSql",
+        )
+      end
+
+      super
+    end
+  end
+
+  # Neutralize MethodProfiler in CI. `Middleware::RequestTracker` wraps every
+  # controller request the in-process test server handles with
+  # `MethodProfiler.start` / `.stop`, and `Hijack` / `Jobs::Base` do the same
+  # for hijacked responses and jobs. While a profiler is active, the
+  # prepended patches on `PG::Connection`, `Redis::Client`,
+  # `RedisClient::RubyConnection`, `Net::HTTP` and `Excon::Connection` record
+  # every call with two `Process.clock_gettime`s plus a hash mutation. A
+  # topic or list request fans out into dozens of SQL queries and Redis
+  # calls, so that is paid hundreds of times per page the system specs
+  # drive. `MethodProfiler.start` also builds a full `GC.stat` Hash on every
+  # request. In CI that timing data only surfaces in the `X-Runtime` header
+  # and lograge's `db`/`redis`/`net` fields, which nothing asserts on.
+  # No-op `start` so `Thread.current[:_method_profiler]` stays nil and every
+  # patched call takes the thread-local nil-check fast path. Every consumer
+  # (`RequestTracker`, `Hijack`, `Jobs::Base`, lograge) is already
+  # nil-guarded on that path.
+  MethodProfiler.singleton_class.prepend(
+    Module.new do
+      def start(_transfer = nil)
+        nil
+      end
+    end,
+  )
+
+  # `UpcomingChanges.clear_caches!` is called per spec via
+  # `TestSetup.test_setup`. The upstream implementation pays three serial
+  # Redis round-trips, and the keys are almost always already gone because
+  # the global `after :each` calls `Discourse.redis.flushdb` at the end of
+  # every spec. Collapse the three DELs into a single multi-key DEL so
+  # workers pay one round-trip per spec, with byte-identical post-condition.
+  UpcomingChanges.singleton_class.prepend(
+    Module.new do
+      def clear_caches!
+        Discourse.redis.del(
+          Discourse.cache.normalize_key(current_statuses_cache_key),
+          Discourse.cache.normalize_key(permanent_upcoming_changes_cache_key),
+          DiscourseUpdates.send(:latest_new_feature_created_at_key),
+        )
+      end
+    end,
+  )
+end
+
 require "rspec/rails"
 require "shoulda-matchers"
 require "sidekiq/testing"


### PR DESCRIPTION
Under `RAILS_TEST_LOG_LEVEL=error`, several instrumentation paths produce output that never surfaces but still pay their full compute cost on every query or request the test suite drives:

1. **ActiveRecord query log tags** run the `request_path` and `Thread.current.object_id` lambdas and build an SQL comment on every query, and `verbose_query_logs` walks the Ruby stack via `caller_locations` on every log emit.
2. **The `sql.active_record` notification** allocates an Event and dispatches start/finish across subscribers on every query, only for `ActiveRecord::LogSubscriber#sql` to exit immediately because the logger level is above its `:debug` threshold. This mirrors the production-only optimization in `config/initializers/300-perf.rb`.
3. **`MiniSqlMultisiteConnection#run`** builds the `sql.mini_sql` notification payload eagerly. The `sql:` value runs `sanitize_sql_array` (regex parameter interpolation) on every parameterized query before `instrument` even checks for listeners.
4. **`MethodProfiler.start`** builds a full `GC.stat` hash on every request, and while a profiler is active the prepended patches on `PG::Connection`, `Redis::Client`, `Net::HTTP` and `Excon` record every call with two `clock_gettime`s plus a hash mutation. A topic or list request fans out into dozens of SQL queries and Redis calls, so this is paid hundreds of times per page in system specs.
5. **`UpcomingChanges.clear_caches!`** pays three serial Redis round-trips per spec for keys the global `flushdb` in the after-each hook has already removed.

This change neutralizes all five, but only in system test builds. The workflow sets `DISCOURSE_PRUNE_TEST_INSTRUMENTATION=1` when `matrix.build_type == 'system'` and `spec/rails_helper.rb` keys off that variable. The backend suite keeps full instrumentation because it contains specs that exercise these paths directly (`method_profiler_spec`, `hijack_spec`, `request_tracker_spec`, `jobs_base_spec`). Query-counting helpers like `track_sql_queries` attach transient subscribers, so the `listening?` guards keep those tests working unchanged. Unset the variable to restore everything when debugging.

In isolated measurement on the `core system` job these were worth roughly 5% of the step combined.

## Measurements

Five marker-bump runs of this branch interleaved with five runs of unmodified `main`, strictly sequential so no two measured runs compete for the runner pool. Durations are the test step of each job, excluding job setup. Each cell is the median of 5 runs unless noted.

Rounds 1 and 2 ran before the gating fix and applied the pruning to every suite, which failed `core backend` on the instrumentation specs (those two runs are excluded from that row). From round 3 on, backend and frontend jobs run code identical to `main`, so those rows are noise readings of the protocol itself.

| Job | `main` | this branch | Δ |
|---|---|---|---|
| core system | 612s | 598s | -2.3% |
| plugins (core) system | 462s | 498s | +7.8% |
| plugins (chat) system | 530s | 537s | +1.3% |
| plugins (official) system | 287s | 283s | -1.4% |
| themes system | 335s | 335s | 0.0% |
| core backend | 422s | 468s (n=3) | +10.9% |
| plugins backend | 337s | 321s | -4.7% |
| core frontend (control) | 218s | 222s | +1.8% |
| plugins frontend (control) | 128s | 129s | +0.8% |
| themes frontend (control) | 44s | 47s | +6.8% |

**Verdict: no row separates from the noise floor.** The core backend row makes the floor concrete, +10.9% on a 3-run median of code identical to `main`. Pairing each run against the baseline run from the same round, core system comes out 0.5% faster with mixed signs across rounds. The isolated 5% measurement sits at the resolution limit of this protocol, so this sweep neither confirms nor refutes it.

Runs measured, `main`: [1](https://github.com/discourse/discourse/actions/runs/27312583139), [2](https://github.com/discourse/discourse/actions/runs/27314613079), [3](https://github.com/discourse/discourse/actions/runs/27316760051), [4](https://github.com/discourse/discourse/actions/runs/27318495373), [5](https://github.com/discourse/discourse/actions/runs/27320210025)
Runs measured, this branch: [1](https://github.com/discourse/discourse/actions/runs/27313641571), [2](https://github.com/discourse/discourse/actions/runs/27315885346), [3](https://github.com/discourse/discourse/actions/runs/27317632694), [4](https://github.com/discourse/discourse/actions/runs/27319416863), [5](https://github.com/discourse/discourse/actions/runs/27321048004)
