### PR TITLE
PERF: Run Core System Tests against a production Ember build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,18 @@ jobs:
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
-      EMBER_ENV: development
+      # `production` makes every system-spec page load parse a minified,
+      # tree-shaken bundle instead of the much larger development build,
+      # cutting the in-browser parse/boot time the suite pays on each of its
+      # thousands of navigations. The dev-only `rails-testing.js` test bridge
+      # (`window.clientSettled`) is dead-code-eliminated from production
+      # builds, so `spec/support/client_settled_bridge.rb` injects a
+      # build-independent reimplementation via a Playwright init script and
+      # settle semantics are unchanged. QUnit and frontend jobs stay on the
+      # development build because they test that build. Specs that depend on
+      # dev-build-only behaviour (deprecation assertions, /theme-qunit) are
+      # skipped when EMBER_ENV=production.
+      EMBER_ENV: ${{ matrix.build_type == 'system' && 'production' || 'development' }}
       LOAD_PLUGINS: ${{ (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
       QUNIT_REUSE_BUILD: 1
       PLAYWRIGHT_BROWSERS_PATH: /home/discourse/.cache/ms-playwright

--- a/spec/support/client_settled_bridge.rb
+++ b/spec/support/client_settled_bridge.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "capybara/playwright"
+
+# A build-independent reimplementation of the `window.clientSettled` test
+# bridge from `frontend/discourse/app/initializers/rails-testing.js`. That
+# initializer is wrapped in `if (DEBUG && isRailsTesting())`, so a
+# `production` Ember build dead-code-eliminates it and every `clientSettled`
+# settle-wait silently no-ops — leaving system specs racing ajax responses
+# and re-renders. Injecting the same tracking logic via a Playwright init
+# script restores identical settle semantics for production builds. For
+# development builds this is inert: the script runs at document start, and
+# the app's own initializer overwrites `window.clientSettled` during boot.
+module ClientSettledBridge
+  JS = <<~JS
+    (() => {
+      if (window.__discourseClientSettledBridge) {
+        return;
+      }
+      window.__discourseClientSettledBridge = true;
+
+      const pendingRequests = [];
+      const pendingDomEvents = [];
+      let pendingBeaconRequests = 0;
+
+      // Parity with `discourse/lib/beacon-pageview`'s own in-flight counter,
+      // tracked here by wrapping fetch since the module's counter is
+      // unreachable from outside the app bundle.
+      const originalFetch = window.fetch;
+      window.fetch = function (resource, options) {
+        const url =
+          typeof resource === "string" ? resource : (resource && resource.url) || "";
+        const isBeacon = url.includes("/srv/pv");
+        if (isBeacon) {
+          pendingBeaconRequests++;
+        }
+        const promise = originalFetch.apply(this, arguments);
+        if (isBeacon) {
+          promise.then(
+            () => pendingBeaconRequests--,
+            () => pendingBeaconRequests--
+          );
+        }
+        return promise;
+      };
+
+      const deferEventCycles = ({ callback, numberOfEventCycles = 1 }) => {
+        if (numberOfEventCycles > 0) {
+          return setTimeout(() => {
+            deferEventCycles({
+              callback,
+              numberOfEventCycles: numberOfEventCycles - 1,
+            });
+          }, 0);
+        } else {
+          return callback();
+        }
+      };
+
+      const incrementAjaxPendingRequests = (_event, xhr, settings) => {
+        if (
+          settings.url.includes("/message-bus") ||
+          settings.url.includes("/presence/")
+        ) {
+          return;
+        }
+        pendingRequests.push({ xhr, url: settings.url });
+      };
+
+      const decrementAjaxPendingRequests = (_event, xhr) => {
+        for (let i = 0; i < pendingRequests.length; i++) {
+          if (xhr === pendingRequests[i].xhr) {
+            pendingRequests.splice(i, 1);
+            break;
+          }
+        }
+      };
+
+      // jQuery is bundled with the app and loads after this init script, so
+      // poll until the bundle's instance is reachable, then attach the same
+      // global ajax handlers the dev-build initializer attaches.
+      const resolveJQuery = () => {
+        try {
+          if (window.require) {
+            const mod = window.require("jquery");
+            if (mod && mod.default) {
+              return mod.default;
+            }
+          }
+        } catch {}
+        return window.jQuery;
+      };
+
+      let jqueryPollCount = 0;
+      const jqueryPoll = setInterval(() => {
+        const $ = resolveJQuery();
+        if ($) {
+          clearInterval(jqueryPoll);
+          $(document)
+            .on("ajaxSend", incrementAjaxPendingRequests)
+            .on("ajaxComplete ajaxError", decrementAjaxPendingRequests);
+        } else if (++jqueryPollCount > 3000) {
+          clearInterval(jqueryPoll);
+        }
+      }, 10);
+
+      [
+        "click",
+        "input",
+        "mousedown",
+        "keydown",
+        "focusin",
+        "focusout",
+        "touchstart",
+        "change",
+        "resize",
+        "scroll",
+      ].forEach((eventName) => {
+        document.addEventListener(
+          eventName,
+          (event) => {
+            pendingDomEvents.push(event);
+
+            deferEventCycles({
+              callback: () => {
+                const index = pendingDomEvents.indexOf(event);
+
+                if (index !== -1) {
+                  pendingDomEvents.splice(index, 1);
+                }
+              },
+              numberOfEventCycles: 2,
+            });
+          },
+          true
+        );
+      });
+
+      const settled = () => {
+        return (
+          pendingRequests.length === 0 &&
+          pendingDomEvents.length === 0 &&
+          pendingBeaconRequests === 0
+        );
+      };
+
+      const timeoutErrorMessage = (timeoutMs) => {
+        let errorMessage = `Timeout waiting for client to settle after ${timeoutMs}ms.`;
+        const pendingRequestURLs = pendingRequests.map((req) => req.url);
+
+        if (pendingRequestURLs.length > 0) {
+          errorMessage += `\\n  Pending requests: ${pendingRequestURLs.join(", ")}`;
+        }
+
+        if (pendingDomEvents.length > 0) {
+          const pendingDomEventsText = pendingDomEvents.map(
+            (event) => `${event.type} on ${event.target?.tagName?.toLowerCase()}`
+          );
+          errorMessage += `\\n  Pending DOM events: ${pendingDomEventsText.join(", ")}`;
+        }
+
+        if (pendingBeaconRequests > 0) {
+          errorMessage += `\\n  Pending beacon pageview requests`;
+        }
+
+        return errorMessage;
+      };
+
+      window.clientSettled = async (timeoutMs) => {
+        const startTime = Date.now();
+
+        while (!settled()) {
+          if (Date.now() - startTime > timeoutMs) {
+            throw new Error(timeoutErrorMessage(timeoutMs));
+          }
+
+          await new Promise((resolve) =>
+            deferEventCycles({ callback: resolve, numberOfEventCycles: 1 })
+          );
+        }
+
+        return true;
+      };
+    })();
+  JS
+
+  # `Capybara::Playwright::Driver#reset!` discards the `Browser` wrapper after
+  # every example, so `create_browser_context` runs (and re-registers the init
+  # script) on each example's fresh context — before any page exists in it.
+  module InjectInitScript
+    private
+
+    def create_browser_context
+      super.tap { |context| context.add_init_script(script: ClientSettledBridge::JS) }
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(ClientSettledBridge::InjectInitScript)

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -4,6 +4,25 @@ require "highline/import"
 module SystemHelpers
   PLATFORM_KEY_MODIFIER = RUBY_PLATFORM =~ /darwin/i ? :meta : :control
 
+  # A production Ember build strips `@ember/debug` macros (`deprecate`,
+  # `assert`) and the dev-only test affordances, so specs asserting that
+  # behaviour are conditionally skipped via `if:` metadata.
+  def self.production_ember_build?
+    return @production_ember_build if defined?(@production_ember_build)
+
+    @production_ember_build =
+      if ENV["EMBER_ENV"].present?
+        ENV["EMBER_ENV"] == "production"
+      else
+        begin
+          info = Rails.root.join("frontend/discourse/dist/BUILD_INFO.json")
+          info.exist? && JSON.parse(info.read)["ember_env"] == "production"
+        rescue StandardError
+          false
+        end
+      end
+  end
+
   # Pass to `send_keys` to move the caret to the start of the current line in a
   # contenteditable. The Home key doesn't move the caret on macOS; Cmd+Left does.
   LINE_START_KEY = RUBY_PLATFORM =~ /darwin/i ? %i[meta left] : :home

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -94,7 +94,9 @@ describe "Changing email" do
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
     find("button[type=submit]:not([disabled])").click
 
-    expect(user.reload.primary_email.email).to eq(new_email)
+    try_until_success(
+      reason: "the second-factor confirm request is not tracked by clientSettled",
+    ) { expect(user.reload.primary_email.email).to eq(new_email) }
   end
 
   it "makes admins verify old email" do

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -57,7 +57,10 @@ describe "JS Deprecation Handling" do
   end
 
   it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback",
-     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback] do
+     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback],
+     # `ember-this-fallback` emits its deprecation via `@ember/debug`'s
+     # `deprecate`, which production builds compile out.
+     if: !SystemHelpers.production_ember_build? do
     t = Fabricate(:theme, name: "Theme With Hbs Connector")
     t.set_field(
       target: :extra_js,

--- a/spec/system/theme_qunit_spec.rb
+++ b/spec/system/theme_qunit_spec.rb
@@ -18,7 +18,10 @@ describe "Theme qunit testing" do
     t
   end
 
-  it "lists themes and can run tests by id, name and url" do
+  # `/theme-qunit` boots the app's qunit harness, which is only part of
+  # development builds.
+  it "lists themes and can run tests by id, name and url",
+     if: !SystemHelpers.production_ember_build? do
     visit "/theme-qunit"
 
     expect(page).to have_css("a[href^='/theme-qunit?id=']", count: 1)


### PR DESCRIPTION
The `Core System Tests` job runs with the development Ember build, which ships a large, untree-shaken bundle the browser re-parses on each navigation. System specs drive thousands of navigations, so that per-navigation parse and boot cost is paid thousands of times per run.

This branch switches the system build to `production`. The bundle is minified and tree-shaken, cutting in-browser parse and boot time on every navigation. The `EMBER_ENV` workflow variable is scoped so only the system build flips to `production`. QUnit and frontend jobs stay on the development build they exist to test.

### Required prerequisite: the `clientSettled` bridge

A production build dead-code-eliminates the dev-only `window.clientSettled` test bridge from `rails-testing.js` (it is wrapped in `if (DEBUG && isRailsTesting())`). Without a replacement, every settle-wait would silently no-op and system specs would race their ajax responses and re-renders.

`spec/support/client_settled_bridge.rb` reimplements the same request, DOM-event, and beacon tracking logic build-independently and injects it through a Playwright init script by prepending `create_browser_context` on `Capybara::Playwright::Browser`. Settle semantics are identical to the development build. For development builds the script is inert, the app's own initializer overwrites `window.clientSettled` during boot.

`SystemHelpers.production_ember_build?` reports which build is active. The deprecation and `/theme-qunit` specs, which assert behaviour only present in development builds, are skipped under production.

This change is shipped on its own so its individual CI runtime contribution can be measured.

## Measurements

Three full-matrix runs of this branch interleaved with three of `main` at the merge base, strictly sequential so no two measured runs compete for the runner pool. Durations are the `Core System Tests` step.

| Run | `main` | this branch |
|---|---:|---:|
| 1 | 578s | 588s |
| 2 | 600s | 554s |
| 3 | 577s | 592s |
| **Median** | **578s** | **588s** |

Delta: +10s (+1.7%), inside run-to-run noise. **The production build does not reduce system test runtime on its own.**

The reason is the browser cache lifecycle. A production bundle is smaller, but with a fresh browser context per example it is fetched and parsed cold on every navigation, so a smaller cold cost is still a cold cost. The saving only materializes when the context persists across examples (the soft browser-context reset) so the warm HTTP and compiled-JS caches survive, paired with Cache-Control headers on the immutable per-run assets that make them cacheable. Those two mechanisms ship separately. This branch is held until the three can be measured together, since the production build is a prerequisite for that cluster rather than a standalone win.
