### PR TITLE
MT: Fix IP addresses being nulled by the converter

### DIFF
--- a/migrations/core/lib/migrations/database.rb
+++ b/migrations/core/lib/migrations/database.rb
@@ -59,6 +59,9 @@ module Migrations
 
     def self.format_ip_address(value)
       return nil if value.blank?
+      # `PG::BasicTypeMapForResults` decodes `inet` columns into `IPAddr`
+      # objects, which `IPAddr.new` rejects
+      return value.to_s if value.is_a?(IPAddr)
       IPAddr.new(value).to_s
     rescue ArgumentError
       nil

--- a/migrations/core/spec/lib/database_spec.rb
+++ b/migrations/core/spec/lib/database_spec.rb
@@ -129,6 +129,16 @@ RSpec.describe Migrations::Database do
     it "returns nil for nil input" do
       expect(described_class.format_ip_address(nil)).to be_nil
     end
+
+    it "formats an IPv4 `IPAddr`" do
+      expect(described_class.format_ip_address(IPAddr.new("192.168.1.1"))).to eq("192.168.1.1")
+    end
+
+    it "formats an IPv6 `IPAddr`" do
+      expect(
+        described_class.format_ip_address(IPAddr.new("2001:0db8:85a3:0000:0000:8a2e:0370:7334")),
+      ).to eq("2001:db8:85a3::8a2e:370:7334")
+    end
   end
 
   describe ".to_blob" do


### PR DESCRIPTION
Previously, every conversion wrote NULL for `users.ip_address` and `users.registration_ip_address`: `PG::BasicTypeMapForResults` decodes `inet` columns into `IPAddr` objects by default, and `Database.format_ip_address` passed them to `IPAddr.new`, which raises `IPAddr::AddressFamilyError` — an `ArgumentError` subclass the method rescues to nil. This silent data loss affected serial and parallel mode alike (verified empirically; found during the wire-type audit for #40827).

This change makes `format_ip_address` accept `IPAddr` input and format it via `#to_s`, so both columns now carry the real addresses.

### Notes

- **Converter output changes intentionally**: the two IP columns go from NULL to real values. Landing this before the upcoming primitive-wire-format PR keeps that PR's byte-identical IntermediateDB diff gate clean.
- `IPAddr#to_s` returns the base address (drops any prefix) — fine for these host-address columns; noted in the code so it's a recorded decision.
- The audit found no other `inet` columns crossing any step.

Verified: new specs for IPv4/IPv6 `IPAddr` input alongside the existing string/invalid/nil cases; `migrations-core` suite green.