### PR TITLE
DEV: Remove ?flat=1 query param for nested topics

### DIFF
--- a/frontend/discourse/app/components/header/topic/info.gjs
+++ b/frontend/discourse/app/components/header/topic/info.gjs
@@ -8,6 +8,7 @@ import TopicStatus from "discourse/components/topic-status";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { wantsNewWindow } from "discourse/lib/intercept-click";
 import renderTags from "discourse/lib/render-tags";
+import { scrollTop } from "discourse/lib/scroll-top";
 import DiscourseURL from "discourse/lib/url";
 import { and, gt, not, or } from "discourse/truth-helpers";
 import dCategoryLink from "discourse/ui-kit/helpers/d-category-link";
@@ -78,6 +79,11 @@ export default class Info extends Component {
 
     e.preventDefault();
     if (this.args.topicInfo) {
+      if (this.args.topicInfo.is_nested_view) {
+        scrollTop();
+        return;
+      }
+
       DiscourseURL.routeTo(this.args.topicInfo.firstPostUrl, {
         keepFilter: true,
       });

--- a/frontend/discourse/app/components/topic-admin-menu.gjs
+++ b/frontend/discourse/app/components/topic-admin-menu.gjs
@@ -179,7 +179,6 @@ export default class TopicAdminMenu extends Component {
         data: { enabled: newValue },
       });
       topic.set("is_nested_view", newValue);
-      topic.set("_forcedFlat", !newValue);
 
       if (newValue) {
         DiscourseURL.routeTo(`/t/${slug}/${topicId}`);

--- a/frontend/discourse/app/controllers/topic.js
+++ b/frontend/discourse/app/controllers/topic.js
@@ -68,7 +68,6 @@ const TOPIC_QUERY_PARAMS = [
   "filter",
   "username_filters",
   "replies_to_post_number",
-  "flat",
   "sort",
   "context",
   { collapseReplies: "collapse_replies" },
@@ -125,7 +124,6 @@ export default class TopicController extends Controller {
   username_filters = null;
   replies_to_post_number = null;
   filter = null;
-  flat = null;
   sort = null;
   context = null;
   collapseReplies = false;
@@ -162,7 +160,6 @@ export default class TopicController extends Controller {
     "filter",
     "username_filters",
     "replies_to_post_number",
-    "flat",
     "sort",
     "context",
     "collapseReplies"
@@ -171,19 +168,9 @@ export default class TopicController extends Controller {
     return getProperties(this, TOPIC_PAGE_QUERY_PARAM_PROPERTIES);
   }
 
-  @computed("flat", "model._forcedFlat")
-  get forceFlatView() {
-    return (
-      this.flat === true ||
-      this.flat === "true" ||
-      this.flat === "1" ||
-      this.model?._forcedFlat
-    );
-  }
-
-  @computed("model.is_nested_view", "forceFlatView")
+  @computed("model.is_nested_view")
   get shouldRenderNestedView() {
-    return this.model?.is_nested_view && !this.forceFlatView;
+    return this.model?.is_nested_view;
   }
 
   @computed("model.isPrivateMessage")

--- a/frontend/discourse/app/models/topic.js
+++ b/frontend/discourse/app/models/topic.js
@@ -685,9 +685,9 @@ export default class Topic extends RestModel {
     return this.unread_posts || this.new_posts;
   }
 
-  @computed("last_read_post_number", "url", "is_nested_view", "_forcedFlat")
+  @computed("last_read_post_number", "url", "is_nested_view")
   get lastReadUrl() {
-    if (this.is_nested_view && !this._forcedFlat) {
+    if (this.is_nested_view) {
       return this.url;
     }
     return this.urlForPostNumber(this.last_read_post_number);
@@ -697,11 +697,10 @@ export default class Topic extends RestModel {
     "last_read_post_number",
     "highest_post_number",
     "url",
-    "is_nested_view",
-    "_forcedFlat"
+    "is_nested_view"
   )
   get lastUnreadUrl() {
-    if (this.is_nested_view && !this._forcedFlat) {
+    if (this.is_nested_view) {
       return this.url;
     }
 
@@ -733,9 +732,9 @@ export default class Topic extends RestModel {
     return this.urlForPostNumber(postNumber);
   }
 
-  @computed("highest_post_number", "url", "is_nested_view", "_forcedFlat")
+  @computed("highest_post_number", "url", "is_nested_view")
   get lastPostUrl() {
-    if (this.is_nested_view && !this._forcedFlat) {
+    if (this.is_nested_view) {
       return this.url;
     }
     return this.urlForPostNumber(this.highest_post_number);

--- a/frontend/discourse/app/routes/topic.js
+++ b/frontend/discourse/app/routes/topic.js
@@ -41,7 +41,6 @@ export default class TopicRoute extends DiscourseRoute {
   queryParams = {
     filter: { replace: true },
     username_filters: { replace: true },
-    flat: { replace: true },
     sort: { replace: true, refreshModel: true },
     context: { refreshModel: true },
     collapseReplies: { replace: true },

--- a/frontend/discourse/app/routes/topic/from-params.js
+++ b/frontend/discourse/app/routes/topic/from-params.js
@@ -62,10 +62,7 @@ export default class TopicFromParams extends DiscourseRoute {
     const topic = this.modelFor("topic");
 
     const queryParams = transition?.to?.queryParams || {};
-    const flatParam = this.#truthyQueryParam(
-      queryParams.flat || transition?.to?.parent?.queryParams?.flat
-    );
-    if (topic.is_nested_view && !flatParam && !topic._forcedFlat) {
+    if (topic.is_nested_view) {
       return this.#loadNestedModel(topic, params, queryParams).catch((e) => {
         if (!isTesting()) {
           // eslint-disable-next-line no-console
@@ -87,7 +84,7 @@ export default class TopicFromParams extends DiscourseRoute {
     return postStream
       .refresh(params)
       .then(() => {
-        if (topic.is_nested_view && !flatParam && !topic._forcedFlat) {
+        if (topic.is_nested_view) {
           return this.#loadNestedModel(topic, params, queryParams);
         }
         return params;
@@ -102,22 +99,12 @@ export default class TopicFromParams extends DiscourseRoute {
       });
   }
 
-  afterModel(model, transition) {
+  afterModel(model) {
     const topic = this.modelFor("topic");
 
     if (model._nested) {
       this.header.enterTopic(model._nested.topic, !model._nested.contextMode);
       return;
-    }
-
-    if (topic.is_nested_view) {
-      const flatParam = this.#truthyQueryParam(
-        transition?.to?.queryParams?.flat ||
-          transition?.to?.parent?.queryParams?.flat
-      );
-      if (flatParam || topic._forcedFlat) {
-        topic.set("_forcedFlat", true);
-      }
     }
 
     const isLoadingFirstPost =

--- a/frontend/discourse/tests/integration/components/header/topic/info-test.gjs
+++ b/frontend/discourse/tests/integration/components/header/topic/info-test.gjs
@@ -1,0 +1,72 @@
+import { getOwner } from "@ember/owner";
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import TopicInfo from "discourse/components/header/topic/info";
+import DiscourseURL from "discourse/lib/url";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+function createTopic(context, attrs = {}) {
+  return context.store.createRecord("topic", {
+    id: 1,
+    slug: "header-title-topic",
+    title: "Header title topic",
+    fancy_title: "Header title topic",
+    details: {
+      allowed_groups: [],
+      allowed_users: [],
+      loaded: false,
+    },
+    ...attrs,
+  });
+}
+
+function renderComponent(context) {
+  return render(
+    <template><TopicInfo @topicInfo={{context.topic}} /></template>
+  );
+}
+
+module("Integration | Component | Header | Topic | Info", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = getOwner(this).lookup("service:store");
+    this.routeTo = sinon.stub(DiscourseURL, "routeTo");
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  test("routes flat topic title clicks to the first post", async function (assert) {
+    this.topic = createTopic(this);
+
+    await renderComponent(this);
+    await click(".topic-link");
+
+    assert.true(this.routeTo.calledOnce, "routes the title click");
+    assert.strictEqual(
+      this.routeTo.firstCall.args[0],
+      "/t/header-title-topic/1/1",
+      "routes to the first post URL"
+    );
+    assert.deepEqual(
+      this.routeTo.firstCall.args[1],
+      { keepFilter: true },
+      "keeps the current topic filter"
+    );
+  });
+
+  test("does not route nested topic title clicks to the first post", async function (assert) {
+    this.topic = createTopic(this, { is_nested_view: true });
+
+    await renderComponent(this);
+    await click(".topic-link");
+
+    assert.true(
+      this.routeTo.notCalled,
+      "does not route nested header title clicks through the post URL"
+    );
+  });
+});

--- a/spec/system/nested_category_default_spec.rb
+++ b/spec/system/nested_category_default_spec.rb
@@ -87,33 +87,5 @@ RSpec.describe "Nested view category default" do
       expect(page).to have_current_path(%r{/t/#{normal_topic.slug}/#{normal_topic.id}})
       expect(nested_view).to have_no_nested_view
     end
-
-    it "respects ?flat=1 to force flat view even in nested-default category" do
-      page.visit("/t/#{topic.slug}/#{topic.id}?flat=1")
-
-      expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
-      expect(page).to have_current_path(/flat=1/)
-      expect(nested_view).to have_no_nested_view
-    end
-
-    it "does not redirect to nested when navigating within flat view (e.g. topic timeline)" do
-      page.visit("/t/#{topic.slug}/#{topic.id}?flat=1")
-      expect(nested_view).to have_no_nested_view
-
-      # Simulate the exact code path the topic timeline uses:
-      # topic.urlForPostNumber() → DiscourseURL.routeTo()
-      # This exercises the topic-url-for-post-number transformer which rewrites
-      # URLs to /nested/ for nested-default categories.
-      page.execute_script(<<~JS)
-        (function() {
-          var topic = Discourse.lookup("controller:topic").model;
-          var url = topic.urlForPostNumber(#{reply.post_number});
-          require("discourse/lib/url").default.routeTo(url);
-        })();
-      JS
-
-      expect(page).to have_current_path(%r{/t/#{topic.slug}/#{topic.id}})
-      expect(nested_view).to have_no_nested_view
-    end
   end
 end


### PR DESCRIPTION
This PR started as simply fixing clicking the title in the .d-header when you're scroll down. That is fixed here, but it exposed that we still had some "toggle to flat" related logic that is no longer needed. Cleaned up.