### PR TITLE
FEATURE: Add Bypass permission checks to create post

### DIFF
--- a/lib/post_creator.rb
+++ b/lib/post_creator.rb
@@ -35,6 +35,7 @@ class PostCreator
   #                             call `enqueue_jobs` after the transaction is committed.
   #   hidden_reason_id        - Reason for hiding the post (optional)
   #   skip_validations        - Do not validate any of the content in the post
+  #   skip_staff_author_pm_membership_sync - Do not add the post author to private message allowed users when a staff guardian authorizes the post
   #   draft_key               - the key of the draft we are creating (will be deleted on success)
   #   advance_draft           - Destroy draft after creating post or topic
   #   silent                  - Do not update topic stats and fields like last_post_user_id
@@ -85,6 +86,10 @@ class PostCreator
 
   def skip_validations?
     @opts[:skip_validations]
+  end
+
+  def skip_staff_author_pm_membership_sync?
+    @opts[:skip_staff_author_pm_membership_sync]
   end
 
   def guardian
@@ -209,7 +214,7 @@ class PostCreator
         create_embedded_topic
         @post.link_post_uploads
         delete_owned_bookmarks
-        ensure_in_allowed_users if guardian.is_staff?
+        ensure_in_allowed_users if guardian.is_staff? && !skip_staff_author_pm_membership_sync?
         unarchive_message if !@opts[:import_mode]
         DraftSequence.next!(@user, draft_key) if !@opts[:import_mode] && @opts[:advance_draft]
         @post.save_reply_relationships

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -406,6 +406,11 @@ en:
         reply_to_post_number_description: "Reply to a specific post number in the topic"
         whisper: "Create as whisper"
         whisper_description: "Create the post as a whisper. The author must be allowed to create whispers."
+        authorization_mode: "Posting permission"
+        authorization_modes:
+          author: "Author permissions"
+          system: "System authorization"
+        authorization_mode_tooltip: "Author permissions requires the author to see and reply to the topic. System authorization allows trusted workflows to reply to the current topic as the selected author without adding that author as a PM participant."
         author_username: "Author"
         post_id: "Post ID"
         editor_username: "Editor"

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -406,11 +406,8 @@ en:
         reply_to_post_number_description: "Reply to a specific post number in the topic"
         whisper: "Create as whisper"
         whisper_description: "Create the post as a whisper. The author must be allowed to create whispers."
-        authorization_mode: "Posting permission"
-        authorization_modes:
-          author: "Author permissions"
-          system: "System authorization"
-        authorization_mode_tooltip: "Author permissions requires the author to see and reply to the topic. System authorization allows trusted workflows to reply to the current topic as the selected author without adding that author as a PM participant."
+        bypass_permission_checks: "Bypass permission checks"
+        bypass_permission_checks_description: "The post will be created as the selected author even if they cannot see or reply to the topic — including closed topics, secure categories, and personal messages. The author will not be granted access to the topic."
         author_username: "Author"
         post_id: "Post ID"
         editor_username: "Editor"

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -327,13 +327,13 @@ module DiscourseWorkflows
         topic_id:,
         reply_to_post_number: nil,
         whisper: false,
-        authorization_mode: "author"
+        bypass_permission_checks: false
       )
         topic = ::Topic.find(topic_id)
-        system_authorization = system_authorization_mode?(authorization_mode)
-        guardian = system_authorization ? Discourse.system_user.guardian : user.guardian
+        bypass_permission_checks = ActiveModel::Type::Boolean.new.cast(bypass_permission_checks)
+        guardian = bypass_permission_checks ? Discourse.system_user.guardian : user.guardian
 
-        if !system_authorization
+        if !bypass_permission_checks
           guardian.ensure_can_see!(topic)
           raise Discourse::InvalidAccess if !guardian.can_create_post?(topic)
 
@@ -362,13 +362,13 @@ module DiscourseWorkflows
           post_args[:post_type] = ::Post.types[:whisper]
         end
 
