### PR TITLE
FIX: Add composer to scroll-lock on iOS devices

### DIFF
--- a/frontend/discourse/app/lib/body-scroll-lock.js
+++ b/frontend/discourse/app/lib/body-scroll-lock.js
@@ -5,12 +5,24 @@
  */
 
 const isServer = () => typeof window === "undefined";
+const isDiscourseIOS = () => {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const html = document.documentElement;
+  return (
+    html.classList.contains("ios-device") ||
+    html.classList.contains("ipados-device")
+  );
+};
 const detectOS = (ua) => {
+  const uaProvided = Boolean(ua);
   ua = ua || navigator.userAgent;
   const ipad = /(iPad).*OS\s([\d_]+)/.test(ua);
   const iphone = !ipad && /(iPhone\sOS)\s([\d_]+)/.test(ua);
   const android = /(Android);?[\s/]+([\d.]+)?/.test(ua);
-  const ios = iphone || ipad;
+  const ios = iphone || ipad || (!uaProvided && isDiscourseIOS());
   return { ios, android };
 };
 function getEventListenerOptions(options) {

--- a/frontend/discourse/app/lib/composer/composer-position.js
+++ b/frontend/discourse/app/lib/composer/composer-position.js
@@ -1,4 +1,5 @@
 import { later } from "@ember/runloop";
+import { lock, unlock } from "discourse/lib/body-scroll-lock";
 import { applyBehaviorTransformer } from "discourse/lib/transformer";
 
 export function setupComposerPosition(editor) {
@@ -6,6 +7,54 @@ export function setupComposerPosition(editor) {
   // for Safari iOS/iPad and Firefox on Android
   // The fixes here go together with styling in base/compose.css
   const html = document.documentElement;
+  const isIOS = html.classList.contains("ios-device");
+  const isIpadOS = html.classList.contains("ipados-device");
+  const isMobileOrIpad = isIOS || isIpadOS;
+
+  let editorFocused = document.activeElement === editor;
+  let scrollLocked = false;
+  let scrollLockTargets = null;
+
+  function shouldLockScroll() {
+    const ipadHardwareKeyboard =
+      isIpadOS && !html.classList.contains("keyboard-visible");
+    return (
+      editorFocused &&
+      html.classList.contains("ios-device") &&
+      !ipadHardwareKeyboard
+    );
+  }
+
+  function getAllowedScrollTargets() {
+    const replyControl = document.getElementById("reply-control");
+    return [
+      editor,
+      replyControl?.querySelector(".d-editor-preview-wrapper"),
+      replyControl?.querySelector(".d-editor-button-bar__wrap"),
+    ].filter(Boolean);
+  }
+
+  function refreshScrollLock() {
+    if (shouldLockScroll() && !scrollLocked) {
+      scrollLockTargets = getAllowedScrollTargets();
+      lock(scrollLockTargets);
+      scrollLocked = true;
+    } else if (!shouldLockScroll() && scrollLocked) {
+      unlock(scrollLockTargets);
+      scrollLockTargets = null;
+      scrollLocked = false;
+    }
+  }
+
+  function onFocus() {
+    editorFocused = true;
+    refreshScrollLock();
+  }
+
+  function onBlur() {
+    editorFocused = false;
+    refreshScrollLock();
+  }
 
   function editorTouchMove(event) {
     // This is an alternative to locking up the body
@@ -21,23 +70,47 @@ export function setupComposerPosition(editor) {
     });
   }
 
-  if (
-    html.classList.contains("mobile-device") ||
-    html.classList.contains("ipados-device")
-  ) {
+  let classObserver;
+  if (isMobileOrIpad) {
     window.addEventListener("scroll", correctScrollPosition);
     correctScrollPosition();
     editor.addEventListener("touchmove", editorTouchMove);
   }
 
+  if (isIOS) {
+    editor.addEventListener("focus", onFocus);
+    editor.addEventListener("blur", onBlur);
+    refreshScrollLock();
+  }
+
+  if (isIpadOS) {
+    classObserver = new MutationObserver(refreshScrollLock);
+    classObserver.observe(html, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  }
+
   // destructor
   return () => {
-    if (
-      html.classList.contains("mobile-device") ||
-      html.classList.contains("ipados-device")
-    ) {
+    if (isMobileOrIpad) {
       window.removeEventListener("scroll", correctScrollPosition);
       editor.removeEventListener("touchmove", editorTouchMove);
+    }
+
+    if (isIOS) {
+      editor.removeEventListener("focus", onFocus);
+      editor.removeEventListener("blur", onBlur);
+
+      if (scrollLocked) {
+        unlock(scrollLockTargets);
+        scrollLockTargets = null;
+        scrollLocked = false;
+      }
+    }
+
+    if (isIpadOS) {
+      classObserver?.disconnect();
     }
   };
 }

--- a/frontend/discourse/app/lib/composer/composer-position.js
+++ b/frontend/discourse/app/lib/composer/composer-position.js
@@ -20,11 +20,7 @@ export function setupComposerPosition(editor) {
   function shouldLockScroll() {
     const ipadHardwareKeyboard =
       isIpadOS && !html.classList.contains("keyboard-visible");
-    return (
-      editorFocused &&
-      html.classList.contains("ios-device") &&
-      !ipadHardwareKeyboard
-    );
+    return editorFocused && isIOS && !ipadHardwareKeyboard;
   }
 
   function getAllowedScrollTargets() {

--- a/frontend/discourse/app/lib/composer/composer-position.js
+++ b/frontend/discourse/app/lib/composer/composer-position.js
@@ -7,9 +7,11 @@ export function setupComposerPosition(editor) {
   // for Safari iOS/iPad and Firefox on Android
   // The fixes here go together with styling in base/compose.css
   const html = document.documentElement;
+  const isMobileOrIpad =
+    html.classList.contains("mobile-device") ||
+    html.classList.contains("ipados-device");
   const isIOS = html.classList.contains("ios-device");
   const isIpadOS = html.classList.contains("ipados-device");
-  const isMobileOrIpad = isIOS || isIpadOS;
 
   let editorFocused = document.activeElement === editor;
   let scrollLocked = false;

--- a/frontend/discourse/select-kit/components/select-kit/select-kit-collection.gjs
+++ b/frontend/discourse/select-kit/components/select-kit/select-kit-collection.gjs
@@ -17,7 +17,7 @@ export default class SelectKitCollection extends Component {
     }
 
     const isChildOfLock = getLockState().lockedElements.some((locked) =>
-      locked.targetElement.contains(element)
+      (locked.targetElement ?? locked).contains(element)
     );
 
     if (isChildOfLock) {


### PR DESCRIPTION
There are quite a few issues with the composer positioning on iOS devices, especially on iPad because that requests the desktop site and gives a desktop-looking user agent. The main issue is that the cursor drops 1-3 lines when scrolling the background behind the composer.

This utilizes the existing body-scroll-lock library to lock the scroll of the background when the composer is open on iOS devices. This fix adds extra logic to body-scroll-lock to account for 'iPad' when the user agent is requesting the desktop site. Then it wires up the lock/unlock logic to the composer position code.

This effectively locks the background while the composer is focused on iOS devices, which prevents the cursor from dropping. It also mitigates quite a few other UI quirks that occur with background scrolling.

The change to select-kit-collection.gjs was defense against a potential future issue where the select-kit collection could be the target element and would therefore throw in the check.