### PR TITLE
UX: don't show shared issue button on deleted, disable for closed

### DIFF
--- a/plugins/discourse-solved/assets/javascripts/discourse/components/solved-shared-issue-button.gjs
+++ b/plugins/discourse-solved/assets/javascripts/discourse/components/solved-shared-issue-button.gjs
@@ -37,8 +37,31 @@ export default class SolvedSharedIssueButton extends Component {
     return this.currentUser && this.currentUser.id === this.args.post.user_id;
   }
 
+  get isClosed() {
+    return this.args.post.topic.closed;
+  }
+
+  get isArchived() {
+    return this.args.post.topic.archived;
+  }
+
   get disabled() {
-    return this.saving || this.isTopicAuthor;
+    return (
+      this.saving || this.isTopicAuthor || this.isClosed || this.isArchived
+    );
+  }
+
+  get titleKey() {
+    if (this.isTopicAuthor) {
+      return "solved.shared_issue.author_title";
+    }
+    if (this.isClosed) {
+      return "solved.shared_issue.closed_title";
+    }
+    if (this.isArchived) {
+      return "solved.shared_issue.archived_title";
+    }
+    return "solved.shared_issue.title";
   }
 
   get label() {
@@ -54,7 +77,7 @@ export default class SolvedSharedIssueButton extends Component {
 
   @action
   async toggle() {
-    if (this.isTopicAuthor) {
+    if (this.isTopicAuthor || this.isClosed || this.isArchived) {
       return;
     }
 
@@ -89,18 +112,14 @@ export default class SolvedSharedIssueButton extends Component {
             "btn-default"
             "post-action-menu__solved-shared-issue"
             (if this.hasSharedIssue "has-shared-issue")
-            (if this.isTopicAuthor "disabled")
+            (if this.disabled "disabled")
           }}
           ...attributes
           @action={{this.toggle}}
           @disabled={{this.disabled}}
           @icon="hand"
           @translatedLabel={{this.label}}
-          @title={{if
-            this.isTopicAuthor
-            "solved.shared_issue.author_title"
-            "solved.shared_issue.title"
-          }}
+          @title={{this.titleKey}}
         />
       </div>
     {{/if}}

--- a/plugins/discourse-solved/config/locales/client.en.yml
+++ b/plugins/discourse-solved/config/locales/client.en.yml
@@ -64,6 +64,8 @@ en:
         label_with_count: "%{label} (%{count})"
         title: "I am also experiencing this issue"
         author_title: "You started this topic"
+        closed_title: "This topic is closed"
+        archived_title: "This topic is archived"
 
       no_answer:
         title: Has your question been answered?

--- a/plugins/discourse-solved/lib/discourse_solved/guardian_extensions.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/guardian_extensions.rb
@@ -68,7 +68,7 @@ module DiscourseSolved
     def shared_issue_visible?(topic)
       return false if topic.blank?
       return false if topic.private_message?
-      return false if topic.trashed? || topic.closed? || topic.archived?
+      return false if topic.trashed?
       return false unless topic_in_support_category?(topic)
       return false unless shared_issues_enabled_for_category?(topic)
       unless UpcomingChanges.enabled_for_user?(:enable_solved_shared_issues, current_user)

--- a/plugins/discourse-solved/lib/discourse_solved/guardian_extensions.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/guardian_extensions.rb
@@ -57,6 +57,7 @@ module DiscourseSolved
       return false if topic.blank? || !authenticated?
       return false if topic.user_id == current_user.id
       return false if topic.private_message?
+      return false if topic.trashed? || topic.closed? || topic.archived?
       return false if topic.solved.present? && !SiteSetting.solved_allow_multiple_solutions
       return false unless topic_in_support_category?(topic)
       return false unless shared_issues_enabled_for_category?(topic)
@@ -67,6 +68,7 @@ module DiscourseSolved
     def shared_issue_visible?(topic)
       return false if topic.blank?
       return false if topic.private_message?
+      return false if topic.trashed? || topic.closed? || topic.archived?
       return false unless topic_in_support_category?(topic)
       return false unless shared_issues_enabled_for_category?(topic)
       unless UpcomingChanges.enabled_for_user?(:enable_solved_shared_issues, current_user)

--- a/plugins/discourse-solved/spec/requests/discourse_solved/shared_issue_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/discourse_solved/shared_issue_controller_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe DiscourseSolved::SharedIssueController do
         expect(response.status).to eq(403)
       end
 
+      it "rejects when the topic is closed" do
+        topic.update!(closed: true)
+        post "/solution/shared_issue.json", params: { topic_id: topic.id }
+        expect(response.status).to eq(403)
+      end
+
+      it "rejects when the topic is archived" do
+        topic.update!(archived: true)
+        post "/solution/shared_issue.json", params: { topic_id: topic.id }
+        expect(response.status).to eq(403)
+      end
+
       it "returns 404 for unknown topic" do
         post "/solution/shared_issue.json", params: { topic_id: -1 }
         expect(response.status).to eq(404)

--- a/plugins/discourse-solved/spec/system/shared_issue_spec.rb
+++ b/plugins/discourse-solved/spec/system/shared_issue_spec.rb
@@ -114,22 +114,24 @@ describe "Solved | Shared issue button" do
     expect(shared_issue_button).to have_no_shared_issue_button
   end
 
-  it "hides the button when the topic is closed" do
+  it "shows the button as read-only when the topic is closed" do
     topic.update!(closed: true)
 
     sign_in(member)
     topic_page.visit_topic(topic)
 
-    expect(shared_issue_button).to have_no_shared_issue_button
+    expect(shared_issue_button).to have_shared_issue_button
+    expect(shared_issue_button).to have_read_only
   end
 
-  it "hides the button when the topic is archived" do
+  it "shows the button as read-only when the topic is archived" do
     topic.update!(archived: true)
 
     sign_in(member)
     topic_page.visit_topic(topic)
 
-    expect(shared_issue_button).to have_no_shared_issue_button
+    expect(shared_issue_button).to have_shared_issue_button
+    expect(shared_issue_button).to have_read_only
   end
 
   it "shows the button as read-only for the topic author" do

--- a/plugins/discourse-solved/spec/system/shared_issue_spec.rb
+++ b/plugins/discourse-solved/spec/system/shared_issue_spec.rb
@@ -114,6 +114,24 @@ describe "Solved | Shared issue button" do
     expect(shared_issue_button).to have_no_shared_issue_button
   end
 
+  it "hides the button when the topic is closed" do
+    topic.update!(closed: true)
+
+    sign_in(member)
+    topic_page.visit_topic(topic)
+
+    expect(shared_issue_button).to have_no_shared_issue_button
+  end
+
+  it "hides the button when the topic is archived" do
+    topic.update!(archived: true)
+
+    sign_in(member)
+    topic_page.visit_topic(topic)
+
+    expect(shared_issue_button).to have_no_shared_issue_button
+  end
+
   it "shows the button as read-only for the topic author" do
     sign_in(author)
     topic_page.visit_topic(topic)


### PR DESCRIPTION
This hides the "me too" button for support categories when the topic is deleted, and disables it for closed/archived topics. 
