### PR TITLE
DEV: Update discourse-details description and README

### DIFF
--- a/plugins/discourse-details/README.md
+++ b/plugins/discourse-details/README.md
@@ -1,8 +1,10 @@
 ### discourse-details
 
-HTML 5.1 `<details>` polyfill for [Discourse](https://www.discourse.org).
+Adds collapsible `[details]` sections to posts in [Discourse](https://www.discourse.org).
 
-NOTE: Does not work on IE9, but we don't support IE9 as of Jan 1 2016.
+The plugin registers the `[details]` BBCode tag, a composer toolbar button and
+rich editor support, and handles rendering these sections in emails and
+excerpts. It renders to the native HTML `<details>`/`<summary>` elements.
 
 ## Usage
 
@@ -12,11 +14,6 @@ For example:
 ``` text
    I watched the murder mystery on TV last night. [details=Who did it?]The butler did it[/details].
 ```
-
-## Installation
-
-Follow our [Install a Plugin](https://meta.discourse.org/t/install-a-plugin/19157) howto, using
-`git clone https://github.com/discourse/discourse-details.git` as the plugin command.
 
 ## Issues
 

--- a/plugins/discourse-details/plugin.rb
+++ b/plugins/discourse-details/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # name: discourse-details
-# about: HTML5.1 Details polyfill for Discourse
+# about: Adds collapsible `[details]` sections to posts
 # version: 0.4
 # authors: Régis Hanol
 # url: https://github.com/discourse/discourse/tree/main/plugins/discourse-details


### PR DESCRIPTION
The plugin metadata and README described it as an "HTML5.1 Details
polyfill" with an IE9 note, which is long obsolete now that
`<details>/<summary>` is universally supported. The plugin is really the
implementation of the [details] BBCode feature (markdown rule, composer
button, rich editor support, email/excerpt rendering).

Update the about line and README to describe what the plugin actually
does, and drop the stale standalone-repo installation instructions since
it ships bundled with core.
