### PR TITLE
UX: fix signup form placeholder style

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -263,7 +263,8 @@ body.signup-page {
 
     .user-field.text label.control-label,
     .user-field.dropdown label.control-label,
-    .user-field.multiselect label.control-label {
+    .user-field.multiselect label.control-label,
+    .user-field.date label.control-label {
       top: -8px;
       left: calc(1em - 0.25em);
       background-color: var(--secondary);
@@ -304,16 +305,6 @@ body.signup-page {
       .more-info,
       .instructions {
         opacity: 1;
-      }
-    }
-
-    .user-field.date {
-      .alt-placeholder {
-        display: none;
-      }
-
-      input:focus + .alt-placeholder {
-        display: block;
       }
     }
 
@@ -395,7 +386,8 @@ body.signup-page {
         }
 
         .user-field.dropdown label.control-label,
-        .user-field.multiselect label.control-label {
+        .user-field.multiselect label.control-label,
+        .user-field.date label.control-label {
           top: -10px;
         }
       }

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .uc-modernize-foundation-theme {
   --d-button-default-bg-color: var(--secondary);
   --d-button-default-border: 1px solid var(--primary-300);
@@ -61,28 +63,6 @@
     ) {
       width: var(--d-control-height);
     }
-  }
-
-  .login-fullpage .input-group label.alt-placeholder,
-  .login-fullpage .input-group .user-field.text label.control-label,
-  .login-fullpage .input-group .user-field.dropdown label.control-label,
-  .login-fullpage .input-group .user-field.multiselect label.control-label,
-  .signup-fullpage .input-group label.alt-placeholder,
-  .signup-fullpage .input-group .user-field.text label.control-label,
-  .signup-fullpage .input-group .user-field.dropdown label.control-label,
-  .signup-fullpage .input-group .user-field.multiselect label.control-label,
-  .invites-show .input-group label.alt-placeholder,
-  .invites-show .input-group .user-field.text label.control-label,
-  .invites-show .input-group .user-field.dropdown label.control-label,
-  .invites-show .input-group .user-field.multiselect label.control-label,
-  .password-reset-page .input-group label.alt-placeholder,
-  .password-reset-page .input-group .user-field.text label.control-label,
-  .password-reset-page .input-group .user-field.dropdown label.control-label,
-  .password-reset-page
-    .input-group
-    .user-field.multiselect
-    label.control-label {
-    top: 8px;
   }
 
   .form-kit__control-password-wrapper {
@@ -161,6 +141,70 @@
     &:hover {
       border-bottom: none;
       border-right: none;
+    }
+  }
+
+  .login-fullpage,
+  .signup-fullpage,
+  .invites-show,
+  .password-reset-page {
+    .input-group {
+      label.alt-placeholder,
+      .user-field.text label.control-label {
+        top: 8px;
+      }
+
+      .user-field.dropdown label.control-label,
+      .user-field.multiselect label.control-label,
+      .user-field.date label.control-label {
+        top: -8px;
+      }
+    }
+  }
+
+  .invite-page,
+  .signup-fullpage {
+    .user-fields .input-group {
+      .user-field.text,
+      .user-field.textarea {
+        &:not(.value-entered, :focus-within)
+          label.alt-placeholder.control-label {
+          top: 8px;
+        }
+      }
+    }
+  }
+
+  @include viewport.until(md) {
+    .login-form,
+    #login-form,
+    .invite-form {
+      .input-group {
+        input {
+          height: var(--d-control-height);
+        }
+
+        label.alt-placeholder,
+        .user-field.text label.control-label,
+        .user-field.textarea label.control-label {
+          top: 7px;
+        }
+
+        input:focus + label,
+        input.value-entered + label.alt-placeholder,
+        div.user-field:not(.dropdown)
+          .controls
+          input:focus
+          + label.alt-placeholder.control-label,
+        div.user-field.value-entered:not(.dropdown)
+          .controls
+          label.alt-placeholder.control-label,
+        .user-field.dropdown label.control-label,
+        .user-field.multiselect label.control-label,
+        .user-field.date label.control-label {
+          top: -9px;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
There were some issues with placeholder for custom fields in the modernized foundation change, and this gets them looking correct again. 

The multiselect placeholder needs to be in a fixed position like the date input, to avoid issues with overlapping the default placeholder. This also fixes the alignment of placeholders for custom text fields. 

Before:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/6f239e04-802b-44ba-ad88-f92180e1bf65" />


After:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/905dc292-519d-4085-a99b-c85f7d28ef87" />
