### PR TITLE
FIX: Preserve poll view and in-progress vote across post cloaking

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -49,17 +49,7 @@ export default class PollComponent extends Component {
   @tracked preloadedVoters = this.defaultPreloadedVoters();
   @tracked voterListExpanded = false;
 
-  @tracked vote = this.args.post.polls_votes?.[this.args.poll.name] || [];
-  @tracked hasSavedVote = this.vote.length > 0;
-
-  @tracked
-  showResults =
-    !(this.poll.results === ON_CLOSE && !this.closed) &&
-    !(this.staffOnly && !this.isStaff) &&
-    (this.hasSavedVote ||
-      (this.topicArchived && !this.staffOnly) ||
-      (this.closed && !this.staffOnly));
-
+  @tracked hasSavedVote = this.savedVote.length > 0;
   @tracked showTally = false;
 
   registerPollButtons = (element) => {
@@ -79,7 +69,6 @@ export default class PollComponent extends Component {
 
     return userGroups && pollGroups.some((g) => userGroups.includes(g));
   };
-
   areRanksValid = (arr) => {
     let ranks = new Set(); // Using a Set to keep track of unique ranks
     let hasNonZeroDuplicate = false;
@@ -100,6 +89,9 @@ export default class PollComponent extends Component {
 
     return !hasNonZeroDuplicate && !allZeros;
   };
+  @tracked _vote = this.initialVote();
+
+  @tracked _showResults = this.initialShowResults();
 
   _toggleOption = (option, rank = 0) => {
     if (this.isMultiple) {
@@ -133,6 +125,67 @@ export default class PollComponent extends Component {
 
     this.vote = [...this.vote];
   };
+
+  get showResults() {
+    return this._showResults;
+  }
+
+  set showResults(value) {
+    this._showResults = value;
+    this.poll.showResultsToggle = value;
+  }
+
+  get resultsVisibilityAllowed() {
+    return (
+      !(this.poll.results === ON_CLOSE && !this.closed) &&
+      !(this.staffOnly && !this.isStaff)
+    );
+  }
+
+  get resultsToggleAllowed() {
+    return !this.hideResultsDisabled && this.resultsVisibilityAllowed;
+  }
+
+  initialShowResults() {
+    if (
+      this.poll.showResultsToggle !== undefined &&
+      this.resultsToggleAllowed
+    ) {
+      return this.poll.showResultsToggle;
+    }
+
+    return (
+      this.resultsVisibilityAllowed &&
+      (this.hasSavedVote || this.hideResultsDisabled)
+    );
+  }
+
+  get vote() {
+    return this._vote;
+  }
+
+  set vote(value) {
+    this._vote = value;
+    this.poll.inProgressVote = value;
+  }
+
+  initialVote() {
+    if (this.poll.inProgressVote !== undefined) {
+      return this.copyVote(this.poll.inProgressVote);
+    }
+
+    return this.savedVote;
+  }
+
+  get savedVote() {
+    return this.copyVote(this.args.post.polls_votes?.[this.poll.name] || []);
+  }
+
+  copyVote(votes) {
+    return this.isRankedChoice
+      ? votes.map((vote) => ({ ...vote }))
+      : [...votes];
+  }
 
   get poll() {
     return this.args.poll;
@@ -236,7 +289,8 @@ export default class PollComponent extends Component {
       if (!this.args.post.polls_votes) {
         this.args.post.polls_votes = trackedObject();
       }
-      this.args.post.polls_votes[this.poll.name] = this.vote;
+      this.args.post.polls_votes[this.poll.name] = this.copyVote(this.vote);
+      this.poll.inProgressVote = undefined;
       Object.assign(this.poll, poll);
 
       this.appEvents.trigger("poll:voted", poll, this.post, this.vote);
@@ -612,6 +666,7 @@ export default class PollComponent extends Component {
         if (this.args.post.polls_votes) {
           delete this.args.post.polls_votes[this.poll.name];
         }
+        this.poll.inProgressVote = undefined;
         this.appEvents.trigger("poll:voted", poll, this.post, this.vote);
         this.showResults = false;
       })

--- a/plugins/poll/test/javascripts/component/poll-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-test.gjs
@@ -1,6 +1,6 @@
 import EmberObject from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
-import { click, render } from "@ember/test-helpers";
+import { click, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
@@ -360,6 +360,317 @@ module("Component | Poll", function (hooks) {
       .hasText(i18n("poll.results.groups.title", { groups: "foo" }));
     assert.strictEqual(requests, 0);
     assert.dom(".chosen").doesNotExist();
+  });
+
+  test("keeps the voting view after the poll component is re-rendered", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+        polls_votes: {
+          poll: ["1f972d1df351de3ce35a787c89faad29"],
+        },
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "multiple",
+        status: "open",
+        results: "always",
+        min: 1,
+        max: 2,
+        options: [
+          { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 1 },
+          { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+        ],
+        voters: 1,
+        chart_type: "bar",
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert.dom("ul.results").exists("results are shown for the saved vote");
+    assert.dom(".poll-buttons .cast-votes").doesNotExist();
+
+    await click(".poll-buttons .toggle-results");
+
+    assert
+      .dom("ul.options")
+      .exists("clicking the button shows the voting view");
+    assert.dom(".poll-buttons .cast-votes").exists();
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert
+      .dom("ul.options")
+      .exists("the voting view survives the component being re-rendered");
+    assert.dom("ul.results").doesNotExist();
+    assert.dom(".poll-buttons .cast-votes").exists();
+  });
+
+  test("keeps an uncommitted selection after the poll component is re-rendered", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "multiple",
+        status: "open",
+        results: "always",
+        min: 1,
+        max: 2,
+        options: [
+          { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 0 },
+          { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+        ],
+        voters: 0,
+        chart_type: "bar",
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    await click(
+      "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'] button"
+    );
+    assert
+      .dom(
+        "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'] .d-icon-far-square-check"
+      )
+      .exists("the option is selected but not yet cast");
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert
+      .dom(
+        "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'] .d-icon-far-square-check"
+      )
+      .exists("the uncommitted selection survives the re-render");
+    assert.dom(".poll-buttons .cast-votes").exists();
+  });
+
+  test("ignores a stale hidden-results toggle on a closed poll", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+        polls_votes: {
+          poll: ["1f972d1df351de3ce35a787c89faad29"],
+        },
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "multiple",
+        status: "closed",
+        results: "always",
+        min: 1,
+        max: 2,
+        showResultsToggle: false,
+        options: [
+          { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 1 },
+          { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+        ],
+        voters: 1,
+        chart_type: "bar",
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert
+      .dom("ul.results")
+      .exists("a closed poll shows results despite a stale hidden toggle");
+    assert.dom("ul.options").doesNotExist();
+  });
+
+  test("does not mutate the saved vote when toggling an uncast option", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+        polls_votes: {
+          poll: ["1f972d1df351de3ce35a787c89faad29"],
+        },
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "multiple",
+        status: "open",
+        results: "always",
+        min: 1,
+        max: 2,
+        showResultsToggle: false,
+        options: [
+          { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 1 },
+          { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+        ],
+        voters: 1,
+        chart_type: "bar",
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    await click(
+      "li[data-poll-option-id='d7ebc3a9beea2e680815a1e4f57d6db6'] button"
+    );
+
+    assert.deepEqual(
+      this.post.polls_votes.poll,
+      ["1f972d1df351de3ce35a787c89faad29"],
+      "toggling an uncast option leaves the saved vote array untouched"
+    );
+  });
+
+  test("keeps a ranked-choice selection after the poll component is re-rendered", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "ranked_choice",
+        status: "open",
+        results: "always",
+        options: [
+          {
+            id: "1f972d1df351de3ce35a787c89faad29",
+            html: "this",
+            votes: 0,
+            rank: 0,
+          },
+          {
+            id: "d7ebc3a9beea2e680815a1e4f57d6db6",
+            html: "that",
+            votes: 0,
+            rank: 0,
+          },
+          {
+            id: "6c986ebcde3d5822a6e91a695c388094",
+            html: "other",
+            votes: 0,
+            rank: 0,
+          },
+        ],
+        voters: 0,
+        chart_type: "bar",
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    await click(
+      ".ranked-choice-poll-option[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'] button"
+    );
+    await click(".dropdown-menu__item:nth-child(2) button");
+
+    assert
+      .dom(
+        ".ranked-choice-poll-option[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'][data-poll-option-rank='1']"
+      )
+      .exists("the option is ranked first before re-render");
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert
+      .dom(
+        ".ranked-choice-poll-option[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'][data-poll-option-rank='1']"
+      )
+      .exists("the ranked-choice selection survives the re-render");
+  });
+
+  test("keeps an uncommitted selection across a server poll refresh and re-render", async function (assert) {
+    this.setProperties({
+      post: EmberObject.create({
+        id: 42,
+        topic: {
+          archived: false,
+        },
+        user_id: 29,
+      }),
+      poll: trackedObject({
+        name: "poll",
+        type: "multiple",
+        status: "open",
+        results: "always",
+        min: 1,
+        max: 2,
+        options: [
+          { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 0 },
+          { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 0 },
+        ],
+        voters: 0,
+        chart_type: "bar",
+      }),
+    });
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    await click(
+      "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'] button"
+    );
+
+    Object.assign(this.poll, {
+      voters: 9,
+      options: [
+        { id: "1f972d1df351de3ce35a787c89faad29", html: "yes", votes: 4 },
+        { id: "d7ebc3a9beea2e680815a1e4f57d6db6", html: "no", votes: 5 },
+      ],
+    });
+    await settled();
+
+    await render(
+      <template><Poll @post={{this.post}} @poll={{this.poll}} /></template>
+    );
+
+    assert
+      .dom(
+        "li[data-poll-option-id='1f972d1df351de3ce35a787c89faad29'] .d-icon-far-square-check"
+      )
+      .exists(
+        "the uncommitted selection survives a server refresh plus re-render"
+      );
+    assert.strictEqual(
+      this.poll.inProgressVote.length,
+      1,
+      "the persisted in-progress vote is not clobbered by the server merge"
+    );
   });
 
   test("voting on a multiple poll with no min attribute", async function (assert) {


### PR DESCRIPTION
Previously, users could not amend their votes on large, open polls — clicking the "Vote" button left them stuck on the results view, because the poll component's view and in-progress selection reset whenever the post was cloaked and re-rendered while scrolling.

This change persists the results toggle and the in-progress selection on the durable poll object so they survive a re-mount, restoring the ballot (and any uncommitted choices) when the user scrolls back to the poll.

Meta: https://meta.discourse.org/t/large-poll-bug-users-cannot-amend-votes-on-open-polls/405511
