### PR TITLE
UX: fix scroll while browsing chat channels on iOS

### DIFF
--- a/plugins/chat/assets/stylesheets/common/base-common.scss
+++ b/plugins/chat/assets/stylesheets/common/base-common.scss
@@ -25,9 +25,12 @@ html.ios-device.has-full-page-chat body {
 }
 
 html.ios-device.has-full-page-chat body #main-outlet {
-  .c-routes.--channel-info {
-    @include chat-height;
-    overflow-y: auto;
+  .c-routes {
+    &.--channel-info,
+    &.--browse {
+      @include chat-height;
+      overflow-y: auto;
+    }
   }
 }
 


### PR DESCRIPTION
When you go to create a new channel on iOS, the channel lists on the /chat/browse route aren't scrollable — this fixes it by applying the same styles applied to make the settings scrollable 

before (can't reach the channel at the very bottom... the whole page scrolls but not the nested content hidden by overflow):
<img width="387" height="749" alt="image" src="https://github.com/user-attachments/assets/811aa991-597d-4c00-bbd1-40e95e586a8c" />



after (last channel reachable, can scroll to overflow):
<img width="392" height="716" alt="image" src="https://github.com/user-attachments/assets/e1fe7bb3-d19b-44b6-b1c1-7fef95492a9c" />
