### PR TITLE
UX: Move location of nested view floating actions

### DIFF
--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -972,6 +972,11 @@ export default class Nested extends Component {
           @outletArgs={{lazyHash model=@topic}}
         />
 
+        <NestedFloatingActions
+          @topic={{@topic}}
+          @replyAction={{fn @replyToPost @opPost 0}}
+        />
+
         <MoreTopics @topic={{@topic}} />
 
         <PluginOutlet
@@ -987,10 +992,6 @@ export default class Nested extends Component {
         @outletArgs={{lazyHash model=@topic}}
       />
 
-      <NestedFloatingActions
-        @topic={{@topic}}
-        @replyAction={{fn @replyToPost @opPost 0}}
-      />
     </div>
   </template>
 }


### PR DESCRIPTION
This should mean that after stickiness is done, the actions stop above any related/suggested topics.