### PR TITLE
UX: add cancel + footernote

### DIFF
--- a/app/assets/stylesheets/common/modal/manage-reports-modal.scss
+++ b/app/assets/stylesheets/common/modal/manage-reports-modal.scss
@@ -127,6 +127,19 @@
 
   .d-modal__footer {
     justify-content: flex-end;
+
+    @include viewport.until(sm) {
+      flex-direction: column;
+      align-items: flex-end;
+      gap: var(--space-2);
+    }
+  }
+
+  &__footer-note {
+    margin: 0;
+    margin-right: auto;
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
   }
 
   .de-cta__description {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7168,6 +7168,7 @@ en:
             disable: "Disable %{title}"
             move_up: "Move %{title} up"
             move_down: "Move %{title} down"
+            footer_note: "These changes will apply for all users."
 
         configure:
           button: "Configure"

--- a/frontend/discourse/admin/components/modal/manage-reports.gjs
+++ b/frontend/discourse/admin/components/modal/manage-reports.gjs
@@ -486,13 +486,25 @@ export default class ManageReports extends Component {
       </:aboveFooter>
 
       <:footer>
-        <DButton
-          @label="admin.dashboard.reports_section.modal.apply"
-          @action={{this.apply}}
-          @disabled={{this.applying}}
-          @isLoading={{this.applying}}
-          class="btn-primary manage-reports__apply"
-        />
+        <p class="manage-reports__footer-note">
+          {{i18n "admin.dashboard.reports_section.modal.footer_note"}}
+        </p>
+        <div class="manage-reports__footer-actions">
+
+          <DButton
+            @label="js.cancel_value"
+            @action={{@closeModal}}
+            class="btn-transparent manage-reports__cancel"
+          />
+          <DButton
+            @label="admin.dashboard.reports_section.modal.apply"
+            @action={{this.apply}}
+            @disabled={{this.applying}}
+            @isLoading={{this.applying}}
+            class="btn-primary manage-reports__apply"
+          />
+        </div>
+
       </:footer>
     </DModal>
   </template>


### PR DESCRIPTION
| BC | AC |
|--------|--------|
| <img width="615" height="791" alt="CleanShot 2026-06-16 at 13 33 19" src="https://github.com/user-attachments/assets/0901df61-4265-4401-8f1a-c4ab484d990d" /> | <img width="615" height="791" alt="CleanShot 2026-06-16 at 13 32 41" src="https://github.com/user-attachments/assets/767a7ee5-b554-4be1-8a63-a80b2cbbe083" /> | 