### PR TITLE
FEATURE: Allow `topic_timers_allowed_groups` to manage topic timers

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -653,7 +653,7 @@ class TopicsController < ApplicationController
     params.require(:duration_minutes) if based_on_last_post
 
     topic = Topic.find_by(id: params[:topic_id])
-    guardian.ensure_can_moderate!(topic)
+    guardian.ensure_can_set_topic_timer!(topic)
 
     guardian.ensure_can_delete!(topic) if TopicTimer.destructive_types.values.include?(status_type)
 

--- a/app/jobs/regular/bump_topic.rb
+++ b/app/jobs/regular/bump_topic.rb
@@ -3,7 +3,9 @@
 module Jobs
   class BumpTopic < ::Jobs::TopicTimerBase
     def execute_timer_action(topic_timer, topic)
-      if Guardian.new(topic_timer.user).can_create_post_on_topic?(topic)
+      guardian = Guardian.new(topic_timer.user)
+
+      if guardian.can_create_post_on_topic?(topic) || guardian.can_set_topic_timer?(topic)
         topic.add_small_action(Discourse.system_user, "autobumped", nil, bump: true)
       end
 

--- a/app/jobs/regular/close_topic.rb
+++ b/app/jobs/regular/close_topic.rb
@@ -11,7 +11,7 @@ module Jobs
         return
       end
 
-      if !Guardian.new(user).can_close_topic?(topic)
+      if !Guardian.new(user).can_set_topic_timer?(topic)
         topic_timer.destroy!
         topic.reload
 

--- a/app/jobs/regular/open_topic.rb
+++ b/app/jobs/regular/open_topic.rb
@@ -5,7 +5,7 @@ module Jobs
     def execute_timer_action(topic_timer, topic)
       user = topic_timer.user
 
-      if !Guardian.new(user).can_open_topic?(topic) || topic.open?
+      if !Guardian.new(user).can_set_topic_timer?(topic) || topic.open?
         topic_timer.destroy!
         topic.reload
 

--- a/app/jobs/regular/publish_topic_to_category.rb
+++ b/app/jobs/regular/publish_topic_to_category.rb
@@ -8,7 +8,7 @@ module Jobs
       category = topic_timer.category
 
       return if category.blank?
-      return unless guardian.can_see?(topic)
+      return unless guardian.can_set_topic_timer?(topic)
       return unless guardian.can_create_topic_on_category?(category)
       return if topic.private_message? && !guardian.can_convert_topic?(topic)
 

--- a/app/jobs/regular/toggle_topic_closed.rb
+++ b/app/jobs/regular/toggle_topic_closed.rb
@@ -24,7 +24,7 @@ module Jobs
 
       user = topic_timer.user
 
