### PR TITLE
FIX: Resolve all of a deleted spammer's reviewables

### DIFF
--- a/app/jobs/regular/notify_reviewable.rb
+++ b/app/jobs/regular/notify_reviewable.rb
@@ -16,7 +16,10 @@ class Jobs::NotifyReviewable < ::Jobs::Base
       Reviewable
         .where(id: args[:updated_reviewable_ids])
         .each do |r|
-          payload = { last_performing_username: args[:performing_username], status: r.status }
+          payload = {
+            last_performing_username: args[:performing_username],
+            status: r.status_for_database,
+          }
 
           all_updates[:admins][r.id] = payload
           all_updates[:moderators][r.id] = payload if r.reviewable_by_moderator?

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -359,6 +359,8 @@ class Reviewable < ActiveRecord::Base
 
     validate_action!(guardian, action_id, perform_method, args)
 
+    affected_candidate_ids = reviewable_ids_affected_by(action_id)
+
     result = nil
     update_count = false
     Reviewable.transaction do
@@ -373,6 +375,10 @@ class Reviewable < ActiveRecord::Base
     end
 
     result.after_commit.call if result && result.after_commit
+
+    if result&.success? && affected_candidate_ids.present?
+      result.affected_reviewable_ids |= resolved_reviewable_ids(affected_candidate_ids)
+    end
 
     unless status == :pending
       if update_count || result.remove_reviewable_ids.present?
@@ -845,6 +851,35 @@ class Reviewable < ActiveRecord::Base
   end
 
   private
+
+  # Pending reviewables this action may resolve as a side effect, snapshotted
+  # before it runs so #perform can report the ones it cleared. Override to
+  # change which reviewables a type sweeps.
+  def reviewable_ids_affected_by(action_id)
+    return [] unless delete_user_action?(action_id)
+    pending_reviewable_ids_for_target_user
+  end
+
+  def delete_user_action?(action_id)
+    resolved_action = (aliases[action_id] || action_id).to_sym
+    %i[delete_user delete_and_block_user delete_user_block].include?(resolved_action)
+  end
+
+  def pending_reviewable_ids_for_target_user
+    user = target_created_by || (target if target_type == "User")
+    return [] if user.blank?
+
+    Reviewable
+      .pending
+      .where(target_created_by: user)
+      .or(Reviewable.pending.where(target: user))
+      .where.not(id: id)
+      .pluck(:id)
+  end
+
+  def resolved_reviewable_ids(candidate_ids)
+    candidate_ids - Reviewable.pending.where(id: candidate_ids).pluck(:id)
+  end
 
   def aliases
     self.class.action_aliases

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -359,7 +359,8 @@ class Reviewable < ActiveRecord::Base
 
     validate_action!(guardian, action_id, perform_method, args)
 
-    affected_candidate_ids = reviewable_ids_affected_by(action_id)
+    affected_candidate_ids =
+      delete_user_action?(action_id) ? pending_reviewable_ids_for_target_user : []
 
     result = nil
     update_count = false
@@ -851,14 +852,6 @@ class Reviewable < ActiveRecord::Base
   end
 
   private
-
-  # Pending reviewables this action may resolve as a side effect, snapshotted
-  # before it runs so #perform can report the ones it cleared. Override to
-  # change which reviewables a type sweeps.
-  def reviewable_ids_affected_by(action_id)
-    return [] unless delete_user_action?(action_id)
-    pending_reviewable_ids_for_target_user
-  end
 
   def delete_user_action?(action_id)
     resolved_action = (aliases[action_id] || action_id).to_sym

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -187,13 +187,19 @@ class ReviewableFlaggedPost < Reviewable
   end
 
   def perform_delete_user(performed_by, args)
+    candidate_ids = pending_reviewable_ids_for_target_user
     super
-    agree(performed_by, args)
+    result = agree(performed_by, args)
+    result.affected_reviewable_ids = resolved_reviewable_ids(candidate_ids)
+    result
   end
 
   def perform_delete_and_block_user(performed_by, args)
+    candidate_ids = pending_reviewable_ids_for_target_user
     super
