### PR TITLE
DEV: Promote events category type setup to stable

### DIFF
--- a/plugins/discourse-calendar/config/settings.yml
+++ b/plugins/discourse-calendar/config/settings.yml
@@ -137,7 +137,7 @@ discourse_calendar:
     hidden: true
     client: true
     upcoming_change:
-      status: "beta"
+      status: "stable"
       impact: "feature,staff"
       learn_more_url: "https://meta.discourse.org/t/-/401309"
   livestream_enabled:


### PR DESCRIPTION
Promotes the `enable_events_category_type_setup` upcoming change from beta to stable.