-      if Guardian.new(user).can_close_topic?(topic)
+      if Guardian.new(user).can_set_topic_timer?(topic)
         if state == false && topic.auto_close_threshold_reached?
           topic.set_or_create_timer(
             TopicTimer.types[:open],

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1697,12 +1697,12 @@ class Topic < ActiveRecord::Base
     end
 
     if topic_timer.execute_at
-      if by_user&.staff? || by_user&.trust_level == TrustLevel[4]
+      if Guardian.new(by_user).can_set_topic_timer?(self)
         topic_timer.user = by_user
       else
         topic_timer.user ||=
           (
-            if user.staff? || user.trust_level == TrustLevel[4]
+            if Guardian.new(user).can_set_topic_timer?(self)
               user
             else
               Discourse.system_user

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -53,6 +53,7 @@ class CurrentUserSerializer < BasicUserSerializer
              :primary_group_id,
              :flair_group_id,
              :can_create_topic,
+             :can_set_topic_timer,
              :can_create_category,
              :can_create_group,
              :link_posting_access,
@@ -143,6 +144,10 @@ class CurrentUserSerializer < BasicUserSerializer
 
   def can_create_topic
     scope.can_create_topic?(nil)
+  end
+
+  def can_set_topic_timer
+    scope.can_set_topic_timer?
   end
 
   def can_create_category

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2319,6 +2319,7 @@ en:
     edit_all_post_groups: "Allow users in this group to edit other users' posts"
 
     create_topic_allowed_groups: "Groups that are allowed to create new topics. Admins and moderators can always create topics."
+    topic_timers_allowed_groups: "Groups that are allowed to set topic timers. Admins and moderators can always set topic timers."
     allow_flagging_staff: "If enabled, users can flag posts from staff accounts."
 
     edit_wiki_post_allowed_groups: "Groups that are allowed to edit posts marked as wiki. Admins and moderators can always edit posts marked as wiki."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2645,6 +2645,14 @@ trust:
     refresh: true
     disallowed_groups: "4"
     area: "group_permissions"
+  topic_timers_allowed_groups:
+    default: "1|2|14" # auto group admins, moderators, trust_level_4
+    mandatory_values: "1|2" # auto group admins, moderators
+    type: group_list
+    allow_any: false
+    refresh: true
+    disallowed_groups: "4"
+    area: "group_permissions"
   edit_wiki_post_allowed_groups:
     default: "1|2|11" # auto group admins, moderators, trust_level_1
     mandatory_values: "1|2" # auto group admins, moderators

--- a/frontend/discourse/app/components/topic-admin-menu.gjs
+++ b/frontend/discourse/app/components/topic-admin-menu.gjs
@@ -110,9 +110,44 @@ export default class TopicAdminMenu extends Component {
   get showAdminButton() {
     return (
       this.currentUser?.canManageTopic ||
+      this.currentUser?.canSetTopicTimer ||
       this.details?.can_archive_topic ||
       this.details?.can_close_topic ||
       this.details?.can_split_merge_topic
+    );
+  }
+
+  get showTopicTimerItem() {
+    return this.currentUser?.canSetTopicTimer;
+  }
+
+  get showTopicManagementSection() {
+    return this.currentUser?.canManageTopic || this.showTopicTimerItem;
+  }
+
+  get showTopicManagementSectionDivider() {
+    const showsMultiSelect =
+      this.currentUser?.canManageTopic || this.details?.can_split_merge_topic;
+    const showsDeleteOrRecover =
+      (this.currentUser?.canManageTopic ||
+        this.details?.can_moderate_category) &&
+      (this.canDelete || this.canRecover);
+    const showsPin =
+      this.details?.can_pin_unpin_topic &&
+      !this.isPrivateMessage &&
+      (this.visible || this.featured || this.details?.can_banner_topic);
+    const showsArchive =
+      this.details?.can_archive_topic && !this.isPrivateMessage;
+
+    return (
+      this.showTopicManagementSection &&
+      (showsMultiSelect ||
+        showsDeleteOrRecover ||
+        this.details?.can_close_topic ||
+        showsPin ||
+        showsArchive ||
+        this.details?.can_toggle_topic_visibility ||
+        this.details?.can_convert_topic)
     );
   }
 
@@ -302,42 +337,48 @@ export default class TopicAdminMenu extends Component {
               </dropdown.item>
             {{/if}}
 
-            <dropdown.divider />
+            {{#if this.showTopicManagementSection}}
+              {{#if this.showTopicManagementSectionDivider}}
+                <dropdown.divider />
+              {{/if}}
 
-            {{#if this.currentUser.canManageTopic}}
-              <dropdown.item class="admin-topic-timer-update">
-                <DButton
-                  @label="topic.actions.timed_update"
-                  @action={{fn this.onButtonAction "showTopicTimerModal"}}
-                  @icon="far-clock"
-                />
-              </dropdown.item>
-
-              {{#if this.currentUser.staff}}
-                <dropdown.item class="topic-admin-change-timestamp">
+              {{#if this.showTopicTimerItem}}
+                <dropdown.item class="admin-topic-timer-update">
                   <DButton
-                    @label="topic.change_timestamp.title"
-                    @action={{fn this.onButtonAction "showChangeTimestamp"}}
-                    @icon="calendar-days"
+                    @label="topic.actions.timed_update"
+                    @action={{fn this.onButtonAction "showTopicTimerModal"}}
+                    @icon="far-clock"
                   />
                 </dropdown.item>
               {{/if}}
 
-              <dropdown.item class="topic-admin-reset-bump-date">
-                <DButton
-                  @label="topic.actions.reset_bump_date"
-                  @action={{fn this.onButtonAction "resetBumpDate"}}
-                  @icon="anchor"
-                />
-              </dropdown.item>
+              {{#if this.currentUser.canManageTopic}}
+                {{#if this.currentUser.staff}}
+                  <dropdown.item class="topic-admin-change-timestamp">
+                    <DButton
+                      @label="topic.change_timestamp.title"
+                      @action={{fn this.onButtonAction "showChangeTimestamp"}}
+                      @icon="calendar-days"
+                    />
+                  </dropdown.item>
+                {{/if}}
 
-              <dropdown.item class="topic-admin-slow-mode">
-                <DButton
-                  @label="topic.actions.slow_mode"
-                  @action={{fn this.onButtonAction "showTopicSlowModeUpdate"}}
-                  @icon="hourglass-start"
-                />
-              </dropdown.item>
+                <dropdown.item class="topic-admin-reset-bump-date">
+                  <DButton
+                    @label="topic.actions.reset_bump_date"
+                    @action={{fn this.onButtonAction "resetBumpDate"}}
+                    @icon="anchor"
+                  />
+                </dropdown.item>
+
+                <dropdown.item class="topic-admin-slow-mode">
+                  <DButton
+                    @label="topic.actions.slow_mode"
+                    @action={{fn this.onButtonAction "showTopicSlowModeUpdate"}}
+                    @icon="hourglass-start"
+                  />
+                </dropdown.item>
+              {{/if}}
             {{/if}}
 
             {{#if

--- a/frontend/discourse/app/components/topic-timer-info.gjs
+++ b/frontend/discourse/app/components/topic-timer-info.gjs
@@ -37,9 +37,9 @@ export default class TopicTimerInfo extends Component {
     }
   }
 
-  @computed
+  @computed("currentUser.canSetTopicTimer")
   get canModifyTimer() {
-    return this.currentUser && this.currentUser.get("canManageTopic");
+    return this.currentUser?.get("canSetTopicTimer");
   }
 
   @computed("canModifyTimer", "removeTopicTimer")

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -297,6 +297,11 @@ export default class User extends RestModel.extend(Evented) {
     return this.staff || this.isLeader;
   }
 
+  @computed("can_set_topic_timer", "canManageTopic")
+  get canSetTopicTimer() {
+    return this.can_set_topic_timer ?? this.canManageTopic;
+  }
+
   @computed("sidebar_category_ids")
   get sidebarCategoryIds() {
     return this.sidebar_category_ids;

--- a/frontend/discourse/tests/acceptance/topic-admin-menu-test.js
+++ b/frontend/discourse/tests/acceptance/topic-admin-menu-test.js
@@ -32,6 +32,25 @@ acceptance("Topic - Admin Menu", function (needs) {
     assert.dom(".topic-admin-delete").exists("the delete item is rendered");
   });
 
+  test("Enter as a user with topic timer permissions", async function (assert) {
+    updateCurrentUser({
+      admin: false,
+      moderator: false,
+      trust_level: 1,
+      can_set_topic_timer: true,
+    });
+
+    await visit("/t/internationalization-localization/280");
+    await click(".toggle-admin-menu");
+
+    assert
+      .dom(".admin-topic-timer-update")
+      .exists("the topic timer item is rendered");
+    assert
+      .dom(".topic-admin-slow-mode")
+      .doesNotExist("topic management items are not rendered");
+  });
+
   test("Enter as a user with moderator and admin permissions", async function (assert) {
     updateCurrentUser({ moderator: true, admin: true, trust_level: 4 });
 

--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -59,6 +59,15 @@ module TopicGuardian
       (!category || Category.topic_create_allowed(self).where(id: category_id).count == 1)
   end
 
+  def can_set_topic_timer?(topic = nil)
+    return false if anonymous? || is_silenced?
+    return true if @user.is_system_user?
+    return false if topic && !can_see_topic?(topic)
+    return true if is_staff?
+
+    @user.in_any_groups?(SiteSetting.topic_timers_allowed_groups_map)
+  end
+
   def can_move_topic_to_category?(category)
     category =
       (

--- a/spec/jobs/close_topic_spec.rb
+++ b/spec/jobs/close_topic_spec.rb
@@ -50,6 +50,26 @@ RSpec.describe Jobs::CloseTopic do
     end
   end
 
+  describe "when user is allowed to set topic timers" do
+    fab!(:user)
+    fab!(:group)
+    fab!(:topic) { Fabricate(:topic_timer, user: user).topic }
+
+    before do
+      group.add(user)
+      user.reload
+      SiteSetting.topic_timers_allowed_groups = group.id.to_s
+    end
+
+    it "closes the topic" do
+      freeze_time(topic.public_topic_timer.execute_at + 1.minute)
+
+      described_class.new.execute(topic_timer_id: topic.public_topic_timer.id)
+
+      expect(topic.reload.closed).to eq(true)
+    end
+  end
+
   describe "when user is no longer authorized to close topics" do
     fab!(:user)
 

--- a/spec/jobs/open_topic_spec.rb
+++ b/spec/jobs/open_topic_spec.rb
@@ -51,6 +51,27 @@ RSpec.describe Jobs::OpenTopic do
     end
   end
 
+  describe "when user is allowed to set topic timers" do
+    fab!(:user)
+    fab!(:group)
+    fab!(:topic) { Fabricate(:topic_timer, status_type: TopicTimer.types[:open], user: user).topic }
+
+    before do
+      topic.update!(closed: true)
+      group.add(user)
+      user.reload
+      SiteSetting.topic_timers_allowed_groups = group.id.to_s
+    end
+
+    it "opens the topic" do
+      freeze_time(topic.public_topic_timer.execute_at + 1.minute)
+
+      described_class.new.execute(topic_timer_id: topic.public_topic_timer.id)
+
+      expect(topic.reload.open?).to eq(true)
+    end
+  end
+
   describe "when user is no longer authorized to open topics" do
     fab!(:user)
 

--- a/spec/lib/guardian/topic_guardian_spec.rb
+++ b/spec/lib/guardian/topic_guardian_spec.rb
@@ -338,6 +338,25 @@ RSpec.describe TopicGuardian do
     end
   end
 
+  describe "#can_set_topic_timer?" do
+    it "uses topic_timers_allowed_groups and requires topic visibility" do
+      expect(Guardian.new(admin).can_set_topic_timer?(topic)).to eq(true)
+      expect(Guardian.new(moderator).can_set_topic_timer?(topic)).to eq(true)
+      expect(Guardian.new(tl4_user).can_set_topic_timer?(topic)).to eq(true)
+      expect(Guardian.new(tl3_user).can_set_topic_timer?(topic)).to eq(false)
+
+      group.add(user)
+      SiteSetting.topic_timers_allowed_groups = group.id.to_s
+
+      inaccessible_private_topic =
+        Fabricate(:topic, category: Fabricate(:private_category, group: Fabricate(:group)))
+
+      expect(Guardian.new(user.reload).can_set_topic_timer?(topic)).to eq(true)
+      expect(Guardian.new(tl4_user).can_set_topic_timer?(topic)).to eq(false)
+      expect(Guardian.new(user).can_set_topic_timer?(inaccessible_private_topic)).to eq(false)
+    end
+  end
+
   describe "#can_see_unlisted_topics?" do
     it "is allowed for staff users" do
       expect(Guardian.new(moderator).can_see_unlisted_topics?).to eq(true)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2375,9 +2375,10 @@ RSpec.describe Topic do
     end
 
     it "sets topic status update user to topic creator if it is a TL4 user" do
-      tl4_topic = Fabricate.build(:topic, user: Fabricate.build(:trust_level_4, id: 998))
+      topic_creator = Fabricate(:trust_level_4)
+      tl4_topic = Fabricate.build(:topic, user: topic_creator)
       tl4_topic.set_or_create_timer(TopicTimer.types[:close], 3)
-      expect(tl4_topic.topic_timers.first.user_id).to eq(998)
+      expect(tl4_topic.topic_timers.first.user).to eq(topic_creator)
     end
 
     it "removes close topic status update if arg is nil" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -6344,6 +6344,32 @@ RSpec.describe TopicsController do
       end
     end
 
+    context "when logged in as a user in the topic timers allowed groups" do
+      fab!(:topic_timer_group, :group)
+
+      before do
+        topic_timer_group.add(user)
+        user.reload
+        SiteSetting.topic_timers_allowed_groups = topic_timer_group.id.to_s
+        sign_in(user)
+      end
+
+      it "allows creating a topic timer" do
+        post "/t/#{topic.id}/timer.json", params: { time: "24", status_type: TopicTimer.types[1] }
+
+        expect(response.status).to eq(200)
+        expect(topic.reload.public_topic_timer.user).to eq(user)
+      end
+
+      it "requires delete permissions for destructive timers" do
+        post "/t/#{topic.id}/timer.json", params: { time: "24", status_type: "delete" }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(topic.reload.public_topic_timer).to eq(nil)
+      end
+    end
+
     context "when time is in the past" do
       it "returns an error" do
         freeze_time

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -168,6 +168,19 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  describe "#can_set_topic_timer" do
+    let(:payload) { serializer.as_json }
+
+    it "reflects the topic_timers_allowed_groups setting" do
+      group = Fabricate(:group)
+      group.add(user)
+      user.reload
+      SiteSetting.topic_timers_allowed_groups = group.id.to_s
+
+      expect(payload[:can_set_topic_timer]).to eq(true)
+    end
+  end
+
   describe "#pending_posts_count" do
     subject(:pending_posts_count) { serializer.pending_posts_count }
 


### PR DESCRIPTION
Previously managing topic timers was staff + TL4 only. This moves the logic to a group site setting so that other groups can set timers.