### PR TITLE
DEV: Scope reactions-received to only posts the owner can see

### DIFF
--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -88,7 +88,7 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
     raise Discourse::InvalidAccess unless guardian.can_see_notifications?(user)
 
     posts = Post.joins(:topic).where(user_id: user.id)
-    posts = guardian.filter_allowed_categories(posts)
+    posts = visible_posts_for_reactions_received(posts)
     post_ids = posts.select(:id)
 
     reaction_users =
@@ -286,6 +286,15 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   end
 
   private
+
+  def visible_posts_for_reactions_received(posts)
+    visible_topic_ids = guardian.can_see_topic_ids(topic_ids: posts.distinct.pluck(:topic_id))
+
+    posts =
+      posts.where(topic_id: visible_topic_ids, post_type: Topic.visible_post_types(current_user))
+
+    guardian.filter_hidden_posts(posts)
+  end
 
   def get_users(reaction)
     DiscourseReactions::PostReactionsQuery

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -342,6 +342,39 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed[0]["reaction"]["id"]).to eq(open_mouth_reaction.id)
     end
 
+    it "omits reactions for posts in topics the requester can no longer see" do
+      pm_op =
+        Fabricate(
+          :private_message_post,
+          user: user_1,
+          recipient: user_2,
+          raw: "private message OP reaction excerpt",
+        )
+      pm_reply =
+        Fabricate(:post, topic: pm_op.topic, user: user_1, raw: "private message reply excerpt")
+
+      [pm_op, pm_reply].each do |pm_post|
+        pm_reaction = Fabricate(:reaction, post: pm_post, reaction_value: "open_mouth")
+        Fabricate(:reaction_user, reaction: pm_reaction, user: user_2, post: pm_post)
+      end
+
+      pm_op.topic.remove_allowed_user(user_2, user_1)
+
+      sign_in(user_1)
+
+      get "/discourse-reactions/posts/reactions-received.json",
+          params: {
+            username: user_1.username,
+          }
+
+      expect(response.status).to eq(200)
+      post_ids = response.parsed_body.map { |reaction| reaction["post_id"] }
+      expect(post_ids).not_to include(pm_op.id)
+      expect(post_ids).not_to include(pm_reply.id)
+      expect(response.body).not_to include(pm_op.raw)
+      expect(response.body).not_to include(pm_reply.raw)
+    end
+
     it "does not return reactions received by a user when current user is not an admin" do
       sign_in(user_1)
 


### PR DESCRIPTION
`reactions_received` built its post list with `filter_allowed_categories`, which only scopes by category. We should be checking it as we would for a regular post list

With this change, this method is in line with `reactions_given`, which already runs its results through a visibility guard. 

relates to: PATCH-1292