### PR TITLE
DEV: Explore a faster system test stack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,16 @@ jobs:
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
-      EMBER_ENV: development
+      # `production` for system builds makes every system-spec page load parse
+      # a minified, tree-shaken bundle instead of the much larger development
+      # build, cutting the in-browser parse/boot time the suite pays on each
+      # of its thousands of navigations. The dev-only `rails-testing.js` test
+      # bridge (`window.clientSettled`) is dead-code-eliminated from
+      # production builds, so spec/support injects a build-independent
+      # reimplementation via a Playwright init script and settle semantics are
+      # unchanged. Specs that depend on dev-build-only behaviour (deprecation
+      # assertions, /theme-qunit) are skipped when EMBER_ENV=production.
+      EMBER_ENV: ${{ matrix.build_type == 'system' && 'production' || 'development' }}
       LOAD_PLUGINS: ${{ (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
       QUNIT_REUSE_BUILD: 1
       PLAYWRIGHT_BROWSERS_PATH: /home/discourse/.cache/ms-playwright
@@ -103,6 +112,11 @@ jobs:
         if: matrix.build_type == 'system'
         run: |
           echo "PARALLEL_TEST_PROCESSORS=$(($(nproc) / 2 + 2))" >> $GITHUB_ENV
+
+      - name: Prune test instrumentation for system tests
+        if: matrix.build_type == 'system'
+        run: |
+          echo "DISCOURSE_PRUNE_TEST_INSTRUMENTATION=1" >> $GITHUB_ENV
 
       - name: Set QUNIT_PARALLEL for QUnit tests
         if: matrix.build_type == 'frontend'

--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,7 @@ group :test do
   gem "test-prof"
   gem "rails-dom-testing", require: false
   gem "minio_runner", require: false
-  gem "capybara-playwright-driver"
+  gem "capybara-playwright-driver", path: "vendor/gems/capybara-playwright-driver"
   gem "puma", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,14 @@ PATH
       migrations-core
       zeitwerk
 
+PATH
+  remote: vendor/gems/capybara-playwright-driver
+  specs:
+    capybara-playwright-driver (0.5.9)
+      addressable
+      capybara
+      playwright-ruby-client (>= 1.16.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -162,10 +170,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-playwright-driver (0.5.9)
-      addressable
-      capybara
-      playwright-ruby-client (>= 1.16.0)
     cbor (0.5.10.2)
     certified (1.0.0)
     cgi (0.5.1)
@@ -832,7 +836,7 @@ DEPENDENCIES
   bootsnap
   bullet
   capybara
-  capybara-playwright-driver
+  capybara-playwright-driver!
   cbor
   certified
   cgi (>= 0.3.6)
@@ -1013,7 +1017,7 @@ CHECKSUMS
   bullet (8.1.3) sha256=c8163c527324fe1180775be48719875726891622f0a73784658b2992acf3c7cb
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
-  capybara-playwright-driver (0.5.9) sha256=4c17fed20817b7e1bde2cfc8186e7bf5cd72017ce1aa695e35130f8e600e7282
+  capybara-playwright-driver (0.5.9)
   cbor (0.5.10.2) sha256=df5104f7a62c881123e6505441b1e276208be1771540c2cc3b1de8a210a7c52c
   certified (1.0.0) sha256=aa4cdf0e90e7ee96f6e0ce3daae39eaa8f0486124e0d92daf64d2105aeb9069c
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,31 @@ ENV["RAILS_ENV"] ||= "test"
 ENV["ENABLE_LOGSTASH_LOGGER"] ||= "1"
 require File.expand_path("../../config/environment", __FILE__)
 Discourse.singleton_class.prepend(RspecWarnExceptionCapture)
+
+# In CI system test builds, remove the permanently attached LogSubscribers
+# whose output is unreachable under `RAILS_TEST_LOG_LEVEL=error` but whose
+# dispatch cost is paid on every request the browser drives. Every AR query
+# fires `sql.active_record` and every model-loading SELECT fires
+# `instantiation.active_record`, and each server-rendered bootstrap template
+# or partial fires a `render_*.action_view` event. With a LogSubscriber
+# attached, each event allocates a notification Event and dispatches
+# start/finish, only for the subscriber to exit immediately because the log
+# level is above its `:debug` threshold. With no subscriber, `instrument`
+# short-circuits via `notifier.listening?`. Helpers like `track_sql_queries`
+# attach transient subscribers for the duration of a block, so query-counting
+# specs are unaffected. The workflow only sets this variable when
+# `matrix.build_type == 'system'`.
+if ENV["DISCOURSE_PRUNE_TEST_INSTRUMENTATION"] == "1"
+  %w[
+    sql.active_record
+    instantiation.active_record
+    render_template.action_view
+    render_partial.action_view
+    render_collection.action_view
+    render_layout.action_view
+  ].each { |event| ActiveSupport::Notifications.notifier.unsubscribe(event) }
+end
+
 require "rspec/rails"
 require "shoulda-matchers"
 require "sidekiq/testing"

--- a/spec/support/client_settled_bridge.rb
+++ b/spec/support/client_settled_bridge.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "capybara/playwright"
+
+# A build-independent reimplementation of the `window.clientSettled` test
+# bridge from `frontend/discourse/app/initializers/rails-testing.js`. That
+# initializer is wrapped in `if (DEBUG && isRailsTesting())`, so a
+# `production` Ember build dead-code-eliminates it and every `clientSettled`
+# settle-wait silently no-ops — leaving system specs racing ajax responses
+# and re-renders. Injecting the same tracking logic via a Playwright init
+# script restores identical settle semantics for production builds. For
+# development builds this is inert: the script runs at document start, and
+# the app's own initializer overwrites `window.clientSettled` during boot.
+module ClientSettledBridge
+  JS = <<~JS
+    (() => {
+      if (window.__discourseClientSettledBridge) {
+        return;
+      }
+      window.__discourseClientSettledBridge = true;
+
+      const pendingRequests = [];
+      const pendingDomEvents = [];
+      let pendingBeaconRequests = 0;
+
+      // Parity with `discourse/lib/beacon-pageview`'s own in-flight counter,
+      // tracked here by wrapping fetch since the module's counter is
+      // unreachable from outside the app bundle.
+      const originalFetch = window.fetch;
+      window.fetch = function (resource, options) {
+        const url =
+          typeof resource === "string" ? resource : (resource && resource.url) || "";
+        const isBeacon = url.includes("/srv/pv");
+        if (isBeacon) {
+          pendingBeaconRequests++;
+        }
+        const promise = originalFetch.apply(this, arguments);
+        if (isBeacon) {
+          promise.then(
+            () => pendingBeaconRequests--,
+            () => pendingBeaconRequests--
+          );
+        }
+        return promise;
+      };
+
+      const deferEventCycles = ({ callback, numberOfEventCycles = 1 }) => {
+        if (numberOfEventCycles > 0) {
+          return setTimeout(() => {
+            deferEventCycles({
+              callback,
+              numberOfEventCycles: numberOfEventCycles - 1,
+            });
+          }, 0);
+        } else {
+          return callback();
+        }
+      };
+
+      const incrementAjaxPendingRequests = (_event, xhr, settings) => {
+        if (
+          settings.url.includes("/message-bus") ||
+          settings.url.includes("/presence/")
+        ) {
+          return;
+        }
+        pendingRequests.push({ xhr, url: settings.url });
+      };
+
+      const decrementAjaxPendingRequests = (_event, xhr) => {
+        for (let i = 0; i < pendingRequests.length; i++) {
+          if (xhr === pendingRequests[i].xhr) {
+            pendingRequests.splice(i, 1);
+            break;
+          }
+        }
+      };
+
+      // jQuery is bundled with the app and loads after this init script, so
+      // poll until the bundle's instance is reachable, then attach the same
+      // global ajax handlers the dev-build initializer attaches.
+      const resolveJQuery = () => {
+        try {
+          if (window.require) {
+            const mod = window.require("jquery");
+            if (mod && mod.default) {
+              return mod.default;
+            }
+          }
+        } catch {}
+        return window.jQuery;
+      };
+
+      let jqueryPollCount = 0;
+      const jqueryPoll = setInterval(() => {
+        const $ = resolveJQuery();
+        if ($) {
+          clearInterval(jqueryPoll);
+          $(document)
+            .on("ajaxSend", incrementAjaxPendingRequests)
+            .on("ajaxComplete ajaxError", decrementAjaxPendingRequests);
+        } else if (++jqueryPollCount > 3000) {
+          clearInterval(jqueryPoll);
+        }
+      }, 10);
+
+      [
+        "click",
+        "input",
+        "mousedown",
+        "keydown",
+        "focusin",
+        "focusout",
+        "touchstart",
+        "change",
+        "resize",
+        "scroll",
+      ].forEach((eventName) => {
+        document.addEventListener(
+          eventName,
+          (event) => {
+            pendingDomEvents.push(event);
+
+            deferEventCycles({
+              callback: () => {
+                const index = pendingDomEvents.indexOf(event);
+
+                if (index !== -1) {
+                  pendingDomEvents.splice(index, 1);
+                }
+              },
+              numberOfEventCycles: 2,
+            });
+          },
+          true
+        );
+      });
+
+      const settled = () => {
+        return (
+          pendingRequests.length === 0 &&
+          pendingDomEvents.length === 0 &&
+          pendingBeaconRequests === 0
+        );
+      };
+
+      const timeoutErrorMessage = (timeoutMs) => {
+        let errorMessage = `Timeout waiting for client to settle after ${timeoutMs}ms.`;
+        const pendingRequestURLs = pendingRequests.map((req) => req.url);
+
+        if (pendingRequestURLs.length > 0) {
+          errorMessage += `\\n  Pending requests: ${pendingRequestURLs.join(", ")}`;
+        }
+
+        if (pendingDomEvents.length > 0) {
+          const pendingDomEventsText = pendingDomEvents.map(
+            (event) => `${event.type} on ${event.target?.tagName?.toLowerCase()}`
+          );
+          errorMessage += `\\n  Pending DOM events: ${pendingDomEventsText.join(", ")}`;
+        }
+
+        if (pendingBeaconRequests > 0) {
+          errorMessage += `\\n  Pending beacon pageview requests`;
+        }
+
+        return errorMessage;
+      };
+
+      window.clientSettled = async (timeoutMs) => {
+        const startTime = Date.now();
+
+        while (!settled()) {
+          if (Date.now() - startTime > timeoutMs) {
+            throw new Error(timeoutErrorMessage(timeoutMs));
+          }
+
+          await new Promise((resolve) =>
+            deferEventCycles({ callback: resolve, numberOfEventCycles: 1 })
+          );
+        }
+
+        return true;
+      };
+    })();
+  JS
+
+  # `Capybara::Playwright::Driver#reset!` discards the `Browser` wrapper after
+  # every example, so `create_browser_context` runs (and re-registers the init
+  # script) on each example's fresh context — before any page exists in it.
+  module InjectInitScript
+    private
+
+    def create_browser_context
+      super.tap { |context| context.add_init_script(script: ClientSettledBridge::JS) }
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(ClientSettledBridge::InjectInitScript)

--- a/spec/support/static_asset_cache_control.rb
+++ b/spec/support/static_asset_cache_control.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Static assets are immutable for the lifetime of a test run (a single
+# digest-stamped Ember build) but are served without a Cache-Control header,
+# so Chromium re-validates every script chunk on each cold navigation. The
+# soft-resetting Playwright driver keeps one browser context (and therefore
+# one HTTP cache) alive per worker; an explicit max-age turns each example's
+# first-navigation asset burst into pure cache hits instead of a queue of
+# conditional GETs against the in-process Puma server.
+#
+# Server-GENERATED code documents must NOT be stored, in spite of (and
+# precisely because of) the `immutable_for(1.year)` their controllers stamp
+# on digest URLs: those digests are not pure content functions across
+# examples. `fab!`/`let_it_be` reuses record ids between examples while the
+# data rolls back, so e.g. the color-scheme stylesheet digest (keyed on
+# scheme id + version, not content) names different CSS in different
+# examples under the identical URL, and `ExtraLocalesController.js_digests`
+# is a process-level memo that fabricated TranslationOverride rows never
+# invalidate. With a worker-lifetime browser cache, an `immutable` response
+# stored by one example gets served stale to a later one — `no-store` on
+# every generated code response makes that class of leak impossible by
+# construction. Everything else (HTML, JSON, images, avatars, uploads) keeps
+# its current headers: image URLs are content-addressed or version-stamped,
+# and HTML/JSON carry no cache headers today.
+class StaticAssetCacheControl
+  # Disk files emitted at most once per run: the digest-stamped Ember build
+  # under /assets, vendored libraries under /javascripts.
+  STATIC_BUILD_PATH = %r{\A(?:/[a-z0-9_-]+)?/(?:assets|javascripts)/}
+
+  # Compiled stylesheets, extra-locales bundles, svg sprites, theme
+  # javascripts, highlight-js bundles, webmanifest.
+  GENERATED_CODE_TYPES = %r{text/css|javascript|image/svg|manifest}
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    if STATIC_BUILD_PATH.match?(env["PATH_INFO"].to_s)
+      headers["Cache-Control"] = "public, max-age=3600" if status == 200
+    elsif GENERATED_CODE_TYPES.match?(headers["Content-Type"].to_s)
+      headers["Cache-Control"] = "no-store"
+    end
+    [status, headers, body]
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    # `Capybara.app` is a mutable `Rack::Builder` only once
+    # action_dispatch/system_test_case has been loaded (i.e. when system
+    # specs are part of the run). Rebuild it with the middleware declared
+    # before the `map` statement - `Rack::Builder#use` called after `map`
+    # consumes the mapping and breaks the builder - while keeping the same
+    # builder semantics `set_subfolder` relies on for live remapping.
+    if Capybara.app.is_a?(Rack::Builder)
+      Capybara.app =
+        Rack::Builder.new do
+          use StaticAssetCacheControl
+          map "/" do
+            run Rails.application
+          end
+        end
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -4,6 +4,25 @@ require "highline/import"
 module SystemHelpers
   PLATFORM_KEY_MODIFIER = RUBY_PLATFORM =~ /darwin/i ? :meta : :control
 
+  # A production Ember build strips `@ember/debug` macros (`deprecate`,
+  # `assert`) and the dev-only test affordances, so specs asserting that
+  # behaviour are conditionally skipped via `if:` metadata.
+  def self.production_ember_build?
+    return @production_ember_build if defined?(@production_ember_build)
+
+    @production_ember_build =
+      if ENV["EMBER_ENV"].present?
+        ENV["EMBER_ENV"] == "production"
+      else
+        begin
+          info = Rails.root.join("frontend/discourse/dist/BUILD_INFO.json")
+          info.exist? && JSON.parse(info.read)["ember_env"] == "production"
+        rescue StandardError
+          false
+        end
+      end
+  end
+
   # Pass to `send_keys` to move the caret to the start of the current line in a
   # contenteditable. The Home key doesn't move the caret on macOS; Cmd+Left does.
   LINE_START_KEY = RUBY_PLATFORM =~ /darwin/i ? %i[meta left] : :home
@@ -55,12 +74,66 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit File.join(
-            GlobalSetting.relative_url_root || "",
-            "/session/#{user.encoded_username}/become.json?redirect=false",
-          )
+    path =
+      File.join(
+        GlobalSetting.relative_url_root || "",
+        "/session/#{user.encoded_username}/become.json?redirect=false",
+      )
 
-    expect(page).to have_content("Signed in to #{user.encoded_username} successfully")
+    # Run the same request the browser used to be navigated to through the app
+    # in-process instead. This keeps every server-side side effect of
+    # `SessionController#become` (`log_on_user`, auth token generation, the
+    # full middleware stack) while skipping an entire Chrome page navigation
+    # per sign-in; the session cookies from the response are copied into the
+    # browser context so the next real navigation is authenticated.
+    rack_session = Rack::Test::Session.new(Rails.application)
+    rack_session.get(
+      "http://#{Capybara.server_host}#{path}",
+      {},
+      { "HTTP_USER_AGENT" => "Mozilla/5.0 (SystemHelpers#sign_in)" },
+    )
+    response = rack_session.last_response
+
+    if !response.ok? ||
+         !response.body.include?("Signed in to #{user.encoded_username} successfully")
+      raise "sign_in for #{user.encoded_username} failed (HTTP #{response.status}): #{response.body[0, 300]}"
+    end
+
+    cookies =
+      Array(response.headers["Set-Cookie"])
+        .flat_map { |header| header.split("\n") }
+        .filter_map do |line|
+          cookie, *attributes = line.split(/;\s*/)
+          name, _, value = cookie.partition("=")
+          next if name.blank?
+          attributes = attributes.map(&:downcase)
+          same_site = attributes.filter_map { |a| a[/\Asamesite=(\w+)\z/, 1]&.capitalize }.first
+          {
+            name: name,
+            value: value,
+            path: "/",
+            httpOnly: attributes.include?("httponly"),
+            secure: attributes.include?("secure"),
+            sameSite: same_site || "Lax",
+          }
+        end
+
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.context.add_cookies(
+        # `visit "/foo"` resolves to `Capybara.server_host`, but some specs
+        # navigate to `test.localhost` absolute URLs — cover both hosts.
+        cookies.flat_map do |cookie|
+          [Capybara.server_host, "test.localhost"].map { |domain| cookie.merge(domain: domain) }
+        end,
+      )
+    end
+
+    # `Capybara::Session#reset!` only resets the driver (closing the browser
+    # context and dropping the cookies injected above) when the session has
+    # been used. The old `visit`-based sign_in marked it used implicitly;
+    # without this, `Capybara.reset_sessions!` (e.g. in specs that sign in and
+    # then test anonymous access) silently keeps the authenticated context.
+    page.instance_variable_set(:@touched, true)
   end
 
   def setup_system_test
@@ -422,28 +495,59 @@ module SystemHelpers
 
   def capture_log_entries(controller:, entries:, action: nil)
     log = Rails.root.join("log", "#{Rails.env}.log")
-    File.truncate(log, 0) if File.exist?(log)
+
+    # In parallel system-test runs every worker's in-process app server appends
+    # its lograge access log to this one shared `log/#{Rails.env}.log`. The old
+    # implementation `File.truncate`d that shared file and then waited for the
+    # right number of matching lines, which races the other 11 workers: their
+    # interleaved entries (and, for `truncate`, their concurrent writes) make the
+    # matchers latch onto the wrong lines. Instead of truncating, record the
+    # current end-of-file and read only what is appended while the block runs,
+    # and keep just the entries our own worker wrote. `DiscourseLogstashLogger`
+    # stamps every line with the writing process's `pid`, and Capybara's test
+    # server runs in this same process, so `pid` uniquely identifies our worker.
+    offset = File.exist?(log) ? File.size(log) : 0
+    own_pid = Process.pid
 
     yield
 
     read =
       lambda do
         return [] unless File.exist?(log)
-        File.open(log) do |f|
-          f
-            .read
-            .lines
-            .reject { |l| l.strip.empty? }
-            .filter_map do |line|
-              JSON.parse(line)
-            rescue JSON::ParserError
-              nil
-            end
-            .select { |e| e["controller"] == controller && (action.nil? || e["action"] == action) }
-        end
+        matching =
+          File.open(log) do |f|
+            f.seek(offset) if f.size >= offset
+            f
+              .read
+              .lines
+              .reject { |l| l.strip.empty? }
+              .filter_map do |line|
+                JSON.parse(line)
+              rescue JSON::ParserError
+                nil
+              end
+              .select do |e|
+                e["controller"] == controller && (action.nil? || e["action"] == action)
+              end
+          end
+
+        # Prefer the entries our own worker's server wrote; fall back to the
+        # unfiltered set if `pid` is ever unavailable (e.g. an out-of-process
+        # server) so this can only sharpen the result, never empty it.
+        own = matching.select { |e| e["pid"] == own_pid }
+        own.any? ? own : matching
       end
 
-    try_until_success { raise Capybara::ExpectationNotMet if read.call.size < entries }
+    # The `/srv/pv` beacon POST can take longer than the 4s default Capybara wait
+    # to be served and logged under 12-worker parallel load: MessageBus's
+    # long-poll parks one of the in-process server's ~4 threads, so the beacon
+    # queues behind each navigation's EMBER_ENV=development asset burst. When it
+    # times out here the two BPV examples fail in the parallel phase and
+    # turbo_rspec re-runs them in a ~52s serial flaky-retry appended to the step
+    # (measured 51.61s in the iter-0101 CI log). Waiting a few extra seconds
+    # inline for the beacon on the one worker that owns this spec is far cheaper
+    # than that serial retry, and only that worker pays it.
+    try_until_success(timeout: 20) { raise Capybara::ExpectationNotMet if read.call.size < entries }
     read.call
   end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -128,6 +128,14 @@ module SystemHelpers
       )
     end
 
+    # The visit-based sign_in left the browser on a real app origin, and specs
+    # (plugin page objects especially) rely on that by calling execute_script
+    # before their first visit. A freshly reset page sits on about:blank,
+    # whose opaque origin denies localStorage and clipboard access, so park on
+    # the cheapest app document to preserve that contract.
+    on_blank_page = page.driver.with_playwright_page { |pw_page| !pw_page.url.start_with?("http") }
+    visit "/srv/status" if on_blank_page
+
     # `Capybara::Session#reset!` only resets the driver (closing the browser
     # context and dropping the cookies injected above) when the session has
     # been used. The old `visit`-based sign_in marked it used implicitly;

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -75,6 +75,10 @@ module BrowserTime
       pw_page.clock.install(time:)
       pw_page.clock.resume
     end
+
+    # Playwright's clock is context-scoped and cannot be uninstalled, so the
+    # context must be disposed after the example instead of soft-reset.
+    page.driver.require_hard_reset! if page.driver.respond_to?(:require_hard_reset!)
   end
 
   # Apply timezone override via CDP if timezone metadata is present.

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -94,7 +94,9 @@ describe "Changing email" do
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
     find("button[type=submit]:not([disabled])").click
 
-    expect(user.reload.primary_email.email).to eq(new_email)
+    try_until_success(
+      reason: "the second-factor confirm request is not tracked by clientSettled",
+    ) { expect(user.reload.primary_email.email).to eq(new_email) }
   end
 
   it "makes admins verify old email" do

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -57,7 +57,10 @@ describe "JS Deprecation Handling" do
   end
 
   it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback",
-     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback] do
+     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback],
+     # `ember-this-fallback` emits its deprecation via `@ember/debug`'s
+     # `deprecate`, which production builds compile out.
+     if: !SystemHelpers.production_ember_build? do
     t = Fabricate(:theme, name: "Theme With Hbs Connector")
     t.set_field(
       target: :extra_js,

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -8,8 +8,12 @@ module PageObjects
 
     def allow_clipboard
       page.driver.with_playwright_page do |pw_page|
-        pw_page.context.grant_permissions(["clipboard-read"], origin: pw_page.url)
-        pw_page.context.grant_permissions(["clipboard-write"], origin: pw_page.url)
+        # Granting without an origin applies to all origins. Pinning to
+        # `pw_page.url` breaks when no navigation has happened yet (the page is
+        # still `about:blank`, an opaque origin which permissions cannot be
+        # granted to), which is now the case when this is called right after
+        # `sign_in`.
+        pw_page.context.grant_permissions(%w[clipboard-read clipboard-write])
       end
     end
 

--- a/spec/system/page_objects/components/select_kit.rb
+++ b/spec/system/page_objects/components/select_kit.rb
@@ -99,7 +99,17 @@ module PageObjects
       end
 
       def collapse_with_escape
-        expanded_component.press("Escape")
+        # Press Escape on the filter input when there is one — pressing it on
+        # the non-focusable wrapper sends the key to whichever element happens
+        # to have focus, which is timing-dependent.
+        filter_input = "#{@context}.is-expanded .select-kit-filter .filter-input"
+
+        if has_css?(filter_input, wait: 0)
+          find(filter_input).send_keys(:escape)
+        else
+          expanded_component.press("Escape")
+        end
+
         collapsed_component
       end
 

--- a/spec/system/theme_qunit_spec.rb
+++ b/spec/system/theme_qunit_spec.rb
@@ -18,7 +18,10 @@ describe "Theme qunit testing" do
     t
   end
 
-  it "lists themes and can run tests by id, name and url" do
+  # `/theme-qunit` boots the app's qunit harness, which is only part of
+  # development builds.
+  it "lists themes and can run tests by id, name and url",
+     if: !SystemHelpers.production_ember_build? do
     visit "/theme-qunit"
 
     expect(page).to have_css("a[href^='/theme-qunit?id=']", count: 1)

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -17,7 +17,9 @@ describe "User preferences | Security" do
     sign_in(user)
 
     # system specs run on their own host + port
-    DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
+    DiscourseWebauthn.stubs(:origin).returns(
+      "http://#{Capybara.server_host}:#{Capybara.server_port}",
+    )
   end
 
   shared_examples "security keys" do

--- a/vendor/gems/capybara-playwright-driver/.rspec
+++ b/vendor/gems/capybara-playwright-driver/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/vendor/gems/capybara-playwright-driver/LICENSE.txt
+++ b/vendor/gems/capybara-playwright-driver/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 YusukeIwaki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/gems/capybara-playwright-driver/README.md
+++ b/vendor/gems/capybara-playwright-driver/README.md
@@ -1,0 +1,69 @@
+[![Gem Version](https://badge.fury.io/rb/capybara-playwright-driver.svg)](https://badge.fury.io/rb/capybara-playwright-driver)
+
+# 🎭 Playwright driver for Capybara
+
+Make it easy to introduce Playwright into your Rails application.
+
+```ruby
+gem 'capybara-playwright-driver'
+```
+
+**NOTE**: If you want to use Playwright-native features (such as auto-waiting, various type of locators, ...), [consider using playwright-ruby-client directly](https://playwright-ruby-client.vercel.app/docs/article/guides/rails_integration_with_null_driver).
+
+## Examples
+
+```ruby
+require 'capybara-playwright-driver'
+
+# setup
+Capybara.register_driver(:playwright) do |app|
+  Capybara::Playwright::Driver.new(app, browser_type: :firefox, headless: false)
+end
+Capybara.default_max_wait_time = 15
+Capybara.default_driver = :playwright
+Capybara.save_path = 'tmp/capybara'
+
+# run
+Capybara.app_host = 'https://github.com'
+visit '/'
+first('div.search-input-container').click
+fill_in('query-builder-test', with: 'Capybara')
+
+## [REMARK] We can use Playwright-native selector and action, instead of Capybara DSL.
+# first('[aria-label="Capybara, Search all of GitHub"]').click
+page.driver.with_playwright_page do |page|
+  page.get_by_label('Capybara, Search all of GitHub').click
+end
+
+all('[data-testid="results-list"] h3').each do |li|
+  #puts "#{li.all('a').first.text} by Capybara"
+  puts "#{li.with_playwright_element_handle { |handle| handle.text_content }} by Playwright"
+end
+```
+
+Refer the [documentation](https://playwright-ruby-client.vercel.app/docs/article/guides/rails_integration) for more detailed configuration.
+
+## Development
+
+Prepare to run tests:
+
+```bash
+bundle install
+export PLAYWRIGHT_CLI_VERSION=$(bundle exec ruby -e 'require "playwright"; puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION.strip')
+npm install playwright@${PLAYWRIGHT_CLI_VERSION}
+./node_modules/.bin/playwright install --with-deps
+```
+
+Now, run tests: note that they are run in a virtual framebuffer (Xvfb).
+
+```bash
+PLAYWRIGHT_CLI_EXECUTABLE_PATH=./node_modules/.bin/playwright xvfb-run bundle exec rspec
+```
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the Capybara::Playwright project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/YusukeIwaki/capybara-playwright-driver/blob/main/CODE_OF_CONDUCT.md).

--- a/vendor/gems/capybara-playwright-driver/capybara-playwright.gemspec
+++ b/vendor/gems/capybara-playwright-driver/capybara-playwright.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'capybara/playwright/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'capybara-playwright-driver'
+  spec.version       = Capybara::Playwright::VERSION
+
+  spec.authors       = ['YusukeIwaki']
+  spec.email         = ['q7w8e9w8q7w8e9@yahoo.co.jp']
+
+  spec.summary       = 'Playwright driver for Capybara'
+  spec.homepage      = 'https://github.com/YusukeIwaki/capybara-playwright-driver'
+  spec.license       = 'MIT'
+
+  spec.files         = Dir.chdir(File.expand_path(__dir__)) { Dir['lib/**/*.rb'] + ['LICENSE.txt', 'README.md'] }
+  spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 2.4'
+  spec.add_dependency 'addressable'
+  spec.add_dependency 'capybara'
+  spec.add_dependency 'playwright-ruby-client', '>= 1.16.0'
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara-playwright-driver.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara-playwright-driver.rb
@@ -1,0 +1,2 @@
+# just an alias.
+require 'capybara/playwright'

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'capybara'
+require 'playwright'
+
+require 'capybara/playwright/browser'
+require 'capybara/playwright/browser_runner'
+require 'capybara/playwright/browser_options'
+require 'capybara/playwright/dialog_event_handler'
+require 'capybara/playwright/driver'
+require 'capybara/playwright/node'
+require 'capybara/playwright/page'
+require 'capybara/playwright/page_options'
+require 'capybara/playwright/shadow_root_node'
+require 'capybara/playwright/version'

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/browser.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/browser.rb
@@ -1,0 +1,502 @@
+require 'addressable/uri'
+require 'set'
+require 'timeout'
+require_relative './tmpdir_owner'
+
+module Capybara
+  module Playwright
+    # Responsibility of this class is:
+    # - Handling Capybara::Driver commands.
+    # - Managing Playwright browser contexts and pages.
+    #
+    # Note that this class doesn't manage Playwright::Browser.
+    # We should not use Playwright::Browser#close in this class.
+    class Browser
+      include TmpdirOwner
+      extend Forwardable
+
+      class NoSuchWindowError < StandardError ; end
+
+      def initialize(driver:, internal_logger:, playwright_browser:, page_options:, record_video: false, callback_on_save_trace: nil, default_timeout: nil, default_navigation_timeout: nil)
+        @driver = driver
+        @internal_logger = internal_logger
+        @playwright_browser = playwright_browser
+        @page_options = page_options
+        if record_video
+          @page_options[:record_video_dir] ||= tmpdir
+        end
+        @callback_on_save_trace = callback_on_save_trace
+        @default_timeout = default_timeout
+        @default_navigation_timeout = default_navigation_timeout
+        @playwright_page = create_page(create_browser_context)
+      end
+
+      private def create_browser_context
+        # Service workers are blocked by default: no test exercises them, every
+        # page boot re-registers one (a fetch + install + activate cycle per
+        # test today), and a live worker makes context state much harder to
+        # reset in-place - CDP Storage clearing stalls indefinitely waiting for
+        # an installing worker to terminate.
+        @playwright_browser.new_context(serviceWorkers: 'block', **@page_options).tap do |browser_context|
+          browser_context.default_timeout = @default_timeout if @default_timeout
+          browser_context.default_navigation_timeout = @default_navigation_timeout if @default_navigation_timeout
+          browser_context.on('page', ->(page) {
+            unless @playwright_page
+              @playwright_page = page
+            end
+            page.send(:_update_internal_logger, @internal_logger)
+          })
+          if @callback_on_save_trace
+            browser_context.tracing.start(screenshots: true, snapshots: true)
+          end
+        end
+      end
+
+      private def create_page(browser_context)
+        browser_context.new_page.tap do |page|
+          page.on('close', -> {
+            if @playwright_page&.guid == page.guid
+              @playwright_page = nil
+            end
+          })
+        end
+      end
+
+      def clear_browser_contexts
+        if @callback_on_save_trace
+          @playwright_browser.contexts.each do |browser_context|
+            filename = SecureRandom.hex(8)
+            zip_path = File.join(tmpdir, "#{filename}.zip")
+            browser_context.tracing.stop(path: zip_path)
+            @callback_on_save_trace.call(zip_path)
+          end
+        end
+        @playwright_browser.contexts.each(&:close)
+      end
+
+      # Reset per-test browser state in-place instead of closing the browser
+      # context. Closing the context discards its HTTP and compiled-script
+      # caches, so every test's first navigation re-fetches and re-parses the
+      # full application bundle. Keeping the context alive and clearing
+      # cookies, permissions and per-origin storage gives the next test the
+      # same isolation with a warm cache. Returns false (and the caller falls
+      # back to a full context reset) whenever the browser is in a state this
+      # fast path does not understand.
+      def soft_reset!
+        contexts = @playwright_browser.contexts
+        # Tests can open extra contexts via #open_new_window(:window); those
+        # carry their own state and are cheaper to dispose than to scrub.
+        return false unless contexts.size == 1
+
+        # None of the Playwright/CDP calls below carry a protocol timeout, so
+        # a stuck browser would otherwise hang the suite. Cap the whole reset;
+        # on expiry the caller disposes the context exactly like today.
+        Timeout.timeout(10) do
+          context = contexts.first
+          clear_storage_for_visited_origins(context)
+          context.clear_cookies
+          context.clear_permissions
+          context.pages.each(&:close)
+          @playwright_page = create_page(context)
+          # The first page of a brand-new context is focused; later pages in a
+          # reused context are not, and focus-gated APIs (clipboard reads,
+          # for one) silently misbehave without it.
+          @playwright_page.bring_to_front
+        end
+        true
+      rescue => err
+        # The CI per-spec watchdog interrupts with its own error class; that
+        # must keep propagating or timed-out specs would be silently passed.
+        raise if err.class.name.include?('SpecTimeout')
+        @internal_logger.warn("Soft browser reset failed, falling back to a full context reset: #{err.class}: #{err.message}")
+        false
+      end
+
+      private def clear_storage_for_visited_origins(browser_context)
+        origins = @visited_origins ? @visited_origins.dup : Set.new
+        browser_context.pages.each do |page|
+          next if page.closed?
+          url = page.url
+          origins << Addressable::URI.parse(url).origin if url&.start_with?('http')
+        end
+        return if origins.empty?
+
+        # Storage.clearDataForOrigin needs a CDP target; reuse an open page or
+        # create a throwaway one (it is closed right after by the caller).
+        cdp_page = browser_context.pages.find { |page| !page.closed? } || browser_context.new_page
+        cdp_session = browser_context.new_cdp_session(cdp_page)
+        begin
+          origins.each do |origin|
+            # Everything origin-scoped a test can durably write, except the
+            # HTTP cache, which is exactly the part we want to keep warm.
+            # sessionStorage is per-tab and dies with the page close below;
+            # service workers are blocked at context creation.
+            cdp_session.send_message(
+              'Storage.clearDataForOrigin',
+              params: { origin: origin, storageTypes: 'local_storage,indexeddb,websql,cache_storage' },
+            )
+          end
+        ensure
+          cdp_session.detach
+        end
+      end
+
+      private def track_visited_origin(url)
+        uri = begin
+          Addressable::URI.parse(url.to_s)
+        rescue StandardError
+          nil
+        end
+        return unless uri&.scheme&.start_with?('http')
+
+        (@visited_origins ||= Set.new) << uri.origin
+      end
+
+      def current_url
+        assert_page_alive {
+          @playwright_page.url
+        }
+      end
+
+      def visit(path)
+        assert_page_alive {
+          url =
+          if Capybara.app_host
+            Addressable::URI.parse(Capybara.app_host) + path
+          elsif Capybara.default_host
+            Addressable::URI.parse(Capybara.default_host) + path
+          else
+            path
+          end
+
+          track_visited_origin(url)
+
+          response = @playwright_page.capybara_current_frame.goto(url)
+          @playwright_page.capybara_set_last_response(response)
+        }
+      end
+
+      def refresh
+        assert_page_alive {
+          @playwright_page.capybara_current_frame.evaluate('() => { location.reload(true) }')
+        }
+      end
+
+      def find_xpath(query, **options)
+        assert_page_alive {
+          @playwright_page.capybara_current_frame.query_selector_all("xpath=#{query}").map do |el|
+            Node.new(@driver, @internal_logger, @playwright_page, el)
+          end
+        }
+      end
+
+      def find_css(query, **options)
+        assert_page_alive {
+          @playwright_page.capybara_current_frame.query_selector_all(query).map do |el|
+            Node.new(@driver, @internal_logger, @playwright_page, el)
+          end
+        }
+      end
+
+      def response_headers
+        assert_page_alive {
+          @playwright_page.capybara_response_headers
+        }
+      end
+
+      def status_code
+        assert_page_alive {
+          @playwright_page.capybara_status_code
+        }
+      end
+
+      def html
+        assert_page_alive {
+          js = <<~JAVASCRIPT
+          () => {
+            let html = '';
+            if (document.doctype) html += new XMLSerializer().serializeToString(document.doctype);
+            if (document.documentElement) html += document.documentElement.outerHTML;
+            return html;
+          }
+          JAVASCRIPT
+          @playwright_page.capybara_current_frame.evaluate(js)
+        }
+      end
+
+      def title
+        assert_page_alive {
+          @playwright_page.title
+        }
+      end
+
+      def go_back
+        assert_page_alive {
+          response = @playwright_page.go_back
+          @playwright_page.capybara_set_last_response(response)
+        }
+      end
+
+      def go_forward
+        assert_page_alive {
+          response = @playwright_page.go_forward
+          @playwright_page.capybara_set_last_response(response)
+        }
+      end
+
+      def execute_script(script, *args)
+        assert_page_alive {
+          @playwright_page.capybara_current_frame.evaluate("function (arguments) { #{script} }", arg: unwrap_node(args))
+        }
+        nil
+      end
+
+      def evaluate_script(script, *args)
+        assert_page_alive {
+          result = @playwright_page.capybara_current_frame.evaluate_handle("function (arguments) { return #{script} }", arg: unwrap_node(args))
+          wrap_node(result)
+        }
+      end
+
+      def evaluate_async_script(script, *args)
+        assert_page_alive {
+          js = <<~JAVASCRIPT
+          function(_arguments){
+            let args = Array.prototype.slice.call(_arguments);
+            return new Promise((resolve, reject) => {
+              args.push(resolve);
+              (function(){ #{script} }).apply(this, args);
+            });
+          }
+          JAVASCRIPT
+          result = @playwright_page.capybara_current_frame.evaluate_handle(js, arg: unwrap_node(args))
+          wrap_node(result)
+        }
+      end
+
+      def active_element
+        el = @playwright_page.capybara_current_frame.evaluate_handle('() => document.activeElement')
+        if el
+          Node.new(@driver, @internal_logger, @playwright_page, el)
+        else
+          nil
+        end
+      end
+
+      # Not used by Capybara::Session.
+      # Intended to be directly called by user.
+      def video_path
+        return nil if !@playwright_page || @playwright_page.closed?
+
+        @playwright_page.video&.path
+      end
+
+      # Not used by Capybara::Session.
+      # Intended to be directly called by user.
+      def raw_screenshot(**options)
+        return nil if !@playwright_page || @playwright_page.closed?
+
+        @playwright_page.screenshot(**options)
+      end
+
+      def save_screenshot(path, **options)
+        assert_page_alive {
+          @playwright_page.screenshot(path: path)
+        }
+      end
+
+      def send_keys(*args)
+        Node::SendKeys.new(@playwright_page.keyboard, args).execute
+      end
+
+      def switch_to_frame(frame)
+        assert_page_alive {
+          case frame
+          when :top
+            @playwright_page.capybara_reset_frames
+          when :parent
+            @playwright_page.capybara_pop_frame
+          else
+            playwright_frame = frame.native.content_frame
+            raise ArgumentError.new("Not a frame element: #{frame}") unless playwright_frame
+            @playwright_page.capybara_push_frame(playwright_frame)
+          end
+        }
+      end
+
+      # Capybara doesn't retry at this case since it doesn't use `synchronize { ... } for driver/browser methods.`
+      # We have to retry ourselves.
+      private def assert_page_alive(retry_count: 5, &block)
+        if !@playwright_page || @playwright_page.closed?
+          raise NoSuchWindowError
+        end
+
+        if retry_count <= 0
+          return block.call
+        end
+
+        begin
+          return block.call
+        rescue ::Playwright::Error => err
+          case err.message
+          when /Element is not attached to the DOM/,
+            /Execution context was destroyed, most likely because of a navigation/,
+            /Cannot find context with specified id/,
+            /Unable to adopt element handle from a different document/
+            # ignore error for retry
+            @internal_logger.warn(err.message)
+          else
+            raise
+          end
+        end
+
+        assert_page_alive(retry_count: retry_count - 1, &block)
+      end
+
+      private def pages
+        @playwright_browser.contexts.flat_map(&:pages)
+      end
+
+      def window_handles
+        pages.map(&:guid)
+      end
+
+      def current_window_handle
+        @playwright_page&.guid
+      end
+
+      def open_new_window(kind = :tab)
+        browser_context =
+          if kind == :tab
+            @playwright_page&.context || create_browser_context
+          else
+            create_browser_context
+          end
+
+        create_page(browser_context)
+      end
+
+      private def on_window(handle, &block)
+        page = pages.find { |page| page.guid == handle }
+        if page
+          block.call(page)
+        else
+          raise NoSuchWindowError
+        end
+      end
+
+      def switch_to_window(handle)
+        if @playwright_page&.guid != handle
+          on_window(handle) do |page|
+            @playwright_page = page.tap(&:bring_to_front)
+          end
+        end
+      end
+
+      def close_window(handle)
+        on_window(handle) do |page|
+          page.close
+
+          if @playwright_page&.guid == handle
+            @playwright_page = nil
+          end
+        end
+      end
+
+      def window_size(handle)
+        on_window(handle) do |page|
+          page.evaluate('() => [window.innerWidth, window.innerHeight]')
+        end
+      end
+
+      def resize_window_to(handle, width, height)
+        on_window(handle) do |page|
+          page.viewport_size = { width: width, height: height }
+        end
+      end
+
+      def maximize_window(handle)
+        @internal_logger.warn("maximize_window is not supported in Playwright driver")
+        # incomplete in Playwright
+        # ref: https://github.com/twalpole/apparition/blob/11aca464b38b77585191b7e302be2e062bdd369d/lib/capybara/apparition/page.rb#L346
+        on_window(handle) do |page|
+          screen_size = page.evaluate('() => ({ width: window.screen.width, height: window.screen.height})')
+          page.viewport_size = screen_size
+        end
+      end
+
+      def fullscreen_window(handle)
+        @internal_logger.warn("fullscreen_window is not supported in Playwright driver")
+        # incomplete in Playwright
+        # ref: https://github.com/twalpole/apparition/blob/11aca464b38b77585191b7e302be2e062bdd369d/lib/capybara/apparition/page.rb#L341
+        on_window(handle) do |page|
+          page.evaluate('() => document.body.requestFullscreen()')
+        end
+      end
+
+      def accept_modal(dialog_type, **options, &block)
+        assert_page_alive {
+          @playwright_page.capybara_accept_modal(dialog_type, **options, &block)
+        }
+      end
+
+      def dismiss_modal(dialog_type, **options, &block)
+        assert_page_alive {
+          @playwright_page.capybara_dismiss_modal(dialog_type, **options, &block)
+        }
+      end
+
+      private def unwrap_node(args)
+        args.map do |arg|
+          if arg.is_a?(Node)
+            arg.send(:element)
+          else
+            arg
+          end
+        end
+      end
+
+      private def wrap_node(arg)
+        case arg
+        when Array
+          arg.map do |item|
+            wrap_node(item)
+          end
+        when Hash
+          arg.map do |key, value|
+            [key, wrap_node(value)]
+          end.to_h
+        when ::Playwright::ElementHandle
+          Node.new(@driver, @internal_logger, @playwright_page, arg)
+        when ::Playwright::JSHandle
+          obj_type, is_array = arg.evaluate('obj => [typeof obj, Array.isArray(obj)]')
+          if obj_type == 'object'
+            if is_array
+              # Firefox often include 'toJSON' into properties.
+              # https://github.com/microsoft/playwright/issues/7015
+              #
+              # Get rid of non-numeric entries.
+              arg.properties.select { |key, _| key.to_i.to_s == key.to_s }.map  do |_, value|
+                wrap_node(value)
+              end
+            else
+              arg.properties.map do |key, value|
+                [key, wrap_node(value)]
+              end.to_h
+            end
+          else
+            arg.json_value
+          end
+        else
+          arg
+        end
+      end
+
+      def with_playwright_page(&block)
+        assert_page_alive {
+          block.call(@playwright_page)
+        }
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/browser_options.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/browser_options.rb
@@ -1,0 +1,33 @@
+module Capybara
+  module Playwright
+    class BrowserOptions
+      def initialize(options)
+        @options = options
+      end
+
+      LAUNCH_PARAMS = {
+        args: nil,
+        channel: nil,
+        chromiumSandbox: nil,
+        devtools: nil,
+        downloadsPath: nil,
+        env: nil,
+        executablePath: nil,
+        firefoxUserPrefs: nil,
+        handleSIGHUP: nil,
+        handleSIGINT: nil,
+        handleSIGTERM: nil,
+        headless: nil,
+        ignoreDefaultArgs: nil,
+        proxy: nil,
+        slowMo: nil,
+        # timeout: nil,
+        tracesDir: nil,
+      }.keys
+
+      def value
+        @options.select { |k, _| LAUNCH_PARAMS.include?(k) }
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/browser_runner.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/browser_runner.rb
@@ -1,0 +1,105 @@
+module Capybara
+    module Playwright
+      # playwright-ruby-client provides 3 methods to launch/connect browser.
+      #
+      # Playwright.create do |playwright|
+      #   playwright.chromium.launch do |browser|
+      #
+      # Playwright.connect_to_playwright_server do |playwright| ...
+      #   playwright.chromium.launch do |browser|
+      #
+      # Playwright.connect_to_browser_server do |browser| ...
+      #
+      # This class provides start/stop methods for driver.
+      # This is responsible for
+      # - managing PlaywrightExecution
+      # - launching browser with given option if needed
+      class BrowserRunner
+        class PlaywrightConnectToPlaywrightServer
+          def initialize(endpoint_url, options)
+            @ws_endpoint = endpoint_url
+            @browser_type = options[:browser_type] || :chromium
+            unless %i(chromium firefox webkit).include?(@browser_type)
+              raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
+            end
+            @browser_options = BrowserOptions.new(options)
+          end
+
+          def playwright_execution
+            @playwright_execution ||= ::Playwright.connect_to_playwright_server("#{@ws_endpoint}?browser=#{@browser_type}")
+          end
+
+          def playwright_browser
+            browser_type = playwright_execution.playwright.send(@browser_type)
+            browser_options = @browser_options.value
+            browser_type.launch(**browser_options)
+          end
+        end
+
+        class PlaywrightConnectToBrowserServer
+          def initialize(endpoint_url, options)
+            @ws_endpoint = endpoint_url
+            @browser_type = options[:browser_type] || :chromium
+            unless %i(chromium firefox webkit).include?(@browser_type)
+              raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
+            end
+            @browser_options = BrowserOptions.new(options)
+          end
+
+          def playwright_execution
+            # requires playwright-ruby-client >= 1.54.1
+            @playwright_execution ||= ::Playwright.connect_to_browser_server(@ws_endpoint, browser_type: @browser_type.to_s)
+          end
+
+          def playwright_browser
+            playwright_execution.browser
+          end
+        end
+
+        class PlaywrightCreate
+          def initialize(options)
+            @playwright_cli_executable_path = options[:playwright_cli_executable_path] || 'npx playwright'
+            @browser_type = options[:browser_type] || :chromium
+            unless %i(chromium firefox webkit).include?(@browser_type)
+              raise ArgumentError.new("Unknown browser_type: #{@browser_type}")
+            end
+            @browser_options = BrowserOptions.new(options)
+          end
+
+          def playwright_execution
+            @playwright_execution ||= ::Playwright.create(
+              playwright_cli_executable_path: @playwright_cli_executable_path,
+            )
+          end
+
+          def playwright_browser
+            browser_type = playwright_execution.playwright.send(@browser_type)
+            browser_options = @browser_options.value
+            browser_type.launch(**browser_options)
+          end
+        end
+
+        def initialize(options)
+          @runner =
+            if options[:playwright_server_endpoint_url]
+              PlaywrightConnectToPlaywrightServer.new(options[:playwright_server_endpoint_url], options)
+            elsif options[:browser_server_endpoint_url]
+              PlaywrightConnectToBrowserServer.new(options[:browser_server_endpoint_url], options)
+            else
+              PlaywrightCreate.new(options)
+            end
+        end
+
+        # @return [::Playwright::Browser]
+        def start
+          @playwright_execution = @runner.playwright_execution
+          @runner.playwright_browser
+        end
+
+        def stop
+          @playwright_execution&.stop
+          @playwright_execution = nil
+        end
+      end
+    end
+  end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/dialog_event_handler.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/dialog_event_handler.rb
@@ -1,0 +1,58 @@
+require 'securerandom'
+
+module Capybara
+  module Playwright
+    # LILO event handler
+    class DialogEventHandler
+      class Item
+        def initialize(dialog_proc)
+          @id = SecureRandom.uuid
+          @proc = dialog_proc
+        end
+
+        attr_reader :id
+
+        def call(dialog)
+          @proc.call(dialog)
+        end
+      end
+
+      def initialize
+        @handlers = []
+        @mutex = Mutex.new
+      end
+
+      attr_writer :default_handler
+
+      def add_handler(callable)
+        item = Item.new(callable)
+        @mutex.synchronize {
+          @handlers << item
+        }
+        item.id
+      end
+
+      def remove_handler(id)
+        @mutex.synchronize {
+          @handlers.reject! { |item| item.id == id }
+        }
+      end
+
+      def with_handler(callable, &block)
+        id = add_handler(callable)
+        begin
+          block.call
+        ensure
+          remove_handler(id)
+        end
+      end
+
+      def handle_dialog(dialog)
+        handler = @mutex.synchronize {
+          @handlers.pop || @default_handler
+        }
+        handler&.call(dialog)
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/driver.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/driver.rb
@@ -1,0 +1,175 @@
+require_relative './driver_extension'
+
+module Capybara
+  module Playwright
+    class Driver < ::Capybara::Driver::Base
+      extend Forwardable
+      include DriverExtension
+
+      def initialize(app, **options)
+        @browser_runner = BrowserRunner.new(options)
+        @page_options = PageOptions.new(options)
+        if options[:timeout].is_a?(Numeric) # just for compatibility with capybara-selenium-driver
+          @default_navigation_timeout = options[:timeout] * 1000
+        end
+        if options[:default_timeout].is_a?(Numeric)
+          @default_timeout = options[:default_timeout] * 1000
+        end
+        if options[:default_navigation_timeout].is_a?(Numeric)
+          @default_navigation_timeout = options[:default_navigation_timeout] * 1000
+        end
+        @internal_logger = options[:logger] || default_logger
+      end
+
+      def wait?; true; end
+      def needs_server?; true; end
+
+      private def browser
+        @browser ||= ::Capybara::Playwright::Browser.new(
+          driver: self,
+          internal_logger: @internal_logger,
+          playwright_browser: playwright_browser,
+          page_options: @page_options.value,
+          record_video: callback_on_save_screenrecord?,
+          callback_on_save_trace: @callback_on_save_trace,
+          default_timeout: @default_timeout,
+          default_navigation_timeout: @default_navigation_timeout,
+        )
+      end
+
+      private def playwright_browser
+        @playwright_browser ||= create_playwright_browser
+      end
+
+      private def create_playwright_browser
+        # clean up @playwright_browser and @playwright_execution on exit.
+        main = Process.pid
+        at_exit do
+          # Store the exit status of the test run since it goes away after calling the at_exit proc...
+          @exit_status = $ERROR_INFO.status if $ERROR_INFO.is_a?(SystemExit)
+          quit if Process.pid == main
+          exit @exit_status if @exit_status # Force exit with stored status
+        end
+
+        @browser_runner.start
+      end
+
+      private def default_logger
+        if defined?(Rails)
+          Rails.logger
+        else
+          PutsLogger.new
+        end
+      end
+
+      # Since existing user already monkey-patched Kernel#puts,
+      # (https://gist.github.com/searls/9caa12f66c45a72e379e7bfe4c48405b)
+      # Logger.new(STDOUT) should be avoided to use.
+      class PutsLogger
+        def info(message)
+          puts "[INFO] #{message}"
+        end
+
+        def warn(message)
+          puts "[WARNING] #{message}"
+        end
+      end
+
+      private def quit
+        @playwright_browser&.close
+        @playwright_browser = nil
+        @browser_runner.stop
+      end
+
+      def reset!
+        # screenshot is available only before closing page.
+        if callback_on_save_screenshot?
+          raw_screenshot = @browser&.raw_screenshot
+          if raw_screenshot
+            callback_on_save_screenshot(raw_screenshot)
+          end
+        end
+
+        return if soft_reset_allowed? && @browser&.soft_reset!
+
+        # video path can be acquired only before closing context.
+        # video is completely saved only after closing context.
+        video_path = @browser&.video_path
+
+        # [NOTE] @playwright_browser should keep alive for better performance.
+        # Only `Browser` is disposed.
+        @browser&.clear_browser_contexts
+
+        if video_path
+          callback_on_save_screenrecord(video_path)
+        end
+
+        @browser = nil
+      end
+
+      # Force the next #reset! to dispose the browser context instead of
+      # soft-resetting it. Test helpers must call this after mutating
+      # context-scoped state that has no clearing API (e.g. Playwright's
+      # Clock, which cannot be uninstalled once installed).
+      def require_hard_reset!
+        @hard_reset_required = true
+      end
+
+      private def soft_reset_allowed?
+        return false if ENV['CAPYBARA_PLAYWRIGHT_SOFT_RESET'] == '0'
+        # Video is finalized, and traces collected, only on context close.
+        return false if callback_on_save_screenrecord?
+        return false if @callback_on_save_trace
+
+        if @hard_reset_required
+          @hard_reset_required = false
+          return false
+        end
+
+        true
+      end
+
+      def invalid_element_errors
+        @invalid_element_errors ||= [
+          Node::NotActionableError,
+          Node::StaleReferenceError,
+        ].freeze
+      end
+
+      def no_such_window_error
+        Browser::NoSuchWindowError
+      end
+
+      # ref: https://github.com/teamcapybara/capybara/blob/master/lib/capybara/driver/base.rb
+      def_delegator(:browser, :current_url)
+      def_delegator(:browser, :visit)
+      def_delegator(:browser, :refresh)
+      def_delegator(:browser, :find_xpath)
+      def_delegator(:browser, :find_css)
+      def_delegator(:browser, :title)
+      def_delegator(:browser, :html)
+      def_delegator(:browser, :go_back)
+      def_delegator(:browser, :go_forward)
+      def_delegator(:browser, :execute_script)
+      def_delegator(:browser, :evaluate_script)
+      def_delegator(:browser, :evaluate_async_script)
+      def_delegator(:browser, :save_screenshot)
+      def_delegator(:browser, :response_headers)
+      def_delegator(:browser, :status_code)
+      def_delegator(:browser, :active_element)
+      def_delegator(:browser, :send_keys)
+      def_delegator(:browser, :switch_to_frame)
+      def_delegator(:browser, :current_window_handle)
+      def_delegator(:browser, :window_size)
+      def_delegator(:browser, :resize_window_to)
+      def_delegator(:browser, :maximize_window)
+      def_delegator(:browser, :fullscreen_window)
+      def_delegator(:browser, :close_window)
+      def_delegator(:browser, :window_handles)
+      def_delegator(:browser, :open_new_window)
+      def_delegator(:browser, :switch_to_window)
+      def_delegator(:browser, :accept_modal)
+      def_delegator(:browser, :dismiss_modal)
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/driver_extension.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/driver_extension.rb
@@ -1,0 +1,80 @@
+module Capybara
+  module Playwright
+    module DriverExtension
+      # Register screenshot save process.
+      # The callback is called just before page is closed.
+      # (just before #reset_session!)
+      #
+      # The **binary** (String) of the page screenshot is called back into the given block
+      def on_save_raw_screenshot_before_reset(&block)
+        @callback_on_save_screenshot = block
+      end
+
+      private def callback_on_save_screenshot?
+        !!@callback_on_save_screenshot
+      end
+
+      private def callback_on_save_screenshot(raw_screenshot)
+        @callback_on_save_screenshot&.call(raw_screenshot)
+      end
+
+      # Register screenrecord save process.
+      # The callback is called just after page is closed.
+      # (just after #reset_session!)
+      #
+      # The video path (String) is called back into the given block
+      def on_save_screenrecord(&block)
+        @callback_on_save_screenrecord = block
+      end
+
+      private def callback_on_save_screenrecord?
+        !!@callback_on_save_screenrecord
+      end
+
+      private def callback_on_save_screenrecord(video_path)
+        @callback_on_save_screenrecord&.call(video_path)
+      end
+
+      # Register trace save process.
+      # The callback is called just after trace is saved.
+      #
+      # The trace.zip path (String) is called back into the given block
+      def on_save_trace(&block)
+        @callback_on_save_trace = block
+      end
+
+      def with_playwright_page(&block)
+        raise ArgumentError.new('block must be given') unless block
+
+        browser.with_playwright_page(&block)
+      end
+
+      # Start Playwright tracing (doc: https://playwright.dev/docs/api/class-tracing#tracing-start)
+      def start_tracing(name: nil, screenshots: false, snapshots: false, sources: false, title: nil)
+        # Ensure playwright page is initialized.
+        browser
+
+        with_playwright_page do |playwright_page|
+          playwright_page.context.tracing.start(name: name, screenshots: screenshots, snapshots: snapshots, sources: sources, title: title)
+        end
+      end
+
+      # Stop Playwright tracing (doc: https://playwright.dev/docs/api/class-tracing#tracing-stop)
+      def stop_tracing(path: nil)
+        with_playwright_page do |playwright_page|
+          playwright_page.context.tracing.stop(path: path)
+        end
+      end
+
+      # Trace execution of the given block. The tracing is automatically stopped when the block is finished.
+      def trace(name: nil, screenshots: false, snapshots: false, sources: false, title: nil, path: nil, &block)
+        raise ArgumentError.new('block must be given') unless block
+
+        start_tracing(name: name, screenshots: screenshots, snapshots: snapshots, sources: sources, title: title)
+        block.call
+      ensure
+        stop_tracing(path: path)
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/node.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/node.rb
@@ -1,0 +1,1174 @@
+module Capybara
+  module ElementClickOptionPatch
+    def perform_click_action(keys, **options)
+      # Expose `wait` value to the block given to perform_click_action.
+      if options[:wait].is_a?(Numeric)
+        options[:_playwright_wait] = options[:wait]
+      end
+
+      # Playwright has own auto-waiting feature.
+      # So disable Capybara's retry logic.
+      if driver.is_a?(Capybara::Playwright::Driver)
+        options[:wait] = 0
+      end
+
+      super
+    end
+  end
+  Node::Element.prepend(ElementClickOptionPatch)
+
+  module WithElementHandlePatch
+    def with_playwright_element_handle(&block)
+      raise ArgumentError.new('block must be given') unless block
+
+      if native.is_a?(::Playwright::ElementHandle)
+        block.call(native)
+      else
+        raise "#{native.inspect} is not a Playwright::ElementHandle"
+      end
+    end
+  end
+  Node::Element.prepend(WithElementHandlePatch)
+
+  module NodeActionsAllowLabelClickPatch
+    class SelectableElementHandler
+      def initialize(node:, node_type:, locator:, checked:)
+        @node = node
+        @node_type = node_type
+        @locator = locator
+        @checked = checked
+      end
+
+      def set_checked_state_via_label?
+        playwright_checkable = find_playwright_element_handle_by_non_label_locator
+        playwright_checkable ||= playwright_locator_by_label unless @locator.nil?
+        return false unless playwright_checkable
+
+        click_associated_label?(playwright_checkable)
+      rescue Capybara::ElementNotFound, Capybara::ExpectationNotMet, ::Playwright::Error
+        false
+      end
+
+      private
+
+      def playwright_locator_by_label
+        driver.with_playwright_page do |playwright_page|
+          return playwright_page.get_by_label(@locator.to_s)
+        end
+      end
+
+      def click_associated_label?(playwright_element_handle_or_locator)
+        return true if playwright_element_handle_or_locator.evaluate('el => !!el.checked') == @checked
+
+        label_element_handle = playwright_element_handle_or_locator.evaluate_handle('(el) => (el.labels && el.labels[0]) || el.closest("label") || null')
+        return false unless label_element_handle.is_a?(::Playwright::ElementHandle)
+
+        label_element_handle.click
+
+        playwright_element_handle_or_locator.evaluate('el => !!el.checked') == @checked
+      end
+
+      def find_playwright_element_handle_by_non_label_locator
+        return nil if @locator.nil?
+
+        locator_string = @locator.to_s
+        test_id_attr = session_options.test_id&.to_s
+
+        driver.with_playwright_page do |playwright_page|
+          return non_label_playwright_element_handle_candidates(playwright_page).find do |element_handle|
+            attribute_values = element_handle.evaluate(<<~JAVASCRIPT, arg: test_id_attr)
+            (el, testIdAttr) => ({
+              id: el.id || '',
+              name: el.getAttribute('name') || '',
+              testId: testIdAttr ? (el.getAttribute(testIdAttr) || '') : '',
+            })
+            JAVASCRIPT
+            [attribute_values['id'], attribute_values['name'], attribute_values['testId']].include?(locator_string)
+          end
+        end
+      rescue ::Playwright::Error
+        nil
+      end
+
+      def non_label_playwright_element_handle_candidates(playwright_page)
+        input_type =
+          case @node_type
+          when :checkbox
+            'checkbox'
+          when :radio_button
+            'radio'
+          else
+            return []
+          end
+
+        current_scope = scope_element
+        return current_scope.query_selector_all(%(input[type="#{input_type}"])) if current_scope
+
+        playwright_page.capybara_current_frame.query_selector_all(%(input[type="#{input_type}"]))
+      end
+
+      def scope_element
+        return nil unless @node.is_a?(Capybara::Node::Element)
+        return nil unless @node.send(:base).is_a?(Capybara::Playwright::Node)
+
+        @node.send(:base).send(:element)
+      end
+
+      def driver
+        @node.send(:driver)
+      end
+
+      def session_options
+        @node.send(:session_options)
+      end
+    end
+
+    def choose(locator = nil, **options)
+      check_via_label_click(:radio_button, locator, checked: true, **options) { super }
+    end
+
+    def check(locator = nil, **options)
+      check_via_label_click(:checkbox, locator, checked: true, **options) { super }
+    end
+
+    def uncheck(locator = nil, **options)
+      check_via_label_click(:checkbox, locator, checked: false, **options) { super }
+    end
+
+    private def check_via_label_click(node_type, locator, checked:, allow_label_click: session_options.automatic_label_click, **options)
+      unless should_use_label_click?(allow_label_click, options)
+        return yield
+      end
+
+      handler = SelectableElementHandler.new(
+        node: self,
+        node_type: node_type,
+        locator: locator,
+        checked: checked,
+      )
+      return self if handler.set_checked_state_via_label?
+
+      yield
+    end
+
+    private def should_use_label_click?(allow_label_click, options)
+      return false unless allow_label_click
+      return false unless driver.is_a?(Capybara::Playwright::Driver)
+      return false if Hash.try_convert(allow_label_click)
+      return false unless options.empty?
+
+      true
+    end
+  end
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7')
+    # Prepend to Node::Base instead of Node::Actions because Ruby < 3.1
+    # does not propagate Module#prepend to classes that have already
+    # included the target module. Node::Base includes Node::Actions at
+    # load time, so prepending to Node::Actions afterwards has no effect
+    # on Node::Document / Node::Element in older Rubies.
+    Node::Base.prepend(NodeActionsAllowLabelClickPatch)
+  end
+
+  module CapybaraObscuredPatch
+    # ref: https://github.com/teamcapybara/capybara/blob/f7ab0b5cd5da86185816c2d5c30d58145fe654ed/lib/capybara/selenium/node.rb#L523
+    OBSCURED_OR_OFFSET_SCRIPT = <<~JAVASCRIPT
+    (el, [x, y]) => {
+      var box = el.getBoundingClientRect();
+      if (!x && x != 0) x = box.width/2;
+      if (!y && y != 0) y = box.height/2;
+      var px = box.left + x,
+          py = box.top + y,
+          e = document.elementFromPoint(px, py);
+      if (!el.contains(e))
+        return true;
+      return { x: px, y: py };
+    }
+    JAVASCRIPT
+
+    def capybara_obscured?(x: nil, y: nil)
+      res = evaluate(OBSCURED_OR_OFFSET_SCRIPT, arg: [x, y])
+      return true if res == true
+
+      # ref: https://github.com/teamcapybara/capybara/blob/f7ab0b5cd5da86185816c2d5c30d58145fe654ed/lib/capybara/selenium/driver.rb#L182
+      frame = owner_frame
+      return false unless frame.parent_frame
+
+      frame.frame_element.capybara_obscured?(x: res['x'], y: res['y'])
+    end
+  end
+  ::Playwright::ElementHandle.prepend(CapybaraObscuredPatch)
+
+  # ref: https://github.com/teamcapybara/capybara/pull/2424
+  module ElementDropPathCompatPatch
+    def drop(*args)
+      options = args.map { |arg| arg.respond_to?(:to_path) ? arg.to_path : arg }
+      synchronize { base.drop(*options) }
+      self
+    end
+  end
+  if Gem::Version.new(Capybara::VERSION) < Gem::Version.new('3.34.0')
+    # Older Capybara returns early for Pathname arguments in Element#drop,
+    # so the driver implementation never runs.
+    Node::Element.prepend(ElementDropPathCompatPatch)
+  end
+
+  module Playwright
+    # Selector and checking methods are derived from twapole/apparition
+    # Action methods (click, select_option, ...) uses playwright.
+    #
+    # ref:
+    #   selenium:   https://github.com/teamcapybara/capybara/blob/master/lib/capybara/selenium/node.rb
+    #   apparition: https://github.com/twalpole/apparition/blob/master/lib/capybara/apparition/node.rb
+    class Node < ::Capybara::Driver::Node
+      def initialize(driver, internal_logger, page, element)
+        super(driver, element)
+        @internal_logger = internal_logger
+        @page = page
+        @element = element
+      end
+
+      protected def element
+        @element
+      end
+
+      private def assert_element_not_stale(&block)
+        # Playwright checks the staled state only when
+        # actionable methods. (click, select_option, hover, ...)
+        # Capybara expects stale checking also when getting inner text, and so on.
+        @element.enabled?
+
+        block.call
+      rescue ::Playwright::Error => err
+        case err.message
+        when /Element is not attached to the DOM/
+          raise StaleReferenceError.new(err)
+        when /Execution context was destroyed, most likely because of a navigation/
+          raise StaleReferenceError.new(err)
+        when /Cannot find context with specified id/
+          raise StaleReferenceError.new(err)
+        when /Unable to adopt element handle from a different document/ # for WebKit.
+          raise StaleReferenceError.new(err)
+        when /error in channel "content::page": exception while running method "adoptNode"/ # for Firefox
+          raise StaleReferenceError.new(err)
+        when /(: Shadow DOM element - no XPath :)/
+          raise StaleReferenceError.new(err)
+        else
+          raise
+        end
+      end
+
+      private def capybara_default_wait_time
+        Capybara.default_max_wait_time * 1100 # with 10% buffer for allowing overhead.
+      end
+
+      class NotActionableError < StandardError ; end
+      class StaleReferenceError < StandardError ; end
+
+      def all_text
+        assert_element_not_stale {
+          text = @element.text_content
+          text.to_s.gsub(/[\u200b\u200e\u200f]/, '')
+              .gsub(/[\ \n\f\t\v\u2028\u2029]+/, ' ')
+              .gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
+              .gsub(/[[:space:]&&[^\u00a0]]+\z/, '')
+              .tr("\u00a0", ' ')
+        }
+      end
+
+      def visible_text
+        assert_element_not_stale {
+          return '' unless visible?
+
+          text = @element.evaluate(<<~JAVASCRIPT)
+            function(el){
+              if (el.nodeName == 'TEXTAREA'){
+                return el.textContent;
+              } else if (el instanceof SVGElement) {
+                return el.textContent;
+              } else {
+                return el.innerText;
+              }
+            }
+          JAVASCRIPT
+          text.to_s.scrub.gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
+              .gsub(/[[:space:]&&[^\u00a0]]+\z/, '')
+              .gsub(/\n+/, "\n")
+              .tr("\u00a0", ' ')
+        }
+      end
+
+      def [](name)
+        assert_element_not_stale {
+          property(name) || attribute(name)
+        }
+      end
+
+      private def property(name)
+        value = @element.get_property(name)
+        value.evaluate("value => ['object', 'function'].includes(typeof value) ? null : value")
+      end
+
+      private def attribute(name)
+        @element.get_attribute(name)
+      end
+
+      def value
+        assert_element_not_stale {
+          # ref: https://github.com/teamcapybara/capybara/blob/f7ab0b5cd5da86185816c2d5c30d58145fe654ed/lib/capybara/selenium/node.rb#L31
+          # ref: https://github.com/twalpole/apparition/blob/11aca464b38b77585191b7e302be2e062bdd369d/lib/capybara/apparition/node.rb#L728
+          if tag_name == 'select' && @element.evaluate('el => el.multiple')
+            @element.query_selector_all('option:checked').map do |option|
+              option.evaluate('el => el.value')
+            end
+          else
+            @element.evaluate('el => el.value')
+          end
+        }
+      end
+
+      def style(styles)
+        # Capybara provides default implementation.
+        # ref: https://github.com/teamcapybara/capybara/blob/f7ab0b5cd5da86185816c2d5c30d58145fe654ed/lib/capybara/node/element.rb#L92
+        raise NotImplementedError
+      end
+
+      # @param value [String, Array] Array is only allowed if node has 'multiple' attribute
+      # @param options [Hash] Driver specific options for how to set a value on a node
+      def set(value, **options)
+        settable_class =
+          case tag_name
+          when 'input'
+            case attribute('type')
+            when 'radio'
+              RadioButton
+            when 'checkbox'
+              Checkbox
+            when 'file'
+              FileUpload
+            when 'date'
+              DateInput
+            when 'time'
+              TimeInput
+            when 'datetime-local'
+              DateTimeInput
+            when 'color'
+              JSValueInput
+            when 'range'
+              JSValueInput
+            else
+              TextInput
+            end
+          when 'textarea'
+            TextInput
+          else
+            if @element.editable?
+              TextInput
+            else
+              raise NotSupportedByDriverError
+            end
+          end
+
+        settable_class.new(@element, capybara_default_wait_time, @internal_logger).set(value, **options)
+      rescue ::Playwright::TimeoutError => err
+        raise NotActionableError.new(err)
+      end
+
+      class Settable
+        def initialize(element, timeout, internal_logger)
+          @element = element
+          @timeout = timeout
+          @internal_logger = internal_logger
+        end
+      end
+
+      class RadioButton < Settable
+        def set(_, **options)
+          @element.check(timeout: @timeout)
+        end
+      end
+
+      class Checkbox < Settable
+        def set(value, **options)
+          if value
+            @element.check(timeout: @timeout)
+          else
+            @element.uncheck(timeout: @timeout)
+          end
+        end
+      end
+
+      class TextInput < Settable
+        def set(value, **options)
+          case options[:clear]
+          when :backspace
+            @element.press('End', timeout: @timeout)
+            existing_text = @element.evaluate('el => el.value')
+            existing_text.length.times { @element.press('Backspace', timeout: @timeout) }
+          when :none
+            @element.press('End', timeout: @timeout)
+          when Array
+            @internal_logger.warn "options { clear: #{options[:clear]} } is ignored"
+          end
+
+          text = value.to_s
+          if press_enter = text.end_with?("\n")
+            text = text[0...-1]
+          end
+
+          if options[:clear] == :none
+            @element.type(text, timeout: @timeout)
+          else
+            @element.fill(text, timeout: @timeout)
+          end
+
+          if press_enter
+            @element.press('Enter', timeout: @timeout)
+          end
+        rescue ::Playwright::TimeoutError
+          raise if @element.editable?
+
+          @internal_logger.info("Node#set: element is not editable. #{@element}")
+        end
+      end
+
+      class FileUpload < Settable
+        def set(value, **options)
+          file =
+            if value.is_a?(File)
+              value.path
+            elsif value.is_a?(Enumerable)
+              value.map(&:to_s)
+            else
+              value.to_s
+            end
+          @element.set_input_files(file, timeout: @timeout)
+        end
+      end
+
+      module UpdateValueJS
+        def update_value_js(element, value)
+          # ref: https://github.com/teamcapybara/capybara/blob/f7ab0b5cd5da86185816c2d5c30d58145fe654ed/lib/capybara/selenium/node.rb#L343
+          js = <<~JAVASCRIPT
+          (el, value) => {
+            if (el.readOnly) { return };
+            if (document.activeElement !== el){
+              el.focus();
+            }
+            if (el.value != value) {
+              el.value = value;
+              el.dispatchEvent(new InputEvent('input'));
+              el.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+          }
+          JAVASCRIPT
+          element.evaluate(js, arg: value)
+        end
+      end
+
+      class DateInput < Settable
+        include UpdateValueJS
+
+        def set(value, **options)
+          if !value.is_a?(String) && value.respond_to?(:to_date)
+            update_value_js(@element, value.to_date.iso8601)
+          else
+            @element.fill(value.to_s, timeout: @timeout)
+          end
+        end
+      end
+
+      class TimeInput < Settable
+        include UpdateValueJS
+
+        def set(value, **options)
+          if !value.is_a?(String) && value.respond_to?(:to_time)
+            update_value_js(@element, value.to_time.strftime('%H:%M'))
+          else
+            @element.fill(value.to_s, timeout: @timeout)
+          end
+        end
+      end
+
+      class DateTimeInput < Settable
+        include UpdateValueJS
+
+        def set(value, **options)
+          if !value.is_a?(String) && value.respond_to?(:to_time)
+            update_value_js(@element, value.to_time.strftime('%Y-%m-%dT%H:%M'))
+          else
+            @element.fill(value.to_s, timeout: @timeout)
+          end
+        end
+      end
+
+      class JSValueInput < Settable
+        include UpdateValueJS
+
+        def set(value, **options)
+          update_value_js(@element, value)
+        end
+      end
+
+      def select_option
+        return false if disabled?
+
+        select_element = parent_select_element
+        if select_element.evaluate('el => el.multiple')
+          selected_options = select_element.query_selector_all('option:checked')
+          selected_options << @element
+          select_element.select_option(element: selected_options, timeout: capybara_default_wait_time)
+        else
+          select_element.select_option(element: @element, timeout: capybara_default_wait_time)
+        end
+      end
+
+      def unselect_option
+        if parent_select_element.evaluate('el => el.multiple')
+          return false if disabled?
+
+          @element.evaluate('el => el.selected = false')
+        else
+          raise Capybara::UnselectNotAllowed, 'Cannot unselect option from single select box.'
+        end
+      end
+
+      private def parent_select_element
+        @element.query_selector('xpath=ancestor::select')
+      end
+
+      def click(keys = [], **options)
+        click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
+        @element.click(**click_options.as_params)
+      end
+
+      def right_click(keys = [], **options)
+        click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
+        params = click_options.as_params
+        params[:button] = 'right'
+        @element.click(**params)
+      end
+
+      def double_click(keys = [], **options)
+        click_options = ClickOptions.new(@element, keys, options, capybara_default_wait_time)
+        @element.dblclick(**click_options.as_params)
+      end
+
+      class ClickOptions
+        def initialize(element, keys, options, default_timeout)
+          @element = element
+          @modifiers = keys.map do |key|
+            MODIFIERS[key.to_sym] or raise ArgumentError.new("Unknown modifier key: #{key}")
+          end
+          if options[:x] && options[:y]
+            @coords = {
+              x: options[:x],
+              y: options[:y],
+            }
+            @offset_center = options[:offset] == :center
+          end
+          @wait = options[:_playwright_wait]
+          @delay = options[:delay]
+          @default_timeout = default_timeout
+        end
+
+        def as_params
+          {
+            delay: delay_ms,
+            modifiers: modifiers,
+            position: position,
+            timeout: timeout + delay_ms.to_i,
+          }.compact
+        end
+
+        private def timeout
+          if @wait
+            if @wait <= 0
+              raise NotSupportedByDriverError.new("wait should be > 0 (wait = 0 is not supported on this driver)")
+            end
+
+            @wait * 1000
+          else
+            @default_timeout
+          end
+        end
+
+        private def delay_ms
+          if @delay && @delay > 0
+            @delay * 1000
+          else
+            nil
+          end
+        end
+
+        MODIFIERS = {
+          alt: 'Alt',
+          ctrl: 'Control',
+          control: 'Control',
+          meta: 'Meta',
+          command: 'Meta',
+          cmd: 'Meta',
+          shift: 'Shift',
+        }.freeze
+
+        private def modifiers
+          if @modifiers.empty?
+            nil
+          else
+            @modifiers
+          end
+        end
+
+        private def position
+          if @offset_center
+            box = @element.bounding_box
+
+            {
+              x: @coords[:x] + box['width'] / 2,
+              y: @coords[:y] + box['height'] / 2,
+            }
+          else
+            @coords
+          end
+        end
+      end
+
+      def send_keys(*args)
+        SendKeys.new(@element, args).execute
+      end
+
+      class SendKeys
+        MODIFIERS = {
+          alt: 'Alt',
+          ctrl: 'Control',
+          control: 'Control',
+          meta: 'Meta',
+          command: 'Meta',
+          cmd: 'Meta',
+          shift: 'Shift',
+        }.freeze
+
+        KEYS = {
+          cancel: 'Cancel',
+          help: 'Help',
+          backspace: 'Backspace',
+          tab: 'Tab',
+          clear: 'Clear',
+          return: 'Enter',
+          enter: 'Enter',
+          shift: 'Shift',
+          control: 'Control',
+          alt: 'Alt',
+          pause: 'Pause',
+          escape: 'Escape',
+          space: 'Space',
+          page_up: 'PageUp',
+          page_down: 'PageDown',
+          end: 'End',
+          home: 'Home',
+          left: 'ArrowLeft',
+          up: 'ArrowUp',
+          right: 'ArrowRight',
+          down: 'ArrowDown',
+          insert: 'Insert',
+          delete: 'Delete',
+          semicolon: 'Semicolon',
+          equals: 'Equal',
+          numpad0: 'Numpad0',
+          numpad1: 'Numpad1',
+          numpad2: 'Numpad2',
+          numpad3: 'Numpad3',
+          numpad4: 'Numpad4',
+          numpad5: 'Numpad5',
+          numpad6: 'Numpad6',
+          numpad7: 'Numpad7',
+          numpad8: 'Numpad8',
+          numpad9: 'Numpad9',
+          multiply: 'NumpadMultiply',
+          add: 'NumpadAdd',
+          separator: 'NumpadDecimal',
+          subtract: 'NumpadSubtract',
+          decimal: 'NumpadDecimal',
+          divide: 'NumpadDivide',
+          f1: 'F1',
+          f2: 'F2',
+          f3: 'F3',
+          f4: 'F4',
+          f5: 'F5',
+          f6: 'F6',
+          f7: 'F7',
+          f8: 'F8',
+          f9: 'F9',
+          f10: 'F10',
+          f11: 'F11',
+          f12: 'F12',
+          meta: 'Meta',
+          command: 'Meta',
+        }
+
+        def initialize(element_or_keyboard, keys)
+          @element_or_keyboard = element_or_keyboard
+
+          holding_keys = []
+          @executables = keys.each_with_object([]) do |key, executables|
+            if MODIFIERS[key]
+              holding_keys << key
+            else
+              if holding_keys.empty?
+                case key
+                when String
+                  executables << TypeText.new(key)
+                when Symbol
+                  executables << PressKey.new(
+                    key: key_for(key),
+                    modifiers: [],
+                  )
+                when Array
+                  _key = key.last
+                  code =
+                    if _key.is_a?(String) && _key.length == 1
+                      _key
+                    elsif _key.is_a?(Symbol)
+                      key_for(_key)
+                    else
+                      raise ArgumentError.new("invalid key: #{_key}. Symbol of 1-length String is expected.")
+                    end
+                  modifiers = key.first(key.size - 1).map { |k| modifier_for(k) }
+                  executables << PressKey.new(
+                    key: code,
+                    modifiers: modifiers,
+                  )
+                end
+              else
+                modifiers = holding_keys.map { |k| modifier_for(k) }
+
+                case key
+                when String
+                  key.each_char do |char|
+                    executables << PressKey.new(
+                      key: char,
+                      modifiers: modifiers,
+                    )
+                  end
+                when Symbol
+                  executables << PressKey.new(
+                    key: key_for(key),
+                    modifiers: modifiers
+                  )
+                else
+                  raise ArgumentError.new("#{key} cannot be handled with holding key #{holding_keys}")
+                end
+              end
+            end
+          end
+        end
+
+        private def modifier_for(modifier)
+          MODIFIERS[modifier] or raise ArgumentError.new("invalid modifier specified: #{modifier}")
+        end
+
+        private def key_for(key)
+          KEYS[key] or raise ArgumentError.new("invalid key specified: #{key}")
+        end
+
+        def execute
+          @executables.each do |executable|
+            executable.execute_for(@element_or_keyboard)
+          end
+        end
+
+        class PressKey
+          def initialize(key:, modifiers:)
+            # Shift requires an explicitly uppercase a-z key to produce the correct output
+            # See https://playwright.dev/docs/input#keys-and-shortcuts
+            key = key.upcase if modifiers == [MODIFIERS[:shift]] && key.match?(/^[a-z]$/)
+
+            # puts "PressKey: key=#{key} modifiers: #{modifiers}"
+            if modifiers.empty?
+              @key = key
+            else
+              @key = (modifiers + [key]).join('+')
+            end
+          end
+
+          def execute_for(element)
+            element.press(@key)
+          end
+        end
+
+        class TypeText
+          def initialize(text)
+            @text = text
+          end
+
+          def execute_for(element)
+            element.type(@text)
+          end
+        end
+      end
+
+      def hover
+        @element.hover(timeout: capybara_default_wait_time)
+      end
+
+      def drag_to(element, **options)
+        DragTo.new(@page, @element, element.element, options).execute
+      end
+
+      class DragTo
+        MODIFIERS = {
+          alt: 'Alt',
+          ctrl: 'Control',
+          control: 'Control',
+          meta: 'Meta',
+          command: 'Meta',
+          cmd: 'Meta',
+          shift: 'Shift',
+        }.freeze
+
+        # @param page [Playwright::Page]
+        # @param source [Playwright::ElementHandle]
+        # @param target [Playwright::ElementHandle]
+        def initialize(page, source, target, options)
+          @page = page
+          @source = source
+          @target = target
+          @options = options
+        end
+
+        def execute
+          @source.scroll_into_view_if_needed
+
+          # down
+          position_from = center_of(@source)
+          @page.mouse.move(*position_from)
+          @page.mouse.down
+
+          @target.scroll_into_view_if_needed
+
+          # move and up
+          sleep_delay
+          position_to = center_of(@target)
+          with_key_pressing(drop_modifiers) do
+            @page.mouse.move(*position_to, steps: 6)
+            sleep_delay
+            @page.mouse.up
+          end
+          sleep_delay
+        end
+
+        # @param element [Playwright::ElementHandle]
+        private def center_of(element)
+          box = element.bounding_box
+          [box["x"] + box["width"] / 2, box["y"] + box["height"] / 2]
+        end
+
+        private def with_key_pressing(keys, &block)
+          keys.each { |key| @page.keyboard.down(key) }
+          block.call
+          keys.each { |key| @page.keyboard.up(key) }
+        end
+
+        # @returns Array<String>
+        private def drop_modifiers
+          return [] unless @options[:drop_modifiers]
+
+          Array(@options[:drop_modifiers]).map do |key|
+            MODIFIERS[key.to_sym]  or raise ArgumentError.new("Unknown modifier key: #{key}")
+          end
+        end
+
+        private def sleep_delay
+          return unless @options[:delay]
+
+          sleep @options[:delay]
+        end
+      end
+
+      ATTACH_FILE = <<~JAVASCRIPT
+        () => {
+          const input = document.createElement('INPUT');
+          input.type = 'file';
+          input.multiple = true;
+          input.style.display = 'none';
+          document.body.appendChild(input);
+          return input;
+        }
+      JAVASCRIPT
+
+      DROP_FILE = <<~JAVASCRIPT
+        (el, input) => {
+          const dt = new DataTransfer();
+          for (const file of input.files) { dt.items.add(file); }
+          input.remove();
+          el.dispatchEvent(new DragEvent('drop', {
+            cancelable: true, bubbles: true, dataTransfer: dt
+          }));
+        }
+      JAVASCRIPT
+
+      DROP_STRING = <<~JAVASCRIPT
+        (el, items) => {
+          const dt = new DataTransfer();
+          for (const item of items) { dt.items.add(item.data, item.type); }
+          el.dispatchEvent(new DragEvent('drop', {
+            cancelable: true, bubbles: true, dataTransfer: dt
+          }));
+        }
+      JAVASCRIPT
+
+      def drop(*args)
+        if args.first.is_a?(String) || args.first.is_a?(Pathname)
+          input = @page.evaluate_handle(ATTACH_FILE)
+          input.as_element.set_input_files(args.map(&:to_s))
+          @element.evaluate(DROP_FILE, arg: input)
+        else
+          items = args.flat_map { |arg| arg.map { |(type, data)| { type: type, data: data } } }
+          @element.evaluate(DROP_STRING, arg: items)
+        end
+      end
+
+      def scroll_by(x, y)
+        js = <<~JAVASCRIPT
+        (el, [x, y]) => {
+          if (el.scrollBy){
+            el.scrollBy(x, y);
+          } else {
+            el.scrollTop = el.scrollTop + y;
+            el.scrollLeft = el.scrollLeft + x;
+          }
+        }
+        JAVASCRIPT
+
+        @element.evaluate(js, arg: [x, y])
+      end
+
+      def scroll_to(element, location, position = nil)
+        # location, element = element, nil if element.is_a? Symbol
+        if element.is_a? Capybara::Playwright::Node
+          scroll_element_to_location(element, location)
+        elsif location.is_a? Symbol
+          scroll_to_location(location)
+        else
+          scroll_to_coords(*position)
+        end
+
+        self
+      end
+
+      private def scroll_element_to_location(element, location)
+        scroll_opts =
+          case location
+          when :top
+            'true'
+          when :bottom
+            'false'
+          when :center
+            "{behavior: 'instant', block: 'center'}"
+          else
+            raise ArgumentError, "Invalid scroll_to location: #{location}"
+          end
+
+        element.native.evaluate("(el) => { el.scrollIntoView(#{scroll_opts}) }")
+      end
+
+      SCROLL_POSITIONS = {
+        top: '0',
+        bottom: 'el.scrollHeight',
+        center: '(el.scrollHeight - el.clientHeight)/2'
+      }.freeze
+
+      private def scroll_to_location(location)
+        position = SCROLL_POSITIONS[location]
+
+        @element.evaluate(<<~JAVASCRIPT)
+        (el) => {
+          if (el.scrollTo){
+            el.scrollTo(0, #{position});
+          } else {
+            el.scrollTop = #{position};
+          }
+        }
+        JAVASCRIPT
+      end
+
+      private def scroll_to_coords(x, y)
+        js = <<~JAVASCRIPT
+        (el, [x, y]) => {
+          if (el.scrollTo){
+            el.scrollTo(x, y);
+          } else {
+            el.scrollTop = y;
+            el.scrollLeft = x;
+          }
+        }
+        JAVASCRIPT
+
+        @element.evaluate(js, arg: [x, y])
+      end
+
+      def tag_name
+        @tag_name ||= @element.evaluate('e => e.tagName.toLowerCase()')
+      end
+
+      def visible?
+        assert_element_not_stale {
+          # if an area element, check visibility of relevant image
+          @element.evaluate(<<~JAVASCRIPT)
+          function(el) {
+            if (el.tagName == 'AREA'){
+              const map_name = document.evaluate('./ancestor::map/@name', el, null, XPathResult.STRING_TYPE, null).stringValue;
+              el = document.querySelector(`img[usemap='#${map_name}']`);
+              if (!el){
+              return false;
+              }
+            }
+            var forced_visible = false;
+            while (el) {
+              const style = window.getComputedStyle(el);
+              if (style.visibility == 'visible')
+                forced_visible = true;
+              if ((style.display == 'none') ||
+                  ((style.visibility == 'hidden') && !forced_visible) ||
+                  (parseFloat(style.opacity) == 0)) {
+                return false;
+              }
+              var parent = el.parentElement;
+              if (parent && (parent.tagName == 'DETAILS') && !parent.open && (el.tagName != 'SUMMARY')) {
+                return false;
+              }
+              el = parent;
+            }
+            return true;
+          }
+          JAVASCRIPT
+        }
+      end
+
+      def obscured?
+        @element.capybara_obscured?
+      end
+
+      def checked?
+        assert_element_not_stale {
+          @element.evaluate('el => !!el.checked')
+        }
+      end
+
+      def selected?
+        assert_element_not_stale {
+          @element.evaluate('el => !!el.selected')
+        }
+      end
+
+      def disabled?
+        @element.evaluate(<<~JAVASCRIPT)
+        function(el) {
+          const xpath = 'parent::optgroup[@disabled] | \
+                        ancestor::select[@disabled] | \
+                        parent::fieldset[@disabled] | \
+                        ancestor::*[not(self::legend) or preceding-sibling::legend][parent::fieldset[@disabled]]';
+          return el.disabled || document.evaluate(xpath, el, null, XPathResult.BOOLEAN_TYPE, null).booleanValue
+        }
+        JAVASCRIPT
+      end
+
+      def readonly?
+        !@element.editable?
+      end
+
+      def multiple?
+        @element.evaluate('el => el.multiple')
+      end
+
+      def rect
+        assert_element_not_stale {
+          @element.evaluate(<<~JAVASCRIPT)
+          function(el){
+            const rects = [...el.getClientRects()]
+            const rect = rects.find(r => (r.height && r.width)) || el.getBoundingClientRect();
+            return rect.toJSON();
+          }
+          JAVASCRIPT
+        }
+      end
+
+      def path
+        assert_element_not_stale {
+          @element.evaluate(<<~JAVASCRIPT)
+          (el) => {
+            var xml = document;
+            var xpath = '';
+            var pos, tempitem2;
+            if (el.getRootNode && el.getRootNode() instanceof ShadowRoot) {
+              return "(: Shadow DOM element - no XPath :)";
+            };
+            while(el !== xml.documentElement) {
+              pos = 0;
+              tempitem2 = el;
+              while(tempitem2) {
+                if (tempitem2.nodeType === 1 && tempitem2.nodeName === el.nodeName) { // If it is ELEMENT_NODE of the same name
+                  pos += 1;
+                }
+                tempitem2 = tempitem2.previousSibling;
+              }
+              if (el.namespaceURI != xml.documentElement.namespaceURI) {
+                xpath = "*[local-name()='"+el.nodeName+"' and namespace-uri()='"+(el.namespaceURI===null?'':el.namespaceURI)+"']["+pos+']'+'/'+xpath;
+              } else {
+                xpath = el.nodeName.toUpperCase()+"["+pos+"]/"+xpath;
+              }
+              el = el.parentNode;
+              if (!el) {
+                throw "(: Shadow DOM element - no XPath :)";
+              }
+            }
+            xpath = '/'+xml.documentElement.nodeName.toUpperCase()+'/'+xpath;
+            xpath = xpath.replace(/\\/$/, '');
+            return xpath;
+          }
+          JAVASCRIPT
+        }
+      end
+
+      def trigger(event)
+        @element.dispatch_event(event)
+      end
+
+      def shadow_root
+        # Playwright does not distinguish shadow DOM.
+        # https://playwright.dev/docs/selectors#selecting-elements-in-shadow-dom
+        # Just do with Host element as shadow root Element.
+        #
+        #   Node.new(@driver, @page, @element.evaluate_handle('el => el.shadowRoot'))
+        #
+        # does not work well because of the Playwright Error 'Element is not attached to the DOM'
+        ShadowRootNode.new(@driver, @internal_logger, @page, @element)
+      end
+
+      def inspect
+        %(#<#{self.class} tag="#{tag_name}" path="#{path}">)
+      end
+
+      def ==(other)
+        return false unless other.is_a?(Node)
+
+        @element.evaluate('(self, other) => self == other', arg: other.element)
+      end
+
+      def find_xpath(query, **options)
+        assert_element_not_stale {
+          @element.query_selector_all("xpath=#{query}").map do |el|
+            Node.new(@driver, @internal_logger, @page, el)
+          end
+        }
+      end
+
+      def find_css(query, **options)
+        assert_element_not_stale {
+          @element.query_selector_all(query).map do |el|
+            Node.new(@driver, @internal_logger, @page, el)
+          end
+        }
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/page.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/page.rb
@@ -1,0 +1,192 @@
+require 'fileutils'
+
+module Capybara
+  module Playwright
+    module PageExtension
+      def initialize(*args, **kwargs)
+        if kwargs.empty?
+          super(*args)
+        else
+          super(*args, **kwargs)
+        end
+        capybara_initialize
+      end
+
+      private def _update_internal_logger(internal_logger)
+        @internal_logger = internal_logger
+      end
+
+      private def capybara_initialize
+        @capybara_response_mutex = Mutex.new
+        @capybara_last_response = nil
+        @capybara_frames = []
+
+        on('dialog', -> (dialog) {
+          capybara_dialog_event_handler.handle_dialog(dialog)
+        })
+        on('download', -> (download) {
+          FileUtils.mkdir_p(Capybara.save_path)
+          dest = File.join(Capybara.save_path, download.suggested_filename)
+          # download.save_as blocks main thread until download completes.
+          Thread.new(dest) { |_dest| download.save_as(_dest) }
+        })
+        on('response', -> (response) {
+          if response.request.navigation_request?
+            capybara_set_last_response(response)
+          end
+        })
+      end
+
+      private def capybara_dialog_event_handler
+        @capybara_dialog_event_handler ||= DialogEventHandler.new.tap do |h|
+          h.default_handler = method(:capybara_on_unexpected_modal)
+        end
+      end
+
+      private def capybara_on_unexpected_modal(dialog)
+        @internal_logger.warn "Unexpected modal - \"#{dialog.message}\""
+        if dialog.type == 'beforeunload'
+          dialog.accept_async
+        else
+          dialog.dismiss
+        end
+      end
+
+      class DialogAcceptor
+        def initialize(dialog_type, options)
+          @dialog_type = dialog_type
+          @options = options
+        end
+
+        def handle(dialog)
+          if @dialog_type == :prompt
+            dialog.accept_async(promptText: @options[:with] || dialog.default_value)
+          else
+            dialog.accept_async
+          end
+        end
+      end
+
+      class DialogMessageMatcher
+        def initialize(text_or_regex_or_nil)
+          if [NilClass, Regexp, String].none? { |k| text_or_regex_or_nil.is_a?(k) }
+            raise ArgumentError.new("invalid type: #{text_or_regex_or_nil.inspect}")
+          end
+
+          @filter = text_or_regex_or_nil
+        end
+
+        def matches?(message)
+          case @filter
+          when nil
+            true
+          when Regexp
+            message =~ @filter
+          when String
+            message&.include?(@filter)
+          end
+        end
+      end
+
+      def capybara_accept_modal(dialog_type, **options, &block)
+        timeout_sec = options[:wait]
+        acceptor = DialogAcceptor.new(dialog_type, options)
+        matcher = DialogMessageMatcher.new(options[:text])
+        message_promise = Concurrent::Promises.resolvable_future
+        handler = -> (dialog) {
+          message = dialog.message
+          if matcher.matches?(message)
+            message_promise.fulfill(message)
+            acceptor.handle(dialog)
+          else
+            message_promise.reject(Capybara::ModalNotFound.new("Dialog message=\"#{message}\" doesn't match"))
+            dialog.dismiss
+          end
+        }
+        capybara_dialog_event_handler.with_handler(handler) do
+          block.call
+
+          message = message_promise.value!(timeout_sec)
+          if message_promise.fulfilled?
+            message
+          else
+            # timed out
+            raise Capybara::ModalNotFound
+          end
+        end
+      end
+
+      def capybara_dismiss_modal(dialog_type, **options, &block)
+        timeout_sec = options[:wait]
+        matcher = DialogMessageMatcher.new(options[:text])
+        message_promise = Concurrent::Promises.resolvable_future
+        handler = -> (dialog) {
+          message = dialog.message
+          if matcher.matches?(message)
+            message_promise.fulfill(message)
+          else
+            message_promise.reject(Capybara::ModalNotFound.new("Dialog message=\"#{message}\" doesn't match"))
+          end
+          dialog.dismiss
+        }
+        capybara_dialog_event_handler.with_handler(handler) do
+          block.call
+
+          message = message_promise.value!(timeout_sec)
+          if message_promise.fulfilled?
+            message
+          else
+            # timed out
+            raise Capybara::ModalNotFound
+          end
+        end
+      end
+
+      def capybara_set_last_response(response)
+        @capybara_response_mutex.synchronize do
+          @capybara_last_response = response
+        end
+      end
+
+      class Headers < Hash
+        def [](key)
+          # Playwright accepts lower-cased keys.
+          # However allow users to specify "Content-Type" or "User-Agent".
+          super(key.downcase)
+        end
+      end
+
+      def capybara_response_headers
+        headers = @capybara_response_mutex.synchronize { @capybara_last_response&.headers || {} }
+
+        Headers.new.tap do |h|
+          headers.each do |key, value|
+            h[key] = value
+          end
+        end
+      end
+
+      def capybara_status_code
+        @capybara_response_mutex.synchronize { @capybara_last_response&.status.to_i }
+      end
+
+      def capybara_reset_frames
+        @capybara_frames.clear
+      end
+
+      # @param frame [Playwright::Frame]
+      def capybara_push_frame(frame)
+        @capybara_frames << frame
+      end
+
+      def capybara_pop_frame
+        @capybara_frames.pop
+      end
+
+      def capybara_current_frame
+        @capybara_frames.last || main_frame
+      end
+    end
+    ::Playwright::Page.prepend(PageExtension)
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/page_options.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/page_options.rb
@@ -1,0 +1,46 @@
+module Capybara
+  module Playwright
+    class PageOptions
+      def initialize(options)
+        @options = options
+      end
+
+      NEW_PAGE_PARAMS = {
+        acceptDownloads: nil,
+        bypassCSP: nil,
+        colorScheme: nil,
+        deviceScaleFactor: nil,
+        extraHTTPHeaders: nil,
+        geolocation: nil,
+        hasTouch: nil,
+        httpCredentials: nil,
+        ignoreHTTPSErrors: nil,
+        isMobile: nil,
+        javaScriptEnabled: nil,
+        locale: nil,
+        noViewport: nil,
+        offline: nil,
+        permissions: nil,
+        proxy: nil,
+        record_har_omit_content: nil,
+        record_har_path: nil,
+        record_video_dir: nil,
+        record_video_size: nil,
+        reducedMotion: nil,
+        screen: nil,
+        serviceWorkers: nil,
+        storageState: nil,
+        timezoneId: nil,
+        userAgent: nil,
+        viewport: nil,
+      }.keys
+
+      def value
+        @options.select { |k, _| NEW_PAGE_PARAMS.include?(k) }.tap do |options|
+          # Set default value
+          options[:acceptDownloads] = true
+        end
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/shadow_root_node.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/shadow_root_node.rb
@@ -1,0 +1,40 @@
+require_relative './node'
+
+module Capybara
+  module Playwright
+    class ShadowRootNode < Node
+      def initialize(driver, internal_logger, page, element)
+        super
+        @shadow_root_element = element.evaluate_handle('el => el.shadowRoot')
+      end
+
+      def all_text
+        assert_element_not_stale {
+          text = @shadow_root_element.text_content
+          text.to_s.gsub(/[\u200b\u200e\u200f]/, '')
+              .gsub(/[\ \n\f\t\v\u2028\u2029]+/, ' ')
+              .gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
+              .gsub(/[[:space:]&&[^\u00a0]]+\z/, '')
+              .tr("\u00a0", ' ')
+        }
+      end
+
+      def visible_text
+        assert_element_not_stale {
+
+          return '' unless visible?
+
+          # https://github.com/teamcapybara/capybara/blob/1c164b608fa6452418ec13795b293655f8a0102a/lib/capybara/rack_test/node.rb#L18
+          displayed_text = @shadow_root_element.text_content.to_s.
+                              gsub(/[\u200b\u200e\u200f]/, '').
+                              gsub(/[\ \n\f\t\v\u2028\u2029]+/, ' ')
+          displayed_text.squeeze(' ')
+            .gsub(/[\ \n]*\n[\ \n]*/, "\n")
+            .gsub(/\A[[:space:]&&[^\u00a0]]+/, '')
+            .gsub(/[[:space:]&&[^\u00a0]]+\z/, '')
+            .tr("\u00a0", ' ')
+        }
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/tmpdir_owner.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/tmpdir_owner.rb
@@ -1,0 +1,40 @@
+module Capybara
+  module Playwright
+    module TmpdirOwner
+      require 'tmpdir'
+
+      def tmpdir
+        return @tmpdir if @tmpdir
+
+        dir = Dir.mktmpdir
+        ObjectSpace.define_finalizer(self, TmpdirRemover.new(dir))
+        @tmpdir = dir
+      end
+
+      def remove_tmpdir
+        if @tmpdir
+          FileUtils.remove_entry(@tmpdir, true)
+          ObjectSpace.undefine_finalizer(self)
+          @tmpdir = nil
+        end
+      end
+
+      class TmpdirRemover
+        def initialize(tmpdir)
+          @pid = Process.pid
+          @tmpdir = tmpdir
+        end
+
+        def call(*args)
+          return if @pid != Process.pid
+
+          begin
+            FileUtils.remove_entry(@tmpdir, true)
+          rescue => err
+            $stderr.puts err
+          end
+        end
+      end
+    end
+  end
+end

--- a/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/version.rb
+++ b/vendor/gems/capybara-playwright-driver/lib/capybara/playwright/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Capybara
+  module Playwright
+    VERSION = '0.5.9'
+  end
+end


### PR DESCRIPTION
Draft exploration of the largest remaining win from the system test optimization work. The five mechanisms below ship as one stack. They were measured together, several only pay off in combination (the cache headers need the kept browser context, the settle bridge exists because of the production build), and the measurement below treats them as a unit.

In the optimization loop this stack moved the `core system` test step median from 510s (samples 507 to 534) to 468s (samples 454 to 473) on a 16-core runner, with a visibly tighter spread. The stack carries five mechanisms:

1. **Production Ember build for system test builds.** Every system spec page load parses a minified, tree-shaken bundle instead of the development build. The dev-only `window.clientSettled` test bridge is dead-code-eliminated from production builds, so `spec/support/client_settled_bridge.rb` reimplements it build-independently via a Playwright init script. Specs that rely on dev-build behaviour (deprecation assertions, /theme-qunit) are skipped under `EMBER_ENV=production`. Scoped to system builds so the QUnit jobs keep testing the development build.

2. **Soft browser-context reset between examples.** The vendored `capybara-playwright-driver` replaces the per-example browser-context teardown with an in-place reset: clear cookies, permissions and origin storage via first-class APIs, fresh page in the kept context, service workers blocked, hard-reset fallback on a 10s timeout. Vendoring is the exploration shortcut here. If this mechanism survives measurement, the changes should go upstream or into a maintained fork.

3. **Explicit Cache-Control on the immutable per-run `/assets` build** (`spec/support/static_asset_cache_control.rb`) so each example's first navigation hits warm HTTP and compiled-JS caches instead of re-fetching the bundle through a cold context. Pairs with mechanism 2, which is what keeps the caches alive between examples.

4. **In-process Rack `sign_in`.** `SystemHelpers#sign_in` calls the existing session/become endpoint through the Rack stack and injects the resulting cookie via Playwright. This replaces roughly 1,800 full page loads per run (measured at 40 to 450ms each browser-side) with a 14ms in-process call while preserving every `log_on_user` side effect and the full middleware stack.

5. **Cheaper logging on the hot path.** System builds unsubscribe the permanently attached LogSubscribers whose output is unreachable at `RAILS_TEST_LOG_LEVEL=error` (`sql.active_record`, `instantiation.active_record`, `render_*.action_view`), and `capture_log_entries` switches from truncating the shared `log/test.log` (12 workers appending to one file) to offset plus pid-filtered reads. The latter targets the variance tail: the Browser Pageview serial flaky retry measured 52s when the truncate race fired.

Known deltas from the loop version: the LogSubscriber block is gated to system builds via `DISCOURSE_PRUNE_TEST_INSTRUMENTATION` (the loop ran it everywhere, and #40774 showed backend specs exercise instrumentation directly), and `EMBER_ENV=production` is scoped to system builds rather than job-wide.

## Measurements

Five marker-bump runs of this branch interleaved with five runs of a baseline branch carrying this branch's own merge-base, strictly sequential so no two measured runs compete with each other. Durations are the test step of each job in seconds, job setup excluded. Each header column links to the workflow run. An optimization loop shared the runner pool during this window, which inflates absolute numbers roughly evenly in both arms, so the deltas are the measurement.

### Before, merge-base

| Job | [Run 1](https://github.com/discourse/discourse/actions/runs/27351727757) | [Run 2](https://github.com/discourse/discourse/actions/runs/27353602241) | [Run 3](https://github.com/discourse/discourse/actions/runs/27355161593) | [Run 4](https://github.com/discourse/discourse/actions/runs/27356912030) | [Run 5](https://github.com/discourse/discourse/actions/runs/27358729023) | Median |
|---|---:|---:|---:|---:|---:|---:|
| core system | 855 | 611 | 684 | 646 | 943 | **684s** |
| plugins (core) system | 492 | 497 | 593 | 462 | 773 | **497s** |
| plugins (official) system | 381 | 274 | 405 | 303 | 281 | **303s** |
| plugins (chat) system | 607 | 573 | 629 | 578 | 579 | **579s** |
| themes system | 380 | 338 | 422 | 329 | 369 | **369s** |

### After, this branch

| Job | [Run 1](https://github.com/discourse/discourse/actions/runs/27352780972) | [Run 2](https://github.com/discourse/discourse/actions/runs/27354391902) | [Run 3](https://github.com/discourse/discourse/actions/runs/27356139840) | [Run 4](https://github.com/discourse/discourse/actions/runs/27357737886) | [Run 5](https://github.com/discourse/discourse/actions/runs/27359894357) | Median |
|---|---:|---:|---:|---:|---:|---:|
| core system | 628 | 530 | 564 | 777 | 541 | **564s** |
| plugins (core) system | 508 | 411 | 399 | 642 | 400 | **411s** |
| plugins (official) system | 253 | 247 | 312 | 256 | 251 | **253s** |
| plugins (chat) system | 538 | 548 | 520 | 550 | 490 | **538s** |
| themes system | 382 | 343 | 342 | 358 | 301 | **343s** |

### Δ

| Job | Before | After | Δ | Δ% |
|---|---:|---:|---:|---:|
| **core system** | 684s | **564s** | -120s | **-17.5%** |
| **plugins (core) system** | 497s | **411s** | -86s | **-17.3%** |
| plugins (official) system | 303s | 253s | -50s | -16.5% |
| plugins (chat) system | 579s | 538s | -41s | -7.1% |
| themes system | 369s | 343s | -26s | -7.0% |

The backend and frontend jobs are not touched by this change and serve as controls. Their medians moved between -8.4% and +5.4% across the same windows, which bounds the ambient drift. The 16 to 17.5% wins on core, plugins (core) and plugins (official) system clear that band comfortably. One data point was excluded: run 4's `core frontend` job failed on the known `DOtp: allows editing after all slots are filled` ui-kit QUnit flake, unrelated to this change (frontend builds keep the development Ember build).
