### PR TITLE
FEATURE: Also delete api logs when user / user content is deleted

### DIFF
--- a/plugins/discourse-ai/lib/ai_api_audit_log_cleaner.rb
+++ b/plugins/discourse-ai/lib/ai_api_audit_log_cleaner.rb
@@ -13,5 +13,16 @@ module DiscourseAi
     def self.delete_for_user(user_id)
       AiApiAuditLog.where(user_id:).delete_all
     end
+
+    # logs reference the content they were generated against, so when a user's
+    # posts and topics are removed alongside the account we clear those too.
+    # with_deleted covers content already soft-deleted (e.g. "delete all posts")
+    # before the account itself is deleted.
+    def self.delete_for_user_content(user)
+      AiApiAuditLog.where(post_id: Post.with_deleted.where(user_id: user.id).select(:id)).delete_all
+      AiApiAuditLog.where(
+        topic_id: Topic.with_deleted.where(user_id: user.id).select(:id),
+      ).delete_all
+    end
   end
 end

--- a/plugins/discourse-ai/lib/ai_api_audit_log_cleaner.rb
+++ b/plugins/discourse-ai/lib/ai_api_audit_log_cleaner.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  class AiApiAuditLogCleaner
+    def self.delete_for_post(post_id)
+      AiApiAuditLog.where(post_id:).delete_all
+    end
+
+    def self.delete_for_topic(topic_id)
+      AiApiAuditLog.where(topic_id:).delete_all
+    end
+
+    def self.delete_for_user(user_id)
+      AiApiAuditLog.where(user_id:).delete_all
+    end
+  end
+end

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -139,11 +139,29 @@ after_initialize do
     end
   end
 
-  on(:post_destroyed) { |post| DiscourseAi::AiApiAuditLogCleaner.delete_for_post(post.id) }
-
-  on(:topic_destroyed) { |topic| DiscourseAi::AiApiAuditLogCleaner.delete_for_topic(topic.id) }
-
+  # when an account is removed, clear the user's own logs and the logs tied to
+  # the content being deleted with the account. the content callback runs before
+  # discourse reassigns/soft-deletes the user's posts, so ownership is still intact.
   on(:user_destroyed) { |user| DiscourseAi::AiApiAuditLogCleaner.delete_for_user(user.id) }
+
+  register_user_destroyer_on_content_deletion_callback(
+    Proc.new { |user| DiscourseAi::AiApiAuditLogCleaner.delete_for_user_content(user) },
+  )
+
+  # outside account deletion, only purge logs once the content is permanently
+  # gone; a soft-deleted (trashed) post or topic is still recoverable, so its
+  # audit log must remain
+  on(:post_destroyed) do |post|
+    if !Post.with_deleted.exists?(post.id)
+      DiscourseAi::AiApiAuditLogCleaner.delete_for_post(post.id)
+    end
+  end
+
+  on(:topic_destroyed) do |topic|
+    if !Topic.with_deleted.exists?(topic.id)
+      DiscourseAi::AiApiAuditLogCleaner.delete_for_topic(topic.id)
+    end
+  end
 
   if Rails.env.test?
     require_relative "spec/support/embeddings_generation_stubs"

--- a/plugins/discourse-ai/plugin.rb
+++ b/plugins/discourse-ai/plugin.rb
@@ -139,6 +139,12 @@ after_initialize do
     end
   end
 
+  on(:post_destroyed) { |post| DiscourseAi::AiApiAuditLogCleaner.delete_for_post(post.id) }
+
+  on(:topic_destroyed) { |topic| DiscourseAi::AiApiAuditLogCleaner.delete_for_topic(topic.id) }
+
+  on(:user_destroyed) { |user| DiscourseAi::AiApiAuditLogCleaner.delete_for_user(user.id) }
+
   if Rails.env.test?
     require_relative "spec/support/embeddings_generation_stubs"
     require_relative "spec/support/fake_external_agent"

