### PR TITLE
DEV: Add hide_settings metadata to upcoming changes framework

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -167,6 +167,11 @@ module SiteSettingExtension
   #       Omit to allow all options (the default permissive behavior).
   #     body_class: (optional) boolean to include CSS data-attrs for the upcoming change,
   #       useful for scoping style changes related to the change.
+  #     hide_settings: (optional) array of other site setting names to hide from
+  #       admins while this change is enabled (manual opt-in or auto-promotion).
+  #       Use for legacy settings that stop making sense once the change is in
+  #       effect. Hiding is computed per request so it is multisite-safe and
+  #       tracks both opt-in paths live. See UpcomingChanges.settings_hidden_while_enabled.
   def upcoming_change_metadata
     @upcoming_change_metadata ||= {}
   end
@@ -1305,13 +1310,16 @@ module SiteSettingExtension
         impact_type, impact_role = opts[:upcoming_change][:impact].split(",")
         allow_enabled_for = opts[:upcoming_change][:allow_enabled_for]
         allow_enabled_for = Array(allow_enabled_for).map(&:to_sym) if allow_enabled_for
+        hide_settings = opts[:upcoming_change][:hide_settings]
+        hide_settings = Array(hide_settings).map(&:to_sym) if hide_settings
         upcoming_change_metadata[name].merge!(
-          **opts[:upcoming_change].except(:impact, :allow_enabled_for),
+          **opts[:upcoming_change].except(:impact, :allow_enabled_for, :hide_settings),
           impact_type: impact_type,
           impact_role: impact_role,
           status: opts[:upcoming_change][:status].to_sym,
           allow_enabled_for: allow_enabled_for,
           body_class: opts[:upcoming_change][:body_class],
+          hide_settings: hide_settings,
         )
       end
 

--- a/lib/site_settings/hidden_provider.rb
+++ b/lib/site_settings/hidden_provider.rb
@@ -18,6 +18,15 @@ class SiteSettings::HiddenProvider
   end
 
   def all
-    DiscoursePluginRegistry.apply_modifier(:hidden_site_settings, @hidden_settings)
+    hidden = @hidden_settings
+
+    # Settings hidden because an upcoming change that replaces them is enabled.
+    # Unioned before the modifier so plugins can still explicitly un-hide a
+    # setting via the :hidden_site_settings modifier. Skipped entirely when no
+    # change opts in, to avoid allocating a new Set on every read.
+    upcoming_change_hidden = UpcomingChanges.settings_hidden_while_enabled
+    hidden = hidden | upcoming_change_hidden if upcoming_change_hidden.present?
+
+    DiscoursePluginRegistry.apply_modifier(:hidden_site_settings, hidden)
   end
 end

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -463,4 +463,27 @@ module UpcomingChanges
       upcoming_change if settings_provider.upcoming_change_metadata[upcoming_change][:body_class]
     end
   end
+
+  # Site settings to hide from admins because an upcoming change that declares
+  # `hide_settings:` (in its site_settings.yml metadata) is currently enabled.
+  # Legacy settings a change replaces stop making sense once the change is in
+  # effect, so they are hidden while it is enabled.
+  #
+  # Consulted by SiteSettings::HiddenProvider#all, which runs on every
+  # hidden_settings read. It is computed live rather than toggled at opt-in time
+  # so it tracks both opt-in paths (manual and auto-promotion) and is
+  # multisite-safe: the hidden set is process-global, but enabled? resolves
+  # per-site, so we never hide a setting for sites that haven't opted in.
+  #
+  # `enabled?` is only called for the (usually zero) changes that declare
+  # `hide_settings`, so the common case is a cheap metadata scan with no DB hit.
+  def self.settings_hidden_while_enabled
+    metadata = settings_provider.upcoming_change_metadata
+    return [] if metadata.empty?
+
+    metadata.each_with_object([]) do |(change_name, change_metadata), hidden|
+      next if change_metadata[:hide_settings].blank?
+      hidden.concat(change_metadata[:hide_settings]) if enabled?(change_name)
+    end
+  end
 end

--- a/spec/integrity/upcoming_change_metadata_spec.rb
+++ b/spec/integrity/upcoming_change_metadata_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "upcoming change metadata integrity checks" do
 
     it "#{label} is valid" do
       metadata = setting[:upcoming_change]
-      allowed_keys = %i[status impact learn_more_url allow_enabled_for body_class]
+      allowed_keys = %i[status impact learn_more_url allow_enabled_for body_class hide_settings]
       required_keys = %i[status impact]
       unsupported_keys = metadata.keys - allowed_keys
       missing_keys = required_keys - metadata.keys
@@ -56,6 +56,7 @@ RSpec.describe "upcoming change metadata integrity checks" do
       learn_more_url = metadata[:learn_more_url]
       allow_enabled_for = metadata[:allow_enabled_for]
       body_class = metadata[:body_class]
