### PR TITLE
FEATURE: Add Site Advice section to the redesigned admin dashboard

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -1,5 +1,77 @@
 @use "lib/viewport";
 
+.db-site-advice {
+  border: 1px solid var(--primary-low);
+  border-radius: var(--d-border-radius-large);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--primary-very-low);
+    padding: var(--space-2) var(--space-4);
+    border-top-left-radius: var(--d-border-radius-large);
+    border-top-right-radius: var(--d-border-radius-large);
+    border-bottom: 1px solid var(--primary-low);
+
+    h3 {
+      margin: 0;
+      font-size: var(--font-0);
+    }
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+
+    &:has(ul) {
+      align-items: flex-start;
+    }
+
+    @include viewport.until(sm) {
+      align-items: flex-start;
+    }
+    gap: var(--space-3);
+    padding: var(--space-4);
+
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--primary-low);
+    }
+
+    .btn {
+      margin-left: auto;
+    }
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    margin-top: 0.125rem;
+
+    &.--high {
+      color: var(--danger);
+    }
+
+    &.--low {
+      color: var(--tertiary);
+    }
+  }
+
+  &__message {
+    overflow-wrap: anywhere;
+  }
+}
+
 .db-main {
   display: flex;
   flex-direction: column;
@@ -201,6 +273,10 @@
   }
 
   &__subintro {
+    h3 {
+      margin: 0;
+    }
+
     p {
       font-size: var(--font-down-1-rem);
       color: var(--primary-high);
@@ -990,46 +1066,4 @@
 
 .db-reports {
   display: contents;
-}
-
-.db-site-advice {
-  &__list {
-    margin: 0;
-    padding: 0;
-    list-style: none;
-  }
-
-  &__item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding-block: var(--space-2);
-  }
-
-  &__icon {
-    flex-shrink: 0;
-
-    &.--high {
-      color: var(--danger);
-    }
-
-    &.--low {
-      color: var(--tertiary);
-    }
-  }
-
-  &__message {
-    flex-grow: 1;
-    overflow-wrap: anywhere;
-
-    ul {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--space-1) var(--space-3);
-      margin-block: var(--space-1) 0;
-      margin-inline: 0;
-      padding: 0;
-      list-style: none;
-    }
-  }
 }

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -991,3 +991,45 @@
 .db-reports {
   display: contents;
 }
+
+.db-site-advice {
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding-block: var(--space-2);
+  }
+
+  &__icon {
+    flex-shrink: 0;
+
+    &.--high {
+      color: var(--danger);
+    }
+
+    &.--low {
+      color: var(--tertiary);
+    }
+  }
+
+  &__message {
+    flex-grow: 1;
+    overflow-wrap: anywhere;
+
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-1) var(--space-3);
+      margin-block: var(--space-1) 0;
+      margin-inline: 0;
+      padding: 0;
+      list-style: none;
+    }
+  }
+}

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -42,7 +42,7 @@ class Admin::DashboardController < Admin::StaffController
   def problems
     ProblemCheck.realtime.run_all
 
-    render json: { problems: serialize_data(AdminNotice.problem.all, AdminNoticeSerializer) }
+    render json: { problems: serialized_problems }
   end
 
   def new_features
@@ -131,6 +131,10 @@ class Admin::DashboardController < Admin::StaffController
 
   private
 
+  def serialized_problems
+    serialize_data(AdminNotice.problem.order(:id), AdminNoticeSerializer)
+  end
+
   def dashboard_sections_payload
     visible_ids = AdminDashboardSectionConfiguration.visible_section_ids
     data = {
@@ -141,6 +145,7 @@ class Admin::DashboardController < Admin::StaffController
           start_date: params[:start_date],
           end_date: params[:end_date],
         ),
+      problems: serialized_problems,
     }
     if current_user.admin?
       data[:configuration] = { sections: AdminDashboardSectionConfiguration.sections }

--- a/app/jobs/scheduled/run_problem_checks.rb
+++ b/app/jobs/scheduled/run_problem_checks.rb
@@ -25,6 +25,8 @@ module Jobs
           end
         end
       end
