### PR TITLE
DEV: Fail core build if plugin import is attempted

### DIFF
--- a/frontend/discourse/rolldown.config.mjs
+++ b/frontend/discourse/rolldown.config.mjs
@@ -122,14 +122,18 @@ export function buildConfig({ devMode } = {}) {
       wrapTestModulesPlugin(),
       discourseChunkNamesPlugin(),
       {
-        name: "resolve-externals",
-        resolveId(source) {
-          if (
-            source.startsWith("/extra-locales/") ||
-            source.startsWith("/bootstrap/")
-          ) {
-            return { external: true, id: source };
-          }
+        name: "forbid-plugin-imports",
+        resolveId: {
+          filter: { id: /^discourse\/plugins\// },
+          handler(source, importer) {
+            this.error(
+              `Forbidden import of plugin module "${source}"` +
+                (importer
+                  ? ` from ${relative(import.meta.dirname, importer)}`
+                  : "") +
+                ". Core cannot import plugin modules."
+            );
+          },
         },
       },
       {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "lttf:output": "lint-to-the-future output -o ./lint-progress/",
     "lint-progress": "pnpm lttf:output && npx html-pages ./lint-progress --no-cache",
     "playwright-install": "playwright install --no-shell chromium",
-    "build": "pnpm --dir=frontend/discourse build",
-    "start": "pnpm --dir=frontend/discourse start"
+    "build": "pnpm --silent --dir=frontend/discourse build",
+    "start": "pnpm --silent --dir=frontend/discourse start"
   },
   "engines": {
     "node": ">= 20",


### PR DESCRIPTION
Plugins cannot be imported from core code. If interaction is needed, it should be handled via tools like behavior/value transformers.

Drops `/bootstrap` and `/extra-locales` handling, which was left-over from earlier vite experiments. Also adds --silent to reduce log noise when building