### PR TITLE
FIX: Prevent off-by-one date periods for dashboard highlights vs sections

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/connectors/admin-dashboard-highlights-before-kpis/ai-admin-dashboard-highlight.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/connectors/admin-dashboard-highlights-before-kpis/ai-admin-dashboard-highlight.gjs
@@ -14,6 +14,8 @@ export default class AiAdminDashboardHighlight extends Component {
   @tracked loading = true;
   @tracked failed = false;
 
+  loadId = 0;
+
   get queryKey() {
     const { period, startDate, endDate } = this.args.outletArgs;
     return `${period}:${this.formatDate(startDate)}:${this.formatDate(endDate)}`;
@@ -29,6 +31,7 @@ export default class AiAdminDashboardHighlight extends Component {
 
   @action
   async loadHighlight() {
+    const loadId = ++this.loadId;
     this.loading = true;
     this.failed = false;
 
@@ -45,11 +48,19 @@ export default class AiAdminDashboardHighlight extends Component {
           },
         }
       );
+      if (loadId !== this.loadId) {
+        return;
+      }
       this.highlight = result.highlight;
     } catch {
+      if (loadId !== this.loadId) {
+        return;
+      }
       this.failed = true;
     } finally {
-      this.loading = false;
+      if (loadId === this.loadId) {
+        this.loading = false;
+      }
     }
   }
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/connectors/admin-dashboard-highlights-before-kpis/ai-admin-dashboard-highlight.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/connectors/admin-dashboard-highlights-before-kpis/ai-admin-dashboard-highlight.gjs
@@ -16,15 +16,15 @@ export default class AiAdminDashboardHighlight extends Component {
 
   get queryKey() {
     const { period, startDate, endDate } = this.args.outletArgs;
-    return `${period}:${startDate}:${endDate}`;
+    return `${period}:${this.formatDate(startDate)}:${this.formatDate(endDate)}`;
   }
 
-  isoDate(value) {
+  formatDate(value) {
     if (!value) {
       return value;
     }
-    const date = value instanceof Date ? value : new Date(value);
-    return isNaN(date) ? value : date.toISOString().slice(0, 10);
+    const date = moment(value);
+    return date.isValid() ? date.format("YYYY-MM-DD") : value;
   }
 
   @action
@@ -40,8 +40,8 @@ export default class AiAdminDashboardHighlight extends Component {
         {
           data: {
             period,
-            start_date: this.isoDate(startDate),
-            end_date: this.isoDate(endDate),
+            start_date: this.formatDate(startDate),
+            end_date: this.formatDate(endDate),
           },
         }
       );

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-admin-dashboard-highlight-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-admin-dashboard-highlight-test.gjs
@@ -41,6 +41,50 @@ module("Integration | Component | AiAdminDashboardHighlight", function (hooks) {
       .hasAttribute("aria-live", "polite", "it announces the loaded highlight");
   });
 
+  test("requests highlights for the same local dates as the dashboard sections", async function (assert) {
+    const outletArgs = {
+      period: "custom",
+      startDate: moment.parseZone("2026-05-01T00:00:00-04:00"),
+      endDate: moment.parseZone("2026-05-31T23:59:59-04:00"),
+      kpis: [],
+    };
+
+    pretender.get(
+      "/admin/plugins/discourse-ai/admin-dashboard-highlights.json",
+      (request) => {
+        assert.strictEqual(
+          request.queryParams.start_date,
+          "2026-05-01",
+          "it preserves the selected start date"
+        );
+        assert.strictEqual(
+          request.queryParams.end_date,
+          "2026-05-31",
+          "it preserves the selected end date"
+        );
+
+        return [
+          200,
+          { "Content-Type": "application/json" },
+          { highlight: "May stayed aligned with the KPI tiles." },
+        ];
+      }
+    );
+
+    await render(
+      <template>
+        <AiAdminDashboardHighlight @outletArgs={{outletArgs}} />
+      </template>
+    );
+
+    assert
+      .dom(".ai-admin-dashboard-highlight__text")
+      .hasText(
+        "May stayed aligned with the KPI tiles.",
+        "it renders the returned highlight"
+      );
+  });
+
   test("renders nothing when the endpoint fails", async function (assert) {
     pretender.get(
       "/admin/plugins/discourse-ai/admin-dashboard-highlights.json",


### PR DESCRIPTION
The AI dashboard highlight is loaded separately from the dashboard KPI sections. When the dashboard first loads the default 30d range, the plugin starts generating a 30d highlight. If the user quickly switches to another range, the newer request can finish first, then the original 30d request can overwrite it. This can leave the AI highlight describing a different period than the KPI tiles below it.

The connector also now formats `start_date` and `end_date` the same way as the dashboard section request, so both requests use the same selected calendar range.