### PR TITLE
UX: fix linked event image behavior

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/image.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/image.gjs
@@ -2,8 +2,9 @@ import { modifier } from "ember-modifier";
 import getURL from "discourse/lib/get-url";
 import lightbox from "discourse/lib/lightbox";
 
-const setupLightbox = modifier((element) => {
-  lightbox(element.closest(".event-image"));
+const setupLightbox = modifier((element, _positional, { post }) => {
+  // Pass the post so the lightbox's quote-image action can build a reply
+  lightbox(element.closest(".event-image"), { post });
 
   return () => window.pswp?.close();
 });
@@ -16,7 +17,11 @@ const setupLightbox = modifier((element) => {
           <img src={{@imageUpload.url}} alt={{@alt}} />
         </a>
       {{else}}
-        <a class="lightbox" href={{@imageUpload.url}} {{setupLightbox}}>
+        <a
+          class="lightbox"
+          href={{@imageUpload.url}}
+          {{setupLightbox post=@post}}
+        >
           <img src={{@imageUpload.url}} alt={{@alt}} />
         </a>
       {{/if}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/image.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/image.gjs
@@ -1,9 +1,25 @@
+import { modifier } from "ember-modifier";
+import getURL from "discourse/lib/get-url";
+import lightbox from "discourse/lib/lightbox";
+
+const setupLightbox = modifier((element) => {
+  lightbox(element.closest(".event-image"));
+
+  return () => window.pswp?.close();
+});
+
 <template>
   {{#if @imageUpload}}
     <section class="event__section event-image">
-      <a class="lightbox" href={{@imageUpload.url}}>
-        <img src={{@imageUpload.url}} alt={{@alt}} />
-      </a>
+      {{#if @linkToPost}}
+        <a href={{getURL @postUrl}} rel="noopener noreferrer">
+          <img src={{@imageUpload.url}} alt={{@alt}} />
+        </a>
+      {{else}}
+        <a class="lightbox" href={{@imageUpload.url}} {{setupLightbox}}>
+          <img src={{@imageUpload.url}} alt={{@alt}} />
+        </a>
+      {{/if}}
     </section>
   {{/if}}
 </template>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -197,6 +197,8 @@ export default class DiscoursePostEvent extends Component {
               <Image
                 @imageUpload={{event.imageUpload}}
                 @alt={{this.eventName}}
+                @linkToPost={{@linkToPost}}
+                @postUrl={{event.post.url}}
               />
               <header class="event-header" {{this.setupMessageBus}}>
                 <div class="event-date">
@@ -287,7 +289,11 @@ export default class DiscoursePostEvent extends Component {
                   Status=(component Status event=event)
                   ChatChannel=(component ChatChannel event=event)
                   Image=(component
-                    Image imageUpload=event.imageUpload alt=this.eventName
+                    Image
+                    imageUpload=event.imageUpload
+                    alt=this.eventName
+                    linkToPost=@linkToPost
+                    postUrl=event.post.url
                   )
                 }}
               >

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -199,6 +199,7 @@ export default class DiscoursePostEvent extends Component {
                 @alt={{this.eventName}}
                 @linkToPost={{@linkToPost}}
                 @postUrl={{event.post.url}}
+                @post={{@post}}
               />
               <header class="event-header" {{this.setupMessageBus}}>
                 <div class="event-date">
@@ -294,6 +295,7 @@ export default class DiscoursePostEvent extends Component {
                     alt=this.eventName
                     linkToPost=@linkToPost
                     postUrl=event.post.url
+                    post=@post
                   )
                 }}
               >

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -1216,6 +1216,7 @@ export default class PostEventBuilder extends Component {
                       "discourse_post_event.builder_modal.custom_fields.description"
                     }}
                     @format="full"
+                    class="form-kit__container-custom-fields"
                   >
                     <form.Object @name="customFields" as |customFields|>
                       {{#each this.allowedCustomFields as |allowedCustomField|}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/initializers/discourse-post-event-decorator.gjs
@@ -62,7 +62,9 @@ function initializeDiscoursePostEventDecorator(api) {
 
         helper.renderGlimmer(
           wrapper,
-          <template><DiscoursePostEvent @event={{event}} /></template>
+          <template>
+            <DiscoursePostEvent @event={{event}} @post={{post}} />
+          </template>
         );
       }
     },

--- a/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -1,5 +1,5 @@
 import { getOwner } from "@ember/owner";
-import { render, waitFor } from "@ember/test-helpers";
+import { click, render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DiscoursePostEvent from "../../discourse/components/discourse-post-event";
@@ -68,7 +68,7 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
       );
   });
 
-  test("renders the event image as a lightbox inside a topic", async function (assert) {
+  test("wires up the event image lightbox inside a topic", async function (assert) {
     stubApi.call(
       this,
       buildEvent({
@@ -78,15 +78,13 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
 
     const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
     await render(<template><DiscoursePostEvent @event={{event}} /></template>);
-    await waitFor(".event-image");
+    await waitFor(".event-image a.lightbox");
+    await click(".event-image a.lightbox");
+    await waitFor(".pswp--open");
 
-    assert
-      .dom(".event-image a.lightbox")
-      .hasAttribute(
-        "href",
-        "/uploads/default/original/1X/event.png",
-        "links the image to the upload so it can be lightboxed"
-      );
+    assert.dom(".pswp--open").exists("opens the PhotoSwipe lightbox");
+
+    await click(".pswp__button--close");
   });
 
   test("links the event image to the post when linkToPost is set", async function (assert) {

--- a/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/discourse-post-event-test.gjs
@@ -68,6 +68,55 @@ module("Integration | Component | DiscoursePostEvent", function (hooks) {
       );
   });
 
+  test("renders the event image as a lightbox inside a topic", async function (assert) {
+    stubApi.call(
+      this,
+      buildEvent({
+        image_upload: { url: "/uploads/default/original/1X/event.png" },
+      })
+    );
+
+    const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
+    await render(<template><DiscoursePostEvent @event={{event}} /></template>);
+    await waitFor(".event-image");
+
+    assert
+      .dom(".event-image a.lightbox")
+      .hasAttribute(
+        "href",
+        "/uploads/default/original/1X/event.png",
+        "links the image to the upload so it can be lightboxed"
+      );
+  });
+
+  test("links the event image to the post when linkToPost is set", async function (assert) {
+    stubApi.call(
+      this,
+      buildEvent({
+        image_upload: { url: "/uploads/default/original/1X/event.png" },
+      })
+    );
+
+    const event = { id: 1, startsAt: "2026-06-04T14:00:00Z" };
+    await render(
+      <template>
+        <DiscoursePostEvent @event={{event}} @linkToPost={{true}} />
+      </template>
+    );
+    await waitFor(".event-image");
+
+    assert
+      .dom(".event-image a.lightbox")
+      .doesNotExist("does not wire up a lightbox in calendar contexts");
+    assert
+      .dom(".event-image a")
+      .hasAttribute(
+        "href",
+        "/t/foo/1",
+        "links the image to the event topic instead"
+      );
+  });
+
   test("derives the weekday from the date for all-day events, ignoring the timezone offset", async function (assert) {
     // Midnight UTC in a negative-offset timezone rolls back to the previous
     // day; an all-day event's weekday must come from the date, not the offset.


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/event-calendar-ux-issues/405388

Currently when an image is uploaded to an event, we wrap it in a lightbox link that does not work, so clicking on the image results in navigating to the image URL directly. 

This updates the behavior so that when within the topic the event is posted in, the image properly lightboxes. When viewed in the calendar context, like on /upcoming-events, the image instead links to the topic which is probably the more expected behavior. 

Calendar view image links to topic:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/173c2200-90aa-428d-94a7-f8adfddd5dde" />


Topic view lightboxes:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/ccaeca47-9054-4834-81dd-4592ac2360f7" />

also snuck in a class name for custom event fields 