### PR TITLE
UX: prevent nested footnotes

### DIFF
--- a/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
+++ b/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
@@ -53,7 +53,15 @@ export default apiInitializer((api) => {
       }
 
       const footnoteId = refLink.getAttribute("href");
-      const footnoteContent = elem.querySelector(footnoteId)?.innerHTML;
+
+      const footnoteElement = elem.querySelector(footnoteId)?.cloneNode(true);
+      footnoteElement
+        ?.querySelectorAll("sup.footnote-ref")
+        .forEach((nestedRef) => {
+          nestedRef.replaceWith(nestedRef.textContent);
+        });
+
+      const footnoteContent = footnoteElement?.innerHTML;
 
       const expandableFootnote = document.createElement("span");
       expandableFootnote.className = "inline-footnote";

--- a/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
+++ b/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
@@ -56,28 +56,8 @@ export default apiInitializer((api) => {
       const footnoteElement = elem.querySelector(footnoteId)?.cloneNode(true);
 
       footnoteElement
-        ?.querySelectorAll("sup.footnote-ref")
-        .forEach((nestedRef) => {
-          const nestedId = nestedRef.querySelector("a")?.getAttribute("href");
-
-          if (!nestedId || nestedId === footnoteId) {
-            nestedRef.remove();
-            return;
-          }
-
-          const nestedNote = elem.querySelector(nestedId)?.cloneNode(true);
-          nestedNote
-            ?.querySelectorAll(".footnote-backref")
-            .forEach((backref) => backref.remove());
-
-          nestedRef.replaceWith(
-            nestedNote?.textContent.trim() ?? nestedRef.textContent
-          );
-        });
-
-      footnoteElement
-        ?.querySelectorAll(".footnote-backref")
-        .forEach((backref) => backref.remove());
+        ?.querySelectorAll("sup.footnote-ref, .footnote-backref")
+        .forEach((element) => element.remove());
 
       const footnoteContent = footnoteElement?.innerHTML;
 

--- a/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
+++ b/plugins/footnote/assets/javascripts/api-initializers/inline-footnotes.gjs
@@ -53,13 +53,31 @@ export default apiInitializer((api) => {
       }
 
       const footnoteId = refLink.getAttribute("href");
-
       const footnoteElement = elem.querySelector(footnoteId)?.cloneNode(true);
+
       footnoteElement
         ?.querySelectorAll("sup.footnote-ref")
         .forEach((nestedRef) => {
-          nestedRef.replaceWith(nestedRef.textContent);
+          const nestedId = nestedRef.querySelector("a")?.getAttribute("href");
+
+          if (!nestedId || nestedId === footnoteId) {
+            nestedRef.remove();
+            return;
+          }
+
+          const nestedNote = elem.querySelector(nestedId)?.cloneNode(true);
+          nestedNote
+            ?.querySelectorAll(".footnote-backref")
+            .forEach((backref) => backref.remove());
+
+          nestedRef.replaceWith(
+            nestedNote?.textContent.trim() ?? nestedRef.textContent
+          );
         });
+
+      footnoteElement
+        ?.querySelectorAll(".footnote-backref")
+        .forEach((backref) => backref.remove());
 
       const footnoteContent = footnoteElement?.innerHTML;
 

--- a/plugins/footnote/assets/stylesheets/footnotes.scss
+++ b/plugins/footnote/assets/stylesheets/footnotes.scss
@@ -47,10 +47,6 @@
     flex-direction: column;
   }
 
-  .footnote-backref {
-    display: none;
-  }
-
   img {
     object-fit: cover;
     max-width: 100%;

--- a/plugins/footnote/test/javascripts/acceptance/footnote-test.js
+++ b/plugins/footnote/test/javascripts/acceptance/footnote-test.js
@@ -19,6 +19,7 @@ acceptance("Discourse Footnote Plugin", function (needs) {
         <p>Lorem ipsum dolor sit amet<sup class="footnote-ref"><a href="#footnote-17-1" id="footnote-ref-17-1">[1]</a></sup></p>
         <p class="second">Second reference should also work. <sup class="footnote-ref"><a href="#footnote-17-1" id="footnote-ref-17-0">[1]</a></sup></p>
         <p class="other">Other page should close<sup class="footnote-ref"><a href="#footnote-17-2" id="footnote-ref-17-2">[2]</a></sup></p>
+        <p class="nested">Nested footnote<sup class="footnote-ref"><a href="#footnote-17-3" id="footnote-ref-17-3">[3]</a></sup></p>
         <hr class="footnotes-sep">
         <ol class="footnotes-list">
           <li id="footnote-17-1" class="footnote-item">
@@ -26,6 +27,9 @@ acceptance("Discourse Footnote Plugin", function (needs) {
           </li>
           <li id="footnote-17-2" class="footnote-item">
           <p><a class="link-in-tooltip" href="/">Index ↩︎</a></p>
+          </li>
+          <li id="footnote-17-3" class="footnote-item">
+          <p>Nested content <sup class="footnote-ref"><a href="#footnote-17-4" id="footnote-ref-17-4">[4]</a></sup> <a href="#footnote-ref-17-3" class="footnote-backref">↩︎</a></p>
           </li>
         </ol>
       `;
@@ -66,5 +70,18 @@ acceptance("Discourse Footnote Plugin", function (needs) {
 
     await click(".link-in-tooltip");
     assert.dom(TOOLTIP_SELECTOR).doesNotExist();
+  });
+
+  test("flattens a nested footnote ref inside the tooltip", async function (assert) {
+    await visit("/t/-/45");
+
+    await click(".nested .expand-footnote");
+
+    // the nested footnote does not work, so it is shown as flat text rather
+    // than being styled as an interactive footnote ref
+    assert
+      .dom(`${TOOLTIP_SELECTOR} sup.footnote-ref`)
+      .doesNotExist("removes the nested footnote-ref styling");
+    assert.dom(TOOLTIP_SELECTOR).hasText("Nested content [4] ↩︎");
   });
 });

--- a/plugins/footnote/test/javascripts/acceptance/footnote-test.js
+++ b/plugins/footnote/test/javascripts/acceptance/footnote-test.js
@@ -43,7 +43,7 @@ acceptance("Discourse Footnote Plugin", function (needs) {
     // open
     await click(".expand-footnote");
 
-    assert.dom(TOOLTIP_SELECTOR).hasText("consectetur adipiscing elit ↩︎");
+    assert.dom(TOOLTIP_SELECTOR).hasText("consectetur adipiscing elit");
 
     // close by clicking outside
     await triggerEvent(".d-header", "pointerdown");
@@ -51,14 +51,14 @@ acceptance("Discourse Footnote Plugin", function (needs) {
 
     // open again
     await click(".expand-footnote");
-    assert.dom(TOOLTIP_SELECTOR).hasText("consectetur adipiscing elit ↩︎");
+    assert.dom(TOOLTIP_SELECTOR).hasText("consectetur adipiscing elit");
   });
 
   test("clicking a second footnote with same name works", async function (assert) {
     await visit("/t/-/45");
 
     await click(".second .expand-footnote");
-    assert.dom(TOOLTIP_SELECTOR).hasText("consectetur adipiscing elit ↩︎");
+    assert.dom(TOOLTIP_SELECTOR).hasText("consectetur adipiscing elit");
   });
 
   test("closes tooltip when clicking link within tooltip content", async function (assert) {
@@ -72,16 +72,15 @@ acceptance("Discourse Footnote Plugin", function (needs) {
     assert.dom(TOOLTIP_SELECTOR).doesNotExist();
   });
 
-  test("flattens a nested footnote ref inside the tooltip", async function (assert) {
+  test("removes nested footnotes", async function (assert) {
     await visit("/t/-/45");
 
     await click(".nested .expand-footnote");
 
-    // the nested footnote does not work, so it is shown as flat text rather
-    // than being styled as an interactive footnote ref
+    // the nested footnote does not work, so we strip them out completely
     assert
       .dom(`${TOOLTIP_SELECTOR} sup.footnote-ref`)
-      .doesNotExist("removes the nested footnote-ref styling");
-    assert.dom(TOOLTIP_SELECTOR).hasText("Nested content [4] ↩︎");
+      .doesNotExist("removes the nested footnote-ref");
+    assert.dom(TOOLTIP_SELECTOR).hasText("Nested content");
   });
 });


### PR DESCRIPTION
Nested footnotes do not work, but still render as if they do.
This commit strips out any nested footnotes, and pretends they aren't there.

| Then | Now |
|--------|--------|
| <img width="437" height="106" alt="CleanShot 2026-07-01 at 11 39 03" src="https://github.com/user-attachments/assets/1bb915c4-d63d-438f-a51b-a5e246be3dcf" /> | <img width="325" height="103" alt="CleanShot 2026-07-01 at 14 49 20" src="https://github.com/user-attachments/assets/b74594ab-84dc-437c-bea5-089aa72178e0" /> | 

Also deleted old CSS to hide the `footnote-backref `, since these are no longer rendered in the inline-footnote at all.