### PR TITLE
UX: various mondernized foundation style adjustments

### DIFF
--- a/app/assets/stylesheets/common/base/review.scss
+++ b/app/assets/stylesheets/common/base/review.scss
@@ -654,6 +654,9 @@
 
   &__textarea-wrapper {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
   }
 
   textarea {

--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -274,6 +274,11 @@
 
   .always-public-tooltip {
     padding-right: 0.5rem;
+
+    .fk-d-tooltip__trigger-container {
+      align-items: center;
+      gap: var(--space-1);
+    }
   }
 
   .d-modal__footer {

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/_index.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/_index.scss
@@ -10,3 +10,5 @@
 @import "categories";
 @import "calendar";
 @import "chat";
+@import "groups";
+@import "personal-messages";

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -66,6 +66,10 @@
     }
   }
 
+  .sidebar-section-header-dropdown-btn {
+    --d-button-default-border: none;
+  }
+
   .c-footer button {
     padding-block: 0.75rem !important;
     height: unset !important;
@@ -122,6 +126,18 @@
       height: calc(
         var(--d-control-height) - var(--space-2)
       ) !important; // overrides very specific btn selector at the top of this file
+    }
+  }
+
+  // button on /my/badges
+  .favorite-btn {
+    border-color: var(--primary-low);
+    border-bottom: none;
+    border-right: none;
+
+    &:hover {
+      border-bottom: none;
+      border-right: none;
     }
   }
 }

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/groups.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/groups.scss
@@ -1,0 +1,8 @@
+.uc-modernize-foundation-theme {
+  .group-details-container {
+    background: transparent;
+    border: 1px solid var(--content-border-color);
+    border-radius: var(--d-border-radius);
+    padding: var(--space-4);
+  }
+}

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/personal-messages.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/personal-messages.scss
@@ -1,0 +1,22 @@
+.uc-modernize-foundation-theme {
+  &.archetype-private_message .topic-map {
+    section {
+      border-radius: var(--d-border-radius);
+      padding: var(--space-4) var(--space-4) 0;
+    }
+
+    .participants {
+      margin-bottom: 0;
+      padding-bottom: var(--space-4);
+
+      .user {
+        border: var(--d-button-default-border);
+        background: var(--d-button-default-bg-color);
+
+        .username:last-child {
+          margin-right: var(--space-1);
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/select-kit.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/select-kit.scss
@@ -37,7 +37,8 @@
   .select-kit.combo-box.category-drop .caret-icon,
   .select-kit.combo-box.tag-drop .tag-drop-header,
   .select-kit.combo-box.tag-drop .selected-name,
-  .select-kit.combo-box.tag-drop .caret-icon {
+  .select-kit.combo-box.tag-drop .caret-icon,
+  .select-kit.combo-box.solved-status-filter .selected-name {
     color: var(--primary);
   }
 

--- a/app/assets/stylesheets/common/components/d-icon-grid-picker.scss
+++ b/app/assets/stylesheets/common/components/d-icon-grid-picker.scss
@@ -17,8 +17,8 @@
     color: var(--icon-color, currentColor);
   }
 
-  &.--has-label .d-icon-grid-picker-trigger {
-    gap: var(--space-2);
+  .d-icon-grid-picker-trigger {
+    gap: var(--space-1);
   }
 
   /* Split-button layout: DMenu trigger + clear button side by side */

--- a/frontend/discourse/app/components/reviewable-bundled-action.gjs
+++ b/frontend/discourse/app/components/reviewable-bundled-action.gjs
@@ -26,20 +26,6 @@ export default class ReviewableBundledAction extends Component {
     return `${vertical}-${horizontal}`;
   }
 
-  get buttonClass() {
-    const buttonIdentifier = dasherize(
-      this.first.button_class || this.first.id
-    );
-
-    if (buttonIdentifier === "reject-post") {
-      return "btn-danger";
-    } else if (buttonIdentifier === "approve-post") {
-      return "btn-success";
-    } else {
-      return "btn-default";
-    }
-  }
-
   @action
   perform(id) {
     if (id) {
@@ -61,8 +47,6 @@ export default class ReviewableBundledAction extends Component {
           disabled=@reviewableUpdating
           placement=this.placement
           translatedNone=@bundle.label
-          customStyle=true
-          btnCustomClasses=this.buttonClass
         }}
         class={{dConcatClass
           "reviewable-action-dropdown"
@@ -77,10 +61,10 @@ export default class ReviewableBundledAction extends Component {
         @translatedLabel={{this.first.label}}
         @disabled={{@reviewableUpdating}}
         class={{dConcatClass
+          "btn-default"
           "reviewable-action"
           (dasherize this.first.id)
           this.first.button_class
-          this.buttonClass
         }}
       />
     {{/if}}

--- a/frontend/discourse/app/components/sidebar/section-form-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-link.gjs
@@ -105,7 +105,7 @@ export default class SectionFormLink extends Component {
           @value={{@link.icon}}
           @onChange={{fn (mut @link.icon)}}
           @showCaret={{true}}
-          @btnClass={{@link.iconCssClass}}
+          @btnClass={{dConcatClass "btn-default" @link.iconCssClass}}
           aria-label={{i18n "sidebar.sections.custom.links.icon.label"}}
         />
 

--- a/frontend/discourse/app/components/sidebar/section.gjs
+++ b/frontend/discourse/app/components/sidebar/section.gjs
@@ -228,6 +228,7 @@ export default class SidebarSection extends Component {
                 @options={{hash
                   icon=@headerActionsIcon
                   placementStrategy="absolute"
+                  btnCustomClasses="sidebar-section-header-dropdown-btn"
                 }}
                 @content={{@headerActions}}
                 @onChange={{this.handleMultipleHeaderActions}}

--- a/frontend/discourse/app/components/topic-footer-buttons.gjs
+++ b/frontend/discourse/app/components/topic-footer-buttons.gjs
@@ -251,7 +251,6 @@ export default class TopicFooterButtons extends Component {
                           @disabled={{button.disabled}}
                           id={{concat "topic-footer-button-" button.id}}
                           class={{dConcatClass
-                            "btn-default"
                             "topic-footer-button"
                             button.classNames
                           }}

--- a/plugins/discourse-solved/assets/stylesheets/solutions.scss
+++ b/plugins/discourse-solved/assets/stylesheets/solutions.scss
@@ -58,6 +58,10 @@ $solved-color: var(--success);
     .select-kit-header {
       color: var(--primary-high);
     }
+
+    .angle-icon {
+      color: currentcolor;
+    }
   }
 }
 

--- a/spec/system/reviewables_spec.rb
+++ b/spec/system/reviewables_spec.rb
@@ -79,16 +79,6 @@ describe "Reviewables" do
       expect(review_page).to have_no_post_body_collapsed
       expect(review_page).to have_no_post_body_toggle
     end
-
-    it "should apply correct button classes to actions" do
-      visit("/review")
-
-      expect(page).to have_css(".approve-post.btn-success")
-      expect(page).to have_css(".reject-post .btn-danger")
-
-      expect(page).to have_no_css(".approve-post.btn-default")
-      expect(page).to have_no_css(".reject-post .btn-default")
-    end
   end
 
   describe "when there is a reviewable user" do


### PR DESCRIPTION
Various style fixes for the modernized foundation upcoming change. Also noticed we have some unused button classes in the review queue in general. 


Before/After
<img width="700" alt="image" src="https://github.com/user-attachments/assets/547c49ee-5d7c-42e5-be60-de06218b3329" />

<img width="700"  alt="image" src="https://github.com/user-attachments/assets/54f5e698-00db-4855-86e0-74053c49408a" />


Before/After
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/24881ca3-d10b-40e4-b6a6-b55eb507642f" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/320aaa5b-6493-4bc0-bd72-8c1f4391134b" />

Before/After:
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/5b719e1e-24d5-434d-a370-de2477d13219" />

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/de39de34-c393-4ee1-b560-70622b2dd245" />



Before/After:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/b87107bd-1484-4716-96f1-b8a227a5d59f" />

<img width="220"  alt="image" src="https://github.com/user-attachments/assets/8123f817-4b21-453b-bfb7-e934cd2d5e99" />


