### PR TITLE
DEV: Extract mutating EventsController actions into services

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/events_controller.rb
@@ -88,14 +88,12 @@ module DiscoursePostEvent
     end
 
     def invite
-      event = Event.find(params[:id])
-      guardian.ensure_can_act_on_discourse_post_event!(event)
-      invites = Array(params.permit(invites: [])[:invites])
-      users = User.real.where(username: invites)
-
-      users.each { |user| event.create_notification!(user, event.post) }
-
-      render json: success_json
+      Invite.call(service_params.deep_merge(params: { event_id: params[:id] })) do
+        on_success { render json: success_json }
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_failed_policy(:can_act_on_event) { raise Discourse::InvalidAccess }
+        on_failed_contract { raise Discourse::InvalidParameters }
+      end
     end
 
     def show
@@ -107,82 +105,58 @@ module DiscoursePostEvent
     end
 
     def destroy
-      event = Event.includes(:image_upload).find(params[:id])
-      guardian.ensure_can_act_on_discourse_post_event!(event)
-      event.publish_update!
-      payload = WebHook.build_calendar_event_payload(event)
-      event.destroy!
-      WebHook.enqueue_calendar_event_hooks(:calendar_event_destroyed, event, payload)
-      render json: success_json
+      DestroyEvent.call(service_params.deep_merge(params: { event_id: params[:id] })) do
+        on_success { render json: success_json }
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_failed_policy(:can_act_on_event) { raise Discourse::InvalidAccess }
+        on_failed_contract { raise Discourse::InvalidParameters }
+      end
     end
 
     def csv_bulk_invite
-      require "csv"
-
-      event = Event.find(params[:id])
-      guardian.ensure_can_edit!(event.post)
-      guardian.ensure_can_create_discourse_post_event!
-
       file = params[:file] || (params[:files] || []).first
-      raise Discourse::InvalidParameters.new(:file) if file.blank?
 
+      # Render (don't raise) every outcome: exceptions raised inside `hijack`
+      # surface as a 500 instead of the intended status.
       hijack do
-        invitees = []
-
-        CSV.foreach(file.tempfile) do |row|
-          invitees << { identifier: row[0], attendance: row[1] || "going" } if row[0].present?
+        CsvBulkInvite.call(
+          service_params.deep_merge(params: { event_id: params[:id], file: file }),
+        ) do
+          on_success { render json: success_json }
+          on_model_not_found(:event) { render json: failed_json, status: :not_found }
+          on_failed_policy(:can_edit_post) { render json: failed_json, status: :forbidden }
+          on_failed_policy(:can_create_event) { render json: failed_json, status: :forbidden }
+          on_failed_policy(:file_present) do
+            render json: failed_json.merge(error_type: "invalid_parameters"), status: :bad_request
+          end
+          on_model_not_found(:invitees) { render_bulk_invite_error }
+          on_failed_contract { render_bulk_invite_error }
+          on_exceptions { render_bulk_invite_error }
+          on_failure { render_bulk_invite_error }
         end
-
-        if invitees.present?
-          Jobs.enqueue(
-            :discourse_post_event_bulk_invite,
-            event_id: event.id,
-            invitees: invitees,
-            current_user_id: current_user.id,
-          )
-          render json: success_json
-        else
-          render json:
-                   failed_json.merge(
-                     errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
-                   ),
-                 status: :unprocessable_entity
-        end
-      rescue StandardError
-        render json:
-                 failed_json.merge(
-                   errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
-                 ),
-               status: :unprocessable_entity
       end
     end
 
     def bulk_invite
