### PR TITLE
MT: Run-level IntermediateDB writer (direct inline)

### DIFF
--- a/migrations/converters/lib/migrations/converters/adapter/postgres.rb
+++ b/migrations/converters/lib/migrations/converters/adapter/postgres.rb
@@ -55,7 +55,7 @@ module Migrations
           @connection = nil
 
           if @fork_hook
-            ForkManager.remove_after_fork_child_hook(@fork_hook)
+            ForkManager.remove_after_fork_child(@fork_hook)
             @fork_hook = nil
           end
         end

--- a/migrations/converters/spec/lib/migrations/converters/adapter/postgres_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/adapter/postgres_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe Migrations::Converters::Adapter::Postgres do
     end
 
     it "registers a fork hook on creation and removes it on `close`" do
-      expect(Migrations::ForkManager.size).to eq(0)
+      expect(Migrations::ForkManager.hook_count).to eq(0)
 
       create_adapter do |adapter|
-        expect(Migrations::ForkManager.size).to eq(1)
+        expect(Migrations::ForkManager.hook_count).to eq(1)
         adapter.close
-        expect(Migrations::ForkManager.size).to eq(0)
+        expect(Migrations::ForkManager.hook_count).to eq(0)
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Migrations::Converters::Adapter::Postgres do
 
           expect { adapter.close }.to_not raise_error
           expect(connection).to_not have_received(:finish)
-          expect(Migrations::ForkManager.size).to eq(0)
+          expect(Migrations::ForkManager.hook_count).to eq(0)
         end
       end
     end

--- a/migrations/core/lib/migrations/common/fork_manager.rb
+++ b/migrations/core/lib/migrations/common/fork_manager.rb
@@ -8,7 +8,7 @@ module Migrations
     @execute_parent_forks = true
 
     class << self
-      def batch_forks
+      def with_batched_forks
         @execute_parent_forks = false
         run_before_fork_hooks
 
@@ -25,7 +25,7 @@ module Migrations
         end
       end
 
-      def remove_before_fork_hook(block)
+      def remove_before_fork(block)
         @before_fork_hooks.delete(block)
       end
 
@@ -36,7 +36,7 @@ module Migrations
         end
       end
 
-      def remove_after_fork_parent_hook(block)
+      def remove_after_fork_parent(block)
         @after_fork_parent_hooks.delete(block)
       end
 
@@ -47,7 +47,7 @@ module Migrations
         end
       end
 
-      def remove_after_fork_child_hook(block)
+      def remove_after_fork_child(block)
         @after_fork_child_hooks.delete(block)
       end
 
@@ -65,7 +65,7 @@ module Migrations
         pid
       end
 
-      def size
+      def hook_count
         @before_fork_hooks.size + @after_fork_parent_hooks.size + @after_fork_child_hooks.size
       end
 

--- a/migrations/core/lib/migrations/conversion/base.rb
+++ b/migrations/core/lib/migrations/conversion/base.rb
@@ -76,7 +76,7 @@ module Migrations
         db_path = File.expand_path(settings[:intermediate_db][:path], Migrations.root_path)
         Database.migrate(db_path, migrations_path: Database::INTERMEDIATE_DB_SCHEMA_PATH)
 
-        db = Database.connect(db_path)
+        db = Database::DbWriter.new(path: db_path)
         Database::IntermediateDB.setup(db)
       end
 

--- a/migrations/core/lib/migrations/conversion/progress_step_executor.rb
+++ b/migrations/core/lib/migrations/conversion/progress_step_executor.rb
@@ -55,12 +55,12 @@ module Migrations
         work_queue = SizedQueue.new(MAX_QUEUE_SIZE)
 
         workers = start_workers(work_queue, worker_output_queue)
-        writer_thread = start_db_writer(worker_output_queue)
+        collector_thread = start_collector(worker_output_queue)
         push_work(work_queue)
 
         workers.each(&:wait)
         worker_output_queue.close
-        writer_thread.join
+        collector_thread.join
       end
 
       def calculate_max_progress
@@ -84,9 +84,9 @@ module Migrations
         ExtendedProgressBar.new(max_progress: @max_progress).run { |progressbar| yield progressbar }
       end
 
-      def start_db_writer(worker_output_queue)
+      def start_collector(worker_output_queue)
         Thread.new do
-          Thread.current.name = "writer_thread"
+          Thread.current.name = "collector_thread"
 
           with_progressbar do |progressbar|
             while (parametrized_insert_statements, stats = worker_output_queue.pop)
