### PR TITLE
FEATURE: Provider-native built-in tools for agents (web search)

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
@@ -281,6 +281,67 @@ export default class AgentEditor extends Component {
     return this.allTools.filter((tool) => tools.includes(tool.id));
   }
 
+  @cached
+  get llmsById() {
+    const map = {};
+    for (const llm of this.args.agents.resultSetMeta.llms || []) {
+      map[llm.id] = llm;
+    }
+    return map;
+  }
+
+  // Provider-native tools are only offered when the agent forces a default LLM
+  // whose provider supports the tool.
+  supportedNativeToolIds(forceDefaultLlm, defaultLlmId) {
+    if (!forceDefaultLlm || !defaultLlmId) {
+      return [];
+    }
+    return this.llmsById[defaultLlmId]?.supported_native_tools || [];
+  }
+
+  @action
+  availableTools(data) {
+    const supported = this.supportedNativeToolIds(
+      data?.force_default_llm,
+      data?.default_llm_id
+    );
+    return this.allTools.filter((tool) => {
+      if (!tool.native) {
+        return true;
+      }
+      return supported.includes(tool.id.replace("native-", ""));
+    });
+  }
+
+  pruneNativeTools(form, data, forceDefaultLlm, defaultLlmId) {
+    const supported = this.supportedNativeToolIds(
+      forceDefaultLlm,
+      defaultLlmId
+    );
+    const tools = data.tools || [];
+    const kept = tools.filter((toolId) => {
+      if (!toolId.startsWith("native-")) {
+        return true;
+      }
+      return supported.includes(toolId.replace("native-", ""));
+    });
+    if (kept.length !== tools.length) {
+      this.updateToolNames(form, data, kept);
+    }
+  }
+
+  @action
+  onDefaultLlmChange(form, data, value) {
+    form.set("default_llm_id", value);
+    this.pruneNativeTools(form, data, data.force_default_llm, value);
+  }
+
+  @action
+  onForceDefaultLlmChange(form, data, value, { set }) {
+    set("force_default_llm", value);
+    this.pruneNativeTools(form, data, value, data.default_llm_id);
+  }
+
   mcpServerById(serverId) {
     return this.allMcpServers.find((item) => item.id === serverId);
   }
