### PR TITLE
UX: Explain invalid automatic membership email domains

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -23,6 +23,7 @@ class Admin::GroupsController < Admin::StaffController
                  ),
                status: :unprocessable_entity
       end
+      on_model_errors(:group) { |group:| render_json_error(group) }
       on_failure { render(json: failed_json, status: :unprocessable_entity) }
     end
   end
@@ -77,7 +78,11 @@ class Admin::GroupsController < Admin::StaffController
 
   def automatic_membership_count
     guardian.ensure_can_create_group!
-    domains = Group.get_valid_email_domains(params.require(:automatic_membership_email_domains))
+    invalid_domains = []
+    domains =
+      Group.get_valid_email_domains(params.require(:automatic_membership_email_domains)) do |domain|
+        invalid_domains << domain
+      end
     group_id = params[:id]
     user_count = 0
 
@@ -93,18 +98,13 @@ class Admin::GroupsController < Admin::StaffController
       end
 
       if domains.size > MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP
-        raise Discourse::InvalidParameters.new(
-                I18n.t(
-                  "groups.errors.counting_too_many_email_domains",
-                  count: MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP,
-                ),
-              )
+        user_count = nil
+      else
+        user_count = Group.automatic_membership_users(domains.join("|")).count
       end
-
-      user_count = Group.automatic_membership_users(domains.join("|")).count
     end
 
-    render json: { user_count: user_count }
+    render json: { user_count:, invalid_domains: invalid_domains.uniq }
   end
 
   protected

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7443,6 +7443,10 @@ en:
             effects: Effects
             trust_levels_none: "None"
             automatic_membership_email_domains: "Users who register with an email domain that exactly matches one in this list will be automatically added to this group:"
+            automatic_membership_email_domains_instructions: "Enter each domain on its own, without the @ symbol, for example discourse.org."
+            automatic_membership_email_domains_invalid:
+              one: "%{domains} isn't a valid domain. Enter a bare domain, for example discourse.org."
+              other: "These aren't valid domains: %{domains}. Enter each as a bare domain, for example discourse.org."
             automatic_membership_user_count:
               one: "%{count} user has the new email domains and will be added to the group."
               other: "%{count} users have the new email domains and will be added to the group."

