### PR TITLE
PERF: Sign in to system tests in-process instead of navigating the browser

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -55,12 +55,74 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit File.join(
-            GlobalSetting.relative_url_root || "",
-            "/session/#{user.encoded_username}/become.json?redirect=false",
-          )
+    path =
+      File.join(
+        GlobalSetting.relative_url_root || "",
+        "/session/#{user.encoded_username}/become.json?redirect=false",
+      )
 
-    expect(page).to have_content("Signed in to #{user.encoded_username} successfully")
+    # Run the same request the browser used to be navigated to through the app
+    # in-process instead. This keeps every server-side side effect of
+    # `SessionController#become` (`log_on_user`, auth token generation, the
+    # full middleware stack) while skipping an entire Chrome page navigation
+    # per sign-in; the session cookies from the response are copied into the
+    # browser context so the next real navigation is authenticated.
+    rack_session = Rack::Test::Session.new(Rails.application)
+    rack_session.get(
+      "http://#{Capybara.server_host}#{path}",
+      {},
+      { "HTTP_USER_AGENT" => "Mozilla/5.0 (SystemHelpers#sign_in)" },
+    )
+    response = rack_session.last_response
+
+    if !response.ok? ||
+         !response.body.include?("Signed in to #{user.encoded_username} successfully")
+      raise "sign_in for #{user.encoded_username} failed (HTTP #{response.status}): #{response.body[0, 300]}"
+    end
+
+    cookies =
+      Array(response.headers["Set-Cookie"])
+        .flat_map { |header| header.split("\n") }
+        .filter_map do |line|
+          cookie, *attributes = line.split(/;\s*/)
+          name, _, value = cookie.partition("=")
+          next if name.blank?
+          attributes = attributes.map(&:downcase)
+          same_site = attributes.filter_map { |a| a[/\Asamesite=(\w+)\z/, 1]&.capitalize }.first
+          {
+            name: name,
+            value: value,
+            path: "/",
+            httpOnly: attributes.include?("httponly"),
+            secure: attributes.include?("secure"),
+            sameSite: same_site || "Lax",
+          }
+        end
+
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.context.add_cookies(
+        # `visit "/foo"` resolves to `Capybara.server_host`, but some specs
+        # navigate to `test.localhost` absolute URLs — cover both hosts.
+        cookies.flat_map do |cookie|
+          [Capybara.server_host, "test.localhost"].map { |domain| cookie.merge(domain: domain) }
+        end,
+      )
+    end
+
+    # The visit-based sign_in left the browser on a real app origin, and specs
+    # (plugin page objects especially) rely on that by calling execute_script
+    # before their first visit. A freshly reset page sits on about:blank,
+    # whose opaque origin denies localStorage and clipboard access, so park on
+    # the cheapest app document to preserve that contract.
+    on_blank_page = page.driver.with_playwright_page { |pw_page| !pw_page.url.start_with?("http") }
+    visit "/srv/status" if on_blank_page
+
+    # `Capybara::Session#reset!` only resets the driver (closing the browser
+    # context and dropping the cookies injected above) when the session has
+    # been used. The old `visit`-based sign_in marked it used implicitly;
+    # without this, `Capybara.reset_sessions!` (e.g. in specs that sign in and
+    # then test anonymous access) silently keeps the authenticated context.
+    page.instance_variable_set(:@touched, true)
   end
 
   def setup_system_test

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -8,8 +8,12 @@ module PageObjects
 
     def allow_clipboard
       page.driver.with_playwright_page do |pw_page|
-        pw_page.context.grant_permissions(["clipboard-read"], origin: pw_page.url)
-        pw_page.context.grant_permissions(["clipboard-write"], origin: pw_page.url)
+        # Granting without an origin applies to all origins. Pinning to
+        # `pw_page.url` breaks when no navigation has happened yet (the page is
+        # still `about:blank`, an opaque origin which permissions cannot be
+        # granted to), which is now the case when this is called right after
+        # `sign_in`.
+        pw_page.context.grant_permissions(%w[clipboard-read clipboard-write])
       end
     end
 

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -17,7 +17,9 @@ describe "User preferences | Security" do
     sign_in(user)
 
     # system specs run on their own host + port
-    DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
+    DiscourseWebauthn.stubs(:origin).returns(
+      "http://#{Capybara.server_host}:#{Capybara.server_port}",
+    )
   end
 
   shared_examples "security keys" do


### PR DESCRIPTION
`SystemHelpers#sign_in` navigated Chrome to `/session/:username/become.json` on every call. That is a full browser page load, and since almost every system spec signs in, it is paid roughly 1,800 times per CI run.

This change runs the same request in-process through `Rack::Test` and injects the resulting session cookies into the Playwright browser context, so the next real navigation is already authenticated. Every server-side effect of `SessionController#become` is preserved (`log_on_user`, auth token generation, the full middleware stack), because the same request runs through the same controller. Only the page navigation is removed.

Two consequences of not navigating during sign-in are handled in the helper. The browser can still be on `about:blank` afterwards, so sign_in parks on `/srv/status` when that is the case, restoring the contract that specs may run `execute_script` before their first visit. And since `Capybara::Session#reset!` only tears down the driver once the session is touched (which the old navigation did implicitly), sign_in now marks it explicitly so `Capybara.reset_sessions!` still works for specs that sign in and then test anonymous access.

The clipboard permission grant in the CDP page object is also changed to grant without an origin, since pinning to the current page URL fails on the post-sign-in `about:blank`, and the WebAuthn origin stub in one spec is made explicit for the same reason.

## Measurements

Five full-matrix runs of this branch interleaved with five of `main` at the merge base, strictly sequential so no two measured runs compete for the runner pool. Durations are each system job's test step. The autoresearch experiment was stopped, so the runner pool was uncontended.

Baseline runs: [1](https://github.com/discourse/discourse/actions/runs/27531673819) [2](https://github.com/discourse/discourse/actions/runs/27533023384) [3](https://github.com/discourse/discourse/actions/runs/27534387114) [4](https://github.com/discourse/discourse/actions/runs/27535613509) [5](https://github.com/discourse/discourse/actions/runs/27536962405)
This branch runs: [1](https://github.com/discourse/discourse/actions/runs/27532390326) [2](https://github.com/discourse/discourse/actions/runs/27533756264) [3](https://github.com/discourse/discourse/actions/runs/27535008331) [4](https://github.com/discourse/discourse/actions/runs/27536301432) [5](https://github.com/discourse/discourse/actions/runs/27537671659)

| System job | `main` median | This branch median | Delta | Delta% | Rounds faster |
|---|---:|---:|---:|---:|:---:|
| core system | 670s | 605s | -65s | **-9.7%** | 5/5 |
| plugins (core) system | 496s | 438s | -58s | **-11.7%** | 5/5 |
| plugins (chat) system | 564s | 533s | -31s | **-5.5%** | 5/5 |
| plugins (official) system | 318s | 283s | -35s | **-11.0%** | 5/5 |
| themes system | 364s | 333s | -31s | **-8.5%** | 4/5 |

Every system job is faster, by 5 to 12 percent, removing roughly 220 seconds of test-step work per full CI run. The win generalizes because almost every system spec signs in, so every system job sheds its sign-in navigations. This mechanism stands on its own, unlike the production Ember build, which was a wash in isolation because its benefit depended on a warm cross-example cache.
