### PR TITLE
FIX: Show composer education message once per session

### DIFF
--- a/app/models/user_history.rb
+++ b/app/models/user_history.rb
@@ -167,7 +167,7 @@ class UserHistory < ActiveRecord::Base
         upcoming_change_toggled: 122,
         change_site_setting_groups: 123,
         upcoming_change_available: 124,
-        notified_about_composer_education: 125,
+        notified_about_composer_education: 125, # not used anymore
         recover_post: 126,
       )
   end

--- a/frontend/discourse/app/components/composer-messages.gjs
+++ b/frontend/discourse/app/components/composer-messages.gjs
@@ -20,13 +20,19 @@ import { i18n } from "discourse-i18n";
 import { autoTrackedArray } from "../lib/tracked-tools";
 
 let _messagesCache = {};
+let _educationMessageShown = false;
 
 export function resetComposerMessagesCache() {
   _messagesCache = {};
+  _educationMessageShown = false;
 }
 
-function containsEducationMessage(messages) {
-  return messages?.content?.some((msg) => msg.id === "education");
+function visibleMessages(messages) {
+  if (!_educationMessageShown) {
+    return messages?.content || [];
+  }
+
+  return messages?.content?.filter((msg) => msg.id !== "education") || [];
 }
 
 @tagName("")
@@ -57,6 +63,7 @@ export default class ComposerMessages extends Component {
     this.appEvents.on("composer:find-similar", this, this._findSimilar);
     this.appEvents.on("composer-messages:close", this, this._closeTop);
     this.appEvents.on("composer-messages:create", this, this._create);
+    this.appEvents.on("composer:saved", this, this._resetEducationMessageState);
     this.reset();
   }
 
@@ -68,6 +75,11 @@ export default class ComposerMessages extends Component {
     this.appEvents.off("composer:find-similar", this, this._findSimilar);
     this.appEvents.off("composer-messages:close", this, this._closeTop);
     this.appEvents.off("composer-messages:create", this, this._create);
+    this.appEvents.off(
+      "composer:saved",
+      this,
+      this._resetEducationMessageState
+    );
   }
 
   _closeTop() {
@@ -93,6 +105,10 @@ export default class ComposerMessages extends Component {
       this.reset();
       this.popup(EmberObject.create(info));
     });
+  }
+
+  _resetEducationMessageState() {
+    _educationMessageShown = false;
   }
 
   // Resets all active messages.
@@ -124,6 +140,10 @@ export default class ComposerMessages extends Component {
       }
 
       this.popup(msg);
+
+      if (msg.id === "education") {
+        _educationMessageShown = true;
+      }
     }
 
     if (this.composer.privateMessage) {
@@ -287,10 +307,7 @@ export default class ComposerMessages extends Component {
     const cacheKey = `${args.composer_action}${args.topic_id}${args.post_id}`;
 
     let messages;
-    if (
-      _messagesCache.cacheKey === cacheKey &&
-      !containsEducationMessage(_messagesCache.messages)
-    ) {
+    if (_messagesCache.cacheKey === cacheKey) {
       messages = _messagesCache.messages;
     } else {
       messages = await this.composer.store.find("composer-message", args);
@@ -298,11 +315,7 @@ export default class ComposerMessages extends Component {
         return;
       }
 
-      if (containsEducationMessage(messages)) {
-        _messagesCache = {};
-      } else {
-        _messagesCache = { messages, cacheKey };
-      }
+      _messagesCache = { messages, cacheKey };
     }
 
     // Checking composer messages on replies can give us a list of links to check for
@@ -313,11 +326,14 @@ export default class ComposerMessages extends Component {
 
     this.set("checkedMessages", true);
 
-    messages.content.forEach((msg) => {
+    visibleMessages(messages).forEach((msg) => {
       if (msg.wait_for_typing) {
         addUniqueValueToArray(this.queuedForTyping, msg);
       } else {
         this.popup(msg);
+        if (msg.id === "education") {
+          _educationMessageShown = true;
+        }
       }
     });
   }

--- a/lib/composer_messages_finder.rb
+++ b/lib/composer_messages_finder.rb
@@ -26,17 +26,11 @@ class ComposerMessagesFinder
   # Determines whether to show the user education text
   def check_education_message
     return if @topic&.private_message?
-    return if UserHistory.exists_for_user?(@user, :notified_about_composer_education)
 
     education_key = creating_topic? ? "education.new-topic" : "education.new-reply"
     count = @user.topic_count + @user.post_count
 
     if count < SiteSetting.educate_until_posts
-      UserHistory.create!(
-        action: UserHistory.actions[:notified_about_composer_education],
-        target_user_id: @user.id,
-      )
-
       return(
         {
           id: "education",

--- a/spec/lib/composer_messages_finder_spec.rb
+++ b/spec/lib/composer_messages_finder_spec.rb
@@ -40,26 +40,6 @@ RSpec.describe ComposerMessagesFinder do
         user.expects(:topic_count).returns(2)
         expect(finder.check_education_message).to be_blank
       end
-
-      it "returns no message when the user has already been shown composer education" do
-        UserHistory.create!(
-          action: UserHistory.actions[:notified_about_composer_education],
-          target_user_id: user.id,
-        )
-
-        user.expects(:post_count).never
-        user.expects(:topic_count).never
-        expect(finder.check_education_message).to be_blank
-      end
-
-      it "records that composer education was shown" do
-        user.expects(:post_count).returns(8)
-        user.expects(:topic_count).returns(1)
-
-        finder.check_education_message
-
-        expect(UserHistory.exists_for_user?(user, :notified_about_composer_education)).to eq(true)
-      end
     end
 
     context "with private message" do


### PR DESCRIPTION
Follow up to c84b8a25e6a32c01682ca42c7384e086f51227a3

Keep the composer education notice from reappearing while typing in the same session. Reset it when the composer is refreshed or the post is saved, without changing the backend educate_until_posts behavior.