### PR TITLE
SECURITY: Missing visibility check in click tracking endpoint

### DIFF
--- a/app/controllers/clicks_controller.rb
+++ b/app/controllers/clicks_controller.rb
@@ -12,6 +12,7 @@ class ClicksController < ApplicationController
       topic_id: params[:topic_id],
       ip: request.remote_ip,
       user_id: current_user&.id,
+      guardian: guardian,
     )
 
     render json: success_json

--- a/app/models/topic_link_click.rb
+++ b/app/models/topic_link_click.rb
@@ -103,6 +103,9 @@ class TopicLinkClick < ActiveRecord::Base
       return nil
     end
 
+    guardian = args[:guardian]
+    return nil if guardian && !(guardian.can_see?(link.topic) && guardian.can_see?(link.post))
+
     return url if args[:user_id] && link.user_id == args[:user_id]
 
     # Rate limit the click counts to once in 24 hours

--- a/spec/requests/clicks_controller_spec.rb
+++ b/spec/requests/clicks_controller_spec.rb
@@ -27,6 +27,33 @@ RSpec.describe ClicksController do
       expect(response.parsed_body["success"]).to eq("OK")
     end
 
+    it "creates a TopicLinkClick for a private message post the recipient can see" do
+      private_url = "https://example.com/private-recipient-click-test"
+      private_message_post =
+        create_post(
+          user: user,
+          archetype: Archetype.private_message,
+          target_usernames: [recipient.username],
+          raw: "this private message has a link #{private_url}",
+        )
+      expect(private_message_post.topic_links.find_by(url: private_url)).to be_present
+
+      sign_in(recipient)
+
+      expect {
+        post "/clicks/track",
+             params: {
+               url: private_url,
+               post_id: private_message_post.id,
+               topic_id: private_message_post.topic_id,
+             },
+             headers: headers
+      }.to change { TopicLinkClick.count }.by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["success"]).to eq("OK")
+    end
+
     it "does not create a TopicLinkClick for a private message post the user cannot see" do
       private_url = "https://example.com/private-click-test"
       private_message_post =

--- a/spec/requests/clicks_controller_spec.rb
+++ b/spec/requests/clicks_controller_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.describe ClicksController do
+  fab!(:user, :trust_level_1)
+  fab!(:recipient, :trust_level_1)
+  fab!(:unauthorized_user, :user)
+
   let(:url) { "https://discourse.org/" }
   let(:headers) { { REMOTE_ADDR: "192.168.0.1" } }
   let(:post_with_url) { create_post(raw: "this is a post with a link #{url}") }
 
   describe "#track" do
     it "creates a TopicLinkClick" do
-      sign_in(Fabricate(:user))
+      sign_in(user)
 
       expect {
         post "/clicks/track",
@@ -18,6 +22,36 @@ RSpec.describe ClicksController do
              },
              headers: headers
       }.to change { TopicLinkClick.count }.by(1)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["success"]).to eq("OK")
+    end
+
+    it "does not create a TopicLinkClick for a private message post the user cannot see" do
+      private_url = "https://example.com/private-click-test"
+      private_message_post =
+        create_post(
+          user: user,
+          archetype: Archetype.private_message,
+          target_usernames: [recipient.username],
+          raw: "this private message has a link #{private_url}",
+        )
+      expect(private_message_post.topic_links.find_by(url: private_url)).to be_present
+
+      sign_in(unauthorized_user)
+
+      expect {
+        post "/clicks/track",
+             params: {
+               url: private_url,
+               post_id: private_message_post.id,
+               topic_id: private_message_post.topic_id,
+             },
+             headers: headers
+      }.not_to change { TopicLinkClick.count }
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["success"]).to eq("OK")
     end
   end
 end


### PR DESCRIPTION
## Summary

The /clicks/track endpoint allowed users to manipulate click counts for links inside private messages and restricted topics they could not access. This integrity issue is resolved by passing the user's guardian to the model layer and verifying visibility before recording the click.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1148
- HackerOne report: https://hackerone.com/reports/3701904

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>