### PR TITLE
UX: Truncate long cells in the dashboard data tables

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -493,6 +493,38 @@
   }
 }
 
+.db-search-table {
+  width: 100%;
+  table-layout: fixed;
+
+  th,
+  td {
+    @include ellipsis;
+  }
+
+  thead th {
+    color: var(--primary-high);
+    font-size: var(--font-down-1-rem);
+  }
+
+  &__col-status,
+  &__col-number {
+    width: 20%;
+  }
+
+  &__col-number,
+  &__cell-number {
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__empty {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1-rem);
+    margin: 0;
+  }
+}
+
 .db-whos-posting {
   display: flex;
   flex-direction: column;

--- a/frontend/discourse/admin/components/dashboard/search.gjs
+++ b/frontend/discourse/admin/components/dashboard/search.gjs
@@ -234,110 +234,100 @@ export default class DashboardSearch extends Component {
                 </:content>
               </DTooltip>
             </h3>
-            <div class="db-activity">
-              {{#if @search.trending.length}}
-                <div class="db-activity__table-scroll-container">
-                  <table class="db-activity-table">
-                    <thead>
-                      <tr>
-                        <th>{{i18n
-                            "admin.dashboard.sections.search.table.term"
-                          }}</th>
-                        <th class="db-activity-table__col-number">
-                          {{i18n
-                            "admin.dashboard.sections.search.table.searches"
+            {{#if @search.trending.length}}
+              <table class="db-search-table">
+                <thead>
+                  <tr>
+                    <th>{{i18n
+                        "admin.dashboard.sections.search.table.term"
+                      }}</th>
+                    <th class="db-search-table__col-number">
+                      {{i18n "admin.dashboard.sections.search.table.searches"}}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{#each @search.trending as |row|}}
+                    <tr data-test-search-term-row>
+                      <td>
+                        <LinkTo
+                          @route="adminSearchLogs.term"
+                          @query={{hash
+                            term=row.term
+                            period=this.trendingTermPeriod
+                            searchType="logged_in_only"
                           }}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {{#each @search.trending as |row|}}
-                        <tr data-test-search-term-row>
-                          <td>
-                            <LinkTo
-                              @route="adminSearchLogs.term"
-                              @query={{hash
-                                term=row.term
-                                period=this.trendingTermPeriod
-                                searchType="logged_in_only"
-                              }}
-                            >
-                              {{row.term}}
-                            </LinkTo>
-                          </td>
-                          <td class="db-activity-table__cell-number">
-                            {{formatCount row.searches}}
-                          </td>
-                        </tr>
-                      {{/each}}
-                    </tbody>
-                  </table>
-                </div>
-              {{else}}
-                <p class="db-activity__empty">
-                  {{i18n "admin.dashboard.sections.search.trending.empty"}}
-                </p>
-              {{/if}}
-            </div>
+                          title={{row.term}}
+                        >
+                          {{row.term}}
+                        </LinkTo>
+                      </td>
+                      <td class="db-search-table__cell-number">
+                        {{formatCount row.searches}}
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            {{else}}
+              <p class="db-search-table__empty">
+                {{i18n "admin.dashboard.sections.search.trending.empty"}}
+              </p>
+            {{/if}}
           </div>
 
           <div class="db-section__row-block">
             <h3 class="db-section__row-block-title">
               {{i18n "admin.dashboard.sections.search.content_gaps.title"}}
             </h3>
-            <div class="db-activity">
-              {{#if @search.content_gaps.length}}
-                <div class="db-activity__table-scroll-container">
-                  <table class="db-activity-table">
-                    <thead>
-                      <tr>
-                        <th>{{i18n
-                            "admin.dashboard.sections.search.table.term"
-                          }}</th>
-                        <th>{{i18n
-                            "admin.dashboard.sections.search.table.status"
-                          }}</th>
-                        <th class="db-activity-table__col-number">
-                          {{i18n
-                            "admin.dashboard.sections.search.table.searches"
-                          }}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {{#each @search.content_gaps as |row|}}
-                        <tr data-test-search-term-row>
-                          <td>
-                            <LinkTo
-                              @route="full-page-search"
-                              @query={{hash q=row.term}}
-                            >
-                              {{row.term}}
-                            </LinkTo>
-                          </td>
-                          <td>
-                            <DTooltip
-                              class="db-pill --neg"
-                              @identifier="search-gap-badge-tooltip"
-                            >
-                              <:trigger>{{badgeLabel row.status}}</:trigger>
-                              <:content>{{badgeTooltip row.status}}</:content>
-                            </DTooltip>
-                          </td>
-                          <td class="db-activity-table__cell-number">
-                            {{formatCount row.searches}}
-                          </td>
-                        </tr>
-                      {{/each}}
-                    </tbody>
-                  </table>
-                </div>
-              {{else}}
-                <p class="db-activity__empty">
-                  {{i18n "admin.dashboard.sections.search.content_gaps.empty"}}
-                </p>
-              {{/if}}
-            </div>
+            {{#if @search.content_gaps.length}}
+              <table class="db-search-table">
+                <thead>
+                  <tr>
+                    <th>{{i18n
+                        "admin.dashboard.sections.search.table.term"
+                      }}</th>
+                    <th class="db-search-table__col-status">{{i18n
+                        "admin.dashboard.sections.search.table.status"
+                      }}</th>
+                    <th class="db-search-table__col-number">
+                      {{i18n "admin.dashboard.sections.search.table.searches"}}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{#each @search.content_gaps as |row|}}
+                    <tr data-test-search-term-row>
+                      <td>
+                        <LinkTo
+                          @route="full-page-search"
+                          @query={{hash q=row.term}}
+                          title={{row.term}}
+                        >
+                          {{row.term}}
+                        </LinkTo>
+                      </td>
+                      <td>
+                        <DTooltip
+                          class="db-pill --neg"
+                          @identifier="search-gap-badge-tooltip"
+                        >
+                          <:trigger>{{badgeLabel row.status}}</:trigger>
+                          <:content>{{badgeTooltip row.status}}</:content>
+                        </DTooltip>
+                      </td>
+                      <td class="db-search-table__cell-number">
+                        {{formatCount row.searches}}
+                      </td>
+                    </tr>
+                  {{/each}}
+                </tbody>
+              </table>
+            {{else}}
+              <p class="db-search-table__empty">
+                {{i18n "admin.dashboard.sections.search.content_gaps.empty"}}
+              </p>
+            {{/if}}
           </div>
         </div>
       {{/if}}


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="1400" height="1400" alt="image" src="https://github.com/user-attachments/assets/56558e20-9d25-4ab2-ba85-565677bba374" /> | <img width="1400" height="1400" alt="image" src="https://github.com/user-attachments/assets/043891a7-df02-4adf-b043-316be8cfe78b" /> |

Also clean up some AI slop where it was reusing HTML/CSS from `db-activity` when the two tables serve different purposes.