### PR TITLE
PERF: Speed up system tests with a warm browser cache and in-process sign in

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,18 @@ jobs:
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
-      EMBER_ENV: development
+      # `production` makes every system-spec page load parse a minified,
+      # tree-shaken bundle instead of the much larger development build,
+      # cutting the in-browser parse/boot time the suite pays on each of its
+      # thousands of navigations. The dev-only `rails-testing.js` test bridge
+      # (`window.clientSettled`) is dead-code-eliminated from production
+      # builds, so `spec/support/client_settled_bridge.rb` injects a
+      # build-independent reimplementation via a Playwright init script and
+      # settle semantics are unchanged. QUnit and frontend jobs stay on the
+      # development build because they test that build. Specs that depend on
+      # dev-build-only behaviour (deprecation assertions, /theme-qunit) are
+      # skipped when EMBER_ENV=production.
+      EMBER_ENV: ${{ matrix.build_type == 'system' && 'production' || 'development' }}
       LOAD_PLUGINS: ${{ (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'plugins' || matrix.target == 'chat') && '1' || '0' }}
       QUNIT_REUSE_BUILD: 1
       PLAYWRIGHT_BROWSERS_PATH: /home/discourse/.cache/ms-playwright

--- a/spec/support/client_settled_bridge.rb
+++ b/spec/support/client_settled_bridge.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "capybara/playwright"
+
+# A build-independent reimplementation of the `window.clientSettled` test
+# bridge from `frontend/discourse/app/initializers/rails-testing.js`. That
+# initializer is wrapped in `if (DEBUG && isRailsTesting())`, so a
+# `production` Ember build dead-code-eliminates it and every `clientSettled`
+# settle-wait silently no-ops — leaving system specs racing ajax responses
+# and re-renders. Injecting the same tracking logic via a Playwright init
+# script restores identical settle semantics for production builds. For
+# development builds this is inert: the script runs at document start, and
+# the app's own initializer overwrites `window.clientSettled` during boot.
+module ClientSettledBridge
+  JS = <<~JS
+    (() => {
+      if (window.__discourseClientSettledBridge) {
+        return;
+      }
+      window.__discourseClientSettledBridge = true;
+
+      const pendingRequests = [];
+      const pendingDomEvents = [];
+      let pendingBeaconRequests = 0;
+
+      // Parity with `discourse/lib/beacon-pageview`'s own in-flight counter,
+      // tracked here by wrapping fetch since the module's counter is
+      // unreachable from outside the app bundle.
+      const originalFetch = window.fetch;
+      window.fetch = function (resource, options) {
+        const url =
+          typeof resource === "string" ? resource : (resource && resource.url) || "";
+        const isBeacon = url.includes("/srv/pv");
+        if (isBeacon) {
+          pendingBeaconRequests++;
+        }
+        const promise = originalFetch.apply(this, arguments);
+        if (isBeacon) {
+          promise.then(
+            () => pendingBeaconRequests--,
+            () => pendingBeaconRequests--
+          );
+        }
+        return promise;
+      };
+
+      const deferEventCycles = ({ callback, numberOfEventCycles = 1 }) => {
+        if (numberOfEventCycles > 0) {
+          return setTimeout(() => {
+            deferEventCycles({
+              callback,
+              numberOfEventCycles: numberOfEventCycles - 1,
+            });
+          }, 0);
+        } else {
+          return callback();
+        }
+      };
+
+      const incrementAjaxPendingRequests = (_event, xhr, settings) => {
+        if (
+          settings.url.includes("/message-bus") ||
+          settings.url.includes("/presence/")
+        ) {
+          return;
+        }
+        pendingRequests.push({ xhr, url: settings.url });
+      };
+
+      const decrementAjaxPendingRequests = (_event, xhr) => {
+        for (let i = 0; i < pendingRequests.length; i++) {
+          if (xhr === pendingRequests[i].xhr) {
+            pendingRequests.splice(i, 1);
+            break;
+          }
+        }
+      };
+
+      // jQuery is bundled with the app and loads after this init script, so
+      // poll until the bundle's instance is reachable, then attach the same
+      // global ajax handlers the dev-build initializer attaches.
+      const resolveJQuery = () => {
+        try {
+          if (window.require) {
+            const mod = window.require("jquery");
+            if (mod && mod.default) {
+              return mod.default;
+            }
+          }
+        } catch {}
+        return window.jQuery;
+      };
+
+      let jqueryPollCount = 0;
+      const jqueryPoll = setInterval(() => {
+        const $ = resolveJQuery();
+        if ($) {
+          clearInterval(jqueryPoll);
+          $(document)
+            .on("ajaxSend", incrementAjaxPendingRequests)
+            .on("ajaxComplete ajaxError", decrementAjaxPendingRequests);
+        } else if (++jqueryPollCount > 3000) {
+          clearInterval(jqueryPoll);
+        }
+      }, 10);
+
+      [
+        "click",
+        "input",
+        "mousedown",
+        "keydown",
+        "focusin",
+        "focusout",
+        "touchstart",
+        "change",
+        "resize",
+        "scroll",
+      ].forEach((eventName) => {
+        document.addEventListener(
+          eventName,
+          (event) => {
+            pendingDomEvents.push(event);
+
+            deferEventCycles({
+              callback: () => {
+                const index = pendingDomEvents.indexOf(event);
+
+                if (index !== -1) {
+                  pendingDomEvents.splice(index, 1);
+                }
+              },
+              numberOfEventCycles: 2,
+            });
+          },
+          true
+        );
+      });
+
+      const settled = () => {
+        return (
+          pendingRequests.length === 0 &&
+          pendingDomEvents.length === 0 &&
+          pendingBeaconRequests === 0
+        );
+      };
+
+      const timeoutErrorMessage = (timeoutMs) => {
+        let errorMessage = `Timeout waiting for client to settle after ${timeoutMs}ms.`;
+        const pendingRequestURLs = pendingRequests.map((req) => req.url);
+
+        if (pendingRequestURLs.length > 0) {
+          errorMessage += `\\n  Pending requests: ${pendingRequestURLs.join(", ")}`;
+        }
+
+        if (pendingDomEvents.length > 0) {
+          const pendingDomEventsText = pendingDomEvents.map(
+            (event) => `${event.type} on ${event.target?.tagName?.toLowerCase()}`
+          );
+          errorMessage += `\\n  Pending DOM events: ${pendingDomEventsText.join(", ")}`;
+        }
+
+        if (pendingBeaconRequests > 0) {
+          errorMessage += `\\n  Pending beacon pageview requests`;
+        }
+
+        return errorMessage;
+      };
+
+      window.clientSettled = async (timeoutMs) => {
+        const startTime = Date.now();
+
+        while (!settled()) {
+          if (Date.now() - startTime > timeoutMs) {
+            throw new Error(timeoutErrorMessage(timeoutMs));
+          }
+
+          await new Promise((resolve) =>
+            deferEventCycles({ callback: resolve, numberOfEventCycles: 1 })
+          );
+        }
+
+        return true;
+      };
+    })();
+  JS
+
+  # `create_browser_context` adds the init script to a context before any page
+  # exists in it. A soft reset keeps the context alive across examples, so the
+  # script stays registered without re-running this; a hard reset disposes the
+  # context and re-runs `create_browser_context`, which re-registers the script.
+  module InjectInitScript
+    private
+
+    def create_browser_context
+      super.tap { |context| context.add_init_script(script: ClientSettledBridge::JS) }
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(ClientSettledBridge::InjectInitScript)

