### PR TITLE
FEATURE: Show bounce rate and average session duration on the dashboard

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -453,8 +453,7 @@ module ApplicationHelper
       tags << tag.meta(name: "discourse-beacon-pageview-enabled", content: "true")
     end
 
-    if UpcomingChanges.enabled?(:dashboard_improvements) &&
-         SiteSetting.persist_browser_pageview_events
+    if SiteSetting.persist_browser_pageview_events
       tags << tag.meta(name: "discourse-engagement-tracking-enabled", content: "true")
     end
     tags.html_safe

--- a/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
+++ b/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
@@ -9,21 +9,42 @@ module Jobs
     def execute(_args)
       return if !SiteSetting.persist_browser_pageview_events
 
-      aggregate
-      backfill
+      aggregate_pageviews
+      aggregate_engagement
+      backfill_referrers
     end
 
     private
 
-    def aggregate
-      start_date, end_date = aggregation_window
+    def aggregate_pageviews
+      start_date, end_date = pageview_aggregation_window
       return if start_date.nil?
 
       BrowserPageviewCountryDailyRollup.aggregate(start_date: start_date, end_date: end_date)
       BrowserPageviewReferrerDailyRollup.aggregate(start_date: start_date, end_date: end_date)
     end
 
-    def aggregation_window
+    def aggregate_engagement
+      start_date, end_date = engagement_aggregation_window
+      return if start_date.nil?
+
+      BrowserPageviewSessionEngagementDailyRollup.aggregate(
+        start_date: start_date,
+        end_date: end_date,
+      )
+    end
+
+    def engagement_aggregation_window
+      end_date = Time.zone.today
+      start_date =
+        BrowserPageviewSessionEngagementDailyRollup.where("date < ?", end_date).maximum(:date) ||
+          BrowserPageviewSessionEngagement.minimum(:created_at)&.to_date
+      return nil, nil if start_date.nil?
+
+      [start_date, end_date]
+    end
+
+    def pageview_aggregation_window
       end_date = Time.zone.today
 
       if BrowserPageviewCountryDailyRollup.none? && BrowserPageviewReferrerDailyRollup.none?
@@ -38,7 +59,7 @@ module Jobs
       end
     end
 
-    def backfill
+    def backfill_referrers
       rows = next_batch
       return if rows.empty?
 

--- a/app/models/browser_pageview_session_engagement_daily_rollup.rb
+++ b/app/models/browser_pageview_session_engagement_daily_rollup.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class BrowserPageviewSessionEngagementDailyRollup < ActiveRecord::Base
+  BOUNCE_ENGAGED_SECONDS_THRESHOLD = 10
+  MIN_SESSION_AGE = 10.minutes
+  private_constant :BOUNCE_ENGAGED_SECONDS_THRESHOLD, :MIN_SESSION_AGE
+
+  def self.aggregate(start_date:, end_date:, source: BrowserPageviewEvent.rollup_source)
+    start_date = start_date.to_date
+    end_date = end_date.to_date + 1
+
+    transaction do
+      DB.exec(<<~SQL, start_date:, end_date:, source:)
+        DELETE FROM browser_pageview_session_engagement_daily_rollups rollup
+        WHERE rollup.date >= :start_date
+          AND rollup.date < :end_date
+          AND EXISTS (
+            SELECT 1
+            FROM browser_pageview_events
+            WHERE created_at >= rollup.date
+              AND created_at < rollup.date + 1
+              AND source = :source
+          )
+      SQL
+
+      DB.exec(
+        <<~SQL,
+        WITH active_sessions AS (
+          SELECT DISTINCT session_id
+          FROM browser_pageview_events
+          WHERE created_at >= :start_date
+            AND created_at < LEAST(:end_date::timestamp, :session_started_before::timestamp)
+            AND source = :source
+        ),
+        session_pageviews AS (
+          SELECT
+            bpe.session_id,
+            MIN(bpe.created_at)::date AS date,
+            COUNT(*) AS pageview_count,
+            bool_or(bpe.user_id IS NOT NULL) AS logged_in
+          FROM browser_pageview_events bpe
+          JOIN active_sessions ON active_sessions.session_id = bpe.session_id
+          WHERE bpe.source = :source
+          GROUP BY bpe.session_id
+          HAVING MIN(bpe.created_at) >= :start_date
+        )
+        INSERT INTO browser_pageview_session_engagement_daily_rollups
+          (date, logged_in, sessions, bounced, engaged_seconds_total)
+        SELECT
+          session_pageviews.date,
+          session_pageviews.logged_in,
+          COUNT(*) AS sessions,
+          COUNT(*) FILTER (
+            WHERE session_pageviews.pageview_count = 1
+              AND COALESCE(engagement.engaged_seconds, 0) < :bounce_threshold
+          ) AS bounced,
+          COALESCE(SUM(engagement.engaged_seconds), 0) AS engaged_seconds_total
+        FROM session_pageviews
+        LEFT JOIN browser_pageview_session_engagements engagement
+          ON engagement.session_id = session_pageviews.session_id
+        GROUP BY session_pageviews.date, session_pageviews.logged_in
+      SQL
+        start_date:,
+        end_date:,
+        session_started_before: MIN_SESSION_AGE.ago,
+        bounce_threshold: BOUNCE_ENGAGED_SECONDS_THRESHOLD,
+        source:,
+      )
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: browser_pageview_session_engagement_daily_rollups
+#
+#  id                    :bigint           not null, primary key
+#  bounced               :bigint           not null
+#  date                  :date             not null
+#  engaged_seconds_total :bigint           not null
+#  logged_in             :boolean          not null
+#  sessions              :bigint           not null
+#
+# Indexes
+#
+#  idx_bpse_rollups_date_logged_in_unique  (date,logged_in) UNIQUE
+#

