### PR TITLE
DEV: Drop dead leftovers from the Rolldown migration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,12 +59,6 @@
 
     <%= module_preloads_for "discourse", (staff? ? "admin/compat-modules" : nil) %>
 
-    <%- if staff? %>
-      <% EmberAssets.script_chunks["chunk.admin"]&.each do |script_name| %>
-        <link rel="preload" href="<%= script_asset_path(script_name) %>" as="script" nonce="<%= csp_nonce_placeholder %>" data-discourse-entrypoint="admin">
-      <% end %>
-    <%- end %>
-
     <%- unless customization_disabled? %>
       <%- theme_js_assets.each do |asset| %>
         <link rel="modulepreload" href="<%= asset[:url] %>" data-theme-id="<%= asset[:theme_id] %>" nonce="<%= csp_nonce_placeholder %>">

--- a/spec/lib/stylesheet/compiler_spec.rb
+++ b/spec/lib/stylesheet/compiler_spec.rb
@@ -5,8 +5,6 @@ require "stylesheet/compiler"
 RSpec.describe Stylesheet::Compiler do
   describe "compilation" do
     Dir["#{Rails.root.join("app/assets/stylesheets/*.scss")}"].each do |path|
-      next if path =~ /ember_cli/
-
       path = File.basename(path, ".scss")
 
       # mobile and desktop scss files are intentionally empty stubs


### PR DESCRIPTION
Two bits of dead code left behind by the Rolldown migration (#35963).

- The layout preloaded `EmberAssets.script_chunks["chunk.admin"]`, but Rolldown no longer produces that key — entrypoints are now named after their chunk, and the admin one (`admin/compat-modules`) is already preloaded by `module_preloads_for` on the line just above. The lookup returned nil, so the block emitted nothing.
- A stylesheet compiler spec skipped `app/assets/stylesheets/ember_cli.scss`, a file the migration deleted, so the guard could never match.

---

<sub>This PR originally also taught `discourse.js` to honour the `data-discourse-entrypoint="admin"` preload marker, to fix admin-bundle loading for non-staff users of [discourse-theme-creator](https://github.com/discourse/discourse-theme-creator). That plugin instead shipped a self-contained fix ([#139](https://github.com/discourse/discourse-theme-creator/pull/139)) that works against unmodified core, so the core change was dropped — only the two dead-code cleanups remain.</sub>
