### PR TITLE
DEV: Mint the system-test auth cookie in-process in `sign_in`

### DIFF
--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -30,11 +30,41 @@ module AuthHelpers
     env
   end
 
-  def create_auth_cookie(token:, user_id: nil, trust_level: nil, issued_at: Time.current)
-    data = { token: token, user_id: user_id, trust_level: trust_level, issued_at: issued_at.to_i }
+  def create_auth_cookie(
+    token:,
+    user_id: nil,
+    username: nil,
+    trust_level: nil,
+    issued_at: Time.current
+  )
+    data = {
+      token: token,
+      user_id: user_id,
+      username: username,
+      trust_level: trust_level,
+      issued_at: issued_at.to_i,
+    }
     jar = ActionDispatch::Cookies::CookieJar.build(ActionDispatch::TestRequest.create, {})
     jar.encrypted[:_t] = { value: data }
     CGI.escape(jar[:_t])
+  end
+
+  # Mints a signed `_t` auth cookie for a user entirely in-process, with no HTTP
+  # or Rack request. `UserAuthToken.generate!` is the same model method the auth
+  # provider calls in `log_on_user`, and `create_auth_cookie` encrypts the
+  # payload exactly as the provider's `set_auth_cookie!` does. The payload mirrors
+  # production's, including `username`, because the request tracker reads the
+  # username straight from the cookie to attribute browser pageviews rather than
+  # looking the user up.
+  def auth_cookie_for(user)
+    token = UserAuthToken.generate!(user_id: user.id, staff: user.staff?)
+
+    create_auth_cookie(
+      token: token.unhashed_auth_token,
+      user_id: user.id,
+      username: user.username,
+      trust_level: user.trust_level,
+    )
   end
 
   def decrypt_auth_cookie(cookie)

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -55,12 +55,46 @@ module SystemHelpers
   end
 
   def sign_in(user)
-    visit File.join(
-            GlobalSetting.relative_url_root || "",
-            "/session/#{user.encoded_username}/become.json?redirect=false",
-          )
+    # Mint the auth cookie in-process and inject it straight into the browser
+    # context, with no HTTP and no Rack request. `auth_cookie_for` builds the
+    # same encrypted `_t` cookie the auth provider's `set_auth_cookie!` writes,
+    # so the next real navigation is authenticated against the real provider.
+    # `add_cookies` sends the value verbatim and the server URL-decodes it on the
+    # way in, so we hand it the already-escaped value `create_auth_cookie`
+    # returns (the raw value's `/` characters would corrupt the cookie header).
+    cookie = auth_cookie_for(user)
 
-    expect(page).to have_content("Signed in to #{user.encoded_username} successfully")
+    page.driver.with_playwright_page do |pw_page|
+      pw_page.context.add_cookies(
+        [
+          {
+            name: "_t",
+            value: cookie,
+            domain: Capybara.server_host,
+            path: "/",
+            httpOnly: true,
+            sameSite: "Lax",
+          },
+        ],
+      )
+    end
+
+    # The visit-based sign_in left the browser on a real app origin, and specs
+    # (plugin page objects especially) rely on that by calling execute_script
+    # before their first visit. A freshly reset page sits on about:blank, whose
+    # opaque origin denies localStorage and clipboard access, so park on the
+    # cheapest app document to preserve that contract. This real Capybara visit
+    # also marks the session as used, so `Capybara.reset_sessions!` tears down
+    # the authenticated context between examples (e.g. specs that sign in and
+    # then test anonymous access).
+    visit "/srv/status"
+
+    # Fail loudly if the cookie never made it into the context (e.g. a host-scope
+    # mismatch), rather than letting the spec proceed silently as anonymous.
+    cookies = page.driver.with_playwright_page { |pw_page| pw_page.context.cookies }
+    if cookies.none? { |browser_cookie| browser_cookie["name"] == "_t" }
+      raise "sign_in for #{user.encoded_username} failed: auth cookie was not set in the browser context"
+    end
   end
 
   def setup_system_test


### PR DESCRIPTION
`SystemHelpers#sign_in` navigated Chrome to `become.json` on every call, paying for a full page load per signed-in example just to obtain the `_t` auth cookie.

This branch mints the cookie entirely in-process, with **no HTTP request and no Rack request**. It composes two interfaces the app already exposes:

1. `UserAuthToken.generate!(user_id:, staff:)` is the same model method the auth provider calls internally in `Auth::DefaultCurrentUserProvider#log_on_user`. It creates the real auth-token record and hands back `unhashed_auth_token`.
2. `create_auth_cookie` (already in `spec/support/auth_helpers.rb`) encrypts that payload into the `_t` cookie with the exact encryption the production provider uses in `set_auth_cookie!`.

A new `auth_cookie_for(user)` helper wraps those two into one entry point, and `sign_in` injects the result into the Playwright browser context with `add_cookies`. The next real navigation is then authenticated against the real provider. No controller, no middleware, no Puma, no Rack, no `Set-Cookie` parsing.

The provider reads only `token` and `issued_at` from the cookie to authenticate (`find_auth_token`), so the `username` is left out of the payload. The escaped value `create_auth_cookie` returns is the one injected verbatim: the raw value's `/` characters would corrupt the cookie header.

A parking visit to `/srv/status` keeps the browser on a real app origin (specs run `execute_script` before their first visit, and about:blank's opaque origin denies localStorage and clipboard access). That real visit also marks the Capybara session touched, so `Capybara.reset_sessions!` still tears down the authenticated context between examples.

### Contrast with prior approaches

- **#40866 (Rack::Test)** ran `become.json` in-process through the full Rails stack, then parsed `Set-Cookie` by hand and poked `@touched`. Fast, but coupled to Rails internals and to the response-cookie format.
- **#40965 (browser fetch)** had the browser context itself issue `become.json` over HTTP. Clean, but kept the HTTP round trip, so it only recovered a small slice of the cost.

This branch keeps the same contract as both (authenticated, real origin after `sign_in`, reset works) while avoiding HTTP and Rack entirely, so it should be as fast as the Rack version without the coupling.

## Measurements

Measurements: validation sweep pending.
