### PR TITLE
FIX: Prevent unauthorized access via email alias normalization

### DIFF
--- a/app/services/email_login_code/redeem.rb
+++ b/app/services/email_login_code/redeem.rb
@@ -22,7 +22,7 @@ class EmailLoginCode::Redeem
   end
 
   def fetch_user(params:)
-    User::Action::FindByEmail.call(email: params.email)
+    User.real.where(staged: false).with_email(params.email).first
   end
 
   def consume_code(login_code:)

--- a/app/services/email_login_code/request.rb
+++ b/app/services/email_login_code/request.rb
@@ -33,7 +33,7 @@ class EmailLoginCode::Request
   private
 
   def fetch_user(params:)
-    User::Action::FindByEmail.call(email: params.email)
+    User.real.where(staged: false).with_email(params.email).first
   end
 
   def existing_account?(user:)

--- a/app/services/email_login_code/verify.rb
+++ b/app/services/email_login_code/verify.rb
@@ -31,6 +31,6 @@ class EmailLoginCode::Verify
   end
 
   def fetch_user(params:)
-    User::Action::FindByEmail.call(email: params.email)
+    User.real.where(staged: false).with_email(params.email).first
   end
 end

--- a/spec/requests/session_controller_spec.rb
+++ b/spec/requests/session_controller_spec.rb
@@ -622,6 +622,20 @@ RSpec.describe SessionController do
       expect(EmailLoginCode.for_email(user.email).count).to eq(1)
     end
 
+    it "does not generate a code for an address that only matches after normalization" do
+      SiteSetting.normalize_emails = true
+      user.update!(email: "foobar@example.com")
+      alias_email = "foo.bar@example.com"
+
+      expect_not_enqueued_with(job: :send_email_login_code, args: { to_address: alias_email }) do
+        post "/session/login-code.json", params: honeypot_magic(email: alias_email)
+      end
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["success"]).to eq("OK")
+      expect(EmailLoginCode.for_email(alias_email)).to be_empty
+    end
+
     it "renders the same response for existing and unknown emails" do
       post "/session/login-code.json", params: honeypot_magic(email: user.email)
       expect(response.status).to eq(200)
@@ -750,6 +764,24 @@ RSpec.describe SessionController do
       expect(response.parsed_body.dig("user", "username")).to eq(user.username)
       expect(session[:current_user_id]).to eq(user.id)
       expect(EmailLoginCode.active.for_email(user.email)).to be_empty
+    end
+
+    it "does not log in with a code issued for a normalized email alias" do
+      SiteSetting.normalize_emails = true
+      user.update!(email: "foobar@example.com")
+      alias_email = "foo.bar@example.com"
+      alias_login_code = EmailLoginCode.generate!(email: alias_email)
+
+      post "/session/login-code/verify.json",
+           params: {
+             email: alias_email,
+             code: alias_login_code.code,
+           }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["error"]).to eq(I18n.t("email_login_code.invalid_code"))
+      expect(session[:current_user_id]).to be_nil
+      expect(alias_login_code.reload.consumed_at).to be_nil
     end
 
     it "does not log in a suspended user" do

--- a/spec/services/email_login_code/request_spec.rb
+++ b/spec/services/email_login_code/request_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe EmailLoginCode::Request do
       end
     end
 
-    context "when the email matches an existing user after normalization" do
+    context "when the email only matches an existing user after normalization" do
       let(:email) { "f.oo+anything@gmail.com" }
 
       before do
@@ -53,11 +53,15 @@ RSpec.describe EmailLoginCode::Request do
 
       it { is_expected.to run_successfully }
 
-      it "treats it as an existing account" do
-        events = DiscourseEvent.track_events(:before_email_login) { result }
+      it "does not treat it as an existing account" do
+        events = nil
 
-        expect(events).to contain_exactly(event_name: :before_email_login, params: [user])
-        expect(EmailLoginCode.for_email(email).count).to eq(1)
+        expect_not_enqueued_with(job: :send_email_login_code) do
+          events = DiscourseEvent.track_events(:before_email_login) { result }
+        end
+
+        expect(events).to be_empty
+        expect(EmailLoginCode.count).to eq(0)
       end
     end
 


### PR DESCRIPTION
Prevent unauthorized account access via email login codes by requiring an exact email address match for code issuance and redemption. This change disables the normalized-email fallback for the login-code flow, ensuring codes are only sent to and valid for addresses explicitly registered to an account.