### PR TITLE
UX: increase UX for incoming mail modal

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -741,24 +741,20 @@
   }
 
   .incoming-email-content {
-    height: 300px;
     max-width: 100%;
-    width: 90vw; // forcing textarea wider
 
-    textarea,
     .incoming-email-html-part {
-      height: 95%;
       border: none;
       border-top: 1px solid var(--content-border-color);
       padding-top: 10px;
       width: 100%;
     }
 
-    textarea {
+    .incoming-email-raw {
       font-family: var(--d-font-family--monospace);
-      resize: none;
-      border-radius: 0;
-      box-shadow: none;
+      margin: 0;
+      white-space: pre-wrap;
+      word-break: break-word;
     }
 
     .incoming-email-html-part {

--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -742,6 +742,7 @@
 
   .incoming-email-content {
     max-width: 100%;
+    height: 300px;
 
     .incoming-email-html-part {
       border: none;

--- a/frontend/discourse/app/components/modal/raw-email.gjs
+++ b/frontend/discourse/app/components/modal/raw-email.gjs
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { Textarea } from "@ember/component";
 import { action } from "@ember/object";
 import IframedHtml from "discourse/components/iframed-html";
 import Post from "discourse/models/post";
@@ -82,13 +81,13 @@ export default class RawEmailComponent extends Component {
         <div class="incoming-email-content">
           {{#if (eq this.tab "raw")}}
             {{#if this.rawEmail}}
-              <Textarea @value={{this.rawEmail}} />
+              <pre class="incoming-email-raw">{{this.rawEmail}}</pre>
             {{else}}
               {{i18n "raw_email.not_available"}}
             {{/if}}
           {{/if}}
           {{#if (eq this.tab "text_part")}}
-            <Textarea @value={{this.textPart}} />
+            <pre class="incoming-email-raw">{{this.textPart}}</pre>
           {{/if}}
           {{#if (eq this.tab "html_part")}}
             <IframedHtml


### PR DESCRIPTION
Replace textarea, which is a form element, with a `pre` tag + sizing fixes

<img width="1262" height="970" alt="CleanShot 2026-06-24 at 14 17 30@2x" src="https://github.com/user-attachments/assets/06774ef5-0163-4f25-b201-50c176087d1d" />

⬇️ 

<img width="1272" height="1636" alt="CleanShot 2026-06-24 at 14 10 37@2x" src="https://github.com/user-attachments/assets/d6b9b547-94d2-46cc-91bc-1d8a8926335d" />
