### PR TITLE
UX: Update copy of empty checkbox on unsolved topic category setting

### DIFF
--- a/plugins/discourse-solved/config/locales/client.en.yml
+++ b/plugins/discourse-solved/config/locales/client.en.yml
@@ -24,7 +24,7 @@ en:
       allow_accepted_answers: "Allow topic owner and staff to mark a reply as the solution"
       solved_topics_auto_close_hours: "Auto close topic (n) hours after the last reply once the topic has been marked as solved."
       notify_on_staff_accept_solved: "Notify topic creator when staff marks a solution"
-      empty_box_on_unsolved: "Display an empty checkbox next to unsolved topics in the topic list"
+      empty_box_on_unsolved: "Display unsolved topic state in the topic list for supported themes"
       accept_answer: "Select if this reply solves the problem"
       accepted_description: "This is the accepted solution to this topic"
       has_no_accepted_answer: "This topic has no solution"

--- a/plugins/discourse-solved/config/locales/server.en.yml
+++ b/plugins/discourse-solved/config/locales/server.en.yml
@@ -17,7 +17,7 @@ en:
       notify_on_staff_accept_solved:
         label: "Notify topic creator when staff marks a solution"
       empty_box_on_unsolved:
-        label: "Display an empty checkbox next to unsolved topics in the topic list"
+        label: "Display unsolved topic state in the topic list for supported themes"
       solved_topics_auto_close_duration:
         label: "Auto close solved topics"
         description: "Automatically close solved topics after this duration from the last reply. Set to 0 to disable."


### PR DESCRIPTION
This checkbox does nothing on Horizon, so make the setting more
vague to indicate themes may do different things with it