--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -111,7 +111,42 @@ class AdminDashboardSiteTraffic
     direct_traffic = direct_traffic_value
     kpis[:direct_traffic] = { value: direct_traffic } if !direct_traffic.nil?
 
+    if SiteSetting.persist_browser_pageview_events
+      kpis[:bounce_rate] = { value: bounce_rate_value }
+      kpis[:average_session_duration_seconds] = { value: average_session_duration_value }
+    end
+
     kpis
+  end
+
+  def bounce_rate_value
+    sessions = session_engagement_totals[:sessions]
+    return nil if sessions.zero?
+
+    ((session_engagement_totals[:bounced].to_f / sessions) * 100).round
+  end
+
+  def average_session_duration_value
+    sessions = session_engagement_totals[:sessions]
+    return nil if sessions.zero?
+
+    (session_engagement_totals[:engaged_seconds_total].to_f / sessions).round
+  end
+
+  def session_engagement_totals
+    @session_engagement_totals ||=
+      DB
+        .query_hash(<<~SQL, start_date: start_date.to_date, end_date: end_date.to_date)
+          SELECT
+            COALESCE(SUM(sessions), 0)::bigint AS sessions,
+            COALESCE(SUM(bounced), 0)::bigint AS bounced,
+            COALESCE(SUM(engaged_seconds_total), 0)::bigint AS engaged_seconds_total
+          FROM browser_pageview_session_engagement_daily_rollups
+          WHERE date >= :start_date
+            AND date <= :end_date
+        SQL
+        .first
+        .symbolize_keys
   end
 
   def browser_pageviews_kpi(totals, prior_rows)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -134,6 +134,7 @@ en:
         x_minutes:
           one: "%{count}m"
           other: "%{count}m"
+        x_minutes_seconds: "%{minutes}m %{seconds}s"
         about_x_hours:
           one: "%{count}h"
           other: "%{count}h"
@@ -7329,6 +7330,14 @@ en:
             direct_traffic:
               label: "Direct traffic"
               tooltip: "The share of pageviews that came directly to your community, such as by typing your URL or using a browser bookmark."
+            bounce_rate:
+              label: "Bounce rate"
+              tooltip: "The share of sessions with a single pageview and less than 10 seconds of engaged time."
+            average_session_duration:
+              label: "Avg. session duration"
+              tooltip: "The average amount of time visitors spent in your community for the selected period."
+            session_metrics:
+              empty_tooltip: "Shown once visits are recorded for this period."
           top_countries:
             title: "Top countries"
             empty: "No country data for this period."

--- a/db/migrate/20260701073045_create_browser_pageview_session_engagement_daily_rollups.rb
+++ b/db/migrate/20260701073045_create_browser_pageview_session_engagement_daily_rollups.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class CreateBrowserPageviewSessionEngagementDailyRollups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :browser_pageview_session_engagement_daily_rollups do |t|
+      t.date :date, null: false
+      t.boolean :logged_in, null: false
+      t.bigint :sessions, null: false
+      t.bigint :bounced, null: false
+      t.bigint :engaged_seconds_total, null: false
+    end
+
+    add_index :browser_pageview_session_engagement_daily_rollups,
+              %i[date logged_in],
+              unique: true,
+              name: "idx_bpse_rollups_date_logged_in_unique"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2050,6 +2050,39 @@ ALTER SEQUENCE public.browser_pageview_referrer_daily_rollups_id_seq OWNED BY pu
 
 
 --
+-- Name: browser_pageview_session_engagement_daily_rollups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.browser_pageview_session_engagement_daily_rollups (
+    id bigint NOT NULL,
+    date date NOT NULL,
+    logged_in boolean NOT NULL,
+    sessions bigint NOT NULL,
+    bounced bigint NOT NULL,
+    engaged_seconds_total bigint NOT NULL
+);
+
+
+--
+-- Name: browser_pageview_session_engagement_daily_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.browser_pageview_session_engagement_daily_rollups_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: browser_pageview_session_engagement_daily_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.browser_pageview_session_engagement_daily_rollups_id_seq OWNED BY public.browser_pageview_session_engagement_daily_rollups.id;
+
+
+--
 -- Name: browser_pageview_session_engagements; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -12411,6 +12444,13 @@ ALTER TABLE ONLY public.browser_pageview_referrer_daily_rollups ALTER COLUMN id 
 
 
 --
