### PR TITLE
SECURITY: Prevent PM invite metadata disclosure

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -906,6 +906,14 @@ class TopicsController < ApplicationController
         :id,
       )
 
+    if Email.is_valid?(username_or_email)
+      if !guardian.can_invite_via_email?(topic)
+        return render(json: failed_json, status: :unprocessable_entity)
+      end
+
+      return render(json: success_json) if User.find_by_email(username_or_email)
+    end
+
     begin
       if topic.invite(current_user, username_or_email, group_ids, params[:custom_message])
         if user = User.find_by_username_or_email(username_or_email)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -6872,6 +6872,16 @@ RSpec.describe TopicsController do
         end
       end
 
+      it "does not disclose an existing user from an email invite" do
+        pm = Fabricate(:private_message_topic, user: user)
+
+        post "/t/#{pm.id}/invite.json", params: { email: user_2.email }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["failed"]).to eq("FAILED")
+        expect(pm.reload.topic_allowed_users.pluck(:user_id)).not_to include(user_2.id)
+      end
+
       context "when user does not have permission to invite to the topic" do
         fab!(:topic) { pm }
 


### PR DESCRIPTION
Email PM invites could resolve an existing account before the email-invite permission check, exposing user details and adding that account to the PM.

This change handles valid email input before the username lookup can run, returning generic responses for existing-user emails and users who cannot invite by email.