### PR TITLE
UX: Edit category scope fix

### DIFF
--- a/app/assets/stylesheets/common/base/edit-category.scss
+++ b/app/assets/stylesheets/common/base/edit-category.scss
@@ -3,7 +3,7 @@
 
 $number-input-width: var(--form-kit-small-input);
 
-.edit-category {
+.edit-category-page {
   display: block;
   max-width: 75ch;
   width: 100%;

--- a/frontend/discourse/admin/templates/edit-category/tabs.gjs
+++ b/frontend/discourse/admin/templates/edit-category/tabs.gjs
@@ -63,7 +63,9 @@ export default class Tabs extends Component {
   }
 
   <template>
-    <div class="edit-category {{if @controller.expandedMenu 'expanded-menu'}}">
+    <div
+      class="edit-category-page {{if @controller.expandedMenu 'expanded-menu'}}"
+    >
       <EditCategoryTabsHorizontal
         @controller={{@controller}}
         class="edit-category-page-header"

--- a/spec/system/page_objects/pages/category.rb
+++ b/spec/system/page_objects/pages/category.rb
@@ -67,7 +67,7 @@ module PageObjects
       end
 
       def back_to_category
-        find(".edit-category .back-button").click
+        find(".edit-category-page .back-button").click
         self
       end
 


### PR DESCRIPTION
`edit-category` was already in use for the button on the mainpage:
<img width="1087" height="72" alt="CleanShot 2026-06-23 at 11 59 07" src="https://github.com/user-attachments/assets/45f673a9-f077-4560-81e4-03b7db72a9cf" />

And conflicted with the `edit-category` container used for the new category pages. Changed this to `edit-category-page`