-        if system_authorization
+        if bypass_permission_checks
           post_args[:guardian] = guardian
           post_args[:skip_staff_author_pm_membership_sync] = true
         end
 
         post = PostCreator.new(user, post_args).create!
-        record_system_authorized_post!(post) if system_authorization
+        record_system_authorized_post!(post) if bypass_permission_checks
         post
       end
 
@@ -471,10 +471,6 @@ module DiscourseWorkflows
       end
 
       private
-
-      def system_authorization_mode?(authorization_mode)
-        authorization_mode.to_s == SYSTEM_AUTHORIZATION_MODE
-      end
 
       def record_system_authorized_post!(post)
         post.custom_fields[SYSTEM_AUTHORIZED_POST_FIELD] = SYSTEM_AUTHORIZATION_MODE

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -3,11 +3,10 @@
 module DiscourseWorkflows
   class Executor
     class NodeExecutionContext
-      SYSTEM_AUTHORIZATION_MODE = "system"
-      SYSTEM_AUTHORIZED_POST_FIELD = "discourse_workflows_authorization_mode"
-      SYSTEM_AUTHORIZED_WORKFLOW_ID_FIELD = "discourse_workflows_workflow_id"
-      SYSTEM_AUTHORIZED_WORKFLOW_VERSION_ID_FIELD = "discourse_workflows_workflow_version_id"
-      SYSTEM_AUTHORIZED_NODE_ID_FIELD = "discourse_workflows_node_id"
+      BYPASSED_PERMISSION_CHECKS_FIELD = "discourse_workflows_bypassed_permission_checks"
+      WORKFLOW_ID_FIELD = "discourse_workflows_workflow_id"
+      WORKFLOW_VERSION_ID_FIELD = "discourse_workflows_workflow_version_id"
+      NODE_ID_FIELD = "discourse_workflows_node_id"
 
       MISSING = ParameterResolver::MISSING
       RUN_CODE = CodeRunner::RUN_CODE
@@ -368,7 +367,7 @@ module DiscourseWorkflows
         end
 
         post = PostCreator.new(user, post_args).create!
-        record_system_authorized_post!(post) if bypass_permission_checks
+        record_permission_bypass!(post) if bypass_permission_checks
         post
       end
 
@@ -472,15 +471,13 @@ module DiscourseWorkflows
 
       private
 
-      def record_system_authorized_post!(post)
-        post.custom_fields[SYSTEM_AUTHORIZED_POST_FIELD] = SYSTEM_AUTHORIZATION_MODE
-        post.custom_fields[SYSTEM_AUTHORIZED_WORKFLOW_ID_FIELD] = @workflow.id if @workflow&.id
+      def record_permission_bypass!(post)
+        post.custom_fields[BYPASSED_PERMISSION_CHECKS_FIELD] = "true"
+        post.custom_fields[WORKFLOW_ID_FIELD] = @workflow.id if @workflow&.id
         if @workflow&.active_version_id
-          post.custom_fields[
-            SYSTEM_AUTHORIZED_WORKFLOW_VERSION_ID_FIELD
-          ] = @workflow.active_version_id
+          post.custom_fields[WORKFLOW_VERSION_ID_FIELD] = @workflow.active_version_id
         end
-        post.custom_fields[SYSTEM_AUTHORIZED_NODE_ID_FIELD] = @node_id if @node_id
+        post.custom_fields[NODE_ID_FIELD] = @node_id if @node_id
         post.save_custom_fields
       end
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -3,6 +3,12 @@
 module DiscourseWorkflows
   class Executor
     class NodeExecutionContext
