### PR TITLE
DEV: Track beacon browser pageviews behind `dashboard_improvements`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -422,9 +422,7 @@ module ApplicationHelper
   end
 
   def discourse_pageview_tracking_meta_tags
-    if !SiteSetting.trigger_browser_pageview_events &&
-         !SiteSetting.use_beacon_for_browser_page_views &&
-         !SiteSetting.persist_browser_pageview_events
+    if !SiteSetting.trigger_browser_pageview_events && !SiteSetting.persist_browser_pageview_events
       return ""
     end
 
@@ -433,7 +431,7 @@ module ApplicationHelper
       name: "discourse-track-view-session-id",
       content: track_view_session_id_placeholder,
     )
-    if SiteSetting.use_beacon_for_browser_page_views
+    if UpcomingChanges.enabled?(:dashboard_improvements)
       tags << tag.meta(name: "discourse-beacon-pageview-enabled", content: "true")
     end
     tags.html_safe

--- a/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
+++ b/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
@@ -27,7 +27,11 @@ module Jobs
       end_date = Time.zone.today
 
       if BrowserPageviewCountryDailyRollup.none? && BrowserPageviewReferrerDailyRollup.none?
-        earliest_event_date = BrowserPageviewEvent.minimum(:created_at)&.to_date
+        earliest_event_date =
+          BrowserPageviewEvent
+            .where(source: BrowserPageviewEvent.rollup_source)
+            .minimum(:created_at)
+            &.to_date
         [earliest_event_date, end_date]
       else
         [1.day.ago.to_date, end_date]
@@ -46,7 +50,11 @@ module Jobs
     end
 
     def next_batch
-      params = { version: BrowserPageviewReferrerInspector::VERSION, limit: batch_size }
+      params = {
+        source: BrowserPageviewEvent.rollup_source,
+        version: BrowserPageviewReferrerInspector::VERSION,
+        limit: batch_size,
+      }
 
       retention_clause = ""
       if SiteSetting.clean_up_browser_pageview_events
@@ -61,6 +69,7 @@ module Jobs
         SELECT id, referrer
         FROM browser_pageview_events
         WHERE referrer IS NOT NULL
+          AND source = :source
           AND (
             normalized_referrer_version IS NULL
             OR normalized_referrer_version < :version
@@ -87,7 +96,11 @@ module Jobs
     end
 
     def recomputable_dates(ids)
-      params = { ids: ids, version: BrowserPageviewReferrerInspector::VERSION }
+      params = {
+        ids: ids,
+        source: BrowserPageviewEvent.rollup_source,
+        version: BrowserPageviewReferrerInspector::VERSION,
+      }
 
       retention_clause = ""
       if SiteSetting.clean_up_browser_pageview_events
@@ -111,6 +124,7 @@ module Jobs
           FROM browser_pageview_events e
           WHERE e.created_at >= touched_dates.date
             AND e.created_at < touched_dates.date + 1
+            AND e.source = :source
             AND e.referrer IS NOT NULL
             AND NOT EXISTS (
               SELECT 1

--- a/app/models/browser_pageview_country_daily_rollup.rb
+++ b/app/models/browser_pageview_country_daily_rollup.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
 class BrowserPageviewCountryDailyRollup < ActiveRecord::Base
-  def self.aggregate(start_date:, end_date:)
-    DB.exec(<<~SQL, start_date: start_date.to_date, end_date: end_date.to_date + 1)
-        INSERT INTO browser_pageview_country_daily_rollups (date, country_code, count, logged_in_count)
-        SELECT
-          created_at::date AS date,
-          country_code,
-          COUNT(*) AS count,
-          COUNT(*) FILTER (WHERE user_id IS NOT NULL) AS logged_in_count
-        FROM browser_pageview_events
-        WHERE created_at >= :start_date
-          AND created_at < :end_date
-        GROUP BY date, country_code
-        ON CONFLICT (date, country_code) DO UPDATE
-        SET count = EXCLUDED.count,
-            logged_in_count = EXCLUDED.logged_in_count
-      SQL
+  def self.aggregate(start_date:, end_date:, source: BrowserPageviewEvent.rollup_source)
+    start_date = start_date.to_date
+    end_date = end_date.to_date + 1
+
+    DB.exec(<<~SQL, start_date:, end_date:, source:)
+      INSERT INTO browser_pageview_country_daily_rollups (date, country_code, count, logged_in_count)
+      SELECT
+        created_at::date AS date,
+        country_code,
+        COUNT(*) AS count,
+        COUNT(*) FILTER (WHERE user_id IS NOT NULL) AS logged_in_count
+      FROM browser_pageview_events
+      WHERE created_at >= :start_date
+        AND created_at < :end_date
+        AND source = :source
+      GROUP BY date, country_code
+      ON CONFLICT (date, country_code) DO UPDATE
+      SET count = EXCLUDED.count,
+          logged_in_count = EXCLUDED.logged_in_count
+    SQL
   end
 end
 

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -7,11 +7,15 @@ class BrowserPageviewEvent < ActiveRecord::Base
   MAX_USER_AGENT_LENGTH = 1000
   MAX_NORMALIZED_REFERRER_LENGTH = 2000
   RETENTION_PERIOD = 3.months
+  SOURCE_PIGGYBACK = 1
+  SOURCE_BEACON = 2
   REDIS_QUEUE_KEY = "browser_pageview_events:pending"
   REDIS_FLUSH_LOCK_KEY = "browser_pageview_events:flush"
   REDIS_FLUSH_BATCH_SIZE = 1000
   REDIS_QUEUE_MAX_SIZE = 1_000_000
   REDIS_QUEUE_TTL = 1.day
+
+  enum :source, { piggyback: SOURCE_PIGGYBACK, beacon: SOURCE_BEACON }, scopes: false
 
   class << self
     def enqueue_for_later(payload)
@@ -131,6 +135,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
         user_agent: payload[:user_agent]&.slice(0, MAX_USER_AGENT_LENGTH),
         session_id: payload[:session_id]&.slice(0, MAX_SESSION_ID_LENGTH),
         topic_id: payload[:topic_id],
+        source: payload[:source],
         occurred_at: payload[:occurred_at],
       }
     end
@@ -154,6 +159,7 @@ class BrowserPageviewEvent < ActiveRecord::Base
         session_id: payload[:session_id]&.slice(0, MAX_SESSION_ID_LENGTH),
         user_id: payload[:user_id],
         topic_id: payload[:topic_id],
+        source: payload[:source],
         created_at: payload[:occurred_at],
       }
     end
