### PR TITLE
UX: Prevent incomplete crawler localization settings

### DIFF
--- a/app/views/common/_hreflang_tags.html.erb
+++ b/app/views/common/_hreflang_tags.html.erb
@@ -1,4 +1,4 @@
-<% if SiteSetting.content_localization_enabled && SiteSetting.content_localization_crawler_param %>
+<% if ContentLocalization.crawler_locale_param_enabled? %>
   <% locales = SiteSetting.content_localization_supported_locales&.split('|') || [] %>
   <% if locales.any? %>
     <% current_path = request.path %>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3012,6 +3012,7 @@ en:
       invalid_search_ranking_weights: "Value is invalid for search_ranking_weights site setting. Example: '{0.1,0.2,0.3,1.0}'. Note that maximum value for each weight is 1.0."
       content_localization_locale_limit: "The number of supported locales cannot exceed %{max}."
       content_localization_language_switcher_requirements: "The language switcher requires the 'set locale from cookie' and 'allow user locale' site settings to be enabled, and 'content localization supported locales' to have at least one language."
+      content_localization_crawler_param_requirements: "You must first enable 'set locale from param' before enabling this setting."
       mediaconvert_role_arn_required: "AWS IAM role ARN is required when using AWS MediaConvert for video conversion."
       mediaconvert_output_subdirectory_required: "MediaConvert output subdirectory is required."
       s3_credentials_required_for_video_conversion: "S3 credentials are required for video conversion. Please configure S3 access keys or enable IAM profile."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1916,6 +1916,7 @@ content_localization:
   content_localization_crawler_param:
     default: false
     area: "localization"
+    validator: "ContentLocalizationCrawlerParamValidator"
   content_localization_use_default_locale_when_unsupported:
     default: true
     area: "localization"

--- a/lib/canonical_url.rb
+++ b/lib/canonical_url.rb
@@ -34,8 +34,7 @@ module CanonicalURL
     private
 
     def append_content_localization_param(url)
-      return url unless SiteSetting.content_localization_enabled
-      return url unless SiteSetting.content_localization_crawler_param
+      return url unless ContentLocalization.crawler_locale_param_enabled?
       return url unless use_crawler_layout?
 
       locale = params[Discourse::LOCALE_PARAM]

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -45,4 +45,9 @@ class ContentLocalization
   def self.show_translated_tag?(tag, scope)
     SiteSetting.content_localization_enabled && tag.locale.present? && !tag.in_user_locale?
   end
+
+  def self.crawler_locale_param_enabled?
+    SiteSetting.content_localization_enabled && SiteSetting.content_localization_crawler_param &&
+      SiteSetting.set_locale_from_param
+  end
 end

--- a/lib/middleware/crawler_hooks.rb
+++ b/lib/middleware/crawler_hooks.rb
@@ -15,8 +15,7 @@ module Middleware
       if status == 200 && headers["X-Discourse-Crawler-View"] &&
            headers["Content-Type"]&.include?("text/html") &&
            !non_localizable_path?(request_path_without_base_path(request)) &&
-           SiteSetting.content_localization_enabled &&
-           SiteSetting.content_localization_crawler_param
+           ContentLocalization.crawler_locale_param_enabled?
         response = transform_response(request:, response:)
       end
 
@@ -28,8 +27,7 @@ module Middleware
     def transform_response(request:, response:)
       locale = request.params[Discourse::LOCALE_PARAM]
 
-      if SiteSetting.content_localization_enabled &&
-           SiteSetting.content_localization_crawler_param && locale.present?
+      if ContentLocalization.crawler_locale_param_enabled? && locale.present?
         html_fragment = Nokogiri::HTML5.parse(response.body)
 
         html_fragment

--- a/lib/validators/content_localization_crawler_param_validator.rb
+++ b/lib/validators/content_localization_crawler_param_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ContentLocalizationCrawlerParamValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val == "f"
+    SiteSetting.set_locale_from_param
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.content_localization_crawler_param_requirements")
+  end
+end

--- a/spec/lib/canonical_url_spec.rb
+++ b/spec/lib/canonical_url_spec.rb
@@ -25,6 +25,8 @@ describe CanonicalURL::ControllerExtensions do
     let(:instance) { host_class.new(Discourse::LOCALE_PARAM => "ja") }
 
     before do
+      SiteSetting.allow_user_locale = true
+      SiteSetting.set_locale_from_param = true
       SiteSetting.content_localization_enabled = true
       SiteSetting.content_localization_crawler_param = true
       SiteSetting.content_localization_supported_locales = "en|ja|es"
