### PR TITLE
FEATURE: Passkeys satisfy enforced two-factor authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -848,10 +848,7 @@ class ApplicationController < ActionController::Base
   end
 
   def should_enforce_2fa?
-    enforcing_2fa =
-      (SiteSetting.enforce_second_factor == "staff" && current_user.staff?) ||
-        SiteSetting.enforce_second_factor == "all"
-    !disqualified_from_2fa_enforcement && enforcing_2fa &&
+    !disqualified_from_2fa_enforcement && current_user.subject_to_enforced_second_factor? &&
       !current_user.has_any_second_factor_methods_enabled?
   end
 

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -441,13 +441,17 @@ class SessionController < ApplicationController
         )
       end
 
-      if matched_user&.security_keys_enabled?
+      if matched_user&.security_keys_enabled? || matched_user&.passkey_required_as_second_factor?
         DiscourseWebauthn.stage_challenge(matched_user, server_session)
         response.merge!(
-          DiscourseWebauthn.allowed_credentials(matched_user, server_session).merge(
-            security_key_required: true,
+          DiscourseWebauthn.allowed_credentials(
+            matched_user,
+            server_session,
+            include_passkeys: matched_user.passkey_required_as_second_factor?,
           ),
         )
+        response[:security_key_required] = matched_user.security_keys_enabled?
+        response[:passkeys_enabled] = matched_user.passkey_required_as_second_factor?
       end
 
       render json: response
@@ -795,9 +799,15 @@ class SessionController < ApplicationController
     second_factor_authentication_result = user.authenticate_second_factor(params, server_session)
     if !second_factor_authentication_result.ok
       failure_payload = second_factor_authentication_result.to_h
-      if user.security_keys_enabled?
+      if user.security_keys_enabled? || user.passkey_required_as_second_factor?
         DiscourseWebauthn.stage_challenge(user, server_session)
-        failure_payload.merge!(DiscourseWebauthn.allowed_credentials(user, server_session))
+        failure_payload.merge!(
+          DiscourseWebauthn.allowed_credentials(
+            user,
+            server_session,
+            include_passkeys: user.passkey_required_as_second_factor?,
+          ),
+        )
       end
       @second_factor_failure_payload = failed_json.merge(failure_payload)
       return second_factor_authentication_result

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -833,6 +833,7 @@ class UsersController < ApplicationController
         admin: @user.admin?,
         second_factor_required: @user.totp_enabled?,
         security_key_required: @user.security_keys_enabled?,
+        passkeys_enabled: @user.passkey_required_as_second_factor?,
         backup_enabled: @user.backup_codes_enabled?,
         multiple_second_factor_methods: @user.has_multiple_second_factor_methods?,
       }
@@ -846,7 +847,13 @@ class UsersController < ApplicationController
         store_preloaded(
           "password_reset",
           MultiJson.dump(
-            security_params.merge(DiscourseWebauthn.allowed_credentials(@user, server_session)),
+            security_params.merge(
+              DiscourseWebauthn.allowed_credentials(
+                @user,
+                server_session,
+                include_passkeys: @user.passkey_required_as_second_factor?,
+              ),
+            ),
           ),
         )
 
@@ -858,7 +865,13 @@ class UsersController < ApplicationController
 
         DiscourseWebauthn.stage_challenge(@user, server_session)
         render json:
-                 security_params.merge(DiscourseWebauthn.allowed_credentials(@user, server_session))
+                 security_params.merge(
+                   DiscourseWebauthn.allowed_credentials(
+                     @user,
+                     server_session,
+                     include_passkeys: @user.passkey_required_as_second_factor?,
+                   ),
+                 )
       end
     end
   end
@@ -956,9 +969,16 @@ class UsersController < ApplicationController
           admin: @user.admin?,
           second_factor_required: @user.totp_enabled?,
           security_key_required: @user.security_keys_enabled?,
+          passkeys_enabled: @user.passkey_required_as_second_factor?,
           backup_enabled: @user.backup_codes_enabled?,
           multiple_second_factor_methods: @user.has_multiple_second_factor_methods?,
-        }.merge(DiscourseWebauthn.allowed_credentials(@user, server_session))
+        }.merge(
+          DiscourseWebauthn.allowed_credentials(
+            @user,
+            server_session,
+            include_passkeys: @user.passkey_required_as_second_factor?,
+          ),
+        )
 
         store_preloaded("password_reset", MultiJson.dump(security_params))
 

--- a/app/models/concerns/second_factor_manager.rb
+++ b/app/models/concerns/second_factor_manager.rb
@@ -15,6 +15,7 @@ module SecondFactorManager
       :totp_enabled,
       :multiple_second_factor_methods,
       :used_2fa_method,
+      :passkeys_enabled,
     )
 
   def create_totp(opts = {})
@@ -88,16 +89,37 @@ module SecondFactorManager
   end
   alias_method :passkeys_for_2fa_enabled?, :passkeys_available_as_second_factor?
 
-  # Passkey-as-2FA (`passkeys_available_as_second_factor?`) is intentionally
-  # excluded: it only satisfies `/session/2fa`. Password login, email login,
-  # and password reset have no passkey UI yet, so counting passkeys here would
-  # make those flows skip 2FA for passkey-only users.
+  # `enforce_second_factor` is the only setting that forces 2FA. A passkey is
+  # primarily a passwordless login credential, so merely owning one must not
+  # silently turn password/email/reset logins into a second step. We therefore
+  # only require (and advertise) a passkey as 2FA in those flows when the site
+  # enforces 2FA for this user; `allow_passkeys_for_2fa` just lets a passkey
+  # satisfy that enforcement.
+  def passkey_required_as_second_factor?
+    passkeys_available_as_second_factor? && subject_to_enforced_second_factor?
+  end
+
+  def subject_to_enforced_second_factor?
+    case SiteSetting.enforce_second_factor
+    when "all"
+      true
+    when "staff"
+      staff?
+    else
+      false
+    end
+  end
+
   def has_any_second_factor_methods_enabled?
-    totp_enabled? || security_keys_enabled?
+    totp_enabled? || security_keys_enabled? || passkeys_available_as_second_factor?
   end
 
   def has_multiple_second_factor_methods?
-    security_keys_enabled? && totp_or_backup_codes_enabled?
+    [
+      security_keys_enabled?,
+      totp_or_backup_codes_enabled?,
+      passkey_required_as_second_factor?,
+    ].count(true) > 1
   end
 
   def totp_or_backup_codes_enabled?
@@ -116,12 +138,23 @@ module SecondFactorManager
     user_second_factors&.backup_codes&.count
   end
 
+  # Whether an in-progress authentication (password login, email login, password
+  # reset, or an explicit `/session/2fa` confirmation) must validate a second
+  # factor before succeeding.
+  def second_factor_required_for_authentication?(params)
+    return true if security_keys_enabled? || totp_or_backup_codes_enabled?
+    return false if !passkeys_available_as_second_factor?
+
+    # Passkey-only user: require it when the client explicitly submits a second
+    # factor (the `/session/2fa` page or the passkey button) or when the site
+    # enforces 2FA for them. Otherwise the passkey stays a passwordless-login
+    # convenience and authentication proceeds with the password alone.
+    params[:second_factor_method].present? || subject_to_enforced_second_factor?
+  end
+
   def authenticate_second_factor(params, server_session)
     ok_result = SecondFactorAuthenticationResult.new(true)
