### PR TITLE
DEV: Improve JS chunk configuration & naming

### DIFF
--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -133,7 +133,11 @@ export async function loadThemesAndPlugins() {
 export async function loadAdmin() {
   defineModules(
     "discourse/admin",
-    (await import("discourse/admin/compat-modules")).default
+    (
+      await import(
+        /* dynamicChunkName: "admin" */ "discourse/admin/compat-modules"
+      )
+    ).default
   );
 }
 

--- a/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
+++ b/frontend/discourse/app/components/modal/spreadsheet-editor.gjs
@@ -132,7 +132,7 @@ export default class SpreadsheetEditor extends Component {
   async loadJspreadsheet() {
     const [jspreadsheetModule] = await waitForPromise(
       Promise.all([
-        import("jspreadsheet-ce"),
+        import(/* dynamicChunkName: "jspreadsheet" */ "jspreadsheet-ce"),
         import("jspreadsheet-ce/dist/jspreadsheet.css"),
         import("jsuites/dist/jsuites.css"),
       ])

--- a/frontend/discourse/app/initializers/dev-tools.js
+++ b/frontend/discourse/app/initializers/dev-tools.js
@@ -48,7 +48,9 @@ export default {
 
       app.deferReadiness();
 
-      import("discourse/static/dev-tools/entrypoint").then((devTools) => {
+      import(
+        /* dynamicChunkName: "dev-tools" */ "discourse/static/dev-tools/entrypoint"
+      ).then((devTools) => {
         devTools.init();
 
         // eslint-disable-next-line no-console

--- a/frontend/discourse/app/lib/composer/rich-editor-extensions.js
+++ b/frontend/discourse/app/lib/composer/rich-editor-extensions.js
@@ -161,7 +161,9 @@ export function registerRichEditorExtension(extension) {
 export async function clearRichEditorExtensions() {
   // Import it first - a lazy import later would re-register the defaults.
   const module = await waitForPromise(
-    import("discourse/static/prosemirror/extensions/register-default")
+    import(
+      /* dynamicChunkName: "prosemirror-extensions" */ "discourse/static/prosemirror/extensions/register-default"
+    )
   );
   registeredExtensions.length = 0;
   defaultExtensionsRegistered = false;

--- a/frontend/discourse/app/lib/highlight-syntax.js
+++ b/frontend/discourse/app/lib/highlight-syntax.js
@@ -74,7 +74,7 @@ export async function ensureHighlightJs(langFile) {
 
 async function loadHighlightJs(langFile) {
   const [hljsModule, languageInitializer] = await Promise.all([
-    import("highlight.js/lib/core"),
+    import(/* dynamicChunkName: "highlightjs" */ "highlight.js/lib/core"),
     loadLanguageInitializer(langFile),
   ]);
 
@@ -91,9 +91,15 @@ async function loadLanguageInitializer(langFile) {
   if (DEBUG && isTesting()) {
     // Rails server is not available. Load up three languages direct from node_modules
     const [javascript, sql, ruby] = await Promise.all([
-      import("highlight.js/lib/languages/javascript"),
-      import("highlight.js/lib/languages/sql"),
-      import("highlight.js/lib/languages/ruby"),
+      import(
+        /* dynamicChunkName: "highlightjs-javascript" */ "highlight.js/lib/languages/javascript"
+      ),
+      import(
+        /* dynamicChunkName: "highlightjs-sql" */ "highlight.js/lib/languages/sql"
+      ),
+      import(
+        /* dynamicChunkName: "highlightjs-ruby" */ "highlight.js/lib/languages/ruby"
+      ),
     ]);
 
     return (hljs) => {

--- a/frontend/discourse/app/lib/lightbox.js
+++ b/frontend/discourse/app/lib/lightbox.js
@@ -71,7 +71,7 @@ async function initLightbox(elem, additionalData = {}) {
   const caps = helperContext().capabilities;
 
   const { default: PhotoSwipeLightbox } = await waitForPromise(
-    import("photoswipe/lightbox")
+    import(/* dynamicChunkName: "photoswipe-lightbox" */ "photoswipe/lightbox")
   );
   const isTestEnv = isTesting() || isRailsTesting();
   const canDownload =
@@ -106,7 +106,10 @@ async function initLightbox(elem, additionalData = {}) {
     escKey: false,
     tapAction,
     paddingFn,
-    pswpModule: async () => await waitForPromise(import("photoswipe")),
+    pswpModule: async () =>
+      await waitForPromise(
+        import(/* dynamicChunkName: "photoswipe" */ "photoswipe")
+      ),
     appendToEl: isTesting() && document.getElementById("ember-testing"),
   });
 

--- a/frontend/discourse/app/lib/load-faker.js
+++ b/frontend/discourse/app/lib/load-faker.js
@@ -7,7 +7,9 @@ Plugins & themes are unable to async-import npm modules directly.
 This wrapper provides them with a way to use fakerjs, while keeping the `import()` in core's codebase.
 */
 export default async function loadFaker() {
-  faker ??= await waitForPromise(import("@faker-js/faker"));
+  faker ??= await waitForPromise(
+    import(/* dynamicChunkName: "faker" */ "@faker-js/faker")
+  );
   return faker;
 }
 

--- a/frontend/discourse/app/lib/load-js-diff.js
+++ b/frontend/discourse/app/lib/load-js-diff.js
@@ -9,5 +9,5 @@ This wrapper provides them with a way to use morphlex, while keeping the `import
  * @returns {Promise<import("diff")>}
  */
 export default async function loadJSDiff() {
-  return await waitForPromise(import("diff"));
+  return await waitForPromise(import(/* dynamicChunkName: "diff" */ "diff"));
 }

--- a/frontend/discourse/app/lib/load-minimasonry.js
+++ b/frontend/discourse/app/lib/load-minimasonry.js
@@ -1,7 +1,7 @@
 import { waitForPromise } from "@ember/test-waiters";
 
 export default async function loadMiniMasonry() {
-  const promise = import("minimasonry");
+  const promise = import(/* dynamicChunkName: "minimasonry" */ "minimasonry");
   waitForPromise(promise);
   return (await promise).default;
 }

--- a/frontend/discourse/app/lib/to-markdown.js
+++ b/frontend/discourse/app/lib/to-markdown.js
@@ -10,7 +10,9 @@ async function ensureDefaultExtensions() {
   }
 
   // The module's side effect registers the defaults and marks them as registered
-  await import("discourse/static/prosemirror/extensions/register-default");
+  await import(
+    /* dynamicChunkName: "prosemirror-extensions" */ "discourse/static/prosemirror/extensions/register-default"
+  );
 }
 
 // Deprecated no-ops - kept for backward compatibility
@@ -55,8 +57,12 @@ export default async function toMarkdown(html) {
       { isBoundary },
     ] = await Promise.all([
       import("prosemirror-model"),
-      import("discourse/static/prosemirror/core/schema"),
-      import("discourse/static/prosemirror/core/serializer"),
+      import(
+        /* dynamicChunkName: "prosemirror-schema" */ "discourse/static/prosemirror/core/schema"
+      ),
+      import(
+        /* dynamicChunkName: "prosemirror-serializer" */ "discourse/static/prosemirror/core/serializer"
+      ),
       import("discourse/static/prosemirror/extensions/word-paste"),
       import("discourse/static/prosemirror/lib/plugin-utils"),
     ]);

--- a/frontend/discourse/app/static/prosemirror/components/image-node-view.gjs
+++ b/frontend/discourse/app/static/prosemirror/components/image-node-view.gjs
@@ -703,7 +703,7 @@ async function openLightbox(editorElement, currentImage) {
   });
 
   const { default: PhotoSwipeLightbox } = await waitForPromise(
-    import("photoswipe/lightbox")
+    import(/* dynamicChunkName: "photoswipe-lightbox" */ "photoswipe/lightbox")
   );
   const isTestEnv = isTesting() || isRailsTesting();
 
@@ -714,7 +714,8 @@ async function openLightbox(editorElement, currentImage) {
     zoomTitle: i18n("lightbox.zoom"),
     arrowPrevTitle: i18n("lightbox.previous"),
     arrowNextTitle: i18n("lightbox.next"),
-    pswpModule: () => waitForPromise(import("photoswipe")),
+    pswpModule: () =>
+      waitForPromise(import(/* dynamicChunkName: "photoswipe" */ "photoswipe")),
     tapAction: (pt, e) => {
       if (e.target.classList.contains("pswp__img")) {
         lightbox.pswp?.element?.classList.toggle("pswp--ui-visible");

--- a/frontend/discourse/lib/discourse-chunk-names.mjs
+++ b/frontend/discourse/lib/discourse-chunk-names.mjs
@@ -1,0 +1,76 @@
+const DYNAMIC_CHUNK_NAME_COMMENT_REGEX =
+  /import\(\s*\/\*\s*dynamicChunkName:\s*"([^"]+)"\s*\*\/\s*"([^"]+)"\s*\)/g;
+
+function embroiderRouteName(facadeModuleId) {
+  const match = facadeModuleId.match(
+    /-embroider-route-entrypoint\.js:route=(.+)$/
+  );
+  if (match) {
+    return `route-${match[1].replaceAll(/\W/g, "-")}`;
+  }
+}
+
+function emberInspectorName(facadeModuleId) {
+  if (facadeModuleId.includes("@embroider/legacy-inspector-support")) {
+    return `ember-inspector-support`;
+  }
+}
+
+export default function discourseChunkNamesPlugin() {
+  const chunkNamesFromComments = new Map();
+
+  return {
+    name: "discourse-chunk-names",
+
+    // Finds all dynamicChunkName comments in our source files, and adds them
+    // to the list of chunkNamesFromComments for later use in the chunkFileNames hook.
+    // Regex is not ideal... but this isn't worth the cost of a proper AST parse.
+    // Does not actually transform any files.
+    transform: {
+      filter: {
+        id: { exclude: /\/node_modules\// },
+        code: DYNAMIC_CHUNK_NAME_COMMENT_REGEX,
+      },
+
+      async handler(code, id) {
+        await Promise.all(
+          [...code.matchAll(DYNAMIC_CHUNK_NAME_COMMENT_REGEX)].map(
+            async ([, name, specifier]) => {
+              const resolved = await this.resolve(specifier, id).catch(
+                () => null
+              );
+              if (resolved?.id) {
+                chunkNamesFromComments.set(resolved.id, name);
+              }
+            }
+          )
+        );
+
+        return null;
+      },
+    },
+
+    outputOptions(options) {
+      const original = options.chunkFileNames;
+      return {
+        ...options,
+        chunkFileNames: (chunk) => {
+          if (!chunk.isDynamicEntry) {
+            return original.replaceAll("[name]", "chunk");
+          }
+
+          if (!chunk.facadeModuleId) {
+            return original;
+          }
+
+          const name =
+            chunkNamesFromComments.get(chunk.facadeModuleId) ||
+            embroiderRouteName(chunk.facadeModuleId) ||
+            emberInspectorName(chunk.facadeModuleId);
+
+          return name ? original.replaceAll("[name]", () => name) : original;
+        },
+      };
+    },
+  };
+}

--- a/frontend/discourse/rolldown.config.mjs
+++ b/frontend/discourse/rolldown.config.mjs
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import { basename, relative } from "path";
 import { viteAliasPlugin, viteImportGlobPlugin } from "rolldown/experimental";
+import discourseChunkNamesPlugin from "./lib/discourse-chunk-names.mjs";
 import dynamicChunkUrlPlugin from "./lib/dynamic-chunk-url-plugin.mjs";
 import writeResolverConfig from "./lib/embroider-vite-resolver-options.mjs";
 import maybeBabel from "./lib/maybe-babel.mjs";
@@ -99,17 +100,13 @@ export function buildConfig({ devMode } = {}) {
       sourcemap: true,
       cleanDir: !devMode,
       hashCharacters: "base36",
-      // All assets (including .wasm) go in assets/js/ so that the
-      // assets:precompile br/gz compression and the assets/js/ -> assets/br//gz/
-      // S3 path renames in s3.rake apply to them too.
       assetFileNames: "assets/js/[name]-[hash].digested[extname]",
-      chunkFileNames: "assets/js/[name]-[hash].digested.js",
+      chunkFileNames: "assets/js/[name]-[hash].digested.js", // See also: discourseChunkNamesPlugin
       entryFileNames: "assets/js/[name]-[hash].digested.js",
     },
     watch: {
       clearScreen: false,
     },
-    preserveEntrySignatures: "strict",
     plugins: [
       viteAliasPlugin({ entries: aliases }),
       dynamicChunkUrlPlugin(),
@@ -123,6 +120,7 @@ export function buildConfig({ devMode } = {}) {
         babelrc: false, // Skip per-file `.babelrc`/`.babelignore` checks
       }),
       wrapTestModulesPlugin(),
+      discourseChunkNamesPlugin(),
       {
         name: "resolve-externals",
         resolveId(source) {


### PR DESCRIPTION
- Introduce `/* dynamicChunkName: "foo" */` support via a rolldown plugin. This allows us to intentionally name our dynamic `import()` chunks

- Add specific logic for Embroider routes and ember-inspector dynamic chunks

- For non-entrypoint chunks, stop rolldown auto-generating a potentially confusing name. Just name it `chunk-[hash]`.

- Remove `preserveEntrySignatures: "strict"` config. This was added in the early days of Vite experimentation, but doesn't seem to be required any more. Switching back to the default reduces the number of chunks in our build