@@ -183,6 +189,14 @@ class BrowserPageviewEvent < ActiveRecord::Base
     RETENTION_PERIOD.ago.beginning_of_day
   end
 
+  def self.rollup_source
+    if UpcomingChanges.enabled?(:dashboard_improvements)
+      SOURCE_BEACON
+    else
+      SOURCE_PIGGYBACK
+    end
+  end
+
   before_save :truncate_fields
 
   private
@@ -210,6 +224,7 @@ end
 #  normalized_referrer_version :integer
 #  referrer                    :string(2000)
 #  score                       :integer
+#  source                      :integer          default("piggyback"), not null
 #  url                         :string(2000)     not null
 #  user_agent                  :string(1000)     not null
 #  created_at                  :datetime         not null

--- a/app/models/browser_pageview_referrer_daily_rollup.rb
+++ b/app/models/browser_pageview_referrer_daily_rollup.rb
@@ -1,33 +1,39 @@
 # frozen_string_literal: true
 
 class BrowserPageviewReferrerDailyRollup < ActiveRecord::Base
-  def self.aggregate(start_date:, end_date:)
-    DB.exec(<<~SQL, start_date: start_date.to_date, end_date: end_date.to_date + 1)
-        INSERT INTO browser_pageview_referrer_daily_rollups (date, normalized_referrer, count, logged_in_count)
-        SELECT
-          created_at::date AS date,
-          normalized_referrer,
-          COUNT(*) AS count,
-          COUNT(*) FILTER (WHERE user_id IS NOT NULL) AS logged_in_count
-        FROM browser_pageview_events
-        WHERE created_at >= :start_date
-          AND created_at < :end_date
-        GROUP BY date, normalized_referrer
-        ON CONFLICT (date, normalized_referrer) DO UPDATE
-        SET count = EXCLUDED.count,
-            logged_in_count = EXCLUDED.logged_in_count
-      SQL
+  def self.aggregate(start_date:, end_date:, source: BrowserPageviewEvent.rollup_source)
+    start_date = start_date.to_date
+    end_date = end_date.to_date + 1
+
+    DB.exec(<<~SQL, start_date:, end_date:, source:)
+      INSERT INTO browser_pageview_referrer_daily_rollups (date, normalized_referrer, count, logged_in_count)
+      SELECT
+        created_at::date AS date,
+        normalized_referrer,
+        COUNT(*) AS count,
+        COUNT(*) FILTER (WHERE user_id IS NOT NULL) AS logged_in_count
+      FROM browser_pageview_events
+      WHERE created_at >= :start_date
+        AND created_at < :end_date
+        AND source = :source
+      GROUP BY date, normalized_referrer
+      ON CONFLICT (date, normalized_referrer) DO UPDATE
+      SET count = EXCLUDED.count,
+          logged_in_count = EXCLUDED.logged_in_count
+    SQL
   end
 
   def self.recompute(dates)
     dates = Array(dates).map(&:to_date).uniq
     return if dates.empty?
 
