### PR TITLE
FIX: Ensure each flag gets a unique `name_key`

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -66,8 +66,21 @@ class Flag < ActiveRecord::Base
   end
 
   def set_name_key
+    return if name_key.present? && !will_save_change_to_name?
+
     prefix = system? ? "" : "custom_"
-    self.name_key = "#{prefix}#{name.squeeze(" ").gsub(" ", "_").gsub(/[^\w]/, "").downcase}"
+    slug = name.squeeze(" ").gsub(" ", "_").gsub(/[^\w]/, "").downcase
+    base = slug.present? ? "#{prefix}#{slug}" : "#{prefix}flag"
+
+    suffix = 1
+    candidate = base
+
+    while Flag.unscoped.where(name_key: candidate).where.not(id: id).exists?
+      suffix += 1
+      candidate = "#{base}_#{suffix}"
+    end
+
+    self.name_key = candidate
   end
 end
 
@@ -88,4 +101,8 @@ end
 #  score_type       :boolean          default(FALSE), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_flags_on_name_key  (name_key) UNIQUE
 #

--- a/db/post_migrate/20260624140945_ensure_unique_flag_name_keys.rb
+++ b/db/post_migrate/20260624140945_ensure_unique_flag_name_keys.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class EnsureUniqueFlagNameKeys < ActiveRecord::Migration[8.0]
+  def up
+    execute(<<~SQL)
+      UPDATE flags
+      SET name_key = name_key || '_' || id
+      WHERE name_key IS NOT NULL
+        AND id <> (
+          SELECT MIN(other.id)
+          FROM flags other
+          WHERE other.name_key = flags.name_key
+        )
+    SQL
+
+    add_index :flags, :name_key, unique: true, if_not_exists: true
+  end
+
+  def down
+    remove_index :flags, :name_key, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -18787,6 +18787,13 @@ CREATE INDEX index_external_upload_stubs_on_status ON public.external_upload_stu
 
 
 --
+-- Name: index_flags_on_name_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_flags_on_name_key ON public.flags USING btree (name_key);
+
+
+--
 -- Name: index_for_rebake_old; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -22057,6 +22064,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260624140945'),
 ('20260617053237'),
 ('20260615084100'),
 ('20260615082047'),

--- a/spec/migrations/ensure_unique_flag_name_keys_spec.rb
+++ b/spec/migrations/ensure_unique_flag_name_keys_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require Rails.root.join("db/post_migrate/20260624140945_ensure_unique_flag_name_keys.rb")
+
+RSpec.describe EnsureUniqueFlagNameKeys do
+  subject(:migrate) { described_class.new.up }
+
+  before do
+    @verbose = ActiveRecord::Migration.verbose
+    ActiveRecord::Migration.verbose = false
+  end
+
+  after { ActiveRecord::Migration.verbose = @verbose }
+
+  it "disambiguates duplicate name_keys and enforces uniqueness" do
+    flag1 = Fabricate(:flag, name: "alpha")
+    flag2 = Fabricate(:flag, name: "beta")
+    flag3 = Fabricate(:flag, name: "gamma")
+
+    ActiveRecord::Base.connection.remove_index(:flags, :name_key, if_exists: true)
+    Flag.unscoped.where(id: [flag1.id, flag2.id, flag3.id]).update_all(name_key: "custom_")
+
+    migrate
+
+    keys = Flag.unscoped.where(id: [flag1.id, flag2.id, flag3.id]).order(:id).pluck(:name_key)
+
+    expect(keys.first).to eq("custom_")
+    expect(keys[1]).to eq("custom__#{flag2.id}")
+    expect(keys[2]).to eq("custom__#{flag3.id}")
+    expect(keys.uniq.size).to eq(3)
+
+    expect(ActiveRecord::Base.connection.index_exists?(:flags, :name_key, unique: true)).to eq(true)
+  end
+
+  it "leaves already-unique name_keys untouched" do
+    flag = Fabricate(:flag, name: "unique flag")
+    original = flag.name_key
+
+    migrate
+
+    expect(flag.reload.name_key).to eq(original)
+  end
+end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -29,6 +29,38 @@ RSpec.describe Flag, type: :model do
     flag.destroy!
   end
 
+  it "generates a unique, non-empty name key for non-ASCII names" do
+    flag1 = Fabricate(:flag, name: "测试举报一")
+    flag2 = Fabricate(:flag, name: "测试举报二")
+    flag3 = Fabricate(:flag, name: "测试举报三")
+
+    keys = [flag1, flag2, flag3].map(&:name_key)
+    expect(keys).to eq(%w[custom_flag custom_flag_2 custom_flag_3])
+    expect(keys.uniq.size).to eq(3)
+
+    [flag1, flag2, flag3].each(&:destroy!)
+  end
+
+  it "generates a unique name key when distinct names normalize identically" do
+    flag1 = Fabricate(:flag, name: "Spam!")
+    flag2 = Fabricate(:flag, name: "Spam?")
+
+    expect(flag1.name_key).to eq("custom_spam")
+    expect(flag2.name_key).to eq("custom_spam_2")
+
+    [flag1, flag2].each(&:destroy!)
+  end
+
+  it "keeps the name key stable when the name does not change" do
+    flag = Fabricate(:flag, name: "测试举报一")
+    expect(flag.name_key).to eq("custom_flag")
+
+    flag.update!(enabled: false)
+    expect(flag.reload.name_key).to eq("custom_flag")
+
+    flag.destroy!
+  end
+
   it "updates post action types when created, modified or destroyed" do
     expect(PostActionType.flag_types.keys).to eq(
       %i[notify_user off_topic inappropriate spam illegal notify_moderators],


### PR DESCRIPTION
Previously, flag names with no ASCII word characters (e.g. Chinese) all normalized to the same `name_key` of `custom_`, because `set_name_key` stripped non-`\w` characters and Ruby's `\w` is ASCII-only. The flag system keys lookups by `name_key` (the `disabled_flag_types` enum, the frontend `actionByName` map), so once two flags shared a key, disabling one of them flipped `can_act` for the whole group and hid every other flag that shared it.

This makes `name_key` reliably unique:

- `set_name_key` falls back to `custom_flag` when the slug is empty and appends a counter (`_2`, `_3`, ...) on collision, so distinct names always produce distinct keys. It now only re-derives the key when the name actually changes, keeping it stable across other saves.
- A post-deploy migration backfills existing duplicate keys and adds the unique index on `flags.name_key` that the original `create_flags` migration intended (`unique: true` is a no-op in `create_table`).

https://meta.discourse.org/t/405254