### PR TITLE
DEV: Refactor redesigned admin dashboard header to use `DPageHeader`

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -8,31 +8,10 @@
 }
 
 .db-header {
-  display: flex;
-  align-items: center;
-  padding: var(--space-3) 0;
-  margin-bottom: var(--space-8);
   position: sticky;
   top: var(--header-offset, 60px);
   z-index: 1;
   background: var(--d-content-background, var(--secondary));
-
-  &__title {
-    @include viewport.until(sm) {
-      font-size: var(--font-up-3-rem);
-    }
-  }
-
-  &__actions {
-    display: flex;
-    gap: var(--space-4);
-    margin-left: auto;
-  }
-
-  @include viewport.until(sm) {
-    flex-direction: column-reverse;
-    align-items: flex-start;
-  }
 }
 
 .db-delta {

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -12,6 +12,7 @@ import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import DMenu from "discourse/float-kit/components/d-menu";
 import { eq } from "discourse/truth-helpers";
+import DPageHeader from "discourse/ui-kit/d-page-header";
 import { i18n } from "discourse-i18n";
 
 export default class RedesignedAdminDashboard extends Component {
@@ -22,9 +23,13 @@ export default class RedesignedAdminDashboard extends Component {
   }
 
   <template>
-    <div class="db-header">
-      <h1 class="db-header__title">Dashboard</h1>
-      <div class="db-header__actions">
+    <DPageHeader
+      class="db-header"
+      @titleLabel={{i18n "admin.dashboard.title"}}
+      @hideTabs={{true}}
+      @collapseActionsOnMobile={{false}}
+    >
+      <:actions>
         <DashboardDateRange
           @period={{@requestedPeriod}}
           @startDate={{@requestedStartDate}}
@@ -51,8 +56,8 @@ export default class RedesignedAdminDashboard extends Component {
             </:content>
           </DMenu>
         {{/if}}
-      </div>
-    </div>
+      </:actions>
+    </DPageHeader>
 
     <PluginOutlet
       @name="redesigned-admin-dashboard-after-header"


### PR DESCRIPTION
The redesigned admin dashboard (`RedesignedAdminDashboard`, shown when the `dashboard_improvements` setting is on) built its header from a bespoke `.db-header` block that duplicated what the shared `DPageHeader` ui-kit component already provides (a title plus an actions row), and rendered its title as a hardcoded, untranslated `Dashboard` string.

This PR renders the header through `DPageHeader` so it picks up the same styling as every other admin page header.

Key technical changes:

1. Render the header with `DPageHeader`, moving the date-range and Configure controls into its `<:actions>` block and sourcing the title from the `admin.dashboard.title` key so it is now translatable (it still renders "Dashboard").

2. Pass `@collapseActionsOnMobile={{false}}` so the date-range and Configure menus stay as direct controls. Without it `DPageHeader` folds actions into its mobile ellipsis dropdown, which expects its own action-button helpers rather than these `DMenu`-based controls.

3. Keep only the dashboard's sticky positioning on `.db-header`. No other admin header pins itself while the page scrolls and `DPageHeader` does not provide it, so the sticky behavior stays. Everything else (title-row layout, action spacing, mobile stacking) now comes from the component rather than custom CSS.

No backend, route, or feature-flag changes. The existing redesigned-dashboard system specs (configure menu, date range, sections) continue to pass unchanged.