+    source = BrowserPageviewEvent.rollup_source
+
     # The rollups are the permanent record, but their source events are pruned
     # after a retention period (CleanUpBrowserPageviewEvents). Only rebuild
     # dates that still have events so we never delete a rollup we can no longer
     # reconstruct from events.
-    dates = DB.query_single(<<~SQL, dates: dates)
+    dates = DB.query_single(<<~SQL, dates:, source:)
       SELECT d.date
       FROM unnest(ARRAY[:dates]::date[]) AS d(date)
       WHERE EXISTS (
@@ -35,6 +41,7 @@ class BrowserPageviewReferrerDailyRollup < ActiveRecord::Base
         FROM browser_pageview_events e
         WHERE e.created_at >= d.date
           AND e.created_at < d.date + 1
+          AND e.source = :source
       )
     SQL
     return if dates.empty?
@@ -45,7 +52,7 @@ class BrowserPageviewReferrerDailyRollup < ActiveRecord::Base
         WHERE date IN (:dates)
       SQL
 
-      dates.each { |date| aggregate(start_date: date, end_date: date) }
+      dates.each { |date| aggregate(start_date: date, end_date: date, source:) }
     end
   end
 end

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -597,10 +597,6 @@ basic:
   trigger_browser_pageview_events:
     default: false
     hidden: true
-  use_beacon_for_browser_page_views:
-    default: false
-    hidden: true
-    client: true
   persist_browser_pageview_events:
     default: true
     hidden: true

--- a/db/migrate/20260615082047_add_source_to_browser_pageview_events.rb
+++ b/db/migrate/20260615082047_add_source_to_browser_pageview_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSourceToBrowserPageviewEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :browser_pageview_events, :source, :integer, limit: 2, default: 1, null: false
+  end
+end

--- a/db/migrate/20260615084100_remove_use_beacon_for_browser_page_views_site_setting.rb
+++ b/db/migrate/20260615084100_remove_use_beacon_for_browser_page_views_site_setting.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveUseBeaconForBrowserPageViewsSiteSetting < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'use_beacon_for_browser_page_views'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1951,7 +1951,8 @@ CREATE TABLE public.browser_pageview_events (
     asn integer,
     score integer,
     normalized_referrer character varying(2000),
-    normalized_referrer_version smallint
+    normalized_referrer_version smallint,
+    source smallint DEFAULT 1 NOT NULL
 );
 
 
@@ -22057,6 +22058,8 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260617053237'),
+('20260615084100'),
+('20260615082047'),
 ('20260612092612'),
 ('20260610205840'),
 ('20260610075829'),

