### PR TITLE
DEV: remove and replace Uncategorized

### DIFF
--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -78,6 +78,9 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
     Site.clear_cache
   end
 
+  # Capture once: the first opt-in/promotion snapshot is the canonical
+  # pre-migration state. Later opt-ins intentionally reuse it (so their events
+  # keep event_data: nil), and opt-out always restores that original state.
   def capture_snapshot(snapshot)
     return if snapshot_event.present?
 

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -8,9 +8,11 @@
 # in place by repointing `uncategorized_category_id` to -1 (the category's
 # "special" behavior is derived entirely from that setting), then disallows
 # uncategorized topics. No category is created and no topics are moved. If the
-# composer defaulted to the special Uncategorized category (explicitly or
-# because no default was set), the now-normal category is pinned as the
-# `default_composer_category` so the composer keeps pre-selecting it.
+# composer had no explicit default (so it fell back to the special
+# Uncategorized category), the now-normal category is pinned as the
+# `default_composer_category` so the composer keeps pre-selecting it. An
+# explicit default already pointing at that category needs no change — the id
+# simply becomes a normal category.
 #
 # The site's prior state is snapshotted onto the change's UpcomingChangeEvent
 # so that opt-out can either restore the special category or do nothing.
@@ -45,8 +47,7 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
         uncategorized_category_id: former_uncategorized_id,
       )
 
