### PR TITLE
FIX: feature gate solved shared issues fields

### DIFF
--- a/plugins/discourse-solved/app/services/discourse_solved/categories/types/support.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/categories/types/support.rb
@@ -54,7 +54,7 @@ module DiscourseSolved
           end
 
           def configuration_schema
-            {
+            schema = {
               general_category_settings: {
                 name: {
                   default: I18n.t("category_types.support.name"),
@@ -107,23 +107,31 @@ module DiscourseSolved
                   type: :bool,
                   label: I18n.t("discourse_solved.category_type.empty_box_on_unsolved.label"),
                 },
-                DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD => {
-                  default: true,
-                  type: :bool,
-                  label: I18n.t("discourse_solved.category_type.enable_shared_issues.label"),
-                  description:
-                    I18n.t("discourse_solved.category_type.enable_shared_issues.description"),
-                },
               },
               site_texts: {
-                "js.solved.shared_issue.label" => {
-                  label: I18n.t("discourse_solved.category_type.shared_issue_label.label"),
-                  description:
-                    I18n.t("discourse_solved.category_type.shared_issue_label.description"),
-                  depends_on: DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD,
-                },
               },
             }
+
+            if SiteSetting.enable_solved_shared_issues
+              schema[:category_custom_fields][
+                DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD
+              ] = {
+                default: true,
+                type: :bool,
+                label: I18n.t("discourse_solved.category_type.enable_shared_issues.label"),
+                description:
+                  I18n.t("discourse_solved.category_type.enable_shared_issues.description"),
+              }
+
+              schema[:site_texts]["js.solved.shared_issue.label"] = {
+                label: I18n.t("discourse_solved.category_type.shared_issue_label.label"),
+                description:
+                  I18n.t("discourse_solved.category_type.shared_issue_label.description"),
+                depends_on: DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD,
+              }
+            end
+
+            schema
           end
 
           def icon

--- a/plugins/discourse-solved/spec/models/discourse_solved/categories_types_support_spec.rb
+++ b/plugins/discourse-solved/spec/models/discourse_solved/categories_types_support_spec.rb
@@ -99,7 +99,8 @@ RSpec.describe DiscourseSolved::Categories::Types::Support do
       )
     end
 
-    it "enables shared issues by default" do
+    it "enables shared issues by default when the upcoming change is enabled" do
+      SiteSetting.enable_solved_shared_issues = true
       described_class.configure_category(category, guardian: admin.guardian)
 
       expect(category.custom_fields[DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD]).to eq(
@@ -109,6 +110,7 @@ RSpec.describe DiscourseSolved::Categories::Types::Support do
     end
 
     it "uses provided configuration_values for shared issues" do
+      SiteSetting.enable_solved_shared_issues = true
       described_class.configure_category(
         category,
         guardian: admin.guardian,
@@ -122,19 +124,38 @@ RSpec.describe DiscourseSolved::Categories::Types::Support do
   end
 
   describe "configuration_schema" do
-    it "passes schema validation with the shared issues fields" do
+    it "passes schema validation" do
       expect { described_class.validate_schema! }.not_to raise_error
     end
 
-    it "declares the shared issues toggle as a category custom field" do
-      keys = described_class.configuration_schema[:category_custom_fields].keys
-      expect(keys).to include(DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD)
+    context "when enable_solved_shared_issues is enabled" do
+      before { SiteSetting.enable_solved_shared_issues = true }
+
+      it "declares the shared issues toggle as a category custom field" do
+        keys = described_class.configuration_schema[:category_custom_fields].keys
+        expect(keys).to include(DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD)
+      end
+
+      it "declares the shared issue label as a dependent site text" do
+        label = described_class.configuration_schema[:site_texts]["js.solved.shared_issue.label"]
+        expect(label[:label]).to be_present
+        expect(label[:depends_on]).to eq(DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD)
+      end
     end
 
-    it "declares the shared issue label as a dependent site text" do
-      label = described_class.configuration_schema[:site_texts]["js.solved.shared_issue.label"]
-      expect(label[:label]).to be_present
-      expect(label[:depends_on]).to eq(DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD)
+    context "when enable_solved_shared_issues is disabled" do
+      before { SiteSetting.enable_solved_shared_issues = false }
+
+      it "omits the shared issues toggle from the category custom fields" do
+        keys = described_class.configuration_schema[:category_custom_fields].keys
+        expect(keys).not_to include(DiscourseSolved::SHARED_ISSUES_ENABLED_CUSTOM_FIELD)
+      end
+
+      it "omits the shared issue label site text" do
+        expect(described_class.configuration_schema[:site_texts]).not_to have_key(
+          "js.solved.shared_issue.label",
+        )
+      end
     end
   end
 

--- a/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
+++ b/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
@@ -125,6 +125,7 @@ RSpec.describe "Support Category Type Setup" do
     end
 
     it "edits the shared issue label as a translation override when enabled" do
+      SiteSetting.enable_solved_shared_issues = true
       visit("/c/#{category.slug}/edit/support")
 
       expect(form.field("custom_fields.enable_shared_issues").value).to be_truthy
@@ -144,6 +145,7 @@ RSpec.describe "Support Category Type Setup" do
     end
 
     it "hides the shared issue label field when shared issues are disabled" do
+      SiteSetting.enable_solved_shared_issues = true
       visit("/c/#{category.slug}/edit/support")
 
       expect(form).to have_field_with_name(shared_issue_field)


### PR DESCRIPTION
When the upcoming change for `Enable Solved Shared Issues` is disabled we should hide the custom fields in the edit category page.