### PR TITLE
FIX: Single-occurrence RSVPs filled the "My events" calendar

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -38,6 +38,7 @@ module DiscoursePostEvent
                     after: after_time,
                     before: before_time,
                     limit: 52,
+                    current_occurrence_only: current_occurrence_only_event_ids.include?(event.id),
                   )
                 expanded[:occurrences].map { |occ| { event: event, **occ } }
               else
@@ -63,6 +64,7 @@ module DiscoursePostEvent
                   after: filtered_events_params[:after]&.to_datetime || Time.current,
                   before: filtered_events_params[:before]&.to_datetime,
                   limit: filtered_events_params[:limit]&.to_i || 50,
+                  current_occurrence_only: current_occurrence_only_event_ids.include?(event.id),
                 )
 
               formatted_occurrences =
@@ -175,6 +177,25 @@ module DiscoursePostEvent
         :after,
         :order,
       )
+    end
+
+    def current_occurrence_only_event_ids
+      @current_occurrence_only_event_ids ||= single_occurrence_rsvp_event_ids
+    end
+
+    def single_occurrence_rsvp_event_ids
+      attending_username = filtered_events_params[:attending_user]
+      return Set.new if attending_username.blank?
+
+      attending_user = User.find_by(username_lower: attending_username.downcase)
+      return Set.new if attending_user.blank?
+
+      DiscoursePostEvent::Invitee
+        .unscoped
+        .with_status(:going)
+        .where(post_id: @events.map(&:id), user_id: attending_user.id, recurring: false)
+        .pluck(:post_id)
+        .to_set
     end
 
     def format_time(event, time)

--- a/plugins/discourse-calendar/app/services/discourse_post_event/action/expand_occurrences.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/action/expand_occurrences.rb
@@ -9,9 +9,11 @@ module DiscoursePostEvent
       option :after
       option :before, optional: true
       option :limit, default: -> { 50 }
+      option :current_occurrence_only, default: -> { false }
 
       def call
         return non_recurring_result unless event.recurring?
+        return current_occurrence_result if current_occurrence_only
 
         build_recurring_occurrences
       end
@@ -23,6 +25,16 @@ module DiscoursePostEvent
           event: event,
           occurrences: [{ starts_at: event.original_starts_at, ends_at: event.original_ends_at }],
         }
+      end
+
+      def current_occurrence_result
+        starts_at = event.starts_at
+
+        return { event:, occurrences: [] } if starts_at.nil?
+        return { event:, occurrences: [] } if after && starts_at < after
+        return { event:, occurrences: [] } if before && starts_at >= before
+
+        { event:, occurrences: [{ starts_at:, ends_at: event.ends_at }] }
       end
 
       def build_recurring_occurrences

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -8,9 +8,7 @@ import bodyClass from "discourse/helpers/body-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { bind } from "discourse/lib/decorators";
 import getURL from "discourse/lib/get-url";
-import DAsyncContent from "discourse/ui-kit/d-async-content";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
@@ -43,16 +41,61 @@ const InfoSection = <template>
   </section>
 </template>;
 
