### PR TITLE
SECURITY: Restrict tagged group message lists

### DIFF
--- a/lib/topic_query/private_message_lists.rb
+++ b/lib/topic_query/private_message_lists.rb
@@ -250,7 +250,18 @@ class TopicQuery
         return ids
       end
 
-      @group_with_messages_ids[user.id] = user.groups.where(has_messages: true).pluck(:id)
+      group_ids = user.groups.where(has_messages: true)
+
+      group_ids =
+        if user.admin? || user.in_any_groups?(SiteSetting.personal_message_enabled_groups_map)
+          group_ids.pluck(:id)
+        elsif user.moderator?
+          group_ids.where(id: Group::AUTO_GROUPS[:moderators]).pluck(:id)
+        else
+          []
+        end
+
+      @group_with_messages_ids[user.id] = group_ids
     end
 
     private

--- a/spec/lib/topic_query/private_message_lists_spec.rb
+++ b/spec/lib/topic_query/private_message_lists_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe TopicQuery::PrivateMessageLists do
   fab!(:admin)
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
-  fab!(:user_2, :user)
-  fab!(:user_3, :user)
-  fab!(:user_4, :user)
+  fab!(:user_2) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:user_3) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:user_4) { Fabricate(:user, refresh_auto_groups: true) }
 
   fab!(:group) do
     Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]).tap { |g| g.add(user_2) }

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -477,6 +477,28 @@ RSpec.describe ListController do
 
       expect(response.status).to eq(200)
     end
+
+    it "returns only visible tagged private messages" do
+      SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:staff]
+      SiteSetting.pm_tags_allowed_for_groups = group.name
+      group.add(user)
+      group.update!(has_messages: true)
+      direct_message = Fabricate(:private_message_topic, user: admin, recipient: user)
+      group_message = Fabricate(:group_private_message_topic, user: admin, recipient_group: group)
+      Fabricate(:topic_tag, tag: tag, topic: direct_message)
+      Fabricate(:topic_tag, tag: tag, topic: group_message)
+
+      sign_in(user)
+      get "/topics/private-messages-group/#{user.username}/#{group.name}.json"
+
+      expect(response.status).to eq(404)
+
+      get "/topics/private-messages-tags/#{user.username}/#{tag.name}.json"
+
+      expect(response.status).to eq(200)
+      topic_ids = response.parsed_body["topic_list"]["topics"].map { |topic| topic["id"] }
+      expect(topic_ids).to contain_exactly(direct_message.id)
+    end
   end
 
   describe "#private_messages_group" do


### PR DESCRIPTION
Filter combined private-message group IDs through group-message visibility so tagged PM lists do not include group topics the viewer cannot access.