### PR TITLE
FEATURE: Warn admins when Content Security Policy is disabled

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -67,6 +67,7 @@ class ProblemCheck
   #
   CORE_PROBLEM_CHECKS = [
     ProblemCheck::BadFaviconUrl,
+    ProblemCheck::ContentSecurityPolicyDisabled,
     ProblemCheck::EmailSendingFailures,
     ProblemCheck::EmailPollingErroredRecently,
     ProblemCheck::FacebookConfig,

--- a/app/services/problem_check/content_security_policy_disabled.rb
+++ b/app/services/problem_check/content_security_policy_disabled.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ProblemCheck::ContentSecurityPolicyDisabled < ProblemCheck
+  self.priority = "low"
+
+  def call
+    return no_problem if SiteSetting.content_security_policy
+
+    problem
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1787,6 +1787,7 @@ en:
       twitter_login: 'Twitter login appears to not be working at the moment. Check the credentials in <a href="%{base_path}/admin/site_settings/category/login?filter=twitter">the Site Settings</a>.'
       group_email_credentials: 'There was an issue with the email credentials for the group <a href="%{base_path}/g/%{group_name}/manage/email">%{group_full_name}</a>. No emails will be sent from the group inbox until this problem is addressed. %{error}'
       upcoming_change_stable_opted_out: 'Your site has opted-out of the "%{upcoming_change}" upcoming change. This change has now reached the "Stable" status and may soon be removed or made permanent. Visit <a href="%{base_path}/admin/config/upcoming-changes">the upcoming changes page</a> to review details about this change.'
+      content_security_policy_disabled: "The content-security-policy feature has been disabled. This is an important security feature, and should never be disabled in production environments. <a href='%{base_path}/admin/site_settings/category/all_results?filter=content_security_policy'>Re-enable it here</a>."
       rails_env: "Your server is running in %{env} mode."
       host_names: "Your config/database.yml file is using the default localhost hostname. Update it to use your site's hostname."
       sidekiq_check: 'Sidekiq is not running. Many tasks, like sending emails, are executed asynchronously by Sidekiq. Please ensure at least one Sidekiq process is running. <a href="https://github.com/mperham/sidekiq" target="_blank">Learn about Sidekiq here</a>.'

--- a/spec/services/problem_check/content_security_policy_disabled_spec.rb
+++ b/spec/services/problem_check/content_security_policy_disabled_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::ContentSecurityPolicyDisabled do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    before { SiteSetting.stubs(content_security_policy: configured) }
+
+    context "when the content security policy is enabled" do
+      let(:configured) { true }
+
+      it { expect(check).to be_chill_about_it }
+    end
+
+    context "when the content security policy is disabled" do
+      let(:configured) { false }
+
+      it do
+        expect(check).to have_a_problem.with_priority("low").with_message(
+          "Your site has the content security policy disabled. This protection will soon become mandatory and the <a href='/admin/site_settings/category/all_results?filter=content_security_policy'>content_security_policy</a> setting will be removed. Re-enable it now and resolve any breakage it causes before the opt-out goes away.",
+        )
+      end
+    end
+  end
+end

--- a/spec/services/problem_check/content_security_policy_disabled_spec.rb
+++ b/spec/services/problem_check/content_security_policy_disabled_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProblemCheck::ContentSecurityPolicyDisabled do
 
       it do
         expect(check).to have_a_problem.with_priority("low").with_message(
-          I18n.t("dashboard.problem.content_security_policy_disabled", base_path: "")
+          I18n.t("dashboard.problem.content_security_policy_disabled", base_path: ""),
         )
       end
     end

--- a/spec/services/problem_check/content_security_policy_disabled_spec.rb
+++ b/spec/services/problem_check/content_security_policy_disabled_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProblemCheck::ContentSecurityPolicyDisabled do
 
       it do
         expect(check).to have_a_problem.with_priority("low").with_message(
-          "Your site has the content security policy disabled. This protection will soon become mandatory and the <a href='/admin/site_settings/category/all_results?filter=content_security_policy'>content_security_policy</a> setting will be removed. Re-enable it now and resolve any breakage it causes before the opt-out goes away.",
+          I18n.t("dashboard.problem.content_security_policy_disabled", base_path: "")
         )
       end
     end


### PR DESCRIPTION
When disabled, admins will be shown this warning in the dashboard:

> The content-security-policy feature has been disabled. This is an important security feature, and should never be disabled in production environments. <a href=''>Re-enable it here</a>.