### PR TITLE
FIX: Event image crashed the advanced post-event builder

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -115,7 +115,7 @@ export default class PostEventBuilder extends Component {
           : this.event.status || "public",
       rawInvitees: this.event.rawInvitees ?? [],
       recurrence: this.event.recurrence ?? null,
-      imageUpload: this.event.imageUpload ?? null,
+      imageUpload: this.event.imageUpload?.url ?? null,
       timezone: this.event.timezone ?? null,
       // clone so the form draft owns its own reminders
       reminders: (this.event.reminders ?? []).map((r) => ({ ...r })),
@@ -204,8 +204,8 @@ export default class PostEventBuilder extends Component {
 
   @action
   handleImageChange(value, { set }) {
-    set("imageUpload", value);
-    this.event.imageUpload = value;
+    set("imageUpload", value?.url ?? null);
+    this.event.imageUpload = value ?? null;
   }
 
   @action
@@ -740,6 +740,7 @@ export default class PostEventBuilder extends Component {
       }}
       @closeModal={{@closeModal}}
       @flash={{this.flash}}
+      @inline={{@inline}}
       class="post-event-builder-modal
         {{if this.isAdvancedScreen 'is-advanced' 'is-compact'}}"
     >

--- a/plugins/discourse-calendar/test/javascripts/integration/components/post-event-builder-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/post-event-builder-test.gjs
@@ -1,0 +1,70 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import PostEventBuilder from "../../discourse/components/modal/post-event-builder";
+import DiscoursePostEventEvent from "../../discourse/models/discourse-post-event-event";
+
+module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const store = getOwner(this).lookup("service:store");
+    this.user = store.createRecord("user", {
+      username: "tom",
+      id: 1,
+      admin: true,
+    });
+
+    getOwner(this).unregister("service:current-user");
+    getOwner(this).register("service:current-user", this.user, {
+      instantiate: false,
+    });
+  });
+
+  test("advanced screen renders an existing image upload as its URL", async function (assert) {
+    const event = DiscoursePostEventEvent.create({
+      name: "My event",
+      starts_at: "2022-07-01T10:00:00Z",
+      ends_at: "2022-07-01T11:00:00Z",
+      timezone: "UTC",
+      status: "public",
+      reminders: [],
+      raw_invitees: [],
+      custom_fields: {},
+      image_upload: {
+        url: "/uploads/default/original/1X/test-event-image.png",
+        short_url: "upload://test-event-image",
+      },
+    });
+
+    const model = {
+      event,
+      initialScreen: "advanced",
+      onUpdate: () => {},
+      toolbarEvent: {},
+    };
+    const closeModal = () => {};
+
+    await render(
+      <template>
+        <PostEventBuilder
+          @inline={{true}}
+          @model={{model}}
+          @closeModal={{closeModal}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(`[data-name="imageUpload"] .file-uploader`)
+      .hasClass("has-image", "the image control shows the uploaded image");
+    assert
+      .dom(`[data-name="imageUpload"] .file-uploader__preview`)
+      .hasAttribute(
+        "style",
+        /url\(\/uploads\/default\/original\/1X\/test-event-image\.png\)/,
+        "renders the upload url, not the raw object"
+      );
+  });
+});


### PR DESCRIPTION
Follow-up to #39835, which converted the post-event builder to FormKit.

The FormKit `image` control expects its field value to be a URL string: it forwards the value straight to `UppyImageUploader`, which runs it through `getURLWithCDN`. The advanced builder instead stored the whole upload object as the field value, so the control handed an object to `getURLWithCDN` and threw `startsWith is not a function`. 

This was erroring on deployed sites, but on locally it was working as normal.

Store the URL string in the form field (what the image control needs) while keeping the upload object on the event model (what `buildParams` needs for the `[event image="…"]` short_url). Everything else behaves as before.

---

Also updated the modal to use `@inline` so it can be mounted in a rendering test; it is `undefined` in regular run mode (modals open via `modal.show`), so there is no behaviour change.


Demo before:


https://github.com/user-attachments/assets/9fd7fe7c-b317-4192-9256-7f46d11b9859



Demo now:


https://github.com/user-attachments/assets/eb9ed34f-a0a5-43b1-abd5-2ca6ea8c8e11

