### PR TITLE
DEV: Configure pnpm builtDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,10 @@
 strictPeerDependencies: true
+strictDepBuilds: true
+onlyBuiltDependencies:
+- lefthook
+ignoredBuiltDependencies:
+- core-js
+- rete
 packages:
 - "docs/developer-guides"
 - "frontend/deprecation-silencer"


### PR DESCRIPTION
- Allow lefthook, and block others
- Set `strictDepBuilds`, so that `pnpm i` will fail on any un-decided builds, instead of printing the noisy warning