### PR TITLE
FIX: ZIP symlink entries are extracted as real directories

### DIFF
--- a/lib/compression/strategy.rb
+++ b/lib/compression/strategy.rb
@@ -17,6 +17,10 @@ module Compression
         available_size = calculate_available_size(max_size)
 
         entries_of(compressed_file).each do |entry|
+          # only extract regular files and directories; skip symlinks,
+          # hardlinks, devices and any other special entry types
+          next if !is_file?(entry) && !is_directory?(entry)
+
           entry_path = build_entry_path(sanitized_dest_path, entry, sanitized_compressed_file_path)
           next if !is_safe_path_for_extraction?(entry_path, sanitized_dest_path)
 
@@ -48,6 +52,10 @@ module Compression
 
     def is_file?(entry)
       entry.file?
+    end
+
+    def is_directory?(entry)
+      entry.directory?
     end
 
     def chunk_size

--- a/lib/compression/zip.rb
+++ b/lib/compression/zip.rb
@@ -30,9 +30,6 @@ module Compression
     private
 
     def extract_folder(entry, entry_path)
-      return unless entry.directory?
-      return if ::File.symlink?(entry_path) || ::Dir.exist?(entry_path)
-
       FileUtils.mkdir_p(entry_path)
     end
 

--- a/lib/compression/zip.rb
+++ b/lib/compression/zip.rb
@@ -30,11 +30,10 @@ module Compression
     private
 
     def extract_folder(entry, entry_path)
-      return if entry.symlink?
       return unless entry.directory?
+      return if ::File.symlink?(entry_path) || ::Dir.exist?(entry_path)
 
       FileUtils.mkdir_p(entry_path)
-      entry.set_extra_attributes_on_path(entry_path)
     end
 
     def get_compressed_file_stream(compressed_file_path)

--- a/lib/compression/zip.rb
+++ b/lib/compression/zip.rb
@@ -30,7 +30,11 @@ module Compression
     private
 
     def extract_folder(entry, entry_path)
+      return if entry.symlink?
+      return unless entry.directory?
+
       FileUtils.mkdir_p(entry_path)
+      entry.set_extra_attributes_on_path(entry_path)
     end
 
     def get_compressed_file_stream(compressed_file_path)

--- a/spec/lib/compression/engine_spec.rb
+++ b/spec/lib/compression/engine_spec.rb
@@ -81,6 +81,32 @@ RSpec.describe Compression::Engine do
         end
       end
 
+      it "skips symlink entries when decompressing zip files" do
+        FileUtils.rm_rf(temp_folder)
+        FileUtils.mkdir(temp_folder)
+
+        source_dir = "#{temp_folder}/source"
+        FileUtils.mkdir(source_dir)
+        File.write("#{source_dir}/real-file", "real file")
+        File.symlink("#{source_dir}/real-file", "#{source_dir}/symlink-entry")
+
+        zip_file = "#{temp_folder}/theme.zip"
+        Zip::File.open(zip_file, create: true) do |zipfile|
+          zipfile.get_output_stream("child-file") { |f| f.write("child file") }
+          zipfile.add("symlink-entry", "#{source_dir}/symlink-entry")
+        end
+        FileUtils.rm_rf(source_dir)
+
+        extract_location = "#{temp_folder}/extract_location"
+        FileUtils.mkdir(extract_location)
+        engine = described_class.engine_for(zip_file)
+        engine.decompress(extract_location, zip_file, available_size)
+
+        expect(read_file("extract_location/child-file")).to eq("child file")
+        expect(File.exist?("#{extract_location}/symlink-entry")).to eq(false)
+        expect(File.symlink?("#{extract_location}/symlink-entry")).to eq(false)
+      end
+
       it "decompresses into symlinked directory" do
         real_location = "#{temp_folder}/extract_location"
         extract_location = "#{temp_folder}/is/symlinked"

--- a/spec/lib/compression/engine_spec.rb
+++ b/spec/lib/compression/engine_spec.rb
@@ -102,9 +102,12 @@ RSpec.describe Compression::Engine do
         engine = described_class.engine_for(zip_file)
         engine.decompress(extract_location, zip_file, available_size)
 
+        symlink_entry_path = "#{extract_location}/symlink-entry"
+
         expect(read_file("extract_location/child-file")).to eq("child file")
-        expect(File.exist?("#{extract_location}/symlink-entry")).to eq(false)
-        expect(File.symlink?("#{extract_location}/symlink-entry")).to eq(false)
+        expect(File.exist?(symlink_entry_path)).to eq(false)
+        expect(File.symlink?(symlink_entry_path)).to eq(false)
+        expect(Dir.exist?(symlink_entry_path)).to eq(false)
       end
 
       it "decompresses into symlinked directory" do


### PR DESCRIPTION
## Summary

ZIP symlink entries are extracted as real directories – we should verify before extracting

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/890

---

🤖 Auto-generated from the patch diff via Patch Triage. Review carefully before merging.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>