### PR TITLE
FIX: Reject DiscourseConnect SSO payloads when secret is blank

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -180,6 +180,10 @@ class SessionController < ApplicationController
       end
 
       return render_sso_error(text: I18n.t("discourse_connect.payload_parse_error"), status: 422)
+    rescue DiscourseConnect::BlankSecretError
+      connect_verbose_warn { "Verbose SSO log: blank secret detected" }
+
+      return render_sso_error(text: I18n.t("discourse_connect.signature_error"), status: 422)
     rescue DiscourseConnect::SignatureError => e
       connect_verbose_warn do
         "Verbose SSO log: Signature verification failed\n\n#{e.message}\n\n#{sso&.diagnostics}"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2955,6 +2955,7 @@ en:
       staged_users_disabled: "You must first enable 'staged users' before enabling this setting."
       reply_by_email_disabled: "You must first enable 'reply by email' before enabling this setting."
       discourse_connect_url_is_empty: "You must set a 'discourse connect url' before enabling this setting."
+      discourse_connect_secret_is_too_short: "You must set a 'discourse connect secret' of at least 10 characters before enabling this setting."
       enable_local_logins_disabled: "You must first enable 'enable local logins' before enabling this setting."
       min_username_length_exists: "You cannot set 'min username length' above the shortest username (%{username})."
       min_group_name_length_exists: "You cannot set 'min username length' above the shortest group name (%{group_name})."

--- a/lib/discourse_connect_base.rb
+++ b/lib/discourse_connect_base.rb
@@ -10,6 +10,9 @@ class DiscourseConnectBase
   class SignatureError < ParseError
   end
 
