### PR TITLE
DEV: Ensure db_timestamps_mover only touches non-null columns

### DIFF
--- a/script/db_timestamps_mover.rb
+++ b/script/db_timestamps_mover.rb
@@ -114,6 +114,7 @@ class TimestampsUpdater
     sql = <<~SQL
       UPDATE #{table_name}
       SET #{column_name} = #{new_value}
+      WHERE #{column_name} IS NOT NULL
     SQL
     @raw_connection.exec(sql)
   end


### PR DESCRIPTION
The change in 08666408a68ca037b272a9ff5f47920083a73018 caused all timestamp columns to fallback to use `now()`, even if they were previously null. That included things like `users.silenced_at`, `topic.deleted_at`, etc., which caused all sorts of strange behavior.