### PR TITLE
UX: Use a single step-aware heading for email code signup

### DIFF
--- a/app/assets/stylesheets/common/login/code-login-form.scss
+++ b/app/assets/stylesheets/common/login/code-login-form.scss
@@ -17,6 +17,11 @@
   flex-direction: column;
   gap: 1em;
 
+  // No waving-hand icon here, so drop the welcome header's icon grid.
+  .login-welcome-header {
+    display: block;
+  }
+
   &__email-step {
     display: flex;
     flex-direction: column;

--- a/app/assets/stylesheets/common/login/code-login-form.scss
+++ b/app/assets/stylesheets/common/login/code-login-form.scss
@@ -20,6 +20,11 @@
   // No waving-hand icon here, so drop the welcome header's icon grid.
   .login-welcome-header {
     display: block;
+
+    // Keep a trailing emoji/short word from orphaning onto its own line.
+    .login-title {
+      text-wrap: pretty;
+    }
   }
 
   &__email-step {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2942,7 +2942,7 @@ en:
       use_different_email: "Use a different email address"
       use_password_instead: "Log in with your password instead"
       email_me_code: "Email me a one-time login code"
-      signup_title: "Join this community"
+      signup_title: "Create your account"
       signup_instructions: "Enter your email address to join this community. We'll send you a code to confirm it and you'll be on your way!"
       user_fields_title: "Almost done"
       user_fields_instructions: "Just a few more details to finish creating your account."

--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -8,9 +8,12 @@ import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import Form from "discourse/components/form";
 import AvatarSelectorModal from "discourse/components/modal/avatar-selector";
+import PluginOutlet from "discourse/components/plugin-outlet";
 import SecondFactorForm from "discourse/components/second-factor-form";
 import SecurityKeyForm from "discourse/components/security-key-form";
 import UserField from "discourse/components/user-field";
+import WelcomeHeader from "discourse/components/welcome-header";
+import lazyHash from "discourse/helpers/lazy-hash";
 import valueEntered from "discourse/helpers/value-entered";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -113,6 +116,37 @@ export default class CodeLoginForm extends Component {
 
   get isCompleteStep() {
     return this.step === "complete";
+  }
+
+  // Login has its own page heading; only signup needs a per-step one here.
+  get heading() {
+    if (!this.isSignup) {
+      return null;
+    }
+
+    switch (this.step) {
+      case "code":
+        return {
+          title: i18n("code_login.check_your_email"),
+          subtitle: this.codeInstructions,
+        };
+      case "user-fields":
+        return {
+          title: i18n("code_login.user_fields_title"),
+          subtitle: i18n("code_login.user_fields_instructions"),
+        };
+      case "complete":
+        return {
+          title: i18n("code_login.account_ready_title"),
+          subtitle: this.usernameEditable
+            ? i18n("code_login.account_ready_edit")
+            : null,
+        };
+      case "second-factor":
+        return { title: i18n("login.second_factor_title"), subtitle: null };
+      default:
+        return { title: i18n("code_login.signup_title"), subtitle: null };
+    }
   }
 
   get continueDisabled() {
@@ -515,6 +549,28 @@ export default class CodeLoginForm extends Component {
 
   <template>
     <div class="code-login-form">
+      {{#if this.heading}}
+        {{! Plugins can replace this via the signup-heading outlet. }}
+        <PluginOutlet
+          @name="signup-heading"
+          @outletArgs={{lazyHash
+            step=this.step
+            context=@context
+            title=this.heading.title
+            subtitle=this.heading.subtitle
+          }}
+        >
+          <WelcomeHeader
+            id="create-account-title"
+            @header={{this.heading.title}}
+          >
+            {{#if this.heading.subtitle}}
+              <p class="login-subheader">{{this.heading.subtitle}}</p>
+            {{/if}}
+          </WelcomeHeader>
+        </PluginOutlet>
+      {{/if}}
+
       {{#if this.isEmailStep}}
         {{#if this.isSignup}}
           <p class="code-login-form__instructions">
@@ -560,12 +616,14 @@ export default class CodeLoginForm extends Component {
         </Form>
       {{else if this.isCodeStep}}
         <div class="code-login-form__code-step">
-          <h2 class="code-login-form__title">
-            {{i18n "code_login.check_your_email"}}
-          </h2>
-          <p class="code-login-form__instructions">
-            {{this.codeInstructions}}
-          </p>
+          {{#unless this.isSignup}}
+            <h2 class="code-login-form__title">
+              {{i18n "code_login.check_your_email"}}
+            </h2>
+            <p class="code-login-form__instructions">
+              {{this.codeInstructions}}
+            </p>
+          {{/unless}}
 
           {{#each this.otpGenerationArray as |generation|}}
             <DOtp
@@ -609,14 +667,16 @@ export default class CodeLoginForm extends Component {
         </div>
       {{else if this.isCompleteStep}}
         <div class="code-login-form__complete-step">
-          <h2 class="code-login-form__title">
-            {{i18n "code_login.account_ready_title"}}
-          </h2>
-          {{#if this.usernameEditable}}
-            <p class="code-login-form__instructions">
-              {{i18n "code_login.account_ready_edit"}}
-            </p>
-          {{/if}}
+          {{#unless this.isSignup}}
+            <h2 class="code-login-form__title">
+              {{i18n "code_login.account_ready_title"}}
+            </h2>
+            {{#if this.usernameEditable}}
+              <p class="code-login-form__instructions">
+                {{i18n "code_login.account_ready_edit"}}
+              </p>
+            {{/if}}
+          {{/unless}}
 
           <div class="code-login-form__new-account">
             <button
@@ -672,12 +732,14 @@ export default class CodeLoginForm extends Component {
         </div>
       {{else if this.isUserFieldsStep}}
         <div class="code-login-form__user-fields-step">
-          <h2 class="code-login-form__title">
-            {{i18n "code_login.user_fields_title"}}
-          </h2>
-          <p class="code-login-form__instructions">
-            {{i18n "code_login.user_fields_instructions"}}
-          </p>
+          {{#unless this.isSignup}}
+            <h2 class="code-login-form__title">
+              {{i18n "code_login.user_fields_title"}}
+            </h2>
+            <p class="code-login-form__instructions">
+              {{i18n "code_login.user_fields_instructions"}}
+            </p>
+          {{/unless}}
 
           <div class="user-fields">
             {{#each this.userFields as |f|}}

--- a/frontend/discourse/app/templates/signup.gjs
+++ b/frontend/discourse/app/templates/signup.gjs
@@ -50,22 +50,28 @@ export default <template>
         }}
       >
         {{#unless @controller.skipConfirmation}}
+          {{! Code signup renders its own heading inside CodeLoginForm. }}
           {{#unless @controller.showCodeSignupForm}}
             <SignupProgressBar @step={{@controller.progressBarStep}} />
-          {{/unless}}
-          <WelcomeHeader
-            id="create-account-title"
-            @header={{if
-              @controller.showCodeSignupForm
-              (i18n "code_login.signup_title")
-              (i18n "create_account.header_title")
-            }}
-          >
             <PluginOutlet
-              @name="create-account-header-bottom"
-              @outletArgs={{lazyHash showLogin=(routeAction "showLogin")}}
-            />
-          </WelcomeHeader>
+              @name="signup-heading"
+              @outletArgs={{lazyHash
+                step="form"
+                context="signup"
+                title=(i18n "create_account.header_title")
+              }}
+            >
+              <WelcomeHeader
+                id="create-account-title"
+                @header={{i18n "create_account.header_title"}}
+              >
+                <PluginOutlet
+                  @name="create-account-header-bottom"
+                  @outletArgs={{lazyHash showLogin=(routeAction "showLogin")}}
+                />
+              </WelcomeHeader>
+            </PluginOutlet>
+          {{/unless}}
         {{/unless}}
         {{#if @controller.showCodeSignupForm}}
           <CodeLoginForm

--- a/frontend/discourse/tests/integration/components/code-login-form-test.gjs
+++ b/frontend/discourse/tests/integration/components/code-login-form-test.gjs
@@ -99,4 +99,41 @@ module("Integration | Component | CodeLoginForm", function (hooks) {
     assert.dom(".code-login-form__email-step").exists();
     assert.form().field("email").hasValue("user@example.com");
   });
+
+  test("signup context shows a single step-aware heading that is replaced, not stacked", async function (assert) {
+    stubCodeRequest();
+
+    await render(<template><CodeLoginForm @context="signup" /></template>);
+
+    assert.dom(".login-welcome-header").exists({ count: 1 });
+    assert.dom(".login-title").hasText(i18n("code_login.signup_title"));
+    assert.dom(".login-subheader").doesNotExist();
+    assert.dom(".code-login-form__title").doesNotExist();
+    assert
+      .dom(".code-login-form__instructions")
+      .hasText(i18n("code_login.signup_instructions"));
+
+    await fillIn(
+      ".code-login-form__email-step .form-kit__control-input",
+      "user@example.com"
+    );
+    await formKit().submit();
+
+    assert.dom(".code-login-form__code-step").exists();
+    assert.dom(".login-welcome-header").exists({ count: 1 });
+    assert.dom(".login-title").hasText(i18n("code_login.check_your_email"));
+    assert.dom(".login-subheader").includesText("user@example.com");
+    assert.dom(".code-login-form__title").doesNotExist();
+  });
+
+  test("login context keeps the inline step heading and adds no page header", async function (assert) {
+    stubCodeRequest();
+
+    await goToCodeStep();
+
+    assert.dom(".login-welcome-header").doesNotExist();
+    assert
+      .dom(".code-login-form__title")
+      .hasText(i18n("code_login.check_your_email"));
+  });
 });

--- a/spec/system/code_signup_spec.rb
+++ b/spec/system/code_signup_spec.rb
@@ -59,6 +59,34 @@ describe "Sign up via email code" do
     expect(user.user_password).to be_nil
   end
 
+  it "shows a single heading that is replaced as the flow advances" do
+    visit("/signup")
+
+    expect(page).to have_css(".code-login-form__email-step")
+    expect(page).to have_css(".login-welcome-header", count: 1)
+    expect(page).to have_css(".login-title", text: I18n.t("js.code_login.signup_title"))
+    expect(page).to have_no_css(".login-subheader")
+    expect(page).to have_no_css(".code-login-form__title")
+    expect(page).to have_css(
+      ".code-login-form__instructions",
+      text: I18n.t("js.code_login.signup_instructions"),
+    )
+
+    submit_email("new.person@example.com")
+
+    expect(page).to have_css(".code-login-form__code-step")
+    expect(page).to have_css(".login-welcome-header", count: 1)
+    expect(page).to have_css(".login-title", text: I18n.t("js.code_login.check_your_email"))
+    expect(page).to have_no_css(".code-login-form__title")
+
+    fill_code(latest_emailed_code("new.person@example.com"))
+
+    expect(page).to have_css(".code-login-form__complete-step")
+    expect(page).to have_css(".login-welcome-header", count: 1)
+    expect(page).to have_css(".login-title", text: I18n.t("js.code_login.account_ready_title"))
+    expect(page).to have_no_css(".code-login-form__title")
+  end
+
   it "blocks continuing while the picked username is taken" do
     Fabricate(:user, username: "takenname")
 


### PR DESCRIPTION
**Previously**, the email code signup flow rendered a static page heading on top of separate per-step titles, and the heading couldn't be customized by plugins.

**In this update**, signup shows one heading that updates with each step (starting with "Create your account") and exposes it through a new `signup-heading` plugin outlet.

## Screenshots

The single heading updates as the flow advances — no stacked titles:

| Email | Code | Custom fields | Account ready |
| --- | --- | --- | --- |
| <img width="230" alt="Email step" src="https://github.com/user-attachments/assets/556d0f73-31be-469b-9df8-c37142d23707" /> | <img width="230" alt="Code step" src="https://github.com/user-attachments/assets/4533d85a-8a2f-45db-89d8-e024ef31a48f" /> | <img width="230" alt="Custom fields step" src="https://github.com/user-attachments/assets/caacfd78-d1ee-4d9b-b877-953e547a179e" /> | <img width="230" alt="Account ready step" src="https://github.com/user-attachments/assets/13365251-5ab5-4243-b686-1185f7c5a7d3" /> |
