### PR TITLE
MT: Fix `suspended_by_id` always being NULL in converted user suspensions

### DIFF
--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_suspensions.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_suspensions.rb
@@ -42,7 +42,7 @@ module Migrations
                                END
                        ELSE u.suspended_till
                        END          AS suspended_till,
-                   a.acting_user_id AS suspended_by,
+                   a.acting_user_id AS suspended_by_id,
                    a.details        AS reason
             FROM actions a
                  JOIN users u ON a.target_user_id = u.id


### PR DESCRIPTION
The SQL aliased the acting user as `suspended_by` while `process_item` read `item[:suspended_by_id]`, so every suspension was written to the IntermediateDB without the suspending user.

The mismatch dates back to the first version of the Discourse converter (7c6b116dfde). Nothing caught it because every layer silently accepts nil: a missing hash key returns nil, the `suspended_by_id:` kwarg of `IntermediateDB::UserSuspension.create` is optional, and the `user_suspensions.suspended_by_id` column is nullable.

Extracted from #40816 so the data fix isn't gated on that refactor's review.