### PR TITLE
DEV: Add plugin helper to get own plugin name from code

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -379,6 +379,62 @@ module Discourse
     @plugins_by_name ||= {}
   end
 
+  # Returns the `Plugin::Instance` that owns the given absolute file path, or
+  # `nil` if the path does not live inside any loaded plugin (e.g. core code).
+  #
+  # Matching is done by directory prefix and is symlink-aware: plugins are
+  # commonly symlinked into `plugins/`, so we compare against both the
+  # plugin's `directory` and its `resolved_dir` (the real target). Both the
+  # input path and the candidate directories are resolved with `File.realpath`
+  # before comparison so that symlinked components on either side line up.
+  def self.plugin_for_path(path)
+    return if path.blank?
+    real = resolve_real_path(path)
+    plugins.find do |plugin|
+      [plugin.directory, plugin.resolved_dir].compact.uniq.any? do |dir|
+        resolved = resolve_real_path(dir)
+        real == resolved || real.start_with?("#{resolved}/")
+      end
+    end
+  end
+
+  # Convenience wrapper around `plugin_for_path` that accepts what plugin code
+  # naturally has on hand:
+  #
+  #   Discourse.plugin_for(__FILE__)        # a path string
+  #   Discourse.plugin_for(self)            # an instance
+  #   Discourse.plugin_for(Chat::Message)   # a class/module
+  #
+  # For modules and objects the defining file is derived via
+  # `Object.const_source_location`. Caveats:
+  #   - `const_source_location` points at where the constant *name* was first
+  #     defined, so for classes reopened across files it resolves to the first
+  #     definition. Pass `__FILE__` when in doubt.
+  #   - Anonymous classes/modules (no `name`) can't be resolved this way; pass
+  #     `__FILE__` instead.
+  # Returns `nil` for core (non-plugin) code.
+  def self.plugin_for(arg)
+    path =
+      case arg
+      when String
+        arg
+      when Module
+        Object.const_source_location(arg.name)&.first if arg.name
+      else
+        Object.const_source_location(arg.class.name)&.first if arg.class.name
+      end
+    plugin_for_path(path)
+  end
+
+  # Resolves `path` to its real (symlink-free) location, falling back to the
+  # original path when it can't be resolved (e.g. it doesn't exist).
+  def self.resolve_real_path(path)
+    File.realpath(path)
+  rescue StandardError
+    path
+  end
+  private_class_method :resolve_real_path
+
   def self.visible_plugins
     plugins.filter(&:visible?)
   end

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -213,6 +213,110 @@ RSpec.describe Discourse do
     end
   end
 
