### PR TITLE
SECURITY: Channel member list exposes other users' chat read state and notification settings

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channels_memberships_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_memberships_controller.rb
@@ -19,7 +19,7 @@ class Chat::Api::ChannelsMembershipsController < Chat::Api::ChannelsController
 
     render_serialized(
       memberships,
-      Chat::UserChannelMembershipSerializer,
+      Chat::MemberListChannelMembershipSerializer,
       root: "memberships",
       meta: {
         total_rows: channel_from_params.user_count,

--- a/plugins/chat/app/serializers/chat/member_list_channel_membership_serializer.rb
+++ b/plugins/chat/app/serializers/chat/member_list_channel_membership_serializer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Chat
+  class MemberListChannelMembershipSerializer < ApplicationSerializer
+    has_one :user, embed: :objects
+
+    def user
+      user = object.user || Chat::NullUser.new
+      Chat::BasicUserSerializer.new(user, root: false, scope: scope, include_status: true)
+    end
+  end
+end

--- a/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_memberships_controller_spec.rb
@@ -15,6 +15,31 @@ RSpec.describe Chat::Api::ChannelsMembershipsController do
     sign_in(current_user)
   end
 
+  describe "#index" do
+    it "does not expose other users' membership state" do
+      chat_message = Fabricate(:chat_message, chat_channel: channel_1, user: other_user)
+      other_membership = channel_1.membership_for(other_user)
+      other_membership.update!(
+        following: false,
+        muted: true,
+        notification_level: :never,
+        last_read_message_id: chat_message.id,
+        last_viewed_at: 1.hour.ago,
+        last_viewed_pins_at: 30.minutes.ago,
+        starred: true,
+      )
+
+      get "/chat/api/channels/#{channel_1.id}/memberships"
+
+      expect(response.status).to eq(200)
+      membership =
+        response.parsed_body["memberships"].find { |item| item.dig("user", "id") == other_user.id }
+
+      expect(membership.dig("user", "username")).to eq(other_user.username)
+      expect(membership.keys).to contain_exactly("user")
+    end
+  end
+
   describe "#create" do
     describe "success" do
       it "works" do


### PR DESCRIPTION
## Summary

This patch updates the channel member list endpoint (GET /chat/api/channels/:channel_id/memberships) to return only public user details instead of exposing other users’ private membership state. It fixes an information disclosure issue where fields like read state, notification settings, mute/follow status, and starred state could be returned for other channel members, with test coverage added to confirm only the user payload is exposed.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1288

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>