@@ -615,7 +676,7 @@ export default class AgentEditor extends Component {
             <AiLlmSelector
               @value={{field.value}}
               @llms={{@agents.resultSetMeta.llms}}
-              @onChange={{field.set}}
+              @onChange={{fn this.onDefaultLlmChange form data}}
               class="ai-agent-editor__llms"
             />
           </field.Control>
@@ -733,6 +794,7 @@ export default class AgentEditor extends Component {
           <form.Field
             @name="tools"
             @title={{i18n "discourse_ai.ai_agent.tools"}}
+            @description={{i18n "discourse_ai.ai_agent.native_tools_help"}}
             @format="large"
             @type="custom"
             as |field|
@@ -742,7 +804,7 @@ export default class AgentEditor extends Component {
                 @value={{field.value}}
                 @disabled={{data.system}}
                 @onChange={{fn this.updateToolNames form data}}
-                @content={{@agents.resultSetMeta.tools}}
+                @content={{this.availableTools data}}
               />
             </field.Control>
           </form.Field>
@@ -1170,6 +1232,7 @@ export default class AgentEditor extends Component {
                 @showTitle={{false}}
                 @format="large"
                 @type="checkbox"
+                @onSet={{fn this.onForceDefaultLlmChange form data}}
                 as |field|
               >
                 <field.Control />

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-editor.gjs
@@ -682,6 +682,20 @@ export default class AgentEditor extends Component {
           </field.Control>
         </form.Field>
 
+        {{#if (and (not @model.isNew) data.default_llm_id)}}
+          <form.Field
+            @name="force_default_llm"
+            @title={{i18n "discourse_ai.ai_agent.force_default_llm"}}
+            @showTitle={{false}}
+            @format="large"
+            @type="checkbox"
+            @onSet={{fn this.onForceDefaultLlmChange form data}}
+            as |field|
+          >
+            <field.Control />
+          </form.Field>
+        {{/if}}
+
         <form.Field
           @name="allowed_group_ids"
           @title={{i18n "discourse_ai.ai_agent.allowed_groups"}}
@@ -794,7 +808,7 @@ export default class AgentEditor extends Component {
           <form.Field
             @name="tools"
             @title={{i18n "discourse_ai.ai_agent.tools"}}
-            @description={{i18n "discourse_ai.ai_agent.native_tools_help"}}
+            @tooltip={{i18n "discourse_ai.ai_agent.native_tools_help"}}
             @format="large"
             @type="custom"
             as |field|
@@ -1222,23 +1236,7 @@ export default class AgentEditor extends Component {
             <field.Control />
           </form.Field>
 
-          {{#if @model.isNew}}
-            <div>{{i18n "discourse_ai.ai_agent.ai_bot.save_first"}}</div>
-          {{else}}
-            {{#if data.default_llm_id}}
-              <form.Field
-                @name="force_default_llm"
-                @title={{i18n "discourse_ai.ai_agent.force_default_llm"}}
-                @showTitle={{false}}
-                @format="large"
-                @type="checkbox"
-                @onSet={{fn this.onForceDefaultLlmChange form data}}
-                as |field|
-              >
-                <field.Control />
-              </form.Field>
-            {{/if}}
-
+          {{#unless @model.isNew}}
             <form.Container
               @title={{i18n "discourse_ai.ai_agent.user"}}
               @tooltip={{unless
@@ -1266,70 +1264,64 @@ export default class AgentEditor extends Component {
                 />
               {{/if}}
             </form.Container>
+          {{/unless}}
 
-            {{#if data.user}}
-              <form.Field
-                @name="allow_personal_messages"
-                @title={{i18n "discourse_ai.ai_agent.allow_personal_messages"}}
-                @tooltip={{i18n
-                  "discourse_ai.ai_agent.allow_personal_messages_help"
-                }}
-                @showTitle={{false}}
-                @format="large"
-                @type="checkbox"
-                as |field|
-              >
-                <field.Control />
-              </form.Field>
+          <form.Field
+            @name="allow_personal_messages"
+            @title={{i18n "discourse_ai.ai_agent.allow_personal_messages"}}
+            @tooltip={{i18n
+              "discourse_ai.ai_agent.allow_personal_messages_help"
+            }}
+            @showTitle={{false}}
+            @format="large"
+            @type="checkbox"
+            as |field|
+          >
+            <field.Control />
+          </form.Field>
 
-              <form.Field
-                @name="allow_topic_mentions"
-                @title={{i18n "discourse_ai.ai_agent.allow_topic_mentions"}}
-                @tooltip={{i18n
-                  "discourse_ai.ai_agent.allow_topic_mentions_help"
-                }}
-                @showTitle={{false}}
-                @format="large"
-                @type="checkbox"
-                as |field|
-              >
-                <field.Control />
-              </form.Field>
+          <form.Field
+            @name="allow_topic_mentions"
+            @title={{i18n "discourse_ai.ai_agent.allow_topic_mentions"}}
+            @tooltip={{i18n "discourse_ai.ai_agent.allow_topic_mentions_help"}}
+            @showTitle={{false}}
+            @format="large"
+            @type="checkbox"
+            as |field|
+          >
+            <field.Control />
+          </form.Field>
 
-              {{#if this.chatPluginEnabled}}
-                <form.Field
-                  @name="allow_chat_direct_messages"
-                  @title={{i18n
-                    "discourse_ai.ai_agent.allow_chat_direct_messages"
-                  }}
-                  @tooltip={{i18n
-                    "discourse_ai.ai_agent.allow_chat_direct_messages_help"
-                  }}
-                  @showTitle={{false}}
-                  @format="large"
-                  @type="checkbox"
-                  as |field|
-                >
-                  <field.Control />
-                </form.Field>
+          {{#if this.chatPluginEnabled}}
+            <form.Field
+              @name="allow_chat_direct_messages"
+              @title={{i18n "discourse_ai.ai_agent.allow_chat_direct_messages"}}
+              @tooltip={{i18n
+                "discourse_ai.ai_agent.allow_chat_direct_messages_help"
+              }}
+              @showTitle={{false}}
+              @format="large"
+              @type="checkbox"
+              as |field|
+            >
+              <field.Control />
+            </form.Field>
 
-                <form.Field
-                  @name="allow_chat_channel_mentions"
-                  @title={{i18n
-                    "discourse_ai.ai_agent.allow_chat_channel_mentions"
-                  }}
-                  @tooltip={{i18n
-                    "discourse_ai.ai_agent.allow_chat_channel_mentions_help"
-                  }}
-                  @showTitle={{false}}
-                  @format="large"
-                  @type="checkbox"
-                  as |field|
-                >
-                  <field.Control />
-                </form.Field>
-              {{/if}}
-            {{/if}}
+            <form.Field
+              @name="allow_chat_channel_mentions"
+              @title={{i18n
+                "discourse_ai.ai_agent.allow_chat_channel_mentions"
+              }}
+              @tooltip={{i18n
+                "discourse_ai.ai_agent.allow_chat_channel_mentions_help"
+              }}
+              @showTitle={{false}}
+              @format="large"
+              @type="checkbox"
+              as |field|
+            >
+              <field.Control />
+            </form.Field>
           {{/if}}
         </form.Section>
 

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_agents_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_agents_controller.rb
@@ -81,6 +81,7 @@ module DiscourseAi
         ai_agent = AiAgent.new(params.except(:rag_uploads))
 
         if ai_agent.save
+          ensure_ai_agent_user(ai_agent)
           if mcp_server_ids
             sync_mcp_server_assignments(ai_agent, mcp_server_ids, mcp_server_tool_names)
           end
@@ -105,6 +106,7 @@ module DiscourseAi
         initial_attributes = @ai_agent.attributes.dup
 
         if @ai_agent.update(params.except(:rag_uploads))
+          ensure_ai_agent_user(@ai_agent)
           if mcp_server_ids
             sync_mcp_server_assignments(@ai_agent, mcp_server_ids, mcp_server_tool_names)
           end
@@ -434,6 +436,17 @@ module DiscourseAi
 
       def attached_upload_ids
         ai_agent_params[:rag_uploads].to_a.map { |h| h[:id] }
+      end
+
+      def ensure_ai_agent_user(agent)
+        return if agent.system? || agent.user_id.present? || !agent_needs_user?(agent)
+
+        agent.create_user!
+      end
+
+      def agent_needs_user?(agent)
+        agent.force_default_llm? || agent.allow_topic_mentions? ||
+          agent.allow_chat_direct_messages? || agent.allow_chat_channel_mentions?
       end
 
       def ai_agent_params

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_agents_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_agents_controller.rb
@@ -36,6 +36,15 @@ module DiscourseAi
             }
           end
 
+        DiscourseAi::Completions::NativeTools.all.each do |native_tool|
+          tools << {
+            id: "#{DiscourseAi::Completions::NativeTools::PREFIX}#{native_tool.id}",
+            name: native_tool.name,
+            help: native_tool.help,
+            native: true,
+          }
+        end
+
         llms = DiscourseAi::Configuration::LlmEnumerator.values_for_serialization
         mcp_servers =
           AiMcpServer

--- a/plugins/discourse-ai/app/models/ai_agent.rb
+++ b/plugins/discourse-ai/app/models/ai_agent.rb
@@ -46,6 +46,7 @@ class AiAgent < ActiveRecord::Base
   validates :forced_tool_count, numericality: { greater_than: -2, maximum: 100_000 }
 
   validate :tools_can_not_be_duplicated
+  validate :native_tools_require_supported_forced_llm
 
   has_many :rag_document_fragments, dependent: :destroy, as: :target
   has_many :ai_agent_mcp_servers, dependent: :destroy
@@ -205,6 +206,29 @@ class AiAgent < ActiveRecord::Base
     end
   end
 
+  def native_tools_require_supported_forced_llm
+    return unless tools.is_a?(Array)
+
+    native_ids =
+      tools.filter_map do |tool|
+        inner_name, _, _ = tool.is_a?(Array) ? tool : [tool, nil]
+        next unless DiscourseAi::Completions::NativeTools.prefixed?(inner_name)
+        DiscourseAi::Completions::NativeTools.strip_prefix(inner_name)
+      end
+
+    return if native_ids.empty?
+
+    if !force_default_llm || default_llm.blank?
+      errors.add(:tools, I18n.t("discourse_ai.ai_bot.agents.native_tool_requires_forced_llm"))
+      return
+    end
+
+    supported = DiscourseAi::Completions::NativeTools.supported_ids_for(default_llm)
+    if (native_ids - supported).present?
+      errors.add(:tools, I18n.t("discourse_ai.ai_bot.agents.native_tool_unsupported_by_llm"))
+    end
+  end
+
   def class_instance
     attributes = %i[
       id
@@ -242,6 +266,7 @@ class AiAgent < ActiveRecord::Base
 
     options = {}
     force_tool_use = []
+    native_tools = []
 
     tools =
       self.tools.filter_map do |element|
@@ -252,7 +277,11 @@ class AiAgent < ActiveRecord::Base
         inner_name, current_options, should_force_tool_use =
           element.is_a?(Array) ? element : [element, nil]
 
-        if inner_name.start_with?("custom-")
+        if DiscourseAi::Completions::NativeTools.prefixed?(inner_name)
+          id = DiscourseAi::Completions::NativeTools.strip_prefix(inner_name)
+          native_tools << id if DiscourseAi::Completions::NativeTools.valid?(id)
+          next
+        elsif inner_name.start_with?("custom-")
           custom_tool_id = inner_name.split("-", 2).last.to_i
           if AiTool.exists?(id: custom_tool_id, enabled: true)
             klass = DiscourseAi::Agents::Tools::Custom.class_instance(custom_tool_id)
@@ -306,6 +335,7 @@ class AiAgent < ActiveRecord::Base
             define_singleton_method(key) { value } if key != :description && key != :name
           end
           define_method(:options) { options }
+          define_method(:native_tools) { native_tools }
         end
       )
     end
@@ -327,6 +357,7 @@ class AiAgent < ActiveRecord::Base
       end
 
       define_method(:tools) { tools }
+      define_method(:native_tools) { native_tools }
       define_method(:force_tool_use) { force_tool_use }
       define_method(:forced_tool_count) { @ai_agent&.forced_tool_count }
       define_method(:options) { options }

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -537,6 +537,7 @@ en:
 
       ai_agent:
         ai_tools: "Tools"
+        native_tools_help: "Provider-native tools (like web search) only appear once \"Force default LLM\" is enabled and the selected LLM supports them."
         mcp_servers: "MCP servers"
         mcp_server_tools_help: "Selected MCP servers expose all of their tools by default. Narrow them per agent to reduce token usage and keep tool choice focused."
         mcp_server_tool_count:

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -537,7 +537,7 @@ en:
 
       ai_agent:
         ai_tools: "Tools"
-        native_tools_help: "Provider-native tools (like web search) only appear once \"Force default LLM\" is enabled and the selected LLM supports them."
+        native_tools_help: "Provider-native tools, such as web search or page fetch, appear when \"Always use default language model\" is enabled and the selected default language model supports them."
         mcp_servers: "MCP servers"
         mcp_server_tools_help: "Selected MCP servers expose all of their tools by default. Narrow them per agent to reduce token usage and keep tool choice focused."
         mcp_server_tool_count:

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -572,8 +572,11 @@ en:
             description: "Controls whether the post is reviewed, hidden, deleted, or treated as spam."
       native_tools:
         web_search:
-          name: "Web search"
-          help: "Lets the model search the web using the provider's built-in search, when the agent is forced to a supported LLM"
+          name: "Web Search (native)"
+          help: "Lets the model search the web using the provider's built-in search, when the agent is forced to a supported LLM."
+        web_fetch:
+          name: "Web Fetch (native)"
+          help: "Lets the model open and read web pages using the provider's built-in web access, when the agent is forced to a supported LLM."
       tool_summary:
         read_artifact: "Read a web artifact"
         search_uploaded_documents: "Search uploaded documents"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -397,6 +397,8 @@ en:
         cannot_delete_system_agent: "System agents cannot be deleted, please disable it instead"
         cannot_edit_system_agent: "System agents can only be renamed, you may not edit tools or system prompt, instead disable and make a copy"
         cannot_have_duplicate_tools: "Can not have duplicate tools"
+        native_tool_requires_forced_llm: "Provider-native tools require a default LLM with \"Force default LLM\" enabled"
+        native_tool_unsupported_by_llm: "The selected default LLM does not support one of the enabled provider-native tools"
         admin_dashboard_highlights:
           name: "Admin Dashboard Highlights"
           description: "Writes the brief readout shown at the top of the admin dashboard, explaining what changed and what deserves attention this period"
@@ -568,6 +570,10 @@ en:
           flag_type:
             name: "Flag Type"
             description: "Controls whether the post is reviewed, hidden, deleted, or treated as spam."
+      native_tools:
+        web_search:
+          name: "Web search"
+          help: "Lets the model search the web using the provider's built-in search, when the agent is forced to a supported LLM"
       tool_summary:
         read_artifact: "Read a web artifact"
         search_uploaded_documents: "Search uploaded documents"

--- a/plugins/discourse-ai/lib/agents/agent.rb
+++ b/plugins/discourse-ai/lib/agents/agent.rb
@@ -284,6 +284,10 @@ module DiscourseAi
         []
       end
 
+      def native_tools
+        []
+      end
+
       def available_tools
         self
           .class
@@ -338,6 +342,7 @@ module DiscourseAi
 
         prompt.max_pixels = self.class.vision_max_pixels if self.class.vision_enabled
         prompt.tools = available_tools.map(&:signature) if available_tools
+        prompt.native_tools = native_tools if native_tools.present?
         available_tools.each do |tool|
           tool.inject_prompt(prompt: prompt, context: context, agent: self)
         end

--- a/plugins/discourse-ai/lib/agents/bot.rb
+++ b/plugins/discourse-ai/lib/agents/bot.rb
@@ -102,6 +102,7 @@ module DiscourseAi
           execution_context.token_usage_tracker ||= DiscourseAi::Completions::TokenUsageTracker.new
         end
         llm_kwargs[:execution_context] = execution_context if execution_context
+        enable_gemini_thought_summaries!(llm_kwargs, current_llm, context)
         token_usage_tracker = execution_context&.token_usage_tracker
 
         final_answer_requested = false
@@ -263,6 +264,15 @@ module DiscourseAi
 
       private
 
+      def enable_gemini_thought_summaries!(llm_kwargs, current_llm, context)
+        return if current_llm.llm_model.provider != "google"
+        return if context.skip_show_thinking != false
+
+        extra_model_params = (llm_kwargs[:extra_model_params] || {}).dup
+        extra_model_params[:include_thought_summaries] = true
+        llm_kwargs[:extra_model_params] = extra_model_params
+      end
+
       def embed_thinking(raw_context)
         embedded_thinking = []
         thinking_bundle = nil
@@ -270,7 +280,10 @@ module DiscourseAi
         raw_context.each do |context|
           if context.is_a?(DiscourseAi::Completions::Thinking)
             thinking_bundle ||= { message: nil, provider_info: {} }
-            thinking_bundle[:message] = context.message if context.message.present?
+            thinking_bundle[:message] = merge_thinking_message(
+              thinking_bundle[:message],
+              context.message,
+            )
             thinking_bundle[
               :provider_info
             ] = DiscourseAi::Completions::Thinking.merge_provider_info(
@@ -296,6 +309,13 @@ module DiscourseAi
         end
 
         embedded_thinking
+      end
+
+      def merge_thinking_message(existing, incoming)
+        return existing if incoming.blank?
+        return incoming if existing.blank?
+
+        "#{existing}\n\n#{incoming}"
       end
 
       def tool_requires_approval?(tool)
@@ -362,7 +382,7 @@ module DiscourseAi
           provider_payload = {}
 
           current_thinking.each do |thinking|
-            thinking_message = thinking.message if thinking.message.present?
+            thinking_message = merge_thinking_message(thinking_message, thinking.message)
             provider_payload =
               DiscourseAi::Completions::Thinking.merge_provider_info(
                 provider_payload,

--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -568,11 +568,17 @@ module DiscourseAi
             next if type == :structured_output && !partial.finished?
 
             if should_start_thinking?(partial:, context:, type:, started_thinking:, placeholder:)
+              reply << "\n\n" if reply.present? && !reply.end_with?("\n")
               reply << "<details class='ai-thinking'><summary>#{I18n.t("discourse_ai.ai_bot.thinking")}</summary>\n\n"
               started_thinking = true
             elsif should_stop_thinking?(partial:, context:, type:, started_thinking:, placeholder:)
               reply << "</details>\n\n"
               started_thinking = false
+            end
+
+            if type == :thinking && partial.present? && placeholder.blank? && started_thinking &&
+                 !reply.end_with?("\n")
+              reply << "\n\n"
             end
 
             reply << partial
@@ -592,6 +598,11 @@ module DiscourseAi
           end
 
         return if reply.blank? || silent_mode
+
+        if started_thinking
+          reply << "\n\n</details>"
+          started_thinking = false
+        end
 
         if stream_reply
           post_streamer.finish

--- a/plugins/discourse-ai/lib/completions/anthropic_message_processor.rb
+++ b/plugins/discourse-ai/lib/completions/anthropic_message_processor.rb
@@ -57,6 +57,10 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
     @streaming_mode = streaming_mode
     @tool_calls = []
     @current_tool_call = nil
+    @current_server_tool_use = nil
+    @current_anthropic_content_block = nil
+    @current_anthropic_thinking_block = nil
+    @anthropic_content_blocks = []
     @partial_tool_calls = partial_tool_calls
     @output_thinking = output_thinking
     @thinking = nil
@@ -64,6 +68,12 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
 
   def to_tool_calls
     @tool_calls.map { |tool_call| tool_call.to_tool_call }
+  end
+
+  def finish
+    return [] if !@output_thinking
+
+    [build_anthropic_content_blocks_thinking].compact
   end
 
   def process_streamed_message(parsed)
@@ -78,63 +88,116 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
           tool_id,
           partial_tool_calls: @partial_tool_calls,
         ) if tool_name
+    elsif parsed[:type] == "content_block_start" && parsed.dig(:content_block, :type) == "text"
+      start_anthropic_text_block(parsed.dig(:content_block, :text).to_s)
+    elsif parsed[:type] == "content_block_start" &&
+          parsed.dig(:content_block, :type) == "server_tool_use"
+      block = parsed[:content_block].deep_dup
+      block[:input] ||= {}
+      @anthropic_content_blocks << block
+      @current_anthropic_content_block = block
+      @current_server_tool_use = {
+        name: block[:name],
+        raw_json: +block[:input].presence&.to_json.to_s,
+        block: block,
+      }
+    elsif parsed[:type] == "content_block_start" &&
+          server_tool_result_block?(parsed[:content_block])
+      block = parsed[:content_block].deep_dup
+      @anthropic_content_blocks << block
+      @current_anthropic_content_block = block
+    elsif parsed[:type] == "content_block_start" &&
+          parsed.dig(:content_block, :type) == "redacted_thinking"
+      block = { type: "redacted_thinking", data: parsed.dig(:content_block, :data) }
+      @anthropic_content_blocks << block
+      @current_anthropic_content_block = block
+      if @output_thinking
+        result =
+          DiscourseAi::Completions::Thinking.new(
+            message: nil,
+            partial: false,
+            provider_info: {
+              PROVIDER_KEY => {
+                redacted_signature: parsed.dig(:content_block, :data),
+                redacted: true,
+              },
+            },
+          )
+      end
     elsif parsed[:type] == "content_block_start" && parsed.dig(:content_block, :type) == "thinking"
+      thinking = parsed.dig(:content_block, :thinking).to_s
+      @current_anthropic_thinking_block = {
+        type: "thinking",
+        thinking: thinking.dup,
+        signature: +"",
+      }
+      @anthropic_content_blocks << @current_anthropic_thinking_block
+      @current_anthropic_content_block = @current_anthropic_thinking_block
       if @output_thinking
         provider_info = { PROVIDER_KEY => { signature: +"", redacted: false } }
         @thinking =
           DiscourseAi::Completions::Thinking.new(
-            message: +parsed.dig(:content_block, :thinking).to_s,
+            message: thinking.dup,
             partial: true,
             provider_info: provider_info,
           )
         result = @thinking.dup
       end
     elsif parsed[:type] == "content_block_delta" && parsed.dig(:delta, :type) == "thinking_delta"
+      delta = parsed.dig(:delta, :thinking).to_s
+      @current_anthropic_thinking_block[:thinking] << delta if @current_anthropic_thinking_block
       if @output_thinking
-        delta = parsed.dig(:delta, :thinking)
         @thinking.message << delta if @thinking
         result = DiscourseAi::Completions::Thinking.new(message: delta, partial: true)
       end
     elsif parsed[:type] == "content_block_delta" && parsed.dig(:delta, :type) == "signature_delta"
+      signature = parsed.dig(:delta, :signature).to_s
+      if @current_anthropic_thinking_block
+        @current_anthropic_thinking_block[:signature] << signature
+      end
       if @output_thinking
         if @thinking
           info = (@thinking.provider_info[PROVIDER_KEY] ||= { signature: +"", redacted: false })
           info[:signature] ||= +""
-          info[:signature] << parsed.dig(:delta, :signature)
+          info[:signature] << signature
         end
       end
+    elsif parsed[:type] == "content_block_delta" && parsed.dig(:delta, :type) == "citations_delta"
+      append_anthropic_citation(parsed.dig(:delta, :citation))
     elsif parsed[:type] == "content_block_stop" && @thinking
       @thinking.partial = false
       result = @thinking
       @thinking = nil
+      @current_anthropic_thinking_block = nil
     elsif parsed[:type] == "content_block_start" || parsed[:type] == "content_block_delta"
-      if @current_tool_call
+      if @current_server_tool_use
+        @current_server_tool_use[:raw_json] << parsed.dig(:delta, :partial_json).to_s
+      elsif @current_tool_call
         tool_delta = parsed.dig(:delta, :partial_json).to_s
         @current_tool_call.append(tool_delta)
         result = @current_tool_call.partial_tool_call if @current_tool_call.has_partial?
-      elsif parsed.dig(:content_block, :type) == "redacted_thinking"
-        if @output_thinking
-          result =
-            DiscourseAi::Completions::Thinking.new(
-              message: nil,
-              partial: false,
-              provider_info: {
-                PROVIDER_KEY => {
-                  redacted_signature: parsed.dig(:content_block, :data),
-                  redacted: true,
-                },
-              },
-            )
-        end
       else
         result = parsed.dig(:delta, :text).to_s
+        append_anthropic_text(result)
         # no need to return empty strings for streaming, no value
         result = nil if result == ""
       end
     elsif parsed[:type] == "content_block_stop"
-      if @current_tool_call
+      if @current_server_tool_use
+        parsed_input = parse_server_tool_input(@current_server_tool_use[:raw_json])
+        @current_server_tool_use[:block][:input] = parsed_input
+        @current_server_tool_use[:input] = parsed_input
+        result =
+          build_native_tool_thinking(
+            @current_server_tool_use,
+            include_provider_info: false,
+          ) if @output_thinking
+        @current_server_tool_use = nil
+      elsif @current_tool_call
         result = @current_tool_call.to_tool_call
         @current_tool_call = nil
+      elsif @current_anthropic_thinking_block
+        @current_anthropic_thinking_block = nil
       end
     elsif parsed[:type] == "message_start"
       usage = parsed.dig(:message, :usage)
@@ -145,6 +208,7 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
       @output_tokens =
         parsed.dig(:usage, :output_tokens) || parsed.dig(:delta, :usage, :output_tokens)
     elsif parsed[:type] == "message_stop"
+      result = build_anthropic_content_blocks_thinking if @output_thinking
       # bedrock has this ...
       if bedrock_stats = parsed.dig(:"amazon-bedrock-invocationMetrics")
         @input_tokens = bedrock_stats[:inputTokenCount] || @input_tokens
@@ -160,6 +224,7 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
     parsed = JSON.parse(payload, symbolize_names: true) if payload.is_a?(String)
 
     content = parsed.dig(:content)
+    @anthropic_content_blocks = content.deep_dup if content.is_a?(Array)
     if content.is_a?(Array)
       result =
         content
@@ -168,6 +233,8 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
               call = AnthropicToolCall.new(data[:name], data[:id])
               call.append(data[:input].to_json)
               call.to_tool_call
+            elsif data[:type] == "server_tool_use"
+              build_native_tool_thinking(data) if @output_thinking
             elsif data[:type] == "thinking"
               if @output_thinking
                 DiscourseAi::Completions::Thinking.new(
@@ -206,5 +273,88 @@ class DiscourseAi::Completions::AnthropicMessageProcessor
     @cache_read_input_tokens = usage[:cache_read_input_tokens] if usage
 
     result
+  end
+
+  private
+
+  def build_native_tool_thinking(tool_use, include_provider_info: true)
+    provider_info = include_provider_info ? anthropic_content_blocks_provider_info : {}
+
+    DiscourseAi::Completions::Thinking.new(
+      message: native_tool_summary(tool_use),
+      partial: false,
+      provider_info: provider_info,
+    )
+  end
+
+  def build_anthropic_content_blocks_thinking
+    return if @anthropic_content_blocks.blank? || @emitted_anthropic_content_blocks
+    return if !@anthropic_content_blocks.any? { |block| server_tool_block?(block) }
+
+    @emitted_anthropic_content_blocks = true
+    DiscourseAi::Completions::Thinking.new(
+      message: nil,
+      partial: false,
+      provider_info: anthropic_content_blocks_provider_info,
+    )
+  end
+
+  def anthropic_content_blocks_provider_info
+    { PROVIDER_KEY => { content_blocks: @anthropic_content_blocks } }
+  end
+
+  def server_tool_block?(block)
+    block&.dig(:type) == "server_tool_use" || server_tool_result_block?(block)
+  end
+
+  def server_tool_result_block?(block)
+    %w[web_search_tool_result web_fetch_tool_result].include?(block&.dig(:type))
+  end
+
+  def start_anthropic_text_block(text)
+    @current_anthropic_content_block = { type: "text", text: +text.to_s }
+    @anthropic_content_blocks << @current_anthropic_content_block
+  end
+
+  def append_anthropic_text(text)
+    return if text.blank?
+
+    start_anthropic_text_block("") if @current_anthropic_content_block&.dig(:type) != "text"
+
+    @current_anthropic_content_block[:text] << text
+  end
+
+  def append_anthropic_citation(citation)
+    return if citation.blank?
+
+    start_anthropic_text_block("") if @current_anthropic_content_block&.dig(:type) != "text"
+
+    @current_anthropic_content_block[:citations] ||= []
+    @current_anthropic_content_block[:citations] << citation.deep_dup
+  end
+
+  def native_tool_summary(tool_use)
+    name = tool_use[:name].to_s
+    input = tool_use[:input] || parse_server_tool_input(tool_use[:raw_json])
+
+    case name
+    when "web_search"
+      query = input[:query] || input["query"]
+      query.present? ? "Web search: #{query}" : "Web search"
+    when "web_fetch"
+      url = input[:url] || input["url"]
+      url.present? ? "Web fetch: #{url}" : "Web fetch"
+    else
+      "Used native tool: #{name.presence || "unknown"}"
+    end
+  end
+
+  def parse_server_tool_input(raw_json)
+    return raw_json if raw_json.is_a?(Hash)
+    return {} if raw_json.blank?
+
+    JSON.parse(raw_json, symbolize_names: true)
+  rescue JSON::ParserError
+    {}
   end
 end

--- a/plugins/discourse-ai/lib/completions/dialects/claude.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/claude.rb
@@ -60,9 +60,14 @@ module DiscourseAi
         end
 
         def native_tools
-          return [] unless prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_SEARCH)
-
-          [{ type: "web_search_20250305", name: "web_search" }]
+          tools = []
+          if prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_SEARCH)
+            tools << { type: "web_search_20250305", name: "web_search" }
+          end
+          if prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_FETCH)
+            tools << { type: "web_fetch_20260209", name: "web_fetch", allowed_callers: %w[direct] }
+          end
+          tools
         end
 
         def max_prompt_tokens
@@ -94,9 +99,25 @@ module DiscourseAi
         end
 
         def model_msg(msg)
-          content_array = []
-
           anthropic = anthropic_reasoning(msg)
+          if (content_blocks = anthropic&.dig(:content_blocks)).present?
+            content_blocks = content_blocks.deep_dup
+            if msg[:thinking] && anthropic[:signature] &&
+                 !content_blocks.any? { |block| content_block_type(block) == "thinking" }
+              content_blocks.unshift(
+                { type: "thinking", thinking: msg[:thinking], signature: anthropic[:signature] },
+              )
+            end
+            if anthropic[:redacted_signature] &&
+                 !content_blocks.any? { |block| content_block_type(block) == "redacted_thinking" }
+              content_blocks.unshift(
+                { type: "redacted_thinking", data: anthropic[:redacted_signature] },
+              )
+            end
+            return { role: "assistant", content: content_blocks }
+          end
+
+          content_array = []
 
           if anthropic.present?
             if msg[:thinking] && anthropic[:signature]
@@ -124,6 +145,10 @@ module DiscourseAi
             )
 
           { role: "assistant", content: no_array_if_only_text(content_array) }
+        end
+
+        def content_block_type(block)
+          block[:type] || block["type"]
         end
 
         def anthropic_reasoning(message)

--- a/plugins/discourse-ai/lib/completions/dialects/claude.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/claude.rb
@@ -54,7 +54,15 @@ module DiscourseAi
           tools = nil
           tools = tools_dialect.translated_tools if native_tool_support?
 
+          tools = (tools || []).concat(native_tools) if native_tools.present?
+
           ClaudePrompt.new(system_prompt.presence, interleving_messages, tools, tool_choice)
+        end
+
+        def native_tools
+          return [] unless prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_SEARCH)
+
+          [{ type: "web_search_20250305", name: "web_search" }]
         end
 
         def max_prompt_tokens

--- a/plugins/discourse-ai/lib/completions/dialects/dialect.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/dialect.rb
@@ -56,6 +56,12 @@ module DiscourseAi
           @tools ||= tools_dialect.translated_tools
         end
 
+        # provider-native built-in tools (e.g. web search) rendered into the
+        # request payload; the provider executes them server-side
+        def native_tools
+          []
+        end
+
         def tool_choice
           prompt.tool_choice
         end

--- a/plugins/discourse-ai/lib/completions/dialects/gemini.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/gemini.rb
@@ -74,6 +74,10 @@ module DiscourseAi
             result << { google_search: {} }
           end
 
+          if prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_FETCH)
+            result << { url_context: {} }
+          end
+
           result.presence
         end
 
@@ -131,11 +135,66 @@ module DiscourseAi
               upload_filter: ->(encoded) { document_allowed?(encoded) },
             )
 
+          apply_thought_signature_parts!(content_array, msg) if role == "model"
+
           if beta_api?
             { role:, parts: content_array }
           else
             { role:, parts: content_array.first }
           end
+        end
+
+        def apply_thought_signature_parts!(content_array, message)
+          thought_signature_parts(message).each do |signature_part|
+            signature = signature_part[:thoughtSignature]
+            next if signature.blank?
+
+            signed_text = signature_part[:text].to_s
+            signed_part = { text: signed_text, thoughtSignature: signature }
+            signed_part[:thought] = signature_part[:thought] if signature_part.key?(:thought)
+
+            if signed_text.present?
+              attach_thought_signature_to_text_suffix!(content_array, signed_part)
+            else
+              insert_thought_signature_part!(content_array, signed_part)
+            end
+          end
+        end
+
+        def attach_thought_signature_to_text_suffix!(content_array, signed_part)
+          signed_text = signed_part[:text]
+          index = content_array.rindex { |part| part[:text].to_s.end_with?(signed_text) }
+
+          if index
+            text_part = content_array[index]
+            prefix = text_part[:text].delete_suffix(signed_text)
+            replacement = []
+            replacement << text_part.merge(text: prefix) if prefix.present?
+            replacement << signed_part
+            content_array[index, 1] = replacement
+          else
+            insert_thought_signature_part!(content_array, signed_part)
+          end
+        end
+
+        def insert_thought_signature_part!(content_array, signed_part)
+          if signed_part[:thought]
+            index = content_array.index { |part| !part[:thought] } || content_array.length
+            content_array.insert(index, signed_part)
+          else
+            content_array << signed_part
+          end
+        end
+
+        def thought_signature_parts(message)
+          Array(gemini_provider_info(message)&.dig(:thought_signature_parts))
+        end
+
+        def gemini_provider_info(message)
+          info = message[:thinking_provider_info]
+          return if info.blank?
+
+          info.deep_symbolize_keys[:gemini]
         end
 
         def image_node(details)

--- a/plugins/discourse-ai/lib/completions/dialects/gemini.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/gemini.rb
@@ -55,16 +55,26 @@ module DiscourseAi
         end
 
         def tools
-          return if prompt.tools.blank?
+          return if prompt.tools.blank? && prompt.native_tools.blank?
 
-          translated_tools =
-            prompt.tools.map do |t|
-              tool = { name: t.name, description: t.description }
-              tool[:parameters] = t.parameters_json_schema if t.parameters
-              tool
-            end
+          result = []
 
-          [{ function_declarations: translated_tools }]
+          if prompt.tools.present?
+            translated_tools =
+              prompt.tools.map do |t|
+                tool = { name: t.name, description: t.description }
+                tool[:parameters] = t.parameters_json_schema if t.parameters
+                tool
+              end
+
+            result << { function_declarations: translated_tools }
+          end
+
+          if prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_SEARCH)
+            result << { google_search: {} }
+          end
+
+          result.presence
         end
 
         def max_prompt_tokens

--- a/plugins/discourse-ai/lib/completions/dialects/open_ai_responses.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/open_ai_responses.rb
@@ -62,6 +62,10 @@ module DiscourseAi
         end
 
         def model_msg(msg)
+          if (output_items = open_ai_response_output_items(msg)).present?
+            return output_items.deep_dup
+          end
+
           message_for_role("assistant", msg)
         end
 
@@ -144,7 +148,12 @@ module DiscourseAi
         def open_ai_reasoning_data(message)
           info = message[:thinking_provider_info]
           return if info.blank?
-          info[:open_ai_responses] || info["open_ai_responses"]
+
+          info.deep_symbolize_keys[:open_ai_responses]
+        end
+
+        def open_ai_response_output_items(message)
+          open_ai_reasoning_data(message)&.dig(:output_items)
         end
 
         def text_node(text, role)

--- a/plugins/discourse-ai/lib/completions/dialects/open_ai_responses.rb
+++ b/plugins/discourse-ai/lib/completions/dialects/open_ai_responses.rb
@@ -30,6 +30,12 @@ module DiscourseAi
           hoist_reasoning(super)
         end
 
+        def native_tools
+          return [] unless prompt.native_tool?(DiscourseAi::Completions::NativeTools::WEB_SEARCH)
+
+          [{ type: "web_search" }]
+        end
+
         private
 
         def disable_native_tools?

--- a/plugins/discourse-ai/lib/completions/endpoints/anthropic_shared.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/anthropic_shared.rb
@@ -56,6 +56,10 @@ module DiscourseAi
           processor.process_message(response_data)
         end
 
+        def decode_chunk_finish
+          processor.finish
+        end
+
         def claude_processor
           @processor ||=
             DiscourseAi::Completions::AnthropicMessageProcessor.new(

--- a/plugins/discourse-ai/lib/completions/endpoints/gemini.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/gemini.rb
@@ -4,6 +4,10 @@ module DiscourseAi
   module Completions
     module Endpoints
       class Gemini < Base
+        GEMINI_PROVIDER_KEY = :gemini
+        GROUNDING_METADATA_KEYS = %i[webSearchQueries groundingChunks groundingSupports]
+        THOUGHT_SIGNATURE_PROVIDER_KEY = :thought_signature_parts
+
         def self.can_contact?(llm_model)
           llm_model.provider == "google"
         end
@@ -22,6 +26,9 @@ module DiscourseAi
 
         def normalize_model_params(model_params)
           model_params = model_params.dup
+
+          @include_thought_summaries =
+            output_thinking && !!model_params.delete(:include_thought_summaries)
 
           if model_params[:stop_sequences]
             model_params[:stopSequences] = model_params.delete(:stop_sequences)
@@ -127,6 +134,11 @@ module DiscourseAi
             payload[:generationConfig][:thinkingConfig] = { thinkingBudget: thinking_tokens }
           end
 
+          if @include_thought_summaries
+            payload[:generationConfig][:thinkingConfig] ||= {}
+            payload[:generationConfig][:thinkingConfig][:includeThoughts] = true
+          end
+
           payload
         end
 
@@ -205,34 +217,13 @@ module DiscourseAi
 
         def decode(chunk)
           json = JSON.parse(chunk, symbolize_names: true)
+          update_usage(json)
 
-          idx = -1
-          parts = json.dig(:candidates, 0, :content, :parts)
+          candidate = json.dig(:candidates, 0)
+          parts = candidate&.dig(:content, :parts)
           batch_token = current_batch_token_for(parts)
 
-          parts&.map do |part|
-            if part[:functionCall]
-              idx += 1
-              provider_data = provider_data_from_part(part, batch_token:)
-              ToolCall.new(
-                id: "tool_#{idx}",
-                name: part[:functionCall][:name],
-                parameters: part[:functionCall][:args],
-                provider_data: provider_data,
-              )
-            elsif part[:inlineData]
-              inline_data_to_upload_markdown(part[:inlineData])
-            else
-              part = part[:text]
-              if part != ""
-                part
-              else
-                nil
-              end
-            end
-            # we could get a nil here cause part can be nil
-            # interface expects an array
-          end || []
+          decode_parts(parts, batch_token:) + native_tool_thinkings_from_candidate(candidate)
         end
 
         def decode_chunk(chunk)
@@ -241,32 +232,156 @@ module DiscourseAi
             .decode(chunk)
             .map do |parsed|
               update_usage(parsed)
-              parts = parsed.dig(:candidates, 0, :content, :parts)
+              candidate = parsed.dig(:candidates, 0)
+              parts = candidate&.dig(:content, :parts)
               batch_token = current_batch_token_for(parts)
-              parts&.map do |part|
-                if part[:text]
-                  part = part[:text]
-                  if part != ""
-                    part
-                  else
-                    nil
-                  end
-                elsif part[:functionCall]
-                  @tool_index += 1
-                  provider_data = provider_data_from_part(part, batch_token:)
-                  ToolCall.new(
-                    id: "tool_#{@tool_index}",
-                    name: part[:functionCall][:name],
-                    parameters: part[:functionCall][:args],
-                    provider_data: provider_data,
-                  )
-                elsif part[:inlineData]
-                  inline_data_to_upload_markdown(part[:inlineData])
-                end
-              end
+              decode_parts(parts, batch_token:, streaming: true) +
+                native_tool_thinkings_from_candidate(candidate)
             end
             .flatten
             .compact
+        end
+
+        def decode_parts(parts, batch_token:, streaming: false)
+          idx = -1
+          (parts || []).each_with_object([]) do |part, result|
+            if part[:thought]
+              result << decode_thought_summary(part[:text], streaming: streaming)
+              next
+            end
+
+            result.concat(finish_thought_summary) if streaming
+
+            if part[:functionCall]
+              tool_index =
+                if streaming
+                  @tool_index += 1
+                else
+                  idx += 1
+                end
+              provider_data = provider_data_from_part(part, batch_token:)
+              result << ToolCall.new(
+                id: "tool_#{tool_index}",
+                name: part[:functionCall][:name],
+                parameters: part[:functionCall][:args],
+                provider_data: provider_data,
+              )
+            elsif part[:inlineData]
+              result << inline_data_to_upload_markdown(part[:inlineData])
+            else
+              text = part[:text]
+              result << text if text != ""
+            end
+            # we could get a nil here cause part can be nil
+            # interface expects an array
+          end
+        end
+
+        def decode_chunk_finish
+          finish_thought_summary
+        end
+
+        def decode_thought_summary(text, streaming: false)
+          return if !output_thinking || text.blank?
+
+          if streaming
+            @thought_summary ||= +""
+            @thought_summary << text
+            Thinking.new(message: text, partial: true)
+          else
+            Thinking.new(message: text, partial: false)
+          end
+        end
+
+        def finish_thought_summary
+          return [] if @thought_summary.blank?
+
+          thinking = Thinking.new(message: @thought_summary, partial: false)
+          @thought_summary = nil
+          [thinking]
+        end
+
+        def native_tool_thinkings_from_candidate(candidate)
+          return [] if !output_thinking || candidate.blank?
+
+          track_thought_signature_parts(candidate)
+
+          thinkings = [
+            native_web_search_thinking(candidate[:groundingMetadata]),
+            native_web_fetch_thinking(candidate[:urlContextMetadata]),
+          ].compact
+
+          if thinkings.blank? && (thinking = thought_signature_thinking)
+            thinkings << thinking
+          end
+
+          thinkings
+        end
+
+        def native_web_search_thinking(metadata)
+          return if metadata.blank? || @emitted_grounding_metadata_thinking
+
+          provider_metadata = metadata.slice(*GROUNDING_METADATA_KEYS).compact
+          return if provider_metadata.blank?
+
+          queries = Array(metadata[:webSearchQueries]).compact_blank
+          message = queries.present? ? "Web search: #{queries.join(", ")}" : nil
+
+          @emitted_grounding_metadata_thinking = true
+          Thinking.new(
+            message: message,
+            partial: false,
+            provider_info: gemini_provider_info(grounding_metadata: provider_metadata),
+          )
+        end
+
+        def native_web_fetch_thinking(metadata)
+          return if metadata.blank? || @emitted_url_context_metadata_thinking
+
+          urls =
+            Array(metadata[:urlMetadata]).map { |url_metadata| url_metadata[:retrievedUrl] }.compact
+          message = urls.present? ? "Web fetch: #{urls.join(", ")}" : "Web fetch"
+
+          @emitted_url_context_metadata_thinking = true
+          Thinking.new(
+            message: message,
+            partial: false,
+            provider_info: gemini_provider_info(url_context_metadata: metadata),
+          )
+        end
+
+        def track_thought_signature_parts(candidate)
+          parts = candidate.dig(:content, :parts) || []
+          parts.each do |part|
+            next if part[:functionCall]
+
+            signature = part[:thoughtSignature]
+            next if signature.blank?
+
+            @thought_signature_parts ||= []
+            @thought_signature_parts << {
+              text: part[:text].to_s,
+              thoughtSignature: signature,
+            }.tap { |signed_part| signed_part[:thought] = part[:thought] if part.key?(:thought) }
+          end
+        end
+
+        def thought_signature_thinking
+          provider_info = gemini_provider_info
+          return if provider_info.blank?
+
+          Thinking.new(message: nil, partial: false, provider_info: provider_info)
+        end
+
+        def gemini_provider_info(**info)
+          pending_thought_signature_parts =
+            (@thought_signature_parts || []).drop(@emitted_thought_signature_parts_count.to_i)
+          if pending_thought_signature_parts.present?
+            info[THOUGHT_SIGNATURE_PROVIDER_KEY] = pending_thought_signature_parts.deep_dup
+            @emitted_thought_signature_parts_count = @thought_signature_parts.length
+          end
+
+          info.present? ? { GEMINI_PROVIDER_KEY => info } : {}
         end
 
         def update_usage(parsed)

--- a/plugins/discourse-ai/lib/completions/endpoints/gemini.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/gemini.rb
@@ -82,19 +82,27 @@ module DiscourseAi
           if tools.present?
             payload[:tools] = tools
 
-            function_calling_config = { mode: "AUTO" }
-            if dialect.tool_choice.present?
-              if dialect.tool_choice == :none
-                function_calling_config = { mode: "NONE" }
-              else
-                function_calling_config = {
-                  mode: "ANY",
-                  allowed_function_names: [dialect.tool_choice],
-                }
-              end
-            end
+            # function_calling_config only applies to function declarations; Gemini
+            # rejects it when the request only carries provider-native tools (e.g.
+            # google_search grounding) with no function_declarations.
+            has_function_declarations =
+              tools.any? { |tool| tool.is_a?(Hash) && tool[:function_declarations].present? }
 
-            payload[:tool_config] = { function_calling_config: function_calling_config }
+            if has_function_declarations
+              function_calling_config = { mode: "AUTO" }
+              if dialect.tool_choice.present?
+                if dialect.tool_choice == :none
+                  function_calling_config = { mode: "NONE" }
+                else
+                  function_calling_config = {
+                    mode: "ANY",
+                    allowed_function_names: [dialect.tool_choice],
+                  }
+                end
+              end
+
+              payload[:tool_config] = { function_calling_config: function_calling_config }
+            end
           end
           if model_params.present?
             payload[:generationConfig].merge!(model_params.except(:response_format))

--- a/plugins/discourse-ai/lib/completions/endpoints/open_ai_responses.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/open_ai_responses.rb
@@ -43,6 +43,10 @@ module DiscourseAi
             end
           end
 
+          if dialect.native_tools.present?
+            payload[:tools] = (payload[:tools] || []).concat(dialect.native_tools)
+          end
+
           convert_payload_to_responses_api!(payload)
           payload[:include] ||= []
           payload[:include] << "reasoning.encrypted_content"

--- a/plugins/discourse-ai/lib/completions/endpoints/open_ai_responses.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/open_ai_responses.rb
@@ -43,13 +43,15 @@ module DiscourseAi
             end
           end
 
-          if dialect.native_tools.present?
-            payload[:tools] = (payload[:tools] || []).concat(dialect.native_tools)
-          end
+          native_tools = dialect.native_tools
+          payload[:tools] = (payload[:tools] || []).concat(native_tools) if native_tools.present?
 
           convert_payload_to_responses_api!(payload)
           payload[:include] ||= []
           payload[:include] << "reasoning.encrypted_content"
+          if native_tools.any? { |tool| tool[:type] == "web_search" }
+            payload[:include] << "web_search_call.action.sources"
+          end
 
           payload
         end

--- a/plugins/discourse-ai/lib/completions/native_tools.rb
+++ b/plugins/discourse-ai/lib/completions/native_tools.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Completions
+    # Registry of provider-native built-in tools.
+    #
+    # Unlike shipped/custom/MCP tools, these are executed server-side by the LLM
+    # provider (e.g. Gemini Google Search grounding, OpenAI web search, Anthropic
+    # web search). Discourse only declares them in the request payload; there is
+    # no tool-call round-trip back to us. They are stored on an agent's `tools`
+    # column with a "native-" prefix and rendered into the request by each
+    # provider dialect.
+    module NativeTools
+      PREFIX = "native-"
+
+      WEB_SEARCH = "web_search"
+
+      # open_ai/azure only expose web search through the Responses API
+      RESPONSES_API_PROVIDERS = %w[open_ai azure].freeze
+
+      class Definition
+        attr_reader :id, :providers
+
+        def initialize(id:, providers:)
+          @id = id
+          @providers = providers
+        end
+
+        def name
+          I18n.t("discourse_ai.ai_bot.native_tools.#{id}.name")
+        end
+
+        def help
+          I18n.t("discourse_ai.ai_bot.native_tools.#{id}.help")
+        end
+
+        def supported?(llm_model)
+          return false if llm_model.blank?
+
+          provider = llm_model.provider
+          return false if providers.exclude?(provider)
+
+          if RESPONSES_API_PROVIDERS.include?(provider)
+            return llm_model.url.to_s.include?("/v1/responses")
+          end
+
+          true
+        end
+      end
+
+      DEFINITIONS = [
+        Definition.new(id: WEB_SEARCH, providers: %w[google anthropic open_ai azure]),
+      ].freeze
+
+      def self.all
+        DEFINITIONS
+      end
+
+      def self.find(id)
+        id = strip_prefix(id)
+        DEFINITIONS.find { |definition| definition.id == id }
+      end
+
+      def self.valid?(id)
+        !find(id).nil?
+      end
+
+      # ids supported by a given LlmModel (encapsulates the Responses-API nuance)
+      def self.supported_ids_for(llm_model)
+        return [] if llm_model.blank?
+        DEFINITIONS.select { |definition| definition.supported?(llm_model) }.map(&:id)
+      end
+
+      def self.prefixed?(name)
+        name.is_a?(String) && name.start_with?(PREFIX)
+      end
+
+      def self.strip_prefix(name)
+        return name unless prefixed?(name)
+        name.delete_prefix(PREFIX)
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/completions/native_tools.rb
+++ b/plugins/discourse-ai/lib/completions/native_tools.rb
@@ -14,6 +14,7 @@ module DiscourseAi
       PREFIX = "native-"
 
       WEB_SEARCH = "web_search"
+      WEB_FETCH = "web_fetch"
 
       # open_ai/azure only expose web search through the Responses API
       RESPONSES_API_PROVIDERS = %w[open_ai azure].freeze
@@ -50,6 +51,7 @@ module DiscourseAi
 
       DEFINITIONS = [
         Definition.new(id: WEB_SEARCH, providers: %w[google anthropic open_ai azure]),
+        Definition.new(id: WEB_FETCH, providers: %w[google anthropic]),
       ].freeze
 
       def self.all

--- a/plugins/discourse-ai/lib/completions/nova_message_processor.rb
+++ b/plugins/discourse-ai/lib/completions/nova_message_processor.rb
@@ -56,6 +56,10 @@ class DiscourseAi::Completions::NovaMessageProcessor
     @tool_calls.map { |tool_call| tool_call.to_tool_call }
   end
 
+  def finish
+    []
+  end
+
   def process_streamed_message(parsed)
     return if !parsed
 

--- a/plugins/discourse-ai/lib/completions/open_ai_responses_message_processor.rb
+++ b/plugins/discourse-ai/lib/completions/open_ai_responses_message_processor.rb
@@ -18,16 +18,22 @@ module DiscourseAi::Completions
       @reasoning_contexts = {}
       @pending_reasonings = []
       @has_first_summary_part = false
+      @response_output_items = []
+      @emitted_response_output_items = false
     end
 
     # @param json [Hash] full JSON response from responses.create / retrieve
     # @return [Array<String,ToolCall>] pieces in the order they were produced
     def process_message(json)
+      json = normalize_provider_payload(json)
       result = []
 
       pending_reasonings = []
 
-      (json[:output] || []).each do |item|
+      output = json[:output] || []
+      @response_output_items = output.deep_dup
+
+      output.each do |item|
         type = item[:type]
 
         case type
@@ -39,6 +45,10 @@ module DiscourseAi::Completions
           end
         when "function_call"
           result << build_tool_call_from_item(item)
+        when "web_search_call"
+          if @output_thinking
+            result << build_native_tool_thinking(item, include_provider_info: true)
+          end
         when "message"
           text = extract_text(item)
           attach_message_id_to_reasonings(pending_reasonings, item[:id])
@@ -53,12 +63,13 @@ module DiscourseAi::Completions
     # @param json [Hash] a single streamed event, already parsed from ND-JSON
     # @return [String, ToolCall, nil] only when a complete chunk is ready
     def process_streamed_message(json)
+      json = normalize_provider_payload(json)
       rval = nil
-      event_type = json[:type] || json["type"]
+      event_type = json[:type]
 
       case event_type
       when "response.output_text.delta"
-        delta = json[:delta] || json["delta"]
+        delta = json[:delta]
         rval = delta if !delta.empty?
       when "response.reasoning_summary_part.added"
         rval = build_partial_reasoning_delta(json, prefix: "\n\n") if @has_first_summary_part
@@ -81,14 +92,19 @@ module DiscourseAi::Completions
       when "response.output_item.done"
         item = json[:item]
         if item
+          track_response_output_item(item)
           if item[:type] == "function_call"
             handle_tool_stream(:done, item) { |finished| rval = finished }
           elsif item[:type] == "reasoning" && @output_thinking
             return finalize_reasoning_context(item)
+          elsif item[:type] == "web_search_call" && @output_thinking
+            return build_native_tool_thinking(item)
           elsif item[:type] == "message"
             attach_message_id_to_pending_stream_reasonings(item[:id])
           end
         end
+      when "response.completed"
+        track_completed_response(json[:response])
       end
 
       update_usage(json)
@@ -118,15 +134,18 @@ module DiscourseAi::Completions
         rval << @tool
         @tool = nil
       end
+      if @output_thinking && (thinking = build_response_output_items_thinking)
+        rval << thinking
+      end
       rval
     end
 
     private
 
     def extract_text(message_item)
-      (message_item[:content] || message_item["content"] || [])
-        .filter { |c| (c[:type] || c["type"]) == "output_text" }
-        .map { |c| c[:text] || c["text"] }
+      (message_item[:content] || [])
+        .filter { |content| content[:type] == "output_text" }
+        .map { |content| content[:text] }
         .join
     end
 
@@ -163,6 +182,59 @@ module DiscourseAi::Completions
           PROVIDER_KEY => { id: item_id, call_id: call_id }.compact,
         },
       )
+    end
+
+    def build_native_tool_thinking(item, include_provider_info: false)
+      provider_info = include_provider_info ? response_output_items_provider_info : {}
+
+      Thinking.new(message: native_tool_summary(item), partial: false, provider_info: provider_info)
+    end
+
+    def normalize_provider_payload(payload)
+      payload.respond_to?(:deep_symbolize_keys) ? payload.deep_symbolize_keys : payload
+    end
+
+    def build_response_output_items_thinking
+      return if @response_output_items.blank? || @emitted_response_output_items
+      return if !@response_output_items.any? { |item| native_tool_item?(item) }
+
+      @emitted_response_output_items = true
+      Thinking.new(message: nil, partial: false, provider_info: response_output_items_provider_info)
+    end
+
+    def response_output_items_provider_info
+      { PROVIDER_KEY => { output_items: @response_output_items } }
+    end
+
+    def track_response_output_item(item)
+      @response_output_items << item.deep_dup
+    end
+
+    def track_completed_response(response)
+      output = response&.dig(:output)
+      @response_output_items = output.deep_dup if output.present?
+    end
+
+    def native_tool_item?(item)
+      item[:type] == "web_search_call"
+    end
+
+    def native_tool_summary(item)
+      action = item[:action] || {}
+
+      case action[:type]
+      when "search"
+        queries = Array(action[:queries]).presence || Array(action[:query])
+        queries.present? ? "Web search: #{queries.join(", ")}" : "Web search"
+      when "open_page"
+        target = action.values_at(:url, :page_url, :title).compact.first
+        target.present? ? "Web fetch: #{target}" : "Web fetch"
+      when "find_in_page"
+        target = action.values_at(:pattern, :query).compact.first
+        target.present? ? "Web page search: #{target}" : "Web page search"
+      else
+        "Used native web tool"
+      end
     end
 
     def handle_tool_stream(event_type, json)

--- a/plugins/discourse-ai/lib/completions/prompt.rb
+++ b/plugins/discourse-ai/lib/completions/prompt.rb
@@ -6,7 +6,7 @@ module DiscourseAi
       INVALID_TURN = Class.new(StandardError)
 
       attr_reader :messages, :tools, :system_message_text
-      attr_accessor :topic_id, :post_id, :max_pixels, :tool_choice, :skip_trim
+      attr_accessor :topic_id, :post_id, :max_pixels, :tool_choice, :skip_trim, :native_tools
 
       def self.text_only(message)
         if message[:content].is_a?(Array)
@@ -23,12 +23,14 @@ module DiscourseAi
         topic_id: nil,
         post_id: nil,
         max_pixels: nil,
-        tool_choice: nil
+        tool_choice: nil,
+        native_tools: []
       )
         raise ArgumentError, "messages must be an array" if !messages.is_a?(Array)
         raise ArgumentError, "tools must be an array" if !tools.is_a?(Array)
 
         @max_pixels = max_pixels || 1_048_576
+        @native_tools = native_tools || []
 
         @topic_id = topic_id
         @post_id = post_id
@@ -151,6 +153,14 @@ module DiscourseAi
         tools.present?
       end
 
+      def has_native_tools?
+        native_tools.present?
+      end
+
+      def native_tool?(id)
+        native_tools.include?(id)
+      end
+
       def encoded_uploads(
         message,
         allow_images: true,
@@ -227,7 +237,7 @@ module DiscourseAi
         return false unless other.is_a?(Prompt)
         messages == other.messages && tools == other.tools && topic_id == other.topic_id &&
           post_id == other.post_id && max_pixels == other.max_pixels &&
-          tool_choice == other.tool_choice
+          tool_choice == other.tool_choice && native_tools == other.native_tools
       end
 
       def eql?(other)
@@ -235,7 +245,7 @@ module DiscourseAi
       end
 
       def hash
-        [messages, tools, topic_id, post_id, max_pixels, tool_choice].hash
+        [messages, tools, topic_id, post_id, max_pixels, tool_choice, native_tools].hash
       end
 
       private

--- a/plugins/discourse-ai/lib/completions/prompt.rb
+++ b/plugins/discourse-ai/lib/completions/prompt.rb
@@ -72,6 +72,7 @@ module DiscourseAi
       # this means anything we get back from the model via endpoint can be easily appended
       def push_model_response(response)
         pending_thinking = nil
+        last_response_message = nil
 
         thinking_attrs =
           lambda do
@@ -89,7 +90,7 @@ module DiscourseAi
           case message
           when Thinking
             next if message.partial?
-            pending_thinking = message
+            pending_thinking = merge_thinking(pending_thinking, message)
           when ToolCall
             next if message.partial?
             push(
@@ -100,12 +101,14 @@ module DiscourseAi
               provider_data: message.provider_data,
               **thinking_attrs.call,
             )
+            last_response_message = messages.last
           when String
             if messages.last&.dig(:type) == :model
               messages.last[:content] = messages.last[:content] + message
             else
               push(type: :model, content: message, **thinking_attrs.call)
             end
+            last_response_message = messages.last
           when ToolResult
             push(
               type: :tool,
@@ -116,6 +119,10 @@ module DiscourseAi
           else
             raise ArgumentError, "unexpected message type: #{message.class}"
           end
+        end
+
+        if pending_thinking && last_response_message
+          attach_thinking_to_message(last_response_message, pending_thinking)
         end
       end
 
@@ -249,6 +256,38 @@ module DiscourseAi
       end
 
       private
+
+      def merge_thinking(existing, incoming)
+        return incoming unless existing
+
+        merged = existing.dup
+        merged.message = merge_thinking_text(merged.message, incoming.message)
+        merged.merge_provider_info!(incoming.provider_info)
+        merged
+      end
+
+      def merge_thinking_text(existing, incoming)
+        return existing if incoming.blank?
+        return incoming if existing.blank?
+
+        "#{existing}\n\n#{incoming}"
+      end
+
+      def attach_thinking_to_message(message, thinking)
+        return if message.blank? || thinking.blank?
+
+        message[:thinking] = merge_thinking_text(
+          message[:thinking],
+          thinking.message,
+        ) if thinking.message.present?
+
+        if thinking.provider_info.present?
+          message[:thinking_provider_info] = Thinking.merge_provider_info(
+            message[:thinking_provider_info],
+            thinking.provider_info,
+          )
+        end
+      end
 
       def allowed_upload_kinds(allow_images:, allow_documents:)
         allowed_kinds = []

--- a/plugins/discourse-ai/lib/completions/prompt_messages_builder.rb
+++ b/plugins/discourse-ai/lib/completions/prompt_messages_builder.rb
@@ -401,26 +401,34 @@ module DiscourseAi
         message[:id] = id.to_s if id
         message[:provider_data] = provider_data.deep_symbolize_keys if provider_data.present?
         if thinking
-          if thinking["message"] || thinking["provider_info"]
-            message[:thinking] = thinking["message"] if thinking["message"]
-            provider_info =
-              DiscourseAi::Completions::Thinking.normalize_provider_info(thinking["provider_info"])
-            message[:thinking_provider_info] = provider_info if provider_info.present?
-          else
-            legacy_provider_info = {}
-            if thinking["thinking_signature"]
-              legacy_provider_info[:anthropic] ||= {}
-              legacy_provider_info[:anthropic][:signature] = thinking["thinking_signature"]
-            end
-            if thinking["redacted_thinking_signature"]
-              legacy_provider_info[:anthropic] ||= {}
-              legacy_provider_info[:anthropic][:redacted_signature] = thinking[
-                "redacted_thinking_signature"
-              ]
-            end
+          if thinking.is_a?(Hash)
+            thinking = thinking.deep_symbolize_keys
 
-            message[:thinking] = thinking["thinking"] if thinking["thinking"]
-            message[:thinking_provider_info] = legacy_provider_info if legacy_provider_info.present?
+            if thinking[:message] || thinking[:provider_info]
+              message[:thinking] = thinking[:message] if thinking[:message]
+              provider_info =
+                DiscourseAi::Completions::Thinking.normalize_provider_info(thinking[:provider_info])
+              message[:thinking_provider_info] = provider_info if provider_info.present?
+            else
+              legacy_provider_info = {}
+              if thinking[:thinking_signature]
+                legacy_provider_info[:anthropic] ||= {}
+                legacy_provider_info[:anthropic][:signature] = thinking[:thinking_signature]
+              end
+              if thinking[:redacted_thinking_signature]
+                legacy_provider_info[:anthropic] ||= {}
+                legacy_provider_info[:anthropic][:redacted_signature] = thinking[
+                  :redacted_thinking_signature
+                ]
+              end
+
+              message[:thinking] = thinking[:thinking] if thinking[:thinking]
+              message[
+                :thinking_provider_info
+              ] = legacy_provider_info if legacy_provider_info.present?
+            end
+          else
+            message[:thinking] = thinking
           end
         end
 

--- a/plugins/discourse-ai/lib/configuration/llm_enumerator.rb
+++ b/plugins/discourse-ai/lib/configuration/llm_enumerator.rb
@@ -95,14 +95,25 @@ module DiscourseAi
         true
       end
 
-      # returns an array of hashes (id: , name:, vision_enabled:)
+      # returns an array of hashes (id: , name:, vision_enabled:, supported_native_tools:)
       def self.values_for_serialization
         return [] unless table_exists?
 
-        DB.query_hash(<<~SQL).map(&:symbolize_keys)
-          SELECT id, display_name AS name, vision_enabled
-          FROM llm_models
-        SQL
+        llm_models = LlmModel.all.index_by(&:id)
+
+        DB
+          .query_hash(<<~SQL)
+            SELECT id, display_name AS name, vision_enabled
+            FROM llm_models
+          SQL
+          .map do |row|
+            row = row.symbolize_keys
+            llm_model = llm_models[row[:id]]
+            row[:supported_native_tools] = DiscourseAi::Completions::NativeTools.supported_ids_for(
+              llm_model,
+            )
+            row
+          end
       end
 
       def self.values

--- a/plugins/discourse-ai/spec/configuration/llm_enumerator_spec.rb
+++ b/plugins/discourse-ai/spec/configuration/llm_enumerator_spec.rb
@@ -20,13 +20,22 @@ RSpec.describe DiscourseAi::Configuration::LlmEnumerator do
           id: seeded_model.id,
           name: seeded_model.display_name,
           vision_enabled: seeded_model.vision_enabled,
+          supported_native_tools: [],
         },
         {
           id: llm_model.id,
           name: llm_model.display_name,
           vision_enabled: llm_model.vision_enabled,
+          supported_native_tools: [],
         },
       )
+    end
+
+    it "advertises supported provider-native tools" do
+      gemini = Fabricate(:gemini_model)
+
+      serialized = described_class.values_for_serialization.find { |row| row[:id] == gemini.id }
+      expect(serialized[:supported_native_tools]).to eq(["web_search"])
     end
   end
 

--- a/plugins/discourse-ai/spec/configuration/llm_enumerator_spec.rb
+++ b/plugins/discourse-ai/spec/configuration/llm_enumerator_spec.rb
@@ -33,8 +33,13 @@ RSpec.describe DiscourseAi::Configuration::LlmEnumerator do
 
     it "advertises supported provider-native tools" do
       gemini = Fabricate(:gemini_model)
+      openai_responses = Fabricate(:llm_model, url: "https://api.openai.com/v1/responses")
 
       serialized = described_class.values_for_serialization.find { |row| row[:id] == gemini.id }
+      expect(serialized[:supported_native_tools]).to eq(%w[web_search web_fetch])
+
+      serialized =
+        described_class.values_for_serialization.find { |row| row[:id] == openai_responses.id }
       expect(serialized[:supported_native_tools]).to eq(["web_search"])
     end
   end

--- a/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
@@ -60,6 +60,50 @@ RSpec.describe DiscourseAi::Agents::Bot do
       expect(last_call[:model_params][:temperature]).to eq(0.4)
     end
 
+    it "requests Gemini thought summaries when thinking is shown" do
+      gemini = Fabricate(:gemini_model)
+      captured_kwargs = []
+      bot = described_class.as(bot_user, agent: DiscourseAi::Agents::General.new, model: gemini)
+      context =
+        DiscourseAi::Agents::BotContext.new(
+          messages: [{ type: :user, content: "test" }],
+          skip_show_thinking: false,
+        )
+
+      allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+        :generate,
+      ) do |_, *_args, **kwargs|
+        captured_kwargs << kwargs
+        "Answer"
+      end
+
+      bot.reply(context) { |_partial| }
+
+      expect(captured_kwargs.first[:extra_model_params]).to include(include_thought_summaries: true)
+    end
+
+    it "does not request Gemini thought summaries when thinking is hidden" do
+      gemini = Fabricate(:gemini_model)
+      captured_kwargs = []
+      bot = described_class.as(bot_user, agent: DiscourseAi::Agents::General.new, model: gemini)
+      context =
+        DiscourseAi::Agents::BotContext.new(
+          messages: [{ type: :user, content: "test" }],
+          skip_show_thinking: true,
+        )
+
+      allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+        :generate,
+      ) do |_, *_args, **kwargs|
+        captured_kwargs << kwargs
+        "Answer"
+      end
+
+      bot.reply(context) { |_partial| }
+
+      expect(captured_kwargs.first[:extra_model_params]).to be_nil
+    end
+
     context "when using function chaining" do
       it "yields a loading placeholder while proceeds to invoke the command" do
         tool = DiscourseAi::Agents::Tools::ListCategories.new({}, bot_user: nil, llm: nil)

--- a/plugins/discourse-ai/spec/lib/completions/anthropic_message_processor_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/anthropic_message_processor_spec.rb
@@ -72,4 +72,185 @@ describe DiscourseAi::Completions::AnthropicMessageProcessor do
     expect(final_result.provider_info[:anthropic][:signature]).to eq("thinking-sig-123")
     expect(final_result.partial?).to eq(false)
   end
+
+  it "emits thinking for streamed server-side web search" do
+    processor =
+      DiscourseAi::Completions::AnthropicMessageProcessor.new(
+        streaming_mode: true,
+        partial_tool_calls: false,
+        output_thinking: true,
+      )
+
+    processor.process_streamed_message(
+      {
+        type: "content_block_start",
+        content_block: {
+          type: "server_tool_use",
+          id: "srvtoolu_1",
+          name: "web_search",
+          input: {
+          },
+        },
+      },
+    )
+    processor.process_streamed_message(
+      {
+        type: "content_block_delta",
+        delta: {
+          type: "input_json_delta",
+          partial_json: '{"query":"HackerOne AI news today"}',
+        },
+      },
+    )
+
+    result = processor.process_streamed_message({ type: "content_block_stop" })
+
+    expect(result).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result.message).to eq("Web search: HackerOne AI news today")
+    expect(result.provider_info).to eq({})
+    expect(result).not_to be_partial
+
+    processor.process_streamed_message(
+      {
+        type: "content_block_start",
+        content_block: {
+          type: "web_search_tool_result",
+          tool_use_id: "srvtoolu_1",
+          content: [
+            {
+              type: "web_search_result",
+              title: "Example",
+              url: "https://example.com",
+              encrypted_content: "encrypted",
+            },
+          ],
+        },
+      },
+    )
+    processor.process_streamed_message({ type: "content_block_stop" })
+    processor.process_streamed_message(
+      { type: "content_block_start", content_block: { type: "text", text: "" } },
+    )
+    citation = {
+      type: "web_search_result_location",
+      url: "https://example.com",
+      title: "Example",
+      encrypted_index: "encrypted-index",
+      cited_text: "Example cited text",
+    }
+    processor.process_streamed_message(
+      { type: "content_block_delta", delta: { type: "citations_delta", citation: citation } },
+    )
+    processor.process_streamed_message(
+      { type: "content_block_delta", delta: { type: "text_delta", text: "Answer" } },
+    )
+    processor.process_streamed_message({ type: "content_block_stop" })
+
+    provider_result = processor.process_streamed_message({ type: "message_stop" })
+    content_blocks = provider_result.provider_info.dig(:anthropic, :content_blocks)
+
+    expect(provider_result).to be_a(DiscourseAi::Completions::Thinking)
+    expect(provider_result.message).to be_nil
+    expect(content_blocks).to include(
+      {
+        type: "server_tool_use",
+        id: "srvtoolu_1",
+        name: "web_search",
+        input: {
+          query: "HackerOne AI news today",
+        },
+      },
+    )
+    expect(content_blocks).to include(
+      {
+        type: "web_search_tool_result",
+        tool_use_id: "srvtoolu_1",
+        content: [
+          {
+            type: "web_search_result",
+            title: "Example",
+            url: "https://example.com",
+            encrypted_content: "encrypted",
+          },
+        ],
+      },
+      { type: "text", text: "Answer", citations: [citation] },
+    )
+  end
+
+  it "preserves streamed thinking with server tools" do
+    processor =
+      DiscourseAi::Completions::AnthropicMessageProcessor.new(
+        streaming_mode: true,
+        partial_tool_calls: false,
+        output_thinking: true,
+      )
+
+    processor.process_streamed_message(
+      { type: "content_block_start", content_block: { type: "thinking", thinking: "" } },
+    )
+    processor.process_streamed_message(
+      { type: "content_block_delta", delta: { type: "thinking_delta", thinking: "Need search" } },
+    )
+    processor.process_streamed_message(
+      { type: "content_block_delta", delta: { type: "signature_delta", signature: "sig-123" } },
+    )
+    processor.process_streamed_message({ type: "content_block_stop" })
+    processor.process_streamed_message(
+      {
+        type: "content_block_start",
+        content_block: {
+          type: "server_tool_use",
+          id: "srvtoolu_1",
+          name: "web_search",
+          input: {
+          },
+        },
+      },
+    )
+    processor.process_streamed_message(
+      {
+        type: "content_block_delta",
+        delta: {
+          type: "input_json_delta",
+          partial_json: '{"query":"Discourse AI"}',
+        },
+      },
+    )
+    processor.process_streamed_message({ type: "content_block_stop" })
+
+    provider_result = processor.process_streamed_message({ type: "message_stop" })
+
+    expect(provider_result.provider_info.dig(:anthropic, :content_blocks)).to start_with(
+      { type: "thinking", thinking: "Need search", signature: "sig-123" },
+    )
+  end
+
+  it "emits thinking for non-streamed server-side web search" do
+    processor =
+      DiscourseAi::Completions::AnthropicMessageProcessor.new(
+        streaming_mode: false,
+        output_thinking: true,
+      )
+
+    payload = {
+      content: [
+        { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: { query: "x" } },
+        { type: "text", text: "Based on my search, the answer is 42." },
+      ],
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+      },
+    }
+
+    result = processor.process_message(payload)
+
+    expect(result.first).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result.first.message).to eq("Web search: x")
+    expect(result.first.provider_info.dig(:anthropic, :content_blocks)).to include(
+      { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: { query: "x" } },
+    )
+    expect(result.last).to eq("Based on my search, the answer is 42.")
+  end
 end

--- a/plugins/discourse-ai/spec/lib/completions/dialects/claude_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/dialects/claude_spec.rb
@@ -168,4 +168,89 @@ RSpec.describe DiscourseAi::Completions::Dialects::Claude do
       expect(content).not_to include(hash_including(type: "document"))
     end
   end
+
+  describe "#translate with server tools" do
+    it "replays Anthropic server tool content blocks" do
+      content_blocks = [
+        { type: "text", text: "I'll search." },
+        {
+          type: "server_tool_use",
+          id: "srvtoolu_1",
+          name: "web_search",
+          input: {
+            query: "HackerOne AI news",
+          },
+        },
+        {
+          type: "web_search_tool_result",
+          tool_use_id: "srvtoolu_1",
+          content: [
+            {
+              type: "web_search_result",
+              url: "https://example.com",
+              title: "Example",
+              encrypted_content: "encrypted",
+            },
+          ],
+        },
+        { type: "text", text: "Result summary" },
+      ]
+
+      prompt = DiscourseAi::Completions::Prompt.new("You are a bot")
+      prompt.push(type: :user, content: "Search")
+      prompt.push(
+        type: :model,
+        content: "I'll search.Result summary",
+        thinking: "Web search: HackerOne AI news",
+        thinking_provider_info: {
+          anthropic: {
+            content_blocks: content_blocks,
+          },
+        },
+      )
+
+      translated = described_class.new(prompt, llm_model).translate
+      model_message = translated.messages.find { |message| message[:role] == "assistant" }
+
+      expect(model_message[:content]).to eq(content_blocks)
+    end
+
+    it "preserves signed thinking when replaying server tools" do
+      content_blocks = [
+        { type: "text", text: "I'll search." },
+        {
+          type: "server_tool_use",
+          id: "srvtoolu_1",
+          name: "web_search",
+          input: {
+            query: "HackerOne AI news",
+          },
+        },
+      ]
+
+      prompt = DiscourseAi::Completions::Prompt.new("You are a bot")
+      prompt.push(type: :user, content: "Search")
+      prompt.push(
+        type: :model,
+        content: "I'll search.",
+        thinking: "Need current data",
+        thinking_provider_info: {
+          anthropic: {
+            signature: "sig-123",
+            content_blocks: content_blocks,
+          },
+        },
+      )
+
+      translated = described_class.new(prompt, llm_model).translate
+      model_message = translated.messages.find { |message| message[:role] == "assistant" }
+
+      expect(model_message[:content]).to eq(
+        [
+          { type: "thinking", thinking: "Need current data", signature: "sig-123" },
+          *content_blocks,
+        ],
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/completions/dialects/gemini_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/dialects/gemini_spec.rb
@@ -144,6 +144,74 @@ RSpec.describe DiscourseAi::Completions::Dialects::Gemini do
       expect(tool_call_parts[:thoughtSignature]).to eq("sig-123")
     end
 
+    it "preserves text thought signatures on model messages" do
+      prompt = context.prompt
+      prompt.push(type: :user, id: "user1", content: "hello")
+      prompt.push(
+        type: :model,
+        content: "Hello world",
+        thinking_provider_info: {
+          gemini: {
+            thought_signature_parts: [{ text: "", thoughtSignature: "sig-empty" }],
+          },
+        },
+      )
+
+      translated = context.dialect(prompt).translate
+      model_message = translated[:messages].find { |message| message[:role] == "model" }
+
+      expect(model_message[:parts]).to eq(
+        [{ text: "Hello world" }, { text: "", thoughtSignature: "sig-empty" }],
+      )
+    end
+
+    it "preserves signed text suffixes without merging them into unsigned text" do
+      prompt = context.prompt
+      prompt.push(type: :user, id: "user1", content: "hello")
+      prompt.push(
+        type: :model,
+        content: "Hello world",
+        thinking_provider_info: {
+          gemini: {
+            thought_signature_parts: [{ text: "world", thoughtSignature: "sig-world" }],
+          },
+        },
+      )
+
+      translated = context.dialect(prompt).translate
+      model_message = translated[:messages].find { |message| message[:role] == "model" }
+
+      expect(model_message[:parts]).to eq(
+        [{ text: "Hello " }, { text: "world", thoughtSignature: "sig-world" }],
+      )
+    end
+
+    it "preserves signed thought summaries before model text" do
+      prompt = context.prompt
+      prompt.push(type: :user, id: "user1", content: "hello")
+      prompt.push(
+        type: :model,
+        content: "Hello world",
+        thinking_provider_info: {
+          gemini: {
+            thought_signature_parts: [
+              { text: "I should greet the user.", thought: true, thoughtSignature: "sig-thought" },
+            ],
+          },
+        },
+      )
+
+      translated = context.dialect(prompt).translate
+      model_message = translated[:messages].find { |message| message[:role] == "model" }
+
+      expect(model_message[:parts]).to eq(
+        [
+          { text: "I should greet the user.", thought: true, thoughtSignature: "sig-thought" },
+          { text: "Hello world" },
+        ],
+      )
+    end
+
     it "merges multiple tool calls from the same batch into a single model message" do
       prompt = context.prompt
       prompt.push(type: :user, id: "user1", content: "do two things")

--- a/plugins/discourse-ai/spec/lib/completions/dialects/open_ai_responses_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/dialects/open_ai_responses_spec.rb
@@ -66,6 +66,51 @@ RSpec.describe DiscourseAi::Completions::Dialects::OpenAiResponses do
       )
     end
 
+    it "replays Responses API output items for native web search" do
+      output_items = [
+        {
+          id: "ws_1",
+          type: "web_search_call",
+          status: "completed",
+          action: {
+            type: "search",
+            queries: ["Hacker News homepage"],
+            query: "Hacker News homepage",
+          },
+        },
+        {
+          id: "msg_1",
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: "HN summary",
+              annotations: [
+                { type: "url_citation", url: "https://news.ycombinator.com", title: "Hacker News" },
+              ],
+            },
+          ],
+        },
+      ]
+      prompt = DiscourseAi::Completions::Prompt.new("You are a bot")
+      prompt.push(type: :user, content: "Search")
+      prompt.push(
+        type: :model,
+        content: "HN summary",
+        thinking: "Web search: Hacker News homepage",
+        thinking_provider_info: {
+          open_ai_responses: {
+            output_items: output_items,
+          },
+        },
+      )
+
+      translated = described_class.new(prompt, llm_model).translate
+
+      expect(translated).to include(*output_items)
+    end
+
     it "renders converted document uploads as input_text parts" do
       llm_model.update!(allowed_attachment_types: ["docx"])
       converted_text = "Uploaded document: sample.docx (13 Bytes)\n\nConverted text"

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/gemini_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/gemini_spec.rb
@@ -325,6 +325,105 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Gemini do
     expect(parsed.dig(:generationConfig, :thinkingConfig)).to eq({ thinkingLevel: "high" })
   end
 
+  it "requests Gemini thought summaries when enabled" do
+    model.update!(provider_params: { enable_thinking: true, thinking_level: "medium" })
+
+    response = gemini_mock.response("Using thought summaries").to_json
+    req_body = nil
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:generateContent?key=123"
+
+    stub_request(:post, url).with(
+      body:
+        proc do |_req_body|
+          req_body = _req_body
+          true
+        end,
+    ).to_return(status: 200, body: response)
+
+    llm.generate(
+      "Hello",
+      user: user,
+      output_thinking: true,
+      extra_model_params: {
+        include_thought_summaries: true,
+      },
+    )
+
+    parsed = JSON.parse(req_body, symbolize_names: true)
+    expect(parsed.dig(:generationConfig, :thinkingConfig)).to eq(
+      { thinkingLevel: "medium", includeThoughts: true },
+    )
+  end
+
+  it "decodes non-streamed thought summaries as thinking" do
+    response = {
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: "I should inspect the provided URL.", thought: true },
+              { text: "The URL contains latest topic data." },
+            ],
+            role: "model",
+          },
+        },
+      ],
+    }.to_json
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:generateContent?key=123"
+
+    stub_request(:post, url).to_return(status: 200, body: response)
+
+    result = llm.generate("Hello", user: user, output_thinking: true)
+
+    expect(result.first).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result.first.message).to eq("I should inspect the provided URL.")
+    expect(result.last).to eq("The URL contains latest topic data.")
+  end
+
+  it "streams thought summaries separately from answer text" do
+    payload =
+      [
+        {
+          candidates: [
+            { content: { parts: [{ text: "I should ", thought: true }], role: "model" } },
+          ],
+        },
+        {
+          candidates: [
+            { content: { parts: [{ text: "inspect the URL.", thought: true }], role: "model" } },
+          ],
+        },
+        { candidates: [{ content: { parts: [{ text: "Answer text" }], role: "model" } }] },
+      ].map { |row| "data: #{row.to_json}\n\n" }.join
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:streamGenerateContent?alt=sse&key=123"
+    output = []
+
+    stub_request(:post, url).to_return(status: 200, body: payload)
+
+    result =
+      llm.generate("Hello", user: user, output_thinking: true) { |partial| output << partial }
+
+    expect(
+      output.map do |partial|
+        partial.is_a?(String) ? partial : [partial.message, partial.partial?]
+      end,
+    ).to eq(
+      [
+        ["I should ", true],
+        ["inspect the URL.", true],
+        ["I should inspect the URL.", false],
+        "Answer text",
+      ],
+    )
+    expect(result).to eq("Answer text")
+  end
+
   it "thinking_level takes priority over enable_thinking" do
     model.update!(
       provider_params: {
@@ -480,6 +579,232 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Gemini do
     # Gemini rejects function_calling_config when there are no function_declarations
     expect(parsed[:tools]).to eq([{ google_search: {} }])
     expect(parsed).not_to have_key(:tool_config)
+  end
+
+  it "emits native web search thinking from grounding metadata" do
+    prompt = DiscourseAi::Completions::Prompt.new("Hello")
+    prompt.native_tools = ["web_search"]
+
+    grounding_metadata = {
+      webSearchQueries: ["OpenAI news"],
+      searchEntryPoint: {
+        renderedContent: "<div>Search suggestions</div>",
+      },
+      groundingChunks: [{ web: { uri: "https://openai.com/news", title: "OpenAI" } }],
+      groundingSupports: [
+        {
+          segment: {
+            startIndex: 0,
+            endIndex: 15,
+            text: "Grounded answer",
+          },
+          groundingChunkIndices: [0],
+        },
+      ],
+    }
+    response = {
+      candidates: [
+        {
+          content: {
+            parts: [{ text: "Grounded answer" }],
+            role: "model",
+          },
+          groundingMetadata: grounding_metadata,
+        },
+      ],
+    }.to_json
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:generateContent?key=123"
+
+    stub_request(:post, url).to_return(status: 200, body: response)
+
+    result = llm.generate(prompt, user: user, output_thinking: true)
+
+    expect(result.first).to eq("Grounded answer")
+    expect(result.last).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result.last.message).to eq("Web search: OpenAI news")
+    expect(result.last.provider_info.dig(:gemini, :grounding_metadata)).to eq(
+      grounding_metadata.except(:searchEntryPoint),
+    )
+  end
+
+  it "streams native web search thinking from grounding metadata" do
+    prompt = DiscourseAi::Completions::Prompt.new("Hello")
+    prompt.native_tools = ["web_search"]
+
+    rows = [
+      { candidates: [{ content: { parts: [{ text: "Grounded " }], role: "model" } }] },
+      { candidates: [{ content: { parts: [{ text: "answer" }], role: "model" } }] },
+      {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: "", thoughtSignature: "sig-123" }],
+              role: "model",
+            },
+            finishReason: "STOP",
+            groundingMetadata: {
+              webSearchQueries: ["OpenAI news", "Anthropic news"],
+              groundingChunks: [{ web: { uri: "https://openai.com/news", title: "OpenAI" } }],
+            },
+          },
+        ],
+      },
+    ]
+    payload = rows.map { |row| "data: #{row.to_json}\n\n" }.join
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:streamGenerateContent?alt=sse&key=123"
+    output = []
+
+    stub_request(:post, url).to_return(status: 200, body: payload)
+
+    result = llm.generate(prompt, user: user, output_thinking: true) { |partial| output << partial }
+    thinking = output.find { |partial| partial.is_a?(DiscourseAi::Completions::Thinking) }
+
+    expect(output.map { |partial| partial.is_a?(String) ? partial : partial.message }).to eq(
+      ["Grounded ", "answer", "Web search: OpenAI news, Anthropic news"],
+    )
+    expect(thinking.provider_info.dig(:gemini, :grounding_metadata, :webSearchQueries)).to eq(
+      ["OpenAI news", "Anthropic news"],
+    )
+    expect(thinking.provider_info.dig(:gemini, :thought_signature_parts)).to eq(
+      [{ text: "", thoughtSignature: "sig-123" }],
+    )
+    expect(Array(result).join).to eq("Grounded answer")
+  end
+
+  it "keeps grounding metadata hidden when Gemini does not include search queries" do
+    payload =
+      [
+        { candidates: [{ content: { parts: [{ text: "Fetched answer" }], role: "model" } }] },
+        {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "", thoughtSignature: "sig-789" }],
+                role: "model",
+              },
+              finishReason: "STOP",
+              groundingMetadata: {
+                groundingChunks: [
+                  { web: { uri: "https://meta.discourse.org/latest.json", title: "Meta" } },
+                ],
+                groundingSupports: [
+                  {
+                    segment: {
+                      startIndex: 0,
+                      endIndex: 14,
+                      text: "Fetched answer",
+                    },
+                    groundingChunkIndices: [0],
+                  },
+                ],
+              },
+              urlContextMetadata: {
+                urlMetadata: [
+                  {
+                    retrievedUrl: "https://meta.discourse.org/latest.json",
+                    urlRetrievalStatus: "URL_RETRIEVAL_STATUS_SUCCESS",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ].map { |row| "data: #{row.to_json}\n\n" }.join
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:streamGenerateContent?alt=sse&key=123"
+    output = []
+
+    stub_request(:post, url).to_return(status: 200, body: payload)
+
+    llm.generate("Hello", user: user, output_thinking: true) { |partial| output << partial }
+
+    expect(output.map { |partial| partial.is_a?(String) ? partial : partial.message }).to eq(
+      ["Fetched answer", nil, "Web fetch: https://meta.discourse.org/latest.json"],
+    )
+    expect(output.grep(DiscourseAi::Completions::Thinking).first.provider_info[:gemini]).to include(
+      :grounding_metadata,
+      :thought_signature_parts,
+    )
+  end
+
+  it "emits hidden thinking for streamed text thought signatures" do
+    payload =
+      [
+        { candidates: [{ content: { parts: [{ text: "Hello" }], role: "model" } }] },
+        {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: "", thoughtSignature: "sig-456" }],
+                role: "model",
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ].map { |row| "data: #{row.to_json}\n\n" }.join
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:streamGenerateContent?alt=sse&key=123"
+    output = []
+
+    stub_request(:post, url).to_return(status: 200, body: payload)
+
+    result =
+      llm.generate("Hello", user: user, output_thinking: true) { |partial| output << partial }
+    thinking = output.find { |partial| partial.is_a?(DiscourseAi::Completions::Thinking) }
+
+    expect(output.map { |partial| partial.is_a?(String) ? partial : partial.message }).to eq(
+      ["Hello", nil],
+    )
+    expect(thinking.provider_info.dig(:gemini, :thought_signature_parts)).to eq(
+      [{ text: "", thoughtSignature: "sig-456" }],
+    )
+    expect(Array(result).join).to eq("Hello")
+  end
+
+  it "emits native web fetch thinking from URL context metadata" do
+    prompt = DiscourseAi::Completions::Prompt.new("Hello")
+    prompt.native_tools = ["web_fetch"]
+
+    url_context_metadata = {
+      urlMetadata: [
+        {
+          retrievedUrl: "https://example.com/report",
+          urlRetrievalStatus: "URL_RETRIEVAL_STATUS_SUCCESS",
+        },
+      ],
+    }
+    response = {
+      candidates: [
+        {
+          content: {
+            parts: [{ text: "Fetched answer" }],
+            role: "model",
+          },
+          urlContextMetadata: url_context_metadata,
+        },
+      ],
+    }.to_json
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:generateContent?key=123"
+
+    stub_request(:post, url).to_return(status: 200, body: response)
+
+    result = llm.generate(prompt, user: user, output_thinking: true)
+
+    expect(result.first).to eq("Fetched answer")
+    expect(result.last).to be_a(DiscourseAi::Completions::Thinking)
+    expect(result.last.message).to eq("Web fetch: https://example.com/report")
+    expect(result.last.provider_info.dig(:gemini, :url_context_metadata)).to eq(
+      url_context_metadata,
+    )
   end
 
   it "properly encodes tool calls" do

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/gemini_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/gemini_spec.rb
@@ -452,6 +452,36 @@ RSpec.describe DiscourseAi::Completions::Endpoints::Gemini do
     expect(parsed[:tool_config]).to eq({ function_calling_config: { mode: "AUTO" } })
   end
 
+  it "sends google_search grounding without a function_calling_config when only native tools are present" do
+    prompt = DiscourseAi::Completions::Prompt.new("Hello")
+    prompt.native_tools = ["web_search"]
+
+    response = gemini_mock.response("World").to_json
+
+    req_body = nil
+
+    llm = DiscourseAi::Completions::Llm.proxy(model)
+    url = "#{model.url}:generateContent?key=123"
+
+    stub_request(:post, url).with(
+      body:
+        proc do |_req_body|
+          req_body = _req_body
+          true
+        end,
+    ).to_return(status: 200, body: response)
+
+    response = llm.generate(prompt, user: user)
+
+    expect(response).to eq("World")
+
+    parsed = JSON.parse(req_body, symbolize_names: true)
+
+    # Gemini rejects function_calling_config when there are no function_declarations
+    expect(parsed[:tools]).to eq([{ google_search: {} }])
+    expect(parsed).not_to have_key(:tool_config)
+  end
+
   it "properly encodes tool calls" do
     prompt = DiscourseAi::Completions::Prompt.new("Hello", tools: [echo_tool])
 

--- a/plugins/discourse-ai/spec/lib/completions/endpoints/open_ai_responses_api_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/endpoints/open_ai_responses_api_spec.rb
@@ -446,6 +446,33 @@ data: {"type":"response.reasoning_summary_part.added","sequence_number":3,"item_
     expect(parsed_body).to have_key(:input)
   end
 
+  it "requests web search sources when native web search is enabled" do
+    parsed_body = nil
+    stub_request(:post, "https://api.openai.com/v1/responses").with(
+      body:
+        proc do |req_body|
+          parsed_body = JSON.parse(req_body, symbolize_names: true)
+          true
+        end,
+    ).to_return(status: 200, body: { output: [] }.to_json)
+
+    prompt =
+      DiscourseAi::Completions::Prompt.new(
+        "You are a bot",
+        messages: [type: :user, content: "hello"],
+      )
+    prompt.native_tools = ["web_search"]
+    dialect = DiscourseAi::Completions::Dialects::OpenAiResponses.new(prompt, model)
+
+    endpoint.perform_completion!(dialect, Discourse.system_user)
+
+    expect(parsed_body[:tools]).to include({ type: "web_search" })
+    expect(parsed_body[:include]).to contain_exactly(
+      "reasoning.encrypted_content",
+      "web_search_call.action.sources",
+    )
+  end
+
   it "includes service_tier in converted responses payload" do
     model.update!(provider_params: { service_tier: "flex" })
 

--- a/plugins/discourse-ai/spec/lib/completions/native_tools_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/native_tools_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Completions::NativeTools do
+  before { enable_current_plugin }
+
+  fab!(:gemini_model)
+  fab!(:anthropic_model)
+  fab!(:openai_chat_model) do
+    Fabricate(:llm_model, url: "https://api.openai.com/v1/chat/completions")
+  end
+  fab!(:openai_responses_model) do
+    Fabricate(:llm_model, url: "https://api.openai.com/v1/responses")
+  end
+  fab!(:bedrock_model)
+
+  describe ".supported_ids_for" do
+    it "supports Gemini grounding" do
+      expect(described_class.supported_ids_for(gemini_model)).to eq(["web_search"])
+    end
+
+    it "supports Anthropic web search" do
+      expect(described_class.supported_ids_for(anthropic_model)).to eq(["web_search"])
+    end
+
+    it "supports OpenAI web search only on the Responses API" do
+      expect(described_class.supported_ids_for(openai_responses_model)).to eq(["web_search"])
+      expect(described_class.supported_ids_for(openai_chat_model)).to eq([])
+    end
+
+    it "does not support Bedrock" do
+      expect(described_class.supported_ids_for(bedrock_model)).to eq([])
+    end
+
+    it "returns [] for a nil model" do
+      expect(described_class.supported_ids_for(nil)).to eq([])
+    end
+  end
+
+  describe ".valid? and prefixing" do
+    it "validates ids regardless of prefix" do
+      expect(described_class.valid?("web_search")).to eq(true)
+      expect(described_class.valid?("native-web_search")).to eq(true)
+      expect(described_class.valid?("nope")).to eq(false)
+    end
+
+    it "detects and strips the prefix" do
+      expect(described_class.prefixed?("native-web_search")).to eq(true)
+      expect(described_class.prefixed?("web_search")).to eq(false)
+      expect(described_class.strip_prefix("native-web_search")).to eq("web_search")
+    end
+  end
+
+  describe "dialect rendering" do
+    let(:web_search_prompt) do
+      prompt =
+        DiscourseAi::Completions::Prompt.new("system", messages: [{ type: :user, content: "hi" }])
+      prompt.native_tools = ["web_search"]
+      prompt
+    end
+
+    it "renders google_search for Gemini (native tools only)" do
+      dialect = DiscourseAi::Completions::Dialects::Gemini.new(web_search_prompt, gemini_model)
+      expect(dialect.tools).to eq([{ google_search: {} }])
+    end
+
+    it "renders google_search alongside function declarations for Gemini" do
+      web_search_prompt.tools = [
+        {
+          name: "echo",
+          description: "echo",
+          parameters: [{ name: "text", description: "text to echo", type: "string" }],
+        },
+      ]
+
+      dialect = DiscourseAi::Completions::Dialects::Gemini.new(web_search_prompt, gemini_model)
+      tools = dialect.tools
+
+      expect(tools.find { |t| t.key?(:function_declarations) }).to be_present
+      expect(tools).to include({ google_search: {} })
+    end
+
+    it "renders the web search tool for Claude" do
+      dialect = DiscourseAi::Completions::Dialects::Claude.new(web_search_prompt, anthropic_model)
+      translated = dialect.translate
+
+      expect(translated.tools).to include({ type: "web_search_20250305", name: "web_search" })
+    end
+
+    it "renders the web search tool for the OpenAI Responses API" do
+      dialect =
+        DiscourseAi::Completions::Dialects::OpenAiResponses.new(
+          web_search_prompt,
+          openai_responses_model,
+        )
+
+      expect(dialect.native_tools).to eq([{ type: "web_search" }])
+    end
+
+    it "renders nothing when no native tools are enabled" do
+      prompt =
+        DiscourseAi::Completions::Prompt.new("system", messages: [{ type: :user, content: "hi" }])
+
+      gemini = DiscourseAi::Completions::Dialects::Gemini.new(prompt, gemini_model)
+      claude = DiscourseAi::Completions::Dialects::Claude.new(prompt, anthropic_model)
+
+      expect(gemini.tools).to be_nil
+      expect(claude.translate.tools).to be_blank
+    end
+  end
+
+  describe "response handling (enable-only)" do
+    it "ignores Anthropic server-side web search blocks and keeps the text" do
+      processor = DiscourseAi::Completions::AnthropicMessageProcessor.new(streaming_mode: false)
+
+      payload = {
+        content: [
+          { type: "server_tool_use", id: "srvtoolu_1", name: "web_search", input: { query: "x" } },
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srvtoolu_1",
+            content: [{ type: "web_search_result", url: "https://example.com", title: "Example" }],
+          },
+          { type: "text", text: "Based on my search, the answer is 42." },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+        },
+      }
+
+      result = processor.process_message(payload)
+
+      expect(result).to eq(["Based on my search, the answer is 42."])
+      expect(result.any? { |r| r.is_a?(DiscourseAi::Completions::ToolCall) }).to eq(false)
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/lib/completions/native_tools_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/native_tools_spec.rb
@@ -14,12 +14,12 @@ RSpec.describe DiscourseAi::Completions::NativeTools do
   fab!(:bedrock_model)
 
   describe ".supported_ids_for" do
-    it "supports Gemini grounding" do
-      expect(described_class.supported_ids_for(gemini_model)).to eq(["web_search"])
+    it "supports Gemini grounding and URL context" do
+      expect(described_class.supported_ids_for(gemini_model)).to eq(%w[web_search web_fetch])
     end
 
-    it "supports Anthropic web search" do
-      expect(described_class.supported_ids_for(anthropic_model)).to eq(["web_search"])
+    it "supports Anthropic web search and fetch" do
+      expect(described_class.supported_ids_for(anthropic_model)).to eq(%w[web_search web_fetch])
     end
 
     it "supports OpenAI web search only on the Responses API" do
@@ -40,6 +40,8 @@ RSpec.describe DiscourseAi::Completions::NativeTools do
     it "validates ids regardless of prefix" do
       expect(described_class.valid?("web_search")).to eq(true)
       expect(described_class.valid?("native-web_search")).to eq(true)
+      expect(described_class.valid?("web_fetch")).to eq(true)
+      expect(described_class.valid?("native-web_fetch")).to eq(true)
       expect(described_class.valid?("nope")).to eq(false)
     end
 
@@ -58,9 +60,13 @@ RSpec.describe DiscourseAi::Completions::NativeTools do
       prompt
     end
 
-    it "renders google_search for Gemini (native tools only)" do
-      dialect = DiscourseAi::Completions::Dialects::Gemini.new(web_search_prompt, gemini_model)
-      expect(dialect.tools).to eq([{ google_search: {} }])
+    it "renders Gemini native web tools" do
+      prompt =
+        DiscourseAi::Completions::Prompt.new("system", messages: [{ type: :user, content: "hi" }])
+      prompt.native_tools = %w[web_search web_fetch]
+
+      dialect = DiscourseAi::Completions::Dialects::Gemini.new(prompt, gemini_model)
+      expect(dialect.tools).to eq([{ google_search: {} }, { url_context: {} }])
     end
 
     it "renders google_search alongside function declarations for Gemini" do
@@ -79,11 +85,15 @@ RSpec.describe DiscourseAi::Completions::NativeTools do
       expect(tools).to include({ google_search: {} })
     end
 
-    it "renders the web search tool for Claude" do
+    it "renders the web search and fetch tools for Claude" do
+      web_search_prompt.native_tools = %w[web_search web_fetch]
       dialect = DiscourseAi::Completions::Dialects::Claude.new(web_search_prompt, anthropic_model)
       translated = dialect.translate
 
       expect(translated.tools).to include({ type: "web_search_20250305", name: "web_search" })
+      expect(translated.tools).to include(
+        { type: "web_fetch_20260209", name: "web_fetch", allowed_callers: %w[direct] },
+      )
     end
 
     it "renders the web search tool for the OpenAI Responses API" do
@@ -92,6 +102,26 @@ RSpec.describe DiscourseAi::Completions::NativeTools do
           web_search_prompt,
           openai_responses_model,
         )
