### PR TITLE
UX: Allow dragging mobile modals and menu drawers to close

### DIFF
--- a/frontend/discourse/app/ui-kit/d-modal.gjs
+++ b/frontend/discourse/app/ui-kit/d-modal.gjs
@@ -27,6 +27,13 @@ export const CLOSE_INITIATED_BY_MODAL_SHOW = "initiatedByModalShow";
 export const CLOSE_INITIATED_BY_SWIPE_DOWN = "initiatedBySwipeDown";
 
 const SWIPE_VELOCITY_THRESHOLD = 0.4;
+const SWIPE_CLOSE_DISTANCE_RATIO = 0.25;
+const SWIPE_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
+
+// progressive resistance when the modal is dragged past its resting position
+function dampenedOverdrag(distance) {
+  return Math.max(0, 8 * (Math.log(distance + 1) - 2));
+}
 
 export default class DModal extends Component {
   @service appEvents;
@@ -146,14 +153,26 @@ export default class DModal extends Component {
   }
 
   @action
+  handleSwipeStart(swipeState, event) {
+    if (this.#shouldDeferSwipeToContent(swipeState)) {
+      event.preventDefault();
+    }
+  }
+
+  @action
   async handleSwipe(swipeEvent) {
     if (this.animating) {
       return;
     }
 
-    if (swipeEvent.deltaY >= 0) {
-      return await this.#animateWrapperPosition(swipeEvent.deltaY);
-    }
+    // applied instantly so the modal tracks the finger 1:1; easing only
+    // happens when the gesture ends
+    const position =
+      swipeEvent.deltaY >= 0
+        ? swipeEvent.deltaY
+        : -dampenedOverdrag(-swipeEvent.deltaY);
+
+    await this.#animateWrapperPosition(position, 0);
   }
 
   @action
@@ -164,14 +183,18 @@ export default class DModal extends Component {
       return;
     }
 
+    const closeDistance =
+      this.modalContainer.clientHeight * SWIPE_CLOSE_DISTANCE_RATIO;
+
     if (
       swipeEvent.goingUp() ||
-      swipeEvent.velocityY < SWIPE_VELOCITY_THRESHOLD
+      swipeEvent.deltaY <= 0 ||
+      (swipeEvent.velocityY < SWIPE_VELOCITY_THRESHOLD &&
+        swipeEvent.deltaY < closeDistance)
     ) {
-      return await this.#animateWrapperPosition(0);
+      return await this.#animateWrapperPosition(0, getMaxAnimationTimeMs());
     }
 
-    this.modalContainer.style.transform = `translateY(${swipeEvent.deltaY}px)`;
     this.closeModal(CLOSE_INITIATED_BY_SWIPE_DOWN);
   }
 
@@ -212,6 +235,8 @@ export default class DModal extends Component {
 
       if (this.site.desktopView) {
         await this.#animatePopOff();
+      } else if (initiatedBy === CLOSE_INITIATED_BY_SWIPE_DOWN) {
+        await this.#animateSwipeDismiss();
       } else {
         const backdrop = this.wrapperElement.nextElementSibling;
         this.modalContainer.classList.add("is-exiting");
@@ -277,6 +302,40 @@ export default class DModal extends Component {
     return dElement(tagName);
   }
 
+  // lets inner content consume the gesture instead of dragging the modal:
+  // horizontal swipes, and vertical swipes started within scrollable content
+  // that can still scroll in the gesture's direction
+  #shouldDeferSwipeToContent(swipeState) {
+    if (swipeState.direction === "left" || swipeState.direction === "right") {
+      return true;
+    }
+
+    let element = swipeState.originalEvent?.target;
+
+    while (element && element !== this.modalContainer) {
+      if (element.scrollHeight > element.clientHeight) {
+        const { overflowY } = window.getComputedStyle(element);
+
+        if (overflowY === "auto" || overflowY === "scroll") {
+          if (swipeState.direction === "down" && element.scrollTop > 0) {
+            return true;
+          }
+
+          if (
+            swipeState.direction === "up" &&
+            element.scrollTop + element.clientHeight < element.scrollHeight
+          ) {
+            return true;
+          }
+        }
+      }
+
+      element = element.parentElement;
+    }
+
+    return false;
+  }
+
   #animateBackdropOpacity(position) {
     const backdrop = this.wrapperElement.nextElementSibling;
 
@@ -293,7 +352,7 @@ export default class DModal extends Component {
     );
   }
 