@@ -109,7 +109,7 @@ module Migrations
 
         Process.warmup
 
-        ForkManager.batch_forks do
+        ForkManager.with_batched_forks do
           WORKER_COUNT.times do |index|
             job = ParallelJob.new(@step.create_processor)
             workers << Worker.new(index, work_queue, worker_output_queue, job).start

--- a/migrations/core/lib/migrations/database/connection.rb
+++ b/migrations/core/lib/migrations/database/connection.rb
@@ -40,8 +40,8 @@ module Migrations
         close_connection(keep_path: false)
 
         before_hook, after_hook = @fork_hooks
-        ForkManager.remove_before_fork_hook(before_hook)
-        ForkManager.remove_after_fork_parent_hook(after_hook)
+        ForkManager.remove_before_fork(before_hook)
+        ForkManager.remove_after_fork_parent(after_hook)
       end
 
       def closed?

--- a/migrations/core/lib/migrations/database/db_writer.rb
+++ b/migrations/core/lib/migrations/database/db_writer.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Database
+    # Owns the `Connection` of the IntermediateDB for a whole conversion run and
+    # writes to it directly on the caller's thread.
+    #
+    # Steps run sequentially and each has a single IntermediateDB producer (the
+    # main thread for serial and plain `execute` steps, the collector thread for
+    # parallel steps), so there are never two concurrent writers and no
+    # cross-thread serialization is needed. Fork safety comes from the
+    # `Connection`'s own before/after-fork hooks; the single producer is the
+    # thread driving the fork and is never mid-insert when the before-fork hook
+    # runs.
+    #
+    # `insert`, `flush` and `close` are no-ops in forked child processes, where
+    # workers write through an `OfflineConnection` instead.
+    class DbWriter
+      class ClosedError < StandardError
+      end
+
+      def initialize(path:)
+        @owner_pid = Process.pid
+        @closed = false
+        @error = nil
+        @connection = Connection.new(path:)
+      end
+
+      def insert(sql, parameters = [])
+        return if Process.pid != @owner_pid
+
+        check_open!
+        raise @error if @error
+
+        begin
+          @connection.insert(sql, parameters)
+        rescue StandardError => e
+          # A failed statement aborts the run, just like today's inline path.
+          # Storing it keeps later calls failing fast instead of writing into a
+          # broken transaction. Single producer, so the bare flag is safe.
+          @error ||= e
+          raise
+        end
+        nil
+      end
+
+      # No-op in direct mode: every `insert` has already executed. Kept so a
+      # caller can issue a uniform barrier regardless of how the writer works.
+      def flush
+        return if Process.pid != @owner_pid
+
+        check_open!
+        raise @error if @error
+        nil
+      end
+
+      def close
+        return if Process.pid != @owner_pid
+        return if @closed
+
+        @closed = true
+        @connection.close
+        raise @error if @error
+        nil
+      end
+
+      def closed?
+        @closed
+      end
+
+      private
+
+      def check_open!
+        raise ClosedError, "`DbWriter` is closed" if @closed
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db.rb
@@ -2,6 +2,9 @@
 
 module Migrations
   module Database
+    # Facade for all IntermediateDB writes. `@db` is whatever `setup` received:
+    # a `DbWriter` during a conversion run, an `OfflineConnection` in forked
+    # workers, or a plain `Connection`.
     module IntermediateDB
       def self.setup(db_connection)
         close

--- a/migrations/core/spec/lib/common/fork_manager_spec.rb
+++ b/migrations/core/spec/lib/common/fork_manager_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Migrations::ForkManager do
       read_io.close
     end
 
-    it "runs hooks in every fork created by `batch_forks`" do
+    it "runs hooks in every fork created by `with_batched_forks`" do
       read_io, write_io = IO.pipe
       described_class.after_fork_child { write_io.write("x") }
 
-      described_class.batch_forks { 2.times { Process.waitpid(described_class.fork {}) } }
+      described_class.with_batched_forks { 2.times { Process.waitpid(described_class.fork {}) } }
       write_io.close
 
       expect(read_io.read).to eq("xx")
@@ -29,24 +29,24 @@ RSpec.describe Migrations::ForkManager do
 
     it "returns the hook so it can be removed again" do
       hook = described_class.after_fork_child { raise "this hook should not run" }
-      expect(described_class.size).to eq(1)
+      expect(described_class.hook_count).to eq(1)
 
