### PR TITLE
DEV: Rename EmberCli to EmberAssets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -140,7 +140,7 @@ class ApplicationController < ActionController::Base
     with_resolved_locale { render "default/empty" }
   end
 
-  rescue_from EmberCli::BuildError do |e|
+  rescue_from EmberAssets::BuildError do |e|
     @build_error = e.details
     response.headers["Cache-Control"] = "no-store"
     render "default/build_error", layout: false, status: :service_unavailable

--- a/app/controllers/qunit_controller.rb
+++ b/app/controllers/qunit_controller.rb
@@ -23,7 +23,7 @@ class QunitController < ApplicationController
   end
 
   def core
-    @has_test_bundle = EmberCli.has_tests?
+    @has_test_bundle = EmberAssets.has_tests?
     request.env[:resolved_theme_id] = nil
 
     target = params[:target] || "core"
@@ -56,7 +56,7 @@ class QunitController < ApplicationController
   def theme
     raise Discourse::NotFound.new if !can_see_theme_qunit?
 
-    @has_test_bundle = EmberCli.has_tests?
+    @has_test_bundle = EmberAssets.has_tests?
 
     param_key = nil
     if (id = get_param(:id)).present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,14 +140,14 @@ module ApplicationHelper
   end
 
   def preload_script(script, type_module: false, attrs: {})
-    resolved_script = EmberCli.script_chunks[script]&.first || script
+    resolved_script = EmberAssets.script_chunks[script]&.first || script
     path = script_asset_path(resolved_script)
     preload_script_url(path, entrypoint: script, type_module:, attrs:).html_safe
   end
 
   def module_preloads_for(*scripts)
     resolved_preload_scripts =
-      scripts.compact.flat_map { |script| EmberCli.script_chunks[script] }.compact.uniq
+      scripts.compact.flat_map { |script| EmberAssets.script_chunks[script] }.compact.uniq
 
     modulepreload_tags = resolved_preload_scripts.map { |script| <<~HTML }
       <link rel="modulepreload" href="#{script_asset_path script}" nonce="#{csp_nonce_placeholder}">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
     <%= module_preloads_for "discourse", (staff? ? "admin/compat-modules" : nil) %>
 
     <%- if staff? %>
-      <% EmberCli.script_chunks["chunk.admin"]&.each do |script_name| %>
+      <% EmberAssets.script_chunks["chunk.admin"]&.each do |script_name| %>
         <link rel="preload" href="<%= script_asset_path(script_name) %>" as="script" nonce="<%= csp_nonce_placeholder %>" data-discourse-entrypoint="admin">
       <% end %>
     <%- end %>

--- a/app/views/qunit/qunit.html.erb
+++ b/app/views/qunit/qunit.html.erb
@@ -18,7 +18,7 @@
       </script>
 
       <%= tag.iframe srcdoc: tag.script(
-        src: script_asset_path(EmberCli.script_chunks["qunit-live-reload"].first),
+        src: script_asset_path(EmberAssets.script_chunks["qunit-live-reload"].first),
         nonce: csp_nonce_placeholder,
         type: "module",
       ), style: "display: none;" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,7 @@ require "pry-rails" if Rails.env.development?
 
 require "discourse_fonts"
 
-require_relative "../lib/ember_cli"
+require_relative "../lib/ember_assets"
 
 if defined?(Bundler)
   bundler_groups = [:default]

--- a/config/pitchfork.conf.rb
+++ b/config/pitchfork.conf.rb
@@ -137,7 +137,7 @@ before_service_worker_ready do |server, service_worker|
   end
 
   if Rails.env.development?
-    EmberCli.watch!
+    EmberAssets.watch!
 
     workers = server.worker_processes
     parts = ["#{workers} worker#{"s" if workers != 1}"]

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1271,7 +1271,7 @@ module Discourse
       end,
       Thread.new { LetterAvatar.image_magick_version },
       Thread.new { SvgSprite.core_svgs },