+-- Name: browser_pageview_session_engagement_daily_rollups id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.browser_pageview_session_engagement_daily_rollups ALTER COLUMN id SET DEFAULT nextval('public.browser_pageview_session_engagement_daily_rollups_id_seq'::regclass);
+
+
+--
 -- Name: browser_pageview_session_engagements id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -14633,6 +14673,14 @@ ALTER TABLE ONLY public.browser_pageview_events
 
 ALTER TABLE ONLY public.browser_pageview_referrer_daily_rollups
     ADD CONSTRAINT browser_pageview_referrer_daily_rollups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: browser_pageview_session_engagement_daily_rollups browser_pageview_session_engagement_daily_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.browser_pageview_session_engagement_daily_rollups
+    ADD CONSTRAINT browser_pageview_session_engagement_daily_rollups_pkey PRIMARY KEY (id);
 
 
 --
@@ -17034,6 +17082,13 @@ CREATE INDEX idx_bpe_session_created_at ON public.browser_pageview_events USING 
 --
 
 CREATE UNIQUE INDEX idx_bprd_rollups_date_referrer_unique ON public.browser_pageview_referrer_daily_rollups USING btree (date, normalized_referrer) NULLS NOT DISTINCT;
+
+
+--
+-- Name: idx_bpse_rollups_date_logged_in_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_bpse_rollups_date_logged_in_unique ON public.browser_pageview_session_engagement_daily_rollups USING btree (date, logged_in);
 
 
 --
@@ -22415,6 +22470,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260702102111'),
+('20260701073045'),
 ('20260630034050'),
 ('20260629233141'),
 ('20260629081606'),

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -5,6 +5,7 @@ import AdminReportStackedChart from "discourse/admin/components/admin-report-sta
 import DashboardSection from "discourse/admin/components/dashboard/section";
 import { countryFlag, countryName } from "discourse/admin/lib/format-country";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
+import { formatMinutesSeconds } from "discourse/lib/formatter";
 import { or } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
