### PR TITLE
UI: Toggle the copy of the tooltip based on the state of post cooked

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5044,6 +5044,8 @@ en:
       originally_written_in: "Originally in %{language}"
       click_to_show_original: "Click to show original"
       tap_to_show_original: "Tap here to show original"
+      click_to_show_translation: "Click to show translation"
+      tap_to_show_translation: "Tap here to show translation"
       ai_translation_disclaimer: "AI-generated translations may be inaccurate."
 
     category:

--- a/frontend/discourse/app/components/post/meta-data/language.gjs
+++ b/frontend/discourse/app/components/post/meta-data/language.gjs
@@ -6,6 +6,7 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class PostMetaDataLanguage extends Component {
@@ -22,6 +23,10 @@ export default class PostMetaDataLanguage extends Component {
     return this.args.post?.localization_outdated;
   }
 
+  get showingOriginal() {
+    return !!this.args.post?.localizedCooked;
+  }
+
   get tooltipText() {
     const i18nKey = this.outdated
       ? "post.original_language_and_outdated"
@@ -33,6 +38,12 @@ export default class PostMetaDataLanguage extends Component {
   }
 
   get translatePrompt() {
+    if (this.showingOriginal) {
+      return this.site.mobileView
+        ? i18n("post.tap_to_show_translation")
+        : i18n("post.click_to_show_translation");
+    }
+
     return this.site.mobileView
       ? i18n("post.tap_to_show_original")
       : i18n("post.click_to_show_original");
@@ -62,34 +73,37 @@ export default class PostMetaDataLanguage extends Component {
 
   <template>
     <div class="post-info post-language">
-      <PluginOutlet
-        @name="post-language-indicator"
-        @outletArgs={{lazyHash
-          post=@post
-          language=this.language
-          outdated=this.outdated
-          tooltipText=this.tooltipText
-          translate=this.translate
-        }}
+      <DTooltip
+        class={{if this.outdated "heatmap-low"}}
+        @identifier="post-language"
+        {{on "click" this.translateOnDesktop}}
       >
-        <DTooltip
-          class={{if this.outdated "heatmap-low"}}
-          @identifier="post-language"
-          @icon="language"
-          {{on "click" this.translateOnDesktop}}
-        >
-          <:content>
-            <button
-              type="button"
-              class="post-language__original-language"
-              {{on "click" this.translate}}
-            >{{this.tooltipText}}</button>
-            <div class="post-language__disclaimer">{{i18n
-                "post.ai_translation_disclaimer"
-              }}</div>
-          </:content>
-        </DTooltip>
-      </PluginOutlet>
+        <:trigger>
+          <PluginOutlet
+            @name="post-language-indicator"
+            @outletArgs={{lazyHash
+              post=@post
+              language=this.language
+              outdated=this.outdated
+              showingOriginal=this.showingOriginal
+              tooltipText=this.tooltipText
+              translate=this.translate
+            }}
+          >
+            <span class="fk-d-tooltip__icon">{{dIcon "language"}}</span>
+          </PluginOutlet>
+        </:trigger>
+        <:content>
+          <button
+            type="button"
+            class="post-language__original-language"
+            {{on "click" this.translate}}
+          >{{this.tooltipText}}</button>
+          <div class="post-language__disclaimer">{{i18n
+              "post.ai_translation_disclaimer"
+            }}</div>
+        </:content>
+      </DTooltip>
     </div>
   </template>
 }

--- a/frontend/discourse/tests/integration/components/post/post-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/post-test.gjs
@@ -337,6 +337,14 @@ module("Integration | Component | Post", function (hooks) {
       "content is switched to original"
     );
 
+    await triggerEvent(".fk-d-tooltip__trigger", "pointermove");
+    assert
+      .dom(".post-language")
+      .includesText(
+        i18n("post.click_to_show_translation"),
+        "prompt invites showing the translation while the original is shown"
+      );
+
     await click(".fk-d-tooltip__trigger");
 
     assert.strictEqual(
@@ -344,6 +352,14 @@ module("Integration | Component | Post", function (hooks) {
       "<p>Translated post</p>",
       "content is switched back to translated"
     );
+
+    await triggerEvent(".fk-d-tooltip__trigger", "pointermove");
+    assert
+      .dom(".post-language")
+      .includesText(
+        i18n("post.click_to_show_original"),
+        "prompt invites showing the original while the translation is shown"
+      );
   });
 
   test("language indicator plugin outlet can render content before and after the icon", async function (assert) {
@@ -364,22 +380,82 @@ module("Integration | Component | Post", function (hooks) {
 
     await renderComponent(this.post);
 
-    const before = document.querySelector(".language-before");
-    const trigger = document.querySelector(".fk-d-tooltip__trigger");
-    const after = document.querySelector(".language-after");
-
-    assert.dom(before).hasText("Before English (US)");
-    assert.dom(trigger).exists("core language icon renders");
-    assert.dom(after).hasText("After English (US)");
+    assert
+      .dom(".fk-d-tooltip__trigger .language-before")
+      .hasText("Before English (US)");
+    assert
+      .dom(".fk-d-tooltip__trigger .fk-d-tooltip__icon")
+      .exists("core language icon renders");
+    assert
+      .dom(".fk-d-tooltip__trigger .language-after")
+      .hasText("After English (US)");
     assert.deepEqual(
       Array.from(
         document.querySelectorAll(
-          ".language-before, .fk-d-tooltip__trigger, .language-after"
+          ".fk-d-tooltip__trigger .language-before, .fk-d-tooltip__trigger .fk-d-tooltip__icon, .fk-d-tooltip__trigger .language-after"
         )
       ).map((element) => element.classList[0]),
-      ["language-before", "fk-d-tooltip__trigger", "language-after"],
-      "connectors render around the icon"
+      ["language-before", "fk-d-tooltip__icon", "language-after"],
+      "connectors render around the icon inside the clickable trigger"
     );
+  });
+
+  test("language indicator outlet content toggles the post when clicked", async function (assert) {
+    registerTemporaryModule(
+      "discourse/plugins/test-plugin/templates/connectors/post-language-indicator__before/label-before",
+      hbs`<span class="language-before">Before {{@outletArgs.language}}</span>`
+    );
+
+    this.post.is_localized = true;
+    this.post.language = "en";
+    this.post.cooked = "<p>Translated post</p>";
+    this.siteSettings.available_locales = [
+      { value: "en", name: "English (US)" },
+    ];
+
+    pretender.get(`/posts/${this.post.id}/cooked.json`, () =>
+      response({ cooked: "<p>Original post</p>" })
+    );
+
+    await renderComponent(this.post);
+
+    await click(".fk-d-tooltip__trigger .language-before");
+
+    assert.strictEqual(
+      this.post.cooked,
+      "<p>Original post</p>",
+      "clicking the injected outlet item toggles to the original"
+    );
+  });
+
+  test("language indicator outlet exposes whether the original is shown", async function (assert) {
+    registerTemporaryModule(
+      "discourse/plugins/test-plugin/templates/connectors/post-language-indicator__before/translation-only",
+      hbs`{{#unless @outletArgs.showingOriginal}}<span class="translation-only">Translation</span>{{/unless}}`
+    );
+
+    this.post.is_localized = true;
+    this.post.language = "en";
+    this.post.cooked = "<p>Translated post</p>";
+    this.siteSettings.available_locales = [
+      { value: "en", name: "English (US)" },
+    ];
+
+    pretender.get(`/posts/${this.post.id}/cooked.json`, () =>
+      response({ cooked: "<p>Original post</p>" })
+    );
+
+    await renderComponent(this.post);
+
+    assert
+      .dom(".translation-only")
+      .exists("outlet content shows while the translation is displayed");
+
+    await click(".fk-d-tooltip__trigger");
+
+    assert
+      .dom(".translation-only")
+      .doesNotExist("outlet content hides while the original is displayed");
   });
 
   test("language tooltip on mobile translates when tapping the tooltip text", async function (assert) {
@@ -419,6 +495,15 @@ module("Integration | Component | Post", function (hooks) {
       "<p>Original post</p>",
       "content is switched after tapping tooltip text"
     );
+
+    await click(".fk-d-tooltip__trigger");
+
+    assert
+      .dom(".post-language__original-language")
+      .hasText(
+        new RegExp(i18n("post.tap_to_show_translation")),
+        "tap prompt invites showing the translation while the original is shown"
+      );
   });
 
   test("outdated localization", async function (assert) {


### PR DESCRIPTION
- Toggle the copy of the tooltip based on the state of post cooked
- Also, make sure any template inserted into the plugin outlet is also triggering the toggle.

https://github.com/user-attachments/assets/211d80be-51c4-4679-b8c0-62f4cbb9f2bc

