### PR TITLE
FIX: Double Dismiss button for topic list on mobile

### DIFF
--- a/frontend/discourse/app/components/discovery/topics.gjs
+++ b/frontend/discourse/app/components/discovery/topics.gjs
@@ -25,6 +25,8 @@ export default class DiscoveryTopics extends Component {
   @service documentTitle;
   @service currentUser;
   @service topicTrackingState;
+  @service site;
+  @service siteSettings;
 
   get redirectedReason() {
     return this.currentUser?.user_option.redirected_to_top?.reason;
@@ -145,7 +147,12 @@ export default class DiscoveryTopics extends Component {
   }
 
   get showBottomDismissButtons() {
-    return this.allLoaded;
+    return (
+      this.allLoaded &&
+      (!this.site.mobileView ||
+        (this.site.mobileView &&
+          !this.siteSettings.floating_dismiss_topics_on_mobile))
+    );
   }
 
   @action

--- a/frontend/discourse/tests/acceptance/mobile-new-dismiss-test.js
+++ b/frontend/discourse/tests/acceptance/mobile-new-dismiss-test.js
@@ -17,12 +17,11 @@ acceptance("New dismiss - Mobile", function (needs) {
     });
   });
 
-  test("shows the floating dismiss split-button but hides the bottom chevron on mobile", async function (assert) {
+  test("shows the floating dismiss split-button at the top, which is floating, but hides the bottom on mobile", async function (assert) {
     await visit("/new");
 
     assert.dom("#dismiss-new-top").exists();
     assert.dom("#dismiss-new-menu-top .d-icon-chevron-down").exists();
-    assert.dom("#dismiss-new-bottom").exists();
-    assert.dom("#dismiss-new-menu-bottom").isNotVisible();
+    assert.dom("#dismiss-new-bottom").doesNotExist();
   });
 });


### PR DESCRIPTION
When floating dismiss topic on mobile UC is enabled,
there should not be a second Dismiss button at the
bottom of the topic list.

**Before**

<img width="420" height="503" alt="image" src="https://github.com/user-attachments/assets/c07964b1-5e4b-46f2-a089-4bfe196e35ac" />


**After**

<img width="420" height="507" alt="image" src="https://github.com/user-attachments/assets/dbca0d09-41ca-4c4c-837c-cb18252ab938" />
