### PR TITLE
SECURITY: Topic existence oracle in bookmark endpoints [backport 2026.1]

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -27,6 +27,7 @@ class TopicsController < ApplicationController
                    move_to_inbox
                    convert_topic
                    bookmark
+                   remove_bookmarks
                    publish
                    reset_bump_date
                    set_slow_mode

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -673,7 +673,8 @@ class TopicsController < ApplicationController
   end
 
   def remove_bookmarks
-    topic = Topic.find(params[:topic_id].to_i)
+    topic = find_visible_topic_from_topic_id
+
     BookmarkManager.new(current_user).destroy_for_topic(topic)
     render body: nil
   end
@@ -724,7 +725,7 @@ class TopicsController < ApplicationController
   end
 
   def bookmark
-    topic = Topic.find(params[:topic_id].to_i)
+    topic = find_visible_topic_from_topic_id
 
     bookmark_manager = BookmarkManager.new(current_user)
     bookmark_manager.create_for(bookmarkable_id: topic.id, bookmarkable_type: "Topic")
@@ -1354,6 +1355,13 @@ class TopicsController < ApplicationController
 
   def topic_params
     params.permit(:topic_id, :topic_time, timings: {})
+  end
+
+  def find_visible_topic_from_topic_id
+    topic = Topic.find_by(id: params[:topic_id].to_i)
+    raise Discourse::NotFound unless guardian.can_see?(topic)
+
+    topic
   end
 
   def fetch_topic_view(options)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4648,6 +4648,30 @@ RSpec.describe TopicsController do
   end
 
   describe "#remove_bookmarks" do
+    it "requires the user to be logged in" do
+      put "/t/1/remove_bookmarks.json"
+      expect(response.status).to eq(403)
+    end
+
+    it "returns 404 for inaccessible private messages" do
+      sign_in(user_2)
+      private_message =
+        create_post(
+          user: user,
+          archetype: "private_message",
+          target_usernames: [user.username],
+        ).topic
+      missing_topic_id = Topic.maximum(:id) + 1
+
+      put "/t/#{private_message.id}/remove_bookmarks.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
+
+      put "/t/#{missing_topic_id}/remove_bookmarks.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
+    end
+
     it "should remove bookmarks properly from non first post" do
       sign_in(user)
 
@@ -4658,14 +4682,6 @@ RSpec.describe TopicsController do
 
       put "/t/#{post.topic_id}/remove_bookmarks.json"
       expect(Bookmark.where(user: user).count).to eq(0)
-    end
-
-    it "should disallow bookmarks on posts you have no access to" do
-      sign_in(Fabricate(:user))
-      pm = create_post(user: user, archetype: "private_message", target_usernames: [user.username])
-
-      put "/t/#{pm.topic_id}/bookmark.json"
-      expect(response).to be_forbidden
     end
 
     context "with bookmarks with reminders" do
@@ -4681,6 +4697,25 @@ RSpec.describe TopicsController do
 
   describe "#bookmark" do
     before { sign_in(user) }
+
+    it "returns 404 for inaccessible private messages" do
+      sign_in(user_2)
+      private_message =
+        create_post(
+          user: user,
+          archetype: "private_message",
+          target_usernames: [user.username],
+        ).topic
+      missing_topic_id = Topic.maximum(:id) + 1
+
+      put "/t/#{private_message.id}/bookmark.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
+
+      put "/t/#{missing_topic_id}/bookmark.json"
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
+    end
 
     it "should create a new bookmark for the topic" do
       post = create_post


### PR DESCRIPTION
Backport of #41152 to release/2026.1.

---

## Summary

Prevent authenticated users from enumerating private or restricted topics by observing response differences in bookmark endpoints. The remove_bookmarks and bookmark actions now consistently return a 404 Not Found response for both missing and inaccessible topics through a centralized visibility check.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1161
- HackerOne report: https://hackerone.com/reports/3642525

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
