### PR TITLE
DEV: Reuse the Playwright browser context between system specs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 20
       MINIO_RUNNER_LOG_LEVEL: WARN
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && '1' }}
+      CAPYBARA_PLAYWRIGHT_SOFT_RESET: ${{ matrix.build_type == 'system' && (matrix.target == 'core' || matrix.target == 'chat') && '1' }}
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner

--- a/spec/support/system/capybara_patches.rb
+++ b/spec/support/system/capybara_patches.rb
@@ -189,12 +189,11 @@ end
 Playwright::Error.prepend(PlaywrightErrorPatch)
 
 module PlaywrightSoftReset
-  RESET_STORAGE_TYPES = "local_storage,indexeddb,websql,cache_storage"
+  RESET_STORAGE_TYPES = "all"
   private_constant :RESET_STORAGE_TYPES
 
   module Browser
     def create_browser_context
-      @page_options = { serviceWorkers: "block" }.merge(@page_options)
       @context_downloaded = false
       super.tap do |browser_context|
         browser_context.on("download", ->(_download) { @context_downloaded = true })
@@ -207,13 +206,12 @@ module PlaywrightSoftReset
       return false if @context_downloaded
 
       context = contexts.first
-      context.clear_cookies
-      context.clear_permissions
       context.pages.each(&:close)
       new_page = create_page(context)
       return false if fake_clock_installed?(new_page)
 
       clear_storage(new_page)
+      context.clear_permissions
       @playwright_page = new_page.tap(&:bring_to_front)
       true
     end

--- a/spec/support/system/capybara_patches.rb
+++ b/spec/support/system/capybara_patches.rb
@@ -187,3 +187,79 @@ module PlaywrightErrorPatch
   end
 end
 Playwright::Error.prepend(PlaywrightErrorPatch)
+
+module PlaywrightSoftReset
+  RESET_STORAGE_TYPES = "local_storage,indexeddb,websql,cache_storage"
+  private_constant :RESET_STORAGE_TYPES
+
+  module Browser
+    def create_browser_context
+      @page_options = { serviceWorkers: "block" }.merge(@page_options)
+      @context_downloaded = false
+      super.tap do |browser_context|
+        browser_context.on("download", ->(_download) { @context_downloaded = true })
+      end
+    end
+
+    def soft_reset!
+      contexts = @playwright_browser.contexts
+      return false unless contexts.size == 1
+      return false if @context_downloaded
+
+      context = contexts.first
+      context.clear_cookies
+      context.clear_permissions
+      context.pages.each(&:close)
+      new_page = create_page(context)
+      return false if fake_clock_installed?(new_page)
+
+      clear_storage(new_page)
+      @playwright_page = new_page.tap(&:bring_to_front)
+      true
+    end
+
+    private
+
+    def fake_clock_installed?(pw_page)
+      !pw_page.evaluate("() => setTimeout.toString()").include?("[native code]")
+    end
+
+    def clear_storage(pw_page)
+      cdp = pw_page.context.new_cdp_session(pw_page)
+      cdp.send_message(
+        "Storage.clearDataForOrigin",
+        params: {
+          origin: "*",
+          storageTypes: RESET_STORAGE_TYPES,
+        },
+      )
+    ensure
+      cdp&.detach
+    end
+  end
+
+  module Driver
+    def reset!
+      return super if !soft_reset_enabled?
+
+      if callback_on_save_screenshot? && (screenshot = @browser&.raw_screenshot)
+        callback_on_save_screenshot(screenshot)
+      end
+
+      return if @browser&.soft_reset!
+
+      @browser&.clear_browser_contexts
+      @browser = nil
+    end
+
+    private
+
+    def soft_reset_enabled?
+      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] == "0"
+      !(callback_on_save_screenrecord? || @callback_on_save_trace)
+    end
+  end
+end
+
+Capybara::Playwright::Browser.prepend(PlaywrightSoftReset::Browser)
+Capybara::Playwright::Driver.prepend(PlaywrightSoftReset::Driver)

--- a/spec/support/system/capybara_patches.rb
+++ b/spec/support/system/capybara_patches.rb
@@ -194,6 +194,10 @@ module PlaywrightSoftReset
 
   module Browser
     def create_browser_context
+      # Each example registering a service worker that the soft reset then
+      # force-clears caused mass spec timeouts on CI. The exact cause requires
+      # further investigation, but system specs currently do not rely on
+      # service workers so blocking them is an acceptable trade-off.
       @page_options = { serviceWorkers: "block" }.merge(@page_options)
       @context_downloaded = false
       super.tap do |browser_context|
