### PR TITLE
DEV: Extract post event sync into a service object

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -6,6 +6,7 @@ module DiscoursePostEvent
     MIN_NAME_LENGTH = 5
     MAX_NAME_LENGTH = 255
     MAX_DESCRIPTION_LENGTH = 1000
+    DEFAULT_TIMEZONE = "UTC"
 
     self.table_name = "discourse_post_event_events"
     self.ignored_columns = %w[starts_at ends_at]
@@ -317,25 +318,6 @@ module DiscoursePostEvent
         (invitees.exists?(user_id: user.id) || (user.groups.pluck(:name) & raw_invitees).any?)
     end
 
-    def self.resolve_image_upload(image_param, post)
-      return if image_param.blank?
-
-      upload =
-        if image_param.start_with?("upload://")
-          sha1 = Upload.sha1_from_short_url(image_param)
-          Upload.find_by(sha1: sha1) if sha1
-        else
-          Upload.get_from_url(image_param)
-        end
-
-      return if upload.nil?
-
-      if !upload.secure? || upload.user_id == post.user_id ||
-           UserUpload.exists?(upload_id: upload.id, user_id: post.user_id)
-        upload
-      end
-    end
-
     def sync_image_to_post_and_topic(generate_thumbnails: false)
       return unless image_upload_id
 
@@ -362,71 +344,6 @@ module DiscoursePostEvent
       elsif !post.event && had_event_before
         payload = WebHook.build_calendar_event_payload(event_before)
         WebHook.enqueue_calendar_event_hooks(:calendar_event_destroyed, event_before, payload)
-      end
-    end
-
-    def self.update_from_raw(post)
-      events = DiscoursePostEvent::EventParser.extract_events(post)
-
-      if events.present?
-        event_params = events.first
-        event = post.event || DiscoursePostEvent::Event.new(id: post.id)
-
-        tz = ActiveSupport::TimeZone[event_params[:timezone] || "UTC"]
-        parsed_starts_at = tz.parse(event_params[:start])
-        parsed_ends_at = event_params[:end] ? tz.parse(event_params[:end]) : nil
-        parsed_recurrence_until =
-          event_params[:"recurrence-until"] ? tz.parse(event_params[:"recurrence-until"]) : nil
-
-        parsed_all_day = event_params[:"all-day"] == "true"
-        if parsed_all_day
-          parsed_starts_at = Time.utc(*event_params[:start].split("-").map(&:to_i))
-          parsed_ends_at =
-            (
-              if event_params[:end]
-                Time.utc(*event_params[:end].split("-").map(&:to_i)).end_of_day
-              else
-                nil
-              end
-            )
-        end
-
-        params = {
-          name: event_params[:name],
-          original_starts_at: parsed_starts_at,
-          original_ends_at: parsed_ends_at,
-          url: event_params[:url],
-          description: event_params[:description],
-          location: event_params[:location],
-          recurrence: event_params[:recurrence],
-          recurrence_until: parsed_recurrence_until,
-          timezone: event_params[:timezone],
-          show_local_time: event_params[:"show-local-time"] == "true",
-          status: Event.statuses[event_params[:status]&.to_sym] || event.status,
-          reminders: event_params[:reminders],
-          raw_invitees: event_params[:"allowed-groups"]&.split(","),
-          minimal: event_params[:minimal],
-          closed: event_params[:closed] || false,
-          chat_enabled: event_params[:"chat-enabled"]&.downcase == "true",
-          max_attendees: event_params[:"max-attendees"]&.to_i,
-          all_day: parsed_all_day,
-          image_upload_id: resolve_image_upload(event_params[:image], post)&.id,
-        }
-
-        params[:custom_fields] = {}
-        SiteSetting
-          .discourse_post_event_allowed_custom_fields
-          .split("|")
-          .each do |setting|
-            if event_params[setting.to_sym].present?
-              params[:custom_fields][setting] = event_params[setting.to_sym]
-            end
-          end
-
-        event.update_with_params!(params)
-        event.set_topic_bump
-      elsif post.event
-        post.event.destroy!
       end
     end
 
@@ -540,7 +457,7 @@ module DiscoursePostEvent
     end
 
     def rrule_timezone
