### PR TITLE
FIX: add sanitize to category read-only banners

### DIFF
--- a/frontend/discourse/app/components/category-read-only-banner.gjs
+++ b/frontend/discourse/app/components/category-read-only-banner.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+import { sanitize } from "discourse/lib/text";
 
 export default class CategoryReadOnlyBanner extends Component {
   @service currentUser;
@@ -13,11 +14,15 @@ export default class CategoryReadOnlyBanner extends Component {
     );
   }
 
+  get readOnlyBanner() {
+    return trustHTML(sanitize(this.args.category.read_only_banner));
+  }
+
   <template>
     {{#if this.shouldShow}}
       <div class="row">
         <div class="alert alert-info category-read-only-banner">
-          {{trustHTML @category.read_only_banner}}
+          {{this.readOnlyBanner}}
         </div>
       </div>
     {{/if}}

--- a/frontend/discourse/tests/acceptance/category-banner-test.js
+++ b/frontend/discourse/tests/acceptance/category-banner-test.js
@@ -31,7 +31,7 @@ acceptance("Category Banners", function (needs) {
         slug: "test-read-only-with-banner",
         permission: null,
         read_only_banner:
-          "You need to video yourself <div class='inner'>doing</div> the secret handshake to post here",
+          "You need to video yourself <strong>doing</strong> the secret handshake to post here <img src=x onerror=alert(1)>",
       },
     ],
   });
@@ -58,8 +58,12 @@ acceptance("Category Banners", function (needs) {
 
     assert.dom(".category-read-only-banner").exists("shows a banner");
     assert
-      .dom(".category-read-only-banner .inner")
-      .exists({ count: 1 }, "allows staff to embed html in the message");
+      .dom(".category-read-only-banner strong")
+      .hasText("doing", "allows staff to embed safe html in the message");
+
+    assert
+      .dom(".category-read-only-banner img[onerror]")
+      .doesNotExist("sanitizes unsafe html attributes in the message");
   });
 });
 


### PR DESCRIPTION
We added this in 2016, and at the time, staff could add `<div style="...">`.

If users want to add styles, they should use themes/theme components.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>