### PR TITLE
FIX: Keep Data Explorer cache index aligned with result TTLs

### DIFF
--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_result_cache.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/query_result_cache.rb
@@ -29,6 +29,7 @@ module DiscourseDataExplorer
       key = cache_key(query_id, params_hash)
       index_key = cache_index_key(query_id)
       now = Time.now.to_f
+      prune_stale_entries(index_key, now)
       return false if limit_reached?(index_key, key)
 
       Discourse.redis.setex(key, CACHE_TTL, serialized)
@@ -55,6 +56,10 @@ module DiscourseDataExplorer
       Discourse.redis.zcard(index_key) >= MAX_CACHE_ENTRIES
     end
 
-    private_class_method :limit_reached?
+    def self.prune_stale_entries(index_key, now)
+      Discourse.redis.zremrangebyscore(index_key, "-inf", now - CACHE_TTL)
+    end
+
+    private_class_method :limit_reached?, :prune_stale_entries
   end
 end

--- a/plugins/discourse-data-explorer/spec/lib/query_result_cache_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/query_result_cache_spec.rb
@@ -67,6 +67,25 @@ describe DiscourseDataExplorer::QueryResultCache do
         described_class::MAX_CACHE_ENTRIES,
       )
     end
+
+    it "caches new entries after old index members expire" do
+      index_key = described_class.cache_index_key(query.id)
+      stale_score = Time.now.to_f - described_class::CACHE_TTL - 1
+      stale_keys =
+        described_class::MAX_CACHE_ENTRIES.times.map do |i|
+          params = { "value" => i.to_s }
+          described_class.write(query.id, params, result_json)
+          described_class.cache_key(query.id, params)
+        end
+
+      Discourse.redis.del(*stale_keys)
+      stale_keys.each { |stale_key| Discourse.redis.zadd(index_key, stale_score, stale_key) }
+
+      fresh_params = { "value" => "fresh" }
+
+      expect(described_class.write(query.id, fresh_params, result_json)).to eq(true)
+      expect(described_class.read(query.id, fresh_params)).to be_present
+    end
   end
 
   describe ".cache_key" do


### PR DESCRIPTION
Data Explorer result cache keys expired with a TTL, but their per-query index entries could continue counting toward the cache limit. 

This PR prunes expired index entries before checking the limit, so new parameter combinations can be cached as older results age out.