### PR TITLE
UX: Fix several event editor, builder, and calendar card issues

### DIFF
--- a/frontend/discourse/app/lib/textarea-text-manipulation.js
+++ b/frontend/discourse/app/lib/textarea-text-manipulation.js
@@ -189,10 +189,15 @@ export default class TextareaTextManipulation {
       }
 
       if (match) {
-        this._insertAt(match.index, match.index + match[0].length, newVal);
+        this._insertAt(
+          match.index,
+          match.index + match[0].length,
+          newVal,
+          opts
+        );
       }
     } else {
-      this._insertAt(needleStart, needleStart + oldVal.length, newVal);
+      this._insertAt(needleStart, needleStart + oldVal.length, newVal, opts);
     }
 
     if (
@@ -376,8 +381,8 @@ export default class TextareaTextManipulation {
     this.blurAndFocus();
   }
 
-  _insertAt(start, end, text) {
-    insertAtTextarea(this.textarea, start, end, text);
+  _insertAt(start, end, text, opts = {}) {
+    insertAtTextarea(this.textarea, start, end, text, opts);
   }
 
   extractTable(text) {
@@ -1015,7 +1020,19 @@ export default class TextareaTextManipulation {
   }
 }
 
-function insertAtTextarea(textarea, start, end, text) {
+function insertAtTextarea(
+  textarea,
+  start,
+  end,
+  text,
+  { skipFocus = false } = {}
+) {
+  if (skipFocus && document.activeElement !== textarea) {
+    textarea.setRangeText(text, start, end, "preserve");
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    return;
+  }
+
   textarea.setSelectionRange(start, end);
   textarea.focus();
   if (start !== end && text === "") {

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -15,7 +15,8 @@ module DiscoursePostEvent
                :post,
                :duration,
                :occurrences,
-               :all_day
+               :all_day,
+               :custom_fields
 
     def category_id
       object.post.topic.category_id

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -5,7 +5,6 @@ module DiscoursePostEvent
     attributes :can_act_on_discourse_post_event
     attributes :can_update_attendance
     attributes :creator
-    attributes :custom_fields
     attributes :is_closed
     attributes :is_expired
     attributes :is_ongoing

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/compact-event-editor.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/compact-event-editor.gjs
@@ -6,7 +6,9 @@ import { action } from "@ember/object";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
+import lazyHash from "discourse/helpers/lazy-hash";
 import DButton from "discourse/ui-kit/d-button";
 import DExpandingTextArea from "discourse/ui-kit/d-expanding-text-area";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
@@ -231,6 +233,7 @@ export default class CompactEventEditor extends Component {
 
   get eventNamePlaceholder() {
     return (
+      this.args.namePlaceholder ||
       this.composer?.get("model.title") ||
       i18n("discourse_post_event.composer.name_placeholder")
     );
@@ -910,5 +913,10 @@ export default class CompactEventEditor extends Component {
         {{on "focus" this.handleTextInputFocus}}
       />
     </section>
+
+    <PluginOutlet
+      @name="discourse-post-event-composer-editor"
+      @outletArgs={{lazyHash editor=this}}
+    />
   </template>
 }

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/composer-event-editor.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/composer-event-editor.gjs
@@ -98,6 +98,7 @@ export default class ComposerEventEditor extends Component {
     }
     this.appEvents.trigger("composer:replace-text", parsed.full, newBlock, {
       skipNewSelection: true,
+      skipFocus: true,
     });
   }
 

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -401,6 +401,10 @@ export default class PostEventBuilder extends Component {
     return this.args.model.initialScreen !== "advanced";
   }
 
+  get namePlaceholder() {
+    return this.args.model.event?.post?.topic?.title;
+  }
+
   get userTimezone() {
     return this.currentUser?.user_option?.timezone || moment.tz.guess();
   }
@@ -1237,35 +1241,41 @@ export default class PostEventBuilder extends Component {
                 {{/if}}
 
                 {{#if this.allowedCustomFields.length}}
-                  <form.Container
-                    @title={{i18n
-                      "discourse_post_event.builder_modal.custom_fields.label"
-                    }}
-                    @subtitle={{i18n
-                      "discourse_post_event.builder_modal.custom_fields.description"
-                    }}
-                    @format="full"
-                    class="form-kit__container-custom-fields"
+                  <PluginOutlet
+                    @name="discourse-post-event-builder-custom-fields"
+                    @outletArgs={{lazyHash event=@model.event form=form}}
+                    @connectorTagName="div"
                   >
-                    <form.Object @name="customFields" as |customFields|>
-                      {{#each this.allowedCustomFields as |customField|}}
-                        <customFields.Field
-                          @name={{customField.name}}
-                          @title={{customField.field}}
-                          @type="input"
-                          @format="full"
-                          @onSet={{fn this.setCustomField customField.field}}
-                          as |field|
-                        >
-                          <field.Control
-                            placeholder={{i18n
-                              "discourse_post_event.builder_modal.custom_fields.placeholder"
-                            }}
-                          />
-                        </customFields.Field>
-                      {{/each}}
-                    </form.Object>
-                  </form.Container>
+                    <form.Container
+                      @title={{i18n
+                        "discourse_post_event.builder_modal.custom_fields.label"
+                      }}
+                      @subtitle={{i18n
+                        "discourse_post_event.builder_modal.custom_fields.description"
+                      }}
+                      @format="full"
+                      class="form-kit__container-custom-fields"
+                    >
+                      <form.Object @name="customFields" as |customFields|>
+                        {{#each this.allowedCustomFields as |customField|}}
+                          <customFields.Field
+                            @name={{customField.name}}
+                            @title={{customField.field}}
+                            @type="input"
+                            @format="full"
+                            @onSet={{fn this.setCustomField customField.field}}
+                            as |field|
+                          >
+                            <field.Control
+                              placeholder={{i18n
+                                "discourse_post_event.builder_modal.custom_fields.placeholder"
+                              }}
+                            />
+                          </customFields.Field>
+                        {{/each}}
+                      </form.Object>
+                    </form.Container>
+                  </PluginOutlet>
                 {{/if}}
 
                 <form.Field
@@ -1288,6 +1298,7 @@ export default class PostEventBuilder extends Component {
                 @initialState={{this.compactInitialState}}
                 @urlTester={{this.urlTester}}
                 @onChange={{this.onCompactChange}}
+                @namePlaceholder={{this.namePlaceholder}}
                 @hideAdvanced={{true}}
               />
             </div>

--- a/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_response.json
+++ b/plugins/discourse-calendar/spec/requests/api/schemas/json/events_index_response.json
@@ -48,6 +48,9 @@
           "all_day": {
             "type": "boolean"
           },
+          "custom_fields": {
+            "type": ["object", "null"]
+          },
           "post": {
             "type": "object",
             "additionalProperties": false,

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/basic_event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/basic_event_serializer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe DiscoursePostEvent::BasicEventSerializer do
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.discourse_post_event_allowed_custom_fields = "team"
+  end
+
+  fab!(:category)
+  fab!(:topic) { Fabricate(:topic, category:) }
+  fab!(:post) { Fabricate(:post, topic:) }
+  fab!(:event) { Fabricate(:event, post:) }
+
+  before { event.update!(custom_fields: { "team" => "rocket" }) }
+
+  it "includes custom_fields so they are readable from event listings" do
+    json = described_class.new(event, scope: Guardian.new, root: false).as_json
+    expect(json[:custom_fields]["team"]).to eq("rocket")
+  end
+end

--- a/plugins/discourse-calendar/spec/system/composer/event_preview_focus_spec.rb
+++ b/plugins/discourse-calendar/spec/system/composer/event_preview_focus_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe "Composer - Event preview focus" do
+  fab!(:admin)
+
+  let(:composer) { PageObjects::Components::Composer.new }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.rich_editor = false
+    sign_in(admin)
+  end
+
+  it "keeps the topic title focused on the first click after editing the event preview" do
+    visit("/new-topic")
+
+    find(".toolbar-menu__options-trigger").click
+    click_button(I18n.t("js.discourse_post_event.builder_modal.attach"))
+
+    expect(page).to have_css(".d-editor-preview .composer-event-editor")
+
+    find(".composer-event-editor .composer-event__name-input").fill_in(with: "My offsite")
+
+    find("#reply-title").click
+
+    title_focused =
+      page.evaluate_script("document.activeElement === document.querySelector('#reply-title')")
+    expect(title_focused).to eq(true)
+
+    # the edit is still committed even though focus never moved to the editor
+    expect(composer).to have_value(/name="My offsite"/)
+  end
+end

--- a/plugins/discourse-calendar/spec/system/composer/prosemirror_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/composer/prosemirror_event_spec.rb
@@ -279,4 +279,23 @@ describe "Composer - ProseMirror - Event Editor" do
       expect(find(".d-editor-input").value).to include("fancyField=\"hello world\"")
     end
   end
+
+  describe "focus" do
+    it "keeps the topic title focused on the first click after editing the event node" do
+      open_composer
+      composer.toggle_rich_editor
+      composer.fill_content(
+        "[event start=\"2025-03-21 15:41\" status=\"public\" timezone=\"Europe/Paris\"]\n[/event]",
+      )
+      composer.toggle_rich_editor
+
+      rich.find(".composer-event__name-input").fill_in(with: "My offsite")
+
+      find("#reply-title").click
+
+      title_focused =
+        page.evaluate_script("document.activeElement === document.querySelector('#reply-title')")
+      expect(title_focused).to eq(true)
+    end
+  end
 end

--- a/plugins/discourse-calendar/spec/system/event_card_spec.rb
+++ b/plugins/discourse-calendar/spec/system/event_card_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe "Event card" do
+  fab!(:admin)
+  fab!(:category)
+  fab!(:upload) { Fabricate(:image_upload, width: 1000, height: 800) }
+
+  let(:category_page) { PageObjects::Pages::Category.new }
+
+  before do
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.events_calendar_categories = category.id.to_s
+    sign_in(admin)
+  end
+
+  it "links the hero image to the topic" do
+    post =
+      PostCreator.create!(
+        admin,
+        title: "Boat party with a banner",
+        category: category.id,
+        raw: "[event start=\"#{2.hours.from_now.iso8601}\"]\n[/event]",
+      )
+    DiscoursePostEvent::Event.find(post.id).update!(image_upload: upload)
+
+    category_page.visit(category)
+
+    expect(page).to have_css("#category-events-calendar .fc")
+    find(".fc-daygrid-event-harness .fc-event-title", text: "Boat party with a banner").click
+
+    expect(page).to have_css(".discourse-post-event .event-image img")
+    # the hero image links to the topic, not to the upload file (lightbox)
+    expect(page).to have_css(".discourse-post-event .event-image a[href*='/t/']")
+    expect(page).to have_no_css(".discourse-post-event .event-image a.lightbox")
+  end
+end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -593,4 +593,19 @@ describe "Post event" do
       expect(ics_content).to include("FREQ=WEEKLY")
     end
   end
+
+  context "when editing an event without an explicit name" do
+    it "shows the topic title as the event name placeholder" do
+      title = "Nameless meetup"
+      raw = "[event start='2222-02-22 14:22']\n[/event]"
+      post = PostCreator.create!(admin, title:, raw:)
+
+      visit(post.topic.url)
+      post_event_page.edit
+
+      expect(page).to have_css(
+        ".post-event-builder-modal .composer-event__name-input[placeholder='#{title}']",
+      )
+    end
+  end
 end


### PR DESCRIPTION
Previously, the renewed calendar event UI had a number of rough edges reported in the [Event (calendar) UX issues](https://meta.discourse.org/t/event-calendar-ux-issues/405388) topic on Meta. The calendar card's hero image and the "Advanced settings" toggle have since been addressed separately (#41135 and #41138), so this change focuses on the remaining issues:

- **Name placeholder** — editing an event with no explicit name now shows the topic title as a placeholder (mirroring the composer) without writing it as a value, keeping the event name decoupled from the topic title.
- **Two-click focus** — flushing the event block triggered `composer:replace-text`, whose `insertAtTextarea` unconditionally focused the textarea and stole the click; a new opt-in `skipFocus` option mutates the value with `setRangeText` + an `input` event so focus never moves. The rich-text editor was never affected (it commits through ProseMirror transactions).
- **Readable custom fields** — event custom fields are now serialized by `BasicEventSerializer`, so they are available from event listings and not just the full event view.
- **Extensibility** — a `discourse-post-event-builder-custom-fields` outlet wraps the builder's custom fields section so it can be replaced or hidden, and a `discourse-post-event-composer-editor` outlet is exposed on the composer event editor.

Covered by new system, request, and serializer specs. Also adds a system spec for the calendar card image behavior shipped in #41135, which previously had no coverage.
