### PR TITLE
DEV: Add banned_acl concept to AccessControlList

### DIFF
--- a/.skills/discourse-acl-authoring/SKILL.md
+++ b/.skills/discourse-acl-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discourse-acl-authoring
-description: Use when creating, editing, or reviewing Discourse access-control-list features built on AccessControlList, AclTarget, Guardian ACL helpers, AccessControlListManager, mandatory_acl, Site access_control metadata, plugin ACL target registration, or the DAccessControl UI component.
+description: Use when creating, editing, or reviewing Discourse access-control-list features built on AccessControlList, AclTarget, Guardian ACL helpers, AccessControlListManager, mandatory_acl, banned_acl, Site access_control metadata, plugin ACL target registration, or the DAccessControl UI component.
 ---
 
 # Discourse ACL Authoring
@@ -22,7 +22,8 @@ Use this skill before adding or reviewing ACL-backed resource permissions in Dis
 - Always call `AccessControlListManager` for writes, including empty submitted ACL arrays, so mandatory ACLs are injected and old rows are replaced intentionally.
 - Treat `AccessControlList.flattened_list` as the API shape for UI/client payloads and `AccessControlList.expand_list_for_bulk_insert` as the DB insert shape.
 - Use Guardian ACL helpers or `AclTarget` visibility scopes for checks and target scopes instead of hand-querying ACL tables in controllers.
-- Register plugin ACL targets with `DiscoursePluginRegistry.register_acl_target_class` so `Site#access_control` exposes mandatory ACL metadata to the frontend.
+- Register plugin ACL targets with `DiscoursePluginRegistry.register_acl_target_class` so `Site#access_control` exposes mandatory and banned ACL metadata to the frontend.
+- Treat `banned_acl` as a server-enforced restriction. `DAccessControl` hides banned permission choices for UX, but `AccessControlListManager` must still reject submitted banned entries.
 - Do not claim user ACL support is complete. Current authoring and UI flows are group-first; `allowed_user_ids` and user entries exist in lower layers but are not fully wired by `expand_list`, `preload_allowed`, cleanup jobs, or `DAccessControl`.
 
 ## Local Anchors

--- a/.skills/discourse-acl-authoring/references/backend-model.md
+++ b/.skills/discourse-acl-authoring/references/backend-model.md
@@ -141,17 +141,27 @@ The concern provides:
 - `.acl_target_key`, defaulting to `name`
 - `.has_mandatory_acl?`
 - `.acl_is_mandatory?(acl)`
+- `.has_banned_acl?`
+- `.acl_is_banned?(acl)`
 - `mandatory_acl_as_expanded_list(owner)`
 
-`AclTarget.acl_matches?(acl_a, acl_b)` is the shared comparator for mandatory ACL matching. It normalizes `type` to symbols and compares `permission` as strings.
+`AclTarget.acl_matches?(acl_a, acl_b)` is the shared comparator for mandatory and banned ACL matching. It normalizes `type` to symbols and compares `permission` as strings.
 
-## Mandatory ACLs
+## Mandatory and Banned ACLs
 
 Define `self.mandatory_acl` on the target class when some grants must always exist:
 
 ```ruby
 def self.mandatory_acl
   [{ type: :group, id: Group::AUTO_GROUPS[:admins], permission: "manage" }]
+end
+```
+
+Define `self.banned_acl` on the target class when specific grants must never be selectable or persisted:
+
+```ruby
+def self.banned_acl
+  [{ type: :group, id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" }]
 end
 ```
 
@@ -162,7 +172,13 @@ Mandatory entries are consumed by both backend writes and frontend rendering:
 - `flattened_list` marks matching entries with `mandatory: true`.
 - `Site#access_control` exposes mandatory ACL metadata for registered targets.
 
-Keep mandatory ACLs group-based unless user ACL support has been completed end-to-end.
+Banned entries are consumed by both backend writes and frontend rendering:
+
+- `AccessControlListManager` rejects submitted ACLs that match the target class's `banned_acl` via the `has_no_banned_acl` policy.
+- `Site#access_control` exposes banned ACL metadata for registered targets.
+- `DAccessControl` filters banned permission options for the matching grantee.
+
+Keep mandatory and banned ACLs group-based unless user ACL support has been completed end-to-end.
 
 ## Stale References
 

