### PR TITLE
SECURITY: Uncontrolled Resource Consumption in Number Poll Generation

### DIFF
--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
@@ -3,6 +3,7 @@ import { i18n } from "discourse-i18n";
 
 const DATA_PREFIX = "data-poll-";
 const DEFAULT_POLL = { name: "poll", status: "open" };
+const DEFAULT_MAXIMUM_OPTIONS = 20;
 const ALLOWED_ATTRIBUTES = [
   "chartType",
   "close",
@@ -19,10 +20,14 @@ const ALLOWED_ATTRIBUTES = [
   "dynamic",
 ];
 
-function addNumberListItems(state, pollTokens, min, max, step) {
+function addNumberListItems(state, pollTokens, min, max, step, maximumOptions) {
   pollTokens.push(new state.Token("bullet_list_open", "ul", 1));
 
-  for (let i = min; i <= max; i += step) {
+  for (
+    let i = min, count = 0;
+    i <= max && count < maximumOptions;
+    i += step, count++
+  ) {
     pollTokens.push(new state.Token("list_item_open", "li", 1));
 
     let token = new state.Token("text", "", 0);
@@ -144,13 +149,21 @@ const rule = {
       let min = parseInt(attrs.min, 10);
       let max = parseInt(attrs.max, 10);
       let step = parseInt(attrs.step, 10);
+      let maximumOptions = parseInt(
+        state.md.options.discourse.pollMaximumOptions,
+        10
+      );
+
+      if (isNaN(maximumOptions) || maximumOptions < 1) {
+        maximumOptions = DEFAULT_MAXIMUM_OPTIONS;
+      }
 
       if (isNaN(min)) {
         min = 1;
       }
 
       if (isNaN(max)) {
-        max = state.md.options.discourse.pollMaximumOptions;
+        max = maximumOptions;
       }
 
       if (isNaN(step) || step < 1) {
@@ -161,7 +174,7 @@ const rule = {
         state.tokens.splice(openTokenIndex, 1);
         return;
       } else if (min <= max) {
-        addNumberListItems(state, pollTokens, min, max, step);
+        addNumberListItems(state, pollTokens, min, max, step, maximumOptions);
       }
     }
 

--- a/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
+++ b/plugins/poll/assets/javascripts/lib/discourse-markdown/poll.js
@@ -23,9 +23,11 @@ const ALLOWED_ATTRIBUTES = [
 function addNumberListItems(state, pollTokens, min, max, step, maximumOptions) {
   pollTokens.push(new state.Token("bullet_list_open", "ul", 1));
 
+  const maximumGeneratedOptions = maximumOptions + 1;
+
   for (
     let i = min, count = 0;
-    i <= max && count < maximumOptions;
+    i <= max && count < maximumGeneratedOptions;
     i += step, count++
   ) {
     pollTokens.push(new state.Token("list_item_open", "li", 1));

--- a/plugins/poll/spec/lib/poll_spec.rb
+++ b/plugins/poll/spec/lib/poll_spec.rb
@@ -338,6 +338,19 @@ RSpec.describe DiscoursePoll::Poll do
       )
     end
 
+    it "caps generated number poll options to the configured maximum" do
+      SiteSetting.poll_maximum_options = 3
+
+      raw = <<~RAW
+      [poll type=number min=1 max=100 step=1]
+      [/poll]
+      RAW
+
+      poll = DiscoursePoll::Poll.extract(raw, 2).first
+
+      expect(poll["options"].map { |option| option["html"] }).to eq(%w[1 2 3])
+    end
+
     it "extracts poll when there are multiple quotes in the post" do
       raw = <<~RAW
       [quote="user1, post:1, topic:123"]

--- a/plugins/poll/spec/lib/poll_spec.rb
+++ b/plugins/poll/spec/lib/poll_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe DiscoursePoll::Poll do
       )
     end
 
-    it "caps generated number poll options to the configured maximum" do
+    it "limits generated number poll options to one more than the configured maximum" do
       SiteSetting.poll_maximum_options = 3
 
       raw = <<~RAW
@@ -348,7 +348,7 @@ RSpec.describe DiscoursePoll::Poll do
 
       poll = DiscoursePoll::Poll.extract(raw, 2).first
 
-      expect(poll["options"].map { |option| option["html"] }).to eq(%w[1 2 3])
+      expect(poll["options"].map { |option| option["html"] }).to eq(%w[1 2 3 4])
     end
 
     it "extracts poll when there are multiple quotes in the post" do

--- a/plugins/poll/spec/lib/polls_validator_spec.rb
+++ b/plugins/poll/spec/lib/polls_validator_spec.rb
@@ -217,6 +217,20 @@ RSpec.describe DiscoursePoll::PollsValidator do
       )
     end
 
+    it "rejects number polls whose generated range exceeds poll_maximum_options" do
+      SiteSetting.poll_maximum_options = 20
+
+      post.raw = <<~RAW
+        [poll type=number min=1 max=100 step=1]
+        [/poll]
+      RAW
+
+      expect(post.valid?).to eq(false)
+      expect(post.errors[:base]).to include(
+        I18n.t("poll.default_poll_must_have_less_options", count: SiteSetting.poll_maximum_options),
+      )
+    end
+
     describe "multiple type polls" do
       it "ensure that min < max" do
         raw = <<~RAW


### PR DESCRIPTION
## Summary

The markdown engine generates poll options in an unbounded loop based on user input, enabling an attacker to trigger massive memory allocation and CPU usage in the V8 process. This blocks a global mutex and can cause worker crashes, effectively DoS-ing markdown processing for all users.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1120
- HackerOne report: https://hackerone.com/reports/3598542

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>