### PR TITLE
FIX: Filter returned reviewable IDs when deleting users and avoid sending emails on failed users deletion

### DIFF
--- a/app/models/concerns/reviewable_action_builder.rb
+++ b/app/models/concerns/reviewable_action_builder.rb
@@ -68,17 +68,23 @@ module ReviewableActionBuilder
     create_result(:success, :rejected)
   end
 
-  def perform_delete_user(performed_by, args, &)
-    delete_user(target_user, delete_opts, performed_by) if target_user
-    create_result(:success, :rejected, [], false, &)
+  def perform_delete_user(performed_by, args)
+    deleted_user = delete_user(target_user, delete_opts, performed_by) if target_user
+
+    create_result(:success, :rejected, [], false) do |result|
+      yield(result, deleted_user) if block_given?
+    end
   end
 
-  def perform_delete_and_block_user(performed_by, args, &)
+  def perform_delete_and_block_user(performed_by, args)
     delete_options = delete_opts
     delete_options.merge!(block_email: true, block_ip: true) if Rails.env.production?
 
-    delete_user(target_user, delete_options, performed_by) if target_user
-    create_result(:success, :rejected, [], false, &)
+    deleted_user = delete_user(target_user, delete_options, performed_by) if target_user
+
+    create_result(:success, :rejected, [], false) do |result|
+      yield(result, deleted_user) if block_given?
+    end
   end
 
   def perform_delete_post(performed_by, _args)
@@ -149,10 +155,14 @@ module ReviewableActionBuilder
   def delete_user(user, delete_options, performed_by)
     email = user.email
 
-    UserDestroyer.new(performed_by).destroy(user, delete_options.merge(reviewable_id: id))
+    deleted_user =
+      UserDestroyer.new(performed_by).destroy(user, delete_options.merge(reviewable_id: id))
+    return if deleted_user.blank?
 
     message = UserNotifications.account_deleted(email, self)
     Email::Sender.new(message, :account_deleted).send
+
+    deleted_user
   end
 
   def map_reviewable_status_to_flag_status(status)

--- a/app/models/reviewable_queued_post.rb
+++ b/app/models/reviewable_queued_post.rb
@@ -195,20 +195,30 @@ class ReviewableQueuedPost < Reviewable
   end
 
   def perform_delete_user(performed_by, args)
-    reviewable_ids = Reviewable.where(created_by: target_created_by).pluck(:id)
-    result = super { |r| r.remove_reviewable_ids += reviewable_ids }
+    reviewable_ids = reviewable_ids_visible_to(performed_by)
+    result =
+      super do |perform_result, deleted_user|
+        perform_result.remove_reviewable_ids |= reviewable_ids if deleted_user
+      end
     update_column(:target_created_by_id, nil)
     result
   end
 
   def perform_delete_and_block_user(performed_by, args)
-    reviewable_ids = Reviewable.where(created_by: target_created_by).pluck(:id)
-    result = super { |r| r.remove_reviewable_ids += reviewable_ids }
+    reviewable_ids = reviewable_ids_visible_to(performed_by)
+    result =
+      super do |perform_result, deleted_user|
+        perform_result.remove_reviewable_ids |= reviewable_ids if deleted_user
+      end
     update_column(:target_created_by_id, nil)
     result
   end
 
   private
