### PR TITLE
DEV: Support other OAuth token auth methods

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -748,7 +748,8 @@ CREATE TABLE public.ai_mcp_servers (
     oauth_registration_endpoint character varying(1000),
     oauth_authorization_params jsonb DEFAULT '{}'::jsonb NOT NULL,
     oauth_token_params jsonb DEFAULT '{}'::jsonb NOT NULL,
-    oauth_require_refresh_token boolean DEFAULT false NOT NULL
+    oauth_require_refresh_token boolean DEFAULT false NOT NULL,
+    oauth_token_endpoint_auth_methods_supported jsonb DEFAULT '[]'::jsonb NOT NULL
 );
 
 
@@ -22133,6 +22134,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260626055145'),
 ('20260624140945'),
 ('20260623090824'),
 ('20260617053237'),

--- a/plugins/discourse-ai/app/models/ai_mcp_server.rb
+++ b/plugins/discourse-ai/app/models/ai_mcp_server.rb
@@ -189,6 +189,7 @@ class AiMcpServer < ActiveRecord::Base
       token_endpoint: oauth_token_endpoint,
       revocation_endpoint: oauth_revocation_endpoint,
       registration_endpoint: oauth_registration_endpoint,
+      token_endpoint_auth_methods_supported: oauth_token_endpoint_auth_methods_supported,
     )
   end
 
@@ -200,6 +201,8 @@ class AiMcpServer < ActiveRecord::Base
       oauth_registration_endpoint: discovery.registration_endpoint,
       oauth_issuer: discovery.issuer,
       oauth_resource_metadata_url: discovery.resource_metadata_url,
+      oauth_token_endpoint_auth_methods_supported:
+        Array(discovery.token_endpoint_auth_methods_supported),
       oauth_last_error: nil,
     )
   end
@@ -262,6 +265,7 @@ class AiMcpServer < ActiveRecord::Base
       oauth_token_endpoint: nil,
       oauth_revocation_endpoint: nil,
       oauth_registration_endpoint: nil,
+      oauth_token_endpoint_auth_methods_supported: [],
       oauth_issuer: nil,
       oauth_resource_metadata_url: nil,
       oauth_last_error: nil,
@@ -473,6 +477,7 @@ end
 #  oauth_scopes                     :string(2000)
 #  oauth_status                     :string(50)       default("disconnected"), not null
 #  oauth_token_endpoint             :string(1000)
+#  oauth_token_endpoint_auth_methods_supported :jsonb            not null
 #  oauth_token_params               :jsonb            not null
 #  oauth_token_type                 :string(100)
 #  protocol_version                 :string(100)

--- a/plugins/discourse-ai/app/models/ai_mcp_server.rb
+++ b/plugins/discourse-ai/app/models/ai_mcp_server.rb
@@ -450,46 +450,46 @@ end
 #
 # Table name: ai_mcp_servers
 #
