### PR TITLE
FIX: Post serialization exposes hidden-profile user status messages

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -934,19 +934,18 @@ class User < ActiveRecord::Base
       payload = nil
     end
 
-    # When silenced, only the user themselves and staff should see the status
-    if silenced?
+    if Guardian.new.can_see_user_status?(self)
+      MessageBus.publish(
+        "/user-status",
+        { id => payload },
+        group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
+      )
+    elsif guardian.can_see_user_status?(self)
       MessageBus.publish(
         "/user-status",
         { id => payload },
         user_ids: [id],
         group_ids: [Group::AUTO_GROUPS[:staff]],
-      )
-    else
-      MessageBus.publish(
-        "/user-status",
-        { id => payload },
-        group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
       )
     end
   end

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -128,6 +128,7 @@ module UserGuardian
 
   def can_see_user_status?(user)
     return false if user.blank?
+    return false if user.user_option&.hide_profile?
 
     if user.silenced?
       is_me?(user) || is_staff?

--- a/spec/requests/user_status_controller_spec.rb
+++ b/spec/requests/user_status_controller_spec.rb
@@ -171,6 +171,19 @@ RSpec.describe UserStatusController do
         expect(messages[0].data[user.id][:ends_at]).to eq(ends_at)
       end
 
+      it "doesn't publish hidden-profile statuses to the message bus" do
+        user.user_option.update!(hide_profile: true)
+
+        messages =
+          MessageBus.track_publish("/user-status") do
+            put "/user-status.json", params: { description: "off to dentist", emoji: "tooth" }
+          end
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+        expect(messages).to be_empty
+      end
+
       it "only publishes to the silenced user and staff when silenced" do
         user.update!(silenced_till: 1.year.from_now)
 

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -620,6 +620,16 @@ RSpec.describe PostSerializer do
         expect(serialize_user_status).to be_nil
       end
 
+      it "doesn't include status for a public topic author with a hidden profile" do
+        SiteSetting.allow_users_to_hide_profile = true
+        user.user_option.update!(hide_profile: true)
+
+        json = described_class.new(post, scope: Guardian.new, root: false).as_json
+
+        expect(json).not_to have_key(:user_status)
+        expect(json.to_json).not_to include(user_status.description)
+      end
+
       it "respects guardian's can_see_user_status?" do
         user.update!(silenced_till: 1.year.from_now)
         scope = Guardian.new(Fabricate(:user))


### PR DESCRIPTION
## Summary

Fix a bug where users with hidden profiles could still expose their status in post JSON and `/user-status broadcasts` by consistently enforcing `Guardian#can_see_user_status?` before serializing or publishing status updates.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1287

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>