-      if SiteSetting.default_composer_category.blank? ||
-           SiteSetting.default_composer_category == former_uncategorized_id.to_s
+      if SiteSetting.default_composer_category.blank?
         SiteSetting.set_and_log(:default_composer_category, former_uncategorized_id.to_s)
       end
 

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Reacts to the `remove_and_replace_uncategorized` upcoming change being
+# enabled or disabled (manually or via auto-promotion). See
+# config/initializers/015-track-upcoming-change-toggle.rb for the dispatch.
+#
+# Enabling demotes the special Uncategorized category to a normal category
+# in place by repointing `uncategorized_category_id` to -1 (the category's
+# "special" behavior is derived entirely from that setting), then disallows
+# uncategorized topics. No category is created and no topics are moved.
+#
+# The site's prior state is snapshotted onto the change's UpcomingChangeEvent
+# so that opt-out can either restore the special category or do nothing.
+class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::ActionBase
+  UPCOMING_CHANGE = :remove_and_replace_uncategorized
+
+  # These settings only make sense while the special Uncategorized category
+  # exists, so they are hidden while the change is in effect (see the
+  # :hidden_site_settings modifier in 015-track-upcoming-change-toggle.rb).
+  HIDDEN_SETTINGS = %i[allow_uncategorized_topics suppress_uncategorized_badge].freeze
+
+  # Event types this action writes the prior-state snapshot onto. Scoped so the
+  # lookup ignores framework-managed events that also carry event_data (e.g.
+  # `status_changed`, which stores the status transition).
+  SNAPSHOT_EVENT_TYPES = %i[manual_opt_in automatically_promoted].freeze
+
+  option :enabled
+
+  def call
+    enabled ? enable : disable
+  end
+
+  # Drives both the admin-UI visibility (UpcomingChanges::ConditionalDisplay)
+  # and auto-promotion (UpcomingChanges::NotifyPromotion). The change is only
+  # relevant on sites that currently allow uncategorized topics, and it must
+  # stay visible after being enabled (which disables that setting).
+  def self.should_display_upcoming_change?
+    SiteSetting.allow_uncategorized_topics || UpcomingChanges.enabled?(UPCOMING_CHANGE)
+  end
+
+  # Adds the legacy uncategorized settings to the hidden set while the change is
+  # in effect. Wired up as a :hidden_site_settings modifier in
+  # config/initializers/015-track-upcoming-change-toggle.rb.
+  def self.apply_hidden_settings(hidden)
+    return hidden if !UpcomingChanges.enabled?(UPCOMING_CHANGE)
+
+    hidden + HIDDEN_SETTINGS
+  end
+
+  private
+
+  def enable
+    # -1 is the canonical "already migrated" marker, so this is idempotent.
+    return if SiteSetting.uncategorized_category_id == -1
+
+    ActiveRecord::Base.transaction do
+      capture_snapshot(
+        allow_uncategorized_topics: SiteSetting.allow_uncategorized_topics,
+        default_composer_category: SiteSetting.default_composer_category,
+        uncategorized_category_id: SiteSetting.uncategorized_category_id,
+      )
+
+      # Order matters: demote the category before disallowing uncategorized
+      # topics. Once uncategorized_category_id is -1, the old category id is a
+      # normal category, so DefaultComposerCategoryValidator no longer rejects
+      # default_composer_category pointing at it (no need to change that value).
+      SiteSetting.set_and_log(:uncategorized_category_id, -1)
+      SiteSetting.set_and_log(:allow_uncategorized_topics, false)
+    end
+
+    Site.clear_cache
+  end
+
+  def disable
+    snapshot = read_snapshot
+    return if snapshot.blank?
+
+    # If the site was not using uncategorized topics at opt-in, there is no
+    # special category to restore.
+    return unless snapshot["allow_uncategorized_topics"]
+
+    ActiveRecord::Base.transaction do
+      # Reverse order: re-specialize the category and re-allow uncategorized
+      # topics before touching default_composer_category, otherwise restoring a
+      # value equal to the (now special again) uncategorized id would be
+      # rejected by DefaultComposerCategoryValidator.
+      SiteSetting.set_and_log(:uncategorized_category_id, snapshot["uncategorized_category_id"])
+      SiteSetting.set_and_log(:allow_uncategorized_topics, true)
+
+      if SiteSetting.default_composer_category != snapshot["default_composer_category"]
+        SiteSetting.set_and_log(:default_composer_category, snapshot["default_composer_category"])
+      end
+    end
+
+    Site.clear_cache
+  end
+
+  # Persist the snapshot once, before any mutation. The manual opt-in path
+  # already has a `manual_opt_in` UpcomingChangeEvent (created by
+  # UpcomingChanges::Toggle); the auto-promotion path has none, so we create an
+  # `automatically_promoted` event to carry the snapshot.
+  def capture_snapshot(snapshot)
+    return if snapshot_event.present?
+
+    opt_in_event =
+      UpcomingChangeEvent
+        .where(
+          upcoming_change_name: UPCOMING_CHANGE.to_s,
+          event_type: UpcomingChangeEvent.event_types[:manual_opt_in],
+        )
+        .order(created_at: :desc)
+        .first
+
+    if opt_in_event
+      opt_in_event.update!(event_data: snapshot)
+    else
+      UpcomingChangeEvent.create!(
+        event_type: :automatically_promoted,
+        upcoming_change_name: UPCOMING_CHANGE.to_s,
+        acting_user: Discourse.system_user,
+        event_data: snapshot,
+      )
+    end
+  end
+
+  def read_snapshot
+    snapshot_event&.event_data
+  end
+
+  def snapshot_event
+    UpcomingChangeEvent
+      .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
+      .where.not(event_data: nil)
+      .order(created_at: :desc)
+      .first
+  end
+end

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -11,17 +11,10 @@
 #
 # The site's prior state is snapshotted onto the change's UpcomingChangeEvent
 # so that opt-out can either restore the special category or do nothing.
+
 class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::ActionBase
   UPCOMING_CHANGE = :remove_and_replace_uncategorized
 
-  # These settings only make sense while the special Uncategorized category
-  # exists, so they are hidden while the change is in effect (see the
-  # :hidden_site_settings modifier in 015-track-upcoming-change-toggle.rb).
-  HIDDEN_SETTINGS = %i[allow_uncategorized_topics suppress_uncategorized_badge].freeze
-
-  # Event types this action writes the prior-state snapshot onto. Scoped so the
-  # lookup ignores framework-managed events that also carry event_data (e.g.
-  # `status_changed`, which stores the status transition).
   SNAPSHOT_EVENT_TYPES = %i[manual_opt_in automatically_promoted].freeze
 
   option :enabled
@@ -30,21 +23,8 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
     enabled ? enable : disable
   end
 
-  # Drives both the admin-UI visibility (UpcomingChanges::ConditionalDisplay)
-  # and auto-promotion (UpcomingChanges::NotifyPromotion). The change is only
-  # relevant on sites that currently allow uncategorized topics, and it must
-  # stay visible after being enabled (which disables that setting).
   def self.should_display_upcoming_change?
     SiteSetting.allow_uncategorized_topics || UpcomingChanges.enabled?(UPCOMING_CHANGE)