-      timezone || "UTC"
+      timezone || DEFAULT_TIMEZONE
     end
 
     private

--- a/plugins/discourse-calendar/app/services/discourse_post_event/event/action/attributes_from_raw.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/event/action/attributes_from_raw.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  # Coerces the parsed event hash into the attributes accepted by Event#update_with_params!.
+  class Event::Action::AttributesFromRaw < Service::ActionBase
+    option :raw_event
+    option :current_status
+
+    def call
+      {
+        name: raw_event[:name],
+        original_starts_at: starts_at,
+        original_ends_at: ends_at,
+        url: raw_event[:url],
+        description: raw_event[:description],
+        location: raw_event[:location],
+        recurrence: raw_event[:recurrence],
+        recurrence_until: parse_in_zone(raw_event[:"recurrence-until"]),
+        timezone: raw_event[:timezone],
+        show_local_time: raw_event[:"show-local-time"] == "true",
+        status: Event.statuses[raw_event[:status]&.to_sym] || current_status,
+        reminders: raw_event[:reminders],
+        raw_invitees: raw_event[:"allowed-groups"]&.split(","),
+        minimal: raw_event[:minimal],
+        closed: raw_event[:closed] || false,
+        chat_enabled: raw_event[:"chat-enabled"]&.downcase == "true",
+        max_attendees: raw_event[:"max-attendees"]&.to_i,
+        all_day: all_day?,
+        custom_fields: custom_fields,
+      }
+    end
+
+    private
+
+    def all_day?
+      raw_event[:"all-day"] == "true"
+    end
+
+    def timezone
+      ActiveSupport::TimeZone[raw_event[:timezone] || Event::DEFAULT_TIMEZONE]
+    end
+
+    def parse_in_zone(value)
+      value ? timezone.parse(value) : nil
+    end
+
+    def starts_at
+      return timezone.parse(raw_event[:start]) unless all_day?
+      Time.utc(*raw_event[:start].split("-").map(&:to_i))
+    end
+
+    def ends_at
+      return parse_in_zone(raw_event[:end]) unless all_day?
+      raw_event[:end] ? Time.utc(*raw_event[:end].split("-").map(&:to_i)).end_of_day : nil
+    end
+
+    def custom_fields
+      SiteSetting
+        .discourse_post_event_allowed_custom_fields
+        .split("|")
+        .each_with_object({}) do |setting, fields|
+          value = raw_event[setting.to_sym]
+          fields[setting] = value if value.present?
+        end
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/event/action/resolve_image_upload.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/event/action/resolve_image_upload.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  # Resolves an event's image into an Upload, returning a secure upload only when the post author may use it.
+  class Event::Action::ResolveImageUpload < Service::ActionBase
+    option :image
+    option :post
+
+    def call
+      return if image.blank?
+
+      upload = find_upload
+      return if upload.nil?
+
+      upload if usable_by_author?(upload)
+    end
+
+    private
+
+    def find_upload
+      if image.start_with?("upload://")
+        sha1 = Upload.sha1_from_short_url(image)
+        Upload.find_by(sha1: sha1) if sha1
+      else
+        Upload.get_from_url(image)
+      end
+    end
+
+    def usable_by_author?(upload)
+      !upload.secure? || upload.user_id == post.user_id ||
+        UserUpload.exists?(upload_id: upload.id, user_id: post.user_id)
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/event/sync_from_post.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/event/sync_from_post.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  # Creates, updates or removes a post's event to match the `[event]` block in its raw.
+  class Event::SyncFromPost
+    include Service::Base
+
+    params do
+      attribute :post_id, :integer
+
+      validates :post_id, presence: true
+    end
+
+    model :post
+    model :raw_event, :parse_event, optional: true
+
+    only_if :event_removed do
+      step :remove_event
+    end
+
+    only_if :event_present do
+      model :event, :upsert_event
+      step :schedule_topic_bump
+    end
+
+    private
+
+    def fetch_post(params:)
+      Post.find_by(id: params.post_id)
+    end
+
+    def parse_event(post:)
+      EventParser.extract_events(post).first
+    end
+
+    def event_removed(raw_event:, post:)
+      return if raw_event.present?
+      post.event.present?
+    end
+
+    def event_present(raw_event:)
+      raw_event.present?
+    end
+
+    def remove_event(post:)
+      post.event.destroy!
+    end
+
+    def upsert_event(post:, raw_event:)
+      event = post.event || Event.new(id: post.id)
+      attributes = Event::Action::AttributesFromRaw.call(raw_event:, current_status: event.status)
+      attributes[:image_upload_id] = Event::Action::ResolveImageUpload.call(
+        image: raw_event[:image],
+        post:,
+      )&.id
+      event.update_with_params!(attributes)
+      event
+    end
+
+    def schedule_topic_bump(event:)
+      event.set_topic_bump
+    end
+  end
+end

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -283,7 +283,7 @@ after_initialize do
   ) { DiscoursePostEvent::EventSerializer.new(object.event, scope: scope, root: false) }
 
   on(:post_created) do |post|
