### PR TITLE
PERF: Parallelize section loading in new dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -133,34 +133,19 @@ class Admin::DashboardController < Admin::StaffController
 
   def dashboard_sections_payload
     visible_ids = AdminDashboardSectionConfiguration.visible_section_ids
-    data = { sections: visible_ids.map { |id| { id: id, data: section_data(id) } } }
+    data = {
+      sections:
+        AdminDashboardSectionLoader.build(
+          section_ids: visible_ids,
+          current_user: current_user,
+          start_date: params[:start_date],
+          end_date: params[:end_date],
+        ),
+    }
     if current_user.admin?
       data[:configuration] = { sections: AdminDashboardSectionConfiguration.sections }
     end
     data
-  end
-
-  def section_data(id)
-    case id
-    when "highlights"
-      AdminDashboardHighlights.build(start_date: params[:start_date], end_date: params[:end_date])
-    when "traffic"
-      AdminDashboardSiteTraffic.build(
-        start_date: params[:start_date],
-        end_date: params[:end_date],
-        guardian: guardian,
-      )
-    when "engagement"
-      AdminDashboardEngagement.build(
-        start_date: params[:start_date],
-        end_date: params[:end_date],
-        current_user: current_user,
-      )
-    when "reports"
-      AdminDashboard::Reports::Section.build(guardian: guardian)
-    when "search"
-      AdminDashboardSearch.build(start_date: params[:start_date], end_date: params[:end_date])
-    end
   end
 
   def mark_new_features_as_seen

--- a/app/services/admin_dashboard_section_loader.rb
+++ b/app/services/admin_dashboard_section_loader.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class AdminDashboardSectionLoader
+  POOL_SIZE = 4
+
+  def self.build(section_ids:, current_user:, start_date:, end_date:)
+    new(
+      section_ids: section_ids,
+      current_user: current_user,
+      start_date: start_date,
+      end_date: end_date,
+    ).build
+  end
+
+  def self.thread_pool
+    @thread_pool ||=
+      Scheduler::ThreadPool.new(min_threads: 0, max_threads: POOL_SIZE, idle_time: 30)
+  end
+
+  def initialize(section_ids:, current_user:, start_date:, end_date:)
+    @section_ids = section_ids
+    @user_id = current_user.id
+    @start_date = start_date
+    @end_date = end_date
+    @locale = I18n.locale
+  end
+
+  def build
+    results = Queue.new
+
+    section_ids.each do |id|
+      self.class.thread_pool.post do
+        I18n.with_locale(locale) do
+          user = User.find(user_id)
+          results << { id: id, data: section_data(id, user) }
+        rescue StandardError => e
+          results << { id: id, error: e }
+        end
+      end
+    end
+
+    results_by_id = {}
+
+    section_ids.size.times do
+      result = results.pop
+      raise result[:error] if result[:error]
+
+      results_by_id[result[:id]] = result
+    end
+
+    section_ids.map { |id| results_by_id.fetch(id) }
+  end
+
+  private
+
+  attr_reader :section_ids, :user_id, :start_date, :end_date, :locale
+
+  def section_data(id, user)
+    case id
+    when "highlights"
+      AdminDashboardHighlights.build(start_date: start_date, end_date: end_date)
+    when "traffic"
+      AdminDashboardSiteTraffic.build(
+        start_date: start_date,
+        end_date: end_date,
+        guardian: user.guardian,
+      )
+    when "engagement"
+      AdminDashboardEngagement.build(start_date: start_date, end_date: end_date, current_user: user)
+    when "reports"
+      AdminDashboard::Reports::Section.build(guardian: user.guardian)
+    when "search"
+      AdminDashboardSearch.build(start_date: start_date, end_date: end_date)
+    end
+  end
+end

--- a/app/services/admin_dashboard_section_loader.rb
+++ b/app/services/admin_dashboard_section_loader.rb
@@ -19,10 +19,9 @@ class AdminDashboardSectionLoader
 
   def initialize(section_ids:, current_user:, start_date:, end_date:)
     @section_ids = section_ids
-    @user_id = current_user.id
+    @current_user = current_user
     @start_date = start_date
     @end_date = end_date
-    @locale = I18n.locale
   end
 
   def build
@@ -30,12 +29,9 @@ class AdminDashboardSectionLoader
 
     section_ids.each do |id|
       self.class.thread_pool.post do
-        I18n.with_locale(locale) do
-          user = User.find(user_id)
-          results << { id: id, data: section_data(id, user) }
-        rescue StandardError => e
-          results << { id: id, error: e }
-        end
+        results << { id: id, data: section_data(id, current_user) }
+      rescue StandardError => e
+        results << { id: id, error: e }
       end
     end
 
@@ -53,7 +49,7 @@ class AdminDashboardSectionLoader
 
   private
 
-  attr_reader :section_ids, :user_id, :start_date, :end_date, :locale
+  attr_reader :section_ids, :current_user, :start_date, :end_date
 
   def section_data(id, user)
     case id

--- a/app/services/admin_dashboard_section_loader.rb
+++ b/app/services/admin_dashboard_section_loader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AdminDashboardSectionLoader
-  POOL_SIZE = 4
+  POOL_SIZE = AdminDashboardSectionConfiguration::KNOWN_SECTIONS.size
 
   def self.build(section_ids:, current_user:, start_date:, end_date:)
     new(

--- a/spec/services/admin_dashboard_section_loader_spec.rb
+++ b/spec/services/admin_dashboard_section_loader_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe AdminDashboardSectionLoader do
+  fab!(:admin)
+
+  after do
+    if thread_pool = described_class.instance_variable_get(:@thread_pool)
+      thread_pool.shutdown
+      thread_pool.wait_for_termination(timeout: 1)
+      described_class.remove_instance_variable(:@thread_pool)
+    end
+  end
+
+  describe ".build" do
+    it "ensures the sections are built in order with current user and dates" do
+      AdminDashboardSiteTraffic
+        .expects(:build)
+        .with do |kwargs|
+          kwargs[:start_date] == "2026-05-01" && kwargs[:end_date] == "2026-05-07" &&
+            kwargs[:guardian].is_a?(Guardian) && kwargs[:guardian].user.id == admin.id
+        end
+        .returns({ value: "traffic" })
+      AdminDashboardEngagement
+        .expects(:build)
+        .with(start_date: "2026-05-01", end_date: "2026-05-07", current_user: admin)
+        .returns({ value: "engagement" })
+      AdminDashboardSearch
+        .expects(:build)
+        .with(start_date: "2026-05-01", end_date: "2026-05-07")
+        .returns({ value: "search" })
+
+      expect(
+        described_class.build(
+          section_ids: %w[traffic engagement search],
+          current_user: admin,
+          start_date: "2026-05-01",
+          end_date: "2026-05-07",
+        ),
+      ).to eq(
+        [
+          { id: "traffic", data: { value: "traffic" } },
+          { id: "engagement", data: { value: "engagement" } },
+          { id: "search", data: { value: "search" } },
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
Since we're loading different sections at once on the dash, it might make sense to load them in parallel.

| Metric | Current parallel | Baseline serial | Delta |
|---|---:|---:|---:|
| Runs | 2543, 1558, 1693, 1336, 1383 ms | 3104, 1985, 2147, 2428, 2372 ms |  |
| Min | 1336 ms | 1985 ms | -649 ms |
| Median | 1558 ms | 2372 ms | -814 ms (-34.3%) |
| Average | 1703 ms | 2407 ms | -704 ms (-29.2%) |
| Max | 2543 ms | 3104 ms | -561 ms |