### PR TITLE
FIX: Stop applying a color palette that is no longer user selectable

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -667,7 +667,11 @@ module ApplicationHelper
   def user_scheme_id
     return @user_scheme_id if defined?(@user_scheme_id)
     scheme_id = cookies[:color_scheme_id] || current_user&.user_option&.color_scheme_id
-    @user_scheme_id = scheme_id if scheme_id && ColorScheme.find_by_id(scheme_id)
+    @user_scheme_id = scheme_id if scheme_id &&
+      (
+        ColorScheme.exists?(id: scheme_id, user_selectable: true) ||
+          theme.color_scheme_id == scheme_id.to_i
+      )
   end
 
   def scheme_id
@@ -683,10 +687,18 @@ module ApplicationHelper
     @scheme_id = Theme.where(id: theme_id).pick(:color_scheme_id)
   end
 
+  def theme
+    @theme = theme_id ? Theme.find_by_id(theme_id) : Theme.find_default
+  end
+
   def user_dark_scheme_id
     return @user_dark_scheme_id if defined?(@user_dark_scheme_id)
     scheme_id = cookies[:dark_scheme_id] || current_user&.user_option&.dark_scheme_id
-    @user_dark_scheme_id = scheme_id if scheme_id && ColorScheme.find_by_id(scheme_id)
+    @user_dark_scheme_id = scheme_id if scheme_id &&
+      (
+        ColorScheme.exists?(id: scheme_id, user_selectable: true) ||
+          theme.dark_color_scheme_id == scheme_id.to_i
+      )
   end
 
   def dark_scheme_id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -697,7 +697,7 @@ module ApplicationHelper
     @user_dark_scheme_id = scheme_id if scheme_id &&
       (
         ColorScheme.exists?(id: scheme_id, user_selectable: true) ||
-          theme.dark_color_scheme_id == scheme_id.to_i
+          theme&.dark_color_scheme_id == scheme_id.to_i
       )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -670,7 +670,7 @@ module ApplicationHelper
     @user_scheme_id = scheme_id if scheme_id &&
       (
         ColorScheme.exists?(id: scheme_id, user_selectable: true) ||
-          theme.color_scheme_id == scheme_id.to_i
+          theme&.color_scheme_id == scheme_id.to_i
       )
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -860,13 +860,29 @@ RSpec.describe ApplicationHelper do
 
     context "with custom light scheme" do
       before do
-        @new_cs = Fabricate(:color_scheme, name: "Flamboyant")
+        @new_cs = Fabricate(:color_scheme, name: "Flamboyant", user_selectable: true)
         user.user_option.color_scheme_id = @new_cs.id
         user.user_option.save!
         helper.request.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY] = user
       end
 
       it "returns color scheme from user option value" do
+        color_stylesheets = helper.discourse_color_scheme_stylesheets
+        expect(color_stylesheets).to include("color_definitions_flamboyant")
+      end
+
+      it "falls back to base scheme when the scheme is no longer user selectable" do
+        @new_cs.update!(user_selectable: false)
+
+        color_stylesheets = helper.discourse_color_scheme_stylesheets
+        expect(color_stylesheets).not_to include("color_definitions_flamboyant")
+        expect(color_stylesheets).to include("color_definitions_light-default")
+      end
+
+      it "keeps a non-user-selectable scheme that is the theme's own color scheme" do
+        @new_cs.update!(user_selectable: false)
+        Theme.find_default.update!(color_scheme_id: @new_cs.id)
+
         color_stylesheets = helper.discourse_color_scheme_stylesheets
         expect(color_stylesheets).to include("color_definitions_flamboyant")
       end
@@ -895,7 +911,7 @@ RSpec.describe ApplicationHelper do
         user.user_option.interface_color_mode = UserOption::LIGHT_MODE
         user.user_option.save!
         helper.request.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY] = user