+  class BlankSecretError < ParseError
+  end
+
   ACCESSORS = %i[
     add_groups
     admin
@@ -84,6 +87,8 @@ class DiscourseConnectBase
   def self.parse(payload, sso_secret = nil, **init_kwargs)
     sso = new(**init_kwargs)
     sso.sso_secret = sso_secret if sso_secret
+
+    raise BlankSecretError if sso.sso_secret.blank?
 
     parsed = Rack::Utils.parse_query(payload)
 

--- a/lib/validators/enable_sso_validator.rb
+++ b/lib/validators/enable_sso_validator.rb
@@ -5,9 +5,13 @@ class EnableSsoValidator
     @opts = opts
   end
 
+  MIN_SECRET_LENGTH = 10
+
   def valid_value?(val)
     return true if val == "f"
-    return false if SiteSetting.discourse_connect_url.blank? || is_2fa_enforced?
+    if SiteSetting.discourse_connect_url.blank? || secret_too_short? || is_2fa_enforced?
+      return false
+    end
     true
   end
 
@@ -16,6 +20,8 @@ class EnableSsoValidator
       return I18n.t("site_settings.errors.discourse_connect_url_is_empty")
     end
 
+    return I18n.t("site_settings.errors.discourse_connect_secret_is_too_short") if secret_too_short?
+
     if is_2fa_enforced?
       I18n.t("site_settings.errors.discourse_connect_cannot_be_enabled_if_second_factor_enforced")
     end
@@ -23,5 +29,11 @@ class EnableSsoValidator
 
   def is_2fa_enforced?
     SiteSetting.enforce_second_factor? != "no"
+  end
+
+  private
+
+  def secret_too_short?
+    SiteSetting.discourse_connect_secret.length < MIN_SECRET_LENGTH
   end
 end

--- a/spec/integration/github_omniauth_spec.rb
+++ b/spec/integration/github_omniauth_spec.rb
@@ -186,6 +186,7 @@ describe "GitHub Oauth2" do
 
   it "doesn't log in the user if discourse connect is enabled" do
     SiteSetting.discourse_connect_url = "https://example.com/sso"
+    SiteSetting.discourse_connect_secret = "x" * 10
     SiteSetting.enable_discourse_connect = true
     post "/auth/github"
     expect(response.status).to eq(302)

--- a/spec/integration/twitter_omniauth_spec.rb
+++ b/spec/integration/twitter_omniauth_spec.rb
@@ -108,6 +108,7 @@ describe "Twitter OAuth 1.0a" do
 
   it "doesn't sign in the user discourse connect is enabled" do
     SiteSetting.discourse_connect_url = "https://example.com/sso"
+    SiteSetting.discourse_connect_secret = "x" * 10
     SiteSetting.enable_discourse_connect = true
     post "/auth/twitter"
     expect(response.status).to eq(302)

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -467,6 +467,7 @@ RSpec.describe Jobs::ExportCsvFile do
 
   it "exports sso data" do
     SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+    SiteSetting.discourse_connect_secret = "x" * 10
     SiteSetting.enable_discourse_connect = true
     user = Fabricate(:user)
     user.user_profile.update_column(:location, "La,La Land")

--- a/spec/lib/concern/second_factor_manager_spec.rb
+++ b/spec/lib/concern/second_factor_manager_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe SecondFactorManager do
     describe "when SSO is enabled" do
       it "should return false" do
         SiteSetting.discourse_connect_url = "http://someurl.com"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
 
         expect(user.totp_enabled?).to eq(false)
@@ -533,6 +534,7 @@ RSpec.describe SecondFactorManager do
       describe "when SSO is enabled" do
         it "should return false" do
           SiteSetting.discourse_connect_url = "http://someurl.com"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
 
           expect(user_backup.backup_codes_enabled?).to eq(false)

--- a/spec/lib/guardian/invite_guardian_spec.rb
+++ b/spec/lib/guardian/invite_guardian_spec.rb
@@ -233,6 +233,7 @@ RSpec.describe InviteGuardian do
 
     it "returns true for all users when sso is enabled" do
       SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+      SiteSetting.discourse_connect_secret = "x" * 10
       SiteSetting.enable_discourse_connect = true
 
       expect(Guardian.new(trust_level_2).can_invite_via_email?(topic)).to be_truthy

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -532,6 +532,7 @@ RSpec.describe UserGuardian do
 
       it "isn't allowed when SSO is enabled" do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         expect(guardian.can_delete_user?(user)).to eq(false)
       end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -2294,6 +2294,7 @@ RSpec.describe Guardian do
     context "when SSO username override is active" do
       before do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.auth_overrides_username = true
       end
@@ -2389,6 +2390,7 @@ RSpec.describe Guardian do
       before do
         SiteSetting.email_editable = false
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.auth_overrides_email = true
       end
@@ -2485,6 +2487,7 @@ RSpec.describe Guardian do
       context "when SSO is enabled" do
         before do
           SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
         end
 

--- a/spec/lib/site_settings/validations_spec.rb
+++ b/spec/lib/site_settings/validations_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe SiteSettings::Validations do
         end
         before do
           SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
         end
 

--- a/spec/lib/validators/enable_sso_validator_spec.rb
+++ b/spec/lib/validators/enable_sso_validator_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe EnableSsoValidator do
     end
 
     describe "when 'sso url' is present" do
-      before { SiteSetting.discourse_connect_url = "https://www.example.com/sso" }
+      before do
+        SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
+      end
 
       describe "when value is false" do
         it "should be valid" do
@@ -40,8 +43,48 @@ RSpec.describe EnableSsoValidator do
       end
     end
 
-    describe "when 2FA is enforced" do
+    describe "when 'sso secret' is blank" do
       before { SiteSetting.discourse_connect_url = "https://www.example.com/sso" }
+
+      describe "when val is false" do
+        it "should be valid" do
+          expect(validator.valid_value?("f")).to eq(true)
+        end
+      end
+
+      describe "when value is true" do
+        it "should not be valid" do
+          expect(validator.valid_value?("t")).to eq(false)
+
+          expect(validator.error_message).to eq(
+            I18n.t("site_settings.errors.discourse_connect_secret_is_too_short"),
+          )
+        end
+      end
+    end
+
+    describe "when 'sso secret' is shorter than the minimum length" do
+      before do
+        SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 9
+      end
+
+      describe "when value is true" do
+        it "should not be valid" do
+          expect(validator.valid_value?("t")).to eq(false)
+
+          expect(validator.error_message).to eq(
+            I18n.t("site_settings.errors.discourse_connect_secret_is_too_short"),
+          )
+        end
+      end
+    end
+
+    describe "when 2FA is enforced" do
+      before do
+        SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
+      end
 
       it "should be invalid" do
         SiteSetting.enforce_second_factor = "all"

--- a/spec/lib/validators/sso_overrides_email_validator_spec.rb
+++ b/spec/lib/validators/sso_overrides_email_validator_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SsoOverridesEmailValidator do
     describe "when 'email editable' is true" do
       before do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.email_editable = true
       end
@@ -31,6 +32,7 @@ RSpec.describe SsoOverridesEmailValidator do
     describe "when 'email editable' is false" do
       before do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.email_editable = false
       end

--- a/spec/models/concerns/reports/associated_accounts_by_provider_spec.rb
+++ b/spec/models/concerns/reports/associated_accounts_by_provider_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe "Reports::AssociatedAccountsByProvider" do
     context "with DiscourseConnect enabled" do
       before do
         SiteSetting.discourse_connect_url = "https://example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
       end
 

--- a/spec/models/discourse_connect_spec.rb
+++ b/spec/models/discourse_connect_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe DiscourseConnect do
 
   before do
     SiteSetting.discourse_connect_url = discourse_connect_url
-    SiteSetting.enable_discourse_connect = true
     SiteSetting.discourse_connect_secret = discourse_connect_secret
+    SiteSetting.enable_discourse_connect = true
     SiteSetting.reserved_usernames = ""
     Jobs.run_immediately!
   end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -2440,11 +2440,11 @@ RSpec.describe Admin::UsersController do
     before do
       SiteSetting.email_editable = false
       SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+      SiteSetting.discourse_connect_secret = sso_secret
       SiteSetting.enable_discourse_connect = true
       SiteSetting.auth_overrides_email = true
       SiteSetting.auth_overrides_name = true
       SiteSetting.auth_overrides_username = true
-      SiteSetting.discourse_connect_secret = sso_secret
       sso.sso_secret = sso_secret
     end
 
@@ -2983,6 +2983,7 @@ RSpec.describe Admin::UsersController do
 
     before do
       SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+      SiteSetting.discourse_connect_secret = "x" * 10
       SiteSetting.enable_discourse_connect = true
     end
 

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe "users" do
 
         before do
           SiteSetting.discourse_connect_url = "http://someurl.com"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
           user.create_single_sign_on_record(external_id: "1", last_payload: "")
         end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe ApplicationController do
 
     it "should redirect to SSO if enabled" do
       SiteSetting.discourse_connect_url = "http://someurl.com"
+      SiteSetting.discourse_connect_secret = "x" * 10
       SiteSetting.enable_discourse_connect = true
       get "/"
       expect(response).to redirect_to("/session/sso")
@@ -115,6 +116,7 @@ RSpec.describe ApplicationController do
     it "should not redirect to SSO when auth_immediately is disabled" do
       SiteSetting.auth_immediately = false
       SiteSetting.discourse_connect_url = "http://someurl.com"
+      SiteSetting.discourse_connect_secret = "x" * 10
       SiteSetting.enable_discourse_connect = true
 
       get "/"

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -2065,6 +2065,7 @@ RSpec.describe GroupsController do
 
       it "adds known users by email when DiscourseConnect is enabled" do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
 
         expect do

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -1153,6 +1153,7 @@ RSpec.describe InvitesController do
 
       it "fails when discourse connect is enabled" do
         SiteSetting.discourse_connect_url = "https://example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
 
         put "/invites/show/#{invite.invite_key}.json"
@@ -1934,6 +1935,7 @@ RSpec.describe InvitesController do
 
       it "allows admin to bulk invite when DiscourseConnect enabled" do
         SiteSetting.discourse_connect_url = "https://example.com"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
 
         sign_in(admin)

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe SessionController do
     context "when SSO enabled" do
       before do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
       end
 
@@ -601,8 +602,8 @@ RSpec.describe SessionController do
   describe "#sso" do
     before do
       SiteSetting.discourse_connect_url = "http://example.com/discourse_sso"
-      SiteSetting.enable_discourse_connect = true
       SiteSetting.discourse_connect_secret = "shjkfdhsfkjh"
+      SiteSetting.enable_discourse_connect = true
     end
 
     it "redirects correctly" do
@@ -618,8 +619,8 @@ RSpec.describe SessionController do
       @sso_secret = "shjkfdhsfkjh"
 
       SiteSetting.discourse_connect_url = @sso_url
-      SiteSetting.enable_discourse_connect = true
       SiteSetting.discourse_connect_secret = @sso_secret
+      SiteSetting.enable_discourse_connect = true
 
       Fabricate(:admin)
     end
@@ -636,6 +637,29 @@ RSpec.describe SessionController do
       sso.nonce = nonce
       sso.sso_secret = @sso_secret
       sso
+    end
+
+    context "when the configured secret is blank" do
+      before { SiteSetting.discourse_connect_secret = "" }
+
+      it "rejects a payload signed with an empty secret without logging in or creating a user" do
+        sso = get_sso("/")
+        sso.sso_secret = ""
+        sso.external_id = "1337"
+        sso.email = "someone@example.com"
+        sso.name = "Some One"
+        sso.username = "someone"
+        sso.admin = true
+
+        expect {
+          get "/session/sso_login", params: Rack::Utils.parse_query(sso.payload), headers: headers
+        }.not_to change { User.count }
+
+        expect(response.status).to eq(422)
+
+        logged_on_user = Discourse.current_user_provider.new(request.env).current_user
+        expect(logged_on_user).to eq(nil)
+      end
     end
 
     context "when in staff writes only mode" do
@@ -1908,6 +1932,7 @@ RSpec.describe SessionController do
     context "when SSO is enabled" do
       before do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
 
         post "/session.json", params: { login: user.username, password: "myawesomepassword" }
@@ -2577,6 +2602,7 @@ RSpec.describe SessionController do
 
     it "redirects to /login-required when SSO and login_required" do
       SiteSetting.discourse_connect_url = "https://example.com/sso"
+      SiteSetting.discourse_connect_secret = "x" * 10
       SiteSetting.enable_discourse_connect = true
 
       user = sign_in(Fabricate(:user))
@@ -2893,6 +2919,7 @@ RSpec.describe SessionController do
       context "when SSO is enabled" do
         before do
           SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
 
           post "/session.json", params: { login: user.username, password: "myawesomepassword" }
@@ -3522,6 +3549,7 @@ RSpec.describe SessionController do
 
         it "fails when discourse connect is enabled" do
           SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
           simulate_localhost_passkey_challenge
           user.activate

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -909,6 +909,7 @@ RSpec.describe UsersController do
       context "with discourse connect enabled" do
         before do
           SiteSetting.discourse_connect_url = "http://example.com/sso"
+          SiteSetting.discourse_connect_secret = "x" * 10
           SiteSetting.enable_discourse_connect = true
         end
 
@@ -2119,6 +2120,7 @@ RSpec.describe UsersController do
 
       it "should respond with proper error message if auth_overrides_username is enabled" do
         SiteSetting.discourse_connect_url = "http://someurl.com"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.auth_overrides_username = true
         acting_user = admin
@@ -3106,6 +3108,7 @@ RSpec.describe UsersController do
       before do
         DiscoursePluginRegistry.register_auth_provider(plugin_auth_provider)
         SiteSetting.discourse_connect_url = "http://localhost"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
       end
 
@@ -6067,6 +6070,7 @@ RSpec.describe UsersController do
         describe "when SSO is enabled" do
           it "should return the right response" do
             SiteSetting.discourse_connect_url = "http://someurl.com"
+            SiteSetting.discourse_connect_secret = "x" * 10
             SiteSetting.enable_discourse_connect = true
 
             post "/users/create_second_factor_totp.json"
@@ -6370,6 +6374,7 @@ RSpec.describe UsersController do
         describe "when SSO is enabled" do
           it "should return the right response" do
             SiteSetting.discourse_connect_url = "http://someurl.com"
+            SiteSetting.discourse_connect_secret = "x" * 10
             SiteSetting.enable_discourse_connect = true
 
             put "/users/second_factors_backup.json"
@@ -7023,6 +7028,7 @@ RSpec.describe UsersController do
     context "when SSO is enabled" do
       before do
         SiteSetting.discourse_connect_url = "https://discourse.test/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
       end
 
@@ -7109,6 +7115,7 @@ RSpec.describe UsersController do
     context "when SSO is enabled" do
       before do
         SiteSetting.discourse_connect_url = "https://discourse.test/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
       end
 

--- a/spec/services/site_settings_spec.rb
+++ b/spec/services/site_settings_spec.rb
@@ -9,10 +9,15 @@ RSpec.describe SiteSettingsTask do
       SiteSetting.provider.all.each { |setting| SiteSetting.remove_override!(setting.name) }
 
       SiteSetting.discourse_connect_url = sso_url
+      SiteSetting.discourse_connect_secret = "x" * 10
       SiteSetting.enable_discourse_connect = true
       hash = SiteSettingsTask.export_to_hash
 
-      expect(hash).to eq("enable_discourse_connect" => "true", "discourse_connect_url" => sso_url)
+      expect(hash).to eq(
+        "discourse_connect_secret" => "x" * 10,
+        "enable_discourse_connect" => "true",
+        "discourse_connect_url" => sso_url,
+      )
     end
   end
 

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -346,6 +346,7 @@ RSpec.describe UserUpdater do
     context "when sso overrides bio" do
       it "does not change bio" do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.discourse_connect_overrides_bio = true
 
@@ -361,6 +362,7 @@ RSpec.describe UserUpdater do
     context "when sso overrides location" do
       it "does not change location" do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.discourse_connect_overrides_location = true
 
@@ -376,6 +378,7 @@ RSpec.describe UserUpdater do
     context "when sso overrides website" do
       it "does not change website" do
         SiteSetting.discourse_connect_url = "https://www.example.com/sso"
+        SiteSetting.discourse_connect_secret = "x" * 10
         SiteSetting.enable_discourse_connect = true
         SiteSetting.discourse_connect_overrides_website = true
 


### PR DESCRIPTION
DiscourseConnect verified SSO payload signatures with whatever `discourse_connect_secret` was configured, including an empty string, so an instance with DiscourseConnect enabled but no secret set did not fail safely.

`DiscourseConnectBase#parse` now fails when the effective secret is blank, and `EnableSsoValidator` refuses to enable DiscourseConnect unless a secret of at least 10 characters is set.