-    if !security_keys_enabled? && !totp_or_backup_codes_enabled? &&
-         (!passkeys_available_as_second_factor? || params[:second_factor_method].blank?)
-      return ok_result
-    end
+    return ok_result if !second_factor_required_for_authentication?(params)
 
     second_factor_token = params[:second_factor_token]
     second_factor_method = params[:second_factor_method]&.to_i
@@ -241,6 +274,8 @@ module SecondFactorManager
       security_keys_enabled?,
       totp_enabled?,
       has_multiple_second_factor_methods?,
+      nil,
+      passkey_required_as_second_factor?,
     )
   end
 

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -52,7 +52,7 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   end
 
   def second_factor_enabled
-    object.totp_enabled? || object.security_keys_enabled?
+    object.has_any_second_factor_methods_enabled?
   end
 
   def can_disable_second_factor

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -351,7 +351,7 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def second_factor_enabled
-    object.totp_enabled? || object.security_keys_enabled?
+    object.has_any_second_factor_methods_enabled?
   end
 
   def include_featured_topic?

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -115,7 +115,7 @@ class UserSerializer < UserCardSerializer
   end
 
   def second_factor_enabled
-    object.totp_enabled? || object.security_keys_enabled?
+    object.has_any_second_factor_methods_enabled?
   end
 
   def include_second_factor_backup_enabled?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2135,7 +2135,7 @@ en:
 
     enable_local_logins: "Enable local username and password login based accounts. WARNING: if disabled, you may be unable to log in if you have not previously configured at least one alternate login method."
     enable_local_logins_via_email: "Allow users to request a one-click login link to be sent to them via email."
-    allow_passkeys_for_2fa: "Allow users to use a passkey to satisfy two-factor authentication when confirming a sensitive action."
+    allow_passkeys_for_2fa: "Treat passkeys as a valid two-factor authentication method. Users with a passkey satisfy enforced two-factor authentication and can use it during login, password reset, and sensitive action confirmation."
     allow_new_registrations: "Allow new user registrations. Uncheck this to prevent anyone from creating a new account."
     enable_signup_cta: "Show a notice to returning anonymous users prompting them to sign up for an account."
     enable_discourse_id: "Enable authentication via Discourse ID, a single sign-on service that allows users to log in to multiple Discourse sites using a single account. Common social login providers like Google, Facebook, Apple, and GitHub are supported without additional configuration. See <a href='https://id.discourse.com' target='_blank'>id.discourse.com</a> for more details."

--- a/frontend/discourse/app/components/local-login-form.gjs
+++ b/frontend/discourse/app/components/local-login-form.gjs
@@ -16,6 +16,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { escapeExpression } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
+import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 import DPasswordField from "discourse/ui-kit/d-password-field";
 import DSecondFactorInput from "discourse/ui-kit/d-second-factor-input";
 import DTogglePasswordMask from "discourse/ui-kit/d-toggle-password-mask";
