### PR TITLE
FIX: Don't treat empty translations as missing for locale fallback

### DIFF
--- a/frontend/discourse-i18n/src/index.js
+++ b/frontend/discourse-i18n/src/index.js
@@ -306,19 +306,23 @@ export class I18n {
     let translation = this.findTranslation(scope, options);
 
     if (!this.noFallbacks) {
-      if (!translation && this.fallbackLocale) {
+      // An empty string is a valid translation, so only fall back when the
+      // translation is genuinely missing (`null`/`undefined`). Using a falsy
+      // check here would treat an intentionally-blank value as missing and
+      // surface the raw key when no fallback locale provides the value.
+      if (translation == null && this.fallbackLocale) {
         options.locale = this.fallbackLocale;
         translation = this.findTranslation(scope, options);
       }
 
       options.ignoreMissing = false;
 
-      if (!translation && this.currentLocale() !== this.defaultLocale) {
+      if (translation == null && this.currentLocale() !== this.defaultLocale) {
         options.locale = this.defaultLocale;
         translation = this.findTranslation(scope, options);
       }
 
-      if (!translation && this.currentLocale() !== "en") {
+      if (translation == null && this.currentLocale() !== "en") {
         options.locale = "en";
         translation = this.findTranslation(scope, options);
       }

--- a/frontend/discourse/tests/unit/lib/i18n-test.js
+++ b/frontend/discourse/tests/unit/lib/i18n-test.js
@@ -289,6 +289,17 @@ module("Unit | Utility | i18n", function (hooks) {
     );
   });
 
+  test("empty string translation in the current locale is not treated as missing", function (assert) {
+    I18n.locale = "en";
+    I18n.fallbackLocale = "fr";
+
+    assert.strictEqual(
+      i18n("hello.universe"),
+      "",
+      "returns the empty string instead of falling through to the missing-translation key when a fallback locale is configured but lacks the key"
+    );
+  });
+
   test("Dollar signs are properly escaped", function (assert) {
     assert.strictEqual(
       i18n("dollar_sign", {

--- a/frontend/discourse/tests/unit/lib/i18n-test.js
+++ b/frontend/discourse/tests/unit/lib/i18n-test.js
@@ -48,6 +48,12 @@ module("Unit | Utility | i18n", function (hooks) {
           days: {
             other: "%{count} jours",
           },
+          empty_default: "",
+        },
+      },
+      es: {
+        js: {
+          empty_fallback: "",
         },
       },
       en: {
@@ -56,6 +62,8 @@ module("Unit | Utility | i18n", function (hooks) {
             world: "Hello World!",
             universe: "",
           },
+          empty_fallback: "English fallback value",
+          empty_default: "English default value",
           topic: {
             reply: {
               help: "begin composing a reply to this topic",
@@ -298,6 +306,35 @@ module("Unit | Utility | i18n", function (hooks) {
       "",
       "returns the empty string instead of falling through to the missing-translation key when a fallback locale is configured but lacks the key"
     );
+  });
+
+  test("empty string from the fallback locale is preferred over cascading to the default locale", function (assert) {
+    I18n.locale = "fr";
+    I18n.fallbackLocale = "es";
+
+    assert.strictEqual(
+      i18n("empty_fallback"),
+      "",
+      "stops at the empty fallback-locale value instead of cascading to the default locale"
+    );
+  });
+
+  test("empty string from the default locale is preferred over cascading to English", function (assert) {
+    const originalDefaultLocale = I18n.defaultLocale;
+
+    try {
+      I18n.locale = "ja";
+      I18n.fallbackLocale = null;
+      I18n.defaultLocale = "fr";
+
+      assert.strictEqual(
+        i18n("empty_default"),
+        "",
+        "stops at the empty default-locale value instead of cascading to English"
+      );
+    } finally {
+      I18n.defaultLocale = originalDefaultLocale;
+    }
   });
 
   test("Dollar signs are properly escaped", function (assert) {


### PR DESCRIPTION
When a translation resolves to an empty value `""`, this is valid and intentional...

...but `findTranslationWithFallback` uses a falsy check, `!translation`, to decide to fallback to the next locale. When this happens the key is shown instead of the empty value being handled. 

To reproduce this, you can set your site locale to something not english (French for example) and then change your user's locale to English (`/my/preferences/interface`). Then an empty translation will produce the key instead of remaining blank... like this example from the admin header component: 

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/e9b4b715-6752-419c-af9b-b99facfd24ff" />

This has cropped up in other places before, but never fixed at the root (https://meta.discourse.org/t/bug-with-search-banner-search-button-text-shown-in-search-banner-theme-component/273628/13?u=awesomerobot) 

Switching the check to null will fix it. 