@@ -37,6 +39,11 @@ describe CanonicalURL::ControllerExtensions do
 
     it "returns the url unchanged when content_localization_crawler_param is false" do
       SiteSetting.content_localization_crawler_param = false
+      expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
+    end
+
+    it "returns the url unchanged when set_locale_from_param is false" do
+      SiteSetting.set_locale_from_param = false
       expect(instance.send(:append_content_localization_param, "/latest")).to eq("/latest")
     end
 

--- a/spec/lib/middleware/crawler_hooks_spec.rb
+++ b/spec/lib/middleware/crawler_hooks_spec.rb
@@ -69,6 +69,8 @@ describe Middleware::CrawlerHooks do
   end
 
   before do
+    SiteSetting.allow_user_locale = true
+    SiteSetting.set_locale_from_param = true
     SiteSetting.content_localization_enabled = false
     SiteSetting.content_localization_crawler_param = false
   end
@@ -250,6 +252,28 @@ describe Middleware::CrawlerHooks do
             :path => "https://discourse.site",
             :params => {
               "locale" => "fr",
+            },
+            "HTTP_USER_AGENT" => crawler_user_agent,
+            "X-Discourse-Crawler-View" => true,
+          ),
+        )
+
+      expect(status).to eq(200)
+      expect(headers["Content-Type"]).to include("text/html")
+      expect(response).to eq(html_response)
+    end
+
+    it "does not modify HTML responses when locale params are disabled" do
+      SiteSetting.content_localization_enabled = true
+      SiteSetting.content_localization_crawler_param = true
+      SiteSetting.set_locale_from_param = false
+
+      status, headers, response =
+        middleware.call(
+          env(
+            :path => "https://discourse.site",
+            :params => {
+              Discourse::LOCALE_PARAM => "fr",
             },
             "HTTP_USER_AGENT" => crawler_user_agent,
             "X-Discourse-Crawler-View" => true,

--- a/spec/lib/validators/content_localization_crawler_param_validator_spec.rb
+++ b/spec/lib/validators/content_localization_crawler_param_validator_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe ContentLocalizationCrawlerParamValidator do
+  subject(:validator) { described_class.new }
+
+  it "allows the setting to be disabled" do
+    expect(validator.valid_value?("f")).to eq(true)
+  end
+
+  it "rejects enabling when locale params are disabled" do
+    SiteSetting.set_locale_from_param = false
+
+    expect(validator.valid_value?("t")).to eq(false)
+  end
+
+  it "allows enabling when locale params are enabled" do
+    SiteSetting.allow_user_locale = true
+    SiteSetting.set_locale_from_param = true
+
+    expect(validator.valid_value?("t")).to eq(true)
+  end
+end

--- a/spec/requests/crawler_hreflang_spec.rb
+++ b/spec/requests/crawler_hreflang_spec.rb
@@ -6,6 +6,8 @@ describe "Crawler hreflang tags" do
 
   describe "when viewing a topic as crawler" do
     before do
+      SiteSetting.allow_user_locale = true
+      SiteSetting.set_locale_from_param = true
       SiteSetting.content_localization_enabled = true
       SiteSetting.content_localization_crawler_param = true
       SiteSetting.content_localization_supported_locales = "en|ja|es"
@@ -127,6 +129,22 @@ describe "Crawler hreflang tags" do
       expect(response.body).to match(
         %r{<link rel="canonical" href="#{Regexp.escape(Discourse.base_url)}/t/#{post.topic.slug}/#{post.topic.id}"\s*/?>},
       )
+    end
+
+    it "does not emit translated crawler URLs when locale params are disabled" do
+      SiteSetting.set_locale_from_param = false
+
+      get "/t/#{post.topic.slug}/#{post.topic.id}?#{Discourse::LOCALE_PARAM}=ja",
+          headers: {
+            "User-Agent" => "Googlebot/2.1 (+http://www.google.com/bot.html)",
+          }
+
+      aggregate_failures do
+        expect(response.body).not_to include('<link rel="alternate" href=')
+        expect(response.body).to match(
+          %r{<link rel="canonical" href="#{Regexp.escape(Discourse.base_url)}/t/#{post.topic.slug}/#{post.topic.id}"\s*/?>},
+        )
+      end
     end
 
     it "does not append ?tl= to canonical for non-crawler requests" do


### PR DESCRIPTION
This PR makes sure crawler localization URLs only work when anonymous users can resolve the locale from the URL param. This blocks enabling the crawler param without that prerequisite and keeps hreflang, canonical URLs, and crawler link rewriting behind the same guard.

/406195/4