-      described_class.remove_after_fork_child_hook(hook)
-      expect(described_class.size).to eq(0)
+      described_class.remove_after_fork_child(hook)
+      expect(described_class.hook_count).to eq(0)
 
       _, status = Process.waitpid2(described_class.fork {})
       expect(status).to be_success
     end
   end
 
-  describe ".remove_after_fork_child_hook" do
+  describe ".remove_after_fork_child" do
     it "stops the removed hook from running while other hooks keep running" do
       read_io, write_io = IO.pipe
       hook = described_class.after_fork_child { write_io.write("removed") }
       described_class.after_fork_child { write_io.write("kept") }
 
-      described_class.remove_after_fork_child_hook(hook)
-      expect(described_class.size).to eq(1)
+      described_class.remove_after_fork_child(hook)
+      expect(described_class.hook_count).to eq(1)
 
       Process.waitpid(described_class.fork {})
       write_io.close

--- a/migrations/core/spec/lib/database/connection_spec.rb
+++ b/migrations/core/spec/lib/database/connection_spec.rb
@@ -164,12 +164,12 @@ RSpec.describe Migrations::Database::Connection do
     end
 
     it "cleans up fork hooks when connection gets closed" do
-      expect(Migrations::ForkManager.size).to eq(0)
+      expect(Migrations::ForkManager.hook_count).to eq(0)
 
       create_connection do |connection|
-        expect(Migrations::ForkManager.size).to eq(2)
+        expect(Migrations::ForkManager.hook_count).to eq(2)
         connection.close
-        expect(Migrations::ForkManager.size).to eq(0)
+        expect(Migrations::ForkManager.hook_count).to eq(0)
       end
     end
   end