-    agree(performed_by, args)
+    result = agree(performed_by, args)
+    result.affected_reviewable_ids = resolved_reviewable_ids(candidate_ids)
+    result
   end
 
   def perform_agree_and_hide(performed_by, args)
@@ -344,6 +350,21 @@ class ReviewableFlaggedPost < Reviewable
   end
 
   private
+
+  def pending_reviewable_ids_for_target_user
+    return [] if target_created_by_id.blank?
+
+    Reviewable
+      .pending
+      .where(target_created_by: target_created_by)
+      .or(Reviewable.pending.where(target: target_created_by))
+      .where.not(id: id)
+      .pluck(:id)
+  end
+
+  def resolved_reviewable_ids(candidate_ids)
+    candidate_ids - Reviewable.pending.where(id: candidate_ids).pluck(:id)
+  end
 
   def destroyer(performed_by, post)
     PostDestroyer.new(performed_by, post, reviewable_id: id)

--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -187,19 +187,13 @@ class ReviewableFlaggedPost < Reviewable
   end
 
   def perform_delete_user(performed_by, args)
-    candidate_ids = pending_reviewable_ids_for_target_user
     super
-    result = agree(performed_by, args)
-    result.affected_reviewable_ids = resolved_reviewable_ids(candidate_ids)
-    result
+    agree(performed_by, args)
   end
 
   def perform_delete_and_block_user(performed_by, args)
-    candidate_ids = pending_reviewable_ids_for_target_user
     super
-    result = agree(performed_by, args)
-    result.affected_reviewable_ids = resolved_reviewable_ids(candidate_ids)
-    result
+    agree(performed_by, args)
   end
 
   def perform_agree_and_hide(performed_by, args)
@@ -350,21 +344,6 @@ class ReviewableFlaggedPost < Reviewable
   end
 
   private
-
-  def pending_reviewable_ids_for_target_user
-    return [] if target_created_by_id.blank?
-
-    Reviewable
-      .pending
-      .where(target_created_by: target_created_by)
-      .or(Reviewable.pending.where(target: target_created_by))
-      .where.not(id: id)
-      .pluck(:id)
-  end
-
-  def resolved_reviewable_ids(candidate_ids)
-    candidate_ids - Reviewable.pending.where(id: candidate_ids).pluck(:id)
-  end
 
   def destroyer(performed_by, post)
     PostDestroyer.new(performed_by, post, reviewable_id: id)

--- a/app/serializers/reviewable_perform_result_serializer.rb
+++ b/app/serializers/reviewable_perform_result_serializer.rb
@@ -6,6 +6,7 @@ class ReviewablePerformResultSerializer < ApplicationSerializer
     :created_post_id,
     :created_post_topic_id,
     :remove_reviewable_ids,
+    :reviewable_updates,
     :version,
     :reviewable_count,
     :unseen_reviewable_count,
@@ -13,6 +14,17 @@ class ReviewablePerformResultSerializer < ApplicationSerializer
 
   def success
     object.success?
+  end
+
+  def reviewable_updates
+    Reviewable
+      .where(id: object.affected_reviewable_ids)
+      .pluck(:id, :status)
+      .to_h { |id, status| [id, { status: Reviewable.statuses[status] }] }
+  end
+
+  def include_reviewable_updates?
+    object.affected_reviewable_ids.present?
   end
 
   def version

--- a/app/services/user_destroyer.rb
+++ b/app/services/user_destroyer.rb
@@ -122,10 +122,9 @@ class UserDestroyer
       end
     end
 
-    # After the user is deleted, remove the reviewable unless request comes from reviewable
-    return result if opts[:reviewable_id]
+    # The account reviewable's own perform step handles the deletion it initiated.
     reviewable = ReviewableUser.pending.find_by(target: user)
-    reviewable.perform(@actor, :delete_user) if reviewable
+    reviewable.perform(@actor, :delete_user) if reviewable && reviewable.id != opts[:reviewable_id]
 
     result
   end
@@ -145,7 +144,9 @@ class UserDestroyer
     ReviewableFlaggedPost
       .where(target_created_by: user)
       .find_each do |reviewable|
