### PR TITLE
FIX: Run Discord agents as their associated user

### DIFF
--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -906,6 +906,10 @@ en:
           negative: "Negative"
           neutral: "Neutral"
 
+    discord:
+      configuration:
+        agent_user_required: "The Discord search agent must have an associated user before Discord agent mode can be enabled."
+
     llm:
       configuration:
         create_llm: "You need to setup an LLM before enabling this feature"

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -420,6 +420,7 @@ discourse_ai:
   ai_discord_search_enabled:
     default: false
     client: true
+    validator: "DiscourseAi::Configuration::DiscordSearchAgentValidator"
     area: "ai-features/discord"
   ai_discord_app_id:
     default: ""
@@ -435,11 +436,13 @@ discourse_ai:
     choices:
       - search
       - agent
+    validator: "DiscourseAi::Configuration::DiscordSearchAgentValidator"
     area: "ai-features/discord"
   ai_discord_search_agent:
     default: ""
     type: enum
     enum: "DiscourseAi::Configuration::AgentEnumerator"
+    validator: "DiscourseAi::Configuration::DiscordSearchAgentValidator"
     area: "ai-features/discord"
   ai_discord_allowed_guilds:
     type: list

--- a/plugins/discourse-ai/lib/configuration/discord_search_agent_validator.rb
+++ b/plugins/discourse-ai/lib/configuration/discord_search_agent_validator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Configuration
+    class DiscordSearchAgentValidator
+      def initialize(opts = {})
+        @opts = opts
+      end
+
+      def valid_value?(val)
+        return true if !agent_mode_enabled?(val)
+
+        agent = AiAgent.find_by(id: selected_agent_id(val))
+        agent&.user_id.present?
+      end
+
+      def error_message
+        I18n.t("discourse_ai.discord.configuration.agent_user_required")
+      end
+
+      private
+
+      def agent_mode_enabled?(val)
+        enabled_value = value_for(:ai_discord_search_enabled, val)
+        mode_value = value_for(:ai_discord_search_mode, val)
+
+        truthy?(enabled_value) && mode_value == "agent"
+      end
+
+      def selected_agent_id(val)
+        value_for(:ai_discord_search_agent, val).to_i
+      end
+
+      def value_for(setting_name, val)
+        @opts[:name] == setting_name ? val : SiteSetting.public_send(setting_name)
+      end
+
+      def truthy?(val)
+        val == true || val == "t" || val == "true"
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/discord/bot/agent_replier.rb
+++ b/plugins/discourse-ai/lib/discord/bot/agent_replier.rb
@@ -4,26 +4,36 @@ module DiscourseAi
   module Discord::Bot
     class AgentReplier < Base
       def initialize(body)
-        @agent =
+        super(body)
+
+        @agent_class =
           AiAgent
             .all_agents(enabled_only: false)
             .find { |p| p.id == SiteSetting.ai_discord_search_agent.to_i }
-            .new
+
+        @agent_user = User.find_by(id: @agent_class&.user_id)
+        return if @agent_class.nil? || @agent_user.nil?
+
+        @agent = @agent_class.new
         @bot =
           DiscourseAi::Agents::Bot.as(
-            Discourse.system_user,
+            @agent_user,
             agent: @agent,
             model: LlmModel.find(@agent.class.default_llm_id || SiteSetting.ai_default_llm_model),
           )
-        super(body)
       end
 
       def handle_interaction!
+        if @bot.nil?
+          return create_reply(I18n.t("discourse_ai.discord.configuration.agent_user_required"))
+        end
+
         last_update_sent_at = Time.now - 1
         reply = +""
 
         context =
           DiscourseAi::Agents::BotContext.new(
+            user: @agent_user,
             messages: [{ type: :user, content: @query }],
             skip_show_thinking: true,
           )

