### PR TITLE
UX: Refine nested replies OP layout

### DIFF
--- a/app/assets/stylesheets/common/nested-view.scss
+++ b/app/assets/stylesheets/common/nested-view.scss
@@ -20,7 +20,6 @@
   &__header {
     margin-bottom: 1em;
     padding-bottom: 0.75em;
-    border-bottom: 1px solid var(--primary-low);
   }
 
   &__title {
@@ -189,7 +188,6 @@
   &__op {
     margin-bottom: 1.5em;
     padding: 1em;
-    background: var(--primary-very-low);
     border: 1px solid var(--primary-low);
     border-radius: var(--d-border-radius);
 
@@ -242,6 +240,37 @@
       padding: 0;
       margin-left: 0;
       font-size: var(--font-down-1);
+    }
+
+    @include viewport.from(sm) {
+      > .topic-avatar {
+        position: sticky;
+        top: calc(var(--header-offset) + var(--space-3));
+        align-self: flex-start;
+        margin-bottom: 25px;
+      }
+    }
+
+    @include viewport.until(sm) {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      align-items: start;
+      column-gap: 0.75em;
+      row-gap: 0.5em;
+
+      .nested-view__op-body {
+        display: contents;
+      }
+
+      .topic-meta-data {
+        align-self: center;
+      }
+
+      .nested-view__op-content,
+      .nested-view__op-menu,
+      .post-links-container {
+        grid-column: 1 / -1;
+      }
     }
   }
 


### PR DESCRIPTION
This PR makes changes to nested topic view:
1. Removes background from OP
2. Removes horizontal line for nested mode under the topic title. Duplicate line.
3. Makes OP avatar sticky on scroll like flat
4. makes avatar go on top of OP on mobile so content isn't small:

<img width="1071" height="1325" alt="Screenshot 2026-06-22 at 3 05 58 PM" src="https://github.com/user-attachments/assets/ad318822-02e4-4886-8963-89f6976626f4" />
<img width="458" height="951" alt="Screenshot 2026-06-22 at 3 05 52 PM" src="https://github.com/user-attachments/assets/3f33b2ce-9f1a-4c5f-94ff-b51fcf167d68" />
