### PR TITLE
FIX: improves author property

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/actor-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/actor-control.gjs
@@ -1,0 +1,86 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import ComboBox from "discourse/select-kit/components/combo-box";
+import UserChooser from "discourse/select-kit/components/user-chooser";
+import { i18n } from "discourse-i18n";
+import {
+  ACTOR_KIND,
+  actorKindForValue,
+  ANONYMOUS_ACTOR,
+  SYSTEM_ACTOR,
+} from "../../../lib/workflows/actor";
+import ExpressionWrapper from "./expression-wrapper";
+
+const KIND_OPTIONS = [
+  { id: ACTOR_KIND.system, name: i18n("discourse_workflows.actor.system") },
+  {
+    id: ACTOR_KIND.anonymous,
+    name: i18n("discourse_workflows.actor.anonymous"),
+  },
+  { id: ACTOR_KIND.user, name: i18n("discourse_workflows.actor.user") },
+];
+
+export default class ActorControl extends Component {
+  @tracked kind = actorKindForValue(this.args.field.value);
+
+  get showUserChooser() {
+    return this.kind === ACTOR_KIND.user;
+  }
+
+  get username() {
+    return this.args.field.value || null;
+  }
+
+  @action
+  handleKindChange(kind) {
+    this.kind = kind;
+
+    if (kind === ACTOR_KIND.system) {
+      this.args.field.set(SYSTEM_ACTOR);
+    } else if (kind === ACTOR_KIND.anonymous) {
+      this.args.field.set(ANONYMOUS_ACTOR);
+    } else {
+      const current = this.args.field.value;
+      this.args.field.set(
+        actorKindForValue(current) === ACTOR_KIND.user ? current : ""
+      );
+    }
+  }
+
+  @action
+  handleUserChange(usernames) {
+    this.args.field.set(usernames[0] || "");
+  }
+
+  <template>
+    <ExpressionWrapper
+      @field={{@field}}
+      @supportsExpression={{@supportsExpression}}
+      @placeholder={{@placeholder}}
+      @dynamicValueHint={{@dynamicValueHint}}
+      @session={{@session}}
+    >
+      <div class="workflows-actor-control">
+        <ComboBox
+          @content={{KIND_OPTIONS}}
+          @value={{this.kind}}
+          @nameProperty="name"
+          @valueProperty="id"
+          @onChange={{this.handleKindChange}}
+          class="workflows-actor-control__kind"
+        />
+
+        {{#if this.showUserChooser}}
+          <UserChooser
+            @value={{this.username}}
+            @onChange={{this.handleUserChange}}
+            @options={{hash maximum=1 excludeCurrentUser=false}}
+            class="workflows-actor-control__user"
+          />
+        {{/if}}
+      </div>
+    </ExpressionWrapper>
+  </template>
+}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/actor.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/actor.js
@@ -1,0 +1,20 @@
+export const SYSTEM_ACTOR = "system";
+export const ANONYMOUS_ACTOR = "anonymous";
+
+export const ACTOR_KIND = {
+  system: "system",
+  anonymous: "anonymous",
+  user: "user",
+};
+
+export function actorKindForValue(value) {
+  if (value === ANONYMOUS_ACTOR) {
+    return ACTOR_KIND.anonymous;
+  }
+
+  if (!value || value === SYSTEM_ACTOR) {
+    return ACTOR_KIND.system;
+  }
+
+  return ACTOR_KIND.user;
+}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/field-control-registry.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/field-control-registry.js
@@ -1,3 +1,4 @@
+import ActorControl from "../../components/workflows/configurators/actor-control";
 import BooleanControl from "../../components/workflows/configurators/boolean-control";
 import CategoryControl from "../../components/workflows/configurators/category-control";
 import CodeControl from "../../components/workflows/configurators/code-control";
@@ -23,6 +24,7 @@ import UserOrGroupControl from "../../components/workflows/configurators/user-or
 
 const FIELD_CONTROL_REGISTRY = {
   notice: { kind: "standalone", renderer: NoticeControl },
+  actor: { kind: "field", type: "custom", renderer: ActorControl },
   boolean: { kind: "standalone", renderer: BooleanControl },
   condition_builder: { kind: "standalone", renderer: ConditionBuilder },
   data_table_condition_builder: {

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
@@ -125,6 +125,8 @@ function dynamicValueKey(schema = {}, fieldName) {
   }
 
   switch (fieldControl(schema)) {
+    case "actor":
+      return "username";
     case "category":
       return "category_id";
     case "data_table_column_select":

--- a/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator.scss
@@ -262,3 +262,16 @@
 .workflows-code-control {
   width: 100%;
 }
+
+.workflows-actor-control {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  width: 100%;
+
+  .combo-box,
+  .user-chooser {
+    width: 100%;
+    min-width: 0;
+  }
+}

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -20,6 +20,10 @@ en:
             discourse_workflows_workflow_destroyed: "Delete workflow"
   js:
     discourse_workflows:
+      actor:
+        system: "System user"
+        anonymous: "Anonymous user"
+        user: "Specific user"
       node_unavailable:
         default: "This node is currently unavailable"
         short: "Unavailable"

--- a/plugins/discourse-workflows/config/locales/server.en.yml
+++ b/plugins/discourse-workflows/config/locales/server.en.yml
@@ -34,6 +34,8 @@ en:
       node_does_not_accept_inputs: "%{node} does not accept inputs."
       duplicate_node_names: "Node names must be unique within a workflow. Duplicates: %{names}"
       no_rows_matched_filter: "No rows matched the provided filter."
+      actor:
+        blank: "The user for '%{field}' resolved to a blank value."
       item:
         inconsistent_format_title: "Inconsistent item format"
         inconsistent_format: "Every returned item must use the same format."

--- a/plugins/discourse-workflows/lib/discourse_workflows/anonymous_actor.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/anonymous_actor.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DiscourseWorkflows
+  # Special "Performed by" actor that runs a node operation as a logged-out
+  # visitor. It is selected in the editor through the actor control and stored
+  # as the reserved username +USERNAME+.
+  class AnonymousActor < Guardian::AnonymousUser
+    USERNAME = "anonymous"
+
+    def id
+      nil
+    end
+
+    def username
+      USERNAME
+    end
+
+    def guardian
+      @guardian ||= Guardian.new
+    end
+  end
+end

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/actor_policy.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/actor_policy.rb
@@ -8,6 +8,7 @@ module DiscourseWorkflows
       end
 
       def ensure_allowed!(actor, field:, item_index:, source:, purpose:)
+        return true if actor.is_a?(DiscourseWorkflows::AnonymousActor)
         raise Discourse::InvalidAccess if actor.blank?
         raise Discourse::InvalidAccess if actor.staged?
         raise Discourse::InvalidAccess if actor.silenced?

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -260,7 +260,13 @@ module DiscourseWorkflows
 
       def actor_from_parameter(path, item_index = 0, default: "system")
         username = get_node_parameter(path, item_index, default: default)
-        actor_from(username: username.presence || default, field: path.to_s, item_index: item_index)
+
+        if username.blank?
+          raise DiscourseWorkflows::NodeError,
+                I18n.t("discourse_workflows.errors.actor.blank", field: path.to_s)
+        end
+
+        actor_from(username: username, field: path.to_s, item_index: item_index)
       end
 
       def actor_from(username: nil, id: nil, field: nil, item_index: nil)

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -270,7 +270,12 @@ module DiscourseWorkflows
       end
 
       def actor_from(username: nil, id: nil, field: nil, item_index: nil)
-        actor = find_user(username: username.presence, id: id)
+        actor =
+          if username == DiscourseWorkflows::AnonymousActor::USERNAME
+            DiscourseWorkflows::AnonymousActor.new
+          else
+            find_user(username: username.presence, id: id)
+          end
         ensure_actor_allowed!(actor, field: field, item_index: item_index)
         actor
       end
@@ -297,7 +302,9 @@ module DiscourseWorkflows
 
       def create_post(user:, raw:, topic_id:, reply_to_post_number: nil)
         topic = ::Topic.find(topic_id)
-        user.guardian.ensure_can_see!(topic)
+        guardian = user.guardian
+        guardian.ensure_can_see!(topic)
+        raise Discourse::InvalidAccess if !guardian.can_create_post?(topic)
 
         if topic.closed? || topic.archived?
           raise DiscourseWorkflows::NodeError,

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/badge/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/badge/v1.rb
@@ -56,7 +56,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
             },
           },
@@ -96,6 +96,7 @@ module DiscourseWorkflows
           user = exec_ctx.find_user(username: config["username"])
           badge = ::Badge.find(config["badge_id"])
           actor = exec_ctx.actor_from_parameter("actor_username", item_index)
+          raise Discourse::InvalidAccess if !actor.guardian.can_grant_badges?(user)
 
           case config["operation"]
           when "revoke"

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/group/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/group/v1.rb
@@ -61,7 +61,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
             },
           },

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
@@ -83,7 +83,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
               display_options: {
                 show: {
@@ -105,7 +105,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
               display_options: {
                 show: {
@@ -259,7 +259,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
               display_options: {
                 show: {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic/v1.rb
@@ -167,7 +167,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
             },
           },
@@ -301,7 +301,11 @@ module DiscourseWorkflows
           offset = [Integer(config["offset"] || 0), 0].max
           actor = exec_ctx.actor_from_parameter("actor_username", item_index)
           topic_query =
-            TopicQuery.new(actor, q: config["query"], per_page: [limit + offset, MAX_LIMIT].min)
+            TopicQuery.new(
+              actor.guardian.user,
+              q: config["query"],
+              per_page: [limit + offset, MAX_LIMIT].min,
+            )
           topic_list = topic_query.list_filter
 
           topics = topic_list.topics.slice(offset, limit) || []

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tags/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tags/v1.rb
@@ -43,7 +43,7 @@ module DiscourseWorkflows
               required: false,
               default: "system",
               ui: {
-                control: :user,
+                control: :actor,
               },
             },
           },

--- a/plugins/discourse-workflows/lib/discourse_workflows/property_schema_validator.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/property_schema_validator.rb
@@ -85,6 +85,7 @@ module DiscourseWorkflows
     ].freeze
 
     KNOWN_UI_CONTROLS = %i[
+      actor
       boolean
       category
       checkbox

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
@@ -701,6 +701,28 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
       resolver&.dispose
       sandbox&.dispose
     end
+
+    it "resolves the anonymous sentinel to an anonymous guardian actor" do
+      resolver_context = { "$json" => {} }
+      sandbox = DiscourseWorkflows::JsSandbox.new(resolver_context)
+      resolver = DiscourseWorkflows::ExpressionResolver.new(resolver_context, sandbox: sandbox)
+      ctx =
+        described_class.new(
+          input_items: [],
+          parameters: {
+            "actor_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
+          },
+          resolver: resolver,
+        )
+
+      actor = ctx.actor_from_parameter("actor_username")
+
+      expect(actor).to be_a(DiscourseWorkflows::AnonymousActor)
+      expect(actor.guardian.anonymous?).to eq(true)
+    ensure
+      resolver&.dispose
+      sandbox&.dispose
+    end
   end
 
   describe "#create_post" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
@@ -646,7 +646,19 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
       end
     end
 
-    it "falls back to the default actor for blank actor fields" do
+    it "defaults to the system user when the actor field is not configured" do
+      resolver_context = { "$json" => {} }
+      sandbox = DiscourseWorkflows::JsSandbox.new(resolver_context)
+      resolver = DiscourseWorkflows::ExpressionResolver.new(resolver_context, sandbox: sandbox)
+      ctx = described_class.new(input_items: [], parameters: {}, resolver: resolver)
+
+      expect(ctx.actor_from_parameter("actor_username")).to eq(Discourse.system_user)
+    ensure
+      resolver&.dispose
+      sandbox&.dispose
+    end
+
+    it "raises when a configured actor field resolves to a blank value" do
       resolver_context = { "$json" => {} }
       sandbox = DiscourseWorkflows::JsSandbox.new(resolver_context)
       resolver = DiscourseWorkflows::ExpressionResolver.new(resolver_context, sandbox: sandbox)
@@ -659,7 +671,32 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
           resolver: resolver,
         )
 
-      expect(ctx.actor_from_parameter("actor_username")).to eq(Discourse.system_user)
+      expect { ctx.actor_from_parameter("actor_username") }.to raise_error(
+        DiscourseWorkflows::NodeError,
+        I18n.t("discourse_workflows.errors.actor.blank", field: "actor_username"),
+      )
+    ensure
+      resolver&.dispose
+      sandbox&.dispose
+    end
+
+    it "raises when an actor expression resolves to a blank value" do
+      resolver_context = { "$json" => { "actor" => "" } }
+      sandbox = DiscourseWorkflows::JsSandbox.new(resolver_context)
+      resolver = DiscourseWorkflows::ExpressionResolver.new(resolver_context, sandbox: sandbox)
+      ctx =
+        described_class.new(
+          input_items: [{ "json" => { "actor" => "" } }],
+          parameters: {
+            "actor_username" => "={{ $json.actor }}",
+          },
+          resolver: resolver,
+        )
+
+      expect { ctx.actor_from_parameter("actor_username") }.to raise_error(
+        DiscourseWorkflows::NodeError,
+        I18n.t("discourse_workflows.errors.actor.blank", field: "actor_username"),
+      )
     ensure
       resolver&.dispose
       sandbox&.dispose

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/badge_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/badge_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe DiscourseWorkflows::Nodes::Badge::V1 do
           UserBadge.where(user: user, badge: badge).count
         }
       end
+
+      it "raises when granting as the anonymous actor" do
+        config = {
+          "operation" => "grant",
+          "username" => user.username,
+          "badge_id" => badge.id.to_s,
+          "actor_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
+        }
+
+        expect { execute_node(configuration: config, item: item) }.to raise_error(
+          Discourse::InvalidAccess,
+        ).and not_change { UserBadge.count }
+      end
     end
 
     context "with revoke operation" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
@@ -44,6 +44,23 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       )
     end
 
