### PR TITLE
FIX: Anonymous thread-message access bypasses deleted-thread visibility

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb
@@ -23,6 +23,7 @@ class Chat::Api::ChannelThreadMessagesController < Chat::ApiController
       on_failed_policy(:target_message_exists) { raise Discourse::NotFound }
       on_failed_policy(:can_view_thread) { raise Discourse::InvalidAccess }
       on_failed_policy(:threading_enabled_for_channel) { raise Discourse::NotFound }
+      on_failed_policy(:original_message_not_deleted) { raise Discourse::NotFound }
       on_model_not_found(:thread) { raise Discourse::NotFound }
       on_failed_contract do |contract|
         render(json: failed_json.merge(errors: contract.errors.full_messages), status: :bad_request)

--- a/plugins/chat/app/services/chat/list_channel_thread_messages.rb
+++ b/plugins/chat/app/services/chat/list_channel_thread_messages.rb
@@ -58,6 +58,7 @@ module Chat
     model :thread
     policy :can_view_thread
     policy :threading_enabled_for_channel
+    policy :original_message_not_deleted
     model :membership, optional: true
     model :target_message_id, optional: true
     policy :target_message_exists, class_name: Chat::Thread::Policy::MessageExistence
@@ -69,7 +70,7 @@ module Chat
     def fetch_thread(params:)
       ::Chat::Thread
         .strict_loading
-        .includes(channel: :chatable)
+        .includes(:original_message, channel: :chatable)
         .find_by(id: params.thread_id, channel_id: params.channel_id)
     end
 
@@ -79,6 +80,11 @@ module Chat
 
     def threading_enabled_for_channel(thread:)
       thread.channel.threading_enabled || thread.force
+    end
+
+    def original_message_not_deleted(thread:, guardian:)
+      thread.original_message.deleted_at.blank? ||
+        guardian.can_moderate_chat?(thread.channel.chatable)
     end
 
     def fetch_membership(thread:, guardian:)

--- a/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_thread_messages_controller_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe Chat::Api::ChannelThreadMessagesController do
             [thread.original_message.id, message_1.id],
           )
         end
+
+        it "returns 404 when the thread original message is deleted" do
+          thread.original_message.trash!
+
+          get "/chat/api/channels/#{thread.channel.id}/threads/#{thread.id}/messages"
+
+          expect(response.status).to eq(404)
+          expect(response.parsed_body["error_type"]).to eq("not_found")
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Prevent unauthorized access to messages within a chat thread when the original starting message has been deleted. Introduced in the new feature to allow anonymous users to read messages, by default this is off. 

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1307
- Original commit: https://github.com/discourse/discourse/commit/7cfe964e8de2ce7cbfa7295592687b750fa0fe76
- Affected file: https://github.com/discourse/discourse/blob/main/plugins/chat/app/controllers/chat/api/channel_thread_messages_controller.rb

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>