### PR TITLE
SECURITY: Stored XSS in suspension and silencing reasons on user profiles and cards

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,9 @@ class User < ActiveRecord::Base
 
   DEFAULT_FEATURED_BADGE_COUNT = 3
   MAX_SIMILAR_USERS = 10
+  STAFF_REASON_SANITIZER = Rails::Html::SafeListSanitizer.new
+  STAFF_REASON_ALLOWED_TAGS = %w[a br].freeze
+  STAFF_REASON_ALLOWED_ATTRIBUTES = %w[href rel target].freeze
 
   deprecate_column :flag_level, drop_from: "3.2"
 
@@ -1372,7 +1375,7 @@ class User < ActiveRecord::Base
   def full_silence_reason
     text = silenced_record.try(:details) if silenced?
     return text if text.blank?
-    PrettyText.cleanup(text.gsub("\n", "<br>"))
+    sanitize_staff_reason(text)
   end
 
   def silence_reason
@@ -1398,7 +1401,7 @@ class User < ActiveRecord::Base
   def full_suspend_reason
     text = suspend_record.try(:details) if suspended?
     return text if text.blank?
-    PrettyText.cleanup(text.gsub("\n", "<br>"))
+    sanitize_staff_reason(text)
   end
 
   def suspend_reason
@@ -1407,6 +1410,14 @@ class User < ActiveRecord::Base
     end
 
     nil
+  end
+
+  def sanitize_staff_reason(text)
+    STAFF_REASON_SANITIZER.sanitize(
+      PrettyText.cleanup(text.gsub("\n", "<br>")),
+      tags: STAFF_REASON_ALLOWED_TAGS,
+      attributes: STAFF_REASON_ALLOWED_ATTRIBUTES,
+    )
   end
 
   def suspended_message

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5274,6 +5274,33 @@ RSpec.describe UsersController do
         expect(parsed["trust_level"]).to be_present
       end
 
+      it "sanitizes suspension and silencing reasons" do
+        payload = "public <img src=x onerror=alert(1)> reason"
+        penalized_user = Fabricate(:user)
+        penalized_user.user_stat.update!(post_count: 1)
+
+        UserSuspender.new(
+          penalized_user,
+          suspended_till: 2.days.from_now,
+          reason: payload,
+          by_user: admin,
+        ).suspend
+        UserSilencer.new(
+          penalized_user,
+          admin,
+          keep_posts: true,
+          reason: payload,
+          silenced_till: 2.days.from_now,
+        ).silence
+
+        get "/u/#{penalized_user.username}/card.json"
+
+        expect(response.status).to eq(200)
+        user_json = response.parsed_body["user"]
+        expect(user_json["suspend_reason"]).to eq("public  reason")
+        expect(user_json["silence_reason"]).to eq("public  reason")
+      end
+
       it "should have http status 403 for anonymous user when profiles are hidden" do
         SiteSetting.hide_user_profiles_from_public = true
         get "/u/#{user.username}/card.json"


### PR DESCRIPTION
## Summary

On sites with CSP disabled Staff could enter HTML as a suspension of silencing issue which would show up in HTML

Security hardening

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>