### PR TITLE
DEV: Fix flaky DOtp "allows editing after all slots are filled" test

### DIFF
--- a/frontend/discourse/tests/integration/ui-kit/d-otp-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-otp-test.gjs
@@ -1,5 +1,5 @@
 import { next } from "@ember/runloop";
-import { focus, render, settled, waitUntil } from "@ember/test-helpers";
+import { fillIn, focus, render, settled, waitUntil } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DOtp from "discourse/ui-kit/d-otp";
@@ -198,16 +198,8 @@ module("Integration | ui-kit | DOtp", function (hooks) {
       <template><DOtp @onChange={{this.onChangeCallback}} /></template>
     );
 
-    const input = this.element.querySelector(".d-otp-input");
-    input.value = "123456";
-    input.dispatchEvent(new Event("input"));
-
-    await settled();
-
-    input.value = "12345";
-    input.dispatchEvent(new Event("input"));
-
-    await settled();
+    await fillIn(".d-otp-input", "123456");
+    await fillIn(".d-otp-input", "12345");
 
     assert.strictEqual(this.value, "12345");
     assert.dom(".d-otp-slot:nth-child(6)").hasText("​ ");


### PR DESCRIPTION
The test asserts that the sixth slot shows the empty cursor state, which requires the component's `isFocused` flag to be set — but it never focused the input. It relied on the component's autofocus, which calls `element.focus()` inside `requestAnimationFrame`, and neither `render()` nor `settled()` waits for rAF. On busy CI runners the assertions could run before the rAF callback fired, so the slot still showed the `-` placeholder and the test failed (e.g. https://github.com/discourse/discourse/actions/runs/27353003147/attempts/1).

Use `fillIn()` instead of manually setting the value and dispatching `input` events: it focuses the input first (dispatching the `focus` event synthetically when the browser window is unfocused, as in headless CI), so the cursor assertion no longer races the autofocus. Same class of fix as #40541.