### PR TITLE
DEV: Reuse `SettingDefinitionField` for workflows forms

### DIFF
--- a/frontend/discourse/app/components/setting-definition-field.gjs
+++ b/frontend/discourse/app/components/setting-definition-field.gjs
@@ -21,6 +21,10 @@ export default class SettingDefinitionField extends Component {
       : this.args.definition.description;
   }
 
+  get format() {
+    return this.args.definition.format ?? this.entry.format;
+  }
+
   get validation() {
     return settingFieldValidation(this.args.definition);
   }
@@ -30,13 +34,18 @@ export default class SettingDefinitionField extends Component {
       @name={{@definition.key}}
       @title={{@definition.label}}
       @description={{this.description}}
+      @placeholder={{@definition.placeholder}}
       @validation={{this.validation}}
       @type={{this.entry.type}}
-      @format={{this.entry.format}}
+      @format={{this.format}}
       @labelFormat={{this.entry.labelFormat}}
       as |field|
     >
-      <this.renderer @field={{field}} @definition={{@definition}} />
+      {{#if this.renderer}}
+        <this.renderer @field={{field}} @definition={{@definition}} />
+      {{else}}
+        <field.Control placeholder={{field.placeholder}} />
+      {{/if}}
     </@form.Field>
   </template>
 }

--- a/frontend/discourse/app/components/setting-field/radio-group.gjs
+++ b/frontend/discourse/app/components/setting-field/radio-group.gjs
@@ -1,0 +1,11 @@
+import { or } from "discourse/truth-helpers";
+
+<template>
+  <@field.Control as |radioGroup|>
+    {{#each (or @definition.valid_values @definition.choices) as |choice|}}
+      <radioGroup.Radio @value={{choice.value}}>
+        {{choice.name}}
+      </radioGroup.Radio>
+    {{/each}}
+  </@field.Control>
+</template>

--- a/frontend/discourse/app/components/setting-field/string.gjs
+++ b/frontend/discourse/app/components/setting-field/string.gjs
@@ -1,1 +1,0 @@
-<template><@field.Control /></template>

--- a/frontend/discourse/app/lib/setting-field-registry.js
+++ b/frontend/discourse/app/lib/setting-field-registry.js
@@ -5,9 +5,12 @@ import DurationControl from "discourse/components/setting-field/duration";
 import EnumControl from "discourse/components/setting-field/enum";
 import GroupListControl from "discourse/components/setting-field/group-list";
 import IntegerControl from "discourse/components/setting-field/integer";
-import StringControl from "discourse/components/setting-field/string";
+import RadioGroupControl from "discourse/components/setting-field/radio-group";
 
 const REGISTRY = {};
+
+const ROW = { format: "large", labelFormat: "full" };
+const INLINE = { format: "full" };
 
 export function registerSettingFieldType(type, entry) {
   REGISTRY[type] = entry;
@@ -48,56 +51,49 @@ function typeKeyFor({ type, subtype, list_type }) {
   return "default";
 }
 
+registerSettingFieldType("default", { ...ROW, type: "input" });
+registerSettingFieldType("textarea", { ...ROW, type: "textarea" });
+registerSettingFieldType("email", { ...ROW, type: "input-email" });
+registerSettingFieldType("date", { ...ROW, type: "input-date" });
+registerSettingFieldType("password", { ...ROW, type: "password" });
+registerSettingFieldType("radio-group", {
+  ...ROW,
+  type: "radio-group",
+  renderer: RadioGroupControl,
+});
+registerSettingFieldType("enum", {
+  ...ROW,
+  type: "select",
+  renderer: EnumControl,
+});
+registerSettingFieldType("group_list", {
+  ...ROW,
+  type: "custom",
+  renderer: GroupListControl,
+});
+registerSettingFieldType("category_list", {
+  ...ROW,
+  type: "custom",
+  renderer: CategoryListControl,
+});
+registerSettingFieldType("compact_list", {
+  ...ROW,
+  type: "custom",
+  renderer: CompactListControl,
+});
 registerSettingFieldType("bool", {
+  ...INLINE,
   type: "checkbox",
-  format: "full",
   includeDescription: false,
   renderer: BoolControl,
 });
-
 registerSettingFieldType("integer", {
+  ...INLINE,
   type: "input-number",
-  format: "full",
   renderer: IntegerControl,
 });
-
-registerSettingFieldType("enum", {
-  type: "select",
-  format: "large",
-  labelFormat: "full",
-  renderer: EnumControl,
-});
-
-registerSettingFieldType("group_list", {
-  type: "custom",
-  format: "large",
-  labelFormat: "full",
-  renderer: GroupListControl,
-});
-
-registerSettingFieldType("category_list", {
-  type: "custom",
-  format: "large",
-  labelFormat: "full",
-  renderer: CategoryListControl,
-});
-
-registerSettingFieldType("compact_list", {
-  type: "custom",
-  format: "large",
-  labelFormat: "full",
-  renderer: CompactListControl,
-});
-
 registerSettingFieldType("duration", {
+  ...INLINE,
   type: "custom",
-  format: "full",
   renderer: DurationControl,
-});
-
-registerSettingFieldType("default", {
-  type: "input",
-  format: "large",
-  labelFormat: "full",
-  renderer: StringControl,
 });

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -236,4 +236,111 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
     assert.dom("[data-name='my_list'] .list-setting").exists();
     assert.dom("[data-name='my_list']").containsText("Alpha");
   });
+
+  test("textarea renders a textarea with a placeholder", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_text=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_text"
+              type="textarea"
+              label="My text"
+              placeholder="Type here"
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_text'] textarea")
+      .hasAttribute("placeholder", "Type here");
+  });
+
+  test("a control-typed entry (email) maps to the matching input type", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_email=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash key="my_email" type="email" label="My email"}}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert.dom("[data-name='my_email'] input").hasAttribute("type", "email");
+  });
+
+  test("radio-group renders a radio per choice", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_choice="a"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_choice"
+              type="radio-group"
+              label="My choice"
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_choice'] input[type='radio'][value='a']")
+      .exists();
+    assert
+      .dom("[data-name='my_choice'] input[type='radio'][value='b']")
+      .exists();
+    assert.dom("[data-name='my_choice']").containsText("Apple");
+  });
+
+  test("placeholder is forwarded to a string control", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_setting=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_setting"
+              type="string"
+              label="My setting"
+              placeholder="Enter a value"
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_setting'] input")
+      .hasAttribute("placeholder", "Enter a value");
+  });
+
+  test("a definition can override the registry entry format", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_setting=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_setting"
+              type="string"
+              label="My setting"
+              format="full"
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert.dom("[data-name='my_setting']").hasClass("--full");
+  });
 });