-  end
-
-  # Adds the legacy uncategorized settings to the hidden set while the change is
-  # in effect. Wired up as a :hidden_site_settings modifier in
-  # config/initializers/015-track-upcoming-change-toggle.rb.
-  def self.apply_hidden_settings(hidden)
-    return hidden if !UpcomingChanges.enabled?(UPCOMING_CHANGE)
-
-    hidden + HIDDEN_SETTINGS
   end
 
   private
@@ -60,10 +40,6 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
         uncategorized_category_id: SiteSetting.uncategorized_category_id,
       )
 
-      # Order matters: demote the category before disallowing uncategorized
-      # topics. Once uncategorized_category_id is -1, the old category id is a
-      # normal category, so DefaultComposerCategoryValidator no longer rejects
-      # default_composer_category pointing at it (no need to change that value).
       SiteSetting.set_and_log(:uncategorized_category_id, -1)
       SiteSetting.set_and_log(:allow_uncategorized_topics, false)
     end
@@ -80,10 +56,6 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
     return unless snapshot["allow_uncategorized_topics"]
 
     ActiveRecord::Base.transaction do
-      # Reverse order: re-specialize the category and re-allow uncategorized
-      # topics before touching default_composer_category, otherwise restoring a
-      # value equal to the (now special again) uncategorized id would be
-      # rejected by DefaultComposerCategoryValidator.
       SiteSetting.set_and_log(:uncategorized_category_id, snapshot["uncategorized_category_id"])
       SiteSetting.set_and_log(:allow_uncategorized_topics, true)
 
@@ -95,10 +67,6 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
     Site.clear_cache
   end
 
-  # Persist the snapshot once, before any mutation. The manual opt-in path
-  # already has a `manual_opt_in` UpcomingChangeEvent (created by
-  # UpcomingChanges::Toggle); the auto-promotion path has none, so we create an
-  # `automatically_promoted` event to carry the snapshot.
   def capture_snapshot(snapshot)
     return if snapshot_event.present?
 

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -7,7 +7,10 @@
 # Enabling demotes the special Uncategorized category to a normal category
 # in place by repointing `uncategorized_category_id` to -1 (the category's
 # "special" behavior is derived entirely from that setting), then disallows
-# uncategorized topics. No category is created and no topics are moved.
+# uncategorized topics. No category is created and no topics are moved. If the
+# composer defaulted to the special Uncategorized category (explicitly or
+# because no default was set), the now-normal category is pinned as the
+# `default_composer_category` so the composer keeps pre-selecting it.
 #
 # The site's prior state is snapshotted onto the change's UpcomingChangeEvent
 # so that opt-out can either restore the special category or do nothing.
@@ -33,12 +36,19 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
     # -1 is the canonical "already migrated" marker, so this is idempotent.
     return if SiteSetting.uncategorized_category_id == -1
 
+    former_uncategorized_id = SiteSetting.uncategorized_category_id
+
     ActiveRecord::Base.transaction do
       capture_snapshot(
         allow_uncategorized_topics: SiteSetting.allow_uncategorized_topics,
         default_composer_category: SiteSetting.default_composer_category,
-        uncategorized_category_id: SiteSetting.uncategorized_category_id,
+        uncategorized_category_id: former_uncategorized_id,
       )
+
+      if SiteSetting.default_composer_category.blank? ||
+           SiteSetting.default_composer_category == former_uncategorized_id.to_s
+        SiteSetting.set_and_log(:default_composer_category, former_uncategorized_id.to_s)
+      end
 
       SiteSetting.set_and_log(:uncategorized_category_id, -1)
       SiteSetting.set_and_log(:allow_uncategorized_topics, false)
@@ -82,10 +92,11 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
   end
 
   def snapshot_event
-    UpcomingChangeEvent
-      .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
-      .where.not(event_data: nil)
-      .order(created_at: :desc)
-      .first
+    @snapshot_event ||=
+      UpcomingChangeEvent
+        .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
+        .where.not(event_data: nil)
+        .order(created_at: :desc)
+        .first
   end
 end

