### PR TITLE
FIX: Copy for toggle

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4967,8 +4967,8 @@ en:
       original_language_and_outdated: "This post was originally written in %{language}. Translation may be outdated"
       # This is a loose key to be used beside the post-info post-language icon
       originally_written_in: "Originally in %{language}"
-      click_to_translate: "Click to translate"
-      tap_to_translate: "Tap here to translate"
+      click_to_show_original: "Click to show original"
+      tap_to_show_original: "Tap here to show original"
       ai_translation_disclaimer: "AI-generated translations may be inaccurate."
 
     category:

--- a/frontend/discourse/app/components/post/meta-data/language.gjs
+++ b/frontend/discourse/app/components/post/meta-data/language.gjs
@@ -34,8 +34,8 @@ export default class PostMetaDataLanguage extends Component {
 
   get translatePrompt() {
     return this.site.mobileView
-      ? i18n("post.tap_to_translate")
-      : i18n("post.click_to_translate");
+      ? i18n("post.tap_to_show_original")
+      : i18n("post.click_to_show_original");
   }
 
   @action

--- a/frontend/discourse/tests/integration/components/post/post-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/post-test.gjs
@@ -309,7 +309,7 @@ module("Integration | Component | Post", function (hooks) {
     assert.dom(".post-language").includesText(
       `${i18n("post.original_language", {
         language: "English (US)",
-      })}. ${i18n("post.click_to_translate")}`
+      })}. ${i18n("post.click_to_show_original")}`
     );
     assert
       .dom(".post-language")
@@ -403,7 +403,7 @@ module("Integration | Component | Post", function (hooks) {
     assert.dom(".post-language").includesText(
       `${i18n("post.original_language", {
         language: "English (US)",
-      })}. ${i18n("post.tap_to_translate")}`,
+      })}. ${i18n("post.tap_to_show_original")}`,
       "mobile tooltip uses tap copy"
     );
     assert.strictEqual(
@@ -435,7 +435,7 @@ module("Integration | Component | Post", function (hooks) {
     assert.dom(".post-language").includesText(
       `${i18n("post.original_language_and_outdated", {
         language: "English (US)",
-      })}. ${i18n("post.click_to_translate")}`
+      })}. ${i18n("post.click_to_show_original")}`
     );
     assert
       .dom(".post-language")


### PR DESCRIPTION
The original PR introduced wrong copy - we're actually _not_ translating, but toggling to show original instead.