--- a/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
+++ b/frontend/discourse/tests/unit/lib/setting-field-registry-test.js
@@ -3,7 +3,6 @@ import CategoryListControl from "discourse/components/setting-field/category-lis
 import CompactListControl from "discourse/components/setting-field/compact-list";
 import DurationControl from "discourse/components/setting-field/duration";
 import GroupListControl from "discourse/components/setting-field/group-list";
-import StringControl from "discourse/components/setting-field/string";
 import {
   resolveSettingFieldType,
   settingFieldValidation,
@@ -26,12 +25,17 @@ module("Unit | Lib | setting-field-registry", function () {
       );
     });
 
-    test("falls back to the string control for unknown/missing types", function (assert) {
+    test("falls back to the default text input for unknown/missing types", function (assert) {
       assert.strictEqual(
-        resolveSettingFieldType({ type: "not_a_real_type" }).renderer,
-        StringControl
+        resolveSettingFieldType({ type: "not_a_real_type" }).type,
+        "input"
       );
-      assert.strictEqual(resolveSettingFieldType({}).renderer, StringControl);
+      assert.strictEqual(resolveSettingFieldType({}).type, "input");
+      assert.strictEqual(
+        resolveSettingFieldType({}).renderer,
+        undefined,
+        "the default entry has no custom renderer; the field renders a bare control"
+      );
     });
 
     test("matches a registered subtype before the base type", function (assert) {

--- a/plugins/discourse-workflows/assets/javascripts/discourse/components/workflows-form.gjs
+++ b/plugins/discourse-workflows/assets/javascripts/discourse/components/workflows-form.gjs
@@ -1,22 +1,45 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import Form from "discourse/components/form";
+import SettingDefinitionField from "discourse/components/setting-definition-field";
 import { ajax } from "discourse/lib/ajax";
 import { eq } from "discourse/truth-helpers";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DDecoratedHtml from "discourse/ui-kit/d-decorated-html";
-import dAutoFocus from "discourse/ui-kit/modifiers/d-auto-focus";
 import { i18n } from "discourse-i18n";
 
-function isFormKitType(field, type) {
-  return field.type === type;
-}
+const FIELD_TYPE_TO_SETTING_TYPE = {
+  checkbox: "bool",
+  select: "enum",
+  "input-number": "integer",
+  "input-email": "email",
+  "input-date": "date",
+};
 
-function fieldOptions(field) {
-  return field.options || [];
+function fieldDefinition(field) {
+  const definition = {
+    key: field.name,
+    label: field.title,
+    description: field.description,
+    type: FIELD_TYPE_TO_SETTING_TYPE[field.type] ?? field.type,
+    format: "full",
+    required: (field.validation || "").includes("required"),
+    placeholder: field.placeholder,
+  };
+
+  if (field.options) {
+    definition.valid_values = field.options.map(({ value, label }) => ({
+      value,
+      name: label,
+    }));
+  }
+
+  return definition;
 }
 
 const STRUCTURED_ERROR_TRANSLATIONS = {
@@ -82,19 +105,21 @@ export default class WorkflowsForm extends Component {
 
   @cached
   get fields() {
-    return (this.formSchema.fields || []).map((field, index) => {
+    return (this.formSchema.fields || []).map((field) => {
       if (field.type === "html") {
-        return {
-          ...field,
-          html: trustHTML(field.html || ""),
-          autofocus: index === 0,
-        };
+        return { ...field, html: trustHTML(field.html || "") };
       }
 
-      return {
-        ...field,
-        autofocus: index === 0,
-      };
+      return { ...field, definition: fieldDefinition(field) };
+    });
+  }
+
+  @action
+  focusFirstField(formElement) {
+    schedule("afterRender", () => {
+      formElement
+        .querySelector("input:not([type='hidden']), textarea, select")
+        ?.focus({ preventScroll: true });
     });
   }
 
@@ -260,96 +285,23 @@ export default class WorkflowsForm extends Component {
           {{/if}}
         </div>
 
-        <Form @data={{this.formData}} @onSubmit={{this.handleSubmit}} as |form|>
+        <Form
+          @data={{this.formData}}
+          @onSubmit={{this.handleSubmit}}
+          {{didInsert this.focusFirstField}}
+          as |form|
+        >
           {{#each this.fields as |field|}}
-            {{#if (isFormKitType field "html")}}
+            {{#if (eq field.type "html")}}
               <DDecoratedHtml
                 @html={{field.html}}
                 @className="workflows-form__html"
               />
-            {{else if (isFormKitType field "checkbox")}}
-              <form.Field
-                @type="checkbox"
-                @name={{field.name}}
-                @title={{field.title}}
-                @description={{field.description}}
-                @format="full"
-                as |f|
-              >
-                <f.Control {{(if field.autofocus (modifier dAutoFocus))}} />
-              </form.Field>
-            {{else if (isFormKitType field "textarea")}}
-              <form.Field
-                @type="textarea"
-                @name={{field.name}}
-                @title={{field.title}}
-                @description={{field.description}}
-                @format="full"
-                @validation={{field.validation}}
-                @placeholder={{field.placeholder}}
-                as |f|
-              >
-                <f.Control
-                  placeholder={{field.placeholder}}
-                  {{(if field.autofocus (modifier dAutoFocus))}}
-                />
-              </form.Field>
-            {{else if (isFormKitType field "select")}}
-              <form.Field
-                @type="select"
-                @name={{field.name}}
-                @title={{field.title}}
-                @description={{field.description}}
-                @format="full"
-                @validation={{field.validation}}
-                as |f|
-              >
-                <f.Control
-                  {{(if field.autofocus (modifier dAutoFocus))}}
-                  as |c|
-                >
-                  {{#each (fieldOptions field) as |opt|}}
-                    <c.Option @value={{opt.value}}>{{opt.label}}</c.Option>
-                  {{/each}}
-                </f.Control>
-              </form.Field>
-            {{else if (isFormKitType field "radio-group")}}
-              <form.Field
-                @type="radio-group"
-                @name={{field.name}}
-                @title={{field.title}}
-                @description={{field.description}}
-                @format="full"
-                @validation={{field.validation}}
-                as |f|
-              >
-                <f.Control
-                  {{(if field.autofocus (modifier dAutoFocus))}}
-                  as |RadioGroup|
-                >
-                  {{#each (fieldOptions field) as |opt|}}
-                    <RadioGroup.Radio
-                      @value={{opt.value}}
-                    >{{opt.label}}</RadioGroup.Radio>
-                  {{/each}}
-                </f.Control>
-              </form.Field>
             {{else}}
-              <form.Field
-                @type={{field.type}}
-                @name={{field.name}}
-                @title={{field.title}}
-                @description={{field.description}}
-                @format="full"
-                @validation={{field.validation}}
-                @placeholder={{field.placeholder}}
-                as |f|
-              >
-                <f.Control
-                  placeholder={{field.placeholder}}
-                  {{(if field.autofocus (modifier dAutoFocus))}}
-                />
-              </form.Field>
+              <SettingDefinitionField
+                @definition={{field.definition}}
+                @form={{form}}
+              />
             {{/if}}
           {{/each}}
 

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows-form-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows-form-test.gjs
@@ -106,6 +106,20 @@ module("Integration | Component | WorkflowsForm", function (hooks) {
     assert.dom('input[name="tracking_id"]').doesNotExist();
   });
 
+  test("autofocuses the first field", async function (assert) {
+    this.set("model", {
+      data: { name: "", email: "" },
+      fields: [
+        { name: "name", title: "Name", type: "input" },
+        { name: "email", title: "Email", type: "input-email" },
+      ],
+    });
+
+    await render(<template><WorkflowsForm @model={{this.model}} /></template>);
+
+    assert.dom('input[name="name"]').isFocused();
+  });
+
   test("renders the test mode banner", async function (assert) {
     this.set("model", {
       form_mode: "test",


### PR DESCRIPTION
Follow-up to #41099.

Previously, the workflows form hand-rolled its own `if/else` chain of FormKit fields, duplicating the type-to-control mapping that `SettingDefinitionField` was introduced to centralize.

This change builds a setting definition per field and renders the shared component instead, so workflows forms render consistently with the rest of admin and the mapping lives in one place. Along the way it:

- extends the registry with the field types workflows needs and adds a `radio-group` control;
- collapses the registry's repeated entries into two layout profiles (a labelled "row" and a compact inline control) to cut boilerplate;
- falls back to a bare FormKit control when an entry has no custom renderer, retiring the redundant `StringControl`; and
- focuses the first field at the form level (the per-field autofocus modifier can no longer reach the control now that it's encapsulated inside `SettingDefinitionField`), deferred to `afterRender` and passing `preventScroll` so loading a form no longer jumps the page to the first input.
