### PR TITLE
DEV: pasted images should respect png to jpg site setting

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -321,8 +321,8 @@ class UploadCreator
 
   def convert_png_to_jpeg?
     return false unless @image_info.type == :png
-    return true if @opts[:pasted]
     return false if SiteSetting.ImageQuality.png_to_jpg_quality == 100
+    return true if @opts[:pasted]
     pixels > MIN_PIXELS_TO_CONVERT_TO_JPEG
   end
 

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -266,6 +266,20 @@ RSpec.describe UploadCreator do
             expect(File.extname(upload.url)).to eq(".png")
             expect(upload.original_filename).to eq("large_and_unoptimized.png")
           end
+
+          it "should not convert pasted images to jpeg when png_to_jpg_quality is 100" do
+            upload =
+              UploadCreator.new(
+                large_file,
+                large_filename,
+                pasted: true,
+                force_optimize: true,
+              ).create_for(user.id)
+
+            expect(upload.extension).to eq("png")
+            expect(File.extname(upload.url)).to eq(".png")
+            expect(upload.original_filename).to eq("large_and_unoptimized.png")
+          end
         end
 
         it "should not convert animated WEBP images" do


### PR DESCRIPTION
When manually uploading png images we check the image quality site setting and convert the image to jpg if `SiteSetting.ImageQuality.png_to_jpg_quality` is less than 100.

For copy/pasted images we should also respect this image quality setting.