### PR TITLE
FIX: Add visibility check to Embed info

### DIFF
--- a/app/controllers/embed_controller.rb
+++ b/app/controllers/embed_controller.rb
@@ -137,7 +137,7 @@ class EmbedController < ApplicationController
     embed_url = params.require(:embed_url)
     @topic_embed = TopicEmbed.where(embed_url: embed_url).first
 
-    raise Discourse::NotFound if @topic_embed.nil?
+    raise Discourse::NotFound if @topic_embed.nil? || !guardian.can_see?(@topic_embed.topic)
 
     render_serialized(@topic_embed, TopicEmbedSerializer, root: false)
   end

--- a/spec/requests/embed_controller_spec.rb
+++ b/spec/requests/embed_controller_spec.rb
@@ -35,6 +35,35 @@ RSpec.describe EmbedController do
           expect(response.parsed_body["post_id"]).to eq(topic_embed.post.id)
           expect(response.parsed_body["topic_slug"]).to eq(topic_embed.topic.slug)
         end
+
+        it "returns not found for topics the API user cannot see" do
+          user = Fabricate(:user)
+          api_key = Fabricate(:api_key, user: user)
+          restricted_category = Fabricate(:category)
+          restricted_category.set_permissions(staff: :full)
+          restricted_category.save!
+          restricted_topic = Fabricate(:topic, category: restricted_category, posts_count: 5)
+          restricted_topic_embed =
+            Fabricate(
+              :topic_embed,
+              post: Fabricate(:post, topic: restricted_topic),
+              topic: restricted_topic,
+              embed_url: "http://eviltrout.com/private-article",
+            )
+
+          get "/embed/info.json",
+              params: {
+                embed_url: restricted_topic_embed.embed_url,
+              },
+              headers: {
+                HTTP_API_KEY: api_key.key,
+                HTTP_API_USERNAME: user.username,
+              }
+
+          expect(response.status).to eq(404)
+          expect(response.parsed_body["error_type"]).to eq("not_found")
+          expect(response.body).not_to include(restricted_topic.slug)
+        end
       end
 
       context "without invalid embed url" do


### PR DESCRIPTION
## Summary

Add a visibility check to the embed info endpoint so it only returns embedded topic metadata when the current API user can see the topic; otherwise it now responds with not found instead of exposing restricted details like the topic slug.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1284

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>