### PR TITLE
FIX: Prevent double-escaping of HTML entities in titles and meta descriptions

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -121,8 +121,7 @@ class GroupsController < ApplicationController
       format.html do
         @title = group.full_name.present? ? group.full_name.capitalize : group.name
         @full_title = "#{@title} - #{SiteSetting.title}"
-        @description_meta =
-          group.bio_cooked.present? ? PrettyText.excerpt(group.bio_cooked, 300) : @title
+        @description_meta = group.bio_summary || @title
         render :show
       end
 

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -449,10 +449,8 @@ class ListController < ApplicationController
     @description_meta =
       if @category.uncategorized?
         I18n.t("category.uncategorized_description", locale: SiteSetting.default_locale)
-      elsif @category.description_text.present?
-        @category.description_text
       else
-        SiteSetting.site_description
+        @category.plain_text_description || SiteSetting.site_description
       end
 
     if use_crawler_layout?

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1562,7 +1562,7 @@ class TopicsController < ApplicationController
           helpers.localize_topic_view_content(@topic_view)
         end
         @breadcrumbs = helpers.categories_breadcrumb(@topic_view.topic) || []
-        @description_meta = @topic_view.topic.excerpt.presence || @topic_view.summary
+        @description_meta = @topic_view.topic.plain_text_excerpt || @topic_view.summary
         store_preloaded("topic_#{@topic_view.topic.id}", MultiJson.dump(topic_view_serializer))
         render :show
       end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -605,9 +605,17 @@ class Category < ActiveRecord::Base
 
     @@cache_text ||= LruRedux::ThreadSafeCache.new(1000)
     @@cache_text.getset(description) do
-      text = Nokogiri::HTML5.fragment(description).text.strip
-      ERB::Util.html_escape(text).html_safe
+      ERB::Util.html_escape(plain_text_description.to_s).html_safe
     end
+  end
+
+  def plain_text_description
+    return nil unless description
+
+    @@cache_plain_text ||= LruRedux::ThreadSafeCache.new(1000)
+    @@cache_plain_text
+      .getset(description) { Nokogiri::HTML5.fragment(description).text.strip }
+      .presence
   end
 
   def description_excerpt

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -403,7 +403,7 @@ class Emoji
       match = Regexp.last_match
       code = match[1]
 
-      result << ERB::Util.html_escape(str[last_index...match.begin(0)])
+      result << ERB::Util.html_escape_once(str[last_index...match.begin(0)])
 
       result << if code && Emoji.custom?(code)
         emoji = Emoji[code]
@@ -411,13 +411,13 @@ class Emoji
       elsif code && Emoji.exists?(code)
         emoji_img_tag(Emoji.url_for(code), code)
       else
-        ERB::Util.html_escape(match[0])
+        ERB::Util.html_escape_once(match[0])
       end
 
       last_index = match.end(0)
     end
 
-    result << ERB::Util.html_escape(str[last_index..])
+    result << ERB::Util.html_escape_once(str[last_index..])
     result
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -392,6 +392,17 @@ class Group < ActiveRecord::Base
     end
   end
 
+  def bio_summary
+    PrettyText.excerpt(
+      bio_cooked,
+      300,
+      strip_links: true,
+      strip_images: true,
+      text_entities: true,
+      plain_hashtags: true,
+    ).presence
+  end
+
   def record_email_setting_changes!(user)
     if (previous_changes.keys & SMTP_SETTING_ATTRIBUTES).any?
       self.smtp_updated_at = Time.zone.now

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1980,6 +1980,10 @@ class Topic < ActiveRecord::Base
     ApplicationLayoutPreloader.banner_json_cache.clear if archetype == "banner"
   end
 
+  def plain_text_excerpt
+    ExcerptParser.to_plain_text(excerpt)
+  end
+
   def pm_with_non_human_user?
     sql = <<~SQL
     SELECT 1 FROM topics