@@ -104,6 +105,32 @@ export default class DashboardTraffic extends Component {
 
   #kpiValue(key) {
     return this.args.traffic?.kpis?.[key]?.value;
+  }
+
+  get showSessionMetrics() {
+    return this.#kpiValue("bounce_rate") !== undefined;
+  }
+
+  get showMetrics() {
+    return (
+      this.showLoggedInShare ||
+      this.showDirectTraffic ||
+      this.showSessionMetrics
+    );
+  }
+
+  get sessionMetricsEmpty() {
+    return this.#kpiValue("bounce_rate") == null;
+  }
+
+  get bounceRate() {
+    const value = this.#kpiValue("bounce_rate");
+    return value == null ? "—" : `${value}%`;
+  }
+
+  get averageSessionDuration() {
+    const value = this.#kpiValue("average_session_duration_seconds");
+    return value == null ? "—" : formatMinutesSeconds(value);
   }
 
   get chartModel() {
@@ -230,7 +257,7 @@ export default class DashboardTraffic extends Component {
             </h3>
           </div>
 
-          {{#if (or this.showLoggedInShare this.showDirectTraffic)}}
+          {{#if this.showMetrics}}
             <div class="db-section__metrics">
               {{#if this.showLoggedInShare}}
                 <div class="db-section__metric">
@@ -274,6 +301,67 @@ export default class DashboardTraffic extends Component {
                         {{i18n
                           "admin.dashboard.site_traffic.kpi.direct_traffic.tooltip"
                         }}
+                      </:content>
+                    </DTooltip>
+                  </div>
+                </div>
+              {{/if}}
+
+              {{#if this.showSessionMetrics}}
+                <div class="db-section__metric" data-test-kpi="bounce_rate">
+                  <div
+                    class="db-section__metric-number"
+                  >{{this.bounceRate}}</div>
+                  <div class="db-section__metric-label">
+                    {{i18n
+                      "admin.dashboard.site_traffic.kpi.bounce_rate.label"
+                    }}
+                    <DTooltip
+                      class="db-section__info"
+                      @identifier="site-traffic-bounce-rate-tooltip"
+                      @icon="far-circle-question"
+                    >
+                      <:content>
+                        {{#if this.sessionMetricsEmpty}}
+                          {{i18n
+                            "admin.dashboard.site_traffic.kpi.session_metrics.empty_tooltip"
+                          }}
+                        {{else}}
+                          {{i18n
+                            "admin.dashboard.site_traffic.kpi.bounce_rate.tooltip"
+                          }}
+                        {{/if}}
+                      </:content>
+                    </DTooltip>
+                  </div>
+                </div>
+
+                <div
+                  class="db-section__metric"
+                  data-test-kpi="average_session_duration"
+                >
+                  <div
+                    class="db-section__metric-number"
+                  >{{this.averageSessionDuration}}</div>
+                  <div class="db-section__metric-label">
+                    {{i18n
+                      "admin.dashboard.site_traffic.kpi.average_session_duration.label"
+                    }}
+                    <DTooltip
+                      class="db-section__info"
+                      @identifier="site-traffic-average-session-duration-tooltip"
+                      @icon="far-circle-question"
+                    >
+                      <:content>
+                        {{#if this.sessionMetricsEmpty}}
+                          {{i18n
+                            "admin.dashboard.site_traffic.kpi.session_metrics.empty_tooltip"
+                          }}
+                        {{else}}
+                          {{i18n
+                            "admin.dashboard.site_traffic.kpi.average_session_duration.tooltip"
+                          }}
+                        {{/if}}
                       </:content>
                     </DTooltip>
                   </div>

--- a/frontend/discourse/app/lib/formatter.js
+++ b/frontend/discourse/app/lib/formatter.js
@@ -210,6 +210,22 @@ export function durationTiny(distance, ageOpts) {
   return duration(distance, { format: "tiny", ...ageOpts });
 }
 
+export function formatMinutesSeconds(seconds) {
+  const totalSeconds = Math.floor(seconds);
+
+  if (totalSeconds < 60) {
+    return i18n("dates.tiny.x_seconds", { count: totalSeconds });
+  }
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainderSeconds = totalSeconds % 60;
+
+  return i18n("dates.tiny.x_minutes_seconds", {
+    minutes,
+    seconds: remainderSeconds,
+  });
+}
+
 function relativeAgeTiny(date, ageOpts) {
   const format = "tiny";
   let distance = Math.round((new Date() - date) / 1000);

--- a/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
+++ b/frontend/discourse/tests/unit/lib/format-minutes-seconds-test.js
@@ -1,0 +1,18 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { formatMinutesSeconds } from "discourse/lib/formatter";
+
+module("Unit | Lib | formatMinutesSeconds", function (hooks) {
+  setupTest(hooks);
+
+  test("formats whole seconds below a minute as Xs", function (assert) {
+    assert.strictEqual(formatMinutesSeconds(0), "0s");
+    assert.strictEqual(formatMinutesSeconds(59), "59s");
+  });
+
+  test("formats a minute or more as Xm Ys with both units", function (assert) {
+    assert.strictEqual(formatMinutesSeconds(60), "1m 0s");
+    assert.strictEqual(formatMinutesSeconds(107), "1m 47s");
+    assert.strictEqual(formatMinutesSeconds(1800), "30m 0s");
+  });
+});

--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -692,8 +692,7 @@ class Middleware::RequestTracker
   end
 
   def self.is_engagement_tracking_request?(request)
-    UpcomingChanges.enabled?(:dashboard_improvements) &&
-      SiteSetting.persist_browser_pageview_events && request.post? &&
+    SiteSetting.persist_browser_pageview_events && request.post? &&
       request.path == Discourse.engagement_tracking_path
   end
 

--- a/spec/fabricators/browser_pageview_session_engagement_daily_rollup_fabricator.rb
+++ b/spec/fabricators/browser_pageview_session_engagement_daily_rollup_fabricator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Fabricator(:browser_pageview_session_engagement_daily_rollup) do
+  date { Time.zone.today }
+  logged_in false
+  sessions 1
+  bounced 0
+  engaged_seconds_total 0
+end

--- a/spec/fabricators/browser_pageview_session_engagement_fabricator.rb
+++ b/spec/fabricators/browser_pageview_session_engagement_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:browser_pageview_session_engagement) do
+  session_id { SecureRandom.alphanumeric(32) }
+  engaged_seconds 30
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe ApplicationHelper do
     end
 
     it "includes the engagement tracking meta tag when pageview events are persisted" do
-      SiteSetting.dashboard_improvements = true
       SiteSetting.persist_browser_pageview_events = true
 
       tags = helper.discourse_pageview_tracking_meta_tags

--- a/spec/jobs/maintain_browser_pageview_rollups_spec.rb
+++ b/spec/jobs/maintain_browser_pageview_rollups_spec.rb
@@ -95,6 +95,81 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
       end
     end
 
+    context "when aggregating engagement rollups" do
+      before { freeze_time(Time.utc(2026, 6, 20, 12, 0, 0)) }
+
+      it "does nothing when persist_browser_pageview_events is disabled" do
+        SiteSetting.persist_browser_pageview_events = false
+        Fabricate(:browser_pageview_session_engagement, created_at: Time.utc(2026, 6, 10))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+
+        job.execute({})
+
+        expect(BrowserPageviewSessionEngagementDailyRollup.count).to eq(0)
+      end
+
+      it "aggregates nothing until the first engagement row exists" do
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+
+        job.execute({})
+
+        expect(BrowserPageviewSessionEngagementDailyRollup.count).to eq(0)
+      end
+
+      it "floors aggregation at the earliest engagement row's date" do
+        Fabricate(:browser_pageview_session_engagement, created_at: Time.utc(2026, 6, 10, 8))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 9, 9))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 11, 9))
+
+        job.execute({})
+
+        expect(BrowserPageviewSessionEngagementDailyRollup.order(:date).pluck(:date)).to eq(
+          [Date.new(2026, 6, 10), Date.new(2026, 6, 11)],
+        )
+      end
+
+      it "backfills from the floor forward on the first run" do
+        Fabricate(:browser_pageview_session_engagement, created_at: Time.utc(2026, 6, 12, 8))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 12, 9))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 18, 9))
+
+        job.execute({})
+
+        expect(BrowserPageviewSessionEngagementDailyRollup.pluck(:date)).to contain_exactly(
+          Date.new(2026, 6, 12),
+          Date.new(2026, 6, 18),
+        )
+      end
+
+      it "re-aggregates days a multi-day failure skipped, not only the previous day" do
+        Fabricate(:browser_pageview_session_engagement, created_at: Time.utc(2026, 6, 10, 8))
+        Fabricate(:browser_pageview_session_engagement_daily_rollup, date: Date.new(2026, 6, 10))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 15, 9))
+
+        job.execute({})
+
+        expect(
+          BrowserPageviewSessionEngagementDailyRollup.where(date: Date.new(2026, 6, 15)).sum(
+            :sessions,
+          ),
+        ).to eq(1)
+      end
+
+      it "does not reach back for a late event on a day behind the last rolled-up day" do
+        Fabricate(:browser_pageview_session_engagement, created_at: Time.utc(2026, 6, 18, 8))
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 19, 9))
+        job.execute({})
+
+        Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 18, 9))
+        job.execute({})
+
+        expect(BrowserPageviewSessionEngagementDailyRollup.pluck(:date)).to eq(
+          [Date.new(2026, 6, 19)],
+        )
+      end
+    end
+
     context "when backfilling referrers" do
       it "normalizes historical rows using the inspector and stamps the current version" do
         raw = "https://www.reddit.com/r/discourse/"

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -1961,10 +1961,7 @@ RSpec.describe Middleware::RequestTracker do
   end
 
   describe "session engagement tracking via /srv/se" do
-    before do
-      SiteSetting.dashboard_improvements = true
-      SiteSetting.persist_browser_pageview_events = true
-    end
+    before { SiteSetting.persist_browser_pageview_events = true }
 
     def engagement_env(body_hash, extra = {})
       env(
@@ -2119,12 +2116,16 @@ RSpec.describe Middleware::RequestTracker do
       }.not_to change { BrowserPageviewSessionEngagement.count }
     end
 
-    it "does not intercept the request when dashboard_improvements is disabled" do
-      SiteSetting.dashboard_improvements = false
+    it "does not intercept the request when persist_browser_pageview_events is disabled" do
+      SiteSetting.persist_browser_pageview_events = false
+      SiteSetting.trigger_browser_pageview_events = true
+      SiteSetting.dashboard_improvements = true
       middleware = Middleware::RequestTracker.new(lambda { |_env| [200, {}, ["OK"]] })
 
-      status, = middleware.call(engagement_env(payload, same_origin))
-      expect(status).to eq(200)
+      expect {
+        status, = middleware.call(engagement_env(payload, same_origin))
+        expect(status).to eq(200)
+      }.not_to change { BrowserPageviewSessionEngagement.count }
     end
   end
 end

--- a/spec/models/browser_pageview_session_engagement_daily_rollup_spec.rb
+++ b/spec/models/browser_pageview_session_engagement_daily_rollup_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+RSpec.describe BrowserPageviewSessionEngagementDailyRollup do
+  describe ".aggregate" do
+    let(:start_date) { Date.new(2026, 6, 1) }
+    let(:end_date) { Date.new(2026, 6, 30) }
+
+    before { freeze_time(Time.utc(2026, 6, 20, 12, 0, 0)) }
+
+    it "bounces a single-pageview session with fewer than 10 engaged seconds" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: event.session_id,
+        engaged_seconds: 9,
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1, bounced: 1))
+    end
+
+    it "bounces a single-pageview session that has no engagement row" do
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(
+        have_attributes(sessions: 1, bounced: 1, engaged_seconds_total: 0),
+      )
+    end
+
+    it "does not bounce a single-pageview session with 10 or more engaged seconds" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: event.session_id,
+        engaged_seconds: 10,
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1, bounced: 0))
+    end
+
+    it "does not bounce a multi-pageview session even with fewer than 10 engaged seconds" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        created_at: Time.utc(2026, 6, 10, 9, 1),
+      )
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: event.session_id,
+        engaged_seconds: 2,
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(
+        have_attributes(sessions: 1, bounced: 0, engaged_seconds_total: 2),
+      )
+    end
+
+    it "does not bounce a multi-pageview session that has no engagement row" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9, 0))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        created_at: Time.utc(2026, 6, 10, 9, 1),
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1, bounced: 0))
+    end
+
+    it "does not bounce a session whose second pageview falls past the range end" do
+      freeze_time(Time.utc(2026, 7, 15, 12, 0, 0))
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 30, 23, 30))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        created_at: Time.utc(2026, 7, 1, 0, 30),
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1, bounced: 0))
+    end
+
+    it "splits sessions and bounced counts by the session's logged-in state" do
+      user = Fabricate(:user)
+      Fabricate(:browser_pageview_event, user_id: user.id, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+
+      described_class.aggregate(start_date:, end_date:)
+
+      rows =
+        described_class.order(:logged_in).pluck(
+          :logged_in,
+          :sessions,
+          :bounced,
+          :engaged_seconds_total,
+        )
+      expect(rows).to eq([[false, 1, 1, 0], [true, 1, 1, 0]])
+    end
+
+    it "attributes a session spanning UTC midnight to its first pageview's UTC date" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 23, 30))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        created_at: Time.utc(2026, 6, 11, 0, 30),
+      )
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: event.session_id,
+        engaged_seconds: 42,
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.pluck(:date)).to eq([Date.new(2026, 6, 10)])
+    end
+
+    it "sums engaged seconds per date and logged-in state" do
+      user = Fabricate(:user)
+      anon_event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      logged_in_event =
+        Fabricate(:browser_pageview_event, user_id: user.id, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: anon_event.session_id,
+        engaged_seconds: 30,
+      )
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: logged_in_event.session_id,
+        engaged_seconds: 70,
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      totals = described_class.order(:logged_in).pluck(:logged_in, :engaged_seconds_total)
+      expect(totals).to eq([[false, 30], [true, 70]])
+    end
+
+    it "excludes engagement rows whose session has no pageview events" do
+      Fabricate(:browser_pageview_session_engagement, engaged_seconds: 120)
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.count).to eq(0)
+    end
+
+    it "counts only rollup-source pageviews, even within a single session" do
+      SiteSetting.dashboard_improvements = true
+      beacon_event =
+        Fabricate(:browser_pageview_event, source: :beacon, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: beacon_event.session_id,
+        source: :piggyback,
+        created_at: Time.utc(2026, 6, 10, 10),
+      )
+      Fabricate(:browser_pageview_event, source: :piggyback, created_at: Time.utc(2026, 6, 10, 9))
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1, bounced: 1))
+    end
+
+    it "clears a session's previous logged-in partition when it flips across runs" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      described_class.aggregate(start_date:, end_date:)
+
+      user = Fabricate(:user)
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        user_id: user.id,
+        created_at: Time.utc(2026, 6, 10, 10),
+      )
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(logged_in: true, sessions: 1))
+    end
+
+    it "keeps an existing rollup for a windowed date whose source events were pruned" do
+      Fabricate(
+        :browser_pageview_session_engagement_daily_rollup,
+        date: Date.new(2026, 6, 10),
+        sessions: 5,
+      )
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 12, 9))
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.where(date: Date.new(2026, 6, 10)).pick(:sessions)).to eq(5)
+    end
+
+    it "aggregates sessions on the range's boundary days but excludes those outside it" do
+      freeze_time(Time.utc(2026, 7, 15, 12, 0, 0))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 1, 0, 0))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 30, 23, 0))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 5, 10, 9))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 7, 10, 9))
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.pluck(:date)).to contain_exactly(
+        Date.new(2026, 6, 1),
+        Date.new(2026, 6, 10),
+        Date.new(2026, 6, 30),
+      )
+    end
+
+    it "excludes a session whose first pageview is before the range but continues inside it" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 5, 31, 23, 30))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        created_at: Time.utc(2026, 6, 1, 0, 30),
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.count).to eq(0)
+    end
+
+    it "excludes sessions that started within the last 10 minutes" do
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 11, 55))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 11, 45))
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1))
+    end
+
+    it "does not bounce a session whose second pageview arrived within the last 10 minutes" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 11, 30))
+      Fabricate(
+        :browser_pageview_event,
+        session_id: event.session_id,
+        created_at: Time.utc(2026, 6, 20, 11, 58),
+      )
+
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(have_attributes(sessions: 1, bounced: 0))
+    end
+
+    it "updates existing rows when re-aggregating with new sessions" do
+      first_event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: first_event.session_id,
+        engaged_seconds: 5,
+      )
+      described_class.aggregate(start_date:, end_date:)
+
+      second_event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 10, 9))
+      Fabricate(
+        :browser_pageview_session_engagement,
+        session_id: second_event.session_id,
+        engaged_seconds: 5,
+      )
+      described_class.aggregate(start_date:, end_date:)
+
+      expect(described_class.all).to contain_exactly(
+        have_attributes(sessions: 2, bounced: 2, engaged_seconds_total: 10),
+      )
+    end
+  end
+end

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -720,6 +720,12 @@ RSpec.describe AdminDashboardSiteTraffic do
           direct_traffic: {
             value: 25,
           },
