### PR TITLE
PERF: Improve daily engaged users on new dashboard

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -140,15 +140,50 @@ class UserAction < ActiveRecord::Base
   end
 
   def self.count_daily_engaged_users(start_date = nil, end_date = nil)
-    result = select(:user_id).distinct.where(action_type: USER_ACTED_TYPES)
-
     if start_date && end_date
-      result = result.group("date(created_at)")
-      result = result.where("created_at > ? AND created_at < ?", start_date, end_date)
-      result = result.order("date(created_at)")
-    end
+      sql = <<~SQL
+        SELECT day, COUNT(*) AS count
+        FROM (
+          SELECT DISTINCT date(created_at) AS day, user_id
+          FROM user_actions
+          WHERE action_type IN (:action_types)
+            AND created_at > :start_date
+            AND created_at < :end_date
+        ) distinct_daily_users
+        GROUP BY day
+        ORDER BY day
+      SQL
 
-    result.count
+      DB
+        .query(sql, action_types: USER_ACTED_TYPES, start_date: start_date, end_date: end_date)
+        .each_with_object({}) { |row, counts| counts[row.day] = row.count }
+    else
+      sql = <<~SQL
+        WITH RECURSIVE engaged_users AS (
+          (
+            SELECT user_id
+            FROM user_actions
+            WHERE action_type IN (:action_types)
+            ORDER BY user_id
+            LIMIT 1
+          )
+          UNION ALL
+          SELECT (
+            SELECT user_id
+            FROM user_actions
+            WHERE user_id > engaged_users.user_id
+              AND action_type IN (:action_types)
+            ORDER BY user_id
+            LIMIT 1
+          )
+          FROM engaged_users
+          WHERE engaged_users.user_id IS NOT NULL
+        )
+        SELECT COUNT(*) FROM engaged_users WHERE user_id IS NOT NULL
+      SQL
+
+      DB.query_single(sql, action_types: USER_ACTED_TYPES).first
+    end
   end
 
   def self.stream_item(action_id, guardian)
@@ -506,7 +541,7 @@ end
 #  idx_unique_rows                                   (action_type,user_id,target_topic_id,target_post_id,acting_user_id) UNIQUE
 #  idx_user_actions_speed_up_user_all                (user_id,created_at,action_type)
 #  index_user_actions_on_acting_user_id              (acting_user_id)
-#  index_user_actions_on_action_type_and_created_at  (action_type,created_at)
+#  index_user_actions_on_action_type_and_created_at  (action_type,created_at,user_id)
 #  index_user_actions_on_target_post_id              (target_post_id)
 #  index_user_actions_on_target_user_id              (target_user_id) WHERE (target_user_id IS NOT NULL)
 #  index_user_actions_on_user_id_and_action_type     (user_id,action_type)

--- a/db/migrate/20260617053237_add_user_id_to_user_actions_action_type_created_at_index.rb
+++ b/db/migrate/20260617053237_add_user_id_to_user_actions_action_type_created_at_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class AddUserIdToUserActionsActionTypeCreatedAtIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX = "index_user_actions_on_action_type_and_created_at"
+
+  # Widen the existing index with user_id so the daily engaged users report can
+  # satisfy its per-day distinct-user query with an index-only scan.
+  def up
+    remove_index :user_actions, name: INDEX, algorithm: :concurrently, if_exists: true
+    add_index :user_actions,
+              %i[action_type created_at user_id],
+              name: INDEX,
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :user_actions, name: INDEX, algorithm: :concurrently, if_exists: true
+    add_index :user_actions, %i[action_type created_at], name: INDEX, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -20921,7 +20921,7 @@ CREATE INDEX index_user_actions_on_acting_user_id ON public.user_actions USING b
 -- Name: index_user_actions_on_action_type_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_user_actions_on_action_type_and_created_at ON public.user_actions USING btree (action_type, created_at);
+CREATE INDEX index_user_actions_on_action_type_and_created_at ON public.user_actions USING btree (action_type, created_at, user_id);
 
 
 --
@@ -21913,6 +21913,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260617053237'),
 ('20260612092612'),
 ('20260610075829'),
 ('20260609050938'),


### PR DESCRIPTION
This part of the new dashboard uses an older query `UserAction.count_daily_engaged_users`:

<img width="1189" height="174" alt="Screenshot 2026-06-17 at 12 06 32 PM" src="https://github.com/user-attachments/assets/e8a388d0-07e0-48fd-b238-4cab9d1bbb5e" />

Two queries were slow: the per-day `COUNT(DISTINCT user_id)` (a heap scan plus an 11 MB external-merge disk sort) and the all-time `COUNT(DISTINCT user_id)` over ~3M rows. Widened the existing index rather than adding a new partial index (original PR): same query speed, but it adds one column (+68 MB) to an index that's already there instead of a separate ~98 MB index, so inserts maintain one index, not two.

(note, previous is what this PR originally did, now is .. now)

|                                      | previous new partial index                          | now extend the core index       |
| ------------------------------------ | ------------------------------------------------------- | ------------------------------------ |
| Index                                | `(created_at, user_id) WHERE action_type IN (1,4,5,12)` | `(action_type, created_at, user_id)` |
| Plan                                 | Index Only Scan (partial)                               | Index Only Scan (core)               |
| Buffers (cache-indep.)               | **4,548**                                               | 5,597                                |
| Exec (cold)                          | 150 ms                                                  | 126 ms                               |
| This index's size                    | 98 MB (brand-new)                                       | 271 MB (was 203 MB)                  |
| **Net storage added**                | **+98 MB** (new index)                                  | **+68 MB** (widen existing)          |
| Total `user_actions` index footprint | 203 + 98 = **301 MB**                                   | **271 MB**                           |
| Indexes touched per insert           | core **+** new partial (2)                              | just the wider core (1)              |

Report output is unchanged (specs pass). `EXPLAIN (ANALYZE, BUFFERS)` on the per-day grouped query (1-year window):

| | Scan | Buffers (pages) | Disk reads | Exec |
|---|---|---:|---:|---:|
| Rewrite only (no index) | Bitmap Heap Scan | 36,591 | 36,585 | 348 ms |
| **Rewrite + widened index** | **Index Only Scan** | **5,597** | **3,080** | **126 ms** |

`Buffers` (pages touched) is cache-independent; disk reads / exec are from a cold run.
