### PR TITLE
FIX: Use display_name for DAccessList

### DIFF
--- a/app/models/access_control_list.rb
+++ b/app/models/access_control_list.rb
@@ -267,8 +267,7 @@ class AccessControlList < ActiveRecord::Base
             id: group_id,
             mandatory:,
             permission: access_control_list.permission,
-            name: allowed_group.name,
-            full_name: allowed_group.full_name,
+            display_name: allowed_group.full_name.presence || allowed_group.name,
             metadata: {
               auto_group: allowed_group.automatic?,
             },

--- a/frontend/discourse/app/ui-kit/d-access-control.gjs
+++ b/frontend/discourse/app/ui-kit/d-access-control.gjs
@@ -163,8 +163,7 @@ export default class DAccessControl extends Component {
         acl.push({
           type: "group",
           id: entry.id,
-          name: group.name,
-          full_name: group.full_name,
+          display_name: group.full_name || group.name,
           permission: entry.permission,
           metadata: {
             auto_group: group.automatic,
@@ -185,7 +184,7 @@ export default class DAccessControl extends Component {
         key: `${entry.type}-${entry.id}-${entry.permission}`,
         id: entry.id,
         permission: entry.permission,
-        name: entry.full_name,
+        display_name: entry.display_name,
         type: entry.type,
         mandatory: entry.mandatory,
       }))
@@ -194,7 +193,7 @@ export default class DAccessControl extends Component {
           return a.mandatory ? -1 : 1;
         }
 
-        return (a.name || "").localeCompare(b.name || "");
+        return (a.display_name || "").localeCompare(b.display_name || "");
       });
   }
 
@@ -216,8 +215,7 @@ export default class DAccessControl extends Component {
 
     const newPermission = {
       id: selectedGroup.id,
-      name: selectedGroup.name,
-      full_name: selectedGroup.full_name,
+      display_name: selectedGroup.full_name || selectedGroup.name,
       type: "group",
       permission: READ_ONLY_DEFAULT_AUTO_GROUPS.includes(selectedGroup.id)
         ? READ_ONLY_PERMISSION
@@ -296,7 +294,8 @@ export default class DAccessControl extends Component {
                     </:trigger>
                   </DTooltip>
                 {{/if}}
-                {{row.name}}</span>
+                {{row.display_name}}
+              </span>
               <DropdownSelectBox
                 class="d-access-control__permission"
                 @value={{row.permission}}

--- a/frontend/discourse/tests/integration/components/d-access-control-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-access-control-test.gjs
@@ -81,6 +81,11 @@ module("Integration | Component | DAccessControl", function (hooks) {
     assert.strictEqual(added.id, 42, "adds the chosen group");
     assert.strictEqual(added.type, "group", "marks the entry as a group");
     assert.strictEqual(
+      added.display_name,
+      "Team A",
+      "sets the display name from the chosen group"
+    );
+    assert.strictEqual(
       added.permission,
       "edit",
       "applies the default edit permission for a regular group"
@@ -125,8 +130,7 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 999,
         permission: "view",
-        name: "Some Group",
-        full_name: "Some Group",
+        display_name: "Some Group",
       },
     ]);
 
@@ -176,15 +180,13 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 999,
         permission: "view",
-        name: "Some Group",
-        full_name: "Some Group",
+        display_name: "Some Group",
       },
       {
         type: "group",
         id: 1001,
         permission: "edit",
-        name: "Another Group",
-        full_name: "Another Group",
+        display_name: "Another Group",
       },
     ]);
 
@@ -229,15 +231,13 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 999,
         permission: "view",
-        name: "Some Group",
-        full_name: "Some Group",
+        display_name: "Some Group",
       },
       {
         type: "group",
         id: 1001,
         permission: "edit",
-        name: "Another Group",
-        full_name: "Another Group",
+        display_name: "Another Group",
       },
     ]);
 
@@ -272,8 +272,7 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 999,
         permission: "view",
-        name: "Some Group",
-        full_name: "Some Group",
+        display_name: "Some Group",
       },
     ]);
 
@@ -309,8 +308,7 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 999,
         permission: "view",
-        name: "Some Group",
-        full_name: "Some Group",
+        display_name: "Some Group",
       },
     ]);
 
@@ -354,8 +352,7 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 42,
         permission: "view",
-        name: "Team A",
-        full_name: "Team A",
+        display_name: "Team A",
       },
     ]);
 
@@ -403,16 +400,14 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 999,
         permission: "view",
-        name: "Some Group",
-        full_name: "Some Group",
+        display_name: "Some Group",
         mandatory: true,
       },
       {
         type: "group",
         id: 1001,
         permission: "edit",
-        name: "Another Group",
-        full_name: "Another Group",
+        display_name: "Another Group",
       },
     ]);
 
@@ -493,8 +488,7 @@ module("Integration | Component | DAccessControl", function (hooks) {
         type: "group",
         id: 42,
         permission: "view",
-        name: "Team A",
-        full_name: "Team A",
+        display_name: "Team A",
       },
     ]);
 

--- a/spec/models/access_control_list_spec.rb
+++ b/spec/models/access_control_list_spec.rb
@@ -122,12 +122,19 @@ RSpec.describe AccessControlList do
         type: :group,
         id: group.id,
         permission: "view",
-        name: group.name,
-        full_name: group.full_name,
+        display_name: group.full_name || group.name,
         target_type: "Category",
         target_id: target.id,
       )
       expect(view_entry[:metadata]).to eq({ auto_group: false })
+    end
+
+    it "falls back to the group name for display_name" do
+      group.update!(full_name: "")
+
+      entry = described_class.where(target: target, permission: "view").flattened_list.first
+
+      expect(entry[:display_name]).to eq(group.name)
     end
 
     it "emits an entry for every allowed group on an acl" do


### PR DESCRIPTION
When showing groups in the DAccessList component, we need
to fall back to name when full_name is not defined for a group,
so let's call this a single property "display_name", which user
ACLs will use too.

Fixes this:

<img width="616" height="486" alt="image" src="https://github.com/user-attachments/assets/2c5d21d7-3f33-4666-8244-23b94bac57f7" />
