### PR TITLE
DEV: Remove `queryAll` uses in core tests

### DIFF
--- a/frontend/discourse/tests/acceptance/admin-penalize-user-test.js
+++ b/frontend/discourse/tests/acceptance/admin-penalize-user-test.js
@@ -1,10 +1,9 @@
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, fillIn, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
   fakeTime,
   loggedInUser,
-  queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
@@ -113,9 +112,9 @@ acceptance("Admin - Suspend User - timeframe choosing", function (needs) {
     await click(".suspend-user");
     await click(".future-date-input-selector-header");
 
-    const options = Array.from(
-      queryAll(`ul.select-kit-collection li span.name`)
-    ).map((el) => el.innerText.trim());
+    const options = findAll(`ul.select-kit-collection li span.name`).map((el) =>
+      el.innerText.trim()
+    );
 
     const expected = [
       i18n("time_shortcut.later_today"),
@@ -155,10 +154,8 @@ acceptance("Admin - Silence User", function (needs) {
     await click(".silence-user");
     await click(".future-date-input-selector-header");
 
-    const options = Array.from(
-      queryAll(`ul.select-kit-collection li span.name`).map((_, x) =>
-        x.innerText.trim()
-      )
+    const options = findAll(`ul.select-kit-collection li span.name`).map((x) =>
+      x.innerText.trim()
     );
 
     const expected = [

--- a/frontend/discourse/tests/acceptance/admin-watched-words-test.js
+++ b/frontend/discourse/tests/acceptance/admin-watched-words-test.js
@@ -1,6 +1,12 @@
-import { click, fillIn, triggerKeyEvent, visit } from "@ember/test-helpers";
+import {
+  click,
+  fillIn,
+  findAll,
+  triggerKeyEvent,
+  visit,
+} from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 acceptance("Admin - Watched Words", function (needs) {
@@ -66,7 +72,7 @@ acceptance("Admin - Watched Words", function (needs) {
 
     await click(".watched-word-form .btn-primary");
 
-    const words = [...queryAll(".watched-words-list .watched-word span")].map(
+    const words = findAll(".watched-words-list .watched-word span").map(
       (elem) => elem.innerText.trim()
     );
 

--- a/frontend/discourse/tests/acceptance/composer-editor-mentions-test.js
+++ b/frontend/discourse/tests/acceptance/composer-editor-mentions-test.js
@@ -1,4 +1,4 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import { setCaretPosition } from "discourse/lib/utilities";
@@ -7,7 +7,6 @@ import {
   acceptance,
   fakeTime,
   loggedInUser,
-  queryAll,
   simulateKeys,
 } from "discourse/tests/helpers/qunit-helpers";
 
@@ -132,14 +131,14 @@ acceptance("Composer - editor mentions", function (needs) {
     await simulateKeys(".d-editor-input", "abc @u");
 
     assert.deepEqual(
-      [...queryAll(".ac-user .username")].map((e) => e.innerText),
+      findAll(".ac-user .username").map((e) => e.innerText),
       ["user", "user2", "user_group", "johndoe", "foo"]
     );
 
     await simulateKeys(".d-editor-input", "\bf");
 
     assert.deepEqual(
-      [...queryAll(".ac-user .username")].map((e) => e.innerText),
+      findAll(".ac-user .username").map((e) => e.innerText),
       ["foo", "user", "user2", "johndoe"]
     );
   });

--- a/frontend/discourse/tests/acceptance/do-not-disturb-test.js
+++ b/frontend/discourse/tests/acceptance/do-not-disturb-test.js
@@ -1,9 +1,8 @@
-import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
+import { click, findAll, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import DoNotDisturb from "discourse/lib/do-not-disturb";
 import {
   acceptance,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 
@@ -30,8 +29,10 @@ acceptance("Do not disturb", function (needs) {
 
     assert.dom(".do-not-disturb-modal").exists("modal to choose time appears");
 
-    let tiles = queryAll(".do-not-disturb-tile");
-    assert.strictEqual(tiles.length, 4, "There are 4 duration choices");
+    let tiles = findAll(".do-not-disturb-tile");
+    assert
+      .dom(".do-not-disturb-tile")
+      .exists({ count: 4 }, "There are 4 duration choices");
 
     await click(tiles[0]);
 

--- a/frontend/discourse/tests/acceptance/edit-notification-click-test.js
+++ b/frontend/discourse/tests/acceptance/edit-notification-click-test.js
@@ -1,8 +1,8 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 const revisionResponse = {
   created_at: "2021-07-30T11:19:59.549Z",
@@ -53,7 +53,7 @@ acceptance(
       await visit("/");
       await click(".header-dropdown-toggle.current-user button");
       await click(".notification.edited a");
-      const [v1, v2] = queryAll(".history-modal .revision-content");
+      const [v1, v2] = findAll(".history-modal .revision-content");
 
       assert
         .dom(v1)

--- a/frontend/discourse/tests/acceptance/group-index-test.js
+++ b/frontend/discourse/tests/acceptance/group-index-test.js
@@ -1,8 +1,14 @@
-import { click, currentURL, settled, visit } from "@ember/test-helpers";
+import {
+  click,
+  currentURL,
+  find,
+  findAll,
+  settled,
+  visit,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -70,8 +76,8 @@ acceptance("Group Members", function (needs) {
 
     await click("button.bulk-select");
 
-    await click(queryAll("input.bulk-select")[0]);
-    await click(queryAll("input.bulk-select")[1]);
+    await click(find("input.bulk-select"));
+    await click(findAll("input.bulk-select")[1]);
 
     const memberDropdown = selectKit(".bulk-group-member-dropdown");
     await memberDropdown.expand();
@@ -96,8 +102,8 @@ acceptance("Group Members", function (needs) {
 
     await click("button.bulk-select");
 
-    await click(queryAll("input.bulk-select")[0]);
-    await click(queryAll("input.bulk-select")[1]);
+    await click(find("input.bulk-select"));
+    await click(findAll("input.bulk-select")[1]);
 
     const memberDropdown = selectKit(".bulk-group-member-dropdown");
     await memberDropdown.expand();

--- a/frontend/discourse/tests/acceptance/post-controls-test.js
+++ b/frontend/discourse/tests/acceptance/post-controls-test.js
@@ -38,7 +38,6 @@ acceptance(`Post controls`, function (needs) {
       .dom("#post_1 button.show-replies")
       .hasAria("pressed", "true", "show replies button is now pressed");
 
-    // const replies = Array.from(queryAll("#post_1 .embedded-posts .reply"));
     assert
       .dom("#post_1 .embedded-posts .reply")
       .exists({ count: 1 }, "replies are rendered");

--- a/frontend/discourse/tests/acceptance/search-test.js
+++ b/frontend/discourse/tests/acceptance/search-test.js
@@ -2,6 +2,7 @@ import {
   click,
   currentURL,
   fillIn,
+  findAll,
   focus,
   triggerEvent,
   triggerKeyEvent,
@@ -12,7 +13,7 @@ import { DEFAULT_TYPE_FILTER } from "discourse/components/search-menu";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import searchFixtures from "discourse/tests/fixtures/search-fixtures";
 import pretender from "discourse/tests/helpers/create-pretender";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
@@ -182,7 +183,7 @@ acceptance("Search - Anonymous", function (needs) {
       .hasText("important", "first option includes tag");
 
     await fillIn("#icon-search-input", "smth");
-    const secondOption = queryAll(contextSelector)[1];
+    const secondOption = findAll(contextSelector)[1];
 
     assert
       .dom(".search-item-prefix", secondOption)
@@ -202,7 +203,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/c/bug");
     await click("#search-button");
     await fillIn("#icon-search-input", "smth");
-    const secondOption = queryAll(contextSelector)[1];
+    const secondOption = findAll(contextSelector)[1];
 
     assert
       .dom(".search-item-prefix", secondOption)
@@ -226,7 +227,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/t/internationalization-localization/280");
     await click("#search-button");
     await fillIn("#icon-search-input", "smth");
-    const secondOption = queryAll(contextSelector)[1];
+    const secondOption = findAll(contextSelector)[1];
 
     assert
       .dom(".search-item-prefix", secondOption)
@@ -314,7 +315,7 @@ acceptance("Search - Anonymous", function (needs) {
     await visit("/u/eviltrout");
     await click("#search-button");
     await fillIn("#icon-search-input", "smth");
-    const secondOption = queryAll(contextSelector)[1];
+    const secondOption = findAll(contextSelector)[1];
 
     assert
       .dom(".search-item-prefix", secondOption)

--- a/frontend/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-anonymous-categories-section-test.js
@@ -1,8 +1,8 @@
-import { visit } from "@ember/test-helpers";
+import { findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import Site from "discourse/models/site";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Sidebar - Anonymous - Categories Section", function (needs) {
   needs.settings({
@@ -14,7 +14,7 @@ acceptance("Sidebar - Anonymous - Categories Section", function (needs) {
 
     await visit("/");
 
-    const categorySectionLinks = queryAll(
+    const categorySectionLinks = findAll(
       ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper"
     );
 
@@ -39,7 +39,7 @@ acceptance("Sidebar - Anonymous - Categories Section", function (needs) {
 
     await visit("/");
 
-    const categories = queryAll(
+    const categories = findAll(
       ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper"
     );
 
@@ -63,7 +63,7 @@ acceptance("Sidebar - Anonymous - Categories Section", function (needs) {
 
     await visit("/");
 
-    const categories = queryAll(
+    const categories = findAll(
       ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper"
     );
 

--- a/frontend/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-anonymous-community-section-test.js
@@ -1,6 +1,6 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
@@ -43,7 +43,7 @@ acceptance("Sidebar - Anonymous user - Community Section", function (needs) {
       ".sidebar-section[data-section-name='community'] .sidebar-more-section-trigger"
     );
 
-    const sectionLinks = queryAll(
+    const sectionLinks = findAll(
       ".sidebar-more-section-content .sidebar-section-link"
     );
 

--- a/frontend/discourse/tests/acceptance/sidebar-user-categories-section-test.js
+++ b/frontend/discourse/tests/acceptance/sidebar-user-categories-section-test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { TOP_SITE_CATEGORIES_TO_SHOW } from "discourse/components/sidebar/common/categories-section";
 import { NotificationLevels } from "discourse/lib/notification-levels";
@@ -9,7 +9,6 @@ import discoveryFixture from "discourse/tests/fixtures/discovery-fixtures";
 import {
   acceptance,
   publishToMessageBus,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -152,15 +151,14 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
       .dom(".sidebar-section[data-section-name='categories']")
       .exists("categories section is shown");
 
-    const categorySectionLinks = queryAll(
-      ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id]"
-    );
-
-    assert.strictEqual(
-      categorySectionLinks.length,
-      TOP_SITE_CATEGORIES_TO_SHOW,
-      "the right number of category section links are shown"
-    );
+    assert
+      .dom(
+        ".sidebar-section[data-section-name='categories'] .sidebar-section-link-wrapper[data-category-id]"
+      )
+      .exists(
+        { count: TOP_SITE_CATEGORIES_TO_SHOW },
+        "the right number of category section links are shown"
+      );
 
     const topCategories = Site.current().categoriesByCount.splice(
       0,
@@ -245,11 +243,11 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     await visit("/");
 
-    const categorySectionLinks = queryAll(
+    const categorySectionLinks = findAll(
       ".sidebar-section[data-section-name='categories'] .sidebar-section-link:not(.sidebar-section-link[data-link-name='all-categories'])"
     );
 
-    const categoryNames = [...categorySectionLinks].map((categorySectionLink) =>
+    const categoryNames = categorySectionLinks.map((categorySectionLink) =>
       categorySectionLink.textContent.trim()
     );
 
@@ -317,11 +315,11 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     await visit("/");
 
-    const categorySectionLinks = queryAll(
+    const categorySectionLinks = findAll(
       ".sidebar-section[data-section-name='categories'] .sidebar-section-link:not(.sidebar-section-link[data-link-name='all-categories'])"
     );
 
-    const categoryNames = [...categorySectionLinks].map((categorySectionLink) =>
+    const categoryNames = categorySectionLinks.map((categorySectionLink) =>
       categorySectionLink.textContent.trim()
     );
 
@@ -389,11 +387,11 @@ acceptance("Sidebar - Logged on user - Categories Section", function (needs) {
 
     await visit("/");
 
-    const categorySectionLinks = queryAll(
+    const categorySectionLinks = findAll(
       ".sidebar-section[data-section-name='categories'] .sidebar-section-link:not(.sidebar-section-link[data-link-name='all-categories'])"
     );
 
-    const categoryNames = [...categorySectionLinks].map((categorySectionLink) =>
+    const categoryNames = categorySectionLinks.map((categorySectionLink) =>
       categorySectionLink.textContent.trim()
     );
 

--- a/frontend/discourse/tests/acceptance/tags-test.js
+++ b/frontend/discourse/tests/acceptance/tags-test.js
@@ -1,10 +1,9 @@
-import { click, currentURL, visit } from "@ember/test-helpers";
+import { click, currentURL, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import formKit from "discourse/tests/helpers/form-kit-helper";
 import {
   acceptance,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
@@ -207,12 +206,12 @@ acceptance("Tags listed by group", function (needs) {
         "shows separate lists for the 3 groups and the ungrouped tags"
       );
     assert.deepEqual(
-      [...queryAll(".tag-list h3")].map((el) => el.innerText),
+      findAll(".tag-list h3").map((el) => el.innerText),
       ["Ford Cars", "Honda Cars", "Makes", "Other Tags"],
       "shown in given order and with tags that are not in a group"
     );
     assert.deepEqual(
-      [...queryAll(".tag-list:nth-of-type(1) .discourse-tag")].map(
+      findAll(".tag-list:nth-of-type(1) .discourse-tag").map(
         (el) => el.innerText
       ),
       ["focus", "Escort"],
@@ -247,7 +246,7 @@ acceptance("Tags listed by group", function (needs) {
       .dom(".tag-sort-name")
       .doesNotHaveClass("active", "sort by name is not active");
     assert.deepEqual(
-      [...queryAll(".tag-list:nth-of-type(1) .discourse-tag")].map(
+      findAll(".tag-list:nth-of-type(1) .discourse-tag").map(
         (el) => el.innerText
       ),
       ["focus", "Escort"],
@@ -261,7 +260,7 @@ acceptance("Tags listed by group", function (needs) {
       .doesNotHaveClass("active", "sort by count is no longer active");
     assert.dom(".tag-sort-name").hasClass("active", "sort by name is active");
     assert.deepEqual(
-      [...queryAll(".tag-list:nth-of-type(1) .discourse-tag")].map(
+      findAll(".tag-list:nth-of-type(1) .discourse-tag").map(
         (el) => el.innerText
       ),
       ["Escort", "focus"],
@@ -275,7 +274,7 @@ acceptance("Tags listed by group", function (needs) {
       .dom(".tag-sort-name")
       .doesNotHaveClass("active", "sort by name is not active");
     assert.deepEqual(
-      [...queryAll(".tag-list:nth-of-type(1) .discourse-tag")].map(
+      findAll(".tag-list:nth-of-type(1) .discourse-tag").map(
         (el) => el.innerText
       ),
       ["focus", "Escort"],
@@ -319,7 +318,7 @@ acceptance("Tags sorted alphabetically by default", function (needs) {
       .dom(".tag-sort-count")
       .doesNotHaveClass("active", "sort by count is not active");
     assert.deepEqual(
-      [...queryAll(".tag-list:nth-of-type(1) .discourse-tag")].map(
+      findAll(".tag-list:nth-of-type(1) .discourse-tag").map(
         (el) => el.innerText
       ),
       ["Escort", "focus"],

--- a/frontend/discourse/tests/acceptance/topic-edit-timer-test.js
+++ b/frontend/discourse/tests/acceptance/topic-edit-timer-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, select, visit } from "@ember/test-helpers";
+import { click, fillIn, findAll, select, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import topicFixtures from "discourse/tests/fixtures/topic";
@@ -6,7 +6,6 @@ import {
   acceptance,
   fakeTime,
   loggedInUser,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
@@ -361,7 +360,7 @@ acceptance("Topic - Edit timer", function (needs) {
     await click(".admin-topic-timer-update button");
 
     assert.deepEqual(
-      [...queryAll("div.tap-tile-grid div.tap-tile-title")].map((el) =>
+      findAll("div.tap-tile-grid div.tap-tile-title").map((el) =>
         el.innerText.trim()
       ),
       [

--- a/frontend/discourse/tests/acceptance/topic-set-slow-mode-test.js
+++ b/frontend/discourse/tests/acceptance/topic-set-slow-mode-test.js
@@ -1,10 +1,9 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
   fakeTime,
   loggedInUser,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
@@ -45,10 +44,8 @@ acceptance("Topic - Set Slow Mode", function (needs) {
 
     await click(".future-date-input-selector-header");
 
-    const options = Array.from(
-      queryAll(`ul.select-kit-collection li span.name`).map((_, x) =>
-        x.innerText.trim()
-      )
+    const options = findAll(`ul.select-kit-collection li span.name`).map((x) =>
+      x.innerText.trim()
     );
 
     const expected = [

--- a/frontend/discourse/tests/acceptance/user-activity-read-test.js
+++ b/frontend/discourse/tests/acceptance/user-activity-read-test.js
@@ -1,7 +1,7 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, find, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import userFixtures from "../fixtures/user-fixtures";
-import { acceptance, queryAll } from "../helpers/qunit-helpers";
+import { acceptance } from "../helpers/qunit-helpers";
 
 acceptance("User Activity / Read - bulk actions", function (needs) {
   needs.user();
@@ -20,8 +20,8 @@ acceptance("User Activity / Read - bulk actions", function (needs) {
     await visit("/u/charlie/activity/read");
 
     await click("button.bulk-select");
-    await click(queryAll("input.bulk-select")[0]);
-    await click(queryAll("input.bulk-select")[1]);
+    await click(find("input.bulk-select"));
+    await click(findAll("input.bulk-select")[1]);
     await click(".bulk-select-topics-dropdown-trigger");
     await click(".dropdown-menu__item .close-topics");
 

--- a/frontend/discourse/tests/acceptance/user-activity-topic-test.js
+++ b/frontend/discourse/tests/acceptance/user-activity-topic-test.js
@@ -1,8 +1,8 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, find, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { i18n } from "discourse-i18n";
 import userFixtures from "../fixtures/user-fixtures";
-import { acceptance, queryAll } from "../helpers/qunit-helpers";
+import { acceptance } from "../helpers/qunit-helpers";
 
 acceptance("User Activity / Topics - bulk actions", function (needs) {
   const currentUser = "eviltrout";
@@ -24,8 +24,8 @@ acceptance("User Activity / Topics - bulk actions", function (needs) {
     await visit(`/u/${currentUser}/activity/topics`);
 
     await click("button.bulk-select");
-    await click(queryAll("input.bulk-select")[0]);
-    await click(queryAll("input.bulk-select")[1]);
+    await click(find("input.bulk-select"));
+    await click(findAll("input.bulk-select")[1]);
     await click(".bulk-select-topics-dropdown-trigger");
     await click(".dropdown-menu__item .close-topics");
 

--- a/frontend/discourse/tests/acceptance/user-bookmark-bulk-actions-test.js
+++ b/frontend/discourse/tests/acceptance/user-bookmark-bulk-actions-test.js
@@ -1,6 +1,6 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, find, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
@@ -13,8 +13,8 @@ acceptance("Bookmark - Bulk Actions", function (needs) {
 
     await click("button.bulk-select");
 
-    await click(queryAll("input.bulk-select")[0]);
-    await click(queryAll("input.bulk-select")[1]);
+    await click(find("input.bulk-select"));
+    await click(findAll("input.bulk-select")[1]);
 
     const dropdown = selectKit(".select-kit.bulk-select-bookmarks-dropdown");
     await dropdown.expand();

--- a/frontend/discourse/tests/acceptance/user-menu-test.js
+++ b/frontend/discourse/tests/acceptance/user-menu-test.js
@@ -4,6 +4,7 @@ import {
   click,
   currentRouteName,
   currentURL,
+  findAll,
   triggerEvent,
   triggerKeyEvent,
   visit,
@@ -20,7 +21,6 @@ import {
   acceptance,
   loggedInUser,
   publishToMessageBus,
-  queryAll,
   updateCurrentUser,
 } from "discourse/tests/helpers/qunit-helpers";
 import DButton from "discourse/ui-kit/d-button";
@@ -281,7 +281,7 @@ acceptance("User menu", function (needs) {
       .dom("#user-menu-button-custom-tab-2")
       .exists("second custom tab is rendered");
 
-    const tabs = [...queryAll(".tabs-list.top-tabs .btn")];
+    const tabs = findAll(".tabs-list.top-tabs .btn");
 
     assert.deepEqual(
       tabs.reduce((acc, tab) => {
@@ -343,7 +343,7 @@ acceptance("User menu", function (needs) {
     await visit("/");
     await click(".d-header-icons .current-user button");
 
-    const notifications = queryAll(
+    const notifications = findAll(
       "#quick-access-all-notifications ul li.notification"
     );
     assert

--- a/frontend/discourse/tests/acceptance/user-preferences-notifications-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-notifications-test.js
@@ -1,10 +1,9 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import {
   acceptance,
   fakeTime,
   loggedInUser,
-  queryAll,
 } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
@@ -125,10 +124,8 @@ acceptance("User Notifications - Users - Ignore User", function (needs) {
     await click("div.user-notifications div div button");
     await click(".future-date-input-selector-header");
 
-    const options = Array.from(
-      queryAll(`ul.select-kit-collection li span.name`).map((_, x) =>
-        x.innerText.trim()
-      )
+    const options = findAll(`ul.select-kit-collection li span.name`).map((x) =>
+      x.innerText.trim()
     );
 
     const expected = [

--- a/frontend/discourse/tests/acceptance/users-test.js
+++ b/frontend/discourse/tests/acceptance/users-test.js
@@ -1,9 +1,9 @@
-import { click, triggerKeyEvent, visit } from "@ember/test-helpers";
+import { click, findAll, triggerKeyEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import directoryFixtures from "discourse/tests/fixtures/directory-fixtures";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 acceptance("User Directory", function () {
@@ -201,24 +201,25 @@ acceptance("User directory - Editing columns", function (needs) {
     await visit("/u");
     await click(".open-edit-columns-btn");
 
-    const columns = queryAll(
-      ".edit-directory-columns-container .edit-directory-column"
-    );
-    assert.strictEqual(columns.length, 9);
+    assert
+      .dom(".edit-directory-columns-container .edit-directory-column")
+      .exists({ count: 9 });
 
-    const checked = queryAll(
-      ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:checked"
-    );
-    assert.strictEqual(checked.length, 7);
+    assert
+      .dom(
+        ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:checked"
+      )
+      .exists({ count: 7 });
 
-    const unchecked = queryAll(
-      ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:not(:checked)"
-    );
-    assert.strictEqual(unchecked.length, 2);
+    assert
+      .dom(
+        ".edit-directory-columns-container .edit-directory-column input[type='checkbox']:not(:checked)"
+      )
+      .exists({ count: 2 });
   });
 
   const fetchColumns = function () {
-    return queryAll(".edit-directory-columns-container .edit-directory-column");
+    return findAll(".edit-directory-columns-container .edit-directory-column");
   };
 
   test("Reordering and restoring default positions", async function (assert) {
@@ -251,9 +252,9 @@ acceptance("User directory - Editing columns", function (needs) {
     // Now click restore default and check order of column names
     await click(".reset-to-default");
 
-    let columnNames = queryAll(
+    let columnNames = findAll(
       ".edit-directory-columns-container .edit-directory-column .column-name"
-    ).toArray();
+    );
     columnNames = columnNames.map((el) => el.textContent.trim());
     assert.deepEqual(columnNames, [
       "Received",

--- a/frontend/discourse/tests/helpers/select-kit-helper.js
+++ b/frontend/discourse/tests/helpers/select-kit-helper.js
@@ -1,8 +1,8 @@
 /* eslint-disable ember/no-jquery */
-import { click, fillIn, triggerEvent } from "@ember/test-helpers";
+import { click, fillIn, findAll, triggerEvent } from "@ember/test-helpers";
 import { isEmpty } from "@ember/utils";
 import $ from "jquery";
-import { exists, query, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 
 function checkSelectKitIsNotExpanded(selector) {
   if (query(selector).classList.contains("is-expanded")) {
@@ -58,7 +58,7 @@ async function selectKitSelectNoneRow(selector) {
 
 async function selectKitSelectRowByIndex(index, selector) {
   checkSelectKitIsNotCollapsed(selector);
-  await click(queryAll(`${selector} .select-kit-row`)[index]);
+  await click(findAll(`${selector} .select-kit-row`)[index]);
 }
 
 async function keyboardHelper(value, target, selector) {
@@ -317,7 +317,7 @@ export default function selectKit(selector) {
 
     async deselectItemByIndex(index) {
       await click(
-        queryAll(`${selector} .selected-content .selected-choice`)[index]
+        findAll(`${selector} .selected-content .selected-choice`)[index]
       );
     },
 

--- a/frontend/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-schema-setting/editor-test.gjs
@@ -1,4 +1,4 @@
-import { click, fillIn, render } from "@ember/test-helpers";
+import { click, fillIn, findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import AdminSchemaSettingEditor from "discourse/admin/components/schema-setting/editor";
 import SiteSetting from "discourse/admin/models/site-setting";
@@ -8,7 +8,6 @@ import schemaAndData, {
   SCHEMA_MODES,
 } from "discourse/tests/fixtures/theme-setting-schema-data";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
@@ -18,19 +17,15 @@ class TreeFromDOM {
   }
 
   refresh() {
-    this.nodes = [
-      ...queryAll(
-        ".schema-setting-editor__tree .schema-setting-editor__tree-node.--parent"
-      ),
-    ].map((container, index) => {
+    this.nodes = findAll(
+      ".schema-setting-editor__tree .schema-setting-editor__tree-node.--parent"
+    ).map((container, index) => {
       const li = container;
       const active = li.classList.contains("--active");
 
-      const children = [
-        ...queryAll(
-          `.schema-setting-editor__tree-node.--child[data-test-parent-index="${index}"]`
-        ),
-      ].map((child) => {
+      const children = findAll(
+        `.schema-setting-editor__tree-node.--child[data-test-parent-index="${index}"]`
+      ).map((child) => {
         return {
           element: child,
           textElement: child.querySelector(
@@ -39,11 +34,9 @@ class TreeFromDOM {
         };
       });
 
-      const addButtons = [
-        ...queryAll(
-          `.schema-setting-editor__tree-add-button.--child[data-test-parent-index="${index}"]`
-        ),
-      ];
+      const addButtons = findAll(
+        `.schema-setting-editor__tree-add-button.--child[data-test-parent-index="${index}"]`
+      );
 
       return {
         active,
@@ -65,7 +58,7 @@ class InputFieldsFromDOM {
     this.fields = {};
     this.count = 0;
 
-    [...queryAll(".schema-field")].forEach((field) => {
+    findAll(".schema-field").forEach((field) => {
       this.count += 1;
 
       this.fields[field.dataset.name] = {

--- a/frontend/discourse/tests/integration/components/form-template-field/dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/dropdown-test.gjs
@@ -1,9 +1,8 @@
-import { render } from "@ember/test-helpers";
+import { findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Dropdown from "discourse/components/form-template-field/dropdown";
 import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
@@ -28,7 +27,7 @@ module(
         .dom(".form-template-field__dropdown")
         .exists("a dropdown component exists");
 
-      const dropdown = queryAll(
+      const dropdown = findAll(
         ".form-template-field__dropdown option:not(.form-template-field__dropdown-placeholder)"
       );
       assert.strictEqual(dropdown.length, 3, "it has 3 choices");

--- a/frontend/discourse/tests/integration/components/form-template-field/multi-select-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/multi-select-test.gjs
@@ -1,9 +1,8 @@
-import { render } from "@ember/test-helpers";
+import { findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import MultiSelect from "discourse/components/form-template-field/multi-select";
 import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 module(
@@ -29,7 +28,7 @@ module(
         .dom(".form-template-field__multi-select")
         .exists("a multiselect component exists");
 
-      const dropdown = queryAll(
+      const dropdown = findAll(
         ".form-template-field__multi-select option:not(.form-template-field__multi-select-placeholder)"
       );
       assert.strictEqual(dropdown.length, 3, "it has 3 choices");

--- a/frontend/discourse/tests/integration/components/post/post-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/post-test.gjs
@@ -1,5 +1,11 @@
 import { getOwner } from "@ember/owner";
-import { click, render, settled, triggerEvent } from "@ember/test-helpers";
+import {
+  click,
+  find,
+  render,
+  settled,
+  triggerEvent,
+} from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
 import { module, test } from "qunit";
 import Post from "discourse/components/post";
@@ -8,7 +14,6 @@ import { forceMobile, resetMobile } from "discourse/lib/mobile";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { registerTemporaryModule } from "discourse/tests/helpers/temporary-module-helper";
 import { i18n } from "discourse-i18n";
 
@@ -151,11 +156,11 @@ module("Integration | Component | Post", function (hooks) {
     await renderComponent(this.post);
 
     assert.strictEqual(
-      queryAll("a[data-clicks='1']")[0].getAttribute("data-clicks"),
+      find("a[data-clicks='1']").getAttribute("data-clicks"),
       "1"
     );
     assert.strictEqual(
-      queryAll("a[data-clicks='2']")[0].getAttribute("data-clicks"),
+      find("a[data-clicks='2']").getAttribute("data-clicks"),
       "2"
     );
   });
@@ -181,12 +186,12 @@ module("Integration | Component | Post", function (hooks) {
     await renderComponent(this.post);
 
     assert.strictEqual(
-      queryAll("a[data-clicks='1']")[0].getAttribute("data-clicks"),
+      find("a[data-clicks='1']").getAttribute("data-clicks"),
       "1",
       "First link has correct data attribute and content"
     );
     assert.strictEqual(
-      queryAll("a[data-clicks='2']")[0].getAttribute("data-clicks"),
+      find("a[data-clicks='2']").getAttribute("data-clicks"),
       "2",
       "Second link has correct data attribute and content"
     );

--- a/frontend/discourse/tests/integration/components/select-kit/future-date-input-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/future-date-input-test.gjs
@@ -1,17 +1,15 @@
 import { fn, hash } from "@ember/helper";
-import { fillIn, render } from "@ember/test-helpers";
+import { fillIn, findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { fakeTime, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import DFutureDateInput from "discourse/ui-kit/d-future-date-input";
 import { i18n } from "discourse-i18n";
 
 function getOptions() {
-  return Array.from(
-    queryAll(`.select-kit-collection .select-kit-row`).map(
-      (_, span) => span.dataset.name
-    )
+  return findAll(`.select-kit-collection .select-kit-row`).map(
+    (span) => span.dataset.name
   );
 }
 

--- a/frontend/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.gjs
@@ -1,9 +1,8 @@
 import { hash } from "@ember/helper";
-import { click, render, triggerKeyEvent } from "@ember/test-helpers";
+import { click, findAll, render, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import MiniTagChooser from "discourse/select-kit/components/mini-tag-chooser";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
 
@@ -44,12 +43,12 @@ module(
       await this.subject.expand();
       await this.subject.fillInFilter("mon");
       assert.deepEqual(
-        [...queryAll(".select-kit-row")].map((el) => el.textContent.trim()),
+        findAll(".select-kit-row").map((el) => el.textContent.trim()),
         ["monkey x1", "gazelle x2", "dog x3", "cat x4"]
       );
       await this.subject.fillInFilter("key");
       assert.deepEqual(
-        [...queryAll(".select-kit-row")].map((el) => el.textContent.trim()),
+        findAll(".select-kit-row").map((el) => el.textContent.trim()),
         ["monkey x1", "gazelle x2", "dog x3", "cat x4"]
       );
       await this.subject.selectRowByName("monkey");
@@ -192,7 +191,7 @@ module(
 
       await this.subject.expand();
       assert.deepEqual(
-        [...queryAll(".selected-content .selected-choice")].map((el) =>
+        findAll(".selected-content .selected-choice").map((el) =>
           el.textContent.trim()
         ),
         ["bar"]

--- a/frontend/discourse/tests/integration/components/user-menu/bookmarks-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/bookmarks-list-test.gjs
@@ -1,10 +1,9 @@
-import { render, settled } from "@ember/test-helpers";
+import { findAll, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import BookmarksList from "discourse/components/user-menu/bookmarks-list";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 module("Integration | Component | UserMenu | BookmarksList", function (hooks) {
@@ -12,7 +11,7 @@ module("Integration | Component | UserMenu | BookmarksList", function (hooks) {
 
   test("renders notifications on top and bookmarks on bottom", async function (assert) {
     await render(<template><BookmarksList /></template>);
-    const items = queryAll("ul li");
+    const items = findAll("ul li");
 
     assert.strictEqual(items.length, 2);
 

--- a/frontend/discourse/tests/integration/components/user-menu/menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/menu-test.gjs
@@ -1,10 +1,9 @@
-import { click, render, settled } from "@ember/test-helpers";
+import { click, findAll, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Menu from "discourse/components/user-menu/menu";
 import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 
 module("Integration | Component | UserMenu", function (hooks) {
   setupRenderingTest(hooks);
@@ -16,7 +15,7 @@ module("Integration | Component | UserMenu", function (hooks) {
       .dom(".top-tabs.tabs-list .btn.active")
       .hasAttribute("id", "user-menu-button-all-notifications");
 
-    const notifications = queryAll("#quick-access-all-notifications ul li");
+    const notifications = findAll("#quick-access-all-notifications ul li");
     assert.dom(notifications[0]).hasClass("edited");
     assert.dom(notifications[1]).hasClass("replied");
     assert.dom(notifications[2]).hasClass("liked-consolidated");
@@ -41,7 +40,7 @@ module("Integration | Component | UserMenu", function (hooks) {
   test("the menu has a group of tabs at the top", async function (assert) {
     this.currentUser.set("can_send_private_messages", true);
     await render(<template><Menu /></template>);
-    const tabs = queryAll(".top-tabs.tabs-list .btn");
+    const tabs = findAll(".top-tabs.tabs-list .btn");
     assert.strictEqual(tabs.length, 6);
     ["all-notifications", "replies", "likes", "messages", "bookmarks"].forEach(
       (tab, index) => {
@@ -55,7 +54,7 @@ module("Integration | Component | UserMenu", function (hooks) {
   test("the menu has a group of tabs at the bottom", async function (assert) {
     this.currentUser.set("can_send_private_messages", true);
     await render(<template><Menu /></template>);
-    const tabs = queryAll(".bottom-tabs.tabs-list .btn");
+    const tabs = findAll(".bottom-tabs.tabs-list .btn");
     assert.strictEqual(tabs.length, 1);
     const profileTab = tabs[0];
     assert.strictEqual(profileTab.id, "user-menu-button-profile");
@@ -69,7 +68,7 @@ module("Integration | Component | UserMenu", function (hooks) {
     await render(<template><Menu /></template>);
     assert.dom("#user-menu-button-likes").doesNotExist();
 
-    const tabs = Array.from(queryAll(".tabs-list .btn")); // top and bottom tabs
+    const tabs = findAll(".tabs-list .btn"); // top and bottom tabs
     assert.strictEqual(tabs.length, 6);
 
     assert.deepEqual(
@@ -89,7 +88,7 @@ module("Integration | Component | UserMenu", function (hooks) {
       .dom("#user-menu-button-review-queue")
       .hasAttribute("data-tab-number", "5");
 
-    const tabs = Array.from(queryAll(".tabs-list .btn")); // top and bottom tabs
+    const tabs = findAll(".tabs-list .btn"); // top and bottom tabs
     assert.strictEqual(tabs.length, 8);
 
     assert.deepEqual(
@@ -116,7 +115,7 @@ module("Integration | Component | UserMenu", function (hooks) {
 
     assert.dom("#user-menu-button-messages").doesNotExist();
 
-    const tabs = Array.from(queryAll(".tabs-list .btn")); // top and bottom tabs
+    const tabs = findAll(".tabs-list .btn"); // top and bottom tabs
     assert.strictEqual(tabs.length, 6);
 
     assert.deepEqual(
@@ -271,14 +270,14 @@ module("Integration | Component | UserMenu", function (hooks) {
       "request params has filter_by_types set to `liked`, `liked_consolidated` and `reaction`"
     );
     assert.strictEqual(queryParams.silent, "true");
-    let activeTabs = queryAll(".top-tabs .btn.active");
+    let activeTabs = findAll(".top-tabs .btn.active");
     assert.strictEqual(activeTabs.length, 1);
     assert.strictEqual(
       activeTabs[0].id,
       "user-menu-button-likes",
       "active tab is now the likes tab"
     );
-    assert.strictEqual(queryAll("#quick-access-likes ul li").length, 3);
+    assert.dom("#quick-access-likes ul li").exists({ count: 3 });
 
     await click("#user-menu-button-replies");
     assert.dom("#quick-access-replies.quick-access-panel").exists();
@@ -288,7 +287,7 @@ module("Integration | Component | UserMenu", function (hooks) {
       "request params has filter_by_types set to `mentioned`, `posted`, `quoted` and `replied`"
     );
     assert.strictEqual(queryParams.silent, "true");
-    activeTabs = queryAll(".top-tabs .btn.active");
+    activeTabs = findAll(".top-tabs .btn.active");
     assert.strictEqual(activeTabs.length, 1);
     assert.strictEqual(
       activeTabs[0].id,
@@ -298,14 +297,14 @@ module("Integration | Component | UserMenu", function (hooks) {
 
     await click("#user-menu-button-review-queue");
     assert.dom("#quick-access-review-queue.quick-access-panel").exists();
-    activeTabs = queryAll(".top-tabs .btn.active");
+    activeTabs = findAll(".top-tabs .btn.active");
     assert.strictEqual(activeTabs.length, 1);
     assert.strictEqual(
       activeTabs[0].id,
       "user-menu-button-review-queue",
       "active tab is now the reviewables tab"
     );
-    assert.strictEqual(queryAll("#quick-access-review-queue ul li").length, 8);
+    assert.dom("#quick-access-review-queue ul li").exists({ count: 8 });
   });
 
   test("count on the likes tab", async function (assert) {

--- a/frontend/discourse/tests/integration/components/user-menu/messages-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/messages-list-test.gjs
@@ -1,4 +1,4 @@
-import { render, settled } from "@ember/test-helpers";
+import { findAll, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import MessagesList from "discourse/components/user-menu/messages-list";
 import { cloneJSON, deepMerge } from "discourse/lib/object";
@@ -6,7 +6,6 @@ import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notificati
 import UserMenuFixtures from "discourse/tests/fixtures/user-menu";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 function getMessage(overrides = {}) {
@@ -101,9 +100,9 @@ module("Integration | Component | UserMenu | MessagesList", function (hooks) {
       return response(copy);
     });
     await render(<template><MessagesList /></template>);
-    const items = queryAll("ul li");
+    const items = findAll("ul li");
 
-    assert.strictEqual(items.length, 3);
+    assert.dom("ul li").exists({ count: 3 });
 
     assert.dom(items[0]).hasClass("notification");
     assert.dom(items[0]).hasClass("unread");
@@ -126,9 +125,9 @@ module("Integration | Component | UserMenu | MessagesList", function (hooks) {
     });
 
     await render(<template><MessagesList /></template>);
-    const items = queryAll("ul li");
+    const items = findAll("ul li");
 
-    assert.strictEqual(items.length, 2);
+    assert.dom("ul li").exists({ count: 2 });
 
     assert.dom(items[0]).hasClass("notification");
     assert.dom(items[0]).hasClass("unread");
@@ -148,9 +147,9 @@ module("Integration | Component | UserMenu | MessagesList", function (hooks) {
     });
 
     await render(<template><MessagesList /></template>);
-    const items = queryAll("ul li");
+    const items = findAll("ul li");
 
-    assert.strictEqual(items.length, 2);
+    assert.dom("ul li").exists({ count: 2 });
 
     assert.dom(items[0]).hasClass("notification");
     assert.dom(items[0]).hasClass("unread");
@@ -207,9 +206,9 @@ module("Integration | Component | UserMenu | MessagesList", function (hooks) {
       return response(copy);
     });
     await render(<template><MessagesList /></template>);
-    const items = queryAll("ul li");
+    const items = findAll("ul li");
 
-    assert.strictEqual(items.length, 6);
+    assert.dom("ul li").exists({ count: 6 });
 
     assert.dom(items[0]).hasText(
       i18n("notifications.group_message_summary", {

--- a/frontend/discourse/tests/integration/components/user-menu/notifications-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/notifications-list-test.gjs
@@ -1,4 +1,4 @@
-import { click, render, settled } from "@ember/test-helpers";
+import { click, findAll, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import NotificationsList from "discourse/components/user-menu/notifications-list";
 import { cloneJSON } from "discourse/lib/object";
@@ -6,7 +6,6 @@ import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notificati
 import NotificationFixtures from "discourse/tests/fixtures/notification-fixtures";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 function getNotificationsData() {
@@ -217,7 +216,7 @@ module(
         });
       });
       await render(<template><NotificationsList /></template>);
-      const items = queryAll("ul li");
+      const items = findAll("ul li");
       assert
         .dom(items[0])
         .includesText(

--- a/frontend/discourse/tests/integration/components/user-menu/reviewables-list-test.gjs
+++ b/frontend/discourse/tests/integration/components/user-menu/reviewables-list-test.gjs
@@ -2,7 +2,6 @@ import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import ReviewablesList from "discourse/components/user-menu/reviewables-list";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 module(
@@ -23,8 +22,7 @@ module(
 
     test("renders a list of reviewables", async function (assert) {
       await render(<template><ReviewablesList /></template>);
-      const reviewables = queryAll("ul li");
-      assert.strictEqual(reviewables.length, 8);
+      assert.dom("ul li").exists({ count: 8 });
     });
   }
 );

--- a/frontend/discourse/tests/integration/ui-kit/d-editor-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-editor-test.gjs
@@ -4,6 +4,7 @@ import {
   click,
   fillIn,
   find,
+  findAll,
   focus,
   render,
   settled,
@@ -19,7 +20,7 @@ import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import formatTextWithSelection from "discourse/tests/helpers/d-editor-helper";
 import emojiPicker from "discourse/tests/helpers/emoji-picker-helper";
-import { paste, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { paste } from "discourse/tests/helpers/qunit-helpers";
 import {
   getTextareaSelection,
   setTextareaSelection,
@@ -893,7 +894,7 @@ third line`
     async function (assert) {
       this.siteSettings.rich_editor = false;
       await render(<template><DEditor /></template>);
-      const buttons = queryAll(".d-editor-button-bar .btn");
+      const buttons = findAll(".d-editor-button-bar .btn");
 
       assert
         .dom(buttons[0])
@@ -907,7 +908,7 @@ third line`
     async function (assert) {
       this.siteSettings.rich_editor = true;
       await render(<template><DEditor /></template>);
-      const buttons = queryAll(".d-editor-button-bar .btn");
+      const buttons = findAll(".d-editor-button-bar .btn");
 
       assert
         .dom(buttons[0])

--- a/frontend/discourse/tests/integration/ui-kit/d-time-shortcut-picker-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-time-shortcut-picker-test.gjs
@@ -1,7 +1,7 @@
-import { click, render } from "@ember/test-helpers";
+import { click, findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { fakeTime, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import DTimeShortcutPicker from "discourse/ui-kit/d-time-shortcut-picker";
 import { i18n } from "discourse-i18n";
 
@@ -41,10 +41,8 @@ module("Integration | ui-kit | DTimeShortcutPicker", function (hooks) {
       i18n("time_shortcut.none"),
     ];
 
-    const options = Array.from(
-      queryAll("div.tap-tile-grid div.tap-tile-title").map((_, div) =>
-        div.innerText.trim()
-      )
+    const options = findAll("div.tap-tile-grid div.tap-tile-title").map((div) =>
+      div.innerText.trim()
     );
 
     assert.deepEqual(options, expected);

--- a/plugins/chat/test/javascripts/components/chat-message-collapser-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-collapser-test.gjs
@@ -1,7 +1,6 @@
-import { click, render, settled, waitFor } from "@ember/test-helpers";
+import { click, findAll, render, settled, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import ChatMessageCollapser from "discourse/plugins/chat/discourse/components/chat-message-collapser";
 
 const youtubeCooked =
@@ -91,7 +90,7 @@ module("Component | chat message collapser youtube", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const link = queryAll(".chat-message-collapser-link");
+    const link = findAll(".chat-message-collapser-link");
 
     assert.strictEqual(link.length, 2, "two youtube links rendered");
     assert
@@ -110,7 +109,7 @@ module("Component | chat message collapser youtube", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const text = queryAll(".chat-message-collapser p");
+    const text = findAll(".chat-message-collapser p");
 
     assert.strictEqual(text.length, 3, "shows all written text");
     assert.dom(text[0]).hasText("written text", "first line of written text");
@@ -127,7 +126,7 @@ module("Component | chat message collapser youtube", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const youtubeDivs = queryAll(".youtube-onebox");
+    const youtubeDivs = findAll(".youtube-onebox");
 
     assert.strictEqual(youtubeDivs.length, 2, "two youtube previews rendered");
 
@@ -144,7 +143,7 @@ module("Component | chat message collapser youtube", function (hooks) {
 
     assert.strictEqual(youtubeDivs.length, 2, "two youtube previews rendered");
 
-    await click(queryAll(".chat-message-collapser-opened")[1]);
+    await click(findAll(".chat-message-collapser-opened")[1]);
 
     assert
       .dom(".youtube-onebox[data-video-id='ytId1']")
@@ -285,7 +284,7 @@ module("Component | chat message collapser animated image", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const links = queryAll("a.chat-message-collapser-link-small");
+    const links = findAll("a.chat-message-collapser-link-small");
 
     assert.dom(links[0]).includesText("avatar.png");
     assert.dom(links[0]).hasAttribute("href", "/images/avatar.png");
@@ -303,7 +302,7 @@ module("Component | chat message collapser animated image", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const text = queryAll(".chat-message-collapser p");
+    const text = findAll(".chat-message-collapser p");
 
     assert.strictEqual(text.length, 5, "shows all written text");
     assert.dom(text[0]).hasText("written text");
@@ -318,7 +317,7 @@ module("Component | chat message collapser animated image", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const animatedOneboxes = queryAll(".animated.onebox");
+    const animatedOneboxes = findAll(".animated.onebox");
 
     assert.strictEqual(animatedOneboxes.length, 2, "two oneboxes rendered");
 
@@ -335,7 +334,7 @@ module("Component | chat message collapser animated image", function (hooks) {
 
     assert.strictEqual(animatedOneboxes.length, 2, "two oneboxes rendered");
 
-    await click(queryAll(".chat-message-collapser-opened")[1]);
+    await click(findAll(".chat-message-collapser-opened")[1]);
 
     assert
       .dom(".onebox[src='/images/avatar.png']")
@@ -362,7 +361,7 @@ module(
         <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
       );
 
-      const links = queryAll("a.chat-message-collapser-link-small");
+      const links = findAll("a.chat-message-collapser-link-small");
 
       assert.dom(links[0]).includesText("http://cat1.com");
       assert.dom(links[0]).hasAttribute("href", "http://cat1.com/");
@@ -378,7 +377,7 @@ module(
         <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
       );
 
-      const text = queryAll(".chat-message-collapser p");
+      const text = findAll(".chat-message-collapser p");
 
       assert.strictEqual(text.length, 5, "shows all written text");
       assert.dom(text[0]).hasText("written text");
@@ -393,7 +392,7 @@ module(
         <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
       );
 
-      const imageOneboxes = queryAll(".onebox");
+      const imageOneboxes = findAll(".onebox");
 
       assert.strictEqual(imageOneboxes.length, 2, "two oneboxes rendered");
 
@@ -410,7 +409,7 @@ module(
 
       assert.strictEqual(imageOneboxes.length, 2, "two oneboxes rendered");
 
-      await click(queryAll(".chat-message-collapser-opened")[1]);
+      await click(findAll(".chat-message-collapser-opened")[1]);
 
       assert
         .dom(".onebox[href='http://cat1.com']")
@@ -436,7 +435,7 @@ module("Component | chat message collapser images", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const links = queryAll("a.chat-message-collapser-link-small");
+    const links = findAll("a.chat-message-collapser-link-small");
 
     assert.dom(links[0]).includesText("shows alt");
     assert.dom(links[0]).hasAttribute("href", "/images/avatar.png");
@@ -454,7 +453,7 @@ module("Component | chat message collapser images", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const text = queryAll(".chat-message-collapser p");
+    const text = findAll(".chat-message-collapser p");
 
     assert.strictEqual(text.length, 6, "shows all written text");
     assert.dom(text[0]).hasText("written text");
@@ -469,7 +468,7 @@ module("Component | chat message collapser images", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const images = queryAll("img");
+    const images = findAll("img");
 
     assert.strictEqual(images.length, 3);
 
@@ -486,7 +485,7 @@ module("Component | chat message collapser images", function (hooks) {
 
     assert.strictEqual(images.length, 3);
 
-    await click(queryAll(".chat-message-collapser-opened")[1]);
+    await click(findAll(".chat-message-collapser-opened")[1]);
 
     assert
       .dom("img[src='/images/avatar.png']")
@@ -507,9 +506,9 @@ module("Component | chat message collapser images", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const links = queryAll("a.chat-message-collapser-link-small");
-    const images = queryAll("img");
-    const collapser = queryAll(".chat-message-collapser-opened");
+    const links = findAll("a.chat-message-collapser-link-small");
+    const images = findAll("img");
+    const collapser = findAll(".chat-message-collapser-opened");
 
     assert.strictEqual(links.length, 2);
     assert.strictEqual(images.length, 3, "shows images and emoji");
@@ -566,7 +565,7 @@ module("Component | chat message collapser galleries", function (hooks) {
       <template><ChatMessageCollapser @cooked={{this.cooked}} /></template>
     );
 
-    const text = queryAll(".chat-message-collapser p");
+    const text = findAll(".chat-message-collapser p");
 
     assert.strictEqual(text.length, 2, "shows all written text");
     assert.dom(text[0]).hasText("written text");

--- a/plugins/chat/test/javascripts/components/chat-notices-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-notices-test.gjs
@@ -1,9 +1,8 @@
 import { getOwner } from "@ember/owner";
-import { click, render } from "@ember/test-helpers";
+import { click, findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender from "discourse/tests/helpers/create-pretender";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 import ChatNotices from "discourse/plugins/chat/discourse/components/chat-notices";
 import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
@@ -33,7 +32,7 @@ module("Component | ChatNotice", function (hooks) {
       <template><ChatNotices @channel={{this.channel}} /></template>
     );
 
-    const notices = queryAll(".chat-notices .chat-notices__notice");
+    const notices = findAll(".chat-notices .chat-notices__notice");
 
     assert.strictEqual(notices.length, 2, "Two notices are rendered");
 
@@ -55,19 +54,15 @@ module("Component | ChatNotice", function (hooks) {
       <template><ChatNotices @channel={{this.channel}} /></template>
     );
 
-    assert.strictEqual(
-      queryAll(".chat-notices .chat-notices__notice").length,
-      1,
-      "Notice is present"
-    );
+    assert
+      .dom(".chat-notices .chat-notices__notice")
+      .exists({ count: 1 }, "Notice is present");
 
     await click(".chat-notices__notice__clear");
 
-    assert.strictEqual(
-      queryAll(".chat-notices .chat-notices__notice").length,
-      0,
-      "Notice was cleared"
-    );
+    assert
+      .dom(".chat-notices .chat-notices__notice")
+      .doesNotExist("Notice was cleared");
   });
   test("MentionWithoutMembership notice renders", async function (assert) {
     this.channel = new ChatFabricators(getOwner(this)).channel();
@@ -85,13 +80,11 @@ module("Component | ChatNotice", function (hooks) {
       <template><ChatNotices @channel={{this.channel}} /></template>
     );
 
-    assert.strictEqual(
-      queryAll(
+    assert
+      .dom(
         ".chat-notices .chat-notices__notice .mention-without-membership-notice"
-      ).length,
-      1,
-      "Notice is present"
-    );
+      )
+      .exists({ count: 1 }, "Notice is present");
 
     assert.dom(".mention-without-membership-notice__body__text").hasText(text);
     assert
@@ -108,12 +101,10 @@ module("Component | ChatNotice", function (hooks) {
     // dismiss is called right away instead of waiting 3 seconds.. Not much we can
     // do about this - at least we are testing that nothing broke all the way through
     // clearing the notice
-    assert.strictEqual(
-      queryAll(
+    assert
+      .dom(
         ".chat-notices .chat-notices__notice .mention-without-membership-notice"
-      ).length,
-      0,
-      "Notice has been cleared"
-    );
+      )
+      .doesNotExist("Notice has been cleared");
   });
 });

--- a/plugins/discourse-cakeday/test/javascripts/acceptance/cakeday-test.js
+++ b/plugins/discourse-cakeday/test/javascripts/acceptance/cakeday-test.js
@@ -1,6 +1,6 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 acceptance("Cakeday", function (needs) {
@@ -221,7 +221,7 @@ acceptance("Cakeday", function (needs) {
   test("Anniversary emoji", async function (assert) {
     await visit("/t/some-really-interesting-topic/11");
 
-    const posterIcons = queryAll(".poster-icon");
+    const posterIcons = findAll(".poster-icon");
 
     assert
       .dom(posterIcons[0])
@@ -240,7 +240,7 @@ acceptance("Cakeday", function (needs) {
 
     await click(".trigger-user-card a[data-user-card]");
 
-    const emojiImages = queryAll(".emoji-images div");
+    const emojiImages = findAll(".emoji-images div");
 
     assert
       .dom(emojiImages[1])

--- a/plugins/discourse-calendar/test/javascripts/acceptance/notifications-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/notifications-test.js
@@ -1,6 +1,6 @@
-import { click, visit } from "@ember/test-helpers";
+import { click, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 
 acceptance("Notifications", function (needs) {
@@ -111,7 +111,7 @@ acceptance("Notifications", function (needs) {
     await visit("/");
     await click(".d-header-icons .current-user button");
 
-    const notifications = queryAll(
+    const notifications = findAll(
       "#quick-access-all-notifications ul li.notification a"
     );
     assert.strictEqual(notifications.length, 5);

--- a/plugins/discourse-calendar/test/javascripts/acceptance/topic-title-decorator-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/topic-title-decorator-test.js
@@ -1,9 +1,9 @@
-import { visit } from "@ember/test-helpers";
+import { findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import sinon from "sinon";
 import { cloneJSON } from "discourse/lib/object";
 import discoveryFixtures from "discourse/tests/fixtures/discovery-fixtures";
-import { acceptance, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 acceptance("Event Title Decorator", function (needs) {
   needs.user();
@@ -33,7 +33,7 @@ acceptance("Event Title Decorator", function (needs) {
 
     await visit("/latest");
 
-    const topics = queryAll(".topic-list-item");
+    const topics = findAll(".topic-list-item");
 
     assert.dom(".event-date.past", topics[0]).exists();
     assert.dom(".event-date", topics[0]).hasAttribute("data-starts-at");

--- a/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -1,9 +1,15 @@
 import { hash } from "@ember/helper";
-import { click, currentURL, render, waitFor } from "@ember/test-helpers";
+import {
+  click,
+  currentURL,
+  findAll,
+  render,
+  waitFor,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { fakeTime, queryAll } from "discourse/tests/helpers/qunit-helpers";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 import UpcomingEventsList, {
   DEFAULT_TIME_FORMAT,
@@ -88,7 +94,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     await waitFor(".loading-container .spinner", { count: 0 });
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-date .month")].map(
+      findAll(".upcoming-events-list__event-date .month").map(
         (el) => el.innerText
       ),
       [
@@ -99,7 +105,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     );
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-date .day")].map(
+      findAll(".upcoming-events-list__event-date .day").map(
         (el) => el.innerText
       ),
       [moment(tomorrowAllDay).format("D"), moment(laterThisMonth).format("D")],
@@ -107,9 +113,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     );
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-time")].map(
-        (el) => el.innerText
-      ),
+      findAll(".upcoming-events-list__event-time").map((el) => el.innerText),
       [
         i18n("discourse_post_event.upcoming_events_list.all_day"),
         moment(laterThisMonth).format(DEFAULT_TIME_FORMAT),
@@ -118,9 +122,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     );
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-name")].map(
-        (el) => el.innerText
-      ),
+      findAll(".upcoming-events-list__event-name").map((el) => el.innerText),
       ["Awesome Event", "Another Awesome Event"],
       "displays the event name in the correct order"
     );
@@ -144,9 +146,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
       .exists({ count: 1 }, "multi-day event appears only once");
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-name")].map(
-        (el) => el.innerText
-      ),
+      findAll(".upcoming-events-list__event-name").map((el) => el.innerText),
       ["Awesome Multiday Event"],
       "displays the multiday event name once"
     );
@@ -436,9 +436,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     await waitFor(".loading-container .spinner", { count: 0 });
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-time")].map(
-        (el) => el.innerText
-      ),
+      findAll(".upcoming-events-list__event-time").map((el) => el.innerText),
       [
         i18n("discourse_post_event.upcoming_events_list.all_day"),
         moment(laterThisMonth).format("LLL"),
@@ -447,9 +445,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     );
 
     assert.deepEqual(
-      [...queryAll(".upcoming-events-list__event-name")].map(
-        (el) => el.innerText
-      ),
+      findAll(".upcoming-events-list__event-name").map((el) => el.innerText),
       ["Awesome Event", "Another Awesome Event"],
       "displays the event name"
     );
@@ -584,7 +580,7 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     this.appEvents.trigger("page:changed", { url: "/" });
     await waitFor(".loading-container .spinner", { count: 0 });
 
-    const events = queryAll(".upcoming-events-list__event-name");
+    const events = findAll(".upcoming-events-list__event-name");
 
     assert
       .dom(events[0].querySelector(".d-icon-arrows-rotate"))

--- a/plugins/poll/test/javascripts/component/poll-results-standard-test.gjs
+++ b/plugins/poll/test/javascripts/component/poll-results-standard-test.gjs
@@ -1,7 +1,6 @@
-import { render } from "@ember/test-helpers";
+import { find, findAll, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { queryAll } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
 import PollResultsStandard from "discourse/plugins/poll/discourse/components/poll-results-standard";
 
@@ -66,8 +65,8 @@ module("Component | PollResultsStandard", function (hooks) {
       </template>
     );
 
-    assert.dom(queryAll(".option .percentage")[0]).hasText("56%");
-    assert.dom(queryAll(".option .percentage")[1]).hasText("44%");
+    assert.dom(find(".option .percentage")).hasText("56%");
+    assert.dom(findAll(".option .percentage")[1]).hasText("44%");
     assert.dom("ul.poll-voters-list").exists();
   });
 
@@ -130,8 +129,8 @@ module("Component | PollResultsStandard", function (hooks) {
       </template>
     );
 
-    assert.dom(queryAll(".option .percentage")[0]).hasText("56%");
-    assert.dom(queryAll(".option .percentage")[1]).hasText("44%");
+    assert.dom(find(".option .percentage")).hasText("56%");
+    assert.dom(findAll(".option .percentage")[1]).hasText("44%");
   });
 
   test("options in ascending order", async function (assert) {
@@ -161,15 +160,15 @@ module("Component | PollResultsStandard", function (hooks) {
       </template>
     );
 
-    let percentages = queryAll(".option .percentage");
+    let percentages = findAll(".option .percentage");
     assert.dom(percentages[0]).hasText("41%");
     assert.dom(percentages[1]).hasText("33%");
     assert.dom(percentages[2]).hasText("16%");
     assert.dom(percentages[3]).hasText("8%");
 
-    assert.dom(queryAll(".option")[3].querySelectorAll("span")[1]).hasText("a");
+    assert.dom(findAll(".option")[3].querySelectorAll("span")[1]).hasText("a");
     assert.dom(percentages[4]).hasText("8%");
-    assert.dom(queryAll(".option")[4].querySelectorAll("span")[1]).hasText("b");
+    assert.dom(findAll(".option")[4].querySelectorAll("span")[1]).hasText("b");
   });
 
   test("options in ascending order, showing absolute vote number", async function (assert) {
@@ -201,14 +200,14 @@ module("Component | PollResultsStandard", function (hooks) {
       </template>
     );
 
-    let percentages = queryAll(".option .absolute");
+    let percentages = findAll(".option .absolute");
     assert.dom(percentages[0]).hasText(i18n("poll.votes", { count: 5 }));
     assert.dom(percentages[1]).hasText(i18n("poll.votes", { count: 4 }));
     assert.dom(percentages[2]).hasText(i18n("poll.votes", { count: 2 }));
     assert.dom(percentages[3]).hasText(i18n("poll.votes", { count: 1 }));
 
-    assert.dom(queryAll(".option")[3].querySelectorAll("span")[1]).hasText("a");
+    assert.dom(findAll(".option")[3].querySelectorAll("span")[1]).hasText("a");
     assert.dom(percentages[4]).hasText(i18n("poll.votes", { count: 1 }));
-    assert.dom(queryAll(".option")[4].querySelectorAll("span")[1]).hasText("b");
+    assert.dom(findAll(".option")[4].querySelectorAll("span")[1]).hasText("b");
   });
 });


### PR DESCRIPTION
This is a legacy helper which leans on JQuery. This commit migrates all use-cases to qunit-dom or `findAll()`.