### PR TITLE
DEV: CSRF Token Not Invalidated After Password Reset

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -940,6 +940,7 @@ class UsersController < ApplicationController
             action: UserHistory.actions[:change_password],
           )
 
+          reset_csrf_token(request)
           logon_after_password_reset
         end
       end

--- a/spec/requests/users_email_controller_spec.rb
+++ b/spec/requests/users_email_controller_spec.rb
@@ -162,6 +162,46 @@ RSpec.describe UsersEmailController do
     context "when logged in" do
       before { sign_in(user) }
 
+      context "with CSRF protection enabled" do
+        before { ActionController::Base.allow_forgery_protection = true }
+        after { ActionController::Base.allow_forgery_protection = false }
+
+        it "rejects a CSRF token captured before a password reset" do
+          get "/session/csrf.json"
+          pre_reset_csrf_token = response.parsed_body["csrf"]
+          password_reset_token =
+            user
+              .email_tokens
+              .create!(email: user.email, scope: EmailToken.scopes[:password_reset])
+              .token
+
+          put "/u/password-reset/#{password_reset_token}.json",
+              params: {
+                password: SecureRandom.hex,
+              },
+              headers: {
+                "X-CSRF-Token" => pre_reset_csrf_token,
+              }
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["success"]).to eq(true)
+
+          expect do
+            put "/u/#{user.username}/preferences/email.json",
+                params: {
+                  email: "bubblegum@adventuretime.ooo",
+                },
+                headers: {
+                  "X-CSRF-Token" => pre_reset_csrf_token,
+                  "HTTP_X_REQUESTED_WITH" => "XMLHttpRequest",
+                }
+          end.not_to change(EmailChangeRequest, :count)
+
+          expect(response.status).to eq(403)
+          expect(response.body).to include("BAD CSRF")
+        end
+      end
+
       it "raises an error without an email parameter" do
         put "/u/#{user.username}/preferences/email.json"
         expect(response.status).to eq(400)


### PR DESCRIPTION
## Summary

The password_reset_update destroys user_auth_tokens but does not reset the Rails session/CSRF token, then logs the user back in. This is not a security fix per se, an attacker needs to obtain the token first. But it is defence in depth, a stale token cannot be reused after this change. 

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1198
- HackerOne report: https://hackerone.com/reports/3747766

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>