### PR TITLE
DEV: Skip the pending migrations check in bin/turbo_rspec on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,11 @@ jobs:
       LOAD_PLUGINS: ${{ (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
       QUNIT_REUSE_BUILD: 1
       PLAYWRIGHT_BROWSERS_PATH: /home/discourse/.cache/ms-playwright
+      # The `Create and migrate databases` step migrates the parent and every
+      # worker DB before any rspec process starts, so bin/turbo_rspec's own
+      # migration check is redundant in CI. Skipping it lets the parent skip
+      # booting the Rails app entirely, so workers spawn earlier.
+      TURBO_RSPEC_SKIP_MIGRATIONS_CHECK: "1"
 
     strategy:
       fail-fast: false

--- a/lib/turbo_tests.rb
+++ b/lib/turbo_tests.rb
@@ -6,16 +6,42 @@ require "open3"
 require "fileutils"
 require "json"
 require "rspec"
-require "rails"
-require File.expand_path("../../config/environment", __FILE__)
 
 require "parallel_tests"
 require "parallel_tests/rspec/runner"
 
+# Used by the formatter / flaky-test paths in lieu of `Rails.root` so the
+# parent process can format reporter output without booting the Rails app.
+TURBO_TESTS_REPO_ROOT = File.expand_path("..", __dir__)
+
+module TurboTests
+  # Boot the Discourse Rails application from inside the parent process.
+  # Only the parent's migration check actually needs Rails; everything else
+  # in `bin/turbo_rspec`'s code path runs on stdlib + rspec + parallel_tests
+  # alone. Calling this is a no-op once Rails has been loaded.
+  def self.load_rails_app!
+    return if @rails_app_loaded
+    require "rails"
+    require File.expand_path("../config/environment", __dir__)
+    @rails_app_loaded = true
+  end
+end
+
+# Explicit requires for files that were previously picked up via Rails'
+# `lib/` autoload. The parent does not load Rails by default, so autoload
+# is unavailable; in workers Rails is loaded later and autoload is a no-op
+# for already-defined constants.
+require "./lib/turbo_tests/base_formatter"
 require "./lib/turbo_tests/reporter"
 require "./lib/turbo_tests/runner"
+require "./lib/turbo_tests/json_example"
 require "./lib/turbo_tests/json_rows_formatter"
 require "./lib/turbo_tests/documentation_formatter"
+require "./lib/turbo_tests/progress_formatter"
+require "./lib/turbo_tests/flaky/failed_example"
+require "./lib/turbo_tests/flaky/manager"
+require "./lib/turbo_tests/flaky/failures_logger_formatter"
+require "./lib/turbo_tests/flaky/flaky_detector_formatter"
 
 RSpec.configure do |config|
   # this is an unusual config option because it is used by the formatter, not just the runner
@@ -34,7 +60,7 @@ module TurboTests
 
     def self.from_obj(obj)
       if obj
-        obj = obj.symbolize_keys
+        obj = obj.transform_keys(&:to_sym)
 
         klass = Class.new(FakeException) { define_singleton_method(:name) { obj[:class_name] } }
 
@@ -54,7 +80,7 @@ module TurboTests
     )
   class FakeExecutionResult
     def self.from_obj(obj)
-      obj = obj.symbolize_keys
+      obj = obj.transform_keys(&:to_sym)
       new(
         obj[:example_skipped?],
         obj[:pending_message],
@@ -80,11 +106,11 @@ module TurboTests
 
   class FakeExample
     def self.from_obj(obj, process_id:, command_string:)
-      obj = obj.symbolize_keys
-      metadata = obj[:metadata].symbolize_keys
+      obj = obj.transform_keys(&:to_sym)
+      metadata = obj[:metadata].transform_keys(&:to_sym)
 
       metadata[:shared_group_inclusion_backtrace].map! do |frame|
-        frame = frame.symbolize_keys
+        frame = frame.transform_keys(&:to_sym)
         RSpec::Core::SharedExampleGroupInclusionStackFrame.new(
           frame[:shared_group_name],
           frame[:inclusion_location],

--- a/lib/turbo_tests/base_formatter.rb
+++ b/lib/turbo_tests/base_formatter.rb
@@ -7,10 +7,10 @@ module TurboTests
     RSpec::Core::Formatters.register(self, :dump_summary)
 
     def dump_summary(notification, timings)
-      output_slowest_examples(timings) if timings.present?
+      output_slowest_examples(timings) unless timings.empty?
 
       totals_by_id, totals_by_origin = aggregate_js_deprecations(notification.examples)
-      output_js_deprecations(totals_by_id, totals_by_origin) if totals_by_id.present?
+      output_js_deprecations(totals_by_id, totals_by_origin) unless totals_by_id.empty?
 
       super(notification)
     end
@@ -111,7 +111,7 @@ module TurboTests
       return nil unless example_file_path
 
       expanded_example_file_path = Pathname.new(example_file_path).expand_path
-      return nil unless expanded_example_file_path.to_s.start_with?(Rails.root.to_s)
+      return nil unless expanded_example_file_path.to_s.start_with?(TURBO_TESTS_REPO_ROOT)
 
       extension_match = example_file_path.match(%r{/(plugins|themes)/([^/]+)/})
       if extension_match

--- a/lib/turbo_tests/flaky/manager.rb
+++ b/lib/turbo_tests/flaky/manager.rb
@@ -3,7 +3,7 @@
 module TurboTests
   module Flaky
     class Manager
-      PATH = Rails.root.join("tmp/turbo_rspec_flaky_tests.json")
+      PATH = File.join(TURBO_TESTS_REPO_ROOT, "tmp/turbo_rspec_flaky_tests.json")
 
       def self.potential_flaky_tests
         JSON
@@ -43,10 +43,10 @@ module TurboTests
               end
             end
 
-        if flaky_tests.present?
-          File.write(PATH, flaky_tests.to_json)
-        else
+        if flaky_tests.empty?
           File.delete(PATH)
+        else
+          File.write(PATH, flaky_tests.to_json)
         end
       end
     end

--- a/lib/turbo_tests/runner.rb
+++ b/lib/turbo_tests/runner.rb
@@ -87,7 +87,7 @@ module TurboTests
 
       @threads.each(&:join)
 
-      if @retry_and_log_flaky_tests && @reporter.failed_examples.present?
+      if @retry_and_log_flaky_tests && !@reporter.failed_examples.empty?
         retry_failed_examples_threshold = 10
 
         if @reporter.failed_examples.length <= retry_failed_examples_threshold
@@ -105,6 +105,16 @@ module TurboTests
     protected
 
     def check_for_migrations
+      # In CI the workflow's `Create and migrate databases` step already
+      # runs `parallel:create parallel:migrate`, which migrates the parent
+      # and every worker DB. Re-checking from here only forces the parent
+      # to boot Rails, pure overhead on the step's serial-prefix critical
+      # path. The caller opts out by setting
+      # TURBO_RSPEC_SKIP_MIGRATIONS_CHECK=1. Local dev runs leave it unset
+      # and pay the full Rails boot from inside `load_rails_app!`.
+      return if ENV["TURBO_RSPEC_SKIP_MIGRATIONS_CHECK"] == "1"
+
+      TurboTests.load_rails_app!
       ActiveRecord::Tasks::DatabaseTasks.migrations_paths = %w[db/migrate db/post_migrate]
       ActiveRecord::Migration.check_all_pending!
     rescue ActiveRecord::PendingMigrationError
@@ -208,7 +218,7 @@ module TurboTests
           File.open(tmp_filename) do |fd|
             fd.each_line do |line|
               message = JSON.parse(line)
-              message = message.symbolize_keys
+              message = message.transform_keys(&:to_sym)
               message[:process_id] = process_id
               message[:command_string] = command_string
               @messages << message


### PR DESCRIPTION
In CI the workflow's `Create and migrate databases` step migrates the parent and every worker database before `bin/turbo_rspec` starts, so the runner's own pending migrations check re-verifies a guarantee the workflow already provides. The check was also the only reason `bin/turbo_rspec`'s parent process loaded the Rails app.

This change skips the check when `TURBO_RSPEC_SKIP_MIGRATIONS_CHECK=1`, which the tests workflow now sets for all jobs, and stops the parent from booting Rails at load time. Booting Rails takes about 0.9s without plugins and 1.6s with plugins loaded (`RAILS_ENV=test`, median of 3 on a warm local checkout, longer on CI runners with cold caches). All of it is serial overhead paid before the first worker can spawn, so the saving lands 1:1 on the test step's wall time in every backend and system job.

Local runs are unchanged. The check still runs by default and boots Rails lazily through `TurboTests.load_rails_app!`.

Since the parent no longer loads Rails or ActiveSupport, the parent-side code paths that leaned on them now use stdlib equivalents: `symbolize_keys` becomes `transform_keys(&:to_sym)`, `present?` becomes `empty?` checks, `Rails.root` becomes `TURBO_TESTS_REPO_ROOT`, and files previously reachable through Rails autoloading are required explicitly.
