### PR TITLE
FIX: Record bulk tag and category changes as their own revision

### DIFF
--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -85,7 +85,7 @@ class TopicConverter
   private
 
   def revise_opts
-    { bypass_bump: @silent, skip_revision: @silent, silent: @silent }
+    { bypass_bump: @silent, silent: @silent, hidden: true }
   end
 
   def posters

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2870,8 +2870,6 @@ en:
     share_quote_buttons: "Determine which items appear in the quote sharing widget, and in what order."
     share_quote_visibility: "Determine when to show quote sharing buttons: never, to anonymous users only or all users. "
 
-    create_revision_on_bulk_topic_moves: "Create revision for first posts when topics are moved into a new category in bulk."
-
     allow_changing_staged_user_tracking: "Allow a staged user's category and tag notification preferences to be changed by an admin user."
     use_email_for_username_and_name_suggestions: "Use the first part of email addresses for username and name suggestions. Warning: This can make it easier for bad actors to discover the email address of your members (because many people use common email providers like `gmail.com`)."
     use_name_for_username_suggestions: "Use a user's full name when suggesting usernames during SSO and OAuth signup flows."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4026,10 +4026,6 @@ uncategorized:
     min: 100
     hidden: true
 
-  create_revision_on_bulk_topic_moves:
-    default: true
-    area: "posts_and_topics"
-
   allow_changing_staged_user_tracking:
     default: false
     area: "users"

--- a/db/post_migrate/20260702102111_remove_create_revision_on_bulk_topic_moves_setting.rb
+++ b/db/post_migrate/20260702102111_remove_create_revision_on_bulk_topic_moves_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveCreateRevisionOnBulkTopicMovesSetting < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'create_revision_on_bulk_topic_moves'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22412,6 +22412,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260702102111'),
 ('20260630034050'),
 ('20260629233141'),
 ('20260629081606'),

