### PR TITLE
SECURITY: Honor group visibility in discourse-assign group lookups [backport 2026.1]

### DIFF
--- a/plugins/discourse-assign/app/controllers/discourse_assign/assign_controller.rb
+++ b/plugins/discourse-assign/app/controllers/discourse_assign/assign_controller.rb
@@ -56,6 +56,7 @@ module DiscourseAssign
         )
 
       raise Discourse::NotFound unless assign_to
+      guardian.ensure_can_see_group!(assign_to) if assign_to.is_a?(Group)
       raise Discourse::NotFound if !Assignment.valid_type?(target_type)
       target = target_type.constantize.where(id: target_id).first
       raise Discourse::NotFound unless target
@@ -129,6 +130,7 @@ module DiscourseAssign
 
       group = Group.find_by(name: params[:group_name])
 
+      guardian.ensure_can_see_group!(group)
       guardian.ensure_can_see_group_members!(group)
 
       users_with_assignments_count =

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -442,6 +442,7 @@ after_initialize do
 
   add_to_class(:list_controller, :group_topics_assigned) do
     group = Group.find_by("name = ?", params[:groupname])
+    guardian.ensure_can_see_group!(group)
     guardian.ensure_can_see_group_members!(group)
 
     raise Discourse::NotFound unless group
@@ -985,7 +986,12 @@ after_initialize do
       posts.where(<<~SQL, user_id)
         topics.id IN (SELECT a.topic_id FROM assignments a WHERE a.assigned_to_id = ? AND a.assigned_to_type = 'User' AND a.active)
       SQL
-    elsif group_id = Group.find_by(name: match)&.id
+    elsif group_id =
+          Group
+            .visible_groups(@guardian.user)
+            .members_visible_groups(@guardian.user)
+            .where(name: match)
+            .pick(:id)
       posts.where(<<~SQL, group_id)
         topics.id IN (SELECT a.topic_id FROM assignments a WHERE a.assigned_to_id = ? AND a.assigned_to_type = 'Group' AND a.active)
       SQL

--- a/plugins/discourse-assign/spec/components/search_spec.rb
+++ b/plugins/discourse-assign/spec/components/search_spec.rb
@@ -49,6 +49,35 @@ describe Search do
       ).to eq(2)
     end
 
+    it "does not let assigned:<group> resolve a group the user cannot see" do
+      hidden_group =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:staff],
+          assignable_level: Group::ALIAS_LEVELS[:everyone],
+        )
+      hidden_post = Fabricate(:post)
+      Assigner.new(hidden_post.topic, user).assign(hidden_group)
+
+      # An admin can see the group, so the filter resolves and narrows to its topic.
+      expect(
+        Search
+          .execute("assigned:#{hidden_group.name}", guardian: Guardian.new(Fabricate(:admin)))
+          .posts
+          .map(&:topic_id),
+      ).to include(hidden_post.topic_id)
+
+      # A non-staff assigner cannot see the group, so the name must not resolve: the
+      # filter becomes a no-op (identical to an unknown name) and never narrows the
+      # results to the hidden group's topics.
+      cannot_see = Guardian.new(user)
+      hidden_result = Search.execute("assigned:#{hidden_group.name}", guardian: cannot_see)
+      unknown_result = Search.execute("assigned:#{hidden_group.name}-unknown", guardian: cannot_see)
+
+      expect(hidden_result.posts.map(&:id).sort).to eq(unknown_result.posts.map(&:id).sort)
+      expect(hidden_result.posts.map(&:topic_id)).to include(post1.topic_id)
+    end
+
     it "serializes results" do
       guardian = Guardian.new(user)
       result = Search.execute("in:assigned", guardian: guardian)

--- a/plugins/discourse-assign/spec/components/search_spec.rb
+++ b/plugins/discourse-assign/spec/components/search_spec.rb
@@ -68,14 +68,15 @@ describe Search do
       ).to include(hidden_post.topic_id)
 
       # A non-staff assigner cannot see the group, so the name must not resolve: the
-      # filter becomes a no-op (identical to an unknown name) and never narrows the
-      # results to the hidden group's topics.
+      # filter behaves like an unknown name (a no-op) instead of narrowing the
+      # results down to the hidden group's assigned topics.
       cannot_see = Guardian.new(user)
       hidden_result = Search.execute("assigned:#{hidden_group.name}", guardian: cannot_see)
       unknown_result = Search.execute("assigned:#{hidden_group.name}-unknown", guardian: cannot_see)
 
