### PR TITLE
UX: Fix unread + new "topics remaining" links when unified new enabled

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4287,25 +4287,25 @@ en:
           true {
             { UNREAD, plural,
                  =0 {}
-                one {There is <a href="{basePath}/unread"># unread</a>}
-              other {There are <a href="{basePath}/unread"># unread</a>}
+                one {There is <a href="{unreadUrl}"># unread</a>}
+              other {There are <a href="{unreadUrl}"># unread</a>}
             }
             { NEW, plural,
                  =0 {}
-                one { and <a href="{basePath}/new"># new</a> topic remaining,}
-              other { and <a href="{basePath}/new"># new</a> topics remaining,}
+                one { and <a href="{newUrl}"># new</a> topic remaining,}
+              other { and <a href="{newUrl}"># new</a> topics remaining,}
             }
           }
           false {
             { UNREAD, plural,
                  =0 {}
-                one {There is <a href="{basePath}/unread"># unread</a> topic remaining,}
-              other {There are <a href="{basePath}/unread"># unread</a> topics remaining,}
+                one {There is <a href="{unreadUrl}"># unread</a> topic remaining,}
+              other {There are <a href="{unreadUrl}"># unread</a> topics remaining,}
             }
             { NEW, plural,
                  =0 {}
-                one {There is <a href="{basePath}/new"># new</a> topic remaining,}
-              other {There are <a href="{basePath}/new"># new</a> topics remaining,}
+                one {There is <a href="{newUrl}"># new</a> topic remaining,}
+              other {There are <a href="{newUrl}"># new</a> topics remaining,}
             }
           }
           other {}

--- a/frontend/discourse/app/components/more-topics/browse-more.gjs
+++ b/frontend/discourse/app/components/more-topics/browse-more.gjs
@@ -11,6 +11,7 @@ export default class BrowseMore extends Component {
   @service pmTopicTrackingState;
   @service site;
   @service topicTrackingState;
+  @service siteSettings;
 
   groupLink(groupName) {
     return `<a class="group-link" href="${getURL(
@@ -89,6 +90,12 @@ export default class BrowseMore extends Component {
         HAS_CATEGORY: !!category,
         categoryLink: category ? categoryBadgeHTML(category) : null,
         basePath: getURL(""),
+        unreadUrl: this.siteSettings.enable_unified_new
+          ? getURL("/new?subset=replies")
+          : getURL("/unread"),
+        newUrl: this.siteSettings.enable_unified_new
+          ? getURL("/new?subset=topics")
+          : getURL("/new"),
       });
     } else if (category) {
       return i18n("topic.read_more_in_category", {


### PR DESCRIPTION
Fixes the links in the following browse more section at the bottom of
the topic to point to the correct New tab (Topics, Replies) if unified
new is enabled:

> There are UNREAD_LINK and NEW_LINK topics remaining, or browse other topics in
CATEGORY_LINK

c.f. https://meta.discourse.org/t/introducing-the-unified-new-view-for-the-topic-list/404728/12?u=martin
