### PR TITLE
FIX: calendar event tooltip emoji size

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/common/full-calendar-ext.scss
@@ -107,6 +107,12 @@
   height: 100%;
 }
 
+[data-identifier="post-event-tooltip"] img.only-emoji {
+  width: 1em;
+  height: 1em;
+  margin: 0;
+}
+
 @include viewport.until(md) {
   .fc-header-toolbar {
     display: flex;


### PR DESCRIPTION
When emojis are adding by themselves in a paragraph they get the `only-emoji` class which makes them larger.

In the tooltip we want to inline them and keep the size matching that of the description text.

## Before

<img width="332" height="125" alt="Screenshot 2026-06-26 at 1 45 19 PM" src="https://github.com/user-attachments/assets/63c90983-0f5f-45a2-912b-ad37a438ac28" />


## After

<img width="299" height="95" alt="Screenshot 2026-06-26 at 1 45 32 PM" src="https://github.com/user-attachments/assets/4e45d15d-cc37-4ac5-9753-4ab86292c0a4" />
