### PR TITLE
UX: scope css selector

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -420,7 +420,7 @@ html.composer-open:not(.has-full-page-chat) {
       width: auto;
 
       &.has-selection {
-        .name {
+        .selected-name .name {
           font-size: var(--font-up-1);
         }
       }


### PR DESCRIPTION
`.name` is too broad of a selection, we only want to target the selected name in the main input