### PR TITLE
FIX: Properly scope admin-only browser pageview reports

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -145,7 +145,11 @@ class Admin::DashboardController < Admin::StaffController
     when "highlights"
       AdminDashboardHighlights.build(start_date: params[:start_date], end_date: params[:end_date])
     when "traffic"
-      AdminDashboardSiteTraffic.build(start_date: params[:start_date], end_date: params[:end_date])
+      AdminDashboardSiteTraffic.build(
+        start_date: params[:start_date],
+        end_date: params[:end_date],
+        guardian: guardian,
+      )
     when "engagement"
       AdminDashboardEngagement.build(
         start_date: params[:start_date],

--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -13,11 +13,12 @@ class AdminDashboardSiteTraffic
   private_constant :TOP_CARD_LIMIT
   private_constant :SERIES_LABEL_REQS
 
-  def self.build(start_date:, end_date:)
-    new(start_date: start_date, end_date: end_date).build
+  def self.build(start_date:, end_date:, guardian:)
+    new(start_date: start_date, end_date: end_date, guardian: guardian).build
   end
 
-  def initialize(start_date:, end_date:)
+  def initialize(start_date:, end_date:, guardian:)
+    @guardian = guardian
     @start_date = parse_date(start_date) || (DEFAULT_RANGE_DAYS - 1).days.ago.beginning_of_day
     @end_date = parse_date(end_date)&.end_of_day || Time.zone.now.end_of_day
 
@@ -39,8 +40,11 @@ class AdminDashboardSiteTraffic
     }
 
     if SiteSetting.persist_browser_pageview_events
-      response[:top_countries] = fetch_card("top_countries_by_browser_pageviews")
-      response[:top_referrers] = fetch_card("top_referrers_by_browser_pageviews")
+      top_countries = fetch_card("top_countries_by_browser_pageviews")
+      response[:top_countries] = top_countries if top_countries
+
+      top_referrers = fetch_card("top_referrers_by_browser_pageviews")
+      response[:top_referrers] = top_referrers if top_referrers
     end
 
     response
@@ -48,12 +52,15 @@ class AdminDashboardSiteTraffic
 
   private
 
-  attr_reader :start_date, :end_date
+  attr_reader :start_date, :end_date, :guardian
 
   def fetch_card(type)
+    return nil if Report.hidden?(type, guardian: guardian)
+
     opts = {
       start_date: start_date,
       end_date: end_date,
+      guardian: guardian,
       filters: {
         login_required: SiteSetting.login_required,
         host: Discourse.current_hostname,

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -255,6 +255,54 @@ RSpec.describe Admin::DashboardController do
             ],
           )
         end
+
+        it "does not expose admin-only browser pageview cards to moderators" do
+          SiteSetting.persist_browser_pageview_events = true
+          configure_dashboard_sections(%w[traffic])
+
+          country_code = "US"
+          normalized_referrer = "sensitive-referrer.example"
+          event_date = Time.zone.local(2026, 5, 2, 12)
+
+          2.times do
+            Fabricate(
+              :browser_pageview_event,
+              country_code: country_code,
+              normalized_referrer: normalized_referrer,
+              created_at: event_date,
+            )
+          end
+
+          rollup_range = {
+            start_date: Date.iso8601("2026-05-01"),
+            end_date: Date.iso8601("2026-05-03"),
+          }
+          BrowserPageviewCountryDailyRollup.aggregate(**rollup_range)
+          BrowserPageviewReferrerDailyRollup.aggregate(**rollup_range)
+
+          get "/admin/dashboard.json", params: { start_date: "2026-05-01", end_date: "2026-05-03" }
+
+          expect(response.status).to eq(200)
+          admin_traffic_data =
+            response.parsed_body["sections"].find { |section| section["id"] == "traffic" }["data"]
+          expect(admin_traffic_data.dig("top_countries", "rows", 0, "country_code")).to eq(
+            country_code,
+          )
+          expect(admin_traffic_data.dig("top_referrers", "rows", 0, "normalized_referrer")).to eq(
+            normalized_referrer,
+          )
+
+          sign_in(moderator)
+
+          get "/admin/dashboard.json", params: { start_date: "2026-05-01", end_date: "2026-05-03" }
+
+          expect(response.status).to eq(200)
+          moderator_traffic_data =
+            response.parsed_body["sections"].find { |section| section["id"] == "traffic" }["data"]
+          expect(moderator_traffic_data).not_to have_key("top_countries")
+          expect(moderator_traffic_data).not_to have_key("top_referrers")
+          expect(response.body).not_to include(normalized_referrer)
+        end
       end
 
       context "with search_data" do

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe AdminDashboardSiteTraffic do
+  fab!(:admin)
+
   before do
     freeze_time(Time.zone.local(2026, 5, 14, 12, 0, 0))
     SiteSetting.use_legacy_pageviews = false
     SiteSetting.persist_browser_pageview_events = false
+  end
+
+  def build_traffic(start_date: nil, end_date: nil, guardian: admin.guardian)
+    described_class.build(start_date: start_date, end_date: end_date, guardian: guardian)
   end
 
   def traffic_point(date, count)
