### PR TITLE
UX: horizon chat reaction popup z-index fix

### DIFF
--- a/themes/horizon/scss/chat.scss
+++ b/themes/horizon/scss/chat.scss
@@ -65,7 +65,8 @@ body.has-full-page-chat {
   }
 }
 
-.fk-d-menu[data-identifier="usercard"] {
+.fk-d-menu[data-identifier="usercard"],
+.fk-d-menu[data-identifier="chat-message-reaction-users"] {
   .has-drawer-chat & {
     z-index: z("modal", "dialog");
   }


### PR DESCRIPTION
Fixes the positioning of the new chat reactions popup on the Horizon theme. Previously the popup was behind the chat drawer.

How it looks:

<img width="299" height="279" alt="Screenshot 2026-06-26 at 3 25 26 PM" src="https://github.com/user-attachments/assets/b0760825-f04d-49e9-b7bf-6661af6f1dff" />
