### PR TITLE
SECURITY: BestTopics report includes unlisted topics

### DIFF
--- a/plugins/discourse-rewind/app/services/discourse_rewind/action/best_topics.rb
+++ b/plugins/discourse-rewind/app/services/discourse_rewind/action/best_topics.rb
@@ -35,7 +35,7 @@ module DiscourseRewind
             .includes(:topic)
             .references(:topic)
             .joins(topic: :category)
-            .where(topic: { deleted_at: nil, created_at: date, user_id: user.id })
+            .where(topic: { deleted_at: nil, created_at: date, user_id: user.id, visible: true })
             .where.not(topic: { archetype: Archetype.private_message })
             .where("NOT categories.read_restricted")
             .order("yearly_score DESC NULLS LAST")

--- a/plugins/discourse-rewind/spec/actions/best_topics_spec.rb
+++ b/plugins/discourse-rewind/spec/actions/best_topics_spec.rb
@@ -55,6 +55,19 @@ RSpec.describe DiscourseRewind::Action::BestTopics do
       end
     end
 
+    context "when a topic is unlisted" do
+      before do
+        topic_1.update!(visible: false)
+        TopTopic.find_by(topic_id: topic_1.id).update!(yearly_score: 99)
+      end
+
+      it "does not expose the topic title or excerpt" do
+        topic_ids = call_report[:data].map { |topic| topic[:topic_id] }
+
+        expect(topic_ids).not_to include(topic_1.id)
+      end
+    end
+
     context "when a topic belongs to another user" do
       before { topic_1.update!(user: Fabricate(:user)) }
 


### PR DESCRIPTION
## Summary

This is a minor security issue, DiscourseRewind::Action::BestTopics filters deleted/private/read-restricted topics,  but doesn't filter by `visible=true`. 

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1174
- HackerOne report: https://hackerone.com/reports/3748532

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>