### PR TITLE
FIX: show nested reply login prompt to anonymous users

### DIFF
--- a/frontend/discourse/app/components/nested/floating-actions.gjs
+++ b/frontend/discourse/app/components/nested/floating-actions.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -17,7 +18,20 @@ export default class NestedFloatingActions extends Component {
   topicRoute = getOwner(this).lookup("route:topic");
 
   get canCreatePost() {
-    return this.currentUser && this.args.topic?.details?.can_create_post;
+    return this.args.topic?.details?.can_create_post;
+  }
+
+  get showReplyButton() {
+    return !this.currentUser || this.canCreatePost;
+  }
+
+  @action
+  reply() {
+    if (!this.currentUser) {
+      return getOwner(this).lookup("route:application").send("showLogin");
+    }
+
+    return this.args.replyAction?.();
   }
 
   <template>
@@ -53,10 +67,10 @@ export default class NestedFloatingActions extends Component {
         @showChangeTimestamp={{this.topicRoute.showChangeTimestamp}}
       />
 
-      {{#if this.canCreatePost}}
+      {{#if this.showReplyButton}}
         <DButton
           class="btn-primary nested-view__floating-reply"
-          @action={{@replyAction}}
+          @action={{this.reply}}
           @icon="reply"
           @label="topic.reply.title"
           title={{i18n "topic.reply.help"}}

--- a/spec/system/nested_floating_actions_spec.rb
+++ b/spec/system/nested_floating_actions_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe "Nested view floating actions" do
   end
 
   describe "as anonymous user" do
-    it "does not show notification button or reply button" do
+    it "does not show notification button but does show login reply button" do
       nested_view.visit_nested(topic)
       expect(nested_view).to have_no_notification_button
-      expect(nested_view).to have_no_floating_reply_button
+      expect(nested_view).to have_floating_reply_button
     end
   end
 

--- a/spec/system/nested_replying_spec.rb
+++ b/spec/system/nested_replying_spec.rb
@@ -58,10 +58,15 @@ RSpec.describe "Nested view replying" do
       expect(nested_view).to have_floating_reply_button
     end
 
-    it "is not visible for anonymous users" do
+    it "is visible for anonymous users and opens the login flow" do
       Capybara.reset_sessions!
       nested_view.visit_nested(topic)
-      expect(nested_view).to have_no_floating_reply_button
+
+      expect(nested_view).to have_floating_reply_button
+
+      nested_view.click_floating_reply_button
+
+      expect(page).to have_css("#login-account-name")
     end
 
     it "opens the composer for a top-level reply" do

--- a/spec/system/nested_view_spec.rb
+++ b/spec/system/nested_view_spec.rb
@@ -549,12 +549,12 @@ RSpec.describe "Nested view" do
       expect(nested_view).to have_op_post
     end
 
-    it "does not show reply buttons for anonymous users" do
+    it "shows login reply only in floating actions for anonymous users" do
       nested_view.visit_nested(topic)
 
       expect(nested_view).to have_no_reply_button_for(root_reply)
       expect(nested_view).to have_no_reply_button_on_op
-      expect(nested_view).to have_no_floating_reply_button
+      expect(nested_view).to have_floating_reply_button
     end
 
     it "shows login page when anonymous user clicks like" do


### PR DESCRIPTION
The reply button wasn't rendering at all for anons when it should have. Now it does, with the login CTA.