### PR TITLE
FIX: Do not send notifications for upcoming changes not displayed

### DIFF
--- a/app/jobs/scheduled/check_upcoming_changes.rb
+++ b/app/jobs/scheduled/check_upcoming_changes.rb
@@ -75,6 +75,8 @@ module Jobs
               case status[:error_key]
               when :does_not_meet_or_exceed_promotion_status
                 :info
+              when :should_not_be_displayed
+                :debug
               when :already_notified_about_promotion
                 :debug
               when :already_manually_toggled

--- a/app/jobs/scheduled/notify_admins_of_available_upcoming_changes.rb
+++ b/app/jobs/scheduled/notify_admins_of_available_upcoming_changes.rb
@@ -177,10 +177,11 @@ module Jobs
           since: 1.week.ago,
           upcoming_changes_meeting_notify_status:
             SiteSetting.upcoming_change_site_settings.filter do |upcoming_change_name|
-              UpcomingChanges.meets_or_exceeds_status?(
-                upcoming_change_name,
-                UpcomingChanges.previous_status(SiteSetting.promote_upcoming_changes_on_status),
-              )
+              UpcomingChanges::ConditionalDisplay.should_display?(upcoming_change_name) &&
+                UpcomingChanges.meets_or_exceeds_status?(
+                  upcoming_change_name,
+                  UpcomingChanges.previous_status(SiteSetting.promote_upcoming_changes_on_status),
+                )
             end,
         )
     end

--- a/app/services/upcoming_changes/notify_promotion.rb
+++ b/app/services/upcoming_changes/notify_promotion.rb
@@ -26,6 +26,7 @@ class UpcomingChanges::NotifyPromotion
   end
 
   policy :setting_is_available
+  policy :change_should_be_displayed
   policy :meets_or_exceeds_status
   policy :change_has_not_already_been_notified_about_promotion
   policy :admin_has_not_manually_toggled
@@ -47,6 +48,10 @@ class UpcomingChanges::NotifyPromotion
 
   def setting_is_available(params:)
     SiteSetting.respond_to?(params.setting_name)
+  end
+
+  def change_should_be_displayed(params:)
+    UpcomingChanges::ConditionalDisplay.should_display?(params.setting_name)
   end
 
   def meets_or_exceeds_status(params:)

--- a/app/services/upcoming_changes/notify_promotions.rb
+++ b/app/services/upcoming_changes/notify_promotions.rb
@@ -46,6 +46,13 @@ class UpcomingChanges::NotifyPromotions
           status_hash[:error_key] = :setting_not_available
         end
 
