### PR TITLE
FEATURE: Add a granular API key scope to list badges

### DIFF
--- a/app/models/api_key_scope.rb
+++ b/app/models/api_key_scope.rb
@@ -198,6 +198,9 @@ class ApiKeyScope < ActiveRecord::Base
           },
         },
         badges: {
+          list: {
+            actions: %w[badges#index admin/badges#index],
+          },
           create: {
             actions: %w[admin/badges#create],
           },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7542,6 +7542,7 @@ en:
             invites:
               create: Send email invites or generate invite links.
             badges:
+              list: Get a list of badges.
               create: Create a new badge.
               show: Obtain information about a badge.
               update: Update a badge.

--- a/spec/requests/admin/badges_controller_spec.rb
+++ b/spec/requests/admin/badges_controller_spec.rb
@@ -36,6 +36,35 @@ RSpec.describe Admin::BadgesController do
 
       include_examples "badges inaccessible"
     end
+
+    context "with an API key scoped to badges -> list" do
+      it "allows an admin's key to list badges" do
+        api_key = Fabricate(:api_key, user: admin)
+        Fabricate(:api_key_scope, resource: "badges", action: "list", api_key_id: api_key.id)
+
+        get "/admin/badges.json",
+            headers: {
+              "HTTP_API_KEY" => api_key.key,
+              "HTTP_API_USERNAME" => admin.username,
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["badges"]).to be_present
+      end
+
+      it "denies a non-admin's key, since the admin route stays admin-only" do
+        api_key = Fabricate(:api_key, user: user)
+        Fabricate(:api_key_scope, resource: "badges", action: "list", api_key_id: api_key.id)
+
+        get "/admin/badges.json",
+            headers: {
+              "HTTP_API_KEY" => api_key.key,
+              "HTTP_API_USERNAME" => user.username,
+            }
+
+        expect(response.status).to eq(404)
+      end
+    end
   end
 
   describe "#preview" do

--- a/spec/requests/badges_controller_spec.rb
+++ b/spec/requests/badges_controller_spec.rb
@@ -83,6 +83,45 @@ RSpec.describe BadgesController do
       expect(badge_ids).not_to include(disabled_badge.id)
       expect(badge_ids).not_to include(non_listable_badge.id)
     end
+
+    context "with an API key" do
+      let(:api_key) { Fabricate(:api_key, user:) }
+
+      def list_badges
+        get "/badges.json",
+            headers: {
+              "HTTP_API_KEY" => api_key.key,
+              "HTTP_API_USERNAME" => user.username,
+            }
+      end
+
+      it "allows listing badges with the badges -> list scope" do
+        Fabricate(:api_key_scope, resource: "badges", action: "list", api_key_id: api_key.id)
+
+        list_badges
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["badges"]).to be_present
+      end
+
+      it "denies listing badges with a non-matching scope" do
+        Fabricate(:api_key_scope, resource: "badges", action: "show", api_key_id: api_key.id)
+
+        list_badges
+
+        expect(response.status).to eq(403)
+      end
+
+      it "allows listing badges with the badges -> list scope when login is required" do
+        SiteSetting.login_required = true
+        Fabricate(:api_key_scope, resource: "badges", action: "list", api_key_id: api_key.id)
+
+        list_badges
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["badges"]).to be_present
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
Previously, listing badges over the API required either a global-scope key or disabling "Login required" and issuing an anonymous request, because no granular scope was mapped to the badge-listing endpoints — a problem for closed-site integrations that want to avoid global keys.

This change adds a `badges -> list` scope mapped to both the public `badges#index` and the admin `admin/badges#index`, so a non-admin key can list enabled/listable badges (even on a login-required site, via the API JSON login bypass) and an admin-owned key can additionally fetch the full payload from `/admin/badges.json`. The admin route stays gated by `ensure_admin` / `AdminConstraint`, so the scope grants no admin access on its own.

Meta: https://meta.discourse.org/t/api-granular-scope-to-list-all-badges/405734
