### PR TITLE
UX: refactor advanced mode toggle to shared component

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -370,11 +370,11 @@
   }
 }
 
-.d-modal.discourse-local-dates-create-modal {
-  .advanced-mode-btn {
-    margin-left: auto;
-  }
+.d-modal__footer .advanced-mode-btn {
+  margin-left: auto;
+}
 
+.d-modal.discourse-local-dates-create-modal {
   .date-time-configuration {
     display: flex;
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -497,6 +497,9 @@ en:
     age: "Age"
     joined: "Joined"
     admin_title: "Admin"
+    advanced_mode_toggle:
+      advanced_mode: "Advanced mode"
+      simple_mode: "Simple mode"
     show_more: "show more"
     show_help: "Options"
     links: "Links"

--- a/frontend/discourse/app/components/advanced-mode-toggle.gjs
+++ b/frontend/discourse/app/components/advanced-mode-toggle.gjs
@@ -2,7 +2,7 @@ import DButton from "discourse/ui-kit/d-button";
 
 const AdvancedModeToggle = <template>
   <DButton
-    class="btn-default advanced-mode-btn{{if @active ' --active'}}"
+    class="btn-default advanced-mode-btn"
     @icon="gear"
     @label={{if
       @active

--- a/frontend/discourse/app/components/advanced-mode-toggle.gjs
+++ b/frontend/discourse/app/components/advanced-mode-toggle.gjs
@@ -1,0 +1,17 @@
+import DButton from "discourse/ui-kit/d-button";
+
+const AdvancedModeToggle = <template>
+  <DButton
+    class="btn-default advanced-mode-btn{{if @active ' --active'}}"
+    @icon="gear"
+    @label={{if
+      @active
+      "advanced_mode_toggle.simple_mode"
+      "advanced_mode_toggle.advanced_mode"
+    }}
+    @action={{@onToggle}}
+    ...attributes
+  />
+</template>;
+
+export default AdvancedModeToggle;

--- a/frontend/discourse/tests/integration/components/advanced-mode-toggle-test.gjs
+++ b/frontend/discourse/tests/integration/components/advanced-mode-toggle-test.gjs
@@ -1,3 +1,4 @@
+import { tracked } from "@glimmer/tracking";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import AdvancedModeToggle from "discourse/components/advanced-mode-toggle";
@@ -8,12 +9,14 @@ module("Integration | Component | AdvancedModeToggle", function (hooks) {
   setupRenderingTest(hooks);
 
   test("label reflects @active and flips on toggle", async function (assert) {
-    let active = false;
-    const onToggle = () => (active = !active);
+    const state = new (class {
+      @tracked active = false;
+    })();
+    const onToggle = () => (state.active = !state.active);
 
     await render(
       <template>
-        <AdvancedModeToggle @active={{active}} @onToggle={{onToggle}} />
+        <AdvancedModeToggle @active={{state.active}} @onToggle={{onToggle}} />
       </template>
     );
 

--- a/frontend/discourse/tests/integration/components/advanced-mode-toggle-test.gjs
+++ b/frontend/discourse/tests/integration/components/advanced-mode-toggle-test.gjs
@@ -1,0 +1,36 @@
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import AdvancedModeToggle from "discourse/components/advanced-mode-toggle";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+module("Integration | Component | AdvancedModeToggle", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("label reflects @active and flips on toggle", async function (assert) {
+    let active = false;
+    const onToggle = () => (active = !active);
+
+    await render(
+      <template>
+        <AdvancedModeToggle @active={{active}} @onToggle={{onToggle}} />
+      </template>
+    );
+
+    assert
+      .dom(".advanced-mode-btn")
+      .hasText(
+        i18n("advanced_mode_toggle.advanced_mode"),
+        "shows 'Advanced mode' when inactive"
+      );
+
+    await click(".advanced-mode-btn");
+
+    assert
+      .dom(".advanced-mode-btn")
+      .hasText(
+        i18n("advanced_mode_toggle.simple_mode"),
+        "shows 'Simple mode' once active"
+      );
+  });
+});

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/modal/post-event-builder.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { concat, fn } from "@ember/helper";
 import EmberObject, { action } from "@ember/object";
 import { service } from "@ember/service";
+import AdvancedModeToggle from "discourse/components/advanced-mode-toggle";
 import Form from "discourse/components/form";
 import GroupSelector from "discourse/components/group-selector";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -1288,12 +1289,9 @@ export default class PostEventBuilder extends Component {
         {{/if}}
 
         {{#if this.showScreenToggle}}
-          <DButton
-            class="btn-default advanced-settings
-              {{if this.isAdvancedScreen 'is-active'}}"
-            @icon="gear"
-            @label="discourse_post_event.builder_modal.advanced_settings"
-            @action={{this.toggleAdvanced}}
+          <AdvancedModeToggle
+            @active={{this.isAdvancedScreen}}
+            @onToggle={{this.toggleAdvanced}}
           />
         {{/if}}
       </:footer>

--- a/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/post-event-builder.scss
@@ -36,10 +36,6 @@
     background: transparent;
   }
 
-  .d-modal__footer .advanced-settings {
-    margin-left: auto;
-  }
-
   .reminders {
     .form-kit__container-content {
       flex-wrap: wrap;

--- a/plugins/discourse-calendar/config/locales/client.en.yml
+++ b/plugins/discourse-calendar/config/locales/client.en.yml
@@ -494,7 +494,6 @@ en:
         create_event_title: "Create Event"
         update_event_title: "Edit Event"
         advanced_settings_title: "Advanced settings"
-        advanced_settings: "Advanced settings"
         confirm_delete: "Are you sure you want to delete this event?"
         confirm_close: "Are you sure you want to close this event?"
         confirm_open: "Are you sure you want to open this event?"

--- a/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event_form.rb
+++ b/plugins/discourse-calendar/spec/system/page_objects/discourse_calendar/post_event_form.rb
@@ -26,8 +26,8 @@ module PageObjects
         end
 
         def open_advanced
-          if modal.has_css?(".d-modal__footer .advanced-settings", wait: 0)
-            modal.find(".d-modal__footer .advanced-settings").click
+          if modal.has_css?(".d-modal__footer .advanced-mode-btn", wait: 0)
+            modal.find(".d-modal__footer .advanced-mode-btn").click
           end
           self
         end

--- a/plugins/discourse-calendar/spec/system/post_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_event_spec.rb
@@ -464,7 +464,7 @@ describe "Post event" do
     expect(page).to have_css(".discourse-post-event")
 
     post_event_page.edit
-    find(".d-modal .d-modal__footer .advanced-settings").click
+    find(".d-modal .d-modal__footer .advanced-mode-btn").click
 
     form = PageObjects::Components::FormKit.new(".d-modal form")
     expect(form.field("eventType")).to have_value("private")

--- a/plugins/discourse-local-dates/assets/javascripts/discourse/components/modal/local-dates-create.gjs
+++ b/plugins/discourse-local-dates/assets/javascripts/discourse/components/modal/local-dates-create.gjs
@@ -8,6 +8,7 @@ import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import { tagName } from "@ember-decorators/component";
 import { observes } from "@ember-decorators/object";
+import AdvancedModeToggle from "discourse/components/advanced-mode-toggle";
 import { debounce } from "discourse/lib/decorators";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import { applyLocalDates } from "discourse/lib/local-dates";
@@ -289,13 +290,6 @@ export default class LocalDatesCreate extends Component {
 
   _generateDateMarkup(fromDateTime, options, isRange, toDateTime) {
     return generateDateMarkup(fromDateTime, options, isRange, toDateTime);
-  }
-
-  @computed("advancedMode")
-  get toggleModeBtnLabel() {
-    return this.advancedMode
-      ? "discourse_local_dates.create.form.simple_mode"
-      : "discourse_local_dates.create.form.advanced_mode";
   }
 
   @computed("computedConfig.{from,to,options}", "options", "isValid", "isRange")
@@ -613,11 +607,9 @@ export default class LocalDatesCreate extends Component {
           class="btn-flat"
         />
 
-        <DButton
-          @action={{this.toggleAdvancedMode}}
-          @icon="gear"
-          @label={{this.toggleModeBtnLabel}}
-          class="btn-default advanced-mode-btn"
+        <AdvancedModeToggle
+          @active={{this.advancedMode}}
+          @onToggle={{this.toggleAdvancedMode}}
         />
       </:footer>
     </DModal>

--- a/plugins/discourse-local-dates/config/locales/client.en.yml
+++ b/plugins/discourse-local-dates/config/locales/client.en.yml
@@ -16,8 +16,6 @@ en:
       create:
         form:
           insert: Insert
-          advanced_mode: Advanced mode
-          simple_mode: Simple mode
           format_description: "Format used to display the date to the user. Use Z to show the offset and zz for the timezone name."
           timezones_title: Timezones to display
           timezones_description: Timezones will be used to display dates in preview and fallback.

--- a/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/modal/poll-ui-builder.gjs
@@ -6,6 +6,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
 import { service } from "@ember/service";
+import AdvancedModeToggle from "discourse/components/advanced-mode-toggle";
 import withEventValue from "discourse/helpers/with-event-value";
 import { removeValueFromArray } from "discourse/lib/array-tools";
 import { AUTO_GROUPS } from "discourse/lib/constants";
@@ -704,15 +705,9 @@ export default class PollUiBuilderModal extends Component {
 
         <DButton @label="cancel" @action={{@closeModal}} class="btn-flat" />
 
-        <DButton
-          @action={{this.toggleAdvanced}}
-          @icon="gear"
-          @title={{if
-            this.showAdvanced
-            "poll.ui_builder.hide_advanced"
-            "poll.ui_builder.show_advanced"
-          }}
-          class="btn-default show-advanced"
+        <AdvancedModeToggle
+          @active={{this.showAdvanced}}
+          @onToggle={{this.toggleAdvanced}}
         />
 
       </:footer>

--- a/plugins/poll/assets/stylesheets/common/poll-ui-builder.scss
+++ b/plugins/poll/assets/stylesheets/common/poll-ui-builder.scss
@@ -1,10 +1,3 @@
-.poll-ui-builder-modal {
-  .show-advanced {
-    margin-left: auto;
-    margin-right: 0;
-  }
-}
-
 .poll-ui-builder {
   label {
     font-weight: bold;

--- a/plugins/poll/config/locales/client.en.yml
+++ b/plugins/poll/config/locales/client.en.yml
@@ -173,5 +173,3 @@ en:
           add: Add option
         automatic_close:
           label: Automatically close poll
-        show_advanced: "Show Advanced Options"
-        hide_advanced: "Hide Advanced Options"

--- a/plugins/poll/test/javascripts/component/poll-ui-builder-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-ui-builder-test.gjs
@@ -37,7 +37,7 @@ module("Component | PollUiBuilder", function (hooks) {
       .dom(".poll-type-value-number")
       .doesNotExist("number type is hidden by default");
 
-    await click(".show-advanced");
+    await click(".advanced-mode-btn");
     assert
       .dom(".poll-type-value-number")
       .exists("number type appears in advanced mode");
@@ -94,7 +94,7 @@ module("Component | PollUiBuilder", function (hooks) {
   test("number mode", async function (assert) {
     const results = await setupBuilder();
 
-    await click(".show-advanced");
+    await click(".advanced-mode-btn");
     await click(".poll-type-value-number");
 
     await click(".insert-poll");
@@ -139,7 +139,7 @@ module("Component | PollUiBuilder", function (hooks) {
       "has correct output"
     );
 
-    await click(".show-advanced");
+    await click(".advanced-mode-btn");
 
     await click(".poll-toggle-public");
 
@@ -188,7 +188,7 @@ module("Component | PollUiBuilder", function (hooks) {
       "has correct output"
     );
 
-    await click(".show-advanced");
+    await click(".advanced-mode-btn");
 
     await click(".poll-toggle-public");
 
@@ -203,7 +203,7 @@ module("Component | PollUiBuilder", function (hooks) {
   test("staff_only option is not present for non-staff", async function (assert) {
     await setupBuilder();
 
-    await click(".show-advanced");
+    await click(".advanced-mode-btn");
     const resultVisibility = selectKit(".poll-result");
 
     assert.strictEqual(resultVisibility.header().value(), "always");


### PR DESCRIPTION
Events, Polls, and Dates all have "advanced mode" toggles, but they're all just a little different. This unifies them behind one reusable core component. Now they're all consisently toggling between "advanced mode" and "simple mode" 

Before:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/0b92e8f1-1dd0-4617-8ab6-6d968ca980cc" />
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/d02a8464-b782-4c1e-a7f0-d1a90e87798d" />
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/f5d074d3-0e32-41e6-a3fb-f6a3b0f32ae3" />



After: 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c25cd693-d4e7-4906-a346-197dcf6d5f6e" />
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/a3e1d7c3-f796-448d-83bb-cae611114030" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/90eecacb-9868-4fd3-b74f-722b32b9425e" />
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/881b5a8a-7731-40f1-af33-ba6bc94910de" />
