### PR TITLE
UX: remove orphaned class selectors

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -538,13 +538,6 @@ $mobile-avatar-height: 1.532em;
   }
 }
 
-.d-header-mode {
-  .fk-d-button-tooltip .fk-d-tooltip__trigger {
-    color: var(--header_primary-high);
-    background: transparent;
-  }
-}
-
 #additional-panel-wrapper {
   position: absolute;
 

--- a/themes/horizon/scss/desktop-full-width.scss
+++ b/themes/horizon/scss/desktop-full-width.scss
@@ -99,15 +99,6 @@ $sidebar-width: 17em;
         auto
         minmax(auto, 1fr);
 
-      .d-header-mode {
-        grid-area: extra-info;
-        white-space: nowrap;
-
-        @include viewport.until(md) {
-          display: none;
-        }
-      }
-
       .d-header .title {
         min-width: auto;
       }
@@ -138,10 +129,6 @@ $sidebar-width: 17em;
 
         @media screen and (width <= 1000px) {
           gap: 0.5em;
-        }
-
-        .d-header-mode {
-          grid-area: extra-info;
         }
       }
     }
@@ -197,7 +184,6 @@ body.has-sidebar-page {
     max-width: unset; // undoing core default
   }
 
-  .d-header-mode,
   .extra-info-wrapper {
     padding: 0;
   }


### PR DESCRIPTION
Commits #37694 and #36231 removed the `.d-header-mode`. These classes were leftovers.