### PR TITLE
UX: add arrow to chat reactions popup

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message-reaction.gjs
@@ -61,6 +61,8 @@ export default class ChatMessageReaction extends Component {
       groupIdentifier: "chat-message-reaction-users",
       component: ChatMessageReactionsUsers,
       modalForMobile: true,
+      arrow: true,
+      offset: 15,
       placement: "bottom",
       fallbackPlacements: ["top"],
       triggers: desktop ? ["hover"] : ["hold"],


### PR DESCRIPTION
We added a new chat reactions popup in #41028 - the popup arrow that points to the reaction on desktop was missing.

<img width="327" height="144" alt="Screenshot 2026-06-25 at 3 45 43 PM" src="https://github.com/user-attachments/assets/eeb2c451-896d-4494-9a5e-f115b335a1e7" />
