### PR TITLE
FIX: Show solved status on topic titles loaded directly

### DIFF
--- a/plugins/discourse-solved/lib/discourse_solved/topic_view_serializer_extension.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/topic_view_serializer_extension.rb
@@ -3,7 +3,7 @@
 module DiscourseSolved::TopicViewSerializerExtension
   extend ActiveSupport::Concern
 
-  prepended { attributes :accepted_answers }
+  prepended { attributes :accepted_answers, :has_accepted_answer }
 
   def include_accepted_answers?
     SiteSetting.solved_enabled? && object.topic.topic_answers.any?
@@ -11,5 +11,13 @@ module DiscourseSolved::TopicViewSerializerExtension
 
   def accepted_answers
     DiscourseSolved::AcceptedAnswersHelper.serialize(object.topic, scope)
+  end
+
+  def include_has_accepted_answer?
+    SiteSetting.solved_enabled?
+  end
+
+  def has_accepted_answer
+    object.topic.topic_answers.any?
   end
 end

--- a/plugins/discourse-solved/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-solved/spec/serializers/topic_view_serializer_spec.rb
@@ -51,4 +51,25 @@ describe TopicViewSerializer do
       end
     end
   end
+
+  describe "#has_accepted_answer" do
+    it "is true when the topic has an accepted answer" do
+      Fabricate(:solved_topic, topic: topic, answer_post: post2)
+      serializer = TopicViewSerializer.new(TopicView.new(topic), scope: Guardian.new(user))
+      expect(serializer.as_json[:topic_view][:has_accepted_answer]).to eq(true)
+    end
+
+    it "is false when the topic has no accepted answer" do
+      unsolved_topic = Fabricate(:topic)
+      serializer = TopicViewSerializer.new(TopicView.new(unsolved_topic), scope: Guardian.new(user))
+      expect(serializer.as_json[:topic_view][:has_accepted_answer]).to eq(false)
+    end
+
+    it "is not included when solved is disabled" do
+      SiteSetting.solved_enabled = false
+      Fabricate(:solved_topic, topic: topic, answer_post: post2)
+      serializer = TopicViewSerializer.new(TopicView.new(topic), scope: Guardian.new(user))
+      expect(serializer.as_json[:topic_view]).not_to have_key(:has_accepted_answer)
+    end
+  end
 end


### PR DESCRIPTION
### What & why
The solved status checkmark next to a topic **title** renders inconsistently: it shows when you
reach a solved topic from a topic list, but is **missing on a direct load / hard refresh** of the
same topic (the accepted-answer accordion is unaffected).

The `after-topic-status` connector gates the title tick on
`topic.has_accepted_answer || topic.accepted_answer`. `has_accepted_answer` is added (via
`TopicAnswerMixin`) only to the topic **list** serializers, **not** `TopicViewSerializer`, which
serializes only `accepted_answers` (plural, for the accordion). So on a direct topic load neither
flag is present and the connector renders nothing — the tick only appears when the topic was
reached from a list (whose serializer carries the flag on the cached record).

### Fix
Expose `has_accepted_answer` on `TopicViewSerializer` too (mirroring the mixin), so the title
indicator is consistent regardless of navigation path. No front-end change.

### Tests
Adds `#has_accepted_answer` specs to `topic_view_serializer_spec.rb` (true when solved, false when
not, omitted when `solved_enabled` is off).