--- a/migrations/core/spec/lib/database/db_writer_spec.rb
+++ b/migrations/core/spec/lib/database/db_writer_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+RSpec.describe Migrations::Database::DbWriter do
+  def create_db_writer
+    Dir.mktmpdir do |storage_path|
+      db_path = File.join(storage_path, "test.db")
+
+      db = Extralite::Database.new(db_path)
+      db.execute("CREATE TABLE foo (id INTEGER)")
+      db.close
+
+      db_writer = described_class.new(path: db_path)
+
+      return db_writer if !block_given?
+
+      begin
+        yield db_writer, db_path
+      ensure
+        begin
+          db_writer.close
+        rescue StandardError
+          # a stored write error surfaces on close; the example already asserted it
+        end
+      end
+    end
+  end
+
+  def insert(db_writer, id)
+    db_writer.insert("INSERT INTO foo (id) VALUES (?)", [id])
+  end
+
+  def all_ids(db_path)
+    db = Extralite::Database.new(db_path)
+    db.query_splat("SELECT id FROM foo ORDER BY rowid")
+  ensure
+    db.close if db
+  end
+
+  describe "class" do
+    subject(:db_writer) { create_db_writer }
+
+    after { db_writer.close }
+
+    it_behaves_like "a database connection"
+  end
+
+  describe "#initialize" do
+    it "leaks no fork hooks when the connection cannot be opened" do
+      allow(Migrations::Database::Connection).to receive(:new).and_raise(
+        Extralite::Error,
+        "unable to open database file",
+      )
+
+      expect { described_class.new(path: "unused.db") }.to raise_error(Extralite::Error)
+      expect(Migrations::ForkManager.hook_count).to eq(0)
+    end
+  end
+
+  describe "#insert" do
+    it "writes statements in call order, visible after close" do
+      create_db_writer do |db_writer, db_path|
+        ids = (1..1_000).to_a
+        ids.each { |id| insert(db_writer, id) }
+        db_writer.close
+
+        expect(all_ids(db_path)).to eq(ids)
+      end
+    end
+
+    it "writes on the caller's thread, spawning no background thread" do
+      create_db_writer do |db_writer|
+        thread_count = Thread.list.size
+        insert(db_writer, 1)
+        expect(Thread.list.size).to eq(thread_count)
+      end
+    end
+
+    it "raises after close" do
+      create_db_writer do |db_writer|
+        db_writer.close
+        expect { insert(db_writer, 1) }.to raise_error(described_class::ClosedError)
+      end
+    end
+  end
+
+  describe "#flush" do
+    it "is a no-op" do
+      create_db_writer do |db_writer|
+        insert(db_writer, 1)
+        expect(db_writer.flush).to be_nil
+      end
+    end
+  end
+
+  describe "#close" do
+    it "commits all statements and makes them visible to other connections" do
+      create_db_writer do |db_writer, db_path|
+        1.upto(10) { |id| insert(db_writer, id) }
+        db_writer.close
+
+        expect(all_ids(db_path)).to eq((1..10).to_a)
+      end
+    end
+
+    it "can be called multiple times" do
+      create_db_writer do |db_writer|
+        insert(db_writer, 1)
+        db_writer.close
+        expect { db_writer.close }.not_to raise_error
+        expect(db_writer.closed?).to be true
+      end
+    end
+
+    it "cleans up the connection's fork hooks" do
+      expect(Migrations::ForkManager.hook_count).to eq(0)
+
+      create_db_writer do |db_writer|
+        # only the connection's own before/after-fork hook pair
+        expect(Migrations::ForkManager.hook_count).to eq(2)
+        db_writer.close
+        expect(Migrations::ForkManager.hook_count).to eq(0)
+      end
+    end
+  end
+
+  describe "error propagation" do
+    it "fails fast on a bad statement and keeps failing on the stored error" do
+      create_db_writer do |db_writer|
+        expect {
+          db_writer.insert("INSERT INTO missing_table (id) VALUES (?)", [1])
+        }.to raise_error(Extralite::Error)
+
+        # the stored error keeps surfacing
+        expect { insert(db_writer, 1) }.to raise_error(Extralite::Error)
+        expect { db_writer.flush }.to raise_error(Extralite::Error)
+
+        # close re-raises it but still closes the connection
+        expect { db_writer.close }.to raise_error(Extralite::Error)
+        expect(db_writer.closed?).to be true
+        expect(Migrations::ForkManager.hook_count).to eq(0)
+      end
+    end
+  end
+
+  context "in a forked child process" do
+    it "no-ops `insert`/`flush`/`close` and leaves the parent intact" do
+      create_db_writer do |db_writer, db_path|
+        insert(db_writer, 1)
+
+        child_pid =
+          fork do
+            insert(db_writer, 999)
+            db_writer.flush
+            db_writer.close
+            exit!(0)
+          rescue Exception
+            exit!(1)
+          end
+
+        Process.wait(child_pid)
+        expect($?.exitstatus).to eq(0)
+
+        # parent's writer is untouched; the child's row was never written
+        db_writer.close
+        expect(all_ids(db_path)).to eq([1])
+      end
+    end
+  end
+
+  context "when `Migrations::ForkManager` opens a fork window" do
+    it "commits and reopens via the connection's own hooks, losing nothing" do
+      create_db_writer do |db_writer, db_path|
+        connection = db_writer.instance_variable_get(:@connection)
+
+        1.upto(5) { |id| insert(db_writer, id) }
+
+        Migrations::ForkManager.with_batched_forks do
+          # the connection's own before-fork hook committed and closed it, so
+          # earlier statements are visible to other connections
+          expect(connection.closed?).to be true
+          expect(all_ids(db_path)).to eq((1..5).to_a)
+        end
+
+        # reopened after the fork window
+        expect(connection.closed?).to be false
+        insert(db_writer, 6)
+
+        db_writer.close
+        expect(all_ids(db_path)).to eq((1..6).to_a)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Second foundation PR for step-level concurrency.

Right now IntermediateDB writes hit the SQLite connection from two places: serial and plain
`execute` steps write inline on the main thread, parallel steps from a per-step collector thread.
This adds one run-owned `DbWriter` — created in `Conversion::Base#create_database`, alive for the
whole run — that owns the `Connection` and writes **directly on the caller's thread**.

No queue, no writer thread: there's only ever one producer at a time today (steps run
sequentially). Benchmarks on `mt/db-writer-parallelism-research` showed a per-row queue handoff
is up to ~8x slower than inline for cheap rows — the cost is GVL contention between a live
producer thread and the SQLite-busy consumer, not the queue itself — and it buys nothing without
concurrent producers. Fork safety comes from the `Connection`'s own fork hooks; the single
producer drives the fork and is never mid-insert. `insert`/`flush`/`close` are pid-guarded no-ops
in forked children, where workers write to an `OfflineConnection`.

Behavior-preserving on the current sequential path — no scheduler, no concurrency between steps,
no API changes for step authors. The sharded-writer scaling work (separate processes + a cheap
merge) is a later PR. Also clarifies the ForkManager hook API names.
