### PR TITLE
FEATURE: adds combine operation to merge node

### DIFF
--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -657,6 +657,16 @@ en:
         descending: "Descending"
         code_field: "JavaScript code"
         code_description: "Write a comparator function body. Variables a and b are item objects. Return -1, 0, or 1."
+      merge:
+        mode: "Mode"
+        mode_append: "Append"
+        mode_combine: "Combine"
+        include_unpaired: "Include unpaired items"
+        include_unpaired_description: "When the two inputs have different numbers of items, keep the leftover items that have no counterpart to pair with instead of dropping them."
+        resolve_clash: "When fields clash"
+        resolve_clash_add_suffix: "Add a suffix"
+        resolve_clash_prefer_first: "Prefer first item"
+        resolve_clash_prefer_last: "Prefer last item"
       log:
         mode: "Mode"
         mode_description: "Choose whether entries are logged once per item or once for all items"

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/merge/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/merge/v1.rb
@@ -18,16 +18,146 @@ module DiscourseWorkflows
             { key: "main", type: "main", display_name: "Input", required: false, multiple: true },
           ],
           required_inputs: 1,
+          properties: {
+            mode: {
+              type: :options,
+              required: true,
+              options: %w[append combine],
+              default: "append",
+            },
+            resolve_clash: {
+              type: :options,
+              required: false,
+              options: %w[add_suffix prefer_first prefer_last],
+              default: "add_suffix",
+              display_options: {
+                show: {
+                  mode: ["combine"],
+                },
+              },
+            },
+            include_unpaired: {
+              type: :boolean,
+              required: false,
+              default: false,
+              display_options: {
+                show: {
+                  mode: ["combine"],
+                },
+              },
+            },
+          },
         )
 
         def execute(exec_ctx)
-          [append_inputs(exec_ctx)]
+          return [append_inputs(exec_ctx)] unless combine_mode?(exec_ctx)
+
+          @input_item_indexes = item_indexes_by_input(exec_ctx.inputs)
+          [combine_by_position(two_inputs(exec_ctx), combine_config(exec_ctx))]
         end
 
         private
 
+        def combine_mode?(exec_ctx)
+          exec_ctx.get_node_parameter("mode", 0, default: "append") == "combine"
+        end
+
+        def combine_config(exec_ctx)
+          {
+            "include_unpaired" =>
+              exec_ctx.get_node_parameter("include_unpaired", 0, default: false),
+            "resolve_clash" =>
+              exec_ctx.get_node_parameter("resolve_clash", 0, default: "add_suffix"),
+          }
+        end
+
         def append_inputs(exec_ctx)
           exec_ctx.inputs.flatten(1)
+        end
+
+        def two_inputs(exec_ctx)
+          [exec_ctx.input_items(0), exec_ctx.input_items(1)]
+        end
+
+        def combine_by_position(inputs, config)
+          preferred_index = preferred_input_index(config, inputs.length)
+          count =
+            if config["include_unpaired"]
+              inputs.map(&:length).max || 0
+            else
+              inputs.map(&:length).min || 0
+            end
+
+          count.times.map do |index|
+            entries = inputs.map { |input| input[index] || { "json" => {} } }
+            merge_entries(entries, config, preferred_index:)
+          end
+        end
+
+        def merge_entries(entries, config, preferred_index:)
+          paired_items = paired_items(entries)
+          entries = suffix_entries(entries) if config["resolve_clash"] == "add_suffix"
+          ordered_entries = entries.dup
+          preferred = ordered_entries.delete_at(preferred_index) || { "json" => {} }
+          ordered_entries << preferred
+
+          wrap(merge_hashes(ordered_entries.map { |entry| entry.fetch("json") { {} } })).merge(
+            "pairedItem" => paired_items,
+          )
+        end
+
+        def merge_hashes(hashes)
+          hashes.each_with_object({}) { |hash, result| merge_deep!(result, hash) }
+        end
+
+        def merge_deep!(target, source)
+          source.each do |key, value|
+            target[key] = if target[key].is_a?(Hash) && value.is_a?(Hash)
+              merge_deep!(target[key].dup, value)
+            else
+              value
+            end
+          end
+          target
+        end
+
+        def suffix_entries(entries)
+          entries.map.with_index do |entry, index|
+            json =
+              entry
+                .fetch("json") { {} }
+                .each_with_object({}) do |(key, value), result|
+                  result["#{key}_#{index + 1}"] = value
+                end
+            entry.merge("json" => json)
+          end
+        end
+
+        def paired_items(entries)
+          entries.each_with_index.filter_map do |entry, input_index|
+            paired_item_for_entry(entry, input_index)
+          end
+        end
+
+        def paired_item_for_entry(entry, input_index)
+          item_index = @input_item_indexes&.dig(input_index, entry.object_id)
+          return unless item_index
+
+          { "input" => input_index, "item" => item_index }
+        end
+
+        def item_indexes_by_input(inputs)
+          inputs
+            .each_with_index
+            .each_with_object({}) do |(items, input_index), indexes|
+              indexes[input_index] = items.each_with_index.to_h do |item, item_index|
+                [item.object_id, item_index]
+              end
+            end
+        end
+
+        def preferred_input_index(config, input_count)
+          config["resolve_clash"] == "prefer_first" ? 0 : input_count - 1
         end
       end
     end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor_loop_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor_loop_spec.rb