+          bounce_rate: {
+            value: nil,
+          },
+          average_session_duration_seconds: {
+            value: nil,
+          },
         )
       end
 
@@ -742,6 +748,12 @@ RSpec.describe AdminDashboardSiteTraffic do
           },
           direct_traffic: {
             value: 0,
+          },
+          bounce_rate: {
+            value: nil,
+          },
+          average_session_duration_seconds: {
+            value: nil,
           },
         )
       end
@@ -779,6 +791,12 @@ RSpec.describe AdminDashboardSiteTraffic do
           direct_traffic: {
             value: 33,
           },
+          bounce_rate: {
+            value: nil,
+          },
+          average_session_duration_seconds: {
+            value: nil,
+          },
         )
       end
 
@@ -802,6 +820,172 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       it "omits direct traffic when no pageviews were tracked in the period" do
         expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+          bounce_rate: {
+            value: nil,
+          },
+          average_session_duration_seconds: {
+            value: nil,
+          },
+        )
+      end
+    end
+
+    context "for bounce rate and average session duration" do
+      before { SiteSetting.persist_browser_pageview_events = true }
+
+      it "returns bounce rate and average session duration summed across the audience" do
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 10),
+          logged_in: false,
+          sessions: 8,
+          bounced: 3,
+          engaged_seconds_total: 400,
+        )
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 10),
+          logged_in: true,
+          sessions: 12,
+          bounced: 2,
+          engaged_seconds_total: 200,
+        )
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 4, 20),
+          logged_in: false,
+          sessions: 100,
+          bounced: 100,
+          engaged_seconds_total: 100_000,
+        )
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 20),
+          logged_in: false,
+          sessions: 100,
+          bounced: 100,
+          engaged_seconds_total: 100_000,
+        )
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-14")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+          bounce_rate: {
+            value: 25,
+          },
+          average_session_duration_seconds: {
+            value: 30,
+          },
+        )
+      end
+
+      it "reports zero average duration, not a placeholder, for visits with no engaged time" do
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 10),
+          logged_in: false,
+          sessions: 8,
+          bounced: 8,
+          engaged_seconds_total: 0,
+        )
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-14")[:kpis]).to include(
+          bounce_rate: {
+            value: 100,
+          },
+          average_session_duration_seconds: {
+            value: 0,
+          },
+        )
+      end
+
+      it "rounds bounce rate and average session duration to whole numbers" do
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 10),
+          logged_in: false,
+          sessions: 7,
+          bounced: 3,
+          engaged_seconds_total: 102,
+        )
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-14")[:kpis]).to include(
+          bounce_rate: {
+            value: 43,
+          },
+          average_session_duration_seconds: {
+            value: 15,
+          },
+        )
+      end
+
+      it "includes rollup rows on the exact first and last day of the period" do
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 1),
+          logged_in: false,
+          sessions: 4,
+          bounced: 1,
+          engaged_seconds_total: 40,
+        )
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 14),
+          logged_in: false,
+          sessions: 6,
+          bounced: 4,
+          engaged_seconds_total: 120,
+        )
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-14")[:kpis]).to include(
+          bounce_rate: {
+            value: 50,
+          },
+          average_session_duration_seconds: {
+            value: 16,
+          },
+        )
+      end
+
+      it "returns nil values when no sessions fall in the period" do
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-14")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+          bounce_rate: {
+            value: nil,
+          },
+          average_session_duration_seconds: {
+            value: nil,
+          },
+        )
+      end
+
+      it "omits the KPIs entirely when persist_browser_pageview_events is off" do
+        SiteSetting.persist_browser_pageview_events = false
+        Fabricate(
+          :browser_pageview_session_engagement_daily_rollup,
+          date: Date.new(2026, 5, 10),
+          logged_in: false,
+          sessions: 8,
+          bounced: 3,
+          engaged_seconds_total: 240,
+        )
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-14")[:kpis]).to eq(
           browser_pageviews: {
             value: 0,
           },

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -298,4 +298,67 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
       )
     end
   end
