### PR TITLE
FIX: Remap category hashtags when slugs change

### DIFF
--- a/app/jobs/regular/remap_category_hashtag.rb
+++ b/app/jobs/regular/remap_category_hashtag.rb
@@ -6,29 +6,33 @@ module Jobs
     cluster_concurrency 1
 
     def execute(args)
+      return if args[:category_id].blank?
+      category = category_from(args)
+      return if category.blank?
+
       old_ref = args[:old_ref].presence
-      new_ref = current_ref(args).presence || args[:new_ref].presence
+      new_ref = category&.slug_ref.presence || args[:new_ref].presence
       return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
 
-      posts_matching(old_ref, args[:category_id]).find_each do |post|
-        update_post(post, old_ref, new_ref)
-      end
+      posts_matching(old_ref, category.id).find_each { |post| update_post(post, old_ref, new_ref) }
     end
 
     private
 
-    def current_ref(args)
-      Category.find_by(id: args[:category_id])&.slug_ref if args[:category_id].present?
+    def category_from(args)
+      Category.find_by(id: args[:category_id])
     end
 
     def posts_matching(old_ref, category_id)
-      category_id = category_id.to_i if category_id.present?
       posts =
         Post
           .joins(:topic)
           .where("topics.deleted_at IS NULL")
           .where("posts.raw ~* ?", "(?n)#{raw_hashtag_pattern(old_ref)}")
 