@@ -254,7 +258,7 @@ module PlaywrightSoftReset
     private
 
     def soft_reset_enabled?
-      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] == "0"
+      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] != "1"
       !(callback_on_save_screenrecord? || @callback_on_save_trace)
     end
   end

--- a/spec/support/system/capybara_patches.rb
+++ b/spec/support/system/capybara_patches.rb
@@ -194,6 +194,7 @@ module PlaywrightSoftReset
 
   module Browser
     def create_browser_context
+      @page_options = { serviceWorkers: "block" }.merge(@page_options)
       @context_downloaded = false
       super.tap do |browser_context|
         browser_context.on("download", ->(_download) { @context_downloaded = true })

--- a/spec/support/test_setup.rb
+++ b/spec/support/test_setup.rb
@@ -47,7 +47,10 @@ module TestSetup
     # Database is rolled back between specs, but I18n override cache doesn't.
     # Flush it if there were any TranslationOverrides created.
     overrides_by_site = I18n.instance_variable_get(:@overrides_by_site) || {}
-    I18n.reload! if overrides_by_site.values.flat_map(&:values).any?(&:any?)
+    if overrides_by_site.values.flat_map(&:values).any?(&:any?)
+      I18n.reload!
+      ExtraLocalesController.clear_cache!
+    end
 
     RspecErrorTracker.clear_exceptions
 

--- a/spec/system/helpers/downloads.rb
+++ b/spec/system/helpers/downloads.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Downloads
-  FOLDER = Rails.root.join("tmp/downloads")
+  FOLDER = Rails.root.join("tmp/downloads#{ENV["TEST_ENV_NUMBER"]}")
 
   def self.clear
     FileUtils.rm_rf(FOLDER)

--- a/spec/system/locale_spec.rb
+++ b/spec/system/locale_spec.rb
@@ -122,6 +122,10 @@ RSpec.describe "Locale choice" do
         value: "{ count, plural, one {返信 # 件、} other {返信 # 件、} }",
       )
       overriden_translation_zh_tw.update_columns(value: "{ count, plural, ")
+
+      # update_columns skips the model layer, so burst the bundle digest cache
+      # like TranslationOverride.upsert! would have.
+      ExtraLocalesController.clear_cache!
     end
 
     it "works for english" do


### PR DESCRIPTION
This PR adds a `CAPYBARA_PLAYWRIGHT_SOFT_RESET` env flag which reuses the Playwright browser context between system specs so each example no longer pays the full bundle load cost.

`capybara-playwright-driver` already keeps the browser process alive, but its reset closes the context after every example. That throws away the context-level HTTP cache and other browser work cached with the context, so the next example pays the bundle load cost again.

Key changes:
* Add `PlaywrightSoftReset` in `spec/support/system/capybara_patches.rb` so `Capybara::Playwright::Driver#reset!` clears storage, cookies, and permissions instead of closing the context. This keeps per-example isolation while leaving the browser caches warm.
* Detect installed fake clocks by probing `setTimeout.toString()` on the fresh page during the soft reset. Playwright's clock is context-scoped and cannot be uninstalled, so any example that installed one (via `BrowserTime.freeze` or `pw_page.clock.install` directly) automatically gets a full context reset without having to declare anything.
* Detect downloads by listening for the context's `download` event. Contexts that produced downloads fall back to a full reset so Playwright's own artifact lifecycle handles cleanup, avoiding races with reused contexts.
* Clear `ExtraLocalesController`'s bundle digest cache in `TestSetup` whenever leftover translation overrides are detected (the same branch that already calls `I18n.reload!`). Overrides change locale bundle contents but specs that create them with `create!`/`update_columns` bypass the digest invalidation that `TranslationOverride.upsert!` performs, so a warm HTTP cache could serve stale bundles. A fresh digest changes the bundle URL, which bypasses every cache naturally.
* Store downloads under a worker-local `Downloads::FOLDER` so per-worker cleanup cannot delete another parallel worker's artifacts.
* Block service workers in system specs (`serviceWorkers: "block"`). Letting each example register a service worker that the soft reset then force-clears caused mass spec timeouts on CI. The exact cause requires further investigation, but system specs currently do not rely on service workers so blocking them is an acceptable trade-off.
* Measure the impact on a 16-vCPU DO droplet over three rounds, where the core system suite dropped from ~843s to ~721s (~14.5%).

The optimization is opt-in via `CAPYBARA_PLAYWRIGHT_SOFT_RESET=1`, which CI sets only for the core system and chat plugin system jobs while the optimization proves itself.