### PR TITLE
FIX: Support topic lifecycle hooks in nested view

### DIFF
--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import NestedActivityLog from "discourse/components/modal/nested-activity-log";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { dispatchCustomPostMessageCallback } from "discourse/lib/custom-post-message-callbacks";
 import { bind } from "discourse/lib/decorators";
 import {
   NESTED_VIEW_CACHE_FORMAT_VERSION,
@@ -723,6 +724,18 @@ export default class NestedController extends Controller {
       case "recovered":
       case "acted":
         this.#handlePostChanged(data);
+        break;
+      default:
+        if (
+          !dispatchCustomPostMessageCallback(
+            data.type,
+            this.#topicController,
+            data
+          )
+        ) {
+          // eslint-disable-next-line no-console
+          console.warn("unknown nested topic bus message type", data);
+        }
         break;
     }
   }

--- a/frontend/discourse/app/controllers/topic.js
+++ b/frontend/discourse/app/controllers/topic.js
@@ -26,6 +26,11 @@ import {
 } from "discourse/lib/array-tools";
 import { BookmarkFormData } from "discourse/lib/bookmark-form-data";
 import { resetCachedTopicList } from "discourse/lib/cached-topic-list";
+import {
+  dispatchCustomPostMessageCallback,
+  registerCustomPostMessageCallback,
+  resetCustomPostMessageCallbacks,
+} from "discourse/lib/custom-post-message-callbacks";
 import { bind } from "discourse/lib/decorators";
 import EmbedMode from "discourse/lib/embed-mode";
 import { isTesting } from "discourse/lib/environment";
@@ -54,22 +59,10 @@ import TopicTimer from "discourse/models/topic-timer";
 import { spinnerHTML } from "discourse/ui-kit/helpers/d-loading-spinner";
 import { i18n } from "discourse-i18n";
 
-let customPostMessageCallbacks = {};
-
 const RETRIES_ON_RATE_LIMIT = 4;
 const MIN_BOTTOM_MAP_WORD_COUNT = 200;
 