--- a/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -340,6 +340,7 @@ export default class BulkSelectTopicsDropdown extends Component {
         break;
       case "manage-tags":
         this.showBulkTopicActionsModal(actionId, "manage_tags", {
+          allowSilent: true,
           confirmButtonTranslationKey: "topics.bulk.confirm_apply_to_topics",
         });
         break;

--- a/frontend/discourse/app/components/modal/bulk-topic-actions.gjs
+++ b/frontend/discourse/app/components/modal/bulk-topic-actions.gjs
@@ -108,8 +108,8 @@ export default class BulkTopicActions extends Component {
     const mergedTagCategoryErrors = {};
     const options = {};
 
-    if (this.model.allowSilent && !this.notifyUsers) {
-      operation.silent = true;
+    if (this.model.allowSilent) {
+      operation.silent = !this.notifyUsers;
     }
 
     if (this.isCloseAction && this.closeNote) {

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -275,6 +275,7 @@ class PostRevisor
   # @option opts [Boolean] :skip_revision Do not create a new PostRevision record
   # @option opts [Boolean] :skip_staff_log Skip creating an entry in the staff action log
   # @option opts [Boolean] :silent Don't send notifications to user
+  # @option opts [Boolean] :hidden Force the created revision to be hidden from non-staff users
   # @return [Boolean] Returns true if the revision was successful, false otherwise
   def revise!(editor, fields, opts = {})
     @editor = editor
@@ -443,9 +444,10 @@ class PostRevisor
     # topic-only changes (without post content changes) should always create a new version
     # since the grace period concept doesn't apply to metadata changes like tags
     if topic_changed? && !post_changed?
-      # Allow hidden tag-only changes to update a previous hidden revision
-      # so that reverting hidden tag changes collapses the revisions
-      if only_hidden_tags_changed? &&
+      # Allow the same user to collapse a hidden tag-only change into their
+      # previous hidden revision (e.g. reverting); a different user's change must
+      # still create its own revision so authorship is not folded into theirs.
+      if only_hidden_tags_changed? && !edited_by_another_user? &&
            PostRevision.where(post_id: @post.id, number: @post.version).pick(:hidden)
         return false
       end
@@ -536,7 +538,7 @@ class PostRevisor
     @version_changed = true
     @post.version += 1
 
-    @hidden_revision = only_hidden_tags_changed?
+    @hidden_revision = @opts[:hidden] == true || only_hidden_tags_changed?
     @post.public_version += 1 unless @hidden_revision
 
     @post.last_version_at = @revised_at

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -172,22 +172,14 @@ class TopicsBulkAction
   def change_category
     updatable_topics = topics.where.not(category_id: @operation[:category_id])
 
-    opts = {
-      bypass_bump: true,
-      validate_post: false,
-      bypass_rate_limiter: true,
-      silent: @operation[:silent],
-      skip_revision: !SiteSetting.create_revision_on_bulk_topic_moves,
-    }
-
     updatable_topics.each do |t|
-      if guardian.can_edit?(t)
-        changes = { category_id: @operation[:category_id] }
-        if t.first_post.revise(@user, changes, opts)
-          @changed_ids << t.id
-        else
-          t.errors.full_messages.each { |msg| @errors[msg] += 1 }
-        end
+      next unless guardian.can_edit?(t) && t.first_post
+
+      changes = { category_id: @operation[:category_id] }
+      if t.first_post.revise(@user, changes, bulk_revision_opts)
+        @changed_ids << t.id
+      else
+        t.errors.full_messages.each { |msg| @errors[msg] += 1 }
       end
     end
   end
@@ -387,7 +379,7 @@ class TopicsBulkAction
     return false unless guardian.can_edit?(topic)
     return false unless topic.first_post
 
-    if topic.first_post.revise(@user, { tags: tag_names }, bulk_tag_opts)
+    if topic.first_post.revise(@user, { tags: tag_names }, bulk_revision_opts)
       @changed_ids << topic.id
       true
     else
@@ -429,13 +421,12 @@ class TopicsBulkAction
     end
   end
 
-  def bulk_tag_opts
-    {
+  def bulk_revision_opts
+    @bulk_revision_opts ||= {
       bypass_bump: true,
       validate_post: false,
       bypass_rate_limiter: true,
-      skip_revision: true,
-      silent: true,
+      silent: @operation.fetch(:silent, true),
     }
   end
 

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1554,17 +1554,15 @@ describe PostRevisor do
           end
 
           context "with hidden tags" do
+            fab!(:super_tag) { Fabricate(:tag, name: "super") }
+            fab!(:stuff_tag) { Fabricate(:tag, name: "stuff") }
             let(:bumped_at) { 1.day.ago }
 
             before do
               topic.update!(bumped_at: bumped_at)
               create_hidden_tags(%w[important secret])
               topic = post.topic
-              topic.tags = [
-                Fabricate(:tag, name: "super"),
-                Tag.where(name: "important").first,
-                Fabricate(:tag, name: "stuff"),
-              ]
+              topic.tags = [super_tag, Tag.where(name: "important").first, stuff_tag]
             end
 
             it "creates a hidden revision" do
@@ -1596,6 +1594,27 @@ describe PostRevisor do
               expect(post.version).to eq(1)
               expect(post.public_version).to eq(1)
               expect(post.revisions.count).to eq(0)
+            end
+
+            it "creates a separate revision when a different user changes hidden tags instead of folding into the first author's revision" do
+              admin_a = Fabricate(:admin)
+              admin_b = Fabricate(:admin)
+              original_tags = topic.tags.map(&:name)
+
+              PostRevisor.new(post.reload).revise!(
+                admin_a,
+                raw: post.raw,
+                tags: original_tags + ["secret"],
+              )
+              post.reload
+              expect(post.version).to eq(2)
+              expect(post.revisions.last.user_id).to eq(admin_a.id)
+
+              PostRevisor.new(post.reload).revise!(admin_b, raw: post.raw, tags: original_tags)
+              post.reload
+              expect(post.version).to eq(3)
+              expect(post.revisions.count).to eq(2)
+              expect(post.revisions.last.user_id).to eq(admin_b.id)
             end
 
             it "increments public_version when hidden tag added with other visible changes" do

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -161,18 +161,19 @@ RSpec.describe TopicsBulkAction do
 
     describe "silent option" do
       fab!(:admin)
+      fab!(:topic_watcher, :user)
+      fab!(:category_watcher, :user)
 
       before do
         Jobs.run_immediately!
         PostActionNotifier.enable
-        SiteSetting.create_revision_on_bulk_topic_moves = true
         TopicUser.change(
-          Fabricate(:user),
+          topic_watcher,
           topic.id,
           notification_level: TopicUser.notification_levels[:watching],
         )
         CategoryUser.set_notification_level_for_category(
-          Fabricate(:user),
+          category_watcher,
           CategoryUser.notification_levels[:watching_first_post],
           category.id,
         )
@@ -197,50 +198,30 @@ RSpec.describe TopicsBulkAction do
             [topic.id],
             type: "change_category",
             category_id: category.id,
+            silent: false,
           ).perform!
         end.to change { Notification.count }
       end
     end
 
     context "when the user can edit the topic" do
-      context "when create_revision_on_bulk_topic_moves is enabled" do
-        before { SiteSetting.create_revision_on_bulk_topic_moves = true }
+      it "changes category and creates a revision attributed to the acting user" do
+        old_category_id = topic.category_id
 
-        it "changes category and creates revision" do
-          old_category_id = topic.category_id
+        topic_ids =
+          TopicsBulkAction.new(
+            topic.user,
+            [topic.id],
+            type: "change_category",
+            category_id: category.id,
+          ).perform!
 
-          topic_ids =
-            TopicsBulkAction.new(
-              topic.user,
-              [topic.id],
-              type: "change_category",
-              category_id: category.id,
-            ).perform!
+        expect(topic_ids).to eq([topic.id])
+        expect(topic.reload.category).to eq(category)
 
-          expect(topic_ids).to eq([topic.id])
-          expect(topic.reload.category).to eq(category)
-
-          revision = topic.first_post.revisions.last
-          expect(revision.modifications).to eq({ "category_id" => [old_category_id, category.id] })
-        end
-      end
-
-      context "when create_revision_on_bulk_topic_moves is disabled" do
-        before { SiteSetting.create_revision_on_bulk_topic_moves = false }
-
-        it "changes category without revision" do
-          topic_ids =
-            TopicsBulkAction.new(
-              topic.user,
-              [topic.id],
-              type: "change_category",
-              category_id: category.id,
-            ).perform!
-
-          expect(topic_ids).to eq([topic.id])
-          expect(topic.reload.category).to eq(category)
-          expect(topic.first_post.revisions.last).to be_nil
-        end
+        revision = topic.first_post.revisions.last
+        expect(revision.user_id).to eq(topic.user.id)
+        expect(revision.modifications).to eq({ "category_id" => [old_category_id, category.id] })
       end
 
       it "does nothing when category stays the same" do
@@ -769,6 +750,7 @@ RSpec.describe TopicsBulkAction do
           [topic.id],
           type: "change_tags",
           tag_ids: [fab_tag3.id],
+          silent: true,
         ).perform!
       end.to not_change { Notification.where(user: topic_watcher).count }
     end
@@ -863,6 +845,7 @@ RSpec.describe TopicsBulkAction do
           [topic.id],
           type: "append_tags",
           tag_ids: [tag3.id],
+          silent: true,
         ).perform!
       end.to not_change { Notification.where(user: topic_watcher).count }
     end
@@ -912,7 +895,12 @@ RSpec.describe TopicsBulkAction do
       )
 
       expect do
-        TopicsBulkAction.new(Fabricate(:admin), [topic.id], type: "remove_tags").perform!
+        TopicsBulkAction.new(
+          Fabricate(:admin),
+          [topic.id],
+          type: "remove_tags",
+          silent: true,
+        ).perform!
       end.to not_change { Notification.where(user: topic_watcher).count }
     end
   end
@@ -939,7 +927,7 @@ RSpec.describe TopicsBulkAction do
       expect(pm.category_id).to eq(category.id)
     end
 
-    it "is silent by default" do
+    it "records a revision but stays silent (no bump, no small action) by default" do
       Jobs.run_immediately!
       bumped_at = pm.bumped_at
 
@@ -950,7 +938,7 @@ RSpec.describe TopicsBulkAction do
           type: "convert_to_public_topic",
           category_id: category.id,
         ).perform!