--- a/.skills/discourse-acl-authoring/references/frontend-d-access-control.md
+++ b/.skills/discourse-acl-authoring/references/frontend-d-access-control.md
@@ -27,7 +27,7 @@ Arguments:
 - `@groups`: group records available for selection. Each group should have `id`, `name`, `full_name`, and `automatic`.
 - `@acl`: flattened ACL entries from the backend or form state.
 - `@onChange`: called with the next flattened ACL array when the user adds/removes/changes a row.
-- `@aclTarget`: optional key used to load mandatory ACL entries from `site.access_control.mandatory_acl`.
+- `@aclTarget`: optional key used to load mandatory ACL entries from `site.access_control.mandatory_acl` and banned entries from `site.access_control.banned_acl`.
 - `@transformPermissionOptions`: optional callback to customize default permission labels/descriptions or add target-specific permissions.
 
 `@aclTarget` must match `target_class.acl_target_key`; by default this is the Ruby class name such as `"DiscourseKanban::Board"`.
@@ -46,6 +46,8 @@ aclChanged(acl) {
 ```
 
 Mandatory ACL rows are injected for display from `this.site.access_control`. The component does not call `@onChange` during render when it injects mandatory rows. Backend saves must still call `AccessControlListManager` with the submitted ACL array so mandatory entries are injected server-side too.
+
+Banned ACL rows are also read from `this.site.access_control`. The component filters matching permission options for the row's grantee by comparing `permission`, `type`, and `id`. This is only a UX guard; backend saves must still go through `AccessControlListManager`, which rejects banned entries.
 
 ## Permission Options
 
@@ -76,11 +78,15 @@ transformPermissionOptions(options) {
 
 Keep permission copy aligned with backend semantics. If a displayed `manage` role also requires a global site setting or staff gate, make that clear in the surrounding UI or choose a different label.
 
+Target-specific options added via `@transformPermissionOptions` can still be banned for individual grantees. For example, a target may add `manage` and then define `banned_acl` entries that remove `edit` and `manage` from the `anonymous_users` auto group.
+
 ## Row Behavior
 
 - Rows are sorted with mandatory rows first, then by group name.
 - Mandatory rows show a lock icon, are styled with `--mandatory`, and have their permission select disabled.
 - A mandatory ACL replaces an existing row for the same type/id in the component's display list.
+- Banned permissions are filtered per row only when the banned entry's `type`, `id`, and `permission` match the row.
+- The remove action remains available unless the row is mandatory.
 - Newly added regular groups default to `edit`.
 - Read-only default auto groups (`anonymous_users`, `everyone`, `trust_level_0`) default to `view`.
 - Already selected groups are removed from the add-group chooser.
@@ -124,6 +130,7 @@ Consumer tests should cover:
 
 - target-specific permission options are present
 - `@aclTarget` renders mandatory rows from `site.access_control`
+- `@aclTarget` filters banned permissions from `site.access_control` for the matching grantee only
 - mandatory rows are locked and not duplicated
 - `@onChange` updates parent/form state when the user changes a row
 - default ACL construction for new records includes expected groups, if the consumer builds defaults

--- a/.skills/discourse-acl-authoring/references/manager-and-plugin-integration.md
+++ b/.skills/discourse-acl-authoring/references/manager-and-plugin-integration.md
@@ -30,6 +30,7 @@ Behavior:
 - validates `target` and `owner`
 - fetches previous target permissions
 - injects mandatory ACLs into `flattened_acl`
+- fails `has_no_banned_acl` if any final flattened ACL entry matches the target class's `banned_acl`
 - fails `has_at_least_one_acl` if the final ACL list is empty
 - destroys all current ACL rows for the target
 - inserts expanded ACL rows
@@ -86,10 +87,17 @@ Shape:
       { type: :group, id: Group::AUTO_GROUPS[:admins], permission: "manage" },
     ],
   },
+  banned_acl: {
+    "DiscourseKanban::Board" => [
+      { type: :group, id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" },
+    ],
+  },
 }
 ```
 
 The key is `target_class.acl_target_key`, which defaults to the class name. If a frontend passes `@aclTarget`, it must match this key exactly.
+
+`mandatory_acl` and `banned_acl` are both always present in the serialized `access_control` payload. Each map only includes target classes that define non-empty metadata for that ACL type.
 
 ## Serializing Target ACLs
 

--- a/.skills/discourse-acl-authoring/references/testing-and-review.md
+++ b/.skills/discourse-acl-authoring/references/testing-and-review.md
@@ -22,6 +22,7 @@ For services using `AccessControlListManager`:
 - Creation with omitted `acl` persists mandatory ACLs.
 - Creation with `acl: []` persists mandatory ACLs or fails closed when no mandatory ACL exists.
 - Update with explicit `acl: []` replaces existing ACLs with mandatory ACLs.
+- Submitted ACLs that match the target class's `banned_acl` fail the `has_no_banned_acl` policy.
 - Update with a non-empty ACL replaces old rows and logs/records permission history if the feature has history.
 - After a successful manager call, the target instance has been reloaded and should not retain a stale `permission_acl` cache.
 - Unauthorized actors fail before the manager mutates ACL rows.
@@ -53,6 +54,7 @@ For `DAccessControl` consumers:
 
 - Rendered permissions match target-specific labels/descriptions.
 - Mandatory ACL from `site.access_control.mandatory_acl[targetKey]` appears and is locked.
+- Banned ACL from `site.access_control.banned_acl[targetKey]` removes matching permission options for the matching grantee.
 - Existing rows with the same group as a mandatory row are not duplicated.
 - `onChange` writes updated ACL arrays into parent state.
 - The final save payload includes the intended ACL array.
@@ -67,6 +69,7 @@ Ask these questions during code review:
 - Does the caller authorize the actor before the manager can replace ACL rows?
 - Does the service distinguish omitted ACL params from explicit empty ACL params when that matters?
 - Are mandatory ACLs enforced in both backend writes and frontend display?
+- Are banned ACLs enforced in backend writes and filtered from the frontend for matching grantees?
 - Does the UI `@aclTarget` string match the target's `acl_target_key`?
 - Is ACL serialization limited to users who can manage the specific target?
 - Are list/index queries using `Target.with_acl_permission`, `Target.with_any_acl_permissions`, `guardian.target_ids_with_acl_permission`, or `target_ids_with_any_acl_permissions` instead of ad hoc SQL?
@@ -80,5 +83,6 @@ Ask these questions during code review:
 - `AccessControlListManager` currently assumes caller-side authorization.
 - Group support is complete enough for current UI; user ACL support is not.
 - `DAccessControl` injects mandatory rows for display but does not notify the parent on render.
+- `DAccessControl` filters banned permission options for UX, but hidden options are not authorization. The manager policy is the enforcement point.
 - Mandatory ACLs from site settings need extra care in migrations because raw stored settings may omit `mandatory_values`.
 - `flattened_list` skips stale group IDs and unknown target classes, so a missing row can disappear from serialized ACL output while cleanup or validation catches up.

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -248,7 +248,7 @@ class Category < ActiveRecord::Base
                 :subcategory_count
 
   # Allows us to skip creating the category definition topic in tests.
-  attr_accessor :skip_category_definition
+  attr_accessor :skip_category_definition, :skip_publish
 
   enum :style_type, { square: 0, icon: 1, emoji: 2 }
 
@@ -665,6 +665,8 @@ class Category < ActiveRecord::Base
   end
 
   def publish_category
+    return if skip_publish
+
     if read_restricted
       group_ids = groups.pluck(:id)
 

--- a/app/models/concerns/acl_target.rb
+++ b/app/models/concerns/acl_target.rb
@@ -69,5 +69,13 @@ module AclTarget
       has_mandatory_acl? &&
         mandatory_acl.any? { |mandatory_acl| AclTarget.acl_matches?(acl, mandatory_acl) }
     end
+
+    def has_banned_acl?
+      defined?(banned_acl).present? && banned_acl.length.positive?
+    end
+
+    def acl_is_banned?(acl)
+      has_banned_acl? && banned_acl.any? { |banned_acl| AclTarget.acl_matches?(acl, banned_acl) }
+    end
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -84,6 +84,13 @@ class Site
 
           mandatory_acl[target_class.acl_target_key] = target_class.mandatory_acl
         end,
+      banned_acl:
+        target_classes.each_with_object({}) do |target_class, banned_acl|
+          next if !target_class.respond_to?(:has_banned_acl?)
+          next if !target_class.has_banned_acl?
+
+          banned_acl[target_class.acl_target_key] = target_class.banned_acl
+        end,
     }
   end
 

