### PR TITLE
FIX: Include rollup file hash in plugin entrypoint filenames

### DIFF
--- a/frontend/asset-processor/theme-rollup.js
+++ b/frontend/asset-processor/theme-rollup.js
@@ -115,7 +115,7 @@ async function performRollup(modules, opts) {
   const bundle = await result.generate({
     format: "es",
     sourcemap: "hidden",
-    entryFileNames: `${opts.filenamePrefix ?? ""}[name]${opts.filenameSuffix ?? ""}.js`,
+    entryFileNames: `${opts.filenamePrefix ?? ""}[name].[hash:6]${opts.filenameSuffix ?? ""}.js`,
     chunkFileNames: `${opts.filenamePrefix ?? ""}chunk.[hash:6]${opts.filenameSuffix ?? ""}.js`,
   });
 

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AssetProcessor
-  BASE_COMPILER_VERSION = 109
+  BASE_COMPILER_VERSION = 110
 
   PROCESSOR_DIR = "tmp/asset-processor"
   LOCK_FILE = "#{PROCESSOR_DIR}/build.lock"

--- a/lib/plugin/js_manager.rb
+++ b/lib/plugin/js_manager.rb
@@ -117,12 +117,15 @@ module Plugin
       filename_prefix = "#{plugin.directory_name}_"
       filename_suffix = "-#{base36_digest}.digested"
 
-      expected_entrypoints =
-        entrypoints_config.keys.map do |name|
-          "#{js_dir}/#{filename_prefix}#{name}#{filename_suffix}.js"
-        end
+      existing_files = Dir.glob("#{js_dir}/*").map { |path| File.basename(path) }
 
-      files_exist = expected_entrypoints.all? { |path| File.exist?(path) }
+      files_exist =
+        entrypoints_config.keys.all? do |name|
+          existing_files.any? do |file|
+            file.start_with?("#{filename_prefix}#{name}.") &&
+              file.end_with?("#{filename_suffix}.js")
+          end
+        end
 
       if !cache? || !files_exist
         compiler =

--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -61,6 +61,8 @@ def assets
   load_path.assets.each do |asset|
     fullpath = "#{Rails.root.join("public/assets/#{asset.digested_path}")}"
 
+    next if fullpath.end_with?(".gz", ".br")
+
     content_type = MiniMime.lookup_by_filename(fullpath)&.content_type
     content_type ||= "application/json" if fullpath.end_with?(".map")
 

--- a/lib/theme_javascript_compiler.rb
+++ b/lib/theme_javascript_compiler.rb
@@ -49,8 +49,9 @@ class ThemeJavascriptCompiler
           },
         )
 
-      @content = output["main.js"]["code"]
-      @source_map = output["main.js"]["map"]
+      main = output.values.find { |chunk| chunk["name"] == "main" }
+      @content = main["code"]
+      @source_map = main["map"]
     end
     [@content, @source_map]
   rescue AssetProcessor::TranspileError => e

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe AssetProcessor do
+  def entrypoint(result, name)
+    result.values.find { |chunk| chunk["name"] == name }
+  end
+
   describe "skip_module?" do
     it "returns false for empty strings" do
       expect(AssetProcessor.skip_module?(nil)).to eq(false)
@@ -121,11 +125,11 @@ RSpec.describe AssetProcessor do
           { entrypoints: { main: { modules: ["discourse/initializers/hello.gjs"] } } },
         )
 
-      code = result["main.js"]["code"]
+      code = entrypoint(result, "main")["code"]
       expect(code).to include('"hello world"')
       expect(code).to include("dt7948") # Decorator transform
 
-      expect(result["main.js"]["map"]).not_to be_nil
+      expect(entrypoint(result, "main")["map"]).not_to be_nil
     end
 
     it "supports decorators and class properties without error" do
@@ -147,7 +151,7 @@ RSpec.describe AssetProcessor do
           { "discourse/initializers/foo.js" => script },
           { entrypoints: { main: { modules: ["discourse/initializers/foo.js"] } } },
         )
-      expect(result["main.js"]["code"]).to include("dt7948.n")
+      expect(entrypoint(result, "main")["code"]).to include("dt7948.n")
     end
 
     it "supports object literal decorators without errors" do
@@ -167,7 +171,7 @@ RSpec.describe AssetProcessor do
           { "discourse/initializers/foo.js" => script },
           { entrypoints: { main: { modules: ["discourse/initializers/foo.js"] } } },
         )
-      expect(result["main.js"]["code"]).to include("dt7948")
+      expect(entrypoint(result, "main")["code"]).to include("dt7948")
     end
 
     it "can use themePrefix in a template" do
