### PR TITLE
FIX: Moved reviewable post content leaks to old category moderators

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -145,6 +145,7 @@ class PostMover
     update_last_post_stats
     update_upload_security_status
     update_bookmarks
+    update_reviewables
 
     close_topic_and_schedule_deletion if @full_move
 
@@ -751,6 +752,13 @@ class PostMover
       Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: @original_topic.id)
       Jobs.enqueue(:sync_topic_user_bookmarked, topic_id: @destination_topic.id)
     end
+  end
+
+  def update_reviewables
+    Reviewable.where(target_type: "Post", target_id: @post_ids).update_all(
+      topic_id: @destination_topic.id,
+      category_id: @destination_topic.category_id,
+    )
   end
 
   def watch_new_topic

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -3448,6 +3448,60 @@ RSpec.describe PostMover do
       end
     end
 
+    context "with reviewables" do
+      fab!(:original_category, :category)
+      fab!(:original_topic) { Fabricate(:topic, category: original_category) }
+      fab!(:target_post) { Fabricate(:post, topic: original_topic) }
+
+      fab!(:private_category) { Fabricate(:private_category, group: Fabricate(:group)) }
+      fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+
+      fab!(:reviewable) do
+        Fabricate(
+          :reviewable_flagged_post,
+          target: target_post,
+          target_created_by: target_post.user,
+          topic: original_topic,
+          category: original_category,
+        )
+      end
+
+      it "updates reviewable category_id and topic_id when moving posts to another topic" do
+        expect(reviewable.category_id).to eq(original_category.id)
+        expect(reviewable.topic_id).to eq(original_topic.id)
+
+        PostMover.new(original_topic, admin, [target_post.id]).to_topic(private_topic.id)
+
+        reviewable.reload
+        expect(reviewable.category_id).to eq(private_category.id)
+        expect(reviewable.topic_id).to eq(private_topic.id)
+      end
+
+      it "updates multiple reviewables when moving multiple flagged posts" do
+        target_post_2 = Fabricate(:post, topic: original_topic)
+        reviewable_2 =
+          Fabricate(
+            :reviewable_flagged_post,
+            target: target_post_2,
+            target_created_by: target_post_2.user,
+            topic: original_topic,
+            category: original_category,
+          )
+
+        PostMover.new(original_topic, admin, [target_post.id, target_post_2.id]).to_topic(
+          private_topic.id,
+        )
+
+        reviewable.reload
+        reviewable_2.reload
+
+        expect(reviewable.category_id).to eq(private_category.id)
+        expect(reviewable.topic_id).to eq(private_topic.id)
+        expect(reviewable_2.category_id).to eq(private_category.id)
+        expect(reviewable_2.topic_id).to eq(private_topic.id)
+      end
+    end
+
     def create_post_timing(post, user, msecs)
       PostTiming.create!(
         topic_id: post.topic_id,


### PR DESCRIPTION
### Description 

Moderators of a specific category could view the content of flagged posts even after those posts were moved to a category they no longer had permission to access.

This PR updates reviewables for moved posts to reflect their new topic and category. This ensures category moderators lose access to reviewables when posts move to categories they can't access, matching the behavior when entire topics change categories (see Topic#change_category_to_id).

Note: We use @post_ids (original IDs), not @post_ids_after_move, because reviewables still reference the original post IDs even after posts are moved.

Context: `patch-triage/1283`