### PR TITLE
UX: On touch sidebar, perform action directly

### DIFF
--- a/frontend/discourse/app/components/sidebar/section-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-link.gjs
@@ -40,6 +40,7 @@ export function isHex(input) {
  * @param {Object} @suffixArgs - Arguments to pass to the suffix component
  */
 export default class SectionLink extends Component {
+  @service capabilities;
   @service currentUser;
 
   @tracked hovering = false;
@@ -140,9 +141,13 @@ export default class SectionLink extends Component {
     }
   }
 
+  get shouldRenderHoverAction() {
+    return this.args.hoverValue && !this.capabilities.touch;
+  }
+
   @action
   hoveringSectionLink() {
-    if (this.hoverActionActive) {
+    if (this.capabilities.touch || this.hoverActionActive) {
       return;
     }
     this.hovering = true;
@@ -150,7 +155,7 @@ export default class SectionLink extends Component {
 
   @action
   stopHoveringSectionLink() {
-    if (this.hoverActionActive) {
+    if (this.capabilities.touch || this.hoverActionActive) {
       return;
     }
     this.hovering = false;
@@ -247,7 +252,7 @@ export default class SectionLink extends Component {
             {{/if}}
 
             {{! eslint-disable ember/template-no-nested-interactive }}
-            {{#if @hoverValue}}
+            {{#if this.shouldRenderHoverAction}}
               <span class="sidebar-section-link-hover">
                 <button
                   {{on "click" this.runHoverAction}}
@@ -314,7 +319,7 @@ export default class SectionLink extends Component {
               </span>
             {{/if}}
 
-            {{#if @hoverValue}}
+            {{#if this.shouldRenderHoverAction}}
               <span class="sidebar-section-link-hover">
                 <button
                   {{on "click" this.runHoverAction}}

--- a/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
+++ b/frontend/discourse/tests/integration/components/sidebar/section-link-test.gjs
@@ -1,10 +1,17 @@
-import { render } from "@ember/test-helpers";
+import { render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import SectionLink from "discourse/components/sidebar/section-link";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
 module("Integration | Component | Sidebar | SectionLink", function (hooks) {
   setupRenderingTest(hooks);
+
+  function setTouch(owner, value) {
+    Object.defineProperty(owner.lookup("service:capabilities"), "touch", {
+      configurable: true,
+      value,
+    });
+  }
 
   test("default class attribute for link", async function (assert) {
     const template = <template>
@@ -59,5 +66,47 @@ module("Integration | Component | Sidebar | SectionLink", function (hooks) {
     await render(template);
 
     assert.dom("a").hasAttribute("target", "_blank");
+  });
+
+  test("hover action is rendered on non-touch devices", async function (assert) {
+    setTouch(this.owner, false);
+
+    const template = <template>
+      <SectionLink
+        @linkName="test"
+        @route="discovery.latest"
+        @hoverType="icon"
+        @hoverValue="ellipsis-vertical"
+      />
+    </template>;
+
+    await render(template);
+
+    assert.dom(".sidebar-section-hover-button").exists();
+
+    await triggerEvent(".sidebar-section-link-wrapper", "mouseenter");
+
+    assert.dom(".sidebar-section-link-wrapper").hasClass("--hovering");
+  });
+
+  test("hover action is not rendered on touch devices", async function (assert) {
+    setTouch(this.owner, true);
+
+    const template = <template>
+      <SectionLink
+        @linkName="test"
+        @route="discovery.latest"
+        @hoverType="icon"
+        @hoverValue="ellipsis-vertical"
+      />
+    </template>;
+
+    await render(template);
+
+    assert.dom(".sidebar-section-hover-button").doesNotExist();
+
+    await triggerEvent(".sidebar-section-link-wrapper", "mouseenter");
+
+    assert.dom(".sidebar-section-link-wrapper").doesNotHaveClass("--hovering");
   });
 });


### PR DESCRIPTION
This means on mobile, tapping on chat elements will load the channel immediately. Actions in the hover menu are available in other places.

Might need some tweaks for tablets.