### PR TITLE
UX: minor expanding textarea fixes

### DIFF
--- a/app/assets/stylesheets/common/base/modal.scss
+++ b/app/assets/stylesheets/common/base/modal.scss
@@ -178,7 +178,10 @@ html:not(.keyboard-visible).mobile-device {
 
     textarea {
       width: 100%;
-      height: 80px;
+
+      &:not(.--expandable) {
+        height: 80px;
+      }
     }
 
     .password-confirmation {

--- a/app/assets/stylesheets/common/base/tagging.scss
+++ b/app/assets/stylesheets/common/base/tagging.scss
@@ -422,12 +422,17 @@ body.tags-intersection {
     gap: 0.5em;
     margin-block: 0.5em 1em;
 
+    .expanding-text-area {
+      width: min(24em, 100%);
+
+      --expanding-text-area-min-height: var(--d-control-height);
+      --expanding-text-area-padding: 0.35em 0.65em;
+    }
+
     textarea {
       box-sizing: border-box;
-      min-height: 2.25em;
-      padding: 0.35em;
       margin: 0;
-      width: min(20em, 100%);
+      width: 100%;
       border-radius: var(--d-input-border-radius);
     }
   }

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -106,10 +106,6 @@
 
   .paginated-topics-list {
     position: relative;
-
-    tbody {
-      border-top: none;
-    }
   }
 
   .show-mores {

--- a/app/assets/stylesheets/common/components/expanding-text-area.scss
+++ b/app/assets/stylesheets/common/components/expanding-text-area.scss
@@ -7,6 +7,7 @@
     height: auto;
     resize: none;
     max-width: 100%;
+    padding: var(--expanding-text-area-padding, 0.5em 0.65em);
     min-height: var(--expanding-text-area-min-height, auto);
     max-height: var(--expanding-text-area-max-height, none);
   }
@@ -26,7 +27,7 @@
       visibility: hidden;
       grid-area: 1 / 1;
       box-sizing: border-box;
-      padding: 0.5em 0.65em;
+      padding: var(--expanding-text-area-padding, 0.5em 0.65em);
       border: 1px solid transparent;
       font: inherit;
       min-height: var(--expanding-text-area-min-height, auto);

--- a/frontend/discourse/app/components/modal/request-group-membership-form.gjs
+++ b/frontend/discourse/app/components/modal/request-group-membership-form.gjs
@@ -58,7 +58,7 @@ export default class RequestGroupMembershipForm extends Component {
 
           <DExpandingTextArea
             {{on "input" (withEventValue (fn (mut this.reason)))}}
-            value={{this.reason}}
+            @value={{this.reason}}
             maxlength="5000"
           />
         </div>

--- a/frontend/discourse/app/templates/tags/index.gjs
+++ b/frontend/discourse/app/templates/tags/index.gjs
@@ -76,7 +76,7 @@ export default <template>
           </label>
           <DExpandingTextArea
             {{on "input" (withEventValue (fn (mut @controller.bulkTagInput)))}}
-            value={{@controller.bulkTagInput}}
+            @value={{@controller.bulkTagInput}}
             placeholder={{i18n "tagging.bulk_create_inline_placeholder"}}
             disabled={{@controller.isCreatingTags}}
             rows="1"

--- a/frontend/discourse/app/ui-kit/d-expanding-text-area.gjs
+++ b/frontend/discourse/app/ui-kit/d-expanding-text-area.gjs
@@ -7,7 +7,7 @@ const DExpandingTextArea = <template>
       {{(if @autoFocus dAutoFocus)}}
       {{! deprecated args: }}
       autocorrect={{@autocorrect}}
-      class={{@class}}
+      class="--expandable {{@class}}"
       maxlength={{@maxlength}}
       name={{@name}}
       rows={{@rows}}


### PR DESCRIPTION
There were some minor regressions to the expanding textarea after it was adjusted in an earlier commit... this adds a new css variable to adjust padding as needed, fixes some `@value` references and adjusts specific styles on the /tags page. Also added a modifier class to the child textarea so it can more easily be separated from normal textareas. 

before:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/c7cb28ce-a626-49e2-90d1-7bbee166b79b" />


after:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/0393c9ba-9ea9-43f1-87ba-5c34076cd1c1" />