--- a/plugins/discourse-ai/spec/fabricators/ai_api_audit_log_fabricator.rb
+++ b/plugins/discourse-ai/spec/fabricators/ai_api_audit_log_fabricator.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Fabricator(:ai_api_audit_log) { provider_id { AiApiAuditLog::Provider::OpenAI } }

--- a/plugins/discourse-ai/spec/jobs/regular/delete_user_posts_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/delete_user_posts_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Jobs::DeleteUserPosts do
     Topic.any_instance.stubs(:topic_chat_channel).returns(nil)
   end
 
-  it "deletes audit logs for target posts across batches" do
+  it "keeps audit logs for target posts since the batch only soft-deletes them" do
     first_post = Fabricate(:post, user: admin)
     target_posts = Fabricate.times(21, :post, topic: first_post.topic, user: target_user)
     target_logs = target_posts.map { |post| Fabricate(:ai_api_audit_log, post_id: post.id) }
@@ -22,7 +22,9 @@ RSpec.describe Jobs::DeleteUserPosts do
 
     described_class.new.execute(user_id: target_user.id, acting_user_id: admin.id)
 
-    expect(AiApiAuditLog.where(id: target_logs.map(&:id))).to be_empty
+    expect(AiApiAuditLog.where(id: target_logs.map(&:id)).pluck(:id)).to contain_exactly(
+      *target_logs.map(&:id),
+    )
     expect(
       AiApiAuditLog.where(id: [other_user_log.id, other_post_log.id, other_topic_log.id]).pluck(
         :id,

--- a/plugins/discourse-ai/spec/jobs/regular/delete_user_posts_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/delete_user_posts_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::DeleteUserPosts do
+  fab!(:admin)
+  fab!(:target_user, :user)
+  fab!(:other_user, :user)
+
+  before do
+    enable_current_plugin
+    Topic.any_instance.stubs(:topic_chat_channel).returns(nil)
+  end
+
+  it "deletes audit logs for target posts across batches" do
+    first_post = Fabricate(:post, user: admin)
+    target_posts = Fabricate.times(21, :post, topic: first_post.topic, user: target_user)
+    target_logs = target_posts.map { |post| Fabricate(:ai_api_audit_log, post_id: post.id) }
+    other_post = Fabricate(:post, user: other_user)
+    other_topic = other_post.topic
+    other_user_log = Fabricate(:ai_api_audit_log, user_id: other_user.id)
+    other_post_log = Fabricate(:ai_api_audit_log, post_id: other_post.id)
+    other_topic_log = Fabricate(:ai_api_audit_log, topic_id: other_topic.id)
+
+    described_class.new.execute(user_id: target_user.id, acting_user_id: admin.id)
+
+    expect(AiApiAuditLog.where(id: target_logs.map(&:id))).to be_empty
+    expect(
+      AiApiAuditLog.where(id: [other_user_log.id, other_post_log.id, other_topic_log.id]).pluck(
+        :id,
+      ),
+    ).to contain_exactly(other_user_log.id, other_post_log.id, other_topic_log.id)
+  end
+end

--- a/plugins/discourse-ai/spec/lib/ai_api_audit_log_cleanup_spec.rb
+++ b/plugins/discourse-ai/spec/lib/ai_api_audit_log_cleanup_spec.rb
@@ -10,20 +10,31 @@ RSpec.describe DiscourseAi::AiApiAuditLogCleaner do
     Topic.any_instance.stubs(:topic_chat_channel).returns(nil)
   end
 
-  it "removes only matching post logs when a post is deleted" do
+  it "removes only matching post logs when a post is permanently destroyed" do
     first_post = Fabricate(:post, user: admin)
     target_post = Fabricate(:post, topic: first_post.topic, user: target_user)
     other_post = Fabricate(:post, topic: first_post.topic, user: other_user)
     target_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
     other_log = Fabricate(:ai_api_audit_log, post_id: other_post.id)
 
-    PostDestroyer.new(admin, target_post).destroy
+    PostDestroyer.new(admin, target_post, force_destroy: true).destroy
 
     expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
     expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
   end
 
-  it "removes only matching topic logs when a topic is deleted" do
+  it "keeps post logs when a post is only soft-deleted (recoverable)" do
+    first_post = Fabricate(:post, user: admin)
+    target_post = Fabricate(:post, topic: first_post.topic, user: target_user)
+    target_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
+
+    PostDestroyer.new(admin, target_post).destroy
+
+    expect(target_post.reload.deleted_at).to be_present
+    expect(AiApiAuditLog.where(id: target_log.id)).to be_exists
+  end
+
+  it "removes only matching topic logs when a topic is permanently destroyed" do
     target_post = Fabricate(:post, user: target_user)
     topic = target_post.topic
     other_post = Fabricate(:post, user: other_user)
@@ -31,10 +42,21 @@ RSpec.describe DiscourseAi::AiApiAuditLogCleaner do
     target_log = Fabricate(:ai_api_audit_log, topic_id: topic.id)
     other_log = Fabricate(:ai_api_audit_log, topic_id: other_topic.id)
 
-    PostDestroyer.new(admin, target_post).destroy
+    PostDestroyer.new(admin, target_post, force_destroy: true).destroy
 
     expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
     expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
+  end
+
+  it "keeps topic logs when a topic is only soft-deleted (recoverable)" do
+    target_post = Fabricate(:post, user: target_user)
+    topic = target_post.topic
+    target_log = Fabricate(:ai_api_audit_log, topic_id: topic.id)
+
+    PostDestroyer.new(admin, target_post).destroy
+
+    expect(topic.reload.deleted_at).to be_present
+    expect(AiApiAuditLog.where(id: target_log.id)).to be_exists
   end
 
   it "removes only matching user logs when a user is destroyed" do
@@ -45,5 +67,35 @@ RSpec.describe DiscourseAi::AiApiAuditLogCleaner do
 
     expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
     expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
+  end
+
+  describe ".delete_for_user_content" do
+    it "removes logs for the user's posts and topics, including soft-deleted ones" do
+      live_post = Fabricate(:post, user: target_user)
+      live_topic = live_post.topic
+      trashed_post = Fabricate(:post, user: target_user)
+      trashed_topic = trashed_post.topic
+      PostDestroyer.new(admin, trashed_post).destroy
+
+      target_post_log = Fabricate(:ai_api_audit_log, post_id: live_post.id)
+      target_topic_log = Fabricate(:ai_api_audit_log, topic_id: live_topic.id)
+      trashed_post_log = Fabricate(:ai_api_audit_log, post_id: trashed_post.id)
+      trashed_topic_log = Fabricate(:ai_api_audit_log, topic_id: trashed_topic.id)
+      other_post = Fabricate(:post, user: other_user)
+      other_post_log = Fabricate(:ai_api_audit_log, post_id: other_post.id)
+      target_user_log = Fabricate(:ai_api_audit_log, user_id: target_user.id)
+
+      described_class.delete_for_user_content(target_user)
+
+      expect(
+        AiApiAuditLog.where(
+          id: [target_post_log.id, target_topic_log.id, trashed_post_log.id, trashed_topic_log.id],
+        ),
+      ).to be_empty
+      # only content logs are touched here; user-id logs go through delete_for_user
+      expect(
+        AiApiAuditLog.where(id: [other_post_log.id, target_user_log.id]).pluck(:id),
+      ).to contain_exactly(other_post_log.id, target_user_log.id)
+    end
   end
 end

--- a/plugins/discourse-ai/spec/lib/ai_api_audit_log_cleanup_spec.rb
+++ b/plugins/discourse-ai/spec/lib/ai_api_audit_log_cleanup_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::AiApiAuditLogCleaner do
+  fab!(:admin)
+  fab!(:target_user, :user)
+  fab!(:other_user, :user)
+
+  before do
+    enable_current_plugin
+    Topic.any_instance.stubs(:topic_chat_channel).returns(nil)
+  end
+
+  it "removes only matching post logs when a post is deleted" do
+    first_post = Fabricate(:post, user: admin)
+    target_post = Fabricate(:post, topic: first_post.topic, user: target_user)
+    other_post = Fabricate(:post, topic: first_post.topic, user: other_user)
+    target_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
+    other_log = Fabricate(:ai_api_audit_log, post_id: other_post.id)
+
+    PostDestroyer.new(admin, target_post).destroy
+
+    expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
+    expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
+  end
+
+  it "removes only matching topic logs when a topic is deleted" do
+    target_post = Fabricate(:post, user: target_user)
+    topic = target_post.topic
+    other_post = Fabricate(:post, user: other_user)
+    other_topic = other_post.topic
+    target_log = Fabricate(:ai_api_audit_log, topic_id: topic.id)
+    other_log = Fabricate(:ai_api_audit_log, topic_id: other_topic.id)
+
+    PostDestroyer.new(admin, target_post).destroy
+
+    expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
+    expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
+  end
+
+  it "removes only matching user logs when a user is destroyed" do
+    target_log = Fabricate(:ai_api_audit_log, user_id: target_user.id)
+    other_log = Fabricate(:ai_api_audit_log, user_id: other_user.id)
+
+    UserDestroyer.new(admin).destroy(target_user)
+
+    expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
+    expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
+  end
+end

--- a/plugins/discourse-ai/spec/requests/admin/users_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/users_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::UsersController do
   end
 
   describe "#delete_posts_batch" do
-    it "deletes audit logs for posts removed by the batch" do
+    it "keeps audit logs since the batch only soft-deletes posts" do
       first_post = Fabricate(:post, user: admin)
       target_post = Fabricate(:post, topic: first_post.topic, user: target_user)
       other_post = Fabricate(:post, topic: first_post.topic, user: other_user)
@@ -23,13 +23,14 @@ RSpec.describe Admin::UsersController do
 
       expect(response.status).to eq(200)
       expect(response.parsed_body["posts_deleted"]).to eq(1)
-      expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
+      expect(target_post.reload.deleted_at).to be_present
+      expect(AiApiAuditLog.where(id: target_log.id)).to be_exists
       expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
     end
   end
 
   describe "#destroy" do
-    it "deletes target user and content audit logs" do
+    it "deletes the target user's identity and content audit logs" do
       target_post = Fabricate(:post, user: target_user)
       topic = target_post.topic
       target_user_log = Fabricate(:ai_api_audit_log, user_id: target_user.id)
@@ -52,6 +53,30 @@ RSpec.describe Admin::UsersController do
           :id,
         ),
       ).to contain_exactly(other_user_log.id, other_post_log.id, other_topic_log.id)
