### PR TITLE
UX: update category references in documentation to match meta changes

### DIFF
--- a/docs/INSTALL-cloud.md
+++ b/docs/INSTALL-cloud.md
@@ -319,7 +319,7 @@ After installation, you can enable additional features:
 - [Facebook Login](https://meta.discourse.org/t/configuring-facebook-login-for-discourse/13394)
 - [Twitter/X Login](https://meta.discourse.org/t/configuring-twitter-login-for-discourse/13395)
 - [Single Sign-On (SSO)](https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045)
-- [More auth plugins on meta.discourse.org](https://meta.discourse.org/tags/c/plugin/22/auth-plugins)
+- [More auth plugins on meta.discourse.org](https://meta.discourse.org/tags/c/customization/plugin/22/auth-plugins)
 
 
 ### Email & Notifications

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,7 +1,7 @@
 
 ## List of Discourse Plugins
 
-If you just want to get some plugins for your Discourse instance, check out [the plugin category](https://meta.discourse.org/c/plugin) at meta. This is the most up to date place for plugin discussion and listing.
+If you just want to get some plugins for your Discourse instance, check out [the plugin category](https://meta.discourse.org/c/customization/plugin) at meta. This is the most up to date place for plugin discussion and listing.
 
 If you want to be safe, use only plugins on this list of [Official Plugins](https://github.com/discourse/discourse/blob/main/lib/plugin/metadata.rb): 
 

--- a/docs/developer-guides/docs/04-plugins/07-publish-your-plugin.md
+++ b/docs/developer-guides/docs/04-plugins/07-publish-your-plugin.md
@@ -12,7 +12,7 @@ You've [created your plugin](https://meta.discourse.org/t/beginners-guide-to-cre
 
 ### Documenting your plugin
 
-All plugins require good documentation. Users need to know what the plugin does, how to install it, important settings/configuration changes needed, and how to use it. Plugins should be documented in two different locations: the `README.md` file within your git repo, and a dedicated topic in the #plugin category.
+All plugins require good documentation. Users need to know what the plugin does, how to install it, important settings/configuration changes needed, and how to use it. Plugins should be documented in two different locations: the `README.md` file within your git repo, and a dedicated topic in the #customization:plugin category.
 
 #### GitHub Documentation
 

--- a/docs/developer-guides/docs/05-themes-components/02-quick-reference.md
+++ b/docs/developer-guides/docs/05-themes-components/02-quick-reference.md
@@ -4,7 +4,7 @@ short_title: Quick reference
 id: quick-reference
 ---
 
-As themes grow more powerful, there's more to remember about how they work. We have loads of detailed documentation under [#howto / #themes](https://meta.discourse.org/tags/c/howto/themes), but if you just need something to jog your memory, this guide may help.
+As themes grow more powerful, there's more to remember about how they work. We have loads of detailed documentation under [#theme-guides](https://meta.discourse.org/tag/theme-guides), but if you just need something to jog your memory, this guide may help.
 
 ### General Resources
 

--- a/docs/developer-guides/docs/05-themes-components/16-minimizing-maintenance.md
+++ b/docs/developer-guides/docs/05-themes-components/16-minimizing-maintenance.md
@@ -8,7 +8,7 @@ Discourse is highly customizable, enabling you to modify almost any aspect of it
 
 To maintain compatibility with ongoing Discourse updates and new features, all themes require occasional maintenance. The frequency of maintenance depends on the customization complexity and type. You can minimize maintenance efforts for your theme by following these guidelines:
 
-- Check for official [themes](https://meta.discourse.org/tags/c/theme/61/none/official) or [theme components](https://meta.discourse.org/tags/c/theme-component/120/none/official) that match your desired functionality. These are updated alongside Discourse. These can also serve as examples of how to approach your own customizations.
+- Check for official [themes](https://meta.discourse.org/tags/c/customization/theme/61/none/official) or [theme components](https://meta.discourse.org/tags/c/customization/theme-component/120/none/official) that match your desired functionality. These are updated alongside Discourse. These can also serve as examples of how to approach your own customizations.
 - Replace interface text using the admin → customize → text feature by searching for the specific text and updating it there.
 - Theme CSS is additive, allowing you to override default styles without editing them directly. This approach improves CSS maintainability and minimizes conflicts with updates.
 - Use a version control system like Git with GitHub, GitLab, or Bitbucket for tracking changes. While the HTML and CSS editor at admin → customize → themes is convenient for minor adjustments, version control systems can make it easier to track and troubleshoot more complex changes.

--- a/docs/developer-guides/docs/05-themes-components/23-font-component.md
+++ b/docs/developer-guides/docs/05-themes-components/23-font-component.md
@@ -81,7 +81,7 @@ Create an account on [GitHub.com](https://github.com) and then create a new repo
 
 ### (Optional) create a topic on Discourse as a home to discuss your colors
 
-Ideally you would create a topic in the #plugin:theme category with some screenshots of your color scheme. You will use this as your `about_url`
+Ideally you would create a topic in the #customization:theme category with some screenshots of your color scheme. You will use this as your `about_url`
 
 ### Fill in the missing information in your about.json file
 

--- a/docs/developer-guides/docs/05-themes-components/28-global-icon-changes.md
+++ b/docs/developer-guides/docs/05-themes-components/28-global-icon-changes.md
@@ -113,4 +113,4 @@ Ref: [discourse/icon-library.js at main · discourse/discourse (github.com)](htt
 
 ---
 
-Feel free to create other themes component and share it in our #theme-component category!
+Feel free to create other themes component and share it in our #customization:theme-component category!

--- a/docs/developer-guides/docs/05-themes-components/31-color-scheme.md
+++ b/docs/developer-guides/docs/05-themes-components/31-color-scheme.md
@@ -60,7 +60,7 @@ Create an account on [GitHub.com](https://github.com) and then create a new repo
 
 ### (Optional) create a topic on Discourse as a home to discuss your colors
 
-Ideally you would create a topic in the #plugin:theme category with some screenshots of your color scheme. You will use this as your `about_url`
+Ideally you would create a topic in the #customization:theme category with some screenshots of your color scheme. You will use this as your `about_url`
 
 ### Fill in the missing information in your about.json file
 

--- a/docs/developer-guides/docs/07-theme-developer-tutorial/01-introduction.md
+++ b/docs/developer-guides/docs/07-theme-developer-tutorial/01-introduction.md
@@ -28,7 +28,7 @@ Discourse themes and theme components can either be Local or Remote. Local theme
 
 Once your theme becomes more complex, or if you want to share it with other communities, it's beneficial to make it a Remote Theme. These are stored on GitHub (or another Git hosting system), and can be installed on any community using the repository URL.
 
-All the themes in the #theme and #theme-component categories are remote themes.
+All the themes in the #customization:theme and #customization:theme-component categories are remote themes.
 
 ## Getting started with a local theme
 

--- a/docs/developer-guides/docs/07-theme-developer-tutorial/07-conclusion.md
+++ b/docs/developer-guides/docs/07-theme-developer-tutorial/07-conclusion.md
@@ -8,11 +8,11 @@ This tutorial has been a whistle-stop tour through the process of creating a Dis
 
 ## Existing themes & theme component
 
-One of the best resources when learning about theme development is to read through the code of existing themes. Check out the directories in #theme and #theme-component, or jump straight to our [all-the-themes](http://github.com/discourse/all-the-themes) meta-repository for even more example code!
+One of the best resources when learning about theme development is to read through the code of existing themes. Check out the directories in #customization:theme and #customization:theme-component, or jump straight to our [all-the-themes](http://github.com/discourse/all-the-themes) meta-repository for even more example code!
 
 ## Sharing your themes
 
-Once you have a theme or theme component you're happy with, and it's published on GitHub, it's time to share it! Make a new topic in #theme or #theme-component and we'll review/publish it.
+Once you have a theme or theme component you're happy with, and it's published on GitHub, it's time to share it! Make a new topic in #customization:theme or #customization:theme-component and we'll review/publish it.
 
 ## How to ask for help
 


### PR DESCRIPTION
We've reorganized categories on Meta, and need to update these hashtag references and links to match. 