### PR TITLE
DEV: avoid event error when username collides with group name

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -161,7 +161,12 @@ module DiscoursePostEvent
     end
 
     def raw_invitees_are_groups
-      if raw_invitees && User.select(:id).where(username: raw_invitees).limit(1).count > 0
+      return if raw_invitees.blank?
+
+      non_group_invitees = raw_invitees - Group.where(name: raw_invitees).pluck(:name)
+      return if non_group_invitees.blank?
+
+      if User.where(username: non_group_invitees).exists?
         errors.add(
           :base,
           I18n.t("discourse_post_event.errors.models.event.raw_invitees.only_group"),

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -20,6 +20,44 @@ describe DiscoursePostEvent::Event do
     ).is_at_most(DiscoursePostEvent::Event::MAX_NAME_LENGTH)
   end
 
+  describe "#raw_invitees_are_groups" do
+    fab!(:user) { Fabricate(:user, admin: true) }
+    fab!(:topic) { Fabricate(:topic, user: user) }
+    fab!(:post) { Fabricate(:post, topic: topic) }
+
+    it "is invalid when an invitee matches a username that is not a group" do
+      Fabricate(:user, username: "not_a_group")
+      event =
+        Fabricate.build(
+          :event,
+          post: post,
+          original_starts_at: Time.now,
+          raw_invitees: ["not_a_group"],
+        )
+
+      expect(event).not_to be_valid
+      expect(event.errors[:base]).to include(
+        I18n.t("discourse_post_event.errors.models.event.raw_invitees.only_group"),
+      )
+    end
+
+    it "is valid when an invitee is a group whose name collides with a username" do
+      Fabricate(:user).update_columns(
+        username: DiscoursePostEvent::Event::PUBLIC_GROUP,
+        username_lower: DiscoursePostEvent::Event::PUBLIC_GROUP,
+      )
+      event =
+        Fabricate.build(
+          :event,
+          post: post,
+          original_starts_at: Time.now,
+          raw_invitees: [DiscoursePostEvent::Event::PUBLIC_GROUP],
+        )
+
+      expect(event).to be_valid
+    end
+  end
+
   describe "topic custom fields callback" do
     let(:user) { Fabricate(:user, admin: true) }
     let!(:notified_user) { Fabricate(:user) }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/error-when-trying-to-create-an-event/405428

Creating a public event could fail with "Validation failed: An event accepts only group names" on sites that happen to have a user whose username exactly matches an automatic group name (e.g. `trust_level_0`)

This change excludes valid group names before checking for username collisions. 