### PR TITLE
FIX: Ensure /tag/bad-slug/:id/edit routes to edit page

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -519,6 +519,7 @@ class TagsController < ::ApplicationController
     tag = tag.target_tag if tag.target_tag_id.present?
 
     url = tag.url
+    url += tag_edit_path_suffix
     url += "/l/#{filter}" if filter.present?
 
     if @filter_on_category
@@ -557,6 +558,13 @@ class TagsController < ::ApplicationController
 
   def ensure_tags_enabled
     raise Discourse::NotFound unless SiteSetting.tagging_enabled?
+  end
+
+  def tag_edit_path_suffix
+    return "/edit/#{params[:tab]}" if params[:tab].present?
+    return "/edit" if request.path.delete_prefix(Discourse.base_path).end_with?("/edit")
+
+    ""
   end
 
   def self.tag_counts_json(tags, guardian)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -300,10 +300,16 @@ class Tag < ActiveRecord::Base
     self.slug ||= ""
     return if name.blank?
 
-    if self.slug.blank? || (will_save_change_to_name? && !will_save_change_to_slug?)
+    if self.slug.present? && will_save_change_to_slug? && slug != slugified_custom_slug
+      errors.add(:slug, :invalid)
+    elsif self.slug.blank? || (will_save_change_to_name? && !will_save_change_to_slug?)
       self.slug = Slug.for(name, "")
       self.slug = "" if self.slug.blank? || duplicate_slug?
     end
+  end
+
+  def slugified_custom_slug
+    slug.parameterize
   end
 
   def duplicate_slug?

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5867,6 +5867,7 @@ en:
         slug: "Slug"
         name_placeholder: "Tag name"
         slug_placeholder: "Tag slug (optional, auto-generated from name)"
+        invalid_slug: "Use letters, numbers, or hyphens."
         saved: "Tag settings saved"
         no_synonyms: "No synonyms defined for this tag."
         add_synonym_placeholder: "Search for tags to add as synonyms..."

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5867,7 +5867,7 @@ en:
         slug: "Slug"
         name_placeholder: "Tag name"
         slug_placeholder: "Tag slug (optional, auto-generated from name)"
-        invalid_slug: "Use letters, numbers, or hyphens."
+        invalid_slug: "Use lowercase letters, numbers, and single hyphens between words."
         saved: "Tag settings saved"
         no_synonyms: "No synonyms defined for this tag."
         add_synonym_placeholder: "Search for tags to add as synonyms..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1707,6 +1707,8 @@ Discourse::Application.routes.draw do
 
     scope "/tag/:tag_id", constraints: { tag_id: /\d+/, format: :json } do
       get "/" => "tags#show", :as => "tag_show"
+      get "/edit" => "tags#show"
+      get "/edit/:tab" => "tags#show"
       get "/info" => "tags#info", :as => "tag_info"
       get "/notifications" => "tags#notifications", :as => "tag_notifications"
       put "/notifications" => "tags#update_notifications"

--- a/frontend/discourse/app/components/tag-settings.gjs
+++ b/frontend/discourse/app/components/tag-settings.gjs
@@ -9,6 +9,7 @@ import AddSynonymsConfirmation from "discourse/components/tag-settings/add-synon
 import TagSettingsLocalizations from "discourse/components/tag-settings/localizations";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { slugify } from "discourse/lib/utilities";
 import MiniTagChooser from "discourse/select-kit/components/mini-tag-chooser";
 import TagDropdown from "discourse/select-kit/components/tag-dropdown";
 import { eq } from "discourse/truth-helpers";
@@ -218,6 +219,16 @@ export default class TagSettings extends Component {
     return [this.args.tag?.name].filter(Boolean);
   }
 
+  @action
+  validateSlug(name, slug, { addError }) {
+    if (slug?.trim() && !slugify(slug)) {
+      addError(name, {
+        title: i18n("tagging.settings.slug"),
+        message: i18n("tagging.settings.invalid_slug"),
+      });
+    }
+  }
+
   <template>
     <div class="tag-settings">
       <DPageHeader