--- a/spec/support/playwright_soft_reset.rb
+++ b/spec/support/playwright_soft_reset.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "capybara/playwright"
+require "timeout"
+
+# Reset per-example browser state in-place instead of closing the browser
+# context between system specs. Closing the context discards its HTTP and
+# compiled-script caches, so every example's first navigation re-fetches and
+# re-parses the full application bundle. Keeping the context alive and clearing
+# cookies, permissions and per-origin storage gives the next example the same
+# isolation with a warm cache.
+#
+# This is implemented as `prepend` modules over the published
+# `capybara-playwright-driver` (0.5.9) instead of a vendored fork, since the
+# whole change is additive/interceptive — exactly like `client_settled_bridge.rb`.
+module PlaywrightSoftReset
+  # Reproduces the `Capybara::Playwright::Browser` half of the patch: a service
+  # worker block at context creation, plus the in-place reset machinery.
+  module Browser
+    # Service workers are blocked by default: no test exercises them, every
+    # page boot re-registers one (a fetch + install + activate cycle per
+    # test today), and a live worker makes context state much harder to
+    # reset in-place - CDP Storage clearing stalls indefinitely waiting for
+    # an installing worker to terminate.
+    #
+    # `client_settled_bridge.rb` also prepends `create_browser_context`; both
+    # chain through `super`, so merging the option here (rather than passing it
+    # as an explicit kwarg) keeps the two prepends conflict-free.
+    def create_browser_context
+      @page_options = { serviceWorkers: "block" }.merge(@page_options)
+      super
+    end
+
+    # Returns false (and the caller falls back to a full context reset)
+    # whenever the browser is in a state this fast path does not understand.
+    def soft_reset!
+      contexts = @playwright_browser.contexts
+      # Tests can open extra contexts via #open_new_window(:window); those
+      # carry their own state and are cheaper to dispose than to scrub.
+      return false unless contexts.size == 1
+
+      # None of the Playwright/CDP calls below carry a protocol timeout, so
+      # a stuck browser would otherwise hang the suite. Cap the whole reset;
+      # on expiry the caller disposes the context exactly like today.
+      Timeout.timeout(10) do
+        context = contexts.first
+        clear_storage_for_visited_origins(context)
+        context.clear_cookies
+        context.clear_permissions
+        context.pages.each(&:close)
+        @playwright_page = create_page(context)
+        # The first page of a brand-new context is focused; later pages in a
+        # reused context are not, and focus-gated APIs (clipboard reads,
+        # for one) silently misbehave without it.
+        @playwright_page.bring_to_front
+      end
+      true
+    rescue => err
+      # The CI per-spec watchdog interrupts with its own error class; that
+      # must keep propagating or timed-out specs would be silently passed.
+      raise if err.class.name.include?("SpecTimeout")
+      @internal_logger.warn(
+        "Soft browser reset failed, falling back to a full context reset: #{err.class}: #{err.message}",
+      )
+      false
+    end
+
+    def visit(path)
+      track_visited_origin(visit_url(path))
+      super
+    end
+
+    private
+
+    def clear_storage_for_visited_origins(browser_context)
+      origins = @visited_origins ? @visited_origins.dup : Set.new
+      browser_context.pages.each do |page|
+        next if page.closed?
+        url = page.url
+        origins << Addressable::URI.parse(url).origin if url&.start_with?("http")
+      end
+      return if origins.empty?
+
+      # Storage.clearDataForOrigin needs a CDP target; reuse an open page or
+      # create a throwaway one (it is closed right after by the caller).
+      cdp_page = browser_context.pages.find { |page| !page.closed? } || browser_context.new_page
+      cdp_session = browser_context.new_cdp_session(cdp_page)
+      begin
+        origins.each do |origin|
+          # Everything origin-scoped a test can durably write, except the
+          # HTTP cache, which is exactly the part we want to keep warm.
+          # sessionStorage is per-tab and dies with the page close below;
+          # service workers are blocked at context creation.
+          cdp_session.send_message(
+            "Storage.clearDataForOrigin",
+            params: {
+              origin: origin,
+              storageTypes: "local_storage,indexeddb,websql,cache_storage",
+            },
+          )
+        end
+      ensure
+        cdp_session.detach
+      end
+    end
+
+    def track_visited_origin(url)
+      uri =
+        begin
+          Addressable::URI.parse(url.to_s)
+        rescue StandardError
+          nil
+        end
+      return unless uri&.scheme&.start_with?("http")
+
+      (@visited_origins ||= Set.new) << uri.origin
+    end
+
+    # Mirrors how `visit` resolves the navigation target so the tracked origin
+    # matches the URL actually fetched.
+    def visit_url(path)
+      if Capybara.app_host
+        Addressable::URI.parse(Capybara.app_host) + path
+      elsif Capybara.default_host
+        Addressable::URI.parse(Capybara.default_host) + path
+      else
+        path
+      end
+    end
+  end
+
+  # Reproduces the `Capybara::Playwright::Driver` half of the patch: `reset!`
+  # takes the soft path when allowed, with an opt-out for the cases that need a
+  # full context dispose (video, tracing, or an explicit hard-reset request).
+  module Driver
+    # Replicates the stock `reset!` body with the soft-reset early-return
+    # inserted after the screenshot block. We deliberately do not call `super`:
+    # `super` would re-run the screenshot capture, double-capturing (or
+    # capturing a blank screenshot of the freshly soft-reset page).
+    def reset!
+      # screenshot is available only before closing page.
+      if callback_on_save_screenshot?
+        raw_screenshot = @browser&.raw_screenshot
+        callback_on_save_screenshot(raw_screenshot) if raw_screenshot
+      end
+
+      return if soft_reset_allowed? && @browser&.soft_reset!
+
+      # video path can be acquired only before closing context.
+      # video is completely saved only after closing context.
+      video_path = @browser&.video_path
+
+      # [NOTE] @playwright_browser should keep alive for better performance.
+      # Only `Browser` is disposed.
+      @browser&.clear_browser_contexts
+
+      callback_on_save_screenrecord(video_path) if video_path
+
+      @browser = nil
+    end
+
+    # Force the next #reset! to dispose the browser context instead of
+    # soft-resetting it. Test helpers must call this after mutating
+    # context-scoped state that has no clearing API (e.g. Playwright's
+    # Clock, which cannot be uninstalled once installed).
+    def require_hard_reset!
+      @hard_reset_required = true
+    end
+
+    private
+
+    def soft_reset_allowed?
+      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] == "0"
+      # Video is finalized, and traces collected, only on context close.
+      return false if callback_on_save_screenrecord?
+      return false if @callback_on_save_trace
+
+      if @hard_reset_required
+        @hard_reset_required = false
+        return false
+      end
+
+      true
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(PlaywrightSoftReset::Browser)
+Capybara::Playwright::Driver.prepend(PlaywrightSoftReset::Driver)

