### PR TITLE
DEV: remove use of body:has() in CSS

### DIFF
--- a/app/assets/stylesheets/common/base/_topic-list.scss
+++ b/app/assets/stylesheets/common/base/_topic-list.scss
@@ -683,7 +683,7 @@
   padding: 0 var(--nav-horizontal-padding);
 
   @include viewport.until(sm) {
-    border-bottom: 0.15em solid var(--primary-low);
+    border-bottom: 1px solid var(--primary-low);
     width: 100%;
     display: flex;
     justify-content: center;
@@ -709,8 +709,8 @@
 
       @include viewport.until(sm) {
         &::after {
-          height: 0.15em;
-          bottom: -0.15em;
+          height: 1px;
+          bottom: -1px;
         }
       }
     }
@@ -764,7 +764,7 @@
     &-body {
       border-width: 1px;
 
-      body:has(.topic-replies-toggle-wrapper) & {
+      .topic-replies-toggle-wrapper ~ .topic-list & {
         border-width: 0;
       }
     }

--- a/plugins/discourse-presence/assets/stylesheets/presence.scss
+++ b/plugins/discourse-presence/assets/stylesheets/presence.scss
@@ -78,8 +78,7 @@
 // When topic progress is visible in the posts grid area and is sticky,
 // adjust positioning so presence is on the same line
 @media screen and (width <= 924px) {
-  body:has(.topic-navigation.with-topic-progress)
-    .topic-above-footer-buttons-outlet.presence {
+  .topic-above-footer-buttons-outlet.presence {
     margin-top: -3.2em;
     margin-right: 8em;
   }


### PR DESCRIPTION
`body:has()` ends up checking the whole document, which isn't ideal! we don't actually need them in either of these cases 

in the case of the topic-replies-toggle-wrapper we can use a general sibling selector, and for the presence alignment, the progress bar only shows up at `<= 924px` anyway 