### PR TITLE
FIX: Gate MessageBus groups when closing topic

### DIFF
--- a/app/jobs/regular/close_topic.rb
+++ b/app/jobs/regular/close_topic.rb
@@ -25,7 +25,11 @@ module Jobs
       # this handles deleting the topic timer as well, see TopicStatusUpdater
       topic.update_status("autoclosed", true, user, { silent: silent })
 
-      MessageBus.publish("/topic/#{topic.id}", reload_topic: true)
+      MessageBus.publish(
+        "/topic/#{topic.id}",
+        { reload_topic: true },
+        topic.secure_audience_publish_messages,
+      )
     end
   end
 end

--- a/app/jobs/regular/open_topic.rb
+++ b/app/jobs/regular/open_topic.rb
@@ -31,7 +31,11 @@ module Jobs
 
       topic.inherit_auto_close_from_category(timer_type: :close)
 
-      MessageBus.publish("/topic/#{topic.id}", reload_topic: true)
+      MessageBus.publish(
+        "/topic/#{topic.id}",
+        { reload_topic: true },
+        topic.secure_audience_publish_messages,
+      )
     end
   end
 end

--- a/spec/integration/topic_timer_message_bus_spec.rb
+++ b/spec/integration/topic_timer_message_bus_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe "topic timer message bus security" do
+  fab!(:admin)
+  fab!(:group)
+  fab!(:member, :user)
+  fab!(:group_user) { Fabricate(:group_user, group: group, user: member) }
+  fab!(:private_category) { Fabricate(:private_category, group: group) }
+  fab!(:topic) { Fabricate(:topic, category: private_category) }
+
+  it "does not expose restricted timer reloads", :aggregate_failures do
+    channel = "/topic/#{topic.id}"
+
+    close_timer =
+      Fabricate(
+        :topic_timer,
+        user: admin,
+        topic: topic,
+        execute_at: 1.minute.ago,
+        created_at: 2.minutes.ago,
+      )
+    close_last_id = MessageBus.last_id(channel)
+
+    Jobs::CloseTopic.new.execute(topic_timer_id: close_timer.id)
+
+    post "/message-bus/poll?dlp=t", params: { channel => close_last_id }
+    expect(response.status).to eq(200)
+    expect(reload_topic_messages(channel)).to be_empty
+
+    open_timer =
+      Fabricate(
+        :topic_timer,
+        status_type: TopicTimer.types[:open],
+        user: admin,
+        topic: topic,
+        execute_at: 1.minute.ago,
+        created_at: 2.minutes.ago,
+      )
+    open_last_id = MessageBus.last_id(channel)
+
+    Jobs::OpenTopic.new.execute(topic_timer_id: open_timer.id)
+
+    post "/message-bus/poll?dlp=t", params: { channel => open_last_id }
+    expect(response.status).to eq(200)
+    expect(reload_topic_messages(channel)).to be_empty
+
+    sign_in(member)
+    post "/message-bus/poll?dlp=t", params: { channel => open_last_id }
+    expect(response.status).to eq(200)
+    expect(reload_topic_messages(channel)).to be_present
+  end
+
+  def reload_topic_messages(channel)
+    response.parsed_body.select do |message|
+      data = message["data"]
+      message["channel"] == channel && data.is_a?(Hash) && data["reload_topic"] == true
+    end
+  end
+end

--- a/spec/jobs/close_topic_spec.rb
+++ b/spec/jobs/close_topic_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Jobs::CloseTopic do
 
   it "publishes to the topic message bus so the topic status reloads" do
     MessageBus.expects(:publish).at_least_once
-    MessageBus.expects(:publish).with("/topic/#{topic.id}", reload_topic: true).once
+    MessageBus
+      .expects(:publish)
+      .with("/topic/#{topic.id}", { reload_topic: true }, topic.secure_audience_publish_messages)
+      .once
     freeze_time(61.minutes.from_now) do
       described_class.new.execute(topic_timer_id: topic.public_topic_timer.id)
     end

--- a/spec/jobs/open_topic_spec.rb
+++ b/spec/jobs/open_topic_spec.rb
@@ -19,7 +19,10 @@ RSpec.describe Jobs::OpenTopic do
 
   it "publishes to the topic message bus so the topic status reloads" do
     MessageBus.expects(:publish).at_least_once
-    MessageBus.expects(:publish).with("/topic/#{topic.id}", reload_topic: true).once
+    MessageBus
+      .expects(:publish)
+      .with("/topic/#{topic.id}", { reload_topic: true }, topic.secure_audience_publish_messages)
+      .once
     freeze_time(61.minutes.from_now) do
       described_class.new.execute(topic_timer_id: topic.public_topic_timer.id)
     end


### PR DESCRIPTION
## Summary

Current main still publishes topic timer reload events on /topic/<id> without any MessageBus audience restriction. A focused request spec against the real /message-bus/poll endpoint showed an anonymous client, who cannot see a restricted-category topic, can subscribe from the pre-timer message id and receive the timer-generated {reload_topic: true} event. The payload is small, but it confirms the reported restricted-topic existence/channel activity leak. Nearby code demonstrates other topic MessageBus publishes are expected to merge Topic#secure_audience_publish_messages, which the timer jobs do not do. Patch-triage searches for the report id, GHSA terms, MessageBus/topic timer/secure_audience/CloseTopic/OpenTopic keywords, and related restricted-topic live-notification leaks did not find an exact duplicate; inspected similar patches were different root causes/components.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1156


Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>