### PR TITLE
FIX: Drop flash-based referer fallback in `topics#show`

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -57,8 +57,6 @@ class TopicsController < ApplicationController
       raise Discourse::InvalidParameters.new("Show only accepts a single ID")
     end
 
-    flash["referer"] ||= request.referer[0..255] if request.referer
-
     # TODO: We'd like to migrate the wordpress feed to another url. This keeps up backwards
     # compatibility with existing installs.
     return wordpress if params[:best].present?
@@ -1445,7 +1443,7 @@ class TopicsController < ApplicationController
 
     if !request.format.json?
       hash = {
-        referer: request.referer || flash[:referer],
+        referer: request.referer,
         host: request.host,
         current_user: current_user,
         topic_id: @topic_view.topic.id,


### PR DESCRIPTION
This logic was introduced 12 years ago, so that Referer information could be carried across a redirect boundary. In modern browsers, Referer information is maintained across same-origin 302 redirects, so there is no need for this extra complexity.

Writing data to the session during `GET` requests can also trigger surprising race conditions. For example, if this request is made at the same time as the start of an authentication flow, the Rails session cookie change from the topic endpoint can overwrite the session cookie from the auth endpoint, causing auth to fail.