### PR TITLE
DEV: Use DPageHeader component in new dashboard

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -7,34 +7,6 @@
   margin-bottom: var(--space-12);
 }
 
-.db-header {
-  display: flex;
-  align-items: center;
-  padding: var(--space-3) 0;
-  margin-bottom: var(--space-8);
-  position: sticky;
-  top: var(--header-offset, 60px);
-  z-index: 1;
-  background: var(--d-content-background, var(--secondary));
-
-  &__title {
-    @include viewport.until(sm) {
-      font-size: var(--font-up-3-rem);
-    }
-  }
-
-  &__actions {
-    display: flex;
-    gap: var(--space-4);
-    margin-left: auto;
-  }
-
-  @include viewport.until(sm) {
-    flex-direction: column-reverse;
-    align-items: flex-start;
-  }
-}
-
 .db-delta {
   font-size: var(--font-down-2-rem);
   font-weight: bold;

--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -20,6 +20,18 @@
   }
 }
 
+.dashboard-next .d-page-header__actions {
+  @include viewport.until(md) {
+    flex-direction: row;
+    gap: var(--space-1);
+    margin-block: var(--space-4);
+  }
+
+  @include viewport.until(sm) {
+    width: 100%;
+  }
+}
+
 .db-pill {
   font-size: var(--font-down-3);
   border-radius: 6.25rem;

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -12,6 +12,8 @@ import DashboardTraffic from "discourse/admin/components/dashboard/traffic";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import DMenu from "discourse/float-kit/components/d-menu";
 import { eq } from "discourse/truth-helpers";
+import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
+import DPageHeader from "discourse/ui-kit/d-page-header";
 import { i18n } from "discourse-i18n";
 
 export default class RedesignedAdminDashboard extends Component {
@@ -22,9 +24,18 @@ export default class RedesignedAdminDashboard extends Component {
   }
 
   <template>
-    <div class="db-header">
-      <h1 class="db-header__title">Dashboard</h1>
-      <div class="db-header__actions">
+    <DPageHeader
+      @titleLabel={{i18n "admin.dashboard.title"}}
+      @hideTabs={{true}}
+    >
+      <:breadcrumbs>
+        <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
+        <DBreadcrumbsItem
+          @path="/admin"
+          @label={{i18n "admin.dashboard.title"}}
+        />
+      </:breadcrumbs>
+      <:actions>
         <DashboardDateRange
           @period={{@requestedPeriod}}
           @startDate={{@requestedStartDate}}
@@ -32,7 +43,6 @@ export default class RedesignedAdminDashboard extends Component {
           @setPeriod={{@setPeriod}}
           @setCustomDateRange={{@setCustomDateRange}}
         />
-
         {{#if this.currentUser.admin}}
           <DMenu
             @identifier="db-configure"
@@ -51,8 +61,8 @@ export default class RedesignedAdminDashboard extends Component {
             </:content>
           </DMenu>
         {{/if}}
-      </div>
-    </div>
+      </:actions>
+    </DPageHeader>
 
     <PluginOutlet
       @name="redesigned-admin-dashboard-after-header"

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -27,6 +27,7 @@ export default class RedesignedAdminDashboard extends Component {
     <DPageHeader
       @titleLabel={{i18n "admin.dashboard.title"}}
       @hideTabs={{true}}
+      @collapseActionsOnMobile={{false}}
     >
       <:breadcrumbs>
         <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />
@@ -35,6 +36,7 @@ export default class RedesignedAdminDashboard extends Component {
           @label={{i18n "admin.dashboard.title"}}
         />
       </:breadcrumbs>
+
       <:actions>
         <DashboardDateRange
           @period={{@requestedPeriod}}

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -66,6 +66,12 @@ module PageObjects
       end
 
       def open_configure_menu
+        ensure_redesigned_dashboard
+
+        if has_css?(".d-page-header-mobile-actions-trigger", wait: 0)
+          find(".d-page-header-mobile-actions-trigger").click
+        end
+
         find(".btn[data-identifier='db-configure']").click
         has_css?(".db-configure")
         self
@@ -131,6 +137,12 @@ module PageObjects
       end
 
       private
+
+      def ensure_redesigned_dashboard
+        page.refresh unless has_css?(".db-main", wait: 0)
+        has_css?(".db-main [data-section-id], .db-main__empty")
+        self
+      end
 
       def preset_label(period)
         case period

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -66,7 +66,6 @@ module PageObjects
       end
 
       def open_configure_menu
-        ensure_redesigned_dashboard
         find(".btn[data-identifier='db-configure']").click
         has_css?(".db-configure")
         self
@@ -128,20 +127,6 @@ module PageObjects
         within(".db-configure__row[data-section-id='#{id}']") do
           find(".db-configure__arrow:first-child").click
         end
-        self
-      end
-
-      # The redesigned dashboard (and its configure trigger) only renders once
-      # `dashboard_improvements` is active on the client. That value is pushed to
-      # the browser over MessageBus and can lag briefly under load, leaving the
-      # legacy dashboard showing instead. When that happens, reload to pick up the
-      # correct preloaded value before interacting.
-      def ensure_redesigned_dashboard
-        # `visit` has already settled the page, so the redesigned header is
-        # present immediately when active; use a zero wait here so the common
-        # case is instant and we only pay for a reload on the rare lag.
-        page.refresh unless has_css?(".db-header", wait: 0)
-        has_css?(".db-header")
         self
       end
 

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -66,6 +66,7 @@ module PageObjects
       end
 
       def open_configure_menu
+        ensure_redesigned_dashboard
         find(".btn[data-identifier='db-configure']").click
         has_css?(".db-configure")
         self
@@ -127,6 +128,20 @@ module PageObjects
         within(".db-configure__row[data-section-id='#{id}']") do
           find(".db-configure__arrow:first-child").click
         end
+        self
+      end
+
+      # The redesigned dashboard (and its configure trigger) only renders once
+      # `dashboard_improvements` is active on the client. That value is pushed to
+      # the browser over MessageBus and can lag briefly under load, leaving the
+      # legacy dashboard showing instead. When that happens, reload to pick up the
+      # correct preloaded value before interacting.
+      def ensure_redesigned_dashboard
+        # `visit` has already settled the page, so the redesigned header is
+        # present immediately when active; use a zero wait here so the common
+        # case is instant and we only pay for a reload on the rare lag.
+        page.refresh unless has_css?(".db-header", wait: 0)
+        has_css?(".db-header")
         self
       end
 


### PR DESCRIPTION
This PR migrates the new dashboard to use the reusable DPageHeader component for its header & actions.

| Before | After |
| -- | -- |
|<img width="2738" height="1896" alt="CleanShot 2026-06-18 at 12 47 20@2x" src="https://github.com/user-attachments/assets/cf812263-9d3d-4848-ac1a-0390b5c823d2" />|<img width="2500" height="1682" alt="CleanShot 2026-06-22 at 14 53 46@2x" src="https://github.com/user-attachments/assets/2b6826b5-effe-4b0a-8030-99955b476f4e" />|
|<img width="772" height="1674" alt="CleanShot 2026-06-22 at 15 10 44@2x" src="https://github.com/user-attachments/assets/b1a9af1f-9dde-4d84-9f0b-369fb5d105cb" />|<img width="774" height="1674" alt="CleanShot 2026-06-22 at 14 54 27@2x" src="https://github.com/user-attachments/assets/7104bb01-e95b-4df6-b06c-137860e7e639" />|