### PR TITLE
DEV: Replace local-dates optionalRequire with behaviorTransformer

### DIFF
--- a/frontend/discourse/app/lib/local-dates.js
+++ b/frontend/discourse/app/lib/local-dates.js
@@ -1,14 +1,13 @@
-import { optionalRequire } from "./utilities";
+import { applyBehaviorTransformer } from "discourse/lib/transformer";
 
 export function applyLocalDates(dates, siteSettings, timezone) {
   if (!siteSettings.discourse_local_dates_enabled) {
     return;
   }
 
-  const _applyLocalDates = optionalRequire(
-    "discourse/plugins/discourse-local-dates/initializers/discourse-local-dates",
-    "applyLocalDates"
-  );
-
-  _applyLocalDates(dates, siteSettings, timezone);
+  applyBehaviorTransformer("apply-local-dates", () => {}, {
+    dates,
+    siteSettings,
+    timezone,
+  });
 }

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -9,6 +9,7 @@
  */
 // eslint-discourse keep-array-sorted
 export const BEHAVIOR_TRANSFORMERS = Object.freeze([
+  "apply-local-dates",
   "category-visibility-change",
   "composer-actions-on-select",
   "composer-position:correct-scroll-position",

--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -14,7 +14,8 @@ import generateCurrentDateMarkup from "../lib/generate-current-date-markup";
 import LocalDateBuilder from "../lib/local-date-builder";
 import richEditorExtension from "../lib/rich-editor-extension";
 
-// Import applyLocalDates from discourse/lib/local-dates instead
+// Wired into core via the "apply-local-dates" behavior transformer.
+// Call applyLocalDates from discourse/lib/local-dates instead of importing this directly.
 export function applyLocalDates(dates, siteSettings, timezone) {
   if (!siteSettings.discourse_local_dates_enabled) {
     return;
@@ -126,6 +127,10 @@ function _partitionedRanges(element) {
 
 function initializeDiscourseLocalDates(api) {
   api.registerRichEditorExtension(richEditorExtension);
+
+  api.registerBehaviorTransformer("apply-local-dates", ({ context }) => {
+    applyLocalDates(context.dates, context.siteSettings, context.timezone);
+  });
 
   const modal = api.container.lookup("service:modal");
   const siteSettings = api.container.lookup("service:site-settings");


### PR DESCRIPTION
This clearly separates the responsibility of core & plugins, and brings us closer to being able to drop `optionalRequire` (and the AMD module system)