--- a/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
+++ b/app/services/site_setting/action/remove_and_replace_uncategorized_toggled.rb
@@ -70,25 +70,11 @@ class SiteSetting::Action::RemoveAndReplaceUncategorizedToggled < Service::Actio
   def capture_snapshot(snapshot)
     return if snapshot_event.present?
 
-    opt_in_event =
-      UpcomingChangeEvent
-        .where(
-          upcoming_change_name: UPCOMING_CHANGE.to_s,
-          event_type: UpcomingChangeEvent.event_types[:manual_opt_in],
-        )
-        .order(created_at: :desc)
-        .first
-
-    if opt_in_event
-      opt_in_event.update!(event_data: snapshot)
-    else
-      UpcomingChangeEvent.create!(
-        event_type: :automatically_promoted,
-        upcoming_change_name: UPCOMING_CHANGE.to_s,
-        acting_user: Discourse.system_user,
-        event_data: snapshot,
-      )
-    end
+    UpcomingChangeEvent
+      .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
+      .order(created_at: :desc)
+      .first
+      &.update!(event_data: snapshot)
   end
 
   def read_snapshot

--- a/app/services/upcoming_changes/notify_promotion.rb
+++ b/app/services/upcoming_changes/notify_promotion.rb
@@ -130,6 +130,11 @@ class UpcomingChanges::NotifyPromotion
       upcoming_change_name: params.setting_name,
       acting_user: Discourse.system_user,
     )
+
+    UpcomingChangeEvent.find_or_create_by(
+      event_type: :automatically_promoted,
+      upcoming_change_name: params.setting_name,
+    ) { |event| event.acting_user = Discourse.system_user }
   end
 
   def trigger_discourse_event(params:)

--- a/config/initializers/015-track-upcoming-change-toggle.rb
+++ b/config/initializers/015-track-upcoming-change-toggle.rb
@@ -2,6 +2,14 @@
 
 Rails.application.config.after_initialize { UpcomingChanges.clear_caches! }
 
+# While the `remove_and_replace_uncategorized` change is in effect (manual opt-in
+# or auto-promotion), the legacy uncategorized settings no longer make sense, so
+# hide them. This modifier is re-evaluated on every `hidden_settings` read, so it
+# tracks both opt-in paths live and is multisite-safe.
+DiscoursePluginRegistry.register_modifier(Plugin::Instance.new, :hidden_site_settings) do |hidden|
+  SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.apply_hidden_settings(hidden)
+end
+
 #
 # Similar to 014-track-setting-changes.rb, we can react to upcoming changes
 # being enabled/or disabled here for more complicated scenarios, where
@@ -22,6 +30,8 @@ DiscourseEvent.on(:upcoming_change_enabled) do |setting_name|
     SiteSetting::Action::SimpleEmailSubjectToggled.call(params: { setting_enabled: true })
   elsif setting_name == :enable_horizon_high_context_topic_cards
     Themes::Action::HorizonHighContextTopicCardsToggled.call(enabled: true)
+  elsif setting_name == :remove_and_replace_uncategorized
+    SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.call(enabled: true)
   end
 end
 
@@ -31,5 +41,7 @@ DiscourseEvent.on(:upcoming_change_disabled) do |setting_name|
     SiteSetting::Action::SimpleEmailSubjectToggled.call(params: { setting_enabled: false })
   elsif setting_name == :enable_horizon_high_context_topic_cards
     Themes::Action::HorizonHighContextTopicCardsToggled.call(enabled: false)
+  elsif setting_name == :remove_and_replace_uncategorized
+    SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.call(enabled: false)
   end
 end

--- a/config/initializers/015-track-upcoming-change-toggle.rb
+++ b/config/initializers/015-track-upcoming-change-toggle.rb
@@ -2,14 +2,6 @@
 
 Rails.application.config.after_initialize { UpcomingChanges.clear_caches! }
 
-# While the `remove_and_replace_uncategorized` change is in effect (manual opt-in
-# or auto-promotion), the legacy uncategorized settings no longer make sense, so
-# hide them. This modifier is re-evaluated on every `hidden_settings` read, so it
-# tracks both opt-in paths live and is multisite-safe.
-DiscoursePluginRegistry.register_modifier(Plugin::Instance.new, :hidden_site_settings) do |hidden|
-  SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.apply_hidden_settings(hidden)
-end
-
 #
 # Similar to 014-track-setting-changes.rb, we can react to upcoming changes
 # being enabled/or disabled here for more complicated scenarios, where

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1887,6 +1887,7 @@ en:
     category_search_priority_high_weight: "Weight applied to ranking for high category search priority."
     default_composer_category: "The category used to pre-populate the category dropdown when creating a new topic."
     allow_uncategorized_topics: "Allow topics to be created without a category. WARNING: If there are any uncategorized topics, you must recategorize them before turning this off."
