### PR TITLE
FIX: Stale window height on composer resize

### DIFF
--- a/frontend/discourse/app/components/d-virtual-height.gjs
+++ b/frontend/discourse/app/components/d-virtual-height.gjs
@@ -23,8 +23,6 @@ export default class DVirtualHeight extends Component {
       return;
     }
 
-    this.windowInnerHeight = window.innerHeight;
-
     scheduleOnce("afterRender", this, this.debouncedOnViewportResize);
 
     window.visualViewport.addEventListener(
@@ -80,8 +78,7 @@ export default class DVirtualHeight extends Component {
 
     let keyboardVisible = false;
 
-    let viewportWindowDiff =
-      this.windowInnerHeight - window.visualViewport.height;
+    let viewportWindowDiff = window.innerHeight - window.visualViewport.height;
 
     if (viewportWindowDiff > KEYBOARD_DETECT_THRESHOLD) {
       keyboardVisible = true;


### PR DESCRIPTION
DVirtualHeight cached window.innerHeight at construction time. After device rotation, this value becomes stale, and in some cases causes the composer to be sized incorrectly.

The known path to reproduce the issue was:
1. Fresh load of the page with composer open in landscape orientation
2. Rotate device to portrait orientation
3. Composer will still be open, and will be sized much too small 
 
This also led to the composer not being sticky like it should be, and moving around the page as the user scrolled.

Other paths were working by accident, since the cached/stale value would falsely inflate `viewportWindowDiff` to a value that doesn't get resized

A `// TODO: Handle device rotation` comment used to flag this issue, but the comment was removed in #30241 during a refactor without addressing the underlying issue. This change drops the cached value entirely and reads `window.innerHeight` directly on each viewport resize.


### Before

https://github.com/user-attachments/assets/7a81f398-d0f6-4357-b825-83a4210bf0a8


### After

https://github.com/user-attachments/assets/d642d4c3-a0b3-4d8f-ad11-6f73d5bbdbc6



