### PR TITLE
FIX: Honor `silent=true` on internal links with other query params

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -339,7 +339,7 @@ class TopicLink < ActiveRecord::Base
     elsif route = Discourse.route_for(parsed.to_s[...TopicLink.max_url_length])
       # this is a special case for the silent flag
       # in internal links
-      return nil if url && (url.split("?")[1] == "silent=true")
+      return nil if parsed&.query&.split("&")&.include?("silent=true")
 
       internal = true
 

--- a/spec/models/topic_link_spec.rb
+++ b/spec/models/topic_link_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe TopicLink do
       expect(post.topic.topic_links.count).to eq(0)
     end
 
+    it "can exclude links with silent=true combined with other query params" do
+      url = topic.url
+
+      ["#{url}?u=someuser&silent=true", "#{url}?silent=true&u=someuser"].each do |link_url|
+        post = Fabricate(:post, user:, raw: "[silent link](#{link_url})")
+
+        TopicLink.extract_from(post)
+
+        expect(topic.topic_links.count).to eq(0)
+        expect(post.topic.topic_links.count).to eq(0)
+      end
+    end
+
     it "extracts onebox" do
       other_topic = Fabricate(:topic, user: user)
       Fabricate(:post, topic: other_topic, user: user, raw: "some content for the first post")


### PR DESCRIPTION
Previously, an internal link only suppressed the "linked" notification when `silent=true` was its *sole* query parameter, so links carrying extra params — like the daily summary's `?u=username&silent=true` — still notified the linked user.

This change inspects each query parameter, so `silent=true` is honored regardless of its position or any other params in the URL.
