### PR TITLE
DEV: Sign in system specs via the browser context's own become request

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -55,12 +55,38 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit File.join(
-            GlobalSetting.relative_url_root || "",
-            "/session/#{user.encoded_username}/become.json?redirect=false",
-          )
+    path =
+      File.join(
+        GlobalSetting.relative_url_root || "",
+        "/session/#{user.encoded_username}/become.json?redirect=false",
+      )
+    url = "http://#{Capybara.server_host}:#{Capybara.server_port}#{path}"
 
-    expect(page).to have_content("Signed in to #{user.encoded_username} successfully")
+    # Have the browser context itself issue the `become` request instead of
+    # navigating Chrome to it. Playwright's APIRequestContext sends the
+    # request with the context's cookies and writes the response cookies back
+    # into the same context, so the auth cookie lands in the browser's own
+    # cookie jar with the right host scope automatically. This keeps every
+    # server-side side effect of `SessionController#become` (`log_on_user`,
+    # auth token generation, the full middleware stack) while skipping an
+    # entire Chrome page navigation per sign-in, with no manual `Set-Cookie`
+    # parsing and no `add_cookies` call.
+    response = page.driver.with_playwright_page { |pw_page| pw_page.context.request.get(url) }
+
+    if !response.ok? ||
+         !response.text.include?("Signed in to #{user.encoded_username} successfully")
+      raise "sign_in for #{user.encoded_username} failed (HTTP #{response.status}): #{response.text[0, 300]}"
+    end
+
+    # The visit-based sign_in left the browser on a real app origin, and specs
+    # (plugin page objects especially) rely on that by calling execute_script
+    # before their first visit. A freshly reset page sits on about:blank, whose
+    # opaque origin denies localStorage and clipboard access, so park on the
+    # cheapest app document to preserve that contract. This real Capybara visit
+    # also marks the session as used, so `Capybara.reset_sessions!` tears down
+    # the authenticated context between examples (e.g. specs that sign in and
+    # then test anonymous access).
+    visit "/srv/status" if !page.current_url.start_with?("http")
   end
 
   def setup_system_test


### PR DESCRIPTION
System spec `sign_in` navigated Chrome to `/session/:username/become.json` to authenticate, spending a full Chrome page load per sign-in just to land the auth cookie. With ~2,000 examples calling `sign_in`, that navigation is pure overhead, the response body is a one-line confirmation the browser never needs to render.

This branch has the **browser context itself** issue the `become` request through Playwright's `APIRequestContext`, reached via `page.driver.with_playwright_page { |pw_page| pw_page.context.request.get(url) }`. That request context is documented to send the context's cookies and write the response cookies back into the same context, so the auth cookie lands in the browser's own cookie jar automatically, scoped to the host the spec then navigates to. No Chrome navigation, no manual `Set-Cookie` parsing, no `add_cookies`.

The request is issued against `http://#{Capybara.server_host}:#{Capybara.server_port}`, which is exactly the origin `visit "/path"` resolves to, so the cookie scope always matches what the spec navigates to next. The response is validated the same way the old `visit`-based flow was: `response.ok?` plus the `"Signed in to ... successfully"` body, raising loudly otherwise.

After the request, the browser is parked on `/srv/status` only when it is still on `about:blank` (specs run `execute_script` and grant clipboard permissions before their first `visit`, and an opaque origin denies both). That park is a real Capybara visit, so it also marks the session as used, which means `Capybara.reset_sessions!` keeps tearing down the authenticated context between examples (e.g. specs that sign in and then assert anonymous access).

### Contrast with the Rack approach (#40866)

#40866 reached the same speedup by running `Rack::Test::Session.new(Rails.application).get(...)` in-process, then hand-parsing the `Set-Cookie` headers, injecting the cookies into the Playwright context for two hosts, and forcing `page.instance_variable_set(:@touched, true)`. That works but couples to Rails internals, re-implements cookie handling, and pokes a Capybara private ivar.

This approach drops all of that:

- **No in-process call into the Rails app.** The browser makes a normal HTTP request through the full running server.
- **No manual cookie handling.** The browser stores the response cookie in its own jar with the right host scope.
- **No `@touched` ivar poke.** The `/srv/status` park is a real visit that marks the session used naturally. Verified that `Capybara.reset_sessions!` still tears down auth by running a signed-in spec followed by an anonymous-access spec in the same process with `--order defined`, both green.
- **No coupled-file changes.** `cdp.rb` (clipboard grant) and `user_preferences_security_spec.rb` (webauthn origin) both pass unmodified, because the `/srv/status` park leaves the browser on a real `localhost` origin before those run.

Net change is a single file, `spec/support/system_helpers.rb`.

## Measurements

Five full-matrix runs of this branch interleaved with five of `main` at the merge base, strictly sequential so no two measured runs compete for the runner pool. Durations are each system job's test step. The autoresearch experiment was stopped, so the runner pool was uncontended.

Baseline runs: [1](https://github.com/discourse/discourse/actions/runs/27659613507) [2](https://github.com/discourse/discourse/actions/runs/27660621465) [3](https://github.com/discourse/discourse/actions/runs/27661459652) [4](https://github.com/discourse/discourse/actions/runs/27662242319) [5](https://github.com/discourse/discourse/actions/runs/27663133994)
This branch runs: [1](https://github.com/discourse/discourse/actions/runs/27660033082) [2](https://github.com/discourse/discourse/actions/runs/27661062139) [3](https://github.com/discourse/discourse/actions/runs/27661856636) [4](https://github.com/discourse/discourse/actions/runs/27662710758) [5](https://github.com/discourse/discourse/actions/runs/27663524036)

| System job | `main` median | This branch median | Delta | Delta% | Rounds faster |
|---|---:|---:|---:|---:|:---:|
| core system | 591s | 580s | -11s | **-1.9%** | 3/5 |
| plugins (core) system | 452s | 432s | -20s | -4.4% | 4/5 |
| plugins (chat) system | 550s | 525s | -25s | -4.5% | 4/5 |
| plugins (official) system | 266s | 285s | +19s | +7.1% | 2/5 |
| themes system | 320s | 319s | -1s | -0.3% | 4/5 |

### This is much smaller than the in-process variant, and the reason is informative

The Rack::Test version of this mechanism (#40866) measured -9.7% on core system. This browser-fetch version measures about -2%. The two differ only in how the become.json request is made: #40866 calls the app in-process, this branch issues a real HTTP request from the browser context.

That difference is most of the win. The old browser-navigation sign_in paid two costs, an HTTP round trip to become.json through Puma plus a full page load and render of the response. The Rack version removes both. This fetch version removes only the page load, the HTTP round trip through Puma and the Playwright protocol hop remain, and that round trip turns out to be the dominant cost. On core system this branch was even slightly slower than `main` in 2 of 5 rounds, and the official-plugins row is within noise of zero given that job's wide baseline spread.

The branch is the cleanest possible implementation, one file with no Rails internals, no manual cookie handling, and no Capybara private state. It is kept as a documented reference for the tradeoff: the in-process call buys roughly 5x the speedup at the cost of that coupling.