--- a/frontend/discourse/app/instance-initializers/page-tracking.js
+++ b/frontend/discourse/app/instance-initializers/page-tracking.js
@@ -31,9 +31,10 @@ export default {
     // eslint-disable-next-line ember/no-private-routing-service
     const router = owner.lookup("router:main");
     router.on("routeWillChange", this.handleRouteWillChange);
-
-    const siteSettings = owner.lookup("service:site-settings");
-    if (siteSettings.use_beacon_for_browser_page_views) {
+    const dashboardImprovementsEnabled =
+      document.querySelector("meta[name=discourse-beacon-pageview-enabled]")
+        ?.content === "true";
+    if (dashboardImprovementsEnabled) {
       router.on("routeDidChange", this.handleRouteDidChange);
     }
 

--- a/lib/crawler_scorer.rb
+++ b/lib/crawler_scorer.rb
@@ -66,16 +66,20 @@ class CrawlerScorer
 
   SQL = <<~SQL
     WITH events AS (
-      SELECT id, session_id, ip_address, user_agent, referrer, asn, created_at
+      SELECT id, session_id, ip_address, user_agent, referrer, asn, created_at, source
       FROM browser_pageview_events
       WHERE created_at >= :window_start
         AND created_at <  :window_end
     ),
 
+    -- Per-heuristic stats are partitioned by source as well as ip/ua so that
+    -- pageviews recorded through different transports (e.g. piggyback vs
+    -- beacon) never inflate one another's velocity, churn or navigation gaps.
     ipua_stats AS (
       SELECT
         ip_address,
         user_agent,
+        source,
         COUNT(*) AS pageviews,
         COUNT(DISTINCT session_id) AS distinct_sessions,
         AVG(
@@ -86,15 +90,16 @@ class CrawlerScorer
           END
         ) AS bad_referrer_ratio
       FROM events
-      GROUP BY ip_address, user_agent
+      GROUP BY ip_address, user_agent, source
     ),
 
     gaps AS (
       SELECT
         ip_address,
         user_agent,
+        source,
         EXTRACT(EPOCH FROM created_at - LAG(created_at) OVER (
-          PARTITION BY ip_address, user_agent ORDER BY created_at
+          PARTITION BY ip_address, user_agent, source ORDER BY created_at
         )) AS gap_seconds
       FROM events
     ),
@@ -103,12 +108,13 @@ class CrawlerScorer
       SELECT
         ip_address,
         user_agent,
+        source,
         percentile_cont(0.5) WITHIN GROUP (ORDER BY gap_seconds)
           AS median_gap_seconds,
         COUNT(*) AS gap_count
       FROM gaps
       WHERE gap_seconds IS NOT NULL
-      GROUP BY ip_address, user_agent
+      GROUP BY ip_address, user_agent, source
     ),
 
     breakdown AS (
@@ -151,8 +157,8 @@ class CrawlerScorer
           ELSE 0
         END AS referrer_score
       FROM events e
-      LEFT JOIN ipua_stats iu USING (ip_address, user_agent)
-      LEFT JOIN median_gap mg USING (ip_address, user_agent)
+      LEFT JOIN ipua_stats iu USING (ip_address, user_agent, source)
+      LEFT JOIN median_gap mg USING (ip_address, user_agent, source)
     ),
 
     totals AS (

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -132,7 +132,6 @@ class Middleware::RequestTracker
           ApplicationRequest.increment!(:page_view_anon_browser_beacon)
           ApplicationRequest.increment!(:page_view_anon_browser_mobile_beacon) if data[:is_mobile]
         end
-        trigger_beacon_browser_pageview_event(data)
       else
         if data[:is_embed]
           ApplicationRequest.increment!(:page_view_embed)
@@ -659,8 +658,10 @@ class Middleware::RequestTracker
   end
 
   def self.is_beacon_tracking_request?(request)
-    SiteSetting.use_beacon_for_browser_page_views && request.post? &&
-      request.path == Discourse.beacon_pv_tracking_path
+    UpcomingChanges.enabled?(:dashboard_improvements) &&
+      (
+        SiteSetting.persist_browser_pageview_events || SiteSetting.trigger_browser_pageview_events
+      ) && request.post? && request.path == Discourse.beacon_pv_tracking_path
   end
 
   def self.same_origin_beacon_request?(request)
@@ -715,15 +716,29 @@ class Middleware::RequestTracker
   private_class_method :extract_beacon_view_tracking_data
 
   def self.track_browser_pageview(data)
-    return if data[:is_beacon]
     return if !tracks_browser_page_view?(data)
+    if !SiteSetting.persist_browser_pageview_events && !SiteSetting.trigger_browser_pageview_events
+      return
+    end
 
-    if SiteSetting.persist_browser_pageview_events
-      persist_browser_pageview_event(build_browser_pageview_event_payload(data))
-    elsif SiteSetting.trigger_browser_pageview_events
-      DiscourseEvent.trigger(:browser_pageview, build_browser_pageview_event_payload(data))
+    payload = build_browser_pageview_event_payload(data)
+
+    persist_browser_pageview_event(payload) if SiteSetting.persist_browser_pageview_events
+
+    if data[:is_beacon]
+      trigger_beacon_browser_pageview_event(payload)
+    else
+      trigger_browser_pageview_event(payload)
     end
   end
+
+  def self.trigger_browser_pageview_event(payload)
+    return if SiteSetting.persist_browser_pageview_events
+    return if !SiteSetting.trigger_browser_pageview_events
+
+    DiscourseEvent.trigger(:browser_pageview, payload)
+  end
+  private_class_method :trigger_browser_pageview_event
 
   def self.persist_browser_pageview_event(payload)
     if REQUIRED_BROWSER_PAGEVIEW_EVENT_FIELDS.any? { |key| payload[key].blank? }
@@ -764,10 +779,12 @@ class Middleware::RequestTracker
   end
   private_class_method :queue_browser_pageview_event
 
-  def self.trigger_beacon_browser_pageview_event(data)
-    if SiteSetting.trigger_browser_pageview_events
-      DiscourseEvent.trigger(:beacon_browser_pageview, build_browser_pageview_event_payload(data))
-    end
+  def self.trigger_beacon_browser_pageview_event(payload)
+    return if !UpcomingChanges.enabled?(:dashboard_improvements)
+    return if SiteSetting.persist_browser_pageview_events
+    return if !SiteSetting.trigger_browser_pageview_events
+
+    DiscourseEvent.trigger(:beacon_browser_pageview, payload)
   end
   private_class_method :trigger_beacon_browser_pageview_event
 
@@ -784,6 +801,14 @@ class Middleware::RequestTracker
       session_id: data[:tracking_session_id],
       topic_id: data[:topic_id],
       occurred_at: data[:occurred_at],
+      source:
+        (
+          if data[:is_beacon]
+            BrowserPageviewEvent::SOURCE_BEACON
+          else
+            BrowserPageviewEvent::SOURCE_PIGGYBACK
+          end
+        ),
     }
   end
   private_class_method :build_browser_pageview_event_payload

--- a/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
+++ b/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
@@ -348,7 +348,9 @@ module DiscourseAi
       def landing_topic
         return if @period_days > MAX_LANDING_TOPIC_DAYS
 
-        row = DB.query(<<~SQL, start_date: @start_date, end_date: @end_date).first
+        row =
+          DB.query(
+            <<~SQL,
             SELECT e.topic_id, t.title, COUNT(*) AS visits
             FROM browser_pageview_events e
             JOIN topics t ON t.id = e.topic_id
@@ -356,10 +358,15 @@ module DiscourseAi
               AND e.created_at < (:end_date::date + 1)
               AND e.topic_id IS NOT NULL
               AND e.normalized_referrer IS NOT NULL
+              AND e.source = :source
             GROUP BY e.topic_id, t.title
             ORDER BY visits DESC
             LIMIT 1
           SQL
+            start_date: @start_date,
+            end_date: @end_date,
+            source: BrowserPageviewEvent.rollup_source,
+          ).first
         return if row.nil? || row.visits.to_i < 50
 
         signal(

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,6 +2,38 @@
 # frozen_string_literal: true
 
 RSpec.describe ApplicationHelper do
+  describe "#discourse_pageview_tracking_meta_tags" do
+    it "includes beacon tracking meta tags for anonymous users when dashboard_improvements is enabled" do
+      SiteSetting.dashboard_improvements = true
+      helper.stubs(:current_user).returns(nil)
+
+      tags = helper.discourse_pageview_tracking_meta_tags
+
+      expect(tags).to include('name="discourse-track-view-session-id"')
+      expect(tags).to include('name="discourse-beacon-pageview-enabled"')
+    end
+
+    it "omits beacon tracking meta tags when dashboard_improvements is disabled" do
+      SiteSetting.dashboard_improvements = false
+
+      tags = helper.discourse_pageview_tracking_meta_tags
+
+      expect(tags).to include('name="discourse-track-view-session-id"')
+      expect(tags).not_to include('name="discourse-beacon-pageview-enabled"')
+    end
+
+    it "includes beacon tracking meta tags for browser pageview event triggers" do
+      SiteSetting.dashboard_improvements = true
+      SiteSetting.persist_browser_pageview_events = false
+      SiteSetting.trigger_browser_pageview_events = true
+
+      tags = helper.discourse_pageview_tracking_meta_tags
+
+      expect(tags).to include('name="discourse-track-view-session-id"')
+      expect(tags).to include('name="discourse-beacon-pageview-enabled"')
+    end
+  end
+
   describe "preload_script" do
     def script_tag(url, entrypoint, nonce)
       <<~HTML

--- a/spec/jobs/flush_browser_pageview_events_spec.rb
+++ b/spec/jobs/flush_browser_pageview_events_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Jobs::FlushBrowserPageviewEvents do
       ip_address: "1.2.3.4",
       user_agent: "Mozilla/5.0",
       session_id: "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
+      source: BrowserPageviewEvent::SOURCE_BEACON,
       occurred_at: Time.zone.parse("2026-05-27 10:30:00").iso8601(6),
     }
   end

--- a/spec/jobs/maintain_browser_pageview_rollups_spec.rb
+++ b/spec/jobs/maintain_browser_pageview_rollups_spec.rb
@@ -34,6 +34,40 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
         ).to eq(1)
       end
 
