### PR TITLE
DEV: Reintroduce reporting_improvements upcoming change as permanent

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2928,6 +2928,7 @@ en:
     floating_dismiss_topics_on_mobile: "Shows a floating 'Dismiss...' button on mobile for the topic list for easier access and to free up space in the top of the topic list"
     rename_faq_to_guidelines: "This change renames the FAQ page to Guidelines. The FAQ page will still be available at /faq. The {{setting:faq_url}} setting works as before."
     enable_simplified_category_creation: "Enables a simplified category creation flow with fewer options and a cleaner interface."
+    reporting_improvements: "Improvements to navigation, design, and usability for Discourse's admin reports."
     modernize_foundation_theme: "This change introduces design modifcations to the Foundation theme in Discourse."
     enable_horizon_high_context_topic_cards: "Shows richer topic cards in the Horizon theme, including topic excerpts, tags, and plugin extended information."
     granular_anonymous_and_logged_in_groups_permissions: "Makes group-based site setting permissions treat 'everyone' as 'all logged-in users', and enables the new 'anonymous_users' and 'logged_in_users' pseudogroups so admins can explicitly target anonymous visitors and authenticated users."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4476,6 +4476,15 @@ dashboard:
     client: true
 
 experimental:
+  reporting_improvements:
+    default: false
+    client: true
+    hidden: true
+    area: "experimental"
+    upcoming_change:
+      status: "permanent"
+      impact: "feature,staff"
+      learn_more_url: "https://meta.discourse.org/t/-/395768"
   enable_auto_grid_images:
     default: true
     client: true


### PR DESCRIPTION
Follow-up to #41259, which removed the `reporting_improvements` upcoming change while it was still at `beta`.

Per the Upcoming Changes lifecycle, a change should graduate to `stable`/`permanent` rather than being deleted mid-ladder.