### PR TITLE
MT: Add reads_table to generate a step's items and max_progress

### DIFF
--- a/migrations/converters/lib/migrations/converters/adapter/postgres.rb
+++ b/migrations/converters/lib/migrations/converters/adapter/postgres.rb
@@ -50,6 +50,19 @@ module Migrations
           query_value(sql).to_i
         end
 
+        # Reads every row of `table`, optionally narrowed by the `where` body
+        # (nil reads the whole table). Backs the `reads_table` default in a step's
+        # source; the table name is quoted here so the SQL stays in the adapter.
+        def select_all(table, where: nil)
+          query("SELECT * FROM #{connection.quote_ident(table)}#{where_clause(where)}")
+        end
+
+        # The row count of `table`, optionally narrowed by `where`. Backs
+        # `reads_table`'s default `max_progress`.
+        def count_all(table, where: nil)
+          count("SELECT COUNT(*) FROM #{connection.quote_ident(table)}#{where_clause(where)}")
+        end
+
         def close
           @connection.finish if @connection && !@connection.finished?
           @connection = nil
@@ -95,6 +108,13 @@ module Migrations
         end
 
         private
+
+        # `" WHERE <filter>"`, or "" when there's no filter — so a missing filter
+        # reads the whole table instead of leaning on a `WHERE TRUE` that not every
+        # dialect accepts.
+        def where_clause(filter)
+          filter ? " WHERE #{filter}" : ""
+        end
 
         def connection
           if @discarded

--- a/migrations/converters/lib/migrations/converters/discourse/steps/badge_groupings.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/badge_groupings.rb
@@ -5,24 +5,8 @@ module Migrations
     module Discourse
       class BadgeGroupings < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM badge_groupings
-              WHERE id NOT IN (1, 2, 3, 4, 5) -- Exclude system groupings
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM badge_groupings
-              WHERE id NOT IN (1, 2, 3, 4, 5) -- Exclude system groupings
-              ORDER BY id
-            SQL
-          end
+          # Skip the system badge groupings.
+          reads_table "badge_groupings", where: "id NOT IN (1, 2, 3, 4, 5)"
         end
 
         processor do

--- a/migrations/converters/lib/migrations/converters/discourse/steps/badges.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/badges.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class Badges < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*) FROM badges

--- a/migrations/converters/lib/migrations/converters/discourse/steps/categories.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/categories.rb
@@ -12,8 +12,6 @@ module Migrations
         ].freeze
 
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*) FROM categories