+      it "uses beacon source for rollups when dashboard_improvements is enabled" do
+        SiteSetting.dashboard_improvements = false
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "US",
+          normalized_referrer: "google.com",
+          source: BrowserPageviewEvent::SOURCE_PIGGYBACK,
+        )
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "GB",
+          normalized_referrer: "reddit.com",
+          source: BrowserPageviewEvent::SOURCE_BEACON,
+        )
+
+        job.execute({})
+
+        expect(BrowserPageviewCountryDailyRollup.pluck(:country_code, :count)).to eq([["US", 1]])
+        expect(BrowserPageviewReferrerDailyRollup.pluck(:normalized_referrer, :count)).to eq(
+          [["google.com", 1]],
+        )
+
+        SiteSetting.dashboard_improvements = true
+        job.execute({})
+
+        expect(BrowserPageviewCountryDailyRollup.pluck(:country_code, :count)).to contain_exactly(
+          ["US", 1],
+          ["GB", 1],
+        )
+        expect(
+          BrowserPageviewReferrerDailyRollup.pluck(:normalized_referrer, :count),
+        ).to contain_exactly(["google.com", 1], ["reddit.com", 1])
+      end
+
       it "backfills from the earliest event date on the first run when rollups are empty" do
         Fabricate(:browser_pageview_event, country_code: "US", created_at: 60.days.ago)
         Fabricate(:browser_pageview_event, country_code: "GB", created_at: 5.days.ago)
