### PR TITLE
FIX: Preserve dots in tag slugs and URLs

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -135,6 +135,21 @@ class Tag < ActiveRecord::Base
     find_by("lower(name) = ?", name.downcase)
   end
 
+  def self.slug_for_name(name)
+    return "" if name.blank?
+
+    slug =
+      I18n.with_locale(SiteSetting.default_locale) do
+        ActiveSupport::Inflector.transliterate(name.tr("'", ""))
+      end
+
+    slug = slug.downcase.gsub(/[^a-z0-9._-]+/, "-").tr("_", "-")
+    slug = slug.squeeze(".").squeeze("-").gsub(/\A[.\-]+|[.\-]+\z/, "")
+    slug = slug[0, Slug::MAX_LENGTH] || ""
+
+    slug.match?(/\A\d*\z/) ? "" : slug
+  end
+
   def self.top_tags(limit_arg: nil, category: nil, guardian: Guardian.new)
     # we add 1 to max_tags_in_filter_list to efficiently know we have more tags
     # than the limit. Frontend is responsible to enforce limit.
@@ -301,7 +316,7 @@ class Tag < ActiveRecord::Base
     return if name.blank?
 
     if self.slug.blank? || (will_save_change_to_name? && !will_save_change_to_slug?)
-      self.slug = Slug.for(name, "")
+      self.slug = Tag.slug_for_name(name)
       self.slug = "" if self.slug.blank? || duplicate_slug?
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1722,7 +1722,12 @@ Discourse::Application.routes.draw do
       end
     end
 
-    scope "/tag/:tag_slug/:tag_id", constraints: { tag_id: /\d+/, format: :json } do
+    scope "/tag/:tag_slug/:tag_id",
+          constraints: {
+            tag_slug: %r{[^/]+?},
+            tag_id: /\d+/,
+            format: :json,
+          } do
       get "/" => "tags#show", :as => "tag_show_with_slug"
       get "/edit" => "tags#show"
       get "/edit/:tab" => "tags#show"
@@ -1734,12 +1739,13 @@ Discourse::Application.routes.draw do
 
     get "/tag/:tag_slug/:tag_id" => "tags#tag_feed",
         :constraints => {
+          tag_slug: %r{[^/]+?},
           tag_id: /\d+/,
           format: :rss,
         },
         :as => "tag_feed_with_id"
 
-    scope "/tag/:tag_name" do
+    scope "/tag/:tag_name", constraints: { tag_name: %r{[^/]+?(?<!\.json)(?<!\.rss)} } do
       constraints format: :json do
         get "/" => "tags#show", :as => "tag_show_by_name"
         get "/info" => "tags#info"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -60,6 +60,31 @@ RSpec.describe Tag do
     end
   end
 
+  describe "slug" do
+    it "keeps dots in the slug so dotted names keep their dot in the URL" do
+      expect(Fabricate(:tag, name: "node.js").slug).to eq("node.js")
+      expect(Fabricate(:tag, name: "1.5").slug).to eq("1.5")
+      expect(Fabricate(:tag, name: "1.6-alpha").slug).to eq("1.6-alpha")
+    end
+
+    it "recomputes the slug when the name is renamed to a dotted name" do
+      tag = Fabricate(:tag, name: "1-5")
+      expect(tag.slug).to eq("1-5")
+
+      tag.update!(name: "1.5")
+      expect(tag.slug).to eq("1.5")
+      expect(tag.url).to eq("/tag/1.5/#{tag.id}")
+    end
+
+    it "still flattens characters that are not URL-safe" do
+      expect(Fabricate(:tag, name: "Hello World").slug).to eq("hello-world")
+    end
+
+    it "leaves a purely numeric name without a slug so it can't be read as an id" do
+      expect(Fabricate(:tag, name: "123").slug).to eq("")
+    end
+  end
+
   describe "destroy" do
     subject(:tag) { Fabricate(:tag) }
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -442,6 +442,21 @@ RSpec.describe TagsController do
       )
     end
 
+    it "shows tags with periods by the unencoded legacy URL" do
+      node = Fabricate(:tag, name: "node.js")
+      node_topic = Fabricate(:topic, tags: [node])
+
+      get "/tag/node.js.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["topic_list"]["topics"].map { |t| t["id"] }).to contain_exactly(
+        node_topic.id,
+      )
+
+      get "/tag/node.js"
+      expect(response.status).to eq(301)
+      expect(response.redirect_url).to end_with(node.url)
+    end
+
     it "shows tag intersections with encoded period tag names" do
       node = Fabricate(:tag, name: "node.js")
       other = Fabricate(:tag, name: "other")
@@ -835,6 +850,16 @@ RSpec.describe TagsController do
 
       get "/tag/#{tag.slug}/#{tag.id}.rss"
       expect(response.status).to eq(404)
+    end
+
+    it "serves the feed for a tag with periods without swallowing the extension" do
+      node = Fabricate(:tag, name: "node.js")
+      Fabricate(:topic, tags: [node])
+
+      get "/tag/node.js.rss"
+
+      expect(response.status).to eq(200)
+      expect(response.media_type).to eq("application/rss+xml")
     end
   end
 


### PR DESCRIPTION
Follow-up to #39679, which allowed dots in tag *names* but still ran them through `parameterize` to build the slug. So `node.js` got the slug `node-js`, its canonical URL was `/tag/node-js/:id`, and `/tag/node.js` 404'd — Rails treats a trailing `.js`/`.json`/`.rss` as a format.

- `Tag.slug_for_name` keeps interior dots, so `node.js` → slug `node.js` and the canonical URL becomes `/tag/node.js/:id`. Renaming `node-js` → `node.js` recomputes the slug, and the old URL 301-redirects.
- Tag routes accept dotted segments: a dotted `:tag_slug` on the canonical and feed routes, and a `:tag_name` constraint that still lets `.json`/`.rss` parse as formats.

See the demo:


https://github.com/user-attachments/assets/1edfc2fe-ae24-450e-82fe-a3073064c7ae

