### PR TITLE
UX: exclude language switcher from upcoming change icon resize

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/header.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/header.scss
@@ -33,7 +33,9 @@
   }
 
   .header-sidebar-toggle button .d-icon,
-  .d-header-icons .header-dropdown-toggle:not(.user-menu-panel) .d-icon {
+  .d-header-icons
+    .header-dropdown-toggle:not(.user-menu-panel, .language-switcher)
+    .d-icon {
     font-size: var(--font-up-3);
   }
 


### PR DESCRIPTION
This fixes an issue where the icon became too large due to a new wrapper added in 6278d763ad73e09f1d1f8ee2b2cb032293bbcf12

before
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b795b018-7bdc-4c04-aac5-fd44fee68927" />

after
<img width="250" alt="image" src="https://github.com/user-attachments/assets/e8f6a73c-9267-4c6e-aa2c-a24e516c7019" />