+      SYSTEM_AUTHORIZATION_MODE = "system"
+      SYSTEM_AUTHORIZED_POST_FIELD = "discourse_workflows_authorization_mode"
+      SYSTEM_AUTHORIZED_WORKFLOW_ID_FIELD = "discourse_workflows_workflow_id"
+      SYSTEM_AUTHORIZED_WORKFLOW_VERSION_ID_FIELD = "discourse_workflows_workflow_version_id"
+      SYSTEM_AUTHORIZED_NODE_ID_FIELD = "discourse_workflows_node_id"
+
       MISSING = ParameterResolver::MISSING
       RUN_CODE = CodeRunner::RUN_CODE
       RUN_ONCE_FOR_ALL_ITEMS = CodeRunner::RUN_ONCE_FOR_ALL_ITEMS
@@ -315,15 +321,26 @@ module DiscourseWorkflows
         HttpClient.new(self, item_index).request(method:, url:, headers:, body:, options:)
       end
 
-      def create_post(user:, raw:, topic_id:, reply_to_post_number: nil, whisper: false)
+      def create_post(
+        user:,
+        raw:,
+        topic_id:,
+        reply_to_post_number: nil,
+        whisper: false,
+        authorization_mode: "author"
+      )
         topic = ::Topic.find(topic_id)
-        guardian = user.guardian
-        guardian.ensure_can_see!(topic)
-        raise Discourse::InvalidAccess if !guardian.can_create_post?(topic)
+        system_authorization = system_authorization_mode?(authorization_mode)
+        guardian = system_authorization ? Discourse.system_user.guardian : user.guardian
 