+
+      expect(dialect.native_tools).to eq([{ type: "web_search" }])
+    end
+
+    it "does not render OpenAI web fetch" do
+      prompt =
+        DiscourseAi::Completions::Prompt.new("system", messages: [{ type: :user, content: "hi" }])
+      prompt.native_tools = ["web_fetch"]
+      dialect =
+        DiscourseAi::Completions::Dialects::OpenAiResponses.new(prompt, openai_responses_model)
+
+      expect(dialect.native_tools).to eq([])
+    end
+
+    it "does not duplicate the OpenAI native web tool when unknown fetch is also present" do
+      prompt =
+        DiscourseAi::Completions::Prompt.new("system", messages: [{ type: :user, content: "hi" }])
+      prompt.native_tools = %w[web_search web_fetch]
+      dialect =
+        DiscourseAi::Completions::Dialects::OpenAiResponses.new(prompt, openai_responses_model)
 
       expect(dialect.native_tools).to eq([{ type: "web_search" }])
     end

--- a/plugins/discourse-ai/spec/lib/completions/open_ai_responses_message_processor_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/open_ai_responses_message_processor_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Completions::OpenAiResponsesMessageProcessor do
+  describe "native web tool activity" do
+    it "emits a thinking item for streamed web search calls" do
+      processor = described_class.new(output_thinking: true)
+
+      streamed_web_search_item = {
+        id: "ws_1",
+        type: "web_search_call",
+        status: "completed",
+        action: {
+          type: "search",
+          queries: ["Hacker News homepage"],
+          query: "Hacker News homepage",
+        },
+      }
+      completed_web_search_item = {
+        **streamed_web_search_item,
+        action: {
+          **streamed_web_search_item[:action],
+          sources: [
+            { type: "url_citation", url: "https://news.ycombinator.com", title: "Hacker News" },
+          ],
+        },
+      }
+      result =
+        processor.process_streamed_message(
+          type: "response.output_item.done",
+          item: streamed_web_search_item,
+        )
+
+      message_item = {
+        id: "msg_1",
+        type: "message",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: "HN summary",
+            annotations: [
+              { type: "url_citation", url: "https://news.ycombinator.com", title: "Hacker News" },
+            ],
+          },
+        ],
+      }
+      processor.process_streamed_message(type: "response.output_item.done", item: message_item)
+      processor.process_streamed_message(
+        type: "response.completed",
+        response: {
+          output: [completed_web_search_item, message_item],
+        },
+      )
+
+      provider_result = processor.finish.last
+
+      expect(result).to be_a(DiscourseAi::Completions::Thinking)
+      expect(result.message).to eq("Web search: Hacker News homepage")
+      expect(result.provider_info).to eq({})
+      expect(result).not_to be_partial
+      expect(provider_result.provider_info.dig(:open_ai_responses, :output_items)).to eq(
+        [completed_web_search_item, message_item],
+      )
+    end
+
+    it "emits a thinking item for non-streamed web search calls" do
+      processor = described_class.new(output_thinking: true)
+
+      output_items = [
+        {
+          id: "ws_1",
+          type: "web_search_call",
+          status: "completed",
+          action: {
+            type: "search",
+            query: "Hacker News homepage",
+          },
+        },
+        { id: "msg_1", type: "message", content: [{ type: "output_text", text: "HN summary" }] },
+      ]
+      result = processor.process_message(output: output_items)
+
+      expect(result.first).to be_a(DiscourseAi::Completions::Thinking)
+      expect(result.first.message).to eq("Web search: Hacker News homepage")
+      expect(result.first.provider_info.dig(:open_ai_responses, :output_items)).to eq(output_items)
+      expect(result.last).to eq("HN summary")
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_messages_builder_spec.rb
@@ -914,6 +914,51 @@ describe DiscourseAi::Completions::PromptMessagesBuilder do
           ],
         )
       end
