### PR TITLE
FEAT: Support excluding topics in posts filters

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3036,6 +3036,7 @@ en:
       group: "Show posts by members of a group"
       groups_any: "Show posts by members of any specified group (comma-separated)"
       topic: "Show posts in specific topics"
+      exclude_topic: "Exclude posts from specific topics"
       after: "Show posts created after a date (YYYY-MM-DD or days ago)"
       before: "Show posts created before a date (YYYY-MM-DD or days ago)"
       topic_after: "Show posts in topics created after a date (YYYY-MM-DD or days ago)"

--- a/lib/posts_filter.rb
+++ b/lib/posts_filter.rb
@@ -203,6 +203,7 @@ class PostsFilter
         alias: "topics:",
         description: I18n.t("posts_filter.description.topic"),
         type: "number",
+        prefixes: [{ name: "-", description: I18n.t("posts_filter.description.exclude_topic") }],
       },
       { name: "after:", description: I18n.t("posts_filter.description.after"), type: "date" },
       { name: "before:", description: I18n.t("posts_filter.description.before"), type: "date" },
@@ -450,8 +451,10 @@ class PostsFilter
     when "category", "tag"
       true
     when "before", "after", "topic_before", "topic_after", "keywords", "topic_keywords",
-         "usernames", "groups", "topics"
+         "usernames", "groups"
       !parsed_filter[:exclude] && parsed_filter[:prefix].exclude?("=")
+    when "topics"
+      parsed_filter[:prefix].exclude?("=")
     when "status"
       !parsed_filter[:exclude] && STATUS_VALUES.include?(value.downcase)
     when "post_type"
@@ -498,7 +501,7 @@ class PostsFilter
       set_order!(order_value(parsed_filter[:value]))
       relation
     when "topics"
-      filter_topics(relation, parsed_filter[:value])
+      filter_topics(relation, parsed_filter)
     when "post_type"
       filter_post_type(relation, parsed_filter[:value])
     else
@@ -643,11 +646,15 @@ class PostsFilter
     )
   end
 
-  def filter_topics(relation, topics_param)
-    topic_ids = split_values(topics_param).map(&:to_i).reject(&:zero?)
-    return relation.where("1 = 0") if topic_ids.empty?
+  def filter_topics(relation, parsed_filter)
+    topic_ids = split_values(parsed_filter[:value]).map(&:to_i).reject(&:zero?)
+    return parsed_filter[:exclude] ? relation : relation.where("1 = 0") if topic_ids.empty?
 
-    relation.where("posts.topic_id IN (?)", topic_ids)
+    if parsed_filter[:exclude]
+      relation.where.not(topic_id: topic_ids)
+    else
+      relation.where("posts.topic_id IN (?)", topic_ids)
+    end
   end
 
   def filter_post_type(relation, post_type)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
@@ -377,6 +377,33 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       )
     end
 
+    it "lists posts while excluding topics in the query field" do
+      included_topic =
+        Fabricate(:topic, category: category, user: user, title: "Included topic title")
+      included_post = Fabricate(:post, topic: included_topic, user: user, post_number: 1)
+      excluded_topic =
+        Fabricate(:topic, category: category, user: user, title: "Excluded topic title")
+      Fabricate(:post, topic: excluded_topic, user: user, post_number: 1)
+      other_excluded_topic =
+        Fabricate(:topic, category: category, user: user, title: "Other excluded title")
+      Fabricate(:post, topic: other_excluded_topic, user: user, post_number: 1)
+
+      result =
+        execute_node_output(
+          configuration: {
+            "operation" => "list",
+            "query" =>
+              "category:#{category.slug} -topic:#{excluded_topic.id},#{other_excluded_topic.id}",
+            "limit" => "10",
+          },
+          item: item,
+        ).first
+
+      expect(result.map { |output_item| output_item.dig("json", "post", "id") }).to contain_exactly(
+        included_post.id,
+      )
+    end
+
     it "lists posts matching the advanced filter" do
       matching_post = Fabricate(:post, user: user, raw: "advanced body")
       Fabricate(:post, user: other_user, raw: "ignored body")

--- a/spec/lib/posts_filter_spec.rb
+++ b/spec/lib/posts_filter_spec.rb
@@ -90,6 +90,9 @@ RSpec.describe PostsFilter do
         description: I18n.t("posts_filter.description.post_type_whisper"),
       },
     )
+    expect(options.find { |option| option[:name] == "topic:" }).to include(
+      prefixes: [{ name: "-", description: I18n.t("posts_filter.description.exclude_topic") }],
+    )
     expect(options.find { |option| option[:name] == "order:" }).not_to include(
       :type,
       :extra_entries,
@@ -193,6 +196,15 @@ RSpec.describe PostsFilter do
     expect(filtered_post_ids("topic:#{feature_topic.id}")).to contain_exactly(
       feature_post.id,
       reply_post.id,
+    )
+    expect(filtered_post_ids("-topic:#{feature_topic.id}")).to contain_exactly(
+      bug_post.id,
+      feature_bug_post.id,
+      no_tag_post.id,
+    )
+    expect(filtered_post_ids("-topic:#{feature_topic.id},#{bug_topic.id}")).to contain_exactly(
+      feature_bug_post.id,
+      no_tag_post.id,
     )
     expect(filtered_post_ids("post_type:first")).to contain_exactly(
       feature_post.id,


### PR DESCRIPTION
Allow posts filter queries to use -topic: to omit posts from one or more topic IDs. Expose the prefix in filter options and cover the behavior in posts filter and workflow specs.