-        if topic.closed? || topic.archived?
-          raise DiscourseWorkflows::NodeError,
-                I18n.t("discourse_workflows.errors.post.topic_closed_or_archived")
+        if !system_authorization
+          guardian.ensure_can_see!(topic)
+          raise Discourse::InvalidAccess if !guardian.can_create_post?(topic)
+
+          if topic.closed? || topic.archived?
+            raise DiscourseWorkflows::NodeError,
+                  I18n.t("discourse_workflows.errors.post.topic_closed_or_archived")
+          end
         end
 
         post_args = {
@@ -345,7 +362,11 @@ module DiscourseWorkflows
           post_args[:post_type] = ::Post.types[:whisper]
         end
 
-        PostCreator.new(user, post_args).create!
+        post_args[:skip_guardian] = true if system_authorization
+
+        post = PostCreator.new(user, post_args).create!
+        record_system_authorized_post!(post) if system_authorization
+        post
       end
 
       def edit_post(user:, post_id:, raw:)
@@ -447,6 +468,22 @@ module DiscourseWorkflows
       end
 
       private
+
+      def system_authorization_mode?(authorization_mode)
+        authorization_mode.to_s == SYSTEM_AUTHORIZATION_MODE
+      end
+
+      def record_system_authorized_post!(post)
+        post.custom_fields[SYSTEM_AUTHORIZED_POST_FIELD] = SYSTEM_AUTHORIZATION_MODE
+        post.custom_fields[SYSTEM_AUTHORIZED_WORKFLOW_ID_FIELD] = @workflow.id if @workflow&.id
+        if @workflow&.active_version_id
+          post.custom_fields[
+            SYSTEM_AUTHORIZED_WORKFLOW_VERSION_ID_FIELD
+          ] = @workflow.active_version_id
+        end
+        post.custom_fields[SYSTEM_AUTHORIZED_NODE_ID_FIELD] = @node_id if @node_id
+        post.save_custom_fields
+      end
 
       def fetch_credentials(slot, item_index)
         raise ArgumentError, "credential slot is required" if slot.blank?

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -362,7 +362,10 @@ module DiscourseWorkflows
           post_args[:post_type] = ::Post.types[:whisper]
         end
 
-        post_args[:skip_guardian] = true if system_authorization
+        if system_authorization
+          post_args[:guardian] = guardian
+          post_args[:skip_staff_author_pm_membership_sync] = true
+        end
 
         post = PostCreator.new(user, post_args).create!
         record_system_authorized_post!(post) if system_authorization

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
@@ -4,6 +4,7 @@ module DiscourseWorkflows
   module Nodes
     module Post
       class V1 < NodeType
+        AUTHORIZATION_MODE_OPTIONS = %w[author system].freeze
         OPERATIONS = %w[create edit get list].freeze
         STATUS_OPTIONS = %w[
           any
@@ -109,6 +110,20 @@ module DiscourseWorkflows
               default: "system",
               ui: {
                 control: :actor,
+              },
+              display_options: {
+                show: {
+                  operation: ["create"],
+                },
+              },
+            },
+            authorization_mode: {
+              type: :options,
+              required: false,
+              options: AUTHORIZATION_MODE_OPTIONS,
+              default: "author",
+              ui: {
+                show_description: false,
               },
               display_options: {
                 show: {
@@ -327,6 +342,8 @@ module DiscourseWorkflows
             "reply_to_post_number" =>
               exec_ctx.get_node_parameter("reply_to_post_number", item_index),
             "whisper" => exec_ctx.get_node_parameter("whisper", item_index, default: false),
+            "authorization_mode" =>
+              exec_ctx.get_node_parameter("authorization_mode", item_index, default: "author"),
             "post_id" => exec_ctx.get_node_parameter("post_id", item_index),
             "editor_username" => exec_ctx.get_node_parameter("editor_username", item_index),
             "include_raw" => exec_ctx.get_node_parameter("include_raw", item_index, default: true),
@@ -389,6 +406,7 @@ module DiscourseWorkflows
               topic_id: config["topic_id"],
               reply_to_post_number: config["reply_to_post_number"],
               whisper: config["whisper"],
+              authorization_mode: config["authorization_mode"],
             )
 
           {

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post/v1.rb
@@ -4,7 +4,6 @@ module DiscourseWorkflows
   module Nodes
     module Post
       class V1 < NodeType
-        AUTHORIZATION_MODE_OPTIONS = %w[author system].freeze
         OPERATIONS = %w[create edit get list].freeze
         STATUS_OPTIONS = %w[
           any
@@ -117,13 +116,12 @@ module DiscourseWorkflows
                 },
               },
             },
-            authorization_mode: {
-              type: :options,
+            bypass_permission_checks: {
+              type: :boolean,
               required: false,
-              options: AUTHORIZATION_MODE_OPTIONS,
-              default: "author",
+              default: false,
               ui: {
-                show_description: false,
+                control: :boolean,
               },
               display_options: {
                 show: {
@@ -342,8 +340,8 @@ module DiscourseWorkflows
             "reply_to_post_number" =>
               exec_ctx.get_node_parameter("reply_to_post_number", item_index),
             "whisper" => exec_ctx.get_node_parameter("whisper", item_index, default: false),
-            "authorization_mode" =>
-              exec_ctx.get_node_parameter("authorization_mode", item_index, default: "author"),
+            "bypass_permission_checks" =>
+              exec_ctx.get_node_parameter("bypass_permission_checks", item_index, default: false),
             "post_id" => exec_ctx.get_node_parameter("post_id", item_index),
             "editor_username" => exec_ctx.get_node_parameter("editor_username", item_index),
             "include_raw" => exec_ctx.get_node_parameter("include_raw", item_index, default: true),
@@ -406,7 +404,7 @@ module DiscourseWorkflows
               topic_id: config["topic_id"],
               reply_to_post_number: config["reply_to_post_number"],
               whisper: config["whisper"],
-              authorization_mode: config["authorization_mode"],
+              bypass_permission_checks: config["bypass_permission_checks"],
             )
 
           {

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
@@ -982,6 +982,55 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
     end
   end
 
+  describe "#create_post" do
+    it "records bypass provenance custom fields on the created post" do
+      author = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      workflow = Fabricate(:discourse_workflows_workflow, published: true)
+      first_post = Fabricate(:post)
+
+      ctx =
+        described_class.new(input_items: [], resolver: nil, workflow: workflow, node_id: "post-1")
+
+      post =
+        ctx.create_post(
+          user: author,
+          raw: "Reply created with a permission bypass",
+          topic_id: first_post.topic_id,
+          bypass_permission_checks: true,
+        )
+
+      expect(post.reload.custom_fields).to include(
+        described_class::BYPASSED_PERMISSION_CHECKS_FIELD => "true",
+        described_class::WORKFLOW_ID_FIELD => workflow.id.to_s,
+        described_class::WORKFLOW_VERSION_ID_FIELD => workflow.active_version_id.to_s,
+        described_class::NODE_ID_FIELD => "post-1",
+      )
+    end
+
+    it "does not record provenance custom fields without a bypass" do
+      author = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      workflow = Fabricate(:discourse_workflows_workflow, published: true)
+      first_post = Fabricate(:post)
+
+      ctx =
+        described_class.new(input_items: [], resolver: nil, workflow: workflow, node_id: "post-1")
+
+      post =
+        ctx.create_post(
+          user: author,
+          raw: "Reply created with the author permissions",
+          topic_id: first_post.topic_id,
+        )
+
+      expect(post.reload.custom_fields.keys).not_to include(
+        described_class::BYPASSED_PERMISSION_CHECKS_FIELD,
+        described_class::WORKFLOW_ID_FIELD,
+        described_class::WORKFLOW_VERSION_ID_FIELD,
+        described_class::NODE_ID_FIELD,
+      )
+    end
+  end
+
   def workflow_with_data_table_dependency(data_table)
     graph =
       build_workflow_graph do |g|

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
@@ -226,8 +226,8 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       expect(reply.raw).to eq("Automated reply from a TL0 user.")
       expect(private_message.topic_allowed_users.where(user_id: tl0_user.id)).to be_blank
       expect(reply.custom_fields).to include(
-        DiscourseWorkflows::Executor::NodeExecutionContext::SYSTEM_AUTHORIZED_POST_FIELD =>
-          "system",
+        DiscourseWorkflows::Executor::NodeExecutionContext::BYPASSED_PERMISSION_CHECKS_FIELD =>
+          "true",
       )
       expect(result["post"]).to include("id" => reply.id, "username" => tl0_user.username)
     end
@@ -261,10 +261,6 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       expect(reply.user_id).to eq(tl0_user.id)
       expect(reply.raw).to eq("Secure category automated reply.")
       expect(group.users.exists?(tl0_user.id)).to eq(false)
-      expect(reply.custom_fields).to include(
-        DiscourseWorkflows::Executor::NodeExecutionContext::SYSTEM_AUTHORIZED_POST_FIELD =>
-          "system",
-      )
       expect(result["post"]).to include("id" => reply.id, "username" => tl0_user.username)
     end
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
@@ -194,6 +194,145 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       end.to raise_error(Discourse::InvalidAccess).and not_change { hidden_topic.posts.count }
     end
 
+    it "creates a PM reply as a TL0 user with system authorization", :aggregate_failures do
+      tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      private_message = Fabricate(:private_message_topic, user: user, recipient: other_user)
+      Fabricate(
+        :post,
+        topic: private_message,
+        user: user,
+        raw: "Please help with my account.",
+        post_number: 1,
+      )
+      item = { "json" => { "topic" => { "id" => private_message.id } } }
+      result = nil
+
+      expect do
+        result =
+          execute_node(
+            configuration: {
+              "operation" => "create",
+              "topic_id" => private_message.id.to_s,
+              "raw" => "Automated reply from a TL0 user.",
+              "author_username" => tl0_user.username,
+              "authorization_mode" => "system",
+            },
+            item: item,
+          )
+      end.to change { private_message.posts.count }.by(1)
+
+      reply = private_message.posts.order(:id).last
+      expect(reply.user_id).to eq(tl0_user.id)
+      expect(reply.raw).to eq("Automated reply from a TL0 user.")
+      expect(private_message.topic_allowed_users.where(user_id: tl0_user.id)).to be_blank
+      expect(reply.custom_fields).to include(
+        DiscourseWorkflows::Executor::NodeExecutionContext::SYSTEM_AUTHORIZED_POST_FIELD =>
+          "system",
+      )
+      expect(result["post"]).to include("id" => reply.id, "username" => tl0_user.username)
+    end
+
+    it "creates a secure category reply as a TL0 user with system authorization",
+       :aggregate_failures do
+      tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      group = Fabricate(:group)
+      private_category = Fabricate(:private_category, group: group)
+      first_post =
+        create_post(user: admin, category: private_category, raw: "Secure category topic.")
+      topic = first_post.topic
+      item = { "json" => { "post" => { "topic_id" => topic.id } } }
+      result = nil
+
+      expect do
+        result =
+          execute_node(
+            configuration: {
+              "operation" => "create",
+              "topic_id" => topic.id.to_s,
+              "raw" => "Secure category automated reply.",
+              "author_username" => tl0_user.username,
+              "authorization_mode" => "system",
+            },
+            item: item,
+          )
+      end.to change { topic.posts.count }.by(1)
+
+      reply = topic.posts.order(:id).last
+      expect(reply.user_id).to eq(tl0_user.id)
+      expect(reply.raw).to eq("Secure category automated reply.")
+      expect(group.users.exists?(tl0_user.id)).to eq(false)
+      expect(reply.custom_fields).to include(
+        DiscourseWorkflows::Executor::NodeExecutionContext::SYSTEM_AUTHORIZED_POST_FIELD =>
+          "system",
+      )
+      expect(result["post"]).to include("id" => reply.id, "username" => tl0_user.username)
+    end
+
+    it "creates a whisper as a TL0 user with system authorization", :aggregate_failures do
+      SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
+      tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      private_message = Fabricate(:private_message_topic, user: user, recipient: other_user)
+      Fabricate(
+        :post,
+        topic: private_message,
+        user: user,
+        raw: "Please help with my account.",
+        post_number: 1,
+      )
+      item = { "json" => { "topic" => { "id" => private_message.id } } }
+      result = nil
+
+      expect do
+        result =
+          execute_node(
+            configuration: {
+              "operation" => "create",
+              "topic_id" => private_message.id.to_s,
+              "raw" => "Staff-only automated note from a TL0 user.",
+              "author_username" => tl0_user.username,
+              "authorization_mode" => "system",
+              "whisper" => true,
+            },
+            item: item,
+          )
+      end.to change { private_message.posts.count }.by(1)
+
+      reply = private_message.posts.order(:id).last
+      expect(reply.user_id).to eq(tl0_user.id)
+      expect(reply.raw).to eq("Staff-only automated note from a TL0 user.")
+      expect(reply.post_type).to eq(Post.types[:whisper])
+      expect(private_message.topic_allowed_users.where(user_id: tl0_user.id)).to be_blank
+      expect(result["post"]).to include(
+        "id" => reply.id,
+        "username" => tl0_user.username,
+        "post_type" => Post.types[:whisper],
+      )
+    end
+
+    it "creates a post in a closed topic with system authorization", :aggregate_failures do
+      tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
+      topic = first_post.topic
+      topic.update!(closed: true)
+
+      expect do
+        execute_node(
+          configuration: {
+            "operation" => "create",
+            "topic_id" => topic.id.to_s,
+            "raw" => "System authorization can reply to closed topics.",
+            "author_username" => tl0_user.username,
+            "authorization_mode" => "system",
+          },
+          item: item,
+        )
+      end.to change { topic.posts.count }.by(1)
+
+      reply = topic.posts.order(:id).last
+      expect(reply.user_id).to eq(tl0_user.id)
+      expect(reply.raw).to eq("System authorization can reply to closed topics.")
+    end
+
     it "raises when creating in a closed or archived topic" do
       first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
       topic = first_post.topic

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       end.to raise_error(Discourse::InvalidAccess).and not_change { hidden_topic.posts.count }
     end
 
-    it "creates a PM reply as a TL0 user with system authorization", :aggregate_failures do
+    it "creates a PM reply as a TL0 user when bypassing permission checks", :aggregate_failures do
       tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
       private_message = Fabricate(:private_message_topic, user: user, recipient: other_user)
       Fabricate(
@@ -215,7 +215,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
               "topic_id" => private_message.id.to_s,
               "raw" => "Automated reply from a TL0 user.",
               "author_username" => tl0_user.username,
-              "authorization_mode" => "system",
+              "bypass_permission_checks" => true,
             },
             item: item,
           )
@@ -232,7 +232,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       expect(result["post"]).to include("id" => reply.id, "username" => tl0_user.username)
     end
 
-    it "creates a secure category reply as a TL0 user with system authorization",
+    it "creates a secure category reply as a TL0 user when bypassing permission checks",
        :aggregate_failures do
       tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
       group = Fabricate(:group)
@@ -251,7 +251,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
               "topic_id" => topic.id.to_s,
               "raw" => "Secure category automated reply.",
               "author_username" => tl0_user.username,
-              "authorization_mode" => "system",
+              "bypass_permission_checks" => true,
             },
             item: item,
           )
@@ -268,7 +268,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       expect(result["post"]).to include("id" => reply.id, "username" => tl0_user.username)
     end
 
-    it "creates a whisper as a TL0 user with system authorization", :aggregate_failures do
+    it "creates a whisper as a TL0 user when bypassing permission checks", :aggregate_failures do
       SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff].to_s
       tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
       private_message = Fabricate(:private_message_topic, user: user, recipient: other_user)
@@ -290,7 +290,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
               "topic_id" => private_message.id.to_s,
               "raw" => "Staff-only automated note from a TL0 user.",
               "author_username" => tl0_user.username,
-              "authorization_mode" => "system",
+              "bypass_permission_checks" => true,
               "whisper" => true,
             },
             item: item,
@@ -309,7 +309,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
       )
     end
 
