### PR TITLE
UX: Explain why a revision diff can't be shown in the edit history

### DIFF
--- a/app/assets/stylesheets/common/base/history.scss
+++ b/app/assets/stylesheets/common/base/history.scss
@@ -125,6 +125,14 @@
     }
   }
 
+  .revision__hidden-notice {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 1em 0;
+    color: var(--primary-medium);
+  }
+
   &:not(.--mode-inline) {
     .-tag-revisions .tag-revision__wrapper {
       flex: 0 1 50%;

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5008,7 +5008,8 @@ en:
           other: "Are you sure you want to merge these %{count} posts?"
 
       revisions:
-        diff_too_complex: "The diff is too complex to display. Please try viewing individual smaller edits."
+        diff_too_complex: "This edit changed too much of the post at once, so it can't be shown."
+        diff_hidden: "Some of this post's edit history has been hidden, so this edit can't be shown."
         locale:
           no_locale_set: "No language set"
           locale_removed: "Language removed"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -286,7 +286,7 @@ en:
   errors: &errors
     format: ! "%{attribute} %{message}"
     format_with_full_message: "<b>%{attribute}</b>: %{message}"
-    diff_too_complex: "The diff is too complex to compute safely. Please try smaller edits."
+    diff_too_complex: "There are too many changes to show."
     messages:
       invalid_locale: "%{invalid_locale} is not a valid locale"
       too_long_validation:

--- a/frontend/discourse/app/components/modal/history.gjs
+++ b/frontend/discourse/app/components/modal/history.gjs
@@ -117,6 +117,14 @@ export default class History extends Component {
     return this.postRevision?.body_changes?.[this.viewMode];
   }
 
+  get diffHidden() {
+    return (
+      !this.postRevision?.body_changes &&
+      !this.postRevision?.diff_error &&
+      (this.postRevision?.previous_hidden || this.postRevision?.current_hidden)
+    );
+  }
+
   @action
   async calculateBodyDiff(_, [bodyDiff]) {
     let html = bodyDiff;
@@ -261,6 +269,10 @@ export default class History extends Component {
   }
 
   get hiddenClasses() {
+    if (this.diffHidden) {
+      return null;
+    }
+
     if (this.viewMode === "inline") {
       return this.postRevision?.previous_hidden ||
         this.postRevision?.current_hidden
@@ -408,6 +420,7 @@ export default class History extends Component {
             <Revisions
               @model={{this.postRevision}}
               @hiddenClasses={{this.hiddenClasses}}
+              @diffHidden={{this.diffHidden}}
               @mobileView={{this.site.mobileView}}
               @userChanges={{this.user_changes}}
               @previousCategory={{this.previousCategory}}

--- a/frontend/discourse/app/components/modal/history/revisions.gjs
+++ b/frontend/discourse/app/components/modal/history/revisions.gjs
@@ -220,13 +220,20 @@ export default class Revisions extends Component {
         />
       </span>
 
-      <LinksRedirect
-        {{didInsert @calculateBodyDiff @bodyDiffHTML}}
-        {{didUpdate @calculateBodyDiff @bodyDiffHTML}}
-        class="row body-diff"
-      >
-        {{trustHTML @bodyDiff}}
-      </LinksRedirect>
+      {{#if @diffHidden}}
+        <div class="row revision__hidden-notice">
+          {{dIcon "far-eye-slash"}}
+          <span>{{i18n "post.revisions.diff_hidden"}}</span>
+        </div>
+      {{else}}
+        <LinksRedirect
+          {{didInsert @calculateBodyDiff @bodyDiffHTML}}
+          {{didUpdate @calculateBodyDiff @bodyDiffHTML}}
+          class="row body-diff"
+        >
+          {{trustHTML @bodyDiff}}
+        </LinksRedirect>
+      {{/if}}
     </div>
   </template>
 }

--- a/spec/system/page_objects/modals/post_history.rb
+++ b/spec/system/page_objects/modals/post_history.rb
@@ -39,6 +39,18 @@ module PageObjects
         body.has_css?(".-tag-revisions")
       end
 
+      def has_hidden_diff_notice?
+        body.has_css?(".revision__hidden-notice", text: I18n.t("js.post.revisions.diff_hidden"))
+      end
+
+      def has_no_hidden_diff_notice?
+        body.has_no_css?(".revision__hidden-notice")
+      end
+
+      def has_body_diff?(text)
+        body.has_css?(".body-diff", text: text)
+      end
+
       def previous_tags
         body.find(".-tag-revisions .tag-revision__wrapper:first-child")
       end

--- a/spec/system/post_history_spec.rb
+++ b/spec/system/post_history_spec.rb
@@ -64,3 +64,45 @@ describe "Post history with tag changes" do
     expect(post_history_modal.inserted_tags).to contain_exactly(tag2.name, tag3.name)
   end
 end
+
+describe "Post history with a hidden revision" do
+  include ThemeScreenshotMarker
+
+  fab!(:admin)
+  fab!(:post_owner, :user)
+  fab!(:topic) { Fabricate(:topic, user: post_owner) }
+  fab!(:post) { Fabricate(:post, topic: topic, user: post_owner, raw: "Initial public version") }
+
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:post_history_modal) { PageObjects::Modals::PostHistory.new }
+
+  before do
+    SiteSetting.editing_grace_period = 0
+
+    post.revise(post_owner, raw: "Second public version")
+    post.revise(post_owner, raw: "Hidden secret version")
+    post.revise(post_owner, raw: "Latest public version")
+    post.revisions.find_by(number: 3).hide!
+  end
+
+  it "tells anonymous users why a diff can't be displayed instead of showing a blank space" do
+    topic_page.visit_topic(topic)
+    find(".post-info.edits").click
+
+    expect(post_history_modal).to have_hidden_diff_notice
+    screenshot_marker(label: "post-history-hidden-edit", only: :desktop)
+
+    post_history_modal.click_previous_revision
+
+    expect(post_history_modal).to have_hidden_diff_notice
+  end
+
+  it "still shows the diffs around the hidden revision to staff" do
+    sign_in(admin)
+    topic_page.visit_topic(topic)
+    find(".post-info.edits").click
+
+    expect(post_history_modal).to have_no_hidden_diff_notice
+    expect(post_history_modal).to have_body_diff("Latest public version")
+  end
+end


### PR DESCRIPTION
Previously, when a post revision was hidden, the history modal showed a completely blank diff area for the revisions next to it, with no explanation — the diffs on either side of a hidden revision aren't rendered because they can expose the hidden revision's content, but users were left thinking the edit history was broken. Reported in https://meta.discourse.org/t/diff-between-revisions-no-longer-visible-when-there-is-a-hidden-revision-in-between/406254.

This change shows an explanatory notice in place of the blank diff, driven by the `previous_hidden`/`current_hidden` flags the serializer already exposes for exactly these revisions. The `hiddenClasses` dimming is skipped when the notice shows, since it exists to fade hidden content staff can still see and would fade the notice in the inline view. It also rewords the related `diff_too_complex` messages in the same plain language, since "diff" and "revision" aren't words most users know.