### PR TITLE
FEATURE: Record who closed a poll

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -276,6 +276,8 @@ class UserHistory < ActiveRecord::Base
       deleted_tag
       chat_channel_status_change
       chat_auto_remove_membership
+      poll_closed
+      poll_opened
       create_watched_word_group
       update_watched_word_group
       delete_watched_word_group

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7151,7 +7151,9 @@ CREATE TABLE public.polls (
     chart_type integer DEFAULT 0 NOT NULL,
     groups character varying,
     title character varying,
-    dynamic boolean DEFAULT false NOT NULL
+    dynamic boolean DEFAULT false NOT NULL,
+    closed_by_id integer,
+    closed_at timestamp(6) without time zone
 );
 
 
@@ -22279,6 +22281,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260622201005'),
 ('20260622140747'),
 ('20260617180115'),
+('20260617104005'),
 ('20260617053237'),
 ('20260615084100'),
 ('20260615082047'),

--- a/plugins/poll/app/models/poll.rb
+++ b/plugins/poll/app/models/poll.rb
@@ -5,6 +5,7 @@ class Poll < ActiveRecord::Base
   self.inheritance_column = nil
 
   belongs_to :post, -> { with_deleted }
+  belongs_to :closed_by, class_name: "User", optional: true
 
   has_many :poll_options, -> { order(:id) }, dependent: :destroy
   has_many :poll_votes
@@ -104,6 +105,7 @@ end
 #  anonymous_voters :integer
 #  chart_type       :integer          default("bar"), not null
 #  close_at         :datetime
+#  closed_at        :datetime
 #  dynamic          :boolean          default(FALSE), not null
 #  groups           :string
 #  max              :integer
@@ -117,6 +119,7 @@ end
 #  visibility       :integer          default("secret"), not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  closed_by_id     :integer
 #  post_id          :bigint
 #
 # Indexes

--- a/plugins/poll/app/serializers/poll_serializer.rb
+++ b/plugins/poll/app/serializers/poll_serializer.rb
@@ -18,7 +18,15 @@ class PollSerializer < ApplicationSerializer
              :chart_type,
              :groups,
              :title,
-             :ranked_choice_outcome
+             :ranked_choice_outcome,
+             :closed_at,
+             :closed_by
+
+  def closed_by
+    return if object.closed_by_id.blank? || object.closed_by_id == Discourse::SYSTEM_USER_ID
+
+    BasicUserSerializer.new(object.closed_by, root: false, scope:).as_json
+  end
 
   def public
     true