+
+  context "with bounce rate and average session duration metrics" do
+    before { SiteSetting.persist_browser_pageview_events = true }
+
+    it "shows staff the bounce rate and average session duration for the period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      Fabricate(
+        :browser_pageview_session_engagement_daily_rollup,
+        date: Date.new(2026, 5, 12),
+        logged_in: false,
+        sessions: 8,
+        bounced: 3,
+        engaged_seconds_total: 480,
+      )
+      Fabricate(
+        :browser_pageview_session_engagement_daily_rollup,
+        date: Date.new(2026, 5, 12),
+        logged_in: true,
+        sessions: 12,
+        bounced: 2,
+        engaged_seconds_total: 720,
+      )
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_bounce_rate("25%")
+      expect(traffic).to have_average_session_duration("1m 0s")
+    end
+
+    it "shows staff a placeholder and tooltip when no visits fall in the period",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_bounce_rate("—")
+      expect(traffic).to have_average_session_duration("—")
+
+      traffic.hover_bounce_rate_tooltip
+      expect(traffic).to have_session_metric_tooltip(
+        "Shown once visits are recorded for this period.",
+      )
+    end
+
+    it "does not show the metric tiles when persist_browser_pageview_events is off",
+       time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+      SiteSetting.persist_browser_pageview_events = false
+      Fabricate(
+        :browser_pageview_session_engagement_daily_rollup,
+        date: Date.new(2026, 5, 12),
+        logged_in: false,
+        sessions: 8,
+        bounced: 3,
+        engaged_seconds_total: 480,
+      )
+
+      dashboard.visit
+      traffic = dashboard.site_traffic
+
+      expect(traffic).to have_no_bounce_rate
+      expect(traffic).to have_no_average_session_duration
+    end
+  end
 end

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -133,7 +133,40 @@ module PageObjects
         within_top_card("Top countries") { has_css?("h3.db-section__row-block-title a") }
       end
 
