### PR TITLE
DEV: Re-fetch bundler in linting CI so its checksum survives

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -44,6 +44,8 @@ jobs:
           bundle config --local deployment true
           bundle config --local without development
           bundle config --local lockfile_checksums true
+          # Drop the prebuilt bundler so `bundle install` re-fetches it, caching the .gem its checksum line needs
+          rm -rf vendor/bundle/ruby/*/gems/bundler-* vendor/bundle/ruby/*/specifications/bundler-*
           bundle install --jobs 4
           bundle clean
 
@@ -57,7 +59,13 @@ jobs:
           bundle lock --add-checksums
           bundle lock --normalize-platforms
           if [[ $(git status -s Gemfile.lock) ]]; then
-            echo "Gemfile.lock is not up to date. Please run 'bundle lock --add-checksums' and 'bundle lock --normalize-platforms'." && false
+            echo "Gemfile.lock is not up to date. To resolve, run:"
+            echo "  bundle lock --add-checksums && bundle lock --normalize-platforms"
+            echo
+            echo "Or manually apply the diff printed below:"
+            echo "---------------------------------------------"
+            git -c color.ui=always diff Gemfile.lock
+            exit 1
           fi
 
       - name: Rubocop


### PR DESCRIPTION
The discourse_test image installs the locked bundler into vendor/bundle and then deletes the gem cache. bundler's CHECKSUMS line is computed from the cached .gem, so when BUNDLED WITH points at a bundler that only lives in the stripped vendor/bundle cache, `bundle lock --add-checksums` silently drops the line and the lockfile check fails.

Removing the prebuilt bundler makes `bundle install` auto-install it, which re-caches the .gem the checksum step needs.

This commit also improves the checksums CI step, so that any problematic diff is printed to the console (like we do for annotations & db structure steps)