### PR TITLE
SECURITY: Respect hidden profile visibility in activity serializers

### DIFF
--- a/app/serializers/group_user_with_custom_fields_serializer.rb
+++ b/app/serializers/group_user_with_custom_fields_serializer.rb
@@ -10,7 +10,21 @@ class GroupUserWithCustomFieldsSerializer < UserWithCustomFieldsSerializer
     options[:include_status] = true
   end
 
+  def include_last_posted_at?
+    can_see_profile?
+  end
+
+  def include_last_seen_at?
+    can_see_profile?
+  end
+
   def include_added_at?
     object.respond_to? :added_at
+  end
+
+  private
+
+  def can_see_profile?
+    (scope || Guardian.new).can_see_profile?(object)
   end
 end

--- a/app/serializers/invited_user_record_serializer.rb
+++ b/app/serializers/invited_user_record_serializer.rb
@@ -50,7 +50,15 @@ class InvitedUserRecordSerializer < BasicUserSerializer
     can_see_invite_details?
   end
 
+  def include_last_seen_at?
+    can_see_profile?
+  end
+
   private
+
+  def can_see_profile?
+    (scope || Guardian.new).can_see_profile?(object)
+  end
 
   def can_see_invite_details?
     @can_see_invite_details ||= scope.can_see_invite_details?(invited_by)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -848,6 +848,31 @@ RSpec.describe GroupsController do
       expect(response.status).to eq(403)
     end
 
+    it "hides activity timestamps for hidden profiles" do
+      SiteSetting.allow_users_to_hide_profile = true
+
+      hidden_user = Fabricate(:user, last_seen_at: 1.hour.ago, last_posted_at: 2.hours.ago)
+      hidden_user.user_option.update!(hide_profile: true)
+      visible_user = Fabricate(:user, last_seen_at: 3.hours.ago, last_posted_at: 4.hours.ago)
+      viewer = Fabricate(:user, trust_level: TrustLevel[2])
+      group.add(hidden_user)
+      group.add(visible_user)
+
+      sign_in(viewer)
+      get "/groups/#{group.name}/members.json"
+
+      expect(response.status).to eq(200)
+
+      members = response.parsed_body["members"]
+      hidden_member = members.find { |member| member["id"] == hidden_user.id }
+      visible_member = members.find { |member| member["id"] == visible_user.id }
+
+      expect(hidden_member).to be_present
+      expect(visible_member).to be_present
+      expect(hidden_member).not_to include("last_seen_at", "last_posted_at")
+      expect(visible_member).to include("last_seen_at", "last_posted_at")
+    end
+
     it "ensures that membership can be paginated" do
       freeze_time
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2364,6 +2364,36 @@ RSpec.describe UsersController do
       expect(invites[0]["user"]).to be_present
     end
 
+    it "hides last seen timestamps for hidden profiles" do
+      SiteSetting.allow_users_to_hide_profile = true
+
+      inviter = Fabricate(:user, trust_level: TrustLevel[2])
+      hidden_invitee = Fabricate(:user, last_seen_at: 1.hour.ago)
+      hidden_invitee.user_option.update!(hide_profile: true)
+      visible_invitee = Fabricate(:user, last_seen_at: 2.hours.ago)
+
+      [hidden_invitee, visible_invitee].each do |redeemed_user|
+        invite = Fabricate(:invite, invited_by: inviter)
+        Fabricate(:invited_user, invite: invite, user: redeemed_user)
+      end
+
+      sign_in(inviter)
+      get "/u/#{inviter.username}/invited.json"
+
+      expect(response.status).to eq(200)
+
+      invited_users = response.parsed_body["invites"].map { |invite| invite["user"] }
+      hidden_user_record =
+        invited_users.find { |invited_user| invited_user["id"] == hidden_invitee.id }
+      visible_user_record =
+        invited_users.find { |invited_user| invited_user["id"] == visible_invitee.id }
+
+      expect(hidden_user_record).to be_present
+      expect(visible_user_record).to be_present
+      expect(hidden_user_record).not_to include("last_seen_at")
+      expect(visible_user_record).to include("last_seen_at")
+    end
+
     it "doesn't filter by email if another regular user" do
       inviter = Fabricate(:user, trust_level: TrustLevel[2])
       sign_in(Fabricate(:user, trust_level: TrustLevel[2]))


### PR DESCRIPTION
Users who hide their profile should not expose activity timestamps through group member and invitee payloads. This change gates those fields behind the same profile visibility check used elsewhere.