### PR TITLE
FIX: Avoid duplicate AI triage reviewables when review precedes spam

### DIFF
--- a/plugins/discourse-ai/lib/automation/llm_triage.rb
+++ b/plugins/discourse-ai/lib/automation/llm_triage.rb
@@ -54,6 +54,21 @@ module DiscourseAi
       end
       private_class_method :promote_post_reviewable_to_flagged!
 
+      def self.review_reviewable_for(post)
+        # If a spam triage rule already flagged this post, reuse that reviewable
+        # instead of creating a separate ReviewablePost. This mirrors
+        # `promote_post_reviewable_to_flagged!` for the opposite ordering, so
+        # moderators always see a single review item regardless of which rule
+        # ran first.
+        ReviewableFlaggedPost.pending.find_by(target: post) ||
+          ReviewablePost.needs_review!(
+            target: post,
+            created_by: Discourse.system_user,
+            reviewable_by_moderator: true,
+          )
+      end
+      private_class_method :review_reviewable_for
+
       def self.handle(
         post:,
         triage_agent_id:,
@@ -258,12 +273,7 @@ module DiscourseAi
                   end
                 end
               else
-                reviewable =
-                  ReviewablePost.needs_review!(
-                    target: post,
-                    created_by: Discourse.system_user,
-                    reviewable_by_moderator: true,
-                  )
+                reviewable = review_reviewable_for(post)
 
                 reviewable.add_score(
                   Discourse.system_user,

--- a/plugins/discourse-ai/spec/lib/modules/automation/llm_triage_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/automation/llm_triage_spec.rb
@@ -180,6 +180,40 @@ describe DiscourseAi::Automation::LlmTriage do
     end
   end
 
+  it "keeps one reviewable when review follows spam" do
+    DiscourseAi::Completions::Llm.with_prepared_responses(%w[bad bad]) do
+      triage(
+        post: post,
+        triage_agent_id: ai_agent.id,
+        search_for_text: "bad",
+        flag_post: true,
+        flag_type: :spam,
+        automation: nil,
+      )
+
+      triage(
+        post: post,
+        triage_agent_id: ai_agent.id,
+        search_for_text: "bad",
+        flag_post: true,
+        flag_type: :review,
+        automation: nil,
+      )
+    end
+
+    reviewables = Reviewable.pending.where(target: post)
+    reviewable = reviewables.first
+
+    aggregate_failures do
+      expect(reviewables.size).to eq(1)
+      expect(reviewable).to be_a(ReviewableFlaggedPost)
+      expect(reviewable.reviewable_scores.map(&:reviewable_score_type)).to contain_exactly(
+        ReviewableScore.types[:needs_approval],
+        ReviewableScore.types[:spam],
+      )
+    end
+  end
+
   it "can handle spam+silence flags" do
     DiscourseAi::Completions::Llm.with_prepared_responses(["bad"]) do
       triage(


### PR DESCRIPTION
Previously, AI triage only collapsed a duplicate reviewable when a spam flag followed an existing review flag; the reverse order still left a separate `ReviewablePost` alongside the `ReviewableFlaggedPost`.

This change adds `review_reviewable_for` so a later review flag reuses an existing flagged reviewable, ensuring moderators see a single review item regardless of which triage rule runs first.

Follow up to https://github.com/discourse/discourse/pull/41043