### PR TITLE
FEATURE: Bulk suspend users and filter the admin users list by activation

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1304,6 +1304,7 @@ a.inline-editable-field {
 @import "admin/schema_setting_editor";
 @import "admin/customize_show_schema";
 @import "admin/admin_bulk_users_delete_modal";
+@import "admin/admin_bulk_users_suspend_modal";
 @import "admin/color-palette-editor";
 @import "admin/admin_config_color_palettes";
 @import "admin/admin_config_components";

--- a/app/assets/stylesheets/admin/admin_bulk_users_suspend_modal.scss
+++ b/app/assets/stylesheets/admin/admin_bulk_users_suspend_modal.scss
@@ -1,0 +1,26 @@
+.bulk-user-suspend-confirmation {
+  &__progress {
+    font-family: var(--d-font-family--monospace);
+    max-height: 400px;
+    background: var(--blend-primary-secondary-5);
+    padding: 1em;
+    overflow-y: auto;
+  }
+
+  &__progress-line {
+    overflow-anchor: none;
+
+    &.-success {
+      color: var(--success);
+    }
+
+    &.-error {
+      color: var(--danger);
+    }
+  }
+
+  &__progress-anchor {
+    overflow-anchor: auto;
+    height: 1px;
+  }
+}

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -159,7 +159,8 @@
     &__column-header {
       &--username,
       &---email,
-      &--silence-reason {
+      &--silence-reason,
+      &--suspend-reason {
         .header-contents {
           text-align: left;
         }
@@ -178,7 +179,8 @@
       margin-right: 1em;
     }
 
-    &__cell.silence_reason {
+    &__cell.silence_reason,
+    &__cell.suspend_reason {
       text-align: left;
       justify-content: start;
 
@@ -202,6 +204,20 @@
   &__controls {
     display: flex;
     gap: 1em;
+  }
+
+  &__search {
+    flex: 1 1 auto;
+  }
+
+  &__activation-filter.d-select {
+    flex: 0 1 auto;
+    max-width: 14em;
+    height: auto;
+
+    @media screen and (width <= 500px) {
+      max-width: none;
+    }
   }
 }
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -30,9 +30,17 @@ class Admin::UsersController < Admin::StaffController
                 ]
 
   def index
-    users = ::AdminUserIndexQuery.new(params, guardian: guardian).find_users
+    query = ::AdminUserIndexQuery.new(params, guardian:)
+    users = query.find_users
 
-    opts = { include_can_be_deleted: true, include_silence_reason: true }
+    opts = {
+      include_can_be_deleted: true,
+      include_can_be_suspended: true,
+      include_silence_reason: true,
+      include_suspend_reason: true,
+      silence_reasons: query.penalty_reasons(users.select(&:silenced?), :silence_user),
+      suspend_reasons: query.penalty_reasons(users.select(&:suspended?), :suspend_user),
+    }
     if params[:show_emails] == "true"
       StaffActionLogger.new(current_user).log_show_emails(users, context: request.path)
       opts[:emails_desired] = true
@@ -429,8 +437,6 @@ class Admin::UsersController < Admin::StaffController
   end
 
   def destroy_bulk
-    # capture service_params outside the hijack block to avoid thread safety
-    # issues
     service_arg = service_params
 
     hijack do
@@ -444,6 +450,28 @@ class Admin::UsersController < Admin::StaffController
 
         on_failed_policy(:can_delete_users) do
           render json: failed_json.merge(errors: [I18n.t("user.cannot_bulk_delete")]),
+                 status: :forbidden
+        end
+
+        on_model_not_found(:users) { render json: failed_json, status: :not_found }
+      end
+    end
+  end
+
+  def suspend_bulk
+    service_arg = service_params
+
+    hijack do
+      User::BulkSuspend.call(service_arg) do
+        on_success { render json: { suspended: true } }
+
+        on_failed_contract do |contract|
+          render json: failed_json.merge(errors: contract.errors.full_messages),
+                 status: :bad_request
+        end
+
+        on_failed_policy(:can_suspend_users) do
+          render json: failed_json.merge(errors: [I18n.t("user.cannot_bulk_suspend")]),
                  status: :forbidden
         end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -305,6 +305,7 @@ class User < ActiveRecord::Base
   scope :suspended, -> { where("suspended_till IS NOT NULL AND suspended_till > ?", Time.zone.now) }
   scope :not_suspended, -> { where("suspended_till IS NULL OR suspended_till <= ?", Time.zone.now) }
   scope :activated, -> { where(active: true) }
+  scope :not_activated, -> { where(active: false) }
   scope :not_staged, -> { where(staged: false) }
   scope :approved, -> { where(approved: true) }
 
@@ -1373,22 +1374,29 @@ class User < ActiveRecord::Base
     !!(silenced_till && silenced_till > Time.zone.now)
   end
 
+  def self.format_penalty_reason(details)
+    return if details.blank?
+    sanitize_staff_reason(details).split("<br>").first
+  end
+
+  def self.sanitize_staff_reason(text)
+    STAFF_REASON_SANITIZER.sanitize(
+      PrettyText.cleanup(text.gsub("\n", "<br>")),
+      tags: STAFF_REASON_ALLOWED_TAGS,
+      attributes: STAFF_REASON_ALLOWED_ATTRIBUTES,
+    )
+  end
+
   def silenced_record
     user_histories.where(action: UserHistory.actions[:silence_user]).order("id DESC").first
   end
 
   def full_silence_reason
-    text = silenced_record.try(:details) if silenced?
-    return text if text.blank?
-    sanitize_staff_reason(text)
+    full_penalty_reason(silenced_record) if silenced?
   end
 
   def silence_reason
-    if details = full_silence_reason
-      return details.split("<br>")[0]
-    end
-
-    nil
+    full_silence_reason&.split("<br>")&.first
   end
 
   def silenced_at
@@ -1404,25 +1412,17 @@ class User < ActiveRecord::Base
   end
 
   def full_suspend_reason
-    text = suspend_record.try(:details) if suspended?
-    return text if text.blank?
-    sanitize_staff_reason(text)
+    full_penalty_reason(suspend_record) if suspended?
   end
 
   def suspend_reason
-    if details = full_suspend_reason
-      return details.split("<br>")[0]
-    end
-
-    nil
+    full_suspend_reason&.split("<br>")&.first
   end
 
-  def sanitize_staff_reason(text)
-    STAFF_REASON_SANITIZER.sanitize(
-      PrettyText.cleanup(text.gsub("\n", "<br>")),
-      tags: STAFF_REASON_ALLOWED_TAGS,
-      attributes: STAFF_REASON_ALLOWED_ATTRIBUTES,
-    )
+  def full_penalty_reason(record)
+    text = record&.details
+    return if text.blank?
+    User.sanitize_staff_reason(text)
   end
 
   def suspended_message

--- a/app/serializers/admin_user_list_serializer.rb
+++ b/app/serializers/admin_user_list_serializer.rb
@@ -25,7 +25,9 @@ class AdminUserListSerializer < BasicUserSerializer
              :staged,
              :second_factor_enabled,
              :can_be_deleted,
-             :silence_reason
+             :can_be_suspended,
+             :silence_reason,
+             :suspend_reason
 
   %i[days_visited posts_read_count topics_entered post_count].each do |sym|
     attributes sym
@@ -117,11 +119,27 @@ class AdminUserListSerializer < BasicUserSerializer
     @options[:include_can_be_deleted]
   end
 
+  def can_be_suspended
+    scope.can_suspend?(object) && !object.suspended?
+  end
+
+  def include_can_be_suspended?
+    @options[:include_can_be_suspended]
+  end
+
   def silence_reason
-    object.silence_reason
+    User.format_penalty_reason(@options[:silence_reasons].to_h[object.id])
   end
 
   def include_silence_reason?
     @options[:include_silence_reason]
+  end
+
+  def suspend_reason
+    User.format_penalty_reason(@options[:suspend_reasons].to_h[object.id])
+  end
+
+  def include_suspend_reason?
+    @options[:include_suspend_reason]
   end
 end

--- a/app/services/user/action/suspend_and_publish.rb
+++ b/app/services/user/action/suspend_and_publish.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class User::Action::SuspendAndPublish < Service::ActionBase
+  option :user
+  option :position
+  option :guardian
+  option :total_size
+  option :suspend_until
+  option :reason
+  option :message, default: proc { nil }
+
+  def call
+    data = { position:, username: user.username, total: total_size }
+    ::MessageBus.publish("/bulk-user-suspend", data.merge(suspend_user!), user_ids: [actor.id])
+  end
+
+  private
+
+  def actor
+    guardian.user
+  end
+
+  def suspend_user!
+    UserSuspender.new(
+      user,
+      suspended_till: suspend_until,
+      reason:,
+      by_user: actor,
+      message:,
+    ).suspend
+    { success: true }
+  rescue => err
+    { failed: true, error: err.message }
+  end
+end

--- a/app/services/user/bulk_suspend.rb
+++ b/app/services/user/bulk_suspend.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class User::BulkSuspend
+  include Service::Base
+
+  params do
+    attribute :user_ids, :array, compact_blank: true
+    attribute :reason, :string
+    attribute :suspend_until, :datetime
+    attribute :message, :string
+
+    validates :user_ids, length: { minimum: 1, maximum: 100 }
+    validates :reason, presence: true, length: { maximum: 300 }
+    validates :suspend_until, presence: true
+  end
+
+  model :users
+  policy :can_suspend_users
+  step :suspend
+
+  private
+
+  def fetch_users(params:)
+    # this order clause ensures we retrieve the users in the same order as the
+    # IDs in the param. we do this to ensure the users are suspended in the same
+    # order as they're selected in the UI
+    User
+      .where(id: params.user_ids)
+      .order(DB.sql_fragment("array_position(ARRAY[?], users.id)", params.user_ids))
+      .to_a
+  end
+
+  def can_suspend_users(guardian:, users:)
+    users.all? { guardian.can_suspend?(it) && !it.suspended? }
+  end
+
+  def suspend(users:, guardian:, params:)
+    users
+      .each
+      .with_index(1) do |user, position|
+        User::Action::SuspendAndPublish.call(
+          user:,
+          position:,
+          guardian:,
+          total_size: users.size,
+          suspend_until: params.suspend_until,
+          reason: params.reason,
+          message: params.message,
+        )
+      end
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9010,13 +9010,33 @@ en:
         show_emails: "Show emails"
         hide_emails: "Hide emails"
         silence_reason: "Silence reason"
+        suspend_reason: "Suspend reason"
         bulk_actions:
           title: "Bulk actions"
-          admin_cant_be_deleted: "This user can't be deleted because they're an admin"
-          too_many_or_old_posts: "This user can't be deleted they have too many posts or a very old post"
+          select_all: "Select all"
+          clear_all: "Clear all"
+          staff_cant_be_actioned: "This user can't be deleted or suspended because they're a staff member"
+          no_users_can_be_deleted: "None of the selected users can be deleted."
+          no_users_can_be_suspended: "None of the selected users can be suspended."
           too_many_selected_users:
-            one: "You've reached the %{count} user limit for bulk deletion"
-            other: "You've reached the %{count} users limit for bulk deletion"
+            one: "You've reached the %{count} user limit for bulk actions"
+            other: "You've reached the %{count} users limit for bulk actions"
+          suspend:
+            label: "Suspend users…"
+            confirmation_modal:
+              prompt_text:
+                one: "You're about to suspend %{count} user. Set a duration and reason below:"
+                other: "You're about to suspend %{count} users. Set a duration and reason below:"
+              close: "Close"
+              confirm: "Suspend"
+              title:
+                one: "Suspend %{count} user"
+                other: "Suspend %{count} users"
+              bulk_suspend_starting: "Starting bulk suspend…"
+              user_suspend_succeeded: "[%{position}/%{total}] Successfully suspended @%{username}"
+              user_suspend_failed: "[%{position}/%{total}] Failed to suspend @%{username} - %{error}"
+              bulk_suspend_finished: "Bulk suspend operation completed."
+              failed_to_suspend_users: "The following users failed to be suspended:"
           delete:
             label: "Delete users…"
             confirmation_modal:
@@ -9044,6 +9064,11 @@ en:
           suspended: "Suspended"
           silenced: "Silenced"
           staged: "Staged"
+        activation_filter:
+          label: "Activation status"
+          all: "All users"
+          activated: "Activated"
+          not_activated: "Not activated"
         approved: "Approved?"
         titles:
           active: "Active users"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3426,6 +3426,7 @@ en:
       one: "User %{username} has %{count} post in a public topic or personal message, so they can't be deleted."
       other: "User %{username} has %{count} posts in public topics or personal messages, so they can't be deleted."
     cannot_bulk_delete: "One or more users cannot be deleted either because they're an admin, have too many posts or have a very old post."
+    cannot_bulk_suspend: "One or more of the selected users can't be suspended."
     cannot_remove_all_auth: "You must have at least one associated account, a passkey, or a password set."
 
   unsubscribe_mailer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Discourse::Application.routes.draw do
           delete "delete-others-with-same-ip" => "users#delete_other_accounts_with_same_ip"
           get "total-others-with-same-ip" => "users#total_other_accounts_with_same_ip"
           put "approve-bulk" => "users#approve_bulk"
+          put "suspend-bulk" => "users#suspend_bulk"
           delete "destroy-bulk" => "users#destroy_bulk"
         end
         delete "penalty_history", constraints: AdminConstraint.new

--- a/frontend/discourse/admin/components/bulk-user-delete-confirmation.gjs
+++ b/frontend/discourse/admin/components/bulk-user-delete-confirmation.gjs
@@ -134,7 +134,7 @@ export default class BulkUserDeleteConfirmation extends Component {
   closeModal() {
     this.args.closeModal();
     if (this.callAfterBulkDelete) {
-      this.args.model?.afterBulkDelete();
+      this.args.model?.afterBulkAction();
     }
   }
 

--- a/frontend/discourse/admin/components/bulk-user-suspend-confirmation.gjs
+++ b/frontend/discourse/admin/components/bulk-user-suspend-confirmation.gjs
@@ -1,0 +1,202 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { fn } from "@ember/helper";
+import { action } from "@ember/object";
+import { trackedArray } from "@ember/reactive/collections";
+import { service } from "@ember/service";
+import { isEmpty } from "@ember/utils";
+import { modifier as modifierFn } from "ember-modifier";
+import AdminPenaltyReason from "discourse/admin/components/admin-penalty-reason";
+import { ajax } from "discourse/lib/ajax";
+import { extractError } from "discourse/lib/ajax-error";
+import { bind } from "discourse/lib/decorators";
+import DButton from "discourse/ui-kit/d-button";
+import DFutureDateInput from "discourse/ui-kit/d-future-date-input";
+import DModal from "discourse/ui-kit/d-modal";
+import { i18n } from "discourse-i18n";
+
+const BULK_SUSPEND_CHANNEL = "/bulk-user-suspend";
+
+export default class BulkUserSuspendConfirmation extends Component {
+  @service messageBus;
+
+  @tracked suspendUntil;
+  @tracked reason;
+  @tracked suspendStarted = false;
+  @tracked submitting = false;
+  message;
+
+  logs = trackedArray();
+  failedUsernames = [];
+
+  callAfterBulkSuspend = false;
+
+  logsListener = modifierFn(() => {
+    this.messageBus.subscribe(BULK_SUSPEND_CHANNEL, this.onSuspendProgress);
+
+    return () => {
+      this.messageBus.unsubscribe(BULK_SUSPEND_CHANNEL, this.onSuspendProgress);
+    };
+  });
+
+  get submitDisabled() {
+    return (
+      this.submitting ||
+      isEmpty(this.suspendUntil) ||
+      isEmpty(this.reason?.trim())
+    );
+  }
+
+  #logError(line) {
+    this.#log(line, "error");
+  }
+
+  #logSuccess(line) {
+    this.#log(line, "success");
+  }
+
+  #logNeutral(line) {
+    this.#log(line, "neutral");
+  }
+
+  #log(line, type) {
+    this.logs.push({
+      line,
+      type,
+    });
+  }
+
+  @bind
+  onSuspendProgress(data) {
+    if (data.success) {
+      this.#logSuccess(
+        i18n(
+          "admin.users.bulk_actions.suspend.confirmation_modal.user_suspend_succeeded",
+          data
+        )
+      );
+    } else if (data.failed) {
+      this.failedUsernames.push(data.username);
+      this.#logError(
+        i18n(
+          "admin.users.bulk_actions.suspend.confirmation_modal.user_suspend_failed",
+          data
+        )
+      );
+    }
+
+    if (data.position === data.total) {
+      this.callAfterBulkSuspend = true;
+      this.#logNeutral(
+        i18n(
+          "admin.users.bulk_actions.suspend.confirmation_modal.bulk_suspend_finished"
+        )
+      );
+      if (this.failedUsernames.length > 0) {
+        this.#logNeutral(
+          i18n(
+            "admin.users.bulk_actions.suspend.confirmation_modal.failed_to_suspend_users"
+          )
+        );
+        for (const username of this.failedUsernames) {
+          this.#logNeutral(`* ${username}`);
+        }
+      }
+    }
+  }
+
+  @action
+  async startSuspend() {
+    this.submitting = true;
+    this.suspendStarted = true;
+    this.#logNeutral(
+      i18n(
+        "admin.users.bulk_actions.suspend.confirmation_modal.bulk_suspend_starting"
+      )
+    );
+
+    try {
+      await ajax("/admin/users/suspend-bulk.json", {
+        type: "PUT",
+        data: {
+          user_ids: this.args.model.userIds,
+          suspend_until: this.suspendUntil,
+          reason: this.reason,
+          message: this.message,
+        },
+      });
+      this.callAfterBulkSuspend = true;
+    } catch (err) {
+      this.#logError(extractError(err));
+      this.submitting = false;
+    }
+  }
+
+  @action
+  closeModal() {
+    this.args.closeModal();
+    if (this.callAfterBulkSuspend) {
+      this.args.model?.afterBulkAction();
+    }
+  }
+
+  <template>
+    <DModal
+      class="bulk-user-suspend-confirmation"
+      @closeModal={{this.closeModal}}
+      @title={{i18n
+        "admin.users.bulk_actions.suspend.confirmation_modal.title"
+        count=@model.userIds.length
+      }}
+      {{this.logsListener}}
+    >
+      <:body>
+        {{#if this.suspendStarted}}
+          <div class="bulk-user-suspend-confirmation__progress">
+            {{#each this.logs as |entry|}}
+              <div
+                class="bulk-user-suspend-confirmation__progress-line -{{entry.type}}"
+              >
+                {{entry.line}}
+              </div>
+            {{/each}}
+            <div class="bulk-user-suspend-confirmation__progress-anchor">
+            </div>
+          </div>
+        {{else}}
+          <p>{{i18n
+              "admin.users.bulk_actions.suspend.confirmation_modal.prompt_text"
+              count=@model.userIds.length
+            }}
+          </p>
+          <DFutureDateInput
+            @label="admin.user.suspend_duration"
+            @clearable={{false}}
+            @input={{this.suspendUntil}}
+            @onChangeInput={{fn (mut this.suspendUntil)}}
+            class="suspend-until"
+          />
+          <AdminPenaltyReason
+            @penaltyType="suspend"
+            @reason={{this.reason}}
+            @message={{this.message}}
+          />
+        {{/if}}
+      </:body>
+      <:footer>
+        <DButton
+          class="confirm-suspend btn-danger"
+          @icon="ban"
+          @label="admin.users.bulk_actions.suspend.confirmation_modal.confirm"
+          @disabled={{this.submitDisabled}}
+          @action={{this.startSuspend}}
+        />
+        <DButton
+          class="btn-default"
+          @label="admin.users.bulk_actions.suspend.confirmation_modal.close"
+          @action={{this.closeModal}}
+        />
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/frontend/discourse/admin/controllers/admin-users-list/show.js
+++ b/frontend/discourse/admin/controllers/admin-users-list/show.js
@@ -5,6 +5,7 @@ import { dependentKeyCompat } from "@ember/object/compat";
 import { trackedArray } from "@ember/reactive/collections";
 import { service } from "@ember/service";
 import BulkUserDeleteConfirmation from "discourse/admin/components/bulk-user-delete-confirmation";
+import BulkUserSuspendConfirmation from "discourse/admin/components/bulk-user-suspend-confirmation";
 import AdminUser from "discourse/admin/models/admin-user";
 import CanCheckEmailsHelper from "discourse/lib/can-check-emails-helper";
 import discourseDebounce from "discourse/lib/debounce";
@@ -20,12 +21,12 @@ export default class AdminUsersListShowController extends Controller {
 
   @tracked bulkSelect = false;
   @tracked displayBulkActions = false;
-  @tracked bulkSelectedUserIdsSet = new Set();
   @tracked bulkSelectedUsersMap = {};
 
   query = null;
   order = null;
   asc = null;
+  activation = null;
   showEmails = false;
   refreshing = false;
   listFilter = null;
@@ -92,6 +93,16 @@ export default class AdminUsersListShowController extends Controller {
     return this.query === "silenced";
   }
 
+  @computed("query")
+  get showSuspendReason() {
+    return this.query === "suspended";
+  }
+
+  @computed("query")
+  get showActivationFilter() {
+    return this.query === "new";
+  }
+
   resetFilters() {
     this._page = 1;
     this._results.length = 0;
@@ -100,6 +111,9 @@ export default class AdminUsersListShowController extends Controller {
   }
 
   stripHtml(html) {
+    if (!html) {
+      return "";
+    }
     const doc = new DOMParser().parseFromString(html, "text/html");
     return doc.body.textContent || "";
   }
@@ -117,6 +131,7 @@ export default class AdminUsersListShowController extends Controller {
       show_emails: this.showEmails,
       order: this.order,
       asc: this.asc,
+      activation: this.activation,
       page,
     })
       .then((result) => {
@@ -160,18 +175,45 @@ export default class AdminUsersListShowController extends Controller {
   }
 
   @action
+  updateActivation(value) {
+    this.set("activation", value);
+  }
+
+  @action
   toggleBulkSelect() {
     this.bulkSelect = !this.bulkSelect;
     this.displayBulkActions = false;
     this.bulkSelectedUsersMap = {};
-    this.bulkSelectedUserIdsSet = new Set();
+  }
+
+  @action
+  bulkSelectAll() {
+    const unchecked = [
+      ...document.querySelectorAll(
+        "input.directory-table__cell-bulk-select:not(:checked)"
+      ),
+    ];
+    const remaining = MAX_BULK_SELECT_LIMIT - this.bulkSelectedUsers.length;
+    unchecked.slice(0, remaining).forEach((input) => input.click());
+
+    if (unchecked.length > remaining) {
+      this.#showBulkSelectionLimitToast();
+    }
+  }
+
+  @action
+  bulkClearAll() {
+    document
+      .querySelectorAll("input.directory-table__cell-bulk-select:checked")
+      .forEach((input) => input.click());
   }
 
   @action
   bulkSelectItemToggle(userId, event) {
     if (event.target.checked) {
       if (!this.#canBulkSelectMoreUsers(1)) {
-        this.#showBulkSelectionLimitToast(event);
+        event.preventDefault();
+        this.#showBulkSelectionLimitToast();
         return;
       }
 
@@ -188,7 +230,8 @@ export default class AdminUsersListShowController extends Controller {
           const end = Math.max(lastSelectedIndex, newSelectedIndex);
 
           if (!this.#canBulkSelectMoreUsers(end - start)) {
-            this.#showBulkSelectionLimitToast(event);
+            event.preventDefault();
+            this.#showBulkSelectionLimitToast();
             return;
           }
 
@@ -201,41 +244,70 @@ export default class AdminUsersListShowController extends Controller {
       this.#addUserToBulkSelection(userId);
       this.lastSelected = event.target;
     } else {
-      this.bulkSelectedUserIdsSet.delete(userId);
       delete this.bulkSelectedUsersMap[userId];
     }
 
-    this.displayBulkActions = this.bulkSelectedUserIdsSet.size > 0;
+    this.displayBulkActions = this.bulkSelectedUsers.length > 0;
+  }
+
+  get bulkSelectedUsers() {
+    return Object.values(this.bulkSelectedUsersMap);
   }
 
   @bind
-  async afterBulkDelete() {
+  async afterBulkAction() {
     await this.resetFilters();
     this.bulkSelectedUsersMap = {};
-    this.bulkSelectedUserIdsSet = new Set();
     this.displayBulkActions = false;
+  }
+
+  #openBulkActionConfirmation({ canBeActioned, emptyMessageKey, modal }) {
+    const userIds = this.bulkSelectedUsers
+      .filter(canBeActioned)
+      .map((user) => user.id);
+
+    if (userIds.length === 0) {
+      this.toasts.error({
+        duration: "short",
+        data: { message: i18n(emptyMessageKey) },
+      });
+      return;
+    }
+
+    this.modal.show(modal, {
+      model: { userIds, afterBulkAction: this.afterBulkAction },
+    });
   }
 
   @action
   openBulkDeleteConfirmation() {
-    this.modal.show(BulkUserDeleteConfirmation, {
-      model: {
-        userIds: Array.from(this.bulkSelectedUserIdsSet),
-        afterBulkDelete: this.afterBulkDelete,
-      },
+    this.#openBulkActionConfirmation({
+      canBeActioned: (user) => user.can_be_deleted,
+      emptyMessageKey: "admin.users.bulk_actions.no_users_can_be_deleted",
+      modal: BulkUserDeleteConfirmation,
+    });
+  }
+
+  @action
+  openBulkSuspendConfirmation() {
+    this.#openBulkActionConfirmation({
+      canBeActioned: (user) => user.can_be_suspended,
+      emptyMessageKey: "admin.users.bulk_actions.no_users_can_be_suspended",
+      modal: BulkUserSuspendConfirmation,
     });
   }
 
   #addUserToBulkSelection(userId) {
-    this.bulkSelectedUserIdsSet.add(userId);
-    this.bulkSelectedUsersMap[userId] = 1;
+    this.bulkSelectedUsersMap[userId] = this.users.find(
+      (user) => user.id === userId
+    );
   }
 
   #canBulkSelectMoreUsers(count) {
-    return this.bulkSelectedUserIdsSet.size + count <= MAX_BULK_SELECT_LIMIT;
+    return this.bulkSelectedUsers.length + count <= MAX_BULK_SELECT_LIMIT;
   }
 
-  #showBulkSelectionLimitToast(event) {
+  #showBulkSelectionLimitToast() {
     this.toasts.error({
       duration: "short",
       data: {
@@ -244,6 +316,5 @@ export default class AdminUsersListShowController extends Controller {
         }),
       },
     });
-    event.preventDefault();
   }
 }

--- a/frontend/discourse/admin/routes/admin-users-list/show.js
+++ b/frontend/discourse/admin/routes/admin-users-list/show.js
@@ -5,6 +5,7 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
     order: { refreshModel: true },
     asc: { refreshModel: true },
     username: { refreshModel: true },
+    activation: { refreshModel: true },
   };
 
   // TODO: this has been introduced to fix a bug in admin-users-list-show
@@ -23,6 +24,10 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
           asc: transition.to.queryParams.asc,
           listFilter: transition.to.queryParams.username,
           query: params.filter,
+          activation:
+            params.filter === "new"
+              ? transition.to.queryParams.activation
+              : null,
           refreshing: false,
           bulkSelectedUsersMap: {},
           bulkSelectedUserIdsSet: new Set(),

--- a/frontend/discourse/admin/templates/admin-users-list/show.gjs
+++ b/frontend/discourse/admin/templates/admin-users-list/show.gjs
@@ -8,13 +8,14 @@ import DTooltip from "discourse/float-kit/components/d-tooltip";
 import i18nYesNo from "discourse/helpers/i18n-yes-no";
 import lazyHash from "discourse/helpers/lazy-hash";
 import rawDate from "discourse/helpers/raw-date";
-import { eq, not, or } from "discourse/truth-helpers";
+import { not, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DResponsiveTable from "discourse/ui-kit/d-responsive-table";
+import DSelect from "discourse/ui-kit/d-select";
 import DTableHeaderToggle from "discourse/ui-kit/d-table-header-toggle";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -57,11 +58,29 @@ export default <template>
         {{on "input" @controller.onListFilterChange}}
       />
     </div>
+    {{#if @controller.showActivationFilter}}
+      <DSelect
+        @value={{@controller.activation}}
+        @onChange={{@controller.updateActivation}}
+        @nonePlaceholder={{i18n "admin.users.activation_filter.all"}}
+        class="admin-users-list__activation-filter"
+        aria-label={{i18n "admin.users.activation_filter.label"}}
+        as |select|
+      >
+        <select.Option @value="activated">
+          {{i18n "admin.users.activation_filter.activated"}}
+        </select.Option>
+        <select.Option @value="not_activated">
+          {{i18n "admin.users.activation_filter.not_activated"}}
+        </select.Option>
+      </DSelect>
+    {{/if}}
     {{#if @controller.displayBulkActions}}
       <div class="bulk-actions-dropdown">
         <DMenu
           @autofocus={{true}}
           @identifier="bulk-select-admin-users-dropdown"
+          @triggerClass="btn-default"
         >
           <:trigger>
             <span class="d-button-label">
@@ -72,6 +91,16 @@ export default <template>
 
           <:content>
             <DDropdownMenu as |dropdown|>
+              <dropdown.item>
+                <DButton
+                  @translatedLabel={{i18n
+                    "admin.users.bulk_actions.suspend.label"
+                  }}
+                  @icon="ban"
+                  @action={{@controller.openBulkSuspendConfirmation}}
+                  class="bulk-suspend btn-danger"
+                />
+              </dropdown.item>
               <dropdown.item>
                 <DButton
                   @translatedLabel={{i18n
@@ -108,6 +137,18 @@ export default <template>
               @icon="list-check"
               @action={{@controller.toggleBulkSelect}}
             />
+            {{#if @controller.bulkSelect}}
+              <DButton
+                class="btn-flat bulk-select-all"
+                @label="admin.users.bulk_actions.select_all"
+                @action={{@controller.bulkSelectAll}}
+              />
+              <DButton
+                class="btn-flat bulk-clear-all"
+                @label="admin.users.bulk_actions.clear_all"
+                @action={{@controller.bulkClearAll}}
+              />
+            {{/if}}
             <DTableHeaderToggle
               @onToggle={{@controller.updateOrder}}
               @field="username"
@@ -147,7 +188,9 @@ export default <template>
             @asc={{@controller.asc}}
             @automatic={{true}}
           />
-          {{#unless @controller.showSilenceReason}}
+          {{#unless
+            (or @controller.showSilenceReason @controller.showSuspendReason)
+          }}
             <DTableHeaderToggle
               @onToggle={{@controller.updateOrder}}
               @field="topics_viewed"
@@ -192,6 +235,17 @@ export default <template>
               class="directory-table__column-header--silence-reason"
             />
           {{/if}}
+          {{#if @controller.showSuspendReason}}
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="suspend_reason"
+              @labelKey="admin.users.suspend_reason"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+              class="directory-table__column-header--suspend-reason"
+            />
+          {{/if}}
           <PluginOutlet
             @name="admin-users-list-thead-after"
             @outletArgs={{lazyHash order=@controller.order asc=@controller.asc}}
@@ -217,14 +271,11 @@ export default <template>
             >
               <div class="directory-table__cell username">
                 {{#if @controller.bulkSelect}}
-                  {{#if user.can_be_deleted}}
+                  {{#if (or user.can_be_deleted user.can_be_suspended)}}
                     <input
                       type="checkbox"
                       class="directory-table__cell-bulk-select"
-                      checked={{eq
-                        (get @controller.bulkSelectedUsersMap user.id)
-                        1
-                      }}
+                      checked={{get @controller.bulkSelectedUsersMap user.id}}
                       data-user-id={{user.id}}
                       {{on
                         "click"
@@ -233,7 +284,7 @@ export default <template>
                     />
                   {{else}}
                     <DTooltip
-                      @identifier="bulk-delete-unavailable-reason"
+                      @identifier="bulk-action-unavailable-reason"
                       @placement="bottom-start"
                     >
                       <:trigger>
@@ -244,15 +295,9 @@ export default <template>
                         />
                       </:trigger>
                       <:content>
-                        {{#if user.admin}}
-                          {{i18n
-                            "admin.users.bulk_actions.admin_cant_be_deleted"
-                          }}
-                        {{else}}
-                          {{i18n
-                            "admin.users.bulk_actions.too_many_or_old_posts"
-                          }}
-                        {{/if}}
+                        {{i18n
+                          "admin.users.bulk_actions.staff_cant_be_actioned"
+                        }}
                       </:content>
                     </DTooltip>
                   {{/if}}
@@ -315,7 +360,9 @@ export default <template>
                 </span>
               </div>
 
-              {{#unless @controller.showSilenceReason}}
+              {{#unless
+                (or @controller.showSilenceReason @controller.showSuspendReason)
+              }}
                 <div class="directory-table__cell topics-entered">
                   <span class="directory-table__label">
                     <span>{{i18n "admin.user.topics_entered"}}</span>
@@ -363,6 +410,20 @@ export default <template>
                   </span>
                   <span class="directory-table__value">
                     {{trustHTML user.silence_reason}}
+                  </span>
+                </div>
+              {{/if}}
+
+              {{#if @controller.showSuspendReason}}
+                <div
+                  class="directory-table__cell suspend_reason"
+                  title={{@controller.stripHtml user.suspend_reason}}
+                >
+                  <span class="directory-table__label">
+                    <span>{{i18n "admin.users.suspend_reason"}}</span>
+                  </span>
+                  <span class="directory-table__value">
+                    {{trustHTML user.suspend_reason}}
                   </span>
                 </div>
               {{/if}}

--- a/frontend/discourse/tests/acceptance/admin-users-list-test.js
+++ b/frontend/discourse/tests/acceptance/admin-users-list-test.js
@@ -6,6 +6,8 @@ import { i18n } from "discourse-i18n";
 acceptance("Admin - Users List", function (needs) {
   needs.user();
 
+  let lastActivationFilter;
+
   needs.pretender((server, helper) => {
     server.get("/admin/users/list/silenced.json", () =>
       helper.response([
@@ -18,6 +20,33 @@ acceptance("Admin - Users List", function (needs) {
         },
       ])
     );
+
+    server.get("/admin/users/list/suspended.json", () =>
+      helper.response([
+        {
+          id: 4,
+          username: "ben",
+          email: "<small>ben@example.com</small>",
+          suspended_at: "2020-01-01T00:00:00.000Z",
+          suspend_reason: "<strong>spam</strong>",
+        },
+      ])
+    );
+
+    server.get("/admin/users/list/new.json", (request) => {
+      lastActivationFilter = request.queryParams.activation;
+
+      const users = [
+        { id: 2, username: "sam", active: true },
+        { id: 3, username: "notactivated", active: false },
+      ];
+
+      if (request.queryParams.activation === "not_activated") {
+        return helper.response(users.filter((user) => !user.active));
+      }
+
+      return helper.response(users);
+    });
   });
 
   test("lists users", async function (assert) {
@@ -116,5 +145,40 @@ acceptance("Admin - Users List", function (needs) {
     assert
       .dom(".silence_reason .directory-table__value")
       .hasHtml("<strong>spam</strong>");
+  });
+
+  test("shows the suspend reason on the suspended tab", async function (assert) {
+    await visit("/admin/users/list/suspended");
+
+    assert.dom(".suspend_reason").hasAttribute("title", "spam");
+    assert
+      .dom(".suspend_reason .directory-table__value")
+      .hasHtml("<strong>spam</strong>");
+  });
+
+  test("activation filter is only shown on the new tab", async function (assert) {
+    await visit("/admin/users/list/active");
+    assert.dom(".admin-users-list__activation-filter").doesNotExist();
+
+    await visit("/admin/users/list/new");
+    assert.dom(".admin-users-list__activation-filter").exists();
+  });
+
+  test("filters the new tab by activation status", async function (assert) {
+    await visit("/admin/users/list/new");
+
+    assert.dom(".users-list .user").exists({ count: 2 });
+
+    await fillIn(".admin-users-list__activation-filter", "not_activated");
+
+    assert.strictEqual(
+      lastActivationFilter,
+      "not_activated",
+      "sends the activation filter to the server"
+    );
+    assert.dom(".users-list .user").exists({ count: 1 });
+    assert
+      .dom(".users-list .user:nth-child(1) .username")
+      .includesText("notactivated");
   });
 });

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -29,6 +29,7 @@ class AdminUserIndexQuery
     "posts" => "user_stats.post_count",
     "read_time" => "user_stats.time_read",
     "silence_reason" => "silence_reason",
+    "suspend_reason" => "suspend_reason",
   }
 
   SAME_IP_ADDRESS_COLUMNS = { "last" => :ip_address, "registration" => :registration_ip_address }
@@ -48,8 +49,7 @@ class AdminUserIndexQuery
 
     custom_order = params[:order]
     custom_direction = params[:asc].present? ? "ASC" : "DESC"
-    if custom_order.present? &&
-         without_dir = SORTABLE_MAPPING[custom_order.downcase.sub(/ (asc|desc)\z/, "")]
+    if custom_order.present? && without_dir = SORTABLE_MAPPING[normalized_order]
       order << "#{without_dir} #{custom_direction} NULLS LAST"
     end
 
@@ -76,6 +76,15 @@ class AdminUserIndexQuery
     levels = trust_levels.map { |key, _| key.to_s }
     if levels.include?(params[:query])
       @query.where("trust_level = ?", trust_levels[params[:query].to_sym])
+    end
+  end
+
+  def filter_by_activation
+    case params[:activation]
+    when "activated"
+      @query.activated
+    when "not_activated"
+      @query.not_activated
     end
   end
 
@@ -167,28 +176,53 @@ class AdminUserIndexQuery
     guardian&.can_see_ip?
   end
 
-  def with_silence_reason
-    @query.joins(
-      "LEFT JOIN LATERAL (
-        SELECT user_histories.details silence_reason
+  def with_penalty_reason(action, till_column, name)
+    @query.joins(<<~SQL)
+      LEFT JOIN LATERAL (
+        SELECT user_histories.details #{name}
         FROM user_histories
         WHERE user_histories.target_user_id = users.id
-        AND user_histories.action = #{UserHistory.actions[:silence_user]}
-        AND users.silenced_till IS NOT NULL
-        ORDER BY user_histories.created_at DESC
+          AND user_histories.action = #{UserHistory.actions[action]}
+          AND users.#{till_column} IS NOT NULL
+        ORDER BY user_histories.id DESC
         LIMIT 1
-      ) user_histories ON true",
-    )
+      ) #{name}s ON true
+    SQL
+  end
+
+  def penalty_reasons(users, action)
+    return {} if users.empty?
+
+    UserHistory
+      .where(action: UserHistory.actions[action], target_user_id: users.map(&:id))
+      .order(:target_user_id, id: :desc)
+      .select(Arel.sql("DISTINCT ON (target_user_id) target_user_id, details"))
+      .each_with_object({}) { |record, hash| hash[record.target_user_id] = record.details }
+  end
+
+  def normalized_order
+    params[:order]&.downcase&.sub(/ (asc|desc)\z/, "")
+  end
+
+  def sorting_by?(column)
+    normalized_order == column
   end
 
   def find_users_query
     append filter_by_trust
     append filter_by_query_classification
+    append filter_by_activation
     append filter_by_ip
     append filter_by_same_ip_user
     append filter_exclude
     append filter_by_search
-    append with_silence_reason
+
+    if sorting_by?("silence_reason")
+      append with_penalty_reason(:silence_user, :silenced_till, "silence_reason")
+    elsif sorting_by?("suspend_reason")
+      append with_penalty_reason(:suspend_user, :suspended_till, "suspend_reason")
+    end
+
     @query
   end
 end

--- a/spec/lib/admin_user_index_query_spec.rb
+++ b/spec/lib/admin_user_index_query_spec.rb
@@ -162,6 +162,31 @@ RSpec.describe AdminUserIndexQuery do
     end
   end
 
+  describe "sorting by a penalty reason" do
+    fab!(:user_a) { Fabricate(:user, suspended_till: 1.year.from_now, suspended_at: Time.zone.now) }
+    fab!(:user_z) { Fabricate(:user, suspended_till: 1.year.from_now, suspended_at: Time.zone.now) }
+
+    before do
+      UserHistory.create!(
+        action: UserHistory.actions[:suspend_user],
+        target_user_id: user_a.id,
+        acting_user_id: Discourse.system_user.id,
+        details: "aaa reason",
+      )
+      UserHistory.create!(
+        action: UserHistory.actions[:suspend_user],
+        target_user_id: user_z.id,
+        acting_user_id: Discourse.system_user.id,
+        details: "zzz reason",
+      )
+    end
+
+    it "orders by the suspend reason (joining only when sorting by it)" do
+      query = ::AdminUserIndexQuery.new(query: "suspended", order: "suspend_reason", asc: "true")
+      expect(real_users(query).map(&:id)).to eq([user_a.id, user_z.id])
+    end
+  end
+
   describe "with a staged user" do
     fab!(:user) { Fabricate(:user, staged: true) }
     fab!(:user2) { Fabricate(:user, staged: false) }
@@ -169,6 +194,26 @@ RSpec.describe AdminUserIndexQuery do
     it "finds the staged user" do
       query = ::AdminUserIndexQuery.new(query: "staged")
       expect(real_users(query)).to eq([user])
+    end
+  end
+
+  describe "with the activation filter" do
+    fab!(:activated_user) { Fabricate(:user, active: true) }
+    fab!(:not_activated_user) { Fabricate(:user, active: false) }
+
+    it "finds only not activated users" do
+      query = ::AdminUserIndexQuery.new(query: "new", activation: "not_activated")
+      expect(real_users(query)).to contain_exactly(not_activated_user)
+    end
+
+    it "finds only activated users" do
+      query = ::AdminUserIndexQuery.new(query: "new", activation: "activated")
+      expect(real_users(query)).to contain_exactly(activated_user)
+    end
+
+    it "finds all users when no activation filter is provided" do
+      query = ::AdminUserIndexQuery.new(query: "new")
+      expect(real_users(query)).to contain_exactly(activated_user, not_activated_user)
     end
   end
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -38,6 +38,47 @@ RSpec.describe Admin::UsersController do
         expect(silenced_user["silence_reason"]).to eq("because I said so")
       end
 
+      it "returns suspend reason when user is suspended" do
+        UserSuspender.new(
+          user,
+          suspended_till: 1.year.from_now,
+          reason: "because I said so",
+          by_user: admin,
+        ).suspend
+
+        get "/admin/users/list.json"
+        expect(response.status).to eq(200)
+
+        suspended_user = response.parsed_body.find { |u| u["id"] == user.id }
+        expect(suspended_user["suspend_reason"]).to eq("because I said so")
+      end
+
+      it "reports an already-suspended user as not suspendable" do
+        UserSuspender.new(
+          user,
+          suspended_till: 1.year.from_now,
+          reason: "spam",
+          by_user: admin,
+        ).suspend
+
+        get "/admin/users/list/suspended.json"
+        expect(response.status).to eq(200)
+
+        suspended_user = response.parsed_body.find { |u| u["id"] == user.id }
+        expect(suspended_user["can_be_suspended"]).to eq(false)
+      end
+
+      it "filters by activation status on the new tab" do
+        not_activated_user = Fabricate(:user, active: false)
+
+        get "/admin/users/list/new.json", params: { activation: "not_activated" }
+        expect(response.status).to eq(200)
+
+        ids = response.parsed_body.map { |u| u["id"] }
+        expect(ids).to include(not_activated_user.id)
+        expect(ids).not_to include(admin.id)
+      end
+
       context "when showing emails" do
         it "returns email for all the users" do
           get "/admin/users/list.json", params: { show_emails: "true" }
@@ -1785,6 +1826,98 @@ RSpec.describe Admin::UsersController do
         delete "/admin/users/destroy-bulk.json", params: { user_ids: deleted_users.map(&:id) }
         expect(response.status).to eq(404)
         expect(User.where(id: deleted_users.map(&:id)).count).to eq(3)
+      end
+    end
+  end
+
+  describe "#suspend_bulk" do
+    fab!(:suspended_users) { Fabricate.times(3, :user) }
+
+    let(:suspend_params) do
+      { user_ids: suspended_users.map(&:id), reason: "spam wave", suspend_until: 1.year.from_now }
+    end
+
+    def suspended_count
+      User.where(id: suspended_users.map(&:id)).where.not(suspended_till: nil).count
+    end
+
+    shared_examples "bulk user suspension possible" do
+      before { sign_in(current_user) }
+
+      it "can suspend multiple users" do
+        put "/admin/users/suspend-bulk.json", params: suspend_params
+        expect(response.status).to eq(200)
+        expect(suspended_count).to eq(3)
+      end
+
+      it "responds with 404 when sending non-existent user ids" do
+        put "/admin/users/suspend-bulk.json",
+            params: {
+              user_ids: [0],
+              reason: "spam wave",
+              suspend_until: 1.year.from_now,
+            }
+        expect(response.status).to eq(404)
+      end
+
+      it "responds with 400 when no reason is provided" do
+        put "/admin/users/suspend-bulk.json",
+            params: {
+              user_ids: suspended_users.map(&:id),
+              suspend_until: 1.year.from_now,
+            }
+        expect(response.status).to eq(400)
+        expect(suspended_count).to eq(0)
+      end
+
+      it "doesn't allow suspending a user that can't be suspended" do
+        suspended_users[0].update!(admin: true)
+
+        put "/admin/users/suspend-bulk.json", params: suspend_params
+        expect(response.status).to eq(403)
+        expect(suspended_count).to eq(0)
+      end
+
+      it "doesn't accept more than 100 user ids" do
+        put "/admin/users/suspend-bulk.json",
+            params: suspend_params.merge(user_ids: suspended_users.map(&:id) + (1..101).to_a)
+        expect(response.status).to eq(400)
+        expect(suspended_count).to eq(0)
+      end
+
+      it "doesn't re-suspend an already-suspended user" do
+        UserSuspender.new(
+          suspended_users[0],
+          suspended_till: 1.year.from_now,
+          reason: "spam",
+          by_user: current_user,
+        ).suspend
+
+        put "/admin/users/suspend-bulk.json", params: suspend_params
+        expect(response.status).to eq(403)
+        expect(suspended_count).to eq(1)
+      end
+    end
+
+    context "when logged in as an admin" do
+      include_examples "bulk user suspension possible" do
+        let(:current_user) { admin }
+      end
+    end
+
+    context "when logged in as a moderator" do
+      include_examples "bulk user suspension possible" do
+        let(:current_user) { moderator }
+      end
+    end
+
+    context "when logged in as a non-staff user" do
+      before { sign_in(user) }
+
+      it "responds with a 404 and doesn't suspend users" do
+        put "/admin/users/suspend-bulk.json", params: suspend_params
+        expect(response.status).to eq(404)
+        expect(suspended_count).to eq(0)
       end
     end
   end

--- a/spec/services/user/bulk_suspend_spec.rb
+++ b/spec/services/user/bulk_suspend_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe User::BulkSuspend do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_length_of(:user_ids).as_array.is_at_most(100).is_at_least(1) }
+    it { is_expected.to validate_presence_of(:reason) }
+    it { is_expected.to validate_length_of(:reason).is_at_most(300) }
+    it { is_expected.to validate_presence_of(:suspend_until) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin)
+    fab!(:users) { Fabricate.times(5, :user) }
+
+    let(:params) { { user_ids:, reason: "spam wave", suspend_until: 1.year.from_now } }
+    let(:dependencies) { { guardian: } }
+    let(:guardian) { admin.guardian }
+    let(:user_ids) { users.map(&:id) }
+
+    context "when invalid data is provided" do
+      let(:user_ids) { nil }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when no reason is provided" do
+      let(:params) { { user_ids:, suspend_until: 1.year.from_now } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when provided users does not exist" do
+      let(:user_ids) { 0 }
+
+      it { is_expected.to fail_to_find_a_model(:users) }
+    end
+
+    context "when at least one user cannot be suspended" do
+      before { users << Fabricate(:admin) }
+
+      it { is_expected.to fail_a_policy(:can_suspend_users) }
+    end
+
+    context "when at least one user is already suspended" do
+      before { users.first.update!(suspended_till: 1.day.from_now, suspended_at: Time.zone.now) }
+
+      it { is_expected.to fail_a_policy(:can_suspend_users) }
+    end
+
+    context "when everything's ok" do
+      before { allow(MessageBus).to receive(:publish) }
+
+      it "suspends each user" do
+        result
+        expect(User.where(id: user_ids).where.not(suspended_till: nil).count).to eq(users.size)
+      end
+
+      it "logs the suspension with its reason" do
+        result
+        histories =
+          UserHistory.where(action: UserHistory.actions[:suspend_user], target_user_id: user_ids)
+        expect(histories.count).to eq(users.size)
+        expect(histories.pluck(:details).uniq).to eq(["spam wave"])
+      end
+
+      it "publishes suspension progress" do
+        result
+        expect(MessageBus).to have_received(:publish)
+          .with("/bulk-user-suspend", a_kind_of(Hash), user_ids: [admin.id])
+          .exactly(user_ids.size)
+          .times
+      end
+    end
+  end
+end

--- a/spec/system/admin_users_list_spec.rb
+++ b/spec/system/admin_users_list_spec.rb
@@ -16,10 +16,25 @@ describe "Admin Users Page" do
     expect(admin_users_page).to have_correct_breadcrumbs
   end
 
+  it "selects and clears all actionable users with the bulk select buttons" do
+    admin_users_page.visit
+    admin_users_page.bulk_select_button.click
+
+    admin_users_page.bulk_select_all_button.click
+    expect(admin_users_page.user_row(user_1.id).bulk_select_checkbox).to be_checked
+    expect(admin_users_page.user_row(user_2.id).bulk_select_checkbox).to be_checked
+    expect(admin_users_page.user_row(user_3.id).bulk_select_checkbox).to be_checked
+    expect(admin_users_page).to have_bulk_actions_dropdown
+
+    admin_users_page.bulk_clear_all_button.click
+    expect(admin_users_page.user_row(user_1.id).bulk_select_checkbox).not_to be_checked
+    expect(admin_users_page).to have_no_bulk_actions_dropdown
+  end
+
   describe "bulk user delete" do
     let(:confirmation_modal) { PageObjects::Modals::BulkUserDeleteConfirmation.new }
 
-    it "disables checkboxes for users that can't be deleted" do
+    it "disables checkboxes for users that can't be deleted or suspended" do
       admin_users_page.visit
 
       admin_users_page.bulk_select_button.click
@@ -29,8 +44,8 @@ describe "Admin Users Page" do
       expect(admin_users_page.user_row(user_1.id).bulk_select_checkbox.disabled?).to eq(false)
 
       admin_users_page.user_row(another_admin.id).bulk_select_checkbox.hover
-      expect(PageObjects::Components::Tooltips.new("bulk-delete-unavailable-reason")).to be_present(
-        text: I18n.t("admin_js.admin.users.bulk_actions.admin_cant_be_deleted"),
+      expect(PageObjects::Components::Tooltips.new("bulk-action-unavailable-reason")).to be_present(
+        text: I18n.t("admin_js.admin.users.bulk_actions.staff_cant_be_actioned"),
       )
     end
 
@@ -103,7 +118,7 @@ describe "Admin Users Page" do
       expect(confirmation_modal).to have_confirm_button_enabled
     end
 
-    xit "remembers selected users when the user list refreshes due to search" do
+    it "remembers selected users when the user list refreshes due to search" do
       admin_users_page.visit
       admin_users_page.bulk_select_button.click
       admin_users_page.search_input.fill_in(with: user_1.username)
@@ -190,6 +205,45 @@ describe "Admin Users Page" do
       expect(
         ScreenedEmail.exists?(email: user_1.email, action_type: ScreenedEmail.actions[:block]),
       ).to be_truthy
+    end
+  end
+
+  describe "bulk user suspend" do
+    let(:confirmation_modal) { PageObjects::Modals::BulkUserSuspendConfirmation.new }
+
+    it "can suspend multiple users" do
+      admin_users_page.visit
+      admin_users_page.bulk_select_button.click
+
+      admin_users_page.user_row(user_1.id).bulk_select_checkbox.click
+      admin_users_page.user_row(user_2.id).bulk_select_checkbox.click
+      admin_users_page.bulk_actions_dropdown.expand
+      admin_users_page.bulk_actions_dropdown.option(".bulk-suspend").click
+
+      expect(confirmation_modal).to be_open
+      expect(confirmation_modal).to have_confirm_button_disabled
+
+      confirmation_modal.set_future_date("tomorrow")
+      confirmation_modal.fill_in_reason("spamming")
+      expect(confirmation_modal).to have_confirm_button_enabled
+
+      confirmation_modal.confirm
+
+      expect(confirmation_modal).to have_successful_log_entry_for_user(
+        user: user_1,
+        position: 1,
+        total: 2,
+      )
+      expect(confirmation_modal).to have_successful_log_entry_for_user(
+        user: user_2,
+        position: 2,
+        total: 2,
+      )
+      expect(confirmation_modal).to have_no_error_log_entries
+
+      confirmation_modal.close
+
+      expect(User.where(id: [user_1.id, user_2.id]).where.not(suspended_till: nil).count).to eq(2)
     end
   end
 

--- a/spec/system/page_objects/modals/bulk_user_suspend_confirmation.rb
+++ b/spec/system/page_objects/modals/bulk_user_suspend_confirmation.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class BulkUserSuspendConfirmation < Base
+      MODAL_SELECTOR = ".bulk-user-suspend-confirmation"
+
+      def confirm
+        confirm_button.click
+      end
+
+      def confirm_button
+        within(modal) { find(".btn.confirm-suspend") }
+      end
+
+      def has_confirm_button_disabled?
+        within(modal) { has_css?(".btn.confirm-suspend[disabled]") }
+      end
+
+      def has_confirm_button_enabled?
+        within(modal) do
+          has_no_css?(".btn.confirm-suspend[disabled]") && has_css?(".btn.confirm-suspend")
+        end
+      end
+
+      def set_future_date(date)
+        select = PageObjects::Components::SelectKit.new(".future-date-input details")
+        select.expand
+        select.select_row_by_value(date)
+      end
+
+      def fill_in_reason(reason)
+        find("input.suspend-reason").fill_in(with: reason)
+      end
+
+      def has_successful_log_entry_for_user?(user:, position:, total:)
+        within(modal) do
+          has_css?(
+            ".bulk-user-suspend-confirmation__progress-line.-success",
+            text:
+              I18n.t(
+                "admin_js.admin.users.bulk_actions.suspend.confirmation_modal.user_suspend_succeeded",
+                position:,
+                total:,
+                username: user.username,
+              ),
+          )
+        end
+      end
+
+      def has_no_error_log_entries?
+        within(modal) { has_no_css?(".bulk-user-suspend-confirmation__progress-line.-error") }
+      end
+
+      private
+
+      def modal
+        find(MODAL_SELECTOR)
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_users.rb
+++ b/spec/system/page_objects/pages/admin_users.rb
@@ -35,6 +35,14 @@ module PageObjects
         find(".btn.bulk-select")
       end
 
+      def bulk_select_all_button
+        find(".btn.bulk-select-all")
+      end
+
+      def bulk_clear_all_button
+        find(".btn.bulk-clear-all")
+      end
+
       def search_input
         find(".admin-users-list__search input")
       end


### PR DESCRIPTION
- Adds an activation filter (All / Activated / Not activated) to the Admin > Users > New tab so unverified accounts can be isolated in the UI.
- Adds a bulk suspend action next to the existing bulk delete, plus a "Select all" / "Clear all" control so a whole page of accounts can be actioned at once.
- Shows the suspend reason on the Suspended tab, mirroring the silenced tab.

Already-suspended users are excluded from bulk suspension, and the penalty-reason columns are populated from a single batched query instead of one query per row.

**SCREENSHOTS**

<img width="1400" height="1200" alt="desktop-horizon-light-admin-users-activation-filter" src="https://github.com/user-attachments/assets/31165d10-42cb-479b-897c-fafeb3283526" />
<img width="1400" height="1200" alt="desktop-horizon-light-admin-users-bulk-select" src="https://github.com/user-attachments/assets/037e8149-2ac6-40de-aaae-0d0e443ec143" />
<img width="1400" height="1200" alt="desktop-horizon-light-admin-users-suspended" src="https://github.com/user-attachments/assets/e6dbefed-4aaf-49bb-a9bd-52c7253e14b6" />
<img width="1400" height="1200" alt="desktop-horizon-light-admin-users-bulk-suspend" src="https://github.com/user-attachments/assets/5bdf85ef-4e30-4d8d-b521-d8639c1a2b97" />