-    DiscoursePostEvent::Event.update_from_raw(post)
+    DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
     post.association(:event).reload
     if SiteSetting.discourse_post_event_enabled && post.event
       WebHook.enqueue_calendar_event_hooks(:calendar_event_created, post.event)
@@ -293,7 +293,7 @@ after_initialize do
   on(:post_edited) do |post|
     event_before = post.event
     had_image_before = event_before&.image_upload_id.present?
-    DiscoursePostEvent::Event.update_from_raw(post)
+    DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
     post.association(:event).reload
 
     if SiteSetting.discourse_post_event_enabled

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/event_spec.rb
@@ -814,7 +814,7 @@ describe DiscoursePostEvent::Event do
     end
   end
 
-  describe ".update_from_raw" do
+  describe "syncing from raw" do
     fab!(:user) { Fabricate(:user, admin: true) }
     fab!(:topic) { Fabricate(:topic, user: user) }
     fab!(:post) { Fabricate(:post, topic: topic, user: user) }
@@ -826,7 +826,7 @@ describe DiscoursePostEvent::Event do
           raw: "[event start=\"2020-04-24 14:15\" image=\"#{upload.short_url}\"]\n[/event]",
         )
         post.rebake!
-        DiscoursePostEvent::Event.update_from_raw(post)
+        DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
         post.reload
       end
 
@@ -838,7 +838,7 @@ describe DiscoursePostEvent::Event do
       it "clears image_upload_id when image is removed" do
         post.update!(raw: "[event start=\"2020-04-24 14:15\"]\n[/event]")
         post.rebake!
-        DiscoursePostEvent::Event.update_from_raw(post)
+        DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
         post.reload
 
         expect(post.event.image_upload_id).to be_nil
@@ -858,7 +858,7 @@ describe DiscoursePostEvent::Event do
             raw: "[event start=\"2020-04-24 14:15\" image=\"#{upload.short_url}\"]\n[/event]",
           )
         post.rebake!
-        DiscoursePostEvent::Event.update_from_raw(post)
+        DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
         post.reload
         CookedPostProcessor.new(post).post_process
 
@@ -872,7 +872,7 @@ describe DiscoursePostEvent::Event do
           raw: "[event start=\"2020-04-24 14:15\" image=\"#{upload.short_url}\"]\n[/event]",
         )
         post.rebake!
-        DiscoursePostEvent::Event.update_from_raw(post)
+        DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
         post.reload
         CookedPostProcessor.new(post).post_process
 
@@ -891,7 +891,7 @@ describe DiscoursePostEvent::Event do
             raw: "[event start=\"2020-04-24 14:15\"]\n[/event]\n![image](#{other_upload.url})",
           )
         post.rebake!
-        DiscoursePostEvent::Event.update_from_raw(post)
+        DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
         post.reload
         CookedPostProcessor.new(post).post_process
 
@@ -930,7 +930,7 @@ describe DiscoursePostEvent::Event do
       end
 
       it "does not associate the upload" do
