### PR TITLE
FIX: Allow CDN asset host in worker-src CSP

### DIFF
--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -12,7 +12,7 @@ class ContentSecurityPolicy
           directives[:base_uri] = [:self]
           directives[:object_src] = [:none]
           directives[:script_src] = script_src
-          directives[:worker_src] = [:self, "blob:"]
+          directives[:worker_src] = worker_src
           directives[:frame_ancestors] = frame_ancestors if restrict_embed?
           directives[:manifest_src] = ["'self'"]
         end
@@ -22,6 +22,21 @@ class ContentSecurityPolicy
 
     def script_src
       %w['strict-dynamic' 'wasm-unsafe-eval']
+    end
+
+    def worker_src
+      [:self, "blob:", *worker_asset_host]
+    end
+
+    def worker_asset_host
+      if GlobalSetting.use_s3? && GlobalSetting.s3_cdn_url.present?
+        s3_cdn = GlobalSetting.s3_asset_cdn_url.presence || GlobalSetting.s3_cdn_url
+        ["#{s3_cdn}/assets/"]
+      elsif GlobalSetting.cdn_url.present?
+        ["#{GlobalSetting.cdn_url}#{Discourse.base_path}/assets/"]
+      else
+        []
+      end
     end
 
     def frame_ancestors

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -43,6 +43,23 @@ RSpec.describe ContentSecurityPolicy do
       worker_src = parse(policy)["worker-src"]
       expect(worker_src).to contain_exactly("'self'", "blob:")
     end
+
+    it "includes the CDN asset host in worker-src so the worker chunk can be imported" do
+      set_cdn_url "https://cdn.example.com"
+      worker_src = parse(policy)["worker-src"]
+      expect(worker_src).to contain_exactly("'self'", "blob:", "https://cdn.example.com/assets/")
+    end
+
+    it "includes the s3 asset CDN host in worker-src" do
+      global_setting :s3_bucket, "test_bucket"
+      global_setting :s3_region, "ap-australia"
+      global_setting :s3_access_key_id, "123"
+      global_setting :s3_secret_access_key, "123"
+      global_setting :s3_cdn_url, "https://s3cdn.example.com"
+
+      worker_src = parse(policy)["worker-src"]
+      expect(worker_src).to contain_exactly("'self'", "blob:", "https://s3cdn.example.com/assets/")
+    end
   end
 
   describe "manifest-src" do


### PR DESCRIPTION
The media-optimization worker is launched from a same-origin blob: bootstrap that imports the real worker chunk by absolute URL. When assets are served from a CDN, that import is fetched with a worker destination and is therefore checked against worker-src (not script-src), so strict-dynamic does not apply. With only `'self' blob:`, the cross-origin CDN import is blocked:

```
Creating a worker from 'https://cdn/assets/.../entrypoint.digested.js' violates the following Content Security Policy directive: "worker-src 'self' blob:".
```

To fix, we add the asset host to worker-src so the worker chunk can be imported on CDN/S3 deployments. Non-CDN deployments are unchanged ('self' blob:).

Unfortunately strict-dynamic is not consistently supported in worker-src.

Followup to a32f09021f5711d8215be5b59ddcd2ed274205bb