### PR TITLE
UX: minor reactions style fixes

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1098,10 +1098,11 @@ table#user-badges {
 
     .value-input {
       box-sizing: border-box;
-      flex: 1 0 0px;
+      flex: 1 0 0;
       border-color: var(--primary-low);
       cursor: pointer;
       margin: 0;
+      min-width: 0;
 
       &:focus {
         border-color: var(--tertiary);
@@ -1111,6 +1112,7 @@ table#user-badges {
 
     .remove-value-btn {
       margin-right: 0.25em;
+      flex: 0 0 auto;
 
       @include value-btn;
     }
@@ -1151,6 +1153,8 @@ table#user-badges {
 
     .emoji-name {
       margin-left: 0.5em;
+
+      @include ellipsis;
     }
 
     &:not(.can-edit) {

--- a/frontend/discourse/app/components/emoji-picker/index.gjs
+++ b/frontend/discourse/app/components/emoji-picker/index.gjs
@@ -48,7 +48,11 @@ export default class EmojiPicker extends Component {
 
   <template>
     <DMenu
-      @triggerClass={{dConcatClass @btnClass (if this.hasLabel "--has-label")}}
+      @triggerClass={{dConcatClass
+        "btn-default"
+        @btnClass
+        (if this.hasLabel "--has-label")
+      }}
       @onRegisterApi={{this.onRegisterMenu}}
       @identifier="emoji-picker"
       @groupIdentifier="emoji-picker"

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-picker.gjs
@@ -10,6 +10,7 @@ import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 import { i18n } from "discourse-i18n";
 
 export default class DiscourseReactionsPicker extends Component {
+  @service capabilities;
   @service currentUser;
   @service siteSettings;
 
@@ -100,7 +101,8 @@ export default class DiscourseReactionsPicker extends Component {
     }
 
     let x;
-    const colsByRow = [5, 6, 7, 8];
+    // below the small breakpoint, 8 cols is slightly too wide, so cap at 7
+    const colsByRow = this.capabilities.viewport.sm ? [5, 6, 7, 8] : [5, 6, 7];
 
     // if small count, just use it
     if (count < colsByRow[0]) {


### PR DESCRIPTION
The 8-column reaction panel on posts is slightly too wide on viewports under 360px wide, so this caps it at 7 for small screens. 

I also noticed some minor setting issues with long emoji name and a missing button class...


before:
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/58bc9f35-208e-4182-84be-939996321f9d" />


after:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/b9442254-89b8-4256-ae80-e2249c6fe9d1" />
