### PR TITLE
FIX: Prevent the site itself from being quoted as an external referrer

### DIFF
--- a/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
+++ b/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
@@ -221,7 +221,7 @@ module DiscourseAi
         source = dominant_referrer_for(peak.date)
         headline =
           if source
-            "Traffic spiked on #{peak.date} (#{multiple}x the typical day), driven by #{source}"
+            "Traffic spiked on #{peak.date} (#{multiple}x the typical day), with #{source} as the top external referrer"
           else
             "Traffic spiked on #{peak.date} (#{multiple}x the typical day)"
           end
@@ -231,7 +231,7 @@ module DiscourseAi
 
       def dominant_referrer_for(date)
         rows = DB.query(<<~SQL, date: date)
-            SELECT normalized_referrer AS referrer, count
+            SELECT normalized_referrer, count
             FROM browser_pageview_referrer_daily_rollups
             WHERE date = :date AND normalized_referrer IS NOT NULL
             ORDER BY count DESC
@@ -240,9 +240,19 @@ module DiscourseAi
         return if rows.blank?
 
         total = rows.sum(&:count)
-        top = rows.first
+        top = rows.find { |row| external_referrer?(row.normalized_referrer) }
+        return if top.nil?
         return if total.zero? || (top.count.to_f / total) < 0.4
-        top.referrer
+        top.normalized_referrer
+      end
+
+      def external_referrer?(referrer)
+        site_host = BrowserPageviewReferrerInspector.normalize_host(Discourse.current_hostname)
+        referrer = referrer.to_s
+        return false if referrer.blank? || site_host.blank?
+
+        referrer != site_host && !referrer.start_with?("#{site_host}/") &&
+          !referrer.start_with?("#{site_host}?")
       end
 
       def geography

--- a/plugins/discourse-ai/spec/lib/admin_dashboard/admin_dashboard_facts_spec.rb
+++ b/plugins/discourse-ai/spec/lib/admin_dashboard/admin_dashboard_facts_spec.rb
@@ -75,4 +75,52 @@ RSpec.describe DiscourseAi::AdminDashboard::AdminDashboardFacts do
 
     expect(spike[:headline]).to include("news.ycombinator.com")
   end
+
+  it "does not report the site's own hostname as the traffic spike source" do
+    allow(Discourse).to receive(:current_hostname).and_return("meta.discourse.org")
+    base = 29.days.ago.to_date
+    spike_day = 20.days.ago.to_date
+    base.upto(Date.current) do |date|
+      ApplicationRequest.create!(
+        date: date,
+        req_type: ApplicationRequest.req_types[:page_view_logged_in_browser],
+        count: date == spike_day ? 5000 : 100,
+      )
+    end
+    BrowserPageviewReferrerDailyRollup.create!(
+      date: spike_day,
+      normalized_referrer: "meta.discourse.org",
+      count: 4000,
+      logged_in_count: 0,
+    )
+
+    spike = compute.fetch(:signals).find { |s| s[:key] == :traffic_spike }
+
+    expect(spike[:headline]).not_to include("meta.discourse.org")
+    expect(spike[:headline]).not_to include("external referrer")
+  end
+
+  it "does not report a same-site subfolder referrer as the traffic spike source" do
+    allow(Discourse).to receive(:current_hostname).and_return("meta.discourse.org")
+    base = 29.days.ago.to_date
+    spike_day = 20.days.ago.to_date
+    base.upto(Date.current) do |date|
+      ApplicationRequest.create!(
+        date: date,
+        req_type: ApplicationRequest.req_types[:page_view_logged_in_browser],
+        count: date == spike_day ? 5000 : 100,
+      )
+    end
+    BrowserPageviewReferrerDailyRollup.create!(
+      date: spike_day,
+      normalized_referrer: "meta.discourse.org/forum/latest",
+      count: 4000,
+      logged_in_count: 0,
+    )
+
+    spike = compute.fetch(:signals).find { |s| s[:key] == :traffic_spike }
+
+    expect(spike[:headline]).not_to include("meta.discourse.org")
+    expect(spike[:headline]).not_to include("external referrer")
+  end
 end


### PR DESCRIPTION
We're seeing AI highlights on a site, e.g. meta, that looks like this:

> This was a mixed period: sign-ups grew while stickiness and resolved questions both fell. With 87 new topics unanswered and staff writing 44% of posts, community contribution may need a boost despite the traffic spike from meta.discourse.org.

The highlight should not quote the site itself as external traffic. This PR prevents treating the current site hostname as an external traffic source.