-    it "creates a post in a closed topic with system authorization", :aggregate_failures do
+    it "creates a post in a closed topic when bypassing permission checks", :aggregate_failures do
       tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
       first_post = Fabricate(:post, user: user, raw: "First post", post_number: 1)
       topic = first_post.topic
@@ -322,7 +322,7 @@ RSpec.describe DiscourseWorkflows::Nodes::Post::V1 do
             "topic_id" => topic.id.to_s,
             "raw" => "System authorization can reply to closed topics.",
             "author_username" => tl0_user.username,
-            "authorization_mode" => "system",
+            "bypass_permission_checks" => true,
           },
           item: item,
         )

--- a/spec/lib/post_creator_spec.rb
+++ b/spec/lib/post_creator_spec.rb
@@ -1174,6 +1174,17 @@ RSpec.describe PostCreator do
       PostCreator.create!(admin2, raw: "I am also an admin, and a mod", topic_id: post.topic_id)
 
       expect(post.topic.topic_allowed_users.where(user_id: admin2.id).count).to eq(0)
+
+      tl0_user = Fabricate(:user, trust_level: 0, refresh_auto_groups: true)
+      PostCreator.create!(
+        tl0_user,
+        raw: "Automated support reply",
+        topic_id: post.topic_id,
+        guardian: Discourse.system_user.guardian,
+        skip_staff_author_pm_membership_sync: true,
+      )
+
+      expect(post.topic.topic_allowed_users.where(user_id: tl0_user.id).count).to eq(0)
     end
 
     it "does not add whisperers to allowed users of the topic" do


### PR DESCRIPTION
Allow post workflow to bypass permission checks. Record info using custom fields for audit log.

<img width="925" height="40" alt="Screenshot 2026-07-17 at 21 54 34" src="https://github.com/user-attachments/assets/1580fc43-ebbd-473b-9f41-3d3d98ab7f78" />

This is needed for a few reasons: 
- Sometimes a workflow may want to post on a closed topic (a whisper, summary, whatever) 
- Sometimes for cases of triage you may want to post as a whisper without adding to topic allowed users 

This gives workflow authors an escape hatch to post wherever they want by whoever they want ... it is a very powerful feature and default disabled.