+      def has_bounce_rate?(value)
+        has_kpi_value?("bounce_rate", value)
+      end
+
+      def has_no_bounce_rate?
+        has_no_kpi?("bounce_rate")
+      end
+
+      def has_average_session_duration?(value)
+        has_kpi_value?("average_session_duration", value)
+      end
+
+      def has_no_average_session_duration?
+        has_no_kpi?("average_session_duration")
+      end
+
+      def hover_bounce_rate_tooltip
+        find("[data-test-kpi='bounce_rate'] [data-trigger]").hover
+        self
+      end
+
+      def has_session_metric_tooltip?(text)
+        Tooltips.new("site-traffic-bounce-rate-tooltip").present?(text: text)
+      end
+
       private
+
+      def has_kpi_value?(key, value)
+        has_css?("[data-test-kpi='#{key}'] .db-section__metric-number", exact_text: value)
+      end
+
+      def has_no_kpi?(key)
+        has_no_css?("[data-test-kpi='#{key}']")
+      end
 
       def has_no_top_card?(title)
         has_no_css?(".db-section__row-block", text: title)


### PR DESCRIPTION
This PR adds two KPI tiles to the Traffic section — bounce rate and average session duration — measured per browsing session as real engaged time: the seconds a tab is both visible and focused.

<img width="1076" height="125" alt="image" src="https://github.com/user-attachments/assets/de829ba5-cba3-4e1a-935e-55d69be58047"/>