+    it "raises when creating a post as the anonymous actor" do
+      first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
+      topic = first_post.topic
+
+      expect do
+        execute_node(
+          configuration: {
+            "operation" => "create",
+            "topic_id" => topic.id.to_s,
+            "raw" => "Anonymous reply",
+            "author_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
+          },
+          item: item,
+        )
+      end.to raise_error(Discourse::InvalidAccess).and not_change { topic.posts.count }
+    end
+
     it "defaults to creating a post" do
       first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
       topic = first_post.topic
@@ -232,6 +249,23 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
             "operation" => "get",
             "post_id" => hidden_post.id.to_s,
             "actor_username" => other_user.username,
+          },
+          item: item,
+        )
+      end.to raise_error(Discourse::InvalidAccess)
+    end
+
+    it "raises when the anonymous actor cannot see the post" do
+      group = Fabricate(:group)
+      private_category = Fabricate(:private_category, group: group)
+      hidden_post = create_post(user: admin, category: private_category)
+
+      expect do
+        execute_node(
+          configuration: {
+            "operation" => "get",
+            "post_id" => hidden_post.id.to_s,
+            "actor_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
           },
           item: item,
         )

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_spec.rb
@@ -116,6 +116,20 @@ RSpec.describe DiscourseWorkflows::Nodes::Topic::V1 do
         expect(Topic.last.user_id).to eq(Discourse.system_user.id)
       end
 
