### PR TITLE
SECURITY: Prevent expired invite details from leaking

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -545,12 +545,13 @@ class UsersController < ApplicationController
         fetch_user_from_params(
           include_inactive: current_user.staff? || SiteSetting.show_inactive_accounts,
         )
+      can_see_invite_details = guardian.can_see_invite_details?(inviter)
 
       invites =
-        if filter == "pending" && guardian.can_see_invite_details?(inviter)
+        if filter == "pending" && can_see_invite_details
           Invite.includes(:topics, :groups).pending(inviter)
-        elsif filter == "expired"
-          Invite.expired(inviter)
+        elsif filter == "expired" && can_see_invite_details
+          Invite.includes(:topics, :groups).expired(inviter)
         elsif filter == "redeemed"
           Invite.redeemed_users(inviter)
         else
@@ -567,8 +568,8 @@ class UsersController < ApplicationController
         invites = invites.where(filter_sql, filter: "%#{params[:search].downcase}%")
       end
 
-      pending_count = Invite.pending(inviter).reorder(nil).count.to_i
-      expired_count = Invite.expired(inviter).reorder(nil).count.to_i
+      pending_count = can_see_invite_details ? Invite.pending(inviter).reorder(nil).count.to_i : 0
+      expired_count = can_see_invite_details ? Invite.expired(inviter).reorder(nil).count.to_i : 0
       redeemed_count = Invite.redeemed_users(inviter).reorder(nil).count.to_i
 
       render json:

--- a/app/serializers/invite_serializer.rb
+++ b/app/serializers/invite_serializer.rb
@@ -20,12 +20,28 @@ class InviteSerializer < ApplicationSerializer
   has_many :topics, embed: :object, serializer: BasicTopicSerializer
   has_many :groups, embed: :object, serializer: BasicGroupSerializer
 
+  def include_invite_key?
+    can_see_invite_details?
+  end
+
+  def include_link?
+    can_see_invite_details?
+  end
+
+  def include_description?
+    can_see_invite_details?
+  end
+
   def include_email?
-    options[:show_emails] && !object.redeemed?
+    options[:show_emails] && !object.redeemed? && can_see_invite_emails?
+  end
+
+  def include_domain?
+    can_see_invite_details?
   end
 
   def include_emailed?
-    email.present?
+    email.present? && can_see_invite_details?
   end
 
   def emailed
@@ -37,18 +53,44 @@ class InviteSerializer < ApplicationSerializer
   end
 
   def include_custom_message?
-    email.present?
+    email.present? && can_see_invite_details?
   end
 
   def include_max_redemptions_allowed?
-    email.blank?
+    email.blank? && can_see_invite_details?
   end
 
   def include_redemption_count?
-    email.blank?
+    email.blank? && can_see_invite_details?
+  end
+
+  def include_topics?
+    can_see_invite_details?
+  end
+
+  def topics
+    object.topics.select { |topic| scope.can_see?(topic) }
+  end
+
+  def include_groups?
+    can_see_invite_details?
   end
 
   def expired
     object.expired?
+  end
+
+  private
+
+  def can_see_invite_details?
+    return @can_see_invite_details if defined?(@can_see_invite_details)
+
+    @can_see_invite_details = scope.can_see_invite_details?(object.invited_by)
+  end
+
+  def can_see_invite_emails?
+    return @can_see_invite_emails if defined?(@can_see_invite_emails)
+
+    @can_see_invite_emails = scope.can_see_invite_emails?(object.invited_by)
   end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2529,6 +2529,25 @@ RSpec.describe UsersController do
           expect(invites[0]).to include("id" => invite.id)
         end
       end
+
+      context "with expired invites" do
+        it "returns an empty list without permission to see invite details" do
+          viewer = Fabricate(:user, trust_level: TrustLevel[2])
+          sign_in(viewer)
+          Fabricate(:invite, invited_by: inviter, expires_at: 1.day.ago)
+
+          get "/u/#{inviter.username}/invited/expired.json"
+
+          expect(response.status).to eq(200)
+          expect(response.parsed_body["can_see_invite_details"]).to eq(false)
+          expect(response.parsed_body["invites"]).to eq([])
+          expect(response.parsed_body["counts"]).to include(
+            "pending" => 0,
+            "expired" => 0,
+            "total" => 0,
+          )
+        end
+      end
     end
   end
 

--- a/spec/serializers/invite_serializer_spec.rb
+++ b/spec/serializers/invite_serializer_spec.rb
@@ -1,6 +1,55 @@
 # frozen_string_literal: true
 
 RSpec.describe InviteSerializer do
+  describe "#as_json" do
+    fab!(:user)
+    fab!(:viewer) { Fabricate(:user, trust_level: TrustLevel[2]) }
+    fab!(:group)
+    fab!(:private_category) { Fabricate(:private_category, group: group) }
+    fab!(:private_topic) { Fabricate(:topic, category: private_category) }
+
+    it "hides sensitive fields without permission to see invite details" do
+      invite =
+        Fabricate(
+          :invite,
+          invited_by: user,
+          description: "private invite note",
+          custom_message: "private invite message",
+        )
+
+      json =
+        InviteSerializer.new(
+          invite,
+          scope: Guardian.new(viewer),
+          root: false,
+          show_emails: true,
+        ).as_json
+
+      expect(json).not_to include(
+        :invite_key,
+        :link,
+        :description,
+        :email,
+        :domain,
+        :emailed,
+        :max_redemptions_allowed,
+        :redemption_count,
+        :custom_message,
+        :topics,
+        :groups,
+      )
+    end
+
+    it "filters topics by guardian visibility" do
+      invite = Fabricate(:invite, invited_by: user)
+      TopicInvite.create!(invite: invite, topic: private_topic)
+
+      json = InviteSerializer.new(invite, scope: Guardian.new(user), root: false).as_json
+
+      expect(json[:topics]).to eq([])
+    end
+  end
+
   describe "#can_delete_invite" do
     fab!(:user)
     fab!(:admin)


### PR DESCRIPTION
This PR applies the existing invite-details guard to expired invites, matching pending invites.