### PR TITLE
DEV: Tidy atomic_ln_s specs and align describe block naming

### DIFF
--- a/spec/lib/discourse_spec.rb
+++ b/spec/lib/discourse_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe Discourse do
     end
   end
 
-  describe "Utils.execute_command" do
+  describe ".execute_command" do
     it "works for individual commands" do
       expect(Discourse::Utils.execute_command("pwd").strip).to eq(Rails.root.to_s)
       expect(Discourse::Utils.execute_command("pwd", chdir: "plugins").strip).to eq(
@@ -631,12 +631,13 @@ RSpec.describe Discourse do
     end
   end
 
-  describe "Utils.atomic_ln_s" do
-    let(:source) { Dir.mktmpdir }
-
+  describe ".atomic_ln_s" do
     it "creates the destination symlink pointing at the source" do
       Dir.mktmpdir do |dir|
+        source = File.join(dir, "source")
+        Dir.mkdir(source)
         destination = File.join(dir, "link")
+
         Discourse::Utils.atomic_ln_s(source, destination)
 
         expect(File.symlink?(destination)).to eq(true)
@@ -646,8 +647,12 @@ RSpec.describe Discourse do
 
     it "replaces an existing symlink at the destination" do
       Dir.mktmpdir do |dir|
+        source = File.join(dir, "source")
+        Dir.mkdir(source)
+        old_target = File.join(dir, "old")
+        Dir.mkdir(old_target)
         destination = File.join(dir, "link")
-        File.symlink(Dir.mktmpdir, destination)
+        File.symlink(old_target, destination)
 
         Discourse::Utils.atomic_ln_s(source, destination)
 
@@ -659,6 +664,8 @@ RSpec.describe Discourse do
       # rename(2) raises EXDEV across filesystem boundaries (e.g. containers
       # where Rails.root/tmp is a separate mount). The link must still land.
       Dir.mktmpdir do |dir|
+        source = File.join(dir, "source")
+        Dir.mkdir(source)
         destination = File.join(dir, "link")
         allow(File).to receive(:rename).and_raise(Errno::EXDEV)
 


### PR DESCRIPTION
Follow-up to #41330.
