### PR TITLE
FIX: add desktopView key to createTopicLabel for responsiveness

### DIFF
--- a/frontend/discourse/app/components/d-navigation.gjs
+++ b/frontend/discourse/app/components/d-navigation.gjs
@@ -36,6 +36,7 @@ export default class DNavigation extends Component {
     return this.siteSettings.fixed_category_positions;
   }
 
+  @computed("category", "site.shared_drafts_category_id", "site.desktopView")
   get createTopicLabel() {
     const defaultKey = "topic.create";
     let value = this.site.desktopView ? defaultKey : "";

--- a/frontend/discourse/app/components/d-navigation.gjs
+++ b/frontend/discourse/app/components/d-navigation.gjs
@@ -36,7 +36,6 @@ export default class DNavigation extends Component {
     return this.siteSettings.fixed_category_positions;
   }
 
-  @computed("category", "site.shared_drafts_category_id")
   get createTopicLabel() {
     const defaultKey = "topic.create";
     let value = this.site.desktopView ? defaultKey : "";


### PR DESCRIPTION
Concerns the new topic button

<img width="200" alt="image" src="https://github.com/user-attachments/assets/53ef9221-10eb-4e55-bc9e-2da95cac0036" />

Adding `"site.desktopView"` allows this to recompute on viewport change, initially thought we could remove the computed values and autotrack but that wasn't working for button changes for the events plugin 