### PR TITLE
FIX: Save staff group before enabling an "everyone"-excluded change

### DIFF
--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -261,15 +261,15 @@ export default class UpcomingChangeItem extends Component {
     const isEnabled = newValue !== "no_one";
 
     try {
-      await this.toggleChange(isEnabled, newValue);
-
       if (newValue === this.staffGroupName) {
         this.groupsChanged(this.staffGroupName);
-      } else if (newValue === "everyone" || newValue === "no_one") {
+        await this.saveGroups({ silenceToast: true });
+        await this.toggleChange(isEnabled, newValue);
+      } else {
+        await this.toggleChange(isEnabled, newValue);
         this.groupsChanged("");
+        await this.saveGroups({ silenceToast: true });
       }
-
-      await this.saveGroups({ silenceToast: true });
 
       this.args.enabledForChanged?.(this.args.change.setting, newValue);
     } catch (error) {

--- a/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-config-areas/upcoming-change-item-test.gjs
@@ -1,7 +1,8 @@
-import { render } from "@ember/test-helpers";
+import { fillIn, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import UpcomingChangeItem from "discourse/admin/components/admin-config-areas/upcoming-change-item";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { i18n } from "discourse-i18n";
 
 function buildChange(overrides = {}) {
@@ -248,5 +249,98 @@ module("Integration | Component | UpcomingChangeItem", function (hooks) {
           `does not show the permanent soon notice for ${status} changes`
         );
     });
+  });
+
+  test("selecting staff on a change that excludes 'everyone' saves the staff group before enabling", async function (assert) {
+    const requests = [];
+    let groupSaved = false;
+
+    pretender.put("/admin/config/upcoming-changes/groups", () => {
+      requests.push("groups");
+      groupSaved = true;
+      return response({ success: "OK" });
+    });
+    pretender.put("/admin/config/upcoming-changes/toggle", () => {
+      requests.push("toggle");
+      if (!groupSaved) {
+        return response(422, { errors: ["everyone is not an allowed target"] });
+      }
+      return response({ success: "OK" });
+    });
+
+    const change = buildChange({
+      setting: "reporting_improvements",
+      value: false,
+      upcoming_change: {
+        status: "beta",
+        impact: "feature,staff",
+        impact_type: "feature",
+        impact_role: "staff",
+        enabled_for: "no_one",
+        allow_enabled_for: ["staff", "specific_groups"],
+      },
+    });
+
+    await render(
+      <template>
+        <table>
+          <tbody><UpcomingChangeItem @change={{change}} /></tbody>
+        </table>
+      </template>
+    );
+
+    await fillIn(".upcoming-change__enabled-for", "staff");
+
+    assert.deepEqual(
+      requests,
+      ["groups", "toggle"],
+      "persists the staff group first, so the toggle passes instead of 422ing"
+    );
+    assert
+      .dom(".upcoming-change__enabled-for")
+      .hasValue("staff", "keeps staff selected");
+  });
+
+  test("selecting everyone toggles the change then clears any groups", async function (assert) {
+    const requests = [];
+
+    pretender.put("/admin/config/upcoming-changes/toggle", () => {
+      requests.push("toggle");
+      return response({ success: "OK" });
+    });
+    pretender.put("/admin/config/upcoming-changes/groups", () => {
+      requests.push("groups");
+      return response({ success: "OK" });
+    });
+
+    const change = buildChange({
+      value: false,
+      upcoming_change: {
+        status: "beta",
+        impact: "feature,all_members",
+        impact_type: "feature",
+        impact_role: "all_members",
+        enabled_for: "no_one",
+      },
+    });
+
+    await render(
+      <template>
+        <table>
+          <tbody><UpcomingChangeItem @change={{change}} /></tbody>
+        </table>
+      </template>
+    );
+
+    await fillIn(".upcoming-change__enabled-for", "everyone");
+
+    assert.deepEqual(
+      requests,
+      ["toggle", "groups"],
+      "enables first then clears groups when 'everyone' is allowed"
+    );
+    assert
+      .dom(".upcoming-change__enabled-for")
+      .hasValue("everyone", "keeps everyone selected");
   });
 });

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -260,6 +260,26 @@ describe "Admin upcoming changes" do
       item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
       expect(item.enabled_for).to eq("staff")
     end
+
+    it "enables the change for staff when everyone is excluded" do
+      mock_with_allow(%i[staff specific_groups])
+      SiteSetting.enable_upload_debug_mode = false
+
+      upcoming_changes_page.visit
+      item = upcoming_changes_page.change_item(:enable_upload_debug_mode)
+      item.select_enabled_for("staff")
+
+      expect(upcoming_changes_page).to have_enabled_for_success_toast(
+        "staff",
+        translation_args: {
+          staffGroupName: I18n.t("groups.default_names.staff").titleize,
+        },
+      )
+      expect(item).to be_enabled
+      expect(SiteSettingGroup.find_by(name: "enable_upload_debug_mode").group_ids).to include(
+        Group::AUTO_GROUPS[:staff].to_s,
+      )
+    end
   end
 
   it "can filter by name, description, plugin, status, impact type, or enabled/disabled" do


### PR DESCRIPTION
Fixes a bug reported at https://meta.discourse.org/t/issue-with-enabling-upcoming-changes/395881/31

### What

When an upcoming change's `allow_enabled_for` excludes `everyone` (for example `[staff, specific_groups]`, as the former `reporting_improvements` change had), selecting **Staff** in the *Enabled for* dropdown failed with a `422` and the selection snapped back to *No one*.

### Why

`enabledForChanged` toggled the setting on **before** persisting the staff group. On the server, `UpcomingChanges::Toggle#allowed_enabled_for_target` treats "enabled with no group configured" as targeting `everyone` — which these changes disallow — so the toggle was rejected and the change was never enabled.

Changes that allow `everyone` (the common case) weren't affected, because the initial toggle passes the policy and the staff group is saved a moment later.

### Fix

Persist the staff group **before** toggling, mirroring the existing "specific groups" path (which already saves groups first and only then enables the change). By the time the setting is toggled on, it is already scoped to staff, so the policy passes.

### Tests

- **Component** (`upcoming-change-item-test.gjs`): asserts the request order is `groups` → `toggle` for the staff selection on an `everyone`-excluded change, and that everyone/no-one still toggle first then clear groups.
- **System** (`admin_upcoming_changes_spec.rb`): enabling for staff on an `everyone`-excluded change now succeeds and persists the staff `SiteSettingGroup`.

### Screenshots

Before / after — selecting **Staff** on an `everyone`-excluded change (Horizon, light, desktop):

<img width="1664" height="466" alt="reporting-improvements-before-after" src="https://github.com/user-attachments/assets/085d9e7d-f61b-47bc-a683-5792e72a7217" />