+const CreatorPlaceholder = <template>
+  <span
+    class="event__placeholder event__placeholder--text placeholder-animation"
+  ></span>
+</template>;
+
+const InviteesPlaceholder = <template>
+  <section class="event__section event-invitees event-invitees--loading">
+    {{dIcon "users"}}
+    <ul class="event-invitees-avatars">
+      <li
+        class="event__placeholder event__placeholder--avatar placeholder-animation"
+      ></li>
+      <li
+        class="event__placeholder event__placeholder--avatar placeholder-animation"
+      ></li>
+      <li
+        class="event__placeholder event__placeholder--avatar placeholder-animation"
+      ></li>
+    </ul>
+  </section>
+</template>;
+
+const StatusPlaceholder = <template>
+  <section
+    class="event__section event-actions event-status event-status--loading"
+  >
+    <span
+      class="event__placeholder event__placeholder--button placeholder-animation"
+    ></span>
+    <span
+      class="event__placeholder event__placeholder--button placeholder-animation"
+    ></span>
+    <span
+      class="event__placeholder event__placeholder--button placeholder-animation"
+    ></span>
+  </section>
+</template>;
+
 export default class DiscoursePostEvent extends Component {
   @service currentUser;
   @service discoursePostEventApi;
   @service messageBus;
   @service siteSettings;
 
-  @tracked event;
+  @tracked fetchedEvent;
+  @tracked isLoading = false;
 
   setupMessageBus = modifier(() => {
-    const path = `/discourse-post-event/${this.event.post.topic.id}`;
+    const topicId = this.event?.post?.topic?.id;
+    if (!topicId) {
+      return;
+    }
+
+    const path = `/discourse-post-event/${topicId}`;
     this.messageBus.subscribe(path, async (msg) => {
       const eventData = await this.discoursePostEventApi.event(msg.id);
       this.event.updateFromEvent(eventData);
@@ -60,6 +103,25 @@ export default class DiscoursePostEvent extends Component {
 
     return () => this.messageBus.unsubscribe(path);
   });
+
+  constructor() {
+    super(...arguments);
+    if (this.isPartialEvent) {
+      this.loadEvent();
+    }
+  }
+
+  get event() {
+    return this.fetchedEvent ?? this.args.event;
+  }
+
+  get isPartialEvent() {
+    return !this.args.event?.creator;
+  }
+
+  get loadingDetails() {
+    return this.isLoading && this.isPartialEvent;
+  }
 
   getDisplayTime(time) {
     if (this.event.allDay) {
@@ -92,7 +154,7 @@ export default class DiscoursePostEvent extends Component {
   }
 
   get eventName() {
-    return this.event.name || this.event.post.topic.title;
+    return this.event.name || this.event.post?.topic?.title;
   }
 
   get isPublicEvent() {
@@ -139,34 +201,35 @@ export default class DiscoursePostEvent extends Component {
     );
   }
 
-  @bind
   async loadEvent() {
-    if (this.event) {
-      return this.event;
+    if (this.fetchedEvent || !this.args.event) {
+      return;
     }
 
-    if (this.args.event) {
-      try {
-        const fetched = await this.discoursePostEventApi.event(
-          this.args.event.id
-        );
-        const displayedStartsAt = this.args.event.startsAt;
+    this.isLoading = true;
 
-        if (
-          fetched.recurrence &&
-          displayedStartsAt &&
-          fetched.startsAt &&
-          displayedStartsAt !== fetched.startsAt
-        ) {
-          this.#filterForFutureOccurrence(fetched);
-        }
+    try {
+      const fetched = await this.discoursePostEventApi.event(
+        this.args.event.id
+      );
+      const displayedStartsAt = this.args.event.startsAt;
 
-        fetched.startsAt = displayedStartsAt;
-        fetched.endsAt = this.args.event.endsAt;
-        this.event = fetched;
-      } catch (error) {
-        popupAjaxError(error);
+      if (
+        fetched.recurrence &&
+        displayedStartsAt &&
+        fetched.startsAt &&
+        displayedStartsAt !== fetched.startsAt
+      ) {
+        this.#filterForFutureOccurrence(fetched);
       }
+
+      fetched.startsAt = displayedStartsAt;
+      fetched.endsAt = this.args.event.endsAt;
+      this.fetchedEvent = fetched;
+    } catch (error) {
+      popupAjaxError(error);
+    } finally {
+      this.isLoading = false;
     }
   }
 
@@ -191,64 +254,68 @@ export default class DiscoursePostEvent extends Component {
   }
 
   <template>
-    <DAsyncContent @asyncData={{this.loadEvent}}>
-      <:content as |event|>
-        <div class="discourse-post-event">
-          <div class="discourse-post-event-widget">
-            {{#if event}}
-              <Image
-                @imageUpload={{event.imageUpload}}
-                @alt={{this.eventName}}
-                @linkToPost={{@linkToPost}}
-                @postUrl={{event.post.url}}
-                @post={{@post}}
-              />
-              <header class="event-header" {{this.setupMessageBus}}>
-                <div class="event-date">
-                  <div class="month">
-                    {{#if this.expiredAndRecurring}}
-                      -
-                    {{else}}
-                      {{this.startsAtMonth}}
-                    {{/if}}
-                  </div>
-                  <div class="day">
-                    {{#if this.expiredAndRecurring}}
-                      -
-                    {{else}}
-                      {{this.startsAtDay}}
-                    {{/if}}
-                  </div>
+    {{#let this.event as |event|}}
+      <div class="discourse-post-event">
+        <div class="discourse-post-event-widget">
+          {{#if event}}
+            <Image
+              @imageUpload={{event.imageUpload}}
+              @alt={{this.eventName}}
+              @linkToPost={{@linkToPost}}
+              @postUrl={{event.post.url}}
+              @post={{@post}}
+            />
+            <header class="event-header" {{this.setupMessageBus}}>
+              <div class="event-date">
+                <div class="month">
+                  {{#if this.expiredAndRecurring}}
+                    -
+                  {{else}}
+                    {{this.startsAtMonth}}
+                  {{/if}}
                 </div>
-                <div class="event-info">
-                  <span class="name">
-                    {{#if @linkToPost}}
-                      <a
-                        href={{getURL event.post.url}}
-                        rel="noopener noreferrer"
-                      >{{dReplaceEmoji this.eventName}}</a>
-                    {{else}}
-                      {{dReplaceEmoji this.eventName}}
-                    {{/if}}
-                  </span>
-                  <div class="status-and-creators">
-                    <PluginOutlet
-                      @name="discourse-post-event-status-and-creators"
-                      @outletArgs={{lazyHash
-                        event=event
-                        Separator=StatusSeparator
-                        Status=(component EventStatus event=event)
-                        Creator=(component Creator user=event.creator)
-                      }}
-                    >
+                <div class="day">
+                  {{#if this.expiredAndRecurring}}
+                    -
+                  {{else}}
+                    {{this.startsAtDay}}
+                  {{/if}}
+                </div>
+              </div>
+              <div class="event-info">
+                <span class="name">
+                  {{#if @linkToPost}}
+                    <a
+                      href={{getURL event.post.url}}
+                      rel="noopener noreferrer"
+                    >{{dReplaceEmoji this.eventName}}</a>
+                  {{else}}
+                    {{dReplaceEmoji this.eventName}}
+                  {{/if}}
+                </span>
+                <div class="status-and-creators">
+                  <PluginOutlet
+                    @name="discourse-post-event-status-and-creators"
+                    @outletArgs={{lazyHash
+                      event=event
+                      Separator=StatusSeparator
+                      Status=(component EventStatus event=event)
+                      Creator=(component Creator user=event.creator)
+                    }}
+                  >
+                    {{#if event.creator}}
                       <EventStatus @event={{event}} />
                       <StatusSeparator />
                       <Creator @user={{event.creator}} />
-                    </PluginOutlet>
-                  </div>
+                    {{else if this.loadingDetails}}
+                      <CreatorPlaceholder />
+                    {{/if}}
+                  </PluginOutlet>
                 </div>
+              </div>
 
-                <div class="event-header__controls">
+              <div class="event-header__controls">
+                {{#if event.creator}}
                   <MoreMenu
                     @event={{event}}
                     @isStandaloneEvent={{this.isStandaloneEvent}}
@@ -256,93 +323,93 @@ export default class DiscoursePostEvent extends Component {
                       "composePrivateMessage"
                     }}
                   />
-
-                  {{#if @onClose}}
-                    <DButton
-                      class="btn-default btn-small discourse-post-event-close"
-                      @icon="xmark"
-                      @action={{@onClose}}
-                    />
-                  {{/if}}
-                </div>
-              </header>
-
-              <PluginOutlet
-                @name="discourse-post-event-info"
-                @outletArgs={{lazyHash
-                  event=event
-                  Section=(component InfoSection event=event)
-                  Url=(component Url url=event.url)
-                  Description=(component
-                    Description
-                    description=event.description
-                    clamp=this.clampDescription
-                  )
-                  Location=(component Location location=event.location)
-                  Dates=(component
-                    Dates
-                    event=event
-                    expiredAndRecurring=this.expiredAndRecurring
-                  )
-                  Recurrence=(component
-                    InfoSection icon="arrows-rotate" class="event-recurrence"
-                  )
-                  recurrenceLabel=this.recurrenceLabel
-                  Invitees=(component Invitees event=event)
-                  Status=(component Status event=event)
-                  ChatChannel=(component ChatChannel event=event)
-                  Image=(component
-                    Image
-                    imageUpload=event.imageUpload
-                    alt=this.eventName
-                    linkToPost=@linkToPost
-                    postUrl=event.post.url
-                    post=@post
-                  )
-                }}
-              >
-                <Dates
-                  @event={{event}}
-                  @expiredAndRecurring={{this.expiredAndRecurring}}
-                />
-                {{#if event.recurrence}}
-                  <InfoSection @icon="arrows-rotate" class="event-recurrence">
-                    {{this.recurrenceLabel}}
-                  </InfoSection>
                 {{/if}}
-                <Location
-                  @location={{event.location}}
-                  @livestream={{event.livestream}}
-                />
-                <Url @url={{event.url}} />
-                <ChatChannel @event={{event}} />
-                <Invitees @event={{event}} />
 
-                {{#if this.withDescription}}
-                  <Description
-                    @descriptionHtml={{event.descriptionHtml}}
-                    @clamp={{this.clampDescription}}
+                {{#if @onClose}}
+                  <DButton
+                    class="btn-default btn-small discourse-post-event-close"
+                    @icon="xmark"
+                    @action={{@onClose}}
                   />
                 {{/if}}
+              </div>
+            </header>
 
-                {{#if this.showStatus}}
-                  <Status @event={{event}} />
-                {{/if}}
+            <PluginOutlet
+              @name="discourse-post-event-info"
+              @outletArgs={{lazyHash
+                event=event
+                Section=(component InfoSection event=event)
+                Url=(component Url url=event.url)
+                Description=(component
+                  Description
+                  description=event.description
+                  clamp=this.clampDescription
+                )
+                Location=(component Location location=event.location)
+                Dates=(component
+                  Dates event=event expiredAndRecurring=this.expiredAndRecurring
+                )
+                Recurrence=(component
+                  InfoSection icon="arrows-rotate" class="event-recurrence"
+                )
+                recurrenceLabel=this.recurrenceLabel
+                Invitees=(component Invitees event=event)
+                Status=(component Status event=event)
+                ChatChannel=(component ChatChannel event=event)
+                Image=(component
+                  Image
+                  imageUpload=event.imageUpload
+                  alt=this.eventName
+                  linkToPost=@linkToPost
+                  postUrl=event.post.url
+                  post=@post
+                )
+              }}
+            >
+              <Dates
+                @event={{event}}
+                @expiredAndRecurring={{this.expiredAndRecurring}}
+              />
+              {{#if event.recurrence}}
+                <InfoSection @icon="arrows-rotate" class="event-recurrence">
+                  {{this.recurrenceLabel}}
+                </InfoSection>
+              {{/if}}
+              <Location
+                @location={{event.location}}
+                @livestream={{event.livestream}}
+              />
+              <Url @url={{event.url}} />
+              <ChatChannel @event={{event}} />
 
-                {{#if event.livestream}}
-                  {{bodyClass "livestream-topic"}}
-                {{/if}}
-                <Livestream @event={{event}} />
-              </PluginOutlet>
-            {{/if}}
-          </div>
+              {{#if event.stats}}
+                <Invitees @event={{event}} />
+              {{else if this.loadingDetails}}
+                <InviteesPlaceholder />
+              {{/if}}
+
+              {{#if this.withDescription}}
+                <Description
+                  @descriptionHtml={{event.descriptionHtml}}
+                  @clamp={{this.clampDescription}}
+                />
+              {{/if}}
+
+              {{#if this.showStatus}}
+                <Status @event={{event}} />
+              {{else if this.loadingDetails}}
+                <StatusPlaceholder />
+              {{/if}}
+
+              {{#if event.livestream}}
+                {{bodyClass "livestream-topic"}}
+              {{/if}}
+              <Livestream @event={{event}} />
+            </PluginOutlet>
+          {{/if}}
         </div>
-      </:content>
-      <:loading>
-        <div class="discourse-post-event-loader">
-          <div class="spinner"></div>
-        </div>
-      </:loading>
-    </DAsyncContent>
+      </div>
+    {{/let}}
   </template>
 }

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-calendar.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-calendar.scss
@@ -281,11 +281,3 @@ a.holiday {
     z-index: z("modal", "dropdown");
   }
 }
-
-.discourse-post-event-loader {
-  width: 100%;
-  min-height: 200px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}

--- a/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/discourse-post-event.scss
@@ -532,3 +532,29 @@ $show-interested: inherit;
     text-align: center;
   }
 }
+
+.discourse-post-event {
+  .event__placeholder {
+    display: inline-block;
+    border-radius: var(--d-border-radius, 0.25em);
+    background-color: var(--primary-low);
+  }
+
+  .event__placeholder--text {
+    width: 8em;
+    height: 0.9em;
+    vertical-align: middle;
+  }
+
+  .event__placeholder--avatar {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+  }
+
+  .event__placeholder--button {
+    width: 5em;
+    height: 2em;
+    margin-right: 0.5em;
+  }
+}

--- a/plugins/discourse-calendar/assets/stylesheets/mobile/discourse-calendar.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/mobile/discourse-calendar.scss
@@ -13,7 +13,3 @@
     }
   }
 }
-
-.discourse-post-event-loader {
-  width: 100%;
-}

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -361,6 +361,42 @@ module DiscoursePostEvent
           expect(response.body).to include("SUMMARY:Interested Event")
         end
       end
+
+      context "when the attending user RSVPed to a recurring event" do
+        fab!(:target_user, :user)
+        fab!(:recurring_event) do
+          Fabricate(
+            :event,
+            original_starts_at: 1.day.from_now,
+            original_ends_at: 1.day.from_now + 1.hour,
+            recurrence: "every_week",
+            name: "Weekly Standup",
+          )
+        end
+
+        before { sign_in(target_user) }
+
+        it "returns only the current occurrence when they RSVPed to a single occurrence" do
+          Invitee.create_attendance!(target_user.id, recurring_event.id, :going, recurring: false)
+
+          get "/discourse-post-event/events.json", params: { attending_user: target_user.username }
+
+          expect(response.status).to eq(200)
+          event_json = response.parsed_body["events"].find { |e| e["id"] == recurring_event.id }
+          expect(event_json["occurrences"].size).to eq(1)
+          expect(event_json["occurrences"].first["starts_at"]).to eq(event_json["starts_at"])
+        end
+
+        it "returns the whole series when they RSVPed to every occurrence" do
+          Invitee.create_attendance!(target_user.id, recurring_event.id, :going, recurring: true)
+
+          get "/discourse-post-event/events.json", params: { attending_user: target_user.username }
+
+          expect(response.status).to eq(200)
+          event_json = response.parsed_body["events"].find { |e| e["id"] == recurring_event.id }
+          expect(event_json["occurrences"].size).to be > 1
+        end
+      end
     end
 
     context "with an all-day event" do

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/action/expand_occurrences_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/action/expand_occurrences_spec.rb
@@ -23,4 +23,50 @@ RSpec.describe DiscoursePostEvent::Action::ExpandOccurrences do
       expect(action[:occurrences].size).to eq(described_class::MAX_LIMIT)
     end
   end
+
+  describe ".call with current_occurrence_only" do
+    subject(:action) do
+      described_class.call(event:, after:, before:, current_occurrence_only: true)
+    end
+
+    let(:current_starts_at) { Time.zone.parse("2030-01-05 09:00:00 UTC") }
+    let(:current_ends_at) { Time.zone.parse("2030-01-05 10:00:00 UTC") }
+    let(:event) do
+      instance_double(
+        DiscoursePostEvent::Event,
+        recurring?: true,
+        starts_at: current_starts_at,
+        ends_at: current_ends_at,
+      )
+    end
+
+    context "when the current occurrence is within the window" do
+      let(:after) { Time.zone.parse("2030-01-01 00:00:00 UTC") }
+      let(:before) { Time.zone.parse("2030-02-01 00:00:00 UTC") }
+
+      it "returns only the current occurrence instead of the whole series" do
+        expect(action[:occurrences]).to eq(
+          [{ starts_at: current_starts_at, ends_at: current_ends_at }],
+        )
+      end
+    end
+
+    context "when the current occurrence is before the requested window" do
+      let(:after) { Time.zone.parse("2030-02-01 00:00:00 UTC") }
+      let(:before) { Time.zone.parse("2030-03-01 00:00:00 UTC") }
+
+      it "returns no occurrences" do
+        expect(action[:occurrences]).to be_empty
+      end
+    end
+
+    context "when the current occurrence is after the requested window" do
+      let(:after) { Time.zone.parse("2029-11-01 00:00:00 UTC") }
+      let(:before) { Time.zone.parse("2029-12-01 00:00:00 UTC") }
+
+      it "returns no occurrences" do
+        expect(action[:occurrences]).to be_empty
+      end
+    end
+  end
 end

--- a/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
+++ b/plugins/discourse-calendar/spec/system/upcoming_events_spec.rb
@@ -74,6 +74,29 @@ describe "Upcoming Events" do
     end
   end
 
+  describe "recurring events on the My events calendar" do
+    it "shows a single occurrence when the user RSVPed to only the next event",
+       time: Time.utc(2026, 6, 11, 12, 0) do
+      post =
+        create_post(
+          user: admin,
+          category:,
+          title: "Daily team sync",
+          raw:
+            "[event status='public' start='2026-06-11 18:00' end='2026-06-11 18:30' recurrence='every_day']\n[/event]",
+        )
+      event = DiscoursePostEvent::Event.find(post.id)
+
+      DiscoursePostEvent::Invitee.create_attendance!(admin.id, event.id, :going, recurring: false)
+
+      visit("/upcoming-events/mine/month/2026/6/1")
+
+      expect(upcoming_events).to have_calendar
+      expect(upcoming_events).to have_event(post.topic.title)
+      expect(upcoming_events).to have_event_count(1)
+    end
+  end
+
   describe "event description in popup" do
     let(:post_event_page) { PageObjects::Pages::DiscourseCalendar::PostEvent.new }
 


### PR DESCRIPTION
Addresses the **My events** calendar issue reported in [meta t/335780](https://meta.discourse.org/t/repeating-event-going-gets-not-deleted-anymore/335780), and improves how the event popup loads.

## FIX: Single-occurrence RSVPs filled the "My events" calendar

When a member RSVPs "going" to only the next occurrence of a recurring event (not the whole series), the personal **My events** calendar — and the personal ICS feed — listed the event on _every_ occurrence instead of just the one they joined.

`EventFinder` matches an event for `attending_user` whenever the member is a "going" invitee, ignoring the invitee's `recurring` flag, and the events endpoint then expands the full recurrence series. The per-occurrence invitee list already filtered single RSVPs out of future occurrences, but the calendar/feed query did not.

`ExpandOccurrences` gains a `current_occurrence_only` option that returns only the event's current occurrence (when it falls inside the requested window). `EventsController#index` sets it for the attending member's non-recurring "going" RSVPs, in both the JSON and ICS responses. RSVPs to every occurrence still expand fully; the non-personal calendars (all events / category) are unaffected.

This is a targeted fix — properly modelling per-occurrence RSVPs (storing each date instead of only the recurrence formula) remains a larger follow-up.

## UX: Render event popup details immediately instead of a spinner

Clicking an event opened a popup that showed only a loading spinner until a full event fetch resolved — slow on poor connections. The component wrapped its whole body in `DAsyncContent`, blocking every field on the request even though the calendar already provides each event's core fields (`BasicEventSerializer`) and the inline post widget provides the complete event (`EventSerializer`).

It now renders the data already on the client immediately (title, date, recurrence) and fills in the rest (creator, attendees, RSVP buttons) when the background request returns. Inline event widgets in a topic render fully with no fetch at all (and no longer fire a redundant request). Still-loading sections use core's `.placeholder-animation` shimmer.

## Testing

- Request spec — single-occurrence RSVP returns one occurrence; all-occurrences RSVP returns the series.
- Service spec — `current_occurrence_only` returns the current occurrence only when it is inside the window.
- System spec — a daily recurring event RSVPed once shows a single tile on `/upcoming-events/mine`.
- Existing popup integration + system specs cover the immediate-render behaviour.
