### PR TITLE
DEV: Don't check `expanded` in d-float-body

### DIFF
--- a/frontend/discourse/float-kit/components/d-float-body.gjs
+++ b/frontend/discourse/float-kit/components/d-float-body.gjs
@@ -6,7 +6,6 @@ import DFloatPortal from "discourse/float-kit/components/d-float-portal";
 import { getScrollParent } from "discourse/float-kit/lib/get-scroll-parent";
 import FloatKitApplyFloatingUi from "discourse/float-kit/modifiers/apply-floating-ui";
 import FloatKitCloseOnEscape from "discourse/float-kit/modifiers/close-on-escape";
-import { and } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dCloseOnClickOutside from "discourse/ui-kit/modifiers/d-close-on-click-outside";
 import dTrapTab from "discourse/ui-kit/modifiers/d-trap-tab";
@@ -40,15 +39,15 @@ export default class DFloatBody extends Component {
   });
 
   get supportsCloseOnClickOutside() {
-    return this.args.instance.expanded && this.options.closeOnClickOutside;
+    return this.options.closeOnClickOutside;
   }
 
   get supportsCloseOnEscape() {
-    return this.args.instance.expanded && this.options.closeOnEscape;
+    return this.options.closeOnEscape;
   }
 
   get supportsCloseOnScroll() {
-    return this.args.instance.expanded && this.options.closeOnScroll;
+    return this.options.closeOnScroll;
   }
 
   get trigger() {
@@ -93,7 +92,7 @@ export default class DFloatBody extends Component {
         {{this.trapInteractionPropagation}}
         {{(if @trapTab (modifier dTrapTab autofocus=this.options.autofocus))}}
         {{(if
-          (and @instance.expanded this.supportsCloseOnClickOutside)
+          this.supportsCloseOnClickOutside
           (modifier
             dCloseOnClickOutside
             (fn @instance.close (hash focusTrigger=false))


### PR DESCRIPTION
`DFloatBody` only renders while expanded, so there's no need to check `instance.expanded` inside it.

Also, due to a weird timing issue, reading `expanded` there makes the app remove these modifiers in the same render that destroys the component. That lead to leaks, which in turn caused some test flakes. (that's the theory 🙃)

Should fix the `Integration | Component | SearchMenu: rendering standalone` flake.