### PR TITLE
FIX: match core report chart colors with Data Explorer

### DIFF
--- a/frontend/discourse/admin/components/admin-report-chart.gjs
+++ b/frontend/discourse/admin/components/admin-report-chart.gjs
@@ -55,11 +55,14 @@ export default class AdminReportChart extends Component {
     );
 
     const incompleteColor = getCSSColor("--primary-medium");
-    let pointColors = model.primary_color;
+    const tertiaryRgb = getCSSColor("--tertiary-rgb");
+    const primaryColor = `rgb(${tertiaryRgb})`;
+    const secondaryColor = `rgba(${tertiaryRgb}, 0.1)`;
+    let pointColors = primaryColor;
     let segment;
 
     if (isLastPointInCurrentPeriod) {
-      pointColors = Array(chartData.length).fill(model.primary_color);
+      pointColors = Array(chartData.length).fill(primaryColor);
       pointColors[lastDataPointIndex] = incompleteColor;
 
       const isIncompleteSegment = (ctx) =>
@@ -67,7 +70,7 @@ export default class AdminReportChart extends Component {
       segment = {
         borderDash: (ctx) => (isIncompleteSegment(ctx) ? DOTTED_LINE : []),
         borderColor: (ctx) =>
-          isIncompleteSegment(ctx) ? incompleteColor : model.primary_color,
+          isIncompleteSegment(ctx) ? incompleteColor : primaryColor,
       };
     }
 
@@ -78,8 +81,8 @@ export default class AdminReportChart extends Component {
           data: chartData.map((d) => Math.round(parseFloat(d.y))),
           backgroundColor: prevChartData.length
             ? "transparent"
-            : model.secondary_color,
-          borderColor: model.primary_color,
+            : secondaryColor,
+          borderColor: primaryColor,
           pointRadius: 3,
           borderWidth: 2,
           pointBackgroundColor: pointColors,
@@ -97,7 +100,7 @@ export default class AdminReportChart extends Component {
     if (prevChartData.length) {
       data.datasets.push({
         data: prevChartData.map((d) => Math.round(parseFloat(d.y))),
-        borderColor: model.primary_color,
+        borderColor: primaryColor,
         borderDash: DOTTED_LINE,
         backgroundColor: "transparent",
         borderWidth: 1,


### PR DESCRIPTION
Core report charts read their line color from a value computed server-side, while Data Explorer charts read it from the live theme. The two could differ when using a custom color palette. Core charts now read the color from the active theme so both render the same.

Before:

<img width=700 src="https://github.com/user-attachments/assets/db38aa35-9cee-4fce-a30a-5e3ff489441c" />

After:

<img width=700 src="https://github.com/user-attachments/assets/6d31828a-194c-4c01-8146-6d47b239cb0d" />
