### PR TITLE
DEV: Support locking the AI spam detection toggle via a transformer

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-spam.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-spam.gjs
@@ -12,6 +12,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import getURL from "discourse/lib/get-url";
 import { autoTrackedArray } from "discourse/lib/tracked-tools";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import DButton from "discourse/ui-kit/d-button";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
@@ -110,8 +111,18 @@ export default class AiSpam extends Component {
     return this.args.model?.available_agents || [];
   }
 
+  get toggleDisabled() {
+    return applyValueTransformer("ai-spam-toggle-disabled", false, {
+      spam: this.args.model,
+    });
+  }
+
   @action
   async toggleEnabled() {
+    if (this.toggleDisabled) {
+      return;
+    }
+
     this.isEnabled = !this.isEnabled;
     const data = { is_enabled: this.isEnabled };
     if (this.autoSelectedLLM) {
@@ -240,11 +251,16 @@ export default class AiSpam extends Component {
             class="ai-spam__toggle"
             @state={{this.isEnabled}}
             @label="discourse_ai.spam.enable"
+            disabled={{this.toggleDisabled}}
             {{on "click" this.toggleEnabled}}
           />
           <DTooltip
             @icon="circle-question"
-            @content={{i18n "discourse_ai.spam.spam_tip"}}
+            @content={{if
+              this.toggleDisabled
+              (i18n "discourse_ai.spam.enabled_locked_tip")
+              (i18n "discourse_ai.spam.spam_tip")
+            }}
           />
         </div>
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/pre-initializers/ai-spam-transformers.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/pre-initializers/ai-spam-transformers.js
@@ -1,0 +1,11 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+
+export default {
+  before: "freeze-valid-transformers",
+
+  initialize() {
+    withPluginApi((api) => {
+      api.addValueTransformerName("ai-spam-toggle-disabled");
+    });
+  },
+};

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -466,6 +466,7 @@ en:
         spam_detected: "Spam detected"
         custom_instructions_placeholder: "Site-specific instructions for the AI to help identify spam more accurately"
         enable: "Enable"
+        enabled_locked_tip: "AI spam detection can't be disabled on this site."
         spam_tip: "AI spam detection will scan the first 3 posts by all new users on public topics. It will flag them for review and block users if they are likely spam."
         settings_saved: "Settings saved"
         spam_description: "Identifies potential spam using the selected LLM and flags it for site moderators to inspect in the review queue"


### PR DESCRIPTION
**Previously**, the AI spam detection enable/disable toggle was always interactive, with no way to lock it.

**In this update**, its disabled state is driven by a new `ai-spam-toggle-disabled` value transformer, so it can be locked (with an explanatory tooltip) when needed.