### PR TITLE
FIX: Agentic agents crash when `max_turn_tokens` is empty

### DIFF
--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -575,7 +575,7 @@ en:
           default: "Default (Fixed Limits)"
           agentic: "Agentic (Token Budget)"
         max_turn_tokens: "Max Turn Tokens"
-        max_turn_tokens_help: "Maximum total tokens (input + output) consumed across all LLM calls during a single bot reply. When set, replaces the fixed completion/tool limits with a token budget, enabling more agentic behavior. Leave empty for default limits."
+        max_turn_tokens_help: "Maximum total tokens (input + output) consumed across all LLM calls during a single bot reply. When set, replaces the fixed completion/tool limits with a token budget, enabling more agentic behavior. Leave empty to default to half of the model's context window."
         compression_threshold: "Compression Threshold"
         compression_threshold_help: "Percentage of context usage (20–99) at which automatic compression kicks in. Lower values trigger compression earlier, preserving more headroom."
         vision_enabled: Include image uploads

--- a/plugins/discourse-ai/lib/agents/bot.rb
+++ b/plugins/discourse-ai/lib/agents/bot.rb
@@ -22,6 +22,16 @@ module DiscourseAi
         prompt.push(type: :user, content: BUDGET_EXHAUSTED_HINT)
       end
 
+      # When an agentic agent has no explicit max_turn_tokens, default the turn
+      # budget to half of the LLM's context window (see the max_turn_tokens_help
+      # string). Returns nil when the LLM exposes no usable context window, in
+      # which case callers fall back to the fixed completion/tool limits.
+      def self.default_max_turn_tokens(llm)
+        max_prompt_tokens = llm&.max_prompt_tokens.to_i
+        return if max_prompt_tokens <= 0
+        max_prompt_tokens / 2
+      end
+
       def self.as(bot_user, agent: DiscourseAi::Agents::General.new, model: nil)
         new(bot_user, agent, model)
       end
@@ -89,8 +99,17 @@ module DiscourseAi
         needs_newlines = false
         tools_ran = 0
 
-        use_token_budget = agent.class.execution_mode == "agentic"
         token_budget = agent.class.max_turn_tokens
+        use_token_budget = agent.class.execution_mode == "agentic"
+
+        if use_token_budget && token_budget.blank?
+          # max_turn_tokens is optional; default the turn budget to half of the
+          # LLM context window. If the LLM exposes no context window, fall back
+          # to the fixed completion/tool limits rather than crashing on a nil
+          # budget comparison.
+          token_budget = self.class.default_max_turn_tokens(current_llm)
+          use_token_budget = token_budget.present?
+        end
 
         # In token budget mode, compression manages context size instead of
         # the dialect's destructive trim_messages. Disabling trim prevents

--- a/plugins/discourse-ai/lib/ai_bot/stream_reply_custom_tools_session.rb
+++ b/plugins/discourse-ai/lib/ai_bot/stream_reply_custom_tools_session.rb
@@ -178,6 +178,15 @@ module DiscourseAi
         token_budget = resolve_token_budget
         use_token_budget = resolve_execution_mode == "agentic"
 
+        if use_token_budget && token_budget.blank?
+          # max_turn_tokens is optional; default the turn budget to half of the
+          # LLM context window. If the LLM exposes no context window, fall back
+          # to the fixed completion/tool limits rather than crashing on a nil
+          # budget comparison.
+          token_budget = DiscourseAi::Agents::Bot.default_max_turn_tokens(llm)
+          use_token_budget = token_budget.present?
+        end
+
         execution_context = nil
         token_usage_tracker = nil
         if use_token_budget

--- a/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
@@ -255,6 +255,56 @@ RSpec.describe DiscourseAi::Agents::Bot do
         expect(call_count).to eq(described_class::MAX_COMPLETIONS + 1)
       end
 