-  async #animateWrapperPosition(position) {
+  async #animateWrapperPosition(position, duration) {
     this.#animateBackdropOpacity(position);
 
     await waitForPromise(
@@ -301,9 +360,33 @@ export default class DModal extends Component {
         [{ transform: `translateY(${position}px)` }],
         {
           fill: "forwards",
-          duration: getMaxAnimationTimeMs(),
+          duration,
+          easing: SWIPE_SETTLE_EASING,
         }
       ).finished
+    );
+  }
+
+  // dismisses from the current dragged position; the `is-exiting` CSS
+  // animation can't be used here as it animates from translateY(0) and is
+  // overridden by the drag's fill-forwards animations anyway
+  async #animateSwipeDismiss() {
+    const duration = getMaxAnimationTimeMs();
+    const backdrop = this.wrapperElement.nextElementSibling;
+
+    if (backdrop) {
+      waitForPromise(
+        backdrop.animate([{ opacity: 0 }], { fill: "forwards", duration })
+          .finished
+      );
+    }
+
+    await waitForPromise(
+      this.modalContainer.animate([{ transform: "translateY(100%)" }], {
+        fill: "forwards",
+        duration,
+        easing: SWIPE_SETTLE_EASING,
+      }).finished
     );
   }
 
@@ -350,7 +433,16 @@ export default class DModal extends Component {
         {{willDestroy this.cleanupModal}}
         {{dTrapTab preventScroll=false autofocus=this.autofocus}}
       >
-        <div class="d-modal__container" {{this.registerModalContainer}}>
+        <div
+          class="d-modal__container"
+          {{this.registerModalContainer}}
+          {{dSwipe
+            onDidStartSwipe=this.handleSwipeStart
+            onDidSwipe=this.handleSwipe
+            onDidEndSwipe=this.handleSwipeEnded
+            enabled=this.dismissable
+          }}
+        >
           {{yield to="aboveHeader"}}
 
           {{#if
@@ -372,11 +464,6 @@ export default class DModal extends Component {
                   "--has-primary-action"
                 )
                 @headerClass
-              }}
-              {{dSwipe
-                onDidSwipe=this.handleSwipe
-                onDidEndSwipe=this.handleSwipeEnded
-                enabled=this.dismissable
               }}
             >
               {{yield to="headerAboveTitle"}}

--- a/frontend/discourse/app/ui-kit/modifiers/d-swipe.js
+++ b/frontend/discourse/app/ui-kit/modifiers/d-swipe.js
@@ -68,10 +68,11 @@ export default class DSwipeModifier extends Modifier {
     }
   ) {
     if (enabled === false || this.site.desktopView) {
-      this.enabled = enabled;
+      this.enabled = false;
       return;
     }
 
+    this.enabled = true;
     this.lockBody = lockBody ?? true;
     this.element = element;
     this.onDidSwipeCallback = onDidSwipe;
@@ -89,16 +90,23 @@ export default class DSwipeModifier extends Modifier {
   }
 
   /**
-   * Handler for swipe start event.
+   * Handler for swipe start event. The callback can cancel the gesture by
+   * calling `preventDefault()` on the event, in which case the body is not
+   * locked and no further swipe events are fired for this gesture.
    * @param {Event} event - The swipe start event.
    */
   @bind
   onDidStartSwipe(event) {
-    if (this.lockBody) {
-      lock(this.element);
+    this.onDidStartSwipeCallback?.(event.detail, event);
+
+    if (event.defaultPrevented) {
+      return;
     }
 
-    this.onDidStartSwipeCallback?.(event.detail, event);
+    if (this.lockBody) {
+      lock(this.element);
+      this.bodyLocked = true;
+    }
   }
 
   /**
@@ -107,10 +115,7 @@ export default class DSwipeModifier extends Modifier {
    */
   @bind
   onDidEndSwipe(event) {
-    if (this.lockBody) {
-      unlock(this.element);
-    }
-
+    this.#unlockBody();
     this.onDidEndSwipeCallback?.(event.detail);
   }
 
@@ -129,10 +134,7 @@ export default class DSwipeModifier extends Modifier {
    */
   @bind
   onDidCancelSwipe(event) {
-    if (this.lockBody) {
-      unlock(this.element);
-    }
-
+    this.#unlockBody();
     this.onDidCancelSwipeCallback?.(event.detail);
   }
 
@@ -158,9 +160,13 @@ export default class DSwipeModifier extends Modifier {
     this.element.removeEventListener("swipe", this.onDidSwipe);
     this.element.removeEventListener("scroll", this.onScroll);
     this._swipeEvents.removeTouchListeners();
+    this.#unlockBody();
+  }
 
-    if (this.lockBody) {
+  #unlockBody() {
+    if (this.bodyLocked) {
       unlock(this.element);
+      this.bodyLocked = false;
     }
   }
 }

--- a/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/float-kit/d-menu-test.gjs
@@ -29,6 +29,21 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     await triggerEvent(".fk-d-menu__trigger.-expanded", "click");
   }
 
+  async function swipeDown(selector) {
+    await triggerEvent(selector, "touchstart", {
+      touches: [{ clientX: 0, clientY: 0 }],
+      changedTouches: [{ clientX: 0, clientY: 0 }],
+    });
+    await triggerEvent(selector, "touchmove", {
+      touches: [{ clientX: 0, clientY: 200 }],
+      changedTouches: [{ clientX: 0, clientY: 200 }],
+    });
+    await triggerEvent(selector, "touchend", {
+      touches: [],
+      changedTouches: [{ clientX: 0, clientY: 200 }],
+    });
+  }
+
   test("@label", async function (assert) {
     await render(
       <template><DMenu @inline={{true}} @label="label" /></template>
@@ -70,6 +85,49 @@ module("Integration | Component | FloatKit | DMenu", function (hooks) {
     await open();
 
     assert.dom(".fk-d-menu-modal[data-identifier='foo']").hasText("content");
+  });
+
+  test("@modalForMobile - swipe down to close", async function (assert) {
+    forceMobile();
+
+    await render(
+      <template>
+        <DMenu
+          @identifier="foo"
+          @inline={{true}}
+          @modalForMobile={{true}}
+          @content="content"
+        />
+      </template>
+    );
+    await open();
+
+    assert.dom(".fk-d-menu-modal").exists();
+
+    await swipeDown(".fk-d-menu-modal .d-modal__container");
+
+    assert.dom(".fk-d-menu-modal").doesNotExist();
+  });
+
+  test("@modalForMobile - swipe down defers to scrolled content", async function (assert) {
+    forceMobile();
+
+    await render(
+      <template>
+        <DMenu @identifier="foo" @inline={{true}} @modalForMobile={{true}}>
+          <div class="test-scroll-area" style="height: 50px; overflow-y: auto">
+            <div style="height: 500px">tall content</div>
+          </div>
+        </DMenu>
+      </template>
+    );
+    await open();
+
+    document.querySelector(".test-scroll-area").scrollTop = 100;
+
+    await swipeDown(".test-scroll-area");
+
+    assert.dom(".fk-d-menu-modal").exists();
   });
 
   test("@onRegisterApi", async function (assert) {


### PR DESCRIPTION
Previously, drag-to-close only worked on the modal header and the backdrop, so `modalForMobile` d-menu drawers (which hide the header) could only be dismissed by dragging *outside* the drawer; the drag also lagged behind the finger because each frame was applied through a 200ms animation, and a released swipe froze in place instead of animating off-screen.

This change attaches the swipe handling to the whole modal container with scroll-aware coordination (vertical drags defer to inner scrollable content that can consume them), tracks the finger 1:1 during the drag, dismisses from the released position with an eased slide-out, and closes on drag distance (25% of the sheet) in addition to flick velocity.

It also fixes two latent `d-swipe` modifier bugs the new path would have exposed: a body-scroll-lock leak when a swipe start is cancelled, and `cleanup()` never running because `this.enabled` was never set on the enabled path.