+      # More accurate way to find matching hashtags than looking
+      # at raw since we can have tags/chat channels with the same
+      # hashtag ref
       if category_id.present?
         posts =
           posts.where(
@@ -46,8 +50,12 @@ module Jobs
       return if new_raw == post.raw
 
       post.revise(Discourse.system_user, { raw: new_raw }, bypass_bump: true, skip_revision: true)
-    rescue => e
-      Discourse.warn_exception(e, message: "Failed to remap category hashtag in post #{post.id}")
+    rescue => err
+      Discourse.warn_exception(
+        err,
+        message:
+          "Failed to remap category hashtag #{old_ref} to #{new_ref} for category ID #{category.id} in post ID #{post.id}",
+      )
     end
 
     def raw_hashtag_pattern(ref)

--- a/app/jobs/regular/remap_category_hashtag.rb
+++ b/app/jobs/regular/remap_category_hashtag.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RemapCategoryHashtag < ::Jobs::Base
+    sidekiq_options queue: "low"
+    cluster_concurrency 1
+
+    def execute(args)
+      old_ref = args[:old_ref].presence
+      new_ref = current_ref(args).presence || args[:new_ref].presence
+      return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
+
+      posts_matching(old_ref, args[:category_id]).find_each do |post|
+        update_post(post, old_ref, new_ref)
+      end
+    end
+
+    private
+
+    def current_ref(args)
+      Category.find_by(id: args[:category_id])&.slug_ref if args[:category_id].present?
+    end
+
+    def posts_matching(old_ref, category_id)
+      category_id = category_id.to_i if category_id.present?
+      posts =
+        Post
+          .joins(:topic)
+          .where("topics.deleted_at IS NULL")
+          .where("posts.raw ~* ?", "(?n)#{raw_hashtag_pattern(old_ref)}")
+
+      if category_id.present?
+        posts =
+          posts.where(
+            "posts.cooked LIKE ? AND posts.cooked LIKE ?",
+            '%data-type="category"%',
+            "%data-id=\"#{category_id}\"%",
+          )
+      end
+
+      posts
+    end
+
+    def update_post(post, old_ref, new_ref)
+      new_raw = post.raw.gsub(raw_hashtag_regex(old_ref), "##{new_ref}")
+      return if new_raw == post.raw
+
+      post.revise(Discourse.system_user, { raw: new_raw }, bypass_bump: true, skip_revision: true)
+    rescue => e
+      Discourse.warn_exception(e, message: "Failed to remap category hashtag in post #{post.id}")
+    end
+
+    def raw_hashtag_pattern(ref)
+      "(?<![:\\w])##{Regexp.escape(ref)}(?![\\w:-])"
+    end
+
+    def raw_hashtag_regex(ref)
+      /(?<![:\w])##{Regexp.escape(ref)}(?![\w:-])/i
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -130,6 +130,7 @@ class Category < ActiveRecord::Base
   after_update :create_category_permalink, if: :saved_change_to_slug?
   after_update :revise_category_definition, if: :saved_change_to_description?
   after_update :run_plugin_category_update_param_callbacks
+  after_update :enqueue_category_hashtag_remap, if: :saved_change_to_hashtag_ref?
   after_destroy :trash_category_definition
   after_destroy :clear_related_site_settings
 
@@ -1185,6 +1186,11 @@ class Category < ActiveRecord::Base
       .find_each { |category| category.create_category_definition }
   end
 
+  def self.hashtag_ref_from(slug:, parent_category_id:)
+    parent_slug = Category.where(id: parent_category_id).pick(:slug) if parent_category_id.present?
+    [parent_slug, slug].compact.join(Category::SLUG_REF_SEPARATOR)
+  end
+
   def slug_path(parent_ids = Set.new)
     if parent_category_id.present?
       if parent_ids.add?(parent_category_id)
@@ -1209,6 +1215,43 @@ class Category < ActiveRecord::Base
     else
       slug
     end
+  end
+
+  def saved_change_to_hashtag_ref?
+    saved_change_to_slug? || saved_change_to_parent_category_id?
+  end
+
+  def enqueue_category_hashtag_remap
+    old_slug = saved_change_to_slug? ? slug_before_last_save : slug
+    old_parent_category_id =
+      if saved_change_to_parent_category_id?
+        parent_category_id_before_last_save
+      else
+        parent_category_id
+      end
+
+    enqueue_category_hashtag_remap_job(
+      category_id: id,
+      old_ref:
+        Category.hashtag_ref_from(slug: old_slug, parent_category_id: old_parent_category_id),
+      new_ref: slug_ref,
+    )
+
+    if saved_change_to_slug?
+      subcategories.find_each do |subcategory|
+        enqueue_category_hashtag_remap_job(
+          category_id: subcategory.id,
+          old_ref: [old_slug, subcategory.slug].join(Category::SLUG_REF_SEPARATOR),
+          new_ref: [slug, subcategory.slug].join(Category::SLUG_REF_SEPARATOR),
+        )
+      end
+    end
+  end
+
+  def enqueue_category_hashtag_remap_job(category_id:, old_ref:, new_ref:)
+    return if old_ref.blank? || new_ref.blank? || old_ref == new_ref
+
+    DB.after_commit { Jobs.enqueue(:remap_category_hashtag, category_id:, old_ref:, new_ref:) }
   end
 
   def cannot_delete_reason

--- a/spec/jobs/remap_category_hashtag_spec.rb
+++ b/spec/jobs/remap_category_hashtag_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe Jobs::RemapCategoryHashtag do
     expect(post.reload.raw).to eq("See #bug")
   end
 
+  it "skips raw matches when the category no longer exists" do
+    category = Fabricate(:category, slug: "bug")
+    post = create_post(raw: "See #bug")
+    category_id = category.id
+
+    category.destroy!
+
+    described_class.new.execute(category_id:, old_ref: "bug", new_ref: "issue")
+
+    expect(post.reload.raw).to eq("See #bug")
+  end
+
   it "uses the current category ref as the replacement target" do
     category = Fabricate(:category, slug: "bug")
     post = create_post(raw: "See #bug")

--- a/spec/jobs/remap_category_hashtag_spec.rb
+++ b/spec/jobs/remap_category_hashtag_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::RemapCategoryHashtag do
+  it "rewrites category hashtag refs and rebakes posts" do
+    parent_category = Fabricate(:category, slug: "support")
+    category = Fabricate(:category, slug: "bucks", parent_category: parent_category)
+    post = create_post(raw: "See #support:bucks for details.")
+
+    parent_category.update!(slug: "help")
+
+    described_class.new.execute(
+      category_id: category.id,
+      old_ref: "support:bucks",
+      new_ref: "help:bucks",
+    )
+
+    post.reload
+    category.reload
+
+    expect(post.raw).to eq("See #help:bucks for details.")
+    expect(post.cooked).to include(category.url)
+  end
+
+  it "rewrites only standalone matching hashtag refs" do
+    category = Fabricate(:category, slug: "bug")
+    post = create_post(raw: "#bug #bug-more #bug:suffix #bug::tag #other:bug #bug.")
+
+    category.update!(slug: "issue")
+
+    described_class.new.execute(category_id: category.id, old_ref: "bug", new_ref: "issue")
+
+    expect(post.reload.raw).to eq("#issue #bug-more #bug:suffix #bug::tag #other:bug #issue.")
+  end
+
+  it "skips raw matches that were cooked for a different category" do
+    category = Fabricate(:category, slug: "bug")
+    other_category = Fabricate(:category, slug: "other")
+    post = create_post(raw: "See #bug")
+
+    category.update!(slug: "issue")
+
+    described_class.new.execute(category_id: other_category.id, old_ref: "bug", new_ref: "issue")
+
+    expect(post.reload.raw).to eq("See #bug")
+  end
+
+  it "uses the current category ref as the replacement target" do
+    category = Fabricate(:category, slug: "bug")
+    post = create_post(raw: "See #bug")
+
+    category.update!(slug: "issue")
+    category.update!(slug: "defect")
+
+    described_class.new.execute(category_id: category.id, old_ref: "bug", new_ref: "issue")
+
+    expect(post.reload.raw).to eq("See #defect")
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1636,6 +1636,55 @@ RSpec.describe Category do
     end
   end
 
+  describe "category hashtag remapping" do
+    it "enqueues a remap job when the slug changes" do
+      category = Fabricate(:category, slug: "support")
+
+      expect_enqueued_with(
+        job: :remap_category_hashtag,
+        args: {
+          category_id: category.id,
+          old_ref: "support",
+          new_ref: "help",
+        },
+      ) { category.update!(slug: "help") }
+    end
+
+    it "enqueues a remap job when the parent changes" do
+      category = Fabricate(:category, slug: "bucks")
+      parent_category = Fabricate(:category, slug: "support")
+
+      expect_enqueued_with(
+        job: :remap_category_hashtag,
+        args: {
+          category_id: category.id,
+          old_ref: "bucks",
+          new_ref: "support:bucks",
+        },
+      ) { category.update!(parent_category: parent_category) }
+    end
+
+    it "enqueues child remap jobs when the slug changes" do
+      parent_category = Fabricate(:category, slug: "support")
+      category = Fabricate(:category, slug: "bucks", parent_category: parent_category)
+
+      expect_enqueued_with(
+        job: :remap_category_hashtag,
+        args: {
+          category_id: category.id,
+          old_ref: "support:bucks",
+          new_ref: "help:bucks",
+        },
+      ) { parent_category.update!(slug: "help") }
+    end
+
+    it "does not enqueue a remap job for unrelated changes" do
+      category = Fabricate(:category, slug: "support")
+
+      expect_not_enqueued_with(job: :remap_category_hashtag) { category.update!(color: "ABCDEF") }
+    end
+  end
+
   describe ".ancestors_of" do
     fab!(:category)
     fab!(:subcategory) { Fabricate(:category, parent_category: category) }


### PR DESCRIPTION
When an admin changes a category's slug or the parent category,
we need to update posts referencing the category with a `#hashtag`
and rebake it with the new hashtag reference.

Now, we enqueue a background job when a category slug or parent
changes to remap matching hashtag references in posts.
