### PR TITLE
SECURITY: Prevent badge lookup from exposing hidden profiles

### DIFF
--- a/app/controllers/user_badges_controller.rb
+++ b/app/controllers/user_badges_controller.rb
@@ -23,8 +23,11 @@ class UserBadgesController < ApplicationController
     grant_count = nil
 
     if params[:username]
-      user_id = User.where(username_lower: params[:username].downcase).pick(:id)
-      user_badges = user_badges.where(user_id: user_id) if user_id
+      user = fetch_user_from_params(include_inactive: true)
+      raise Discourse::NotFound unless guardian.can_see_profile?(user)
+
+      user_id = user.id
+      user_badges = user_badges.where(user_id: user_id)
       grant_count = badge.user_badges.where(user_id: user_id).count
     end
 

--- a/spec/requests/user_badges_controller_spec.rb
+++ b/spec/requests/user_badges_controller_spec.rb
@@ -47,6 +47,36 @@ RSpec.describe UserBadgesController do
       get "/user_badges.json"
       expect(response.status).to eq(400)
     end
+
+    it "returns not found for hidden new user profiles" do
+      hidden_user = Fabricate(:trust_level_0)
+      hidden_user.user_stat.update!(post_count: 1)
+      Fabricate(:user_badge, user: hidden_user, badge: badge)
+
+      get "/user_badges.json", params: { badge_id: badge.id, username: hidden_user.username }
+
+      expect(response.status).to eq(404)
+      expect(response.body).not_to include(hidden_user.username)
+    end
+
+    it "returns badges for visible inactive profiles" do
+      inactive_user = Fabricate(:user, active: false)
+      inactive_user.user_stat.update!(post_count: 1)
+      Fabricate(:user_badge, user: inactive_user, badge: badge)
+
+      get "/user_badges.json", params: { badge_id: badge.id, username: inactive_user.username }
+
+      expect(response.status).to eq(200)
+
+      parsed_body = response.parsed_body
+      aggregate_failures do
+        expect(parsed_body["user_badge_info"]["grant_count"]).to eq(1)
+        expect(parsed_body["user_badge_info"]["username"]).to eq(inactive_user.username)
+        expect(parsed_body["user_badge_info"]["user_badges"].first["user_id"]).to eq(
+          inactive_user.id,
+        )
+      end
+    end
   end
 
   describe "#show" do


### PR DESCRIPTION
The endpoint resolved the username directly and returned badge grant data without checking whether the requester could see that user's profile. This could expose badge metadata for hidden new-user profiles.

`/user_badges.json` now checks profile visibility when filtering badge grants by `username`.