### PR TITLE
UX: close menus on click inside workflow canvas

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/index.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/index.gjs
@@ -54,6 +54,7 @@ export default class WorkflowCanvas extends Component {
   #hasSetupStarted = false;
   #pendingSync = false;
   #syncTask = null;
+  #outsideClickAbort = null;
   #ZOOM_STEP = 0.1;
   #ZOOM_MIN = 0.25;
   #ZOOM_MAX = 4;
@@ -62,6 +63,7 @@ export default class WorkflowCanvas extends Component {
     super.willDestroy();
     this.rete?.destroy();
     this.keyboard?.teardown();
+    this.#outsideClickAbort?.abort();
   }
 
   get workflowPublished() {
@@ -396,10 +398,29 @@ export default class WorkflowCanvas extends Component {
     );
 
     this.args.onAreaReady?.(this.rete.area);
+    this.#forwardTrappedPointerdowns();
 
     await this.#queueSync();
     this.isLoading = false;
     element.focus();
+  }
+
+  // Left clicks are trapped on the canvas and never reach the document
+  // so we re-emit one to clean up any open menus outside of the canvas
+  #forwardTrappedPointerdowns() {
+    this.#outsideClickAbort = new AbortController();
+
+    this.containerElement.addEventListener(
+      "pointerdown",
+      (event) => {
+        if (event.button === 0) {
+          document.body.dispatchEvent(
+            new PointerEvent("pointerdown", { bubbles: true })
+          );
+        }
+      },
+      { capture: true, signal: this.#outsideClickAbort.signal }
+    );
   }
 
   @action


### PR DESCRIPTION
When using the workflows plugin, the canvas traps left clicks (`stopPropagation()`) so they don't bubble up to the document and close any menus that would be closed by a click outside. This re-emits a pointerdown on the body to close anything that would be open.