### PR TITLE
UX: Fit large Graphviz graphs to the box instead of overflowing

### DIFF
--- a/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
+++ b/plugins/discourse-graphviz/assets/stylesheets/common/graphviz.scss
@@ -54,6 +54,13 @@ div.graphviz.is-loading {
   > * {
     flex: 0 0 auto;
   }
+
+  > svg {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+  }
 }
 
 .graph-error {
@@ -84,8 +91,9 @@ div.graphviz.is-loading {
 
       > svg {
         max-width: none;
+        max-height: none;
         width: auto;
-        height: 100%;
+        height: auto;
       }
     }
   }


### PR DESCRIPTION
Since be74f5ff1cb1e841f89a45f4f2ac7ce5c44e80f9, large Graphviz diagrams rendered at their natural SVG size, overflowing the post box and the fullscreen view.

This change scales graphs down to fit the box in both dimensions while preserving their aspect ratio. Graphs are only rendered at full size once zoomed.