### PR TITLE
UX: Dismiss alt text input when clicking image instead of opening lightbox

### DIFF
--- a/app/assets/stylesheets/common/rich-editor/rich-editor.scss
+++ b/app/assets/stylesheets/common/rich-editor/rich-editor.scss
@@ -497,6 +497,10 @@
       cursor: zoom-in;
     }
   }
+
+  &:has(.image-alt-text-input:focus-within) img.ProseMirror-selectednode {
+    cursor: default;
+  }
 }
 
 .image-alt-text-input {

--- a/frontend/discourse/app/static/prosemirror/components/image-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/image-node-view.gjs
@@ -611,8 +611,27 @@ export default class ImageNodeView extends Component {
     this.imageLoaded = true;
   }
 
+  get altInputHasFocus() {
+    return !!this.altMenuInstance?.content?.contains(document.activeElement);
+  }
+
+  @action
+  handleImageMouseDown(event) {
+    // keep the alt input focused so handleImageClick treats this click as
+    // a dismissal — ProseMirror also ignores default-prevented events
+    if (event.button === 0 && this.altInputHasFocus) {
+      event.preventDefault();
+    }
+  }
+
   @action
   async handleImageClick(event) {
+    if (this.altInputHasFocus) {
+      event.preventDefault();
+      this.args.view.focus();
+      return;
+    }
+
     if (this.image.classList.contains("ProseMirror-selectednode")) {
       event?.preventDefault();
       event?.stopPropagation();
@@ -644,6 +663,8 @@ export default class ImageNodeView extends Component {
       role="button"
       {{didInsert this.setupImage}}
       {{on "load" this.updateImageLoaded}}
+      {{! eslint-disable ember/template-no-pointer-down-event-binding }}
+      {{on "mousedown" this.handleImageMouseDown}}
       {{on "click" this.handleImageClick}}
     />
     {{#if this.isPlaceholder}}

--- a/spec/system/composer/prosemirror_images_spec.rb
+++ b/spec/system/composer/prosemirror_images_spec.rb
@@ -195,7 +195,7 @@ describe "Composer - ProseMirror - Images" do
   describe "image lightbox" do
     let(:lightbox) { PageObjects::Components::PhotoSwipe.new }
 
-    def click_selected_image_to_open_lightbox
+    def click_selected_image
       page.execute_script(<<~JS)
         document.querySelector('.composer-image-node img.ProseMirror-selectednode')?.click();
       JS
@@ -205,7 +205,7 @@ describe "Composer - ProseMirror - Images" do
       open_composer
       paste_and_click_image
 
-      click_selected_image_to_open_lightbox
+      click_selected_image
 
       expect(lightbox).to be_visible
       expect(lightbox).to have_no_counter
@@ -227,7 +227,7 @@ describe "Composer - ProseMirror - Images" do
       first_image.click
       expect(first_image[:class]).to include("ProseMirror-selectednode")
 
-      click_selected_image_to_open_lightbox
+      click_selected_image
 
       expect(lightbox).to be_visible
       expect(lightbox).to have_css(".pswp__counter", text: "1 / 2")
@@ -241,12 +241,29 @@ describe "Composer - ProseMirror - Images" do
       expect(page).to have_css("[data-identifier='composer-image-toolbar']")
     end
 
+    it "lets the user dismiss the alt text input by clicking the image without opening the lightbox" do
+      open_composer
+      paste_and_click_image
+
+      find(".image-alt-text-input__display").click
+      find(".image-alt-text-input__field").fill_in(with: "described image")
+
+      click_selected_image
+
+      expect(page).to have_no_css(".image-alt-text-input.--expanded")
+      expect(rich.find(".composer-image-node img")["alt"]).to eq("described image")
+      expect(page).to have_no_css(".pswp")
+
+      click_selected_image
+      expect(lightbox).to be_visible
+    end
+
     it "navigates between images using prev/next buttons" do
       open_composer
       composer.type_content("![first](upload://test1.png)\n\n![second](upload://test2.png)")
 
       rich.find(".composer-image-node img[alt='first']").click
-      click_selected_image_to_open_lightbox
+      click_selected_image
 
       expect(lightbox).to be_visible
       expect(lightbox).to have_caption_title("first")


### PR DESCRIPTION
Previously, clicking a composer image while its alt text input had focus opened the lightbox, because the click handler only checked whether the node was selected.

This change prevents the default `mousedown` action while the input has focus, keeping focus in place and letting ProseMirror skip the gesture, so the click dismisses and saves the alt text input instead of opening the lightbox, with the `zoom-in` cursor suppressed accordingly.