### PR TITLE
FEATURE: Handle Word quote styles and review markup on paste

### DIFF
--- a/frontend/discourse/app/lib/to-markdown.js
+++ b/frontend/discourse/app/lib/to-markdown.js
@@ -53,7 +53,7 @@ export default async function toMarkdown(html) {
       { DOMParser: ProseMirrorDOMParser },
       { createSchema },
       { default: Serializer },
-      { transformWordListsHtml },
+      { transformWordHtml },
       { isBoundary },
     ] = await Promise.all([
       import("prosemirror-model"),
@@ -73,7 +73,7 @@ export default async function toMarkdown(html) {
     const pluginParams = { utils: { isBoundary } };
     const serializer = new Serializer(extensions, pluginParams);
 
-    const processedHtml = transformWordListsHtml(html);
+    const processedHtml = transformWordHtml(html);
     const parsedDoc = new DOMParser().parseFromString(
       processedHtml,
       "text/html"

--- a/frontend/discourse/app/static/prosemirror/extensions/word-paste.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/word-paste.js
@@ -4,6 +4,21 @@ const MSO_LIST_CLASSES = [
   "MsoListParagraphCxSpLast",
 ];
 
+// Word's built-in quote-like paragraph styles ("Quote", "Intense Quote",
+// "Block Text"). Word has no semantic blockquote, so it emits styled paragraphs
+// instead of <blockquote>. Bare indentation (margin-left) is intentionally not
+// treated as a quote - it's too ambiguous to convert reliably.
+//
+// Desktop Word marks the style with a non-localized class (e.g. MsoQuote).
+// Word for the web ("WAC") instead tags runs with data-ccp-parastyle set to the
+// internal (English) style name, regardless of the document language - so these
+// match reliably across locales.
+const MSO_QUOTE_CLASSES = ["MsoQuote", "MsoIntenseQuote", "MsoBlockText"];
+const WAC_QUOTE_STYLES = ["Quote", "Intense Quote", "Block Text"];
+const WAC_QUOTE_SELECTOR = WAC_QUOTE_STYLES.map(
+  (style) => `[data-ccp-parastyle="${style}"]`
+).join(", ");
+
 /**
  * Extracts the list level from a Word list paragraph's style attribute.
  * Word uses styles like "mso-list:l0 level2 lfo1" to indicate nesting.
@@ -208,20 +223,166 @@ export function transformWordLists(container) {
   });
 }
 
+function isQuoteParagraph(node) {
+  if (node?.nodeType !== Node.ELEMENT_NODE || node.tagName !== "P") {
+    return false;
+  }
+
+  return (
+    MSO_QUOTE_CLASSES.some((cls) => node.classList.contains(cls)) ||
+    node.querySelector(WAC_QUOTE_SELECTOR) !== null
+  );
+}
+
+function nextElementSibling(node) {
+  let sibling = node.nextSibling;
+  while (sibling && sibling.nodeType !== Node.ELEMENT_NODE) {
+    sibling = sibling.nextSibling;
+  }
+  return sibling;
+}
+
 /**
- * Transforms Word list HTML string into standard HTML list structure.
+ * Transforms Word quote-style paragraphs into <blockquote> elements, for both
+ * desktop Word (class-based) and Word for the web (data-ccp-parastyle).
+ * Consecutive quote paragraphs are merged into a single blockquote. This
+ * function processes the DOM in place.
+ *
+ * @param {Document|Element} container - The container to process
+ */
+export function transformWordQuotes(container) {
+  const candidates = new Set();
+
+  // Desktop Word: quote style is a class on the paragraph
+  container
+    .querySelectorAll(MSO_QUOTE_CLASSES.map((c) => `p.${c}`).join(", "))
+    .forEach((p) => candidates.add(p));
+
+  // Word for the web: quote style is on a run inside the paragraph
+  container.querySelectorAll(WAC_QUOTE_SELECTOR).forEach((run) => {
+    const p = run.closest("p");
+    if (p) {
+      candidates.add(p);
+    }
+  });
+
+  if (candidates.size === 0) {
+    return;
+  }
+
+  // Walk paragraphs in document order so consecutive-sibling merging is stable
+  const paragraphs = Array.from(container.querySelectorAll("p")).filter((p) =>
+    candidates.has(p)
+  );
+
+  const absorbed = new Set();
+
+  paragraphs.forEach((paragraph) => {
+    if (absorbed.has(paragraph)) {
+      return;
+    }
+
+    const blockquote = document.createElement("blockquote");
+    paragraph.parentNode.insertBefore(blockquote, paragraph);
+
+    // Merge this paragraph and any consecutive quote paragraphs into one
+    // blockquote, preserving each as a paragraph with its inline formatting.
+    let current = paragraph;
+    while (isQuoteParagraph(current)) {
+      const next = nextElementSibling(current);
+      absorbed.add(current);
+      current.classList.remove(...MSO_QUOTE_CLASSES);
+      if (current.classList.length === 0) {
+        current.removeAttribute("class");
+      }
+      blockquote.appendChild(current);
+      current = next;
+    }
+  });
+}
+
+// Word review markup that should never make it into a post: comment reference
+// anchors/markers, the comment body list Word appends at the end, and tracked
+// deletions. Manual strikethrough is exported as <s>, not <del>, so dropping
+// <del> only removes revision deletions.
+const WORD_REVIEW_SELECTORS = [
+  "a.msocomanchor",
+  "span.MsoCommentReference",
+  "[style*='mso-comment-reference']",
+  "[style*='mso-special-character:comment']",
+  "a[href^='#_msocom']",
+  "a[name^='_msocom']",
+  "hr.msocomoff",
+  "[style*='mso-element:comment-list']",
+  "[style*='mso-element:comment']",
+  "p.MsoCommentText",
+  "p.MsoCommentSubject",
+  "del",
+].join(", ");
+
+/**
+ * Detects whether an HTML string originated from Microsoft Word, so that
+ * Word-only cleanup (e.g. review markup) is not applied to other sources.
+ *
+ * @param {string} html - The HTML string to inspect
+ * @returns {boolean}
+ */
+function isWordHtml(html) {
+  return (
+    html.includes("mso-") ||
+    html.includes("urn:schemas-microsoft-com") ||
+    /class=["']?Mso/.test(html)
+  );
+}
+
+/**
+ * Removes Word review markup (comments and tracked deletions) from a document.
+ * This function processes the DOM in place.
+ *
+ * @param {Document|Element} container - The container to process
+ */
+export function stripWordReviewMarkup(container) {
+  container
+    .querySelectorAll(WORD_REVIEW_SELECTORS)
+    .forEach((el) => el.remove());
+}
+
+/**
+ * Transforms Word-specific markup in an HTML string into standard HTML:
+ * converts Word lists and quote styles, and strips Word review markup
+ * (comments and tracked deletions).
  *
  * @param {string} html - The HTML string to transform
  * @returns {string} The transformed HTML
  */
-export function transformWordListsHtml(html) {
-  // Quick check if there's any Word list content
-  if (!MSO_LIST_CLASSES.some((cls) => html.includes(cls))) {
+export function transformWordHtml(html) {
+  const hasLists = MSO_LIST_CLASSES.some((cls) => html.includes(cls));
+  const hasQuotes =
+    MSO_QUOTE_CLASSES.some((cls) => html.includes(cls)) ||
+    WAC_QUOTE_STYLES.some((style) =>
+      html.includes(`data-ccp-parastyle="${style}"`)
+    );
+  const isWord = isWordHtml(html);
+
+  // Quick check if there's any Word content we handle
+  if (!hasLists && !hasQuotes && !isWord) {
     return html;
   }
 
   const doc = new DOMParser().parseFromString(html, "text/html");
-  transformWordLists(doc.body);
+
+  if (hasLists) {
+    transformWordLists(doc.body);
+  }
+
+  if (hasQuotes) {
+    transformWordQuotes(doc.body);
+  }
+
+  if (isWord) {
+    stripWordReviewMarkup(doc.body);
+  }
+
   return doc.body.innerHTML;
 }
 
@@ -231,7 +392,7 @@ const extension = {
     return new Plugin({
       props: {
         transformPastedHTML(html) {
-          return transformWordListsHtml(html);
+          return transformWordHtml(html);
         },
       },
     });

--- a/frontend/discourse/tests/unit/lib/to-markdown-test.js
+++ b/frontend/discourse/tests/unit/lib/to-markdown-test.js
@@ -415,6 +415,35 @@ helloWorld();</code>consectetur.`;
     assert.strictEqual(await toMarkdown(html), markdown);
   });
 
+  test("converts quote style from word", async function (assert) {
+    const html = `Intro<!--StartFragment-->
+    <p class=MsoQuote style='margin-left:.5in'>First quoted line</p>
+    <p class=MsoQuote style='margin-left:.5in'>Second quoted line</p>
+    <!--EndFragment-->Outro`;
+    const markdown = `Intro\n\n> First quoted line\n>\n> Second quoted line\n\nOutro`;
+    assert.strictEqual(await toMarkdown(html), markdown);
+  });
+
+  test("strips word comments and tracked deletions", async function (assert) {
+    const html = `<!--StartFragment-->
+    <p class=MsoNormal>Identify significant accounts<a class=msocomanchor
+      href="#_msocom_1" style='mso-comment-reference:SK_1;mso-comment-date:1'><span
+      class=MsoCommentReference>[J1]</span></a> and relevant assertions.</p>
+    <p class=MsoNormal>This involves <del>old removed phrase </del>using risk procedures.</p>
+    <div style='mso-element:comment-list'><div style='mso-element:comment'>
+      <p class=MsoCommentText><a name="_msocom_1"></a>Consider removing.</p>
+    </div></div>
+    <!--EndFragment-->`;
+
+    const markdown = await toMarkdown(html);
+
+    assert.true(markdown.includes("Identify significant accounts and"));
+    assert.true(markdown.includes("This involves using risk procedures."));
+    assert.false(markdown.includes("[J1]"));
+    assert.false(markdown.includes("Consider removing."));
+    assert.false(markdown.includes("old removed phrase"));
+  });
+
   test("keeps mention/hash class", async function (assert) {
     const html = `
       <p>User mention: <a class="mention" href="/u/discourse">@discourse</a></p>

--- a/frontend/discourse/tests/unit/static/prosemirror/extensions/word-paste-test.js
+++ b/frontend/discourse/tests/unit/static/prosemirror/extensions/word-paste-test.js
@@ -1,7 +1,9 @@
 import { module, test } from "qunit";
 import {
+  stripWordReviewMarkup,
+  transformWordHtml,
   transformWordLists,
-  transformWordListsHtml,
+  transformWordQuotes,
 } from "discourse/static/prosemirror/extensions/word-paste";
 
 module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
@@ -31,7 +33,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
 
   test("no-op when no Word list classes present", function (assert) {
     const html = "<p>Regular paragraph</p><ul><li>Normal list</li></ul>";
-    assert.strictEqual(transformWordListsHtml(html), html);
+    assert.strictEqual(transformWordHtml(html), html);
   });
 
   test("converts unordered list", function (assert) {
@@ -39,7 +41,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       { marker: "·", text: "Item 1" },
       { marker: "·", text: "Item 2" },
     ]);
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
 
     assert.strictEqual(doc.querySelectorAll("ul").length, 1);
     assert.strictEqual(doc.querySelectorAll("li").length, 2);
@@ -68,7 +70,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
         { marker, text: "First" },
         { marker: "2.", text: "Second" },
       ]);
-      const doc = createDoc(transformWordListsHtml(html));
+      const doc = createDoc(transformWordHtml(html));
       assert.strictEqual(
         doc.querySelectorAll("ol").length,
         1,
@@ -82,7 +84,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       { marker: "5.", text: "Fifth" },
       { marker: "6.", text: "Sixth" },
     ]);
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
     assert.strictEqual(doc.querySelector("ol").getAttribute("start"), "5");
   });
 
@@ -93,7 +95,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       { marker: "·", text: "Level 3", level: 3 },
       { marker: "·", text: "Back to 1", level: 1 },
     ]);
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
 
     assert.strictEqual(doc.querySelectorAll("ul").length, 3);
     assert.strictEqual(doc.querySelectorAll("li").length, 4);
@@ -108,7 +110,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
         <![if !supportLists]><span style="mso-list:Ignore">2.</span><![endif]>Second
       </p>
     `;
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
 
     assert.strictEqual(doc.querySelectorAll("ol").length, 1);
     assert.false(doc.querySelector("li").textContent.includes("1."));
@@ -119,7 +121,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       { marker: "·", text: "<b>Bold</b>" },
       { marker: "·", text: "<i>Italic</i>" },
     ]);
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
 
     assert.true(!!doc.querySelector("li b"));
     assert.true(!!doc.querySelector("li i"));
@@ -130,7 +132,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       { marker: "·", text: "Item 1" },
       { marker: "·", text: "Item 2" },
     ]);
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
     assert.strictEqual(
       doc.querySelector("ul").getAttribute("data-tight"),
       "true"
@@ -144,7 +146,7 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       <p>Middle</p>
       ${wordListHtml([{ marker: "1.", text: "Numbered" }])}
     `;
-    const doc = createDoc(transformWordListsHtml(html));
+    const doc = createDoc(transformWordHtml(html));
 
     assert.strictEqual(doc.querySelectorAll("ul").length, 1);
     assert.strictEqual(doc.querySelectorAll("ol").length, 1);
@@ -160,5 +162,138 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
       doc.querySelectorAll("p.MsoListParagraphCxSpFirst").length,
       0
     );