+
+  def reviewable_ids_visible_to(user)
+    Reviewable.viewable_by(user, preload: false).where(created_by: target_created_by).pluck(:id)
+  end
 
   def delete_opts
     {

--- a/spec/models/reviewable_queued_post_spec.rb
+++ b/spec/models/reviewable_queued_post_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe ReviewableQueuedPost, type: :model do
   fab!(:admin)
 
   describe "creating a post" do
-    let!(:topic) { Fabricate(:topic, category: category) }
-    let(:reviewable) { Fabricate(:reviewable_queued_post, topic: topic) }
-
+    fab!(:topic) { Fabricate(:topic, category: category) }
+    fab!(:reviewable) { Fabricate(:reviewable_queued_post, topic: topic) }
+    let(:new_reviewable) { Fabricate(:reviewable_queued_post, topic: topic) }
     context "when creating" do
       it "triggers queued_post_created" do
-        event = DiscourseEvent.track(:queued_post_created) { reviewable.save! }
+        event = DiscourseEvent.track(:queued_post_created) { new_reviewable.save! }
         expect(event).to be_present
-        expect(event[:params][0]).to eq(reviewable)
+        expect(event[:params][0]).to eq(new_reviewable)
       end
 
       it "returns the appropriate create options" do
@@ -266,19 +266,78 @@ RSpec.describe ReviewableQueuedPost, type: :model do
       end
 
       context "with delete_user" do
+        fab!(:other_reviewable) do
+          Fabricate(:reviewable_queued_post, created_by: reviewable.target_created_by)
+        end
+
         it "deletes the user and rejects the post" do
-          other_reviewable =
-            Fabricate(:reviewable_queued_post, created_by: reviewable.target_created_by)
+          other_reviewable_id = other_reviewable.id
 
           result = reviewable.perform(moderator, :delete_user)
           expect(result.success?).to eq(true)
           expect(User.find_by(id: reviewable.target_created_by)).to be_blank
 
           expect(result.remove_reviewable_ids).to include(reviewable.id)
-          expect(result.remove_reviewable_ids).to include(other_reviewable.id)
+          expect(result.remove_reviewable_ids).to include(other_reviewable_id)
 
           expect(ReviewableQueuedPost.where(id: reviewable.id)).to be_present
-          expect(ReviewableQueuedPost.where(id: other_reviewable.id)).to be_blank
+          expect(ReviewableQueuedPost.where(id: other_reviewable_id)).to be_blank
+        end
+
+        it "does not expose restricted reviewable IDs after deletion succeeds" do
+          restricted_group = Fabricate(:group)
+          restricted_category = Fabricate(:private_category, group: restricted_group)
+          restricted_reviewable =
+            Fabricate(
+              :reviewable_queued_post,
+              created_by: reviewable.target_created_by,
+              category: restricted_category,
+            )
+          restricted_reviewable_id = restricted_reviewable.id
+
+          visible_reviewable_ids = Reviewable.viewable_by(moderator, preload: false).pluck(:id)
+          expect(visible_reviewable_ids).not_to include(restricted_reviewable_id)
+
+          result = reviewable.perform(moderator, :delete_user)
+
+          expect(result.remove_reviewable_ids).not_to include(restricted_reviewable_id)
+        end
+
+        context "when user deletion fails" do
+          fab!(:spammer) { reviewable.target_created_by }
+          fab!(:other_queued_post) { Fabricate(:reviewable_queued_post, created_by: spammer) }
+          fab!(:another_queued_post) do
+            Fabricate(:reviewable_queued_post, target_created_by: spammer)
+          end
+
+          before { UserDestroyer.any_instance.stubs(:destroy).returns(nil) }
+
+          it "does not resolve related reviewables" do
+            result = reviewable.perform(moderator, :delete_user)
+
+            # User should still exist since deletion failed
+            expect(User.find_by(id: spammer.id)).to be_present
+
+            expect(result.remove_reviewable_ids).not_to include(other_queued_post.id)
+
+            # Both reviewables should still be pending since deletion failed
+            expect(other_queued_post.reload).to be_pending
+            expect(another_queued_post.reload).to be_pending
+          end
+
+          it "does not expose reviewable IDs from restricted categories" do
+            restricted_group = Fabricate(:group)
+            restricted_category = Fabricate(:private_category, group: restricted_group)
+            restricted_reviewable =
+              Fabricate(:reviewable_queued_post, created_by: spammer, category: restricted_category)
+
+            visible_reviewables = Reviewable.viewable_by(moderator, preload: false).pluck(:id)
+            expect(visible_reviewables).not_to include(restricted_reviewable.id)
+
+            result = reviewable.perform(moderator, :delete_user)
+
+            expect(result.remove_reviewable_ids).not_to include(restricted_reviewable.id)
+          end
         end
       end
     end

--- a/spec/models/reviewable_user_spec.rb
+++ b/spec/models/reviewable_user_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe ReviewableUser, type: :model do
-  fab!(:moderator)
   let(:user) do
     user = Fabricate(:user)
     user.activate
     user
   end
   fab!(:admin)
+  fab!(:moderator)
 
   describe "#actions_for" do
     fab!(:reviewable)
@@ -64,7 +64,6 @@ RSpec.describe ReviewableUser, type: :model do
   end
 
   describe "#update_fields" do
-    fab!(:moderator)
     fab!(:reviewable)
 
     it "doesn't raise errors with an empty update" do


### PR DESCRIPTION
#### Description

Previously, deleting a user from a queued-post reviewable could return related reviewable IDs before confirming deletion succeeded, including IDs from reviewables the moderator could not view.

This change only adds visible related reviewable IDs to remove_reviewable_ids after user deletion succeeds, and avoids sending account-deleted email when deletion fails.

Context: `patch-triage/1205`