### PR TITLE
UX: Remove spacing between post cooked and post menu on nested topics

### DIFF
--- a/app/assets/stylesheets/common/nested-view.scss
+++ b/app/assets/stylesheets/common/nested-view.scss
@@ -6,6 +6,18 @@
   }
 }
 
+// PostCookedHtml appends a selection barrier after the final block, so
+// `:last-child` does not usually match the final cooked paragraph.
+.nested-view__op-content,
+.nested-post__content {
+  .cooked > p {
+    &:last-child,
+    &:has(+ .cooked-selection-barrier:last-child) {
+      margin-bottom: 0;
+    }
+  }
+}
+
 // ── Top-level nested view ──────────────────────────────────────────
 .nested-view {
   background: var(--secondary);


### PR DESCRIPTION
Before: 
<img width="1100" height="993" alt="Screenshot 2026-06-23 at 2 45 07 PM" src="https://github.com/user-attachments/assets/212d7451-24b9-431c-8d0c-dbc4ee55bc18" />

After:
<img width="1103" height="997" alt="Screenshot 2026-06-23 at 2 45 12 PM" src="https://github.com/user-attachments/assets/90e4e0aa-fc2d-40ef-a24e-092fa994515e" />