+      it "normalizes saved thinking provider info" do
+        custom_prompt = [
+          [
+            "Grounded answer",
+            bot_user.username,
+            nil,
+            nil,
+            {
+              "message" => "Web search: OpenAI news",
+              "provider_info" => {
+                "gemini" => {
+                  "grounding_metadata" => {
+                    "webSearchQueries" => ["OpenAI news"],
+                  },
+                },
+              },
+            },
+          ],
+        ]
+
+        PostCustomPrompt.create!(post: second_post, custom_prompt: custom_prompt)
+
+        context =
+          described_class.messages_from_post(
+            third_post,
+            max_posts: 10,
+            bot_usernames: [bot_user.username],
+            include_uploads: false,
+          )
+
+        expect(context).to include(
+          {
+            type: :model,
+            content: "Grounded answer",
+            thinking: "Web search: OpenAI news",
+            thinking_provider_info: {
+              gemini: {
+                grounding_metadata: {
+                  webSearchQueries: ["OpenAI news"],
+                },
+              },
+            },
+          },
+        )
+      end
     end
   end
 end

--- a/plugins/discourse-ai/spec/lib/completions/prompt_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/prompt_spec.rb
@@ -185,6 +185,67 @@ RSpec.describe DiscourseAi::Completions::Prompt do
       expect(model_messages.first[:content]).to eq("Hello World")
     end
 
