### PR TITLE
FIX: merge duplicate records in fix_missing_s3

### DIFF
--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1173,6 +1173,17 @@ def fix_missing_s3
 
       if fix_error
         puts "Failed to fix upload #{fix_error}"
+      elsif fixed_upload.id != upload.id
+        # UploadCreator found an existing record for the same file -- the upload
+        # being fixed is a duplicate. Move all references to the canonical record
+        # and destroy the duplicate rather than leaving two records with the same URL.
+        puts "Upload #{upload.id} is a duplicate of #{fixed_upload.id}, merging references"
+        rebake_ids =
+          UploadReference.where(upload_id: upload.id, target_type: "Post").pluck(:target_id)
+        UploadReference.where(upload_id: upload.id).update_all(upload_id: fixed_upload.id)
+        OptimizedImage.where(upload_id: upload.id).destroy_all
+        upload.destroy!
+        Post.where(id: rebake_ids).each { |post| post.rebake! }
       else
         # we do not fix sha, it may be wrong for arbitrary reasons, if we correct it
         # we may end up breaking posts

--- a/spec/tasks/uploads_spec.rb
+++ b/spec/tasks/uploads_spec.rb
@@ -258,6 +258,53 @@ RSpec.describe "tasks/uploads" do
     end
   end
 
+  describe "uploads:fix_missing_s3" do
+    def invoke_task
+      capture_stdout { invoke_rake_task("uploads:fix_missing_s3") }
+    end
+
+    before { setup_s3 }
+
+    it "does not leave a duplicate upload record when the fixed file already exists as a non-secure upload" do
+      # Simulate the Zoe bug: a secure upload whose URL was corrupted to point at the same
+      # S3 object as a non-secure upload of the same file. fix_missing_s3 downloads the
+      # file, runs it through UploadCreator, gets back the existing non-secure record, and
+      # should merge rather than leave two records pointing at the same URL.
+      real_sha1 = "3e3cecf141a7312ec621608d6df0aef7436e3713"
+      fake_sha1 = "293e44361d7a706e6c1247e3326934d74a3837b9"
+      public_url = "//bucket.s3.amazonaws.com/original/2X/2/#{real_sha1}.png"
+
+      # The keeper: a normal non-secure upload with the correct sha1
+      keeper = Fabricate(:upload_s3, sha1: real_sha1, original_sha1: nil, secure: false)
+      keeper.update_columns(
+        url: public_url,
+        verification_status: Upload.verification_statuses[:verified],
+      )
+
+      # The orphan: a formerly-secure upload whose URL was corrupted to match the keeper's
+      orphan = Fabricate(:upload_s3, sha1: fake_sha1, original_sha1: real_sha1, secure: false)
+      orphan.update_columns(
+        url: public_url,
+        verification_status: Upload.verification_statuses[:invalid_etag],
+      )
+
+      post = Fabricate(:post)
+      UploadReference.create!(target: post, upload: orphan)
+
+      tempfile = Tempfile.new(%w[upload .png])
+      FileHelper.stubs(:download).returns(tempfile)
+
+      UploadCreator.any_instance.stubs(:create_for).returns(keeper)
+
+      invoke_task
+
+      # The orphan record should be gone, with no duplicate URL records remaining
+      expect(Upload.exists?(orphan.id)).to eq(false)
+      expect(Upload.where(url: public_url).count).to eq(1)
+      expect(Upload.where(url: public_url).first.id).to eq(keeper.id)
+    end
+  end
+
   describe "uploads:downsize" do
     def invoke_task
       capture_stdout { invoke_rake_task("uploads:downsize") }


### PR DESCRIPTION
When fix_missing_s3 passes a downloaded file through UploadCreator, it may get back an existing record rather than a new one -- meaning the upload being fixed is a duplicate of something already in the DB. Previously the task would just overwrite the broken record's URL, leaving two records pointing at the same S3 object and causing backup failures with "same file" errors.

Move all UploadReferences to the canonical record, destroy the duplicate, and rebake affected posts.