@@ -131,6 +131,50 @@ RSpec.describe DiscourseWorkflows::Executor do
       )
     end
 
+    it "combines two branches into a single item by position" do
+      graph =
+        build_workflow_graph do |g|
+          g.node "trigger-1", "trigger:manual"
+          g.node "left-1",
+                 "action:set_fields",
+                 configuration: {
+                   "mode" => "raw",
+                   "include_other_fields" => false,
+                   "json_output" => '{"id": 1, "left": "yes"}',
+                 }
+          g.node "right-1",
+                 "action:set_fields",
+                 configuration: {
+                   "mode" => "raw",
+                   "include_other_fields" => false,
+                   "json_output" => '{"topic_id": 1, "right": "yes"}',
+                 }
+          g.node "merge-1",
+                 "flow:merge",
+                 name: "Merge branches",
+                 configuration: {
+                   "mode" => "combine",
+                   "resolve_clash" => "prefer_last",
+                 }
+          g.connect "trigger-1", "left-1"
+          g.connect "trigger-1", "right-1"
+          g.connect "left-1", "merge-1", input: "input_1"
+          g.connect "right-1", "merge-1", input: "input_2"
+        end
+      workflow =
+        Fabricate(:discourse_workflows_workflow, created_by: user, published: true, **graph)
+
+      execution = described_class.new(workflow, "trigger-1", {}).run
+
+      expect(execution.status).to eq("success")
+      merge_steps =
+        execution.execution_data.steps_array.select { |step| step["node_id"] == "merge-1" }
+      expect(merge_steps.length).to eq(1)
+      expect(merge_steps.first["output"].map { |item| item["json"] }).to eq(
+        [{ "id" => 1, "left" => "yes", "topic_id" => 1, "right" => "yes" }],
+      )
+    end
+
     it "waits for all incoming branches before executing append merge" do
       graph =
         build_workflow_graph do |g|

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/merge_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/merge_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe DiscourseWorkflows::Nodes::Merge::V1 do
     { "json" => json }
   end
 
+  def json_items(items)
+    items.map { |entry| { "json" => entry["json"] } }
+  end
+
   def execute_merge(input_1:, input_2:, input_groups: {}, configuration: {})
     execute_node_output(
       configuration: configuration,
@@ -44,5 +48,92 @@ RSpec.describe DiscourseWorkflows::Nodes::Merge::V1 do
       )
 
     expect(output).to eq([item("a" => 1), item("b" => 2), item("c" => 3)])
+  end
+
+  it "combines items by position" do
+    output =
+      execute_merge(
+        configuration: {
+          "mode" => "combine",
+          "resolve_clash" => "prefer_last",
+        },
+        input_1: [item("id" => 1, "a" => "A")],
+        input_2: [item("b" => "B")],
+      )
+
+    expect(json_items(output)).to eq([item("id" => 1, "a" => "A", "b" => "B")])
+  end
+
+  it "pairs items by index and records pairedItem lineage" do
+    output =
+      execute_merge(
+        configuration: {
+          "mode" => "combine",
+          "resolve_clash" => "prefer_last",
+        },
+        input_1: [item("a" => 1), item("a" => 2)],
+        input_2: [item("b" => 3), item("b" => 4)],
+      )
+
+    expect(json_items(output)).to eq([item("a" => 1, "b" => 3), item("a" => 2, "b" => 4)])
+    expect(output.first["pairedItem"]).to eq(
+      [{ "input" => 0, "item" => 0 }, { "input" => 1, "item" => 0 }],
+    )
+  end
+
+  it "defaults clash handling to add_suffix (matches n8n position combine)" do
+    output =
+      execute_merge(
+        configuration: {
+          "mode" => "combine",
+        },
+        input_1: [item("markdown" => "table 1")],
+        input_2: [item("markdown" => "table 2")],
+      )
+
+    expect(json_items(output)).to eq([item("markdown_1" => "table 1", "markdown_2" => "table 2")])
+  end
+
+  it "prefers input 1 on a clash when configured" do
+    output =
+      execute_merge(
+        configuration: {
+          "mode" => "combine",
+          "resolve_clash" => "prefer_first",
+        },
+        input_1: [item("value" => "one")],
+        input_2: [item("value" => "two")],
+      )
+
+    expect(json_items(output)).to eq([item("value" => "one")])
+  end
+
+  it "drops unpaired items by default when inputs differ in length" do
+    output =
+      execute_merge(
+        configuration: {
+          "mode" => "combine",
+          "resolve_clash" => "prefer_last",
+        },
+        input_1: [item("a" => 1), item("a" => 2)],
+        input_2: [item("b" => 3)],
+      )
+
+    expect(json_items(output)).to eq([item("a" => 1, "b" => 3)])
+  end
+
+  it "keeps unpaired items when include_unpaired is enabled" do
+    output =
+      execute_merge(
+        configuration: {
+          "mode" => "combine",
+          "resolve_clash" => "prefer_last",
+          "include_unpaired" => true,
+        },
+        input_1: [item("a" => 1), item("a" => 2)],
+        input_2: [item("b" => 3)],
+      )
+
+    expect(json_items(output)).to eq([item("a" => 1, "b" => 3), item("a" => 2)])
   end
 end


### PR DESCRIPTION
In discourse workflows you can now choose the combine operation on the merge node. This operation will allow you to transform multiple items into one, useful for gathering multiple reports for example.