### PR TITLE
FIX: Exclude anonymous searches from the dashboard search section

### DIFF
--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -95,6 +95,7 @@ class SearchLog < ActiveRecord::Base
     result = result.where("search_type = ?", search_types[search_type]) if search_type == :header ||
       search_type == :full_page
     result = result.where.not(search_result_id: nil) if search_type == :click_through_only
+    result = result.where.not(user_id: nil) if search_type == :logged_in_only
 
     result
       .order("date")
@@ -133,7 +134,11 @@ class SearchLog < ActiveRecord::Base
 
     result = result.where("created_at < ?", end_date) if end_date
 
-    result = result.where("search_type = ?", search_types[search_type]) unless search_type == :all
+    if search_type == :logged_in_only
+      result = result.where.not(user_id: nil)
+    elsif search_type != :all
+      result = result.where("search_type = ?", search_types[search_type])
+    end
 
     result.group("lower(term)").order("searches DESC, click_through DESC, term ASC").limit(limit)
   end

--- a/app/services/admin_dashboard_search.rb
+++ b/app/services/admin_dashboard_search.rb
@@ -111,6 +111,7 @@ class AdminDashboardSearch
                  SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
           FROM search_logs
           WHERE created_at >= :window_start AND created_at <= :window_end
+            AND user_id IS NOT NULL
           GROUP BY lower(term)
           ORDER BY searches DESC, clicks DESC, term ASC
           LIMIT :limit
@@ -136,6 +137,7 @@ class AdminDashboardSearch
                  SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
           FROM search_logs
           WHERE created_at >= :window_start AND created_at <= :window_end
+            AND user_id IS NOT NULL
           GROUP BY lower(term)
           HAVING SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) * 100 <=
             COUNT(*) * :max_ctr_percent
@@ -164,6 +166,7 @@ class AdminDashboardSearch
                SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
         FROM search_logs
         WHERE created_at >= :window_start AND created_at <= :window_end
+          AND user_id IS NOT NULL
         GROUP BY lower(term)
       )
       SELECT COALESCE(SUM(searches), 0)::bigint AS total,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7125,14 +7125,14 @@ en:
             headline:
               no_signal_title: "Not enough search activity to summarise yet."
               no_signal: "Pick a longer date range or come back once members have searched more."
-              content_gaps: "More than 10% of searches ended without a click this period. Review the content gaps below to see what's missing."
+              content_gaps: "More than 10% of member searches ended without a click this period. Review the content gaps below to see what's missing."
               rate_climbing: "The no-result rate is climbing compared with the previous period. Keep an eye on the content gaps below."
               shrinking: "Search volume is down compared with the previous period, while most searches still lead to content."
               healthy: "Members keep finding what they search for, and search volume is steady or growing."
             kpi:
               total_searches:
                 label: "Total searches"
-                tooltip: "The number of searches performed in your community."
+                tooltip: "The number of searches performed by members in your community."
               no_result_rate:
                 label: "No-result rate"
                 tooltip: "The percentage of searches where members didn't click any result (0% CTR). This indicates that members may be searching for content your community doesn't have."
@@ -7142,7 +7142,7 @@ en:
               status: "Status"
             trending:
               title: "Trending searches"
-              tooltip: "The most popular search terms."
+              tooltip: "The most popular search terms among members."
               empty: "No searches in this period."
             content_gaps:
               title: "Content gaps"
@@ -8740,6 +8740,7 @@ en:
             header: "Header"
             full_page: "Full page"
             click_through_only: "All (click through only)"
+            logged_in_only: "Logged in only"
           header_search_results: "Header search results"
         logster:
           title: "Error logs"