+    end
+
+    it "purges content logs through the delete-all-posts then delete-user flow" do
+      target_post = Fabricate(:post, user: target_user)
+      topic = target_post.topic
+      target_user_log = Fabricate(:ai_api_audit_log, user_id: target_user.id)
+      target_post_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
+      target_topic_log = Fabricate(:ai_api_audit_log, topic_id: topic.id)
+
+      put "/admin/users/#{target_user.id}/delete_posts_batch.json"
+
+      # posts are only soft-deleted here, so the logs must survive until the
+      # account itself is removed
+      expect(target_post.reload.deleted_at).to be_present
+      expect(
+        AiApiAuditLog.where(id: [target_user_log.id, target_post_log.id, target_topic_log.id]),
+      ).to be_exists
+
+      delete "/admin/users/#{target_user.id}.json", params: { delete_posts: true }
+
+      expect(response.status).to eq(200)
+      expect(
+        AiApiAuditLog.where(id: [target_user_log.id, target_post_log.id, target_topic_log.id]),
+      ).to be_empty
     end
 
     it "leaves audit logs when deleting a user with posts is forbidden" do

--- a/plugins/discourse-ai/spec/requests/admin/users_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/users_controller_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::UsersController do
+  fab!(:admin)
+  fab!(:target_user, :user)
+  fab!(:other_user, :user)
+
+  before do
+    enable_current_plugin
+    sign_in(admin)
+    Topic.any_instance.stubs(:topic_chat_channel).returns(nil)
+  end
+
+  describe "#delete_posts_batch" do
+    it "deletes audit logs for posts removed by the batch" do
+      first_post = Fabricate(:post, user: admin)
+      target_post = Fabricate(:post, topic: first_post.topic, user: target_user)
+      other_post = Fabricate(:post, topic: first_post.topic, user: other_user)
+      target_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
+      other_log = Fabricate(:ai_api_audit_log, post_id: other_post.id)
+
+      put "/admin/users/#{target_user.id}/delete_posts_batch.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["posts_deleted"]).to eq(1)
+      expect(AiApiAuditLog.where(id: target_log.id)).to be_empty
+      expect(AiApiAuditLog.where(id: other_log.id)).to be_exists
+    end
+  end
+
+  describe "#destroy" do
+    it "deletes target user and content audit logs" do
+      target_post = Fabricate(:post, user: target_user)
+      topic = target_post.topic
+      target_user_log = Fabricate(:ai_api_audit_log, user_id: target_user.id)
+      target_post_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
+      target_topic_log = Fabricate(:ai_api_audit_log, topic_id: topic.id)
+      other_post = Fabricate(:post, user: other_user)
+      other_topic = other_post.topic
+      other_user_log = Fabricate(:ai_api_audit_log, user_id: other_user.id)
+      other_post_log = Fabricate(:ai_api_audit_log, post_id: other_post.id)
+      other_topic_log = Fabricate(:ai_api_audit_log, topic_id: other_topic.id)
+
+      delete "/admin/users/#{target_user.id}.json", params: { delete_posts: true }
+
+      expect(response.status).to eq(200)
+      expect(
+        AiApiAuditLog.where(id: [target_user_log.id, target_post_log.id, target_topic_log.id]),
+      ).to be_empty
+      expect(
+        AiApiAuditLog.where(id: [other_user_log.id, other_post_log.id, other_topic_log.id]).pluck(
+          :id,
+        ),
+      ).to contain_exactly(other_user_log.id, other_post_log.id, other_topic_log.id)
+    end
+
+    it "leaves audit logs when deleting a user with posts is forbidden" do
+      target_post = Fabricate(:post, user: target_user)
+      topic = target_post.topic
+      target_user_log = Fabricate(:ai_api_audit_log, user_id: target_user.id)
+      target_post_log = Fabricate(:ai_api_audit_log, post_id: target_post.id)
+      target_topic_log = Fabricate(:ai_api_audit_log, topic_id: topic.id)
+
+      delete "/admin/users/#{target_user.id}.json"
+
+      expect(response.status).to eq(403)
+      expect(
+        AiApiAuditLog.where(
+          id: [target_user_log.id, target_post_log.id, target_topic_log.id],
+        ).pluck(:id),
+      ).to contain_exactly(target_user_log.id, target_post_log.id, target_topic_log.id)
+    end
+  end
+end


### PR DESCRIPTION
AI API audit logs could be left behind when posts, topics, or users were deleted when an admin needs to delete a user.

This PR will remove those logs through the existing destroy hooks, so batched post deletion and user deletion remove the matching audit records.

Note: This delete can be expensive because user_id is not the leading column of an index. Given user deletion is rare and this table is very large, I'm not adding an index just for this unless we have evidence it hurts in production. It may be worth accepting the occasional scan.

/399458/42