### PR TITLE
DEV: Exclude admin-created topics in support stats

### DIFF
--- a/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
+++ b/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
@@ -131,11 +131,13 @@ module DiscourseAi
         DB.query_single(<<~SQL, start_date: start_date, end_date: end_date).first.to_i
             SELECT COUNT(*)
             FROM topics t
+            JOIN users u ON u.id = t.user_id
             WHERE t.created_at >= :start_date
               AND t.created_at < (:end_date::date + 1)
               AND t.deleted_at IS NULL
               AND t.visible = true
               AND t.archetype = 'regular'
+              AND NOT (u.admin OR u.moderator)
           SQL
       end
 
@@ -196,19 +198,21 @@ module DiscourseAi
         count = DB.query_single(<<~SQL, start_date: @start_date, end_date: @end_date).first.to_i
             SELECT COUNT(*)
             FROM topics t
+            JOIN users u ON u.id = t.user_id
             WHERE t.created_at >= :start_date
               AND t.created_at < (:end_date::date + 1)
               AND t.posts_count = 1
               AND t.deleted_at IS NULL
               AND t.visible = true
               AND t.archetype = 'regular'
+              AND NOT (u.admin OR u.moderator)
           SQL
         return if count < 5
 
         total = new_topics_count(@start_date, @end_date)
         share = total.positive? ? ((count.to_f / total) * 100).round : 0
-        headline = "#{count} new topics received no reply"
-        headline = "#{headline} (#{share}% of new topics)" if share >= 10
+        headline = "#{count} new member-created topics received no reply"
+        headline = "#{headline} (#{share}% of member-created topics)" if share >= 10
 
         signal(
           :unanswered_gap,

--- a/plugins/discourse-ai/spec/lib/admin_dashboard/admin_dashboard_facts_spec.rb
+++ b/plugins/discourse-ai/spec/lib/admin_dashboard/admin_dashboard_facts_spec.rb
@@ -41,7 +41,34 @@ RSpec.describe DiscourseAi::AdminDashboard::AdminDashboardFacts do
 
     headlines = compute(start_date: 1.day.ago.to_date.to_s).fetch(:signals).map { |s| s[:headline] }
 
-    expect(headlines).to include(match(/new topics received no reply \(100% of new topics\)/))
+    expect(headlines).to include(
+      match(/new member-created topics received no reply \(100% of member-created topics\)/),
+    )
+  end
+
+  it "excludes staff-created topics from the unanswered signal" do
+    user = Fabricate(:user)
+    admin = Fabricate(:admin)
+    moderator = Fabricate(:moderator)
+
+    Fabricate.times(6, :post, user: user, created_at: 1.day.ago)
+    Fabricate.times(3, :post, user: admin, created_at: 1.day.ago)
+    Fabricate.times(3, :post, user: moderator, created_at: 1.day.ago)
+
+    4.times do
+      topic = Fabricate(:topic, user: user, created_at: 1.day.ago)
+      Fabricate(:post, topic: topic, user: user, created_at: 1.day.ago)
+      Fabricate(:post, topic: topic, user: user, created_at: 1.day.ago)
+    end
+
+    unanswered_gap =
+      compute(start_date: 2.days.ago.to_date.to_s)
+        .fetch(:signals)
+        .find { |signal| signal[:key] == :unanswered_gap }
+
+    expect(unanswered_gap).to include(
+      headline: "6 new member-created topics received no reply (60% of member-created topics)",
+    )
   end
 
   it "reports when new-topic volume changes sharply" do

--- a/plugins/discourse-ai/spec/lib/admin_dashboard/highlight_generator_spec.rb
+++ b/plugins/discourse-ai/spec/lib/admin_dashboard/highlight_generator_spec.rb
@@ -140,11 +140,38 @@ RSpec.describe DiscourseAi::AdminDashboard::HighlightGenerator do
     end
 
     it "surfaces a real signal as a fact the agent can cite" do
-      Fabricate.times(5, :post) # 5 topics with no replies
+      user = Fabricate(:user)
+      now = Time.zone.now
+      DB.exec(
+        <<~SQL,
+          INSERT INTO topics (
+            title, fancy_title, created_at, updated_at, bumped_at, last_posted_at, posts_count,
+            user_id, last_post_user_id, category_id, visible, archetype, highest_post_number
+          )
+          SELECT
+            'Unanswered topic ' || topic_number,
+            'Unanswered topic ' || topic_number,
+            :now,
+            :now,
+            :now,
+            :now,
+            1,
+            :user_id,
+            :user_id,
+            :category_id,
+            true,
+            'regular',
+            1
+          FROM generate_series(1, 5) AS topic_number
+        SQL
+        now: now,
+        user_id: user.id,
+        category_id: SiteSetting.uncategorized_category_id,
+      )
 
       message = message_for(1.day.ago.to_date.to_s, Date.current.to_s)
 
-      expect(message).to match(/new topics received no reply/)
+      expect(message).to match(/new member-created topics received no reply/)
     end
 
     it "asks the agent to write in the requesting user's language" do


### PR DESCRIPTION
When providing highlights regarding support stats for a community, we want to exclude admin-created topics.