+    it "attaches trailing thinking to the previous response" do
+      prompt.push(type: :user, content: user_msg, id: username)
+
+      thinking =
+        DiscourseAi::Completions::Thinking.new(
+          message: nil,
+          partial: false,
+          provider_info: {
+            gemini: {
+              thought_signature_parts: [{ text: "", thoughtSignature: "sig-123" }],
+            },
+          },
+        )
+
+      prompt.push_model_response(["Hello", thinking])
+
+      expect(prompt.messages.last).to include(type: :model, content: "Hello")
+      expect(prompt.messages.last[:thinking_provider_info]).to include(
+        gemini: include(thought_signature_parts: [{ text: "", thoughtSignature: "sig-123" }]),
+      )
+    end
+
+    it "merges consecutive thinking before attaching it to the response" do
+      prompt.push(type: :user, content: user_msg, id: username)
+
+      prompt.push_model_response(
+        [
+          DiscourseAi::Completions::Thinking.new(
+            message: "first",
+            provider_info: {
+              gemini: {
+                thought_signature_parts: [{ text: "", thoughtSignature: "sig-1" }],
+              },
+            },
+          ),
+          DiscourseAi::Completions::Thinking.new(
+            message: "second",
+            provider_info: {
+              gemini: {
+                grounding_metadata: {
+                  webSearchQueries: ["query"],
+                },
+              },
+            },
+          ),
+          "Hello",
+        ],
+      )
+
+      expect(prompt.messages.last[:thinking]).to eq("first\n\nsecond")
+      expect(prompt.messages.last[:thinking_provider_info]).to include(
+        gemini:
+          include(
+            thought_signature_parts: [{ text: "", thoughtSignature: "sig-1" }],
+            grounding_metadata: {
+              webSearchQueries: ["query"],
+            },
+          ),
+      )
+    end
+
     it "attaches thinking metadata to the tool call message" do
       prompt.push(type: :user, content: user_msg, id: username)
 

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
@@ -171,6 +171,55 @@ RSpec.describe DiscourseAi::AiBot::Playground do
       expect(prompts[0].tool_choice).to eq(nil)
     end
 