+      it "does not create a topic as the anonymous actor" do
+        expect do
+          execute_node(
+            configuration: {
+              "operation" => "create",
+              "title" => "Anonymous topic",
+              "raw" => "Created by workflows",
+              "actor_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
+            },
+            item: item,
+          )
+        end.to raise_error(DiscourseWorkflows::NodeError).and not_change(Topic, :count)
+      end
+
       it "accepts tags from an array" do
         execute_node(
           configuration: {
@@ -320,6 +334,26 @@ RSpec.describe DiscourseWorkflows::Nodes::Topic::V1 do
           topic_1.id,
           topic_2.id,
         )
+      end
+
+      it "lists only publicly visible topics as the anonymous actor" do
+        group = Fabricate(:group)
+        private_category = Fabricate(:private_category, group: group)
+        private_topic = Fabricate(:topic, category: private_category, user: admin)
+        Fabricate(:post, topic: private_topic, user: admin)
+
+        result =
+          execute_list(
+            configuration: {
+              "operation" => "list",
+              "limit" => "50",
+              "actor_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
+            },
+          )
+
+        ids = result.map { |output_item| output_item["json"]["topic"]["id"] }
+        expect(ids).to include(topic_1.id, topic_2.id)
+        expect(ids).not_to include(private_topic.id)
       end
 
       it "respects the limit parameter" do
@@ -528,6 +562,21 @@ RSpec.describe DiscourseWorkflows::Nodes::Topic::V1 do
               "operation" => "close",
               "topic_id" => topic.id.to_s,
               "actor_username" => user.username,
+            },
+            item: item,
+          )
+        end.to raise_error(Discourse::InvalidAccess)
+
+        expect(topic.reload).not_to be_closed
+      end
+
+      it "raises when closing as the anonymous actor" do
+        expect do
+          execute_node(
+            configuration: {
+              "operation" => "close",
+              "topic_id" => topic.id.to_s,
+              "actor_username" => DiscourseWorkflows::AnonymousActor::USERNAME,
             },
             item: item,
           )

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe DiscourseWorkflows::NodeTypesController do
       expect(properties["editor_username"]).to include(
         "type" => "string",
         "default" => "system",
-        "ui" => include("control" => "user"),
+        "ui" => include("control" => "actor"),
       )
       expect(properties["categories"]["ui"]).to include("hidden" => true)
       expect(properties["advanced_filter"]["ui"]).to include("hidden" => true)

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/actor-control-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/actor-control-test.gjs
@@ -1,0 +1,105 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import ActorControl from "discourse/plugins/discourse-workflows/admin/components/workflows/configurators/actor-control";
+
+function fieldFor(value) {
+  return {
+    value,
+    set(newValue) {
+      this.value = newValue;
+    },
+  };
+}
+
+module("Integration | Component | workflows actor control", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    pretender.get("/u/search/users", () => response(200, { users: [] }));
+  });
+
+  test("defaults to the system kind without a user chooser", async function (assert) {
+    this.field = fieldFor("system");
+
+    await render(
+      <template>
+        <ActorControl @field={{this.field}} @supportsExpression={{false}} />
+      </template>
+    );
+
+    assert.dom(".workflows-actor-control__user").doesNotExist();
+    assert.strictEqual(
+      selectKit(".workflows-actor-control__kind").header().value(),
+      "system"
+    );
+  });
+
+  test("renders the anonymous kind without a user chooser", async function (assert) {
+    this.field = fieldFor("anonymous");
+
+    await render(
+      <template>
+        <ActorControl @field={{this.field}} @supportsExpression={{false}} />
+      </template>
+    );
+
+    assert.dom(".workflows-actor-control__user").doesNotExist();
+    assert.strictEqual(
+      selectKit(".workflows-actor-control__kind").header().value(),
+      "anonymous"
+    );
+  });
+
+  test("renders the user chooser for a specific username", async function (assert) {
+    this.field = fieldFor("alice");
+
+    await render(
+      <template>
+        <ActorControl @field={{this.field}} @supportsExpression={{false}} />
+      </template>
+    );
+
+    assert.dom(".workflows-actor-control__user").exists();
+    assert.strictEqual(
+      selectKit(".workflows-actor-control__kind").header().value(),
+      "user"
+    );
+  });
+
+  test("selecting the anonymous kind stores the anonymous sentinel", async function (assert) {
+    this.field = fieldFor("system");
+
+    await render(
+      <template>
+        <ActorControl @field={{this.field}} @supportsExpression={{false}} />
+      </template>
+    );
+
+    const kind = selectKit(".workflows-actor-control__kind");
+    await kind.expand();
+    await kind.selectRowByValue("anonymous");
+
+    assert.strictEqual(this.field.value, "anonymous");
+    assert.dom(".workflows-actor-control__user").doesNotExist();
+  });
+
+  test("switching to the specific-user kind reveals the user chooser", async function (assert) {
+    this.field = fieldFor("system");
+
+    await render(
+      <template>
+        <ActorControl @field={{this.field}} @supportsExpression={{false}} />
+      </template>
+    );
+
+    const kind = selectKit(".workflows-actor-control__kind");
+    await kind.expand();
+    await kind.selectRowByValue("user");
+
+    assert.dom(".workflows-actor-control__user").exists();
+    assert.strictEqual(this.field.value, "");
+  });
+});

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
@@ -89,6 +89,13 @@ module("Unit | Utility | workflows property engine", function () {
       }),
       "Must resolve to a username."
     );
+    assert.strictEqual(
+      propertyDynamicValueHint("action:group", "actor_username", {
+        type: "string",
+        ui: { control: "actor" },
+      }),
+      "Must resolve to a username."
+    );
   });
 
   test("supports plugin translation roots", function (assert) {


### PR DESCRIPTION
Currently a workflows would default on system for actions which is fine, but it would also fallback to system if the value would end up being blank for this property. In this case, it will now error, the actor is important enough to ensure this is an explicit choice.

On top of this change, we will now allow admin to choose "anonymous user" to perform their actions:

<img width="621" height="204" alt="Screenshot 2026-06-17 at 09 49 48" src="https://github.com/user-attachments/assets/9bd02dbd-316e-44bf-9018-fa0ef8af5f44" />