-      end.to not_change { PostRevision.count }
+      end.to change { PostRevision.count }.by(1)
 
       expect(pm.reload.bumped_at).to be_within(1.second).of(bumped_at)
       expect(pm.posts.where(post_type: Post.types[:small_action])).to be_empty
@@ -1101,9 +1089,10 @@ RSpec.describe TopicsBulkAction do
       expect(topic_3.reload.tags).to contain_exactly(tag_2)
     end
 
-    it "does not bump, revise, or notify watchers" do
+    it "records a revision without bumping or notifying watchers when silent" do
       topic_watcher = Fabricate(:user)
       Jobs.run_immediately!
+      PostActionNotifier.enable
       TopicUser.change(
         topic_watcher,
         topic_1.id,
@@ -1111,20 +1100,67 @@ RSpec.describe TopicsBulkAction do
       )
       topic_1.update!(bumped_at: 1.week.ago)
 
-      notifications_before = Notification.where(user: topic_watcher).count
       bumped_at_before = topic_1.bumped_at
       version_before = topic_1.first_post.version
 
+      expect do
+        TopicsBulkAction.new(
+          Fabricate(:admin),
+          [topic_1.id],
+          type: "manage_tags",
+          add_tag_ids: [tag_4.id],
+          silent: true,
+        ).perform!
+      end.to not_change { Notification.count }
+
+      expect(topic_1.first_post.reload.version).to eq(version_before + 1)
+      expect(topic_1.reload.bumped_at).to be_within(1.second).of(bumped_at_before)
+    end
+
+    it "records the bulk change as its own revision instead of rewriting an earlier user's revision (meta t/402693)" do
+      earlier_editor = Fabricate(:admin)
+      acting_user = Fabricate(:admin)
+
+      original_tags = [tag_1.name, tag_2.name]
+      after_earlier_edit = [tag_1.name, tag_2.name, tag_3.name]
+      after_bulk_removal = [tag_2.name, tag_3.name]
+
+      PostRevisor.new(topic_1.first_post).revise!(
+        earlier_editor,
+        { tags: after_earlier_edit },
+        force_new_version: true,
+      )
+      earlier_revision = topic_1.first_post.reload.revisions.last
+      expect(earlier_revision.user_id).to eq(earlier_editor.id)
+      earlier_diff = earlier_revision.modifications["tags"]
+
       TopicsBulkAction.new(
-        Fabricate(:admin),
+        acting_user,
         [topic_1.id],
         type: "manage_tags",
-        add_tag_ids: [tag_4.id],
+        remove_tag_ids: [tag_1.id],
       ).perform!
 