--- a/app/services/access_control_list_manager.rb
+++ b/app/services/access_control_list_manager.rb
@@ -19,6 +19,7 @@ class AccessControlListManager
 
   model :previous_permissions, optional: true
   model :flattened_acl_with_mandatory, optional: true
+  policy :has_no_banned_acl
   policy :has_at_least_one_acl
 
   transaction do
@@ -44,6 +45,11 @@ class AccessControlListManager
 
   def fetch_flattened_acl_with_mandatory(params:)
     AccessControlList.inject_mandatory_acl(params.flattened_acl, params.target)
+  end
+
+  def has_no_banned_acl(params:, flattened_acl_with_mandatory:)
+    return true if !params.target.class.has_banned_acl?
+    flattened_acl_with_mandatory.none? { |acl| params.target.class.acl_is_banned?(acl) }
   end
 
   def has_at_least_one_acl(flattened_acl_with_mandatory:)

--- a/frontend/discourse/app/ui-kit/d-access-control.gjs
+++ b/frontend/discourse/app/ui-kit/d-access-control.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
@@ -98,12 +98,19 @@ export default class DAccessControl extends Component {
       });
   }
 
+  // TODO (martin) Handle user type ACLs here in next PR
   get selectedGroupIds() {
     return this.acl
       .filter((entry) => entry.type === "group")
       .map((entry) => entry.id);
   }
 
