### PR TITLE
FIX: correctly log and redact http headers

### DIFF
--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/http_request/authenticator.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/http_request/authenticator.rb
@@ -11,7 +11,7 @@ module DiscourseWorkflows
 
         def self.apply(config, headers, exec_ctx, item_index: 0)
           auth_mode = config.fetch("authentication") { "none" }
-          return if auth_mode == "none"
+          return [] if auth_mode == "none"
 
           cred_data = fetch_credential_data(exec_ctx, auth_mode, item_index)
 
@@ -22,6 +22,8 @@ module DiscourseWorkflows
             apply_bearer_token(headers, cred_data)
           when "header_auth"
             apply_header_auth(headers, cred_data)
+          else
+            []
           end
         end
 
@@ -38,11 +40,13 @@ module DiscourseWorkflows
           user = cred_data["user"]
           password = cred_data["password"]
           headers["Authorization"] = "Basic #{Base64.strict_encode64("#{user}:#{password}")}"
+          ["Authorization"]
         end
 
         def self.apply_bearer_token(headers, cred_data)
           token = cred_data["token"]
           headers["Authorization"] = "Bearer #{token}"
+          ["Authorization"]
         end
 
         def self.apply_header_auth(headers, cred_data)
@@ -51,6 +55,7 @@ module DiscourseWorkflows
             raise_node_error!(I18n.t("discourse_workflows.errors.http_request.header_name_invalid"))
           end
           headers[name] = cred_data["value"]
+          [name]
         end
 
         private_class_method :fetch_credential_data,

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/http_request/request_builder.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/http_request/request_builder.rb
@@ -21,12 +21,30 @@ module DiscourseWorkflows
 
           uri = build_uri(@config["url"], @config["query_params"])
           headers = (@config["headers"] || {}).to_h.compact
-          Authenticator.apply(@config, headers, @exec_ctx, item_index: @item_index)
+          secret_headers = Authenticator.apply(@config, headers, @exec_ctx, item_index: @item_index)
           body = @config.key?("body") ? @config["body"] : build_body(method, @config, headers)
+          log_request(method, uri, headers, body, secret_headers)
           [method, uri, headers, body]
         end
 
         private
+
+        def log_request(method, uri, headers, body, secret_headers)
+          log = @exec_ctx&.log
+          return if log.nil?
+
+          log.info("#{method.to_s.upcase} #{filtered_url_for_logging(uri.to_s)}")
+          if headers.present?
+            redact_headers(headers, secret_headers).each { |k, v| log.info("#{k}: #{v}") }
+          end
+          log.info("[body omitted]") if body.present?
+        end
+
+        def redact_headers(headers, secret_headers)
+          ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters).filter(
+            headers.merge(secret_headers.index_with { FILTERED_QUERY_VALUE }),
+          )
+        end
 
         def build_uri(url, query_params)
           uri = URI.parse(url)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/http_request/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/http_request/v1.rb
@@ -232,7 +232,6 @@ module DiscourseWorkflows
               form_params: exec_ctx.get_node_parameter("body_form.values", item_index, default: []),
             )
           query_params = exec_ctx.get_node_parameter("query_params.values", item_index, default: [])
-          log_request(exec_ctx.log, method, config["url"], headers, body, query_params:)
           response =
             exec_ctx.http_request(
               method: method,
@@ -268,26 +267,6 @@ module DiscourseWorkflows
 
         def wrap_response_body(body, paired_item:)
           wrap(body.is_a?(Hash) ? body : { data: body }, paired_item:)
-        end
-
-        def log_request(log, method, uri, headers, body, query_params: [])
-          log.info("#{method.to_s.upcase} #{filtered_url_for_logging(uri, query_params)}")
-          if headers.present?
-            filtered =
-              ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters).filter(
-                headers,
-              )
-            filtered.each { |k, v| log.info("#{k}: #{v}") }
-          end
-          if body.is_a?(Hash)
-            filtered_body =
-              ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters).filter(
-                body,
-              )
-            log.info(filtered_body.to_json)
-          elsif body.present?
-            log.info("[body omitted]")
-          end
         end
 
         def request_options(config, query_params)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/http_request/authenticator_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/http_request/authenticator_spec.rb
@@ -4,16 +4,18 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::Authenticator do
   describe ".apply" do
     it "does nothing when authentication is none" do
       headers = {}
