### PR TITLE
PERF: cache list of active nodes

### DIFF
--- a/plugins/discourse-workflows/app/models/discourse_workflows/workflow_dependency.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/workflow_dependency.rb
@@ -5,6 +5,7 @@ module DiscourseWorkflows
     self.table_name = "discourse_workflows_workflow_dependencies"
 
     TOPIC_ADMIN_BUTTON_CACHE_KEY = "topic_admin_buttons"
+    ACTIVE_NODE_TYPES_KEY = "active_node_types"
 
     belongs_to :workflow, class_name: "DiscourseWorkflows::Workflow"
     belongs_to :workflow_version,
@@ -39,6 +40,20 @@ module DiscourseWorkflows
               icon: NodeData.parameters(published_trigger.trigger_node)["icon"],
             }
           end
+      end
+    end
+
+    def self.active_node_types
+      cache.defer_get_set(ACTIVE_NODE_TYPES_KEY) do
+        of_type("node_type")
+          .joins(:workflow)
+          .where(
+            "discourse_workflows_workflow_dependencies.workflow_version_id = " \
+              "discourse_workflows_workflows.active_version_id",
+          )
+          .distinct
+          .pluck(:dependency_key)
+          .to_set
       end
     end
 

--- a/plugins/discourse-workflows/app/models/discourse_workflows/workflow_dependency.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/workflow_dependency.rb
@@ -55,6 +55,7 @@ module DiscourseWorkflows
           .distinct
           .pluck(:dependency_key)
           .to_set
+      end
     end
 
     def self.cached_user_modals?

--- a/plugins/discourse-workflows/lib/discourse_workflows/event_listener.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/event_listener.rb
@@ -4,6 +4,7 @@ module DiscourseWorkflows
   class EventListener
     def self.handle(trigger_class, *args)
       return unless SiteSetting.discourse_workflows_enabled
+      return if WorkflowDependency.active_node_types.exclude?(trigger_class.identifier)
 
       trigger = trigger_class.new(*args)
       return unless trigger.valid?

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/event_listener_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/event_listener_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe DiscourseWorkflows::EventListener do
   fab!(:topic) { Fabricate(:topic, category: category) }
   fab!(:tag) { Fabricate(:tag, name: "matched") }
 
-  before { SiteSetting.tagging_enabled = true }
+  before do
+    SiteSetting.tagging_enabled = true
+    DiscourseWorkflows::WorkflowDependency.clear_cache!
+  end
 
   it "enqueues a job when a matching event fires" do
     graph = build_workflow_graph { |g| g.node "trigger-1", "trigger:topic_closed" }
@@ -217,6 +220,21 @@ RSpec.describe DiscourseWorkflows::EventListener do
     described_class.handle(DiscourseWorkflows::Nodes::PostEdited::V1, post, "<p>Cooked</p>")
 
     expect(enqueued_trigger_node_ids).not_to include("first-post-only")
+  end
+
+  it "does not query the dependencies table when no live workflow uses the fired trigger type" do
+    create_published_workflow("closed-trigger", "trigger:topic_closed")
+    DiscourseWorkflows::WorkflowDependency.active_node_types # warm the cache
+
+    queries =
+      track_sql_queries do
+        described_class.handle(DiscourseWorkflows::Nodes::TopicCreated::V1, topic)
+      end
+
+    dependency_queries =
+      queries.select { |sql| sql.include?("discourse_workflows_workflow_dependencies") }
+    expect(dependency_queries).to be_empty
+    expect(enqueued_trigger_node_ids).to be_empty
   end
 
   def create_published_workflow(trigger_node_id, trigger_type, configuration: {})

--- a/plugins/discourse-workflows/spec/models/discourse_workflows/workflow_dependency_spec.rb
+++ b/plugins/discourse-workflows/spec/models/discourse_workflows/workflow_dependency_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe DiscourseWorkflows::WorkflowDependency do
     it "excludes node types that only exist in an unpublished workflow" do
       graph = build_workflow_graph { |g| g.node "trigger-1", "trigger:topic_closed" }
       Fabricate(:discourse_workflows_workflow, created_by: user, **graph)
+
+      expect(described_class.active_node_types).not_to include("trigger:topic_closed")
     end
   end
 

--- a/plugins/discourse-workflows/spec/models/discourse_workflows/workflow_dependency_spec.rb
+++ b/plugins/discourse-workflows/spec/models/discourse_workflows/workflow_dependency_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::WorkflowDependency do
+  fab!(:user)
+
+  before { described_class.clear_cache! }
+  after { described_class.clear_cache! }
+
+  describe ".active_node_types" do
+    it "returns the node types referenced by the active version of a published workflow" do
+      graph = build_workflow_graph { |g| g.node "trigger-1", "trigger:topic_closed" }
+      Fabricate(:discourse_workflows_workflow, created_by: user, published: true, **graph)
+
+      expect(described_class.active_node_types).to include("trigger:topic_closed")
+    end
+
+    it "excludes node types that only exist in an unpublished workflow" do
+      graph = build_workflow_graph { |g| g.node "trigger-1", "trigger:topic_closed" }
+      Fabricate(:discourse_workflows_workflow, created_by: user, **graph)
+
+      expect(described_class.active_node_types).not_to include("trigger:topic_closed")
+    end
+  end
+end


### PR DESCRIPTION
This cache prevents fetching active triggers for each discourse event we support even if they are never used.