### PR TITLE
DEV: Restore `data-test-*` stripping

### DIFF
--- a/frontend/asset-processor/package.json
+++ b/frontend/asset-processor/package.json
@@ -33,6 +33,7 @@
     "postcss-nesting": "^14.0.0",
     "rolldown": "1.0.3",
     "source-map-js": "^1.2.1",
+    "strip-test-selectors": "^0.1.0",
     "terser": "^5.47.1"
   },
   "engines": {

--- a/frontend/asset-processor/theme-rollup.js
+++ b/frontend/asset-processor/theme-rollup.js
@@ -6,6 +6,7 @@ import DecoratorTransforms from "decorator-transforms";
 import colocatedBabelPlugin from "ember-cli-htmlbars/lib/colocated-babel-plugin";
 import { precompile } from "ember-source/ember-template-compiler/index.js";
 import EmberThisFallback from "ember-this-fallback";
+import StripTestSelectorsPlugin from "strip-test-selectors/src/strip-test-selectors";
 import { browsers } from "../discourse/config/targets";
 import babelTransformModuleRenames from "../discourse/lib/babel-transform-module-renames";
 import AddThemeGlobals from "./add-theme-globals";
@@ -92,6 +93,7 @@ async function performRollup(modules, opts) {
                 }).plugin,
                 buildEmberTemplateManipulatorPlugin(opts.themeId),
                 transformActionSyntax,
+                ...(opts.minify ? [StripTestSelectorsPlugin] : []),
               ],
             },
           ],

--- a/frontend/discourse/babel.config.cjs
+++ b/frontend/discourse/babel.config.cjs
@@ -1,4 +1,5 @@
 const { buildMacros } = require("@embroider/macros/babel");
+const StripTestSelectors = require("strip-test-selectors");
 
 const macros = buildMacros({
   configure(macrosConfig) {
@@ -7,6 +8,8 @@ const macros = buildMacros({
     });
   },
 });
+
+const PRODUCTION = process.env.EMBER_ENV === "production";
 
 module.exports = {
   plugins: [
@@ -19,7 +22,10 @@ module.exports = {
           "ember-cli-htmlbars-inline-precompile",
           "htmlbars-inline-precompile",
         ],
-        transforms: [...macros.templateMacros],
+        transforms: [
+          ...macros.templateMacros,
+          ...(PRODUCTION ? [StripTestSelectors] : []),
+        ],
       },
     ],
     [
@@ -45,13 +51,13 @@ module.exports = {
           {
             source: "@glimmer/env",
             flags: {
-              DEBUG: process.env.EMBER_ENV !== "production",
+              DEBUG: !PRODUCTION,
               CI: !!process.env.CI,
             },
           },
         ],
         debugTools: {
-          isDebug: process.env.EMBER_ENV !== "production",
+          isDebug: !PRODUCTION,
           source: "@ember/debug",
           assertPredicateIndex: 1,
         },

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -99,7 +99,8 @@
     "rete-connection-plugin": "^2.0.5",
     "rete-history-plugin": "^2.1.1",
     "rete-render-utils": "^2.0.3",
-    "rrule": "^2.8.1"
+    "rrule": "^2.8.1",
+    "strip-test-selectors": "^0.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/lib/asset_processor.rb
+++ b/lib/asset_processor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AssetProcessor
-  BASE_COMPILER_VERSION = 110
+  BASE_COMPILER_VERSION = 111
 
   PROCESSOR_DIR = "tmp/asset-processor"
   LOCK_FILE = "#{PROCESSOR_DIR}/build.lock"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       source-map-js:
         specifier: ^1.2.1
         version: 1.2.1
+      strip-test-selectors:
+        specifier: ^0.1.0
+        version: 0.1.0
       terser:
         specifier: ^5.47.1
         version: 5.48.0
@@ -420,6 +423,9 @@ importers:
       rrule:
         specifier: ^2.8.1
         version: 2.8.1
+      strip-test-selectors:
+        specifier: ^0.1.0
+        version: 0.1.0
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -7350,6 +7356,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-test-selectors@0.1.0:
+    resolution: {integrity: sha512-wkVYph30L7wYkMf5EypfTqhY4qZwmQ0hpFOTksaXne49YbUr2jenJl5w5yj9IWx3ojtoH9BGAQ7cShnYEzbs5g==}
 
   stubborn-fs@2.0.0:
     resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
@@ -15939,6 +15948,8 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-test-selectors@0.1.0: {}
 
   stubborn-fs@2.0.0:
     dependencies:

--- a/spec/lib/asset_processor_spec.rb
+++ b/spec/lib/asset_processor_spec.rb
@@ -192,6 +192,28 @@ RSpec.describe AssetProcessor do
       )
     end
 
+    it "strips data-test-* attributes in production mode" do
+      script = <<~JS.chomp
+        export default class Foo {
+          <template>
+            <div data-test-my-element class="keep">hello</div>
+          </template>
+        }
+      JS
+
+      modules = { "discourse/components/foo.gjs" => script }
+      entrypoints = { main: { modules: ["discourse/components/foo.gjs"] } }
+
+      unminified = AssetProcessor.new.rollup(modules, { themeId: 22, entrypoints: entrypoints })
+      expect(entrypoint(unminified, "main")["code"]).to include("data-test-my-element")
+
+      minified =
+        AssetProcessor.new.rollup(modules, { minify: true, themeId: 22, entrypoints: entrypoints })
+      code = entrypoint(minified, "main")["code"]
+      expect(code).not_to include("data-test-my-element")
+      expect(code).to include("keep")
+    end
+
     it "can use themePrefix not in a template" do
       script = <<~JS.chomp
         export default function foo() {


### PR DESCRIPTION
Since we moved to rolldown, the ember-test-selectors addon was removed. This commit restores the `strip-test-selectors`, which is the functional part of that addon, without the ember-cli scaffolding.

This is added to the core build and to theme/plugin builds.