@@ -49,7 +55,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       Fabricate(:embedded_application_request, date: "2026-05-02", count: 4)
       Fabricate(:crawler_application_request, date: "2026-05-03", count: 3)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
         kpis: {
           browser_pageviews: {
             value: 30,
@@ -105,7 +111,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 5)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
         kpis: {
           browser_pageviews: {
             value: 5,
@@ -157,7 +163,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       Fabricate(:logged_in_browser_application_request, date: "2026-04-04", count: 8)
       Fabricate(:anonymous_browser_application_request, date: "2026-03-08", count: 10)
 
-      response = described_class.build(start_date: "2026-03-01", end_date: "2026-04-04")
+      response = build_traffic(start_date: "2026-03-01", end_date: "2026-04-04")
 
       dates = (Date.iso8601("2026-03-01")..Date.iso8601("2026-04-04")).map(&:iso8601)
       logged_in_counts = {
@@ -181,7 +187,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 8)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
         browser_pageviews: {
           value: 8,
         },
@@ -196,7 +202,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 8)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
         browser_pageviews: {
           value: 8,
         },
@@ -211,7 +217,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 200_001)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
         browser_pageviews: {
           value: 200_001,
         },
@@ -226,7 +232,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 10_050)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
         browser_pageviews: {
           value: 10_050,
           percent_change: 0.5,
@@ -246,7 +252,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 110)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
         browser_pageviews: {
           value: 110,
           percent_change: 10,
@@ -270,7 +276,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       Fabricate(:anonymous_browser_mobile_application_request, date: "2026-05-01", count: 300)
       Fabricate(:anonymous_browser_beacon_application_request, date: "2026-05-01", count: 400)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
         kpis: {
           browser_pageviews: {
             value: 30,
@@ -298,7 +304,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:crawler_application_request, date: "2026-05-01", count: 4)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
         kpis: {
           browser_pageviews: {
             value: 33,
@@ -318,7 +324,7 @@ RSpec.describe AdminDashboardSiteTraffic do
     it "only includes embedded traffic when embedding is configured" do
       Fabricate(:embedded_application_request, date: "2026-05-01", count: 7)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
         kpis: {
           browser_pageviews: {
             value: 0,
@@ -337,7 +343,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       SiteSetting.embed_topics_list = true
       Fabricate(:embeddable_host)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
         kpis: {
           browser_pageviews: {
             value: 0,
@@ -361,7 +367,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       Fabricate(:embeddable_host)
       Fabricate(:embedded_application_request, date: "2026-05-01", count: 7)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
         kpis: {
           browser_pageviews: {
             value: 0,
@@ -389,7 +395,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       Fabricate(:crawler_application_request, date: "2026-05-01", count: 29)
       Fabricate(:embedded_application_request, date: "2026-05-01", count: 5)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-01")).to eq(
         kpis: {
           browser_pageviews: {
             value: 9,
@@ -404,7 +410,7 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 8)
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
         kpis: {
           browser_pageviews: {
             value: 8,
@@ -445,7 +451,7 @@ RSpec.describe AdminDashboardSiteTraffic do
     it "returns zero-value KPIs and series when no traffic has been recorded" do
       ApplicationRequest.delete_all
 
-      expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
         kpis: {
           browser_pageviews: {
             value: 0,
@@ -488,9 +494,9 @@ RSpec.describe AdminDashboardSiteTraffic do
 
       response_summaries =
         [
-          described_class.build(start_date: nil, end_date: nil),
-          described_class.build(start_date: "not-a-date", end_date: "also-not-a-date"),
-          described_class.build(start_date: "2026-05-10", end_date: "2026-05-01"),
+          build_traffic(start_date: nil, end_date: nil),
+          build_traffic(start_date: "not-a-date", end_date: "also-not-a-date"),
+          build_traffic(start_date: "2026-05-10", end_date: "2026-05-01"),
         ].map do |response|
           logged_in_series_data = traffic_series_data(response, :logged_in)
 
@@ -538,7 +544,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       it "omits top_countries and top_referrers when persist_browser_pageview_events is disabled" do
         SiteSetting.persist_browser_pageview_events = false
 
-        result = described_class.build(start_date: nil, end_date: nil)
+        result = build_traffic(start_date: nil, end_date: nil)
         expect(result).not_to have_key(:top_countries)
         expect(result).not_to have_key(:top_referrers)
       end
@@ -549,7 +555,7 @@ RSpec.describe AdminDashboardSiteTraffic do
         end
         aggregate_rollups
 
-        result = described_class.build(start_date: nil, end_date: nil)
+        result = build_traffic(start_date: nil, end_date: nil)
 
         expect(result[:top_countries][:rows].first[:country_code]).to eq("US")
         expect(result[:top_countries][:error]).to be_nil
@@ -568,17 +574,17 @@ RSpec.describe AdminDashboardSiteTraffic do
         end
         aggregate_rollups
 
-        fresh = described_class.build(start_date: nil, end_date: nil)
+        fresh = build_traffic(start_date: nil, end_date: nil)
         expect(fresh[:top_countries][:rows].size).to eq(5)
         expect(fresh[:top_referrers][:rows].size).to eq(5)
 
-        cached = described_class.build(start_date: nil, end_date: nil)
+        cached = build_traffic(start_date: nil, end_date: nil)
         expect(cached[:top_countries][:rows].size).to eq(5)
         expect(cached[:top_referrers][:rows].size).to eq(5)
       end
 
       it "returns empty rows when no events match the date range" do
-        result = described_class.build(start_date: nil, end_date: nil)
+        result = build_traffic(start_date: nil, end_date: nil)
         expect(result[:top_countries]).to eq(rows: [], error: nil)
         expect(result[:top_referrers]).to eq(rows: [], error: nil)
       end
@@ -586,7 +592,7 @@ RSpec.describe AdminDashboardSiteTraffic do
       it "returns an exception error payload when the underlying report cannot be built" do
         allow(Report).to receive(:find).and_return(nil)
 
-        result = described_class.build(start_date: nil, end_date: nil)
+        result = build_traffic(start_date: nil, end_date: nil)
         expect(result[:top_countries]).to eq(rows: [], error: "exception")
         expect(result[:top_referrers]).to eq(rows: [], error: "exception")
       end
@@ -597,14 +603,14 @@ RSpec.describe AdminDashboardSiteTraffic do
         end
         aggregate_rollups
 
-        first = described_class.build(start_date: nil, end_date: nil)
+        first = build_traffic(start_date: nil, end_date: nil)
         expect(first[:top_countries][:rows].first[:country_code]).to eq("US")
 
         BrowserPageviewCountryDailyRollup.delete_all
         BrowserPageviewReferrerDailyRollup.delete_all
         BrowserPageviewEvent.delete_all
 
-        second = described_class.build(start_date: nil, end_date: nil)
+        second = build_traffic(start_date: nil, end_date: nil)
         expect(second[:top_countries][:rows].first[:country_code]).to eq("US")
         expect(second[:top_countries][:rows].first.keys).to all(be_a(Symbol))
       end
@@ -616,11 +622,11 @@ RSpec.describe AdminDashboardSiteTraffic do
         aggregate_rollups
 
         SiteSetting.login_required = false
-        first = described_class.build(start_date: nil, end_date: nil)
+        first = build_traffic(start_date: nil, end_date: nil)
         expect(first[:top_countries][:rows].first[:country_code]).to eq("US")
 
         SiteSetting.login_required = true
-        second = described_class.build(start_date: nil, end_date: nil)
+        second = build_traffic(start_date: nil, end_date: nil)
         expect(second[:top_countries][:rows]).to be_empty
       end
 
@@ -629,13 +635,13 @@ RSpec.describe AdminDashboardSiteTraffic do
         Fabricate(:browser_pageview_event, normalized_referrer: "forum-b.example.com/path")
         aggregate_rollups
 
-        first = described_class.build(start_date: nil, end_date: nil)
+        first = build_traffic(start_date: nil, end_date: nil)
         expect(first[:top_referrers][:rows].first[:normalized_referrer]).to eq(
           "forum-b.example.com/path",
         )
 
         Discourse.stubs(:current_hostname).returns("forum-b.example.com")
-        second = described_class.build(start_date: nil, end_date: nil)
+        second = build_traffic(start_date: nil, end_date: nil)
         expect(second[:top_referrers][:rows]).to be_empty
       end
 
@@ -649,12 +655,12 @@ RSpec.describe AdminDashboardSiteTraffic do
             end
         end
 
-        first = described_class.build(start_date: nil, end_date: nil)
+        first = build_traffic(start_date: nil, end_date: nil)
         expect(first[:top_countries]).to eq(rows: [], error: "exception")
 
         allow(Report).to receive(:find).and_call_original
 
-        second = described_class.build(start_date: nil, end_date: nil)
+        second = build_traffic(start_date: nil, end_date: nil)
         expect(second[:top_countries]).to eq(rows: [], error: "exception")
       end
 
@@ -668,7 +674,7 @@ RSpec.describe AdminDashboardSiteTraffic do
             end
         end
 
-        first = described_class.build(start_date: nil, end_date: nil)
+        first = build_traffic(start_date: nil, end_date: nil)
         expect(first[:top_countries]).to eq(rows: [], error: "timeout")
         expect(first[:top_referrers]).to eq(rows: [], error: "timeout")
 
@@ -676,7 +682,7 @@ RSpec.describe AdminDashboardSiteTraffic do
         Fabricate(:browser_pageview_event, country_code: "US", normalized_referrer: "google.com")
         aggregate_rollups
 
-        second = described_class.build(start_date: nil, end_date: nil)
+        second = build_traffic(start_date: nil, end_date: nil)
         expect(second[:top_countries][:rows].first[:country_code]).to eq("US")
       end
     end


### PR DESCRIPTION
## Summary

Scope the admin-only browser pageview reports in the staff dashboard to staff only.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1269

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>