### PR TITLE
PERF: Warm the system-test browser cache across examples

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,18 @@ jobs:
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
-      EMBER_ENV: development
+      # `production` makes every system-spec page load parse a minified,
+      # tree-shaken bundle instead of the much larger development build,
+      # cutting the in-browser parse/boot time the suite pays on each of its
+      # thousands of navigations. The dev-only `rails-testing.js` test bridge
+      # (`window.clientSettled`) is dead-code-eliminated from production
+      # builds, so `spec/support/client_settled_bridge.rb` injects a
+      # build-independent reimplementation via a Playwright init script and
+      # settle semantics are unchanged. QUnit and frontend jobs stay on the
+      # development build because they test that build. Specs that depend on
+      # dev-build-only behaviour (deprecation assertions, /theme-qunit) are
+      # skipped when EMBER_ENV=production.
+      EMBER_ENV: ${{ matrix.build_type == 'system' && 'production' || 'development' }}
       LOAD_PLUGINS: ${{ (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
       QUNIT_REUSE_BUILD: 1
       PLAYWRIGHT_BROWSERS_PATH: /home/discourse/.cache/ms-playwright

--- a/spec/support/client_settled_bridge.rb
+++ b/spec/support/client_settled_bridge.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "capybara/playwright"
+
+# A build-independent reimplementation of the `window.clientSettled` test
+# bridge from `frontend/discourse/app/initializers/rails-testing.js`. That
+# initializer is wrapped in `if (DEBUG && isRailsTesting())`, so a
+# `production` Ember build dead-code-eliminates it and every `clientSettled`
+# settle-wait silently no-ops — leaving system specs racing ajax responses
+# and re-renders. Injecting the same tracking logic via a Playwright init
+# script restores identical settle semantics for production builds. For
+# development builds this is inert: the script runs at document start, and
+# the app's own initializer overwrites `window.clientSettled` during boot.
+module ClientSettledBridge
+  JS = <<~JS
+    (() => {
+      if (window.__discourseClientSettledBridge) {
+        return;
+      }
+      window.__discourseClientSettledBridge = true;
+
+      const pendingRequests = [];
+      const pendingDomEvents = [];
+      let pendingBeaconRequests = 0;
+
+      // Parity with `discourse/lib/beacon-pageview`'s own in-flight counter,
+      // tracked here by wrapping fetch since the module's counter is
+      // unreachable from outside the app bundle.
+      const originalFetch = window.fetch;
+      window.fetch = function (resource, options) {
+        const url =
+          typeof resource === "string" ? resource : (resource && resource.url) || "";
+        const isBeacon = url.includes("/srv/pv");
+        if (isBeacon) {
+          pendingBeaconRequests++;
+        }
+        const promise = originalFetch.apply(this, arguments);
+        if (isBeacon) {
+          promise.then(
+            () => pendingBeaconRequests--,
+            () => pendingBeaconRequests--
+          );
+        }
+        return promise;
+      };
+
+      const deferEventCycles = ({ callback, numberOfEventCycles = 1 }) => {
+        if (numberOfEventCycles > 0) {
+          return setTimeout(() => {
+            deferEventCycles({
+              callback,
+              numberOfEventCycles: numberOfEventCycles - 1,
+            });
+          }, 0);
+        } else {
+          return callback();
+        }
+      };
+
+      const incrementAjaxPendingRequests = (_event, xhr, settings) => {
+        if (
+          settings.url.includes("/message-bus") ||
+          settings.url.includes("/presence/")
+        ) {
+          return;
+        }
+        pendingRequests.push({ xhr, url: settings.url });
+      };
+
+      const decrementAjaxPendingRequests = (_event, xhr) => {
+        for (let i = 0; i < pendingRequests.length; i++) {
+          if (xhr === pendingRequests[i].xhr) {
+            pendingRequests.splice(i, 1);
+            break;
+          }
+        }
+      };
+
+      // jQuery is bundled with the app and loads after this init script, so
+      // poll until the bundle's instance is reachable, then attach the same
+      // global ajax handlers the dev-build initializer attaches.
+      const resolveJQuery = () => {
+        try {
+          if (window.require) {
+            const mod = window.require("jquery");
+            if (mod && mod.default) {
+              return mod.default;
+            }
+          }
+        } catch {}
+        return window.jQuery;
+      };
+
+      let jqueryPollCount = 0;
+      const jqueryPoll = setInterval(() => {
+        const $ = resolveJQuery();
+        if ($) {
+          clearInterval(jqueryPoll);
+          $(document)
+            .on("ajaxSend", incrementAjaxPendingRequests)
+            .on("ajaxComplete ajaxError", decrementAjaxPendingRequests);
+        } else if (++jqueryPollCount > 3000) {
+          clearInterval(jqueryPoll);
+        }
+      }, 10);
+
+      [
+        "click",
+        "input",
+        "mousedown",
+        "keydown",
+        "focusin",
+        "focusout",
+        "touchstart",
+        "change",
+        "resize",
+        "scroll",
+      ].forEach((eventName) => {
+        document.addEventListener(
+          eventName,
+          (event) => {
+            pendingDomEvents.push(event);
+
+            deferEventCycles({
+              callback: () => {
+                const index = pendingDomEvents.indexOf(event);
+
+                if (index !== -1) {
+                  pendingDomEvents.splice(index, 1);
+                }
+              },
+              numberOfEventCycles: 2,
+            });
+          },
+          true
+        );
+      });
+
+      const settled = () => {
+        return (
+          pendingRequests.length === 0 &&
+          pendingDomEvents.length === 0 &&
+          pendingBeaconRequests === 0
+        );
+      };
+
+      const timeoutErrorMessage = (timeoutMs) => {
+        let errorMessage = `Timeout waiting for client to settle after ${timeoutMs}ms.`;
+        const pendingRequestURLs = pendingRequests.map((req) => req.url);
+
+        if (pendingRequestURLs.length > 0) {
+          errorMessage += `\\n  Pending requests: ${pendingRequestURLs.join(", ")}`;
+        }
+
+        if (pendingDomEvents.length > 0) {
+          const pendingDomEventsText = pendingDomEvents.map(
+            (event) => `${event.type} on ${event.target?.tagName?.toLowerCase()}`
+          );
+          errorMessage += `\\n  Pending DOM events: ${pendingDomEventsText.join(", ")}`;
+        }
+
+        if (pendingBeaconRequests > 0) {
+          errorMessage += `\\n  Pending beacon pageview requests`;
+        }
+
+        return errorMessage;
+      };
+
+      window.clientSettled = async (timeoutMs) => {
+        const startTime = Date.now();
+
+        while (!settled()) {
+          if (Date.now() - startTime > timeoutMs) {
+            throw new Error(timeoutErrorMessage(timeoutMs));
+          }
+
+          await new Promise((resolve) =>
+            deferEventCycles({ callback: resolve, numberOfEventCycles: 1 })
+          );
+        }
+
+        return true;
+      };
+    })();
+  JS
+
+  # `create_browser_context` adds the init script to a context before any page
+  # exists in it. A soft reset keeps the context alive across examples, so the
+  # script stays registered without re-running this; a hard reset disposes the
+  # context and re-runs `create_browser_context`, which re-registers the script.
+  module InjectInitScript
+    private
+
+    def create_browser_context
+      super.tap { |context| context.add_init_script(script: ClientSettledBridge::JS) }
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(ClientSettledBridge::InjectInitScript)

--- a/spec/support/playwright_soft_reset.rb
+++ b/spec/support/playwright_soft_reset.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "capybara/playwright"
+require "timeout"
+
+# Reset per-example browser state in-place instead of closing the browser
+# context between system specs. Closing the context discards its HTTP and
+# compiled-script caches, so every example's first navigation re-fetches and
+# re-parses the full application bundle. Keeping the context alive and clearing
+# cookies, permissions and per-origin storage gives the next example the same
+# isolation with a warm cache.
+#
+# This is implemented as `prepend` modules over the published
+# `capybara-playwright-driver` (0.5.9) instead of a vendored fork, since the
+# whole change is additive/interceptive — exactly like `client_settled_bridge.rb`.
+module PlaywrightSoftReset
+  # Reproduces the `Capybara::Playwright::Browser` half of the patch: a service
+  # worker block at context creation, plus the in-place reset machinery.
+  module Browser
+    # Service workers are blocked by default: no test exercises them, every
+    # page boot re-registers one (a fetch + install + activate cycle per
+    # test today), and a live worker makes context state much harder to
+    # reset in-place - CDP Storage clearing stalls indefinitely waiting for
+    # an installing worker to terminate.
+    #
+    # `client_settled_bridge.rb` also prepends `create_browser_context`; both
+    # chain through `super`, so merging the option here (rather than passing it
+    # as an explicit kwarg) keeps the two prepends conflict-free.
+    def create_browser_context
+      @page_options = { serviceWorkers: "block" }.merge(@page_options)
+      super
+    end
+
+    # Returns false (and the caller falls back to a full context reset)
+    # whenever the browser is in a state this fast path does not understand.
+    def soft_reset!
+      contexts = @playwright_browser.contexts
+      # Tests can open extra contexts via #open_new_window(:window); those
+      # carry their own state and are cheaper to dispose than to scrub.
+      return false unless contexts.size == 1
+
+      # None of the Playwright/CDP calls below carry a protocol timeout, so
+      # a stuck browser would otherwise hang the suite. Cap the whole reset;
+      # on expiry the caller disposes the context exactly like today.
+      Timeout.timeout(10) do
+        context = contexts.first
+        clear_storage_for_visited_origins(context)
+        context.clear_cookies
+        context.clear_permissions
+        context.pages.each(&:close)
+        @playwright_page = create_page(context)
+        # The first page of a brand-new context is focused; later pages in a
+        # reused context are not, and focus-gated APIs (clipboard reads,
+        # for one) silently misbehave without it.
+        @playwright_page.bring_to_front
+      end
+      true
+    rescue => err
+      # The CI per-spec watchdog interrupts with its own error class; that
+      # must keep propagating or timed-out specs would be silently passed.
+      raise if err.class.name.include?("SpecTimeout")
+      @internal_logger.warn(
+        "Soft browser reset failed, falling back to a full context reset: #{err.class}: #{err.message}",
+      )
+      false
+    end
+
+    def visit(path)
+      track_visited_origin(visit_url(path))
+      super
+    end
+
+    private
+
+    def clear_storage_for_visited_origins(browser_context)
+      origins = @visited_origins ? @visited_origins.dup : Set.new
+      browser_context.pages.each do |page|
+        next if page.closed?
+        url = page.url
+        origins << Addressable::URI.parse(url).origin if url&.start_with?("http")
+      end
+      return if origins.empty?
+
+      # Storage.clearDataForOrigin needs a CDP target; reuse an open page or
+      # create a throwaway one (it is closed right after by the caller).
+      cdp_page = browser_context.pages.find { |page| !page.closed? } || browser_context.new_page
+      cdp_session = browser_context.new_cdp_session(cdp_page)
+      begin
+        origins.each do |origin|
+          # Everything origin-scoped a test can durably write, except the
+          # HTTP cache, which is exactly the part we want to keep warm.
+          # sessionStorage is per-tab and dies with the page close below;
+          # service workers are blocked at context creation.
+          cdp_session.send_message(
+            "Storage.clearDataForOrigin",
+            params: {
+              origin: origin,
+              storageTypes: "local_storage,indexeddb,websql,cache_storage",
+            },
+          )
+        end
+      ensure
+        cdp_session.detach
+      end
+    end
+
+    def track_visited_origin(url)
+      uri =
+        begin
+          Addressable::URI.parse(url.to_s)
+        rescue StandardError
+          nil
+        end
+      return unless uri&.scheme&.start_with?("http")
+
+      (@visited_origins ||= Set.new) << uri.origin
+    end
+
+    # Mirrors how `visit` resolves the navigation target so the tracked origin
+    # matches the URL actually fetched.
+    def visit_url(path)
+      if Capybara.app_host
+        Addressable::URI.parse(Capybara.app_host) + path
+      elsif Capybara.default_host
+        Addressable::URI.parse(Capybara.default_host) + path
+      else
+        path
+      end
+    end
+  end
+
+  # Reproduces the `Capybara::Playwright::Driver` half of the patch: `reset!`
+  # takes the soft path when allowed, with an opt-out for the cases that need a
+  # full context dispose (video, tracing, or an explicit hard-reset request).
+  module Driver
+    # Replicates the stock `reset!` body with the soft-reset early-return
+    # inserted after the screenshot block. We deliberately do not call `super`:
+    # `super` would re-run the screenshot capture, double-capturing (or
+    # capturing a blank screenshot of the freshly soft-reset page).
+    def reset!
+      # screenshot is available only before closing page.
+      if callback_on_save_screenshot?
+        raw_screenshot = @browser&.raw_screenshot
+        callback_on_save_screenshot(raw_screenshot) if raw_screenshot
+      end
+
+      return if soft_reset_allowed? && @browser&.soft_reset!
+
+      # video path can be acquired only before closing context.
+      # video is completely saved only after closing context.
+      video_path = @browser&.video_path
+
+      # [NOTE] @playwright_browser should keep alive for better performance.
+      # Only `Browser` is disposed.
+      @browser&.clear_browser_contexts
+
+      callback_on_save_screenrecord(video_path) if video_path
+
+      @browser = nil
+    end
+
+    # Force the next #reset! to dispose the browser context instead of
+    # soft-resetting it. Test helpers must call this after mutating
+    # context-scoped state that has no clearing API (e.g. Playwright's
+    # Clock, which cannot be uninstalled once installed).
+    def require_hard_reset!
+      @hard_reset_required = true
+    end
+
+    private
+
+    def soft_reset_allowed?
+      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] == "0"
+      # Video is finalized, and traces collected, only on context close.
+      return false if callback_on_save_screenrecord?
+      return false if @callback_on_save_trace
+
+      if @hard_reset_required
+        @hard_reset_required = false
+        return false
+      end
+
+      true
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(PlaywrightSoftReset::Browser)
+Capybara::Playwright::Driver.prepend(PlaywrightSoftReset::Driver)

--- a/spec/support/static_asset_cache_control.rb
+++ b/spec/support/static_asset_cache_control.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Static assets are immutable for the lifetime of a test run (a single
+# digest-stamped Ember build) but are served without a Cache-Control header,
+# so Chromium re-validates every script chunk on each cold navigation. The
+# soft-resetting Playwright driver keeps one browser context (and therefore
+# one HTTP cache) alive per worker; an explicit max-age turns each example's
+# first-navigation asset burst into pure cache hits instead of a queue of
+# conditional GETs against the in-process Puma server.
+#
+# Server-GENERATED code documents must NOT be stored, in spite of (and
+# precisely because of) the `immutable_for(1.year)` their controllers stamp
+# on digest URLs: those digests are not pure content functions across
+# examples. `fab!`/`let_it_be` reuses record ids between examples while the
+# data rolls back, so e.g. the color-scheme stylesheet digest (keyed on
+# scheme id + version, not content) names different CSS in different
+# examples under the identical URL, and `ExtraLocalesController.js_digests`
+# is a process-level memo that fabricated TranslationOverride rows never
+# invalidate. With a worker-lifetime browser cache, an `immutable` response
+# stored by one example gets served stale to a later one — `no-store` on
+# every generated code response makes that class of leak impossible by
+# construction. Everything else (HTML, JSON, images, avatars, uploads) keeps
+# its current headers: image URLs are content-addressed or version-stamped,
+# and HTML/JSON carry no cache headers today.
+class StaticAssetCacheControl
+  # Disk files emitted at most once per run: the digest-stamped Ember build
+  # under /assets, vendored libraries under /javascripts.
+  STATIC_BUILD_PATH = %r{\A(?:/[a-z0-9_-]+)?/(?:assets|javascripts)/}
+
+  # Compiled stylesheets, extra-locales bundles, svg sprites, theme
+  # javascripts, highlight-js bundles, webmanifest.
+  GENERATED_CODE_TYPES = %r{text/css|javascript|image/svg|manifest}
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    if STATIC_BUILD_PATH.match?(env["PATH_INFO"].to_s)
+      headers["Cache-Control"] = "public, max-age=3600" if status == 200
+    elsif GENERATED_CODE_TYPES.match?(headers["Content-Type"].to_s)
+      headers["Cache-Control"] = "no-store"
+    end
+    [status, headers, body]
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    # `Capybara.app` is a mutable `Rack::Builder` only once
+    # action_dispatch/system_test_case has been loaded (i.e. when system
+    # specs are part of the run). Rebuild it with the middleware declared
+    # before the `map` statement - `Rack::Builder#use` called after `map`
+    # consumes the mapping and breaks the builder - while keeping the same
+    # builder semantics `set_subfolder` relies on for live remapping.
+    if Capybara.app.is_a?(Rack::Builder)
+      Capybara.app =
+        Rack::Builder.new do
+          use StaticAssetCacheControl
+          map "/" do
+            run Rails.application
+          end
+        end
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -4,6 +4,25 @@ require "highline/import"
 module SystemHelpers
   PLATFORM_KEY_MODIFIER = RUBY_PLATFORM =~ /darwin/i ? :meta : :control
 
+  # A production Ember build strips `@ember/debug` macros (`deprecate`,
+  # `assert`) and the dev-only test affordances, so specs asserting that
+  # behaviour are conditionally skipped via `if:` metadata.
+  def self.production_ember_build?
+    return @production_ember_build if defined?(@production_ember_build)
+
+    @production_ember_build =
+      if ENV["EMBER_ENV"].present?
+        ENV["EMBER_ENV"] == "production"
+      else
+        begin
+          info = Rails.root.join("frontend/discourse/dist/BUILD_INFO.json")
+          info.exist? && JSON.parse(info.read)["ember_env"] == "production"
+        rescue StandardError
+          false
+        end
+      end
+  end
+
   # Pass to `send_keys` to move the caret to the start of the current line in a
   # contenteditable. The Home key doesn't move the caret on macOS; Cmd+Left does.
   LINE_START_KEY = RUBY_PLATFORM =~ /darwin/i ? %i[meta left] : :home

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -75,6 +75,10 @@ module BrowserTime
       pw_page.clock.install(time:)
       pw_page.clock.resume
     end
+
+    # Playwright's clock is context-scoped and cannot be uninstalled, so the
+    # context must be disposed after the example instead of soft-reset.
+    page.driver.require_hard_reset! if page.driver.respond_to?(:require_hard_reset!)
   end
 
   # Apply timezone override via CDP if timezone metadata is present.

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -94,7 +94,9 @@ describe "Changing email" do
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
     find("button[type=submit]:not([disabled])").click
 
-    expect(user.reload.primary_email.email).to eq(new_email)
+    try_until_success(
+      reason: "the second-factor confirm request is not tracked by clientSettled",
+    ) { expect(user.reload.primary_email.email).to eq(new_email) }
   end
 
   it "makes admins verify old email" do

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -57,7 +57,10 @@ describe "JS Deprecation Handling" do
   end
 
   it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback",
-     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback] do
+     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback],
+     # `ember-this-fallback` emits its deprecation via `@ember/debug`'s
+     # `deprecate`, which production builds compile out.
+     if: !SystemHelpers.production_ember_build? do
     t = Fabricate(:theme, name: "Theme With Hbs Connector")
     t.set_field(
       target: :extra_js,

--- a/spec/system/theme_qunit_spec.rb
+++ b/spec/system/theme_qunit_spec.rb
@@ -18,7 +18,10 @@ describe "Theme qunit testing" do
     t
   end
 
-  it "lists themes and can run tests by id, name and url" do
+  # `/theme-qunit` boots the app's qunit harness, which is only part of
+  # development builds.
+  it "lists themes and can run tests by id, name and url",
+     if: !SystemHelpers.production_ember_build? do
     visit "/theme-qunit"
 
     expect(page).to have_css("a[href^='/theme-qunit?id=']", count: 1)


### PR DESCRIPTION
System specs pay an in-browser parse and boot cost on every one of the suite's thousands of navigations, and the browser context is torn down between examples so each one starts from a cold cache. This PR ships one cluster of three complementary optimizations that only pay off together. None of them moves the needle alone, the win comes from combining them.

## The three mechanisms

1. **Production Ember build.** Core system specs run against a production build via `EMBER_ENV`, so every page load parses a minified, tree-shaken bundle instead of the much larger development build. The dev-only `rails-testing.js` test bridge is dead-code-eliminated from production builds, so `client_settled_bridge.rb` injects a build-independent reimplementation via a Playwright init script and settle semantics are unchanged.

2. **Cache-Control on the per-run immutable assets.** The digest-stamped Ember build under `/assets` and `/javascripts` is immutable for the lifetime of a test run but is served without a `Cache-Control` header, so Chromium re-validates every script chunk on each navigation. `StaticAssetCacheControl` stamps an explicit `max-age` on those responses so each example's first-navigation asset burst becomes cache hits. Server-generated code documents (compiled stylesheets, extra-locales bundles, theme javascripts) are marked `no-store` instead, because their digests are not pure content functions across examples and a worker-lifetime cache would otherwise serve one example's response stale to a later one.

3. **In-place soft browser-context reset.** The vendored `capybara-playwright-driver` gains a `soft_reset!` path that keeps one browser context alive per worker instead of disposing it after each example, clearing only cookies, permissions, and origin storage. This is the keystone. Keeping the context alive keeps its warm HTTP and compiled-JS cache alive too, which is the only thing that lets the smaller cacheable bundle from mechanisms 1 and 2 actually be reused.

## Why they only pay off together

The production build was measured on its own in #40862 and came out a wash (+1.7%). A smaller bundle does not help when it is fetched and parsed cold on every example. The soft reset keeps the browser context (and its cache) alive across examples, the cache headers make the assets cacheable, and the production build makes the bundle smaller. Take any one away and the navigation-cost win disappears: without the soft reset the cache is cold every example, without the cache headers the assets are re-validated, without the production build the bundle is large. This PR ships exactly those three and supersedes #40862.

Examples that install a Playwright clock force a hard reset, because the clock is context-scoped and cannot be uninstalled. The `client_settled_bridge` init script survives a soft reset on the kept context and is re-registered by `create_browser_context` on a hard reset, so settle waits keep working across the reuse.

## Measurements

Five full-matrix runs of this branch interleaved with five of `main` at the merge base, strictly sequential so no two measured runs compete for the runner pool. Durations are each system job's test step. The autoresearch experiment was stopped, so the runner pool was uncontended. This sweep measures the spec/support prepend implementation, and it reproduces the result of the earlier vendored-gem implementation (core system was -9.8% there, -7.8% here, the same win within run-to-run noise).

Baseline runs: [1](https://github.com/discourse/discourse/actions/runs/27525094545) [2](https://github.com/discourse/discourse/actions/runs/27525952568) [3](https://github.com/discourse/discourse/actions/runs/27526721966) [4](https://github.com/discourse/discourse/actions/runs/27527604878) [5](https://github.com/discourse/discourse/actions/runs/27528503051)
This branch runs: [1](https://github.com/discourse/discourse/actions/runs/27525573089) [2](https://github.com/discourse/discourse/actions/runs/27526348295) [3](https://github.com/discourse/discourse/actions/runs/27527150179) [4](https://github.com/discourse/discourse/actions/runs/27528070795) [5](https://github.com/discourse/discourse/actions/runs/27528987603)

| System job | `main` median | This branch median | Delta | Delta% | Rounds faster |
|---|---:|---:|---:|---:|:---:|
| core system | 605s | 558s | -47s | **-7.8%** | 5/5 |
| plugins (core) system | 466s | 420s | -46s | **-9.9%** | 5/5 |
| plugins (chat) system | 546s | 474s | -72s | **-13.2%** | 5/5 |
| plugins (official) system | 263s | 241s | -22s | **-8.4%** | 5/5 |
| themes system | 348s | 299s | -49s | **-14.1%** | 5/5 |

Every system job is faster in all five rounds, by 8 to 14 percent. The cluster removes roughly 236 seconds of test-step work per full CI run across the five system jobs. The win generalizes across the whole system matrix because the production build, cache headers, and soft reset apply identically to every system build.

For contrast, the production build shipped alone in #40862 measured +1.7% on core system over the same protocol, a wash. The win is the pairing: the soft browser-context reset keeps the warm HTTP and compiled-JS cache alive across examples, and only then does the smaller cacheable production bundle pay off.