+  /**
+   * Mandatory permissions are defined per-target server-side via a mandatory_acl
+   * method, which is attached to the Site JSON. Any mandatory permissions will
+   * be added to the ACL and cannot be removed or changed in the UI.
+   */
+  @cached
   get mandatoryAcl() {
     if (!this.args.aclTarget) {
       return [];
@@ -112,6 +119,27 @@ export default class DAccessControl extends Component {
     return this.site.access_control?.mandatory_acl?.[this.args.aclTarget] || [];
   }
 
+  /**
+   * Banned permissions are defined per-target server-side via a banned_acl
+   * method, similar to mandatory_acl, which is attached to the Site JSON.
+   * Any banned permisions will be filtered out, e.g. the `edit` permission might
+   * be banned for the `anonymous_users` auto group ID.
+   */
+  @cached
+  get bannedAcl() {
+    if (!this.args.aclTarget) {
+      return [];
+    }
+
+    return this.site.access_control?.banned_acl?.[this.args.aclTarget] || [];
+  }
+
+  /**
+   * Construct the ACL for the target by combining the mandatory ACL with the
+   * ACL passed in via args.  The ACL passed in via args will be whatever is
+   * saved to the database for the target, so for new records this will be an
+   * empty array.
+   */
   get acl() {
     if (!this.mandatoryAcl.length) {
       return this.args.acl || [];
@@ -124,6 +152,7 @@ export default class DAccessControl extends Component {
       (entry) => !mandatoryEntryKeys.has(`${entry.type}-${entry.id}`)
     );
 
+    // TODO (martin) Handle user type ACLs here in next PR
     this.mandatoryAcl.forEach((entry) => {
       if (entry.type !== "group") {
         return;
@@ -204,6 +233,7 @@ export default class DAccessControl extends Component {
     this.addingGroup = false;
   }
 
+  // TODO (martin) Handle user type ACLs here in next PR
   @action
   onPermissionChange(groupId, permission) {
     if (permission === REMOVE_ACTION.id) {
@@ -222,6 +252,23 @@ export default class DAccessControl extends Component {
     );
     this.args.onChange(next);
   }
+
+  @action
+  excludeBannedPermissions(permissions, grantee) {
+    if (!this.bannedAcl.length) {
+      return permissions;
+    }
+
+    return permissions.filter((permission) => {
+      return !this.bannedAcl.some(
+        (banned) =>
+          banned.permission === permission.id &&
+          banned.type === grantee.type &&
+          banned.id === grantee.id
+      );
+    });
+  }
+
   // TODO (martin) How are we going to deal with users that have the Owner permission
   // here if we don't want to expose that in the UI?
 
@@ -253,7 +300,10 @@ export default class DAccessControl extends Component {
               <DropdownSelectBox
                 class="d-access-control__permission"
                 @value={{row.permission}}
-                @content={{this.permissionOptions}}
+                @content={{this.excludeBannedPermissions
+                  this.permissionOptions
+                  row
+                }}
                 @onChange={{fn this.onPermissionChange row.id}}
                 @options={{hash
                   showCaret=true

--- a/frontend/discourse/tests/integration/components/d-access-control-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-access-control-test.gjs
@@ -339,6 +339,64 @@ module("Integration | Component | DAccessControl", function (hooks) {
     );
   });
 
+  test("filters banned permissions for the matching grantee", async function (assert) {
+    this.site.access_control = {
+      banned_acl: {
+        TestTarget: [
+          { type: "group", id: 42, permission: "edit" },
+          { type: "group", id: 42, permission: "manage" },
+          { type: "group", id: 999, permission: "view" },
+        ],
+      },
+    };
+    const state = controlledState([
+      {
+        type: "group",
+        id: 42,
+        permission: "view",
+        name: "Team A",
+        full_name: "Team A",
+      },
+    ]);
+
+    const transformPermissionOptions = (permissions) => [
+      ...permissions,
+      { id: "manage", level: 3, name: "Manager", description: "Full control" },
+    ];
+
+    await render(
+      <template>
+        <DAccessControl
+          @groups={{GROUPS}}
+          @acl={{state.acl}}
+          @aclTarget="TestTarget"
+          @onChange={{state.onChange}}
+          @transformPermissionOptions={{transformPermissionOptions}}
+        />
+      </template>
+    );
+
+    const permission = selectKit(".d-access-control__permission");
+    await permission.expand();
+
+    assert.true(
+      permission.rowByValue("view").exists(),
+      "keeps permissions not banned for this grantee"
+    );
+    assert.false(
+      permission.rowByValue("edit").exists(),
+      "removes a banned default permission"
+    );
+    assert.false(
+      permission.rowByValue("manage").exists(),
+      "removes a banned transformed permission"
+    );
+    assert.true(
+      permission.rowByValue("remove").exists(),
+      "keeps the remove action"
+    );
+  });
+
   test("puts mandatory permissions at the top of the rows and disables removing the permission", async function (assert) {
     const state = controlledState([
       {

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -967,10 +967,15 @@
         "mandatory_acl": {
           "type": "object",
           "additionalProperties": true
+        },
+        "banned_acl": {
+          "type": "object",
+          "additionalProperties": true
         }
       },
       "required": [
-        "mandatory_acl"
+        "mandatory_acl",
+        "banned_acl"
       ]
     }
   },

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe SiteSerializer do
         def self.mandatory_acl
           [{ type: :group, id: Group::AUTO_GROUPS[:admins], permission: "manage" }]
         end
+
+        def self.banned_acl
+          [{ type: :group, id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" }]
+        end
       end
     end
 
@@ -59,6 +63,18 @@ RSpec.describe SiteSerializer do
       expect(serialized.dig(:access_control, :mandatory_acl)).to include(
         "SiteSerializerSpecTarget" => [
           { type: :group, id: Group::AUTO_GROUPS[:admins], permission: "manage" },
+        ],
+      )
+    end
+
+    it "includes banned ACLs by target class" do
+      target_class
+
+      serialized = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+
+      expect(serialized.dig(:access_control, :banned_acl)).to include(
+        "SiteSerializerSpecTarget" => [
+          { type: :group, id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" },
         ],
       )
     end

--- a/spec/services/access_control_list_manager_spec.rb
+++ b/spec/services/access_control_list_manager_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe AccessControlListManager do
+  class AclTargetSpecTarget < Category
+    include AclTarget
+
+    self.table_name = "categories"
+
+    def self.name
+      "AclTargetSpecTarget"
+    end
+  end
+
   describe described_class::Contract, type: :model do
     it { is_expected.to validate_presence_of(:target) }
     it { is_expected.to validate_presence_of(:owner) }
@@ -11,14 +21,18 @@ RSpec.describe AccessControlListManager do
     subject(:result) { described_class.call(params:, **dependencies) }
 
     fab!(:admin)
-    fab!(:category)
     fab!(:group)
     fab!(:other_group, :group)
+    fab!(:target) do
+      cat = AclTargetSpecTarget.new(name: "Test Category", user: admin)
+      cat.skip_publish = true
+      cat.save!
+      cat
+    end
 
     let(:params) { { target:, flattened_acl:, owner: } }
     let(:dependencies) { { guardian: } }
     let(:guardian) { admin.guardian }
-    let(:target) { category }
     let(:owner) { "test_owner" }
 
     let(:flattened_acl) do
@@ -26,11 +40,6 @@ RSpec.describe AccessControlListManager do
         { type: "group", id: group.id, permission: "view" },
         { type: "group", id: other_group.id, permission: "edit" },
       ]
-    end
-
-    before do
-      Category.stubs(:has_mandatory_acl?).returns(false)
-      Category.stubs(:acl_is_mandatory?).returns(false)
     end
 
     context "when the contract is invalid" do
@@ -49,12 +58,10 @@ RSpec.describe AccessControlListManager do
       it { is_expected.to run_successfully }
 
       it "creates one access control list per permission for the target" do
-        expect { result }.to change { AccessControlList.where(target: category).count }.from(0).to(
-          2,
-        )
+        expect { result }.to change { AccessControlList.where(target: target).count }.from(0).to(2)
 
-        view_acl = AccessControlList.find_by(target: category, permission: "view")
-        edit_acl = AccessControlList.find_by(target: category, permission: "edit")
+        view_acl = AccessControlList.find_by(target: target, permission: "view")
+        edit_acl = AccessControlList.find_by(target: target, permission: "edit")
         expect(view_acl.allowed_group_ids).to contain_exactly(group.id)
         expect(edit_acl.allowed_group_ids).to contain_exactly(other_group.id)
       end
@@ -62,7 +69,7 @@ RSpec.describe AccessControlListManager do
       it "stamps the records with the given owner" do
         result
 
-        expect(AccessControlList.where(target: category).pluck(:owner).uniq).to eq(["test_owner"])
+        expect(AccessControlList.where(target: target).pluck(:owner).uniq).to eq(["test_owner"])
       end
 
       it "logs the permission change as a staff action" do
@@ -73,7 +80,7 @@ RSpec.describe AccessControlListManager do
         }.by(1)
 
         log = UserHistory.last
-        expect(log.subject).to eq("Category (#{category.id})")
+        expect(log.subject).to eq("Category (#{target.id})")
         expect(log.new_value).to include("view", "edit")
         expect(log.previous_value).to eq("")
       end
@@ -83,7 +90,7 @@ RSpec.describe AccessControlListManager do
       fab!(:existing_acl) do
         Fabricate(
           :access_control_list_with_groups,
-          target: category,
+          target: target,
           permission: "manage",
           groups: [group],
         )
@@ -93,7 +100,7 @@ RSpec.describe AccessControlListManager do
         existing_id = existing_acl.id
         result
 
-        expect(AccessControlList.where(target: category).pluck(:permission)).to contain_exactly(
+        expect(AccessControlList.where(target: target).pluck(:permission)).to contain_exactly(
           "view",
           "edit",
         )
@@ -104,7 +111,7 @@ RSpec.describe AccessControlListManager do
         result
 
         log = UserHistory.last
-        expect(log.subject).to eq("Category (#{category.id})")
+        expect(log.subject).to eq("Category (#{target.id})")
         expect(log.new_value).to include("view", "edit")
         expect(log.previous_value).to include("manage")
       end
@@ -112,12 +119,10 @@ RSpec.describe AccessControlListManager do
 
     describe "mandatory ACL" do
       context "when the target does not have mandatory ACLs" do
-        before { Category.stubs(:has_mandatory_acl?).returns(false) }
-
         it "does not modify the flattened ACL" do
           result
 
-          expect(AccessControlList.where(target: category).pluck(:permission)).to contain_exactly(
+          expect(AccessControlList.where(target: target).pluck(:permission)).to contain_exactly(
             "edit",
             "view",
           )
@@ -126,8 +131,7 @@ RSpec.describe AccessControlListManager do
 
       context "when the target has mandatory ACLs" do
         before do
-          Category.stubs(:has_mandatory_acl?).returns(true)
-          Category.stubs(:mandatory_acl).returns(
+          AclTargetSpecTarget.stubs(:mandatory_acl).returns(
             [{ type: :group, id: Group::AUTO_GROUPS[:admins], permission: "manage" }],
           )
         end
@@ -135,13 +139,13 @@ RSpec.describe AccessControlListManager do
         it "injects the mandatory ACL into the list of ACLs to be created" do
           result
 
-          expect(AccessControlList.where(target: category).pluck(:permission)).to contain_exactly(
+          expect(AccessControlList.where(target: target).pluck(:permission)).to contain_exactly(
             "view",
             "edit",
             "manage",
           )
 
-          manage_acl = AccessControlList.find_by(target: category, permission: "manage")
+          manage_acl = AccessControlList.find_by(target: target, permission: "manage")
           expect(manage_acl.allowed_group_ids).to contain_exactly(Group::AUTO_GROUPS[:admins])
         end
 
@@ -157,9 +161,40 @@ RSpec.describe AccessControlListManager do
           it "does not create duplicate ACLs" do
             result
 
-            expect(AccessControlList.where(target: category, permission: "manage").count).to eq(1)
+            expect(AccessControlList.where(target: target, permission: "manage").count).to eq(1)
           end
         end
+      end
+    end
+
+    describe "banned ACL" do
+      let(:flattened_acl) do
+        [
+          { type: "group", id: group.id, permission: "view" },
+          { type: "group", id: other_group.id, permission: "edit" },
+          { type: "group", id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" },
+        ]
+      end
+
+      context "when the target does not have banned ACLs" do
+        it "does not modify the flattened ACL" do
+          result
+
+          expect(AccessControlList.where(target: target).pluck(:permission)).to contain_exactly(
+            "edit",
+            "view",
+          )
+        end
+      end
+
+      context "when the target has banned ACLs" do
+        before do
+          AclTargetSpecTarget.stubs(:banned_acl).returns(
+            [{ type: :group, id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" }],
+          )
+        end
+
+        it { is_expected.to fail_a_policy(:has_no_banned_acl) }
       end
     end
   end


### PR DESCRIPTION
Introduces a server-side definition of banned_acl,
similar to mandatory_acl from 5823e4e3b246dd6aa1738f40456848c9e581a668

This allows AclTarget implementing classes to define
which ACLs cannot be used for certain types. For example:

```
def self.banned_acl
  [{ type: :group, id: Group::AUTO_GROUPS[:anonymous_users], permission: "edit" }]
end
```

This prevents anonymous users group from being able to have the Edit
permission on the target, which is practical because the anonymous
user is not logged in and generally cannot create/edit anything.

This restriction is passed to the DAccessControl component via the Site
serializer, same as mandatory_acl, and is used to prevent the user from
selecting the banned ACLs in the UI.

Then, server-side this rule is enforced in `AccessControlListManager`
service as a policy.

**Before**

<img width="971" height="287" alt="image" src="https://github.com/user-attachments/assets/af4ace0f-7b11-4005-8344-774d554693f0" />


**After**

<img width="914" height="194" alt="image" src="https://github.com/user-attachments/assets/b756b976-f6e6-4331-b27d-c9a2d13997aa" />
