### PR TITLE
FEATURE: Add direct traffic KPI to the Site Traffic dashboard

### DIFF
--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -108,6 +108,9 @@ class AdminDashboardSiteTraffic
 
     kpis[:logged_in_share] = { value: logged_in_share } if !logged_in_share.nil?
 
+    direct_traffic = direct_traffic_value
+    kpis[:direct_traffic] = { value: direct_traffic } if !direct_traffic.nil?
+
     kpis
   end
 
@@ -124,6 +127,25 @@ class AdminDashboardSiteTraffic
     return nil if login_required?
 
     totals[:human].positive? ? ((totals[:logged_in].to_f / totals[:human]) * 100).round : 0
+  end
+
+  def direct_traffic_value
+    return nil if !SiteSetting.persist_browser_pageview_events
+
+    count_column = login_required? ? "logged_in_count" : "count"
+
+    row = DB.query(<<~SQL, start_date: start_date.to_date, end_date: end_date.to_date).first
+          SELECT
+            COALESCE(SUM(#{count_column}), 0)::bigint AS total,
+            COALESCE(SUM(#{count_column}) FILTER (WHERE normalized_referrer IS NULL), 0)::bigint AS direct
+          FROM browser_pageview_referrer_daily_rollups
+          WHERE date >= :start_date
+            AND date <= :end_date
+        SQL
+
+    return nil if row.total.zero?
+
+    ((row.direct.to_f / row.total) * 100).round
   end
 
   def pageview_series(rows, include_embedded:)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7319,6 +7319,9 @@ en:
             logged_in_share:
               label: "Logged-in share"
               tooltip: "The share of pageviews from logged-in members."
+            direct_traffic:
+              label: "Direct traffic"
+              tooltip: "The share of pageviews that came directly to your community, such as by typing your URL or using a browser bookmark."
           top_countries:
             title: "Top countries"
             empty: "No country data for this period."

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -95,6 +95,15 @@ export default class DashboardTraffic extends Component {
     return `${this.args.traffic?.kpis?.logged_in_share?.value ?? 0}%`;
   }
 
+  get showDirectTraffic() {
+    const directTraffic = this.args.traffic?.kpis?.direct_traffic?.value;
+    return directTraffic !== null && directTraffic !== undefined;
+  }
+
+  get directTraffic() {
+    return `${this.args.traffic?.kpis?.direct_traffic?.value ?? 0}%`;
+  }
+
   get chartModel() {
     return {
       start_date: this.args.startDate,
@@ -224,29 +233,55 @@ export default class DashboardTraffic extends Component {
             </p> }}
           </div>
 
-          {{#if this.showLoggedInShare}}
+          {{#if (or this.showLoggedInShare this.showDirectTraffic)}}
             <div class="db-section__metrics">
-              <div class="db-section__metric">
-                <div
-                  class="db-section__metric-number"
-                >{{this.loggedInShare}}</div>
-                <div class="db-section__metric-label">
-                  {{i18n
-                    "admin.dashboard.site_traffic.kpi.logged_in_share.label"
-                  }}
-                  <DTooltip
-                    class="db-section__info"
-                    @identifier="site-traffic-logged-in-share-tooltip"
-                    @icon="far-circle-question"
-                  >
-                    <:content>
-                      {{i18n
-                        "admin.dashboard.site_traffic.kpi.logged_in_share.tooltip"
-                      }}
-                    </:content>
-                  </DTooltip>
+              {{#if this.showLoggedInShare}}
+                <div class="db-section__metric">
+                  <div
+                    class="db-section__metric-number"
+                  >{{this.loggedInShare}}</div>
+                  <div class="db-section__metric-label">
+                    {{i18n
+                      "admin.dashboard.site_traffic.kpi.logged_in_share.label"
+                    }}
+                    <DTooltip
+                      class="db-section__info"
+                      @identifier="site-traffic-logged-in-share-tooltip"
+                      @icon="far-circle-question"
+                    >
+                      <:content>
+                        {{i18n
+                          "admin.dashboard.site_traffic.kpi.logged_in_share.tooltip"
+                        }}
+                      </:content>
+                    </DTooltip>
+                  </div>
                 </div>
-              </div>
+              {{/if}}
+
+              {{#if this.showDirectTraffic}}
+                <div class="db-section__metric">
+                  <div
+                    class="db-section__metric-number"
+                  >{{this.directTraffic}}</div>
+                  <div class="db-section__metric-label">
+                    {{i18n
+                      "admin.dashboard.site_traffic.kpi.direct_traffic.label"
+                    }}
+                    <DTooltip
+                      class="db-section__info"
+                      @identifier="site-traffic-direct-traffic-tooltip"
+                      @icon="far-circle-question"
+                    >
+                      <:content>
+                        {{i18n
+                          "admin.dashboard.site_traffic.kpi.direct_traffic.tooltip"
+                        }}
+                      </:content>
+                    </DTooltip>
+                  </div>
+                </div>
+              {{/if}}
             </div>
           {{/if}}
         </div>

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -686,5 +686,107 @@ RSpec.describe AdminDashboardSiteTraffic do
         expect(second[:top_countries][:rows].first[:country_code]).to eq("US")
       end
     end
+
+    context "for direct traffic share" do
+      before { SiteSetting.persist_browser_pageview_events = true }
+
+      def aggregate_referrer_rollups
+        BrowserPageviewReferrerDailyRollup.aggregate(
+          start_date: "2026-05-01".to_date,
+          end_date: "2026-05-01".to_date,
+        )
+      end
+
+      it "returns the rounded share of pageviews that arrived with no referrer" do
+        3.times do
+          Fabricate(:browser_pageview_event, normalized_referrer: nil, created_at: "2026-05-01")
+        end
+        9.times do
+          Fabricate(
+            :browser_pageview_event,
+            normalized_referrer: "google.com",
+            created_at: "2026-05-01",
+          )
+        end
+        aggregate_referrer_rollups
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+          direct_traffic: {
+            value: 25,
+          },
+        )
+      end
+
+      it "computes the share from logged-in pageviews only when login is required" do
+        SiteSetting.login_required = true
+        member = Fabricate(:user)
+
+        Fabricate(
+          :browser_pageview_event,
+          normalized_referrer: nil,
+          user_id: member.id,
+          created_at: "2026-05-01",
+        )
+        Fabricate(
+          :browser_pageview_event,
+          normalized_referrer: nil,
+          user_id: nil,
+          created_at: "2026-05-01",
+        )
+        2.times do
+          Fabricate(
+            :browser_pageview_event,
+            normalized_referrer: "google.com",
+            user_id: member.id,
+            created_at: "2026-05-01",
+          )
+        end
+        aggregate_referrer_rollups
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          direct_traffic: {
+            value: 33,
+          },
+        )
+      end
+
+      it "omits direct traffic when persist_browser_pageview_events is disabled" do
+        SiteSetting.persist_browser_pageview_events = false
+
+        3.times do
+          Fabricate(:browser_pageview_event, normalized_referrer: nil, created_at: "2026-05-01")
+        end
+        aggregate_referrer_rollups
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+        )
+      end
+
+      it "omits direct traffic when no pageviews were tracked in the period" do
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+        )
+      end
+    end
   end
 end

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -723,6 +723,29 @@ RSpec.describe AdminDashboardSiteTraffic do
         )
       end
 
+      it "reports zero direct traffic when every tracked pageview had a referrer" do
+        4.times do
+          Fabricate(
+            :browser_pageview_event,
+            normalized_referrer: "google.com",
+            created_at: "2026-05-01",
+          )
+        end
+        aggregate_referrer_rollups
+
+        expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+          browser_pageviews: {
+            value: 0,
+          },
+          logged_in_share: {
+            value: 0,
+          },
+          direct_traffic: {
+            value: 0,
+          },
+        )
+      end
+
       it "computes the share from logged-in pageviews only when login is required" do
         SiteSetting.login_required = true
         member = Fabricate(:user)

--- a/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/site_traffic_section_spec.rb
@@ -170,6 +170,7 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
 
       expect(traffic).to have_no_top_countries_card
       expect(traffic).to have_no_top_referrers_card
+      expect(traffic).to have_no_metric("Direct traffic")
     end
 
     it "shows ranked top countries and top referrers when events exist in the period",
@@ -234,6 +235,13 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
           { referrer: "reddit.com/r/discourse", percent: 33 },
         ],
       )
+
+      expect(traffic).to have_metric("Direct traffic", "10%")
+
+      traffic.hover_direct_traffic_tooltip
+      expect(traffic).to have_direct_traffic_tooltip(
+        "The share of pageviews that came directly to your community, such as by typing your URL or using a browser bookmark.",
+      )
     end
 
     it "shows an empty state in both cards but keeps the headers as drill-down links when no events qualify",
@@ -245,6 +253,7 @@ describe "Admin Dashboard Redesign | Site Traffic section" do
       expect(traffic).to have_top_referrers_empty_state
       expect(traffic).to have_top_referrers_drilldown
       expect(traffic).to have_top_countries_drilldown
+      expect(traffic).to have_no_metric("Direct traffic")
     end
 
     it "drills into the full top referrers report scoped to the dashboard period",

--- a/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
+++ b/spec/system/page_objects/components/admin_dashboard_site_traffic.rb
@@ -66,6 +66,15 @@ module PageObjects
         Tooltips.new("site-traffic-logged-in-share-tooltip").present?(text: text)
       end
 
+      def hover_direct_traffic_tooltip
+        find("[data-trigger][data-identifier='site-traffic-direct-traffic-tooltip']").hover
+        self
+      end
+
+      def has_direct_traffic_tooltip?(text)
+        Tooltips.new("site-traffic-direct-traffic-tooltip").present?(text: text)
+      end
+
       def has_no_top_countries_card?
         has_no_top_card?("Top countries")
       end


### PR DESCRIPTION
This PR adds a "Direct traffic" KPI tile to the Site Traffic section of the admin dashboard, showing the share of browser pageviews that arrived with no referrer.

<img width="1400" height="1400" alt="image" src="https://github.com/user-attachments/assets/df3af323-97c7-436e-a0ba-6b90a123ceb9" />
<img width="1400" height="1400" alt="image" src="https://github.com/user-attachments/assets/8a238837-2bca-4d81-a4dd-e9f5c089ce32" />
