### PR TITLE
FIX: Stat type grouping

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -51,7 +51,7 @@ class Stat
   end
 
   def self.calculate(stats)
-    stats.map { |stat| stat.calculate }.reduce(Hash.new, :merge)
+    stats.map { |stat| stat.calculate }.reduce({}) { |memo, result| memo.deep_merge(result) }
   end
 
   def self.core_stats

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -45,5 +45,14 @@ RSpec.describe Stat do
         Stat.new("test", stat_type: :test) { { "7_days" => 1, "30_days" => 10, "count" => 100 } }
       expect(stat.calculate).to eq({ test: { test_7_days: 1, test_30_days: 10, test_count: 100 } })
     end
+
+    it "merges multiple stats with the same stat type" do
+      stats = [
+        Stat.new("boards", stat_type: :kanban) { { count: 1 } },
+        Stat.new("cards", stat_type: :kanban) { { count: 2 } },
+      ]
+
+      expect(Stat.send(:calculate, stats)).to eq({ kanban: { boards_count: 1, cards_count: 2 } })
+    end
   end
 end


### PR DESCRIPTION
Followup 11e8302beb6407b6f3f2bb32882a95d1687f14b5

Shallow Hash#merge overwrote nested stat_type buckets when multiple
plugins registered stats under the same type (e.g. :kanban), so only
the last stat survived.

Before:

```
  Stat.all_stats[:kanban]
  # => { kanban_participating_users_last_day: 0, ... }
```

After:

```
  Stat.all_stats[:kanban]
  # => { kanban_total_boards_last_day: 0, kanban_viewed_boards_last_day: 0,
  #      kanban_active_boards_last_day: 0, kanban_active_users_last_day: 0,
  #      kanban_participating_users_last_day: 0, ... }
```
