### PR TITLE
UX: prevent name from blowing out group user table width

### DIFF
--- a/app/assets/stylesheets/common/base/directory.scss
+++ b/app/assets/stylesheets/common/base/directory.scss
@@ -203,6 +203,8 @@
   }
 
   &__cell {
+    min-width: 0;
+
     &,
     &--user-field {
       padding: var(--space-3) var(--space-2);


### PR DESCRIPTION
Long user names could break the user table width on group pages, this allows it to shrink to fit 


before
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/f2c9efc7-48fc-4879-9dfa-05bbd7d96a54" />




after
<img width="800" alt="image" src="https://github.com/user-attachments/assets/ab040360-df31-455e-98ad-c58417827220" />
