### PR TITLE
FIX: Stabilize deferred topic pageview specs

### DIFF
--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -562,31 +562,40 @@ describe "Request tracking" do
     fab!(:topic)
     fab!(:post) { Fabricate(:post, topic: topic) }
 
+    def browser_pageview_event_for_topic(events:, topic:)
+      events
+        .find do |event|
+          event[:event_name] == :browser_pageview && event[:params].last[:topic_id] == topic.id
+        end
+        &.dig(:params)
+        &.last
+    end
+
     context "when logged in" do
       before { sign_in(current_user) }
 
       it "tracks user viewing a topic correctly with deferred tracking" do
-        events =
-          DiscourseEvent.track_events(:browser_pageview) do
-            visit topic.url
+        event = nil
 
-            try_until_success do
-              CachedCounting.flush
-              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(
-                true,
-              )
-              expect(
-                TopicViewStat.exists?(
-                  topic_id: topic.id,
-                  viewed_at: Time.zone.now.to_date,
-                  anonymous_views: 0,
-                  logged_in_views: 1,
-                ),
-              ).to eq(true)
-            end
+        DiscourseEvent.track_events do |captured_events|
+          visit topic.url
+
+          try_until_success do
+            CachedCounting.flush
+            expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(true)
+            expect(
+              TopicViewStat.exists?(
+                topic_id: topic.id,
+                viewed_at: Time.zone.now.to_date,
+                anonymous_views: 0,
+                logged_in_views: 1,
+              ),
+            ).to eq(true)
+
+            event = browser_pageview_event_for_topic(events: captured_events, topic: topic)
+            expect(event).to be_present
           end
-
-        event = events[0][:params].last
+        end
 
         expect(event[:user_id]).to eq(current_user.id)
         expect(event[:url]).to eq(topic.url)
@@ -634,25 +643,27 @@ describe "Request tracking" do
 
     context "when anonymous" do
       it "tracks an anonymous user viewing a topic correctly with deferred tracking" do
-        events =
-          DiscourseEvent.track_events(:browser_pageview) do
-            visit topic.url
+        event = nil
 
-            try_until_success do
-              CachedCounting.flush
-              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
-              expect(
-                TopicViewStat.exists?(
-                  topic_id: topic.id,
-                  viewed_at: Time.zone.now.to_date,
-                  anonymous_views: 1,
-                  logged_in_views: 0,
-                ),
-              ).to eq(true)
-            end
+        DiscourseEvent.track_events do |captured_events|
+          visit topic.url
+
+          try_until_success do
+            CachedCounting.flush
+            expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
+            expect(
+              TopicViewStat.exists?(
+                topic_id: topic.id,
+                viewed_at: Time.zone.now.to_date,
+                anonymous_views: 1,
+                logged_in_views: 0,
+              ),
+            ).to eq(true)
+
+            event = browser_pageview_event_for_topic(events: captured_events, topic: topic)
+            expect(event).to be_present
           end
-
-        event = events[0][:params].last
+        end
 
         expect(event[:user_id]).to be_blank
         expect(event[:url]).to eq(topic.url)

--- a/spec/system/request_tracker_spec.rb
+++ b/spec/system/request_tracker_spec.rb
@@ -562,40 +562,34 @@ describe "Request tracking" do
     fab!(:topic)
     fab!(:post) { Fabricate(:post, topic: topic) }
 
-    def browser_pageview_event_for_topic(events:, topic:)
-      events
-        .find do |event|
-          event[:event_name] == :browser_pageview && event[:params].last[:topic_id] == topic.id
-        end
-        &.dig(:params)
-        &.last
-    end
-
     context "when logged in" do
       before { sign_in(current_user) }
 
       it "tracks user viewing a topic correctly with deferred tracking" do
-        event = nil
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do |captured_events|
+            visit topic.url
 
-        DiscourseEvent.track_events do |captured_events|
-          visit topic.url
-
-          try_until_success do
-            CachedCounting.flush
-            expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(true)
-            expect(
-              TopicViewStat.exists?(
-                topic_id: topic.id,
-                viewed_at: Time.zone.now.to_date,
-                anonymous_views: 0,
-                logged_in_views: 1,
-              ),
-            ).to eq(true)
-
-            event = browser_pageview_event_for_topic(events: captured_events, topic: topic)
-            expect(event).to be_present
+            try_until_success do
+              CachedCounting.flush
+              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: current_user.id)).to eq(
+                true,
+              )
+              expect(
+                TopicViewStat.exists?(
+                  topic_id: topic.id,
+                  viewed_at: Time.zone.now.to_date,
+                  anonymous_views: 0,
+                  logged_in_views: 1,
+                ),
+              ).to eq(true)
+              expect(
+                captured_events.any? { |event| event[:event_name] == :browser_pageview },
+              ).to eq(true)
+            end
           end
-        end
+
+        event = events[0][:params].last
 
         expect(event[:user_id]).to eq(current_user.id)
         expect(event[:url]).to eq(topic.url)
@@ -643,27 +637,28 @@ describe "Request tracking" do
 
     context "when anonymous" do
       it "tracks an anonymous user viewing a topic correctly with deferred tracking" do
-        event = nil
+        events =
+          DiscourseEvent.track_events(:browser_pageview) do |captured_events|
+            visit topic.url
 
-        DiscourseEvent.track_events do |captured_events|
-          visit topic.url
-
-          try_until_success do
-            CachedCounting.flush
-            expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
-            expect(
-              TopicViewStat.exists?(
-                topic_id: topic.id,
-                viewed_at: Time.zone.now.to_date,
-                anonymous_views: 1,
-                logged_in_views: 0,
-              ),
-            ).to eq(true)
-
-            event = browser_pageview_event_for_topic(events: captured_events, topic: topic)
-            expect(event).to be_present
+            try_until_success do
+              CachedCounting.flush
+              expect(TopicViewItem.exists?(topic_id: topic.id, user_id: nil)).to eq(true)
+              expect(
+                TopicViewStat.exists?(
+                  topic_id: topic.id,
+                  viewed_at: Time.zone.now.to_date,
+                  anonymous_views: 1,
+                  logged_in_views: 0,
+                ),
+              ).to eq(true)
+              expect(
+                captured_events.any? { |event| event[:event_name] == :browser_pageview },
+              ).to eq(true)
+            end
           end
-        end
+
+        event = events[0][:params].last
 
         expect(event[:user_id]).to be_blank
         expect(event[:url]).to eq(topic.url)


### PR DESCRIPTION
This PR stabilizes the deferred topic pageview system specs by waiting for the matching browser pageview event before ending event capture.

The deferred topic-view specs previously waited for `TopicViewItem` and `TopicViewStat` persistence, then read the first captured `:browser_pageview` event after the `DiscourseEvent.track_events` block had already closed. The pageview event is produced by a separate browser tracking request, so the database assertions could pass before the event arrived, leaving the captured events array empty.