### PR TITLE
FIX: Treat all-day calendar events as date-only

### DIFF
--- a/frontend/discourse/app/lib/download-calendar.js
+++ b/frontend/discourse/app/lib/download-calendar.js
@@ -39,23 +39,28 @@ export function downloadIcs(title, dates, options = {}) {
 }
 
 export function downloadGoogle(title, dates, options = {}) {
+  const parsedRrule = _parseRRule(options.rrule);
+
   dates.forEach((date) => {
     const link = new URL("https://www.google.com/calendar/event");
     link.searchParams.append("action", "TEMPLATE");
     link.searchParams.append("text", title);
-    link.searchParams.append(
-      "dates",
-      `${_formatDateForGoogleApi(date.startsAt, date.timezone)}/${_formatDateForGoogleApi(
+
+    let dateRange;
+    if (date.allDay) {
+      const { startDate, endDate } = _allDayMoments(date);
+      dateRange = `${startDate.format("YYYYMMDD")}/${endDate.format("YYYYMMDD")}`;
+    } else {
+      dateRange = `${_formatDateForGoogleApi(date.startsAt, date.timezone)}/${_formatDateForGoogleApi(
         date.endsAt,
         date.timezone
-      )}`
-    );
+      )}`;
+    }
+    link.searchParams.append("dates", dateRange);
 
-    if (options.rrule) {
-      const rrule = _parseRRule(options.rrule);
-      if (rrule && _hasFreq(rrule)) {
-        link.searchParams.append("recur", `RRULE:${rrule}`);
-      }
+    if (parsedRrule && _hasFreq(parsedRrule)) {
+      const rrule = date.allDay ? _dateOnlyUntil(parsedRrule) : parsedRrule;
+      link.searchParams.append("recur", `RRULE:${rrule}`);
     }
 
     if (options.location) {
@@ -76,12 +81,18 @@ export function formatDates(dates) {
       startsAt: date.startsAt,
       endsAt: date.endsAt
         ? date.endsAt
-        : moment.utc(date.startsAt).add(1, "hours").format(),
+        : date.allDay
+          ? null
+          : moment.utc(date.startsAt).add(1, "hours").format(),
     };
 
     // Preserve timezone if present
     if (date.timezone) {
       formatted.timezone = date.timezone;
+    }
+
+    if (date.allDay) {
+      formatted.allDay = true;
     }
 
     return formatted;
@@ -171,38 +182,57 @@ function _hasFreq(rrule) {
   return /FREQ=/i.test(rrule);
 }
 
+function _dateOnlyUntil(rrule) {
+  return rrule.replace(/(UNTIL=\d{8})T\d{6}Z?/i, "$1");
+}
+
+function _allDayMoments(date) {
+  const startDate = moment(date.startsAt, "YYYY-MM-DD");
+  const endDate = (
+    date.endsAt ? moment(date.endsAt, "YYYY-MM-DD") : startDate.clone()
+  ).add(1, "day");
+  return { startDate, endDate };
+}
+
 /**
  * Generate ICS calendar data for the given dates
  *
  * @param {string} title - Event title
- * @param {Array} dates - Array of date objects with startsAt, endsAt, and optional timezone
+ * @param {Array} dates - Array of date objects with startsAt, endsAt, optional timezone, and optional allDay (date-only event)
  * @param {Object} options - Optional parameters (rrule, location, details, timezone)
  * @returns {string} - ICS formatted calendar data
  */
 export function generateIcsData(title, dates, options = {}) {
   let data = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Discourse//EN\r\n";
+  const parsedRrule = _parseRRule(options.rrule);
   dates.forEach((date) => {
-    const timezone = date.timezone || options.timezone;
-    const startDate = timezone
-      ? moment.tz(date.startsAt, timezone)
-      : moment(date.startsAt);
-    const endDate = timezone
-      ? moment.tz(date.endsAt, timezone)
-      : moment(date.endsAt);
-    const rrule = _parseRRule(options.rrule);
+    let rrule = parsedRrule;
 
-    // Format date-time based on whether we have timezone info
-    const formatDateTime = (momentObj) => {
-      return momentObj.format("YYYYMMDDTHHmmss");
-    };
+    let startDate, endDate, dtStartValue, dtEndValue;
 
-    const dtStartValue = timezone
-      ? `DTSTART;TZID=${timezone}:${formatDateTime(startDate)}`
-      : `DTSTART:${startDate.utc().format("YYYYMMDDTHHmmss")}Z`;
+    if (date.allDay) {
+      if (rrule) {
+        rrule = _dateOnlyUntil(rrule);
+      }
+      ({ startDate, endDate } = _allDayMoments(date));
+      dtStartValue = `DTSTART;VALUE=DATE:${startDate.format("YYYYMMDD")}`;
+      dtEndValue = `DTEND;VALUE=DATE:${endDate.format("YYYYMMDD")}`;
+    } else {
+      const timezone = date.timezone || options.timezone;
+      startDate = timezone
+        ? moment.tz(date.startsAt, timezone)
+        : moment(date.startsAt);
+      endDate = timezone
+        ? moment.tz(date.endsAt, timezone)
+        : moment(date.endsAt);
 
-    const dtEndValue = timezone
-      ? `DTEND;TZID=${timezone}:${formatDateTime(endDate)}`
-      : `DTEND:${endDate.utc().format("YYYYMMDDTHHmmss")}Z`;
+      dtStartValue = timezone
+        ? `DTSTART;TZID=${timezone}:${startDate.format("YYYYMMDDTHHmmss")}`
+        : `DTSTART:${startDate.utc().format("YYYYMMDDTHHmmss")}Z`;
+      dtEndValue = timezone
+        ? `DTEND;TZID=${timezone}:${endDate.format("YYYYMMDDTHHmmss")}`
+        : `DTEND:${endDate.utc().format("YYYYMMDDTHHmmss")}Z`;
+    }
 
     data = data.concat(
       "BEGIN:VEVENT\r\n" +

--- a/frontend/discourse/tests/unit/lib/download-calendar-test.js
+++ b/frontend/discourse/tests/unit/lib/download-calendar-test.js
@@ -269,4 +269,86 @@ module("Unit | Utility | download-calendar", function (hooks) {
       "endsAt is one hour after startsAt"
     );
   });
+
+  test("all-day ICS uses DATE values with an exclusive end date", function (assert) {
+    const data = generateIcsData("all day event", [
+      { startsAt: "2026-03-12", endsAt: "2026-03-14", allDay: true },
+    ]);
+
+    assert.true(
+      data.includes("DTSTART;VALUE=DATE:20260312"),
+      "start is a DATE value"
+    );
+    assert.true(
+      data.includes("DTEND;VALUE=DATE:20260315"),
+      "end is the exclusive day after the last day"
+    );
+    assert.false(
+      data.includes("DTSTART:20260312T000000Z"),
+      "does not emit a midnight datetime"
+    );
+    assert.false(data.includes("TZID"), "does not emit a timezone");
+  });
+
+  test("single-day all-day ICS spans one day when no end given", function (assert) {
+    const data = generateIcsData("all day event", [
+      { startsAt: "2026-03-12", allDay: true },
+    ]);
+
+    assert.true(data.includes("DTSTART;VALUE=DATE:20260312"));
+    assert.true(
+      data.includes("DTEND;VALUE=DATE:20260313"),
+      "exclusive end is the day after the start"
+    );
+  });
+
+  test("all-day Google url uses a date-only range", function (assert) {
+    downloadGoogle("all day event", [
+      { startsAt: "2026-03-12", endsAt: "2026-03-14", allDay: true },
+    ]);
+
+    assert.true(
+      window.open.calledWith(
+        "https://www.google.com/calendar/event?action=TEMPLATE&text=all+day+event&dates=20260312%2F20260315",
+        "_blank",
+        "noopener",
+        "noreferrer"
+      )
+    );
+  });
+
+  test("formatDates preserves the all-day flag without adding a time", function (assert) {
+    let dates = formatDates([{ startsAt: "2026-03-12", allDay: true }]);
+    assert.deepEqual(dates, [
+      { startsAt: "2026-03-12", endsAt: null, allDay: true },
+    ]);
+  });
+
+  test("all-day ICS converts the RRULE UNTIL to a DATE value", function (assert) {
+    const data = generateIcsData(
+      "all day event",
+      [{ startsAt: "2026-03-12", allDay: true }],
+      { rrule: "FREQ=WEEKLY;BYDAY=TH;UNTIL=20260531T200000" }
+    );
+
+    assert.true(data.includes("DTSTART;VALUE=DATE:20260312"));
+    assert.true(
+      data.includes("RRULE:FREQ=WEEKLY;BYDAY=TH;UNTIL=20260531"),
+      "UNTIL matches the DATE value type of DTSTART"
+    );
+    assert.false(
+      data.includes("UNTIL=20260531T200000"),
+      "UNTIL carries no time component"
+    );
+  });
+
+  test("all-day Google url converts the RRULE UNTIL to a DATE value", function (assert) {
+    downloadGoogle("event", [{ startsAt: "2026-03-12", allDay: true }], {
+      rrule: "FREQ=WEEKLY;BYDAY=TH;UNTIL=20260531T200000Z",
+    });
+
+    const url = window.open.getCall(0).args[0];
+    assert.true(url.includes("UNTIL%3D20260531"), "UNTIL is present as a date");
+    assert.false(url.includes("20260531T"), "UNTIL carries no time component");
+  });
 });

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -479,9 +479,14 @@ module DiscoursePostEvent
       next_starts_at = calculate_next_recurring_date
       return nil unless next_starts_at
 
-      event_duration =
-        original_ends_at ? original_ends_at - original_starts_at : (all_day ? 86_400 : 3600)
-      next_ends_at = next_starts_at + event_duration
+      next_ends_at =
+        if original_ends_at
+          next_starts_at + (original_ends_at - original_starts_at)
+        elsif all_day
+          next_starts_at.end_of_day
+        else
+          next_starts_at + 3600
+        end
       [next_starts_at, next_ends_at]
     end
 
@@ -494,9 +499,14 @@ module DiscoursePostEvent
       next_starts_at = calculate_next_recurring_date_from(from_time)
       return nil unless next_starts_at
 
-      event_duration =
-        original_ends_at ? original_ends_at - original_starts_at : (all_day ? 86_400 : 3600)
-      next_ends_at = next_starts_at + event_duration
+      next_ends_at =
+        if original_ends_at
+          next_starts_at + (original_ends_at - original_starts_at)
+        elsif all_day
+          next_starts_at.end_of_day
+        else
+          next_starts_at + 3600
+        end
       { starts_at: next_starts_at, ends_at: next_ends_at }
     end
 

--- a/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
+++ b/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
@@ -10,8 +10,14 @@ X-WR-CALNAME:<%= IcalEncoder.encode(@calendar_name) %>
 BEGIN:VEVENT
 UID:calendar_event_#<%= event.id %>_<%= starts_at.to_i %>@<%= Discourse.current_hostname %>
 DTSTAMP:<%= Time.now.utc.strftime("%Y%m%dT%H%M%SZ") %>
+<%- if event.all_day -%>
+<%- last_day = (ends_at.present? ? ends_at.utc - 1.second : starts_at.utc).to_date -%>
+DTSTART;VALUE=DATE:<%= starts_at.utc.strftime("%Y%m%d") %>
+DTEND;VALUE=DATE:<%= (last_day + 1).strftime("%Y%m%d") %>
+<%- else -%>
 DTSTART:<%= starts_at.utc.strftime("%Y%m%dT%H%M%SZ") %>
 DTEND:<%= ends_at.presence ? ends_at.utc.strftime("%Y%m%dT%H%M%SZ") : (starts_at + 1.hour).utc.strftime("%Y%m%dT%H%M%SZ") %>
+<%- end -%>
 SUMMARY:<%= IcalEncoder.encode(event.name.presence || event.post.topic.title) %>
 <%- if event.location.present? -%>LOCATION:<%= IcalEncoder.encode(event.location) %>
 <%- end -%>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/more-menu.gjs
@@ -85,6 +85,7 @@ export default class DiscoursePostEventMoreMenu extends Component {
           startsAt: event.startsAt,
           endsAt: event.endsAt,
           timezone: event.timezone,
+          allDay: event.allDay,
         },
       ],
       {

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -239,6 +239,65 @@ module DiscoursePostEvent
         expect(response.body).to include("SUMMARY:Valid Event")
       end
 
+      describe "with all-day events" do
+        before { freeze_time Time.utc(2026, 3, 1, 12) }
+
+        it "emits all-day events as DATE values with an exclusive end date" do
+          Fabricate(
+            :event,
+            original_starts_at: Time.utc(2026, 3, 12),
+            original_ends_at: Time.utc(2026, 3, 14).end_of_day,
+            all_day: true,
+            name: "All Day Conference",
+          )
+
+          get "/discourse-post-event/events.ics"
+
+          expect(response.status).to eq(200)
+          body = response.body
+          expect(body).to include("SUMMARY:All Day Conference")
+          expect(body).to include("DTSTART;VALUE=DATE:20260312")
+          expect(body).to include("DTEND;VALUE=DATE:20260315")
+          expect(body).not_to include("DTSTART:20260312T000000Z")
+        end
+
+        it "emits a single-day all-day event spanning one day" do
+          Fabricate(
+            :event,
+            original_starts_at: Time.utc(2026, 3, 12),
+            original_ends_at: nil,
+            all_day: true,
+            name: "All Day Holiday",
+          )
+
+          get "/discourse-post-event/events.ics"
+
+          expect(response.status).to eq(200)
+          body = response.body
+          expect(body).to include("DTSTART;VALUE=DATE:20260312")
+          expect(body).to include("DTEND;VALUE=DATE:20260313")
+        end
+
+        it "emits recurring all-day occurrences as DATE values" do
+          Fabricate(
+            :event,
+            original_starts_at: Time.utc(2026, 3, 12),
+            all_day: true,
+            recurrence: "every_week",
+            name: "Weekly All Day",
+          )
+
+          get "/discourse-post-event/events.ics"
+
+          expect(response.status).to eq(200)
+          body = response.body
+          expect(body.scan("DTSTART;VALUE=DATE:").size).to be > 1
+          expect(body).not_to match(/DTSTART:\d{8}T\d{6}Z/)
+          expect(body).to include("DTSTART;VALUE=DATE:20260312")
+          expect(body).to include("DTEND;VALUE=DATE:20260313")
+        end
+      end
+
       context "when include_interested is requested for an attending user" do
         fab!(:target_user, :user)
         fab!(:going_event) do
@@ -320,6 +379,22 @@ module DiscoursePostEvent
         expect(event["starts_at"]).to eq("2026-03-12")
         expect(event["ends_at"]).to eq("2026-03-14")
         expect(event["all_day"]).to eq(true)
+      end
+
+      it "serializes recurring no-end occurrences as a single day" do
+        freeze_time Time.utc(2026, 3, 1, 12)
+        Fabricate(
+          :event,
+          original_starts_at: Time.utc(2026, 2, 1),
+          all_day: true,
+          recurrence: "every_week",
+        )
+
+        get "/discourse-post-event/events.json"
+
+        expect(response.status).to eq(200)
+        occurrence = response.parsed_body["events"].first["occurrences"].first
+        expect(occurrence["ends_at"]).to eq(occurrence["starts_at"])
       end
     end
 


### PR DESCRIPTION
Previously, all-day calendar events were stored and exported as timestamped instants, so iCal and Google Calendar treated them as timed events, and recurring all-day events spanned an extra day.

This change emits all-day events as date values with an exclusive end date in the iCal feed, the "Add to calendar" download, and the Google Calendar link, and ends recurring all-day occurrences at the end of their day so they render as a single day.

Meta:
- https://meta.discourse.org/t/creating-an-all-day-event-that-is-usable-by-ical/253665
- https://meta.discourse.org/t/display-only-the-day-for-full-day-events-in-details/395646