-      expect(Notification.where(user: topic_watcher).count).to eq(notifications_before)
-      expect(topic_1.reload.bumped_at).to be_within(1.second).of(bumped_at_before)
-      expect(topic_1.first_post.reload.version).to eq(version_before)
+      post = topic_1.first_post.reload
+
+      expect(post.revisions.count).to eq(2)
+      bulk_revision = post.revisions.last
+      expect(bulk_revision.user_id).to eq(acting_user.id)
+      expect(bulk_revision.modifications["tags"]).to eq(
+        [after_earlier_edit.sort, after_bulk_removal.sort],
+      )
+
+      expect(earlier_revision.reload.modifications["tags"]).to eq(earlier_diff)
+
+      guardian = Guardian.new(acting_user)
+      [
+        [earlier_revision, earlier_editor, original_tags, after_earlier_edit],
+        [bulk_revision, acting_user, after_earlier_edit, after_bulk_removal],
+      ].each do |revision, user, previous_tags, current_tags|
+        json = PostRevisionSerializer.new(revision, scope: guardian, root: false).as_json
+        expect(json[:username]).to eq(user.username_lower)
+        expect(json[:tags_changes]).to eq(previous: previous_tags.sort, current: current_tags.sort)
+      end
     end
 
     it "only updates topics the acting user can edit" do

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe TopicConverter do
         ).to be_present
       end
 
-      it "skips small action, revision, and bump when silent" do
+      it "records a revision but skips small action and bump when silent" do
         Jobs.run_immediately!
         first_post
         bumped_at = private_message.reload.bumped_at
@@ -139,8 +139,9 @@ RSpec.describe TopicConverter do
           TopicConverter.new(private_message, admin, silent: true).convert_to_public_topic(
             category.id,
           )
-        end.to not_change { PostRevision.count }
+        end.to change { PostRevision.count }.by(1)
 
+        expect(private_message.first_post.revisions.last.hidden).to eq(true)
         expect(private_message.posts.where(post_type: Post.types[:small_action])).to be_empty
         expect(private_message.reload.bumped_at).to be_within(1.second).of(bumped_at)
       end
@@ -270,14 +271,15 @@ RSpec.describe TopicConverter do
         ).to be_present
       end
 
-      it "skips small action, revision, and bump when silent" do
+      it "records a revision but skips small action and bump when silent" do
         Jobs.run_immediately!
         bumped_at = topic.bumped_at
 
         expect do
           TopicConverter.new(topic, admin, silent: true).convert_to_private_message
-        end.to not_change { PostRevision.count }
+        end.to change { PostRevision.count }.by(1)
 
+        expect(topic.first_post.revisions.last.hidden).to eq(true)
         expect(topic.posts.where(post_type: Post.types[:small_action])).to be_empty
         expect(topic.reload.bumped_at).to be_within(1.second).of(bumped_at)
       end


### PR DESCRIPTION
Previously, bulk tag, category, and conversion changes skipped creating a post revision, so each change silently folded into the topic's most recent revision — attributing it to that revision's author and date rather than to whoever ran the bulk action. This was reported for the new bulk "Manage tags" flow on [meta](https://meta.discourse.org/t/better-bulk-tag-management/402693).

This routes every bulk metadata change through `PostRevisor` so it always records its own revision, attributed to the acting user. Along the way it also:

- Unifies the silent/notify handling across bulk actions: the bulk "Manage tags" modal gains a "Notify users" checkbox, and the bulk convert modal's checkbox now actually toggles notifications instead of doing nothing.
- Records topic conversions as a staff-only (hidden) revision so a former private message is not disclosed in public edit history.
- Stops a different user's hidden-tag change from folding into an earlier author's revision.
- Removes the now-redundant `create_revision_on_bulk_topic_moves` site setting, whose disabled state reintroduced the bug and whose enabled state was already the default.
