### PR TITLE
DEV: Yield when not overriding chat join outlet

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/connectors/chat-join-channel-button/join-channel-message.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/connectors/chat-join-channel-button/join-channel-message.gjs
@@ -1,8 +1,6 @@
 import Component from "@glimmer/component";
 import { inject as controller } from "@ember/controller";
 import { service } from "@ember/service";
-import DButton from "discourse/ui-kit/d-button";
-import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 export default class JoinChannelMessage extends Component {
@@ -28,17 +26,7 @@ export default class JoinChannelMessage extends Component {
         {{i18n "discourse_calendar.livestream.chat.join_channel_message"}}
       </p>
     {{else}}
-      <DButton
-        @action={{@outletArgs.onJoinChannel}}
-        @translatedLabel={{@outletArgs.label}}
-        @translatedTitle={{@outletArgs.options.joinTitle}}
-        @icon={{@outletArgs.options.joinIcon}}
-        @disabled={{@outletArgs.isLoading}}
-        class={{dConcatClass
-          "toggle-channel-membership-button -join"
-          @outletArgs.options.joinClass
-        }}
-      />
+      {{yield}}
     {{/if}}
   </template>
 }


### PR DESCRIPTION
No need to repeat here what is already rendered by `ToggleChannelMembershipButton`. 