+    it "separates consecutive thinking messages" do
+      ai_agent.update!(show_thinking: true)
+      agent_klass = AiAgent.all_agents.find { |agent_class| agent_class.name == ai_agent.name }
+      bot = DiscourseAi::Agents::Bot.as(bot_user, agent: agent_klass.new)
+      playground = described_class.new(bot)
+      responses = [
+        [
+          DiscourseAi::Completions::Thinking.new(message: "Web search: Anthropic AI news 2026"),
+          DiscourseAi::Completions::Thinking.new(message: "Web search: OpenAI AI news 2026"),
+          "Done",
+        ],
+      ]
+
+      reply_post = nil
+      DiscourseAi::Completions::Llm.with_prepared_responses(responses) do
+        new_post = Fabricate(:post, raw: "Search AI news")
+        reply_post = playground.reply_to(new_post)
+      end
+
+      expect(reply_post.raw).to include(
+        "Web search: Anthropic AI news 2026\n\nWeb search: OpenAI AI news 2026",
+      )
+      thinking = PostCustomPrompt.find_by(post_id: reply_post.id).custom_prompt.first[4]
+      expect(thinking["message"]).to eq(
+        "Web search: Anthropic AI news 2026\n\nWeb search: OpenAI AI news 2026",
+      )
+    end
+
+    it "keeps trailing thinking outside the response text" do
+      ai_agent.update!(show_thinking: true)
+      agent_klass = AiAgent.all_agents.find { |agent_class| agent_class.name == ai_agent.name }
+      bot = DiscourseAi::Agents::Bot.as(bot_user, agent: agent_klass.new)
+      playground = described_class.new(bot)
+      responses = [
+        ["Done", DiscourseAi::Completions::Thinking.new(message: "Web search: OpenAI news")],
+      ]
+
+      reply_post = nil
+      DiscourseAi::Completions::Llm.with_prepared_responses(responses) do
+        new_post = Fabricate(:post, raw: "Search AI news")
+        reply_post = playground.reply_to(new_post)
+      end
+
+      expect(reply_post.raw).to include("Done\n\n<details")
+      expect(reply_post.raw).to end_with("</details>")
+      thinking = PostCustomPrompt.find_by(post_id: reply_post.id).custom_prompt.first[4]
+      expect(thinking["message"]).to eq("Web search: OpenAI news")
+    end
+
     it "uses custom tool in conversation" do
       ai_agent.update!(show_thinking: true)
       agent_klass = AiAgent.all_agents.find { |p| p.name == ai_agent.name }