+  describe ".plugin_for_path and .plugin_for" do
+    let(:plugin_dir) { Dir.mktmpdir }
+    let(:plugin) do
+      Class
+        .new(Plugin::Instance)
+        .new
+        .tap do |p|
+          p.path = "#{plugin_dir}/plugin.rb"
+          p.metadata = Plugin::Metadata.parse("# name: my-reflection-plugin")
+        end
+    end
+
+    before { Discourse.plugins.append(plugin) }
+
+    after do
+      Discourse.plugins.delete(plugin)
+      FileUtils.remove_entry(plugin_dir)
+    end
+
+    describe ".plugin_for_path" do
+      it "returns the owning plugin for a file directly inside its directory" do
+        File.write("#{plugin_dir}/thing.rb", "")
+        expect(Discourse.plugin_for_path("#{plugin_dir}/thing.rb")).to eq(plugin)
+      end
+
+      it "returns the owning plugin for a deeply nested file" do
+        FileUtils.mkdir_p("#{plugin_dir}/lib/foo")
+        File.write("#{plugin_dir}/lib/foo/bar.rb", "")
+        expect(Discourse.plugin_for_path("#{plugin_dir}/lib/foo/bar.rb")).to eq(plugin)
+      end
+
+      it "returns nil for core (non-plugin) paths" do
+        expect(Discourse.plugin_for_path("#{Rails.root.join("lib/discourse.rb")}")).to be_nil
+      end
+
+      it "returns nil for blank or non-existent paths" do
+        expect(Discourse.plugin_for_path(nil)).to be_nil
+        expect(Discourse.plugin_for_path("")).to be_nil
+        expect(Discourse.plugin_for_path("/this/does/not/exist.rb")).to be_nil
+      end
+
+      it "does not match a sibling directory sharing a name prefix" do
+        sibling = "#{plugin_dir}-extra"
+        FileUtils.mkdir_p(sibling)
+        File.write("#{sibling}/thing.rb", "")
+        expect(Discourse.plugin_for_path("#{sibling}/thing.rb")).to be_nil
+      ensure
+        FileUtils.remove_entry(sibling) if sibling
+      end
+
+      it "resolves a symlinked plugin directory via the real path" do
+        real_target = Dir.mktmpdir
+        symlink = "#{Dir.mktmpdir}/linked-plugin"
+        File.symlink(real_target, symlink)
+        plugin.path = "#{symlink}/plugin.rb"
+        File.write("#{real_target}/thing.rb", "")
+
+        # Queried by the resolved (real) path, which is what callers commonly have.
+        expect(Discourse.plugin_for_path("#{real_target}/thing.rb")).to eq(plugin)
+        # Queried through the symlink, realpath resolves it to the same target.
+        expect(Discourse.plugin_for_path("#{symlink}/thing.rb")).to eq(plugin)
+      ensure
+        FileUtils.remove_entry(real_target) if real_target
+        FileUtils.remove_entry(File.dirname(symlink)) if symlink
+      end
+    end
+
+    describe ".plugin_for" do
+      it "accepts a path string" do
+        File.write("#{plugin_dir}/thing.rb", "")
+        expect(Discourse.plugin_for("#{plugin_dir}/thing.rb")).to eq(plugin)
+      end
+
+      it "resolves a class to its owning plugin via const_source_location" do
+        FileUtils.mkdir_p("#{plugin_dir}/lib")
+        File.write("#{plugin_dir}/lib/thing.rb", "")
+        klass = Class.new
+        Object.stubs(:const_source_location).returns(["#{plugin_dir}/lib/thing.rb", 1])
+        klass.stubs(:name).returns("MyReflectionPlugin::Thing")
+        expect(Discourse.plugin_for(klass)).to eq(plugin)
+      end
+
+      it "resolves an instance to its owning plugin via its class" do
+        FileUtils.mkdir_p("#{plugin_dir}/lib")
+        File.write("#{plugin_dir}/lib/thing.rb", "")
+        klass = Class.new
+        klass.stubs(:name).returns("MyReflectionPlugin::Thing")
+        Object
+          .stubs(:const_source_location)
+          .with("MyReflectionPlugin::Thing")
+          .returns(["#{plugin_dir}/lib/thing.rb", 1])
+        expect(Discourse.plugin_for(klass.new)).to eq(plugin)
+      end
+
+      it "returns nil for core code" do
+        expect(Discourse.plugin_for(Discourse)).to be_nil
+      end
+
+      it "returns nil for an anonymous class with no name" do
+        expect(Discourse.plugin_for(Class.new)).to be_nil
+      end
+    end
+  end
+
   describe "authenticators" do
     it "returns inbuilt authenticators" do
       expect(Discourse.authenticators).to match_array(Discourse::BUILTIN_AUTH.map(&:authenticator))


### PR DESCRIPTION
Adds some plugin helpers to help plugin authors get their
own plugin name from ruby code, which can be useful for
registering the plugin via various APIs, or recording the
plugin name in logs or the creator/owner of a model and so
on.

These can be used from any plugin file/class:

* Discourse.plugin_for(__FILE__)        # => #<Plugin::Instance ...>
* Discourse.plugin_for(self).name       # => "discourse-kanban"
* Discourse.plugin_for_path(__FILE__)&.name
