### PR TITLE
FIX: Localize static topic pages                                     …

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -109,7 +109,13 @@ class StaticController < ApplicationController
           @topic.title
         end
       @title = "#{title_prefix} - #{SiteSetting.title}"
-      @body = @topic.posts.first.cooked
+      post = @topic.posts.first
+      @body =
+        if ContentLocalization.show_translated_post?(post, guardian)
+          post.get_localization&.cooked || post.cooked
+        else
+          post.cooked
+        end
       @faq_overridden = SiteSetting.faq_url.present?
       @rename_faq_to_guidelines = rename_faq
 

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -194,6 +194,54 @@ RSpec.describe StaticController do
       end
     end
 
+    it "renders the localized guidelines post" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.set_locale_from_param = true
+      post = create_post(raw: "Original guidelines body")
+      post.update!(locale: "en")
+      localization =
+        Fabricate(
+          :post_localization,
+          post:,
+          locale: "ja",
+          raw: "翻訳されたガイドライン本文",
+          cooked: "<p>翻訳されたガイドライン本文</p>",
+        )
+      SiteSetting.guidelines_topic_id = post.topic.id
+
+      get "/guidelines", params: { tl: "ja" }
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.body).to include(localization.cooked)
+        expect(response.body).not_to include(post.cooked)
+      end
+    end
+
+    it "renders the localized TOS post" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.set_locale_from_param = true
+      post = create_post(raw: "Original TOS body")
+      post.update!(locale: "en")
+      localization =
+        Fabricate(
+          :post_localization,
+          post:,
+          locale: "ja",
+          raw: "翻訳された利用規約本文",
+          cooked: "<p>翻訳された利用規約本文</p>",
+        )
+      SiteSetting.tos_topic_id = post.topic.id
+
+      get "/tos", params: { tl: "ja" }
+
+      aggregate_failures do
+        expect(response.status).to eq(200)
+        expect(response.body).to include(localization.cooked)
+        expect(response.body).not_to include(post.cooked)
+      end
+    end
+
     context "with a missing file" do
       it "should respond 404" do
         get "/static/does-not-exist"


### PR DESCRIPTION
Use post localizations when rendering guidelines and TOS static pages with a translated locale.

<img width="2732" height="1882" alt="image" src="https://github.com/user-attachments/assets/aff79956-df2c-4fdc-8ac0-79eeffc4b1d7" />
