### PR TITLE
FIX: display emojis in calendar tooltip

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/post-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/post-calendar.gjs
@@ -3,9 +3,8 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
-import { trustHTML } from "@ember/template";
 import getURL from "discourse/lib/get-url";
-import { escapeExpression } from "discourse/lib/utilities";
+import { excerpt } from "discourse/lib/text";
 import { colorToHex, contrastColor, stringToColor } from "../lib/colors";
 import FullCalendar from "./full-calendar";
 
@@ -263,11 +262,7 @@ export default class PostCalendar extends Component {
       event.textColor = contrastColor(color);
     }
 
-    let popupText = detail.message.slice(0, 100);
-    if (detail.message.length > 100) {
-      popupText += "…";
-    }
-    event.extendedProps.htmlContent = trustHTML(escapeExpression(popupText));
+    event.extendedProps.htmlContent = excerpt(detail.message, 100);
     event.title = event.title.replace(/<img[^>]*>/g, "");
     event.participantCount = 1;
 


### PR DESCRIPTION
The tooltip was displaying broken image markup as text due to slicing the string (mid image) and then escaping.
 
The tooltip already receives sanitized cooked HTML for `message.description` as the value uses `PrettyText.excerpt` with `strip_links: true` so we can cleanly use excerpt to safely truncate the text to 100 chars for tooltip without breaking the emoji.

## Before

<img width="426" height="142" alt="Screenshot 2026-06-26 at 10 15 31 AM" src="https://github.com/user-attachments/assets/aa391b43-d8a3-4c10-abea-34457a9124e0" />


## After

<img width="249" height="124" alt="Screenshot 2026-06-26 at 10 13 30 AM" src="https://github.com/user-attachments/assets/3f5b0b6f-96e2-46b6-84f4-3ca994950239" />
