### PR TITLE
DEV: Bundle chart.js into a single async chunk

### DIFF
--- a/frontend/discourse/app/lib/load-chart-js.js
+++ b/frontend/discourse/app/lib/load-chart-js.js
@@ -1,8 +1,8 @@
 import { waitForPromise } from "@ember/test-waiters";
 
 export default async function loadChartJS() {
-  await waitForPromise(import("chartjs-adapter-moment"));
-  return (await waitForPromise(import("chart.js/auto"))).default;
+  return (await waitForPromise(import("discourse/static/chart-js-bundle")))
+    .Chart;
 }
 
 /**
@@ -10,5 +10,6 @@ export default async function loadChartJS() {
  * @returns {import("chart.js").Plugin}
  */
 export async function loadChartJSDatalabels() {
-  return (await waitForPromise(import("chartjs-plugin-datalabels"))).default;
+  return (await waitForPromise(import("discourse/static/chart-js-bundle")))
+    .ChartDataLabels;
 }

--- a/frontend/discourse/app/static/chart-js-bundle.js
+++ b/frontend/discourse/app/static/chart-js-bundle.js
@@ -1,0 +1,4 @@
+import "chartjs-adapter-moment";
+
+export { default as Chart } from "chart.js/auto";
+export { default as ChartDataLabels } from "chartjs-plugin-datalabels";


### PR DESCRIPTION
Previously `loadChartJS()` and `loadChartJSDatalabels()` used three separate `import()` calls (`chartjs-adapter-moment`, `chart.js/auto`, `chartjs-plugin-datalabels`), producing three async chunks in the build.

This introduces `discourse/static/chart-js-bundle`, following the same pattern as the ace-editor, full-calendar and rete bundles, so all chart.js dependencies ship as one chunk. The public API of `discourse/lib/load-chart-js` is unchanged, so no consumers need updating.