--- a/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-buttons-dropdown.gjs
@@ -137,7 +137,10 @@ export default class PollButtonsDropdownComponent extends Component {
           </:trigger>
           <:content>
             <DDropdownMenu as |dropdown|>
-              {{#each this.getDropdownContent as |content|}}
+              {{#each this.getDropdownContent as |content index|}}
+                {{#if index}}
+                  <dropdown.divider />
+                {{/if}}
                 <dropdown.item>
                   <DButton
                     class="widget-button {{content.className}}"
@@ -146,7 +149,6 @@ export default class PollButtonsDropdownComponent extends Component {
                     @action={{fn this.dropDownClick content.action}}
                   />
                 </dropdown.item>
-                <dropdown.divider />
               {{/each}}
             </DDropdownMenu>
           </:content>

--- a/plugins/poll/assets/javascripts/discourse/components/poll-info.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-info.gjs
@@ -149,12 +149,17 @@ export default class PollInfoComponent extends Component {
     return (
       this.showMultipleHelpText ||
       this.args.close ||
+      this.args.closedBy ||
       this.resultsOnVote ||
       this.resultsOnClose ||
       this.resultsStaffOnly ||
       this.publicTitle ||
       this.args.isDynamic
     );
+  }
+
+  get closedByLabel() {
+    return i18n("poll.closed_by", { username: this.args.closedBy.username });
   }
 
   <template>
@@ -197,6 +202,12 @@ export default class PollInfoComponent extends Component {
                 <span>{{this.automaticCloseClosesInLabel}}</span>
               </li>
             {{/if}}
+          {{/if}}
+          {{#if @closedBy}}
+            <li class="poll-info_closed-by">
+              {{dIcon "lock"}}
+              <span>{{this.closedByLabel}}</span>
+            </li>
           {{/if}}
           {{#if this.resultsOnVote}}
             <li class="results-on-vote">

--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -612,8 +612,8 @@ export default class PollComponent extends Component {
             status,
           },
         })
-          .then(() => {
-            this.poll.status = status;
+          .then(({ poll }) => {
+            Object.assign(this.poll, poll);
 
             if (
               this.poll.results === ON_CLOSE ||
@@ -753,6 +753,7 @@ export default class PollComponent extends Component {
         @isMultiple={{this.isMultiple}}
         @close={{this.close}}
         @closed={{this.closed}}
+        @closedBy={{this.poll.closed_by}}
         @results={{this.poll.results}}
         @showResults={{this.showResults}}
         @postUserId={{this.poll.post.user_id}}

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -4,9 +4,15 @@ en:
       site_settings:
         categories:
           poll: "Discourse Poll"
+      logs:
+        staff_actions:
+          actions:
+            poll_closed: "Poll closed"
+            poll_opened: "Poll opened"
   js:
     poll:
       title: "Poll"
+      closed_by: "Closed by %{username}"
       dynamic:
         enabled_hint: "Options can be added or removed."
       voters:

--- a/plugins/poll/db/migrate/20260617104005_add_closed_by_to_polls.rb
+++ b/plugins/poll/db/migrate/20260617104005_add_closed_by_to_polls.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddClosedByToPolls < ActiveRecord::Migration[8.0]
+  def change
+    add_column :polls, :closed_by_id, :integer, null: true
+    add_column :polls, :closed_at, :datetime, null: true
+  end
+end

--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -191,8 +191,23 @@ class DiscoursePoll::Poll
         return
       end
 
-      poll.status = status
-      poll.save!
+      if poll.status != status
+        poll.status = status
+
+        if poll.closed?
+          poll.closed_by = user
+          poll.closed_at = Time.zone.now
+          log_action = "poll_closed"
+        else
+          poll.closed_by = nil
+          poll.closed_at = nil
+          log_action = "poll_opened"
+        end
+
+        poll.save!
+
+        StaffActionLogger.new(user).log_custom(log_action, { post_id:, subject: poll_name })
+      end
 
       serialized_poll = PollSerializer.new(poll, root: false, scope: guardian).as_json
 

--- a/plugins/poll/lib/polls_updater.rb
+++ b/plugins/poll/lib/polls_updater.rb
@@ -174,7 +174,7 @@ module DiscoursePoll
     end
 
     def self.publish_changes(post)
-      polls = ::Poll.includes(poll_options: :poll_votes).where(post: post)
+      polls = ::Poll.includes(:closed_by, poll_options: :poll_votes).where(post: post)
       polls =
         ActiveModel::ArraySerializer.new(
           polls,

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -194,7 +194,7 @@ after_initialize do
           end
 
         if post_with_polls.present?
-          all_polls = Poll.includes(:poll_options).where(post_id: post_with_polls)
+          all_polls = Poll.includes(:poll_options, :closed_by).where(post_id: post_with_polls)
           Poll.preload!(all_polls, user_id: @user&.id)
           DiscoursePoll::Poll.preload_serialized_voters!(all_polls)
           all_polls.each do |p|
@@ -216,7 +216,7 @@ after_initialize do
       if @topic_view.present?
         @topic_view.polls[object.id]
       else
-        Poll.includes(:poll_options).where(post: object)
+        Poll.includes(:poll_options, :closed_by).where(post: object)
       end
   end
 

--- a/plugins/poll/spec/jobs/regular/close_poll_spec.rb
+++ b/plugins/poll/spec/jobs/regular/close_poll_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe Jobs::ClosePoll do
 
     Jobs::ClosePoll.new.execute(post_id: post.id, poll_name: "poll")
 
-    expect(post.polls.first.closed?).to eq(true)
+    poll = post.polls.first
+    expect(poll.closed?).to eq(true)
+    expect(poll.closed_by_id).to eq(Discourse.system_user.id)
+  end
+
+  it "logs the automatic close as the system user" do
+    Jobs::ClosePoll.new.execute(post_id: post.id, poll_name: "poll")
+
+    log = UserHistory.last
+    expect(log.custom_type).to eq("poll_closed")
+    expect(log.acting_user_id).to eq(Discourse.system_user.id)
   end
 end

--- a/plugins/poll/spec/lib/poll_spec.rb
+++ b/plugins/poll/spec/lib/poll_spec.rb
@@ -279,6 +279,74 @@ RSpec.describe DiscoursePoll::Poll do
     end
   end
 
+  describe ".toggle_status" do
+    fab!(:admin)
+
+    it "records who closed the poll and logs a staff action" do
+      DiscoursePoll::Poll.toggle_status(admin, post_with_regular_poll.id, "poll", "closed")
+
+      poll = post_with_regular_poll.polls.first
+      expect(poll.closed?).to eq(true)
+      expect(poll.closed_by_id).to eq(admin.id)
+      expect(poll.closed_at).to be_present
+
+      log = UserHistory.last
+      expect(log.action).to eq(UserHistory.actions[:custom_staff])
+      expect(log.custom_type).to eq("poll_closed")
+      expect(log.acting_user_id).to eq(admin.id)
+      expect(log.subject).to eq("poll")
+    end
+
+    it "logs a poll_opened staff action when a poll is reopened" do
+      DiscoursePoll::Poll.toggle_status(admin, post_with_regular_poll.id, "poll", "closed")
+      DiscoursePoll::Poll.toggle_status(admin, post_with_regular_poll.id, "poll", "open")
+
+      expect(UserHistory.last.custom_type).to eq("poll_opened")
+    end
+
+    it "clears the closer when the poll is reopened" do
+      DiscoursePoll::Poll.toggle_status(admin, post_with_regular_poll.id, "poll", "closed")
+      DiscoursePoll::Poll.toggle_status(admin, post_with_regular_poll.id, "poll", "open")
+
+      poll = post_with_regular_poll.polls.first
+      expect(poll.closed?).to eq(false)
+      expect(poll.closed_by_id).to eq(nil)
+      expect(poll.closed_at).to eq(nil)
+    end
+
+    it "always serializes closed_by and closed_at so reopened polls clear stale values" do
+      json =
+        PollSerializer.new(
+          post_with_regular_poll.polls.first,
+          root: false,
+          scope: Guardian.new,
+        ).as_json
+      expect(json).to include(closed_by: nil, closed_at: nil)
+    end
+
+    it "does not surface the system user as the closer when a poll is automatically closed" do
+      DiscoursePoll::Poll.toggle_status(
+        Discourse.system_user,
+        post_with_regular_poll.id,
+        "poll",
+        "closed",
+      )
+
+      poll = post_with_regular_poll.polls.first
+      expect(poll.closed_by_id).to eq(Discourse.system_user.id)
+
+      json = PollSerializer.new(poll, root: false, scope: Guardian.new).as_json
+      expect(json[:closed_by]).to eq(nil)
+      expect(json[:closed_at]).to be_present
+    end
+
+    it "does not log when the status is unchanged" do
+      expect do
+        DiscoursePoll::Poll.toggle_status(admin, post_with_regular_poll.id, "poll", "open")
+      end.not_to change { UserHistory.count }
+    end
+  end
+
   describe "post_created" do
     it "publishes on message bus if a there are polls" do
       first_post = Fabricate(:post)

--- a/plugins/poll/test/javascripts/component/poll-info-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-info-test.gjs
@@ -119,4 +119,40 @@ module("Component | PollInfo", function (hooks) {
         "displays the public label"
       );
   });
+
+  test("displays who closed the poll", async function (assert) {
+    this.setProperties({
+      options: OPTIONS,
+      close: null,
+      closed: true,
+      closedBy: { username: "jane" },
+      results: [],
+      showResults: false,
+      postUserId: 59,
+      isPublic: false,
+      hasVoted: false,
+      voters: [],
+    });
+
+    await render(
+      <template>
+        <PollInfo
+          @options={{this.options}}
+          @close={{this.close}}
+          @closed={{this.closed}}
+          @closedBy={{this.closedBy}}
+          @results={{this.results}}
+          @showResults={{this.showResults}}
+          @postUserId={{this.postUserId}}
+          @isPublic={{this.isPublic}}
+          @hasVoted={{this.hasVoted}}
+          @voters={{this.voters}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".poll-info_instructions li.poll-info_closed-by span")
+      .hasText(i18n("poll.closed_by", { username: "jane" }));
+  });
 });


### PR DESCRIPTION
Previously, there was no way to tell who closed (or reopened) a poll — neither the staff action log nor the poll itself recorded it, as raised in [meta](https://meta.discourse.org/t/who-closed-the-poll/405495).

This change logs `poll_closed`/`poll_opened` staff actions (auto-close attributed to the system user) and stores `closed_by`/`closed_at` on the poll, surfacing "Closed by @user" in the poll UI and making the closer queryable.

---

Also includes a small fix: the poll buttons dropdown rendered a `<dropdown.divider />` after every item, leaving a stray trailing border below the last option; it now renders dividers only between items.

**Screenshot**

<img width="1400" height="1200" alt="image" src="https://github.com/user-attachments/assets/fd04353a-eac6-448d-904e-47b8e5f8f14f" />