+        on_failed_policy(:change_should_be_displayed) do |policy|
+          status_hash[
+            :error
+          ] = "Setting #{setting_name} is not displayed on this site, skipping promotion notification"
+          status_hash[:error_key] = :should_not_be_displayed
+        end
+
         on_failed_policy(:meets_or_exceeds_status) do |policy|
           status_hash[
             :error

--- a/spec/jobs/scheduled/check_upcoming_changes_spec.rb
+++ b/spec/jobs/scheduled/check_upcoming_changes_spec.rb
@@ -229,6 +229,31 @@ RSpec.describe Jobs::CheckUpcomingChanges do
         end
       end
 
+      context "when the change should not be displayed on this site" do
+        before do
+          UpcomingChangeEvent.where(
+            upcoming_change_name: :enable_upload_debug_mode,
+            event_type: :admins_notified_automatic_promotion,
+          ).delete_all
+          UpcomingChanges::ConditionalDisplay.stubs(
+            :should_display_enable_upload_debug_mode?,
+          ).returns(false)
+        end
+
+        it "does not notify admins and logs the skip at debug level" do
+          track_log_messages do |logger|
+            described_class.new.execute({})
+            expect(logger.infos.join("\n")).not_to include(
+              "Notified site admins about promotion of 'enable_upload_debug_mode'",
+            )
+            expect(logger.errors.join("\n")).not_to include("enable_upload_debug_mode")
+            expect(logger.debugs.join("\n")).to include(
+              "Failed to notify about promotion of 'enable_upload_debug_mode': Setting enable_upload_debug_mode is not displayed on this site",
+            )
+          end
+        end
+      end
+
       context "when notifying about permanent changes" do
         before do
           UpcomingChangeEvent.create!(

--- a/spec/jobs/scheduled/notify_admins_of_available_upcoming_changes_spec.rb
+++ b/spec/jobs/scheduled/notify_admins_of_available_upcoming_changes_spec.rb
@@ -328,6 +328,37 @@ RSpec.describe Jobs::NotifyAdminsOfAvailableUpcomingChanges do
     end
   end
 
+  context "when an upcoming change should not be displayed on this site" do
+    before do
+      UpcomingChanges::ConditionalDisplay.stubs(:should_display_test_upcoming_change?).returns(
+        false,
+      )
+    end
+
+    it "does not create a notification for the hidden change but still notifies for others" do
+      result
+      data =
+        JSON.parse(
+          Notification
+            .where(notification_type: Notification.types[:upcoming_change_available])
+            .last
+            .data,
+          symbolize_names: true,
+        )
+      expect(data[:upcoming_change_names]).to eq(%w[test_upcoming_change_b])
+      expect(data[:count]).to eq(1)
+    end
+
+    it "does not log an admins_notified_available_change event for the hidden change" do
+      expect { result }.not_to change {
+        UpcomingChangeEvent.where(
+          event_type: :admins_notified_available_change,
+          upcoming_change_name: :test_upcoming_change,
+        ).count
+      }
+    end
+  end
+
   context "when there is an added event for an upcoming change that no longer exists" do
     before do
       UpcomingChangeEvent.create!(

--- a/spec/services/upcoming_changes/notify_promotion_spec.rb
+++ b/spec/services/upcoming_changes/notify_promotion_spec.rb
@@ -58,6 +58,29 @@ RSpec.describe UpcomingChanges::NotifyPromotion do
       it { is_expected.to fail_a_policy(:meets_or_exceeds_status) }
     end
 
+    context "when the change should not be displayed on this site" do
+      before do
+        UpcomingChanges::ConditionalDisplay.stubs(
+          :should_display_enable_upload_debug_mode?,
+        ).returns(false)
+      end
+
+      it { is_expected.to fail_a_policy(:change_should_be_displayed) }
+
+      it "does not notify admins or create an event" do
+        expect { result }.to not_change {
+          Notification.where(
+            notification_type: Notification.types[:upcoming_change_automatically_promoted],
+          ).count
+        }.and not_change {
+                UpcomingChangeEvent.where(
+                  event_type: :admins_notified_automatic_promotion,
+                  upcoming_change_name: :enable_upload_debug_mode,
+                ).count
+              }
+      end
+    end
+
     context "when change has already been notified about promotion" do
       let(:changes_already_notified_about_promotion) { [:enable_upload_debug_mode] }
 

--- a/spec/services/upcoming_changes/notify_promotions_spec.rb
+++ b/spec/services/upcoming_changes/notify_promotions_spec.rb
@@ -247,6 +247,32 @@ RSpec.describe UpcomingChanges::NotifyPromotions do
         end
       end
 
+      context "when a change should not be displayed on this site" do
+        before do
+          UpcomingChanges::ConditionalDisplay.stubs(
+            :should_display_enable_upload_debug_mode?,
+          ).returns(false)
+        end
+
+        it "does not notify admins for the hidden setting" do
+          expect { result }.not_to change {
+            Notification
+              .where(notification_type: Notification.types[:upcoming_change_automatically_promoted])
+              .where("data::text LIKE ?", "%enable_upload_debug_mode%")
+              .count
+          }
+        end
+
+        it "returns the correct error and error key" do
+          expect(result[:change_notification_statuses][:enable_upload_debug_mode]).to match(
+            success: false,
+            error:
+              "Setting enable_upload_debug_mode is not displayed on this site, skipping promotion notification",
+            error_key: :should_not_be_displayed,
+          )
+        end
+      end
+
       context "when settings are opted out" do
         before { SiteSetting.enable_upload_debug_mode = false }
 


### PR DESCRIPTION
Some upcoming changes only display based on some condition.
We also need to respect that condition for sending notifications,
since otherwise admins are notified about something they can't
see in the UI.

c.f. https://meta.discourse.org/t/-/405009
