### PR TITLE
FIX: Apply CDN to Custom Emojis loaded from S3/R2

### DIFF
--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -15,6 +15,14 @@ class Emoji
 
   attr_accessor :name, :url, :tonable, :group, :created_by
 
+  # The cached `url` is the raw upload/asset URL. CDN conversion is applied
+  # lazily here (and in EmojiSerializer) so that changing the S3/asset CDN
+  # settings takes effect without having to rebuild the emoji cache.
+  def cdn_url
+    return nil if url.blank?
+    Discourse.store.cdn_url(url)
+  end
+
   def self.global_emoji_cache
     @global_emoji_cache ||= DistributedCache.new("global_emoji_cache", namespace: false)
   end
@@ -266,8 +274,7 @@ class Emoji
         .each do |emoji|
           result << Emoji.new.tap do |e|
             e.name = emoji.name
-            raw_url = emoji.upload&.url
-            e.url = raw_url.present? ? Discourse.store.cdn_url(raw_url) : nil
+            e.url = emoji.upload&.url
             e.group = emoji.group || DEFAULT_GROUP
             e.created_by = User.where(id: emoji.user_id).pick(:username)
           end
@@ -279,7 +286,7 @@ class Emoji
         result << Emoji.new.tap do |e|
           e.name = name
           url = (Discourse.base_path + url) if url[%r{\A/[^/]}]
-          e.url = url.present? ? Discourse.store.cdn_url(url) : nil
+          e.url = url
           e.group = group || DEFAULT_GROUP
         end
       end
@@ -407,7 +414,7 @@ class Emoji
 
       result << if code && Emoji.custom?(code)
         emoji = Emoji[code]
-        emoji_img_tag(emoji.url, code)
+        emoji_img_tag(emoji.cdn_url, code)
       elsif code && Emoji.exists?(code)
         emoji_img_tag(Emoji.url_for(code), code)
       else

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -267,7 +267,7 @@ class Emoji
         .each do |emoji|
           result << Emoji.new.tap do |e|
             e.name = emoji.name
-            e.url = emoji.upload&.url
+            e.url = Discourse.store.cdn_url(emoji.upload&.url)
             e.group = emoji.group || DEFAULT_GROUP
             e.created_by = User.where(id: emoji.user_id).pick(:username)
           end
@@ -279,7 +279,7 @@ class Emoji
         result << Emoji.new.tap do |e|
           e.name = name
           url = (Discourse.base_path + url) if url[%r{\A/[^/]}]
-          e.url = url
+          e.url = Discourse.store.cdn_url(url)
           e.group = group || DEFAULT_GROUP
         end
       end

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -267,7 +267,10 @@ class Emoji
         .each do |emoji|
           result << Emoji.new.tap do |e|
             e.name = emoji.name
-            e.url = Discourse.store.cdn_url(emoji.upload&.url)
+            
+            raw_url = emoji.upload&.url
+            e.url = raw_url.present? ? Discourse.store.cdn_url(raw_url) : nil
+            
             e.group = emoji.group || DEFAULT_GROUP
             e.created_by = User.where(id: emoji.user_id).pick(:username)
           end
@@ -279,7 +282,9 @@ class Emoji
         result << Emoji.new.tap do |e|
           e.name = name
           url = (Discourse.base_path + url) if url[%r{\A/[^/]}]
-          e.url = Discourse.store.cdn_url(url)
+          
+          e.url = url.present? ? Discourse.store.cdn_url(url) : nil
+          
           e.group = group || DEFAULT_GROUP
         end
       end

--- a/app/models/emoji.rb
+++ b/app/models/emoji.rb
@@ -259,7 +259,6 @@ class Emoji
 
   def self.load_custom
     result = []
-
     if !GlobalSetting.skip_db?
       CustomEmoji
         .includes(:upload)
@@ -267,10 +266,8 @@ class Emoji
         .each do |emoji|
           result << Emoji.new.tap do |e|
             e.name = emoji.name
-            
             raw_url = emoji.upload&.url
             e.url = raw_url.present? ? Discourse.store.cdn_url(raw_url) : nil
-            
             e.group = emoji.group || DEFAULT_GROUP
             e.created_by = User.where(id: emoji.user_id).pick(:username)
           end
@@ -282,9 +279,7 @@ class Emoji
         result << Emoji.new.tap do |e|
           e.name = name
           url = (Discourse.base_path + url) if url[%r{\A/[^/]}]
-          
           e.url = url.present? ? Discourse.store.cdn_url(url) : nil
-          
           e.group = group || DEFAULT_GROUP
         end
       end

