### PR TITLE
UX: Fix mobile spacing for chat elements

### DIFF
--- a/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-channel-row.scss
@@ -24,7 +24,6 @@
   }
 
   &__content {
-    padding-inline: 1.5rem;
     padding-block: 0.5rem;
     z-index: 2;
     box-sizing: border-box;

--- a/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
+++ b/plugins/chat/assets/stylesheets/mobile/chat-navbar.scss
@@ -6,7 +6,6 @@
   &__back-button {
     justify-content: flex-start;
     box-sizing: border-box;
-    min-width: calc(2.44em + 1.05rem);
   }
 
   &__title {


### PR DESCRIPTION
Minor changes, see before/after. Regressed in https://github.com/discourse/discourse/pull/40688 

Before 

<img width="400" alt="CleanShot 2026-06-19 at 11 48 59@2x" src="https://github.com/user-attachments/assets/a6149d92-5a3f-4dc9-bd48-b0515be873c7" />
<img width="400" alt="CleanShot 2026-06-19 at 11 49 12@2x" src="https://github.com/user-attachments/assets/ca1f7f3e-dbde-4893-b2b8-fbd17b169716" />

After

<img width="400" alt="CleanShot 2026-06-19 at 11 47 55@2x" src="https://github.com/user-attachments/assets/e3787766-a428-4ea5-ae03-f535e91341ea" />
<img width="400" alt="CleanShot 2026-06-19 at 11 49 56@2x" src="https://github.com/user-attachments/assets/9a6811c3-8b55-4fbb-9227-251ebf12435b" />

