### PR TITLE
PERF: Improve trust level pipeline report

### DIFF
--- a/app/models/concerns/reports/trust_level_pipeline.rb
+++ b/app/models/concerns/reports/trust_level_pipeline.rb
@@ -35,13 +35,17 @@ module Reports::TrustLevelPipeline
       total_down = 0
 
       moves_sql = <<~SQL
+        WITH trust_changes AS MATERIALIZED (
+          SELECT target_user_id, new_value, previous_value, created_at
+          FROM user_histories
+          WHERE action IN (:change_action, :auto_action)
+        )
         SELECT
           new_value::integer AS new_tl,
           previous_value::integer AS prev_tl,
           COUNT(*) AS move_count
-        FROM user_histories
-        WHERE action IN (:change_action, :auto_action)
-          AND created_at >= :start_date
+        FROM trust_changes
+        WHERE created_at >= :start_date
           AND created_at <= :end_date
           AND previous_value ~ '^\\d+$'
           AND new_value ~ '^\\d+$'


### PR DESCRIPTION
Wraps the trust-level `action` filter in a `MATERIALIZED` CTE so Postgres resolves those (rare) rows first via the existing `index_staff_action_logs_on_action_and_id`, instead of mis-estimating the unestim-able regex filters and falling back to a full-table merge join over `target_user_id`... Same results, no new index and ~11× fewer buffers on the 1-year range (from 230k to 20k).

| Range | baseline buffers | rewrite buffers | baseline cold | rewrite cold |
|---|---:|---:|---:|---:|
| 7 day | 12.4k | 12.4k | 30 ms | 32 ms |
| 30 day | 12.8k | 12.8k | 29 ms | 32 ms |
| 3 month | 231k | **14k** | 103 ms | **37 ms** (2.8×) |
| 1 year | 231k | **20k** | 96 ms | **40 ms** (2.4×) |

The better improvement would be to add an index on the user_history table. But I think we can avoid it for now.