+      hide_settings = metadata[:hide_settings]
 
       aggregate_failures do
         expect(setting[:options][:hidden]).to eq(true), "#{label} must set `hidden: true`"
@@ -114,6 +115,16 @@ RSpec.describe "upcoming change metadata integrity checks" do
         unless body_class.nil?
           expect([true, false]).to include(body_class),
           "#{label} `upcoming_change.body_class` must be a boolean"
+        end
+
+        if hide_settings.present?
+          expect(hide_settings).to be_an(Array),
+          "#{label} `upcoming_change.hide_settings` must be an array"
+
+          unknown_settings =
+            Array(hide_settings).map(&:to_s).reject { |s| SiteSetting.respond_to?(s) }
+          expect(unknown_settings).to be_empty,
+          "#{label} `upcoming_change.hide_settings` references unknown site settings: #{unknown_settings.join(", ")}"
         end
       end
     end

--- a/spec/lib/site_settings/hidden_provider_spec.rb
+++ b/spec/lib/site_settings/hidden_provider_spec.rb
@@ -23,5 +23,29 @@ RSpec.describe SiteSettings::HiddenProvider do
       plugin.register_modifier(:hidden_site_settings) { |defaults| defaults + [:other_setting] }
       expect(hidden_provider.all).to contain_exactly(:secret_setting, :other_setting)
     end
+
+    it "includes settings hidden by an enabled upcoming change that declares hide_settings" do
+      mock_upcoming_change_metadata(
+        {
+          enable_upload_debug_mode: {
+            impact: "other,developers",
+            status: :experimental,
+            impact_type: "other",
+            impact_role: "developers",
+            hide_settings: %i[allow_uncategorized_topics],
+          },
+        },
+      )
+      hidden_provider.add_hidden(:secret_setting)
+
+      expect(hidden_provider.all).to contain_exactly(:secret_setting)
+
+      SiteSetting.enable_upload_debug_mode = true
+
+      expect(hidden_provider.all).to contain_exactly(:secret_setting, :allow_uncategorized_topics)
+    ensure
+      SiteSetting.remove_override!(:enable_upload_debug_mode)
+      UpcomingChanges.clear_caches!
+    end
   end
 end

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -498,6 +498,69 @@ RSpec.describe UpcomingChanges do
     end
   end
 
+  describe ".settings_hidden_while_enabled" do
+    # `enable_upload_debug_mode` stands in for the change; the two real settings
+    # below stand in for the legacy settings it would hide.
+    let(:hidden_setting_names) { %i[allow_uncategorized_topics suppress_uncategorized_badge] }
+
+    before do
+      mock_upcoming_change_metadata(
+        {
+          enable_upload_debug_mode: {
+            impact: "other,developers",
+            status: :experimental,
+            impact_type: "other",
+            impact_role: "developers",
+            hide_settings: hidden_setting_names,
+          },
+        },
+      )
+    end
+
+    after do
+      SiteSetting.remove_override!(setting_name)
+      UpcomingChanges.clear_caches!
+    end
+
+    it "returns nothing when the change is not enabled" do
+      SiteSetting.remove_override!(setting_name)
+
+      expect(described_class.settings_hidden_while_enabled).to be_empty
+    end
+
+    it "returns the declared settings when the change is enabled" do
+      SiteSetting.enable_upload_debug_mode = true
+
+      expect(described_class.settings_hidden_while_enabled).to contain_exactly(
+        *hidden_setting_names,
+      )
+    end
+
+    it "ignores changes that do not declare hide_settings" do
+      mock_upcoming_change_metadata(
+        {
+          enable_upload_debug_mode: {
+            impact: "other,developers",
+            status: :experimental,
+            impact_type: "other",
+            impact_role: "developers",
+          },
+        },
+      )
+      SiteSetting.enable_upload_debug_mode = true
+
+      expect(described_class.settings_hidden_while_enabled).to be_empty
+    end
+
+    it "feeds SiteSetting.hidden_settings so the settings are hidden while enabled" do
+      expect(SiteSetting.hidden_settings).not_to include(*hidden_setting_names)
+
+      SiteSetting.enable_upload_debug_mode = true
+
+      expect(SiteSetting.hidden_settings).to include(*hidden_setting_names)
+    end
+  end
+
   describe ".enabled_for_with_groups" do
     let(:setting_name) { :enable_upload_debug_mode }
     let(:groups_hash) { { Group::AUTO_GROUPS[:staff] => "staff" } }


### PR DESCRIPTION
Adds an optional `hide_settings:` key to `upcoming_change` metadata in `site_settings.yml`. It declares other site settings that should be hidden from admins while the change is enabled (manual opt-in or auto-promotion) — useful for legacy settings that stop making sense once the change replaces them.

The hidden set is computed live by `UpcomingChanges.settings_hidden_while_enabled` and consulted by `SiteSettings::HiddenProvider#all`, rather than toggled imperatively at opt-in time.