@@ -183,7 +187,7 @@ RSpec.describe AssetProcessor do
           { "discourse/initializers/foo.gjs" => script },
           { themeId: 22, entrypoints: { main: { modules: ["discourse/initializers/foo.gjs"] } } },
         )
-      expect(result["main.js"]["code"]).to include(
+      expect(entrypoint(result, "main")["code"]).to include(
         'window.moduleBroker.lookup("discourse/lib/theme-settings-store")',
       )
     end
@@ -200,7 +204,7 @@ RSpec.describe AssetProcessor do
           { "discourse/initializers/foo.js" => script },
           { themeId: 22, entrypoints: { main: { modules: ["discourse/initializers/foo.js"] } } },
         )
-      expect(result["main.js"]["code"]).to include(
+      expect(entrypoint(result, "main")["code"]).to include(
         'window.moduleBroker.lookup("discourse/lib/theme-settings-store")',
       )
     end
@@ -223,7 +227,7 @@ RSpec.describe AssetProcessor do
           },
         },
       )
-    code = result["main.js"]["code"]
+    code = entrypoint(result, "main")["code"]
     expect(code).to include("createTemplateFactory")
     expect(code).to include("deprecated(")
     expect(code).to include('id: "discourse.hbs-extension"')
@@ -260,8 +264,8 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["code"]).to include("setComponentTemplate")
-    expect(result["main.js"]["code"]).to include(
+    expect(entrypoint(result, "main")["code"]).to include("setComponentTemplate")
+    expect(entrypoint(result, "main")["code"]).to include(
       "bar = setComponentTemplate(__COLOCATED_TEMPLATE__, templateOnly());",
     )
   end
@@ -298,10 +302,12 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["code"]).to include(
+    expect(entrypoint(result, "main")["code"]).to include(
       'compatModules["discourse/templates/connectors/foo"]',
     ).once
-    expect(result["main.js"]["code"]).to include('compatModules["discourse/connectors/foo"]').once
+    expect(entrypoint(result, "main")["code"]).to include(
+      'compatModules["discourse/connectors/foo"]',
+    ).once
   end
 
   it "handles relative imports from one module to another" do
@@ -330,7 +336,7 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["code"]).not_to include("../components/my-component")
+    expect(entrypoint(result, "main")["code"]).not_to include("../components/my-component")
   end
 
   it "handles relative import of index file" do
@@ -362,7 +368,7 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["code"]).not_to include("../components/my-component")
+    expect(entrypoint(result, "main")["code"]).not_to include("../components/my-component")
   end
 
   it "handles relative import of gjs index file" do
@@ -394,7 +400,7 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["code"]).not_to include("../components/my-component")
+    expect(entrypoint(result, "main")["code"]).not_to include("../components/my-component")
   end
 
   it "prioritizes exact match over /index match" do
@@ -425,8 +431,8 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["code"]).to include("module 1")
-    expect(result["main.js"]["code"]).to include("module 2")
+    expect(entrypoint(result, "main")["code"]).to include("module 1")
+    expect(entrypoint(result, "main")["code"]).to include("module 2")
   end
 
   it "returns the ember version" do
@@ -477,15 +483,15 @@ RSpec.describe AssetProcessor do
         },
       )
 
-    expect(result["main.js"]["imports"].length).to eq(1)
-    expect(result["main.js"]["imports"].first).to include("chunk")
-    expect(result["main.js"]["name"]).to eq("main")
-    expect(result["main.js"]["isEntry"]).to eq(true)
+    expect(entrypoint(result, "main")["imports"].length).to eq(1)
+    expect(entrypoint(result, "main")["imports"].first).to include("chunk")
+    expect(entrypoint(result, "main")["name"]).to eq("main")
+    expect(entrypoint(result, "main")["isEntry"]).to eq(true)
 
-    expect(result["admin.js"]["imports"].length).to eq(1)
-    expect(result["admin.js"]["imports"].first).to include("chunk")
-    expect(result["admin.js"]["name"]).to eq("admin")
-    expect(result["admin.js"]["isEntry"]).to eq(true)
+    expect(entrypoint(result, "admin")["imports"].length).to eq(1)
+    expect(entrypoint(result, "admin")["imports"].first).to include("chunk")
+    expect(entrypoint(result, "admin")["name"]).to eq("admin")
+    expect(entrypoint(result, "admin")["isEntry"]).to eq(true)
   end
 
   it "errors on missing relative imports" do


### PR DESCRIPTION
The content and hash of rollup chunks may vary when various internals/dependencies change. Previously, we didn't include the rollup hash on entrypoint filenames - we just relied on the Discourse-controlled input hash. We did include the rollup hash for chunks. That meant we could end up in a situation where the chunk filenames have changed, but cached entrypoints still reference the old chunk filenames.

Also adds a guard to ensure we don't double-upload `.gz` assets to S3.