### PR TITLE
FIX: Apply house_ads_frequency when no ad networks are configured

### DIFF
--- a/plugins/discourse-adplugin/assets/javascripts/discourse/components/ad-slot.gjs
+++ b/plugins/discourse-adplugin/assets/javascripts/discourse/components/ad-slot.gjs
@@ -222,16 +222,31 @@ export default class AdSlot extends AdComponent {
    */
   @computed("placement", "availableAdTypes", "router.currentRoute")
   get adComponentNames() {
-    if (
-      !this.availableAdTypes.includes("house-ad") ||
-      this.availableAdTypes.length === 1
-    ) {
-      // Current behaviour is to allow multiple ads from different networks
-      // to show in the same place. We could change this to choose one somehow.
+    if (!this.availableAdTypes.includes("house-ad")) {
+      // No house ads here -- network ads are shown as-is. Current behaviour
+      // is to allow multiple ads from different networks to show in the
+      // same place.
       return this.availableAdTypes;
     }
 
     const houseAds = this.site.get("house_creatives");
+
+    // House ads are the only configured ad type in this slot. Honour
+    // house_ads_frequency as a probability of showing an ad at all, so a
+    // site running only house ads can have them appear some of the time
+    // rather than every eligible slot (avoiding banner-blindness). When
+    // networks are also available the ratio logic below applies instead.
+    if (this.availableAdTypes.length === 1) {
+      const frequency = houseAds.settings.house_ads_frequency ?? 100;
+      if (frequency >= 100) {
+        return ["house-ad"];
+      }
+      if (frequency <= 0) {
+        return [];
+      }
+      return Math.random() * 100 < frequency ? ["house-ad"] : [];
+    }
+
     let houseAdsSkipped = false;
 
     if (houseAds.settings.house_ads_frequency === 100) {

--- a/plugins/discourse-adplugin/test/javascripts/acceptance/house-ad-frequency-test.js
+++ b/plugins/discourse-adplugin/test/javascripts/acceptance/house-ad-frequency-test.js
@@ -1,0 +1,84 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+
+// house_ads_frequency should also throttle how often a house ad appears
+// when NO ad networks are configured -- i.e. house ads are the only ad
+// type. Today the ad-slot short-circuits when there is a single available
+// ad type and never consults house_ads_frequency, so a house ad shows on
+// every eligible slot regardless of the setting. Sites that run only
+// house ads (and want the slot to feel novel / not banner-blind) currently
+// have to fake this with "blank" creatives.
+//
+// Intended behaviour:
+//   - 100% (or unset): a house ad always shows  (unchanged)
+//   - 0%:              no house ad shows
+//   - N% (0<N<100):    a house ad shows roughly N% of eligible slots
+//
+// The boundary cases (0 and 100) are deterministic and pinned below. The
+// intermediate percentage is probabilistic, so it is exercised by unit
+// tests around the gating function rather than asserted by exact count
+// here.
+
+function houseOnlySite(needs, frequency) {
+  needs.site({
+    house_creatives: {
+      settings: {
+        topic_list_top: "Topic List",
+        topic_above_post_stream: "Above Post Stream",
+        post_bottom: "Post",
+        after_nth_post: 1,
+        // The client reads frequency from house_creatives.settings (the
+        // server populates it from the SiteSetting); set it here directly.
+        house_ads_frequency: frequency,
+      },
+      creatives: {
+        "Topic List": "<div class='h-topic-list'>TOPIC LIST</div>",
+        "Above Post Stream":
+          "<div class='h-above-post-stream'>ABOVE POST STREAM</div>",
+        Post: "<div class='h-post'>BELOW POST</div>",
+      },
+    },
+  });
+}
+
+acceptance(
+  "House Ad Frequency - house ads only, frequency 100",
+  function (needs) {
+    needs.user();
+    needs.settings({ house_ads_after_nth_post: 1, house_ads_frequency: 100 });
+    houseOnlySite(needs, 100);
+
+    test("house ad always shows at 100%", async function (assert) {
+      updateCurrentUser({ staff: false, trust_level: 1 });
+      await visit("/t/280");
+
+      assert
+        .dom(".house-creative")
+        .exists("house ad renders when frequency is 100% and no networks");
+    });
+  }
+);
+
+acceptance(
+  "House Ad Frequency - house ads only, frequency 0",
+  function (needs) {
+    needs.user();
+    needs.settings({ house_ads_after_nth_post: 1, house_ads_frequency: 0 });
+    houseOnlySite(needs, 0);
+
+    test("no house ad shows at 0%", async function (assert) {
+      updateCurrentUser({ staff: false, trust_level: 1 });
+      await visit("/t/280");
+
+      assert
+        .dom(".house-creative")
+        .doesNotExist(
+          "house ad is suppressed when frequency is 0%, even with no networks configured"
+        );
+    });
+  }
+);


### PR DESCRIPTION
The ad slot short-circuited whenever there was a single available ad type, returning it as-is. For a site running only house ads (no AdSense/ DFP/etc), that meant `house_ads_frequency` was never consulted and a house ad showed on every eligible slot regardless of the setting. Sites that wanted house ads to appear only some of the time had to fake it with blank creatives.

When house ads are the only available type, honor house_ads_frequency as the probability of showing an ad at all: 100 always shows, 0 never shows, and N shows roughly N percent of eligible slots. Mixed house+network slots keep the existing house-vs-network ratio behavior.

Adds an acceptance test covering the 0% (suppressed) and 100% (always shown) boundaries for a house-ads-only site.

Ref: /t/123451