@@ -323,6 +334,7 @@ export default class TagSettings extends Component {
             @type="input"
             @title={{i18n "tagging.settings.slug"}}
             @format="large"
+            @validate={{this.validateSlug}}
             as |field|
           >
             <field.Control

--- a/frontend/discourse/app/components/tag-settings.gjs
+++ b/frontend/discourse/app/components/tag-settings.gjs
@@ -221,7 +221,7 @@ export default class TagSettings extends Component {
 
   @action
   validateSlug(name, slug, { addError }) {
-    if (slug?.trim() && !slugify(slug)) {
+    if (slug?.trim() && slug !== slugify(slug)) {
       addError(name, {
         title: i18n("tagging.settings.slug"),
         message: i18n("tagging.settings.invalid_slug"),

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -587,6 +587,34 @@ RSpec.describe TagsController do
       )
     end
 
+    it "preserves the edit path when redirecting a mismatched slug" do
+      get "/tag/not-the-slug/#{tag.id}/edit"
+
+      expect(response.status).to eq(301)
+      expect(response.redirect_url).to end_with("/tag/#{tag.slug_for_url}/#{tag.id}/edit")
+    end
+
+    it "preserves the edit tab when redirecting a mismatched slug" do
+      get "/tag/not-the-slug/#{tag.id}/edit/general"
+
+      expect(response.status).to eq(301)
+      expect(response.redirect_url).to end_with("/tag/#{tag.slug_for_url}/#{tag.id}/edit/general")
+    end
+
+    it "does not redirect the edit page when the slug already matches" do
+      sign_in(admin)
+
+      get "/tag/#{tag.slug_for_url}/#{tag.id}/edit/general"
+      expect(response.status).to eq(200)
+    end
+
+    it "redirects the id-only edit route to the canonical slug edit URL" do
+      get "/tag/#{tag.id}/edit/general"
+
+      expect(response.status).to eq(301)
+      expect(response.redirect_url).to end_with("/tag/#{tag.slug_for_url}/#{tag.id}/edit/general")
+    end
+
     context "with a category in the path" do
       fab!(:topic_in_category) { Fabricate(:topic, tags: [tag], category: category) }
 

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -1045,6 +1045,20 @@ RSpec.describe TagsController do
         expect(tag.reload.slug).to eq("custom-slug")
       end
 
+      it "rejects tag slugs with unsupported characters" do
+        put "/tag/#{tag.id}/settings.json", params: { tag_settings: { slug: "." } }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include("Slug is invalid")
+        expect(tag.reload.slug).to eq("original-name")
+
+        put "/tag/#{tag.id}/settings.json", params: { tag_settings: { slug: "a.a" } }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include("Slug is invalid")
+        expect(tag.reload.slug).to eq("original-name")
+      end
+
       it "updates the tag description" do
         put "/tag/#{tag.id}/settings.json",
             params: {

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -52,6 +52,21 @@ describe "Tag Settings" do
       expect(page).to have_current_path("/tag/#{tag_1.slug}/#{tag_1.id}")
     end
 
+    it "lets the user open tag settings from a direct placeholder slug URL in a new tab" do
+      sign_in(admin)
+
+      new_tab = open_new_window(:tab)
+      switch_to_window(new_tab)
+
+      page.visit "/tag/-/#{tag_1.id}/edit/general"
+
+      expect(tag_settings_page).to have_tag_settings_page
+      expect(page).to have_current_path("/tag/#{tag_1.slug}/#{tag_1.id}/edit/general")
+      expect(tag_settings_page).to have_name_value(tag_1.name)
+      expect(tag_settings_page).to have_slug_value(tag_1.slug)
+      expect(tag_settings_page).to have_description_value(tag_1.description)
+    end
+
     it "allows privileged users to edit tag, admin to delete tag" do
       sign_in(trust_level_4)
       tags_page.visit_tag(tag_1)

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -112,7 +112,7 @@ describe "Tag Settings" do
       sign_in(admin)
 
       tag_settings_page.visit(tag_1)
-      tag_settings_page.fill_slug(".")
+      tag_settings_page.fill_slug("a.a")
       tag_settings_page.click_save
 
       expect(form.field("slug")).to have_errors(I18n.t("js.tagging.settings.invalid_slug"))

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -3,6 +3,7 @@
 describe "Tag Settings" do
   let(:tags_page) { PageObjects::Pages::Tag.new }
   let(:dialog) { PageObjects::Components::Dialog.new }
+  let(:form) { PageObjects::Components::FormKit.new(".form-kit") }
   let(:tag_settings_page) { PageObjects::Pages::TagSettings.new }
   let(:toasts) { PageObjects::Components::Toasts.new }
 
@@ -105,6 +106,17 @@ describe "Tag Settings" do
       tags_page.edit_tag_btn.click
       tag_settings_page.click_back
       expect(page).to have_current_path("/tag/custom-slug/#{tag_1.id}")
+    end
+
+    it "shows an error when the slug is invalid" do
+      sign_in(admin)
+
+      tag_settings_page.visit(tag_1)
+      tag_settings_page.fill_slug(".")
+      tag_settings_page.click_save
+
+      expect(form.field("slug")).to have_errors(I18n.t("js.tagging.settings.invalid_slug"))
+      expect(tag_1.reload.slug).to eq("design")
     end
 
     it "allows adding an existing tag as synonym" do


### PR DESCRIPTION
When doing `/tag/bad-slug/:id/edit`, we now do not route to the edit page but instead 301 to `/tag/good-slug/:id`. This PR makes it so.

Also adds validation on the form + backend for slugs:
- <img width="300" alt="Screenshot 2026-06-23 at 6 10 53 PM" src="https://github.com/user-attachments/assets/fba5a9e8-20c2-49bc-97c8-ff69ffab582c" />

```
curl 'http://localhost:3000/tag/172/settings.json' \
  -X 'PUT' \
  --data-raw '{"tag_settings":{ ... "slug":"a.a" ... }}'
{"errors":["Slug is invalid"]}%
```