### PR TITLE
FEATURE: preserve branding asset uploads

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -5,6 +5,17 @@ require "fastimage"
 class UploadCreator
   TYPES_TO_CROP = %w[avatar card_background custom_emoji profile_background].each(&:freeze)
 
+  ADMIN_ASSET_TYPES = %w[
+    badge_image
+    branding
+    custom_emoji
+    category_background
+    category_background_dark
+    category_logo
+    category_logo_dark
+    group_flair
+  ].each(&:freeze)
+
   ALLOWED_SVG_ELEMENTS = %w[
     circle
     clipPath
@@ -357,7 +368,7 @@ class UploadCreator
   end
 
   def convert_to_jpeg!
-    return if @opts[:for_site_setting]
+    return if @opts[:for_site_setting] || ADMIN_ASSET_TYPES.include?(@opts[:type])
     return if filesize < MIN_CONVERT_TO_JPEG_BYTES_SAVED
 
     jpeg_tempfile = Tempfile.new(%w[image .jpg])

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -215,20 +215,18 @@ RSpec.describe UploadCreator do
         expect(upload.original_filename).to eq("large_and_unoptimized.png")
       end
 
-      UploadCreator::ADMIN_ASSET_TYPES.each do |type|
-        it "should not convert to jpeg when the image is a #{type} asset" do
-          upload =
-            UploadCreator.new(
-              large_file,
-              large_filename,
-              type: type,
-              force_optimize: true,
-            ).create_for(admin.id)
+      it "should not convert to jpeg for admin asset upload types" do
+        upload =
+          UploadCreator.new(
+            large_file,
+            large_filename,
+            type: "branding",
+            force_optimize: true,
+          ).create_for(admin.id)
 
-          expect(upload.extension).to eq("png")
-          expect(File.extname(upload.url)).to eq(".png")
-          expect(upload.original_filename).to eq("large_and_unoptimized.png")
-        end
+        expect(upload.extension).to eq("png")
+        expect(File.extname(upload.url)).to eq(".png")
+        expect(upload.original_filename).to eq("large_and_unoptimized.png")
       end
 
       context "with jpeg image quality settings" do

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -215,6 +215,22 @@ RSpec.describe UploadCreator do
         expect(upload.original_filename).to eq("large_and_unoptimized.png")
       end
 
+      UploadCreator::ADMIN_ASSET_TYPES.each do |type|
+        it "should not convert to jpeg when the image is a #{type} asset" do
+          upload =
+            UploadCreator.new(
+              large_file,
+              large_filename,
+              type: type,
+              force_optimize: true,
+            ).create_for(admin.id)
+
+          expect(upload.extension).to eq("png")
+          expect(File.extname(upload.url)).to eq(".png")
+          expect(upload.original_filename).to eq("large_and_unoptimized.png")
+        end
+      end
+
       context "with jpeg image quality settings" do
         before do
           SiteSetting.png_to_jpg_quality = 75


### PR DESCRIPTION
Prevents converting PNG uploads to JPG when a site admin uploads branding assets like site logos, custom emojis, badges, group flair etc.