### PR TITLE
DEV: add type:group

### DIFF
--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -46,6 +46,7 @@ const CUSTOM_TYPES = [
   "secret_list",
   "upload",
   "group_list",
+  "group",
   "tag_list",
   "tag_group_list",
   "color",

--- a/frontend/discourse/admin/components/site-settings/group.gjs
+++ b/frontend/discourse/admin/components/site-settings/group.gjs
@@ -1,0 +1,36 @@
+/* eslint-disable ember/no-classic-components */
+import Component from "@ember/component";
+import { hash } from "@ember/helper";
+import { action, computed } from "@ember/object";
+import { tagName } from "@ember-decorators/component";
+import ComboBox from "discourse/select-kit/components/combo-box";
+
+@tagName("")
+export default class Group extends Component {
+  @computed("site.groups", "setting.disallowed_groups")
+  get groupChoices() {
+    const disallowed = (this.setting?.disallowed_groups || "")
+      .split("|")
+      .filter(Boolean);
+
+    return (this.site.groups || [])
+      .filter((g) => !disallowed.includes(g.id.toString()))
+      .map((g) => ({ name: g.name, id: g.id.toString() }));
+  }
+
+  @action
+  onChange(value) {
+    this.changeValueCallback?.(value ?? "");
+  }
+
+  <template>
+    <div ...attributes>
+      <ComboBox
+        @value={{@value}}
+        @content={{this.groupChoices}}
+        @onChange={{this.onChange}}
+        @options={{hash clearable=true}}
+      />
+    </div>
+  </template>
+}

--- a/frontend/discourse/tests/integration/components/site-settings/group-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-settings/group-test.gjs
@@ -1,0 +1,126 @@
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import SiteSettingComponent from "discourse/admin/components/site-setting";
+import SiteSetting from "discourse/admin/models/site-setting";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+
+module("Integration | Component | group site-setting", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("default", async function (assert) {
+    this.site.groups = [
+      {
+        id: 1,
+        name: "Donuts",
+      },
+      {
+        id: 2,
+        name: "Cheese cake",
+      },
+    ];
+
+    this.set(
+      "setting",
+      SiteSetting.create({
+        category: "foo",
+        default: "",
+        description: "Choose a group",
+        placeholder: null,
+        preview: null,
+        secret: false,
+        setting: "foo_bar",
+        type: "group",
+        value: "1",
+      })
+    );
+
+    await render(
+      <template><SiteSettingComponent @setting={{this.setting}} /></template>
+    );
+
+    const subject = selectKit(".combo-box");
+
+    assert.strictEqual(
+      subject.header().value(),
+      "1",
+      "it selects the setting's value"
+    );
+
+    await subject.expand();
+    await subject.selectRowByValue("2");
+
+    assert.strictEqual(
+      subject.header().value(),
+      "2",
+      "it allows selecting a single group from the list of choices"
+    );
+    assert.strictEqual(
+      this.setting.buffered.get("value"),
+      "2",
+      "it stores the selected group id as a string"
+    );
+
+    await click(subject.header().el().querySelector(".btn-clear"));
+
+    assert.strictEqual(
+      this.setting.buffered.get("value"),
+      "",
+      "clearing the selection stores an empty string"
+    );
+  });
+
+  test("disallowed groups", async function (assert) {
+    this.site.groups = [
+      {
+        id: 0,
+        name: "everyone",
+      },
+      {
+        id: 1,
+        name: "Donuts",
+      },
+      {
+        id: 2,
+        name: "Cheese cake",
+      },
+    ];
+
+    this.set(
+      "setting",
+      SiteSetting.create({
+        category: "foo",
+        default: "",
+        description: "Choose a group",
+        placeholder: null,
+        preview: null,
+        secret: false,
+        setting: "foo_bar",
+        type: "group",
+        disallowed_groups: "0",
+        value: "",
+      })
+    );
+
+    await render(
+      <template><SiteSettingComponent @setting={{this.setting}} /></template>
+    );
+
+    const subject = selectKit(".combo-box");
+
+    await subject.expand();
+
+    assert.false(
+      subject.rowByValue("0").exists(),
+      "disallowed group is not in the list"
+    );
+    assert.true(
+      subject.rowByValue("1").exists(),
+      "allowed group is in the list"
+    );
+    assert.true(
+      subject.rowByValue("2").exists(),
+      "allowed group is in the list"
+    );
+  });
+});

--- a/lib/validators/group_setting_validator.rb
+++ b/lib/validators/group_setting_validator.rb
@@ -6,7 +6,10 @@ class GroupSettingValidator
   end
 
   def valid_value?(val)
-    val.blank? || Group.exists?(name: val)
+    return true if val.blank?
+
+    group_id = Integer(val, exception: false)
+    (group_id.present? && Group.exists?(id: group_id)) || Group.exists?(name: val)
   end
 
   def error_message

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1425,6 +1425,27 @@ RSpec.describe SiteSettingExtension do
     end
   end
 
+  describe "group settings" do
+    fab!(:group)
+
+    it "stores a valid group id as a string" do
+      settings.setting(:test_group_setting, "", type: :group)
+      settings.test_group_setting = group.id.to_s
+      expect(settings.test_group_setting).to eq(group.id.to_s)
+    end
+
+    it "rejects a value that does not match an existing group" do
+      settings.setting(:test_group_setting, "", type: :group)
+      expect { settings.test_group_setting = "-9999" }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "allows a blank value" do
+      settings.setting(:test_group_setting, "", type: :group)
+      settings.test_group_setting = ""
+      expect(settings.test_group_setting).to eq("")
+    end
+  end
+
   describe "requires_confirmation settings" do
     it "returns 'simple' for settings that require confirmation with 'simple' type" do
       expect(

--- a/spec/lib/validators/group_setting_validator_spec.rb
+++ b/spec/lib/validators/group_setting_validator_spec.rb
@@ -4,17 +4,26 @@ RSpec.describe GroupSettingValidator do
   describe "#valid_value?" do
     subject(:validator) { described_class.new }
 
+    fab!(:group) { Fabricate(:group, name: "hello") }
+
     it "returns true for blank values" do
       expect(validator.valid_value?("")).to eq(true)
       expect(validator.valid_value?(nil)).to eq(true)
     end
 
-    it "returns true if value matches an existing group" do
-      Fabricate(:group, name: "hello")
-      expect(validator.valid_value?("hello")).to eq(true)
+    it "returns true if value matches an existing group id" do
+      expect(validator.valid_value?(group.id.to_s)).to eq(true)
     end
 
-    it "returns false if value does not match a group" do
+    it "returns true if value matches an existing group name" do
+      expect(validator.valid_value?(group.name)).to eq(true)
+    end
+
+    it "returns false if value does not match a group id" do
+      expect(validator.valid_value?("-9999")).to eq(false)
+    end
+
+    it "returns false for a non-numeric value that does not match a group name" do
       expect(validator.valid_value?("notagroup")).to eq(false)
     end
   end


### PR DESCRIPTION
Allows the use of `type:group` in plugins to select only 1 group in the UI:
```
  some_group:
    default: ""
    type: "group"
```

<img width="712" height="108" alt="CleanShot 2026-06-17 at 12 59 40" src="https://github.com/user-attachments/assets/36d328e9-3a3b-4e01-b6f1-a754b8657114" />
