### PR TITLE
DEV: Determine block customization source at build time, not the call stack

### DIFF
--- a/frontend/asset-processor/asset-processor-rollup.js
+++ b/frontend/asset-processor/asset-processor-rollup.js
@@ -11,6 +11,7 @@ import { browsers } from "../discourse/config/targets";
 import babelTransformModuleRenames from "../discourse/lib/babel-transform-module-renames";
 import AddThemeGlobals from "./add-theme-globals";
 import BabelReplaceImports from "./babel-replace-imports";
+import InjectCustomizationSource from "./inject-customization-source";
 import discourseColocation from "./rollup-plugins/discourse-colocation";
 import discourseExternalLoader from "./rollup-plugins/discourse-external-loader";
 import discourseFileSearch from "./rollup-plugins/discourse-file-search";
@@ -31,6 +32,14 @@ async function performRollup(modules, opts) {
   let basePath = opts.pluginName
     ? `discourse/plugins/${opts.pluginName}/`
     : `theme-${opts.themeId}/`;
+
+  // Identifies which plugin or theme this code belongs to, so registrations can
+  // be attributed at build time instead of via the runtime call stack.
+  const customizationSource = opts.pluginName
+    ? { type: "plugin", name: opts.pluginName }
+    : opts.themeId != null
+      ? { type: "theme", id: opts.themeId }
+      : null;
 
   const inputConfig = {};
 
@@ -74,6 +83,9 @@ async function performRollup(modules, opts) {
         compact: false,
         plugins: [
           [DecoratorTransforms, { runEarly: true }],
+          customizationSource
+            ? [InjectCustomizationSource, { source: customizationSource }]
+            : null,
           opts.themeId ? AddThemeGlobals : null,
           babelTransformModuleRenames,
           colocatedBabelPlugin,

--- a/frontend/asset-processor/inject-customization-source.js
+++ b/frontend/asset-processor/inject-customization-source.js
@@ -1,0 +1,120 @@
+// Build-time transform that records which plugin or theme a piece of code came
+// from, so the runtime no longer has to infer it from the JavaScript call stack.
+//
+// For every call to one of the core API-entry functions (see ENTRY_FUNCTIONS)
+// made from plugin/theme code, it appends a branded source descriptor as the
+// last argument. The matching runtime functions detect the brand, strip the
+// descriptor, and bind it to the API object they hand back.
+//
+// Core code is compiled by a different pipeline and never runs through this
+// transform, so it receives no descriptor and resolves to "core".
+
+// Registry key for the marker symbol. Keep in sync with SOURCE_BRAND
+// (`Symbol.for(...)`) in discourse/lib/customization-source. A registered symbol
+// is used so an ordinary object (e.g. a bogus `opts`) can never be mistaken for
+// a source descriptor.
+const SOURCE_BRAND_KEY = "discourse:customization-source";
+
+// The core functions, keyed by their canonical import, that hand a PluginApi to
+// plugin/theme code. Extend this list as new source-aware entry points appear.
+const ENTRY_FUNCTIONS = [
+  { module: "discourse/lib/plugin-api", export: "withPluginApi" },
+  { module: "discourse/lib/api", export: "apiInitializer" },
+];
+
+export default function (babel, options = {}) {
+  const { types: t } = babel;
+  const source = options.source;
+
+  if (!source) {
+    return { name: "inject-customization-source", visitor: {} };
+  }
+
+  function brandKey() {
+    return t.callExpression(
+      t.memberExpression(t.identifier("Symbol"), t.identifier("for")),
+      [t.stringLiteral(SOURCE_BRAND_KEY)]
+    );
+  }
+
+  function isBrandKey(node) {
+    return (
+      t.isCallExpression(node) &&
+      t.isMemberExpression(node.callee) &&
+      t.isIdentifier(node.callee.object, { name: "Symbol" }) &&
+      t.isIdentifier(node.callee.property, { name: "for" }) &&
+      node.arguments.length === 1 &&
+      t.isStringLiteral(node.arguments[0], { value: SOURCE_BRAND_KEY })
+    );
+  }
+
+  function buildDescriptor() {
+    const properties = [
+      // [Symbol.for("discourse:customization-source")]: true
+      t.objectProperty(brandKey(), t.booleanLiteral(true), true),
+      t.objectProperty(t.identifier("type"), t.stringLiteral(source.type)),
+    ];
+
+    if (source.type === "plugin") {
+      properties.push(
+        t.objectProperty(t.identifier("name"), t.stringLiteral(source.name))
+      );
+    } else if (source.type === "theme") {
+      properties.push(
+        t.objectProperty(t.identifier("id"), t.numericLiteral(source.id))
+      );
+    }
+
+    return t.objectExpression(properties);
+  }
+
+  function isEntryCall(path) {
+    const callee = path.node.callee;
+    if (!t.isIdentifier(callee)) {
+      return false;
+    }
+
+    const binding = path.scope.getBinding(callee.name);
+    if (!binding || binding.kind !== "module") {
+      return false;
+    }
+
+    const specifier = binding.path;
+    if (!t.isImportSpecifier(specifier.node)) {
+      return false;
+    }
+
+    const importedName = specifier.node.imported.name;
+    const moduleName = specifier.parent.source.value;
+
+    return ENTRY_FUNCTIONS.some(
+      (entry) => entry.export === importedName && entry.module === moduleName
+    );
+  }
+
+  function alreadyBranded(args) {
+    const last = args[args.length - 1];
+    return (
+      last &&
+      t.isObjectExpression(last) &&
+      last.properties.some(
+        (property) =>
+          t.isObjectProperty(property) &&
+          property.computed &&
+          isBrandKey(property.key)
+      )
+    );
+  }
+
+  return {
+    name: "inject-customization-source",
+    visitor: {
+      CallExpression(path) {
+        if (!isEntryCall(path) || alreadyBranded(path.node.arguments)) {
+          return;
+        }
+        path.node.arguments.push(buildDescriptor());
+      },
+    },
+  };
+}

--- a/frontend/asset-processor/inject-customization-source.js
+++ b/frontend/asset-processor/inject-customization-source.js
@@ -1,19 +1,46 @@
 // Build-time transform that records which plugin or theme a piece of code came
 // from, so the runtime no longer has to infer it from the JavaScript call stack.
 //
-// For every call to one of the core API-entry functions (see ENTRY_FUNCTIONS)
-// made from plugin/theme code, it appends a branded source descriptor as the
-// last argument. The matching runtime functions detect the brand, strip the
-// descriptor, and bind it to the API object they hand back.
+// For each import of a core API-entry function (see ENTRY_FUNCTIONS) in
+// plugin/theme code, it shadows the imported binding with a thin wrapper that
+// appends a branded source descriptor as the last argument:
+//
+//   import { withPluginApi } from "discourse/lib/plugin-api";
+//   withPluginApi(cb);
+//
+// becomes (descriptor abbreviated):
+//
+//   import { withPluginApi as _customizationSource$withPluginApi } from "...";
+//   function withPluginApi(...args) {
+//     return _customizationSource$withPluginApi(...args, { ...descriptor });
+//   }
+//   withPluginApi(cb);
+//
+// Because the wrapper shadows the import binding, EVERY reference to it is
+// attributed — direct calls, aliased imports, a stored alias
+// (`const w = withPluginApi`), and the function passed as a callback. The
+// matching runtime functions detect the brand, strip the descriptor, and bind
+// it to the API object they hand back.
 //
 // Core code is compiled by a different pipeline and never runs through this
 // transform, so it receives no descriptor and resolves to "core".
+//
+// KNOWN LIMITATIONS (attribution falls back to "core"; the dev-only
+// warnIfSourceUnexpected flags them). Attribution flows through the named import
+// binding, so it does NOT cover: namespace-member access
+// (`import * as api; api.withPluginApi(...)`), dynamic `import()`,
+// import-through-a-re-export, or legacy `<script>`-tag plugins (`_pluginCallbacks`
+// in app.js, which call withPluginApi from core).
 
 // Registry key for the marker symbol. Keep in sync with SOURCE_BRAND
 // (`Symbol.for(...)`) in discourse/lib/customization-source. A registered symbol
 // is used so an ordinary object (e.g. a bogus `opts`) can never be mistaken for
 // a source descriptor.
 const SOURCE_BRAND_KEY = "discourse:customization-source";
+
+// Prefix for the hidden raw-import binding the wrapper forwards to. Also used to
+// detect already-shadowed imports so the transform is idempotent.
+const RAW_PREFIX = "_customizationSource$";
 
 // The core functions, keyed by their canonical import, that hand a PluginApi to
 // plugin/theme code. Extend this list as new source-aware entry points appear.
@@ -30,28 +57,17 @@ export default function (babel, options = {}) {
     return { name: "inject-customization-source", visitor: {} };
   }
 
-  function brandKey() {
-    return t.callExpression(
-      t.memberExpression(t.identifier("Symbol"), t.identifier("for")),
-      [t.stringLiteral(SOURCE_BRAND_KEY)]
-    );
-  }
-
-  function isBrandKey(node) {
-    return (
-      t.isCallExpression(node) &&
-      t.isMemberExpression(node.callee) &&
-      t.isIdentifier(node.callee.object, { name: "Symbol" }) &&
-      t.isIdentifier(node.callee.property, { name: "for" }) &&
-      node.arguments.length === 1 &&
-      t.isStringLiteral(node.arguments[0], { value: SOURCE_BRAND_KEY })
-    );
-  }
-
   function buildDescriptor() {
     const properties = [
       // [Symbol.for("discourse:customization-source")]: true
-      t.objectProperty(brandKey(), t.booleanLiteral(true), true),
+      t.objectProperty(
+        t.callExpression(
+          t.memberExpression(t.identifier("Symbol"), t.identifier("for")),
+          [t.stringLiteral(SOURCE_BRAND_KEY)]
+        ),
+        t.booleanLiteral(true),
+        true
+      ),
       t.objectProperty(t.identifier("type"), t.stringLiteral(source.type)),
     ];
 
@@ -68,52 +84,72 @@ export default function (babel, options = {}) {
     return t.objectExpression(properties);
   }
 
-  function isEntryCall(path) {
-    const callee = path.node.callee;
-    if (!t.isIdentifier(callee)) {
-      return false;
-    }
-
-    const binding = path.scope.getBinding(callee.name);
-    if (!binding || binding.kind !== "module") {
-      return false;
-    }
-
-    const specifier = binding.path;
-    if (!t.isImportSpecifier(specifier.node)) {
-      return false;
-    }
-
-    const importedName = specifier.node.imported.name;
-    const moduleName = specifier.parent.source.value;
-
+  function isEntryExport(moduleName, importedName) {
     return ENTRY_FUNCTIONS.some(
-      (entry) => entry.export === importedName && entry.module === moduleName
+      (entry) => entry.module === moduleName && entry.export === importedName
     );
   }
 
-  function alreadyBranded(args) {
-    const last = args[args.length - 1];
-    return (
-      last &&
-      t.isObjectExpression(last) &&
-      last.properties.some(
-        (property) =>
-          t.isObjectProperty(property) &&
-          property.computed &&
-          isBrandKey(property.key)
-      )
-    );
-  }
+  // Built once per file; cloned into each wrapper.
+  const descriptor = buildDescriptor();
 
   return {
     name: "inject-customization-source",
     visitor: {
-      CallExpression(path) {
-        if (!isEntryCall(path) || alreadyBranded(path.node.arguments)) {
+      ImportDeclaration(path) {
+        const moduleName = path.node.source.value;
+        if (!ENTRY_FUNCTIONS.some((entry) => entry.module === moduleName)) {
           return;
         }
-        path.node.arguments.push(buildDescriptor());
+
+        const wrappers = [];
+
+        for (const specifier of path.node.specifiers) {
+          if (
+            !t.isImportSpecifier(specifier) ||
+            !t.isIdentifier(specifier.imported) ||
+            !isEntryExport(moduleName, specifier.imported.name)
+          ) {
+            continue;
+          }
+
+          // Already shadowed (e.g. a second transform pass) — leave it alone.
+          if (specifier.local.name.startsWith(RAW_PREFIX)) {
+            continue;
+          }
+
+          const localName = specifier.local.name;
+          const rawName = `${RAW_PREFIX}${specifier.imported.name}`;
+
+          // Repoint the import to the hidden raw name; user references keep
+          // `localName` and resolve to the wrapper injected below.
+          specifier.local = t.identifier(rawName);
+
+          // function <local>(...args) { return <raw>(...args, <descriptor>); }
+          wrappers.push(
+            t.functionDeclaration(
+              t.identifier(localName),
+              [t.restElement(t.identifier("args"))],
+              t.blockStatement([
+                t.returnStatement(
+                  t.callExpression(t.identifier(rawName), [
+                    t.spreadElement(t.identifier("args")),
+                    t.cloneNode(descriptor, true),
+                  ])
+                ),
+              ])
+            )
+          );
+        }
+
+        if (wrappers.length > 0) {
+          // Rebuild scope so the now-repointed import (raw name) replaces the
+          // stale original-name binding; otherwise inserting the wrapper under
+          // the original name is seen as a duplicate declaration. References keep
+          // their original names and resolve to the hoisted wrappers.
+          path.scope.crawl();
+          path.insertAfter(wrappers);
+        }
       },
     },
   };

--- a/frontend/asset-processor/inject-customization-source.test.mjs
+++ b/frontend/asset-processor/inject-customization-source.test.mjs
@@ -1,0 +1,108 @@
+/* eslint-disable qunit/require-expect */
+import { transformSync } from "@babel/core";
+import { expect, test } from "vitest";
+import InjectCustomizationSource from "./inject-customization-source.js";
+
+function compile(input, source) {
+  return transformSync(input, {
+    configFile: false,
+    plugins: [[InjectCustomizationSource, { source }]],
+  }).code;
+}
+
+function countOccurrences(haystack, needle) {
+  return haystack.split(needle).length - 1;
+}
+
+test("appends a plugin descriptor to withPluginApi calls", () => {
+  const code = compile(
+    `import { withPluginApi } from "discourse/lib/plugin-api";
+     withPluginApi((api) => api.registerBlock(Foo));`,
+    { type: "plugin", name: "chat" }
+  );
+
+  expect(code).toContain(
+    '[Symbol.for("discourse:customization-source")]: true'
+  );
+  expect(code).toContain('type: "plugin"');
+  expect(code).toContain('name: "chat"');
+});
+
+test("appends a theme descriptor to apiInitializer calls", () => {
+  const code = compile(
+    `import { apiInitializer } from "discourse/lib/api";
+     export default apiInitializer((api) => api.registerBlock(Foo));`,
+    { type: "theme", id: 42 }
+  );
+
+  expect(code).toContain(
+    '[Symbol.for("discourse:customization-source")]: true'
+  );
+  expect(code).toContain('type: "theme"');
+  expect(code).toContain("id: 42");
+});
+
+test("handles aliased imports", () => {
+  const code = compile(
+    `import { withPluginApi as wpa } from "discourse/lib/plugin-api";
+     wpa((api) => {});`,
+    { type: "plugin", name: "chat" }
+  );
+
+  expect(code).toContain(
+    '[Symbol.for("discourse:customization-source")]: true'
+  );
+  expect(code).toContain('name: "chat"');
+});
+
+test("does not rewrite functions that are not source-aware entry points", () => {
+  const code = compile(
+    `import { somethingElse } from "discourse/lib/plugin-api";
+     somethingElse((api) => {});`,
+    { type: "plugin", name: "chat" }
+  );
+
+  expect(code).not.toContain("discourse:customization-source");
+});
+
+test("does not rewrite a same-named local that is not the imported binding", () => {
+  const code = compile(
+    `function withPluginApi() {}
+     withPluginApi();`,
+    { type: "plugin", name: "chat" }
+  );
+
+  expect(code).not.toContain("discourse:customization-source");
+});
+
+test("does not rewrite imports from a different module", () => {
+  const code = compile(
+    `import { withPluginApi } from "somewhere/else";
+     withPluginApi((api) => {});`,
+    { type: "plugin", name: "chat" }
+  );
+
+  expect(code).not.toContain("discourse:customization-source");
+});
+
+test("is idempotent across repeated transforms", () => {
+  const source = { type: "plugin", name: "chat" };
+  const once = compile(
+    `import { withPluginApi } from "discourse/lib/plugin-api";
+     withPluginApi((api) => {});`,
+    source
+  );
+  const twice = compile(once, source);
+
+  expect(countOccurrences(twice, "discourse:customization-source")).toBe(1);
+});
+
+test("is a no-op when no source is provided", () => {
+  const code = compile(
+    `import { withPluginApi } from "discourse/lib/plugin-api";
+     withPluginApi((api) => {});`,
+    undefined
+  );
+
+  expect(code).not.toContain("discourse:customization-source");
+});

--- a/frontend/asset-processor/inject-customization-source.test.mjs
+++ b/frontend/asset-processor/inject-customization-source.test.mjs
@@ -14,21 +14,33 @@ function countOccurrences(haystack, needle) {
   return haystack.split(needle).length - 1;
 }
 
-test("appends a plugin descriptor to withPluginApi calls", () => {
+const DESCRIPTOR_KEY = '[Symbol.for("discourse:customization-source")]: true';
+
+test("shadows withPluginApi with a descriptor-appending wrapper", () => {
   const code = compile(
     `import { withPluginApi } from "discourse/lib/plugin-api";
      withPluginApi((api) => api.registerBlock(Foo));`,
     { type: "plugin", name: "chat" }
   );
 
+  // import repointed to the hidden raw binding
   expect(code).toContain(
-    '[Symbol.for("discourse:customization-source")]: true'
+    "import { withPluginApi as _customizationSource$withPluginApi }"
   );
+  // wrapper under the original name, forwarding to the raw binding + descriptor
+  expect(code).toContain("function withPluginApi(...args)");
+  expect(code).toContain("_customizationSource$withPluginApi(...args,");
+  expect(code).toContain(DESCRIPTOR_KEY);
   expect(code).toContain('type: "plugin"');
   expect(code).toContain('name: "chat"');
+  // the call site is left as a call to `withPluginApi` (now the wrapper); babel
+  // may reprint `(api) =>` as `api =>`, so match loosely.
+  expect(code).toMatch(
+    /withPluginApi\(\(?api\)? *=> *api\.registerBlock\(Foo\)\)/
+  );
 });
 
-test("appends a theme descriptor to apiInitializer calls", () => {
+test("shadows apiInitializer with a theme descriptor", () => {
   const code = compile(
     `import { apiInitializer } from "discourse/lib/api";
      export default apiInitializer((api) => api.registerBlock(Foo));`,
@@ -36,13 +48,14 @@ test("appends a theme descriptor to apiInitializer calls", () => {
   );
 
   expect(code).toContain(
-    '[Symbol.for("discourse:customization-source")]: true'
+    "import { apiInitializer as _customizationSource$apiInitializer }"
   );
+  expect(code).toContain("function apiInitializer(...args)");
   expect(code).toContain('type: "theme"');
   expect(code).toContain("id: 42");
 });
 
-test("handles aliased imports", () => {
+test("handles aliased imports (wrapper under the alias)", () => {
   const code = compile(
     `import { withPluginApi as wpa } from "discourse/lib/plugin-api";
      wpa((api) => {});`,
@@ -50,12 +63,33 @@ test("handles aliased imports", () => {
   );
 
   expect(code).toContain(
-    '[Symbol.for("discourse:customization-source")]: true'
+    "import { withPluginApi as _customizationSource$withPluginApi }"
   );
-  expect(code).toContain('name: "chat"');
+  expect(code).toContain("function wpa(...args)");
+  expect(code).toContain(DESCRIPTOR_KEY);
 });
 
-test("does not rewrite functions that are not source-aware entry points", () => {
+test("attributes a stored alias and a callback reference via the shadow", () => {
+  const code = compile(
+    `import { withPluginApi } from "discourse/lib/plugin-api";
+     const w = withPluginApi;
+     register(withPluginApi);
+     w((api) => {});`,
+    { type: "plugin", name: "chat" }
+  );
+
+  // The only `withPluginApi` binding is the wrapper, so both the stored alias and
+  // the callback reference capture the descriptor-appending wrapper.
+  expect(code).toContain("function withPluginApi(...args)");
+  expect(code).toContain("const w = withPluginApi;");
+  expect(code).toContain("register(withPluginApi)");
+  // the raw import is hidden behind the prefix; user code can't reach it unwrapped
+  expect(code).toContain(
+    "import { withPluginApi as _customizationSource$withPluginApi }"
+  );
+});
+
+test("does not touch non-entry imports", () => {
   const code = compile(
     `import { somethingElse } from "discourse/lib/plugin-api";
      somethingElse((api) => {});`,
@@ -63,9 +97,10 @@ test("does not rewrite functions that are not source-aware entry points", () => 
   );
 
   expect(code).not.toContain("discourse:customization-source");
+  expect(code).not.toContain("function somethingElse");
 });
 
-test("does not rewrite a same-named local that is not the imported binding", () => {
+test("does not touch a same-named local that is not the import", () => {
   const code = compile(
     `function withPluginApi() {}
      withPluginApi();`,
@@ -75,7 +110,7 @@ test("does not rewrite a same-named local that is not the imported binding", () 
   expect(code).not.toContain("discourse:customization-source");
 });
 
-test("does not rewrite imports from a different module", () => {
+test("does not touch imports from a different module", () => {
   const code = compile(
     `import { withPluginApi } from "somewhere/else";
      withPluginApi((api) => {});`,
@@ -94,7 +129,8 @@ test("is idempotent across repeated transforms", () => {
   );
   const twice = compile(once, source);
 
-  expect(countOccurrences(twice, "discourse:customization-source")).toBe(1);
+  expect(countOccurrences(twice, "function withPluginApi(...args)")).toBe(1);
+  expect(countOccurrences(twice, DESCRIPTOR_KEY)).toBe(1);
 });
 
 test("is a no-op when no source is provided", () => {
@@ -105,4 +141,5 @@ test("is a no-op when no source is provided", () => {
   );
 
   expect(code).not.toContain("discourse:customization-source");
+  expect(code).not.toContain("function withPluginApi");
 });

--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -348,6 +348,10 @@ function resolveDiscourseInitializer(moduleName, themeId) {
 }
 
 function expectedSourceIdForModule(moduleName, themeId) {
+  // Only consumed by the development-only check in runWithExpectedSourceId.
+  if (!DEBUG) {
+    return null;
+  }
   if (themeId != null) {
     return `theme:${themeId}`;
   }

--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -19,6 +19,7 @@ import Application from "@ember/application";
 import { VERSION } from "@ember/version";
 import setupInspector from "@embroider/legacy-inspector-support/ember-source-4.12";
 import { importSync } from "@embroider/macros";
+import { runWithExpectedSourceId } from "discourse/lib/customization-source";
 import { normalizeEmberEventHandling } from "discourse/lib/ember-events";
 import { isRailsTesting, isTesting } from "discourse/lib/environment";
 import { withPluginApi } from "discourse/lib/plugin-api";
@@ -327,7 +328,13 @@ function resolveDiscourseInitializer(moduleName, themeId) {
 
   initializer.initialize = (app) => {
     try {
-      return oldInitialize.call(initializer, app.__container__, app);
+      // Record the authoritative source (from the unspoofable module name) so a
+      // development-only check can flag registrations whose build-injected
+      // source went missing. A no-op in production.
+      return runWithExpectedSourceId(
+        expectedSourceIdForModule(moduleName, themeId),
+        () => oldInitialize.call(initializer, app.__container__, app)
+      );
     } catch (error) {
       if (!themeId || isTesting()) {
         throw error;
@@ -338,6 +345,14 @@ function resolveDiscourseInitializer(moduleName, themeId) {
   };
 
   return initializer;
+}
+
+function expectedSourceIdForModule(moduleName, themeId) {
+  if (themeId != null) {
+    return `theme:${themeId}`;
+  }
+  const match = moduleName.match(/^discourse\/plugins\/([^/]+)\//);
+  return match ? `plugin:${match[1]}` : null;
 }
 
 let printedDebugInfo = false;

--- a/frontend/discourse/app/lib/api.js
+++ b/frontend/discourse/app/lib/api.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { isCustomizationSource } from "discourse/lib/customization-source";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 let _apiInitializerId = 0;
@@ -10,15 +11,30 @@ let _apiInitializerId = 0;
  * @param {object} [opts] - Optional additional options to pass to the callback function.
  */
 export function apiInitializer(apiCodeCallback, opts) {
-  if (typeof arguments[0] === "string") {
-    // Old path. First argument is the version string. Silently ignore.
-    [, apiCodeCallback, opts] = arguments;
+  // The asset processor appends a branded customization-source descriptor to
+  // calls made from plugin/theme code; forward it to `withPluginApi` so the
+  // api handed to the callback knows its origin.
+  let args = Array.from(arguments);
+  let source;
+  if (args.length > 0 && isCustomizationSource(args[args.length - 1])) {
+    source = args.pop();
   }
+
+  if (typeof args[0] === "string") {
+    // Old path. First argument is the version string. Silently ignore.
+    args = args.slice(1);
+  }
+
+  apiCodeCallback = args[0];
+  opts = args[1];
+
   return {
     name: `api-initializer${_apiInitializerId++}`,
     after: "inject-objects",
     initialize() {
-      return withPluginApi(apiCodeCallback, opts);
+      return source === undefined
+        ? withPluginApi(apiCodeCallback, opts)
+        : withPluginApi(apiCodeCallback, opts, source);
     },
   };
 }

--- a/frontend/discourse/app/lib/api.js
+++ b/frontend/discourse/app/lib/api.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { isCustomizationSource } from "discourse/lib/customization-source";
+import { splitSourceArgs } from "discourse/lib/customization-source";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 let _apiInitializerId = 0;
@@ -12,29 +12,18 @@ let _apiInitializerId = 0;
  */
 export function apiInitializer(apiCodeCallback, opts) {
   // The asset processor appends a branded customization-source descriptor to
-  // calls made from plugin/theme code; forward it to `withPluginApi` so the
-  // api handed to the callback knows its origin.
-  let args = Array.from(arguments);
+  // calls made from plugin/theme code; splitSourceArgs strips it (and any legacy
+  // version string) so it can be forwarded to `withPluginApi`.
   let source;
-  if (args.length > 0 && isCustomizationSource(args[args.length - 1])) {
-    source = args.pop();
-  }
-
-  if (typeof args[0] === "string") {
-    // Old path. First argument is the version string. Silently ignore.
-    args = args.slice(1);
-  }
-
-  apiCodeCallback = args[0];
-  opts = args[1];
+  ({ apiCodeCallback, opts, source } = splitSourceArgs(Array.from(arguments)));
 
   return {
     name: `api-initializer${_apiInitializerId++}`,
     after: "inject-objects",
     initialize() {
-      return source === undefined
-        ? withPluginApi(apiCodeCallback, opts)
-        : withPluginApi(apiCodeCallback, opts, source);
+      // A trailing undefined source is harmless: withPluginApi only treats a
+      // branded descriptor as the source.
+      return withPluginApi(apiCodeCallback, opts, source);
     },
   };
 }

--- a/frontend/discourse/app/lib/blocks/-internals/registry/block.js
+++ b/frontend/discourse/app/lib/blocks/-internals/registry/block.js
@@ -328,6 +328,7 @@ export function _freezeBlockRegistry() {
  * via `getBlockMetadata()`.
  *
  * @param {BlockClass} BlockClass - The block component class
+ * @param {import("discourse/lib/customization-source").CustomizationSource} [source] - The build-injected source of the calling code.
  * @throws {Error} If called after registry is locked, or if block is invalid
  *
  * @example
@@ -345,7 +346,7 @@ export function _freezeBlockRegistry() {
  * };
  * ```
  */
-export function _registerBlock(BlockClass) {
+export function _registerBlock(BlockClass, source) {
   const blockName = getBlockMetadata(BlockClass)?.blockName;
 
   if (
@@ -370,7 +371,9 @@ export function _registerBlock(BlockClass) {
     return;
   }
 
-  if (!validateSourceNamespace({ name: blockName, entityType: "block" })) {
+  if (
+    !validateSourceNamespace({ name: blockName, entityType: "block", source })
+  ) {
     return;
   }
 
@@ -389,6 +392,7 @@ export function _registerBlock(BlockClass) {
  *
  * @param {string} name - The name to register the block under.
  * @param {BlockFactory} factory - Factory function returning Promise<BlockClass>.
+ * @param {import("discourse/lib/customization-source").CustomizationSource} [source] - The build-injected source of the calling code.
  * @throws {Error} If registry is locked, name is invalid, or factory is not a function.
  *
  * @example
@@ -398,7 +402,7 @@ export function _registerBlock(BlockClass) {
  *
  * @internal
  */
-export function _registerBlockFactory(name, factory) {
+export function _registerBlockFactory(name, factory, source) {
   if (
     !assertRegistryNotFrozen({
       frozen: registryFrozen,
@@ -421,7 +425,7 @@ export function _registerBlockFactory(name, factory) {
     return;
   }
 
-  if (!validateSourceNamespace({ name, entityType: "block" })) {
+  if (!validateSourceNamespace({ name, entityType: "block", source })) {
     return;
   }
 

--- a/frontend/discourse/app/lib/blocks/-internals/registry/condition.js
+++ b/frontend/discourse/app/lib/blocks/-internals/registry/condition.js
@@ -91,6 +91,7 @@ export function _freezeConditionTypeRegistry() {
  * The condition class must be decorated with `@blockCondition`
  *
  * @param {typeof import("discourse/blocks/conditions").BlockCondition} ConditionClass - The condition class to register.
+ * @param {import("discourse/lib/customization-source").CustomizationSource} [source] - The build-injected source of the calling code.
  *
  * @example
  * ```javascript
@@ -108,7 +109,7 @@ export function _freezeConditionTypeRegistry() {
  *
  * @internal
  */
-export function _registerConditionType(ConditionClass) {
+export function _registerConditionType(ConditionClass, source) {
   if (
     !assertRegistryNotFrozen({
       frozen: conditionTypeRegistryFrozen,
@@ -137,7 +138,9 @@ export function _registerConditionType(ConditionClass) {
   }
 
   // Validate namespace requirements for plugins/themes and enforce consistency
-  if (!validateSourceNamespace({ name: type, entityType: "condition" })) {
+  if (
+    !validateSourceNamespace({ name: type, entityType: "condition", source })
+  ) {
     return;
   }
 

--- a/frontend/discourse/app/lib/blocks/-internals/registry/helpers.js
+++ b/frontend/discourse/app/lib/blocks/-internals/registry/helpers.js
@@ -17,7 +17,7 @@ import { getThemeInfo } from "discourse/lib/source-identifier";
  * Tracks which namespace each source (theme/plugin) has used.
  * Enforces that each source can only register blocks with a single namespace.
  *
- * Key: source identifier (e.g., "theme:Tactile Theme" or "plugin:chat")
+ * Key: source identifier (e.g., "theme:42" or "plugin:chat")
  * Value: the namespace prefix used (e.g., "theme:tactile" or "chat")
  *
  * @type {Map<string, string|null>}

--- a/frontend/discourse/app/lib/blocks/-internals/registry/helpers.js
+++ b/frontend/discourse/app/lib/blocks/-internals/registry/helpers.js
@@ -6,8 +6,12 @@ import {
   parseBlockName,
   VALID_NAMESPACED_BLOCK_PATTERN,
 } from "discourse/lib/blocks/-internals/patterns";
+import {
+  resolveSourceId,
+  warnIfSourceUnexpected,
+} from "discourse/lib/customization-source";
 import { isTesting } from "discourse/lib/environment";
-import identifySource from "discourse/lib/source-identifier";
+import { getThemeInfo } from "discourse/lib/source-identifier";
 
 /**
  * Tracks which namespace each source (theme/plugin) has used.
@@ -116,15 +120,17 @@ export function assertNotDuplicate(registry, name, entityType) {
  * @param {Object} options - Validation options.
  * @param {string} options.name - The name being registered.
  * @param {"block"|"outlet"|"condition"} options.entityType - Type of entity for error messages.
+ * @param {import("discourse/lib/customization-source").CustomizationSource} [options.source] - The build-injected source of the calling code.
  * @param {boolean} [options.enforceConsistency=true] - Whether to enforce single namespace per source.
  * @returns {boolean} True if validation passes, false if it failed (error was raised).
  */
 export function validateSourceNamespace({
   name,
   entityType,
+  source,
   enforceConsistency = true,
 }) {
-  const sourceId = getSourceIdentifier();
+  const sourceId = getSourceIdentifier(source);
   if (!sourceId) {
     return true;
   }
@@ -167,9 +173,15 @@ export function validateSourceNamespace({
       existingNamespace !== undefined &&
       existingNamespace !== namespacePrefix
     ) {
+      // Themes are keyed by their immutable id, but resolve a friendly name for
+      // the message so it reads "theme: My Theme" rather than "theme:42".
+      const sourceLabel =
+        source?.type === "theme"
+          ? `theme:${getThemeInfo(source.id).name}`
+          : sourceId;
       raiseBlockError(
         `${entityCapitalized} "${name}" uses namespace "${namespacePrefix ?? "(core)"}" but ` +
-          `${sourceId} already used namespace "${existingNamespace ?? "(core)"}". ` +
+          `${sourceLabel} already used namespace "${existingNamespace ?? "(core)"}". ` +
           `Each theme/plugin must use a single consistent namespace for all blocks, outlets, and conditions.`
       );
       return false;
@@ -227,27 +239,25 @@ export function createTestRegistrationWrapper({
  */
 
 /**
- * Gets a unique identifier for the current source from the call stack.
- * Returns null for core code (no theme or plugin detected).
+ * Gets a unique identifier for the given build-injected customization source.
+ * Returns null for core code (no source descriptor). In tests, a value set via
+ * `setTestSourceIdentifier` takes precedence.
  *
- * @returns {string|null} Source identifier like "theme:Tactile" or "plugin:chat"
+ * @param {import("discourse/lib/customization-source").CustomizationSource} [source] - The source descriptor.
+ * @returns {string|null} Source identifier like "theme:42" or "plugin:chat", or null for core.
  */
-function getSourceIdentifier() {
+function getSourceIdentifier(source) {
   if (DEBUG && testSourceIdentifier !== undefined) {
     return testSourceIdentifier;
   }
 
-  const source = identifySource();
-  if (!source) {
-    return null;
+  const sourceId = resolveSourceId(source);
+
+  if (DEBUG) {
+    warnIfSourceUnexpected(sourceId);
   }
-  if (source.type === "theme") {
-    return `theme:${source.name}`;
-  }
-  if (source.type === "plugin") {
-    return `plugin:${source.name}`;
-  }
-  return null;
+
+  return sourceId;
 }
 
 /**

--- a/frontend/discourse/app/lib/blocks/-internals/registry/outlet.js
+++ b/frontend/discourse/app/lib/blocks/-internals/registry/outlet.js
@@ -93,10 +93,11 @@ export function _freezeOutletRegistry() {
  * @param {string} outletName - The outlet name (must follow naming conventions).
  * @param {Object} [options] - Outlet options.
  * @param {string} [options.description] - Human-readable description.
+ * @param {import("discourse/lib/customization-source").CustomizationSource} [source] - The build-injected source of the calling code.
  *
  * @internal
  */
-export function _registerOutlet(outletName, options = {}) {
+export function _registerOutlet(outletName, options = {}, source) {
   if (
     !assertRegistryNotFrozen({
       frozen: outletRegistryFrozen,
@@ -131,6 +132,7 @@ export function _registerOutlet(outletName, options = {}) {
     !validateSourceNamespace({
       name: outletName,
       entityType: "outlet",
+      source,
     })
   ) {
     return;

--- a/frontend/discourse/app/lib/customization-source.js
+++ b/frontend/discourse/app/lib/customization-source.js
@@ -129,11 +129,18 @@ export function runWithExpectedSourceId(sourceId, fn) {
 }
 
 /**
- * Development-only check: warns once when a registration's build-injected source
- * does not match the authoritative source of the initializer that is running.
- * This catches code that reaches an API-entry function through an indirect
- * reference (an aliased local, a dynamic import, or a namespace import) the build
- * transform cannot attribute. Stripped from production and silent in tests.
+ * Development-only check: warns once per source when a registration made inside a
+ * known plugin/theme initializer carried NO build-injected source (resolved to
+ * core). That flags code which reached an API-entry function through an indirect
+ * reference (an aliased local, a dynamic import, a namespace import, or a
+ * re-export) the build transform cannot attribute.
+ *
+ * Best-effort and synchronous by design: only registrations made synchronously
+ * within the initializer are checked. Registrations deferred past an await/tick,
+ * and legacy `<script>`-tag plugins, resolve to core and are not flagged. A
+ * registration attributed to a *different* (but present) source is treated as
+ * legitimate cross-source registration, not a missing descriptor. Stripped from
+ * production and silent in tests.
  *
  * @param {string|null} resolvedSourceId - The id resolved from the build-injected source.
  */
@@ -143,22 +150,22 @@ export function warnIfSourceUnexpected(resolvedSourceId) {
   }
 
   const expected = _expectedSourceId;
-  if (!expected || resolvedSourceId === expected) {
+  // Only the real gap: a plugin/theme initializer registered something that the
+  // build attributed to no source at all.
+  if (!expected || resolvedSourceId !== null) {
     return;
   }
 
-  const key = `${expected}|${resolvedSourceId ?? "core"}`;
-  if (_warnedMismatches.has(key)) {
+  if (_warnedMismatches.has(expected)) {
     return;
   }
-  _warnedMismatches.add(key);
+  _warnedMismatches.add(expected);
 
   // eslint-disable-next-line no-console
   console.warn(
     `[customization-source] Code from ${expected} performed a registration that resolved to ` +
-      `"${resolvedSourceId ?? "core"}". This usually means an API-entry function was reached ` +
-      `through an indirect reference (an aliased local, a dynamic import, or a namespace import) ` +
-      `that the build cannot attribute. Call withPluginApi / apiInitializer directly so the ` +
-      `source is tracked.`
+      `"core". This usually means an API-entry function was reached through an indirect ` +
+      `reference (an aliased local, a dynamic import, or a namespace import) that the build ` +
+      `cannot attribute. Call withPluginApi / apiInitializer directly so the source is tracked.`
   );
 }

--- a/frontend/discourse/app/lib/customization-source.js
+++ b/frontend/discourse/app/lib/customization-source.js
@@ -132,8 +132,8 @@ export function runWithExpectedSourceId(sourceId, fn) {
  * Development-only check: warns once per source when a registration made inside a
  * known plugin/theme initializer carried NO build-injected source (resolved to
  * core). That flags code which reached an API-entry function through an indirect
- * reference (an aliased local, a dynamic import, a namespace import, or a
- * re-export) the build transform cannot attribute.
+ * reference (a namespace import, a dynamic import, or a re-export) the build
+ * transform cannot attribute.
  *
  * Best-effort and synchronous by design: only registrations made synchronously
  * within the initializer are checked. Registrations deferred past an await/tick,
@@ -163,9 +163,9 @@ export function warnIfSourceUnexpected(resolvedSourceId) {
 
   // eslint-disable-next-line no-console
   console.warn(
-    `[customization-source] Code from ${expected} performed a registration that resolved to ` +
+    `Code from ${expected} performed a registration that resolved to ` +
       `"core". This usually means an API-entry function was reached through an indirect ` +
-      `reference (an aliased local, a dynamic import, or a namespace import) that the build ` +
+      `reference (a namespace import, a dynamic import, or a re-export) that the build ` +
       `cannot attribute. Call withPluginApi / apiInitializer directly so the source is tracked.`
   );
 }

--- a/frontend/discourse/app/lib/customization-source.js
+++ b/frontend/discourse/app/lib/customization-source.js
@@ -21,13 +21,21 @@ import { isTesting } from "discourse/lib/environment";
 export const SOURCE_BRAND = Symbol.for("discourse:customization-source");
 
 /**
- * The origin of a piece of customization code, determined at build time.
+ * The origin of a piece of customization code.
  *
  * @typedef {Object} CustomizationSource
- * @property {"plugin"|"theme"} type - Whether the code came from a plugin or a theme.
+ * @property {"core"|"plugin"|"theme"} type - Whether the code came from core, a plugin, or a theme.
  * @property {string} [name] - The plugin name (for `type: "plugin"`).
  * @property {number} [id] - The theme id (for `type: "theme"`).
  */
+
+/**
+ * The customization source for core code. Exposed as `api.source` when core
+ * (rather than a plugin or theme) uses the plugin API.
+ *
+ * @type {Readonly<CustomizationSource>}
+ */
+export const CORE_SOURCE = Object.freeze({ type: "core" });
 
 /**
  * Returns true if the given value is a branded customization-source descriptor.
@@ -60,6 +68,7 @@ export function resolveSourceId(source) {
   if (source.type === "theme") {
     return `theme:${source.id}`;
   }
+  // Core (or any other type) has no namespace and resolves to null.
   return null;
 }
 

--- a/frontend/discourse/app/lib/customization-source.js
+++ b/frontend/discourse/app/lib/customization-source.js
@@ -50,6 +50,28 @@ export function isCustomizationSource(value) {
 }
 
 /**
+ * Splits the arguments of an API-entry function (`withPluginApi`/`apiInitializer`)
+ * into the build-injected source and the user-facing callback/options. Strips a
+ * trailing branded source descriptor and a leading legacy version string.
+ *
+ * @param {any[]} args - The call arguments (e.g. `Array.from(arguments)`).
+ * @returns {{ source: CustomizationSource|undefined, apiCodeCallback: any, opts: any }}
+ */
+export function splitSourceArgs(args) {
+  let source;
+  if (args.length > 0 && isCustomizationSource(args[args.length - 1])) {
+    source = args.pop();
+  }
+
+  if (typeof args[0] === "string") {
+    // Old path. First argument is the version string. Silently ignore.
+    args = args.slice(1);
+  }
+
+  return { source, apiCodeCallback: args[0], opts: args[1] };
+}
+
+/**
  * Maps a customization-source descriptor to its stable identifier string.
  *
  * Plugins are keyed by name (`plugin:<name>`); themes are keyed by their

--- a/frontend/discourse/app/lib/customization-source.js
+++ b/frontend/discourse/app/lib/customization-source.js
@@ -1,0 +1,133 @@
+// @ts-check
+import { DEBUG } from "@glimmer/env";
+import { isTesting } from "discourse/lib/environment";
+
+/**
+ * Marker key used to distinguish a build-time customization-source descriptor
+ * from arbitrary user arguments. A registered symbol is used (rather than a
+ * string key) so that ordinary object data — e.g. a bogus `opts` argument —
+ * can never be mistaken for a descriptor.
+ *
+ * The asset processor injects descriptors carrying this key into plugin/theme
+ * calls to the API-entry functions (e.g. `withPluginApi`, `apiInitializer`), and
+ * the runtime checks for it before treating a trailing argument as a source.
+ *
+ * IMPORTANT: keep this registry key in sync with the `Symbol.for(...)` literal
+ * emitted by the `inject-customization-source` babel plugin in
+ * `frontend/asset-processor`.
+ *
+ * @type {symbol}
+ */
+export const SOURCE_BRAND = Symbol.for("discourse:customization-source");
+
+/**
+ * The origin of a piece of customization code, determined at build time.
+ *
+ * @typedef {Object} CustomizationSource
+ * @property {"plugin"|"theme"} type - Whether the code came from a plugin or a theme.
+ * @property {string} [name] - The plugin name (for `type: "plugin"`).
+ * @property {number} [id] - The theme id (for `type: "theme"`).
+ */
+
+/**
+ * Returns true if the given value is a branded customization-source descriptor.
+ *
+ * @param {unknown} value - The value to test.
+ * @returns {value is CustomizationSource} True if it is a source descriptor.
+ */
+export function isCustomizationSource(value) {
+  return (
+    typeof value === "object" && value !== null && value[SOURCE_BRAND] === true
+  );
+}
+
+/**
+ * Maps a customization-source descriptor to its stable identifier string.
+ *
+ * Plugins are keyed by name (`plugin:<name>`); themes are keyed by their
+ * immutable id (`theme:<id>`). Core code has no descriptor and resolves to null.
+ *
+ * @param {CustomizationSource|null|undefined} source - The source descriptor.
+ * @returns {string|null} Identifier like "plugin:chat" or "theme:42", or null for core.
+ */
+export function resolveSourceId(source) {
+  if (!source) {
+    return null;
+  }
+  if (source.type === "plugin") {
+    return `plugin:${source.name}`;
+  }
+  if (source.type === "theme") {
+    return `theme:${source.id}`;
+  }
+  return null;
+}
+
+/**
+ * The authoritative source id of the plugin/theme initializer currently running,
+ * recorded by app boot from the (unspoofable) module name. Used only in
+ * development to flag code whose build-injected source went missing.
+ *
+ * @type {string|null|undefined}
+ */
+let _expectedSourceId;
+
+const _warnedMismatches = DEBUG ? new Set() : null;
+
+/**
+ * Runs `fn` while recording `sourceId` as the expected source for any
+ * registration that happens synchronously within it. A no-op in production.
+ *
+ * @template T
+ * @param {string|null} sourceId - The authoritative source id, or null for core.
+ * @param {() => T} fn - The function to run.
+ * @returns {T} The result of `fn`.
+ */
+export function runWithExpectedSourceId(sourceId, fn) {
+  if (!DEBUG) {
+    return fn();
+  }
+
+  const previous = _expectedSourceId;
+  _expectedSourceId = sourceId;
+  try {
+    return fn();
+  } finally {
+    _expectedSourceId = previous;
+  }
+}
+
+/**
+ * Development-only check: warns once when a registration's build-injected source
+ * does not match the authoritative source of the initializer that is running.
+ * This catches code that reaches an API-entry function through an indirect
+ * reference (an aliased local, a dynamic import, or a namespace import) the build
+ * transform cannot attribute. Stripped from production and silent in tests.
+ *
+ * @param {string|null} resolvedSourceId - The id resolved from the build-injected source.
+ */
+export function warnIfSourceUnexpected(resolvedSourceId) {
+  if (!DEBUG || isTesting()) {
+    return;
+  }
+
+  const expected = _expectedSourceId;
+  if (!expected || resolvedSourceId === expected) {
+    return;
+  }
+
+  const key = `${expected}|${resolvedSourceId ?? "core"}`;
+  if (_warnedMismatches.has(key)) {
+    return;
+  }
+  _warnedMismatches.add(key);
+
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[customization-source] Code from ${expected} performed a registration that resolved to ` +
+      `"${resolvedSourceId ?? "core"}". This usually means an API-entry function was reached ` +
+      `through an indirect reference (an aliased local, a dynamic import, or a namespace import) ` +
+      `that the build cannot attribute. Call withPluginApi / apiInitializer directly so the ` +
+      `source is tracked.`
+  );
+}

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -62,8 +62,8 @@ import { addPopupMenuOption } from "discourse/lib/composer/custom-popup-menu-opt
 import { registerRichEditorExtension } from "discourse/lib/composer/rich-editor-extensions";
 import {
   CORE_SOURCE,
-  isCustomizationSource,
   resolveSourceId,
+  splitSourceArgs,
 } from "discourse/lib/customization-source";
 import deprecated from "discourse/lib/deprecated";
 import { registerDesktopNotificationHandler } from "discourse/lib/desktop-notifications";
@@ -3693,15 +3693,10 @@ function getSourceBoundApi(api, source) {
   let boundApi = bySource.get(sourceId);
   if (!boundApi) {
     boundApi = new _PluginApi(api.container);
-    // A clean descriptor without the internal brand symbol. Read-only and
-    // frozen so plugins/themes can neither reassign `api.source` nor mutate it.
-    const publicSource = Object.freeze(
-      source.type === "plugin"
-        ? { type: "plugin", name: source.name }
-        : { type: "theme", id: source.id }
-    );
+    // Read-only and frozen so plugins/themes can neither reassign `api.source`
+    // nor mutate it.
     Object.defineProperty(boundApi, "source", {
-      value: publicSource,
+      value: publicSourceFor(source),
       writable: false,
       configurable: false,
       enumerable: false,
@@ -3715,6 +3710,21 @@ function getSourceBoundApi(api, source) {
 }
 
 /**
+ * Builds the frozen, public-facing descriptor exposed as `api.source`. Kept as
+ * an explicit allowlist (no internal brand symbol, no incidental fields).
+ *
+ * @param {import("discourse/lib/customization-source").CustomizationSource} descriptor - The build-injected source.
+ * @returns {Readonly<import("discourse/lib/customization-source").CustomizationSource>}
+ */
+function publicSourceFor(descriptor) {
+  return Object.freeze(
+    descriptor.type === "plugin"
+      ? { type: "plugin", name: descriptor.name }
+      : { type: "theme", id: descriptor.id }
+  );
+}
+
+/**
  * Executes the provided callback function with the `PluginApi` object.
  *
  * @param {(api: _PluginApi, opts: object) => any} apiCodeCallback - The callback function to execute
@@ -3723,21 +3733,10 @@ function getSourceBoundApi(api, source) {
  */
 export function withPluginApi(apiCodeCallback, opts) {
   // The asset processor appends a branded customization-source descriptor to
-  // calls made from plugin/theme code. Strip it before the user-facing args so
-  // it never leaks into `opts`.
-  let args = Array.from(arguments);
+  // calls made from plugin/theme code; splitSourceArgs strips it (and any legacy
+  // version string) so it never leaks into `opts`.
   let source;
-  if (args.length > 0 && isCustomizationSource(args[args.length - 1])) {
-    source = args.pop();
-  }
+  ({ apiCodeCallback, opts, source } = splitSourceArgs(Array.from(arguments)));
 
-  if (typeof args[0] === "string") {
-    // Old path. First argument is the version string. Silently ignore.
-    args = args.slice(1);
-  }
-
-  apiCodeCallback = args[0];
-  opts = args[1] || {};
-
-  return apiCodeCallback(getSourceBoundApi(getPluginApi(), source), opts);
+  return apiCodeCallback(getSourceBoundApi(getPluginApi(), source), opts || {});
 }

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -60,6 +60,10 @@ import classPrepend, {
 } from "discourse/lib/class-prepend";
 import { addPopupMenuOption } from "discourse/lib/composer/custom-popup-menu-options";
 import { registerRichEditorExtension } from "discourse/lib/composer/rich-editor-extensions";
+import {
+  isCustomizationSource,
+  resolveSourceId,
+} from "discourse/lib/customization-source";
 import deprecated from "discourse/lib/deprecated";
 import { registerDesktopNotificationHandler } from "discourse/lib/desktop-notifications";
 import { downloadCalendar } from "discourse/lib/download-calendar";
@@ -3530,10 +3534,10 @@ class _PluginApi {
           `registerBlock("${blockOrName}", ...) requires a factory function as second argument.`
         );
       }
-      _registerBlockFactory(blockOrName, factory);
+      _registerBlockFactory(blockOrName, factory, this._source);
     } else {
       // Direct class: registerBlock(BlockClass)
-      _registerBlock(blockOrName);
+      _registerBlock(blockOrName, this._source);
     }
   }
 
@@ -3567,7 +3571,7 @@ class _PluginApi {
    * ```
    */
   registerBlockOutlet(outletName, options) {
-    _registerOutlet(outletName, options);
+    _registerOutlet(outletName, options, this._source);
   }
 
   /**
@@ -3615,7 +3619,7 @@ class _PluginApi {
    * ```
    */
   registerBlockConditionType(ConditionClass) {
-    _registerConditionType(ConditionClass);
+    _registerConditionType(ConditionClass, this._source);
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -3649,6 +3653,43 @@ function getPluginApi() {
   return pluginApi;
 }
 
+// Per-owner cache of source-bound API views, keyed by the shared PluginApi
+// instance so it is collected together with its owner (no instance pollution).
+const sourceBoundApiCache = new WeakMap();
+
+/**
+ * Returns a view of the shared PluginApi instance that carries the given
+ * customization source. The view delegates everything to the singleton through
+ * its prototype and only shadows `_source`, so container refreshes and shared
+ * state remain visible. Views are cached per source (keyed by the singleton in
+ * a module-level WeakMap). Returns the singleton unchanged for core code (no
+ * source).
+ *
+ * @param {_PluginApi} api - The shared PluginApi instance.
+ * @param {import("discourse/lib/customization-source").CustomizationSource|undefined} source - The build-injected source.
+ * @returns {_PluginApi} The source-bound view, or the singleton for core.
+ */
+function getSourceBoundApi(api, source) {
+  const sourceId = resolveSourceId(source);
+  if (!sourceId) {
+    return api;
+  }
+
+  let bySource = sourceBoundApiCache.get(api);
+  if (!bySource) {
+    bySource = new Map();
+    sourceBoundApiCache.set(api, bySource);
+  }
+
+  let boundApi = bySource.get(sourceId);
+  if (!boundApi) {
+    boundApi = Object.create(api);
+    boundApi._source = Object.freeze(source);
+    bySource.set(sourceId, boundApi);
+  }
+  return boundApi;
+}
+
 /**
  * Executes the provided callback function with the `PluginApi` object.
  *
@@ -3657,12 +3698,22 @@ function getPluginApi() {
  * @returns {any} The result of the `callback` function, if executed
  */
 export function withPluginApi(apiCodeCallback, opts) {
-  if (typeof arguments[0] === "string") {
-    // Old path. First argument is the version string. Silently ignore.
-    [, apiCodeCallback, opts] = arguments;
+  // The asset processor appends a branded customization-source descriptor to
+  // calls made from plugin/theme code. Strip it before the user-facing args so
+  // it never leaks into `opts`.
+  let args = Array.from(arguments);
+  let source;
+  if (args.length > 0 && isCustomizationSource(args[args.length - 1])) {
+    source = args.pop();
   }
 
-  opts = opts || {};
+  if (typeof args[0] === "string") {
+    // Old path. First argument is the version string. Silently ignore.
+    args = args.slice(1);
+  }
 
-  return apiCodeCallback(getPluginApi(), opts);
+  apiCodeCallback = args[0];
+  opts = args[1] || {};
+
+  return apiCodeCallback(getSourceBoundApi(getPluginApi(), source), opts);
 }

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -3653,17 +3653,17 @@ function getPluginApi() {
   return pluginApi;
 }
 
-// Per-owner cache of source-bound API views, keyed by the shared PluginApi
-// instance so it is collected together with its owner (no instance pollution).
+// Per-owner cache of source-bound API instances, keyed by the shared PluginApi
+// instance so it is collected together with its owner.
 const sourceBoundApiCache = new WeakMap();
 
 /**
- * Returns a view of the shared PluginApi instance that carries the given
- * customization source. The view delegates everything to the singleton through
- * its prototype and only shadows `_source`, so container refreshes and shared
- * state remain visible. Views are cached per source (keyed by the singleton in
- * a module-level WeakMap). Returns the singleton unchanged for core code (no
- * source).
+ * Returns a source-bound view of the PluginApi for the given customization
+ * source. The view is a real `_PluginApi` instance (so private members work and
+ * brand checks pass) sharing the singleton's container and carrying its own
+ * frozen `_source`. Views are cached per source (keyed by the singleton in a
+ * module-level WeakMap) and their container is kept in sync with the singleton.
+ * Returns the singleton unchanged for core code (no source).
  *
  * @param {_PluginApi} api - The shared PluginApi instance.
  * @param {import("discourse/lib/customization-source").CustomizationSource|undefined} source - The build-injected source.
@@ -3683,9 +3683,12 @@ function getSourceBoundApi(api, source) {
 
   let boundApi = bySource.get(sourceId);
   if (!boundApi) {
-    boundApi = Object.create(api);
+    boundApi = new _PluginApi(api.container);
     boundApi._source = Object.freeze(source);
     bySource.set(sourceId, boundApi);
+  } else {
+    // Keep the container current, mirroring getPluginApi's refresh.
+    boundApi.container = api.container;
   }
   return boundApi;
 }

--- a/frontend/discourse/app/lib/plugin-api.gjs
+++ b/frontend/discourse/app/lib/plugin-api.gjs
@@ -61,6 +61,7 @@ import classPrepend, {
 import { addPopupMenuOption } from "discourse/lib/composer/custom-popup-menu-options";
 import { registerRichEditorExtension } from "discourse/lib/composer/rich-editor-extensions";
 import {
+  CORE_SOURCE,
   isCustomizationSource,
   resolveSourceId,
 } from "discourse/lib/customization-source";
@@ -3534,10 +3535,10 @@ class _PluginApi {
           `registerBlock("${blockOrName}", ...) requires a factory function as second argument.`
         );
       }
-      _registerBlockFactory(blockOrName, factory, this._source);
+      _registerBlockFactory(blockOrName, factory, this.source);
     } else {
       // Direct class: registerBlock(BlockClass)
-      _registerBlock(blockOrName, this._source);
+      _registerBlock(blockOrName, this.source);
     }
   }
 
@@ -3571,7 +3572,7 @@ class _PluginApi {
    * ```
    */
   registerBlockOutlet(outletName, options) {
-    _registerOutlet(outletName, options, this._source);
+    _registerOutlet(outletName, options, this.source);
   }
 
   /**
@@ -3619,7 +3620,7 @@ class _PluginApi {
    * ```
    */
   registerBlockConditionType(ConditionClass) {
-    _registerConditionType(ConditionClass, this._source);
+    _registerConditionType(ConditionClass, this.source);
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -3642,6 +3643,14 @@ function getPluginApi() {
 
   if (!pluginApi) {
     pluginApi = new _PluginApi(owner);
+    // The shared instance is core's view; plugins/themes get their own via
+    // getSourceBoundApi. Read-only so it cannot be reassigned.
+    Object.defineProperty(pluginApi, "source", {
+      value: CORE_SOURCE,
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    });
     owner.registry.register("plugin-api:main", pluginApi, {
       instantiate: false,
     });
@@ -3660,8 +3669,8 @@ const sourceBoundApiCache = new WeakMap();
 /**
  * Returns a source-bound view of the PluginApi for the given customization
  * source. The view is a real `_PluginApi` instance (so private members work and
- * brand checks pass) sharing the singleton's container and carrying its own
- * frozen `_source`. Views are cached per source (keyed by the singleton in a
+ * brand checks pass) sharing the singleton's container and exposing a read-only
+ * `source` descriptor. Views are cached per source (keyed by the singleton in a
  * module-level WeakMap) and their container is kept in sync with the singleton.
  * Returns the singleton unchanged for core code (no source).
  *
@@ -3684,7 +3693,19 @@ function getSourceBoundApi(api, source) {
   let boundApi = bySource.get(sourceId);
   if (!boundApi) {
     boundApi = new _PluginApi(api.container);
-    boundApi._source = Object.freeze(source);
+    // A clean descriptor without the internal brand symbol. Read-only and
+    // frozen so plugins/themes can neither reassign `api.source` nor mutate it.
+    const publicSource = Object.freeze(
+      source.type === "plugin"
+        ? { type: "plugin", name: source.name }
+        : { type: "theme", id: source.id }
+    );
+    Object.defineProperty(boundApi, "source", {
+      value: publicSource,
+      writable: false,
+      configurable: false,
+      enumerable: false,
+    });
     bySource.set(sourceId, boundApi);
   } else {
     // Keep the container current, mirroring getPluginApi's refresh.

--- a/frontend/discourse/tests/unit/lib/customization-source-test.js
+++ b/frontend/discourse/tests/unit/lib/customization-source-test.js
@@ -1,0 +1,83 @@
+import { module, test } from "qunit";
+import {
+  CORE_SOURCE,
+  isCustomizationSource,
+  resolveSourceId,
+  SOURCE_BRAND,
+  splitSourceArgs,
+} from "discourse/lib/customization-source";
+
+function branded(descriptor) {
+  return { [SOURCE_BRAND]: true, ...descriptor };
+}
+
+module("Unit | Lib | customization-source", function () {
+  test("SOURCE_BRAND matches the key the build transform emits", function (assert) {
+    // The inject-customization-source babel transform hardcodes this registry
+    // key (its own test pins the emitted `Symbol.for(...)`). This assertion pins
+    // the runtime side so the two cannot drift silently.
+    assert.strictEqual(
+      SOURCE_BRAND.description,
+      "discourse:customization-source"
+    );
+  });
+
+  test("CORE_SOURCE is a frozen core descriptor", function (assert) {
+    assert.deepEqual(CORE_SOURCE, { type: "core" });
+    assert.true(Object.isFrozen(CORE_SOURCE));
+  });
+
+  test("resolveSourceId maps descriptors to stable ids", function (assert) {
+    assert.strictEqual(
+      resolveSourceId({ type: "plugin", name: "chat" }),
+      "plugin:chat"
+    );
+    assert.strictEqual(resolveSourceId({ type: "theme", id: 42 }), "theme:42");
+    assert.strictEqual(resolveSourceId(CORE_SOURCE), null, "core has no id");
+    assert.strictEqual(resolveSourceId(null), null);
+    assert.strictEqual(resolveSourceId(undefined), null);
+  });
+
+  test("isCustomizationSource only matches a branded descriptor", function (assert) {
+    assert.true(
+      isCustomizationSource(branded({ type: "plugin", name: "chat" }))
+    );
+    assert.false(isCustomizationSource({ type: "plugin", name: "chat" }));
+    assert.false(isCustomizationSource({ foo: 1 }));
+    assert.false(isCustomizationSource(null));
+    assert.false(isCustomizationSource(undefined));
+  });
+
+  test("splitSourceArgs separates source from callback/opts across call shapes", function (assert) {
+    const cb = () => {};
+    const opts = { foo: 1 };
+    const source = branded({ type: "plugin", name: "chat" });
+
+    let result = splitSourceArgs([cb]);
+    assert.strictEqual(result.apiCodeCallback, cb, "callback-only: callback");
+    assert.strictEqual(result.opts, undefined, "callback-only: no opts");
+    assert.strictEqual(result.source, undefined, "callback-only: no source");
+
+    result = splitSourceArgs([cb, opts]);
+    assert.strictEqual(result.opts, opts, "callback + opts: opts preserved");
+    assert.strictEqual(result.source, undefined);
+
+    result = splitSourceArgs([cb, opts, source]);
+    assert.strictEqual(result.apiCodeCallback, cb, "with descriptor: callback");
+    assert.strictEqual(result.opts, opts, "with descriptor: opts preserved");
+    assert.strictEqual(
+      result.source,
+      source,
+      "with descriptor: source stripped"
+    );
+
+    result = splitSourceArgs(["1.0", cb, opts, source]);
+    assert.strictEqual(
+      result.apiCodeCallback,
+      cb,
+      "legacy version string is dropped"
+    );
+    assert.strictEqual(result.opts, opts);
+    assert.strictEqual(result.source, source);
+  });
+});

--- a/frontend/discourse/tests/unit/lib/plugin-api-test.js
+++ b/frontend/discourse/tests/unit/lib/plugin-api-test.js
@@ -383,7 +383,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
 
       withPluginApi(
         (api, opts) => {
-          boundSource = api._source;
+          boundSource = api.source;
           receivedOpts = opts;
         },
         { foo: 1 },
@@ -399,11 +399,11 @@ module("Unit | Utility | plugin-api", function (hooks) {
       );
     });
 
-    test("core code (no descriptor) gets the singleton with no source", function (assert) {
+    test("core code (no descriptor) gets the singleton with a core source", function (assert) {
       let api;
       withPluginApi((a) => (api = a));
 
-      assert.strictEqual(api._source, undefined);
+      assert.deepEqual(api.source, { type: "core" });
       assert.strictEqual(
         typeof api.getCurrentUser,
         "function",
@@ -411,7 +411,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       );
     });
 
-    test("caches one bound api per source and delegates to the singleton", function (assert) {
+    test("caches one bound api per source; each exposes the full api", function (assert) {
       let first, second, other, core;
 
       withPluginApi((api) => (first = api), {}, pluginSource("chat"));
@@ -429,7 +429,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       assert.strictEqual(
         typeof first.getCurrentUser,
         "function",
-        "bound api delegates to the singleton via its prototype"
+        "bound api exposes the full PluginApi surface"
       );
     });
 
@@ -437,7 +437,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       let boundSource;
 
       withPluginApi(
-        (api) => (boundSource = api._source),
+        (api) => (boundSource = api.source),
         {},
         pluginSource("chat")
       );
@@ -450,7 +450,7 @@ module("Unit | Utility | plugin-api", function (hooks) {
       let boundSource;
 
       const initializer = apiInitializer(
-        (api) => (boundSource = api._source),
+        (api) => (boundSource = api.source),
         {},
         pluginSource("chat")
       );
@@ -521,6 +521,27 @@ module("Unit | Utility | plugin-api", function (hooks) {
       );
 
       assert.true(true, "modifyClass works on a source-bound api");
+    });
+
+    test("source is read-only and frozen", function (assert) {
+      let api;
+      withPluginApi((a) => (api = a), {}, pluginSource("chat"));
+
+      assert.throws(
+        () => (api.source = { type: "plugin", name: "evil" }),
+        TypeError,
+        "the source binding cannot be reassigned"
+      );
+      assert.throws(
+        () => (api.source.name = "evil"),
+        TypeError,
+        "the source object cannot be mutated"
+      );
+      assert.strictEqual(
+        api.source.name,
+        "chat",
+        "the source is unchanged after both attempts"
+      );
     });
   });
 });

--- a/frontend/discourse/tests/unit/lib/plugin-api-test.js
+++ b/frontend/discourse/tests/unit/lib/plugin-api-test.js
@@ -5,7 +5,9 @@ import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { block } from "discourse/blocks";
 import { BlockCondition, blockCondition } from "discourse/blocks/conditions";
+import { apiInitializer } from "discourse/lib/api";
 import { rollbackAllPrepends } from "discourse/lib/class-prepend";
+import { SOURCE_BRAND } from "discourse/lib/customization-source";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import {
   getBlockEntry,
@@ -360,6 +362,143 @@ module("Unit | Utility | plugin-api", function (hooks) {
           );
         });
       });
+    });
+  });
+
+  module("Customization source", function (nestedHooks) {
+    nestedHooks.beforeEach(function () {
+      resetBlockRegistryForTesting();
+    });
+
+    function pluginSource(name) {
+      return { [SOURCE_BRAND]: true, type: "plugin", name };
+    }
+
+    function themeSource(id) {
+      return { [SOURCE_BRAND]: true, type: "theme", id };
+    }
+
+    test("binds the build-injected source to the api and strips it from opts", function (assert) {
+      let boundSource, receivedOpts;
+
+      withPluginApi(
+        (api, opts) => {
+          boundSource = api._source;
+          receivedOpts = opts;
+        },
+        { foo: 1 },
+        pluginSource("chat")
+      );
+
+      assert.strictEqual(boundSource.type, "plugin");
+      assert.strictEqual(boundSource.name, "chat");
+      assert.strictEqual(receivedOpts.foo, 1, "user opts are preserved");
+      assert.false(
+        SOURCE_BRAND in receivedOpts,
+        "the source descriptor does not leak into opts"
+      );
+    });
+
+    test("core code (no descriptor) gets the singleton with no source", function (assert) {
+      let api;
+      withPluginApi((a) => (api = a));
+
+      assert.strictEqual(api._source, undefined);
+      assert.strictEqual(
+        typeof api.getCurrentUser,
+        "function",
+        "the singleton's methods are available"
+      );
+    });
+
+    test("caches one bound api per source and delegates to the singleton", function (assert) {
+      let first, second, other, core;
+
+      withPluginApi((api) => (first = api), {}, pluginSource("chat"));
+      withPluginApi((api) => (second = api), {}, pluginSource("chat"));
+      withPluginApi((api) => (other = api), {}, themeSource(1));
+      withPluginApi((api) => (core = api));
+
+      assert.strictEqual(first, second, "same source reuses one bound api");
+      assert.notStrictEqual(first, other, "different sources are distinct");
+      assert.notStrictEqual(
+        first,
+        core,
+        "bound api differs from the singleton"
+      );
+      assert.strictEqual(
+        typeof first.getCurrentUser,
+        "function",
+        "bound api delegates to the singleton via its prototype"
+      );
+    });
+
+    test("legacy version-string signature still binds the source", function (assert) {
+      let boundSource;
+
+      withPluginApi(
+        (api) => (boundSource = api._source),
+        {},
+        pluginSource("chat")
+      );
+
+      assert.strictEqual(boundSource.type, "plugin");
+      assert.strictEqual(boundSource.name, "chat");
+    });
+
+    test("apiInitializer forwards the source to the callback", function (assert) {
+      let boundSource;
+
+      const initializer = apiInitializer(
+        (api) => (boundSource = api._source),
+        {},
+        pluginSource("chat")
+      );
+      initializer.initialize();
+
+      assert.strictEqual(boundSource.type, "plugin");
+      assert.strictEqual(boundSource.name, "chat");
+    });
+
+    test("attribution comes from the descriptor, not the call stack", function (assert) {
+      // The descriptor alone decides the source. Code with no descriptor is
+      // treated as core (and may use any namespace) regardless of whatever
+      // frames happen to be on the stack — this is the regression guard for the
+      // monkey-patched-stack misattribution bug.
+      @block("any-namespace-block")
+      class CoreNamespacedBlock extends Component {}
+
+      withPluginApi((api) => api.registerBlock(CoreNamespacedBlock));
+      assert.true(
+        hasBlock("any-namespace-block"),
+        "core code may register any name"
+      );
+
+      // A plugin descriptor enforces the plugin namespace.
+      @block("unnamespaced-from-plugin")
+      class PluginBlock extends Component {}
+
+      withPluginApi(
+        (api) => {
+          assert.throws(
+            () => api.registerBlock(PluginBlock),
+            /Plugin blocks must use the "namespace:block-name" format/
+          );
+        },
+        {},
+        pluginSource("chat")
+      );
+
+      // The same plugin can register a correctly namespaced block.
+      @block("chat:source-block")
+      class NamespacedPluginBlock extends Component {}
+
+      withPluginApi(
+        (api) => api.registerBlock(NamespacedPluginBlock),
+        {},
+        pluginSource("chat")
+      );
+      assert.true(hasBlock("chat:source-block"));
     });
   });
 });

--- a/frontend/discourse/tests/unit/lib/plugin-api-test.js
+++ b/frontend/discourse/tests/unit/lib/plugin-api-test.js
@@ -500,5 +500,27 @@ module("Unit | Utility | plugin-api", function (hooks) {
       );
       assert.true(hasBlock("chat:source-block"));
     });
+
+    test("source-bound api can invoke methods that use private members", function (assert) {
+      // The source-bound api must be a real PluginApi instance, not a prototype
+      // proxy: methods like modifyClass touch a #private, which brand-checks
+      // against real instances and throws "Receiver must be an instance of
+      // class" on anything created via Object.create.
+      class SourceThing {}
+      getOwner(this).register("source-thing:main", SourceThing);
+
+      withPluginApi(
+        (api) => {
+          api.modifyClass(
+            "source-thing:main",
+            (Superclass) => class extends Superclass {}
+          );
+        },
+        {},
+        pluginSource("chat")
+      );
+
+      assert.true(true, "modifyClass works on a source-bound api");
+    });
   });
 });

--- a/frontend/discourse/tests/unit/lib/plugin-api-test.js
+++ b/frontend/discourse/tests/unit/lib/plugin-api-test.js
@@ -437,6 +437,8 @@ module("Unit | Utility | plugin-api", function (hooks) {
       let boundSource;
 
       withPluginApi(
+        // eslint-disable-next-line discourse/plugin-api-no-version -- intentionally exercising the legacy version-string signature
+        "1.0",
         (api) => (boundSource = api.source),
         {},
         pluginSource("chat")


### PR DESCRIPTION
The blocks API attributes each registration to a plugin, theme, or core (it enforces per-source namespacing). It inferred this by parsing the live JavaScript stack at registration time, which is fragile: if a theme component monkey-patches a core JavaScript method, its frame can land in the stack of core code and cause core registrations to be misattributed to the theme.

Attribution now happens at build time. A new asset-processor babel transform (`inject-customization-source`) runs for both plugins and themes and appends a symbol-branded source descriptor to calls of the API-entry functions, `withPluginApi` and `apiInitializer`. Covering `apiInitializer` matters because a plugin or theme that writes `export default apiInitializer(...)` never calls `withPluginApi` itself — that call lives in core and would otherwise lose attribution.

At runtime, `withPluginApi` strips the descriptor and hands the callback a per-source view of the `PluginApi` that delegates to the shared instance through its prototype and shadows only the source; the blocks registry reads the source from there instead of from `identifySource`. Core is compiled by a separate pipeline, so it carries no descriptor and resolves to `core` regardless of what sits on the stack. The descriptor is keyed by a registered `Symbol`, so an ordinary `opts` argument can never be mistaken for one.

The mechanism is intentionally general — a reusable customization-source seam — with the blocks registry as its first consumer. A development-only check uses the initializer's (unspoofable) module name to warn when a registration's build-injected source is missing, catching code that reaches an API-entry function through an indirect reference the build cannot see.

Tests cover the transform, the runtime source binding (per-source views, opts isolation, the legacy version-string signature, and `apiInitializer` forwarding), and a regression asserting attribution comes from the descriptor rather than the call stack.