--- a/plugins/discourse-ai/spec/configuration/discord_search_agent_validator_spec.rb
+++ b/plugins/discourse-ai/spec/configuration/discord_search_agent_validator_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Configuration::DiscordSearchAgentValidator do
+  fab!(:agent_without_user, :ai_agent)
+  fab!(:agent_user, :user)
+  fab!(:agent_with_user) { Fabricate(:ai_agent, user: agent_user) }
+
+  before do
+    enable_current_plugin
+    SiteSetting.ai_discord_search_enabled = false
+    SiteSetting.ai_discord_search_mode = "search"
+    SiteSetting.ai_discord_search_agent = ""
+  end
+
+  it "allows disabling Discord search" do
+    SiteSetting.ai_discord_search_mode = "agent"
+    SiteSetting.ai_discord_search_agent = agent_without_user.id
+
+    validator = described_class.new(name: :ai_discord_search_enabled)
+
+    expect(validator.valid_value?("f")).to eq(true)
+  end
+
+  it "allows search mode without an associated agent user" do
+    SiteSetting.ai_discord_search_enabled = true
+    SiteSetting.ai_discord_search_agent = agent_without_user.id
+
+    validator = described_class.new(name: :ai_discord_search_agent)
+
+    expect(validator.valid_value?(agent_without_user.id)).to eq(true)
+  end
+
+  it "blocks enabling agent mode without an associated agent user" do
+    SiteSetting.ai_discord_search_mode = "agent"
+    SiteSetting.ai_discord_search_agent = agent_without_user.id
+
+    validator = described_class.new(name: :ai_discord_search_enabled)
+
+    expect(validator.valid_value?("t")).to eq(false)
+    expect(validator.error_message).to eq(
+      I18n.t("discourse_ai.discord.configuration.agent_user_required"),
+    )
+  end
+
+  it "blocks switching to agent mode without an associated agent user" do
+    SiteSetting.ai_discord_search_enabled = true
+    SiteSetting.ai_discord_search_agent = agent_without_user.id
+
+    validator = described_class.new(name: :ai_discord_search_mode)
+
+    expect(validator.valid_value?("agent")).to eq(false)
+  end
+
+  it "blocks switching agents when the new agent has no user" do
+    SiteSetting.ai_discord_search_mode = "agent"
+    SiteSetting.ai_discord_search_agent = agent_with_user.id
+    SiteSetting.ai_discord_search_enabled = true
+
+    validator = described_class.new(name: :ai_discord_search_agent)
+
+    expect(validator.valid_value?(agent_without_user.id)).to eq(false)
+  end
+
+  it "allows agent mode when the selected agent has a user" do
+    SiteSetting.ai_discord_search_mode = "agent"
+    SiteSetting.ai_discord_search_agent = agent_with_user.id
+
+    validator = described_class.new(name: :ai_discord_search_enabled)
+
+    expect(validator.valid_value?("t")).to eq(true)
+  end
+end

--- a/plugins/discourse-ai/spec/jobs/regular/stream_discord_reply_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/stream_discord_reply_spec.rb
@@ -12,13 +12,47 @@ RSpec.describe Jobs::StreamDiscordReply, type: :job do
   end
 
   fab!(:llm_model)
-  fab!(:agent) { Fabricate(:ai_agent, default_llm_id: llm_model.id) }
+  fab!(:agent_user) { Fabricate(:user, trust_level: TrustLevel[0]) }
+  fab!(:agent) { Fabricate(:ai_agent, default_llm_id: llm_model.id, user: agent_user) }
 
   before do
     enable_current_plugin
-    SiteSetting.ai_discord_search_enabled = true
-    SiteSetting.ai_discord_search_mode = "agent"
     SiteSetting.ai_discord_search_agent = agent.id
