### PR TITLE
FIX: Close float-kit menus on route change

### DIFF
--- a/frontend/discourse/float-kit/services/menu.js
+++ b/frontend/discourse/float-kit/services/menu.js
@@ -2,11 +2,31 @@ import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { trackedSet } from "@ember/reactive/collections";
 import { schedule } from "@ember/runloop";
-import Service from "@ember/service";
+import Service, { service } from "@ember/service";
 import DMenuInstance from "discourse/float-kit/lib/d-menu-instance";
+import { bind } from "discourse/lib/decorators";
 
 export default class Menu extends Service {
+  @service router;
+
   registeredMenus = trackedSet();
+
+  constructor() {
+    super(...arguments);
+    this.router.on("routeWillChange", this.onRouteWillChange);
+  }
+
+  willDestroy() {
+    this.router.off("routeWillChange", this.onRouteWillChange);
+    super.willDestroy(...arguments);
+  }
+
+  @bind
+  onRouteWillChange() {
+    for (const menu of [...this.registeredMenus]) {
+      menu.close({ focusTrigger: false });
+    }
+  }
 
   /**
    * Render a menu

--- a/frontend/discourse/tests/acceptance/float-kit-menu-test.js
+++ b/frontend/discourse/tests/acceptance/float-kit-menu-test.js
@@ -1,0 +1,22 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("FloatKit - DMenu", function () {
+  test("an open menu closes on route change", async function (assert) {
+    await visit("/");
+
+    await this.owner
+      .lookup("service:menu")
+      .show(document.querySelector("#site-logo"), {
+        identifier: "route-change-test",
+        content: "content",
+      });
+
+    assert.dom("[data-identifier='route-change-test']").exists();
+
+    await visit("/u/eviltrout");
+
+    assert.dom("[data-identifier='route-change-test']").doesNotExist();
+  });
+});


### PR DESCRIPTION
Previously, an open d-menu (e.g. a `modalForMobile` drawer) survived browser back/forward navigation, leaving the menu floating over the new route and — on mobile — leaving the body scroll-locked, which broke scroll restoration and dumped the user at the bottom of the page.

This change closes all registered float-kit menus on `routeWillChange`, so the drawer unmounts and releases its body scroll lock before the new route's scroll restoration runs.