### PR TITLE
SECURITY: Don't leak hidden tag names in one-per-topic conflict reasons

### DIFF
--- a/app/services/tags/search.rb
+++ b/app/services/tags/search.rb
@@ -199,20 +199,24 @@ class Tags::Search
 
       if group
         conflicting_tag_names =
-          Tag
+          visible_tags(guardian)
             .where(id: selected_ids)
             .joins(:tag_group_memberships)
             .where(tag_group_memberships: { tag_group_id: group.id })
             .order(:name)
             .pluck(:name)
 
-        return(
-          I18n.t(
-            "tags.forbidden.one_tag_per_topic_group",
-            tag_group_name: group.name,
-            tag_names: conflicting_tag_names.join(", "),
+        if conflicting_tag_names.present?
+          return(
+            I18n.t(
+              "tags.forbidden.one_tag_per_topic_group",
+              tag_group_name: group.name,
+              tag_names: conflicting_tag_names.join(", "),
+            )
           )
-        )
+        end
+
+        return I18n.t("tags.forbidden.one_tag_per_topic_group_without_names")
       end
     end
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5830,6 +5830,7 @@ en:
       synonym: 'Please use "%{tag_name}" instead'
       has_synonyms: '"%{tag_name}" cannot be used because it has synonyms.'
       one_tag_per_topic_group: 'Conflicts with "%{tag_names}" (only one allowed per topic)'
+      one_tag_per_topic_group_without_names: "Conflicts with a selected tag (only one allowed per topic)"
       missing_parent_tag: 'Available after adding the "%{parent_tag_name}" tag'
       restricted_tags_cannot_be_used_in_category:
         one: 'The "%{tags}" tag cannot be used in the "%{category}" category. Please remove it.'

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -115,6 +115,36 @@ RSpec.describe(Tags::Search) do
       end
     end
 
+    context "with a hidden selected tag in a one_per_topic group" do
+      fab!(:staff_group) { Group[:staff] }
+      fab!(:private_category) { Fabricate(:private_category, group: staff_group) }
+      fab!(:hidden_selected_tag) { Fabricate(:tag, name: "secret-selected") }
+      fab!(:public_sibling_tag) { Fabricate(:tag, name: "public-sibling") }
+      fab!(:tag_group) do
+        Fabricate(
+          :tag_group,
+          name: "Exclusive Group",
+          one_per_topic: true,
+          tags: [hidden_selected_tag, public_sibling_tag],
+        )
+      end
+
+      before { CategoryTag.create!(category: private_category, tag: hidden_selected_tag) }
+
+      let(:params) do
+        { q: "public", filterForInput: true, selected_tag_ids: [hidden_selected_tag.id] }
+      end
+
+      it "uses a generic one_per_topic reason instead of leaking the hidden selected tag name" do
+        disabled = result[:tags].find { |tag| tag[:name] == "public-sibling" && tag[:disabled] }
+        expect(disabled).to be_present
+        expect(disabled[:title]).not_to include(hidden_selected_tag.name)
+        expect(disabled[:title]).to eq(
+          I18n.t("tags.forbidden.one_tag_per_topic_group_without_names"),
+        )
+      end
+    end
+
     context "with filterForInput returning disabled tags for missing parent tag" do
       fab!(:parent_tag) { Fabricate(:tag, name: "parent") }
       fab!(:child_tag) { Fabricate(:tag, name: "childtag") }


### PR DESCRIPTION
Previously, `Tags::Search` looked up conflicting one-per-topic tag names with an unscoped `Tag` query, allowing users to disclose hidden tag names by passing their IDs in `selected_tag_ids`.

This change scopes that lookup to `visible_tags` and returns a generic conflict reason when no conflicting selected tags are visible, so hidden tag names are no longer exposed.

Reported in patch-triage/1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)