### PR TITLE
FIX: Support uppercase and separators in event custom field names

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { concat, fn } from "@ember/helper";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
@@ -22,6 +22,7 @@ import { recurrenceContext } from "../../lib/event-recurrence";
 import {
   attendanceTransition,
   buildParams,
+  customFieldFormName,
   defaultEventState,
   defaultReminderFor,
   getCustomFieldNames,
@@ -118,11 +119,17 @@ export default class PostEventBuilder extends Component {
       recurrence: this.event.recurrence ?? null,
       imageUpload: this.event.imageUpload?.url ?? null,
       timezone: this.event.timezone ?? null,
-      // clone so the form draft owns its own reminders
       reminders: (this.event.reminders ?? []).map((r) => ({ ...r })),
-      // clone so the form draft owns the custom fields
-      customFields: { ...(this.event.customFields ?? {}) },
+      customFields: this.#formCustomFields(),
     };
+  }
+
+  #formCustomFields() {
+    const fields = {};
+    for (const [key, value] of Object.entries(this.event.customFields ?? {})) {
+      fields[customFieldFormName(key)] = value;
+    }
+    return fields;
   }
 
   @action
@@ -351,8 +358,12 @@ export default class PostEventBuilder extends Component {
     ];
   }
 
+  @cached
   get allowedCustomFields() {
-    return getCustomFieldNames(this.siteSettings);
+    return getCustomFieldNames(this.siteSettings).map((field) => ({
+      field,
+      name: customFieldFormName(field),
+    }));
   }
 
   get addReminderDisabled() {
@@ -1220,13 +1231,13 @@ export default class PostEventBuilder extends Component {
                     class="form-kit__container-custom-fields"
                   >
                     <form.Object @name="customFields" as |customFields|>
-                      {{#each this.allowedCustomFields as |allowedCustomField|}}
+                      {{#each this.allowedCustomFields as |customField|}}
                         <customFields.Field
-                          @name={{allowedCustomField}}
-                          @title={{allowedCustomField}}
+                          @name={{customField.name}}
+                          @title={{customField.field}}
                           @type="input"
                           @format="full"
-                          @onSet={{fn this.setCustomField allowedCustomField}}
+                          @onSet={{fn this.setCustomField customField.field}}
                           as |field|
                         >
                           <field.Control

--- a/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/lib/raw-event-helper.js
@@ -257,6 +257,10 @@ export function getCustomFieldNames(siteSettings) {
     .filter(Boolean);
 }
 
+export function customFieldFormName(name) {
+  return name.replace(/[.-]/g, "_");
+}
+
 // anywhere that builds an event state should use this as the single source of truth for defaults
 export function defaultEventState() {
   return {
@@ -372,7 +376,7 @@ export function replaceRaw(params, raw) {
 export function camelCase(input) {
   return input
     .toLowerCase()
-    .replace(/-/g, "_")
+    .replace(/[-.]/g, "_")
     .replace(/_(.)/g, function (match, group1) {
       return group1.toUpperCase();
     });

--- a/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/pre-initializers/rich-editor-extension.js
@@ -1,10 +1,10 @@
-import { camelize } from "@ember/string";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { buildBBCodeAttrs } from "discourse/lib/text";
 import EventNodeView from "../components/event-node-view";
 import { buildEventPreview } from "../lib/event-preview";
 import {
   buildEventSkeleton,
+  camelCase,
   getCustomFieldNames,
 } from "../lib/raw-event-helper";
 
@@ -41,7 +41,7 @@ const buildExtension = (siteSettings) => ({
       get attrs() {
         const attrs = { ...EVENT_ATTRIBUTES };
         getCustomFieldNames(siteSettings).forEach((field) => {
-          attrs[camelize(field)] = { default: null };
+          attrs[camelCase(field)] = { default: null };
         });
         return attrs;
       },
@@ -88,7 +88,7 @@ const buildExtension = (siteSettings) => ({
           const attrs = Object.fromEntries(
             token.attrs
               .filter(([key]) => key.startsWith("data-"))
-              .map(([key, value]) => [camelize(key.slice(5)), value])
+              .map(([key, value]) => [camelCase(key.slice(5)), value])
           );
 
           state.openNode(state.schema.nodes.event, attrs);

--- a/plugins/discourse-calendar/config/locales/server.en.yml
+++ b/plugins/discourse-calendar/config/locales/server.en.yml
@@ -49,6 +49,9 @@ en:
     use_local_event_date: "Use local date after topic title instead of relative time."
     discourse_post_event_allowed_on_groups: "Groups that are allowed to create events."
     discourse_post_event_allowed_custom_fields: "Allows to let each event to set the value of custom fields."
+    discourse_post_event_allowed_custom_fields_invalid: "These custom field names are invalid: %{names}. Names must start and end with a letter or number and use single dots, dashes, or underscores as separators (for example: dress_code, live-stream, q.and.a)."
+    discourse_post_event_allowed_custom_fields_collision: "These custom field names resolve to the same name once dots, dashes, and letter case are normalized: %{names}. Each custom field must be unique."
+    discourse_post_event_allowed_custom_fields_reserved: "These custom field names are reserved by built-in event options (for example name, url, status, location): %{names}. Please choose different names."
     discourse_post_event_edit_notifications_time_extension: "Extends (in minutes) the period after the end of an event when `going` invitees are still being notified from edit in the original post."
     holiday_calendar_topic_id: "Topic ID of staffs holiday / absence calendar."
     holiday_status_emoji: Defines the emoji used for the holiday status.

--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -100,6 +100,7 @@ discourse_calendar:
     list_type: simple
     client: true
     default: ""
+    validator: "CalendarCustomFieldsValidator"
   events_calendar_categories:
     type: category_list
     client: true

--- a/plugins/discourse-calendar/lib/calendar_custom_fields_validator.rb
+++ b/plugins/discourse-calendar/lib/calendar_custom_fields_validator.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class CalendarCustomFieldsValidator
+  NAME_FORMAT = /\A[a-z0-9]+([_.-][a-z0-9]+)*\z/i
+
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    @error_message = nil
+    return true if val.blank?
+
+    names = val.split("|").reject(&:blank?)
+    attributes =
+      names.index_with { |name| DiscoursePostEvent::EventParser.custom_field_data_attribute(name) }
+    errors = []
+
+    malformed = names.reject { |name| name.match?(NAME_FORMAT) }
+    errors << error(:invalid, malformed) if malformed.any?
+
+    colliding =
+      names.group_by { |name| attributes[name] }.values.select { |group| group.size > 1 }.flatten
+    errors << error(:collision, colliding) if colliding.any?
+
+    reserved = DiscoursePostEvent::EventParser.valid_option_attributes
+    reserved_names = names.select { |name| reserved.include?(attributes[name]) }
+    errors << error(:reserved, reserved_names) if reserved_names.any?
+
+    return true if errors.empty?
+
+    @error_message = errors.join(" ")
+    false
+  end
+
+  def error_message
+    @error_message
+  end
+
+  private
+
+  def error(key, names)
+    I18n.t(
+      "site_settings.discourse_post_event_allowed_custom_fields_#{key}",
+      names: names.join(", "),
+    )
+  end
+end

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_parser.rb
@@ -25,18 +25,15 @@ module DiscoursePostEvent
 
     def self.extract_events(post)
       cooked = PrettyText.cook(post.raw, topic_id: post.topic_id, user_id: post.user_id)
-      valid_options = VALID_OPTIONS.map { |o| "data-#{o}" }
+      valid_options = valid_option_attributes
 
-      valid_custom_fields = []
-      SiteSetting
-        .discourse_post_event_allowed_custom_fields
-        .split("|")
-        .each do |setting|
-          valid_custom_fields << {
-            original: "data-#{setting}",
-            normalized: "data-#{setting.gsub(/_/, "-")}",
-          }
-        end
+      valid_custom_fields =
+        SiteSetting
+          .discourse_post_event_allowed_custom_fields
+          .split("|")
+          .map do |setting|
+            { original: "data-#{setting}", normalized: custom_field_data_attribute(setting) }
+          end
 
       Nokogiri
         .HTML(cooked)
@@ -69,6 +66,16 @@ module DiscoursePostEvent
           event
         end
         .compact
+    end
+
+    def self.valid_option_attributes
+      VALID_OPTIONS.map { |option| "data-#{option}" }
+    end
+
+    def self.custom_field_data_attribute(setting)
+      camelized = setting.downcase.gsub(/[-.]/, "_").gsub(/_(.)/) { $1.upcase }
+      dasherized = camelized.gsub(/[A-Z]/) { |char| "-#{char.downcase}" }.sub(/\A-/, "")
+      "data-#{dasherized}"
     end
 
     def self.linkify_description(text, post: nil)

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -11,6 +11,7 @@ libdir = File.join(File.dirname(__FILE__), "vendor/holidays/lib")
 $LOAD_PATH.unshift(libdir) if $LOAD_PATH.exclude?(libdir)
 
 require_relative "lib/calendar_settings_validator"
+require_relative "lib/calendar_custom_fields_validator"
 require_relative "lib/calendar_first_day_of_week"
 require_relative "lib/calendar_upcoming_events_default_view"
 

--- a/plugins/discourse-calendar/spec/lib/calendar_custom_fields_validator_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/calendar_custom_fields_validator_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe CalendarCustomFieldsValidator do
+  def expect_invalid(val)
+    expect(subject.valid_value?(val)).to eq(false)
+    expect(subject.error_message).to be_present
+  end
+
+  def expect_valid(val)
+    expect(subject.valid_value?(val)).to eq(true)
+  end
+
+  def message_for(val)
+    subject.valid_value?(val)
+    subject.error_message
+  end
+
+  it "allows an empty value and unique, unreserved, well-formed names" do
+    expect_valid ""
+    expect_valid "venue"
+    expect_valid "venue|seat_count"
+    expect_valid "dress_CODE|live-stream|q.and.a"
+  end
+
+  it "rejects malformed names (leading, trailing or repeated separators)" do
+    expect_invalid "_secret"
+    expect_invalid "venue|_secret"
+    expect_invalid "trailing_"
+    expect_invalid "double__underscore"
+    expect_invalid "has space"
+  end
+
+  it "rejects names that collide once normalized" do
+    expect_invalid "field-aa|field_aa"
+    expect_invalid "field1|field_1"
+    expect_invalid "Venue|venue"
+  end
+
+  it "rejects names reserved by built-in event options" do
+    expect_invalid "name"
+    expect_invalid "venue|url"
+    expect_invalid "all_day"
+    expect_invalid "max-attendees"
+  end
+
+  it "reports every problem at once, naming each offending field" do
+    message = message_for("_secret|Venue|venue|url")
+
+    expect(message).to include("_secret") # malformed
+    expect(message).to include("Venue").and include("venue") # collide once normalized
+    expect(message).to include("url") # reserved
+  end
+end

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/event_parser_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/event_parser_spec.rb
@@ -191,4 +191,26 @@ describe DiscoursePostEvent::EventParser do
       expect(events[0][:baz]).to eq(nil)
     end
   end
+
+  context "with mixed-case custom fields" do
+    before do
+      SiteSetting.discourse_post_event_allowed_custom_fields =
+        "field_aa|fieldbb|field_CC|fieldDD|my.field"
+    end
+
+    it "parses fields regardless of case or separators" do
+      post_event = build_post user, <<~TXT
+        [event start="2020" fieldAa="1" fieldbb="2" fieldCc="3" fielddd="4" myField="5"]
+        [/event]
+      TXT
+
+      event = parser.extract_events(post_event)[0]
+
+      expect(event[:field_aa]).to eq("1")
+      expect(event[:fieldbb]).to eq("2")
+      expect(event[:field_CC]).to eq("3")
+      expect(event[:fieldDD]).to eq("4")
+      expect(event[:"my.field"]).to eq("5")
+    end
+  end
 end

--- a/plugins/discourse-calendar/test/javascripts/integration/components/post-event-builder-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/post-event-builder-test.gjs
@@ -67,4 +67,41 @@ module("Integration | Component | Modal | PostEventBuilder", function (hooks) {
         "renders the upload url, not the raw object"
       );
   });
+
+  test("advanced screen renders a custom field whose name contains a dash", async function (assert) {
+    this.siteSettings.discourse_post_event_allowed_custom_fields = "field-aa";
+
+    const event = DiscoursePostEventEvent.create({
+      name: "My event",
+      starts_at: "2022-07-01T10:00:00Z",
+      ends_at: "2022-07-01T11:00:00Z",
+      timezone: "UTC",
+      status: "public",
+      reminders: [],
+      raw_invitees: [],
+      custom_fields: {},
+    });
+
+    const model = {
+      event,
+      initialScreen: "advanced",
+      onUpdate: () => {},
+      toolbarEvent: {},
+    };
+    const closeModal = () => {};
+
+    await render(
+      <template>
+        <PostEventBuilder
+          @inline={{true}}
+          @model={{model}}
+          @closeModal={{closeModal}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(`[data-name="customFields.field_aa"] input`)
+      .exists("renders the dashed custom field without crashing");
+  });
 });

--- a/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/rich-editor-extension-test.js
@@ -80,4 +80,18 @@ module("Integration | Component | RichEditorExtension", function (hooks) {
       `[event start="2025-03-21 15:41" status=public timezone=Europe/Paris fancyField="hello world"]\n[/event]\n`
     );
   });
+
+  test("event preserves custom fields with uppercase letters", async function (assert) {
+    this.siteSettings.rich_editor = true;
+    this.siteSettings.discourse_post_event_allowed_custom_fields = "dress_CODE";
+
+    await testMarkdown(
+      assert,
+      `[event start="2025-03-21 15:41" status="public" timezone="Europe/Paris" dressCode="black tie"]\n[/event]\n`,
+      (a) => {
+        a.dom(".composer-event-node").exists("Event node should be rendered");
+      },
+      `[event start="2025-03-21 15:41" status=public timezone=Europe/Paris dressCode="black tie"]\n[/event]\n`
+    );
+  });
 });


### PR DESCRIPTION
Previously, event custom fields whose names contained uppercase letters, dashes, or dots either crashed the event builder's advanced settings dialog or were silently dropped on save, so the feature effectively only worked with plain lowercase names.

This change normalizes custom field names consistently across the composer, server parser, and rich-text editor so they round-trip regardless of case or separator, and validates the `discourse_post_event_allowed_custom_fields` site setting to reject malformed, colliding, or reserved names up front.

Meta: https://meta.discourse.org/t/event-custom-fields-can-only-be-lowercase/405386
