### PR TITLE
FIX: Ensure 'accepted answers' can never include whispers

### DIFF
--- a/plugins/discourse-solved/lib/discourse_solved/accepted_answers_helper.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/accepted_answers_helper.rb
@@ -15,7 +15,9 @@ module DiscourseSolved
       answers =
         topic
           .topic_answers
-          .select { |ta| ta.post.present? }
+          .select do |topic_answer|
+            topic_answer.post.present? && guardian.can_see_post?(topic_answer.post)
+          end
           .sort_by { |ta| ta.post.created_at }
           .map do |ta|
             AcceptedAnswerSerializer.new(

--- a/plugins/discourse-solved/spec/lib/accepted_answers_helper_spec.rb
+++ b/plugins/discourse-solved/spec/lib/accepted_answers_helper_spec.rb
@@ -137,7 +137,9 @@ RSpec.describe DiscourseSolved::AcceptedAnswersHelper do
           }.not_to raise_error
 
           expect(accepted_answers.length).to eq(2)
-          PostDestroyer.new(Discourse.system_user, answer_post, context: "test").destroy
+
+          # Destroying answer_post would delete the whole topic, since it's the OP
+          PostDestroyer.new(Discourse.system_user, answer_post2, context: "test").destroy
 
           expect {
             accepted_answers =

--- a/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/topics_controller_spec.rb
@@ -105,6 +105,20 @@ RSpec.describe TopicsController do
       expect(response.parsed_body["accepted_answers"][0]["username"]).to eq(p2.user.username)
     end
 
+    it "does not serialize accepted answers hidden from the current user" do
+      answer_post =
+        Fabricate(:post, topic:, raw: "secret accepted whisper solution", user: Fabricate(:user))
+      Fabricate(:solved_topic, topic:, answer_post:)
+      answer_post.update!(post_type: Post.types[:whisper])
+      sign_in(Fabricate(:user))
+
+      get "/t/#{topic.slug}/#{topic.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["accepted_answers"]).to be_nil
+      expect(response.parsed_body.to_s).not_to include(answer_post.raw)
+    end
+
     describe "with multiple solutions enabled" do
       before { SiteSetting.solved_allow_multiple_solutions = true }
 


### PR DESCRIPTION
This adds defense-in-depth for the unlikely edge case where an admin converts an accepted answer to a whisper. Previously, it would be serialized to all clients, just like any accepted answer. After this fix, it'll be omitted.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>