### PR TITLE
FIX: Topic Merging with Events

### DIFF
--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/basic_event_serializer.rb
@@ -19,10 +19,12 @@ module DiscoursePostEvent
                :custom_fields
 
     def category_id
-      object.post.topic.category_id
+      object.post&.topic&.category_id
     end
 
     def post
+      return nil if object.post.blank?
+
       {
         id: object.post.id,
         post_number: object.post.post_number,

--- a/plugins/discourse-calendar/lib/discourse_post_event/topic_extension.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/topic_extension.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  module TopicExtension
+    def move_posts(moved_by, post_ids, opts)
+      ensure_event_invariants!(post_ids, opts)
+      super
+    end
+
+    private
+
+    def ensure_event_invariants!(post_ids, opts)
+      return unless SiteSetting.discourse_post_event_enabled
+      return unless opts[:destination_topic_id]
+
+      destination = Topic.find_by(id: opts[:destination_topic_id])
+      return unless destination
+
+      destination_op = destination.first_post
+      destination_has_event = destination_op&.event.present?
+      incoming_event_post = Post.where(id: post_ids).joins(:event).order(:created_at).first
+
+      return unless destination_has_event || incoming_event_post
+
+      raise_event_move_error! if destination_has_event && incoming_event_post
+
+      chronological = !!opts[:chronological_order]
+
+      if destination_has_event && chronological
+        oldest_incoming = Post.where(id: post_ids).order(:created_at).first
+        if oldest_incoming && oldest_incoming.created_at < destination_op.created_at
+          raise_event_move_error!
+        end
+      end
+
+      if incoming_event_post && !destination_has_event
+        becomes_new_op =
+          chronological &&
+            (destination_op.nil? || incoming_event_post.created_at < destination_op.created_at)
+        raise_event_move_error! unless becomes_new_op
+      end
+    end
+
+    def raise_event_move_error!
+      raise ActiveRecord::RecordNotSaved.new(
+              I18n.t("discourse_post_event.errors.models.event.must_be_in_first_post"),
+            )
+    end
+  end
+end

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -183,6 +183,7 @@ after_initialize do
   require_relative "lib/discourse_post_event/export_csv_controller_extension"
   require_relative "lib/discourse_post_event/export_csv_file_extension"
   require_relative "lib/discourse_post_event/post_extension"
+  require_relative "lib/discourse_post_event/topic_extension"
   require_relative "lib/discourse_post_event/rrule_generator"
   require_relative "lib/discourse_post_event/rrule_configurator"
   require_relative "lib/discourse_post_event/web_hook_extension"
@@ -223,6 +224,7 @@ after_initialize do
     Jobs::ExportCsvFile.prepend(DiscoursePostEvent::ExportPostEventCsvReportExtension)
     Post.prepend(DiscoursePostEvent::PostExtension)
     ::WebHook.prepend(DiscoursePostEvent::WebHookExtension)
+    Topic.prepend(DiscoursePostEvent::TopicExtension)
     Topic.prepend(DiscourseCalendar::Livestream::TopicExtension)
     Chat::Channel.prepend(DiscourseCalendar::Livestream::ChatChannelExtension)
   end

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/topic_extension_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/topic_extension_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+describe DiscoursePostEvent::TopicExtension do
+  before do
+    freeze_time
+    Jobs.run_immediately!
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+  end
+
+  fab!(:user) { Fabricate(:user, admin: true, refresh_auto_groups: true) }
+
+  let(:event_topic) { Fabricate(:topic, user:, created_at: 2.days.ago) }
+  let(:event_op) { Fabricate(:post, topic: event_topic, user:, created_at: 2.days.ago) }
+  let!(:event) { Fabricate(:event, post: event_op) }
+
+  let(:plain_topic) { Fabricate(:topic, user:, created_at: 2.days.ago) }
+  let!(:plain_op) { Fabricate(:post, topic: plain_topic, user:, created_at: 2.days.ago) }
+
+  let(:source_topic) { Fabricate(:topic, user:) }
+
+  def move(from:, post_ids:, into:, chronological_order:)
+    from.move_posts(user, post_ids, destination_topic_id: into.id, chronological_order:)
+  end
+
+  def expect_block(&block)
+    expect(&block).to raise_error(
+      ActiveRecord::RecordNotSaved,
+      I18n.t("discourse_post_event.errors.models.event.must_be_in_first_post"),
+    )
+  end
+
+  describe "#move_posts" do
+    context "when destination has an event and incoming does not" do
+      it "blocks chronological merge with an older incoming post (would displace the event)" do
+        older = Fabricate(:post, topic: source_topic, user:, created_at: 5.days.ago)
+
+        expect_block do
+          move(
+            from: source_topic,
+            post_ids: [older.id],
+            into: event_topic,
+            chronological_order: true,
+          )
+        end
+        expect(event_op.reload.post_number).to eq(1)
+      end
+
+      it "allows chronological merge with a newer incoming post" do
+        newer = Fabricate(:post, topic: source_topic, user:, created_at: 1.hour.ago)
+
+        expect {
+          move(
+            from: source_topic,
+            post_ids: [newer.id],
+            into: event_topic,
+            chronological_order: true,
+          )
+        }.not_to raise_error
+        expect(event_op.reload.post_number).to eq(1)
+      end
+
+      it "allows sequential merge regardless of created_at" do
+        older = Fabricate(:post, topic: source_topic, user:, created_at: 5.days.ago)
+
+        expect {
+          move(
+            from: source_topic,
+            post_ids: [older.id],
+            into: event_topic,
+            chronological_order: false,
+          )
+        }.not_to raise_error
+        expect(event_op.reload.post_number).to eq(1)
+      end
+    end
+
+    context "when incoming has an event and destination does not" do
+      let(:incoming_topic) { Fabricate(:topic, user:) }
+      let(:incoming_event_op) do
+        Fabricate(:post, topic: incoming_topic, user:, created_at: 5.days.ago)
+      end
+      let!(:incoming_event) { Fabricate(:event, post: incoming_event_op) }
+
+      it "allows chronological merge when the incoming event is the oldest post" do
+        expect {
+          move(
+            from: incoming_topic,
+            post_ids: [incoming_event_op.id],
+            into: plain_topic,
+            chronological_order: true,
+          )
+        }.not_to raise_error
+      end
+
+      it "blocks chronological merge when the incoming event is newer than the destination OP" do
+        newer_topic = Fabricate(:topic, user:)
+        newer_event_op = Fabricate(:post, topic: newer_topic, user:, created_at: 1.hour.ago)
+        Fabricate(:event, post: newer_event_op)
+
+        expect_block do
+          move(
+            from: newer_topic,
+            post_ids: [newer_event_op.id],
+            into: plain_topic,
+            chronological_order: true,
+          )
+        end
+      end
+
+      it "blocks sequential merge (incoming event would land in a non-OP slot)" do
+        expect_block do
+          move(
+            from: incoming_topic,
+            post_ids: [incoming_event_op.id],
+            into: plain_topic,
+            chronological_order: false,
+          )
+        end
+      end
+    end
+
+    context "when both destination and incoming have an event" do
+      let(:incoming_topic) { Fabricate(:topic, user:) }
+      let(:incoming_event_op) do
+        Fabricate(:post, topic: incoming_topic, user:, created_at: 1.hour.ago)
+      end
+      let!(:incoming_event) { Fabricate(:event, post: incoming_event_op) }
+
+      it "blocks the merge whether chronological or sequential" do
+        expect_block do
+          move(
+            from: incoming_topic,
+            post_ids: [incoming_event_op.id],
+            into: event_topic,
+            chronological_order: true,
+          )
+        end
+
+        expect_block do
+          move(
+            from: incoming_topic,
+            post_ids: [incoming_event_op.id],
+            into: event_topic,
+            chronological_order: false,
+          )
+        end
+      end
+    end
+
+    context "with unrelated merges" do
+      it "allows any merge when neither topic has an event" do
+        other = Fabricate(:post, topic: source_topic, user:, created_at: 5.days.ago)
+
+        expect {
+          move(
+            from: source_topic,
+            post_ids: [other.id],
+            into: plain_topic,
+            chronological_order: true,
+          )
+        }.not_to raise_error
+      end
+
+      it "does not block when discourse_post_event is disabled" do
+        SiteSetting.discourse_post_event_enabled = false
+        older = Fabricate(:post, topic: source_topic, user:, created_at: 5.days.ago)
+
+        expect {
+          move(
+            from: source_topic,
+            post_ids: [older.id],
+            into: event_topic,
+            chronological_order: true,
+          )
+        }.not_to raise_error
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/serializers/discourse_post_event/basic_event_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/discourse_post_event/basic_event_serializer_spec.rb
@@ -5,6 +5,7 @@ describe DiscoursePostEvent::BasicEventSerializer do
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
     SiteSetting.discourse_post_event_allowed_custom_fields = "team"
+    Jobs.run_immediately!
   end
 
   fab!(:category)
@@ -17,5 +18,18 @@ describe DiscoursePostEvent::BasicEventSerializer do
   it "includes custom_fields so they are readable from event listings" do
     json = described_class.new(event, scope: Guardian.new, root: false).as_json
     expect(json[:custom_fields]["team"]).to eq("rocket")
+  end
+
+  it "returns the topic's category_id" do
+    json = described_class.new(event, scope: Guardian.new).as_json
+    expect(json[:basic_event][:category_id]).to eq(category.id)
+  end
+
+  it "serializes without raising when the associated post is gone" do
+    event.stubs(:post).returns(nil)
+
+    json = described_class.new(event, scope: Guardian.new).as_json
+    expect(json[:basic_event][:category_id]).to be_nil
+    expect(json[:basic_event][:post]).to be_nil
   end
 end


### PR DESCRIPTION
meta topic: [`/t/371843`](https://meta.discourse.org/t/nomethoderror-in-topicscontroller-show-error-after-merging-topics/371843)

This fixes the bug pointed out about merging topics with events. The issue was that when merging topics with events, it circumvented the event validation logic and allowed event posts to be merged into topics that already have events or displace the event post in the destination.

Add a topic extension to handle the event validation logic when merging topics with events. Also add null safety in the event serializer to handle cases where the event post is no longer valid.