-        DiscoursePostEvent::Event.update_from_raw(post)
+        DiscoursePostEvent::Event::SyncFromPost.call(params: { post_id: post.id })
         post.reload
 
         expect(post.event.image_upload_id).to be_nil

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/event/action/attributes_from_raw_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/event/action/attributes_from_raw_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscoursePostEvent::Event::Action::AttributesFromRaw do
+  subject(:attributes) { described_class.call(raw_event:, current_status:) }
+
+  let(:current_status) { DiscoursePostEvent::Event.statuses[:public] }
+  let(:raw_event) { { name: "My event", start: "2030-04-24 14:15", timezone: "Europe/Paris" } }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+  end
+
+  it "passes through the simple string attributes" do
+    raw_event.merge!(
+      name: "Party",
+      url: "https://example.com",
+      description: "A nice party",
+      location: "Somewhere",
+      recurrence: "every_week",
+      reminders: "1.hours",
+    )
+
+    expect(attributes).to include(
+      name: "Party",
+      url: "https://example.com",
+      description: "A nice party",
+      location: "Somewhere",
+      recurrence: "every_week",
+      reminders: "1.hours",
+    )
+  end
+
+  context "with timezone parsing" do
+    it "parses start, end and recurrence-until in the event timezone" do
+      raw_event.merge!(
+        start: "2030-04-24 14:15",
+        end: "2030-04-24 18:15",
+        "recurrence-until": "2030-05-24 14:15",
+        timezone: "Europe/Paris",
+      )
+
+      paris = ActiveSupport::TimeZone["Europe/Paris"]
+      expect(attributes[:original_starts_at]).to eq(paris.parse("2030-04-24 14:15"))
+      expect(attributes[:original_ends_at]).to eq(paris.parse("2030-04-24 18:15"))
+      expect(attributes[:recurrence_until]).to eq(paris.parse("2030-05-24 14:15"))
+      expect(attributes[:timezone]).to eq("Europe/Paris")
+    end
+
+    it "falls back to the default timezone when none is provided" do
+      raw_event.merge!(start: "2030-04-24 14:15", timezone: nil)
+
+      utc = ActiveSupport::TimeZone[DiscoursePostEvent::Event::DEFAULT_TIMEZONE]
+      expect(attributes[:original_starts_at]).to eq(utc.parse("2030-04-24 14:15"))
+    end
+
+    it "leaves end and recurrence-until nil when absent" do
+      expect(attributes[:original_ends_at]).to be_nil
+      expect(attributes[:recurrence_until]).to be_nil
+    end
+  end
+
+  context "with an all-day event" do
+    before { raw_event.merge!("all-day": "true", start: "2030-04-24", timezone: "Europe/Paris") }
+
+    it "parses the start as a UTC date ignoring the timezone" do
+      expect(attributes[:all_day]).to eq(true)
+      expect(attributes[:original_starts_at]).to eq(Time.utc(2030, 4, 24))
+    end
+
+    it "parses the end as the UTC end of day when provided" do
+      raw_event[:end] = "2030-04-26"
+
+      expect(attributes[:original_ends_at]).to eq(Time.utc(2030, 4, 26).end_of_day)
+    end
+
+    it "leaves the end nil when absent" do
+      expect(attributes[:original_ends_at]).to be_nil
+    end
+  end
+
+  context "with boolean coercion" do
+    it "coerces show-local-time, chat-enabled and closed" do
+      raw_event.merge!("show-local-time": "true", "chat-enabled": "TRUE", closed: true)
+
+      expect(attributes).to include(show_local_time: true, chat_enabled: true, closed: true)
+    end
+
+    it "defaults the booleans to false when absent" do
+      expect(attributes).to include(show_local_time: false, chat_enabled: false, closed: false)
+    end
+  end
+
+  context "with status resolution" do
+    it "resolves a known raw status to its enum value" do
+      raw_event[:status] = "private"
+
+      expect(attributes[:status]).to eq(DiscoursePostEvent::Event.statuses[:private])
+    end
+
+    it "falls back to the current status when the raw status is missing" do
+      expect(attributes[:status]).to eq(current_status)
+    end
+
+    it "falls back to the current status when the raw status is unknown" do
+      raw_event[:status] = "bogus"
+
+      expect(attributes[:status]).to eq(current_status)
+    end
+  end
+
+  it "coerces max-attendees to an integer" do
+    raw_event[:"max-attendees"] = "12"
+
+    expect(attributes[:max_attendees]).to eq(12)
+  end
+
+  it "splits allowed-groups into raw_invitees" do
+    raw_event[:"allowed-groups"] = "trust_level_0,staff"
+
+    expect(attributes[:raw_invitees]).to eq(%w[trust_level_0 staff])
+  end
+
+  it "leaves raw_invitees nil when allowed-groups is absent" do
+    expect(attributes[:raw_invitees]).to be_nil
+  end
+
+  context "with custom fields" do
+    it "only keeps fields listed in the site setting that have a value" do
+      SiteSetting.discourse_post_event_allowed_custom_fields = "field_a|field_b"
+      raw_event.merge!(field_a: "value", field_b: "", field_c: "ignored")
+
+      expect(attributes[:custom_fields]).to eq("field_a" => "value")
+    end
+
+    it "is empty when the site setting is blank" do
+      SiteSetting.discourse_post_event_allowed_custom_fields = ""
+      raw_event[:field_a] = "value"
+
+      expect(attributes[:custom_fields]).to eq({})
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/event/action/resolve_image_upload_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/event/action/resolve_image_upload_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscoursePostEvent::Event::Action::ResolveImageUpload do
+  subject(:resolved) { described_class.call(image:, post:) }
+
+  fab!(:author, :user)
+  fab!(:post) { Fabricate(:post, user: author) }
+
+  let(:image) { nil }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+  end
+
+  context "when the image is blank" do
+    it "returns nil" do
+      expect(resolved).to be_nil
+    end
+  end
+
+  context "with a short url" do
+    fab!(:upload) { Fabricate(:upload, user: author) }
+
+    let(:image) { upload.short_url }
+
+    it "resolves the upload" do
+      expect(resolved).to eq(upload)
+    end
+
+    it "returns nil when no upload matches the short url" do
+      expect(described_class.call(image: "upload://nonexistent.png", post:)).to be_nil
+    end
+  end
+
+  context "with a regular url" do
+    fab!(:upload) { Fabricate(:upload, user: author) }
+
+    let(:image) { upload.url }
+
+    it "resolves the upload" do
+      expect(resolved).to eq(upload)
+    end
+  end
+
+  context "with a secure upload" do
+    before do
+      setup_s3
+      SiteSetting.secure_uploads = true
+    end
+
+    it "returns nil when the upload is owned by another user" do
+      other_user = Fabricate(:user)
+      secure_upload = Fabricate(:secure_upload, user: other_user)
+
+      expect(described_class.call(image: secure_upload.short_url, post:)).to be_nil
+    end
+
+    it "returns the upload when it is owned by the post author" do
+      secure_upload = Fabricate(:secure_upload, user: author)
+
+      expect(described_class.call(image: secure_upload.short_url, post:)).to eq(secure_upload)
+    end
+
+    it "returns the upload when the post author has a UserUpload link" do
+      other_user = Fabricate(:user)
+      secure_upload = Fabricate(:secure_upload, user: other_user)
+      UserUpload.create!(upload: secure_upload, user: author)
+
+      expect(described_class.call(image: secure_upload.short_url, post:)).to eq(secure_upload)
+    end
+  end
+
+  context "with a non-secure upload owned by another user" do
+    it "returns the upload" do
+      other_user = Fabricate(:user)
+      upload = Fabricate(:upload, user: other_user)
+
+      expect(described_class.call(image: upload.short_url, post:)).to eq(upload)
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/event/sync_from_post_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/event/sync_from_post_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscoursePostEvent::Event::SyncFromPost do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:post_id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:author) { Fabricate(:user, admin: true, refresh_auto_groups: true) }
+    fab!(:topic) { Fabricate(:topic, user: author) }
+    fab!(:post) { Fabricate(:post, topic:, user: author) }
+
+    let(:params) { { post_id: } }
+    let(:dependencies) { {} }
+    let(:post_id) { post.id }
+    let(:raw_event) do
+      { name: "My event", start: "2030-04-24 14:15", timezone: "UTC", status: "public" }
+    end
+
+    before do
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+      Jobs.run_immediately!
+
+      DiscoursePostEvent::EventParser.stubs(:extract_events).returns([raw_event])
+    end
+
+    context "when the contract is invalid" do
+      let(:post_id) { nil }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when the post is not found" do
+      let(:post_id) { 0 }
+
+      it { is_expected.to fail_to_find_a_model(:post) }
+    end
+
+    context "when the raw has an event and the post has none" do
+      it { is_expected.to run_successfully }
+
+      it "creates the event from the raw" do
+        expect { result }.to change { DiscoursePostEvent::Event.count }.by(1)
+
+        event = post.reload.event
+        expect(event.original_starts_at).to eq_time(Time.utc(2030, 4, 24, 14, 15))
+        expect(event.status).to eq(DiscoursePostEvent::Event.statuses[:public])
+        expect(event.name).to eq("My event")
+      end
+
+      it "reconciles invitees through update_with_params! (public status)" do
+        result
+        expect(post.reload.event.raw_invitees).to eq([DiscoursePostEvent::Event::PUBLIC_GROUP])
+      end
+
+      it "publishes the event update" do
+        messages = MessageBus.track_publish("/discourse-post-event/#{topic.id}") { result }
+        expect(messages.map { |m| m.data[:id] }).to include(post.id)
+      end
+    end
+
+    context "when the raw has an event and the post already has one" do
+      fab!(:event) { Fabricate(:event, post:, original_starts_at: "2020-01-01 10:00") }
+
+      it { is_expected.to run_successfully }
+
+      it "updates the existing event" do
+        expect { result }.to change { post.reload.event.reload.original_starts_at }.to(
+          Time.utc(2030, 4, 24, 14, 15),
+        )
+      end
+    end
+
+    context "when the synced event is standalone" do
+      fab!(:event) do
+        Fabricate(:event, post:, status: DiscoursePostEvent::Event.statuses[:standalone])
+      end
+      fab!(:invitee) { Fabricate(:post_event_invitee, event:, user: Fabricate(:user)) }
+
+      let(:raw_event) { { name: "My event", start: "2030-04-24 14:15", timezone: "UTC" } }
+
+      it { is_expected.to run_successfully }
+
+      it "destroys the event's invitees" do
+        expect { result }.to change { DiscoursePostEvent::Invitee.count }.by(-1)
+      end
+    end
+
+    context "when the raw has no event but the post has one" do
+      fab!(:event) { Fabricate(:event, post:) }
+
+      before { DiscoursePostEvent::EventParser.stubs(:extract_events).returns([]) }
+
+      it { is_expected.to run_successfully }
+
+      it "removes the event" do
+        expect { result }.to change { DiscoursePostEvent::Event.count }.by(-1)
+        expect(post.reload.event).to be_nil
+      end
+    end
+
+    context "when the raw has no event and the post has none" do
+      before { DiscoursePostEvent::EventParser.stubs(:extract_events).returns([]) }
+
+      it { is_expected.to run_successfully }
+
+      it "does not create an event" do
+        expect { result }.not_to change { DiscoursePostEvent::Event.count }
+      end
+    end
+
+    context "when the parsed event is invalid downstream of the contract" do
+      let(:raw_event) do
+        {
+          name: "My event",
+          start: "2030-04-24 14:15",
+          timezone: "UTC",
+          status: "public",
+          "max-attendees": "0",
+        }
+      end
+
+      it { is_expected.to be_a_failure }
+
+      it "does not persist the event" do
+        expect { result }.not_to change { DiscoursePostEvent::Event.count }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Move `Event.update_from_raw` out of the `DiscoursePostEvent::Event` model into a dedicated `DiscoursePostEvent::Event::SyncFromPost` service.

The service parses the `[event]` block from a post's raw, coerces it and resolves the image upload, then creates/updates the event or removes it when the block is gone. Attribute coercion and upload resolution are extracted into `Event::Action::AttributesFromRaw` and `Event::Action::ResolveImageUpload`.

Invitee reconciliation and publishing stay on the model's `update_with_params!`, which is shared with the bulk invite job. The `post_created` and `post_edited` handlers now call the service.