-#  id                               :bigint           not null, primary key
-#  auth_header                      :string(100)      default("Authorization"), not null
-#  auth_scheme                      :string(100)      default("Bearer"), not null
-#  auth_type                        :string(50)       default("header_secret"), not null
-#  description                      :string(1000)     not null
-#  enabled                          :boolean          default(TRUE), not null
-#  last_checked_at                  :datetime
-#  last_health_error                :string(1000)
-#  last_health_status               :string(50)
-#  last_tools_synced_at             :datetime
-#  name                             :string(100)      not null
-#  oauth_access_token_expires_at    :datetime
-#  oauth_authorization_endpoint     :string(1000)
-#  oauth_authorization_params       :jsonb            not null
-#  oauth_client_registration        :string(50)       default("client_metadata_document")
-#  oauth_granted_scopes             :string(2000)
-#  oauth_issuer                     :string(1000)
-#  oauth_last_authorized_at         :datetime
-#  oauth_last_error                 :string(1000)
-#  oauth_last_refreshed_at          :datetime
-#  oauth_registration_endpoint      :string(1000)
-#  oauth_require_refresh_token      :boolean          default(FALSE), not null
-#  oauth_resource_metadata_url      :string(1000)
-#  oauth_revocation_endpoint        :string(1000)
-#  oauth_scopes                     :string(2000)
-#  oauth_status                     :string(50)       default("disconnected"), not null
-#  oauth_token_endpoint             :string(1000)
+#  id                                          :bigint           not null, primary key
+#  auth_header                                 :string(100)      default("Authorization"), not null
+#  auth_scheme                                 :string(100)      default("Bearer"), not null
+#  auth_type                                   :string(50)       default("header_secret"), not null
+#  description                                 :string(1000)     not null
+#  enabled                                     :boolean          default(TRUE), not null
+#  last_checked_at                             :datetime
+#  last_health_error                           :string(1000)
+#  last_health_status                          :string(50)
+#  last_tools_synced_at                        :datetime
+#  name                                        :string(100)      not null
+#  oauth_access_token_expires_at               :datetime
+#  oauth_authorization_endpoint                :string(1000)
+#  oauth_authorization_params                  :jsonb            not null
+#  oauth_client_registration                   :string(50)       default("client_metadata_document")
+#  oauth_granted_scopes                        :string(2000)
+#  oauth_issuer                                :string(1000)
+#  oauth_last_authorized_at                    :datetime
+#  oauth_last_error                            :string(1000)
+#  oauth_last_refreshed_at                     :datetime
+#  oauth_registration_endpoint                 :string(1000)
+#  oauth_require_refresh_token                 :boolean          default(FALSE), not null
+#  oauth_resource_metadata_url                 :string(1000)
+#  oauth_revocation_endpoint                   :string(1000)
+#  oauth_scopes                                :string(2000)
+#  oauth_status                                :string(50)       default("disconnected"), not null
+#  oauth_token_endpoint                        :string(1000)
 #  oauth_token_endpoint_auth_methods_supported :jsonb            not null
-#  oauth_token_params               :jsonb            not null
-#  oauth_token_type                 :string(100)
-#  protocol_version                 :string(100)
-#  server_capabilities              :jsonb            not null
-#  timeout_seconds                  :integer          default(30), not null
-#  url                              :string(1000)     not null
-#  created_at                       :datetime         not null
-#  updated_at                       :datetime         not null
-#  ai_secret_id                     :bigint
-#  created_by_id                    :integer
-#  oauth_client_id                  :string(1000)
-#  oauth_client_secret_ai_secret_id :bigint
+#  oauth_token_params                          :jsonb            not null
+#  oauth_token_type                            :string(100)
+#  protocol_version                            :string(100)
+#  server_capabilities                         :jsonb            not null
+#  timeout_seconds                             :integer          default(30), not null
+#  url                                         :string(1000)     not null
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  ai_secret_id                                :bigint
+#  created_by_id                               :integer
+#  oauth_client_id                             :string(1000)
+#  oauth_client_secret_ai_secret_id            :bigint
 #
 # Indexes
 #

--- a/plugins/discourse-ai/db/migrate/20260626055145_add_oauth_token_endpoint_auth_methods_to_ai_mcp_servers.rb
+++ b/plugins/discourse-ai/db/migrate/20260626055145_add_oauth_token_endpoint_auth_methods_to_ai_mcp_servers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddOauthTokenEndpointAuthMethodsToAiMcpServers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :ai_mcp_servers,
+               :oauth_token_endpoint_auth_methods_supported,
+               :jsonb,
+               null: false,
+               default: []
+  end
+end

--- a/plugins/discourse-ai/spec/lib/mcp/oauth_flow_spec.rb
+++ b/plugins/discourse-ai/spec/lib/mcp/oauth_flow_spec.rb
@@ -324,6 +324,59 @@ RSpec.describe DiscourseAi::Mcp::OAuthFlow do
         I18n.t("discourse_ai.mcp_servers.errors.oauth_refresh_token_required"),
       )
     end