--- a/frontend/discourse/admin/components/dashboard/search.gjs
+++ b/frontend/discourse/admin/components/dashboard/search.gjs
@@ -259,6 +259,7 @@ export default class DashboardSearch extends Component {
                               @query={{hash
                                 term=row.term
                                 period=this.trendingTermPeriod
+                                searchType="logged_in_only"
                               }}
                             >
                               {{row.term}}

--- a/frontend/discourse/admin/controllers/admin-search-logs/index.js
+++ b/frontend/discourse/admin/controllers/admin-search-logs/index.js
@@ -12,6 +12,10 @@ export default class AdminSearchLogsIndexController extends Controller {
       id: "all",
       name: i18n("admin.logs.search_logs.types.all_search_types"),
     },
+    {
+      id: "logged_in_only",
+      name: i18n("admin.logs.search_logs.types.logged_in_only"),
+    },
     { id: "header", name: i18n("admin.logs.search_logs.types.header") },
     {
       id: "full_page",

--- a/frontend/discourse/admin/controllers/admin-search-logs/term.js
+++ b/frontend/discourse/admin/controllers/admin-search-logs/term.js
@@ -12,6 +12,10 @@ export default class AdminSearchLogsTermController extends Controller {
       id: "all",
       name: i18n("admin.logs.search_logs.types.all_search_types"),
     },
+    {
+      id: "logged_in_only",
+      name: i18n("admin.logs.search_logs.types.logged_in_only"),
+    },
     { id: "header", name: i18n("admin.logs.search_logs.types.header") },
     {
       id: "full_page",

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -227,6 +227,17 @@ RSpec.describe SearchLog, type: :model do
       expect(term_click_through_details[:period]).to eq("all")
       expect(term_click_through_details[:data][0][:y]).to eq(1)
     end
+
+    it "counts only logged-in members' searches with the logged_in_only search type" do
+      member = Fabricate(:user)
+      Fabricate.times(2, :search_log, term: "ruby", user: member)
+      Fabricate.times(3, :search_log, term: "ruby")
+
+      expect(SearchLog.term_details("ruby")[:data].sum { |point| point[:y] }).to eq(5)
+      expect(
+        SearchLog.term_details("ruby", :weekly, :logged_in_only)[:data].sum { |point| point[:y] },
+      ).to eq(2)
+    end
   end
 
   describe "trending" do
@@ -258,6 +269,12 @@ RSpec.describe SearchLog, type: :model do
       SearchLog.where(term: "ruby", ip_address: "127.0.0.2").update_all(search_result_id: 24)
       top_trending = SearchLog.trending.first
       expect(top_trending.click_through).to eq(3)
+    end
+
+    it "counts only logged-in members' searches with the logged_in_only search type" do
+      results = SearchLog.trending(:all, :logged_in_only).to_a
+
+      expect(results.map { |trend| [trend.term, trend.searches] }).to eq([["ruby", 1]])
     end
   end
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -323,8 +323,9 @@ RSpec.describe Admin::DashboardController do
 
         it "returns the search payload for the selected dates" do
           configure_dashboard_sections(%w[search])
-          Fabricate(:clicked_search_log, term: "ruby", created_at: "2026-05-02 10:00")
-          Fabricate(:search_log, term: "ruby", created_at: "2026-05-02 11:00")
+          member = Fabricate(:user)
+          Fabricate(:clicked_search_log, term: "ruby", user: member, created_at: "2026-05-02 10:00")
+          Fabricate(:search_log, term: "ruby", user: member, created_at: "2026-05-02 11:00")
 
           get "/admin/dashboard.json", params: { start_date: "2026-05-01", end_date: "2026-05-07" }
 

--- a/spec/requests/admin/search_logs_spec.rb
+++ b/spec/requests/admin/search_logs_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe Admin::SearchLogsController do
       before { sign_in(admin) }
 
       include_examples "search logs accessible"
+
+      it "counts both anonymous and logged-in members' searches by default" do
+        Fabricate(:search_log, term: "discobot", user: user)
+        Fabricate.times(2, :search_log, term: "discobot")
+
+        get "/admin/logs/search_logs.json"
+
+        row = response.parsed_body.find { |entry| entry["term"] == "discobot" }
+        expect(row["searches"]).to eq(3)
+      end
+
+      it "counts only logged-in members' searches with the logged_in_only search type" do
+        Fabricate(:search_log, term: "discobot", user: user)
+        Fabricate.times(2, :search_log, term: "discobot")
+
+        get "/admin/logs/search_logs.json", params: { search_type: "logged_in_only" }
+
+        row = response.parsed_body.find { |entry| entry["term"] == "discobot" }
+        expect(row["searches"]).to eq(1)
+      end
     end
 
     context "when logged in as a moderator" do
@@ -64,6 +84,21 @@ RSpec.describe Admin::SearchLogsController do
       before { sign_in(admin) }
 
       include_examples "search log term accessible"
+
+      it "excludes anonymous searches from the graph with the logged_in_only search type" do
+        Fabricate(:search_log, term: "discobot", user: user)
+        Fabricate.times(4, :search_log, term: "discobot")
+
+        get "/admin/logs/search_logs/term.json", params: { term: "discobot" }
+        expect(response.parsed_body["term"]["data"].sum { |point| point["y"] }).to eq(5)
+
+        get "/admin/logs/search_logs/term.json",
+            params: {
+              term: "discobot",
+              search_type: "logged_in_only",
+            }
+        expect(response.parsed_body["term"]["data"].sum { |point| point["y"] }).to eq(1)
+      end
     end
 
     context "when logged in as a moderator" do

--- a/spec/services/admin_dashboard_search_spec.rb
+++ b/spec/services/admin_dashboard_search_spec.rb
@@ -1,30 +1,64 @@
 # frozen_string_literal: true
 
 RSpec.describe AdminDashboardSearch do
+  fab!(:user)
+
   before { freeze_time(Time.zone.local(2026, 5, 14, 12, 0, 0)) }
 
   describe ".build" do
-    it "returns KPIs, trending terms, and content gaps for the selected dates" do
-      Fabricate.times(3, :clicked_search_log, term: "ruby", created_at: "2026-05-02 10:00")
-      Fabricate.times(3, :search_log, term: "ruby", created_at: "2026-05-02 11:00")
+    it "returns KPIs, trending terms, and content gaps for the selected dates, counting only logged-in members" do
+      Fabricate.times(
+        3,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 10:00",
+      )
+      Fabricate.times(3, :search_log, term: "ruby", user: user, created_at: "2026-05-02 11:00")
 
-      Fabricate(:clicked_search_log, term: "markdown tables", created_at: "2026-05-03 10:00")
+      Fabricate(
+        :clicked_search_log,
+        term: "markdown tables",
+        user: user,
+        created_at: "2026-05-03 10:00",
+      )
 
       Fabricate.times(
         4,
         :search_log,
         term: "markdown tables",
+        user: user,
         search_type: SearchLog.search_types[:full_page],
         created_at: "2026-05-03 11:00",
       )
 
-      Fabricate.times(4, :search_log, term: "discobot", created_at: "2026-05-04 10:00")
+      Fabricate.times(4, :search_log, term: "discobot", user: user, created_at: "2026-05-04 10:00")
 
-      Fabricate.times(2, :clicked_search_log, term: "zeta", created_at: "2026-05-04 11:00")
-      Fabricate.times(2, :search_log, term: "zeta", created_at: "2026-05-04 12:00")
+      Fabricate.times(
+        2,
+        :clicked_search_log,
+        term: "zeta",
+        user: user,
+        created_at: "2026-05-04 11:00",
+      )
+      Fabricate.times(2, :search_log, term: "zeta", user: user, created_at: "2026-05-04 12:00")
 
-      Fabricate.times(5, :clicked_search_log, term: "ruby", created_at: "2026-04-26 10:00")
-      Fabricate.times(5, :search_log, term: "ghost", created_at: "2026-04-26 11:00")
+      Fabricate.times(
+        5,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-04-26 10:00",
+      )
+      Fabricate.times(5, :search_log, term: "ghost", user: user, created_at: "2026-04-26 11:00")
+
+      # Anonymous searches (likely crawlers) must be excluded from every metric and from the
+      # prior-window deltas. If counted, "crawler-bait" would top trending, inflate the
+      # no-result rate, and surface as a content gap; the anonymous "ruby" rows would change
+      # its count and the percent change.
+      Fabricate.times(30, :search_log, term: "crawler-bait", created_at: "2026-05-05 10:00")
+      Fabricate.times(10, :search_log, term: "ruby", created_at: "2026-05-02 09:00")
+      Fabricate.times(20, :search_log, term: "crawler-bait", created_at: "2026-04-26 09:00")
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")).to eq(
         logging_enabled: true,
@@ -55,17 +89,58 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "buckets terms by exact CTR boundaries" do
-      Fabricate(:clicked_search_log, term: "tiny-ctr", created_at: "2026-05-02 10:00")
-      Fabricate.times(100, :search_log, term: "tiny-ctr", created_at: "2026-05-02 11:00")
+      Fabricate(:clicked_search_log, term: "tiny-ctr", user: user, created_at: "2026-05-02 10:00")
+      Fabricate.times(
+        100,
+        :search_log,
+        term: "tiny-ctr",
+        user: user,
+        created_at: "2026-05-02 11:00",
+      )
 
-      Fabricate.times(5, :clicked_search_log, term: "just-over", created_at: "2026-05-03 10:00")
-      Fabricate.times(19, :search_log, term: "just-over", created_at: "2026-05-03 11:00")
+      Fabricate.times(
+        5,
+        :clicked_search_log,
+        term: "just-over",
+        user: user,
+        created_at: "2026-05-03 10:00",
+      )
+      Fabricate.times(
+        19,
+        :search_log,
+        term: "just-over",
+        user: user,
+        created_at: "2026-05-03 11:00",
+      )
 
-      Fabricate(:clicked_search_log, term: "exact-twenty", created_at: "2026-05-04 10:00")
-      Fabricate.times(4, :search_log, term: "exact-twenty", created_at: "2026-05-04 11:00")
+      Fabricate(
+        :clicked_search_log,
+        term: "exact-twenty",
+        user: user,
+        created_at: "2026-05-04 10:00",
+      )
+      Fabricate.times(
+        4,
+        :search_log,
+        term: "exact-twenty",
+        user: user,
+        created_at: "2026-05-04 11:00",
+      )
 
-      Fabricate.times(3, :search_log, term: "zero-clicks", created_at: "2026-05-05 10:00")
-      Fabricate.times(3, :search_log, term: "alpha-zero", created_at: "2026-05-05 11:00")
+      Fabricate.times(
+        3,
+        :search_log,
+        term: "zero-clicks",
+        user: user,
+        created_at: "2026-05-05 10:00",
+      )
+      Fabricate.times(
+        3,
+        :search_log,
+        term: "alpha-zero",
+        user: user,
+        created_at: "2026-05-05 11:00",
+      )
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")).to eq(
         logging_enabled: true,
@@ -98,7 +173,12 @@ RSpec.describe AdminDashboardSearch do
 
     it "caps trending and content gaps at the top 10 terms" do
       (1..11).each do |index|
-        Fabricate(:search_log, term: format("gap-%02d", index), created_at: "2026-05-02 10:00")
+        Fabricate(
+          :search_log,
+          term: format("gap-%02d", index),
+          user: user,
+          created_at: "2026-05-02 10:00",
+        )
       end
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")).to eq(
@@ -123,15 +203,51 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "picks the headline state from the rate and volume signals" do
-      Fabricate(:search_log, term: "ghost", created_at: "2026-05-02 10:00")
-      Fabricate.times(11, :clicked_search_log, term: "ruby", created_at: "2026-05-02 11:00")
-      Fabricate.times(12, :clicked_search_log, term: "ruby", created_at: "2026-04-26 10:00")
+      Fabricate(:search_log, term: "ghost", user: user, created_at: "2026-05-02 10:00")
+      Fabricate.times(
+        11,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 11:00",
+      )
+      Fabricate.times(
+        12,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-04-26 10:00",
+      )
 
-      Fabricate.times(4, :clicked_search_log, term: "ruby", created_at: "2026-04-02 10:00")
-      Fabricate.times(10, :clicked_search_log, term: "ruby", created_at: "2026-03-27 10:00")
+      Fabricate.times(
+        4,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-04-02 10:00",
+      )
+      Fabricate.times(
+        10,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-03-27 10:00",
+      )
 
-      Fabricate.times(12, :clicked_search_log, term: "ruby", created_at: "2026-03-02 10:00")
-      Fabricate.times(10, :clicked_search_log, term: "ruby", created_at: "2026-02-24 10:00")
+      Fabricate.times(
+        12,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-03-02 10:00",
+      )
+      Fabricate.times(
+        10,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-02-24 10:00",
+      )
 
       expect(
         described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")[:headline_state],
@@ -147,13 +263,37 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "resolves overlapping headline states by priority" do
-      Fabricate.times(3, :search_log, term: "ghost", created_at: "2026-02-02 10:00")
-      Fabricate.times(7, :clicked_search_log, term: "ruby", created_at: "2026-02-02 11:00")
-      Fabricate.times(10, :clicked_search_log, term: "ruby", created_at: "2026-01-27 10:00")
+      Fabricate.times(3, :search_log, term: "ghost", user: user, created_at: "2026-02-02 10:00")
+      Fabricate.times(
+        7,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-02-02 11:00",
+      )
+      Fabricate.times(
+        10,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-01-27 10:00",
+      )
 
-      Fabricate(:search_log, term: "ghost", created_at: "2026-01-02 10:00")
-      Fabricate.times(9, :clicked_search_log, term: "ruby", created_at: "2026-01-02 11:00")
-      Fabricate.times(20, :clicked_search_log, term: "ruby", created_at: "2025-12-27 10:00")
+      Fabricate(:search_log, term: "ghost", user: user, created_at: "2026-01-02 10:00")
+      Fabricate.times(
+        9,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-01-02 11:00",
+      )
+      Fabricate.times(
+        20,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2025-12-27 10:00",
+      )
 
       expect(
         described_class.build(start_date: "2026-02-01", end_date: "2026-02-07")[:headline_state],
@@ -165,7 +305,13 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "omits deltas when the prior window has no searches" do
-      Fabricate.times(2, :clicked_search_log, term: "ruby", created_at: "2026-05-02 10:00")
+      Fabricate.times(
+        2,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 10:00",
+      )
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")[:kpis]).to eq(
         total_searches: {
@@ -179,7 +325,7 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "omits deltas and rates when the current window has no searches" do
-      Fabricate.times(2, :search_log, term: "ruby", created_at: "2026-04-26 10:00")
+      Fabricate.times(2, :search_log, term: "ruby", user: user, created_at: "2026-04-26 10:00")
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")).to eq(
         logging_enabled: true,
@@ -200,8 +346,20 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "omits deltas when nothing changed between the windows" do
-      Fabricate.times(5, :clicked_search_log, term: "ruby", created_at: "2026-05-02 10:00")
-      Fabricate.times(5, :clicked_search_log, term: "ruby", created_at: "2026-04-26 10:00")
+      Fabricate.times(
+        5,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 10:00",
+      )
+      Fabricate.times(
+        5,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-04-26 10:00",
+      )
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")[:kpis]).to eq(
         total_searches: {
@@ -215,11 +373,23 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "reports the rate delta in percentage points, not relative change" do
-      Fabricate(:search_log, term: "ghost", created_at: "2026-05-02 10:00")
-      Fabricate.times(3, :clicked_search_log, term: "ruby", created_at: "2026-05-02 11:00")
+      Fabricate(:search_log, term: "ghost", user: user, created_at: "2026-05-02 10:00")
+      Fabricate.times(
+        3,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 11:00",
+      )
 
-      Fabricate(:search_log, term: "ghost", created_at: "2026-04-26 10:00")
-      Fabricate.times(9, :clicked_search_log, term: "ruby", created_at: "2026-04-26 11:00")
+      Fabricate(:search_log, term: "ghost", user: user, created_at: "2026-04-26 10:00")
+      Fabricate.times(
+        9,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-04-26 11:00",
+      )
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")[:kpis]).to eq(
         total_searches: {
@@ -235,8 +405,14 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "treats a rate of exactly 10% as within the threshold" do
-      Fabricate(:search_log, term: "ghost", created_at: "2026-05-02 10:00")
-      Fabricate.times(9, :clicked_search_log, term: "ruby", created_at: "2026-05-02 11:00")
+      Fabricate(:search_log, term: "ghost", user: user, created_at: "2026-05-02 10:00")
+      Fabricate.times(
+        9,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 11:00",
+      )
 
       expect(
         described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")[:kpis][
@@ -246,8 +422,14 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "flags a rate just above 10% even when the display rounds to 10%" do
-      Fabricate.times(5, :search_log, term: "ghost", created_at: "2026-05-02 10:00")
-      Fabricate.times(44, :clicked_search_log, term: "ruby", created_at: "2026-05-02 11:00")
+      Fabricate.times(5, :search_log, term: "ghost", user: user, created_at: "2026-05-02 10:00")
+      Fabricate.times(
+        44,
+        :clicked_search_log,
+        term: "ruby",
+        user: user,
+        created_at: "2026-05-02 11:00",
+      )
 
       expect(
         described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")[:kpis][
@@ -274,8 +456,8 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "falls back to the default 30-day window for missing, malformed, or inverted dates" do
-      Fabricate(:search_log, term: "inside-window", created_at: "2026-04-16 10:00")
-      Fabricate(:search_log, term: "outside-window", created_at: "2026-04-13 10:00")
+      Fabricate(:search_log, term: "inside-window", user: user, created_at: "2026-04-16 10:00")
+      Fabricate(:search_log, term: "outside-window", user: user, created_at: "2026-04-13 10:00")
 
       [
         described_class.build(start_date: nil, end_date: nil),
@@ -288,7 +470,7 @@ RSpec.describe AdminDashboardSearch do
     end
 
     it "includes searches at the window start boundary in every list" do
-      Fabricate(:search_log, term: "boundary", created_at: "2026-05-01 00:00:00")
+      Fabricate(:search_log, term: "boundary", user: user, created_at: "2026-05-01 00:00:00")
 
       response = described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")
 
@@ -300,7 +482,7 @@ RSpec.describe AdminDashboardSearch do
     it "returns only the logging flag when search logging is disabled" do
       SiteSetting.log_search_queries = false
 
-      Fabricate(:search_log, term: "ruby", created_at: "2026-05-02 10:00")
+      Fabricate(:search_log, term: "ruby", user: user, created_at: "2026-05-02 10:00")
 
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")).to eq(
         logging_enabled: false,

--- a/spec/system/admin_dashboard_redesign/search_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/search_section_spec.rb
@@ -3,6 +3,7 @@
 describe "Admin Dashboard Redesign | Search section" do
   fab!(:current_user, :admin)
   fab!(:moderator)
+  fab!(:user)
 
   let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
 
@@ -22,21 +23,56 @@ describe "Admin Dashboard Redesign | Search section" do
     sign_in(current_user)
   end
 
-  it "lets staff review search health, inspect tooltips, and drill into terms",
+  it "lets staff review logged-in search health, inspect tooltips, and drill into terms",
      time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-    Fabricate.times(15, :clicked_search_log, term: "ruby", created_at: "2026-05-10 10:00")
-    Fabricate.times(10, :search_log, term: "ruby", created_at: "2026-05-10 11:00")
-    Fabricate.times(5, :search_log, term: "ruby", created_at: "2026-04-20 10:00")
+    Fabricate.times(
+      15,
+      :clicked_search_log,
+      term: "ruby",
+      user: user,
+      created_at: "2026-05-10 10:00",
+    )
+    Fabricate.times(10, :search_log, term: "ruby", user: user, created_at: "2026-05-10 11:00")
+    Fabricate.times(5, :search_log, term: "ruby", user: user, created_at: "2026-04-20 10:00")
 
-    Fabricate.times(2, :clicked_search_log, term: "markdown tables", created_at: "2026-04-20 11:00")
+    Fabricate.times(
+      2,
+      :clicked_search_log,
+      term: "markdown tables",
+      user: user,
+      created_at: "2026-04-20 11:00",
+    )
 
-    Fabricate.times(13, :search_log, term: "markdown tables", created_at: "2026-04-20 12:00")
-    Fabricate.times(3, :search_log, term: "markdown tables", created_at: "2026-05-03 10:00")
+    Fabricate.times(
+      13,
+      :search_log,
+      term: "markdown tables",
+      user: user,
+      created_at: "2026-04-20 12:00",
+    )
+    Fabricate.times(
+      3,
+      :search_log,
+      term: "markdown tables",
+      user: user,
+      created_at: "2026-05-03 10:00",
+    )
 
-    Fabricate.times(2, :search_log, term: "discobot", created_at: "2026-05-10 12:00")
+    Fabricate.times(2, :search_log, term: "discobot", user: user, created_at: "2026-05-10 12:00")
 
-    Fabricate.times(20, :clicked_search_log, term: "ruby", created_at: "2026-03-20 10:00")
-    Fabricate.times(20, :search_log, term: "ruby", created_at: "2026-03-20 11:00")
+    Fabricate.times(
+      20,
+      :clicked_search_log,
+      term: "ruby",
+      user: user,
+      created_at: "2026-03-20 10:00",
+    )
+    Fabricate.times(20, :search_log, term: "ruby", user: user, created_at: "2026-03-20 11:00")
+
+    # Anonymous searches (likely crawlers) must be excluded from every metric. If they
+    # were counted, "crawlerbot" would top trending and the no-result rate would spike.
+    Fabricate.times(100, :search_log, term: "crawlerbot", created_at: "2026-05-10 09:00")
+    Fabricate.times(50, :clicked_search_log, term: "ruby", created_at: "2026-05-10 09:30")
 
     dashboard.visit
     expect(dashboard).to have_section("search")
@@ -54,7 +90,7 @@ describe "Admin Dashboard Redesign | Search section" do
 
     search.hover_total_searches_tooltip
     expect(search).to have_total_searches_tooltip(
-      "The number of searches performed in your community.",
+      "The number of searches performed by members in your community.",
     )
 
     search.hover_no_result_rate_tooltip
@@ -64,7 +100,7 @@ describe "Admin Dashboard Redesign | Search section" do
     )
 
     search.hover_trending_tooltip
-    expect(search).to have_trending_tooltip("The most popular search terms.")
+    expect(search).to have_trending_tooltip("The most popular search terms among members.")
 
     expect(search).to have_trending_rows(
       [
@@ -73,6 +109,7 @@ describe "Admin Dashboard Redesign | Search section" do
         { term: "discobot", searches: 2 },
       ],
     )
+    expect(search).to have_no_trending_term("crawlerbot")
 
     expect(search).to have_content_gap_rows(
       [
@@ -103,7 +140,12 @@ describe "Admin Dashboard Redesign | Search section" do
 
     search.click_trending_term("ruby")
 
-    expect(page).to have_current_path("/admin/logs/search_logs/term?period=weekly&term=ruby")
+    expect(page).to have_current_path("/admin/logs/search_logs/term", ignore_query: true)
+    expect(Rack::Utils.parse_query(URI.parse(page.current_url).query)).to eq(
+      "searchType" => "logged_in_only",
+      "period" => "weekly",
+      "term" => "ruby",
+    )
 
     dashboard.visit
     dashboard.select_preset("last_3_months")
@@ -120,15 +162,21 @@ describe "Admin Dashboard Redesign | Search section" do
 
   it "alerts staff when the no-result rate crosses the threshold",
      time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-    Fabricate.times(5, :search_log, term: "ghost", created_at: "2026-05-10 10:00")
-    Fabricate.times(5, :clicked_search_log, term: "ruby", created_at: "2026-05-10 11:00")
+    Fabricate.times(5, :search_log, term: "ghost", user: user, created_at: "2026-05-10 10:00")
+    Fabricate.times(
+      5,
+      :clicked_search_log,
+      term: "ruby",
+      user: user,
+      created_at: "2026-05-10 11:00",
+    )
 
     dashboard.visit
     search = dashboard.search
 
     expect(search).to have_headline(
       "Members ran 10 on-site searches in the last 30 days",
-      "More than 10% of searches ended without a click this period. " \
+      "More than 10% of member searches ended without a click this period. " \
         "Review the content gaps below to see what's missing.",
     )
     expect(search).to have_total_searches_kpi("10")
@@ -180,12 +228,12 @@ describe "Admin Dashboard Redesign | Search section" do
 
   it "shows staff search activity for a selected custom date range",
      time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
-    Fabricate(:clicked_search_log, term: "ruby", created_at: "2026-05-02 10:00")
-    Fabricate.times(2, :search_log, term: "ruby", created_at: "2026-05-02 11:00")
+    Fabricate(:clicked_search_log, term: "ruby", user: user, created_at: "2026-05-02 10:00")
+    Fabricate.times(2, :search_log, term: "ruby", user: user, created_at: "2026-05-02 11:00")
 
-    Fabricate.times(5, :search_log, term: "ruby", created_at: "2026-04-30 10:00")
+    Fabricate.times(5, :search_log, term: "ruby", user: user, created_at: "2026-04-30 10:00")
 
-    Fabricate(:search_log, term: "solo", created_at: "2026-04-25 10:00")
+    Fabricate(:search_log, term: "solo", user: user, created_at: "2026-04-25 10:00")
 
     dashboard.visit_with_query(range: "custom", start_date: "2026-05-01", end_date: "2026-05-03")
     search = dashboard.search
@@ -201,13 +249,18 @@ describe "Admin Dashboard Redesign | Search section" do
 
     search.click_trending_term("ruby")
 
-    expect(page).to have_current_path("/admin/logs/search_logs/term?period=all&term=ruby")
+    expect(page).to have_current_path("/admin/logs/search_logs/term", ignore_query: true)
+    expect(Rack::Utils.parse_query(URI.parse(page.current_url).query)).to eq(
+      "searchType" => "logged_in_only",
+      "period" => "all",
+      "term" => "ruby",
+    )
 
     dashboard.visit_with_query(range: "custom", start_date: "2026-04-25", end_date: "2026-04-25")
 
     expect(search).to have_headline(
       "Members ran 1 on-site search in the selected period",
-      "More than 10% of searches ended without a click this period. " \
+      "More than 10% of member searches ended without a click this period. " \
         "Review the content gaps below to see what's missing.",
     )
   end

--- a/spec/system/page_objects/components/admin_dashboard_search.rb
+++ b/spec/system/page_objects/components/admin_dashboard_search.rb
@@ -89,6 +89,12 @@ module PageObjects
         end
       end
 
+      def has_no_trending_term?(term)
+        within_block("Trending searches") do
+          has_no_css?("[data-test-search-term-row] a", text: term)
+        end
+      end
+
       def has_trending_empty_state?(message)
         within_block("Trending searches") { has_text?(message) }
       end


### PR DESCRIPTION
The "Search" section of the admin dashboard (the new dashboard behind `dashboard_improvements`) counted every row in `search_logs`, including anonymous traffic that can be dominated by crawlers. All four metrics (Total searches, No-result rate, Trending searches, Content gaps) and the per-term drill-down included that traffic.

This PR restricts the section to logged-in members, whose searches are usually the higher-signal view of what members look for, surfaces a matching "Logged in only" filter on the search log pages, and says so in the tooltips.