-      described_class.apply({ "authentication" => "none" }, headers, nil)
+      result = described_class.apply({ "authentication" => "none" }, headers, nil)
 
       expect(headers).not_to have_key("Authorization")
+      expect(result).to eq([])
     end
 
     it "does nothing when authentication is not specified" do
       headers = {}
-      described_class.apply({}, headers, nil)
+      result = described_class.apply({}, headers, nil)
 
       expect(headers).not_to have_key("Authorization")
+      expect(result).to eq([])
     end
 
     it "raises when the auth credential slot is missing for auth modes" do
@@ -40,10 +42,11 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::Authenticator do
             },
           )
 
-        described_class.apply({ "authentication" => "basic_auth" }, headers, exec_ctx)
+        result = described_class.apply({ "authentication" => "basic_auth" }, headers, exec_ctx)
 
         expected = "Basic #{Base64.strict_encode64("api_user:api_pass")}"
         expect(headers["Authorization"]).to eq(expected)
+        expect(result).to eq(["Authorization"])
       end
     end
 
@@ -58,9 +61,10 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::Authenticator do
             },
           )
 
-        described_class.apply({ "authentication" => "bearer_token" }, headers, exec_ctx)
+        result = described_class.apply({ "authentication" => "bearer_token" }, headers, exec_ctx)
 
         expect(headers["Authorization"]).to eq("Bearer my-secret-token")
+        expect(result).to eq(["Authorization"])
       end
     end
 
@@ -76,9 +80,10 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::Authenticator do
             },
           )
 
-        described_class.apply({ "authentication" => "header_auth" }, headers, exec_ctx)
+        result = described_class.apply({ "authentication" => "header_auth" }, headers, exec_ctx)
 
         expect(headers["X-API-Key"]).to eq("my-secret-key")
+        expect(result).to eq(["X-API-Key"])
       end
 
       it "raises when the resolved header name is blank" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/http_request_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/http_request_spec.rb
@@ -452,6 +452,36 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::V1 do
         result = execute_node(configuration: config, item: item)
         expect(result).to eq("ok" => true)
       end
+
+      it "logs the Authorization header with its value masked" do
+        stub_request(:get, "https://api.example.com/data").to_return(
+          status: 200,
+          body: { ok: true }.to_json,
+          headers: {
+            "content-type" => "application/json",
+          },
+        )
+
+        config = {
+          "method" => "GET",
+          "url" => "https://api.example.com/data",
+          "authentication" => "bearer_token",
+          "credentials" => {
+            "auth" => {
+              "id" => credential.id,
+              "credential_type" => "bearer_token",
+            },
+          },
+        }
+        messages = nil
+
+        execute_node_output(configuration: config, item: item) do |exec_ctx|
+          messages = exec_ctx.log.entries.map { |entry| entry["message"] }
+        end
+
+        expect(messages).to include("Authorization: [FILTERED]")
+        expect(messages).not_to include(a_string_including("my-secret-token"))
+      end
     end
 
     context "with header_auth authentication" do
@@ -493,6 +523,38 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::V1 do
 
         result = execute_node(configuration: config, item: item)
         expect(result).to eq("ok" => true)
+      end
+
+      it "masks the custom auth header value in logs regardless of its name" do
+        credential.update!(data: { "name" => "X-My-Api-Key", "value" => "my-secret-key" })
+
+        stub_request(:get, "https://api.example.com/data").to_return(
+          status: 200,
+          body: { ok: true }.to_json,
+          headers: {
+            "content-type" => "application/json",
+          },
+        )
+
+        config = {
+          "method" => "GET",
+          "url" => "https://api.example.com/data",
+          "authentication" => "header_auth",
+          "credentials" => {
+            "auth" => {
+              "id" => credential.id,
+              "credential_type" => "header_auth",
+            },
+          },
+        }
+        messages = nil
+
+        execute_node_output(configuration: config, item: item) do |exec_ctx|
+          messages = exec_ctx.log.entries.map { |entry| entry["message"] }
+        end
+
+        expect(messages).to include("X-My-Api-Key: [FILTERED]")
+        expect(messages).not_to include(a_string_including("my-secret-key"))
       end
 
       it "resolves credential expressions against each input item" do


### PR DESCRIPTION
Prior to this fix we wouldn't log some headers keys in the http request node. This commit ensures we load them and also properly filter them. To ensure the filtering we use the `ActiveSupport::ParameterFilter` default list and also build a list of keys coming from credentials so we always redact sensitive info from logs.