--- a/app/serializers/emoji_serializer.rb
+++ b/app/serializers/emoji_serializer.rb
@@ -8,7 +8,6 @@ class EmojiSerializer < ApplicationSerializer
   end
 
   def url
-    return nil if object.url.blank?
-    Discourse.store.cdn_url(object.url)
+    object.cdn_url
   end
 end

--- a/lib/pretty_text.rb
+++ b/lib/pretty_text.rb
@@ -198,7 +198,7 @@ module PrettyText
       context = v8
 
       custom_emoji = {}
-      Emoji.custom.map { |e| custom_emoji[e.name] = e.url }
+      Emoji.custom.map { |e| custom_emoji[e.name] = e.cdn_url }
 
       allowed_iframes =
         DiscoursePluginRegistry.apply_modifier(
@@ -305,7 +305,7 @@ module PrettyText
     return title unless SiteSetting.enable_emoji? && title
 
     set = SiteSetting.emoji_set.inspect
-    custom = Emoji.custom.map { |e| [e.name, e.url] }.to_h.to_json
+    custom = Emoji.custom.map { |e| [e.name, e.cdn_url] }.to_h.to_json
 
     protect { v8.eval(<<~JS) }
         __paths = #{paths_json};

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1763,6 +1763,19 @@ RSpec.describe PrettyText do
 
       expect(PrettyText.cook("hello :trout:")).to match(/<img src[^>]+trout[^>]+>/)
     end
+
+    it "rewrites a custom emoji's S3 url through the configured CDN" do
+      setup_s3
+      SiteSetting.s3_cdn_url = "https://cdn.example.com"
+
+      raw_url = "#{SiteSetting.Upload.absolute_base_url}/original/1X/trout.png"
+      CustomEmoji.create!(name: "trout", upload: Fabricate(:upload, url: raw_url))
+      Emoji.clear_cache
+
+      cooked = PrettyText.cook("hello :trout:")
+      expect(cooked).to include("https://cdn.example.com/original/1X/trout.png")
+      expect(cooked).not_to include(raw_url)
+    end
   end
 
   describe "custom emoji translation" do

--- a/spec/lib/pretty_text_spec.rb
+++ b/spec/lib/pretty_text_spec.rb
@@ -1776,6 +1776,21 @@ RSpec.describe PrettyText do
       expect(cooked).to include("https://cdn.example.com/original/1X/trout.png")
       expect(cooked).not_to include(raw_url)
     end
+
+    it "rewrites a custom emoji's S3 url through the CDN when unescaping titles" do
+      setup_s3
+      SiteSetting.s3_cdn_url = "https://cdn.example.com"
+
+      raw_url = "#{SiteSetting.Upload.absolute_base_url}/original/1X/trout.png"
+      CustomEmoji.create!(name: "trout", upload: Fabricate(:upload, url: raw_url))
+      Emoji.clear_cache
+
+      unescaped = PrettyText.unescape_emoji("hello :trout:")
+      expect(unescaped).to match(
+        %r{<img[^>]+\bsrc=['"]https://cdn\.example\.com/original/1X/trout\.png},
+      )
+      expect(unescaped).not_to include(SiteSetting.Upload.absolute_base_url)
+    end
   end
 
   describe "custom emoji translation" do

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -22,20 +22,15 @@ RSpec.describe Emoji do
 
       # 1. Create a single dummy store
       dummy_store = FileStore::LocalStore.new
-      
+
       # 2. Force Discourse to always return this exact dummy store instance
-      allow(Discourse)
-        .to receive(:store)
-        .and_return(dummy_store)
-      
+      allow(Discourse).to receive(:store).and_return(dummy_store)
+
       # 3. Safely mock the cdn_url method for our specific emoji upload
-      allow(dummy_store)
-        .to receive(:cdn_url)
-        .and_call_original
-      allow(dummy_store)
-        .to receive(:cdn_url)
-        .with(upload.url)
-        .and_return("https://cdn.my-site.com/images/my-emoji.png")
+      allow(dummy_store).to receive(:cdn_url).and_call_original
+      allow(dummy_store).to receive(:cdn_url).with(upload.url).and_return(
+        "https://cdn.my-site.com/images/my-emoji.png",
+      )
 
       Emoji.clear_cache
       emoji = Emoji.load_custom.find { |e| e.name == "my_s3_emoji" }

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -17,15 +17,18 @@ RSpec.describe Emoji do
     end
 
     it "applies the CDN url to custom emojis when configured" do
-      SiteSetting.enable_s3_uploads = true
-      SiteSetting.s3_upload_bucket = "my-bucket"
-      SiteSetting.s3_cdn_url = "https://cdn.my-site.com"
-
-      allow(Discourse.store).to receive(:cdn_url).with("//my-bucket.s3.amazonaws.com/images/my-emoji.png").and_return("https://cdn.my-site.com/images/my-emoji.png")
-
-      # fab! is standard for Discourse system specs, but here we can just fabricate normally
       upload = Fabricate(:upload, url: "//my-bucket.s3.amazonaws.com/images/my-emoji.png")
       CustomEmoji.create!(name: "my_s3_emoji", upload: upload)
+
+      # 1. Create a single dummy store
+      dummy_store = FileStore::LocalStore.new
+      
+      # 2. Force Discourse to always return this exact dummy store instance
+      allow(Discourse).to receive(:store).and_return(dummy_store)
+      
+      # 3. Safely mock the cdn_url method for our specific emoji upload
+      allow(dummy_store).to receive(:cdn_url).and_call_original
+      allow(dummy_store).to receive(:cdn_url).with(upload.url).and_return("https://cdn.my-site.com/images/my-emoji.png")
 
       Emoji.clear_cache
       emoji = Emoji.load_custom.find { |e| e.name == "my_s3_emoji" }

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -24,11 +24,18 @@ RSpec.describe Emoji do
       dummy_store = FileStore::LocalStore.new
       
       # 2. Force Discourse to always return this exact dummy store instance
-      allow(Discourse).to receive(:store).and_return(dummy_store)
+      allow(Discourse)
+        .to receive(:store)
+        .and_return(dummy_store)
       
       # 3. Safely mock the cdn_url method for our specific emoji upload
-      allow(dummy_store).to receive(:cdn_url).and_call_original
-      allow(dummy_store).to receive(:cdn_url).with(upload.url).and_return("https://cdn.my-site.com/images/my-emoji.png")
+      allow(dummy_store)
+        .to receive(:cdn_url)
+        .and_call_original
+      allow(dummy_store)
+        .to receive(:cdn_url)
+        .with(upload.url)
+        .and_return("https://cdn.my-site.com/images/my-emoji.png")
 
       Emoji.clear_cache
       emoji = Emoji.load_custom.find { |e| e.name == "my_s3_emoji" }

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -15,6 +15,23 @@ RSpec.describe Emoji do
       expect(emoji.name).to eq("test")
       expect(emoji.url).to be_nil
     end
+
+    it "applies the CDN url to custom emojis when configured" do
+      SiteSetting.enable_s3_uploads = true
+      SiteSetting.s3_upload_bucket = "my-bucket"
+      SiteSetting.s3_cdn_url = "https://cdn.my-site.com"
+
+      Discourse.store.stubs(:cdn_url).with("//my-bucket.s3.amazonaws.com/images/my-emoji.png").returns("https://cdn.my-site.com/images/my-emoji.png")
+
+      # fab! is standard for Discourse system specs, but here we can just fabricate normally
+      upload = Fabricate(:upload, url: "//my-bucket.s3.amazonaws.com/images/my-emoji.png")
+      CustomEmoji.create!(name: "my_s3_emoji", upload: upload)
+
+      Emoji.clear_cache
+      emoji = Emoji.load_custom.find { |e| e.name == "my_s3_emoji" }
+
+      expect(emoji.url).to eq("https://cdn.my-site.com/images/my-emoji.png")
+    end
   end
 
   describe ".unicode_replacements" do

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Emoji do
       SiteSetting.s3_upload_bucket = "my-bucket"
       SiteSetting.s3_cdn_url = "https://cdn.my-site.com"
 
-      Discourse.store.stubs(:cdn_url).with("//my-bucket.s3.amazonaws.com/images/my-emoji.png").returns("https://cdn.my-site.com/images/my-emoji.png")
+      allow(Discourse.store).to receive(:cdn_url).with("//my-bucket.s3.amazonaws.com/images/my-emoji.png").and_return("https://cdn.my-site.com/images/my-emoji.png")
 
       # fab! is standard for Discourse system specs, but here we can just fabricate normally
       upload = Fabricate(:upload, url: "//my-bucket.s3.amazonaws.com/images/my-emoji.png")

--- a/spec/models/emoji_spec.rb
+++ b/spec/models/emoji_spec.rb
@@ -16,26 +16,54 @@ RSpec.describe Emoji do
       expect(emoji.url).to be_nil
     end
 
-    it "applies the CDN url to custom emojis when configured" do
+    it "caches the raw upload url, not the CDN-transformed one" do
       upload = Fabricate(:upload, url: "//my-bucket.s3.amazonaws.com/images/my-emoji.png")
       CustomEmoji.create!(name: "my_s3_emoji", upload: upload)
-
-      # 1. Create a single dummy store
-      dummy_store = FileStore::LocalStore.new
-
-      # 2. Force Discourse to always return this exact dummy store instance
-      allow(Discourse).to receive(:store).and_return(dummy_store)
-
-      # 3. Safely mock the cdn_url method for our specific emoji upload
-      allow(dummy_store).to receive(:cdn_url).and_call_original
-      allow(dummy_store).to receive(:cdn_url).with(upload.url).and_return(
-        "https://cdn.my-site.com/images/my-emoji.png",
-      )
 
       Emoji.clear_cache
       emoji = Emoji.load_custom.find { |e| e.name == "my_s3_emoji" }
 
-      expect(emoji.url).to eq("https://cdn.my-site.com/images/my-emoji.png")
+      # The cached object must hold the raw url so that later CDN setting
+      # changes are reflected (CDN is applied lazily via #cdn_url).
+      expect(emoji.url).to eq(upload.url)
+    end
+  end
+
+  describe "#cdn_url" do
+    it "returns nil when there is no url" do
+      expect(Emoji.new.cdn_url).to be_nil
+    end
+
+    context "with a configured S3 store and CDN" do
+      before do
+        setup_s3
+        SiteSetting.s3_cdn_url = "https://cdn.example.com"
+      end
+
+      def custom_emoji_for(raw_url)
+        upload = Fabricate(:upload, url: raw_url)
+        CustomEmoji.create!(name: "my_s3_emoji", upload: upload)
+        Emoji.clear_cache
+        Emoji.load_custom.find { |e| e.name == "my_s3_emoji" }
+      end
+
+      it "rewrites a schemaless S3 bucket url to the configured s3_cdn_url" do
+        raw_url = "#{SiteSetting.Upload.absolute_base_url}/original/1X/my-emoji.png"
+        emoji = custom_emoji_for(raw_url)
+
+        # the cache still holds the raw bucket url...
+        expect(emoji.url).to eq(raw_url)
+        # ...and the CDN conversion happens lazily on read.
+        expect(emoji.cdn_url).to eq("https://cdn.example.com/original/1X/my-emoji.png")
+      end
+
+      it "does not leak the bucket subfolder into the rewritten url" do
+        SiteSetting.s3_upload_bucket = "s3-upload-bucket/emojis"
+        raw_url = "#{SiteSetting.Upload.absolute_base_url}/emojis/original/1X/my-emoji.png"
+        emoji = custom_emoji_for(raw_url)
+
+        expect(emoji.cdn_url).to eq("https://cdn.example.com/original/1X/my-emoji.png")
+      end
     end
   end
 


### PR DESCRIPTION
When a Discourse instance is configured to use S3 (or S3-compatible storage like Cloudflare R2) for uploads, the Custom Emoji uploader saves the raw bucket URL to the `uploads` table (e.g., `//my-bucket.s3.amazonaws.com/...`).

Currently, when the Emoji cache is generated for `/site.json`, `app/models/emoji.rb` passes `emoji.upload&.url` directly. If a dedicated App CDN (`DISCOURSE_CDN_URL`) is not configured, this causes newly uploaded Custom Emojis to completely bypass the configured `DISCOURSE_S3_CDN_URL` and attempt to load directly from the raw bucket URL, resulting in broken images. 

Additionally, during live uploads via the Admin UI, the API response returns a broken relative path, resulting in a broken image preview until the page is forcibly refreshed.

**Why `DISCOURSE_CDN_URL` is intentionally omitted in this architecture:**
While the standard advice is to configure an App CDN, this is physically impossible for admins who proxy their main domain through Cloudflare to handle their app caching. 
If an admin attempts to define a secondary `DISCOURSE_CDN_URL` (e.g., `cdn.forum.com`) using a standard Cloudflare DNS record, Cloudflare cannot rewrite the `Host` header to match the origin domain (to prevent Domain Fronting). Because the `Host` header doesn't match `DISCOURSE_HOSTNAME`, Discourse's internal NGINX server rejects the CDN requests with a `301 Redirect`, instantly triggering CORS errors and breaking the site's Javascript. 

Therefore, admins using the Cloudflare Proxy + S3/R2 architecture *must* leave `DISCOURSE_CDN_URL` blank while setting `DISCOURSE_S3_CDN_URL`.

**The Solution:**
This PR wraps the assignment in `Discourse.store.cdn_url()` so that Custom Emoji uploads obey the same S3 CDN routing and fallback logic as standard post image uploads. This ensures the emojis route to the S3 CDN successfully, and fixes the broken API response generation during live uploads at the backend level.

**Files touched:**
* `app/models/emoji.rb`
* `spec/models/emoji_spec.rb`