### PR TITLE
FIX: Wrap language switcher in a list item in the header

### DIFF
--- a/app/assets/stylesheets/common/base/header.scss
+++ b/app/assets/stylesheets/common/base/header.scss
@@ -259,6 +259,9 @@
   }
 
   .language-switcher {
+    display: flex;
+    align-items: center;
+
     &__locale {
       color: var(--header_primary-high);
       font-size: var(--font-down-1);
@@ -268,7 +271,6 @@
       border: 1px solid var(--header_primary-low-mid);
       margin-right: var(--space-2);
       gap: var(--space-1);
-      align-self: center;
       padding: var(--space-1) var(--space-2);
 
       html.anon & {

--- a/frontend/discourse/app/components/header/icons.gjs
+++ b/frontend/discourse/app/components/header/icons.gjs
@@ -150,7 +150,9 @@ export default class Icons extends Component {
           {{/if}}
         {{else if (eq entry.key "language-switcher")}}
           {{#if this.showLanguageSwitcher}}
-            <LanguageSwitcher />
+            <li class="header-dropdown-toggle language-switcher">
+              <LanguageSwitcher />
+            </li>
           {{/if}}
         {{else if entry.value}}
           <entry.value />

--- a/frontend/discourse/tests/integration/components/header-icons-test.gjs
+++ b/frontend/discourse/tests/integration/components/header-icons-test.gjs
@@ -102,4 +102,34 @@ module("Integration | Component | Header | Icons", function (hooks) {
         "it does display when the site is in mobile view even if search_experience setting is search_field"
       );
   });
+
+  test("every header icon is a list item", async function (assert) {
+    const noop = () => {};
+    this.siteSettings.content_localization_enabled = true;
+    this.siteSettings.content_localization_supported_locales = "en|fr";
+    this.siteSettings.content_localization_language_switcher = "all";
+
+    await render(
+      <template>
+        <Icons
+          @sidebarEnabled={{true}}
+          @toggleSearchMenu={{noop}}
+          @toggleNavigationMenu={{noop}}
+          @toggleUserMenu={{noop}}
+          @searchButtonId={{SEARCH_BUTTON_ID}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".language-switcher-trigger")
+      .exists("the language switcher renders");
+
+    const children = [...document.querySelectorAll("ul.d-header-icons > *")];
+
+    assert.true(
+      children.every((el) => el.tagName === "LI"),
+      "all direct children of the header icons list are list items"
+    );
+  });
 });


### PR DESCRIPTION
The language switcher component rendered directly into the header icons list. This wraps it in a list item, matching adjacent items and rendering valid html.

Adds an integration test asserting every direct child of the header icons list is a list item.

Before: 

<img width="690" height="356" alt="image" src="https://github.com/user-attachments/assets/02ea092a-85e9-4404-abf8-716cbba4ccf2" />

After:

<img width="949" height="157" alt="image" src="https://github.com/user-attachments/assets/c8962c03-e841-468d-a35e-d4d87b5d700d" />
