### PR TITLE
FEATURE: Add workflow whisper post creation

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/boolean-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/boolean-control.gjs
@@ -28,6 +28,20 @@ const MODE_ITEMS = [
   },
 ];
 
+function valueForModeToggle(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value);
+}
+
+function booleanValueForPlainMode(value) {
+  const plainValue = value.startsWith("=") ? value.slice(1) : value;
+
+  return ["true", "1"].includes(plainValue.trim().toLowerCase());
+}
+
 export default class BooleanControl extends Component {
   @tracked expressionMode = this.#initialExpressionMode();
 
@@ -76,16 +90,14 @@ export default class BooleanControl extends Component {
     }
 
     this.expressionMode = wantsDynamic;
-    const currentValue = field.value || "";
+    const currentValue = valueForModeToggle(field.value);
 
     if (wantsDynamic) {
       field.set(
         currentValue.startsWith("=") ? currentValue : `=${currentValue}`
       );
     } else {
-      field.set(
-        currentValue.startsWith("=") ? currentValue.slice(1) : currentValue
-      );
+      field.set(booleanValueForPlainMode(currentValue));
     }
   }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-wrapper.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-wrapper.gjs
@@ -57,11 +57,24 @@ export default class ExpressionWrapper extends Component {
   }
 
   get expressionMode() {
+    if (this.args.expressionMode !== undefined) {
+      return Boolean(this.args.expressionMode);
+    }
+
     return isExpression(this.args.field?.value);
+  }
+
+  get modeItems() {
+    return this.args.modeItems || MODE_ITEMS;
   }
 
   @action
   toggleMode(value) {
+    if (this.args.onModeChange) {
+      this.args.onModeChange(value);
+      return;
+    }
+
     const wantsDynamic = value === "dynamic";
     if (wantsDynamic === this.expressionMode) {
       return;
@@ -171,7 +184,7 @@ export default class ExpressionWrapper extends Component {
 
       {{#if @supportsExpression}}
         <DSegmentedControl
-          @items={{MODE_ITEMS}}
+          @items={{this.modeItems}}
           @value={{if this.expressionMode "dynamic" "plain"}}
           @onSelect={{this.toggleMode}}
           @size="small"

--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/post_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/post_serializer.rb
@@ -7,6 +7,7 @@ module DiscourseWorkflows
                :topic_title,
                :topic_slug,
                :post_number,
+               :post_type,
                :reply_to_post_number,
                :post_url,
                :username,

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -315,6 +315,8 @@ en:
         raw_description: "Raw content for the post"
         reply_to_post_number: "Reply to post number"
         reply_to_post_number_description: "Reply to a specific post number in the topic"
+        whisper: "Create as whisper"
+        whisper_description: "Create the post as a whisper. The author must be allowed to create whispers."
         author_username: "Author"
         post_id: "Post ID"
         editor_username: "Editor"

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -300,7 +300,7 @@ module DiscourseWorkflows
         HttpClient.new(self, item_index).request(method:, url:, headers:, body:, options:)
       end
 
-      def create_post(user:, raw:, topic_id:, reply_to_post_number: nil)
+      def create_post(user:, raw:, topic_id:, reply_to_post_number: nil, whisper: false)
         topic = ::Topic.find(topic_id)
         guardian = user.guardian
         guardian.ensure_can_see!(topic)
@@ -317,6 +317,18 @@ module DiscourseWorkflows
           reply_to_post_number: reply_to_post_number.presence,
           skip_workflows: true,
         }.compact
+
+        if ActiveModel::Type::Boolean.new.cast(whisper)
+          unless guardian.can_create_whisper?
+            raise Discourse::InvalidAccess.new(
+                    "invalid_whisper_access",
+                    nil,
+                    custom_message: "invalid_whisper_access",
+                  )
+          end
+
+          post_args[:post_type] = ::Post.types[:whisper]
+        end
 
         PostCreator.new(user, post_args).create!
       end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
@@ -89,6 +89,20 @@ module DiscourseWorkflows
                 },
               },
             },
+            whisper: {
+              type: :boolean,
+              required: false,
+              default: false,
+              ui: {
+                control: :boolean,
+                expression: true,
+              },
+              display_options: {
+                show: {
+                  operation: ["create"],
+                },
+              },
+            },
             author_username: {
               type: :string,
               required: false,
@@ -300,6 +314,7 @@ module DiscourseWorkflows
             "raw" => exec_ctx.get_node_parameter("raw", item_index),
             "reply_to_post_number" =>
               exec_ctx.get_node_parameter("reply_to_post_number", item_index),
+            "whisper" => exec_ctx.get_node_parameter("whisper", item_index, default: false),
             "post_id" => exec_ctx.get_node_parameter("post_id", item_index),
             "editor_username" => exec_ctx.get_node_parameter("editor_username", item_index),
             "include_raw" => exec_ctx.get_node_parameter("include_raw", item_index, default: true),
@@ -359,6 +374,7 @@ module DiscourseWorkflows
               raw: config["raw"],
               topic_id: config["topic_id"],
               reply_to_post_number: config["reply_to_post_number"],
+              whisper: config["whisper"],
             )
 
           {

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
@@ -749,6 +749,27 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
       end.to change { topic.posts.count }.by(1)
     end
 
+    it "creates a whisper reply as a whisperer" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+      ctx = described_class.new(input_items: [], resolver: nil)
+
+      expect do
+        post =
+          ctx.create_post(user: admin, raw: "Workflow whisper", topic_id: topic.id, whisper: true)
+
+        expect(post.post_type).to eq(Post.types[:whisper])
+      end.to change { topic.posts.count }.by(1)
+    end
+
+    it "requires the user to create whispers" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+      ctx = described_class.new(input_items: [], resolver: nil)
+
+      expect do
+        ctx.create_post(user: user, raw: "Unauthorized whisper", topic_id: topic.id, whisper: true)
+      end.to raise_error(Discourse::InvalidAccess).and not_change { topic.posts.count }
+    end
+
     it "requires the user to see the topic" do
       group = Fabricate(:group)
       private_category = Fabricate(:private_category, group: group)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
@@ -112,6 +112,54 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       expect(topic.posts.order(:id).last.reply_to_post_number).to eq(first_post.post_number)
     end
 
+    it "creates a whisper when configured" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+      first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
+      topic = first_post.topic
+      result = nil
+
+      expect do
+        result =
+          execute_node(
+            configuration: {
+              "operation" => "create",
+              "topic_id" => topic.id.to_s,
+              "raw" => "Workflow whisper",
+              "whisper" => true,
+              "author_username" => admin.username,
+            },
+            item: item,
+          )
+      end.to change { topic.posts.count }.by(1)
+
+      reply = topic.posts.order(:id).last
+      expect(reply.post_type).to eq(Post.types[:whisper])
+      expect(result["post"]).to include(
+        "id" => reply.id,
+        "post_type" => Post.types[:whisper],
+        "raw" => "Workflow whisper",
+      )
+    end
+
+    it "raises when the create author cannot whisper" do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+      first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
+      topic = first_post.topic
+
+      expect do
+        execute_node(
+          configuration: {
+            "operation" => "create",
+            "topic_id" => topic.id.to_s,
+            "raw" => "Unauthorized whisper",
+            "whisper" => true,
+            "author_username" => user.username,
+          },
+          item: item,
+        )
+      end.to raise_error(Discourse::InvalidAccess).and not_change { topic.posts.count }
+    end
+
     it "raises when the create author cannot be found" do
       first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
 

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/node_types_controller_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe DiscourseWorkflows::NodeTypesController do
         "default" => "system",
         "ui" => include("control" => "actor"),
       )
+      expect(properties["whisper"]).to include(
+        "type" => "boolean",
+        "default" => false,
+        "ui" => include("control" => "boolean", "expression" => true),
+        "display_options" => include("show" => include("operation" => ["create"])),
+      )
       expect(properties["categories"]["ui"]).to include("hidden" => true)
       expect(properties["advanced_filter"]["ui"]).to include("hidden" => true)
     end

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/node_type/list_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/node_type/list_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe DiscourseWorkflows::NodeType::List do
           :topic_id,
           :post_id,
           :reply_to_post_number,
+          :whisper,
           :author_username,
           :editor_username,
           :include_raw,

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/boolean-control-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/boolean-control-test.gjs
@@ -78,6 +78,81 @@ module("Integration | Component | workflows boolean control", function (hooks) {
 
     assert.dom(".form-kit__control-toggle").doesNotExist();
     assert.dom(".workflows-variable-input").exists();
+    assert.strictEqual(this.formApi.get("enabled"), "=false");
+  });
+
+  test("switches true values to expression mode", async function (assert) {
+    this.setProperties({
+      configuration: { enabled: true },
+      formApi: null,
+      schema: { type: "boolean", ui: { expression: true } },
+      registerApi: (api) => this.set("formApi", api),
+    });
+
+    await render(
+      <template>
+        <Form
+          @data={{this.configuration}}
+          @onRegisterApi={{this.registerApi}}
+          as |form transientData|
+        >
+          <BooleanControl
+            @form={{form}}
+            @formApi={{this.formApi}}
+            @configuration={{transientData}}
+            @fieldName="enabled"
+            @label="Enabled"
+            @schema={{this.schema}}
+          />
+        </Form>
+      </template>
+    );
+
+    await click(
+      '.workflows-property-engine__mode-control input[value="dynamic"]'
+    );
+
+    assert.dom(".workflows-variable-input").exists();
+    assert.strictEqual(this.formApi.get("enabled"), "=true");
+  });
+
+  test("switches back to plain mode", async function (assert) {
+    this.setProperties({
+      configuration: { enabled: false },
+      formApi: null,
+      schema: { type: "boolean", ui: { expression: true } },
+      registerApi: (api) => this.set("formApi", api),
+    });
+
+    await render(
+      <template>
+        <Form
+          @data={{this.configuration}}
+          @onRegisterApi={{this.registerApi}}
+          as |form transientData|
+        >
+          <BooleanControl
+            @form={{form}}
+            @formApi={{this.formApi}}
+            @configuration={{transientData}}
+            @fieldName="enabled"
+            @label="Enabled"
+            @schema={{this.schema}}
+          />
+        </Form>
+      </template>
+    );
+
+    await click(
+      '.workflows-property-engine__mode-control input[value="dynamic"]'
+    );
+    await click(
+      '.workflows-property-engine__mode-control input[value="plain"]'
+    );
+
+    assert.dom(".form-kit__control-toggle").exists();
+    assert.dom(".workflows-variable-input").doesNotExist();
+    assert.false(this.formApi.get("enabled"));
   });
 
   test("renders in expression mode when value starts with =", async function (assert) {


### PR DESCRIPTION
Allow the workflows post node to create whisper replies when the author has whisper permissions, and expose post_type in serialized results so callers can identify whisper posts.

Fix the boolean expression configurator to preserve boolean values when switching between plain and dynamic modes.
