### PR TITLE
FEATURE: Challenge passkeys as 2FA in login and recovery flows

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -441,13 +441,17 @@ class SessionController < ApplicationController
         )
       end
 
-      if matched_user&.security_keys_enabled?
+      if matched_user&.security_keys_enabled? || matched_user&.passkeys_available_as_second_factor?
         DiscourseWebauthn.stage_challenge(matched_user, server_session)
         response.merge!(
-          DiscourseWebauthn.allowed_credentials(matched_user, server_session).merge(
-            security_key_required: true,
+          DiscourseWebauthn.allowed_credentials(
+            matched_user,
+            server_session,
+            include_passkeys: true,
           ),
         )
+        response[:security_key_required] = matched_user.security_keys_enabled?
+        response[:passkeys_enabled] = matched_user.passkeys_available_as_second_factor?
       end
 
       render json: response
@@ -795,9 +799,11 @@ class SessionController < ApplicationController
     second_factor_authentication_result = user.authenticate_second_factor(params, server_session)
     if !second_factor_authentication_result.ok
       failure_payload = second_factor_authentication_result.to_h
-      if user.security_keys_enabled?
+      if user.security_keys_enabled? || user.passkeys_available_as_second_factor?
         DiscourseWebauthn.stage_challenge(user, server_session)
-        failure_payload.merge!(DiscourseWebauthn.allowed_credentials(user, server_session))
+        failure_payload.merge!(
+          DiscourseWebauthn.allowed_credentials(user, server_session, include_passkeys: true),
+        )
       end
       @second_factor_failure_payload = failed_json.merge(failure_payload)
       return second_factor_authentication_result

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -833,6 +833,7 @@ class UsersController < ApplicationController
         admin: @user.admin?,
         second_factor_required: @user.totp_enabled?,
         security_key_required: @user.security_keys_enabled?,
+        passkeys_enabled: @user.passkeys_available_as_second_factor?,
         backup_enabled: @user.backup_codes_enabled?,
         multiple_second_factor_methods: @user.has_multiple_second_factor_methods?,
       }
@@ -846,7 +847,9 @@ class UsersController < ApplicationController
         store_preloaded(
           "password_reset",
           MultiJson.dump(
-            security_params.merge(DiscourseWebauthn.allowed_credentials(@user, server_session)),
+            security_params.merge(
+              DiscourseWebauthn.allowed_credentials(@user, server_session, include_passkeys: true),
+            ),
           ),
         )
 
@@ -858,7 +861,13 @@ class UsersController < ApplicationController
 
         DiscourseWebauthn.stage_challenge(@user, server_session)
         render json:
-                 security_params.merge(DiscourseWebauthn.allowed_credentials(@user, server_session))
+                 security_params.merge(
+                   DiscourseWebauthn.allowed_credentials(
+                     @user,
+                     server_session,
+                     include_passkeys: true,
+                   ),
+                 )
       end
     end
   end
@@ -956,9 +965,12 @@ class UsersController < ApplicationController
           admin: @user.admin?,
           second_factor_required: @user.totp_enabled?,
           security_key_required: @user.security_keys_enabled?,
+          passkeys_enabled: @user.passkeys_available_as_second_factor?,
           backup_enabled: @user.backup_codes_enabled?,
           multiple_second_factor_methods: @user.has_multiple_second_factor_methods?,
-        }.merge(DiscourseWebauthn.allowed_credentials(@user, server_session))
+        }.merge(
+          DiscourseWebauthn.allowed_credentials(@user, server_session, include_passkeys: true),
+        )
 
         store_preloaded("password_reset", MultiJson.dump(security_params))
 

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -15,6 +15,7 @@ module SecondFactorManager
       :totp_enabled,
       :multiple_second_factor_methods,
       :used_2fa_method,
+      :passkeys_enabled,
     )
 
   def create_totp(opts = {})
@@ -88,16 +89,21 @@ module SecondFactorManager
   end
   alias_method :passkeys_for_2fa_enabled?, :passkeys_available_as_second_factor?
 
-  # Passkey-as-2FA (`passkeys_available_as_second_factor?`) is intentionally
-  # excluded: it only satisfies `/session/2fa`. Password login, email login,
-  # and password reset have no passkey UI yet, so counting passkeys here would
-  # make those flows skip 2FA for passkey-only users.
+  # Passkey-as-2FA (`passkeys_available_as_second_factor?`) is still excluded
+  # here even though every 2FA flow can now challenge passkeys. Counting them
+  # makes passkey-only users compliant with enforced 2FA (no more redirect to
+  # enrollment), which is the final step of the `allow_passkeys_for_2fa`
+  # rollout and ships separately.
   def has_any_second_factor_methods_enabled?
     totp_enabled? || security_keys_enabled?
   end
 
   def has_multiple_second_factor_methods?
-    security_keys_enabled? && totp_or_backup_codes_enabled?
+    [
+      security_keys_enabled?,
+      totp_or_backup_codes_enabled?,
+      passkeys_available_as_second_factor?,
+    ].count(true) > 1
   end
 
   def totp_or_backup_codes_enabled?
@@ -119,7 +125,7 @@ module SecondFactorManager
   def authenticate_second_factor(params, server_session)
     ok_result = SecondFactorAuthenticationResult.new(true)
     if !security_keys_enabled? && !totp_or_backup_codes_enabled? &&
-         (!passkeys_available_as_second_factor? || params[:second_factor_method].blank?)
+         !passkeys_available_as_second_factor?
       return ok_result
     end
 