-      event = Event.find(params[:id])
-      guardian.ensure_can_edit!(event.post)
-      guardian.ensure_can_create_discourse_post_event!
-
-      invitees = Array(params[:invitees]).reject { |x| x.empty? }
-      raise Discourse::InvalidParameters.new(:invitees) if invitees.blank?
-
-      begin
-        Jobs.enqueue(
-          :discourse_post_event_bulk_invite,
-          event_id: event.id,
-          invitees: invitees.as_json,
-          current_user_id: current_user.id,
-        )
-        render json: success_json
-      rescue StandardError
-        render json:
-                 failed_json.merge(
-                   errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")],
-                 ),
-               status: :unprocessable_entity
+      BulkInvite.call(service_params.deep_merge(params: { event_id: params[:id] })) do
+        on_success { render json: success_json }
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_failed_policy(:can_edit_post) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_create_event) { raise Discourse::InvalidAccess }
+        on_failed_policy(:invitees_present) { raise Discourse::InvalidParameters.new(:invitees) }
+        on_failed_contract { raise Discourse::InvalidParameters }
+        on_exceptions { render_bulk_invite_error }
+        on_failure { render_bulk_invite_error }
       end
     end
 
     private
+
+    def render_bulk_invite_error
+      render json:
+               failed_json.merge(errors: [I18n.t("discourse_post_event.errors.bulk_invite.error")]),
+             status: :unprocessable_entity
+    end
 
     def ics_request?
       request.format.symbol == :ics

--- a/plugins/discourse-calendar/app/services/discourse_post_event/action/parse_invitees_csv.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/action/parse_invitees_csv.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module DiscoursePostEvent
+  module Action
+    class ParseInviteesCsv < Service::ActionBase
+      DEFAULT_ATTENDANCE = "going"
+
+      option :file
+
+      def call
+        invitees = []
+        CSV.foreach(file.tempfile) do |identifier, attendance|
+          next if identifier.blank?
+          invitees << { identifier: identifier, attendance: attendance || DEFAULT_ATTENDANCE }
+        end
+        invitees
+      rescue StandardError
+        # A malformed or unreadable file yields no invitees; the empty result
+        # is surfaced as an upload error downstream.
+        []
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/bulk_invite.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/bulk_invite.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class BulkInvite
+    include Service::Base
+
+    params do
+      attribute :event_id, :integer
+      attribute :invitees, :array
+
+      before_validation { self.invitees = Array(invitees).reject(&:blank?) }
+
+      validates :event_id, presence: true
+    end
+
+    model :event
+    policy :can_edit_post
+    policy :can_create_event
+    policy :invitees_present
+
+    try { step :enqueue_bulk_invite }
+
+    private
+
+    def fetch_event(params:)
+      Event.find_by(id: params.event_id)
+    end
+
+    def can_edit_post(guardian:, event:)
+      guardian.can_edit?(event.post)
+    end
+
+    def can_create_event(guardian:)
+      guardian.can_create_discourse_post_event?
+    end
+
+    def invitees_present(params:)
+      params.invitees.present?
+    end
+
+    def enqueue_bulk_invite(event:, params:, guardian:)
+      Jobs.enqueue(
+        :discourse_post_event_bulk_invite,
+        event_id: event.id,
+        invitees: params.invitees,
+        current_user_id: guardian.user.id,
+      )
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/csv_bulk_invite.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/csv_bulk_invite.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class CsvBulkInvite
+    include Service::Base
+
+    params do
+      attribute :event_id, :integer
+      # Declared only so the steps can read it; the contract drops any
+      # undeclared parameter.
+      attribute :file
+
+      validates :event_id, presence: true
+    end
+
+    model :event
+    policy :can_edit_post
+    policy :can_create_event
+    policy :file_present
+    model :invitees, :parse_invitees
+
+    try { step :enqueue_bulk_invite }
+
+    private
+
+    def fetch_event(params:)
+      Event.find_by(id: params.event_id)
+    end
+
+    def can_edit_post(guardian:, event:)
+      guardian.can_edit?(event.post)
+    end
+
+    def can_create_event(guardian:)
+      guardian.can_create_discourse_post_event?
+    end
+
+    def file_present(params:)
+      params.file.present?
+    end
+
+    def parse_invitees(params:)
+      Action::ParseInviteesCsv.call(file: params.file)
+    end
+
+    def enqueue_bulk_invite(event:, invitees:, guardian:)
+      Jobs.enqueue(
+        :discourse_post_event_bulk_invite,
+        event_id: event.id,
+        invitees: invitees,
+        current_user_id: guardian.user.id,
+      )
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/destroy_event.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/destroy_event.rb
@@ -14,9 +14,7 @@ module DiscoursePostEvent
     policy :can_act_on_event
 
     step :publish_event_update
