### PR TITLE
SECURITY: Whisper metadata disclosure via stale TopicLinks [backport 2026.1]

### DIFF
--- a/app/controllers/composer_messages_controller.rb
+++ b/app/controllers/composer_messages_controller.rb
@@ -11,7 +11,7 @@ class ComposerMessagesController < ApplicationController
     if params[:topic_id].present?
       topic = Topic.where(id: params[:topic_id]).first
       if guardian.can_see?(topic)
-        json[:extras] = { duplicate_lookup: TopicLink.duplicate_lookup(topic) }
+        json[:extras] = { duplicate_lookup: TopicLink.duplicate_lookup(topic, guardian) }
       end
     end
 

--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -179,13 +179,20 @@ class TopicLink < ActiveRecord::Base
     TopicLink.crawl_link_title(id)
   end
 
-  def self.duplicate_lookup(topic)
+  def self.duplicate_lookup(topic, guardian = Guardian.new)
     results =
       TopicLink
         .includes(:post, :user)
         .joins(:post, :user)
         .where("posts.id IS NOT NULL AND users.id IS NOT NULL")
         .where(topic_id: topic.id, reflection: false)
+        .where(
+          posts: {
+            deleted_at: nil,
+            hidden: false,
+            post_type: Topic.visible_post_types(guardian.user),
+          },
+        )
         .last(200)
 
     lookup = {}

--- a/spec/requests/composer_messages_controller_spec.rb
+++ b/spec/requests/composer_messages_controller_spec.rb
@@ -28,6 +28,52 @@ RSpec.describe ComposerMessagesController do
         json = response.parsed_body
         expect(json["composer_messages"].first["id"]).to eq("education")
       end
+
+      it "does not include links from hidden posts in duplicate_lookup" do
+        reply =
+          Fabricate(
+            :post,
+            topic: topic,
+            user: Fabricate(:user, refresh_auto_groups: true),
+            raw: "Check out https://example.com/private-doc for details",
+          )
+        TopicLink.extract_from(reply)
+        reply.hide!(PostActionType.types[:spam])
+
+        get "/composer_messages.json", params: { topic_id: topic.id, composer_action: "reply" }
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        duplicate_lookup = json["extras"]["duplicate_lookup"]
+        expect(duplicate_lookup).not_to have_key("example.com/private-doc")
+      end
+
+      it "does not include links from posts converted to whispers in duplicate_lookup" do
+        SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+        staff_user = Fabricate(:admin)
+        whisper_url = "https://staff.example.com/private-doc"
+        normalized_whisper_url = whisper_url.delete_prefix("https://")
+        reply =
+          Fabricate(
+            :post,
+            topic: topic,
+            user: staff_user,
+            raw: "Check out #{whisper_url} for details",
+          )
+        TopicLink.extract_from(reply)
+
+        sign_in(staff_user)
+        put "/posts/#{reply.id}/post_type.json", params: { post_type: Post.types[:whisper] }
+        expect(response.status).to eq(200)
+
+        sign_in(user)
+        get "/composer_messages.json", params: { topic_id: topic.id, composer_action: "reply" }
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        duplicate_lookup = json["extras"]["duplicate_lookup"]
+        expect(duplicate_lookup).not_to have_key(normalized_whisper_url)
+      end
     end
   end
 


### PR DESCRIPTION
Backport of #41139 to release/2026.1.

---

## Summary

Regular users can access metadata (URL, author, timestamp) of links in staff-only whisper posts or deleted posts via the composer messages endpoint because the lookup logic failed to verify post visibility permissions.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1158
- HackerOne report: https://hackerone.com/reports/3721825

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