-export function resetCustomPostMessageCallbacks() {
-  customPostMessageCallbacks = {};
-}
-
-export function registerCustomPostMessageCallback(type, callback) {
-  if (customPostMessageCallbacks[type]) {
-    throw new Error(`Error ${type} is an already registered post message!`);
-  }
-
-  customPostMessageCallbacks[type] = callback;
-}
+export { registerCustomPostMessageCallback, resetCustomPostMessageCallbacks };
 
 export default class TopicController extends Controller {
   @service appEvents;
@@ -2127,10 +2120,7 @@ export default class TopicController extends Controller {
         break;
       }
       default: {
-        let callback = customPostMessageCallbacks[data.type];
-        if (callback) {
-          callback(this, data);
-        } else {
+        if (!dispatchCustomPostMessageCallback(data.type, this, data)) {
           // eslint-disable-next-line no-console
           console.warn("unknown topic bus message type", data);
         }

--- a/frontend/discourse/app/lib/custom-post-message-callbacks.js
+++ b/frontend/discourse/app/lib/custom-post-message-callbacks.js
@@ -1,0 +1,24 @@
+let customPostMessageCallbacks = {};
+
+export function resetCustomPostMessageCallbacks() {
+  customPostMessageCallbacks = {};
+}
+
+export function registerCustomPostMessageCallback(type, callback) {
+  if (customPostMessageCallbacks[type]) {
+    throw new Error(`Error ${type} is an already registered post message!`);
+  }
+
+  customPostMessageCallbacks[type] = callback;
+}
+
+export function dispatchCustomPostMessageCallback(type, controller, message) {
+  const callback = customPostMessageCallbacks[type];
+
+  if (!callback) {
+    return false;
+  }
+
+  callback(controller, message);
+  return true;
+}

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -39,7 +39,6 @@ import { setNotificationsLimit as setUserMenuNotificationsLimit } from "discours
 import { addUserMenuProfileTabItem } from "discourse/components/user-menu/profile-tab-content";
 import { addDiscoveryQueryParam } from "discourse/controllers/discovery/list";
 import { registerFullPageSearchType } from "discourse/controllers/full-page-search";
-import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1 } from "discourse/controllers/topic";
 import { addBeforeLoadMoreCallback as addBeforeLoadMoreNotificationsCallback } from "discourse/controllers/user-notifications";
 import { registerCustomUserNavMessagesDropdownRow } from "discourse/controllers/user-private-messages";
 import { addUsernameSelectorDecorator } from "discourse/helpers/decorate-username-selector";
@@ -60,6 +59,7 @@ import classPrepend, {
 } from "discourse/lib/class-prepend";
 import { addPopupMenuOption } from "discourse/lib/composer/custom-popup-menu-options";
 import { registerRichEditorExtension } from "discourse/lib/composer/rich-editor-extensions";
+import { registerCustomPostMessageCallback as registerCustomPostMessageCallback1 } from "discourse/lib/custom-post-message-callbacks";
 import deprecated from "discourse/lib/deprecated";
 import { registerDesktopNotificationHandler } from "discourse/lib/desktop-notifications";
 import { downloadCalendar } from "discourse/lib/download-calendar";
@@ -104,6 +104,7 @@ import {
 } from "discourse/lib/sidebar/user/categories-section/category-section-link";
 import { registerCustomTagSectionLinkPrefixIcon } from "discourse/lib/sidebar/user/tags-section/base-tag-section-link";
 import { consolePrefix } from "discourse/lib/source-identifier";
+import { registerTopicLifecycleCallback } from "discourse/lib/topic-lifecycle-callbacks";
 import {
   _addTransformerName,
   _registerTransformer,
@@ -1021,6 +1022,47 @@ class _PluginApi {
    */
   registerCustomPostMessageCallback(type, callback) {
     registerCustomPostMessageCallback1(type, callback);
+  }
+
+  /**
+   * Returns the topic currently being viewed, whether it is being shown through
+   * the classic topic route or the nested topic route.
+   *
+   * Prefer this over `api.container.lookup("controller:topic").model` when all
+   * you need is the current topic model.
+   */
+  getCurrentTopic() {
+    return this._lookupContainer("service:current-topic")?.topic;
+  }
+
+  /**
+   * Runs `callback` whenever a topic is entered or refreshed through either the
+   * classic topic route or the nested topic route. The callback receives
+   * `{ topic, controller, topicController, route, routeName, appEvents,
+   * messageBus, currentTopic }`.
+   *
+   * This lifecycle is tied to route setup, not only topic identity. A same-topic
+   * route refresh can call the cleanup from the previous setup and then run the
+   * callback again.
+   *
+   * Return a function from the callback to clean up subscriptions/listeners. The
+   * cleanup runs before the topic/nested controller's own `unsubscribe()` hook.
+   *
+   * Example:
+   *
+   * ```javascript
+   * api.onTopicEntered(({ topic, messageBus }) => {
+   *   const channel = `/my-plugin/topic/${topic.id}`;
+   *   const callback = (message) => { ... };
+   *   messageBus.subscribe(channel, callback);
+   *   return () => messageBus.unsubscribe(channel, callback);
+   * });
+   * ```
+   */
+  onTopicEntered(callback) {
+    registerTopicLifecycleCallback(
+      wrapWithErrorHandler(callback, "broken_topic_entered_callback")
+    );
   }
 
   /**

--- a/frontend/discourse/app/lib/topic-lifecycle-callbacks.js
+++ b/frontend/discourse/app/lib/topic-lifecycle-callbacks.js
@@ -1,0 +1,65 @@
+import { isTesting } from "discourse/lib/environment";
+
+const topicLifecycleCallbacks = [];
+
+function dispatchLifecycleError(messageKey, error) {
+  if (isTesting()) {
+    return;
+  }
+
+  document.dispatchEvent(
+    new CustomEvent("discourse-error", {
+      detail: { messageKey, error },
+    })
+  );
+}
+
+export function registerTopicLifecycleCallback(callback) {
+  topicLifecycleCallbacks.push(callback);
+}
+
+export function resetTopicLifecycleCallbacks() {
+  topicLifecycleCallbacks.length = 0;
+}
+
+export function cleanupTopicLifecycleCallbacks(cleanups) {
+  const errors = [];
+
+  for (const cleanup of [...cleanups].reverse()) {
+    try {
+      cleanup();
+    } catch (error) {
+      errors.push(error);
+      dispatchLifecycleError("broken_topic_lifecycle_cleanup_callback", error);
+    }
+  }
+
+  if (errors.length > 0 && isTesting()) {
+    throw errors[0];
+  }
+}
+
+export function applyTopicLifecycleCallbacks(context) {
+  const cleanups = [];
+  const errors = [];
+
+  for (const callback of topicLifecycleCallbacks) {
+    try {
+      const cleanup = callback(context);
+
+      if (typeof cleanup === "function") {
+        cleanups.push(cleanup);
+      }
+    } catch (error) {
+      errors.push(error);
+      dispatchLifecycleError("broken_topic_entered_callback", error);
+    }
+  }
+
+  if (errors.length > 0 && isTesting()) {
+    cleanupTopicLifecycleCallbacks(cleanups);
+    throw errors[0];
+  }
+
+  return cleanups;
+}

--- a/frontend/discourse/app/routes/nested.js
+++ b/frontend/discourse/app/routes/nested.js
@@ -23,6 +23,7 @@ import processNode, {
 
 export default class NestedRoute extends DiscourseRoute {
   @service composer;
+  @service currentTopic;
   @service header;
   @service historyStore;
   @service modal;
@@ -115,7 +116,6 @@ export default class NestedRoute extends DiscourseRoute {
     }
 
     controller.setProperties(model);
-    controller.subscribe();
 
     // Hydrate the topic controller so core components that do
     // lookup("controller:topic") (e.g. share modal) find valid state.
@@ -133,6 +133,8 @@ export default class NestedRoute extends DiscourseRoute {
     // topic.details.updateNotifications() can construct the correct URL.
     model.topic.details.set("topic", model.topic);
 
+    controller.subscribe();
+
     this.header.enterTopic(model.topic, !model.contextMode);
 
     // Store the OP in the postStream so core components that read loaded posts
@@ -140,6 +142,14 @@ export default class NestedRoute extends DiscourseRoute {
     if (model.opPost && model.topic.postStream) {
       registerPostInTopicPostStream(model.topic, model.opPost);
     }
+
+    this.currentTopic.enter({
+      topic: model.topic,
+      controller,
+      topicController,
+      route: this,
+      routeName: "nested",
+    });
 
     this.screenTrack.start(model.topic.id, controller);
 
@@ -167,6 +177,7 @@ export default class NestedRoute extends DiscourseRoute {
     this._saveToCache(controller);
 
     this._resetTopicControllerBulkSelection();
+    this.currentTopic.leave(controller.topic);
     controller.unsubscribe();
     this.screenTrack.stop();
     controller.topic = null;
@@ -232,6 +243,7 @@ export default class NestedRoute extends DiscourseRoute {
     }
 
     this._saveToCache(controller);
+    this.currentTopic.leave(controller.topic);
     controller.unsubscribe();
     this.screenTrack.stop();
   }

--- a/frontend/discourse/app/routes/topic/from-params.js
+++ b/frontend/discourse/app/routes/topic/from-params.js
@@ -12,6 +12,7 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default class TopicFromParams extends DiscourseRoute {
   @service appEvents;
   @service composer;
+  @service currentTopic;
   @service header;
   @service router;
 
@@ -100,7 +101,9 @@ export default class TopicFromParams extends DiscourseRoute {
 
   deactivate() {
     super.deactivate(...arguments);
-    this.controllerFor("topic").unsubscribe();
+    const topicController = this.controllerFor("topic");
+    this.currentTopic.leave(topicController.model);
+    topicController.unsubscribe();
   }
 
   setupController(controller, params, { _discourse_anchor }) {
@@ -138,6 +141,13 @@ export default class TopicFromParams extends DiscourseRoute {
 
     this.appEvents.trigger("page:topic-loaded", topic);
     topicController.subscribe();
+    this.currentTopic.enter({
+      topic,
+      controller: topicController,
+      topicController,
+      route: this,
+      routeName: "topic",
+    });
 
     // Highlight our post after the next render
     schedule("afterRender", () =>

--- a/frontend/discourse/app/services/current-topic.js
+++ b/frontend/discourse/app/services/current-topic.js
@@ -1,0 +1,68 @@
+import { tracked } from "@glimmer/tracking";
+import Service, { service } from "@ember/service";
+import {
+  applyTopicLifecycleCallbacks,
+  cleanupTopicLifecycleCallbacks,
+} from "discourse/lib/topic-lifecycle-callbacks";
+
+export default class CurrentTopic extends Service {
+  @service appEvents;
+  @service messageBus;
+
+  @tracked topic = null;
+  @tracked controller = null;
+  @tracked topicController = null;
+  @tracked route = null;
+  @tracked routeName = null;
+
+  #cleanups = [];
+
+  enter({ topic, controller, topicController = controller, route, routeName }) {
+    this.leave();
+
+    this.topic = topic;
+    this.controller = controller;
+    this.topicController = topicController;
+    this.route = route;
+    this.routeName = routeName;
+
+    try {
+      this.#cleanups = applyTopicLifecycleCallbacks({
+        topic,
+        controller,
+        topicController,
+        route,
+        routeName,
+        appEvents: this.appEvents,
+        messageBus: this.messageBus,
+        currentTopic: this,
+      });
+    } catch (error) {
+      this.leave();
+      throw error;
+    }
+  }
+
+  leave(topic = null) {
+    if (
+      topic &&
+      this.topic &&
+      String(this.topic.id) !== String(topic.id ?? topic)
+    ) {
+      return;
+    }
+
+    const cleanups = this.#cleanups;
+    this.#cleanups = [];
+
+    try {
+      cleanupTopicLifecycleCallbacks(cleanups);
+    } finally {
+      this.topic = null;
+      this.controller = null;
+      this.topicController = null;
+      this.route = null;
+      this.routeName = null;
+    }
+  }
+}

--- a/frontend/discourse/tests/helpers/qunit-helpers.js
+++ b/frontend/discourse/tests/helpers/qunit-helpers.js
@@ -33,7 +33,6 @@ import { resetItemSelectCallbacks } from "discourse/components/search-menu/resul
 import { resetQuickSearchRandomTips } from "discourse/components/search-menu/results/random-quick-tip";
 import { resetOnKeyUpCallbacks } from "discourse/components/search-menu/search-term";
 import { resetUserMenuProfileTabItems } from "discourse/components/user-menu/profile-tab-content";
-import { resetCustomPostMessageCallbacks } from "discourse/controllers/topic";
 import { resetCustomUserNavMessagesDropdownRows } from "discourse/controllers/user-private-messages";
 import { clearHTMLCache } from "discourse/helpers/custom-html";
 import { resetUsernameDecorators } from "discourse/helpers/decorate-username-selector";
@@ -43,6 +42,7 @@ import { clearPluginHeaderActionComponents } from "discourse/lib/admin-plugin-he
 import { resetAdditionalReportModes } from "discourse/lib/admin-report-additional-modes";
 import { rollbackAllPrepends } from "discourse/lib/class-prepend";
 import { clearPopupMenuOptions } from "discourse/lib/composer/custom-popup-menu-options";
+import { resetCustomPostMessageCallbacks } from "discourse/lib/custom-post-message-callbacks";
 import deprecated from "discourse/lib/deprecated";
 import { clearDesktopNotificationHandlers } from "discourse/lib/desktop-notifications";
 import { clearRegisteredEditCategoryTabs } from "discourse/lib/edit-category-tabs";
@@ -68,6 +68,7 @@ import { resetLogSearchLinkClickedCallbacks } from "discourse/lib/search";
 import { clearAdditionalAdminSidebarSectionLinks } from "discourse/lib/sidebar/admin-sidebar";
 import { resetDefaultSectionLinks as resetTopicsSectionLinks } from "discourse/lib/sidebar/custom-community-section-links";
 import { resetSidebarPanels } from "discourse/lib/sidebar/custom-sections";
+import { resetTopicLifecycleCallbacks } from "discourse/lib/topic-lifecycle-callbacks";
 import {
   resetHighestReadCache,
   setTopicList,
@@ -218,6 +219,7 @@ export function testCleanup(container, app) {
   resetUsernameDecorators();
   resetOneboxCache();
   resetCustomPostMessageCallbacks();
+  resetTopicLifecycleCallbacks();
   resetUserSearchCache();
   resetHighestReadCache();
   resetCardClickListenerSelector();

--- a/frontend/discourse/tests/unit/controllers/nested-test.js
+++ b/frontend/discourse/tests/unit/controllers/nested-test.js
@@ -1,6 +1,7 @@
 import { settled } from "@ember/test-helpers";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
+import { registerCustomPostMessageCallback } from "discourse/lib/custom-post-message-callbacks";
 import { NESTED_VIEW_CACHE_FORMAT_VERSION } from "discourse/lib/nested-view-cache-snapshot";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
@@ -40,6 +41,35 @@ module("Unit | Controller | nested", function (hooks) {
     post.topic = topic;
     return post;
   }
+
+  test("dispatches custom topic post message callbacks", function (assert) {
+    const topic = buildTopic(this.store, 724);
+    const topicController = this.owner.lookup("controller:topic");
+    topicController.set("model", topic);
+    this.controller.topic = topic;
+
+    registerCustomPostMessageCallback(
+      "nested_custom_message",
+      (controller, message) => {
+        assert.step("custom callback");
+        assert.strictEqual(
+          controller,
+          topicController,
+          "passes the topic controller compatibility shim"
+        );
+        assert.strictEqual(message.value, 123);
+      }
+    );
+
+    this.controller._onMessage({ type: "nested_custom_message", value: 123 });
+
+    assert.verifySteps(["custom callback"]);
+    assert.strictEqual(
+      this.controller.messageBusLastId,
+      undefined,
+      "does not require a message bus id"
+    );
+  });
 
   test("post registry events are scoped to the current topic", function (assert) {
     const previousTopic = buildTopic(this.store, 509);

--- a/frontend/discourse/tests/unit/services/current-topic-test.js
+++ b/frontend/discourse/tests/unit/services/current-topic-test.js
@@ -1,0 +1,130 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  registerTopicLifecycleCallback,
+  resetTopicLifecycleCallbacks,
+} from "discourse/lib/topic-lifecycle-callbacks";
+
+module("Unit | Service | current-topic", function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    getOwner(this).lookup("service:current-topic").leave();
+    resetTopicLifecycleCallbacks();
+  });
+
+  test("tracks the active topic and runs lifecycle callbacks", function (assert) {
+    const service = getOwner(this).lookup("service:current-topic");
+    const topic = { id: 1 };
+    const controller = { name: "nested" };
+    const topicController = { name: "topic" };
+    const route = { name: "nested-route" };
+
+    registerTopicLifecycleCallback((context) => {
+      assert.strictEqual(context.topic, topic);
+      assert.strictEqual(context.controller, controller);
+      assert.strictEqual(context.topicController, topicController);
+      assert.strictEqual(context.route, route);
+      assert.strictEqual(context.routeName, "nested");
+      assert.notStrictEqual(context.appEvents, undefined, "includes appEvents");
+      assert.notStrictEqual(
+        context.messageBus,
+        undefined,
+        "includes messageBus"
+      );
+
+      return () => assert.step("cleanup");
+    });
+
+    service.enter({
+      topic,
+      controller,
+      topicController,
+      route,
+      routeName: "nested",
+    });
+
+    assert.strictEqual(service.topic, topic, "stores the current topic");
+    assert.strictEqual(
+      service.topicController,
+      topicController,
+      "stores the compatibility topic controller"
+    );
+
+    service.leave(topic);
+    assert.verifySteps(["cleanup"]);
+  });
+
+  test("cleans up previous topic lifecycle before re-entering", function (assert) {
+    const service = getOwner(this).lookup("service:current-topic");
+    const firstTopic = { id: 1 };
+    const secondTopic = { id: 2 };
+
+    registerTopicLifecycleCallback(({ topic }) => {
+      assert.step(`enter ${topic.id}`);
+      return () => assert.step(`cleanup ${topic.id}`);
+    });
+
+    service.enter({ topic: firstTopic, controller: {} });
+    service.enter({ topic: secondTopic, controller: {} });
+    service.leave(secondTopic);
+
+    assert.verifySteps(["enter 1", "cleanup 1", "enter 2", "cleanup 2"]);
+  });
+
+  test("runs all cleanups and clears state when a cleanup throws", function (assert) {
+    const service = getOwner(this).lookup("service:current-topic");
+    const topic = { id: 1 };
+
+    registerTopicLifecycleCallback(() => {
+      return () => {
+        assert.step("cleanup one");
+        throw new Error("cleanup failed");
+      };
+    });
+    registerTopicLifecycleCallback(() => {
+      return () => assert.step("cleanup two");
+    });
+
+    service.enter({ topic, controller: {} });
+
+    assert.throws(
+      () => service.leave(topic),
+      /cleanup failed/,
+      "rethrows cleanup failures in tests"
+    );
+    assert.verifySteps(["cleanup two", "cleanup one"]);
+    assert.strictEqual(service.topic, null, "clears the topic state");
+  });
+
+  test("cleans up partial lifecycle callbacks when entering fails", function (assert) {
+    const service = getOwner(this).lookup("service:current-topic");
+    const topic = { id: 1 };
+
+    registerTopicLifecycleCallback(() => {
+      return () => assert.step("cleanup successful callback");
+    });
+    registerTopicLifecycleCallback(() => {
+      throw new Error("enter failed");
+    });
+
+    assert.throws(
+      () => service.enter({ topic, controller: {} }),
+      /enter failed/,
+      "rethrows callback failures in tests"
+    );
+    assert.verifySteps(["cleanup successful callback"]);
+    assert.strictEqual(service.topic, null, "clears the topic state");
+  });
+
+  test("does not clear a different active topic", function (assert) {
+    const service = getOwner(this).lookup("service:current-topic");
+    const topic = { id: 1 };
+
+    service.enter({ topic, controller: {} });
+    service.leave({ id: 2 });
+
+    assert.strictEqual(service.topic, topic, "keeps the active topic");
+  });
+});

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/ai-bot-replies.js
@@ -87,81 +87,73 @@ function initializeAIBotReplies(api) {
     return value;
   });
 
-  api.modifyClass("controller:topic", {
-    pluginId: "discourse-ai",
+  const onAIBotStreamedReply = (topic, data) => {
+    if (!topic?.postStream) {
+      return;
+    }
 
-    onAIBotStreamedReply: function (data) {
-      if (!this.model?.postStream) {
-        return;
+    const streamingState = lookupStreamingState(api);
+    const topicId = topic.id;
+
+    if (data?.noop) {
+      return;
+    }
+
+    if (data?.done) {
+      streamingState?.markFinishedAfterRender(topicId, data?.post_id);
+      if (siteSettings.ai_bot_enable_docked_composer) {
+        appEvents.trigger("discourse-ai:bot-reply-finished", {
+          topicId,
+          postId: data?.post_id,
+        });
       }
-
-      const streamingState = lookupStreamingState(api);
-      const topicId = this.model.id;
-
-      if (data?.noop) {
-        return;
+    } else {
+      const isNewStream = !streamingState?.isStreamingForTopic(topicId);
+      streamingState?.markStarted(topicId, data?.post_id);
+      if (isNewStream && siteSettings.ai_bot_enable_docked_composer) {
+        appEvents.trigger("discourse-ai:bot-reply-started", {
+          topicId,
+          postId: data?.post_id,
+        });
       }
+    }
 
-      if (data?.done) {
-        streamingState?.markFinishedAfterRender(topicId, data?.post_id);
-        if (siteSettings.ai_bot_enable_docked_composer) {
-          appEvents.trigger("discourse-ai:bot-reply-finished", {
-            topicId,
-            postId: data?.post_id,
-          });
-        }
-      } else {
-        const isNewStream = !streamingState?.isStreamingForTopic(topicId);
-        streamingState?.markStarted(topicId, data?.post_id);
-        if (isNewStream && siteSettings.ai_bot_enable_docked_composer) {
-          appEvents.trigger("discourse-ai:bot-reply-started", {
-            topicId,
-            postId: data?.post_id,
-          });
-        }
-      }
+    streamPostText(topic.postStream, data);
+  };
 
-      streamPostText(this.model.postStream, data);
-    },
-    subscribe: function () {
-      this._super();
+  api.onTopicEntered(({ topic, messageBus }) => {
+    if (
+      !topic.isPrivateMessage ||
+      !topic.details.allowed_users ||
+      topic.details.allowed_users.filter(isGPTBot).length < 1
+    ) {
+      return;
+    }
 
-      if (
-        this.model.isPrivateMessage &&
-        this.model.details.allowed_users &&
-        this.model.details.allowed_users.filter(isGPTBot).length >= 1
-      ) {
-        // -2 replays only the last message before listening for new ones.
-        // A completed stream always ends with done:true as its final message,
-        // so replaying just the last event is enough to resume an in-progress
-        // stream AND avoids the stale-state bug where replaying an earlier
-        // chunk calls markStarted right before the done message, leaving the
-        // MutationObserver waiting for a .streaming class that never gets
-        // removed (because streamPostText has nothing left to stream).
-        this.messageBus.subscribe(
-          `discourse-ai/ai-bot/topic/${this.model.id}`,
-          this.onAIBotStreamedReply.bind(this),
-          -2
-        );
-      }
-    },
-    unsubscribe: function () {
+    const callback = (data) => onAIBotStreamedReply(topic, data);
+
+    // -2 replays only the last message before listening for new ones.
+    // A completed stream always ends with done:true as its final message,
+    // so replaying just the last event is enough to resume an in-progress
+    // stream AND avoids the stale-state bug where replaying an earlier
+    // chunk calls markStarted right before the done message, leaving the
+    // MutationObserver waiting for a .streaming class that never gets
+    // removed (because streamPostText has nothing left to stream).
+    messageBus.subscribe(`discourse-ai/ai-bot/topic/${topic.id}`, callback, -2);
+
+    return () => {
       // we may have infected post stream so lets clean it up
-      if (this.model?.postStream) {
-        cleanupStreamingData(this.model.postStream);
+      if (topic.postStream) {
+        cleanupStreamingData(topic.postStream);
       }
 
-      if (this.model?.id) {
-        // Guarded lookup: the container can be destroyed before
-        // `unsubscribe` runs (teardown during test owner destruction),
-        // in which case there's nothing to mark finished anyway.
-        const streamingState = lookupStreamingState(api);
-        streamingState?.markFinished(this.model.id);
-      }
-
-      this.messageBus.unsubscribe("discourse-ai/ai-bot/topic/*");
-      this._super();
-    },
+      // Guarded lookup: the container can be destroyed before `unsubscribe`
+      // runs (teardown during test owner destruction), in which case there's
+      // nothing to mark finished anyway.
+      const streamingState = lookupStreamingState(api);
+      streamingState?.markFinished(topic.id);
+      messageBus.unsubscribe("discourse-ai/ai-bot/topic/*", callback);
+    };
   });
 
   api.onAppEvent("discourse-ai:post-submitted", ({ userPostNumber }) => {

--- a/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -45,6 +45,76 @@ function canAssignTopic(context) {
   return context.topic?.can_assign ?? context.currentUser?.can_assign;
 }
 
+const TOPIC_ASSIGNMENT_CHANNEL = "/staff/topic-assignment";
+
+function applyTopicAssignmentMessage(topic, data) {
+  if (!topic || String(data.topic_id) !== String(topic.id)) {
+    return false;
+  }
+
+  const isAssigned = data.type === "assigned";
+  const post = data.post_id
+    ? topic.postStream?.posts?.find((p) => p.id === data.post_id)
+    : null;
+  const target = post || (!data.post_id ? topic : null);
+
+  if (target) {
+    target.assignment_note = data.assignment_note;
+    target.assignment_status = data.assignment_status;
+
+    if (data.assigned_type === "User") {
+      target.assigned_to_user_id = isAssigned ? data.assigned_to.id : null;
+      target.assigned_to_user = isAssigned ? data.assigned_to : null;
+
+      if (isAssigned) {
+        target.assigned_to_group_id = null;
+        target.assigned_to_group = null;
+      }
+    }
+
+    if (data.assigned_type === "Group") {
+      target.assigned_to_group_id = isAssigned ? data.assigned_to.id : null;
+      target.assigned_to_group = isAssigned ? data.assigned_to : null;
+
+      if (isAssigned) {
+        target.assigned_to_user_id = null;
+        target.assigned_to_user = null;
+      }
+    }
+  }
+
+  if (data.post_id) {
+    const indirectlyAssignedTo = { ...(topic.indirectly_assigned_to || {}) };
+
+    if (isAssigned) {
+      indirectlyAssignedTo[data.post_id] = {
+        assigned_to: data.assigned_to,
+        post_number: data.post_number,
+        assignment_note: data.assignment_note,
+        assignment_status: data.assignment_status,
+      };
+    } else {
+      delete indirectlyAssignedTo[data.post_id];
+    }
+
+    topic.indirectly_assigned_to = indirectlyAssignedTo;
+  }
+
+  return true;
+}
+
+function subscribeToTopicAssignments({ topic, appEvents, messageBus }) {
+  const callback = (data) => {
+    if (applyTopicAssignmentMessage(topic, data)) {
+      appEvents.trigger("header:update-topic", topic);
+    }
+  };
+
+  messageBus.subscribe(TOPIC_ASSIGNMENT_CHANNEL, callback);
+
+  return () => messageBus.unsubscribe(TOPIC_ASSIGNMENT_CHANNEL, callback);
+}
+
 function registerTopicFooterButtons(api) {
   registerTopicFooterDropdown(TopicLevelAssignMenu);
 
@@ -460,69 +530,7 @@ function initialize(api) {
       }
   );
 
-  api.modifyClass(
-    "controller:topic",
-    (Superclass) =>
-      class extends Superclass {
-        subscribe() {
-          super.subscribe(...arguments);
-
-          this.messageBus.subscribe("/staff/topic-assignment", (data) => {
-            const topic = this.model;
-            const topicId = topic.id;
-
-            if (data.topic_id === topicId) {
-              let post;
-              if (data.post_id) {
-                post = topic.postStream.posts.find(
-                  (p) => p.id === data.post_id
-                );
-              }
-              const target = post || topic;
-
-              target.assignment_note = data.assignment_note;
-              target.assignment_status = data.assignment_status;
-              if (data.assigned_type === "User") {
-                target.assigned_to_user_id =
-                  data.type === "assigned" ? data.assigned_to.id : null;
-                target.assigned_to_user = data.assigned_to;
-              }
-              if (data.assigned_type === "Group") {
-                target.assigned_to_group_id =
-                  data.type === "assigned" ? data.assigned_to.id : null;
-                target.assigned_to_group = data.assigned_to;
-              }
-
-              if (data.post_id) {
-                topic.indirectly_assigned_to ||= {};
-                if (data.type === "assigned") {
-                  topic.indirectly_assigned_to[data.post_id] ||= {};
-                  topic.indirectly_assigned_to[data.post_id].assigned_to =
-                    data.assigned_to;
-                } else if (data.type === "unassigned") {
-                  delete topic.indirectly_assigned_to[data.post_id];
-                }
-              }
-            }
-            // force the components tracking `topic.indirectly_assigned_to` to update
-            // eslint-disable-next-line no-self-assign
-            topic.indirectly_assigned_to = topic.indirectly_assigned_to;
-
-            this.appEvents.trigger("header:update-topic", topic);
-          });
-        }
-
-        unsubscribe() {
-          super.unsubscribe(...arguments);
-
-          if (!this.model?.id) {
-            return;
-          }
-
-          this.messageBus.unsubscribe("/staff/topic-assignment");
-        }
-      }
-  );
+  api.onTopicEntered(subscribeToTopicAssignments);
 
   customizePost(api, siteSettings);
 

--- a/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/initializers/extend-for-assigns.js
@@ -87,9 +87,14 @@ function applyTopicAssignmentMessage(topic, data) {
     const indirectlyAssignedTo = { ...(topic.indirectly_assigned_to || {}) };
 
     if (isAssigned) {
+      const existingAssignment = indirectlyAssignedTo[data.post_id] || {};
       indirectlyAssignedTo[data.post_id] = {
+        ...existingAssignment,
         assigned_to: data.assigned_to,
-        post_number: data.post_number,
+        post_number:
+          data.post_number ??
+          existingAssignment.post_number ??
+          post?.post_number,
         assignment_note: data.assignment_note,
         assignment_status: data.assignment_status,
       };

--- a/plugins/discourse-assign/spec/system/assign_post_spec.rb
+++ b/plugins/discourse-assign/spec/system/assign_post_spec.rb
@@ -24,6 +24,30 @@ describe "Assign | Assigning posts" do
     assign_modal.confirm
   end
 
+  describe "with nested topic" do
+    let(:nested_view) { PageObjects::Pages::NestedView.new }
+    fab!(:nested_topic_record) { Fabricate(:nested_topic, topic: topic) }
+
+    before { SiteSetting.nested_replies_enabled = true }
+
+    it "updates the OP assignment display immediately when assigning a nested reply" do
+      nested_view.visit_nested(topic)
+
+      within("[data-post-number='#{post2.post_number}']") do
+        find(".show-more-actions").click if has_css?(".show-more-actions", wait: 2)
+        find(".post-action-menu__assign-post").click
+      end
+      assign_modal.assignee = staff_user
+      assign_modal.confirm
+
+      expect(assign_modal).to be_closed
+      expect(page).to have_css(
+        ".nested-view__op .assigned-to .assigned-indirectly",
+        text: "##{post2.post_number} to #{staff_user.username}",
+      )
+    end
+  end
+
   describe "with open topic" do
     it "can assign and unassign" do
       visit "/t/#{topic.id}"

--- a/plugins/poll/assets/javascripts/discourse/initializers/extend-for-poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/initializers/extend-for-poll.gjs
@@ -1,7 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import EmberObject from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
-import { bind } from "discourse/lib/decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { PIE_CHART_TYPE } from "../components/modal/poll-ui-builder";
 import Poll from "../components/poll";
@@ -61,32 +60,18 @@ function attachPolls(elem, helper) {
 }
 
 function initializePolls(api) {
-  api.modifyClass(
-    "controller:topic",
-    (Superclass) =>
-      class extends Superclass {
-        subscribe() {
-          super.subscribe(...arguments);
-          this.messageBus.subscribe(
-            `/polls/${this.model.id}`,
-            this._onPollMessage
-          );
-        }
-
-        unsubscribe() {
-          this.messageBus.unsubscribe("/polls/*", this._onPollMessage);
-          super.unsubscribe(...arguments);
-        }
-
-        @bind
-        _onPollMessage(msg) {
-          const post = this.get("model.postStream").findLoadedPost(msg.post_id);
-          if (post) {
-            post.polls = msg.polls;
-          }
-        }
+  api.onTopicEntered(({ topic, messageBus }) => {
+    const callback = (msg) => {
+      const post = topic.postStream.findLoadedPost(msg.post_id);
+      if (post) {
+        post.polls = msg.polls;
       }
-  );
+    };
+
+    messageBus.subscribe(`/polls/${topic.id}`, callback);
+
+    return () => messageBus.unsubscribe("/polls/*", callback);
+  });
 
   api.modifyClass(
     "model:post",


### PR DESCRIPTION
## What

Adds shared current-topic lifecycle support that works for both classic `/t/...` topic pages and nested `/n/...` topic pages.

This introduces:

- `service:current-topic`
- `api.getCurrentTopic()`
- `api.onTopicEntered((context) => cleanup)`
- shared custom post-message callback storage/dispatch

Nested now dispatches `api.registerCustomPostMessageCallback(...)` message types through the existing topic-controller compatibility shim, so existing callbacks that expect `topicController.get("model.postStream")` keep working.

## Why

Nested topics use `controller:nested` / `route:nested`, so plugins/features that extend `controller:topic.subscribe()` or depend on topic custom post-message callbacks miss live updates in nested view.

The immediate repro was discourse-assign: assigning a nested reply did not update the OP assignment summary until refresh.

## Plugin migrations included

Moved the highest-confidence bundled topic subscriptions onto `api.onTopicEntered`:

- discourse-assign topic assignment updates
- poll updates
- discourse-ai bot reply streaming

## Tests

```text
pnpm eslint <changed JS files>
pnpm prettier --check <changed JS files>
PGHOST=/tmp DISCOURSE_DISABLE_BROWSER_SANDBOX=1 bin/qunit --standalone \
  frontend/discourse/tests/unit/routes/nested-test.js \
  frontend/discourse/tests/unit/services/current-topic-test.js \
  frontend/discourse/tests/unit/controllers/nested-test.js
SKIP_DB_AND_REDIS=1 LOAD_PLUGINS=1 RAILS_ENV=test bin/rake assets:precompile:build_plugins
PGHOST=/tmp LOAD_PLUGINS=1 RAILS_ENV=test bin/rspec plugins/discourse-assign/spec/system/assign_post_spec.rb
PGHOST=/tmp LOAD_PLUGINS=1 RAILS_ENV=test bin/rspec plugins/discourse-assign/spec/system/assign_topic_spec.rb
```