--- a/frontend/discourse/app/components/groups-form-membership-fields.gjs
+++ b/frontend/discourse/app/components/groups-form-membership-fields.gjs
@@ -330,6 +330,12 @@ export default class GroupsFormMembershipFields extends Component {
             class="group-form-automatic-membership-automatic"
           />
 
+          <div class="control-instructions">
+            {{i18n
+              "admin.groups.manage.membership.automatic_membership_email_domains_instructions"
+            }}
+          </div>
+
           {{#if this.showAssociatedGroups}}
             <label for="automatic_membership_associated_groups">
               {{i18n

--- a/frontend/discourse/app/lib/constants.js
+++ b/frontend/discourse/app/lib/constants.js
@@ -55,8 +55,6 @@ export const GROUP_VISIBILITY_LEVELS = {
   owners: 4,
 };
 
-export const MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP = 10;
-
 export const MAX_NOTIFICATIONS_LIMIT_PARAMS = 60;
 
 export const TOPIC_VISIBILITY_REASONS = {

--- a/frontend/discourse/app/services/group-automatic-members-dialog.js
+++ b/frontend/discourse/app/services/group-automatic-members-dialog.js
@@ -2,7 +2,6 @@ import Service, { service } from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP } from "discourse/lib/constants";
 import { i18n } from "discourse-i18n";
 
 export default class GroupAutomaticMembersDialog extends Service {
@@ -10,24 +9,7 @@ export default class GroupAutomaticMembersDialog extends Service {
 
   async showConfirm(group_id, email_domains) {
     if (isEmpty(email_domains)) {
-      return Promise.resolve(true);
-    }
-
-    const domainCount = email_domains.split("|").length;
-
-    // On the back-end we compare every single user's e-mail to each e-mail
-    // domain by regular expression. At some point this is a but much work
-    // just to display this dialog, so go with a generic message instead.
-    if (domainCount > MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP) {
-      return new Promise((resolve) => {
-        this.dialog.confirm({
-          message: i18n(
-            "admin.groups.manage.membership.automatic_membership_user_unknown_count"
-          ),
-          didConfirm: () => resolve(true),
-          didCancel: () => resolve(false),
-        });
-      });
+      return true;
     }
 
     const data = { automatic_membership_email_domains: email_domains };
@@ -45,24 +27,39 @@ export default class GroupAutomaticMembersDialog extends Service {
         }
       );
 
+      if (result.invalid_domains?.length) {
+        this.dialog.alert(
+          i18n(
+            "admin.groups.manage.membership.automatic_membership_email_domains_invalid",
+            {
+              count: result.invalid_domains.length,
+              domains: result.invalid_domains.join(", "),
+            }
+          )
+        );
+        return false;
+      }
+
       const count = result.user_count;
 
-      if (count > 0) {
-        return new Promise((resolve) => {
-          this.dialog.confirm({
-            message: i18n(
-              "admin.groups.manage.membership.automatic_membership_user_count",
-              {
-                count,
-              }
-            ),
-            didConfirm: () => resolve(true),
-            didCancel: () => resolve(false),
-          });
+      if (count === null) {
+        return this.dialog.confirm({
+          message: i18n(
+            "admin.groups.manage.membership.automatic_membership_user_unknown_count"
+          ),
         });
       }
 
-      return Promise.resolve(true);
+      if (count > 0) {
+        return this.dialog.confirm({
+          message: i18n(
+            "admin.groups.manage.membership.automatic_membership_user_count",
+            { count }
+          ),
+        });
+      }
+
+      return true;
     } catch (error) {
       popupAjaxError(error);
     }

--- a/frontend/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-membership-test.js
@@ -8,6 +8,7 @@ import {
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { i18n } from "discourse-i18n";
 
 acceptance("Managing Group Membership", function (needs) {
   let savedGroup;
@@ -30,6 +31,15 @@ acceptance("Managing Group Membership", function (needs) {
     server.put("/groups/57", (request) => {
       savedGroup = helper.parsePostData(request.requestBody).group;
       return helper.response({ success: "OK" });
+    });
+
+    server.put("/admin/groups/automatic_membership_count.json", (request) => {
+      const domains = (
+        helper.parsePostData(request.requestBody)
+          .automatic_membership_email_domains || ""
+      ).split("|");
+      const invalid_domains = domains.filter((domain) => domain.includes("@"));
+      return helper.response({ user_count: 0, invalid_domains });
     });
   });
 
@@ -98,6 +108,33 @@ acceptance("Managing Group Membership", function (needs) {
     await emailDomains.selectRowByValue("foo.com");
 
     assert.strictEqual(emailDomains.header().value(), "foo.com");
+  });
+
+  test("warns and blocks the save when a domain includes '@'", async function (assert) {
+    updateCurrentUser({ can_create_group: true });
+
+    await visit("/g/alternative-group/manage/membership");
+
+    const emailDomains = selectKit(
+      ".group-form-automatic-membership-automatic"
+    );
+    await emailDomains.expand();
+    await emailDomains.fillInFilter("@harness.io");
+    await emailDomains.selectRowByValue("@harness.io");
+
+    await click(".group-manage-save");
+
+    assert
+      .dom(".dialog-body")
+      .hasText(
+        i18n(
+          "admin.groups.manage.membership.automatic_membership_email_domains_invalid",
+          { count: 1, domains: "@harness.io" }
+        ),
+        "shows the invalid-domain warning"
+      );
+
+    assert.strictEqual(savedGroup, null, "does not save the group");
   });
 
   test("the join method constrains the group's visibility options", async function (assert) {
@@ -274,6 +311,59 @@ acceptance("Managing Group Membership", function (needs) {
       .exists("displays group public exit input");
   });
 });
+
+acceptance(
+  "Managing Group Membership - too many automatic membership domains",
+  function (needs) {
+    let savedGroup;
+
+    needs.user();
+    needs.pretender((server, helper) => {
+      server.put("/admin/groups/automatic_membership_count.json", () =>
+        helper.response({ user_count: null, invalid_domains: [] })
+      );
+
+      server.put("/groups/57", (request) => {
+        savedGroup = helper.parsePostData(request.requestBody).group;
+        return helper.response({ success: "OK" });
+      });
+    });
+
+    needs.hooks.beforeEach(() => (savedGroup = null));
+
+    test("confirms with a generic message when there are too many domains to count", async function (assert) {
+      updateCurrentUser({ can_create_group: true });
+
+      await visit("/g/alternative-group/manage/membership");
+
+      const emailDomains = selectKit(
+        ".group-form-automatic-membership-automatic"
+      );
+      await emailDomains.expand();
+      await emailDomains.fillInFilter("example.com");
+      await emailDomains.selectRowByValue("example.com");
+
+      await click(".group-manage-save");
+
+      assert
+        .dom(".dialog-body")
+        .hasText(
+          i18n(
+            "admin.groups.manage.membership.automatic_membership_user_unknown_count"
+          ),
+          "shows the generic unknown-count confirmation"
+        );
+
+      await click(".dialog-footer .btn-primary");
+
+      assert.notStrictEqual(
+        savedGroup,
+        null,
+        "saves the group after confirming"
+      );
+    });
+  }
+);
 
 acceptance(
   "Managing Group Membership - non-admin owner of a private group",

--- a/lib/tasks/javascript.rake
+++ b/lib/tasks/javascript.rake
@@ -79,8 +79,6 @@ task "javascript:update_constants" => :environment do
 
     export const GROUP_VISIBILITY_LEVELS = #{Group.visibility_levels.to_json};
 
-    export const MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP = #{Admin::GroupsController::MAX_AUTO_MEMBERSHIP_DOMAINS_LOOKUP};
-
     export const MAX_NOTIFICATIONS_LIMIT_PARAMS = #{NotificationsController::INDEX_LIMIT};
 
     export const TOPIC_VISIBILITY_REASONS = #{Topic.visibility_reasons.to_json};

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -98,6 +98,37 @@ RSpec.describe Admin::GroupsController do
           expect(Group.last.allow_unknown_sender_topic_replies).to eq(true)
         end
       end
+
+      context "with automatic membership email domains" do
+        it "surfaces a clear validation error when a domain includes '@'" do
+          post "/admin/groups.json",
+               params: {
+                 group: {
+                   name: "harness-staff",
+                   automatic_membership_email_domains: "@harness.io",
+                 },
+               }
+
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to include(
+            I18n.t("groups.errors.invalid_domain", domain: "@harness.io"),
+          )
+          expect(response.parsed_body["failed"]).to be_nil
+        end
+
+        it "creates the group when the domains are valid" do
+          post "/admin/groups.json",
+               params: {
+                 group: {
+                   name: "harness-staff",
+                   automatic_membership_email_domains: "harness.io",
+                 },
+               }
+
+          expect(response.status).to eq(200)
+          expect(Group.last.automatic_membership_email_domains).to eq("harness.io")
+        end
+      end
     end
 
     context "when logged in as a moderator" do
@@ -451,19 +482,31 @@ RSpec.describe Admin::GroupsController do
         expect(response.parsed_body["user_count"]).to eq(2)
       end
 
-      it "responds with a 400 for a long list of domains" do
+      it "skips the count but still responds for a long list of valid domains" do
         put "/admin/groups/automatic_membership_count.json",
             params: {
               automatic_membership_email_domains: 1.upto(11).map { |n| "domain#{n}.com" }.join("|"),
               id: group.id,
             }
-        expect(response.status).to eq(400)
-        expect(response.parsed_body["errors"]).to contain_exactly(
-          "You supplied invalid parameters to the request: Maximum 10 email domains can be counted at once",
-        )
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["user_count"]).to be_nil
+        expect(response.parsed_body["invalid_domains"]).to be_empty
       end
 
-      it "doesn't respond with 500 if domain is invalid" do
+      it "still reports invalid domains when the count is skipped" do
+        domains = (1.upto(11).map { |n| "domain#{n}.com" } + ["@bad.io"]).join("|")
+
+        put "/admin/groups/automatic_membership_count.json",
+            params: {
+              automatic_membership_email_domains: domains,
+              id: group.id,
+            }
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["user_count"]).to be_nil
+        expect(response.parsed_body["invalid_domains"]).to contain_exactly("@bad.io")
+      end
+
+      it "doesn't respond with 500 if domain is invalid and reports the invalid domains" do
         group = Fabricate(:group)
 
         put "/admin/groups/automatic_membership_count.json",
@@ -473,6 +516,24 @@ RSpec.describe Admin::GroupsController do
             }
         expect(response.status).to eq(200)
         expect(response.parsed_body["user_count"]).to eq(0)
+        expect(response.parsed_body["invalid_domains"]).to contain_exactly(
+          "@somedomain.org",
+          "@somedomain.com",
+        )
+      end
+
+      it "reports invalid domains alongside the valid count" do
+        Fabricate(:user, email: "user1@somedomain.org")
+        group = Fabricate(:group)
+
+        put "/admin/groups/automatic_membership_count.json",
+            params: {
+              automatic_membership_email_domains: "somedomain.org|@bad.com",
+              id: group.id,
+            }
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["user_count"]).to eq(1)
+        expect(response.parsed_body["invalid_domains"]).to contain_exactly("@bad.com")
       end
     end
 


### PR DESCRIPTION
Previously, saving a group with a malformed automatic membership email domain (such as one that includes `@`) failed with an opaque "FAILED" popup that gave no indication of what was wrong or how to fix it.

This change surfaces the underlying validation error on save, warns about and lists the offending domains before the save is attempted, and adds an inline hint describing the expected format.

**Screenshots**

<img width="1400" height="1200" alt="desktop-horizon-light-group-domain-field-hint" src="https://github.com/user-attachments/assets/8fa08914-29bf-4afb-be02-666d5399b446" />

<img width="1400" height="1200" alt="desktop-horizon-light-group-domain-invalid-warning" src="https://github.com/user-attachments/assets/5372ac0b-f59d-4e09-89aa-3f3a53e3fba5" />