+      expect(hidden_result.posts).not_to be_empty
       expect(hidden_result.posts.map(&:id).sort).to eq(unknown_result.posts.map(&:id).sort)
-      expect(hidden_result.posts.map(&:topic_id)).to include(post1.topic_id)
+      expect(hidden_result.posts.map(&:topic_id)).not_to contain_exactly(hidden_post.topic_id)
     end
 
     it "serializes results" do

--- a/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
@@ -143,6 +143,31 @@ RSpec.describe DiscourseAssign::AssignController do
       expect(post.topic.reload.assignment.assigned_to_id).to eq(allowed_user.id)
     end
 
+    it "does not assign to a group hidden from the acting user" do
+      hidden_group =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:staff],
+          assignable_level: Group::ALIAS_LEVELS[:everyone],
+        )
+
+      sign_in(allowed_user)
+
+      get "/g/#{hidden_group.name}.json"
+      expect(response.status).to eq(404)
+
+      put "/assign/assign.json",
+          params: {
+            target_id: post.topic_id,
+            target_type: "Topic",
+            group_name: hidden_group.name,
+          }
+
+      expect(response.status).to eq(403)
+      expect(response.body).not_to include(hidden_group.name)
+      expect(post.topic.reload.assignment).to be_nil
+    end
+
     it "assigns topic with note to a user" do
       put "/assign/assign.json",
           params: {
@@ -420,6 +445,29 @@ RSpec.describe DiscourseAssign::AssignController do
 
       Fabricate(:topic_assignment, assigned_to: allowed_group, assigned_by_user: admin)
       Fabricate(:post_assignment, assigned_to: allowed_group, assigned_by_user: admin)
+    end
+
+    it "does not list members for a group hidden from the user" do
+      hidden_group =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:staff],
+          members_visibility_level: Group.visibility_levels[:logged_on_users],
+        )
+      hidden_member = Fabricate(:user)
+      hidden_group.add(hidden_member)
+      Fabricate(:topic_assignment, assigned_to: hidden_member, assigned_by_user: admin)
+
+      sign_in(allowed_user)
+
+      get "/g/#{hidden_group.name}.json"
+      expect(response.status).to eq(404)
+
+      get "/assign/members/#{hidden_group.name}.json"
+      expect(response.status).to eq(403)
+      expect(
+        response.parsed_body.fetch("members", []).map { |member| member["username"] },
+      ).not_to include(hidden_member.username)
     end
 
     describe "members" do

--- a/plugins/discourse-assign/spec/requests/list_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/list_controller_spec.rb
@@ -64,6 +64,21 @@ describe ListController do
       sign_in(user)
     end
 
+    it "returns 403 for a group hidden from the acting user" do
+      hidden_group =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:staff],
+          assignable_level: Group::ALIAS_LEVELS[:everyone],
+        )
+
+      get "/g/#{hidden_group.name}.json"
+      expect(response.status).to eq(404)
+
+      get "/topics/group-topics-assigned/#{hidden_group.name}.json"
+      expect(response.status).to eq(403)
+    end
+
     it "returns user-assigned-topics-list of users in the assigned_allowed_group and doesnt include deleted topic" do
       get "/topics/group-topics-assigned/#{get_assigned_allowed_group_name}.json"
       expect(


### PR DESCRIPTION
Backport of #41176 to `release/2026.1`.

---

Add `ensure_can_see_group` to the discourse-assign paths that resolve a group by user-supplied name before returning group metadata (`AssignController#assign`, `AssignController#group_members`, `ListController#group_topics_assigned`).

Also guard the `assigned:<name>` search `advanced_filter` with `.visible_groups(@guardian.user).members_visible_groups(@guardian.user)` so a hidden group name resolves to a no-op instead of leaking the group's assigned topics.

### Backport notes
The automated cherry-pick failed with a conflict in `spec/requests/list_controller_spec.rb`. The conflict was purely cosmetic — the original commit also carried an incidental `doesnt` → `doesn't` typo fix on the line adjacent to the new test. Resolved minimally: kept `release/2026.1`'s existing wording and only added the new `returns 403 for a group hidden from the acting user` test. All four code/spec hunks otherwise applied cleanly, and the required core helpers (`can_see_group?`, `visible_groups`/`members_visible_groups`) already exist on `release/2026.1`. Includes the search-spec stabilization from #41176 so the new test isn't order/limit dependent.