-      Thread.new { EmberCli.script_chunks(exception: false) },
+      Thread.new { EmberAssets.script_chunks(exception: false) },
       Thread.new do
         if GlobalSetting.mini_racer_single_threaded
           PrettyText.cook("warm up **pretty text**")

--- a/lib/ember_assets.rb
+++ b/lib/ember_assets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EmberCli < ActiveSupport::CurrentAttributes
+class EmberAssets < ActiveSupport::CurrentAttributes
   # Cache which persists for the duration of a request
   attribute :request_cache
 
@@ -142,7 +142,7 @@ class EmberCli < ActiveSupport::CurrentAttributes
     { "message" => text, "messageHtml" => ERB::Util.html_escape(text) }
   end
 
-  def self.is_ember_cli_asset?(name)
+  def self.is_ember_asset?(name)
     assets.include?(name) || script_chunks.values.flatten.include?(name.delete_suffix(".js"))
   end
 

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -18,7 +18,7 @@ task "assets:precompile:build" do
       exec "#{compile_command} && SKIP_EMBER_CLI_COMPILE=1 bin/rake assets:precompile"
     else
       system compile_command, exception: true
-      EmberCli.clear_cache!
+      EmberAssets.clear_cache!
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ApplicationHelper do
         global_setting :s3_cdn_url, "https://s3cdn.com"
 
         # Backend RSpec tests might be run without real manifest/assets
-        EmberCli.stubs(:script_chunks).returns(
+        EmberAssets.stubs(:script_chunks).returns(
           { "discourse" => ["js/discourse-20n62q6s.digested"] },
         )
       end

--- a/spec/lib/ember_assets_spec.rb
+++ b/spec/lib/ember_assets_spec.rb
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-describe EmberCli do
+describe EmberAssets do
   describe "cache" do
-    after { EmberCli.clear_cache! }
+    after { EmberAssets.clear_cache! }
 
     def simulate_request_cache_clearance
       # this method is defined by ActiveSupport::CurrentAttributes
       # and is called before/after every web request
-      EmberCli.reset
+      EmberAssets.reset
     end
 
     context "in development" do
       before { Rails.env.stubs(:development?).returns(true) }
 
       it "cache works, and is cleared before/after each web request" do
-        EmberCli.cache[:foo] = "bar"
-        expect(EmberCli.cache[:foo]).to eq("bar")
+        EmberAssets.cache[:foo] = "bar"
+        expect(EmberAssets.cache[:foo]).to eq("bar")
 
         simulate_request_cache_clearance
 
-        expect(EmberCli.cache[:foo]).to eq(nil)
+        expect(EmberAssets.cache[:foo]).to eq(nil)
       end
     end
 
@@ -27,17 +27,17 @@ describe EmberCli do
       before { Rails.env.stubs(:development?).returns(false) }
 
       it "cache works, and can be cleared" do
-        EmberCli.cache[:foo] = "bar"
-        expect(EmberCli.cache[:foo]).to eq("bar")
+        EmberAssets.cache[:foo] = "bar"
+        expect(EmberAssets.cache[:foo]).to eq("bar")
 
         simulate_request_cache_clearance
 
         # In production, persists across requests
-        expect(EmberCli.cache[:foo]).to eq("bar")
+        expect(EmberAssets.cache[:foo]).to eq("bar")
 
         # But still can be manually cleared
-        EmberCli.clear_cache!
-        expect(EmberCli.cache[:foo]).to eq(nil)
+        EmberAssets.clear_cache!
+        expect(EmberAssets.cache[:foo]).to eq(nil)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -203,8 +203,8 @@ RSpec.configure do |config|
 
   config.before(:each) do |example|
     if example.metadata[:type] != :system
-      EmberCli.stubs(:read_manifest!).returns(nil)
-      EmberCli.stubs(:script_chunks).returns({})
+      EmberAssets.stubs(:read_manifest!).returns(nil)
+      EmberAssets.stubs(:script_chunks).returns({})
     end
   end
 


### PR DESCRIPTION
We don't use ember-cli any more, so a more generic name is better