+    remove_and_replace_uncategorized: "Replaces the special Uncategorized category with a standard category of the same name, and migrates all topics over to it."
     allow_duplicate_topic_titles: "Allow topics with identical, duplicate titles."
     allow_duplicate_topic_titles_category: "Allow topics with identical, duplicate titles if the category is different. {{setting:allow_duplicate_topic_titles}} must be disabled."
     unique_posts_mins: "How many minutes before a user can make a post with the same content again"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1366,7 +1366,7 @@ posting:
       hide_settings:
         - allow_uncategorized_topics
         - suppress_uncategorized_badge
-      learn_more_url: "https://meta.discourse.org/t/-/123456"
+      learn_more_url: "https://meta.discourse.org/t/-/406373"
   allow_duplicate_topic_titles:
     default: false
     area: "posts_and_topics"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1353,6 +1353,18 @@ posting:
     default: false
     refresh: true
     area: "posts_and_topics"
+  remove_and_replace_uncategorized:
+    default: false
+    client: true
+    hidden: true
+    area: "posts_and_topics"
+    upcoming_change:
+      status: "experimental"
+      impact: "other,all_members"
+      allow_enabled_for:
+        - everyone
+      # TODO: replace with the real Meta announcement topic once published.
+      learn_more_url: "https://meta.discourse.org/t/-/000000"
   allow_duplicate_topic_titles:
     default: false
     area: "posts_and_topics"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1363,8 +1363,10 @@ posting:
       impact: "other,all_members"
       allow_enabled_for:
         - everyone
-      # TODO: replace with the real Meta announcement topic once published.
-      learn_more_url: "https://meta.discourse.org/t/-/000000"
+      hide_settings:
+        - allow_uncategorized_topics
+        - suppress_uncategorized_badge
+      learn_more_url: "https://meta.discourse.org/t/-/123456"
   allow_duplicate_topic_titles:
     default: false
     area: "posts_and_topics"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1357,7 +1357,6 @@ posting:
     default: false
     client: true
     hidden: true
-    area: "posts_and_topics"
     upcoming_change:
       status: "experimental"
       impact: "other,all_members"

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -32,6 +32,12 @@ module UpcomingChanges
     def self.should_display_enable_gifs?
       !DiscourseGifs.component_installed?
     end
+
+    # Only relevant on sites that currently allow uncategorized topics, and must
+    # stay visible after being enabled (which disables that setting).
+    def self.should_display_remove_and_replace_uncategorized?
+      SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.should_display_upcoming_change?
+    end
   end
 
   def self.user_enabled_reasons

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -724,6 +724,7 @@ RSpec.describe SiteSettingExtension do
               },
             )
             settings.refresh!
+            allow(UpcomingChanges).to receive(:enabled?).and_return(false)
             allow(UpcomingChanges).to receive(:enabled?).with(:enable_cool_thing).and_return(true)
           end
 
@@ -745,6 +746,7 @@ RSpec.describe SiteSettingExtension do
               },
             )
             settings.refresh!
+            allow(UpcomingChanges).to receive(:enabled?).and_return(false)
             allow(UpcomingChanges).to receive(:enabled?).with(:enable_cool_thing).and_return(true)
           end
 

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -845,6 +845,18 @@ RSpec.describe UpcomingChanges do
       )
     end
 
+    it "dispatches remove_and_replace_uncategorized to the action service display rule" do
+      SiteSetting.allow_uncategorized_topics = true
+      expect(
+        UpcomingChanges::ConditionalDisplay.should_display?(:remove_and_replace_uncategorized),
+      ).to eq(true)
+
+      SiteSetting.allow_uncategorized_topics = false
+      expect(
+        UpcomingChanges::ConditionalDisplay.should_display?(:remove_and_replace_uncategorized),
+      ).to eq(false)
+    end
+
     context "when the conditional display method is defined for an upcoming change" do
       context "when the conditional display method returns true" do
         before do

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -845,18 +845,6 @@ RSpec.describe UpcomingChanges do
       )
     end
 