-    # The payload must be captured before the event is destroyed, as it reads
-    # state (dates, post) that the deletion removes.
-    step :build_webhook_payload
+    model :webhook_payload, :build_webhook_payload
     transaction { step :destroy_event }
     step :enqueue_destroyed_webhooks
 
@@ -35,7 +33,7 @@ module DiscoursePostEvent
     end
 
     def build_webhook_payload(event:)
-      context[:webhook_payload] = WebHook.build_calendar_event_payload(event)
+      WebHook.build_calendar_event_payload(event)
     end
 
     def destroy_event(event:)

--- a/plugins/discourse-calendar/app/services/discourse_post_event/destroy_event.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/destroy_event.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class DestroyEvent
+    include Service::Base
+
+    params do
+      attribute :event_id, :integer
+
+      validates :event_id, presence: true
+    end
+
+    model :event
+    policy :can_act_on_event
+
+    step :publish_event_update
+    # The payload must be captured before the event is destroyed, as it reads
+    # state (dates, post) that the deletion removes.
+    step :build_webhook_payload
+    transaction { step :destroy_event }
+    step :enqueue_destroyed_webhooks
+
+    private
+
+    def fetch_event(params:)
+      Event.includes(:image_upload).find_by(id: params.event_id)
+    end
+
+    def can_act_on_event(guardian:, event:)
+      guardian.can_act_on_discourse_post_event?(event)
+    end
+
+    def publish_event_update(event:)
+      event.publish_update!
+    end
+
+    def build_webhook_payload(event:)
+      context[:webhook_payload] = WebHook.build_calendar_event_payload(event)
+    end
+
+    def destroy_event(event:)
+      event.destroy!
+    end
+
+    def enqueue_destroyed_webhooks(event:, webhook_payload:)
+      WebHook.enqueue_calendar_event_hooks(:calendar_event_destroyed, event, webhook_payload)
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/invite.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/invite.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class Invite
+    include Service::Base
+
+    params do
+      attribute :event_id, :integer
+      attribute :invites
+
+      before_validation { self.invites = Array(invites) }
+
+      validates :event_id, presence: true
+    end
+
+    model :event
+    policy :can_act_on_event
+    model :invited_users, optional: true
+
+    step :notify_invited_users
+
+    private
+
+    def fetch_event(params:)
+      Event.find_by(id: params.event_id)
+    end
+
+    def can_act_on_event(guardian:, event:)
+      guardian.can_act_on_discourse_post_event?(event)
+    end
+
+    def fetch_invited_users(params:)
+      User.real.where(username: params.invites)
+    end
+
+    def notify_invited_users(event:, invited_users:)
+      invited_users.each { |user| event.create_notification!(user, event.post) }
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/action/parse_invitees_csv_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/action/parse_invitees_csv_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::Action::ParseInviteesCsv) do
+  subject(:result) { described_class.call(file: file) }
+
+  def csv_file(content)
+    tempfile = Tempfile.new(%w[invitees .csv])
+    tempfile.write(content)
+    tempfile.rewind
+    Struct.new(:tempfile).new(tempfile)
+  end
+
+  describe ".call" do
+    context "when the file has identifiers and attendance values" do
+      let(:file) { csv_file("alice,going\nbob,interested\n") }
+
+      it "parses each row into an invitee hash" do
+        expect(result).to eq(
+          [
+            { identifier: "alice", attendance: "going" },
+            { identifier: "bob", attendance: "interested" },
+          ],
+        )
+      end
+    end
+
+    context "when a row has no attendance value" do
+      let(:file) { csv_file("alice\n") }
+
+      it "defaults attendance to going" do
+        expect(result).to include(identifier: "alice", attendance: "going")
+      end
+    end
+
+    context "when a row has a blank identifier" do
+      let(:file) { csv_file(",going\nbob,going\n") }
+
+      it "skips the blank row" do
+        expect(result).to eq([{ identifier: "bob", attendance: "going" }])
+      end
+    end
+
+    context "when the file is malformed" do
+      let(:file) { csv_file("alice,\"unterminated") }
+
+      it "returns an empty array" do
+        expect(result).to be_empty
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/bulk_invite_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/bulk_invite_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::BulkInvite) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:event_id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+    fab!(:invited_user, :user)
+
+    let(:invitees) { [{ "identifier" => invited_user.username, "attendance" => "going" }] }
+    let(:params) { { event_id: event.id, invitees: } }
+    let(:dependencies) { { guardian: admin.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { event_id: nil, invitees: } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when event does not exist" do
+      let(:params) { { event_id: -1, invitees: } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when user cannot edit the post" do
+      fab!(:lurker, :user)
+      let(:dependencies) { { guardian: lurker.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_edit_post) }
+
+      context "with empty invitees" do
+        let(:invitees) { [] }
+
+        it "fails the authorization policy before checking presence" do
+          is_expected.to fail_a_policy(:can_edit_post)
+        end
+      end
+    end
+
+    context "when user can edit the post but cannot create events" do
+      fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+      fab!(:author_topic) { Fabricate(:topic, user: author) }
+      fab!(:author_post) { Fabricate(:post, user: author, topic: author_topic) }
+      fab!(:author_event) { Fabricate(:event, post: author_post) }
+      fab!(:disallowed_group, :group)
+
+      let(:params) { { event_id: author_event.id, invitees: } }
+      let(:dependencies) { { guardian: author.guardian } }
+
+      before { SiteSetting.discourse_post_event_allowed_on_groups = disallowed_group.id.to_s }
+
+      it { is_expected.to fail_a_policy(:can_create_event) }
+    end
+
+    context "when invitees are empty" do
+      let(:invitees) { [] }
+
+      it { is_expected.to fail_a_policy(:invitees_present) }
+    end
+
+    context "when enqueueing the job fails" do
+      before { Jobs.stubs(:enqueue).raises(StandardError.new("boom")) }
+
+      it { is_expected.to fail_with_exception }
+    end
+
+    context "when everything is valid" do
+      before { Jobs.run_later! }
+
+      it { is_expected.to run_successfully }
+
+      it "enqueues the bulk invite job" do
+        expect_enqueued_with(
+          job: :discourse_post_event_bulk_invite,
+          args: {
+            event_id: event.id,
+            invitees: invitees,
+            current_user_id: admin.id,
+          },
+        ) { result }
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/csv_bulk_invite_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/csv_bulk_invite_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::CsvBulkInvite) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:event_id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+    fab!(:invited_user, :user)
+
+    let(:file) { csv_file("#{invited_user.username},going\n") }
+    let(:params) { { event_id: event.id, file: } }
+    let(:dependencies) { { guardian: admin.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    def csv_file(content)
+      tempfile = Tempfile.new("invites.csv")
+      tempfile.write(content)
+      tempfile.rewind
+      Struct.new(:tempfile).new(tempfile)
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { event_id: nil, file: } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when event does not exist" do
+      let(:params) { { event_id: -1, file: } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when user cannot edit the post" do
+      fab!(:lurker, :user)
+      let(:dependencies) { { guardian: lurker.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_edit_post) }
+
+      context "without a file" do
+        let(:file) { nil }
+
+        it "fails the authorization policy before checking the file" do
+          is_expected.to fail_a_policy(:can_edit_post)
+        end
+      end
+    end
+
+    context "when user can edit the post but cannot create events" do
+      fab!(:author) { Fabricate(:user, refresh_auto_groups: true) }
+      fab!(:author_topic) { Fabricate(:topic, user: author) }
+      fab!(:author_post) { Fabricate(:post, user: author, topic: author_topic) }
+      fab!(:author_event) { Fabricate(:event, post: author_post) }
+      fab!(:disallowed_group, :group)
+
+      let(:params) { { event_id: author_event.id, file: } }
+      let(:dependencies) { { guardian: author.guardian } }
+
+      before { SiteSetting.discourse_post_event_allowed_on_groups = disallowed_group.id.to_s }
+
+      it { is_expected.to fail_a_policy(:can_create_event) }
+    end
+
+    context "without a file" do
+      let(:file) { nil }
+
+      it { is_expected.to fail_a_policy(:file_present) }
+    end
+
+    context "with an empty file" do
+      let(:file) { csv_file("") }
+
+      it { is_expected.to fail_to_find_a_model(:invitees) }
+    end
+
+    context "when enqueueing the job fails" do
+      before { Jobs.stubs(:enqueue).raises(StandardError.new("boom")) }
+
+      it { is_expected.to fail_with_exception }
+    end
+
+    context "when everything is valid" do
+      before { Jobs.run_later! }
+
+      it { is_expected.to run_successfully }
+
+      it "enqueues the bulk invite job with the parsed invitees" do
+        expect_enqueued_with(
+          job: :discourse_post_event_bulk_invite,
+          args: {
+            event_id: event.id,
+            invitees: [{ "identifier" => invited_user.username, "attendance" => "going" }],
+            current_user_id: admin.id,
+          },
+        ) { result }
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/destroy_event_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/destroy_event_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::DestroyEvent) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:event_id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+
+    let(:params) { { event_id: event.id } }
+    let(:dependencies) { { guardian: admin.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { event_id: nil } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when event does not exist" do
+      let(:params) { { event_id: -1 } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when user cannot act on the event" do
+      fab!(:other_user, :user)
+      let(:dependencies) { { guardian: other_user.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_act_on_event) }
+    end
+
+    context "when everything is valid" do
+      let(:messages) { MessageBus.track_publish("/discourse-post-event/#{topic.id}") { result } }
+
+      it { is_expected.to run_successfully }
+
+      it "destroys the event" do
+        expect { result }.to change { DiscoursePostEvent::Event.count }.by(-1)
+        expect(DiscoursePostEvent::Event.exists?(event.id)).to eq(false)
+      end
+
+      it "publishes an event update" do
+        expect(messages.size).to eq(1)
+        expect(messages.first.data[:id]).to eq(event.id)
+      end
+
+      it "enqueues the destroyed web hook event" do
+        Jobs.run_later!
+        Fabricate(:outgoing_calendar_event_web_hook)
+
+        expect { result }.to change { Jobs::EmitWebHookEvent.jobs.size }.by(1)
+        job_args = Jobs::EmitWebHookEvent.jobs.last["args"].first
+        expect(job_args["event_name"]).to eq("calendar_event_destroyed")
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/invite_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/invite_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::Invite) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:event_id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+    fab!(:invited_user, :user)
+
+    let(:params) { { event_id: event.id, invites: [invited_user.username] } }
+    let(:dependencies) { { guardian: admin.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { event_id: nil, invites: [invited_user.username] } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when event does not exist" do
+      let(:params) { { event_id: -1, invites: [invited_user.username] } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when user cannot act on the event" do
+      fab!(:other_user, :user)
+      let(:dependencies) { { guardian: other_user.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_act_on_event) }
+    end
+
+    context "when everything is valid" do
+      it { is_expected.to run_successfully }
+
+      it "notifies the invited users" do
+        expect { result }.to change { invited_user.notifications.count }.by(1)
+      end
+    end
+
+    context "when invites is empty" do
+      let(:params) { { event_id: event.id, invites: [] } }
+
+      it { is_expected.to run_successfully }
+
+      it "notifies no one" do
+        expect { result }.not_to change { Notification.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move the `invite`, `destroy`, `bulk_invite` and `csv_bulk_invite` actions of `DiscoursePostEvent::EventsController` into one service per endpoint:

- `DiscoursePostEvent::Invite`
- `DiscoursePostEvent::DestroyEvent`
- `DiscoursePostEvent::BulkInvite`
- `DiscoursePostEvent::CsvBulkInvite`

CSV row parsing lives in `DiscoursePostEvent::Action::ParseInviteesCsv`.

Behaviour is preserved exactly. Notably:

- Input presence (invitees/file) is enforced via policies after the authorization policies, so unauthorized requests still return 403 rather than 400/422.
- The CSV endpoint renders every outcome inside `hijack` instead of raising, since exceptions raised there would surface as a 500.
- `destroy` builds the webhook payload from live state before deleting the event, then enqueues the webhook after the deletion commits.