+
+      ProblemCheck.realtime.run_all
     end
   end
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7001,6 +7001,10 @@ en:
         latest_version: "Latest"
         problems_found: "Some advice based on your current site settings"
         dismiss_notice: "Ignore"
+        site_advice:
+          title:
+            one: "%{count} issue requires your attention based on your site configuration"
+            other: "%{count} issues require your attention based on your site configuration"
         new_features:
           title: "What's new?"
           subtitle: "We are releasing new features and improvements all the time. This page covers the highlights, but you can click 'Learn more' to see extensive release notes."

--- a/frontend/discourse/admin/components/dashboard/site-advice.gjs
+++ b/frontend/discourse/admin/components/dashboard/site-advice.gjs
@@ -50,63 +50,51 @@ export default class DashboardSiteAdvice extends Component {
 
   <template>
     {{#if @problems.length}}
-      <section class="db-section --site-advice">
-        <div class="db-section__wrapper --column">
-          <div class="db-section__subheader">
-            <div class="db-section__subintro">
-              <h3>{{this.title}}</h3>
-            </div>
-
-            <DButton
-              class="btn-flat"
-              data-test-site-advice-refresh="true"
-              @action={{this.refresh}}
-              @isLoading={{this.refreshing}}
-              @icon="arrows-rotate"
-              @label="admin.dashboard.refresh_problems"
-            />
-          </div>
-
-          <div class="db-section__row-group">
-            <div class="db-section__row">
-              <div class="db-section__row-block">
-                <ul class="db-site-advice__list">
-                  {{#each this.sortedProblems key="id" as |problem|}}
-                    <li
-                      class="db-site-advice__item"
-                      data-test-site-advice-problem={{problem.id}}
-                    >
-                      {{dIcon
-                        (if
-                          (eq problem.priority "high")
-                          "triangle-exclamation"
-                          "circle-info"
-                        )
-                        class=(concat
-                          "db-site-advice__icon --" problem.priority
-                        )
-                      }}
-
-                      <div class="db-site-advice__message">
-                        {{trustHTML problem.message}}
-                      </div>
-
-                      {{#if this.currentUser.admin}}
-                        <DButton
-                          class="btn-default"
-                          data-test-site-advice-ignore="true"
-                          @action={{fn this.ignore problem}}
-                          @isLoading={{eq this.ignoringId problem.id}}
-                          @label="admin.dashboard.dismiss_notice"
-                        />
-                      {{/if}}
-                    </li>
-                  {{/each}}
-                </ul>
-              </div>
-            </div>
-          </div>
+      <section class="db-site-advice">
+        <div class="db-site-advice__header">
+          <h3>{{this.title}}</h3>
+          <DButton
+            class="btn-transparent btn-small"
+            data-test-site-advice-refresh="true"
+            @action={{this.refresh}}
+            @isLoading={{this.refreshing}}
+            @icon="arrows-rotate"
+            @label="admin.dashboard.refresh_problems"
+          />
         </div>
+
+        <ul class="db-site-advice__list">
+          {{#each this.sortedProblems key="id" as |problem|}}
+            <li
+              class="db-site-advice__item"
+              data-test-site-advice-problem={{problem.id}}
+            >
+
+              {{dIcon
+                (if
+                  (eq problem.priority "high")
+                  "triangle-exclamation"
+                  "circle-info"
+                )
+                class=(concat "db-site-advice__icon --" problem.priority)
+              }}
+
+              <div class="db-site-advice__message">
+                {{trustHTML problem.message}}
+              </div>
+
+              {{#if this.currentUser.admin}}
+                <DButton
+                  class="btn-default btn-small"
+                  data-test-site-advice-ignore="true"
+                  @action={{fn this.ignore problem}}
+                  @isLoading={{eq this.ignoringId problem.id}}
+                  @label="admin.dashboard.dismiss_notice"
+                />
+              {{/if}}
+            </li>
+          {{/each}}
+        </ul>
       </section>
     {{/if}}
   </template>

--- a/frontend/discourse/admin/components/dashboard/site-advice.gjs
+++ b/frontend/discourse/admin/components/dashboard/site-advice.gjs
@@ -1,0 +1,113 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { concat, fn } from "@ember/helper";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import { trustHTML } from "@ember/template";
+import { compare } from "@ember/utils";
+import { eq } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+export default class DashboardSiteAdvice extends Component {
+  @service currentUser;
+
+  @tracked refreshing = false;
+  @tracked ignoringId = null;
+
+  @action
+  async refresh() {
+    this.refreshing = true;
+    try {
+      await this.args.onRefresh();
+    } finally {
+      this.refreshing = false;
+    }
+  }
+
+  @action
+  async ignore(problem) {
+    this.ignoringId = problem.id;
+    try {
+      await this.args.onIgnore(problem);
+    } finally {
+      this.ignoringId = null;
+    }
+  }
+
+  get sortedProblems() {
+    return [...this.args.problems].sort(
+      (a, b) => compare(a?.priority, b?.priority) || compare(a?.id, b?.id)
+    );
+  }
+
+  get title() {
+    return i18n("admin.dashboard.site_advice.title", {
+      count: this.args.problems.length,
+    });
+  }
+
+  <template>
+    {{#if @problems.length}}
+      <section class="db-section --site-advice">
+        <div class="db-section__wrapper --column">
+          <div class="db-section__subheader">
+            <div class="db-section__subintro">
+              <h3>{{this.title}}</h3>
+            </div>
+
+            <DButton
+              class="btn-flat"
+              data-test-site-advice-refresh="true"
+              @action={{this.refresh}}
+              @isLoading={{this.refreshing}}
+              @icon="arrows-rotate"
+              @label="admin.dashboard.refresh_problems"
+            />
+          </div>
+
+          <div class="db-section__row-group">
+            <div class="db-section__row">
+              <div class="db-section__row-block">
+                <ul class="db-site-advice__list">
+                  {{#each this.sortedProblems key="id" as |problem|}}
+                    <li
+                      class="db-site-advice__item"
+                      data-test-site-advice-problem={{problem.id}}
+                    >
+                      {{dIcon
+                        (if
+                          (eq problem.priority "high")
+                          "triangle-exclamation"
+                          "circle-info"
+                        )
+                        class=(concat
+                          "db-site-advice__icon --" problem.priority
+                        )
+                      }}
+
+                      <div class="db-site-advice__message">
+                        {{trustHTML problem.message}}
+                      </div>
+
+                      {{#if this.currentUser.admin}}
+                        <DButton
+                          class="btn-default"
+                          data-test-site-advice-ignore="true"
+                          @action={{fn this.ignore problem}}
+                          @isLoading={{eq this.ignoringId problem.id}}
+                          @label="admin.dashboard.dismiss_notice"
+                        />
+                      {{/if}}
+                    </li>
+                  {{/each}}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    {{/if}}
+  </template>
+}

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -7,6 +7,7 @@ import DashboardEngagement from "discourse/admin/components/dashboard/engagement
 import DashboardHighlights from "discourse/admin/components/dashboard/highlights";
 import DashboardReports from "discourse/admin/components/dashboard/reports";
 import DashboardSearch from "discourse/admin/components/dashboard/search";
+import DashboardSiteAdvice from "discourse/admin/components/dashboard/site-advice";
 import DashboardSkeleton from "discourse/admin/components/dashboard/skeleton";
 import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -61,6 +62,12 @@ export default class RedesignedAdminDashboard extends Component {
 
     <div class="db-main">
       {{#if @loadedSections}}
+        <DashboardSiteAdvice
+          @problems={{@problems}}
+          @onRefresh={{@onRefreshProblems}}
+          @onIgnore={{@onIgnoreProblem}}
+        />
+
         {{#each @loadedSections.sections key="id" as |section|}}
           {{#if (eq section.id "highlights")}}
             <DashboardHighlights

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -182,6 +182,7 @@ export default class AdminDashboardController extends Controller {
         sections: model.sections,
         configuration: model.configuration,
       };
+      this.problems = model.problems;
     } catch {
       if (id !== this._sectionsLoadId) {
         return;
@@ -304,5 +305,27 @@ export default class AdminDashboardController extends Controller {
   @action
   refreshProblems() {
     this._loadProblems();
+  }
+
+  @action
+  async refreshSiteAdvice() {
+    try {
+      const model = await AdminDashboard.fetchProblems();
+      this.problems = model.problems;
+    } catch (error) {
+      popupAjaxError(error);
+    }
+  }
+
+  @action
+  async ignoreProblem(problem) {
+    try {
+      await ajax(`/admin/admin_notices/${problem.id}`, { type: "DELETE" });
+      this.problems = this.problems.filter(
+        (candidate) => candidate.id !== problem.id
+      );
+    } catch (error) {
+      popupAjaxError(error);
+    }
   }
 }

--- a/frontend/discourse/admin/models/admin-dashboard.js
+++ b/frontend/discourse/admin/models/admin-dashboard.js
@@ -27,6 +27,7 @@ export default class AdminDashboard extends EmberObject {
       version_check: json.version_check,
       sections: json.sections,
       configuration: json.configuration,
+      problems: json.problems,
     });
 
     return model;

--- a/frontend/discourse/admin/templates/admin/dashboard.gjs
+++ b/frontend/discourse/admin/templates/admin/dashboard.gjs
@@ -21,6 +21,9 @@ export default <template>
       @refreshSections={{@controller.fetchSections}}
       @loadingSections={{@controller.loadingSections}}
       @sectionsFetchError={{@controller.sectionsFetchError}}
+      @problems={{@controller.problems}}
+      @onRefreshProblems={{@controller.refreshSiteAdvice}}
+      @onIgnoreProblem={{@controller.ignoreProblem}}
     />
   {{else}}
     <PluginOutlet @name="admin-dashboard-top" @connectorTagName="div" />

--- a/spec/jobs/run_problem_checks_spec.rb
+++ b/spec/jobs/run_problem_checks_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe Jobs::RunProblemChecks do
     ProblemCheck.send(:remove_const, "MultiTargetCheck")
   end
 
+  it "runs the realtime checks in the background" do
+    expect { described_class.new.execute([]) }.to change {
+      ProblemCheckTracker.where(identifier: "non_scheduled_check").count
+    }.by(1)
+  end
+
   context "when a tracker hasn't been created yet" do
     it "still schedules checks" do
       expect_enqueued_with(

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -511,6 +511,69 @@ RSpec.describe Admin::DashboardController do
       end
     end
 
+    describe "problems payload" do
+      before do
+        SiteSetting.dashboard_improvements = true
+        Discourse.cache.clear
+      end
+
+      fab!(:starttls_problem) do
+        Fabricate(:admin_notice, identifier: "starttls_disabled", priority: "high")
+      end
+
+      fab!(:host_names_problem) do
+        Fabricate(:admin_notice, identifier: "host_names", priority: "low")
+      end
+
+      it "returns every active problem check in a top-level problems key for an admin" do
+        sign_in(admin)
+
+        get "/admin/dashboard.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["problems"]).to match_array(
+          [
+            {
+              "id" => starttls_problem.id,
+              "priority" => "high",
+              "message" => starttls_problem.message,
+              "identifier" => "starttls_disabled",
+            },
+            {
+              "id" => host_names_problem.id,
+              "priority" => "low",
+              "message" => host_names_problem.message,
+              "identifier" => "host_names",
+            },
+          ],
+        )
+      end
+
+      it "returns every active problem check in a top-level problems key for a moderator" do
+        sign_in(moderator)
+
+        get "/admin/dashboard.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["problems"]).to match_array(
+          [
+            {
+              "id" => starttls_problem.id,
+              "priority" => "high",
+              "message" => starttls_problem.message,
+              "identifier" => "starttls_disabled",
+            },
+            {
+              "id" => host_names_problem.id,
+              "priority" => "low",
+              "message" => host_names_problem.message,
+              "identifier" => "host_names",
+            },
+          ],
+        )
+      end
+    end
+
     describe "configuration payload" do
       before do
         SiteSetting.dashboard_improvements = true

--- a/spec/system/admin_dashboard_redesign/site_advice_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_advice_section_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+describe "Admin Dashboard Redesign | Site Advice section" do
+  let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
+
+  before { SiteSetting.dashboard_improvements = true }
+
+  context "when signed in as an admin" do
+    fab!(:current_user, :admin)
+
+    before { sign_in(current_user) }
+
+    it "shows every active problem with its count, severity order, and actions" do
+      dashboard.visit
+
+      expect(dashboard).to have_no_site_advice
+
+      Fabricate(:admin_notice, identifier: "host_names", priority: "low")
+      Fabricate(:admin_notice, identifier: "starttls_disabled", priority: "high")
+
+      dashboard.visit
+
+      expect(dashboard).to have_site_advice_at_top
+      expect(dashboard).to have_site_advice_title(
+        "2 issues require your attention based on your site configuration",
+      )
+      expect(dashboard).to have_first_site_advice_problem("STARTTLS disabled")
+      expect(dashboard).to have_site_advice_problem("default localhost hostname")
+      expect(dashboard).to have_ignore_button_for("STARTTLS disabled")
+      expect(dashboard).to have_ignore_button_for("default localhost hostname")
+      expect(dashboard).to have_site_advice_refresh_button
+    end
+
+    it "lets an admin ignore a problem and refresh the list in place" do
+      ProblemCheck.stubs(:realtime).returns(stub(run_all: nil))
+
+      Fabricate(:admin_notice, identifier: "host_names", priority: "low")
+      resolved = Fabricate(:admin_notice, identifier: "starttls_disabled", priority: "high")
+
+      dashboard.visit
+      dashboard.ignore_site_advice_problem("default localhost hostname")
+
+      expect(dashboard).to have_no_site_advice_problem("default localhost hostname")
+
+      resolved.destroy!
+      Fabricate(:admin_notice, identifier: "subfolder_ends_in_slash", priority: "low")
+
+      dashboard.refresh_site_advice
+
+      expect(dashboard).to have_no_site_advice_problem("default localhost hostname")
+      expect(dashboard).to have_no_site_advice_problem("STARTTLS disabled")
+      expect(dashboard).to have_site_advice_problem("subfolder setup is incorrect")
+    end
+  end
+
+  context "when signed in as a moderator" do
+    fab!(:moderator)
+
+    before { sign_in(moderator) }
+
+    it "shows the advice read-only, without any Ignore buttons" do
+      Fabricate(:admin_notice, identifier: "host_names", priority: "low")
+
+      dashboard.visit
+
+      expect(dashboard).to have_site_advice
+      expect(dashboard).to have_site_advice_problem("default localhost hostname")
+      expect(dashboard).to have_no_ignore_buttons
+      expect(dashboard).to have_site_advice_refresh_button
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -27,6 +27,63 @@ module PageObjects
         find(".dashboard-problem", text: message).find(".btn").click
       end
 
+      def has_site_advice?
+        has_css?(".db-section.--site-advice")
+      end
+
+      def has_site_advice_at_top?
+        has_css?(".db-main > .db-section.--site-advice:first-child")
+      end
+
+      def has_no_site_advice?
+        has_no_css?(".db-section.--site-advice")
+      end
+
+      def has_site_advice_title?(text)
+        has_css?(".db-section.--site-advice .db-section__subintro h3", exact_text: text)
+      end
+
+      def has_site_advice_problem?(message)
+        has_css?(".db-section.--site-advice [data-test-site-advice-problem]", text: message)
+      end
+
+      def has_no_site_advice_problem?(message)
+        has_no_css?(".db-section.--site-advice [data-test-site-advice-problem]", text: message)
+      end
+
+      def has_first_site_advice_problem?(message)
+        has_css?(
+          ".db-section.--site-advice [data-test-site-advice-problem]:first-child",
+          text: message,
+        )
+      end
+
+      def has_ignore_button_for?(message)
+        within(".db-section.--site-advice [data-test-site-advice-problem]", text: message) do
+          has_css?("[data-test-site-advice-ignore]")
+        end
+      end
+
+      def has_no_ignore_buttons?
+        has_no_css?(".db-section.--site-advice [data-test-site-advice-ignore]")
+      end
+
+      def has_site_advice_refresh_button?
+        has_css?(".db-section.--site-advice [data-test-site-advice-refresh]")
+      end
+
+      def ignore_site_advice_problem(message)
+        within(".db-section.--site-advice [data-test-site-advice-problem]", text: message) do
+          find("[data-test-site-advice-ignore]").click
+        end
+        self
+      end
+
+      def refresh_site_advice
+        find(".db-section.--site-advice [data-test-site-advice-refresh]").click
+        self
+      end
+
       def has_redesigned_toolbar?
         has_css?(".db-toolbar")
       end

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -28,59 +28,56 @@ module PageObjects
       end
 
       def has_site_advice?
-        has_css?(".db-section.--site-advice")
+        has_css?(".db-site-advice")
       end
 
       def has_site_advice_at_top?
-        has_css?(".db-main > .db-section.--site-advice:first-child")
+        has_css?(".db-main > .db-site-advice:first-child")
       end
 
       def has_no_site_advice?
-        has_no_css?(".db-section.--site-advice")
+        has_no_css?(".db-site-advice")
       end
 
       def has_site_advice_title?(text)
-        has_css?(".db-section.--site-advice .db-section__subintro h3", exact_text: text)
+        has_css?(".db-site-advice__header h3", exact_text: text)
       end
 
       def has_site_advice_problem?(message)
-        has_css?(".db-section.--site-advice [data-test-site-advice-problem]", text: message)
+        has_css?(".db-site-advice [data-test-site-advice-problem]", text: message)
       end
 
       def has_no_site_advice_problem?(message)
-        has_no_css?(".db-section.--site-advice [data-test-site-advice-problem]", text: message)
+        has_no_css?(".db-site-advice [data-test-site-advice-problem]", text: message)
       end
 
       def has_first_site_advice_problem?(message)
-        has_css?(
-          ".db-section.--site-advice [data-test-site-advice-problem]:first-child",
-          text: message,
-        )
+        has_css?(".db-site-advice [data-test-site-advice-problem]:first-child", text: message)
       end
 
       def has_ignore_button_for?(message)
-        within(".db-section.--site-advice [data-test-site-advice-problem]", text: message) do
+        within(".db-site-advice [data-test-site-advice-problem]", text: message) do
           has_css?("[data-test-site-advice-ignore]")
         end
       end
 
       def has_no_ignore_buttons?
-        has_no_css?(".db-section.--site-advice [data-test-site-advice-ignore]")
+        has_no_css?(".db-site-advice [data-test-site-advice-ignore]")
       end
 
       def has_site_advice_refresh_button?
-        has_css?(".db-section.--site-advice [data-test-site-advice-refresh]")
+        has_css?(".db-site-advice [data-test-site-advice-refresh]")
       end
 
       def ignore_site_advice_problem(message)
-        within(".db-section.--site-advice [data-test-site-advice-problem]", text: message) do
+        within(".db-site-advice [data-test-site-advice-problem]", text: message) do
           find("[data-test-site-advice-ignore]").click
         end
         self
       end
 
       def refresh_site_advice
-        find(".db-section.--site-advice [data-test-site-advice-refresh]").click
+        find(".db-site-advice [data-test-site-advice-refresh]").click
         self
       end
 


### PR DESCRIPTION
This PR adds a "Site Advice" section to the redesigned admin dashboard that surfaces failing problem checks to staff.

<img width="1079" height="463" alt="CleanShot 2026-06-23 at 11 26 54" src="https://github.com/user-attachments/assets/b1a2a4dd-cf34-4f11-8fc7-3a973d3e08db" />