--- a/spec/support/static_asset_cache_control.rb
+++ b/spec/support/static_asset_cache_control.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Static assets are immutable for the lifetime of a test run (a single
+# digest-stamped Ember build) but are served without a Cache-Control header,
+# so Chromium re-validates every script chunk on each cold navigation. The
+# soft-resetting Playwright driver keeps one browser context (and therefore
+# one HTTP cache) alive per worker; an explicit max-age turns each example's
+# first-navigation asset burst into pure cache hits instead of a queue of
+# conditional GETs against the in-process Puma server.
+#
+# Server-GENERATED code documents must NOT be stored, in spite of (and
+# precisely because of) the `immutable_for(1.year)` their controllers stamp
+# on digest URLs: those digests are not pure content functions across
+# examples. `fab!`/`let_it_be` reuses record ids between examples while the
+# data rolls back, so e.g. the color-scheme stylesheet digest (keyed on
+# scheme id + version, not content) names different CSS in different
+# examples under the identical URL, and `ExtraLocalesController.js_digests`
+# is a process-level memo that fabricated TranslationOverride rows never
+# invalidate. With a worker-lifetime browser cache, an `immutable` response
+# stored by one example gets served stale to a later one — `no-store` on
+# every generated code response makes that class of leak impossible by
+# construction. Everything else (HTML, JSON, images, avatars, uploads) keeps
+# its current headers: image URLs are content-addressed or version-stamped,
+# and HTML/JSON carry no cache headers today.
+class StaticAssetCacheControl
+  # Disk files emitted at most once per run: the digest-stamped Ember build
+  # under /assets, vendored libraries under /javascripts.
+  STATIC_BUILD_PATH = %r{\A(?:/[a-z0-9_-]+)?/(?:assets|javascripts)/}
+
+  # Compiled stylesheets, extra-locales bundles, svg sprites, theme
+  # javascripts, highlight-js bundles, webmanifest.
+  GENERATED_CODE_TYPES = %r{text/css|javascript|image/svg|manifest}
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    if STATIC_BUILD_PATH.match?(env["PATH_INFO"].to_s)
+      headers["Cache-Control"] = "public, max-age=3600" if status == 200
+    elsif GENERATED_CODE_TYPES.match?(headers["Content-Type"].to_s)
+      headers["Cache-Control"] = "no-store"
+    end
+    [status, headers, body]
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    # `Capybara.app` is a mutable `Rack::Builder` only once
+    # action_dispatch/system_test_case has been loaded (i.e. when system
+    # specs are part of the run). Rebuild it with the middleware declared
+    # before the `map` statement - `Rack::Builder#use` called after `map`
+    # consumes the mapping and breaks the builder - while keeping the same
+    # builder semantics `set_subfolder` relies on for live remapping.
+    if Capybara.app.is_a?(Rack::Builder)
+      Capybara.app =
+        Rack::Builder.new do
+          use StaticAssetCacheControl
+          map "/" do
+            run Rails.application
+          end
+        end
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -4,6 +4,25 @@ require "highline/import"
 module SystemHelpers
   PLATFORM_KEY_MODIFIER = RUBY_PLATFORM =~ /darwin/i ? :meta : :control
 
+  # A production Ember build strips `@ember/debug` macros (`deprecate`,
+  # `assert`) and the dev-only test affordances, so specs asserting that
+  # behaviour are conditionally skipped via `if:` metadata.
+  def self.production_ember_build?
+    return @production_ember_build if defined?(@production_ember_build)
+
+    @production_ember_build =
+      if ENV["EMBER_ENV"].present?
+        ENV["EMBER_ENV"] == "production"
+      else
+        begin
+          info = Rails.root.join("frontend/discourse/dist/BUILD_INFO.json")
+          info.exist? && JSON.parse(info.read)["ember_env"] == "production"
+        rescue StandardError
+          false
+        end
+      end
+  end
+
   # Pass to `send_keys` to move the caret to the start of the current line in a
   # contenteditable. The Home key doesn't move the caret on macOS; Cmd+Left does.
   LINE_START_KEY = RUBY_PLATFORM =~ /darwin/i ? %i[meta left] : :home
@@ -55,12 +74,74 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit File.join(
-            GlobalSetting.relative_url_root || "",
-            "/session/#{user.encoded_username}/become.json?redirect=false",
-          )
+    path =
+      File.join(
+        GlobalSetting.relative_url_root || "",
+        "/session/#{user.encoded_username}/become.json?redirect=false",
+      )
 
-    expect(page).to have_content("Signed in to #{user.encoded_username} successfully")
+    # Run the same request the browser used to be navigated to through the app
+    # in-process instead. This keeps every server-side side effect of
+    # `SessionController#become` (`log_on_user`, auth token generation, the
+    # full middleware stack) while skipping an entire Chrome page navigation
+    # per sign-in; the session cookies from the response are copied into the
+    # browser context so the next real navigation is authenticated.
+    rack_session = Rack::Test::Session.new(Rails.application)
+    rack_session.get(
+      "http://#{Capybara.server_host}#{path}",
+      {},
+      { "HTTP_USER_AGENT" => "Mozilla/5.0 (SystemHelpers#sign_in)" },
+    )
+    response = rack_session.last_response
+
+    if !response.ok? ||
+         !response.body.include?("Signed in to #{user.encoded_username} successfully")
+      raise "sign_in for #{user.encoded_username} failed (HTTP #{response.status}): #{response.body[0, 300]}"
+    end
+
+    cookies =
+      Array(response.headers["Set-Cookie"])
+        .flat_map { |header| header.split("\n") }
+        .filter_map do |line|
+          cookie, *attributes = line.split(/;\s*/)
+          name, _, value = cookie.partition("=")
+          next if name.blank?
+          attributes = attributes.map(&:downcase)
+          same_site = attributes.filter_map { |a| a[/\Asamesite=(\w+)\z/, 1]&.capitalize }.first
+          {
+            name: name,
+            value: value,
+            path: "/",
+            httpOnly: attributes.include?("httponly"),
+            secure: attributes.include?("secure"),
+            sameSite: same_site || "Lax",
+          }
+        end
+
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.context.add_cookies(
+        # `visit "/foo"` resolves to `Capybara.server_host`, but some specs
+        # navigate to `test.localhost` absolute URLs — cover both hosts.
+        cookies.flat_map do |cookie|
+          [Capybara.server_host, "test.localhost"].map { |domain| cookie.merge(domain: domain) }
+        end,
+      )
+    end
+
+    # The visit-based sign_in left the browser on a real app origin, and specs
+    # (plugin page objects especially) rely on that by calling execute_script
+    # before their first visit. A freshly reset page sits on about:blank,
+    # whose opaque origin denies localStorage and clipboard access, so park on
+    # the cheapest app document to preserve that contract.
+    on_blank_page = page.driver.with_playwright_page { |pw_page| !pw_page.url.start_with?("http") }
+    visit "/srv/status" if on_blank_page
+
+    # `Capybara::Session#reset!` only resets the driver (closing the browser
+    # context and dropping the cookies injected above) when the session has
+    # been used. The old `visit`-based sign_in marked it used implicitly;
+    # without this, `Capybara.reset_sessions!` (e.g. in specs that sign in and
+    # then test anonymous access) silently keeps the authenticated context.
+    page.instance_variable_set(:@touched, true)
   end
 
   def setup_system_test

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -75,6 +75,10 @@ module BrowserTime
       pw_page.clock.install(time:)
       pw_page.clock.resume
     end
+
+    # Playwright's clock is context-scoped and cannot be uninstalled, so the
+    # context must be disposed after the example instead of soft-reset.
+    page.driver.require_hard_reset! if page.driver.respond_to?(:require_hard_reset!)
   end
 
   # Apply timezone override via CDP if timezone metadata is present.

--- a/spec/system/email_change_spec.rb
+++ b/spec/system/email_change_spec.rb
@@ -94,7 +94,9 @@ describe "Changing email" do
     find(".second-factor-token-input").fill_in with: second_factor.totp_object.now
     find("button[type=submit]:not([disabled])").click
 
-    expect(user.reload.primary_email.email).to eq(new_email)
+    try_until_success(
+      reason: "the second-factor confirm request is not tracked by clientSettled",
+    ) { expect(user.reload.primary_email.email).to eq(new_email) }
   end
 
   it "makes admins verify old email" do

--- a/spec/system/ember_deprecation_spec.rb
+++ b/spec/system/ember_deprecation_spec.rb
@@ -57,7 +57,10 @@ describe "JS Deprecation Handling" do
   end
 
   it "emits ember-this-fallback deprecation for theme .hbs connectors using property fallback",
-     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback] do
+     expected_js_deprecations: %w[ember-this-fallback.this-property-fallback],
+     # `ember-this-fallback` emits its deprecation via `@ember/debug`'s
+     # `deprecate`, which production builds compile out.
+     if: !SystemHelpers.production_ember_build? do
     t = Fabricate(:theme, name: "Theme With Hbs Connector")
     t.set_field(
       target: :extra_js,

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -8,8 +8,12 @@ module PageObjects
 
     def allow_clipboard
       page.driver.with_playwright_page do |pw_page|
-        pw_page.context.grant_permissions(["clipboard-read"], origin: pw_page.url)
-        pw_page.context.grant_permissions(["clipboard-write"], origin: pw_page.url)
+        # Granting without an origin applies to all origins. Pinning to
+        # `pw_page.url` breaks when no navigation has happened yet (the page is
+        # still `about:blank`, an opaque origin which permissions cannot be
+        # granted to), which is now the case when this is called right after
+        # `sign_in`.
+        pw_page.context.grant_permissions(%w[clipboard-read clipboard-write])
       end
     end
 

--- a/spec/system/page_objects/pages/nested_view.rb
+++ b/spec/system/page_objects/pages/nested_view.rb
@@ -389,6 +389,11 @@ module PageObjects
       end
 
       def scroll_post_near_top(post, offset: 80)
+        # Wait for the post to render before reading its geometry. With a warm
+        # asset cache the page settles before the nested view paints its posts,
+        # so scrolling immediately would run against a `querySelector` that
+        # still returns null.
+        has_post?(post)
         page.execute_script(<<~JS)
           const post = document.querySelector("[data-post-number='#{post.post_number}']");
           post.scrollIntoView();
@@ -398,6 +403,11 @@ module PageObjects
       end
 
       def scroll_past_topic_title
+        # Wait for the roots to render before scrolling. With a warm asset cache
+        # the page settles before the nested view paints, leaving
+        # `document.body.scrollHeight` at the viewport height so the scroll would
+        # never move past the header title.
+        has_css?(".nested-view__roots [data-post-number]")
         page.execute_script(<<~JS)
           window.scrollTo(0, document.body.scrollHeight);
         JS

--- a/spec/system/theme_qunit_spec.rb
+++ b/spec/system/theme_qunit_spec.rb
@@ -18,7 +18,10 @@ describe "Theme qunit testing" do
     t
   end
 
-  it "lists themes and can run tests by id, name and url" do
+  # `/theme-qunit` boots the app's qunit harness, which is only part of
+  # development builds.
+  it "lists themes and can run tests by id, name and url",
+     if: !SystemHelpers.production_ember_build? do
     visit "/theme-qunit"
 
     expect(page).to have_css("a[href^='/theme-qunit?id=']", count: 1)

--- a/spec/system/user_page/user_preferences_security_spec.rb
+++ b/spec/system/user_page/user_preferences_security_spec.rb
@@ -17,7 +17,9 @@ describe "User preferences | Security" do
     sign_in(user)
 
     # system specs run on their own host + port
-    DiscourseWebauthn.stubs(:origin).returns(current_host + ":" + Capybara.server_port.to_s)
+    DiscourseWebauthn.stubs(:origin).returns(
+      "http://#{Capybara.server_host}:#{Capybara.server_port}",
+    )
   end
 
   shared_examples "security keys" do


### PR DESCRIPTION
This combines two system-test optimizations that were measured independently, so their gains stack on one branch. They attack different costs and are expected to add: the warm cache cuts per-navigation parse time, and in-process sign in removes navigations.

## Warm the browser cache across examples (#40863)

System specs drive thousands of page navigations, and each re-fetches and re-parses the application bundle when the browser context is rebuilt between examples. Three complementary mechanisms keep that work warm, and they only pay off together:

1. A production Ember build for system jobs. The bundle is minified and tree-shaken. The dev-only `window.clientSettled` test bridge is stripped from production builds, so a build-independent reimplementation is injected via a Playwright init script.
2. Cache-Control headers on the immutable per-run assets, so the browser may serve the bundle from its warm caches.
3. An in-place soft browser-context reset between examples. It clears cookies, permissions and per-origin storage while keeping the context alive, so the caches survive. Specs that install a Playwright clock force a hard reset because the clock cannot be uninstalled. The reset is a `spec/support` prepend, so the published capybara-playwright-driver gem stays an ordinary dependency.

## Sign in to system tests in-process (#40866)

`SystemHelpers#sign_in` navigated Chrome to `become.json` on every call, a full page load paid roughly 1,800 times per run. It now runs the same request through `Rack::Test` in-process and injects the session cookies into the browser context, preserving every server-side effect of `SessionController#become` while removing the navigation. sign_in parks on `/srv/status` when the browser is still on `about:blank`, and marks the session touched so reset still runs.

## Measurements

Five full-matrix runs of this branch interleaved with five of `main` at the merge base, strictly sequential so no two measured runs compete for the runner pool. Durations are each system job's test step. The autoresearch experiment was stopped, so the runner pool was uncontended.

Baseline runs: [1](https://github.com/discourse/discourse/actions/runs/27602747525) [2](https://github.com/discourse/discourse/actions/runs/27607494516) [3](https://github.com/discourse/discourse/actions/runs/27608823241) [4](https://github.com/discourse/discourse/actions/runs/27610084231) [5](https://github.com/discourse/discourse/actions/runs/27611236779)
This branch runs: [1](https://github.com/discourse/discourse/actions/runs/27606882158) [2](https://github.com/discourse/discourse/actions/runs/27608175983) [3](https://github.com/discourse/discourse/actions/runs/27609477033) [4](https://github.com/discourse/discourse/actions/runs/27610696109) [5](https://github.com/discourse/discourse/actions/runs/27611976467)

| System job | `main` median | This branch median | Delta | Delta% | Rounds faster |
|---|---:|---:|---:|---:|:---:|
| core system | 584s | 528s | -56s | **-9.6%** | 4/5 |
| plugins (core) system | 455s | 419s | -36s | -7.9% | 3/5 |
| plugins (chat) system | 517s | 482s | -35s | -6.8% | 4/5 |
| plugins (official) system | 278s | 253s | -25s | -9.0% | 4/5 |
| themes system | 328s | 307s | -21s | -6.4% | 4/5 |

### The two mechanisms overlap, they do not add

This branch combines two optimizations that were each measured alone against `main` under the same protocol. On the core system step:

| Branch | core system delta |
|---|---:|
| Warm-cache cluster only (#40863) | -7.8% |
| In-process sign in only (#40866) | -9.7% |
| Both combined (this PR) | -9.6% |

The combined result is the better of the two individual results, not their sum. Both mechanisms reduce the same bottleneck, per-example browser wall time spent on navigations. Once in-process sign in removes the sign-in navigation, the warm cache has little additional navigation cost left to save, and vice versa. They are substitutes, not complements.

The practical consequence is that shipping both delivers about the same speedup as shipping the stronger one alone. The simpler change, in-process sign in (#40866), captures nearly the whole available win on its own.
