### PR TITLE
MT: Ignore the new access_control_lists table

### DIFF
--- a/migrations/tooling/config/schema/intermediate_db/ignored.rb
+++ b/migrations/tooling/config/schema/intermediate_db/ignored.rb
@@ -154,7 +154,8 @@ Migrations::Tooling::Schema.ignored do
          :browser_pageview_country_daily_rollups,
          :browser_pageview_referrer_daily_rollups
 
-  tables :admin_notices,
+  tables :access_control_lists,
+         :admin_notices,
          :api_key_scopes,
          :api_keys,
          :application_requests,

--- a/migrations/tooling/config/schema/plugin_manifest.yml
+++ b/migrations/tooling/config/schema/plugin_manifest.yml
@@ -247,7 +247,7 @@ plugin_checksums:
   discourse-user-notes: 4c1e04fac5708b51c1b09bd8ed0d786c
   discourse-workflows: 5644f9ffebcee089e85b16edab52a6a3
   discourse-zendesk-plugin: b78b305590ffedda38455574a19fdd38
-  poll: 4af8698c5fcc1dc9a786b31ec8234171
+  poll: e481f2cfa0e7c22778dee12a1e9c33c6
   styleguide: 0fd92e5ef0c99ee047f206961a587544
 failed_plugins: []
 incomplete: false


### PR DESCRIPTION
Merging main pulled in the ACL feature ([introduce permission acl tables](https://github.com/discourse/discourse/blob/main/db/migrate/20260610064425_introduce_permission_acl_tables.rb)), which adds an `access_control_lists` table. `disco check` flagged it as an unconfigured table and the Migration Tests job went red:

```
✗ The schema config is out of sync with the database.

Unconfigured tables (add to tables/ or ignored.rb):
  + access_control_lists
```

The converter doesn't migrate this table yet, so I added it to `ignored.rb` next to the other core tables we don't import — same as we did for `site_setting_localizations` recently. The plugin manifest also got regenerated and picked up a new `poll` checksum from main.

`migrations/bin/disco check` passes again locally.