### PR TITLE
UX: restore moderator color to PM warnings

### DIFF
--- a/frontend/discourse/app/models/post.js
+++ b/frontend/discourse/app/models/post.js
@@ -449,6 +449,10 @@ export default class Post extends RestModel {
     return this.post_type === this.site.post_types.moderator_action;
   }
 
+  get isWarning() {
+    return this.topic?.is_warning;
+  }
+
   get isSmallAction() {
     return (
       this.post_type === this.site.post_types.small_action ||

--- a/frontend/discourse/tests/integration/components/post/post-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/post-test.gjs
@@ -296,6 +296,25 @@ module("Integration | Component | Post", function (hooks) {
     assert.dom(".post-info.whisper").exists({ count: 1 });
   });
 
+  test("warning first post gets the moderator staff color", async function (assert) {
+    this.post.topic.is_warning = true;
+
+    await renderComponent(this.post);
+
+    assert.dom(".topic-post.moderator").exists({ count: 1 });
+    assert.dom(".topic-post.regular").doesNotExist();
+  });
+
+  test("warning reply does not get the moderator staff color", async function (assert) {
+    this.post.topic.is_warning = true;
+    this.post.post_number = 2;
+
+    await renderComponent(this.post);
+
+    assert.dom(".topic-post.moderator").doesNotExist();
+    assert.dom(".topic-post.regular").exists({ count: 1 });
+  });
+
   test("language", async function (assert) {
     this.post.is_localized = true;
     this.post.language = "en";


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/official-warning-pm-notification-feature/387448/8?u=awesomerobot

We had `isWarning`, but it wasn't wired up to anything after the glimmer migration so it never activated to add the moderator color to warnings
https://github.com/discourse/discourse/blob/8dd0a9c73627a782bf163d3f590da5bb67a4bc3c/frontend/discourse/app/components/post.gjs#L436-L437

this adds the getter so the correct class is added to warning PMs and we get the color 

Before:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/309df242-25b2-4013-910f-31ddafae6ca4" />



After:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/fa3139b8-7ce0-48e5-bc8c-345d30f8d99e" />

included a test to avoid future regressions
