### PR TITLE
FIX: nginx sample configuration should be setting x-f-f to the end user IP

### DIFF
--- a/config/nginx.sample.conf
+++ b/config/nginx.sample.conf
@@ -102,7 +102,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Request-Start "t=${msec}";
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $thescheme;
     proxy_set_header X-Sendfile-Type "";
     proxy_set_header X-Accel-Mapping "";
@@ -171,7 +171,7 @@ server {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Request-Start "t=${msec}";
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;
       proxy_set_header X-Accel-Mapping $public/=/downloads/;
@@ -217,7 +217,7 @@ server {
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Request-Start "t=${msec}";
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-For $remote_addr;
       proxy_set_header X-Forwarded-Proto $thescheme;
       proxy_set_header X-Sendfile-Type X-Accel-Redirect;
       proxy_set_header X-Accel-Mapping $public/=/downloads/;
@@ -275,7 +275,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Request-Start "t=${msec}";
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $thescheme;
     proxy_set_header X-Sendfile-Type "";
     proxy_set_header X-Accel-Mapping "";


### PR DESCRIPTION
nginx's responsibility is to determine the correct end user's IP (as far as we
can trust it) and report that to Discourse.

The correct way to do that is to teach nginx how to determine this for itself -
this means that both the nginx logs and the downstream value will be correct.

(see https://github.com/discourse/discourse_docker/pull/1077 which removes the
only use of `proxy_add_x_forwarded_for`)

Setting the x-f-f header to `$proxy_add_x_forwarded_for` or
`$http_x_forwarded_for` hides this learned knowledge and forces Discourse to go
through the same process and possibly arrive at a edifferent answer.

In most cases this won't make a difference, but when there is more than one
proxy in front of Discourse this exposes a failure case.

client → proxyA → proxyB → nginx → discourse

means Discourse saw:
```
x-real-ip: client_ip
x-forwarded-for: client_ip, proxyA
```

and might end using `client_ip` or `proxyA_ip` depending on codepath.

After this change, Discourse sees:
```
x-real-ip: client_ip
x-forwarded-for: client_ip
```

for the same situation.
