### PR TITLE
FEATURE: Allow HTML for OAuth error message

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -140,7 +140,7 @@ class Users::OmniauthCallbacksController < ApplicationController
   protected
 
   def render_auth_result_failure
-    flash[:error] = @auth_result.failed_reason
+    flash[:error] = PrettyText.sanitize(@auth_result.failed_reason).html_safe
     render "failure"
   end
 

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -291,6 +291,16 @@ module PrettyText
       JS
   end
 
+  def self.sanitize(html, opts = {})
+    protect { v8.eval(<<~JS) }
+        (() => {
+          const AllowLister = require("pretty-text/allow-lister").default;
+          const sanitize = require("pretty-text/sanitizer").sanitize;
+          return sanitize(#{html.to_s.inspect}, new AllowLister(#{opts.to_json}));
+        })()
+      JS
+  end
+
   def self.unescape_emoji(title)
     return title unless SiteSetting.enable_emoji? && title
 

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -2498,6 +2498,17 @@ HTML
     expect(PrettyText.cook("<test>alert(42)</test>")).to eq "<p>alert(42)</p>"
   end
 
+  it "sanitizes html without cooking markdown" do
+    sanitized =
+      PrettyText.sanitize(
+        '<a href="https://example.com" target="_blank" rel="noopener" onclick="alert(1)">learn more</a><a href="javascript:alert(1)">bad</a><script>alert(1)</script>',
+      )
+
+    expect(sanitized).to eq(
+      '<a href="https://example.com" target="_blank">learn more</a><a>bad</a>',
+    )
+  end
+
   it "should not onebox magically linked urls" do
     expect(PrettyText.cook("[url]site.com[/url]")).not_to include("onebox")
   end

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -725,6 +725,38 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(user.email).to eq("anotheremail@example.com")
       end
 
+      it "sanitizes custom failed auth result HTML" do
+        link_html =
+          '<a href="https://pinterest.example/help" target="_blank" rel="noopener" onclick="alert(1)">Learn more</a>'
+        failed_result = Auth::Result.new
+        failed_result.failed = true
+        failed_result.failed_reason = [
+          "Partner accounts only.",
+          link_html,
+          "<script>alert(1)</script>",
+        ].join("\n")
+
+        Auth::GoogleOAuth2Authenticator
+          .any_instance
+          .stubs(:after_authenticate)
+          .returns(failed_result)
+
+        get "/auth/google_oauth2/callback"
+
+        document = Nokogiri.HTML5(response.body)
+        alert = document.at_css(".alert-error")
+        link = alert.at_css("a")
+
+        aggregate_failures do
+          expect(response.status).to eq(200)
+          expect(alert.text).to include("Partner accounts only.")
+          expect(link["href"]).to eq("https://pinterest.example/help")
+          expect(link["target"]).to eq("_blank")
+          expect(link["onclick"]).to be_nil
+          expect(alert.to_html).not_to include("<script")
+        end
+      end
+
       context "when user has TOTP enabled" do
         before { user.create_totp(enabled: true) }
 

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -727,7 +727,7 @@ RSpec.describe Users::OmniauthCallbacksController do
 
       it "sanitizes custom failed auth result HTML" do
         link_html =
-          '<a href="https://pinterest.example/help" target="_blank" rel="noopener" onclick="alert(1)">Learn more</a>'
+          '<a href="https://example.com/help" target="_blank" rel="noopener" onclick="alert(1)">Learn more</a>'
         failed_result = Auth::Result.new
         failed_result.failed = true
         failed_result.failed_reason = [
@@ -750,7 +750,7 @@ RSpec.describe Users::OmniauthCallbacksController do
         aggregate_failures do
           expect(response.status).to eq(200)
           expect(alert.text).to include("Partner accounts only.")
-          expect(link["href"]).to eq("https://pinterest.example/help")
+          expect(link["href"]).to eq("https://example.com/help")
           expect(link["target"]).to eq("_blank")
           expect(link["onclick"]).to be_nil
           expect(alert.to_html).not_to include("<script")


### PR DESCRIPTION
This adds a new method to `PrettyText`, `PrettyText#sanitize`. We then use it for the .erb template that drives OAuth error message to allow HTML, not just plain text.