--- a/plugins/discourse-ai/spec/models/ai_agent_spec.rb
+++ b/plugins/discourse-ai/spec/models/ai_agent_spec.rb
@@ -74,6 +74,35 @@ RSpec.describe AiAgent do
     expect(basic_agent.errors[:tools]).to eq(["Can not have duplicate tools"])
   end
 
+  describe "provider-native tools" do
+    fab!(:gemini_model)
+    fab!(:openai_chat_model) do
+      Fabricate(:llm_model, url: "https://api.openai.com/v1/chat/completions")
+    end
+
+    it "requires a forced default LLM that supports the native tool" do
+      basic_agent.tools = ["native-web_search"]
+
+      # no forced default LLM
+      expect(basic_agent.valid?).to eq(false)
+      expect(basic_agent.errors[:tools]).to include(
+        I18n.t("discourse_ai.ai_bot.agents.native_tool_requires_forced_llm"),
+      )
+
+      # forced LLM whose provider does not support web search (chat completions)
+      basic_agent.default_llm = openai_chat_model
+      basic_agent.force_default_llm = true
+      expect(basic_agent.valid?).to eq(false)
+      expect(basic_agent.errors[:tools]).to include(
+        I18n.t("discourse_ai.ai_bot.agents.native_tool_unsupported_by_llm"),
+      )
+
+      # forced LLM that supports web search
+      basic_agent.default_llm = gemini_model
+      expect(basic_agent.valid?).to eq(true)
+    end
+  end
+
   it "allows creation of user" do
     user = basic_agent.create_user!
     expect(user.username).to eq("test_bot")

