### PR TITLE
UX: Trust level section functional redesign

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -85,9 +85,11 @@
 }
 
 .db-delta {
-  &:not(table &) {
-    font-size: var(--font-down-2-rem);
-    font-weight: bold;
+  font-size: var(--font-down-2-rem);
+  font-weight: bold;
+
+  table & {
+    font-weight: normal;
   }
 
   &.--pos {
@@ -116,17 +118,18 @@
   border-radius: 6.25rem;
   padding: var(--space-half) var(--space-2);
   background: var(--primary-low);
-  color: var(--primary-medium);
   white-space: nowrap;
 
   &.--pos {
-    background: var(--success-low);
-    color: var(--primary);
+    background: var(--success);
+    border: 1px solid var(--success);
+    color: var(--secondary);
   }
 
   &.--neg {
-    background: var(--danger-low);
-    color: var(--primary);
+    background: var(--danger);
+    border: 1px solid var(--danger);
+    color: var(--secondary);
   }
 }
 

--- a/app/assets/stylesheets/admin/dashboard/engagement.scss
+++ b/app/assets/stylesheets/admin/dashboard/engagement.scss
@@ -158,15 +158,15 @@
   }
 
   &__bar-track {
-    height: var(--space-3);
-    border-radius: 1em;
+    height: 10px;
+    border-radius: 4px;
     background: var(--primary-low);
   }
 
   &__bar-fill {
     display: block;
     height: 100%;
-    border-radius: 1em;
+    border-radius: 4px;
 
     &.--new-members {
       background: var(--tertiary);
@@ -200,6 +200,10 @@
   flex-direction: column;
   gap: var(--space-2);
 
+  .db-delta {
+    font-size: var(--font-down-3);
+  }
+
   &__rows {
     list-style: none;
     padding: 0;
@@ -224,6 +228,11 @@
     display: flex;
     align-items: baseline;
     gap: var(--space-2);
+
+    .db-pill {
+      margin-left: auto;
+      align-self: center;
+    }
   }
 
   &__name {
@@ -235,75 +244,36 @@
     color: var(--primary-medium);
   }
 
-  &__bars {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
+  &__deltas {
+    margin-left: auto;
+    display: flex;
     align-items: center;
     gap: var(--space-2);
   }
 
-  &__bar-out,
-  &__bar-in {
+  &__flow {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     min-height: 18px;
   }
 
-  &__bar-out {
-    justify-content: flex-end;
-  }
-
-  &__bar-in {
-    justify-content: flex-start;
-  }
-
   &__bar-track {
     flex: 1 1 auto;
     min-width: 0;
     display: flex;
-
-    .db-tl-pipeline__bar-out & {
-      justify-content: flex-end;
-    }
-
-    .db-tl-pipeline__bar-in & {
-      justify-content: flex-start;
-    }
+    justify-content: flex-start;
   }
 
   &__bar {
     height: 10px;
-    border-radius: 5px;
+    border-radius: 4px;
     flex: 0 0 auto;
+    background: var(--success);
 
-    &--out {
+    &.--demoted {
       background: var(--danger);
     }
-
-    &--in {
-      background: var(--success);
-    }
-  }
-
-  &__delta {
-    font-size: var(--font-down-2-rem);
-    font-weight: bold;
-    white-space: nowrap;
-
-    &--out {
-      color: var(--danger);
-    }
-
-    &--in {
-      color: var(--success);
-    }
-  }
-
-  &__divider {
-    width: 1px;
-    height: 18px;
-    background: var(--primary-low);
   }
 }
 

--- a/app/assets/stylesheets/admin/dashboard/engagement.scss
+++ b/app/assets/stylesheets/admin/dashboard/engagement.scss
@@ -202,6 +202,10 @@
 
   .db-delta {
     font-size: var(--font-down-3);
+
+    &.--signups {
+      color: var(--primary-medium);
+    }
   }
 
   &__rows {

--- a/app/assets/stylesheets/admin/dashboard/engagement.scss
+++ b/app/assets/stylesheets/admin/dashboard/engagement.scss
@@ -200,12 +200,13 @@
   flex-direction: column;
   gap: var(--space-2);
 
-  .db-delta {
+  &__signups {
+    margin-left: auto;
     font-size: var(--font-down-3);
-
-    &.--signups {
-      color: var(--primary-medium);
-    }
+    border-radius: var(--d-border-radius-pill);
+    padding: var(--space-half) var(--space-2);
+    background: var(--primary-low);
+    white-space: nowrap;
   }
 
   &__rows {
@@ -246,13 +247,6 @@
   &__count {
     font-size: var(--font-down-1-rem);
     color: var(--primary-medium);
-  }
-
-  &__deltas {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
   }
 
   &__flow {

--- a/app/models/concerns/reports/trust_level_pipeline.rb
+++ b/app/models/concerns/reports/trust_level_pipeline.rb
@@ -19,23 +19,11 @@ module Reports::TrustLevelPipeline
       snapshot = User.real.group(:trust_level).count
       total_members = snapshot.values.sum
 
-      # Members who joined this period. They arrive at the default trust level,
-      # which is the funnel's entry point: the dashboard shows this as that
-      # level's inflow, since members reach every other level by climbing but
-      # reach the entry level by signing up.
       new_signups = User.real.where(created_at: report.start_date..report.end_date).count
       entry_level = SiteSetting.default_trust_level
 
-      # A trust-level change is directional: moving to a higher level is a
-      # promotion, moving to a lower level a demotion. The same move is a
-      # departure from one level and an arrival at another, so we track all four
-      # flows per level. The dashboard funnel reads the "in" flows (how many
-      # members reached each level this period); the "out" flows are kept for
-      # the report table and tooltips.
       promoted_in_by_tl = Hash.new(0)
-      promoted_out_by_tl = Hash.new(0)
       demoted_in_by_tl = Hash.new(0)
-      demoted_out_by_tl = Hash.new(0)
       total_up = 0
       total_down = 0
 
@@ -69,11 +57,9 @@ module Reports::TrustLevelPipeline
         .each do |row|
           next if row.new_tl == row.prev_tl
           if row.new_tl > row.prev_tl
-            promoted_out_by_tl[row.prev_tl] += row.move_count
             promoted_in_by_tl[row.new_tl] += row.move_count
             total_up += row.move_count
           else
-            demoted_out_by_tl[row.prev_tl] += row.move_count
             demoted_in_by_tl[row.new_tl] += row.move_count
             total_down += row.move_count
           end
@@ -90,9 +76,7 @@ module Reports::TrustLevelPipeline
             share: share,
             share_formatted: "#{share}%",
             promoted_in: promoted_in_by_tl[tl],
-            promoted_out: promoted_out_by_tl[tl],
             demoted_in: demoted_in_by_tl[tl],
-            demoted_out: demoted_out_by_tl[tl],
             signups: tl == entry_level ? new_signups : 0,
           }
         end

--- a/app/models/concerns/reports/trust_level_pipeline.rb
+++ b/app/models/concerns/reports/trust_level_pipeline.rb
@@ -14,23 +14,28 @@ module Reports::TrustLevelPipeline
           title: I18n.t("reports.trust_level_pipeline.labels.count"),
         },
         { property: :share_formatted, title: I18n.t("reports.trust_level_pipeline.labels.share") },
-        {
-          property: :moves_in,
-          type: :number,
-          title: I18n.t("reports.trust_level_pipeline.labels.moves_in"),
-        },
-        {
-          property: :moves_out,
-          type: :number,
-          title: I18n.t("reports.trust_level_pipeline.labels.moves_out"),
-        },
       ]
 
       snapshot = User.real.group(:trust_level).count
       total_members = snapshot.values.sum
 
-      moves_in_by_tl = Hash.new(0)
-      moves_out_by_tl = Hash.new(0)
+      # Members who joined this period. They arrive at the default trust level,
+      # which is the funnel's entry point: the dashboard shows this as that
+      # level's inflow, since members reach every other level by climbing but
+      # reach the entry level by signing up.
+      new_signups = User.real.where(created_at: report.start_date..report.end_date).count
+      entry_level = SiteSetting.default_trust_level
+
+      # A trust-level change is directional: moving to a higher level is a
+      # promotion, moving to a lower level a demotion. The same move is a
+      # departure from one level and an arrival at another, so we track all four
+      # flows per level. The dashboard funnel reads the "in" flows (how many
+      # members reached each level this period); the "out" flows are kept for
+      # the report table and tooltips.
+      promoted_in_by_tl = Hash.new(0)
+      promoted_out_by_tl = Hash.new(0)
+      demoted_in_by_tl = Hash.new(0)
+      demoted_out_by_tl = Hash.new(0)
       total_up = 0
       total_down = 0
 
@@ -63,11 +68,13 @@ module Reports::TrustLevelPipeline
         )
         .each do |row|
           next if row.new_tl == row.prev_tl
-          moves_in_by_tl[row.new_tl] += row.move_count
-          moves_out_by_tl[row.prev_tl] += row.move_count
           if row.new_tl > row.prev_tl
+            promoted_out_by_tl[row.prev_tl] += row.move_count
+            promoted_in_by_tl[row.new_tl] += row.move_count
             total_up += row.move_count
           else
+            demoted_out_by_tl[row.prev_tl] += row.move_count
+            demoted_in_by_tl[row.new_tl] += row.move_count
             total_down += row.move_count
           end
         end
@@ -82,8 +89,11 @@ module Reports::TrustLevelPipeline
             count: count,
             share: share,
             share_formatted: "#{share}%",
-            moves_in: moves_in_by_tl[tl],
-            moves_out: moves_out_by_tl[tl],
+            promoted_in: promoted_in_by_tl[tl],
+            promoted_out: promoted_out_by_tl[tl],
+            demoted_in: demoted_in_by_tl[tl],
+            demoted_out: demoted_out_by_tl[tl],
+            signups: tl == entry_level ? new_signups : 0,
           }
         end
 

--- a/app/models/concerns/reports/trust_level_pipeline.rb
+++ b/app/models/concerns/reports/trust_level_pipeline.rb
@@ -14,6 +14,21 @@ module Reports::TrustLevelPipeline
           title: I18n.t("reports.trust_level_pipeline.labels.count"),
         },
         { property: :share_formatted, title: I18n.t("reports.trust_level_pipeline.labels.share") },
+        {
+          property: :promoted_in,
+          type: :number,
+          title: I18n.t("reports.trust_level_pipeline.labels.promoted_in"),
+        },
+        {
+          property: :demoted_in,
+          type: :number,
+          title: I18n.t("reports.trust_level_pipeline.labels.demoted_in"),
+        },
+        {
+          property: :signups,
+          type: :number,
+          title: I18n.t("reports.trust_level_pipeline.labels.signups"),
+        },
       ]
 
       snapshot = User.real.group(:trust_level).count

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7153,8 +7153,10 @@ en:
                   one: "-%{count} dropping"
                   other: "-%{count} dropping"
               signups:
-                one: "%{formattedCount} signup"
-                other: "%{formattedCount} signups"
+                one: "+ %{formattedCount} signup"
+                other: "+ %{formattedCount} signups"
+              signups_title: "Number of new signups arriving at this trust level"
+              count_title: "Number of total members at this trust level"
               arrivals_aria:
                 one: "%{count} member got promoted to this trust level"
                 other: "%{count} members got promoted to this trust level"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7152,6 +7152,9 @@ en:
                 dropping:
                   one: "-%{count} dropping"
                   other: "-%{count} dropping"
+              signups:
+                one: "%{formattedCount} signup"
+                other: "%{formattedCount} signups"
               arrivals_aria:
                 one: "%{count} member got promoted to this trust level"
                 other: "%{count} members got promoted to this trust level"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7152,12 +7152,12 @@ en:
                 dropping:
                   one: "-%{count} dropping"
                   other: "-%{count} dropping"
-              moves_in_aria:
-                one: "%{count} member moved up"
-                other: "%{count} members moved up"
-              moves_out_aria:
-                one: "%{count} member moved down"
-                other: "%{count} members moved down"
+              arrivals_aria:
+                one: "%{count} member got promoted to this trust level"
+                other: "%{count} members got promoted to this trust level"
+              demotions_in_aria:
+                one: "%{count} member got demoted to this trust level"
+                other: "%{count} members got demoted to this trust level"
               stable_aria: "no movement"
             headline:
               healthy_growth:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1427,7 +1427,7 @@ en:
         staff: "Staff"
     trust_level_pipeline:
       title: "Trust level pipeline"
-      description: "Member movement between trust levels for the selected period. Counts the members currently at each trust level, their share of the total membership, the number of members promoted or demoted into each trust level during the period, and new sign-ups, counted at the site's default trust level."
+      description: "Member movement between trust levels for the selected period. Counts the members currently at each trust level, their share of the total membership, the number of members promoted or demoted into each trust level during the period, and new sign-ups."
       description_link: "https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"
       labels:
         level: "Trust level"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1427,14 +1427,15 @@ en:
         staff: "Staff"
     trust_level_pipeline:
       title: "Trust level pipeline"
-      description: "Member movement between trust levels for the selected period. Counts the members currently at each trust level, their share of the total membership, and the number of members who moved into or out of each trust level during the period."
+      description: "Current membership at each trust level and the arrivals at each level during the selected period: members promoted into the level, members demoted into it, and new sign-ups at the entry trust level."
       description_link: "https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"
       labels:
         level: "Trust level"
         count: "Members"
         share: "Share"
-        moves_in: "Moves in"
-        moves_out: "Moves out"
+        promoted_in: "Promoted in"
+        demoted_in: "Demoted in"
+        signups: "Sign-ups"
       levels:
         "0": "New"
         "1": "Basic"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1427,7 +1427,7 @@ en:
         staff: "Staff"
     trust_level_pipeline:
       title: "Trust level pipeline"
-      description: "Current membership at each trust level and the arrivals at each level during the selected period: members promoted into the level, members demoted into it, and new sign-ups at the entry trust level."
+      description: "Member movement between trust levels for the selected period. Counts the members currently at each trust level, their share of the total membership, the number of members promoted or demoted into each trust level during the period, and new sign-ups, counted at the site's default trust level."
       description_link: "https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/"
       labels:
         level: "Trust level"

--- a/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
@@ -131,14 +131,13 @@ export default class TrustLevelPipeline extends Component {
               {{#if row.showInlineDeltas}}
                 <span class="db-tl-pipeline__deltas">
                   {{#if row.hasClimbers}}
-                    <span
-                      class="db-delta --pos"
-                      aria-label={{i18n
-                        "admin.dashboard.sections.engagement.trust_level_pipeline.arrivals_aria"
-                        (hash count=row.climbedIn)
-                      }}
-                    >{{row.climbedInFormatted}}
-                      {{dIcon "arrow-up"}}</span>
+                    <span class="db-delta --signups">{{i18n
+                        "admin.dashboard.sections.engagement.trust_level_pipeline.signups"
+                        (hash
+                          count=row.climbedIn
+                          formattedCount=row.climbedInFormatted
+                        )
+                      }}</span>
                   {{/if}}
                   {{#if row.hasDroppers}}
                     <span

--- a/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
@@ -2,19 +2,47 @@ import Component from "@glimmer/component";
 import { concat, hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
 import { trustHTML } from "@ember/template";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
 
 export default class TrustLevelPipeline extends Component {
   get rows() {
     const data = this.args.data?.rows ?? [];
-    const max = data.reduce(
-      (acc, row) => Math.max(acc, row.moves_in, row.moves_out),
+    // Each rung reports who arrived this period, split by direction. Members
+    // rise into a level (promoted_in) or, at the entry level, join (signups) —
+    // both are upward arrivals. Members can also fall into a level from above
+    // (demoted_in), a downward arrival.
+    const promotedIn = (row) => row.promoted_in ?? 0;
+    const demotedIn = (row) => row.demoted_in ?? 0;
+    const signups = (row) => row.signups ?? 0;
+
+    // The lowest trust level is the entry point: members reach it by signing
+    // up, not by climbing the ladder. It never draws a bar — its numbers sit
+    // inline on the title row instead — and it's excluded from the bar scale so
+    // its sign-up firehose doesn't dwarf every other level.
+    const entryLevel = data.reduce(
+      (min, row) => Math.min(min, row.trust_level),
+      Infinity
+    );
+    const barMax = data.reduce(
+      (acc, row) =>
+        row.trust_level === entryLevel
+          ? acc
+          : Math.max(acc, promotedIn(row), demotedIn(row)),
       0
     );
 
     return data.map((row) => {
-      const widthIn = this.#barWidth(row.moves_in, max);
-      const widthOut = this.#barWidth(row.moves_out, max);
+      const isEntry = row.trust_level === entryLevel;
+      const climbedIn = promotedIn(row) + signups(row);
+      const droppedIn = demotedIn(row);
+      // Within the ladder flow, the bar follows whichever direction dominates:
+      // green when more members were promoted into the level than demoted into
+      // it, red otherwise — so a net-downward level reads as a red bar.
+      const barDown = droppedIn > promotedIn(row);
+      const barValue = barDown ? droppedIn : promotedIn(row);
+      const hasMovement = climbedIn > 0 || droppedIn > 0;
       return {
         ...row,
         label: i18n(
@@ -22,9 +50,20 @@ export default class TrustLevelPipeline extends Component {
         ),
         shareFormatted: `${I18n.toNumber(row.share, { precision: 2 })}%`,
         countFormatted: I18n.toNumber(row.count, { precision: 0 }),
-        barInStyle: trustHTML(`width: ${widthIn}%`),
-        barOutStyle: trustHTML(`width: ${widthOut}%`),
-        hasMovement: row.moves_in > 0 || row.moves_out > 0,
+        climbedInFormatted: I18n.toNumber(climbedIn, { precision: 0 }),
+        droppedInFormatted: I18n.toNumber(droppedIn, { precision: 0 }),
+        climbedIn,
+        droppedIn,
+        barDown,
+        hasBar: !isEntry && barValue > 0,
+        barStyle: trustHTML(`width: ${this.#barWidth(barValue, barMax)}%`),
+        hasClimbers: climbedIn > 0,
+        hasDroppers: droppedIn > 0,
+        hasMovement,
+        // The entry level has no bar, so its deltas sit inline on the title
+        // row; every other level shows them beside its bar on the row below.
+        showInlineDeltas: isEntry && hasMovement,
+        showFlow: !isEntry && hasMovement,
       };
     });
   }
@@ -89,54 +128,68 @@ export default class TrustLevelPipeline extends Component {
                 {{row.countFormatted}}
                 ({{row.shareFormatted}})
               </span>
+              {{#if row.showInlineDeltas}}
+                <span class="db-tl-pipeline__deltas">
+                  {{#if row.hasClimbers}}
+                    <span
+                      class="db-delta --pos"
+                      aria-label={{i18n
+                        "admin.dashboard.sections.engagement.trust_level_pipeline.arrivals_aria"
+                        (hash count=row.climbedIn)
+                      }}
+                    >{{row.climbedInFormatted}}
+                      {{dIcon "arrow-up"}}</span>
+                  {{/if}}
+                  {{#if row.hasDroppers}}
+                    <span
+                      class="db-delta --neg"
+                      aria-label={{i18n
+                        "admin.dashboard.sections.engagement.trust_level_pipeline.demotions_in_aria"
+                        (hash count=row.droppedIn)
+                      }}
+                    >{{dIcon "arrow-down"}}
+                      {{row.droppedInFormatted}}</span>
+                  {{/if}}
+                </span>
+              {{/if}}
+              {{#unless row.hasMovement}}
+                <span class="db-pill">{{i18n "admin.dashboard.stable"}}</span>
+              {{/unless}}
             </div>
-            {{#if row.hasMovement}}
-              <div class="db-tl-pipeline__bars">
-                <div class="db-tl-pipeline__bar-out">
-                  {{#if row.moves_out}}
+            {{#if row.showFlow}}
+              <div class="db-tl-pipeline__flow">
+                <div class="db-tl-pipeline__bar-track">
+                  {{#if row.hasBar}}
                     <span
-                      class="db-tl-pipeline__delta db-tl-pipeline__delta--out"
-                    >↓
-                      {{row.moves_out}}</span>
-                    <div class="db-tl-pipeline__bar-track">
-                      <span
-                        class="db-tl-pipeline__bar db-tl-pipeline__bar--out"
-                        style={{row.barOutStyle}}
-                        aria-label={{i18n
-                          "admin.dashboard.sections.engagement.trust_level_pipeline.moves_out_aria"
-                          (hash count=row.moves_out)
-                        }}
-                      ></span>
-                    </div>
-                  {{else}}
-                    <span class="db-pill">{{i18n
-                        "admin.dashboard.stable"
-                      }}</span>
+                      class={{dConcatClass
+                        "db-tl-pipeline__bar"
+                        (if row.barDown "--demoted")
+                      }}
+                      style={{row.barStyle}}
+                      aria-hidden="true"
+                    ></span>
                   {{/if}}
                 </div>
-                <div class="db-tl-pipeline__divider"></div>
-                <div class="db-tl-pipeline__bar-in">
-                  {{#if row.moves_in}}
-                    <div class="db-tl-pipeline__bar-track">
-                      <span
-                        class="db-tl-pipeline__bar db-tl-pipeline__bar--in"
-                        style={{row.barInStyle}}
-                        aria-label={{i18n
-                          "admin.dashboard.sections.engagement.trust_level_pipeline.moves_in_aria"
-                          (hash count=row.moves_in)
-                        }}
-                      ></span>
-                    </div>
-                    <span
-                      class="db-tl-pipeline__delta db-tl-pipeline__delta--in"
-                    >{{row.moves_in}}
-                      ↑</span>
-                  {{else}}
-                    <span class="db-pill">{{i18n
-                        "admin.dashboard.stable"
-                      }}</span>
-                  {{/if}}
-                </div>
+                {{#if row.hasClimbers}}
+                  <span
+                    class="db-delta --pos"
+                    aria-label={{i18n
+                      "admin.dashboard.sections.engagement.trust_level_pipeline.arrivals_aria"
+                      (hash count=row.climbedIn)
+                    }}
+                  >{{row.climbedInFormatted}}
+                    {{dIcon "arrow-up"}}</span>
+                {{/if}}
+                {{#if row.hasDroppers}}
+                  <span
+                    class="db-delta --neg"
+                    aria-label={{i18n
+                      "admin.dashboard.sections.engagement.trust_level_pipeline.demotions_in_aria"
+                      (hash count=row.droppedIn)
+                    }}
+                  >{{dIcon "arrow-down"}}
+                    {{row.droppedInFormatted}}</span>
+                {{/if}}
               </div>
             {{/if}}
           </li>

--- a/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/trust-level-pipeline.gjs
@@ -9,40 +9,28 @@ import I18n, { i18n } from "discourse-i18n";
 export default class TrustLevelPipeline extends Component {
   get rows() {
     const data = this.args.data?.rows ?? [];
-    // Each rung reports who arrived this period, split by direction. Members
-    // rise into a level (promoted_in) or, at the entry level, join (signups) —
-    // both are upward arrivals. Members can also fall into a level from above
-    // (demoted_in), a downward arrival.
+
     const promotedIn = (row) => row.promoted_in ?? 0;
     const demotedIn = (row) => row.demoted_in ?? 0;
     const signups = (row) => row.signups ?? 0;
 
-    // The lowest trust level is the entry point: members reach it by signing
-    // up, not by climbing the ladder. It never draws a bar — its numbers sit
-    // inline on the title row instead — and it's excluded from the bar scale so
-    // its sign-up firehose doesn't dwarf every other level.
-    const entryLevel = data.reduce(
-      (min, row) => Math.min(min, row.trust_level),
-      Infinity
-    );
+    // Sign-ups stay out of the scale so the entry level's sign-up volume
+    // can't flatten every ladder bar.
     const barMax = data.reduce(
-      (acc, row) =>
-        row.trust_level === entryLevel
-          ? acc
-          : Math.max(acc, promotedIn(row), demotedIn(row)),
+      (acc, row) => Math.max(acc, promotedIn(row), demotedIn(row)),
       0
     );
 
     return data.map((row) => {
-      const isEntry = row.trust_level === entryLevel;
-      const climbedIn = promotedIn(row) + signups(row);
-      const droppedIn = demotedIn(row);
-      // Within the ladder flow, the bar follows whichever direction dominates:
-      // green when more members were promoted into the level than demoted into
-      // it, red otherwise — so a net-downward level reads as a red bar.
-      const barDown = droppedIn > promotedIn(row);
-      const barValue = barDown ? droppedIn : promotedIn(row);
-      const hasMovement = climbedIn > 0 || droppedIn > 0;
+      const promoted = promotedIn(row);
+      const demoted = demotedIn(row);
+      const signupCount = signups(row);
+      // The bar follows whichever direction dominates: green when more members
+      // were promoted into the level than demoted into it, red otherwise — so a
+      // net-downward level reads as a red bar.
+      const barDown = demoted > promoted;
+      const barValue = barDown ? demoted : promoted;
+      const hasLadderFlow = promoted > 0 || demoted > 0;
       return {
         ...row,
         label: i18n(
@@ -50,20 +38,18 @@ export default class TrustLevelPipeline extends Component {
         ),
         shareFormatted: `${I18n.toNumber(row.share, { precision: 2 })}%`,
         countFormatted: I18n.toNumber(row.count, { precision: 0 }),
-        climbedInFormatted: I18n.toNumber(climbedIn, { precision: 0 }),
-        droppedInFormatted: I18n.toNumber(droppedIn, { precision: 0 }),
-        climbedIn,
-        droppedIn,
+        promotedInFormatted: I18n.toNumber(promoted, { precision: 0 }),
+        demotedInFormatted: I18n.toNumber(demoted, { precision: 0 }),
+        signups: signupCount,
+        signupsFormatted: I18n.toNumber(signupCount, { precision: 0 }),
         barDown,
-        hasBar: !isEntry && barValue > 0,
+        hasBar: barValue > 0,
         barStyle: trustHTML(`width: ${this.#barWidth(barValue, barMax)}%`),
-        hasClimbers: climbedIn > 0,
-        hasDroppers: droppedIn > 0,
-        hasMovement,
-        // The entry level has no bar, so its deltas sit inline on the title
-        // row; every other level shows them beside its bar on the row below.
-        showInlineDeltas: isEntry && hasMovement,
-        showFlow: !isEntry && hasMovement,
+        hasClimbers: promoted > 0,
+        hasDroppers: demoted > 0,
+        hasSignups: signupCount > 0,
+        hasLadderFlow,
+        hasMovement: hasLadderFlow || signupCount > 0,
       };
     });
   }
@@ -124,38 +110,31 @@ export default class TrustLevelPipeline extends Component {
           <li class="db-tl-pipeline__row">
             <div class="db-tl-pipeline__label">
               <span class="db-tl-pipeline__name">{{row.label}}</span>
-              <span class="db-tl-pipeline__count">
+              <span
+                class="db-tl-pipeline__count"
+                title={{i18n
+                  "admin.dashboard.sections.engagement.trust_level_pipeline.count_title"
+                }}
+              >
                 {{row.countFormatted}}
                 ({{row.shareFormatted}})
               </span>
-              {{#if row.showInlineDeltas}}
-                <span class="db-tl-pipeline__deltas">
-                  {{#if row.hasClimbers}}
-                    <span class="db-delta --signups">{{i18n
-                        "admin.dashboard.sections.engagement.trust_level_pipeline.signups"
-                        (hash
-                          count=row.climbedIn
-                          formattedCount=row.climbedInFormatted
-                        )
-                      }}</span>
-                  {{/if}}
-                  {{#if row.hasDroppers}}
-                    <span
-                      class="db-delta --neg"
-                      aria-label={{i18n
-                        "admin.dashboard.sections.engagement.trust_level_pipeline.demotions_in_aria"
-                        (hash count=row.droppedIn)
-                      }}
-                    >{{dIcon "arrow-down"}}
-                      {{row.droppedInFormatted}}</span>
-                  {{/if}}
-                </span>
+              {{#if row.hasSignups}}
+                <span
+                  class="db-tl-pipeline__signups"
+                  title={{i18n
+                    "admin.dashboard.sections.engagement.trust_level_pipeline.signups_title"
+                  }}
+                >{{i18n
+                    "admin.dashboard.sections.engagement.trust_level_pipeline.signups"
+                    (hash count=row.signups formattedCount=row.signupsFormatted)
+                  }}</span>
               {{/if}}
               {{#unless row.hasMovement}}
                 <span class="db-pill">{{i18n "admin.dashboard.stable"}}</span>
               {{/unless}}
             </div>
-            {{#if row.showFlow}}
+            {{#if row.hasLadderFlow}}
               <div class="db-tl-pipeline__flow">
                 <div class="db-tl-pipeline__bar-track">
                   {{#if row.hasBar}}
@@ -174,9 +153,9 @@ export default class TrustLevelPipeline extends Component {
                     class="db-delta --pos"
                     aria-label={{i18n
                       "admin.dashboard.sections.engagement.trust_level_pipeline.arrivals_aria"
-                      (hash count=row.climbedIn)
+                      (hash count=row.promoted_in)
                     }}
-                  >{{row.climbedInFormatted}}
+                  >{{row.promotedInFormatted}}
                     {{dIcon "arrow-up"}}</span>
                 {{/if}}
                 {{#if row.hasDroppers}}
@@ -184,10 +163,10 @@ export default class TrustLevelPipeline extends Component {
                     class="db-delta --neg"
                     aria-label={{i18n
                       "admin.dashboard.sections.engagement.trust_level_pipeline.demotions_in_aria"
-                      (hash count=row.droppedIn)
+                      (hash count=row.demoted_in)
                     }}
                   >{{dIcon "arrow-down"}}
-                    {{row.droppedInFormatted}}</span>
+                    {{row.demotedInFormatted}}</span>
                 {{/if}}
               </div>
             {{/if}}

--- a/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
@@ -114,8 +114,9 @@ module(
       await render(<template><TrustLevelPipeline @data={{data}} /></template>);
 
       assert
-        .dom(".db-tl-pipeline__label .db-delta.--pos", rowAt(4))
-        .hasText("240");
+        .dom(".db-tl-pipeline__label .db-tl-pipeline__signups", rowAt(4))
+        .hasText("240 signups");
+      assert.dom(".db-delta.--pos", rowAt(4)).doesNotExist();
       assert
         .dom(".db-tl-pipeline__label .db-delta.--neg", rowAt(4))
         .hasText("5");

--- a/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
@@ -8,35 +8,38 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
+    const row = (
+      trust_level,
+      count,
+      share,
+      promoted_in,
+      signups = 0,
+      demoted_in = 0
+    ) => ({
+      trust_level,
+      count,
+      share,
+      promoted_in,
+      signups,
+      demoted_in,
+      promoted_out: 0,
+      demoted_out: 0,
+    });
+
     const data = {
       total_members: 105_580,
       trend: { direction: "climbing", net: 72 },
       rows: [
-        { trust_level: 4, count: 25, share: 0.55, moves_in: 4, moves_out: 0 },
-        { trust_level: 3, count: 48, share: 0.85, moves_in: 14, moves_out: 2 },
-        {
-          trust_level: 2,
-          count: 4_800,
-          share: 4.6,
-          moves_in: 42,
-          moves_out: 12,
-        },
-        {
-          trust_level: 1,
-          count: 30_000,
-          share: 28.5,
-          moves_in: 50,
-          moves_out: 18,
-        },
-        {
-          trust_level: 0,
-          count: 69_000,
-          share: 65.5,
-          moves_in: 0,
-          moves_out: 0,
-        },
+        row(4, 25, 0.55, 0),
+        row(3, 48, 0.85, 6, 0, 1),
+        row(2, 4_800, 4.6, 12),
+        row(1, 30_000, 28.5, 0, 0, 1),
+        row(0, 69_000, 65.5, 0, 240, 5),
       ],
     };
+
+    const rowAt = (index) =>
+      [...document.querySelectorAll(".db-tl-pipeline__row")][index];
 
     test("renders one row per trust level in descending order", async function (assert) {
       await render(<template><TrustLevelPipeline @data={{data}} /></template>);
@@ -55,6 +58,16 @@ module(
       assert.dom(".db-pill.--pos").hasText("+72 climbing");
     });
 
+    test("renders a dropping trend pill in negative styling", async function (assert) {
+      const negative = { ...data, trend: { direction: "dropping", net: 24 } };
+
+      await render(
+        <template><TrustLevelPipeline @data={{negative}} /></template>
+      );
+
+      assert.dom(".db-pill.--neg").hasText("-24 dropping");
+    });
+
     test("links the section title to the trust_level_pipeline report", async function (assert) {
       await render(<template><TrustLevelPipeline @data={{data}} /></template>);
 
@@ -63,53 +76,51 @@ module(
         .hasAttribute("href", /\/admin\/reports\/trust_level_pipeline/);
     });
 
-    test("hides the bars section entirely when a row has no movement on either side", async function (assert) {
+    test("shows a stable pill in the label, not a flow, when a level had no movement", async function (assert) {
       await render(<template><TrustLevelPipeline @data={{data}} /></template>);
 
-      const newRow = [...document.querySelectorAll(".db-tl-pipeline__row")].at(
-        -1
-      );
-      assert.dom(".db-tl-pipeline__bars", newRow).doesNotExist();
-      assert.dom(".db-pill", newRow).doesNotExist();
+      assert.dom(".db-tl-pipeline__flow", rowAt(0)).doesNotExist();
+      assert.dom(".db-tl-pipeline__label .db-pill", rowAt(0)).hasText("stable");
     });
 
-    test("shows a stable pill on the side that has no movement when the other side does", async function (assert) {
-      const oneSided = {
-        ...data,
-        rows: data.rows.map((r) =>
-          r.trust_level === 4 ? { ...r, moves_in: 4, moves_out: 0 } : r
-        ),
-      };
+    test("splits arrivals into a positive and a negative marker", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
 
-      await render(
-        <template><TrustLevelPipeline @data={{oneSided}} /></template>
-      );
+      assert.dom(".db-delta.--pos", rowAt(1)).hasText("6");
+      assert.dom(".db-delta.--neg", rowAt(1)).hasText("1");
+    });
 
-      const leaderRow = document.querySelector(".db-tl-pipeline__row");
+    test("shows a demotion into a level as a negative marker, never as a positive one", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-delta.--pos", rowAt(3)).doesNotExist();
+      assert.dom(".db-delta.--neg", rowAt(3)).hasText("1");
+    });
+
+    test("draws a red bar when more members dropped in than climbed in", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-tl-pipeline__bar.--demoted", rowAt(3)).exists();
+    });
+
+    test("keeps the bar green when more members climbed in than dropped in", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-tl-pipeline__bar", rowAt(1)).exists();
+      assert.dom(".db-tl-pipeline__bar.--demoted", rowAt(1)).doesNotExist();
+    });
+
+    test("shows the entry level's numbers inline on the title row, with no bar", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
       assert
-        .dom(".db-tl-pipeline__bar-out .db-pill", leaderRow)
-        .hasText("stable");
-      assert.dom(".db-tl-pipeline__delta--in", leaderRow).includesText("4");
-    });
-
-    test("renders moves_in and moves_out deltas with the count", async function (assert) {
-      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
-
-      assert.dom(".db-tl-pipeline__delta--in").includesText("4");
-      assert.dom(".db-tl-pipeline__delta--out").exists();
-    });
-
-    test("renders a dropping trend pill in negative styling", async function (assert) {
-      const negative = {
-        ...data,
-        trend: { direction: "dropping", net: 24 },
-      };
-
-      await render(
-        <template><TrustLevelPipeline @data={{negative}} /></template>
-      );
-
-      assert.dom(".db-pill.--neg").hasText("-24 dropping");
+        .dom(".db-tl-pipeline__label .db-delta.--pos", rowAt(4))
+        .hasText("240");
+      assert
+        .dom(".db-tl-pipeline__label .db-delta.--neg", rowAt(4))
+        .hasText("5");
+      assert.dom(".db-tl-pipeline__flow", rowAt(4)).doesNotExist();
+      assert.dom(".db-tl-pipeline__bar", rowAt(4)).doesNotExist();
     });
   }
 );

--- a/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/trust-level-pipeline-test.gjs
@@ -22,8 +22,6 @@ module(
       promoted_in,
       signups,
       demoted_in,
-      promoted_out: 0,
-      demoted_out: 0,
     });
 
     const data = {
@@ -110,18 +108,47 @@ module(
       assert.dom(".db-tl-pipeline__bar.--demoted", rowAt(1)).doesNotExist();
     });
 
-    test("shows the entry level's numbers inline on the title row, with no bar", async function (assert) {
+    test("shows the entry level's sign-ups inline as a plain count, never as a promotion", async function (assert) {
       await render(<template><TrustLevelPipeline @data={{data}} /></template>);
 
       assert
         .dom(".db-tl-pipeline__label .db-tl-pipeline__signups", rowAt(4))
-        .hasText("240 signups");
+        .hasText("+ 240 signups");
       assert.dom(".db-delta.--pos", rowAt(4)).doesNotExist();
+    });
+
+    test("still draws a directional bar on the entry level for real trust-level moves", async function (assert) {
+      await render(<template><TrustLevelPipeline @data={{data}} /></template>);
+
+      assert.dom(".db-tl-pipeline__flow", rowAt(4)).exists();
+      assert.dom(".db-tl-pipeline__bar.--demoted", rowAt(4)).exists();
       assert
-        .dom(".db-tl-pipeline__label .db-delta.--neg", rowAt(4))
+        .dom(".db-tl-pipeline__flow .db-delta.--neg", rowAt(4))
         .hasText("5");
-      assert.dom(".db-tl-pipeline__flow", rowAt(4)).doesNotExist();
-      assert.dom(".db-tl-pipeline__bar", rowAt(4)).doesNotExist();
+    });
+
+    test("an entry level above TL0 shows both its sign-ups and a promotion bar", async function (assert) {
+      const raisedEntry = {
+        ...data,
+        rows: [
+          row(4, 25, 0.55, 0),
+          row(3, 48, 0.85, 6),
+          row(2, 4_800, 4.6, 12, 300),
+          row(1, 30_000, 28.5, 3),
+          row(0, 69_000, 65.5, 0, 0, 5),
+        ],
+      };
+
+      await render(
+        <template><TrustLevelPipeline @data={{raisedEntry}} /></template>
+      );
+
+      assert.dom(".db-tl-pipeline__signups", rowAt(2)).hasText("+ 300 signups");
+      assert.dom(".db-tl-pipeline__bar", rowAt(2)).exists();
+      assert.dom(".db-tl-pipeline__bar.--demoted", rowAt(2)).doesNotExist();
+      assert.dom(".db-delta.--pos", rowAt(2)).hasText("12");
+
+      assert.dom(".db-delta.--pos", rowAt(3)).hasText("3");
     });
   }
 );

--- a/spec/models/concerns/reports/trust_level_pipeline_spec.rb
+++ b/spec/models/concerns/reports/trust_level_pipeline_spec.rb
@@ -38,7 +38,7 @@ describe Reports::TrustLevelPipeline do
     expect(report.data.sum { |r| r[:share] }).to be_within(0.1).of(100.0)
   end
 
-  it "splits promotions and demotions into directional in/out flows per level" do
+  it "counts promotions as arrivals at the destination level" do
     user = Fabricate(:user, trust_level: TrustLevel[2])
     record_promotion(user, from: 1, to: 2, at: start_date + 1.day)
     record_promotion(user, from: 2, to: 3, at: start_date + 5.days)
@@ -46,10 +46,8 @@ describe Reports::TrustLevelPipeline do
     report = build
 
     expect(row(report, 2)[:promoted_in]).to eq(1)
-    expect(row(report, 2)[:promoted_out]).to eq(1)
     expect(row(report, 3)[:promoted_in]).to eq(1)
-    expect(row(report, 1)[:promoted_out]).to eq(1)
-    expect(report.data.sum { |r| r[:demoted_in] + r[:demoted_out] }).to eq(0)
+    expect(report.data.sum { |r| r[:demoted_in] }).to eq(0)
   end
 
   it "counts auto_trust_level_change as well as manual change_trust_level" do
@@ -69,10 +67,8 @@ describe Reports::TrustLevelPipeline do
     report = build
 
     expect(row(report, 2)[:promoted_in]).to eq(1)
-    expect(row(report, 2)[:demoted_out]).to eq(1)
-    expect(row(report, 2)[:promoted_out]).to eq(0)
-    expect(row(report, 1)[:promoted_out]).to eq(1)
     expect(row(report, 1)[:demoted_in]).to eq(1)
+    expect(row(report, 1)[:promoted_in]).to eq(0)
   end
 
   it "counts members who joined in the period as sign-ups at the entry level" do
@@ -85,6 +81,16 @@ describe Reports::TrustLevelPipeline do
     entry = row(report, SiteSetting.default_trust_level)
     expect(entry[:signups]).to eq(2)
     expect(row(report, 4)[:signups]).to eq(0)
+  end
+
+  it "attributes sign-ups to the configured entry level, not to trust level 0" do
+    SiteSetting.default_trust_level = TrustLevel[1]
+    Fabricate(:user, created_at: start_date + 3.days)
+
+    report = build
+
+    expect(row(report, 1)[:signups]).to eq(1)
+    expect(row(report, 0)[:signups]).to eq(0)
   end
 
   it "does not count new sign-ups as trust-level moves" do

--- a/spec/models/concerns/reports/trust_level_pipeline_spec.rb
+++ b/spec/models/concerns/reports/trust_level_pipeline_spec.rb
@@ -38,17 +38,18 @@ describe Reports::TrustLevelPipeline do
     expect(report.data.sum { |r| r[:share] }).to be_within(0.1).of(100.0)
   end
 
-  it "counts moves_in and moves_out from UserHistory within the period" do
+  it "splits promotions and demotions into directional in/out flows per level" do
     user = Fabricate(:user, trust_level: TrustLevel[2])
     record_promotion(user, from: 1, to: 2, at: start_date + 1.day)
     record_promotion(user, from: 2, to: 3, at: start_date + 5.days)
 
     report = build
 
-    expect(row(report, 2)[:moves_in]).to eq(1)
-    expect(row(report, 2)[:moves_out]).to eq(1)
-    expect(row(report, 3)[:moves_in]).to eq(1)
-    expect(row(report, 1)[:moves_out]).to eq(1)
+    expect(row(report, 2)[:promoted_in]).to eq(1)
+    expect(row(report, 2)[:promoted_out]).to eq(1)
+    expect(row(report, 3)[:promoted_in]).to eq(1)
+    expect(row(report, 1)[:promoted_out]).to eq(1)
+    expect(report.data.sum { |r| r[:demoted_in] + r[:demoted_out] }).to eq(0)
   end
 
   it "counts auto_trust_level_change as well as manual change_trust_level" do
@@ -57,29 +58,42 @@ describe Reports::TrustLevelPipeline do
 
     report = build
 
-    expect(row(report, 2)[:moves_in]).to eq(1)
+    expect(row(report, 2)[:promoted_in]).to eq(1)
   end
 
-  it "treats up-then-down within the period as one move_in and one move_out per TL" do
+  it "records a downward move as a demotion, not a promotion" do
     user = Fabricate(:user, trust_level: TrustLevel[1])
     record_promotion(user, from: 1, to: 2, at: start_date + 2.days)
     record_promotion(user, from: 2, to: 1, at: start_date + 8.days)
 
     report = build
 
-    expect(row(report, 2)[:moves_in]).to eq(1)
-    expect(row(report, 2)[:moves_out]).to eq(1)
-    expect(row(report, 1)[:moves_in]).to eq(1)
-    expect(row(report, 1)[:moves_out]).to eq(1)
+    expect(row(report, 2)[:promoted_in]).to eq(1)
+    expect(row(report, 2)[:demoted_out]).to eq(1)
+    expect(row(report, 2)[:promoted_out]).to eq(0)
+    expect(row(report, 1)[:promoted_out]).to eq(1)
+    expect(row(report, 1)[:demoted_in]).to eq(1)
   end
 
-  it "does not count new sign-ups as TL0 moves_in" do
+  it "counts members who joined in the period as sign-ups at the entry level" do
     Fabricate(:user, created_at: start_date + 3.days)
     Fabricate(:user, created_at: start_date + 10.days)
+    Fabricate(:user, created_at: start_date - 5.days)
 
     report = build
 
-    expect(row(report, 0)[:moves_in]).to eq(0)
+    entry = row(report, SiteSetting.default_trust_level)
+    expect(entry[:signups]).to eq(2)
+    expect(row(report, 4)[:signups]).to eq(0)
+  end
+
+  it "does not count new sign-ups as trust-level moves" do
+    Fabricate(:user, created_at: start_date + 3.days)
+
+    report = build
+
+    expect(row(report, 0)[:promoted_in]).to eq(0)
+    expect(row(report, 0)[:demoted_in]).to eq(0)
   end
 
   it "ignores history rows outside the period" do
@@ -89,8 +103,8 @@ describe Reports::TrustLevelPipeline do
 
     report = build
 
-    expect(row(report, 2)[:moves_in]).to eq(0)
-    expect(row(report, 3)[:moves_in]).to eq(0)
+    expect(row(report, 2)[:promoted_in]).to eq(0)
+    expect(row(report, 3)[:promoted_in]).to eq(0)
   end
 
   it "excludes the system user and bots from the snapshot" do

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -226,9 +226,7 @@ describe AdminDashboardEngagement do
           :count,
           :share,
           :promoted_in,
-          :promoted_out,
           :demoted_in,
-          :demoted_out,
           :signups,
         )
         expect(pipeline[:trend]).to include(:direction, :net)

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -225,8 +225,11 @@ describe AdminDashboardEngagement do
           :trust_level,
           :count,
           :share,
-          :moves_in,
-          :moves_out,
+          :promoted_in,
+          :promoted_out,
+          :demoted_in,
+          :demoted_out,
+          :signups,
         )
         expect(pipeline[:trend]).to include(:direction, :net)
         expect(pipeline[:total_members]).to be >= 2


### PR DESCRIPTION

 The engagement dashboard's "Trust level pipeline" showed each level's membership
  plus direction-blind "moves in / moves out" counts, colored by **position**
  (in vs. out). That mislabeled healthy movement: a member graduating *out* of Tiers, especially New,
  rendered as a red ↓, reading as negative when it's the best possible outcome.

  This PR reframes the widget as a **directional arrivals funnel** with a focus on the flow, and specifically looks at promoted/demoted-in
  
  ## Design thinking

  - **Direction, not position.** Trust-level movement has a meaningful axis —
    up (promotion) is good, down (demotion) is not. We split every move into `promoted_in` and `demoted_in`, drop the double bars, and colour by direction: if more promotions => green, if more demotions => red. Leaving New is now correctly green.
  - **An "arrivals" funnel.** Each rung answers one consistent question: *how many
    members arrived here this period?* For every bar it's tracked the same way + we add an extra label for the tier that is set as the `Default trust level`.
  - **Sign-ups ≠ promotions.** Signups are excluded from both the trend and the bar scale. It's volume would otherwise often dwarf the other bars.

  ## Backend — `reports/trust_level_pipeline.rb`

  - **Snapshot** per level: `User.real.group(:trust_level).count` + share. No date
    filter — it's the current distribution, not a period metric.
  - **Directional arrivals** from `user_histories` (`change_trust_level` +
    `auto_trust_level_change`) within the period: `promoted_in`,
    `demoted_in` per level.
  - **Sign-ups**: real users created in the period, attributed to the entry level
    (`SiteSetting.default_trust_level`). Not counted as trust-level moves.
  - **Trend** (`prev_period`): net = promotions − demotions across the ladder
    (sign-ups excluded) → `climbing` / `dropping` / `stable`.

## Known limitation
  
The `Default invitee trust level` is not taken into account, which means invitees can be counted at the wrong rung.
However, accounting for it correctly means distinguishing invited from organic sign-ups (joining through invites, and handling that a user's trust level may have moved since they joined), which introduces a second entry point. That breaks the widget's core simplification and adds complexity. Overall I'm expecting the % of invitees to usually not meaningfully muddle the representation of the pipeline flow.

### Visuals

| Old | New |
|--------|--------|
| <img width="523" height="579" alt="CleanShot 2026-06-26 at 17 28 46" src="https://github.com/user-attachments/assets/0d255dca-8ed3-45ba-99d2-1458e5e39e06" /> | <img width="528" height="611" alt="CleanShot 2026-07-01 at 19 24 28" src="https://github.com/user-attachments/assets/937ee963-7555-4012-ab13-6e4434ac4448" /> | 


