### PR TITLE
FIX: Hide Solved empty_box_on_unsolved on Horizon

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -632,7 +632,7 @@ class Theme < ActiveRecord::Base
 
   # def foundation_theme
   # def horizon_theme
-  CORE_THEMES.each { |name, id| define_singleton_method("#{name}_theme") { Theme.find(id) } }
+  CORE_THEMES.each { |name, id| define_singleton_method("#{name}_theme") { Theme.find_by(id: id) } }
   def resolve_baked_field(target, name)
     list_baked_fields(target, name).map { |f| f.value_baked || f.value }.join("\n")
   end

--- a/app/services/themes/action/horizon_high_context_topic_cards_toggled.rb
+++ b/app/services/themes/action/horizon_high_context_topic_cards_toggled.rb
@@ -4,7 +4,7 @@ class Themes::Action::HorizonHighContextTopicCardsToggled < Service::ActionBase
   option :enabled
 
   def call
-    theme = Theme.find_by(id: Theme::CORE_THEMES["horizon"])
+    theme = Theme.horizon_theme
     return if theme.blank?
     return if theme.settings.blank?
 
@@ -21,11 +21,11 @@ class Themes::Action::HorizonHighContextTopicCardsToggled < Service::ActionBase
       # site that got the legacy migration. If no setting exists,
       # it's a new site which has the theme setting for high-context topic cards
       # enabled by default.
-      ThemeSetting.exists?(theme_id: Theme::CORE_THEMES["horizon"], name: :topic_card_high_context)
+      ThemeSetting.exists?(theme_id: Theme.horizon_theme.id, name: :topic_card_high_context)
   end
 
   def self.horizon_theme_available?
-    horizon_theme = Theme.find_by(id: Theme::CORE_THEMES["horizon"])
+    horizon_theme = Theme.horizon_theme
     return false if horizon_theme.blank? || !horizon_theme.enabled?
     return false if !horizon_theme.user_selectable? && !horizon_theme.default?
     horizon_theme.default? || horizon_theme.user_selectable?

--- a/plugins/discourse-solved/app/services/discourse_solved/categories/types/support.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/categories/types/support.rb
@@ -106,15 +106,23 @@ module DiscourseSolved
                   label:
                     I18n.t("discourse_solved.category_type.notify_on_staff_accept_solved.label"),
                 },
-                DiscourseSolved::EMPTY_BOX_ON_UNSOLVED_CUSTOM_FIELD => {
-                  default: true,
-                  type: :bool,
-                  label: I18n.t("discourse_solved.category_type.empty_box_on_unsolved.label"),
-                },
               },
               site_texts: {
               },
             }
+
+            # The empty-box-on-unsolved styling isn't used by the Horizon theme,
+            # so hide the toggle (and the field) when Horizon is the site's
+            # default theme.
+            unless default_theme_horizon?
+              schema[:category_custom_fields][
+                DiscourseSolved::EMPTY_BOX_ON_UNSOLVED_CUSTOM_FIELD
+              ] = {
+                default: true,
+                type: :bool,
+                label: I18n.t("discourse_solved.category_type.empty_box_on_unsolved.label"),
+              }
+            end
 
             if SiteSetting.enable_solved_shared_issues
               schema[:category_custom_fields][
@@ -140,6 +148,12 @@ module DiscourseSolved
 
           def icon
             "person_raising_hand"
+          end
+
+          private
+
+          def default_theme_horizon?
+            SiteSetting.default_theme_id == Theme.horizon_theme.id
           end
         end
       end

--- a/plugins/discourse-solved/spec/models/discourse_solved/categories_types_support_spec.rb
+++ b/plugins/discourse-solved/spec/models/discourse_solved/categories_types_support_spec.rb
@@ -157,6 +157,28 @@ RSpec.describe DiscourseSolved::Categories::Types::Support do
         )
       end
     end
+
+    context "when the Horizon theme is the site's default theme" do
+      before { SiteSetting.default_theme_id = Theme.horizon_theme.id }
+
+      it "omits the empty box on unsolved toggle from the category custom fields" do
+        keys = described_class.configuration_schema[:category_custom_fields].keys
+        expect(keys).not_to include(DiscourseSolved::EMPTY_BOX_ON_UNSOLVED_CUSTOM_FIELD)
+      end
+
+      it "still passes schema validation" do
+        expect { described_class.validate_schema! }.not_to raise_error
+      end
+    end
+
+    context "when the Horizon theme is not the site's default theme" do
+      before { SiteSetting.default_theme_id = Theme.foundation_theme.id }
+
+      it "declares the empty box on unsolved toggle as a category custom field" do
+        keys = described_class.configuration_schema[:category_custom_fields].keys
+        expect(keys).to include(DiscourseSolved::EMPTY_BOX_ON_UNSOLVED_CUSTOM_FIELD)
+      end
+    end
   end
 
   describe ".unconfigure_category" do

--- a/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
+++ b/plugins/discourse-solved/spec/system/support_category_type_setup_spec.rb
@@ -165,6 +165,16 @@ RSpec.describe "Support Category Type Setup" do
       expect(SiteSetting.show_who_marked_solved).to eq(true)
     end
 
+    it "hides the empty box on unsolved toggle when the Horizon theme is the default" do
+      Theme.horizon_theme.update_columns(enabled: true, user_selectable: true)
+      SiteSetting.default_theme_id = Theme.horizon_theme.id
+
+      visit("/c/#{category.slug}/edit/support")
+
+      expect(form).to have_field_with_name("custom_fields.notify_on_staff_accept_solved")
+      expect(form).to have_no_field_with_name("custom_fields.empty_box_on_unsolved")
+    end
+
     it "edits the shared issue label as a translation override when enabled" do
       SiteSetting.enable_solved_shared_issues = true
       visit("/c/#{category.slug}/edit/support")


### PR DESCRIPTION
The Horizon theme doesn't show the empty box on unsolved
topics even if empty_box_on_unsolved is enabled for the
category, so we should hide that setting if the Horizon
theme is default for the site.