+  });
+
+  test("converts Word Quote style to blockquote", function (assert) {
+    const html = `<p class=MsoQuote style='margin-left:.5in'>Quoted line</p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("blockquote").length, 1);
+    assert.strictEqual(doc.querySelectorAll("p.MsoQuote").length, 0);
+    assert.true(
+      doc.querySelector("blockquote").textContent.includes("Quoted line")
+    );
+  });
+
+  test("converts Word Intense Quote style to blockquote", function (assert) {
+    const html = `<p class=MsoIntenseQuote>Intense line</p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("blockquote").length, 1);
+    assert.strictEqual(doc.querySelectorAll("p.MsoIntenseQuote").length, 0);
+  });
+
+  test("merges consecutive quote paragraphs into one blockquote", function (assert) {
+    const html = `
+      <p class=MsoQuote>First line</p>
+      <p class=MsoQuote>Second line</p>
+      <p>Not a quote</p>
+      <p class=MsoQuote>Separate quote</p>
+    `;
+    const doc = createDoc(transformWordHtml(html));
+
+    const blockquotes = doc.querySelectorAll("blockquote");
+    assert.strictEqual(blockquotes.length, 2);
+    assert.strictEqual(blockquotes[0].querySelectorAll("p").length, 2);
+    assert.strictEqual(blockquotes[1].querySelectorAll("p").length, 1);
+  });
+
+  test("preserves inline formatting in quotes", function (assert) {
+    const html = `<p class=MsoQuote>Has <b>bold</b> text</p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.true(!!doc.querySelector("blockquote b"));
+  });
+
+  test("transformWordQuotes modifies DOM in place", function (assert) {
+    const doc = createDoc(`<p class=MsoQuote>Quoted</p>`);
+
+    transformWordQuotes(doc.body);
+
+    assert.strictEqual(doc.querySelectorAll("blockquote").length, 1);
+    assert.strictEqual(doc.querySelectorAll("p.MsoQuote").length, 0);
+  });
+
+  test("converts Word Block Text style to blockquote", function (assert) {
+    const html = `<p class=MsoBlockText>Block text line</p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("blockquote").length, 1);
+    assert.strictEqual(doc.querySelectorAll("p.MsoBlockText").length, 0);
+  });
+
+  test("converts Word for the web Quote style to blockquote regardless of locale", function (assert) {
+    // PT-BR document: visible text is localized but the style id stays English
+    const html = `
+      <div class="OutlineElement"><p class="Paragraph" lang="PT-BR"><span
+        class="TextRun"><span class="NormalTextRun"
+        data-ccp-parastyle="Quote">Citação</span></span></p></div>
+      <div class="OutlineElement"><p class="Paragraph" lang="PT-BR"><span
+        class="TextRun"><span class="NormalTextRun">Regular text</span></span></p></div>
+    `;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("blockquote").length, 1);
+    assert.true(
+      doc.querySelector("blockquote").textContent.includes("Citação")
+    );
+    assert.false(
+      doc.querySelector("blockquote").textContent.includes("Regular text")
+    );
+  });
+
+  test("does not convert non-quote Word for the web styles", function (assert) {
+    const html = `<div class="OutlineElement"><p class="Paragraph"><span
+      class="NormalTextRun" data-ccp-parastyle="Texto de Dica">Tip</span></p></div>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("blockquote").length, 0);
+  });
+
+  test("strips Word comment references and comment body", function (assert) {
+    const html = `<p class=MsoNormal>Significant accounts
+      <a class=msocomanchor href="#_msocom_1">[J1]</a>
+      and assertions.</p>
+      <div style='mso-element:comment-list'>
+        <div style='mso-element:comment'>
+          <p class=MsoCommentText>Consider removing.</p>
+        </div>
+      </div>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("a.msocomanchor").length, 0);
+    assert.strictEqual(
+      doc.querySelectorAll("[style*='mso-element:comment-list']").length,
+      0
+    );
+    assert.false(doc.body.textContent.includes("[J1]"));
+    assert.false(doc.body.textContent.includes("Consider removing."));
+    assert.true(doc.body.textContent.includes("Significant accounts"));
+  });
+
+  test("strips Word tracked deletions but keeps surrounding text", function (assert) {
+    const html = `<p class=MsoNormal>Keep <del>deleted text</del>this.</p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("del").length, 0);
+    assert.false(doc.body.textContent.includes("deleted text"));
+    assert.true(doc.body.textContent.includes("Keep"));
+  });
+
+  test("does not strip <del> from non-Word HTML", function (assert) {
+    const html = `<p>Keep <del>struck</del> text</p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("del").length, 1);
+  });
+
+  test("stripWordReviewMarkup modifies DOM in place", function (assert) {
+    const doc = createDoc(
+      `<p>Text <a class=msocomanchor href="#_msocom_1">[1]</a></p>`
+    );
+
+    stripWordReviewMarkup(doc.body);
+
+    assert.strictEqual(doc.querySelectorAll("a.msocomanchor").length, 0);
   });
 });


### PR DESCRIPTION
Previously, pasting from Microsoft Word turned its "Quote" paragraph styles into plain text and leaked comment references and tracked-change deletions into the post.

This change converts Word's quote styles (`MsoQuote`/`MsoBlockText` on desktop, `data-ccp-parastyle` in Word for the web) into blockquotes, and strips comment and tracked-deletion markup during paste conversion.