### PR TITLE
FIX: render JSONB results as JSON

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-row-content.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-row-content.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { classify } from "@ember/string";
 import getURL from "discourse/lib/get-url";
-import { escapeExpression } from "discourse/lib/utilities";
 import TextViewComponent from "./result-types/text";
 
 export default class QueryRowContent extends Component {
@@ -26,7 +25,7 @@ export default class QueryRowContent extends Component {
       } else if (componentDefinition.name === "text") {
         return {
           component: TextViewComponent,
-          textValue: escapeExpression(this.args.row[idx].toString()),
+          textValue: this.args.row[idx].toString(),
         };
       }
 

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/data_explorer.rb
@@ -5,6 +5,15 @@ module DiscourseDataExplorer
     # Used for ftype calls, see https://www.rubydoc.info/gems/pg/0.17.1/PG%2FResult:ftype
     # and /usr/include/postgresql/server/catalog/pg_type_d.h
     PG_TYPE_OID_JSON = 114
+    PG_TYPE_OID_JSON_ARRAY = 199
+    PG_TYPE_OID_JSONB = 3802
+    PG_TYPE_OID_JSONB_ARRAY = 3807
+    PG_TYPE_OIDS_JSON = [
+      PG_TYPE_OID_JSON,
+      PG_TYPE_OID_JSON_ARRAY,
+      PG_TYPE_OID_JSONB,
+      PG_TYPE_OID_JSONB_ARRAY,
+    ]
 
     # Run a data explorer query on the currently connected database.
     #
@@ -177,7 +186,8 @@ module DiscourseDataExplorer
           needed_classes[cls] << idx
         elsif col =~ /^\w+_url$/
           col_map[idx] = "url"
-        elsif col =~ /^\w+_payload$/ || col == "payload" || pg_result.ftype(idx) == PG_TYPE_OID_JSON
+        elsif col =~ /^\w+_payload$/ || col == "payload" ||
+              PG_TYPE_OIDS_JSON.include?(pg_result.ftype(idx))
           col_map[idx] = "json"
         end
       end

--- a/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
+++ b/plugins/discourse-data-explorer/spec/data_explorer_spec.rb
@@ -121,7 +121,7 @@ describe DiscourseDataExplorer::DataExplorer do
         expect(colrender).to eq({ 1 => "json" })
       end
 
-      it "treats columns with the actual json data type as 'json'" do
+      it "treats columns with the actual json or jsonb data type as 'json'" do
         ApiKeyScope.create(
           resource: "topics",
           action: "update",
@@ -137,6 +137,32 @@ describe DiscourseDataExplorer::DataExplorer do
         result = described_class.run_query(query)
         _, colrender = DiscourseDataExplorer::DataExplorer.add_extra_data(result[:pg_result])
         expect(colrender).to eq({ 1 => "json" })
+      end
+
+      it "treats jsonb columns as 'json'" do
+        query =
+          DiscourseDataExplorer::Query.create!(
+            name: "some query",
+            sql: "SELECT '[{\"key\": \"value\"}]'::jsonb AS response_format",
+          )
+        result = described_class.run_query(query)
+
+        _, colrender = DiscourseDataExplorer::DataExplorer.add_extra_data(result[:pg_result])
+
+        expect(colrender).to eq({ 0 => "json" })
+      end
+
+      it "treats json and jsonb array columns as 'json'" do
+        query = DiscourseDataExplorer::Query.create!(name: "some query", sql: <<~SQL)
+              SELECT
+                ARRAY['{\"key\": \"value\"}'::json] AS json_values,
+                ARRAY['{\"key\": \"value\"}'::jsonb] AS jsonb_values
+            SQL
+        result = described_class.run_query(query)
+
+        _, colrender = DiscourseDataExplorer::DataExplorer.add_extra_data(result[:pg_result])
+
+        expect(colrender).to eq({ 0 => "json", 1 => "json" })
       end
 
       it "limits relation resolution to the query result limit per relation type" do

--- a/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
+++ b/plugins/discourse-data-explorer/test/javascripts/integration/components/query-result-test.gjs
@@ -49,6 +49,48 @@ module("Integration | Component | QueryResult", function (hooks) {
     assert.dom("table tbody tr:nth-child(2) td:nth-child(2)").hasText("20");
   });
 
+  test("renders JSON columns as escaped text with a viewer action", async function (assert) {
+    const content = {
+      colrender: { 1: "json" },
+      result_count: 1,
+      columns: ["name", "response_format"],
+      rows: [["classifier", '[{"key":"<img src=x onerror=alert(1)>"}]']],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
+    assert
+      .dom("table tbody tr:nth-child(1) td:nth-child(2) .result-json-value")
+      .hasText(
+        '[{"key":"<img src=x onerror=alert(1)>"}]',
+        "renders JSON as readable text without HTML entities"
+      );
+    assert
+      .dom("table tbody tr:nth-child(1) td:nth-child(2) img")
+      .doesNotExist("does not render HTML from JSON values");
+    assert
+      .dom("table tbody tr:nth-child(1) td:nth-child(2) .result-json-button")
+      .exists("renders a JSON viewer action");
+  });
+
+  test("renders plain text without double-escaping HTML entities", async function (assert) {
+    const content = {
+      colrender: [],
+      result_count: 1,
+      columns: ["value"],
+      rows: [['{"key":"<script>alert(1)</script>"}']],
+    };
+
+    await render(<template><QueryResult @content={{content}} /></template>);
+
+    assert
+      .dom("table tbody tr:nth-child(1) td:nth-child(1)")
+      .hasText('{"key":"<script>alert(1)</script>"}', "renders readable text");
+    assert
+      .dom("table tbody tr:nth-child(1) td:nth-child(1) script")
+      .doesNotExist("does not render HTML from text values");
+  });
+
   test("renders badge names in query results", async function (assert) {
     const content = {
       colrender: { 0: "badge" },


### PR DESCRIPTION
Treat jsonb and json/jsonb array result columns like JSON so they use
the viewer action.

Avoid pre-escaping plain text values so output stays readable while
Glimmer escaping still prevents HTML injection.
