### PR TITLE
UX: chat scroll to bottom hover bg

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-scroll-to-bottom.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-scroll-to-bottom.scss
@@ -31,8 +31,6 @@
     &:hover,
     &:active,
     &:focus {
-      background: none !important;
-
       .d-icon {
         color: var(--secondary) !important;
       }


### PR DESCRIPTION
When hovering the scroll to bottom button disappears into the text as there is no background color.

## Before

<img width="395" height="160" alt="Screenshot 2026-06-26 at 1 03 23 PM" src="https://github.com/user-attachments/assets/ba31870b-e2a5-4196-9a30-8d97cec54670" />


## After

<img width="395" height="161" alt="Screenshot 2026-06-26 at 1 03 48 PM" src="https://github.com/user-attachments/assets/21fdfb1e-00ac-4a15-be09-9e2cd2846cbc" />

<img width="394" height="160" alt="Screenshot 2026-06-26 at 1 04 00 PM" src="https://github.com/user-attachments/assets/2a7f999d-72b2-404a-892e-194967679868" />