--- a/app/views/list/list.erb
+++ b/app/views/list/list.erb
@@ -146,7 +146,7 @@
     <%= auto_discovery_link_tag(:rss, { action: :category_feed }, rel: 'alternate nofollow', title: t('rss_topics_in_category', category: @category.name)) %>
     <%= raw crawlable_meta_data(
       title: @category.name,
-      description: @category.description_text,
+      description: @category.plain_text_description,
       image: @category.uploaded_logo&.url.presence,
       image_width: @category.uploaded_logo&.width,
       image_height: @category.uploaded_logo&.height,

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -66,7 +66,7 @@
             <link itemprop='url' rel='nofollow' href='<%= Discourse.base_url %>/u/<%= @topic_view.topic.user.username %>'>
           </span>
         <% end %>
-        <meta itemprop='text' content='<%= @topic_view.topic.excerpt %>'>
+        <meta itemprop='text' content='<%= @topic_view.topic.plain_text_excerpt %>'>
       <% end %>
 
       <% @topic_view.crawler_posts.each do |post| %>

--- a/lib/excerpt_parser.rb
+++ b/lib/excerpt_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "htmlentities"
+
 class ExcerptParser < Nokogiri::XML::SAX::Document
   attr_reader :excerpt
 
@@ -42,6 +44,11 @@ class ExcerptParser < Nokogiri::XML::SAX::Document
       options[:keep_onebox_body]
     excerpt = CGI.unescapeHTML(excerpt) if options[:text_entities] == true
     excerpt
+  end
+
+  def self.to_plain_text(excerpt)
+    @html_entities ||= HTMLEntities.new
+    @html_entities.decode(excerpt.to_s.gsub(/<[^>]*>/, "")).presence
   end
 
   def escape_attribute(v)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -582,6 +582,16 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "crawlable_meta_data" do
+    it "escapes the description exactly once" do
+      result =
+        helper.crawlable_meta_data(description: %(Tom & O'Reilly "><script>alert(1)</script>))
+
+      expect(result).to include(
+        %(<meta property="og:description" content="Tom &amp; O&#39;Reilly &quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;" />),
+      )
+      expect(result).not_to include("<script>")
+    end
+
     it "Supports ASCII URLs with odd chars" do
       result =
         helper.crawlable_meta_data(

--- a/spec/lib/excerpt_parser_spec.rb
+++ b/spec/lib/excerpt_parser_spec.rb
@@ -279,4 +279,48 @@ RSpec.describe ExcerptParser do
       end
     end
   end
+
+  describe ".to_plain_text" do
+    it "decodes the entities emitted by the excerpt generator" do
+      excerpt =
+        ExcerptParser.get_excerpt("<p>Tom &amp; Jerry&rsquo;s \"tale\" of 1 &lt; 2</p>", 100, {})
+
+      expect(excerpt).to eq("Tom &amp; Jerry’s &quot;tale&quot; of 1 &lt; 2")
+      expect(ExcerptParser.to_plain_text(excerpt)).to eq(%(Tom & Jerry’s "tale" of 1 < 2))
+    end
+
+    it "decodes the &hellip; truncation marker" do
+      excerpt = ExcerptParser.get_excerpt("<p>Lorem ipsum dolor</p>", 5, {})
+
+      expect(excerpt).to eq("Lorem&hellip;")
+      expect(ExcerptParser.to_plain_text(excerpt)).to eq("Lorem…")
+    end
+
+    it "keeps entities the user literally typed" do
+      excerpt = ExcerptParser.get_excerpt("<p>the &amp;hellip; entity</p>", 100, {})
+
+      expect(ExcerptParser.to_plain_text(excerpt)).to eq("the &hellip; entity")
+    end
+
+    it "strips the markup the parser keeps for hashtags" do
+      html =
+        '<p>see <a class="hashtag-cooked" href="/c/general"><span class="hashtag-icon-placeholder"><svg class="fa d-icon"><use href="#folder"></use></svg></span><span>general</span></a> please</p>'
+      excerpt = ExcerptParser.get_excerpt(html, 100, strip_links: true, strip_images: true)
+
+      expect(excerpt).to include("<span")
+      expect(ExcerptParser.to_plain_text(excerpt)).to eq("see general please")
+    end
+
+    it "neutralizes markup in values that bypassed the generator" do
+      expect(ExcerptParser.to_plain_text(%(pwned "><script>alert(1)</script>))).to eq(
+        %(pwned ">alert(1)),
+      )
+    end
+
+    it "returns nil when nothing is left" do
+      expect(ExcerptParser.to_plain_text(nil)).to be_nil
+      expect(ExcerptParser.to_plain_text("")).to be_nil
+      expect(ExcerptParser.to_plain_text("<span></span>")).to be_nil
+    end
+  end
 end

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -171,6 +171,14 @@ RSpec.describe Emoji do
       )
     end
 
+    it "doesn't double-escape text that already contains HTML entities" do
+      replaced_str = described_class.codes_to_img("Sam&rsquo;s :tada: A &amp; B")
+
+      expect(replaced_str).to eq(
+        %(Sam&rsquo;s <img src="/images/emoji/twitter/tada.png?v=#{Emoji::EMOJI_VERSION}" title="tada" class="emoji" alt="tada" loading="lazy" width="20" height="20"> A &amp; B),
+      )
+    end
+
     it "escapes generated image attribute values" do
       Plugin::CustomEmoji.register("xssxx", %q|" onerror="alert('xss')|)
 

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -526,6 +526,27 @@ RSpec.describe GroupsController do
       )
     end
 
+    it "renders a single-escaped, tag-free meta description from the bio" do
+      group.update!(bio_raw: "Tom & Jerry [blog](https://evil.example) win")
+
+      get "/groups/#{group.name}.html"
+
+      expect(response.body).to have_tag(
+        :meta,
+        with: {
+          name: "description",
+          content: "Tom & Jerry blog win",
+        },
+      )
+      expect(response.body).to have_tag(
+        :meta,
+        with: {
+          property: "og:description",
+          content: "Tom & Jerry blog win",
+        },
+      )
+    end
+
     describe "when accessing by name" do
       include_examples "group show behavior", "/groups", :name
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1139,6 +1139,27 @@ RSpec.describe ListController do
             },
           )
         end
+
+        it "escapes the description exactly once instead of double-escaping entities" do
+          amazing_category.update!(description: "<p>Tom &amp; Jerry&rsquo;s adventures</p>")
+
+          get "/c/#{amazing_category.slug}/#{amazing_category.id}"
+
+          expect(response.body).to have_tag(
+            :meta,
+            with: {
+              name: "description",
+              content: "Tom & Jerry’s adventures",
+            },
+          )
+          expect(response.body).to have_tag(
+            :meta,
+            with: {
+              property: "og:description",
+              content: "Tom & Jerry’s adventures",
+            },
+          )
+        end
       end
 
       context "for category latest view" do

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7083,6 +7083,19 @@ RSpec.describe TopicsController do
         expect(body).to have_tag(:script, with: { "data-discourse-entrypoint" => "discourse" })
         expect(body).to have_tag(:meta, with: { name: "fragment" })
       end
+
+      it "renders the excerpt in the meta description decoded exactly once and tag-free" do
+        topic.update!(
+          excerpt:
+            %(Tom &amp; Jerry&#39;s <span class="hashtag-icon-placeholder"></span>tale&hellip; "><script>alert(1)</script>),
+        )
+
+        get topic.relative_url
+
+        expect(response.body).not_to include("<script>alert(1)</script>")
+        meta = Nokogiri::HTML5.parse(response.body).at("meta[name='description']")
+        expect(meta["content"]).to eq(%(Tom & Jerry's tale… ">alert(1)))
+      end
     end
 
     context "when a crawler" do
@@ -7159,6 +7172,16 @@ RSpec.describe TopicsController do
 
         expect(response.headers["Last-Modified"]).to eq(page3_time.httpdate)
         expect(body).to include('<link rel="prev" href="' + topic.relative_url + "?page=2")
+      end
+
+      it "escapes the excerpt exactly once in the schema.org text meta" do
+        topic.update!(excerpt: %(Tom &amp; Jerry&hellip; "><script>alert(1)</script>))
+
+        get topic.relative_url + "?page=2", env: { "HTTP_USER_AGENT" => bot_user_agent }
+
+        expect(response.body).not_to include("<script>alert(1)</script>")
+        meta = Nokogiri::HTML5.parse(response.body).at("meta[itemprop='text']")
+        expect(meta["content"]).to eq(%(Tom & Jerry… ">alert(1)))
       end
 
       it "only renders one post for non-canonical post-specific URLs" do


### PR DESCRIPTION
Previously, content that was already HTML-escaped — topic `fancy_title`s on the 404/oops pages, GitHub onebox labels, and topic/group/category `<meta>` descriptions — got escaped a second time, so readers (and crawlers) saw literal entities like `&rsquo;` and `&amp;` instead of `'` and `&`.

This change escapes every value exactly once, by converting it to plain text before it reaches the renderer instead of flagging anything `html_safe`:

- `Emoji.codes_to_img` escapes its text segments with `html_escape_once` so the already-escaped `fancy_title` and sanitized GitHub labels aren't escaped again. All of its callers render into element content, and the attribute escaping inside `emoji_img_tag` is untouched.
- the new `ExcerptParser.to_plain_text` converts a stored excerpt (escaped text, the `&hellip;` truncation marker, and the hashtag placeholder markup the parser keeps) back to plain text, exposed as `Topic#plain_text_excerpt`. It's a tag-strip plus a memoized `htmlentities` decode — pure Ruby, a few microseconds per excerpt, no Nokogiri in the hot path.
- `Category#plain_text_description` caches the pre-escape plain text that `description_text` previously discarded, and the category meta descriptions use it directly. This also fixes the double-escaped `og:description`/`twitter:description` on category pages, where `gsub_emoji_to_unicode` silently drops the `html_safe` flag of `description_text`.
- the new `Group#bio_summary` mirrors `UserProfile#bio_summary`: a plain-text excerpt of the bio with links and images stripped and hashtags rendered as plain `#slug`.

Marking the stored values `html_safe` would have worked for the column data — every writer of `topics.excerpt` escapes — but `topic.excerpt` can be swapped in-memory with a localized excerpt that isn't guaranteed to be escaped, so treating everything as unsafe plain text is both simpler and safer.
