### PR TITLE
UX: peek mode with chat drawer stacking order

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-drawer.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-drawer.scss
@@ -47,6 +47,17 @@ html.rtl {
   transition-property: bottom, padding-bottom;
 }
 
+.peek-mode-active {
+  .chat-drawer-outlet-container {
+    z-index: z("composer", "dropdown") + 1;
+  }
+
+  .fk-d-menu[data-identifier="chat-message-reaction-users"],
+  .fk-d-menu[data-identifier="chat-composer-dropdown__menu"] {
+    z-index: z("composer", "dropdown") + 2;
+  }
+}
+
 .chat-drawer {
   pointer-events: auto;
   align-self: flex-end;


### PR DESCRIPTION
Allows chat drawer to work in combination with peek mode outside of the Horizon theme.

## How it looks

<img width="1977" height="1064" alt="Screenshot 2026-06-30 at 2 58 52 PM" src="https://github.com/user-attachments/assets/65aa8ebd-9a01-4044-9d1f-bd85b9b555fe" />