-        @new_cs = Fabricate(:color_scheme, name: "Custom Color Scheme")
+        @new_cs = Fabricate(:color_scheme, name: "Custom Color Scheme", user_selectable: true)
 
         Theme.find_default.update!(dark_color_scheme_id: ColorScheme.where(name: "Dark").pick(:id))
       end
@@ -976,12 +992,12 @@ RSpec.describe ApplicationHelper do
 
   describe "#discourse_theme_color_meta_tags" do
     before do
-      light = Fabricate(:color_scheme)
+      light = Fabricate(:color_scheme, user_selectable: true)
       light.color_scheme_colors << ColorSchemeColor.new(name: "header_background", hex: "abcdef")
       light.save!
       helper.request.cookies["color_scheme_id"] = light.id
 
-      dark = Fabricate(:color_scheme)
+      dark = Fabricate(:color_scheme, user_selectable: true)
       dark.color_scheme_colors << ColorSchemeColor.new(name: "header_background", hex: "defabc")
       dark.save!
       helper.request.cookies["dark_scheme_id"] = dark.id
@@ -1035,7 +1051,7 @@ RSpec.describe ApplicationHelper do
     end
 
     it "renders a 'light dark' color-scheme if a dark scheme is set" do
-      dark = Fabricate(:color_scheme)
+      dark = Fabricate(:color_scheme, user_selectable: true)
       dark.save!
       helper.request.cookies["dark_scheme_id"] = dark.id
 
@@ -1046,8 +1062,8 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#dark_scheme_id" do
-    fab!(:dark_scheme, :color_scheme)
-    fab!(:light_scheme, :color_scheme)
+    fab!(:dark_scheme) { Fabricate(:color_scheme, user_selectable: true) }
+    fab!(:light_scheme) { Fabricate(:color_scheme, user_selectable: true) }
 
     before do
       helper.request.cookies["color_scheme_id"] = light_scheme.id

--- a/spec/system/admin_color_palette_config_area_spec.rb
+++ b/spec/system/admin_color_palette_config_area_spec.rb
@@ -160,6 +160,7 @@ describe "Admin Color Palette Config Area Page" do
   end
 
   it "applies the changes live when editing the currently active palette" do
+    color_scheme.update!(user_selectable: true)
     admin.user_option.update!(color_scheme_id: color_scheme.id)
     config_area.visit(color_scheme.id)
     config_area.color_palette_editor.input_for_color("secondary").fill_in(with: "#aa339f")

--- a/spec/system/admin_color_palettes_config_area_spec.rb
+++ b/spec/system/admin_color_palettes_config_area_spec.rb
@@ -248,7 +248,7 @@ describe "Admin Color Palettes Config Area Page" do
     end
 
     it "shows toast when admin cannot see live preview" do
-      custom_scheme = Fabricate(:color_scheme, name: "Custom Scheme")
+      custom_scheme = Fabricate(:color_scheme, name: "Custom Scheme", user_selectable: true)
       admin.user_option.update!(
         theme_ids: [Theme.find_default.id],
         color_scheme_id: custom_scheme.id,

--- a/spec/system/interface_color_selector_spec.rb
+++ b/spec/system/interface_color_selector_spec.rb
@@ -64,6 +64,7 @@ describe "Interface color selector" do
   end
 
   it "is not available if the user uses the same scheme for dark mode as the light mode" do
+    light_scheme.update!(user_selectable: true)
     user.user_option.update!(color_scheme_id: light_scheme.id, dark_scheme_id: light_scheme.id)
     sign_in(user)
 


### PR DESCRIPTION
Previously, when an admin removed a color palette as user selectable, users who had previously selected it stayed stuck on it instead of reverting to the default.

This change makes `user_scheme_id` and `user_dark_scheme_id` only honor a stored palette when it is still user selectable or is the theme's own light/dark scheme, so an unselectable palette falls back to the default while keeping the user's saved preference if it becomes selectable again.