### PR TITLE
SECURITY: Group report details expose raw Data Explorer SQL to non-admin group members [backport 2026.1]

### DIFF
--- a/plugins/discourse-data-explorer/app/serializers/discourse_data_explorer/query_details_serializer.rb
+++ b/plugins/discourse-data-explorer/app/serializers/discourse_data_explorer/query_details_serializer.rb
@@ -4,6 +4,10 @@ module DiscourseDataExplorer
   class QueryDetailsSerializer < QuerySerializer
     attributes :sql, :param_info, :created_at, :hidden
 
+    def include_sql?
+      scope&.is_admin?
+    end
+
     def param_info
       object&.params&.uniq { |p| p.identifier }&.map(&:to_hash)
     end

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -657,4 +657,45 @@ describe DiscourseDataExplorer::QueryController do
       end
     end
   end
+
+  describe "#group_reports_show SQL visibility" do
+    fab!(:user)
+    fab!(:moderator)
+    fab!(:admin)
+    fab!(:group) { Fabricate(:group, users: [user]) }
+
+    it "omits SQL from group report details for group members" do
+      sign_in(user)
+      query = make_query("SELECT 1977 as leaked_value", {}, [group.id.to_s])
+
+      get "/g/#{group.name}/reports/#{query.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response_json["query"]).not_to have_key("sql")
+      expect(response.body).not_to include(query.sql)
+    end
+
+    it "omits SQL from group report details for moderators" do
+      group.add(moderator)
+      sign_in(moderator)
+      query = make_query("SELECT 1984 as leaked_value", {}, [group.id.to_s])
+
+      get "/g/#{group.name}/reports/#{query.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response_json["query"]).not_to have_key("sql")
+      expect(response.body).not_to include(query.sql)
+    end
+
+    it "includes SQL in group report details for admins" do
+      sign_in(admin)
+      query = make_query("SELECT 1978 as admin_visible_value", {}, [group.id.to_s])
+
+      get "/g/#{group.name}/reports/#{query.id}.json"
+
+      expect(response.status).to eq(200)
+      expect(response_json["query"]["sql"]).to eq(query.sql)
+      expect(response.body).to include(query.sql)
+    end
+  end
 end


### PR DESCRIPTION
Backport of #40919 to release/2026.1.

---

## Summary

Prevent the exposure of raw Data Explorer SQL to non-admin group members when viewing report details. The sql attribute is now correctly gated to administrators within the query details serializer.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1290
- Affected file: https://github.com/discourse/discourse/blob/main/plugins/discourse-data-explorer/app/serializers/discourse_data_explorer/query_details_serializer.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
