### PR TITLE
MT: Verify partial doubles in the gem spec suites

### DIFF
--- a/migrations/core/spec/spec_setup.rb
+++ b/migrations/core/spec/spec_setup.rb
@@ -29,6 +29,14 @@ module MigrationsSpecSetup
     RSpec.configure do |config|
       config.mock_with MultiMock::Adapter.for(:rspec, :mocha)
 
+      # Partial stubs on real objects must name a method that actually exists,
+      # just like `instance_double`/`class_double` already enforce. Set on the
+      # global rspec-mocks config because `mock_with` receives the MultiMock
+      # adapter here, not the `:rspec` adapter that normally exposes this
+      # setting. The gem suites are mocha-free; Discourse core's own suite
+      # never loads this file.
+      RSpec::Mocks.configuration.verify_partial_doubles = true
+
       # Specs tagged `:rails` need a booted Rails environment (live DB
       # introspection, plugin manifests). They run in the Rails integration job,
       # not the isolated gem suite.

--- a/migrations/tooling/spec/lib/migrations/tooling/coverage/reference_check_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/coverage/reference_check_spec.rb
@@ -21,12 +21,12 @@ RSpec.describe Migrations::Tooling::Coverage::ReferenceCheck do
   # `discourse`, so include it unless a test is about its absence.
   #
   # `Migrations::Converters` lives in the converters gem, which isn't loaded in
-  # the tooling gem's isolated specs, so it is stubbed in rather than required.
+  # the tooling gem's isolated specs, so a doubled constant stands in for it
+  # (verified against the real module only where it happens to be loaded).
   def stub_coverage(results, schema:)
-    converters = Module.new
+    converters = class_double("Migrations::Converters").as_stubbed_const
     allow(converters).to receive(:names).and_return(results.keys)
     allow(converters).to receive(:path_of) { |name| name }
-    stub_const("Migrations::Converters", converters)
 
     allow(analyzer_class).to receive(:new) do |path|
       instance_double(analyzer_class, analyze: results.fetch(path))


### PR DESCRIPTION
The migrations gem suites already used verifying doubles (`instance_double` / `class_double`), but partial stubs on real constants weren't checked, so a spec could keep passing after the method it stubs was renamed or removed.

The setting goes on the global rspec-mocks config because `mock_with` receives the MultiMock adapter rather than the `:rspec` adapter that normally exposes it. The gem suites are mocha-free, and Discourse core's own suite never loads `spec_setup.rb`, so core is unaffected.

The only offender was `reference_check_spec`, which stubbed `names` and `path_of` onto a bare `Module.new` standing in for the unloaded `Migrations::Converters`. It now uses a doubled constant, which stays unverified in the isolated tooling suite but verifies against the real module wherever it happens to be loaded.

All four gem suites pass with the setting enabled. Extracted from #40816 — it's spec infrastructure, not parallel processing.