### PR TITLE
DEV: Make automation recursion depth configurable

### DIFF
--- a/plugins/automation/app/models/discourse_automation/automation.rb
+++ b/plugins/automation/app/models/discourse_automation/automation.rb
@@ -151,12 +151,7 @@ module DiscourseAutomation
       return if !enabled
       return if DiscourseAutomation.triggers_suppressed?
 
-      if DiscourseAutomation.recursion_depth >= DiscourseAutomation::MAX_RECURSION_DEPTH
-        Stat.log(id) do
-          raise DiscourseAutomation::RecursionLimitExceeded,
-                "Automation recursion limit exceeded (max: #{DiscourseAutomation::MAX_RECURSION_DEPTH})"
-        end
-      end
+      return if DiscourseAutomation.recursion_depth >= DiscourseAutomation.max_recursion_depth
 
       begin
         DiscourseAutomation.increment_recursion_depth

--- a/plugins/automation/config/locales/server.en.yml
+++ b/plugins/automation/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     discourse_automation_enabled: "Enable discourse-automation plugin"
+    discourse_automation_max_recursion_depth: "Maximum automation recursion depth"
   discourse_automation:
     staff_action_logs:
       empty_value: "(empty)"

--- a/plugins/automation/config/settings.yml
+++ b/plugins/automation/config/settings.yml
@@ -5,3 +5,7 @@ plugins:
   discourse_automation_enable_recurring_debug:
     default: false
     hidden: true
+  discourse_automation_max_recursion_depth:
+    default: 1
+    hidden: true
+    min: 1

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -31,12 +31,8 @@ module ::DiscourseAutomation
   USER_GROUP_MEMBERSHIP_THROUGH_BADGE_BULK_MODIFY_START_COUNT = 1000
   REMOVE_UPLOAD_MARKUP_FROM_DELETED_POSTS_BATCH_SIZE = 1000
 
-  MAX_RECURSION_DEPTH = 5
   RECURSION_DEPTH_KEY = :discourse_automation_recursion_depth
   SUPPRESSED_TRIGGERS_KEY = :discourse_automation_suppressed_triggers
-
-  class RecursionLimitExceeded < StandardError
-  end
 
   def self.set_active_automation(_id)
     deprecated_active_automation_api
@@ -63,6 +59,10 @@ module ::DiscourseAutomation
 
   def self.recursion_depth
     Thread.current[RECURSION_DEPTH_KEY] || 0
+  end
+
+  def self.max_recursion_depth
+    SiteSetting.discourse_automation_max_recursion_depth
   end
 
   def self.increment_recursion_depth

--- a/plugins/automation/spec/integration/infinite_loop_protection_spec.rb
+++ b/plugins/automation/spec/integration/infinite_loop_protection_spec.rb
@@ -37,8 +37,8 @@ describe "Infinite loop protection" do
     )
   end
 
-  it "stops the loop after allowing limited recursive replies" do
-    expected_post_count = 1 + (2 * DiscourseAutomation::MAX_RECURSION_DEPTH)
+  it "silently stops recursive replies at the configured limit" do
+    expected_post_count = 1 + (2 * SiteSetting.discourse_automation_max_recursion_depth)
 
     expect do
       PostCreator.create!(Fabricate(:user), raw: "post", title: "topic", skip_validations: true)
@@ -46,6 +46,6 @@ describe "Infinite loop protection" do
             DiscourseAutomation::Stat.where(automation_id: [automation_1.id, automation_2.id]).sum(
               :total_errors,
             )
-          }.by(2)
+          }.by(0)
   end
 end

--- a/plugins/automation/spec/models/automation_spec.rb
+++ b/plugins/automation/spec/models/automation_spec.rb
@@ -52,7 +52,8 @@ describe DiscourseAutomation::Automation do
 
       after { DiscourseAutomation::Scriptable.remove("recursive_test_scriptable") }
 
-      it "runs nested triggers up to the maximum depth" do
+      it "runs nested triggers up to the configured maximum depth" do
+        SiteSetting.discourse_automation_max_recursion_depth = 5
         automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
 
         list = capture_contexts { automation.trigger!(depth: 1, target_depth: 5) }
@@ -60,23 +61,28 @@ describe DiscourseAutomation::Automation do
         expect(list).to eq([1, 2, 3, 4, 5])
       end
 
-      it "raises when the maximum depth is exceeded" do
+      it "does not allow recursive triggers by default" do
         automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
 
-        expect {
-          capture_contexts { automation.trigger!(depth: 1, target_depth: 6) }
-        }.to raise_error(
-          DiscourseAutomation::RecursionLimitExceeded,
-          /Automation recursion limit exceeded/,
-        )
+        list = capture_contexts { automation.trigger!(depth: 1, target_depth: 2) }
+
+        expect(list).to eq([1])
       end
 
-      it "clears recursion depth after the limit error" do
+      it "silently stops when the configured maximum depth is exceeded" do
+        SiteSetting.discourse_automation_max_recursion_depth = 5
         automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
 
-        expect { automation.trigger!(depth: 1, target_depth: 6) }.to raise_error(
-          DiscourseAutomation::RecursionLimitExceeded,
-        )
+        list = capture_contexts { automation.trigger!(depth: 1, target_depth: 6) }
+
+        expect(list).to eq([1, 2, 3, 4, 5])
+      end
+
+      it "clears recursion depth after the limit is reached" do
+        SiteSetting.discourse_automation_max_recursion_depth = 5
+        automation = Fabricate(:automation, enabled: true, script: "recursive_test_scriptable")
+
+        capture_contexts { automation.trigger!(depth: 1, target_depth: 6) }
 
         list = capture_contexts { automation.trigger!(depth: 1, target_depth: 1) }
 


### PR DESCRIPTION
- Replace the hardcoded automation recursion limit with a hidden site
setting so deployments can tune nested trigger behavior.

discourse_automation_max_recursion_depth

- Stop raising exceptions on recursion guard (to match old behavior)
