### PR TITLE
FIX: Play every chat sound preview selection

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-audio-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-audio-manager.js
@@ -180,9 +180,14 @@ const SOUND_SEQUENCES = {
 export default class ChatAudioManager extends Service {
   canPlay = true;
 
-  async play(name, { type = "incoming" } = {}) {
-    if (this.canPlay) {
+  async play(name, { throttle = true, type = "incoming" } = {}) {
+    if (!throttle || this.canPlay) {
       await this.#tryPlay(name, type);
+
+      if (!throttle) {
+        return;
+      }
+
       this.canPlay = false;
       setTimeout(() => {
         this.canPlay = true;

--- a/plugins/chat/assets/javascripts/discourse/templates/preferences/chat.gjs
+++ b/plugins/chat/assets/javascripts/discourse/templates/preferences/chat.gjs
@@ -139,7 +139,7 @@ export default class Chat extends Component {
   @action
   handleChatSoundSet(sound, { set, name }) {
     if (sound) {
-      this.chatAudioManager?.play(sound);
+      this.chatAudioManager?.play(sound, { throttle: false });
     }
     set(name, sound == null ? null : sound);
   }

--- a/plugins/chat/test/javascripts/unit/services/chat-audio-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-audio-manager-test.js
@@ -95,6 +95,28 @@ module("Unit | Service | chat-audio-manager", function (hooks) {
     );
   });
 
+  test("throttles notification sounds by default", async function (assert) {
+    await this.subject.play("classic");
+    await this.subject.play("soft");
+
+    assert.strictEqual(
+      this.context.oscillators.length,
+      2,
+      "skips the second sound while throttled"
+    );
+  });
+
+  test("can bypass throttling for preference previews", async function (assert) {
+    await this.subject.play("classic", { throttle: false });
+    await this.subject.play("soft", { throttle: false });
+
+    assert.strictEqual(
+      this.context.oscillators.length,
+      4,
+      "plays each selected preview sound"
+    );
+  });
+
   test("normalizes legacy sound names to the default theme", function (assert) {
     assert.strictEqual(
       normalizeChatSoundName("ding"),


### PR DESCRIPTION
Previously, chat sound previews used the same throttled playback path as desktop notifications, so quick preference changes skipped some selected sounds.

This change lets preference previews bypass notification throttling while keeping throttling enabled for real notifications.