### PR TITLE
UX: remove limit width on edit reason composer

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -228,8 +228,6 @@ html.composer-open:not(.has-full-page-chat) {
     }
 
     .composer-actions-trigger .d-button-label {
-      max-width: 10ch;
-
       @include ellipsis;
     }
 


### PR DESCRIPTION

<img width="568" height="93" alt="CleanShot 2026-06-23 at 10 29 12" src="https://github.com/user-attachments/assets/dee7fba8-c2c5-4d66-a1d2-149eee5ce344" />

⬇️ 

<img width="568" height="93" alt="CleanShot 2026-06-23 at 10 28 52" src="https://github.com/user-attachments/assets/7e983b56-ea72-45d1-919c-26bd3b474671" />
