### PR TITLE
DEV: Support action rows in select-kit

### DIFF
--- a/frontend/discourse/select-kit/components/category-chooser.js
+++ b/frontend/discourse/select-kit/components/category-chooser.js
@@ -6,6 +6,7 @@ import Category from "discourse/models/category";
 import PermissionType from "discourse/models/permission-type";
 import CategoryRow from "discourse/select-kit/components/category-row";
 import ComboBoxComponent from "discourse/select-kit/components/combo-box";
+import SelectKitRow from "discourse/select-kit/components/select-kit/select-kit-row";
 import { categoryBadgeHTML } from "discourse/ui-kit/helpers/d-category-link";
 import { i18n } from "discourse-i18n";
 import { pluginApiIdentifiers, selectKitOptions } from "./select-kit";
@@ -51,7 +52,11 @@ export default class CategoryChooser extends ComboBoxComponent {
     return this.siteSettings.fixed_category_positions_on_create;
   }
 
-  modifyComponentForRow() {
+  modifyComponentForRow(collection, item) {
+    if (typeof item?.onSelect === "function") {
+      return SelectKitRow;
+    }
+
     return CategoryRow;
   }
 

--- a/frontend/discourse/select-kit/components/category-row.gjs
+++ b/frontend/discourse/select-kit/components/category-row.gjs
@@ -18,6 +18,18 @@ export default class CategoryRow extends Component {
 
   readOnlyDesc = i18n("category_row.read_only_description");
 
+  get isActionRow() {
+    return typeof this.args.item?.onSelect === "function";
+  }
+
+  get role() {
+    return this.isActionRow ? "menuitem" : "menuitemradio";
+  }
+
+  get ariaChecked() {
+    return this.isActionRow ? undefined : this.isSelected;
+  }
+
   get isNone() {
     return this.rowValue === this.args.selectKit?.noneItem;
   }
@@ -284,7 +296,7 @@ export default class CategoryRow extends Component {
         (if this.isHighlighted "is-highlighted")
         (if this.isNone "is-none")
       }}
-      role="menuitemradio"
+      role={{this.role}}
       data-index={{@index}}
       data-name={{this.rowName}}
       data-value={{this.rowValue}}
@@ -296,7 +308,6 @@ export default class CategoryRow extends Component {
       {{on "mouseenter" this.handleMouseEnter passive=true}}
       {{on "click" this.handleClick}}
       {{on "keydown" this.handleKeyDown}}
-      aria-checked={{this.isSelected}}
       tabindex="-1"
     >
 

--- a/frontend/discourse/select-kit/components/category-row.gjs
+++ b/frontend/discourse/select-kit/components/category-row.gjs
@@ -18,18 +18,6 @@ export default class CategoryRow extends Component {
 
   readOnlyDesc = i18n("category_row.read_only_description");
 
-  get isActionRow() {
-    return typeof this.args.item?.onSelect === "function";
-  }
-
-  get role() {
-    return this.isActionRow ? "menuitem" : "menuitemradio";
-  }
-
-  get ariaChecked() {
-    return this.isActionRow ? undefined : this.isSelected;
-  }
-
   get isNone() {
     return this.rowValue === this.args.selectKit?.noneItem;
   }
@@ -296,7 +284,7 @@ export default class CategoryRow extends Component {
         (if this.isHighlighted "is-highlighted")
         (if this.isNone "is-none")
       }}
-      role={{this.role}}
+      role="menuitemradio"
       data-index={{@index}}
       data-name={{this.rowName}}
       data-value={{this.rowValue}}
@@ -308,6 +296,7 @@ export default class CategoryRow extends Component {
       {{on "mouseenter" this.handleMouseEnter passive=true}}
       {{on "click" this.handleClick}}
       {{on "keydown" this.handleKeyDown}}
+      aria-checked={{this.isSelected}}
       tabindex="-1"
     >
 

--- a/frontend/discourse/select-kit/components/mini-tag-chooser.js
+++ b/frontend/discourse/select-kit/components/mini-tag-chooser.js
@@ -69,6 +69,10 @@ export default class MiniTagChooser extends MultiSelectComponent {
   }
 
   modifyComponentForRow(collection, item) {
+    if (typeof item?.onSelect === "function") {
+      return SelectKitRow;
+    }
+
     if (this.getValue(item) === this.selectKit.filter && !item.count) {
       return SelectKitRow;
     }

--- a/frontend/discourse/select-kit/components/multi-select.gjs
+++ b/frontend/discourse/select-kit/components/multi-select.gjs
@@ -91,6 +91,11 @@ export default class MultiSelect extends SelectKitComponent {
   }
 
   select(value, item) {
+    if (typeof item?.onSelect === "function") {
+      item.onSelect(this.selectKit, item);
+      return;
+    }
+
     if (this.selectKit.hasSelection && this.selectKit.options.maximum === 1) {
       const newItem = item || this.defaultItem(value, value);
       this.selectKit.change(makeArray(value), makeArray(newItem));

--- a/frontend/discourse/select-kit/components/select-kit.js
+++ b/frontend/discourse/select-kit/components/select-kit.js
@@ -916,6 +916,11 @@ export default class SelectKit extends Component {
   }
 
   select(value, item) {
+    if (typeof item?.onSelect === "function") {
+      item.onSelect(this.selectKit, item);
+      return;
+    }
+
     if (!isPresent(value)) {
       this._onClearSelection();
     } else {

--- a/frontend/discourse/select-kit/components/select-kit/select-kit-row.gjs
+++ b/frontend/discourse/select-kit/components/select-kit/select-kit-row.gjs
@@ -42,9 +42,17 @@ import { i18n } from "discourse-i18n";
 export default class SelectKitRow extends Component {
   tabIndex = 0;
   index = 0;
-  role = "menuitemradio";
 
   @tracked _langOverride;
+
+  get isActionRow() {
+    return typeof this.item?.onSelect === "function";
+  }
+
+  @computed("item.onSelect")
+  get role() {
+    return this.isActionRow ? "menuitem" : "menuitemradio";
+  }
 
   @computed("item.lang")
   get lang() {
@@ -86,8 +94,11 @@ export default class SelectKitRow extends Component {
     return guidFor(this.item);
   }
 
-  @computed("isSelected")
+  @computed("isSelected", "item.onSelect")
   get ariaChecked() {
+    if (this.isActionRow) {
+      return undefined;
+    }
     return this.isSelected ? "true" : "false";
   }
 

--- a/frontend/discourse/tests/integration/components/select-kit/api-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/api-test.gjs
@@ -129,6 +129,42 @@ module("Integration | Component | SelectKit | Api", function (hooks) {
     assert.dom("#test").hasText("foo");
   });
 
+  test("an item with onSelect acts as an action row instead of being selected", async function (assert) {
+    setDefaultState(this, "foo", { content: DEFAULT_CONTENT });
+
+    let actioned = false;
+    withPluginApi((api) => {
+      api.modifySelectKit("combo-box").prependContent(() => {
+        return {
+          id: "action",
+          name: "Do something",
+          onSelect: () => {
+            actioned = true;
+          },
+        };
+      });
+    });
+
+    await render(
+      <template>
+        <ComboBox
+          @value={{this.value}}
+          @content={{this.content}}
+          @onChange={{this.onChange}}
+        />
+      </template>
+    );
+    await this.comboBox.expand();
+    await this.comboBox.selectRowByValue("action");
+
+    assert.true(actioned, "the row's onSelect callback runs");
+    assert.strictEqual(this.value, "foo", "the selected value is unchanged");
+    assert.true(this.comboBox.isExpanded(), "the dropdown stays open");
+    assert
+      .dom(".select-kit-row[data-value='action']")
+      .hasAttribute("role", "menuitem");
+  });
+
   test("modifySelectKit(identifier).replaceContent", async function (assert) {
     setDefaultState(this, null, { content: DEFAULT_CONTENT });
 


### PR DESCRIPTION
Previously, select-kit rows could only select a value, so there was no way to add a row that runs a custom action.

This change lets a content item carry an action callback (invoked on selection and rendered as a menuitem).

### Impact
It is opt-in and additive: nothing changes unless an item explicitly sets onSelect.

* Selection path (select-kit.js, multi-select.gjs): the new code is a single early-return guard. Existing items (plain {id, name} objects and Category/Tag/User/Group models) never define an action, so the guard is always false and execution falls through to the identical existing logic. 
* select-kit-row.gjs: role/aria-checked becomes conditional (menuitem + no aria-checked for action rows; unchanged for normal rows)
* category-chooser.js / mini-tag-chooser.js: modifyComponentForRow returns the generic SelectKitRow for action items, so action rows aren't forced through the category/tag-specific row components.
* No API changes: no method signatures, exports, or modifySelectKit hooks were changed. Consumers that don't opt in are untouched.

Tests: added integration coverage in api-test.gjs for the action-row behavior.
Net: no behavioral, visual, or accessibility change for any current select-kit usage; the new capability is entirely opt-in.

Necessary change for #40838
int ref t/185600