### PR TITLE
FIX: Hide events from unlisted topics on the calendar

### DIFF
--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -184,7 +184,9 @@ module DiscoursePostEvent
     end
 
     def self.listable_topics(guardian)
-      Topic.listable_topics.secured(guardian)
+      topics = Topic.listable_topics.secured(guardian)
+      topics = topics.visible unless guardian.can_see_unlisted_topics?
+      topics
     end
 
     def self.private_messages(user)

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -118,6 +118,41 @@ describe DiscoursePostEvent::EventFinder do
     end
   end
 
+  context "when the event is associated to an unlisted topic" do
+    fab!(:admin)
+    fab!(:trust_level_4)
+    let(:post1) do
+      PostCreator.create!(
+        user,
+        title: "We should buy a boat",
+        raw: "The boat market is quite active lately.",
+      )
+    end
+    let!(:event) { Fabricate(:event, post: post1) }
+
+    before { post1.topic.update_column(:visible, false) }
+
+    it "doesn’t return the event for regular users" do
+      expect(finder.search(current_user)).to match_array([])
+    end
+
+    it "doesn’t return the event for anonymous users" do
+      expect(finder.search(nil)).to match_array([])
+    end
+
+    it "doesn’t return the event for the topic author" do
+      expect(finder.search(user)).to match_array([])
+    end
+
+    it "returns the event for staff" do
+      expect(finder.search(admin)).to match_array([event])
+    end
+
+    it "returns the event for trust level 4 users" do
+      expect(finder.search(trust_level_4)).to match_array([event])
+    end
+  end
+
   context "when events are filtered" do
     describe "by post_id" do
       let(:post1) do


### PR DESCRIPTION
Previously, the calendar — along with the `/upcoming-events` page and the `.ics` subscription feed — listed events from unlisted topics to everyone, because `EventFinder` scoped events with `Topic.listable_topics`, which only excludes private messages and never filters out unlisted (`visible: false`) topics. Unlisting a topic (manually, or as a side effect of spam flagging or a moderator action) therefore removed it from the topic list but left its event on the calendar for all users.

This change makes `EventFinder`'s `listable_topics` apply the `visible` scope unless the user can see unlisted topics (`Guardian#can_see_unlisted_topics?`), mirroring how `TopicQuery` filters topic listings: staff and TL4 users still see events from unlisted topics, while everyone else no longer does.

Meta: https://meta.discourse.org/t/events-from-unlisted-topics-show-on-calendar/406032