--- a/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
@@ -32,8 +32,11 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
       get "/admin/plugins/discourse-ai/ai-agents.json"
       tools = response.parsed_body["meta"]["tools"]
       native_tool = tools.find { |t| t["id"] == "native-web_search" }
+      native_fetch_tool = tools.find { |t| t["id"] == "native-web_fetch" }
       expect(native_tool).to be_present
       expect(native_tool["native"]).to eq(true)
+      expect(native_fetch_tool).to be_present
+      expect(native_fetch_tool["native"]).to eq(true)
     end
 
     it "includes external plugin tools in the tools list" do
@@ -318,6 +321,9 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
           agent = AiAgent.find(agent_json["id"])
 
           expect(agent.tools).to eq([["search", { "base_query" => "test" }, true]])
+          expect(agent.user).to be_present
+          expect(agent_json["user_id"]).to eq(agent.user_id)
+          expect(agent_json["user"]["id"]).to eq(agent.user_id)
           expect(agent.ai_mcp_servers.pluck(:name)).to eq(["Jira"])
           expect(agent.ai_agent_mcp_servers.first.selected_tool_names).to eq(["search_issues"])
           expect(agent.top_p).to eq(0.1)
@@ -425,6 +431,65 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
 
         expect(response).not_to have_http_status(:ok)
       end
+    end
+
+    it "creates a missing bot user when forcing the default LLM" do
+      agent = Fabricate(:ai_agent, name: "test_bot2", user_id: nil, default_llm_id: llm_model.id)
+
+      put "/admin/plugins/discourse-ai/ai-agents/#{agent.id}.json",
+          params: {
+            ai_agent: {
+              force_default_llm: true,
+            },
+          }
+
+      expect(response).to have_http_status(:ok)
+      agent.reload
+      expect(agent.user).to be_present
+      expect(response.parsed_body.dig("ai_agent", "user", "id")).to eq(agent.user_id)
+    end
+
+    it "creates a missing bot user when enabling mention/chat entry points" do
+      %i[
+        allow_topic_mentions
+        allow_chat_direct_messages
+        allow_chat_channel_mentions
+      ].each do |field|
+        agent =
+          Fabricate(:ai_agent, name: "#{field}_bot", user_id: nil, default_llm_id: llm_model.id)
+
+        put "/admin/plugins/discourse-ai/ai-agents/#{agent.id}.json",
+            params: {
+              ai_agent: {
+                field => true,
+              },
+            }
+
+        expect(response).to have_http_status(:ok)
+        agent.reload
+        expect(agent.user).to be_present
+        expect(response.parsed_body.dig("ai_agent", "user", "id")).to eq(agent.user_id)
+      end
+    end
+
+    it "does not create a missing bot user for personal messages alone" do
+      agent =
+        Fabricate(
+          :ai_agent,
+          name: "personal_only_bot",
+          user_id: nil,
+          allow_personal_messages: false,
+        )
+
+      put "/admin/plugins/discourse-ai/ai-agents/#{agent.id}.json",
+          params: {
+            ai_agent: {
+              allow_personal_messages: true,
+            },
+          }
+
+      expect(response).to have_http_status(:ok)
+      expect(agent.reload.user).to be_nil
     end
 
     it "allows us to trivially clear top_p and temperature" do

--- a/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_agents_controller_spec.rb
@@ -23,8 +23,17 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
 
       expected_tool_count =
         DiscourseAi::Agents::Agent.all_available_tools.length +
-          DiscourseAi::Agents::Agent.external_tools.length
+          DiscourseAi::Agents::Agent.external_tools.length +
+          DiscourseAi::Completions::NativeTools.all.length
       expect(response.parsed_body["meta"]["tools"].length).to eq(expected_tool_count)
+    end
+
+    it "includes provider-native tools in the tools list" do
+      get "/admin/plugins/discourse-ai/ai-agents.json"
+      tools = response.parsed_body["meta"]["tools"]
+      native_tool = tools.find { |t| t["id"] == "native-web_search" }
+      expect(native_tool).to be_present
+      expect(native_tool["native"]).to eq(true)
     end
 
     it "includes external plugin tools in the tools list" do
@@ -66,6 +75,7 @@ RSpec.describe DiscourseAi::Admin::AiAgentsController do
             id: llm_model.id,
             name: llm_model.display_name,
             vision_enabled: llm_model.vision_enabled,
+            supported_native_tools: [],
           }.stringify_keys,
         ],
       )


### PR DESCRIPTION
Adds a fourth kind of agent tool: provider-native built-in tools that the
LLM provider executes server-side, rather than tools Discourse runs and
feeds back. The first one is web search, supported on Gemini (Google Search
grounding), OpenAI (web search via the Responses API) and Anthropic (Claude
web search).

Native tools are stored on the agent's `tools` column with a `native-`
prefix, flow to the prompt as a separate `native_tools` list (never as
runnable Tool classes), and each provider dialect renders them into its own
request payload. Response processors already ignore the server-side
tool/grounding blocks, so the bot loop never tries to execute them.

They are only selectable when the agent forces a default LLM whose provider
supports the tool; this is enforced both in the editor UI (filtered by the
selected LLM's `supported_native_tools`) and by server-side validation.

Also fixes the Gemini endpoint sending `function_calling_config` without any
`function_declarations`, which the API rejects when only native tools are
present.