-    it "dispatches remove_and_replace_uncategorized to the action service display rule" do
-      SiteSetting.allow_uncategorized_topics = true
-      expect(
-        UpcomingChanges::ConditionalDisplay.should_display?(:remove_and_replace_uncategorized),
-      ).to eq(true)
-
-      SiteSetting.allow_uncategorized_topics = false
-      expect(
-        UpcomingChanges::ConditionalDisplay.should_display?(:remove_and_replace_uncategorized),
-      ).to eq(false)
-    end
-
     context "when the conditional display method is defined for an upcoming change" do
       context "when the conditional display method returns true" do
         before do

--- a/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
+++ b/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
@@ -42,15 +42,16 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       )
     end
 
-    it "creates an automatically_promoted event with the snapshot when there is no opt-in event" do
-      described_class.call(enabled: true)
-
+    it "snapshots the prior state onto the existing automatically_promoted event" do
       event =
-        UpcomingChangeEvent.find_by(
+        UpcomingChangeEvent.create!(
           event_type: :automatically_promoted,
           upcoming_change_name: "remove_and_replace_uncategorized",
         )
-      expect(event.event_data["uncategorized_category_id"]).to eq(uncategorized.id)
+
+      described_class.call(enabled: true)
+
+      expect(event.reload.event_data["uncategorized_category_id"]).to eq(uncategorized.id)
       expect(event.event_data["allow_uncategorized_topics"]).to eq(true)
     end
 
@@ -78,7 +79,12 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
     end
 
     it "is idempotent and does not re-snapshot when already migrated" do
+      UpcomingChangeEvent.create!(
+        event_type: :automatically_promoted,
+        upcoming_change_name: "remove_and_replace_uncategorized",
+      )
       described_class.call(enabled: true)
+      snapshot = UpcomingChangeEvent.last.event_data
       original_event_count = UpcomingChangeEvent.count
 
       # Simulate drift that should be ignored because the change is already applied.
@@ -86,6 +92,7 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       described_class.call(enabled: true)
 
       expect(UpcomingChangeEvent.count).to eq(original_event_count)
+      expect(UpcomingChangeEvent.last.event_data).to eq(snapshot)
     end
   end
 

--- a/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
+++ b/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
       expect(SiteSetting.default_composer_category).to eq(uncategorized.id.to_s)
     end
 
+    it "pins the now-normal category as the composer default when none was set" do
+      SiteSetting.default_composer_category = ""
+
+      described_class.call(enabled: true)
+
+      expect(SiteSetting.default_composer_category).to eq(uncategorized.id.to_s)
+    end
+
+    it "leaves an unrelated default_composer_category untouched" do
+      other_category = Fabricate(:category)
+      SiteSetting.default_composer_category = other_category.id.to_s
+
+      described_class.call(enabled: true)
+
+      expect(SiteSetting.default_composer_category).to eq(other_category.id.to_s)
+    end
+
     it "snapshots the prior state onto the existing manual_opt_in event" do
       SiteSetting.default_composer_category = uncategorized.id.to_s
       event =

--- a/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
+++ b/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
@@ -162,17 +162,17 @@ RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
     end
   end
 
-  describe ".apply_hidden_settings" do
-    it "hides the legacy uncategorized settings only while the change is enabled" do
-      base = Set.new([:some_other_setting])
+  describe "hidden legacy settings" do
+    # Declared via `hide_settings:` in the upcoming change metadata
+    # (config/site_settings.yml) and resolved live by the framework.
+    let(:legacy_settings) { %i[allow_uncategorized_topics suppress_uncategorized_badge] }
 
-      expect(described_class.apply_hidden_settings(base)).to eq(base)
+    it "hides the legacy uncategorized settings only while the change is enabled" do
+      expect(SiteSetting.hidden_settings).not_to include(*legacy_settings)
 
       SiteSetting.remove_and_replace_uncategorized = true
 
-      expect(described_class.apply_hidden_settings(base)).to include(
-        *described_class::HIDDEN_SETTINGS,
-      )
+      expect(SiteSetting.hidden_settings).to include(*legacy_settings)
     end
   end
 end

--- a/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
+++ b/spec/services/site_setting/action/remove_and_replace_uncategorized_toggled_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+RSpec.describe SiteSetting::Action::RemoveAndReplaceUncategorizedToggled do
+  fab!(:uncategorized) { Fabricate(:category, name: "Special category") }
+
+  before do
+    SiteSetting.uncategorized_category_id = uncategorized.id
+    SiteSetting.allow_uncategorized_topics = true
+  end
+
+  describe "enabling" do
+    it "demotes the special category in place and disallows uncategorized topics" do
+      described_class.call(enabled: true)
+
+      expect(SiteSetting.uncategorized_category_id).to eq(-1)
+      expect(SiteSetting.allow_uncategorized_topics).to eq(false)
+      expect(uncategorized.reload.uncategorized?).to eq(false)
+    end
+
+    it "leaves default_composer_category pointing at the now-normal category" do
+      SiteSetting.default_composer_category = uncategorized.id.to_s
+
+      described_class.call(enabled: true)
+
+      expect(SiteSetting.default_composer_category).to eq(uncategorized.id.to_s)
+    end
+
+    it "snapshots the prior state onto the existing manual_opt_in event" do
+      SiteSetting.default_composer_category = uncategorized.id.to_s
+      event =
+        UpcomingChangeEvent.create!(
+          event_type: :manual_opt_in,
+          upcoming_change_name: "remove_and_replace_uncategorized",
+        )
+
+      described_class.call(enabled: true)
+
+      expect(event.reload.event_data).to eq(
+        "allow_uncategorized_topics" => true,
+        "default_composer_category" => uncategorized.id.to_s,
+        "uncategorized_category_id" => uncategorized.id,
+      )
+    end
+
+    it "creates an automatically_promoted event with the snapshot when there is no opt-in event" do
+      described_class.call(enabled: true)
+
+      event =
+        UpcomingChangeEvent.find_by(
+          event_type: :automatically_promoted,
+          upcoming_change_name: "remove_and_replace_uncategorized",
+        )
+      expect(event.event_data["uncategorized_category_id"]).to eq(uncategorized.id)
+      expect(event.event_data["allow_uncategorized_topics"]).to eq(true)
+    end
+
+    it "captures the snapshot even when an unrelated event already carries event_data" do
+      # The framework records a `status_changed` event whose event_data holds the
+      # status transition. The snapshot lookup must ignore it, not treat it as an
+      # existing snapshot.
+      UpcomingChangeEvent.create!(
+        event_type: :status_changed,
+        upcoming_change_name: "remove_and_replace_uncategorized",
+        event_data: {
+          previous_value: nil,
+          new_value: "experimental",
+        },
+      )
+      opt_in =
+        UpcomingChangeEvent.create!(
+          event_type: :manual_opt_in,
+          upcoming_change_name: "remove_and_replace_uncategorized",
+        )
+
+      described_class.call(enabled: true)
+
+      expect(opt_in.reload.event_data).to include("uncategorized_category_id" => uncategorized.id)
+    end
+
+    it "is idempotent and does not re-snapshot when already migrated" do
+      described_class.call(enabled: true)
+      original_event_count = UpcomingChangeEvent.count
+
+      # Simulate drift that should be ignored because the change is already applied.
+      SiteSetting.uncategorized_category_id = -1
+      described_class.call(enabled: true)
+
+      expect(UpcomingChangeEvent.count).to eq(original_event_count)
+    end
+  end
+
+  describe "disabling" do
+    it "restores the special category and the prior settings from the snapshot" do
+      SiteSetting.default_composer_category = uncategorized.id.to_s
+      UpcomingChangeEvent.create!(
+        event_type: :automatically_promoted,
+        upcoming_change_name: "remove_and_replace_uncategorized",
+        event_data: {
+          allow_uncategorized_topics: true,
+          default_composer_category: uncategorized.id.to_s,
+          uncategorized_category_id: uncategorized.id,
+        },
+      )
+      # Site is currently in the "enabled" state.
+      SiteSetting.uncategorized_category_id = -1
+      SiteSetting.allow_uncategorized_topics = false
+      SiteSetting.default_composer_category = ""
+
+      described_class.call(enabled: false)
+
+      expect(SiteSetting.uncategorized_category_id).to eq(uncategorized.id)
+      expect(SiteSetting.allow_uncategorized_topics).to eq(true)
+      expect(SiteSetting.default_composer_category).to eq(uncategorized.id.to_s)
+      expect(uncategorized.reload.uncategorized?).to eq(true)
+    end
+
+    it "does nothing when the site was not using uncategorized topics at opt-in" do
+      UpcomingChangeEvent.create!(
+        event_type: :automatically_promoted,
+        upcoming_change_name: "remove_and_replace_uncategorized",
+        event_data: {
+          allow_uncategorized_topics: false,
+          default_composer_category: "",
+          uncategorized_category_id: uncategorized.id,
+        },
+      )
+      SiteSetting.uncategorized_category_id = -1
+      SiteSetting.allow_uncategorized_topics = false
+
+      described_class.call(enabled: false)
+
+      expect(SiteSetting.uncategorized_category_id).to eq(-1)
+      expect(SiteSetting.allow_uncategorized_topics).to eq(false)
+    end
+
+    it "does nothing when there is no snapshot" do
+      SiteSetting.uncategorized_category_id = -1
+      SiteSetting.allow_uncategorized_topics = false
+
+      described_class.call(enabled: false)
+
+      expect(SiteSetting.uncategorized_category_id).to eq(-1)
+      expect(SiteSetting.allow_uncategorized_topics).to eq(false)
+    end
+  end
+
+  describe ".should_display_upcoming_change?" do
+    it "is displayed while the site allows uncategorized topics" do
+      SiteSetting.allow_uncategorized_topics = true
+      expect(described_class.should_display_upcoming_change?).to eq(true)
+    end
+
+    it "is hidden once uncategorized topics are disallowed and the change is off" do
+      SiteSetting.allow_uncategorized_topics = false
+      expect(described_class.should_display_upcoming_change?).to eq(false)
+    end
+
+    it "stays displayed after the change is enabled even though uncategorized is disallowed" do
+      SiteSetting.allow_uncategorized_topics = false
+      SiteSetting.remove_and_replace_uncategorized = true
+      expect(described_class.should_display_upcoming_change?).to eq(true)
+    end
+  end
+
+  describe ".apply_hidden_settings" do
+    it "hides the legacy uncategorized settings only while the change is enabled" do
+      base = Set.new([:some_other_setting])
+
+      expect(described_class.apply_hidden_settings(base)).to eq(base)
+
+      SiteSetting.remove_and_replace_uncategorized = true
+
+      expect(described_class.apply_hidden_settings(base)).to include(
+        *described_class::HIDDEN_SETTINGS,
+      )
+    end
+  end
+end

--- a/spec/services/upcoming_changes/notify_promotion_spec.rb
+++ b/spec/services/upcoming_changes/notify_promotion_spec.rb
@@ -162,6 +162,29 @@ RSpec.describe UpcomingChanges::NotifyPromotion do
         }.by(1)
       end
 