@@ -72,6 +106,30 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
           BrowserPageviewReferrerInspector.normalize(raw),
         )
         expect(event.normalized_referrer_version).to eq(BrowserPageviewReferrerInspector::VERSION)
+      end
+
+      it "only backfills referrers from the active source" do
+        SiteSetting.dashboard_improvements = true
+        piggyback_event =
+          Fabricate(
+            :browser_pageview_event_with_unnormalized_referrer,
+            referrer: "https://www.google.com/",
+            source: BrowserPageviewEvent::SOURCE_PIGGYBACK,
+          )
+        beacon_event =
+          Fabricate(
+            :browser_pageview_event_with_unnormalized_referrer,
+            referrer: "https://www.reddit.com/",
+            source: BrowserPageviewEvent::SOURCE_BEACON,
+          )
+
+        job.execute({})
+
+        expect(piggyback_event.reload.normalized_referrer_version).to be_nil
+        expect(beacon_event.reload.normalized_referrer).to eq("reddit.com")
+        expect(beacon_event.normalized_referrer_version).to eq(
+          BrowserPageviewReferrerInspector::VERSION,
+        )
       end
 
       it "leaves rows without a referrer untouched and does not let them block completion" do

--- a/spec/lib/crawler_scorer_spec.rb
+++ b/spec/lib/crawler_scorer_spec.rb
@@ -146,4 +146,40 @@ RSpec.describe CrawlerScorer do
 
     expect(event.reload.score).to eq(120)
   end
+
+  it "scores each source but partitions velocity so transports do not inflate each other" do
+    stub_const(CrawlerScorer, :VELOCITY_LOW, 10) do
+      stub_const(CrawlerScorer, :VELOCITY_MEDIUM, 20) do
+        base = 30.minutes.ago
+
+        # Same ip+ua, split across two transports with 12 pageviews each. On
+        # its own each source sits in the LOW velocity tier (+10). Combined they
+        # would be 24 pageviews and reach the MEDIUM tier (+20), so equal
+        # per-source scores prove the heuristics stay partitioned by source.
+        {
+          BrowserPageviewEvent::SOURCE_PIGGYBACK => "piggyback-session",
+          BrowserPageviewEvent::SOURCE_BEACON => "beacon-session",
+        }.each do |source, session_id|
+          12.times do |i|
+            make_event(source: source, session_id: session_id, created_at: base + (i * 15).seconds)
+          end
+        end
+
+        score!
+
+        expect(
+          BrowserPageviewEvent
+            .where(source: BrowserPageviewEvent::SOURCE_PIGGYBACK)
+            .pluck(:score)
+            .uniq,
+        ).to contain_exactly(10)
+        expect(
+          BrowserPageviewEvent
+            .where(source: BrowserPageviewEvent::SOURCE_BEACON)
+            .pluck(:score)
+            .uniq,
+        ).to contain_exactly(10)
+      end
+    end
+  end
 end

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -332,7 +332,8 @@ RSpec.describe Middleware::RequestTracker do
       end
 
       it "counts beacon pageview with embed flag as page_view_embed" do
