### PR TITLE
FEATURE: Allow selecting multiple category types when creating a category

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -209,6 +209,27 @@ class CategoriesController < ApplicationController
             end
           end
         end
+
+        additional_category_types =
+          Array(params[:category_types]).compact_blank.map(&:to_sym) -
+            [category_type&.to_sym, :discussion].compact
+
+        additional_category_types.each do |additional_category_type|
+          Categories::Configure.call(
+            guardian:,
+            params: {
+              category_id: @category.id,
+              category_type: additional_category_type,
+            },
+          ) do
+            on_failed_policy(:type_is_available) do
+              configure_error = category_type_unavailable_error(additional_category_type)
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+
+        @category.reload if category_type.present? || additional_category_types.any?
       end
     end
 

--- a/frontend/discourse/admin/components/upsert-category/general.gjs
+++ b/frontend/discourse/admin/components/upsert-category/general.gjs
@@ -66,9 +66,15 @@ export default class UpsertCategoryGeneral extends Component {
 
   constructor() {
     super(...arguments);
+
+    const primaryTypeId = this.isEditingExistingCategory
+      ? null
+      : this.categoryTypeChooser.currentSelection?.type;
+
     this.categoryTypes = [...this.categoryTypeChooser.allTypes].map((type) => ({
       ...type,
-      preventRemoval: type.id === DISCUSSION_TYPE_ID,
+      preventRemoval:
+        type.id === DISCUSSION_TYPE_ID || type.id === primaryTypeId,
     }));
   }
 
@@ -593,12 +599,13 @@ export default class UpsertCategoryGeneral extends Component {
   }
 
   <template>
-    {{#if this.isEditingExistingCategory}}
+    {{#if (or this.isEditingExistingCategory @showAdvancedTabs)}}
       <@form.Field
         @name="category_types"
         @title={{i18n "category.category_types"}}
         @format="max"
         @type="custom"
+        @showOptional={{false}}
         as |field|
       >
         <field.Control>

--- a/frontend/discourse/admin/components/upsert-category/general.gjs
+++ b/frontend/discourse/admin/components/upsert-category/general.gjs
@@ -67,14 +67,9 @@ export default class UpsertCategoryGeneral extends Component {
   constructor() {
     super(...arguments);
 
-    const primaryTypeId = this.isEditingExistingCategory
-      ? null
-      : this.categoryTypeChooser.currentSelection?.type;
-
     this.categoryTypes = [...this.categoryTypeChooser.allTypes].map((type) => ({
       ...type,
-      preventRemoval:
-        type.id === DISCUSSION_TYPE_ID || type.id === primaryTypeId,
+      preventRemoval: type.id === DISCUSSION_TYPE_ID,
     }));
   }
 

--- a/frontend/discourse/admin/controllers/edit-category/tabs.js
+++ b/frontend/discourse/admin/controllers/edit-category/tabs.js
@@ -67,6 +67,7 @@ const SIMPLIFIED_FIELD_LIST = [
 ];
 
 const SHOW_ADVANCED_TABS_KEY = "category_edit_show_advanced_tabs";
+const DISCUSSION_TYPE_ID = "discussion";
 
 export default class EditCategoryTabsController extends Controller {
   @service currentUser;
@@ -137,6 +138,10 @@ export default class EditCategoryTabsController extends Controller {
     };
     data.site_texts = {};
     data.category_types = Object.keys(this.model.categoryTypes ?? {});
+
+    if (!data.category_types.includes(DISCUSSION_TYPE_ID)) {
+      data.category_types.unshift(DISCUSSION_TYPE_ID);
+    }
 
     Object.values(this.model.categoryTypes ?? {}).forEach((categoryType) => {
       categoryType.configuration_schema.category_custom_fields?.forEach(

--- a/frontend/discourse/admin/templates/edit-category/tabs.gjs
+++ b/frontend/discourse/admin/templates/edit-category/tabs.gjs
@@ -91,6 +91,7 @@ export default class Tabs extends Component {
               @selectedTab={{@controller.selectedTab}}
               @categoryType={{@controller.selectedTab}}
               @category={{@controller.model}}
+              @showAdvancedTabs={{@controller.showAdvancedTabs}}
               @registerValidator={{@controller.registerValidator}}
               @registerAfterReset={{@controller.registerAfterReset}}
               @transientData={{transientData}}

--- a/frontend/discourse/app/models/category.js
+++ b/frontend/discourse/app/models/category.js
@@ -862,7 +862,10 @@ export default class Category extends RestModel {
     };
 
     if (!id && this.categoryTypes) {
-      props.category_type = Object.keys(this.categoryTypes)[0];
+      const primaryType = Object.keys(this.categoryTypes)[0];
+      if (this.category_types?.includes(primaryType)) {
+        props.category_type = primaryType;
+      }
     }
 
     return props;

--- a/plugins/discourse-solved/spec/requests/categories_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/categories_controller_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe CategoriesController do
 
   before { sign_in(admin) }
 
+  describe "#create" do
+    it "can enable the support type alongside another type while creating a category" do
+      post "/categories.json",
+           params: {
+             name: "Multi Type",
+             category_type: "discussion",
+             category_types: %w[discussion support],
+           }
+
+      expect(response.status).to eq(200)
+      cat_json = response.parsed_body["category"]
+      expect(cat_json["category_types"].keys).to include("support", "discussion")
+
+      category = Category.find(cat_json["id"])
+      expect(category.category_types.keys).to include(:support, :discussion)
+      expect(category.enable_accepted_answers?).to eq(true)
+    end
+  end
+
   describe "#update" do
     it "can add the support type to the category" do
       expect(category.enable_accepted_answers?).to eq(false)

--- a/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
+++ b/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
@@ -68,6 +68,25 @@ RSpec.describe "Support Category Type Setup" do
     expect(category.enable_accepted_answers?).to eq(true)
   end
 
+  it "can remove the type picked on the setup screen while creating a category" do
+    visit("/new-category/setup")
+    category_type_card.find_type_card("support").click
+    expect(page).to have_content(I18n.t("js.category.create_with_type", typeName: "support"))
+
+    form.field("name").fill_in("No longer support")
+
+    category_page.toggle_advanced_settings
+
+    category_type_selector = PageObjects::Components::DMenu.new(".category-type-selector")
+    category_type_selector.remove_selected_option("Support")
+    banner.click_save
+
+    expect(page).to have_no_css(".d-nav-submenu__tabs .edit-category-support")
+    category = Category.find_by(name: "No longer support")
+    expect(category.category_types.keys).to eq(%i[discussion])
+    expect(category.enable_accepted_answers?).to eq(false)
+  end
+
   it "is able to click the support tab when creating a new category when solved is disabled" do
     SiteSetting.solved_enabled = false
     visit("/new-category/setup")

--- a/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
+++ b/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
@@ -46,6 +46,28 @@ RSpec.describe "Support Category Type Setup" do
     expect(category.custom_fields["empty_box_on_unsolved"]).to eq("true")
   end
 
+  it "can add the support type via the selector while creating a category of another type" do
+    visit("/new-category/setup")
+    category_type_card.find_type_card("discussion").click
+    expect(page).to have_content(I18n.t("js.category.create_with_type", typeName: "discussion"))
+
+    form.field("name").fill_in("Discussion + Support")
+
+    # The type selector is only available under advanced settings while creating.
+    expect(page).to have_no_css(".category-type-selector")
+    category_page.toggle_advanced_settings
+
+    category_type_selector = PageObjects::Components::DMenu.new(".category-type-selector")
+    category_type_selector.expand
+    category_type_selector.option(".category-type-selector__result.--category-type-support").click
+    banner.click_save
+
+    expect(page).to have_css(".d-nav-submenu__tabs .edit-category-support")
+    category = Category.find_by(name: "Discussion + Support")
+    expect(category.category_types.keys).to include(:discussion, :support)
+    expect(category.enable_accepted_answers?).to eq(true)
+  end
+
   it "is able to click the support tab when creating a new category when solved is disabled" do
     SiteSetting.solved_enabled = false
     visit("/new-category/setup")

--- a/plugins/discourse-topic-voting/spec/system/ideas_category_type_setup_spec.rb
+++ b/plugins/discourse-topic-voting/spec/system/ideas_category_type_setup_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe "Ideas Category Type Setup" do
     expect(Category.can_vote?(category.id)).to eq(true)
   end
 
+  it "can remove the ideas type picked on the setup screen while creating a category" do
+    visit("/new-category/setup")
+    category_type_card.find_type_card("ideas").click
+    expect(page).to have_content(I18n.t("js.category.create_with_type", typeName: "ideas"))
+
+    form.field("name").fill_in("No longer ideas")
+
+    category_page.toggle_advanced_settings
+
+    category_type_selector = PageObjects::Components::DMenu.new(".category-type-selector")
+    category_type_selector.remove_selected_option("Ideas")
+    banner.click_save
+
+    expect(page).to have_no_css(".d-nav-submenu__tabs .edit-category-ideas")
+    category = Category.find_by(name: "No longer ideas")
+    expect(category.category_types.keys).to eq(%i[discussion])
+    expect(Category.can_vote?(category.id)).to eq(false)
+  end
+
   context "when the ideas category type setup is disabled" do
     before { SiteSetting.enable_ideas_category_type_setup = false }
 


### PR DESCRIPTION
Previously, the category type selector only appeared when editing an existing category, so a new category could only be created with the single type picked on the setup screen — making it impossible to combine features like Ideas (voting) and Support (solved) from the start.

This change surfaces the type selector on the creation form under "Advanced settings" and configures every selected type on create (the primary type with its settings, the rest with defaults), so multiple types can be enabled in one pass.