+      it "creates an automatically_promoted event recording the promotion" do
+        expect { result }.to change {
+          UpcomingChangeEvent.where(
+            event_type: :automatically_promoted,
+            upcoming_change_name: :enable_upload_debug_mode,
+          ).count
+        }.by(1)
+      end
+
+      it "does not create a duplicate automatically_promoted event when one already exists" do
+        UpcomingChangeEvent.create!(
+          event_type: :automatically_promoted,
+          upcoming_change_name: :enable_upload_debug_mode,
+        )
+
+        expect { result }.not_to change {
+          UpcomingChangeEvent.where(
+            event_type: :automatically_promoted,
+            upcoming_change_name: :enable_upload_debug_mode,
+          ).count
+        }
+      end
+
       it "triggers DiscourseEvent for the promoted setting" do
         expect(event[:params]).to eq([:enable_upload_debug_mode])
       end


### PR DESCRIPTION
Removes the Uncategorized category concept to reduce product complexity.

We are using an Upcoming Change to safely manage this migration and removal. Part of that process is storing a snapshot of settings prior to toggling the change (either manually or via promotion) so we can easily opt out later without causing disruption.

When enabled we hide the following site settings from the admin screen, all of which will be removed when the change reaches the `permanent` status:

- allow_uncategorized_topics
- suppress_uncategorized_badge
- uncategorized_category_id

Internal ref: /t/183820