+    SiteSetting.ai_discord_search_mode = "agent"
+    SiteSetting.ai_discord_search_enabled = true
+    SiteSetting.ai_discord_app_id = "discord_app"
+  end
+
+  it "runs agent tools as the agent user" do
+    fake_model = Fabricate(:fake_model)
+    agent.update!(
+      default_llm_id: fake_model.id,
+      tools: ["DeleteTopic"],
+      require_approval: false,
+      allowed_group_ids: [Group::AUTO_GROUPS[:everyone]],
+    )
+    AiAgent.agent_cache.flush!
+
+    post = Fabricate(:post)
+    tool_call =
+      DiscourseAi::Completions::ToolCall.new(
+        id: "delete-topic-call",
+        name: "delete_topic",
+        parameters: {
+          topic_id: post.topic_id,
+          deleted: true,
+          reason: "from discord",
+        },
+      )
+    webhook_url = "https://discord.com/api/webhooks/discord_app/interaction_token"
+    stub_request(:post, webhook_url).to_return(status: 200, body: "{}")
+    stub_request(:patch, "#{webhook_url}/messages/@original").to_return(status: 200, body: "{}")
+
+    DiscourseAi::Completions::Endpoints::Fake.with_fake_content([tool_call, "Done"]) do
+      described_class.new.execute(interaction: interaction)
+    end
+
+    expect(post.reload.deleted_at).to be_nil
   end
 
   it "calls AgentReplier when search mode is agent" do

--- a/plugins/discourse-ai/spec/lib/discord/bot/agent_replier_spec.rb
+++ b/plugins/discourse-ai/spec/lib/discord/bot/agent_replier_spec.rb
@@ -4,16 +4,19 @@ RSpec.describe DiscourseAi::Discord::Bot::AgentReplier do
   let(:interaction_body) do
     { data: { options: [{ value: "test query" }] }, token: "interaction_token" }.to_json.to_s
   end
+  let(:selected_agent) { agent }
   let(:agent_replier) { described_class.new(interaction_body) }
 
   fab!(:llm_model)
-  fab!(:agent) { Fabricate(:ai_agent, default_llm_id: llm_model.id) }
+  fab!(:agent_user) { Fabricate(:user, trust_level: TrustLevel[0]) }
+  fab!(:agent) { Fabricate(:ai_agent, default_llm_id: llm_model.id, user: agent_user) }
+  fab!(:agent_without_user) { Fabricate(:ai_agent, default_llm_id: llm_model.id) }
 
   before do
     enable_current_plugin
-    SiteSetting.ai_discord_search_agent = agent.id.to_s
+    SiteSetting.ai_discord_search_agent = selected_agent.id.to_s
     allow_any_instance_of(DiscourseAi::Agents::Bot).to receive(:reply).and_return(
-      "This is a reply from bot!",
+      [["This is a reply from bot!"]],
     )
     allow(agent_replier).to receive(:create_reply)
   end
@@ -24,13 +27,26 @@ RSpec.describe DiscourseAi::Discord::Bot::AgentReplier do
       expect(agent_replier).to have_received(:create_reply).at_least(:once)
     end
 
-    it "uses a BotContext to generate the reply" do
-      expect_any_instance_of(DiscourseAi::Agents::Bot).to receive(:reply) do |bot, context|
+    it "passes the agent user in BotContext" do
+      expect_any_instance_of(DiscourseAi::Agents::Bot).to receive(:reply) do |_bot, context|
         expect(context).to be_a(DiscourseAi::Agents::BotContext)
+        expect(context.user).to eq(agent.user)
         [["This is a reply from bot!"]]
       end
 
       agent_replier.handle_interaction!
+    end
+
+    context "when the selected agent has no associated user" do
+      let(:selected_agent) { agent_without_user }
+
+      it "does not run the agent" do
+        agent_replier.handle_interaction!
+
+        expect(agent_replier).to have_received(:create_reply).with(
+          I18n.t("discourse_ai.discord.configuration.agent_user_required"),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, Discord agent mode ran without an explicit agent user, so tool behavior could differ from the selected agent's configured identity.

This change runs Discord agents as their associated user and validates that Discord agent mode has one before it can be enabled.