### PR TITLE
FIX: Never use `structure.sql` when restoring a backup

### DIFF
--- a/lib/backup_restore/database_restorer.rb
+++ b/lib/backup_restore/database_restorer.rb
@@ -176,6 +176,7 @@ module BackupRestore
               "SKIP_OPTIMIZE_ICONS" => "1",
               "DISABLE_TRANSLATION_OVERRIDES" => "1",
               "SKIP_SEED_FU" => "1",
+              "SKIP_STRUCTURE_SQL" => "1",
             },
             "rake",
             "db:migrate",

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -129,7 +129,11 @@ class SeedHelper
 end
 
 def execute_db_migration
-  ActiveRecord::Tasks::DatabaseTasks.migrate
+  if ENV["SKIP_STRUCTURE_SQL"] == "1"
+    ActiveRecord::Tasks::DatabaseTasks.migrate(skip_initialize: true)
+  else
+    ActiveRecord::Tasks::DatabaseTasks.migrate
+  end
 
   if ENV["SKIP_SEED_FU"] != "1"
     Rake::Task["db:seed"].reenable


### PR DESCRIPTION
We sometimes use 'empty' backup files to reset a site to defaults. Since we added structure.sql, that was being applied instead of properly running all the database migrations. This would cause a problem for the discourse_functions schema, which the backup/restore pipeline manages deliberately.