### PR TITLE
FIX: Preserve scroll position when toggling a poll's results

### DIFF
--- a/plugins/poll/assets/javascripts/discourse/components/poll.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll.gjs
@@ -4,7 +4,9 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { trackedObject } from "@ember/reactive/collections";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
@@ -59,6 +61,10 @@ export default class PollComponent extends Component {
       (this.closed && !this.staffOnly));
 
   @tracked showTally = false;
+
+  registerPollButtons = (element) => {
+    this.pollButtonsElement = element;
+  };
 
   checkUserGroups = (user, poll) => {
     const pollGroups =
@@ -374,7 +380,25 @@ export default class PollComponent extends Component {
 
   @action
   toggleResults() {
+    const anchor = this.pollButtonsElement;
+    const anchorTop = anchor?.getBoundingClientRect().top;
+
     this.showResults = !this.showResults;
+
+    if (anchorTop == null) {
+      return;
+    }
+
+    schedule("afterRender", () => {
+      if (!anchor.isConnected) {
+        return;
+      }
+
+      const shift = anchor.getBoundingClientRect().top - anchorTop;
+      if (shift !== 0) {
+        window.scrollBy(0, shift);
+      }
+    });
   }
 
   get canCastVotes() {
@@ -761,7 +785,7 @@ export default class PollComponent extends Component {
         @hasVoted={{this.hasVoted}}
         @voters={{this.voters}}
       />
-      <div class="poll-buttons">
+      <div class="poll-buttons" {{didInsert this.registerPollButtons}}>
         {{#if this.showCastVotesButton}}
           <button
             class={{this.castVotesButtonClass}}

--- a/plugins/poll/spec/system/large_poll_scroll_spec.rb
+++ b/plugins/poll/spec/system/large_poll_scroll_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe "Returning to the ballot on a large open poll" do
+  fab!(:user)
+  fab!(:topic)
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:poll_page) { PageObjects::Pages::Poll.new(topic_page:) }
+
+  before do
+    SiteSetting.poll_enabled = true
+    SiteSetting.poll_maximum_options = 100
+    sign_in(user)
+  end
+
+  it "keeps the poll on screen when the user clicks back to the ballot" do
+    options = (1..80).map { |i| "* Option #{format("%02d", i)}" }.join("\n")
+    post = Fabricate(:post, topic:, raw: <<~RAW)
+      [poll type=multiple results=always min=1 max=80]
+      #{options}
+      [/poll]
+    RAW
+    20.times do |i|
+      Fabricate(:post, topic:, raw: "Reply #{i} that keeps the topic tall enough to scroll.")
+    end
+
+    page.current_window.resize_to(1100, 700)
+
+    topic_page.visit_topic(topic)
+    expect(poll_page).to have_poll_for_post(post)
+
+    poll_page.vote_for_option(post, "Option 01")
+    poll_page.vote_for_option(post, "Option 02")
+    poll_page.click_cast_votes(post)
+
+    expect(poll_page).to have_results_toggle(post)
+    poll_page.scroll_results_toggle_into_view
+    poll_page.click_results_toggle
+
+    expect(poll_page).to have_voting_options(post)
+    expect(poll_page).to have_poll_within_viewport
+  end
+end

--- a/plugins/poll/spec/system/page_objects/pages/poll.rb
+++ b/plugins/poll/spec/system/page_objects/pages/poll.rb
@@ -34,6 +34,47 @@ module PageObjects
         post_element = @topic_page.post_by_number(post.post_number)
         post_element.has_css?(".poll .info-number", text: count.to_s)
       end
+
+      def click_cast_votes(post)
+        @topic_page.post_by_number(post.post_number).find(".poll-buttons .cast-votes").click
+      end
+
+      def has_results_toggle?(post)
+        @topic_page.post_by_number(post.post_number).has_css?(".poll-buttons button.toggle-results")
+      end
+
+      def scroll_results_toggle_into_view
+        button = find(".poll-buttons button.toggle-results")
+        page.execute_script("arguments[0].scrollIntoView({ block: 'center' });", button)
+      end
+
+      def click_results_toggle
+        page.execute_script(
+          "document.querySelector('.poll-buttons button.toggle-results').click();",
+        )
+      end
+
+      def has_voting_options?(post)
+        @topic_page.post_by_number(post.post_number).has_css?(".poll ul.options")
+      end
+
+      def has_poll_within_viewport?
+        try_until_success { expect(poll_within_viewport?).to eq(true) }
+        true
+      rescue RSpec::Expectations::ExpectationNotMetError
+        false
+      end
+
+      private
+
+      def poll_within_viewport?
+        page.evaluate_script(<<~JS)
+          (() => {
+            const rect = document.querySelector(".poll")?.getBoundingClientRect();
+            return rect ? rect.top < window.innerHeight && rect.bottom > 0 : false;
+          })()
+        JS
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, clicking the button that toggles a large poll between its results and the ballot scroll-jumped the page far down — often to the bottom — leaving the poll off-screen and the vote seemingly impossible to amend (the browser's native scroll anchoring loses its anchor node when the toggle removes the results table the user is scrolled into).

This change pins the poll's button row and restores its viewport position with `window.scrollBy` after the swap, so the poll stays exactly where the user was looking when switching between results and voting.

Meta: https://meta.discourse.org/t/large-poll-bug-users-cannot-amend-votes-on-open-polls/405511
