### PR TITLE
FIX: Restore cross-filesystem fallback in atomic_ln_s (Errno::EXDEV)

### DIFF
--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -115,7 +115,17 @@ module Discourse
 
         temp_destination = Rails.root.join("tmp", SecureRandom.hex).to_s
         execute_command("ln", "-s", source, temp_destination)
-        File.rename(temp_destination, destination)
+
+        begin
+          File.rename(temp_destination, destination)
+        rescue Errno::EXDEV
+          # Rails.root/tmp and the destination can live on different filesystems
+          # (e.g. containerized setups where tmp is a separate mount). rename(2)
+          # cannot cross filesystem boundaries, so fall back to a non-atomic
+          # replace. The flock above already serializes writers.
+          File.delete(destination) if File.symlink?(destination)
+          FileUtils.mv(temp_destination, destination)
+        end
       end
 
       nil

--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -631,6 +631,45 @@ RSpec.describe Discourse do
     end
   end
 
+  describe "Utils.atomic_ln_s" do
+    let(:source) { Dir.mktmpdir }
+
+    it "creates the destination symlink pointing at the source" do
+      Dir.mktmpdir do |dir|
+        destination = File.join(dir, "link")
+        Discourse::Utils.atomic_ln_s(source, destination)
+
+        expect(File.symlink?(destination)).to eq(true)
+        expect(File.readlink(destination)).to eq(source)
+      end
+    end
+
+    it "replaces an existing symlink at the destination" do
+      Dir.mktmpdir do |dir|
+        destination = File.join(dir, "link")
+        File.symlink(Dir.mktmpdir, destination)
+
+        Discourse::Utils.atomic_ln_s(source, destination)
+
+        expect(File.readlink(destination)).to eq(source)
+      end
+    end
+
+    it "falls back to a copy when tmp and destination are on different filesystems" do
+      # rename(2) raises EXDEV across filesystem boundaries (e.g. containers
+      # where Rails.root/tmp is a separate mount). The link must still land.
+      Dir.mktmpdir do |dir|
+        destination = File.join(dir, "link")
+        allow(File).to receive(:rename).and_raise(Errno::EXDEV)
+
+        Discourse::Utils.atomic_ln_s(source, destination)
+
+        expect(File.symlink?(destination)).to eq(true)
+        expect(File.readlink(destination)).to eq(source)
+      end
+    end
+  end
+
   describe ".clear_all_theme_cache!" do
     before do
       setup_s3


### PR DESCRIPTION
### Problem

Since 2026.6.0, `Discourse::Utils.atomic_ln_s` crashes with `Errno::EXDEV` when `Rails.root/tmp` and the link destination are on different filesystems. On a containerized install (Cloudron) where `tmp` is a separate mount, plugin activation aborts `db:migrate` and the app restart-loops:

```
Errno::EXDEV: Invalid cross-device link @ rb_file_s_rename - (/app/code/tmp/bb35a8740ba712fb0fb92b9c14e0fe11, /app/code/public/plugins/chat)
lib/discourse.rb:118:in 'File.rename'
lib/plugin/instance.rb:883:in 'Plugin::Instance#activate!'
lib/discourse.rb:353:in 'Discourse.activate_plugins!'
```

#40319 wrapped `atomic_ln_s` in an `flock` and, in doing so, replaced `FileUtils.mv` (which copies on `EXDEV`) with a bare `File.rename` (which cannot cross filesystems). This reintroduces the exact failure fixed earlier in #13976.

### Fix

```ruby
begin
  File.rename(temp_destination, destination)
rescue Errno::EXDEV
  File.delete(destination) if File.symlink?(destination)
  FileUtils.mv(temp_destination, destination)
end
```

Same-filesystem installs keep the atomic `rename` from #40319; only the cross-filesystem case takes the copy fallback. The `flock` still serializes writers, so the concurrency guarantee is unchanged.

### Testing

- New specs for `Utils.atomic_ln_s`, including one that stubs `File.rename` to raise `Errno::EXDEV` and asserts the destination symlink still resolves to `source`.
- Full Cloudron app lifecycle test on Discourse 2026.6.0 (Ruby 3.4.9): **before** — the app aborts `db:migrate` on plugin activation and never becomes healthy (restart loop); **after** — it boots normally and 42/42 lifecycle steps pass (install, plugin check, OIDC login, backup/restore, update, uninstall).
