### PR TITLE
Fix wildcard hostname matching in FinalDestination

### DIFF
--- a/lib/final_destination.rb
+++ b/lib/final_destination.rb
@@ -453,7 +453,7 @@ class FinalDestination
       has_wildcard = hostname_parts.first == "*"
 
       if has_wildcard
-        @uri.hostname.end_with?(hostname_parts[1..-1].join("."))
+        @uri.hostname.end_with?(".#{hostname_parts[1..-1].join(".")}")
       else
         @uri.hostname == url.hostname
       end

--- a/spec/lib/final_destination_spec.rb
+++ b/spec/lib/final_destination_spec.rb
@@ -403,6 +403,18 @@ RSpec.describe FinalDestination do
         expect(get_stub).to_not have_been_requested
         expect(head_stub).to have_been_requested
       end
+
+      it "will do a HEAD on a host that merely ends with the wildcard domain but isn't a subdomain of it" do
+        url = "https://evilihaveawildcard.com/some/other/content"
+        get_stub = fd_stub_request(:get, url)
+        head_stub = fd_stub_request(:head, url)
+
+        final = FinalDestination.new(url, opts)
+        expect(final.resolve.to_s).to eq(url)
+        expect(final.status).to eq(:resolved)
+        expect(get_stub).to_not have_been_requested
+        expect(head_stub).to have_been_requested
+      end
     end
 
     context "when HEAD not supported" do


### PR DESCRIPTION
While reading through `hostname_matches?` I noticed the wildcard branch does a plain `end_with?` on the domain suffix, without requiring a dot before it. So a pattern like `*.ihaveawildcard.com` (used for `force_get_hosts` etc.) ends up matching `evilihaveawildcard.com` or `notihaveawildcard.com` too, since those strings also end with `ihaveawildcard.com` — they just aren't actual subdomains of it. Added the missing dot to the suffix check and a spec for the look-alike host case, next to the existing wildcard subdomain test.