### PR TITLE
FIX: Render plugin outlets in nested topic actions

### DIFF
--- a/frontend/discourse/app/components/nested/topic-actions.gjs
+++ b/frontend/discourse/app/components/nested/topic-actions.gjs
@@ -29,7 +29,6 @@ export default class NestedTopicActions extends Component {
       @deferTopic={{this.topicController.deferTopic}}
       @replyToPost={{this.topicController.replyToPost}}
       @showCreate={{false}}
-      @showPluginOutlets={{false}}
       class="nested-view__topic-actions"
     />
   </template>

--- a/frontend/discourse/app/components/topic-footer-buttons.gjs
+++ b/frontend/discourse/app/components/topic-footer-buttons.gjs
@@ -138,10 +138,6 @@ export default class TopicFooterButtons extends Component {
     return this.showCreate !== false && this.topic?.details?.can_create_post;
   }
 
-  get renderPluginOutlets() {
-    return this.showPluginOutlets !== false;
-  }
-
   <template>
     <div
       role="region"
@@ -277,13 +273,11 @@ export default class TopicFooterButtons extends Component {
           {{/if}}
         </div>
 
-        {{#if this.renderPluginOutlets}}
-          <PluginOutlet
-            @name="topic-footer-main-buttons-before-create"
-            @outletArgs={{lazyHash topic=this.topic}}
-            @connectorTagName="span"
-          />
-        {{/if}}
+        <PluginOutlet
+          @name="topic-footer-main-buttons-before-create"
+          @outletArgs={{lazyHash topic=this.topic}}
+          @connectorTagName="span"
+        />
 
         {{#if this.showCreateButton}}
           <DButton
@@ -295,13 +289,11 @@ export default class TopicFooterButtons extends Component {
           />
         {{/if}}
 
-        {{#if this.renderPluginOutlets}}
-          <PluginOutlet
-            @name="after-topic-footer-main-buttons"
-            @outletArgs={{lazyHash topic=this.topic}}
-            @connectorTagName="span"
-          />
-        {{/if}}
+        <PluginOutlet
+          @name="after-topic-footer-main-buttons"
+          @outletArgs={{lazyHash topic=this.topic}}
+          @connectorTagName="span"
+        />
       </div>
 
       {{#if this.site.desktopView}}
@@ -332,13 +324,11 @@ export default class TopicFooterButtons extends Component {
         {{/if}}
       {{/if}}
 
-      {{#if this.renderPluginOutlets}}
-        <PluginOutlet
-          @name="after-topic-footer-buttons"
-          @outletArgs={{lazyHash topic=this.topic}}
-          @connectorTagName="span"
-        />
-      {{/if}}
+      <PluginOutlet
+        @name="after-topic-footer-buttons"
+        @outletArgs={{lazyHash topic=this.topic}}
+        @connectorTagName="span"
+      />
     </div>
   </template>
 }


### PR DESCRIPTION
Nested topic actions reuse `TopicFooterButtons`, but passed `@showPluginOutlets={{false}}`. That prevents existing topic-footer button connectors, such as `discourse-unhandled-tagger`, from rendering in nested view.

`showPluginOutlets` was only introduced for that nested topic-actions callsite, so this removes the option and restores the previous behavior of always rendering the topic footer plugin outlets. `@showCreate={{false}}` remains in place to avoid rendering the core Reply button in nested topic actions.

No tests run; template-only change.