### PR TITLE
DEV: Move enable_events_category_type_setup UC to Beta

### DIFF
--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -136,7 +136,7 @@ discourse_calendar:
     hidden: true
     client: true
     upcoming_change:
-      status: "alpha"
+      status: "beta"
       impact: "feature,staff"
       learn_more_url: "https://meta.discourse.org/t/-/401309"
   livestream_enabled:


### PR DESCRIPTION
Previously, the `enable_events_category_type_setup` upcoming change was at the `alpha` stage, limited to internal testing.

This change promotes it to `beta`, opening it up for broader testing.