@@ -241,6 +247,8 @@ module SecondFactorManager
       security_keys_enabled?,
       totp_enabled?,
       has_multiple_second_factor_methods?,
+      nil,
+      passkeys_available_as_second_factor?,
     )
   end
 

--- a/frontend/discourse/app/components/local-login-form.gjs
+++ b/frontend/discourse/app/components/local-login-form.gjs
@@ -16,6 +16,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { escapeExpression } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
+import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 import DPasswordField from "discourse/ui-kit/d-password-field";
 import DSecondFactorInput from "discourse/ui-kit/d-second-factor-input";
 import DTogglePasswordMask from "discourse/ui-kit/d-toggle-password-mask";
@@ -155,6 +156,7 @@ export default class LocalLoginForm extends Component {
 
   @action
   authenticateSecurityKey() {
+    this.args.secondFactorMethodChanged(SECOND_FACTOR_METHODS.SECURITY_KEY);
     getWebauthnCredential(
       this.args.securityKeyChallenge,
       this.args.securityKeyAllowedCredentialIds,
@@ -166,6 +168,24 @@ export default class LocalLoginForm extends Component {
         this.args.flashChanged(error);
         this.args.flashTypeChanged("error");
       }
+    );
+  }
+
+  @action
+  authenticatePasskeySecondFactor() {
+    this.args.secondFactorMethodChanged(SECOND_FACTOR_METHODS.PASSKEY);
+    getWebauthnCredential(
+      this.args.securityKeyChallenge,
+      this.args.passkeyAllowedCredentialIds,
+      (credentialData) => {
+        this.args.securityKeyCredentialChanged(credentialData);
+        this.args.login();
+      },
+      (error) => {
+        this.args.flashChanged(error);
+        this.args.flashTypeChanged("error");
+      },
+      { userVerification: "required" }
     );
   }
 
@@ -259,7 +279,10 @@ export default class LocalLoginForm extends Component {
               @backupEnabled={{@backupEnabled}}
               @totpEnabled={{@totpEnabled}}
               @otherMethodAllowed={{@otherMethodAllowed}}
-              @action={{this.authenticateSecurityKey}}
+              @passkeysEnabled={{@passkeysEnabled}}
+              @securityKeysEnabled={{@securityKeysEnabled}}
+              @passkeyAction={{this.authenticatePasskeySecondFactor}}
+              @securityKeyAction={{this.authenticateSecurityKey}}
             />
           {{else}}
             <DSecondFactorInput

--- a/frontend/discourse/app/components/security-key-form.gjs
+++ b/frontend/discourse/app/components/security-key-form.gjs
@@ -7,9 +7,9 @@ import { i18n } from "discourse-i18n";
 
 export default class SecurityKeyForm extends Component {
   get showSecurityKeyButton() {
-    // when the granular args aren't passed, keep the legacy single-button
-    // rendering driven by `@action`
-    return this.args.securityKeysEnabled ?? true;
+    // when the granular args aren't passed at all, keep the legacy
+    // single-button rendering driven by `@action`
+    return this.args.securityKeysEnabled ?? !this.args.passkeysEnabled;
   }
 
   get securityKeyAction() {

--- a/frontend/discourse/app/controllers/email-login.js
+++ b/frontend/discourse/app/controllers/email-login.js
@@ -6,20 +6,41 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import getURL from "discourse/lib/get-url";
 import DiscourseURL from "discourse/lib/url";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
+import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 
 export default class EmailLoginController extends Controller {
   @service router;
 
   secondFactorMethod;
   secondFactorToken;
+  showTokenInput = false;
 
   lockImageUrl = getURL("/images/lock.svg");
 
   @computed("model")
   get secondFactorRequired() {
     return (
-      this.model.security_key_required || this.model.second_factor_required
+      this.model.security_key_required ||
+      this.model.passkeys_enabled ||
+      this.model.second_factor_required
     );
+  }
+
+  @computed(
+    "model.security_key_required",
+    "model.passkeys_enabled",
+    "showTokenInput"
+  )
+  get showWebauthnForm() {
+    return (
+      (this.model.security_key_required || this.model.passkeys_enabled) &&
+      !this.showTokenInput
+    );
+  }
+
+  @computed("model.totp_enabled", "model.backup_codes_enabled")
+  get otherTokenMethodsAllowed() {
+    return this.model.totp_enabled || this.model.backup_codes_enabled;
   }
 
   @action
@@ -68,6 +89,7 @@ export default class EmailLoginController extends Controller {
 
   @action
   authenticateSecurityKey() {
+    this.set("secondFactorMethod", SECOND_FACTOR_METHODS.SECURITY_KEY);
     getWebauthnCredential(
       this.model.challenge,
       this.model.allowed_credential_ids,
@@ -78,6 +100,23 @@ export default class EmailLoginController extends Controller {
       (errorMessage) => {
         this.set("model.error", errorMessage);
       }
+    );
+  }
+
+  @action
+  authenticatePasskey() {
+    this.set("secondFactorMethod", SECOND_FACTOR_METHODS.PASSKEY);
+    getWebauthnCredential(
+      this.model.challenge,
+      this.model.passkey_allowed_credential_ids,
+      (credentialData) => {
+        this.set("securityKeyCredential", credentialData);
+        this.send("finishLogin");
+      },
+      (errorMessage) => {
+        this.set("model.error", errorMessage);
+      },
+      { userVerification: "required" }
     );
   }
 }

--- a/frontend/discourse/app/controllers/login.js
+++ b/frontend/discourse/app/controllers/login.js
@@ -44,8 +44,11 @@ export default class LoginPageController extends Controller {
   @tracked backupEnabled;
   @tracked totpEnabled;
   @tracked showSecurityKey;
+  @tracked securityKeysEnabled;
+  @tracked passkeysEnabled;
   @tracked securityKeyChallenge;
   @tracked securityKeyAllowedCredentialIds;
+  @tracked passkeyAllowedCredentialIds;
   @tracked secondFactorToken;
   @tracked flash;
   @tracked flashType;
@@ -165,6 +168,11 @@ export default class LoginPageController extends Controller {
   }
 
   @action
+  secondFactorMethodChanged(value) {
+    this.secondFactorMethod = value;
+  }
+
+  @action
   flashChanged(value) {
     this.flash = value;
   }
@@ -224,7 +232,9 @@ export default class LoginPageController extends Controller {
         this.flashType = "error";
 
         if (
-          (result.security_key_enabled || result.totp_enabled) &&
+          (result.security_key_enabled ||
+            result.passkeys_enabled ||
+            result.totp_enabled) &&
           !this.secondFactorRequired
         ) {
           this.otherMethodAllowed = result.multiple_second_factor_methods;
@@ -232,13 +242,22 @@ export default class LoginPageController extends Controller {
           this.showLoginButtons = false;
           this.backupEnabled = result.backup_enabled;
           this.totpEnabled = result.totp_enabled;
+          this.securityKeysEnabled = result.security_key_enabled;
+          this.passkeysEnabled = result.passkeys_enabled;
           this.showSecondFactor = result.totp_enabled;
-          this.showSecurityKey = result.security_key_enabled;
-          this.secondFactorMethod = result.security_key_enabled
-            ? SECOND_FACTOR_METHODS.SECURITY_KEY
-            : SECOND_FACTOR_METHODS.TOTP;
+          this.showSecurityKey =
+            result.security_key_enabled || result.passkeys_enabled;
+          if (result.passkeys_enabled) {
+            this.secondFactorMethod = SECOND_FACTOR_METHODS.PASSKEY;
+          } else if (result.security_key_enabled) {
+            this.secondFactorMethod = SECOND_FACTOR_METHODS.SECURITY_KEY;
+          } else {
+            this.secondFactorMethod = SECOND_FACTOR_METHODS.TOTP;
+          }
           this.securityKeyChallenge = result.challenge;
           this.securityKeyAllowedCredentialIds = result.allowed_credential_ids;
+          this.passkeyAllowedCredentialIds =
+            result.passkey_allowed_credential_ids;
 
           return;
         } else if (result.reason === "not_activated") {

--- a/frontend/discourse/app/controllers/password-reset.js
+++ b/frontend/discourse/app/controllers/password-reset.js
@@ -69,10 +69,25 @@ export default class PasswordResetController extends Controller {
     set(this, "model.backup_enabled", value);
   }
 
-  @computed("model.second_factor_required", "model.security_key_required")
+  @computed("model.passkeys_enabled")
+  get passkeysEnabled() {
+    return this.model?.passkeys_enabled;
+  }
+
+  set passkeysEnabled(value) {
+    set(this, "model.passkeys_enabled", value);
+  }
+
+  @computed(
+    "model.second_factor_required",
+    "model.security_key_required",
+    "model.passkeys_enabled"
+  )
   get securityKeyOrSecondFactorRequired() {
     return (
-      this.model?.second_factor_required || this.model?.security_key_required
+      this.model?.second_factor_required ||
+      this.model?.security_key_required ||
+      this.model?.passkeys_enabled
     );
   }
 
@@ -81,16 +96,28 @@ export default class PasswordResetController extends Controller {
     return this.model?.multiple_second_factor_methods;
   }
 
-  @computed("securityKeyRequired", "selectedSecondFactorMethod")
-  get displaySecurityKeyForm() {
+  @computed("model.second_factor_required", "model.backup_enabled")
+  get tokenMethodsAllowed() {
+    return this.model?.second_factor_required || this.model?.backup_enabled;
+  }
+
+  @computed(
+    "securityKeyRequired",
+    "passkeysEnabled",
+    "selectedSecondFactorMethod"
+  )
+  get displayWebauthnForm() {
     return (
-      this.securityKeyRequired &&
-      this.selectedSecondFactorMethod === SECOND_FACTOR_METHODS.SECURITY_KEY
+      (this.securityKeyRequired || this.passkeysEnabled) &&
+      (this.selectedSecondFactorMethod === SECOND_FACTOR_METHODS.SECURITY_KEY ||
+        this.selectedSecondFactorMethod === SECOND_FACTOR_METHODS.PASSKEY)
     );
   }
 
   initSelectedSecondFactorMethod() {
-    if (this.model.security_key_required) {
+    if (this.model.passkeys_enabled) {
+      this.set("selectedSecondFactorMethod", SECOND_FACTOR_METHODS.PASSKEY);
+    } else if (this.model.security_key_required) {
       this.set(
         "selectedSecondFactorMethod",
         SECOND_FACTOR_METHODS.SECURITY_KEY
@@ -173,10 +200,15 @@ export default class PasswordResetController extends Controller {
             password: null,
             errorMessage: result.message,
           });
-        } else if (this.secondFactorRequired || this.securityKeyRequired) {
+        } else if (
+          this.secondFactorRequired ||
+          this.securityKeyRequired ||
+          this.passkeysEnabled
+        ) {
           this.setProperties({
             secondFactorRequired: false,
             securityKeyRequired: false,
+            passkeysEnabled: false,
             errorMessage: null,
           });
         } else if (result.errors?.["user_password.password"]?.length > 0) {
@@ -222,6 +254,24 @@ export default class PasswordResetController extends Controller {
           errorMessage,
         });
       }
+    );
+  }
+
+  @action
+  authenticatePasskey() {
+    this.set("selectedSecondFactorMethod", SECOND_FACTOR_METHODS.PASSKEY);
+
+    getWebauthnCredential(
+      this.model.challenge,
+      this.model.passkey_allowed_credential_ids,
+      (credentialData) => {
+        this.set("securityKeyCredential", credentialData);
+        this.send("submit");
+      },
+      (errorMessage) => {
+        this.setProperties({ password: null, errorMessage });
+      },
+      { userVerification: "required" }
     );
   }
 }

--- a/frontend/discourse/app/routes/email-login.js
+++ b/frontend/discourse/app/routes/email-login.js
@@ -15,11 +15,15 @@ export default class EmailLogin extends DiscourseRoute {
   setupController(controller, model) {
     super.setupController(...arguments);
 
-    controller.set(
-      "secondFactorMethod",
-      model.security_key_required
-        ? SECOND_FACTOR_METHODS.SECURITY_KEY
-        : SECOND_FACTOR_METHODS.TOTP
-    );
+    let method = SECOND_FACTOR_METHODS.TOTP;
+    if (model.passkeys_enabled) {
+      method = SECOND_FACTOR_METHODS.PASSKEY;
+    } else if (model.security_key_required) {
+      method = SECOND_FACTOR_METHODS.SECURITY_KEY;
+    }
+    controller.setProperties({
+      secondFactorMethod: method,
+      showTokenInput: false,
+    });
   }
 }

--- a/frontend/discourse/app/templates/email-login.gjs
+++ b/frontend/discourse/app/templates/email-login.gjs
@@ -23,18 +23,19 @@ export default <template>
         {{#if @controller.model.can_login}}
           <div class="email-login-form">
             {{#if @controller.secondFactorRequired}}
-              {{#if @controller.model.security_key_required}}
+              {{#if @controller.showWebauthnForm}}
                 <SecurityKeyForm
-                  @setShowSecurityKey={{fn
-                    (mut @controller.model.security_key_required)
-                  }}
+                  @setShowSecondFactor={{fn (mut @controller.showTokenInput)}}
                   @setSecondFactorMethod={{fn
                     (mut @controller.secondFactorMethod)
                   }}
                   @backupEnabled={{@controller.model.backup_codes_enabled}}
                   @totpEnabled={{@controller.model.totp_enabled}}
-                  @otherMethodAllowed={{@controller.secondFactorRequired}}
-                  @action={{@controller.authenticateSecurityKey}}
+                  @otherMethodAllowed={{@controller.otherTokenMethodsAllowed}}
+                  @passkeysEnabled={{@controller.model.passkeys_enabled}}
+                  @securityKeysEnabled={{@controller.model.security_key_required}}
+                  @passkeyAction={{@controller.authenticatePasskey}}
+                  @securityKeyAction={{@controller.authenticateSecurityKey}}
                 />
               {{else}}
                 <SecondFactorForm
@@ -62,7 +63,7 @@ export default <template>
                 }}</p>
             {{/if}}
 
-            {{#unless @controller.model.security_key_required}}
+            {{#unless @controller.showWebauthnForm}}
               <DButton
                 @label="email_login.confirm_button"
                 @action={{@controller.finishLogin}}

--- a/frontend/discourse/app/templates/login.gjs
+++ b/frontend/discourse/app/templates/login.gjs
@@ -95,11 +95,15 @@ export default <template>
                 @loginPassword={{@controller.loginPassword}}
                 @loginPasswordChanged={{@controller.loginPasswordChanged}}
                 @secondFactorMethod={{@controller.secondFactorMethod}}
+                @secondFactorMethodChanged={{@controller.secondFactorMethodChanged}}
                 @secondFactorToken={{@controller.secondFactorToken}}
                 @secondFactorTokenChanged={{@controller.secondFactorTokenChanged}}
                 @backupEnabled={{@controller.backupEnabled}}
                 @totpEnabled={{@controller.totpEnabled}}
+                @passkeysEnabled={{@controller.passkeysEnabled}}
+                @securityKeysEnabled={{@controller.securityKeysEnabled}}
                 @securityKeyAllowedCredentialIds={{@controller.securityKeyAllowedCredentialIds}}
+                @passkeyAllowedCredentialIds={{@controller.passkeyAllowedCredentialIds}}
                 @securityKeyChallenge={{@controller.securityKeyChallenge}}
                 @showSecurityKey={{@controller.showSecurityKey}}
                 @otherMethodAllowed={{@controller.otherMethodAllowed}}

--- a/frontend/discourse/app/templates/password-reset.gjs
+++ b/frontend/discourse/app/templates/password-reset.gjs
@@ -44,15 +44,18 @@ export default <template>
             <br />
           {{/if}}
 
-          {{#if @controller.displaySecurityKeyForm}}
+          {{#if @controller.displayWebauthnForm}}
             <SecurityKeyForm
               @setSecondFactorMethod={{fn
                 (mut @controller.selectedSecondFactorMethod)
               }}
               @backupEnabled={{@controller.backupEnabled}}
               @totpEnabled={{@controller.secondFactorRequired}}
-              @otherMethodAllowed={{@controller.otherMethodAllowed}}
-              @action={{@controller.authenticateSecurityKey}}
+              @otherMethodAllowed={{@controller.tokenMethodsAllowed}}
+              @passkeysEnabled={{@controller.passkeysEnabled}}
+              @securityKeysEnabled={{@controller.securityKeyRequired}}
+              @passkeyAction={{@controller.authenticatePasskey}}
+              @securityKeyAction={{@controller.authenticateSecurityKey}}
             />
           {{else}}
             <SecondFactorForm
@@ -71,7 +74,7 @@ export default <template>
             </SecondFactorForm>
           {{/if}}
 
-          {{#unless @controller.displaySecurityKeyForm}}
+          {{#unless @controller.displayWebauthnForm}}
             <DButton
               @isLoading={{@controller.isLoading}}
               @action={{@controller.submit}}

--- a/frontend/discourse/tests/acceptance/email-login-test.js
+++ b/frontend/discourse/tests/acceptance/email-login-test.js
@@ -1,0 +1,107 @@
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import sinon from "sinon";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+const RESPONSES = {
+  totponly: {
+    can_login: true,
+    token: "totponly",
+    token_email: "eviltrout@example.com",
+    second_factor_required: true,
+    totp_enabled: true,
+    backup_codes_enabled: false,
+  },
+  passkeyonly: {
+    can_login: true,
+    token: "passkeyonly",
+    token_email: "eviltrout@example.com",
+    passkeys_enabled: true,
+    security_key_required: false,
+    passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+    challenge: "somechallenge",
+  },
+  mixedwebauthn: {
+    can_login: true,
+    token: "mixedwebauthn",
+    token_email: "eviltrout@example.com",
+    passkeys_enabled: true,
+    security_key_required: true,
+    allowed_credential_ids: ["c2VjdXJpdHkta2V5LWNyZWRlbnRpYWw="],
+    passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+    challenge: "somechallenge",
+  },
+};
+
+function stubWebauthnCredentialGet() {
+  const calls = [];
+  sinon.stub(navigator.credentials, "get").callsFake((options) => {
+    calls.push(options);
+    const error = new Error("credential get cancelled in tests");
+    error.name = "NotAllowedError";
+    return Promise.reject(error);
+  });
+  return calls;
+}
+
+acceptance("Email login", function (needs) {
+  needs.pretender((server, helper) => {
+    Object.keys(RESPONSES).forEach((token) => {
+      server.get(`/session/email-login/${token}.json`, () =>
+        helper.response(RESPONSES[token])
+      );
+    });
+  });
+
+  test("second factor with TOTP", async function (assert) {
+    await visit("/session/email-login/totponly");
+
+    assert.dom("#second-factor").exists("shows the second factor token prompt");
+    assert
+      .dom(".email-login-form .btn-primary")
+      .exists("shows the confirm button");
+  });
+
+  test("second factor with a passkey only", async function (assert) {
+    const calls = stubWebauthnCredentialGet();
+
+    await visit("/session/email-login/passkeyonly");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .doesNotExist("security key button is not shown without a security key");
+    assert
+      .dom(".email-login-form button[type='submit']")
+      .doesNotExist("hides the confirm button while a ceremony is offered");
+
+    await click("#passkey-authenticate-button");
+    assert.strictEqual(
+      calls[0].publicKey.userVerification,
+      "required",
+      "the passkey ceremony requires user verification"
+    );
+  });
+
+  test("second factor with a passkey and a security key", async function (assert) {
+    const calls = stubWebauthnCredentialGet();
+
+    await visit("/session/email-login/mixedwebauthn");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .exists("shows the security key button");
+
+    await click("#security-key-authenticate-button");
+    assert.strictEqual(
+      calls[0].publicKey.userVerification,
+      "discouraged",
+      "the security key ceremony discourages user verification"
+    );
+  });
+});

--- a/frontend/discourse/tests/acceptance/password-reset-test.js
+++ b/frontend/discourse/tests/acceptance/password-reset-test.js
@@ -105,6 +105,68 @@ acceptance("Password Reset", function (needs) {
     assert.true(DiscourseURL.redirectTo.calledWith("/"), "form is gone");
   });
 
+  test("Password Reset Page With Passkey", async function (assert) {
+    const calls = [];
+    sinon.stub(navigator.credentials, "get").callsFake((options) => {
+      calls.push(options);
+      const error = new Error("credential get cancelled in tests");
+      error.name = "NotAllowedError";
+      return Promise.reject(error);
+    });
+
+    PreloadStore.store("password_reset", {
+      is_developer: false,
+      passkeys_enabled: true,
+      passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+      challenge: "somechallenge",
+    });
+
+    await visit("/u/password-reset/requiretwofactor");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .doesNotExist("security key button is not shown without a security key");
+    assert
+      .dom("#new-account-password")
+      .doesNotExist("does not show the password input");
+
+    await click("#passkey-authenticate-button");
+    assert.strictEqual(
+      calls[0].publicKey.userVerification,
+      "required",
+      "the passkey ceremony requires user verification"
+    );
+  });
+
+  test("Password Reset Page With Passkey and Security Key", async function (assert) {
+    sinon.stub(navigator.credentials, "get").rejects(
+      Object.assign(new Error("credential get cancelled in tests"), {
+        name: "NotAllowedError",
+      })
+    );
+
+    PreloadStore.store("password_reset", {
+      is_developer: false,
+      security_key_required: true,
+      passkeys_enabled: true,
+      allowed_credential_ids: ["c2VjdXJpdHkta2V5LWNyZWRlbnRpYWw="],
+      passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+      challenge: "somechallenge",
+    });
+
+    await visit("/u/password-reset/requiretwofactor");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .exists("shows the security key button");
+  });
+
   test("Password Reset Page With Second Factor", async function (assert) {
     PreloadStore.store("password_reset", {
       is_developer: false,

--- a/frontend/discourse/tests/acceptance/sign-in-test.js
+++ b/frontend/discourse/tests/acceptance/sign-in-test.js
@@ -1,5 +1,6 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import sinon from "sinon";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Signing In", function () {
@@ -122,6 +123,42 @@ acceptance("Signing In", function () {
       .isNotVisible("does not display the second factor prompt");
     assert.dom("#security-key").isVisible("shows the security key prompt");
     assert.dom("#login-button").isNotVisible("hides the login button");
+  });
+
+  test("passkey as second factor", async function (assert) {
+    const calls = [];
+    sinon.stub(navigator.credentials, "get").callsFake((options) => {
+      calls.push(options);
+      const error = new Error("credential get cancelled in tests");
+      error.name = "NotAllowedError";
+      return Promise.reject(error);
+    });
+
+    await visit("/");
+    await click("header .login-button");
+
+    assert.dom(".login-fullpage").exists("shows the login page");
+
+    await fillIn("#login-account-name", "eviltrout");
+    await fillIn("#login-account-password", "need-passkey-2fa");
+    await click(".login-fullpage .btn-primary");
+
+    assert
+      .dom("#credentials")
+      .isNotVisible("hides the username and password prompt");
+    assert
+      .dom("#passkey-authenticate-button")
+      .isVisible("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .doesNotExist("security key button is not shown without a security key");
+
+    await click("#passkey-authenticate-button");
+    assert.strictEqual(
+      calls.at(-1).publicKey.userVerification,
+      "required",
+      "the passkey ceremony requires user verification"
+    );
   });
 
   test("second factor backup - valid token", async function (assert) {

--- a/frontend/discourse/tests/helpers/create-pretender.js
+++ b/frontend/discourse/tests/helpers/create-pretender.js
@@ -803,6 +803,23 @@ export function applyDefaultHandlers() {
       });
     }
 
+    if (data.password === "need-passkey-2fa") {
+      return response({
+        failed: "FAILED",
+        ok: false,
+        error:
+          "The selected second factor method is not enabled for your account.",
+        reason: "not_enabled_second_factor_method",
+        backup_enabled: false,
+        security_key_enabled: false,
+        passkeys_enabled: true,
+        totp_enabled: false,
+        multiple_second_factor_methods: false,
+        passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+        challenge: "challenge",
+      });
+    }
+
     return response(400, { error: "invalid login" });
   });
 

--- a/spec/lib/concern/second_factor_manager_spec.rb
+++ b/spec/lib/concern/second_factor_manager_spec.rb
@@ -148,6 +148,25 @@ RSpec.describe SecondFactorManager do
         expect(user.has_multiple_second_factor_methods?).to eq(false)
       end
     end
+
+    context "when passkeys count as a second factor" do
+      before { SiteSetting.allow_passkeys_for_2fa = true }
+
+      it "counts a passkey alongside totp" do
+        disable_security_key
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+
+        Fabricate(:passkey_with_random_credential, user: user)
+        expect(user.has_multiple_second_factor_methods?).to eq(true)
+      end
+
+      it "returns false for a passkey-only user" do
+        disable_security_key
+        disable_totp
+        Fabricate(:passkey_with_random_credential, user: user)
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+      end
+    end
   end
 
   describe "#only_security_keys_enabled?" do
@@ -213,16 +232,20 @@ RSpec.describe SecondFactorManager do
       end
 
       context "when the user has a passkey and allow_passkeys_for_2fa is enabled" do
-        # Login / email-login / password-reset flows call authenticate_second_factor
-        # without a second_factor_method. They don't advertise passkeys, so a
-        # passkey-only user must still pass through these flows; only the explicit
-        # 2FA endpoint (which submits a method) should require passkey validation.
         before do
           SiteSetting.allow_passkeys_for_2fa = true
           Fabricate(:passkey_with_random_credential, user: user)
         end
 
-        it "returns OK when no second_factor_method is submitted" do
+        it "is rejected when no second_factor_method is submitted" do
+          result = user.authenticate_second_factor(params, server_session)
+          expect(result.ok).to eq(false)
+          expect(result.error).to eq(I18n.t("login.invalid_second_factor_method"))
+          expect(result.passkeys_enabled).to eq(true)
+        end
+
+        it "returns OK when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
           expect(user.authenticate_second_factor(params, server_session).ok).to eq(true)
         end
 

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -126,6 +126,37 @@ RSpec.describe SessionController do
           expect(DiscourseWebauthn.rp_id).to eq("localhost")
         end
       end
+
+      context "when the user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        let!(:passkey) { Fabricate(:passkey_with_random_credential, user: user) }
+
+        before { SiteSetting.allow_passkeys_for_2fa = true }
+
+        it "advertises the passkey as a second factor" do
+          get "/session/email-login/#{email_token.token}.json"
+
+          response_body_parsed = response.parsed_body
+          expect(response_body_parsed["can_login"]).to eq(true)
+          expect(response_body_parsed["passkeys_enabled"]).to eq(true)
+          expect(response_body_parsed["security_key_required"]).to eq(false)
+          expect(response_body_parsed["allowed_credential_ids"]).to eq(nil)
+          expect(response_body_parsed["passkey_allowed_credential_ids"]).to eq(
+            [passkey.credential_id],
+          )
+          expect(response_body_parsed["challenge"]).to be_present
+        end
+
+        it "does not advertise the passkey when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          get "/session/email-login/#{email_token.token}.json"
+
+          response_body_parsed = response.parsed_body
+          expect(response_body_parsed["can_login"]).to eq(true)
+          expect(response_body_parsed["passkeys_enabled"]).to eq(nil)
+          expect(response_body_parsed["passkey_allowed_credential_ids"]).to eq(nil)
+        end
+      end
     end
   end
 
@@ -491,6 +522,71 @@ RSpec.describe SessionController do
             expect(session[:current_user_id]).to eq(user.id)
             expect(user.user_auth_tokens.count).to eq(1)
           end
+        end
+      end
+
+      context "when the user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          simulate_localhost_passkey_challenge
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
+
+          # store challenge in server session by visiting the email login page
+          get "/session/email-login/#{email_token.token}.json"
+        end
+
+        it "denies login without a second factor" do
+          post "/session/email-login/#{email_token.token}.json"
+
+          expect(response.status).to eq(200)
+          expect(session[:current_user_id]).to eq(nil)
+          expect(response.parsed_body["error"]).to eq(I18n.t("login.invalid_second_factor_method"))
+        end
+
+        it "logs the user in with a valid passkey assertion" do
+          post "/session/email-login/#{email_token.token}.json",
+               params: {
+                 second_factor_token: valid_passkey_auth_data,
+                 second_factor_method: UserSecondFactor.methods[:passkey],
+               }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
+        end
+
+        it "denies a passkey assertion posted as the security key method" do
+          post "/session/email-login/#{email_token.token}.json",
+               params: {
+                 second_factor_token: valid_passkey_auth_data,
+                 second_factor_method: UserSecondFactor.methods[:security_key],
+               }
+
+          expect(response.status).to eq(200)
+          expect(session[:current_user_id]).to eq(nil)
+          expect(response.parsed_body["error"]).to eq(
+            I18n.t("login.not_enabled_second_factor_method"),
+          )
+        end
+
+        it "logs the user in without 2FA when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          post "/session/email-login/#{email_token.token}.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
         end
       end
 
@@ -2206,6 +2302,66 @@ RSpec.describe SessionController do
               I18n.t("login.not_enabled_second_factor_method"),
             )
           end
+        end
+      end
+
+      context "when a user has passkey-only 2FA login" do
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
+        end
+
+        it "challenges the user and advertises the passkey on the first attempt" do
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          expect(response.status).to eq(200)
+          expect(session[:current_user_id]).to eq(nil)
+          response_body = response.parsed_body
+          expect(response_body["failed"]).to eq("FAILED")
+          expect(response_body["passkeys_enabled"]).to eq(true)
+          expect(response_body["security_key_enabled"]).to eq(false)
+          expect(response_body["passkey_allowed_credential_ids"]).to eq([passkey.credential_id])
+          expect(response_body["allowed_credential_ids"]).to eq(nil)
+          expect(response_body["challenge"]).to be_present
+        end
+
+        it "logs the user in with a valid passkey assertion" do
+          simulate_localhost_passkey_challenge
+
+          # store challenge in server session by failing login once
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          post "/session.json",
+               params: {
+                 login: user.username,
+                 password: "myawesomepassword",
+                 second_factor_token: valid_passkey_auth_data,
+                 second_factor_method: UserSecondFactor.methods[:passkey],
+               }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
+        end
+
+        it "logs the user in without 2FA when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
         end
       end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe UsersController do
         expect(response.body).to have_tag("div#data-preloaded") do |element|
           json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
           expect(json["password_reset"]).to include(
-            '{"is_developer":false,"admin":false,"second_factor_required":false,"security_key_required":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
+            '{"is_developer":false,"admin":false,"second_factor_required":false,"security_key_required":false,"passkeys_enabled":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
           )
         end
 
@@ -535,7 +535,7 @@ RSpec.describe UsersController do
           expect(response.body).to have_tag("div#data-preloaded") do |element|
             json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
             expect(json["password_reset"]).to include(
-              '{"is_developer":false,"admin":false,"second_factor_required":true,"security_key_required":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
+              '{"is_developer":false,"admin":false,"second_factor_required":true,"security_key_required":false,"passkeys_enabled":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
             )
           end
 
@@ -648,6 +648,69 @@ RSpec.describe UsersController do
             expect(response.body).to include(I18n.t("webauthn.validation.not_found_error"))
             expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(false)
           end
+        end
+      end
+
+      context "when the user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user1,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          simulate_localhost_passkey_challenge
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
+
+          get "/u/password-reset/#{email_token.token}"
+        end
+
+        it "preloads with the passkey allow-list" do
+          expect(response.body).to have_tag("div#data-preloaded") do |element|
+            json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+            password_reset = JSON.parse(json["password_reset"])
+            expect(password_reset["challenge"]).not_to eq(nil)
+            expect(password_reset["passkeys_enabled"]).to eq(true)
+            expect(password_reset["security_key_required"]).to eq(false)
+            expect(password_reset["allowed_credential_ids"]).to eq(nil)
+            expect(password_reset["passkey_allowed_credential_ids"]).to eq([passkey.credential_id])
+          end
+        end
+
+        it "does not change the password without a second factor" do
+          put "/u/password-reset/#{email_token.token}", params: { password: "hg9ow8yHG32O" }
+
+          expect(response.status).to eq(200)
+          expect(response.body).to include(I18n.t("login.invalid_second_factor_method"))
+          expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(false)
+        end
+
+        it "changes the password with a valid passkey assertion" do
+          put "/u/password-reset/#{email_token.token}.json",
+              params: {
+                password: "hg9ow8yHG32O",
+                second_factor_token: valid_passkey_auth_data,
+                second_factor_method: UserSecondFactor.methods[:passkey],
+              }
+
+          expect(response.status).to eq(200)
+          user1.reload
+          expect(user1.confirm_password?("hg9ow8yHG32O")).to eq(true)
+          expect(user1.user_auth_tokens.count).to eq(1)
+        end
+
+        it "ignores the passkey when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          put "/u/password-reset/#{email_token.token}", params: { password: "hg9ow8yHG32O" }
+
+          expect(response.status).to eq(200)
+          expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(true)
         end
       end
     end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -305,6 +305,51 @@ module SystemHelpers
     end
   end
 
+  # Registers a passkey (first-factor credential) for the user on a virtual
+  # authenticator with user verification enabled. The credential is
+  # non-resident so the login page's conditional passkey prompt does not
+  # auto-complete; it can only be exercised through allow-list ceremonies
+  # such as the passkey-as-2FA flows.
+  def with_passkey(user)
+    public_key_base64 =
+      "pQECAyYgASFYIJhY+jDNJM8g0lyKP3ivDxs+mrKXqfKUY3f7Uo4pWTPDIlggj03xktSm0JTSqbDefhu5WAKH7VRQmWXotjtI/8ka/P0="
+    private_key_base64 =
+      "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2AWg10o6aoM0s55halZvcQLnpM2tVO2D8Ugw7wFCjzyhRANCAASYWPowzSTPINJcij94rw8bPpqyl6nylGN3-1KOKVkzw49N8ZLUptCU0qmw3n4buVgCh-1UUJll6LY7SP_JGvz9"
+    credential_id_base64 = Base64.strict_encode64(SecureRandom.random_bytes(32))
+    credential_id_bytes = Base64.urlsafe_decode64(credential_id_base64)
+    private_key_bytes = Base64.urlsafe_decode64(private_key_base64)
+
+    with_virtual_authenticator(
+      hasUserVerification: true,
+      isUserVerified: true,
+    ) do |cdp_client, authenticator_id|
+      cdp_client.send_message(
+        "WebAuthn.addCredential",
+        params: {
+          authenticatorId: authenticator_id,
+          credential: {
+            credentialId: Base64.strict_encode64(credential_id_bytes),
+            isResidentCredential: false,
+            rpId: DiscourseWebauthn.rp_id,
+            privateKey: Base64.strict_encode64(private_key_bytes),
+            signCount: 1,
+          },
+        },
+      )
+
+      Fabricate(
+        :user_security_key,
+        user:,
+        public_key: public_key_base64,
+        credential_id: credential_id_base64,
+        factor_type: UserSecurityKey.factor_types[:first_factor],
+        name: "My Passkey",
+      )
+
+      yield
+    end
+  end
+
   def with_virtual_authenticator(options = {})
     page.driver.with_playwright_page do |pw_page|
       cdp_client = pw_page.context.new_cdp_session(pw_page)

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -431,6 +431,56 @@ shared_examples "login scenarios" do
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end
   end
+
+  context "when the user's only second factor is a passkey" do
+    before do
+      SiteSetting.allow_passkeys_for_2fa = true
+      EmailToken.confirm(Fabricate(:email_token, user: user).token)
+    end
+
+    it "can login with a password and the passkey as 2FA" do
+      with_passkey(user) do
+        login_form.open.fill(username: "john", password: "supersecurepassword").click_login
+
+        expect(page).to have_css("#passkey-authenticate-button")
+        find("#passkey-authenticate-button").click
+
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
+
+    it "can login with a login link and the passkey as 2FA" do
+      with_passkey(user) do
+        login_form.open.fill_username("john").email_login_link
+
+        login_link = wait_for_email_link(user, :email_login)
+        visit login_link
+
+        expect(page).to have_css("#passkey-authenticate-button")
+        find("#passkey-authenticate-button").click
+
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
+
+    it "can reset password with the passkey as 2FA" do
+      with_passkey(user) do
+        login_form.open.fill_username("john").forgot_password
+        find("button.forgot-password-reset").click
+
+        reset_password_link = wait_for_email_link(user, :reset_password)
+        visit reset_password_link
+
+        expect(page).to have_css("#passkey-authenticate-button")
+        find("#passkey-authenticate-button").click
+
+        find("#new-account-password").fill_in(with: "newsuperpassword")
+        find(".change-password-form .btn-primary").click
+
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
+  end
 end
 
 describe "Login" do


### PR DESCRIPTION
With `allow_passkeys_for_2fa` enabled, passkeys could already satisfy 2FA on `/session/2fa`, but password login, email login, and password reset silently skipped the second factor for passkey-only users. Each of those flows now stages a passkey ceremony:

* `authenticate_second_factor` no longer returns OK for passkey-only users when no method is submitted; the failure payload advertises `passkeys_enabled` and `passkey_allowed_credential_ids` alongside the existing security key fields.
* `SessionController#create`, `#email_login_info`/`#email_login`, and `UsersController#password_reset_show`/`#password_reset_update` include passkeys in their challenge payloads.
* `has_multiple_second_factor_methods?` counts passkeys so mixed accounts get the "try another way" links.
* The login, email login, and password reset forms render a "Use passkey" ceremony (user verification required) next to the security key one, defaulting to the passkey when available.

With the setting disabled (default), all flows behave exactly as before. Enforced-2FA compliance for passkey-only accounts is unchanged and ships separately as the final step of the rollout.

Includes end-to-end system specs driving all three flows with a CDP virtual authenticator (new `with_passkey` helper), plus acceptance tests for each form.

Stacked on #40817 (second of three PRs completing the `allow_passkeys_for_2fa` rollout).
