### PR TITLE
MT: Clarify ForkManager hook API names

### DIFF
--- a/migrations/converters/lib/migrations/converters/adapter/postgres.rb
+++ b/migrations/converters/lib/migrations/converters/adapter/postgres.rb
@@ -55,7 +55,7 @@ module Migrations
           @connection = nil
 
           if @fork_hook
-            ForkManager.remove_after_fork_child_hook(@fork_hook)
+            ForkManager.remove_after_fork_child(@fork_hook)
             @fork_hook = nil
           end
         end

--- a/migrations/converters/spec/lib/migrations/converters/adapter/postgres_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/adapter/postgres_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe Migrations::Converters::Adapter::Postgres do
     end
 
     it "registers a fork hook on creation and removes it on `close`" do
-      expect(Migrations::ForkManager.size).to eq(0)
+      expect(Migrations::ForkManager.hook_count).to eq(0)
 
       create_adapter do |adapter|
-        expect(Migrations::ForkManager.size).to eq(1)
+        expect(Migrations::ForkManager.hook_count).to eq(1)
         adapter.close
-        expect(Migrations::ForkManager.size).to eq(0)
+        expect(Migrations::ForkManager.hook_count).to eq(0)
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe Migrations::Converters::Adapter::Postgres do
 
           expect { adapter.close }.to_not raise_error
           expect(connection).to_not have_received(:finish)
-          expect(Migrations::ForkManager.size).to eq(0)
+          expect(Migrations::ForkManager.hook_count).to eq(0)
         end
       end
     end

--- a/migrations/core/lib/migrations/common/fork_manager.rb
+++ b/migrations/core/lib/migrations/common/fork_manager.rb
@@ -8,7 +8,7 @@ module Migrations
     @execute_parent_forks = true
 
     class << self
-      def batch_forks
+      def with_batched_forks
         @execute_parent_forks = false
         run_before_fork_hooks
 
@@ -25,7 +25,7 @@ module Migrations
         end
       end
 
-      def remove_before_fork_hook(block)
+      def remove_before_fork(block)
         @before_fork_hooks.delete(block)
       end
 
@@ -36,7 +36,7 @@ module Migrations
         end
       end
 
-      def remove_after_fork_parent_hook(block)
+      def remove_after_fork_parent(block)
         @after_fork_parent_hooks.delete(block)
       end
 
@@ -47,7 +47,7 @@ module Migrations
         end
       end
 
-      def remove_after_fork_child_hook(block)
+      def remove_after_fork_child(block)
         @after_fork_child_hooks.delete(block)
       end
 
@@ -65,7 +65,7 @@ module Migrations
         pid
       end
 
-      def size
+      def hook_count
         @before_fork_hooks.size + @after_fork_parent_hooks.size + @after_fork_child_hooks.size
       end
 

--- a/migrations/core/lib/migrations/conversion/progress_step_executor.rb
+++ b/migrations/core/lib/migrations/conversion/progress_step_executor.rb
@@ -109,7 +109,7 @@ module Migrations
 
         Process.warmup
 
-        ForkManager.batch_forks do
+        ForkManager.with_batched_forks do
           WORKER_COUNT.times do |index|
             job = ParallelJob.new(@step.create_processor)
             workers << Worker.new(index, work_queue, worker_output_queue, job).start

--- a/migrations/core/lib/migrations/database/connection.rb
+++ b/migrations/core/lib/migrations/database/connection.rb
@@ -40,8 +40,8 @@ module Migrations
         close_connection(keep_path: false)
 
         before_hook, after_hook = @fork_hooks
-        ForkManager.remove_before_fork_hook(before_hook)
-        ForkManager.remove_after_fork_parent_hook(after_hook)
+        ForkManager.remove_before_fork(before_hook)
+        ForkManager.remove_after_fork_parent(after_hook)
       end
 
       def closed?

--- a/migrations/core/spec/lib/common/fork_manager_spec.rb
+++ b/migrations/core/spec/lib/common/fork_manager_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Migrations::ForkManager do
       read_io.close
     end
 
-    it "runs hooks in every fork created by `batch_forks`" do
+    it "runs hooks in every fork created by `with_batched_forks`" do
       read_io, write_io = IO.pipe
       described_class.after_fork_child { write_io.write("x") }
 
-      described_class.batch_forks { 2.times { Process.waitpid(described_class.fork {}) } }
+      described_class.with_batched_forks { 2.times { Process.waitpid(described_class.fork {}) } }
       write_io.close
 
       expect(read_io.read).to eq("xx")
@@ -29,24 +29,24 @@ RSpec.describe Migrations::ForkManager do
 
     it "returns the hook so it can be removed again" do
       hook = described_class.after_fork_child { raise "this hook should not run" }
-      expect(described_class.size).to eq(1)
+      expect(described_class.hook_count).to eq(1)
 
-      described_class.remove_after_fork_child_hook(hook)
-      expect(described_class.size).to eq(0)
+      described_class.remove_after_fork_child(hook)
+      expect(described_class.hook_count).to eq(0)
 
       _, status = Process.waitpid2(described_class.fork {})
       expect(status).to be_success
     end
   end
 
-  describe ".remove_after_fork_child_hook" do
+  describe ".remove_after_fork_child" do
     it "stops the removed hook from running while other hooks keep running" do
       read_io, write_io = IO.pipe
       hook = described_class.after_fork_child { write_io.write("removed") }
       described_class.after_fork_child { write_io.write("kept") }
 
-      described_class.remove_after_fork_child_hook(hook)
-      expect(described_class.size).to eq(1)
+      described_class.remove_after_fork_child(hook)
+      expect(described_class.hook_count).to eq(1)
 
       Process.waitpid(described_class.fork {})
       write_io.close

--- a/migrations/core/spec/lib/database/connection_spec.rb
+++ b/migrations/core/spec/lib/database/connection_spec.rb
@@ -164,12 +164,12 @@ RSpec.describe Migrations::Database::Connection do
     end
 
     it "cleans up fork hooks when connection gets closed" do
-      expect(Migrations::ForkManager.size).to eq(0)
+      expect(Migrations::ForkManager.hook_count).to eq(0)
 
       create_connection do |connection|
-        expect(Migrations::ForkManager.size).to eq(2)
+        expect(Migrations::ForkManager.hook_count).to eq(2)
         connection.close
-        expect(Migrations::ForkManager.size).to eq(0)
+        expect(Migrations::ForkManager.hook_count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
The `ForkManager` hook methods had names that didn't quite fit. `batch_forks` reads like it forks in batches, and the `remove_*_hook` / `size` names don't line up with the `before_fork` / `after_fork_parent` methods they pair with. This renames them so they read consistently:

- `batch_forks` → `with_batched_forks`
- `remove_before_fork_hook` → `remove_before_fork`
- `remove_after_fork_parent_hook` → `remove_after_fork_parent`
- `remove_after_fork_child_hook` → `remove_after_fork_child`
- `size` → `hook_count`

Pure rename, no behavior change. I updated the callers (`Connection`, `ProgressStepExecutor`, the Postgres adapter) and their specs to match; the full suite stays green.