+
+    it "uses persisted client_secret_post token auth methods" do
+      ai_mcp_server.update!(
+        oauth_client_registration: "manual",
+        oauth_client_id: "client-id",
+        oauth_client_secret_ai_secret_id: oauth_client_secret.id,
+      )
+      ai_mcp_server.store_oauth_discovery!(
+        DiscourseAi::Mcp::OAuthDiscovery::Result.new(
+          resource: ai_mcp_server.url,
+          resource_metadata_url: "#{ai_mcp_server.url}/.well-known/oauth-protected-resource",
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          revocation_endpoint: nil,
+          registration_endpoint: nil,
+          token_endpoint_auth_methods_supported: %w[client_secret_post],
+        ),
+      )
+
+      state = SecureRandom.hex(32)
+      Rails.cache.write(
+        "discourse-ai:mcp-oauth-state:#{state}",
+        {
+          "ai_mcp_server_id" => ai_mcp_server.id,
+          "user_id" => user.id,
+          "code_verifier" => "test-verifier",
+        },
+        expires_in: 10.minutes,
+      )
+
+      stub_request(:post, "https://auth.example.com/token")
+        .with do |request|
+          decoded_body = Rack::Utils.parse_nested_query(request.body)
+          request.headers["Authorization"].blank? &&
+            decoded_body["client_secret"] == oauth_client_secret.secret
+        end
+        .to_return(
+          status: 200,
+          body: {
+            access_token: "fresh-access-token",
+            refresh_token: "fresh-refresh-token",
+            token_type: "Bearer",
+          }.to_json,
+          headers: {
+            "Content-Type" => "application/json",
+          },
+        )
+
+      described_class.complete!(params: { state: state, code: "auth-code" }, current_user: user)
+
+      expect(ai_mcp_server.reload.oauth_token.access_token).to eq("fresh-access-token")
+    end
   end
 
   describe ".refresh!" do

--- a/plugins/discourse-ai/spec/models/ai_mcp_server_spec.rb
+++ b/plugins/discourse-ai/spec/models/ai_mcp_server_spec.rb
@@ -146,6 +146,27 @@ RSpec.describe AiMcpServer do
     expect(server.reload.effective_oauth_client_id).to eq("dynamic-client-id")
   end
 
+  it "preserves discovered token endpoint auth methods" do
+    server = Fabricate(:ai_mcp_server, auth_type: "oauth")
+    discovery =
+      DiscourseAi::Mcp::OAuthDiscovery::Result.new(
+        resource: server.url,
+        resource_metadata_url: "#{server.url}/.well-known/oauth-protected-resource",
+        issuer: "https://auth.example.com",
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+        revocation_endpoint: nil,
+        registration_endpoint: nil,
+        token_endpoint_auth_methods_supported: %w[client_secret_post],
+      )
+
+    server.store_oauth_discovery!(discovery)
+
+    expect(server.reload.oauth_discovery_result.token_endpoint_auth_methods_supported).to eq(
+      %w[client_secret_post],
+    )
+  end
+
   it "clears dynamically registered client_id when OAuth credentials are cleared" do
     server = Fabricate(:ai_mcp_server, auth_type: "oauth")
     server.store_dynamic_registration!(client_id: "dynamic-client-id")


### PR DESCRIPTION
Some MCP OAuth providers only support `client_secret_post` at the token endpoint. 

This stores the discovered token endpoint auth methods and reuses them for callback and refresh flows. Here's an example of what we're now saving as part of this change e.g.

```
  {
    ...
    "oauth_status": "connected",
    "oauth_issuer": "https://mcp.hubspot.com",
    "oauth_authorization_endpoint": "https://mcp.hubspot.com/oauth/authorize/user",
    "oauth_token_endpoint": "https://mcp.hubspot.com/oauth/v3/token",
    "oauth_token_endpoint_auth_methods_supported": ["client_secret_post"],
    ...
  }
```

