### PR TITLE
FIX: preserve text selection inside form fields in cooked content

### DIFF
--- a/frontend/discourse/app/components/post-text-selection.gjs
+++ b/frontend/discourse/app/components/post-text-selection.gjs
@@ -250,7 +250,9 @@ export default class PostTextSelection extends Component {
       return; // we changed the range here, so we want to go through the selection change handler again
     }
 
-    if (!window.getSelection().toString().trim().length) {
+    const selection = window.getSelection();
+
+    if (selection.isCollapsed || !selection.toString().trim().length) {
       return;
     }
 


### PR DESCRIPTION
Selecting text inside an `<input>`/`<textarea>` rendered in cooked content (e.g. the placeholder theme component) would immediately collapse the field's selection.

This regressed in d62cc48d9c, which changed the `computeCurrentCooked` guard from `!selectedText()?.length` to `!window.getSelection().toString().trim().length`. The old `selectedText` returned an empty string for a collapsed selection, but `toString()` is non-empty for a field selection even though the document `Range` is collapsed.

That caused `showToolbar` to run and call `virtualElementFromTextRange`, whose collapsed-range path inserts and removes a temp node next to the focused field, resetting its native selection. Bailing on a collapsed selection restores the previous behavior.