+      it "defaults the turn budget to half the context window when agentic without max_turn_tokens" do
+        # The editor lets an agentic agent be saved without a max_turn_tokens
+        # budget ("Leave empty for default limits"). This previously crashed
+        # with "comparison of Integer with nil failed". Instead the agent stays
+        # agentic and the budget defaults to half the LLM context window.
+        agentic_no_budget_agent =
+          Fabricate(
+            :ai_agent,
+            execution_mode: "agentic",
+            max_turn_tokens: nil,
+            compression_threshold: 80,
+            tools: [["ListCategories", nil, false]],
+          )
+
+        klass = agentic_no_budget_agent.class_instance
+
+        # gpt_4 has max_prompt_tokens 131_072, so the default budget is 65_536.
+        expect(DiscourseAi::Agents::Bot.default_max_turn_tokens(bot.send(:llm))).to eq(65_536)
+
+        tool_call =
+          DiscourseAi::Completions::ToolCall.new(id: "call_1", name: "categories", parameters: {})
+
+        responses = [tool_call, "Final answer"]
+        call_count = 0
+
+        DiscourseAi::Completions::Llm.with_prepared_responses(responses) do
+          agent_bot = described_class.as(bot_user, agent: klass.new)
+          context =
+            DiscourseAi::Agents::BotContext.new(messages: [{ type: :user, content: "test" }])
+
+          allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+            :generate,
+          ).and_wrap_original do |original, *args, **kwargs, &blk|
+            call_count += 1
+            result = original.call(*args, **kwargs, &blk)
+            # 70_000 tokens per call exceeds the 65_536 default budget after the
+            # first call, so the loop stops on the token budget (not the legacy
+            # MAX_COMPLETIONS limit).
+            if (tracker = kwargs[:execution_context]&.token_usage_tracker)
+              tracker.add_effective(request: 40_000, response: 30_000)
+            end
+            result
+          end
+
+          agent_bot.reply(context) { |_partial| }
+        end
+
+        expect(call_count).to eq(2)
+      end
+
       it "forces a final text-only call with budget hint when budget exhausted after tool execution" do
         # budget=2000, first call adds 3000 tokens → tool runs → budget exceeded
         # but prompt ends with :tool, so model gets one more tool_choice=:none call

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/stream_reply_custom_tools_session_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/stream_reply_custom_tools_session_spec.rb
@@ -141,6 +141,47 @@ RSpec.describe DiscourseAi::AiBot::StreamReplyCustomToolsSession do
       end
     end
 
+    it "defaults the budget to half the context window when agentic without max_turn_tokens" do
+      # "Leave empty for default limits": an agentic agent with no
+      # max_turn_tokens must not crash, and the budget defaults to half the LLM
+      # context window (fake_llm has max_prompt_tokens 131_072 → 65_536).
+      ai_agent.update!(max_turn_tokens: nil)
+
+      tool_call =
+        DiscourseAi::Completions::ToolCall.new(
+          name: "client_tool",
+          parameters: {
+            input: "test",
+          },
+          id: "tool_4",
+        )
+
+      DiscourseAi::Completions::Llm.with_prepared_responses(
+        [tool_call, "Summary after budget hit."],
+      ) do
+        session = build_session
+
+        allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+          :generate,
+        ).and_wrap_original do |original, *args, **kwargs, &blk|
+          result = original.call(*args, **kwargs, &blk)
+          # 70_000 tokens exceeds the 65_536 default budget after the first call.
+          if (tracker = kwargs[:execution_context]&.token_usage_tracker)
+            tracker.add_effective(request: 40_000, response: 30_000)
+          end
+          result
+        end
+
+        events = collect_events(session)
+
+        partials = events.select { |type, _| type == :partial }.map { |_, data| data }
+        expect(partials.join).to eq("Summary after budget hit.")
+
+        tool_events = events.select { |type, _| type == :tool_calls }
+        expect(tool_events).to be_empty
+      end
+    end
+
     it "persists request and response token counters in resume state" do
       tool_call =
         DiscourseAi::Completions::ToolCall.new(


### PR DESCRIPTION
Previously, an agent in agentic execution mode with an empty `max_turn_tokens` crashed with "comparison of Integer with nil failed" because the token-budget loop compared the running token count against a nil budget.

This change defaults the turn budget to half of the model's context window when `max_turn_tokens` is empty, so agentic agents keep working without an explicit budget.