### PR TITLE
MT: Fix lost wakeup in worker IPC handshake

### DIFF
--- a/migrations/core/lib/migrations/conversion/worker.rb
+++ b/migrations/core/lib/migrations/conversion/worker.rb
@@ -16,6 +16,9 @@ module Migrations
         @threads = []
         @mutex = Mutex.new
         @data_processed = ConditionVariable.new
+        @sent_count = 0
+        @processed_count = 0
+        @output_closed = false
       end
 
       def start
@@ -75,7 +78,14 @@ module Migrations
           begin
             while (data = @input_queue.pop)
               Oj.to_stream(output_stream, data, OJ_SETTINGS)
-              @mutex.synchronize { @data_processed.wait(@mutex) }
+              @sent_count += 1
+
+              # waiting on the condition variable alone would lose the wakeup
+              # when the result arrives before this thread reaches `wait`, so
+              # the counters act as the wait predicate
+              @mutex.synchronize do
+                @data_processed.wait(@mutex) while @processed_count < @sent_count && !@output_closed
+              end
             end
           ensure
             output_stream.close
@@ -91,11 +101,19 @@ module Migrations
           begin
             Oj.load(input_stream, OJ_SETTINGS) do |data|
               @output_queue.push(data)
-              @mutex.synchronize { @data_processed.signal }
+
+              @mutex.synchronize do
+                @processed_count += 1
+                @data_processed.signal
+              end
             end
           ensure
             input_stream.close
-            @mutex.synchronize { @data_processed.signal }
+
+            @mutex.synchronize do
+              @output_closed = true
+              @data_processed.signal
+            end
           end
         end
       end


### PR DESCRIPTION
Previously, `Conversion::Worker`'s input thread waited on its condition variable without a predicate; when the child's result arrived in the window between writing an item and reaching `wait`, the signal fired with no waiter and the input thread blocked forever.

This change tracks sent/processed counts as the wait predicate (same one-item-in-flight semantics, no timing sensitivity) and adds a closed flag so the input thread wakes and fails loudly on the broken pipe instead of hanging when the child dies mid-stream.

### Notes

- With a real job the race window is rarely hit, but a fast job hangs reliably within a few hundred thousand messages — reproduced (as an 8-hour silent hang) while benchmarking this pipeline with a no-op echo job. The echo-job specs in `worker_spec.rb` were exposed to the same flake.
- No user-visible impact today: the parallel path is dormant on main (no step sets `run_in_parallel`). The fix matters for `mt/parallel-processing`, which activates it — and makes that branch's `CrashedError` detection deterministic, since crash detection relies on the input thread actually waking up.
- Split out of the worker IPC serializer benchmark branch (`mt/worker-ipc-json`) so it can merge fast, stay independently revertable, and be rebased into `mt/parallel-processing` without waiting on benchmark review.

Verified: `migrations-core` suite green; worker spec stress-run 5× under a timeout guard.