-        SiteSetting.use_beacon_for_browser_page_views = true
+        SiteSetting.dashboard_improvements = true
+        SiteSetting.trigger_browser_pageview_events = true
         body = {
           session_id: "abc",
           url: "https://example.com/t/slug/1",
@@ -934,6 +935,9 @@ RSpec.describe Middleware::RequestTracker do
           expect(event.country_code).to eq("AU")
           expect(event.user_agent).to be_present
           expect(event.ip_address.to_s).to eq("1.2.3.4")
+          expect(BrowserPageviewEvent.sources[event.source]).to eq(
+            BrowserPageviewEvent::SOURCE_PIGGYBACK,
+          )
         end
 
         it "skips persisted browser pageviews without a URL" do
@@ -1054,7 +1058,8 @@ RSpec.describe Middleware::RequestTracker do
 
   describe "beacon pageview tracking via /srv/pv" do
     before do
-      SiteSetting.use_beacon_for_browser_page_views = true
+      SiteSetting.dashboard_improvements = true
+      SiteSetting.trigger_browser_pageview_events = true
       freeze_time
       ApplicationRequest.clear_cache!
     end
@@ -1151,6 +1156,35 @@ RSpec.describe Middleware::RequestTracker do
       )
     end
 
+    it "persists beacon pageviews to browser_pageview_events with beacon source" do
+      SiteSetting.persist_browser_pageview_events = true
+      DiscourseIpInfo.stubs(:get).returns(country_code: "US")
+      middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
+
+      expect {
+        middleware.call(
+          beacon_env(
+            {
+              url: "https://test.com/t/topic/123",
+              referrer: "https://test.com/",
+              session_id: "abc123",
+              topic_id: 123,
+            },
+            same_origin.merge("action_dispatch.remote_ip" => "1.2.3.4"),
+          ),
+        )
+      }.to change { BrowserPageviewEvent.count }.by(1)
+
+      event = BrowserPageviewEvent.last
+      expect(event.url).to eq("https://test.com/t/topic/123")
+      expect(event.referrer).to eq("https://test.com/")
+      expect(event.session_id).to eq("abc123")
+      expect(event.topic_id).to eq(123)
+      expect(event.country_code).to eq("US")
+      expect(event.ip_address.to_s).to eq("1.2.3.4")
+      expect(BrowserPageviewEvent.sources[event.source]).to eq(BrowserPageviewEvent::SOURCE_BEACON)
+    end
+
     it "increments legacy and BPV counters from non-beacon requests" do
       middleware = Middleware::RequestTracker.new(lambda { |env| [200, {}, ["OK"]] })
       middleware.call(env("HTTP_DISCOURSE_TRACK_VIEW" => "1"))
@@ -1219,8 +1253,30 @@ RSpec.describe Middleware::RequestTracker do
       expect(status).to eq(204)
     end
 
-    context "when SiteSetting.use_beacon_for_browser_page_views is false" do
-      before { SiteSetting.use_beacon_for_browser_page_views = false }
+    context "when dashboard_improvements is disabled" do
+      before { SiteSetting.dashboard_improvements = false }
+
+      it "returns the app's response for beacon requests instead of 204" do
+        app_called = false
+        middleware =
+          Middleware::RequestTracker.new(
+            lambda do |env|
+              app_called = true
+              [404, {}, ["unknown app path"]]
+            end,
+          )
+        status, = middleware.call(beacon_env({}))
+
+        expect(status).to eq(404)
+        expect(app_called).to eq(true)
+      end
+    end
+
+    context "when browser pageview persistence and events are disabled" do
+      before do
+        SiteSetting.persist_browser_pageview_events = false
+        SiteSetting.trigger_browser_pageview_events = false
+      end
 
       it "returns the app's response for beacon requests instead of 204" do
         app_called = false

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -1182,7 +1182,7 @@ RSpec.describe Middleware::RequestTracker do
       expect(event.topic_id).to eq(123)
       expect(event.country_code).to eq("US")
       expect(event.ip_address.to_s).to eq("1.2.3.4")
-      expect(BrowserPageviewEvent.sources[event.source]).to eq(BrowserPageviewEvent::SOURCE_BEACON)
+      expect(event.source).to eq("beacon")
     end
 
     it "increments legacy and BPV counters from non-beacon requests" do

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe BrowserPageviewEvent do
         user_agent: "Mozilla/5.0",
         session_id: "xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx",
         topic_id: 123,
