### PR TITLE
SECURITY: Hidden post link URLs leak through per-post link_counts [backport 2026.4]

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -77,6 +77,9 @@ class TopicLink < ActiveRecord::Base
   def self.counts_for(guardian, topic, posts)
     return {} if posts.blank?
 
+    post_ids = visible_source_post_ids(guardian, topic, posts)
+    return {} if post_ids.blank?
+
     # Sam: this is not tidy in AR and also happens to be a critical path
     # for topic view
     builder =
@@ -120,7 +123,7 @@ class TopicLink < ActiveRecord::Base
     end
 
     # not certain if pluck is right, cause it may interfere with caching
-    builder.where("l.post_id in (:post_ids)", post_ids: posts.map(&:id))
+    builder.where("l.post_id in (:post_ids)", post_ids: post_ids)
     builder.secure_category(guardian.secure_category_ids)
 
     result = {}
@@ -199,6 +202,13 @@ class TopicLink < ActiveRecord::Base
 
     lookup
   end
+
+  def self.visible_source_post_ids(guardian, topic, posts)
+    return posts.map(&:id) if guardian.can_see_all_hidden_posts?(topic&.category)
+
+    posts.filter_map { |post| post.id if !post.hidden? || guardian.can_see_hidden_post?(post) }
+  end
+  private_class_method :visible_source_post_ids
 
   def self.apply_link_visibility_filters(builder, link:, target_topic:, target_posts:)
     builder.where(<<~SQL)

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -402,6 +402,7 @@ class PostSerializer < BasicPostSerializer
   end
 
   def include_link_counts?
+    return false if object.hidden? && !scope.can_see_hidden_post?(object)
     return true if @single_post_link_counts.present?
 
     @topic_view.present? && @topic_view.link_counts.present? &&

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -334,15 +334,22 @@ module PostGuardian
     post.deleted_by_id == @user.id && @user.has_trust_level?(TrustLevel[4])
   end
 
-  def can_see_hidden_post?(post)
-    if SiteSetting.hidden_post_visible_groups_map.include?(Group::AUTO_GROUPS[:everyone])
-      return true
-    end
+  def can_see_all_hidden_posts?(category = nil)
+    hidden_post_visible_groups = SiteSetting.hidden_post_visible_groups_map
+
+    return true if hidden_post_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
     return false if anonymous?
     return true if is_staff?
+    return true if is_category_group_moderator?(category)
+
+    @user.in_any_groups?(hidden_post_visible_groups)
+  end
+
+  def can_see_hidden_post?(post)
+    return true if can_see_all_hidden_posts?
     return true if is_my_own?(post)
 
-    @user.in_any_groups?(SiteSetting.hidden_post_visible_groups_map)
+    false
   end
 
   def can_view_edit_history?(post)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3004,6 +3004,65 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(200)
     end
 
+    it "does not expose hidden post link counts", :aggregate_failures do
+      first_post = Fabricate(:post, user: post_author1)
+      test_topic = first_post.topic
+      visible_post = Fabricate(:post, topic: test_topic, user: post_author1)
+      hidden_post =
+        Fabricate(
+          :post,
+          topic: test_topic,
+          user: post_author1,
+          hidden: true,
+          hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
+        )
+
+      visible_link =
+        Fabricate(
+          :topic_link,
+          post: visible_post,
+          url: "https://visible-link-count.example.com",
+          domain: "visible-link-count.example.com",
+          title: "Visible link count title",
+        )
+      hidden_link =
+        Fabricate(
+          :topic_link,
+          post: hidden_post,
+          url: "https://hidden-link-count.example.com",
+          domain: "hidden-link-count.example.com",
+          title: "Hidden link count title",
+        )
+
+      sign_in(user_2)
+
+      get "/t/#{test_topic.slug}/#{test_topic.id}.json"
+
+      expect(response.status).to eq(200)
+      show_posts = response.parsed_body.dig("post_stream", "posts")
+      show_hidden_post = show_posts.find { |post| post["id"] == hidden_post.id }
+      show_visible_post = show_posts.find { |post| post["id"] == visible_post.id }
+      expect(show_hidden_post).to include("hidden" => true, "can_see_hidden_post" => false)
+      expect(show_hidden_post).not_to have_key("link_counts")
+      expect(show_visible_post["link_counts"]).to contain_exactly(
+        a_hash_including("url" => visible_link.url, "title" => visible_link.title),
+      )
+      expect(response.body).not_to include(hidden_link.url)
+
+      get "/t/#{test_topic.id}/posts.json", params: { post_ids: [hidden_post.id, visible_post.id] }
+
+      expect(response.status).to eq(200)
+      posts = response.parsed_body.dig("post_stream", "posts")
+      posts_hidden_post = posts.find { |post| post["id"] == hidden_post.id }
+      posts_visible_post = posts.find { |post| post["id"] == visible_post.id }
+      expect(posts_hidden_post).to include("hidden" => true, "can_see_hidden_post" => false)
+      expect(posts_hidden_post).not_to have_key("link_counts")
+      expect(posts_visible_post["link_counts"]).to contain_exactly(
+        a_hash_including("url" => visible_link.url, "title" => visible_link.title),
+      )
+      expect(response.body).not_to include(hidden_link.url)
+    end
+
     it "shows a blank-slug topic without redirecting" do
       topic.update_columns(title: "", slug: nil)
       topic.reload


### PR DESCRIPTION
Backport of #40903 to release/2026.4.

---

## Summary

Unauthorized users could discover sensitive URLs or internal titles originally shared in posts that were subsequently hidden by moderators or automated flagging.


## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1281

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
