### PR TITLE
SECURITY: Subscription contributors expose full user profile fields to anonymous viewers

### DIFF
--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -38,7 +38,7 @@ class UserCardSerializer < BasicUserSerializer
     attrs.each do |attr|
       method_name = "include_#{attr}?"
       define_method(method_name) do
-        return false if scope.restrict_user_fields?(object)
+        return false unless include_profile_details?
         public_send(attr).present?
       end
     end
@@ -174,7 +174,7 @@ class UserCardSerializer < BasicUserSerializer
   end
 
   def include_user_fields?
-    user_fields.present?
+    include_profile_details? && user_fields.present?
   end
 
   def custom_fields
@@ -244,6 +244,10 @@ class UserCardSerializer < BasicUserSerializer
   end
 
   private
+
+  def include_profile_details?
+    scope.public_can_see_profiles? && !scope.restrict_user_fields?(object)
+  end
 
   def custom_field_keys
     # Can be extended by other serializers

--- a/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/plugins/discourse-subscriptions/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -26,6 +26,9 @@ module DiscourseSubscriptions
 
     def contributors
       return unless SiteSetting.discourse_subscriptions_campaign_show_contributors
+
+      guardian.ensure_public_can_see_profiles!
+
       contributor_ids = Set.new
 
       campaign_product = SiteSetting.discourse_subscriptions_campaign_product
@@ -35,7 +38,8 @@ module DiscourseSubscriptions
         contributor_ids.merge(Customer.last(5).pluck(:user_id))
       end
 
-      contributors = ::User.where(id: contributor_ids)
+      contributors =
+        ::User.where(id: contributor_ids).filter { |user| guardian.can_see_profile?(user) }
 
       render_serialized(contributors, UserSerializer)
     end

--- a/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
+++ b/plugins/discourse-subscriptions/spec/requests/subscribe_controller_spec.rb
@@ -126,6 +126,8 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
     describe "#get_contributors" do
       before do
         Fabricate(:product, external_id: "prod_campaign")
+        user.user_stat.update!(post_count: 1)
+        campaign_user.user_stat.update!(post_count: 1)
         Fabricate(:customer, product_id: "prodct_23456", user_id: user.id, customer_id: "x")
         Fabricate(
           :customer,
@@ -235,6 +237,43 @@ RSpec.describe DiscourseSubscriptions::SubscribeController do
 
         expect(response.status).to eq(404)
       end
+    end
+  end
+
+  describe "#contributors" do
+    fab!(:contributor, :user)
+    fab!(:hidden_contributor, :user)
+
+    before do
+      SiteSetting.discourse_subscriptions_campaign_show_contributors = true
+      SiteSetting.discourse_subscriptions_campaign_product = ""
+      SiteSetting.hide_user_profiles_from_public = false
+      SiteSetting.allow_users_to_hide_profile = true
+      contributor.user_stat.update!(post_count: 1)
+      hidden_contributor.user_stat.update!(post_count: 1)
+      hidden_contributor.user_option.update!(hide_profile: true)
+      Fabricate(:customer, product_id: "prodct_23456", user_id: contributor.id, customer_id: "x")
+      Fabricate(
+        :customer,
+        product_id: "prod_campaign",
+        user_id: hidden_contributor.id,
+        customer_id: "y",
+      )
+    end
+
+    it "enforces profile visibility for anonymous contributors" do
+      get "/s/contributors.json"
+
+      expect(response).to have_http_status(:ok)
+      visible_contributor_ids = response.parsed_body.map { |serialized_user| serialized_user["id"] }
+
+      SiteSetting.hide_user_profiles_from_public = true
+
+      get "/s/contributors.json"
+
+      expect(visible_contributor_ids).to contain_exactly(contributor.id)
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body).to include("error_type" => "invalid_access")
     end
   end
 

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -438,11 +438,44 @@ RSpec.describe UserSerializer do
     end
 
     it "includes the correct fields for each audience" do
-      expect(admin_json[:user_fields].keys).to contain_exactly(*fields.map { |f| f.id.to_s })
-      expect(other_user_json[:user_fields].keys).to contain_exactly(
-        *fields[2..5].map { |f| f.id.to_s },
+      expect(admin_json[:user_fields].keys).to contain_exactly(
+        *fields.map { |field| field.id.to_s },
       )
-      expect(self_json[:user_fields].keys).to contain_exactly(*fields.map { |f| f.id.to_s })
+      expect(other_user_json[:user_fields].keys).to contain_exactly(
+        *fields[2..5].map { |field| field.id.to_s },
+      )
+      expect(self_json[:user_fields].keys).to contain_exactly(*fields.map { |field| field.id.to_s })
+    end
+  end
+
+  context "when public profiles are hidden from anonymous viewers" do
+    fab!(:user)
+    fab!(:user_field) { Fabricate(:user_field, show_on_profile: true) }
+
+    before do
+      SiteSetting.hide_user_profiles_from_public = true
+      user.user_stat.update!(post_count: 1)
+      user.user_profile.update!(
+        bio_raw: "private bio",
+        bio_cooked: "private cooked bio",
+        location: "private location",
+        website: "https://example.com/private",
+      )
+      user.set_user_field(user_field.id, "private field")
+    end
+
+    it "does not serialize profile details" do
+      json = UserSerializer.new(user, scope: Guardian.new, root: false).as_json
+
+      expect(json.keys).not_to include(
+        :bio_raw,
+        :bio_cooked,
+        :bio_excerpt,
+        :location,
+        :website,
+        :website_name,
+        :user_fields,
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

Correctly enforce profile visibility restrictions in the subscriptions contributors endpoint and user serializers. This prevents the exposure of sensitive profile fields—including bio, location, and website—to anonymous viewers when public profiles are disabled via site settings. The fix also hardens the user and user card serializers to omit profile details for unauthorized scopes as a defense-in-depth measure.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1286

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>