+        source: described_class::SOURCE_BEACON,
         occurred_at: occurred_at.iso8601(6),
       }
     end
@@ -67,6 +68,7 @@ RSpec.describe BrowserPageviewEvent do
       expect(event.asn).to eq(12_345)
       expect(event.normalized_referrer).to eq("example.com/path")
       expect(event.created_at).to eq_time(occurred_at)
+      expect(event.source).to eq("beacon")
       expect(described_class.queued_count).to eq(0)
     end
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -269,6 +269,7 @@ RSpec.describe Admin::DashboardController do
               country_code: country_code,
               normalized_referrer: normalized_referrer,
               created_at: event_date,
+              source: "beacon",
             )
           end
 

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -154,6 +154,8 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
   end
 
   context "with top countries and top referrers cards" do
+    let(:browser_pageview_source) { BrowserPageviewEvent::SOURCE_BEACON }
+
     before do
       SiteSetting.persist_browser_pageview_events = true
       Discourse.stubs(:current_hostname).returns("test.localhost")
@@ -178,6 +180,7 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
           country_code: "US",
           normalized_referrer: "news.ycombinator.com/item?id=42",
           created_at: "2026-05-12",
+          source: browser_pageview_source,
         )
       end
       Fabricate(
@@ -185,12 +188,14 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
         country_code: "GB",
         normalized_referrer: "reddit.com/r/discourse",
         created_at: "2026-05-12",
+        source: browser_pageview_source,
       )
       Fabricate(
         :browser_pageview_event,
         country_code: "DE",
         normalized_referrer: nil,
         created_at: "2026-05-12",
+        source: browser_pageview_source,
       )
       # Internal-referrer and direct (no-referrer) pageviews must not dilute the
       # top referrers percent denominator (it counts external referrer traffic only).
@@ -200,6 +205,7 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
           country_code: "DE",
           normalized_referrer: "test.localhost/t/topic/1",
           created_at: "2026-05-12",
+          source: browser_pageview_source,
         )
       end
 
@@ -247,6 +253,7 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
         :browser_pageview_event,
         normalized_referrer: "news.ycombinator.com/item?id=42",
         created_at: "2026-05-12",
+        source: browser_pageview_source,
       )
       BrowserPageviewReferrerDailyRollup.aggregate(
         start_date: "2026-05-01".to_date,
@@ -263,7 +270,12 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
 
     it "drills into the full top countries report scoped to the dashboard period",
        time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-      Fabricate(:browser_pageview_event, country_code: "US", created_at: "2026-05-12")
+      Fabricate(
+        :browser_pageview_event,
+        country_code: "US",
+        created_at: "2026-05-12",
+        source: browser_pageview_source,
+      )
       BrowserPageviewCountryDailyRollup.aggregate(
         start_date: "2026-05-01".to_date,
         end_date: "2026-05-14".to_date,

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -350,8 +350,8 @@ describe "Request tracking" do
       expect(event[:session_id]).to be_present
     end
 
-    context "when use_beacon_for_browser_page_views is enabled" do
-      before { SiteSetting.use_beacon_for_browser_page_views = true }
+    context "when dashboard_improvements is enabled" do
+      before { SiteSetting.dashboard_improvements = true }
 
       it "tracks an anonymous visit correctly" do
         all_events =
@@ -695,8 +695,8 @@ describe "Request tracking" do
       end
     end
 
-    context "when use_beacon_for_browser_page_views is enabled" do
-      before { SiteSetting.use_beacon_for_browser_page_views = true }
+    context "when dashboard_improvements is enabled" do
+      before { SiteSetting.dashboard_improvements = true }
 
       context "when logged in" do
         before { sign_in(current_user) }
@@ -861,7 +861,7 @@ describe "Request tracking" do
     fab!(:post) { Fabricate(:post, topic: topic) }
 
     before do
-      SiteSetting.use_beacon_for_browser_page_views = true
+      SiteSetting.dashboard_improvements = true
       Middleware::RequestTracker.bpv_notifications_enabled = true
     end
 


### PR DESCRIPTION
Previously, browser pageviews were persisted through the MessageBus piggyback path, which could miss navigation and unload events.

This change records piggyback and sendBeacon pageviews in browser_pageview_events with a source, and uses the beacon transport for dashboard_improvements because keepalive requests can complete after page navigation starts.