@@ -155,6 +156,7 @@ export default class LocalLoginForm extends Component {
 
   @action
   authenticateSecurityKey() {
+    this.args.secondFactorMethodChanged(SECOND_FACTOR_METHODS.SECURITY_KEY);
     getWebauthnCredential(
       this.args.securityKeyChallenge,
       this.args.securityKeyAllowedCredentialIds,
@@ -166,6 +168,24 @@ export default class LocalLoginForm extends Component {
         this.args.flashChanged(error);
         this.args.flashTypeChanged("error");
       }
+    );
+  }
+
+  @action
+  authenticatePasskeySecondFactor() {
+    this.args.secondFactorMethodChanged(SECOND_FACTOR_METHODS.PASSKEY);
+    getWebauthnCredential(
+      this.args.securityKeyChallenge,
+      this.args.passkeyAllowedCredentialIds,
+      (credentialData) => {
+        this.args.securityKeyCredentialChanged(credentialData);
+        this.args.login();
+      },
+      (error) => {
+        this.args.flashChanged(error);
+        this.args.flashTypeChanged("error");
+      },
+      { userVerification: "required" }
     );
   }
 
@@ -259,7 +279,10 @@ export default class LocalLoginForm extends Component {
               @backupEnabled={{@backupEnabled}}
               @totpEnabled={{@totpEnabled}}
               @otherMethodAllowed={{@otherMethodAllowed}}
-              @action={{this.authenticateSecurityKey}}
+              @passkeysEnabled={{@passkeysEnabled}}
+              @securityKeysEnabled={{@securityKeysEnabled}}
+              @passkeyAction={{this.authenticatePasskeySecondFactor}}
+              @securityKeyAction={{this.authenticateSecurityKey}}
             />
           {{else}}
             <DSecondFactorInput

--- a/frontend/discourse/app/components/security-key-form.gjs
+++ b/frontend/discourse/app/components/security-key-form.gjs
@@ -7,9 +7,9 @@ import { i18n } from "discourse-i18n";
 
 export default class SecurityKeyForm extends Component {
   get showSecurityKeyButton() {
-    // when the granular args aren't passed, keep the legacy single-button
-    // rendering driven by `@action`
-    return this.args.securityKeysEnabled ?? true;
+    // when the granular args aren't passed at all, keep the legacy
+    // single-button rendering driven by `@action`
+    return this.args.securityKeysEnabled ?? !this.args.passkeysEnabled;
   }
 
   get securityKeyAction() {

--- a/frontend/discourse/app/controllers/email-login.js
+++ b/frontend/discourse/app/controllers/email-login.js
@@ -6,20 +6,41 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import getURL from "discourse/lib/get-url";
 import DiscourseURL from "discourse/lib/url";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
+import { SECOND_FACTOR_METHODS } from "discourse/models/user";
 
 export default class EmailLoginController extends Controller {
   @service router;
 
   secondFactorMethod;
   secondFactorToken;
+  showTokenInput = false;
 
   lockImageUrl = getURL("/images/lock.svg");
 
   @computed("model")
   get secondFactorRequired() {
     return (
-      this.model.security_key_required || this.model.second_factor_required
+      this.model.security_key_required ||
+      this.model.passkeys_enabled ||
+      this.model.second_factor_required
     );
+  }
+
+  @computed(
+    "model.security_key_required",
+    "model.passkeys_enabled",
+    "showTokenInput"
+  )
+  get showWebauthnForm() {
+    return (
+      (this.model.security_key_required || this.model.passkeys_enabled) &&
+      !this.showTokenInput
+    );
+  }
+
+  @computed("model.totp_enabled", "model.backup_codes_enabled")
+  get otherTokenMethodsAllowed() {
+    return this.model.totp_enabled || this.model.backup_codes_enabled;
   }
 
   @action
@@ -68,6 +89,7 @@ export default class EmailLoginController extends Controller {
 
   @action
   authenticateSecurityKey() {
+    this.set("secondFactorMethod", SECOND_FACTOR_METHODS.SECURITY_KEY);
     getWebauthnCredential(
       this.model.challenge,
       this.model.allowed_credential_ids,
@@ -78,6 +100,23 @@ export default class EmailLoginController extends Controller {
       (errorMessage) => {
         this.set("model.error", errorMessage);
       }
+    );
+  }
+
+  @action
+  authenticatePasskey() {
+    this.set("secondFactorMethod", SECOND_FACTOR_METHODS.PASSKEY);
+    getWebauthnCredential(
+      this.model.challenge,
+      this.model.passkey_allowed_credential_ids,
+      (credentialData) => {
+        this.set("securityKeyCredential", credentialData);
+        this.send("finishLogin");
+      },
+      (errorMessage) => {
+        this.set("model.error", errorMessage);
+      },
+      { userVerification: "required" }
     );
   }
 }

--- a/frontend/discourse/app/controllers/login.js
+++ b/frontend/discourse/app/controllers/login.js
@@ -44,8 +44,11 @@ export default class LoginPageController extends Controller {
   @tracked backupEnabled;
   @tracked totpEnabled;
   @tracked showSecurityKey;
+  @tracked securityKeysEnabled;
+  @tracked passkeysEnabled;
   @tracked securityKeyChallenge;
   @tracked securityKeyAllowedCredentialIds;
+  @tracked passkeyAllowedCredentialIds;
   @tracked secondFactorToken;
   @tracked flash;
   @tracked flashType;
@@ -165,6 +168,11 @@ export default class LoginPageController extends Controller {
   }
 
   @action
+  secondFactorMethodChanged(value) {
+    this.secondFactorMethod = value;
+  }
+
+  @action
   flashChanged(value) {
     this.flash = value;
   }
@@ -224,7 +232,9 @@ export default class LoginPageController extends Controller {
         this.flashType = "error";
 
         if (
-          (result.security_key_enabled || result.totp_enabled) &&
+          (result.security_key_enabled ||
+            result.passkeys_enabled ||
+            result.totp_enabled) &&
           !this.secondFactorRequired
         ) {
           this.otherMethodAllowed = result.multiple_second_factor_methods;
@@ -232,13 +242,22 @@ export default class LoginPageController extends Controller {
           this.showLoginButtons = false;
           this.backupEnabled = result.backup_enabled;
           this.totpEnabled = result.totp_enabled;
+          this.securityKeysEnabled = result.security_key_enabled;
+          this.passkeysEnabled = result.passkeys_enabled;
           this.showSecondFactor = result.totp_enabled;
-          this.showSecurityKey = result.security_key_enabled;
-          this.secondFactorMethod = result.security_key_enabled
-            ? SECOND_FACTOR_METHODS.SECURITY_KEY
-            : SECOND_FACTOR_METHODS.TOTP;
+          this.showSecurityKey =
+            result.security_key_enabled || result.passkeys_enabled;
+          if (result.passkeys_enabled) {
+            this.secondFactorMethod = SECOND_FACTOR_METHODS.PASSKEY;
+          } else if (result.security_key_enabled) {
+            this.secondFactorMethod = SECOND_FACTOR_METHODS.SECURITY_KEY;
+          } else {
+            this.secondFactorMethod = SECOND_FACTOR_METHODS.TOTP;
+          }
           this.securityKeyChallenge = result.challenge;
           this.securityKeyAllowedCredentialIds = result.allowed_credential_ids;
+          this.passkeyAllowedCredentialIds =
+            result.passkey_allowed_credential_ids;
 
           return;
         } else if (result.reason === "not_activated") {

--- a/frontend/discourse/app/controllers/password-reset.js
+++ b/frontend/discourse/app/controllers/password-reset.js
@@ -69,10 +69,25 @@ export default class PasswordResetController extends Controller {
     set(this, "model.backup_enabled", value);
   }
 
-  @computed("model.second_factor_required", "model.security_key_required")
+  @computed("model.passkeys_enabled")
+  get passkeysEnabled() {
+    return this.model?.passkeys_enabled;
+  }
+
+  set passkeysEnabled(value) {
+    set(this, "model.passkeys_enabled", value);
+  }
+
+  @computed(
+    "model.second_factor_required",
+    "model.security_key_required",
+    "model.passkeys_enabled"
+  )
   get securityKeyOrSecondFactorRequired() {
     return (
-      this.model?.second_factor_required || this.model?.security_key_required
+      this.model?.second_factor_required ||
+      this.model?.security_key_required ||
+      this.model?.passkeys_enabled
     );
   }
 
@@ -81,16 +96,28 @@ export default class PasswordResetController extends Controller {
     return this.model?.multiple_second_factor_methods;
   }
 
-  @computed("securityKeyRequired", "selectedSecondFactorMethod")
-  get displaySecurityKeyForm() {
+  @computed("model.second_factor_required", "model.backup_enabled")
+  get tokenMethodsAllowed() {
+    return this.model?.second_factor_required || this.model?.backup_enabled;
+  }
+
+  @computed(
+    "securityKeyRequired",
+    "passkeysEnabled",
+    "selectedSecondFactorMethod"
+  )
+  get displayWebauthnForm() {
     return (
-      this.securityKeyRequired &&
-      this.selectedSecondFactorMethod === SECOND_FACTOR_METHODS.SECURITY_KEY
+      (this.securityKeyRequired || this.passkeysEnabled) &&
+      (this.selectedSecondFactorMethod === SECOND_FACTOR_METHODS.SECURITY_KEY ||
+        this.selectedSecondFactorMethod === SECOND_FACTOR_METHODS.PASSKEY)
     );
   }
 
   initSelectedSecondFactorMethod() {
-    if (this.model.security_key_required) {
+    if (this.model.passkeys_enabled) {
+      this.set("selectedSecondFactorMethod", SECOND_FACTOR_METHODS.PASSKEY);
+    } else if (this.model.security_key_required) {
       this.set(
         "selectedSecondFactorMethod",
         SECOND_FACTOR_METHODS.SECURITY_KEY
@@ -173,10 +200,15 @@ export default class PasswordResetController extends Controller {
             password: null,
             errorMessage: result.message,
           });
-        } else if (this.secondFactorRequired || this.securityKeyRequired) {
+        } else if (
+          this.secondFactorRequired ||
+          this.securityKeyRequired ||
+          this.passkeysEnabled
+        ) {
           this.setProperties({
             secondFactorRequired: false,
             securityKeyRequired: false,
+            passkeysEnabled: false,
             errorMessage: null,
           });
         } else if (result.errors?.["user_password.password"]?.length > 0) {
@@ -222,6 +254,24 @@ export default class PasswordResetController extends Controller {
           errorMessage,
         });
       }
+    );
+  }
+
+  @action
+  authenticatePasskey() {
+    this.set("selectedSecondFactorMethod", SECOND_FACTOR_METHODS.PASSKEY);
+
+    getWebauthnCredential(
+      this.model.challenge,
+      this.model.passkey_allowed_credential_ids,
+      (credentialData) => {
+        this.set("securityKeyCredential", credentialData);
+        this.send("submit");
+      },
+      (errorMessage) => {
+        this.setProperties({ password: null, errorMessage });
+      },
+      { userVerification: "required" }
     );
   }
 }

--- a/frontend/discourse/app/routes/email-login.js
+++ b/frontend/discourse/app/routes/email-login.js
@@ -15,11 +15,15 @@ export default class EmailLogin extends DiscourseRoute {
   setupController(controller, model) {
     super.setupController(...arguments);
 
-    controller.set(
-      "secondFactorMethod",
-      model.security_key_required
-        ? SECOND_FACTOR_METHODS.SECURITY_KEY
-        : SECOND_FACTOR_METHODS.TOTP
-    );
+    let method = SECOND_FACTOR_METHODS.TOTP;
+    if (model.passkeys_enabled) {
+      method = SECOND_FACTOR_METHODS.PASSKEY;
+    } else if (model.security_key_required) {
+      method = SECOND_FACTOR_METHODS.SECURITY_KEY;
+    }
+    controller.setProperties({
+      secondFactorMethod: method,
+      showTokenInput: false,
+    });
   }
 }

--- a/frontend/discourse/app/templates/email-login.gjs
+++ b/frontend/discourse/app/templates/email-login.gjs
@@ -23,18 +23,19 @@ export default <template>
         {{#if @controller.model.can_login}}
           <div class="email-login-form">
             {{#if @controller.secondFactorRequired}}
-              {{#if @controller.model.security_key_required}}
+              {{#if @controller.showWebauthnForm}}
                 <SecurityKeyForm
-                  @setShowSecurityKey={{fn
-                    (mut @controller.model.security_key_required)
-                  }}
+                  @setShowSecondFactor={{fn (mut @controller.showTokenInput)}}
                   @setSecondFactorMethod={{fn
                     (mut @controller.secondFactorMethod)
                   }}
                   @backupEnabled={{@controller.model.backup_codes_enabled}}
                   @totpEnabled={{@controller.model.totp_enabled}}
-                  @otherMethodAllowed={{@controller.secondFactorRequired}}
-                  @action={{@controller.authenticateSecurityKey}}
+                  @otherMethodAllowed={{@controller.otherTokenMethodsAllowed}}
+                  @passkeysEnabled={{@controller.model.passkeys_enabled}}
+                  @securityKeysEnabled={{@controller.model.security_key_required}}
+                  @passkeyAction={{@controller.authenticatePasskey}}
+                  @securityKeyAction={{@controller.authenticateSecurityKey}}
                 />
               {{else}}
                 <SecondFactorForm
@@ -62,7 +63,7 @@ export default <template>
                 }}</p>
             {{/if}}
 
-            {{#unless @controller.model.security_key_required}}
+            {{#unless @controller.showWebauthnForm}}
               <DButton
                 @label="email_login.confirm_button"
                 @action={{@controller.finishLogin}}

--- a/frontend/discourse/app/templates/login.gjs
+++ b/frontend/discourse/app/templates/login.gjs
@@ -95,11 +95,15 @@ export default <template>
                 @loginPassword={{@controller.loginPassword}}
                 @loginPasswordChanged={{@controller.loginPasswordChanged}}
                 @secondFactorMethod={{@controller.secondFactorMethod}}
+                @secondFactorMethodChanged={{@controller.secondFactorMethodChanged}}
                 @secondFactorToken={{@controller.secondFactorToken}}
                 @secondFactorTokenChanged={{@controller.secondFactorTokenChanged}}
                 @backupEnabled={{@controller.backupEnabled}}
                 @totpEnabled={{@controller.totpEnabled}}
+                @passkeysEnabled={{@controller.passkeysEnabled}}
+                @securityKeysEnabled={{@controller.securityKeysEnabled}}
                 @securityKeyAllowedCredentialIds={{@controller.securityKeyAllowedCredentialIds}}
+                @passkeyAllowedCredentialIds={{@controller.passkeyAllowedCredentialIds}}
                 @securityKeyChallenge={{@controller.securityKeyChallenge}}
                 @showSecurityKey={{@controller.showSecurityKey}}
                 @otherMethodAllowed={{@controller.otherMethodAllowed}}

--- a/frontend/discourse/app/templates/password-reset.gjs
+++ b/frontend/discourse/app/templates/password-reset.gjs
@@ -44,15 +44,18 @@ export default <template>
             <br />
           {{/if}}
 
-          {{#if @controller.displaySecurityKeyForm}}
+          {{#if @controller.displayWebauthnForm}}
             <SecurityKeyForm
               @setSecondFactorMethod={{fn
                 (mut @controller.selectedSecondFactorMethod)
               }}
               @backupEnabled={{@controller.backupEnabled}}
               @totpEnabled={{@controller.secondFactorRequired}}
-              @otherMethodAllowed={{@controller.otherMethodAllowed}}
-              @action={{@controller.authenticateSecurityKey}}
+              @otherMethodAllowed={{@controller.tokenMethodsAllowed}}
+              @passkeysEnabled={{@controller.passkeysEnabled}}
+              @securityKeysEnabled={{@controller.securityKeyRequired}}
+              @passkeyAction={{@controller.authenticatePasskey}}
+              @securityKeyAction={{@controller.authenticateSecurityKey}}
             />
           {{else}}
             <SecondFactorForm
@@ -71,7 +74,7 @@ export default <template>
             </SecondFactorForm>
           {{/if}}
 
-          {{#unless @controller.displaySecurityKeyForm}}
+          {{#unless @controller.displayWebauthnForm}}
             <DButton
               @isLoading={{@controller.isLoading}}
               @action={{@controller.submit}}

--- a/frontend/discourse/tests/acceptance/email-login-test.js
+++ b/frontend/discourse/tests/acceptance/email-login-test.js
@@ -1,0 +1,107 @@
+import { click, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import sinon from "sinon";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+const RESPONSES = {
+  totponly: {
+    can_login: true,
+    token: "totponly",
+    token_email: "eviltrout@example.com",
+    second_factor_required: true,
+    totp_enabled: true,
+    backup_codes_enabled: false,
+  },
+  passkeyonly: {
+    can_login: true,
+    token: "passkeyonly",
+    token_email: "eviltrout@example.com",
+    passkeys_enabled: true,
+    security_key_required: false,
+    passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+    challenge: "somechallenge",
+  },
+  mixedwebauthn: {
+    can_login: true,
+    token: "mixedwebauthn",
+    token_email: "eviltrout@example.com",
+    passkeys_enabled: true,
+    security_key_required: true,
+    allowed_credential_ids: ["c2VjdXJpdHkta2V5LWNyZWRlbnRpYWw="],
+    passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+    challenge: "somechallenge",
+  },
+};
+
+function stubWebauthnCredentialGet() {
+  const calls = [];
+  sinon.stub(navigator.credentials, "get").callsFake((options) => {
+    calls.push(options);
+    const error = new Error("credential get cancelled in tests");
+    error.name = "NotAllowedError";
+    return Promise.reject(error);
+  });
+  return calls;
+}
+
+acceptance("Email login", function (needs) {
+  needs.pretender((server, helper) => {
+    Object.keys(RESPONSES).forEach((token) => {
+      server.get(`/session/email-login/${token}.json`, () =>
+        helper.response(RESPONSES[token])
+      );
+    });
+  });
+
+  test("second factor with TOTP", async function (assert) {
+    await visit("/session/email-login/totponly");
+
+    assert.dom("#second-factor").exists("shows the second factor token prompt");
+    assert
+      .dom(".email-login-form .btn-primary")
+      .exists("shows the confirm button");
+  });
+
+  test("second factor with a passkey only", async function (assert) {
+    const calls = stubWebauthnCredentialGet();
+
+    await visit("/session/email-login/passkeyonly");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .doesNotExist("security key button is not shown without a security key");
+    assert
+      .dom(".email-login-form button[type='submit']")
+      .doesNotExist("hides the confirm button while a ceremony is offered");
+
+    await click("#passkey-authenticate-button");
+    assert.strictEqual(
+      calls[0].publicKey.userVerification,
+      "required",
+      "the passkey ceremony requires user verification"
+    );
+  });
+
+  test("second factor with a passkey and a security key", async function (assert) {
+    const calls = stubWebauthnCredentialGet();
+
+    await visit("/session/email-login/mixedwebauthn");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .exists("shows the security key button");
+
+    await click("#security-key-authenticate-button");
+    assert.strictEqual(
+      calls[0].publicKey.userVerification,
+      "discouraged",
+      "the security key ceremony discourages user verification"
+    );
+  });
+});

--- a/frontend/discourse/tests/acceptance/password-reset-test.js
+++ b/frontend/discourse/tests/acceptance/password-reset-test.js
@@ -105,6 +105,68 @@ acceptance("Password Reset", function (needs) {
     assert.true(DiscourseURL.redirectTo.calledWith("/"), "form is gone");
   });
 
+  test("Password Reset Page With Passkey", async function (assert) {
+    const calls = [];
+    sinon.stub(navigator.credentials, "get").callsFake((options) => {
+      calls.push(options);
+      const error = new Error("credential get cancelled in tests");
+      error.name = "NotAllowedError";
+      return Promise.reject(error);
+    });
+
+    PreloadStore.store("password_reset", {
+      is_developer: false,
+      passkeys_enabled: true,
+      passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+      challenge: "somechallenge",
+    });
+
+    await visit("/u/password-reset/requiretwofactor");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .doesNotExist("security key button is not shown without a security key");
+    assert
+      .dom("#new-account-password")
+      .doesNotExist("does not show the password input");
+
+    await click("#passkey-authenticate-button");
+    assert.strictEqual(
+      calls[0].publicKey.userVerification,
+      "required",
+      "the passkey ceremony requires user verification"
+    );
+  });
+
+  test("Password Reset Page With Passkey and Security Key", async function (assert) {
+    sinon.stub(navigator.credentials, "get").rejects(
+      Object.assign(new Error("credential get cancelled in tests"), {
+        name: "NotAllowedError",
+      })
+    );
+
+    PreloadStore.store("password_reset", {
+      is_developer: false,
+      security_key_required: true,
+      passkeys_enabled: true,
+      allowed_credential_ids: ["c2VjdXJpdHkta2V5LWNyZWRlbnRpYWw="],
+      passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+      challenge: "somechallenge",
+    });
+
+    await visit("/u/password-reset/requiretwofactor");
+
+    assert
+      .dom("#passkey-authenticate-button")
+      .exists("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .exists("shows the security key button");
+  });
+
   test("Password Reset Page With Second Factor", async function (assert) {
     PreloadStore.store("password_reset", {
       is_developer: false,

--- a/frontend/discourse/tests/acceptance/sign-in-test.js
+++ b/frontend/discourse/tests/acceptance/sign-in-test.js
@@ -1,5 +1,6 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import sinon from "sinon";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Signing In", function () {
@@ -122,6 +123,42 @@ acceptance("Signing In", function () {
       .isNotVisible("does not display the second factor prompt");
     assert.dom("#security-key").isVisible("shows the security key prompt");
     assert.dom("#login-button").isNotVisible("hides the login button");
+  });
+
+  test("passkey as second factor", async function (assert) {
+    const calls = [];
+    sinon.stub(navigator.credentials, "get").callsFake((options) => {
+      calls.push(options);
+      const error = new Error("credential get cancelled in tests");
+      error.name = "NotAllowedError";
+      return Promise.reject(error);
+    });
+
+    await visit("/");
+    await click("header .login-button");
+
+    assert.dom(".login-fullpage").exists("shows the login page");
+
+    await fillIn("#login-account-name", "eviltrout");
+    await fillIn("#login-account-password", "need-passkey-2fa");
+    await click(".login-fullpage .btn-primary");
+
+    assert
+      .dom("#credentials")
+      .isNotVisible("hides the username and password prompt");
+    assert
+      .dom("#passkey-authenticate-button")
+      .isVisible("shows the passkey button");
+    assert
+      .dom("#security-key-authenticate-button")
+      .doesNotExist("security key button is not shown without a security key");
+
+    await click("#passkey-authenticate-button");
+    assert.strictEqual(
+      calls.at(-1).publicKey.userVerification,
+      "required",
+      "the passkey ceremony requires user verification"
+    );
   });
 
   test("second factor backup - valid token", async function (assert) {

--- a/frontend/discourse/tests/helpers/create-pretender.js
+++ b/frontend/discourse/tests/helpers/create-pretender.js
@@ -803,6 +803,23 @@ export function applyDefaultHandlers() {
       });
     }
 
+    if (data.password === "need-passkey-2fa") {
+      return response({
+        failed: "FAILED",
+        ok: false,
+        error:
+          "The selected second factor method is not enabled for your account.",
+        reason: "not_enabled_second_factor_method",
+        backup_enabled: false,
+        security_key_enabled: false,
+        passkeys_enabled: true,
+        totp_enabled: false,
+        multiple_second_factor_methods: false,
+        passkey_allowed_credential_ids: ["cGFzc2tleS1jcmVkZW50aWFs"],
+        challenge: "challenge",
+      });
+    }
+
     return response(400, { error: "invalid login" });
   });
 

--- a/spec/lib/concern/second_factor_manager_spec.rb
+++ b/spec/lib/concern/second_factor_manager_spec.rb
@@ -148,6 +148,35 @@ RSpec.describe SecondFactorManager do
         expect(user.has_multiple_second_factor_methods?).to eq(false)
       end
     end
+
+    context "when passkeys count as a second factor" do
+      before do
+        SiteSetting.allow_passkeys_for_2fa = true
+        SiteSetting.enforce_second_factor = "all"
+      end
+
+      it "counts a passkey alongside totp when 2FA is enforced" do
+        disable_security_key
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+
+        Fabricate(:passkey_with_random_credential, user: user)
+        expect(user.has_multiple_second_factor_methods?).to eq(true)
+      end
+
+      it "does not count a passkey when 2FA is not enforced" do
+        SiteSetting.enforce_second_factor = "no"
+        disable_security_key
+        Fabricate(:passkey_with_random_credential, user: user)
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+      end
+
+      it "returns false for a passkey-only user" do
+        disable_security_key
+        disable_totp
+        Fabricate(:passkey_with_random_credential, user: user)
+        expect(user.has_multiple_second_factor_methods?).to eq(false)
+      end
+    end
   end
 
   describe "#only_security_keys_enabled?" do
@@ -197,6 +226,67 @@ RSpec.describe SecondFactorManager do
     end
   end
 
+  describe "#passkey_required_as_second_factor?" do
+    before do
+      SiteSetting.allow_passkeys_for_2fa = true
+      Fabricate(:passkey_with_random_credential, user: user)
+    end
+
+    it "is false when 2FA is not enforced" do
+      SiteSetting.enforce_second_factor = "no"
+      expect(user.passkey_required_as_second_factor?).to eq(false)
+    end
+
+    it "is true when 2FA is enforced for everyone" do
+      SiteSetting.enforce_second_factor = "all"
+      expect(user.passkey_required_as_second_factor?).to eq(true)
+    end
+
+    it "follows staff enforcement for staff and non-staff users" do
+      SiteSetting.enforce_second_factor = "staff"
+      expect(user.passkey_required_as_second_factor?).to eq(false)
+
+      user.update!(admin: true)
+      expect(user.passkey_required_as_second_factor?).to eq(true)
+    end
+
+    it "is false when the user has no passkey even if 2FA is enforced" do
+      SiteSetting.enforce_second_factor = "all"
+      user.security_keys.destroy_all
+      expect(user.passkey_required_as_second_factor?).to eq(false)
+    end
+  end
+
+  describe "#has_any_second_factor_methods_enabled?" do
+    it "is true when totp or security keys are enabled" do
+      expect(user.has_any_second_factor_methods_enabled?).to eq(true)
+
+      disable_totp
+      expect(user.has_any_second_factor_methods_enabled?).to eq(true)
+
+      disable_security_key
+      expect(user.has_any_second_factor_methods_enabled?).to eq(false)
+    end
+
+    context "when the user only has a passkey" do
+      before do
+        disable_totp
+        disable_security_key
+        Fabricate(:passkey_with_random_credential, user: user)
+      end
+
+      it "is true when allow_passkeys_for_2fa is enabled, regardless of enforcement" do
+        SiteSetting.allow_passkeys_for_2fa = true
+        expect(user.has_any_second_factor_methods_enabled?).to eq(true)
+      end
+
+      it "is false when allow_passkeys_for_2fa is disabled" do
+        SiteSetting.allow_passkeys_for_2fa = false
+        expect(user.has_any_second_factor_methods_enabled?).to eq(false)
+      end
+    end
+  end
+
   describe "#authenticate_second_factor" do
     let(:params) { {} }
     let(:server_session) { ServerSession.new("some-prefix") }
@@ -213,16 +303,28 @@ RSpec.describe SecondFactorManager do
       end
 
       context "when the user has a passkey and allow_passkeys_for_2fa is enabled" do
-        # Login / email-login / password-reset flows call authenticate_second_factor
-        # without a second_factor_method. They don't advertise passkeys, so a
-        # passkey-only user must still pass through these flows; only the explicit
-        # 2FA endpoint (which submits a method) should require passkey validation.
         before do
           SiteSetting.allow_passkeys_for_2fa = true
           Fabricate(:passkey_with_random_credential, user: user)
         end
 
-        it "returns OK when no second_factor_method is submitted" do
+        it "returns OK without a second factor when 2FA is not enforced" do
+          # a passkey is a passwordless-login convenience here, not a forced
+          # second step on password login
+          result = user.authenticate_second_factor(params, server_session)
+          expect(result.ok).to eq(true)
+        end
+
+        it "is rejected without a second factor when 2FA is enforced" do
+          SiteSetting.enforce_second_factor = "all"
+          result = user.authenticate_second_factor(params, server_session)
+          expect(result.ok).to eq(false)
+          expect(result.error).to eq(I18n.t("login.invalid_second_factor_method"))
+          expect(result.passkeys_enabled).to eq(true)
+        end
+
+        it "returns OK when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
           expect(user.authenticate_second_factor(params, server_session).ok).to eq(true)
         end
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -232,6 +232,26 @@ RSpec.describe ApplicationController do
       expect(response).to redirect_to("/u/#{user.username}/preferences/second-factor")
     end
 
+    it "should not redirect passkey-only users when allow_passkeys_for_2fa is enabled" do
+      SiteSetting.enforce_second_factor = "all"
+      SiteSetting.allow_passkeys_for_2fa = true
+      Fabricate(:passkey_with_random_credential, user: user)
+      sign_in(user)
+
+      get "/"
+      expect(response.status).to eq(200)
+    end
+
+    it "should redirect passkey-only users when allow_passkeys_for_2fa is disabled" do
+      SiteSetting.enforce_second_factor = "all"
+      SiteSetting.allow_passkeys_for_2fa = false
+      Fabricate(:passkey_with_random_credential, user: user)
+      sign_in(user)
+
+      get "/"
+      expect(response).to redirect_to("/u/#{user.username}/preferences/second-factor")
+    end
+
     it "should redirect users when enforce_second_factor is 'all' and authenticated via oauth" do
       SiteSetting.enforce_second_factor = "all"
       sign_in(user)

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -746,6 +746,36 @@ RSpec.describe Users::OmniauthCallbacksController do
         end
       end
 
+      context "when user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          Fabricate(:passkey_with_random_credential, user: user)
+        end
+
+        it "requires completing 2FA through local login" do
+          get "/auth/google_oauth2/callback.json"
+
+          expect(response.status).to eq(302)
+
+          data = JSON.parse(cookies[:authentication_data])
+
+          expect(data["email"]).to eq(user.email)
+          expect(data["omniauth_disallow_totp"]).to eq(true)
+        end
+
+        it "logs the user in when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          get "/auth/google_oauth2/callback.json"
+
+          expect(response.status).to eq(302)
+
+          data = JSON.parse(cookies[:authentication_data])
+
+          expect(data["authenticated"]).to eq(true)
+        end
+      end
+
       context "when user has TOTP enabled but enforce_second_factor_on_external_auth is false" do
         before { user.create_totp(enabled: true) }
 

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -126,6 +126,49 @@ RSpec.describe SessionController do
           expect(DiscourseWebauthn.rp_id).to eq("localhost")
         end
       end
+
+      context "when the user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        let!(:passkey) { Fabricate(:passkey_with_random_credential, user: user) }
+
+        before { SiteSetting.allow_passkeys_for_2fa = true }
+
+        it "advertises the passkey as a second factor when 2FA is enforced" do
+          SiteSetting.enforce_second_factor = "all"
+
+          get "/session/email-login/#{email_token.token}.json"
+
+          response_body_parsed = response.parsed_body
+          expect(response_body_parsed["can_login"]).to eq(true)
+          expect(response_body_parsed["passkeys_enabled"]).to eq(true)
+          expect(response_body_parsed["security_key_required"]).to eq(false)
+          expect(response_body_parsed["allowed_credential_ids"]).to eq(nil)
+          expect(response_body_parsed["passkey_allowed_credential_ids"]).to eq(
+            [passkey.credential_id],
+          )
+          expect(response_body_parsed["challenge"]).to be_present
+        end
+
+        it "does not advertise the passkey when 2FA is not enforced" do
+          get "/session/email-login/#{email_token.token}.json"
+
+          response_body_parsed = response.parsed_body
+          expect(response_body_parsed["can_login"]).to eq(true)
+          expect(response_body_parsed["passkeys_enabled"]).to eq(nil)
+          expect(response_body_parsed["passkey_allowed_credential_ids"]).to eq(nil)
+        end
+
+        it "does not advertise the passkey when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.enforce_second_factor = "all"
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          get "/session/email-login/#{email_token.token}.json"
+
+          response_body_parsed = response.parsed_body
+          expect(response_body_parsed["can_login"]).to eq(true)
+          expect(response_body_parsed["passkeys_enabled"]).to eq(nil)
+          expect(response_body_parsed["passkey_allowed_credential_ids"]).to eq(nil)
+        end
+      end
     end
   end
 
@@ -491,6 +534,82 @@ RSpec.describe SessionController do
             expect(session[:current_user_id]).to eq(user.id)
             expect(user.user_auth_tokens.count).to eq(1)
           end
+        end
+      end
+
+      context "when the user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          SiteSetting.enforce_second_factor = "all"
+          simulate_localhost_passkey_challenge
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
+
+          # store challenge in server session by visiting the email login page
+          get "/session/email-login/#{email_token.token}.json"
+        end
+
+        it "denies login without a second factor when 2FA is enforced" do
+          post "/session/email-login/#{email_token.token}.json"
+
+          expect(response.status).to eq(200)
+          expect(session[:current_user_id]).to eq(nil)
+          expect(response.parsed_body["error"]).to eq(I18n.t("login.invalid_second_factor_method"))
+        end
+
+        it "logs the user in without a passkey challenge when 2FA is not enforced" do
+          SiteSetting.enforce_second_factor = "no"
+
+          post "/session/email-login/#{email_token.token}.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
+        end
+
+        it "logs the user in with a valid passkey assertion" do
+          post "/session/email-login/#{email_token.token}.json",
+               params: {
+                 second_factor_token: valid_passkey_auth_data,
+                 second_factor_method: UserSecondFactor.methods[:passkey],
+               }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
+        end
+
+        it "denies a passkey assertion posted as the security key method" do
+          post "/session/email-login/#{email_token.token}.json",
+               params: {
+                 second_factor_token: valid_passkey_auth_data,
+                 second_factor_method: UserSecondFactor.methods[:security_key],
+               }
+
+          expect(response.status).to eq(200)
+          expect(session[:current_user_id]).to eq(nil)
+          expect(response.parsed_body["error"]).to eq(
+            I18n.t("login.not_enabled_second_factor_method"),
+          )
+        end
+
+        it "logs the user in without 2FA when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          post "/session/email-login/#{email_token.token}.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
         end
       end
 
@@ -2206,6 +2325,77 @@ RSpec.describe SessionController do
               I18n.t("login.not_enabled_second_factor_method"),
             )
           end
+        end
+      end
+
+      context "when a user has passkey-only 2FA login" do
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          SiteSetting.enforce_second_factor = "all"
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
+        end
+
+        it "challenges the user and advertises the passkey when 2FA is enforced" do
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          expect(response.status).to eq(200)
+          expect(session[:current_user_id]).to eq(nil)
+          response_body = response.parsed_body
+          expect(response_body["failed"]).to eq("FAILED")
+          expect(response_body["passkeys_enabled"]).to eq(true)
+          expect(response_body["security_key_enabled"]).to eq(false)
+          expect(response_body["passkey_allowed_credential_ids"]).to eq([passkey.credential_id])
+          expect(response_body["allowed_credential_ids"]).to eq(nil)
+          expect(response_body["challenge"]).to be_present
+        end
+
+        it "logs the user in with a valid passkey assertion" do
+          simulate_localhost_passkey_challenge
+
+          # store challenge in server session by failing login once
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          post "/session.json",
+               params: {
+                 login: user.username,
+                 password: "myawesomepassword",
+                 second_factor_token: valid_passkey_auth_data,
+                 second_factor_method: UserSecondFactor.methods[:passkey],
+               }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
+        end
+
+        it "logs the user in without a passkey challenge when 2FA is not enforced" do
+          SiteSetting.enforce_second_factor = "no"
+
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
+        end
+
+        it "logs the user in without 2FA when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          post "/session.json", params: { login: user.username, password: "myawesomepassword" }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["error"]).not_to be_present
+          expect(session[:current_user_id]).to eq(user.id)
         end
       end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe UsersController do
         expect(response.body).to have_tag("div#data-preloaded") do |element|
           json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
           expect(json["password_reset"]).to include(
-            '{"is_developer":false,"admin":false,"second_factor_required":false,"security_key_required":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
+            '{"is_developer":false,"admin":false,"second_factor_required":false,"security_key_required":false,"passkeys_enabled":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
           )
         end
 
@@ -535,7 +535,7 @@ RSpec.describe UsersController do
           expect(response.body).to have_tag("div#data-preloaded") do |element|
             json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
             expect(json["password_reset"]).to include(
-              '{"is_developer":false,"admin":false,"second_factor_required":true,"security_key_required":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
+              '{"is_developer":false,"admin":false,"second_factor_required":true,"security_key_required":false,"passkeys_enabled":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
             )
           end
 
@@ -648,6 +648,92 @@ RSpec.describe UsersController do
             expect(response.body).to include(I18n.t("webauthn.validation.not_found_error"))
             expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(false)
           end
+        end
+      end
+
+      context "when the user only has a passkey and allow_passkeys_for_2fa is enabled" do
+        let!(:passkey) do
+          Fabricate(
+            :user_security_key,
+            user: user1,
+            credential_id: valid_passkey_data[:credential_id],
+            public_key: valid_passkey_data[:public_key],
+            factor_type: UserSecurityKey.factor_types[:first_factor],
+          )
+        end
+
+        before do
+          SiteSetting.allow_passkeys_for_2fa = true
+          SiteSetting.enforce_second_factor = "all"
+          simulate_localhost_passkey_challenge
+          DiscourseWebauthn.stubs(:origin).returns("http://localhost:3000")
+
+          get "/u/password-reset/#{email_token.token}"
+        end
+
+        it "preloads with the passkey allow-list when 2FA is enforced" do
+          expect(response.body).to have_tag("div#data-preloaded") do |element|
+            json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+            password_reset = JSON.parse(json["password_reset"])
+            expect(password_reset["challenge"]).not_to eq(nil)
+            expect(password_reset["passkeys_enabled"]).to eq(true)
+            expect(password_reset["security_key_required"]).to eq(false)
+            expect(password_reset["allowed_credential_ids"]).to eq(nil)
+            expect(password_reset["passkey_allowed_credential_ids"]).to eq([passkey.credential_id])
+          end
+        end
+
+        it "does not advertise the passkey when 2FA is not enforced" do
+          SiteSetting.enforce_second_factor = "no"
+
+          get "/u/password-reset/#{email_token.token}"
+
+          expect(response.body).to have_tag("div#data-preloaded") do |element|
+            json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+            password_reset = JSON.parse(json["password_reset"])
+            expect(password_reset["passkeys_enabled"]).to eq(false)
+            expect(password_reset["passkey_allowed_credential_ids"]).to eq(nil)
+          end
+        end
+
+        it "does not change the password without a second factor when 2FA is enforced" do
+          put "/u/password-reset/#{email_token.token}", params: { password: "hg9ow8yHG32O" }
+
+          expect(response.status).to eq(200)
+          expect(response.body).to include(I18n.t("login.invalid_second_factor_method"))
+          expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(false)
+        end
+
+        it "changes the password without a second factor when 2FA is not enforced" do
+          SiteSetting.enforce_second_factor = "no"
+
+          put "/u/password-reset/#{email_token.token}", params: { password: "hg9ow8yHG32O" }
+
+          expect(response.status).to eq(200)
+          expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(true)
+        end
+
+        it "changes the password with a valid passkey assertion" do
+          put "/u/password-reset/#{email_token.token}.json",
+              params: {
+                password: "hg9ow8yHG32O",
+                second_factor_token: valid_passkey_auth_data,
+                second_factor_method: UserSecondFactor.methods[:passkey],
+              }
+
+          expect(response.status).to eq(200)
+          user1.reload
+          expect(user1.confirm_password?("hg9ow8yHG32O")).to eq(true)
+          expect(user1.user_auth_tokens.count).to eq(1)
+        end
+
+        it "ignores the passkey when allow_passkeys_for_2fa is disabled" do
+          SiteSetting.allow_passkeys_for_2fa = false
+
+          put "/u/password-reset/#{email_token.token}", params: { password: "hg9ow8yHG32O" }
+
+          expect(response.status).to eq(200)
+          expect(user1.reload.confirm_password?("hg9ow8yHG32O")).to eq(true)
         end
       end
     end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -104,6 +104,22 @@ RSpec.describe CurrentUserSerializer do
         expect(json[:second_factor_enabled]).to eq(true)
       end
     end
+
+    context "when the user only has a passkey" do
+      before do
+        SiteSetting.allow_passkeys_for_2fa = true
+        Fabricate(:passkey_with_random_credential, user: user)
+      end
+
+      it "is true regardless of enforcement" do
+        expect(json[:second_factor_enabled]).to eq(true)
+      end
+
+      it "is false when allow_passkeys_for_2fa is disabled" do
+        SiteSetting.allow_passkeys_for_2fa = false
+        expect(json[:second_factor_enabled]).to eq(false)
+      end
+    end
   end
 
   describe "#groups" do

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -305,6 +305,51 @@ module SystemHelpers
     end
   end
 
+  # Registers a passkey (first-factor credential) for the user on a virtual
+  # authenticator with user verification enabled. The credential is
+  # non-resident so the login page's conditional passkey prompt does not
+  # auto-complete; it can only be exercised through allow-list ceremonies
+  # such as the passkey-as-2FA flows.
+  def with_passkey(user)
+    public_key_base64 =
+      "pQECAyYgASFYIJhY+jDNJM8g0lyKP3ivDxs+mrKXqfKUY3f7Uo4pWTPDIlggj03xktSm0JTSqbDefhu5WAKH7VRQmWXotjtI/8ka/P0="
+    private_key_base64 =
+      "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2AWg10o6aoM0s55halZvcQLnpM2tVO2D8Ugw7wFCjzyhRANCAASYWPowzSTPINJcij94rw8bPpqyl6nylGN3-1KOKVkzw49N8ZLUptCU0qmw3n4buVgCh-1UUJll6LY7SP_JGvz9"
+    credential_id_base64 = Base64.strict_encode64(SecureRandom.random_bytes(32))
+    credential_id_bytes = Base64.urlsafe_decode64(credential_id_base64)
+    private_key_bytes = Base64.urlsafe_decode64(private_key_base64)
+
+    with_virtual_authenticator(
+      hasUserVerification: true,
+      isUserVerified: true,
+    ) do |cdp_client, authenticator_id|
+      cdp_client.send_message(
+        "WebAuthn.addCredential",
+        params: {
+          authenticatorId: authenticator_id,
+          credential: {
+            credentialId: Base64.strict_encode64(credential_id_bytes),
+            isResidentCredential: false,
+            rpId: DiscourseWebauthn.rp_id,
+            privateKey: Base64.strict_encode64(private_key_bytes),
+            signCount: 1,
+          },
+        },
+      )
+
+      Fabricate(
+        :user_security_key,
+        user:,
+        public_key: public_key_base64,
+        credential_id: credential_id_base64,
+        factor_type: UserSecurityKey.factor_types[:first_factor],
+        name: "My Passkey",
+      )
+
+      yield
+    end
+  end
+
   def with_virtual_authenticator(options = {})
     page.driver.with_playwright_page do |pw_page|
       cdp_client = pw_page.context.new_cdp_session(pw_page)

--- a/spec/system/login_spec.rb
+++ b/spec/system/login_spec.rb
@@ -431,6 +431,57 @@ shared_examples "login scenarios" do
       expect(page).to have_css(".header-dropdown-toggle.current-user")
     end
   end
+
+  context "when the user's only second factor is a passkey and 2FA is enforced" do
+    before do
+      SiteSetting.allow_passkeys_for_2fa = true
+      SiteSetting.enforce_second_factor = "all"
+      EmailToken.confirm(Fabricate(:email_token, user: user).token)
+    end
+
+    it "can login with a password and the passkey as 2FA" do
+      with_passkey(user) do
+        login_form.open.fill(username: "john", password: "supersecurepassword").click_login
+
+        expect(page).to have_css("#passkey-authenticate-button")
+        find("#passkey-authenticate-button").click
+
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
+
+    it "can login with a login link and the passkey as 2FA" do
+      with_passkey(user) do
+        login_form.open.fill_username("john").email_login_link
+
+        login_link = wait_for_email_link(user, :email_login)
+        visit login_link
+
+        expect(page).to have_css("#passkey-authenticate-button")
+        find("#passkey-authenticate-button").click
+
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
+
+    it "can reset password with the passkey as 2FA" do
+      with_passkey(user) do
+        login_form.open.fill_username("john").forgot_password
+        find("button.forgot-password-reset").click
+
+        reset_password_link = wait_for_email_link(user, :reset_password)
+        visit reset_password_link
+
+        expect(page).to have_css("#passkey-authenticate-button")
+        find("#passkey-authenticate-button").click
+
+        find("#new-account-password").fill_in(with: "newsuperpassword")
+        find(".change-password-form .btn-primary").click
+
+        expect(page).to have_css(".header-dropdown-toggle.current-user")
+      end
+    end
+  end
 end
 
 describe "Login" do


### PR DESCRIPTION
Alternative to #40818 that adopts @pmusaraj's review feedback there.

**The concern on #40818:** removing the 2FA escape hatch made `allow_passkeys_for_2fa` behave like an enforcement mechanism — any user who owns a passkey was forced to use it as a second factor on every password/email/reset login, even when the site does not enforce 2FA. Since a passkey is primarily a *passwordless login* credential (unlike TOTP, which exists only to be a second factor), registering one for convenience should not silently turn password login into a two-step flow.

**This PR's model:** `enforce_second_factor` remains the only switch that forces 2FA. `allow_passkeys_for_2fa` only makes a passkey *count as* and *be usable as* a valid second factor:

* `has_any_second_factor_methods_enabled?` and the current-user / user / admin-detailed serializers count passkeys, so a passkey-only user satisfies `enforce_second_factor` (no redirect to the enrollment screen) and can drop their last TOTP / security key.
* New `passkey_required_as_second_factor?` (passkey available **and** the user is subject to `enforce_second_factor`) gates the passkey challenge and advertisement in password login, email login, and password reset. When 2FA is **not** enforced, those flows ignore the passkey and authenticate with the password alone.
* `/session/2fa` sensitive-action confirmation still offers passkeys whenever available, regardless of enforcement (a passkey is just an available instrument there).
* The login, email login, and password reset forms render a "Use passkey" ceremony (user verification required) next to the security key one.
* `should_enforce_2fa?` reuses the new `subject_to_enforced_second_factor?` so the role/setting rule lives in one place.

Because the challenge is now driven by enforcement, "challenge a passkey at login" and "a passkey satisfies enforced 2FA" are the same feature and ship together — so this single PR replaces both #40818 and #40819 (which can be closed if this approach is preferred).

With the setting disabled (default), behavior is unchanged.

### Testing
Backend specs (manager, session/users/application controllers, omniauth, serializers), QUnit acceptance (`second-factor-auth`, `sign-in`, `email-login`, `password-reset`), and end-to-end system specs in `login_spec.rb` covering password / email-link / password-reset login with a passkey as 2FA under enforcement (via a new `with_passkey` virtual-authenticator helper). All green.

### Reviewer note
Once this lands, a passkey-only user who loses their passkey on an enforced site cannot complete email login or password reset (no backup codes for passkey-only accounts) — the intended consequence of real enforcement, but worth a release note and a future nudge toward backup codes.