-        if reviewable.actions_for(@guardian).has?(:agree_and_keep)
+        actions = reviewable.actions_for(@guardian)
+
+        if actions.has?(:agree_and_keep) || actions.has?(:agree_and_keep_hidden)
           reviewable.perform(@actor, :agree_and_keep)
         end
       end
@@ -155,6 +156,14 @@ class UserDestroyer
       .find_each do |reviewable|
         if reviewable.actions_for(@guardian).has?(:reject_and_delete)
           reviewable.perform(@actor, :reject_and_delete)
+        end
+      end
+
+    ReviewableQueuedPost
+      .where(target_created_by: user)
+      .find_each do |reviewable|
+        if reviewable.actions_for(@guardian).has?(:reject_post)
+          reviewable.perform(@actor, :reject_post)
         end
       end
   end

--- a/frontend/discourse/app/components/reviewable/index.gjs
+++ b/frontend/discourse/app/components/reviewable/index.gjs
@@ -37,7 +37,11 @@ export default class ReviewIndexRefresh extends Component {
             <div class="reviewables">
               {{#each @controller.reviewables.content as |r|}}
                 {{#if (this.reviewableComponentExists r)}}
-                  <ReviewableItem @reviewable={{r}} @showHelp={{false}} />
+                  <ReviewableItem
+                    @reviewable={{r}}
+                    @showHelp={{false}}
+                    @updateStatuses={{@controller.updateStatuses}}
+                  />
                 {{/if}}
               {{/each}}
             </div>

--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -490,6 +490,10 @@ export default class ReviewableItem extends Component {
     if (this.remove && result.remove_reviewable_ids?.length > 0) {
       this.remove(result.remove_reviewable_ids);
     } else {
+      if (this.updateStatuses && result.reviewable_updates) {
+        this.updateStatuses(result.reviewable_updates);
+      }
+
       return this.store.find("reviewable", reviewable.id);
     }
   }

--- a/frontend/discourse/app/controllers/review/index.js
+++ b/frontend/discourse/app/controllers/review/index.js
@@ -140,6 +140,17 @@ export default class ReviewIndexController extends Controller {
   }
 
   @action
+  updateStatuses(updates) {
+    this.reviewables.content.forEach((reviewable) => {
+      const update = updates[reviewable.id];
+
+      if (update) {
+        reviewable.setProperties(update);
+      }
+    });
+  }
+
+  @action
   resetTopic() {
     this.set("topic_id", null);
     this.refreshModel();

--- a/frontend/discourse/app/routes/review/index.js
+++ b/frontend/discourse/app/routes/review/index.js
@@ -73,12 +73,7 @@ export default class ReviewIndex extends DiscourseRoute {
   @bind
   _updateReviewables(data) {
     if (data.updates) {
-      this.controller.reviewables.content.forEach((reviewable) => {
-        const updates = data.updates[reviewable.id];
-        if (updates) {
-          reviewable.setProperties(updates);
-        }
-      });
+      this.controller.updateStatuses(data.updates);
     }
   }
 

--- a/lib/reviewable/perform_result.rb
+++ b/lib/reviewable/perform_result.rb
@@ -8,6 +8,7 @@ class Reviewable < ActiveRecord::Base
     attr_accessor(
       :transition_to,
       :remove_reviewable_ids,
+      :affected_reviewable_ids,
       :errors,
       :recalculate_score,
       :update_flag_stats,
@@ -18,6 +19,7 @@ class Reviewable < ActiveRecord::Base
       @status = status
       @reviewable = reviewable
       @remove_reviewable_ids = success? ? [reviewable.id] : []
+      @affected_reviewable_ids = []
     end
 
     def created_post=(created_post)

--- a/plugins/discourse-ai/spec/system/reviewable_spec.rb
+++ b/plugins/discourse-ai/spec/system/reviewable_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+describe "Resolving reviewables when deleting a spammer from an AI post reviewable" do
+  fab!(:admin)
+  fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:watching_admin, :admin)
+
+  let(:review_page) { PageObjects::Pages::Review.new }
+
+  before do
+    enable_current_plugin
+    sign_in(admin)
+    Jobs.run_immediately!
+  end
+
+  it "resolves every reviewable tied to the spammer in the acting and watching queues" do
+    acted_ai_post =
+      ReviewableAiPost.needs_review!(
+        target: Fabricate(:post, user: spammer),
+        created_by: Discourse.system_user,
+      )
+    flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
+    flag.target.update!(
+      hidden: true,
+      hidden_at: Time.zone.now,
+      hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+    )
+    queued_post =
+      Fabricate(
+        :reviewable_queued_post,
+        created_by: Discourse.system_user,
+        target_created_by: spammer,
+      )
+    user_review = ReviewableUser.create_for(spammer)
+    review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
+
+    all = [acted_ai_post, flag, queued_post, user_review, review_every_post]
+
+    using_session(:other_tab) do
+      sign_in(watching_admin)
+      visit("/review")
+
+      expect(review_page).to have_reviewables(all)
+    end
+
+    visit("/review")
+
+    expect(review_page).to have_reviewables(all)
+
+    review_page.select_bundled_action(acted_ai_post, "post-delete_user_block", bundle_index: 1)
+
+    expect(review_page).to have_reviewable_with_approved_status(acted_ai_post)
+    expect(review_page).to have_reviewable_with_approved_status(flag)
+    expect(review_page).to have_reviewable_with_rejected_status(queued_post)
+    expect(review_page).to have_reviewable_with_rejected_status(user_review)
+    expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+
+    using_session(:other_tab) do
+      expect(review_page).to have_reviewable_with_approved_status(acted_ai_post)
+      expect(review_page).to have_reviewable_with_approved_status(flag)
+      expect(review_page).to have_reviewable_with_rejected_status(queued_post)
+      expect(review_page).to have_reviewable_with_rejected_status(user_review)
+      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/system/reviewable_spec.rb
+++ b/plugins/discourse-ai/spec/system/reviewable_spec.rb
@@ -1,67 +1,19 @@
 # frozen_string_literal: true
 
-describe "Resolving reviewables when deleting a spammer from an AI post reviewable" do
-  fab!(:admin)
-  fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
-  fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
-  fab!(:watching_admin, :admin)
-
-  let(:review_page) { PageObjects::Pages::Review.new }
+describe "Resolving an AI post reviewable on user deletion" do
+  fab!(:current_user, :admin)
 
   before do
     enable_current_plugin
-    sign_in(admin)
-    Jobs.run_immediately!
+    sign_in(current_user)
   end
 
-  it "resolves every reviewable tied to the spammer in the acting and watching queues" do
-    acted_ai_post =
-      ReviewableAiPost.needs_review!(
-        target: Fabricate(:post, user: spammer),
-        created_by: Discourse.system_user,
-      )
-    flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
-    flag.target.update!(
-      hidden: true,
-      hidden_at: Time.zone.now,
-      hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+  let(:acted_reviewable) do
+    ReviewableAiPost.needs_review!(
+      target: Fabricate(:post, user: spammer),
+      created_by: Discourse.system_user,
     )
-    queued_post =
-      Fabricate(
-        :reviewable_queued_post,
-        created_by: Discourse.system_user,
-        target_created_by: spammer,
-      )
-    user_review = ReviewableUser.create_for(spammer)
-    review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
-
-    all = [acted_ai_post, flag, queued_post, user_review, review_every_post]
-
-    using_session(:other_tab) do
-      sign_in(watching_admin)
-      visit("/review")
-
-      expect(review_page).to have_reviewables(all)
-    end
-
-    visit("/review")
-
-    expect(review_page).to have_reviewables(all)
-
-    review_page.select_bundled_action(acted_ai_post, "post-delete_user_block", bundle_index: 1)
-
-    expect(review_page).to have_reviewable_with_approved_status(acted_ai_post)
-    expect(review_page).to have_reviewable_with_approved_status(flag)
-    expect(review_page).to have_reviewable_with_rejected_status(queued_post)
-    expect(review_page).to have_reviewable_with_rejected_status(user_review)
-    expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
-
-    using_session(:other_tab) do
-      expect(review_page).to have_reviewable_with_approved_status(acted_ai_post)
-      expect(review_page).to have_reviewable_with_approved_status(flag)
-      expect(review_page).to have_reviewable_with_rejected_status(queued_post)
-      expect(review_page).to have_reviewable_with_rejected_status(user_review)
-      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
-    end
   end
+
+  include_examples "resolving a spammer's reviewables on user deletion"
 end

--- a/spec/jobs/notify_reviewable_spec.rb
+++ b/spec/jobs/notify_reviewable_spec.rb
@@ -8,6 +8,27 @@ RSpec.describe Jobs::NotifyReviewable do
     fab!(:group) { group_user.group }
     fab!(:user) { group_user.user }
 
+    it "publishes status updates for handled reviewables as integers" do
+      reviewable = Fabricate(:reviewable, reviewable_by_moderator: false)
+      reviewable.update!(status: Reviewable.statuses[:approved])
+
+      messages =
+        MessageBus.track_publish("/reviewable_counts/#{admin.id}") do
+          described_class.new.execute(
+            reviewable_id: reviewable.id,
+            performing_username: admin.username,
+            updated_reviewable_ids: [reviewable.id],
+          )
+        end
+
+      expect(messages.first.data[:updates]).to eq(
+        reviewable.id => {
+          last_performing_username: admin.username,
+          status: Reviewable.statuses[:approved],
+        },
+      )
+    end
+
     it "will notify users of new reviewable content for the user menu" do
       SiteSetting.navigation_menu = "sidebar"
       SiteSetting.enable_category_group_moderation = true

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -632,6 +632,28 @@ RSpec.describe ReviewablesController do
       fab!(:reviewable)
       before { sign_in(Fabricate(:moderator)) }
 
+      it "includes the statuses of the other reviewables resolved by the action in the response" do
+        sign_in(Fabricate(:admin))
+        spammer = Fabricate(:user, refresh_auto_groups: true)
+        flagger = Fabricate(:user, refresh_auto_groups: true)
+        acted_flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
+        queued_post =
+          Fabricate(
+            :reviewable_queued_post,
+            created_by: Discourse.system_user,
+            target_created_by: spammer,
+          )
+
+        put "/review/#{acted_flag.id}/perform/delete_user_block.json?version=#{acted_flag.version}"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("reviewable_perform_result", "reviewable_updates")).to eq(
+          queued_post.id.to_s => {
+            "status" => Reviewable.statuses[:rejected],
+          },
+        )
+      end
+
       it "returns 404 when the reviewable does not exist" do
         put "/review/12345/perform/approve_user.json?version=0"
         expect(response.code).to eq("404")

--- a/spec/services/user_destroyer_spec.rb
+++ b/spec/services/user_destroyer_spec.rb
@@ -278,6 +278,55 @@ RSpec.describe UserDestroyer do
               reviewable.reload
               expect(reviewable).to be_rejected
             end
+
+            it "approves reviewable flags on hidden posts" do
+              spammer_post = Fabricate(:post, user: user)
+              reviewable = PostActionCreator.inappropriate(admin, spammer_post).reviewable
+              spammer_post.update!(
+                hidden: true,
+                hidden_at: Time.zone.now,
+                hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+              )
+              expect(reviewable).to be_pending
+
+              destroy
+
+              expect(reviewable.reload).to be_approved
+            end
+
+            it "rejects queued posts" do
+              reviewable =
+                Fabricate(
+                  :reviewable_queued_post,
+                  created_by: Discourse.system_user,
+                  target_created_by: user,
+                )
+              expect(reviewable).to be_pending
+
+              destroy
+
+              expect(reviewable.reload).to be_rejected
+            end
+
+            it "rejects the user's account reviewable when reviewable_id is a different reviewable" do
+              flag_reviewable =
+                PostActionCreator.inappropriate(admin, Fabricate(:post, user: user)).reviewable
+              account_reviewable = ReviewableUser.create_for(user)
+              destroy_opts[:reviewable_id] = flag_reviewable.id
+
+              destroy
+
+              expect(account_reviewable.reload).to be_rejected
+            end
+
+            it "leaves the user's account reviewable pending when reviewable_id is its id" do
+              account_reviewable = ReviewableUser.create_for(user)
+              destroy_opts[:reviewable_id] = account_reviewable.id
+
+              destroy
+
+              expect(account_reviewable.reload).to be_pending
+            end
           end
         end
 

--- a/spec/support/shared_examples/resolving_spammer_reviewables_on_user_deletion.rb
+++ b/spec/support/shared_examples/resolving_spammer_reviewables_on_user_deletion.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "resolving a spammer's reviewables on user deletion" do
+  fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:watching_admin, :admin)
+
+  let(:review_page) { PageObjects::Pages::Review.new }
+
+  before { Jobs.run_immediately! }
+
+  it "resolves every reviewable tied to the spammer in the acting and watching queues" do
+    flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
+    flag.target.update!(
+      hidden: true,
+      hidden_at: Time.zone.now,
+      hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+    )
+    queued_post =
+      Fabricate(
+        :reviewable_queued_post,
+        created_by: Discourse.system_user,
+        target_created_by: spammer,
+      )
+    user_review = ReviewableUser.create_for(spammer)
+    review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
+
+    action, resolved_status =
+      case acted_reviewable.type
+      when "ReviewableFlaggedPost", "ReviewableAiPost"
+        ["post-delete_user_block", :approved]
+      when "ReviewableQueuedPost"
+        ["delete_user", :rejected]
+      end
+
+    all = [acted_reviewable, flag, queued_post, user_review, review_every_post]
+
+    using_session(:other_tab) do
+      sign_in(watching_admin)
+      visit("/review")
+
+      expect(review_page).to have_reviewables(all)
+    end
+
+    visit("/review")
+
+    expect(review_page).to have_reviewables(all)
+
+    review_page.delete_user_from_reviewable(acted_reviewable, action)
+
+    expect(review_page).to have_reviewable_with_status(acted_reviewable, resolved_status)
+    expect(review_page).to have_reviewable_with_approved_status(flag)
+    expect(review_page).to have_reviewable_with_rejected_status(queued_post)
+    expect(review_page).to have_reviewable_with_rejected_status(user_review)
+    expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+
+    using_session(:other_tab) do
+      expect(review_page).to have_reviewable_with_status(acted_reviewable, resolved_status)
+      expect(review_page).to have_reviewable_with_approved_status(flag)
+      expect(review_page).to have_reviewable_with_rejected_status(queued_post)
+      expect(review_page).to have_reviewable_with_rejected_status(user_review)
+      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+    end
+  end
+end

--- a/spec/system/page_objects/pages/review.rb
+++ b/spec/system/page_objects/pages/review.rb
@@ -32,6 +32,10 @@ module PageObjects
         end
       end
 
+      def delete_user_from_reviewable(reviewable, action)
+        select_bundled_action(reviewable, action, bundle_index: 1)
+      end
+
       def click_post_body_toggle
         find(POST_BODY_TOGGLE_SELECTOR).click
       end
@@ -189,6 +193,12 @@ module PageObjects
 
       def click_insights_tab
         find(".action-list li.insights").click
+      end
+
+      def has_reviewable_with_status?(reviewable, status)
+        within(reviewable_by_id(reviewable.id)) do
+          page.has_css?(".review-item__status.--#{status}")
+        end
       end
 
       def has_reviewable_with_approved_status?(reviewable)

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -387,4 +387,63 @@ describe "Reviewables" do
       expect(title_html).to include("&lt;b&gt;")
     end
   end
+
+  describe "when deleting and blocking a spammer from a hidden flagged post" do
+    fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:watching_admin, :admin)
+
+    before { Jobs.run_immediately! }
+
+    it "resolves every reviewable tied to the spammer in the acting and watching queues" do
+      acted_flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
+      other_flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
+
+      [acted_flag, other_flag].each do |reviewable|
+        reviewable.target.update!(
+          hidden: true,
+          hidden_at: Time.zone.now,
+          hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+        )
+      end
+
+      queued_post =
+        Fabricate(
+          :reviewable_queued_post,
+          created_by: Discourse.system_user,
+          target_created_by: spammer,
+        )
+      user_review = ReviewableUser.create_for(spammer)
+      review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
+
+      all = [acted_flag, other_flag, queued_post, user_review, review_every_post]
+
+      using_session(:other_tab) do
+        sign_in(watching_admin)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(all)
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables(all)
+
+      review_page.select_bundled_action(acted_flag, "post-delete_user_block", bundle_index: 1)
+
+      expect(review_page).to have_reviewable_with_approved_status(acted_flag)
+      expect(review_page).to have_reviewable_with_approved_status(other_flag)
+      expect(review_page).to have_reviewable_with_rejected_status(queued_post)
+      expect(review_page).to have_reviewable_with_rejected_status(user_review)
+      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_approved_status(acted_flag)
+        expect(review_page).to have_reviewable_with_approved_status(other_flag)
+        expect(review_page).to have_reviewable_with_rejected_status(queued_post)
+        expect(review_page).to have_reviewable_with_rejected_status(user_review)
+        expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+      end
+    end
+  end
 end

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -446,4 +446,56 @@ describe "Reviewables" do
       end
     end
   end
+
+  describe "when deleting a spammer from a queued post" do
+    fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:watching_admin, :admin)
+
+    before { Jobs.run_immediately! }
+
+    it "resolves every reviewable tied to the spammer in the acting and watching queues" do
+      acted_queued_post =
+        Fabricate(
+          :reviewable_queued_post,
+          created_by: Discourse.system_user,
+          target_created_by: spammer,
+        )
+      flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
+      flag.target.update!(
+        hidden: true,
+        hidden_at: Time.zone.now,
+        hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+      )
+      user_review = ReviewableUser.create_for(spammer)
+      review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
+
+      all = [acted_queued_post, flag, user_review, review_every_post]
+
+      using_session(:other_tab) do
+        sign_in(watching_admin)
+        visit("/review")
+
+        expect(review_page).to have_reviewables(all)
+      end
+
+      visit("/review")
+
+      expect(review_page).to have_reviewables(all)
+
+      review_page.select_bundled_action(acted_queued_post, "delete_user")
+
+      expect(review_page).to have_reviewable_with_rejected_status(acted_queued_post)
+      expect(review_page).to have_reviewable_with_approved_status(flag)
+      expect(review_page).to have_reviewable_with_rejected_status(user_review)
+      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+
+      using_session(:other_tab) do
+        expect(review_page).to have_reviewable_with_rejected_status(acted_queued_post)
+        expect(review_page).to have_reviewable_with_approved_status(flag)
+        expect(review_page).to have_reviewable_with_rejected_status(user_review)
+        expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
+      end
+    end
+  end
 end

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -389,113 +389,28 @@ describe "Reviewables" do
   end
 
   describe "when deleting and blocking a spammer from a hidden flagged post" do
-    fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
-    fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
-    fab!(:watching_admin, :admin)
-
-    before { Jobs.run_immediately! }
-
-    it "resolves every reviewable tied to the spammer in the acting and watching queues" do
-      acted_flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
-      other_flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
-
-      [acted_flag, other_flag].each do |reviewable|
-        reviewable.target.update!(
-          hidden: true,
-          hidden_at: Time.zone.now,
-          hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
-        )
-      end
-
-      queued_post =
-        Fabricate(
-          :reviewable_queued_post,
-          created_by: Discourse.system_user,
-          target_created_by: spammer,
-        )
-      user_review = ReviewableUser.create_for(spammer)
-      review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
-
-      all = [acted_flag, other_flag, queued_post, user_review, review_every_post]
-
-      using_session(:other_tab) do
-        sign_in(watching_admin)
-        visit("/review")
-
-        expect(review_page).to have_reviewables(all)
-      end
-
-      visit("/review")
-
-      expect(review_page).to have_reviewables(all)
-
-      review_page.select_bundled_action(acted_flag, "post-delete_user_block", bundle_index: 1)
-
-      expect(review_page).to have_reviewable_with_approved_status(acted_flag)
-      expect(review_page).to have_reviewable_with_approved_status(other_flag)
-      expect(review_page).to have_reviewable_with_rejected_status(queued_post)
-      expect(review_page).to have_reviewable_with_rejected_status(user_review)
-      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
-
-      using_session(:other_tab) do
-        expect(review_page).to have_reviewable_with_approved_status(acted_flag)
-        expect(review_page).to have_reviewable_with_approved_status(other_flag)
-        expect(review_page).to have_reviewable_with_rejected_status(queued_post)
-        expect(review_page).to have_reviewable_with_rejected_status(user_review)
-        expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
-      end
-    end
-  end
-
-  describe "when deleting a spammer from a queued post" do
-    fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
-    fab!(:spammer) { Fabricate(:user, refresh_auto_groups: true) }
-    fab!(:watching_admin, :admin)
-
-    before { Jobs.run_immediately! }
-
-    it "resolves every reviewable tied to the spammer in the acting and watching queues" do
-      acted_queued_post =
-        Fabricate(
-          :reviewable_queued_post,
-          created_by: Discourse.system_user,
-          target_created_by: spammer,
-        )
+    let(:acted_reviewable) do
       flag = PostActionCreator.spam(flagger, Fabricate(:post, user: spammer)).reviewable
       flag.target.update!(
         hidden: true,
         hidden_at: Time.zone.now,
         hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
       )
-      user_review = ReviewableUser.create_for(spammer)
-      review_every_post = ReviewablePost.queue_for_review(Fabricate(:post, user: spammer))
-
-      all = [acted_queued_post, flag, user_review, review_every_post]
-
-      using_session(:other_tab) do
-        sign_in(watching_admin)
-        visit("/review")
-
-        expect(review_page).to have_reviewables(all)
-      end
-
-      visit("/review")
-
-      expect(review_page).to have_reviewables(all)
-
-      review_page.select_bundled_action(acted_queued_post, "delete_user")
-
-      expect(review_page).to have_reviewable_with_rejected_status(acted_queued_post)
-      expect(review_page).to have_reviewable_with_approved_status(flag)
-      expect(review_page).to have_reviewable_with_rejected_status(user_review)
-      expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
-
-      using_session(:other_tab) do
-        expect(review_page).to have_reviewable_with_rejected_status(acted_queued_post)
-        expect(review_page).to have_reviewable_with_approved_status(flag)
-        expect(review_page).to have_reviewable_with_rejected_status(user_review)
-        expect(review_page).to have_reviewable_with_rejected_status(review_every_post)
-      end
+      flag
     end
+
+    include_examples "resolving a spammer's reviewables on user deletion"
+  end
+
+  describe "when deleting a spammer from a queued post" do
+    let(:acted_reviewable) do
+      Fabricate(
+        :reviewable_queued_post,
+        created_by: Discourse.system_user,
+        target_created_by: spammer,
+      )
+    end
+
+    include_examples "resolving a spammer's reviewables on user deletion"
   end
 end


### PR DESCRIPTION
When a moderator picks "Delete User" or "Delete and Block User" on one of the spammer's flagged posts, deleting the user is meant to settle all of their reviewables, since there is no user left to act on. Previously only part of that happened:

- `UserDestroyer#agree_with_flags` resolved the spammer's other flagged posts by checking for the `agree_and_keep` action, but a flag on a hidden post only offers `agree_and_keep_hidden`, so those flags were skipped and stayed pending forever.
- Queued posts by the spammer were never touched, so they also stayed pending.
- `UserDestroyer#destroy` skips resolving the spammer's account reviewable when a `reviewable_id` option is present. That option is meant to prevent the account reviewable from resolving itself twice when the deletion starts from it, but the guard only checked presence, so a deletion starting from a flagged post also skipped the account reviewable.
- The browser updates review queue rows from message bus broadcasts. Those can arrive after the page has stopped waiting, so the acting moderator kept seeing the affected rows as "Pending" until a full reload. Acting on one of those stale rows returns a 403 because the target user no longer exists.

This PR resolves every reviewable tied to the deleted user and updates the acting moderator's review queue without a reload.