It builds on the per-session engagement core already captures (`browser_pageview_session_engagements`), so the only new table is its daily summary `browser_pageview_session_engagement_daily_rollups` — additive, no existing schema changes.

Key technical changes:

1. Reuse core's capture. Engaged time is already recorded per session by core's `human-activity-tracker` → `/srv/se` beacon → `browser_pageview_session_engagements`; this PR adds no second tracker, endpoint, table, or site setting.

2. Key engagement capture on `persist_browser_pageview_events` alone. `Middleware::RequestTracker#is_engagement_tracking_request?` and the `discourse-engagement-tracking-enabled` meta tag no longer also require the `dashboard_improvements` upcoming change, so engagement is captured wherever pageview events are persisted rather than only where the redesigned dashboard is enabled.

3. Pre-compute in a scheduled job. The existing `Jobs::MaintainBrowserPageviewRollups` job, which already maintains the country and referrer rollups on the same cadence and setting gate, now also rolls sessions into `browser_pageview_session_engagement_daily_rollups`, one row per `(date, logged_in)`, so the dashboard reads this small summary instead of scanning raw events. A session is bounced when it has a single pageview and under ten engaged seconds (no engagement counts as zero). Sessions that started within the last ten minutes are held out of aggregation until a later run, so a live session is not counted as a zero-engagement bounce before the client's first engagement flush (three minutes in) has arrived. Engagement rolls up only from the first engagement row's date forward, because pageview rows predate this feature and have no engagement data — counting them would make all of history look like instant bounces.

4. Show the tiles only when there's data. They render when `persist_browser_pageview_events` is on, alongside the existing Direct traffic KPI, with a neutral placeholder until the first visits are recorded; duration is formatted as `Xm Ys`.