### PR TITLE
UX: Order event "going" avatars by RSVP time

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -279,7 +279,7 @@ module DiscoursePostEvent
     end
 
     def most_likely_going(limit = SiteSetting.displayed_invitees_limit)
-      going = invitees.order(%i[status user_id]).limit(limit)
+      going = invitees.order(%i[status created_at user_id]).limit(limit)
 
       if private? && going.count < limit
         # invitees are only created when an attendance is set

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -980,6 +980,62 @@ describe DiscoursePostEvent::Event do
   end
 end
 
+describe DiscoursePostEvent::Event, "#most_likely_going" do
+  before do
+    Jobs.run_immediately!
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+  end
+
+  fab!(:event)
+
+  it "orders going invitees by RSVP time (created_at), not by user id" do
+    early_rsvp = Fabricate(:user)
+    late_rsvp = Fabricate(:user)
+    # later-created user (higher id) RSVP'd first, so should come first
+    expect(late_rsvp.id).to be > early_rsvp.id
+
+    Fabricate(
+      :post_event_invitee,
+      event:,
+      user: late_rsvp,
+      status: DiscoursePostEvent::Invitee.statuses[:going],
+      created_at: 2.hours.ago,
+    )
+    Fabricate(
+      :post_event_invitee,
+      event:,
+      user: early_rsvp,
+      status: DiscoursePostEvent::Invitee.statuses[:going],
+      created_at: 1.hour.ago,
+    )
+
+    expect(event.most_likely_going.map(&:user)).to eq([late_rsvp, early_rsvp])
+  end
+
+  it "groups going invitees ahead of interested ones regardless of RSVP time" do
+    interested = Fabricate(:user)
+    going = Fabricate(:user)
+
+    Fabricate(
+      :post_event_invitee,
+      event:,
+      user: interested,
+      status: DiscoursePostEvent::Invitee.statuses[:interested],
+      created_at: 2.hours.ago,
+    )
+    Fabricate(
+      :post_event_invitee,
+      event:,
+      user: going,
+      status: DiscoursePostEvent::Invitee.statuses[:going],
+      created_at: 1.hour.ago,
+    )
+
+    expect(event.most_likely_going.map(&:user)).to eq([going, interested])
+  end
+end
+
 describe DiscoursePostEvent::Event, "#capacity" do
   before do
     Jobs.run_immediately!


### PR DESCRIPTION
The row of attendee avatars shown on an event previews the members who clicked "Going". These were ordered by user id, which members commonly misread as the order in which people RSVP'd. Hosts then field questions about why the displayed order doesn't match who signed up first.

Order `most_likely_going` by the invitee's `created_at` (their first RSVP) instead of `user_id`, keeping `status` as the primary sort so going members stay grouped ahead of interested/not-going, and `user_id` only as a final tie-breaker for deterministic output when timestamps collide.

Because the `displayed_invitees_limit` cap is applied after ordering, this also changes which members appear when an event has more invitees than the limit: the earliest RSVPers are shown rather than the lowest user ids.