--- a/migrations/converters/lib/migrations/converters/discourse/steps/category_custom_fields.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/category_custom_fields.rb
@@ -4,23 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class CategoryCustomFields < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM category_custom_fields
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT category_id, name, value
-              FROM category_custom_fields
-              ORDER BY category_id
-            SQL
-          end
-        end
+        source { reads_table "category_custom_fields" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/category_moderation_groups.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/category_moderation_groups.rb
@@ -4,25 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class CategoryModerationGroups < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM category_moderation_groups
-              WHERE group_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM category_moderation_groups
-              WHERE group_id > 0
-            SQL
-          end
-        end
+        source { reads_table "category_moderation_groups", where: "group_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/category_users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/category_users.rb
@@ -4,25 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class CategoryUsers < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM category_users
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM category_users
-              WHERE user_id > 0
-            SQL
-          end
-        end
+        source { reads_table "category_users", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/group_users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/group_users.rb
@@ -5,26 +5,8 @@ module Migrations
     module Discourse
       class GroupUsers < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM group_users
-              WHERE group_id NOT IN (10, 11, 12, 13, 14) -- Exclude Trust Level groups
-                    AND user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM group_users
-              WHERE group_id NOT IN (10, 11, 12, 13, 14) -- Exclude Trust Level groups
-                    AND user_id > 0
-              ORDER BY group_id, user_id
-            SQL
-          end
+          # Skip the automatic Trust Level groups.
+          reads_table "group_users", where: "group_id NOT IN (10, 11, 12, 13, 14) AND user_id > 0"
         end
 
         processor do

--- a/migrations/converters/lib/migrations/converters/discourse/steps/groups.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/groups.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class Groups < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*) FROM groups

--- a/migrations/converters/lib/migrations/converters/discourse/steps/muted_users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/muted_users.rb
@@ -4,21 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class MutedUsers < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM muted_users
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT * FROM muted_users
-            SQL
-          end
-        end
+        source { reads_table "muted_users" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/permalink_normalizations.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/permalink_normalizations.rb
@@ -4,8 +4,6 @@ module Migrations
   module Converters
     module Discourse
       class PermalinkNormalizations < Conversion::Step
-        attr_accessor :source_db
-
         def execute
           normalizations = @source_db.query_value <<~SQL
             SELECT value

--- a/migrations/converters/lib/migrations/converters/discourse/steps/site_settings.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/site_settings.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class SiteSettings < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/tag_group_memberships.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/tag_group_memberships.rb
@@ -4,22 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TagGroupMemberships < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-               SELECT COUNT(*) FROM tag_group_memberships
-             SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-                SELECT * FROM tag_group_memberships
-                ORDER BY tag_group_id, tag_id
-             SQL
-          end
-        end
+        source { reads_table "tag_group_memberships" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/tag_group_permissions.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/tag_group_permissions.rb
@@ -4,23 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TagGroupPermissions < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM tag_group_permissions
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM tag_group_permissions
-              ORDER BY id
-            SQL
-          end
-        end
+        source { reads_table "tag_group_permissions" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/tag_groups.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/tag_groups.rb
@@ -4,21 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TagGroups < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM tag_groups
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT * FROM tag_groups
-            SQL
-          end
-        end
+        source { reads_table "tag_groups" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/tag_users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/tag_users.rb
@@ -4,25 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TagUsers < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM tag_users
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT * FROM tag_users
-              WHERE user_id > 0
-              ORDER BY tag_id, user_id
-            SQL
-          end
-        end
+        source { reads_table "tag_users", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/tags.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/tags.rb
@@ -4,21 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class Tags < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM tags
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT * FROM tags
-            SQL
-          end
-        end
+        source { reads_table "tags" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/topic_allowed_groups.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/topic_allowed_groups.rb
@@ -4,23 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TopicAllowedGroups < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM topic_allowed_groups
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM topic_allowed_groups
-              ORDER BY topic_id, group_id
-            SQL
-          end
-        end
+        source { reads_table "topic_allowed_groups" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/topic_allowed_users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/topic_allowed_users.rb
@@ -4,26 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TopicAllowedUsers < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM topic_allowed_users
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM topic_allowed_users
-              WHERE user_id > 0
-              ORDER BY topic_id, user_id
-            SQL
-          end
-        end
+        source { reads_table "topic_allowed_users", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/topic_tags.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/topic_tags.rb
@@ -4,24 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TopicTags < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM topic_tags
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM topic_tags
-              ORDER BY topic_id, tag_id
-            SQL
-          end
-        end
+        source { reads_table "topic_tags" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/topic_users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/topic_users.rb
@@ -4,26 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class TopicUsers < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM topic_users
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM topic_users
-              WHERE user_id > 0
-              ORDER BY topic_id, user_id
-            SQL
-          end
-        end
+        source { reads_table "topic_users", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/topics.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/topics.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class Topics < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*) FROM topics

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_associated_accounts.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_associated_accounts.rb
@@ -4,26 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class UserAssociatedAccounts < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM user_associated_accounts
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM user_associated_accounts
-              WHERE user_id > 0
-              ORDER BY id
-            SQL
-          end
-        end
+        source { reads_table "user_associated_accounts", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_custom_fields.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_custom_fields.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class UserCustomFields < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_emails.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_emails.rb
@@ -4,26 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class UserEmails < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM user_emails
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT user_id, email, "primary", created_at
-              FROM user_emails
-              WHERE user_id > 0
-              ORDER BY user_id, email
-            SQL
-          end
-        end
+        source { reads_table "user_emails", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_field_options.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_field_options.rb
@@ -4,23 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class UserFieldOptions < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM user_field_options
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM user_field_options
-              ORDER BY user_field_id
-            SQL
-          end
-        end
+        source { reads_table "user_field_options" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_field_values.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_field_values.rb
@@ -13,8 +13,6 @@ module Migrations
         USER_FIELD_LIKE_PATTERN = "#{USER_FIELD_PREFIX.gsub("_") { '\_' }}%"
 
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_fields.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_fields.rb
@@ -4,23 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class UserFields < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*) FROM user_fields
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM user_fields
-              ORDER BY id
-            SQL
-          end
-        end
+        source { reads_table "user_fields" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_options.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_options.rb
@@ -4,26 +4,7 @@ module Migrations
   module Converters
     module Discourse
       class UserOptions < Conversion::ProgressStep
-        source do
-          attr_accessor :source_db
-
-          def max_progress
-            @source_db.count <<~SQL
-              SELECT COUNT(*)
-              FROM user_options
-              WHERE user_id > 0
-            SQL
-          end
-
-          def items
-            @source_db.query <<~SQL
-              SELECT *
-              FROM user_options
-              WHERE user_id > 0
-              ORDER BY user_id
-            SQL
-          end
-        end
+        source { reads_table "user_options", where: "user_id > 0" }
 
         processor do
           def process(item)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/user_suspensions.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/user_suspensions.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class UserSuspensions < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*)

--- a/migrations/converters/lib/migrations/converters/discourse/steps/users.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/users.rb
@@ -5,8 +5,6 @@ module Migrations
     module Discourse
       class Users < Conversion::ProgressStep
         source do
-          attr_accessor :source_db
-
           def max_progress
             @source_db.count <<~SQL
               SELECT COUNT(*)

--- a/migrations/converters/spec/lib/migrations/converters/adapter/postgres_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/adapter/postgres_spec.rb
@@ -37,6 +37,35 @@ RSpec.describe Migrations::Converters::Adapter::Postgres do
       end
     end
 
+    describe "#select_all and #count_all" do
+      before { allow(connection).to receive(:quote_ident) { |id| %("#{id}") } }
+
+      it "selects all rows from a quoted table" do
+        create_adapter do |adapter|
+          allow(adapter).to receive(:query).with('SELECT * FROM "things" WHERE active').and_return(
+            [:row],
+          )
+          expect(adapter.select_all("things", where: "active")).to eq([:row])
+        end
+      end
+
+      it "counts rows in a quoted table" do
+        create_adapter do |adapter|
+          allow(adapter).to receive(:count).with(
+            'SELECT COUNT(*) FROM "things" WHERE active',
+          ).and_return(7)
+          expect(adapter.count_all("things", where: "active")).to eq(7)
+        end
+      end
+
+      it "omits the WHERE clause when there's no filter" do
+        create_adapter do |adapter|
+          allow(adapter).to receive(:query).with('SELECT * FROM "things"').and_return([:row])
+          expect(adapter.select_all("things")).to eq([:row])
+        end
+      end
+    end
+
     describe "#discard!" do
       it "redirects the connection's socket to the null device without closing it" do
         create_adapter do |adapter|

--- a/migrations/core/lib/migrations/conversion/progress_step.rb
+++ b/migrations/core/lib/migrations/conversion/progress_step.rb
@@ -48,18 +48,38 @@ module Migrations
       class Source
         include AttributeAssignment
 
-        attr_accessor :settings
+        # `source_db` is the step's connection to the source data, when it has
+        # one. Steps that read from somewhere else (a file, fixed data) leave it
+        # nil. The converter injects it through `step_args`.
+        attr_accessor :settings, :source_db
+
+        class << self
+          # Read a whole table: defines `items` (`SELECT * FROM <name>`) and
+          # `max_progress` (its row count), both filtered by `where`. Override
+          # `items`/`max_progress` for anything custom.
+          def reads_table(name, where: nil)
+            @table = { name:, where: }
+          end
+
+          attr_reader :table
+
+          def reads_table?
+            !table.nil?
+          end
+        end
 
         def initialize(args = {})
           assign_attributes(args)
         end
 
         def max_progress
-          nil
+          return unless self.class.reads_table?
+          @source_db.count_all(self.class.table[:name], where: self.class.table[:where])
         end
 
         def items
-          raise NotImplementedError
+          raise NotImplementedError unless self.class.reads_table?
+          @source_db.select_all(self.class.table[:name], where: self.class.table[:where])
         end
       end
 

--- a/migrations/core/spec/lib/conversion/progress_step_spec.rb
+++ b/migrations/core/spec/lib/conversion/progress_step_spec.rb
@@ -248,6 +248,47 @@ RSpec.describe Migrations::Conversion::ProgressStep do
     end
   end
 
+  describe "reads_table defaults" do
+    # Stands in for the source DB adapter, recording the calls it receives (the
+    # adapter builds the actual SQL; that's covered in its own spec).
+    let(:source_db) do
+      Class
+        .new do
+          attr_reader :select_args, :count_args
+
+          def select_all(table, where:)
+            @select_args = [table, where]
+            [:row]
+          end
+
+          def count_all(table, where:)
+            @count_args = [table, where]
+            4
+          end
+        end
+        .new
+    end
+
+    it "reads the whole table through the adapter" do
+      step_class = define_step { source { reads_table "things", where: "active" } }
+      source = step_class.source_class.new(source_db:)
+
+      expect(source.items).to eq([:row])
+      expect(source_db.select_args).to eq(%w[things active])
+
+      expect(source.max_progress).to eq(4)
+      expect(source_db.count_args).to eq(%w[things active])
+    end
+
+    it "passes no filter when `reads_table` has no `where`" do
+      step_class = define_step { source { reads_table "things" } }
+      source = step_class.source_class.new(source_db:)
+
+      source.items
+      expect(source_db.select_args).to eq(["things", nil])
+    end
+  end
+
   describe "constant resolution" do
     # The role blocks of real steps are written inside a step class body, so
     # constants in their methods resolve through the step's lexical scope and


### PR DESCRIPTION
Most converter steps just read a whole table and map its columns into the IntermediateDB. Each one writes the same shape by hand: a `SELECT *` for `items`, a `COUNT(*)` for `max_progress`, and an `attr_accessor :source_db`. That's a lot of repeated boilerplate for "read this table."

So I added `reads_table` to the source role. A step names the table (and an optional `where`), and the source fills in both `items` and `max_progress` from it:

```ruby
source { reads_table "tags" }
source { reads_table "category_users", where: "user_id > 0" }
```

A few details:

- The SQL is built in the adapter (`select_all` / `count_all`), so the table name is quoted there and core stays free of SQL. A missing `where` means no `WHERE` clause at all, instead of a `WHERE TRUE` that not every database accepts.
- `source_db` moved onto the base source, so steps don't repeat the accessor anymore.
- `reads_table` only fills in the defaults — a step that needs custom SQL defines `items` (and `max_progress`) as before and those win.

20 of the 30 Discourse steps are a plain table read and shrink to one line. The other 10 have joins, CTEs, window functions, or dedup in their `items`, so they keep it and just drop the repeated accessor.

This is groundwork I'm splitting out of the concurrent-converter PR (#41262). It stands on its own and is simpler to review here; the bigger PR builds on it.
