### PR TITLE
FIX: Enforce group visibility when filtering users by group

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -21,8 +21,7 @@ class DirectoryItemsController < ApplicationController
     if params[:group]
       group = Group.find_by(name: params[:group])
       raise Discourse::InvalidParameters.new(:group) if group.blank?
-      guardian.ensure_can_see!(group)
-      guardian.ensure_can_see_group_members!(group)
+      guardian.ensure_can_see_group_and_members!(group)
 
       result = result.includes(user: :groups).where(users: { groups: { id: group.id } })
     else
@@ -155,7 +154,7 @@ class DirectoryItemsController < ApplicationController
   def set_groups_exclusion
     @exclude_group_names = params[:exclude_groups].split("|")
     groups = Group.where(name: @exclude_group_names)
-    groups = groups.select { |g| guardian.can_see?(g) && guardian.can_see_group_members?(g) }
+    groups = groups.select { |g| guardian.can_see_group_and_members?(g) }
     @exclude_group_ids = groups.map(&:id)
     @users_in_exclude_groups = GroupUser.where(group_id: @exclude_group_ids).pluck(:user_id)
   end

--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -172,8 +172,7 @@ class ListController < ApplicationController
   def group_topics
     group = Group.find_by(name: params[:group_name])
     raise Discourse::NotFound unless group
-    guardian.ensure_can_see_group!(group)
-    guardian.ensure_can_see_group_members!(group)
+    guardian.ensure_can_see_group_and_members!(group)
 
     list_opts = build_topic_list_options
     list = generate_list_for("group_topics", group, list_opts)

--- a/app/models/user_search.rb
+++ b/app/models/user_search.rb
@@ -24,7 +24,7 @@ class UserSearch
     @category = Category.find(@category_id) if @category_id
 
     @guardian = Guardian.new(@searching_user)
-    @guardian.ensure_can_see_groups_members!(@groups) if @groups
+    @groups&.each { |group| @guardian.ensure_can_see_group_and_members!(group) }
     @guardian.ensure_can_see_category!(@category) if @category
     @guardian.ensure_can_see_topic!(@topic) if @topic
   end

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -301,6 +301,10 @@ class Guardian
     true
   end
 
+  def can_see_group_and_members?(group)
+    can_see_group?(group) && can_see_group_members?(group)
+  end
+
   def can_see_groups?(groups)
     return false if groups.blank?
     if is_admin? || groups.all? { |g| g.visibility_level == Group.visibility_levels[:public] }

--- a/plugins/discourse-assign/app/controllers/discourse_assign/assign_controller.rb
+++ b/plugins/discourse-assign/app/controllers/discourse_assign/assign_controller.rb
@@ -149,8 +149,7 @@ module DiscourseAssign
 
       group = Group.find_by(name: params[:group_name])
 
-      guardian.ensure_can_see_group!(group)
-      guardian.ensure_can_see_group_members!(group)
+      guardian.ensure_can_see_group_and_members!(group)
       raise Discourse::InvalidAccess if !guardian.can_assign_globally?
 
       users_with_assignments_count =

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -457,8 +457,7 @@ after_initialize do
 
   add_to_class(:list_controller, :group_topics_assigned) do
     group = Group.find_by("name = ?", params[:groupname])
-    guardian.ensure_can_see_group!(group)
-    guardian.ensure_can_see_group_members!(group)
+    guardian.ensure_can_see_group_and_members!(group)
 
     raise Discourse::NotFound unless group
     raise Discourse::InvalidAccess unless guardian.can_assign_globally?

--- a/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
+++ b/plugins/discourse-calendar/jobs/regular/discourse_post_event/bulk_invite.rb
@@ -140,7 +140,7 @@ module Jobs
       invitees.filter do |i|
         group = groups.find { |g| g.name === i[:identifier] }
 
-        !group || (@guardian.can_see_group?(group) && @guardian.can_see_group_members?(group))
+        !group || @guardian.can_see_group_and_members?(group)
       end
     end
   end

--- a/spec/lib/guardian_spec.rb
+++ b/spec/lib/guardian_spec.rb
@@ -3057,6 +3057,59 @@ RSpec.describe Guardian do
     end
   end
 
+  describe "#can_see_group_and_members?" do
+    it "requires both group visibility and member visibility" do
+      visible_group_hidden_members =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:public],
+          members_visibility_level: Group.visibility_levels[:owners],
+        )
+      expect(
+        Guardian.new(another_user).can_see_group_and_members?(visible_group_hidden_members),
+      ).to eq(false)
+
+      hidden_group_public_members =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:logged_on_users],
+          members_visibility_level: Group.visibility_levels[:public],
+        )
+      expect(Guardian.new.can_see_group_and_members?(hidden_group_public_members)).to eq(false)
+      expect(
+        Guardian.new(another_user).can_see_group_and_members?(hidden_group_public_members),
+      ).to eq(true)
+
+      public_group =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:public],
+          members_visibility_level: Group.visibility_levels[:public],
+        )
+      expect(Guardian.new.can_see_group_and_members?(public_group)).to eq(true)
+    end
+
+    it "raises via the ensure_ variant unless both are visible" do
+      hidden_group_public_members =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:logged_on_users],
+          members_visibility_level: Group.visibility_levels[:public],
+        )
+      expect {
+        Guardian.new.ensure_can_see_group_and_members!(hidden_group_public_members)
+      }.to raise_error(Discourse::InvalidAccess)
+
+      public_group =
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:public],
+          members_visibility_level: Group.visibility_levels[:public],
+        )
+      expect { Guardian.new.ensure_can_see_group_and_members!(public_group) }.not_to raise_error
+    end
+  end
+
   describe "#can_see_groups?" do
     it "correctly handles owner visible groups" do
       group = Fabricate(:group, visibility_level: Group.visibility_levels[:owners])

--- a/spec/models/user_search_spec.rb
+++ b/spec/models/user_search_spec.rb
@@ -114,6 +114,68 @@ RSpec.describe UserSearch do
     expect(results).to eq [sam, samantha].map(&:username)
   end
 
+  it "raises when filtering by a group the user cannot see, even if its members are public" do
+    hidden =
+      Fabricate(
+        :group,
+        visibility_level: Group.visibility_levels[:logged_on_users],
+        members_visibility_level: Group.visibility_levels[:public],
+      )
+    hidden.add(Fabricate(:user, username: "hiddenmember"))
+
+    expect { search_for("hiddenmember", groups: [hidden]) }.to raise_error(Discourse::InvalidAccess)
+
+    expect(search_for("hiddenmember", groups: [hidden], searching_user: Fabricate(:user))).to eq(
+      ["hiddenmember"],
+    )
+  end
+
+  it "raises when a non-staff user filters by a group only staff can see" do
+    staff_only =
+      Fabricate(
+        :group,
+        visibility_level: Group.visibility_levels[:staff],
+        members_visibility_level: Group.visibility_levels[:public],
+      )
+    staff_only.add(Fabricate(:user, username: "staffgroupmember"))
+
+    expect {
+      search_for("staffgroupmember", groups: [staff_only], searching_user: Fabricate(:user))
+    }.to raise_error(Discourse::InvalidAccess)
+
+    expect(search_for("staffgroupmember", groups: [staff_only], searching_user: admin)).to eq(
+      ["staffgroupmember"],
+    )
+  end
+
+  it "checks each group's visibility independently for mixed-visibility filters" do
+    member = Fabricate(:user, username: "mixedmember")
+    public_group = Fabricate(:group, visibility_level: Group.visibility_levels[:public])
+    logged_on_group = Fabricate(:group, visibility_level: Group.visibility_levels[:logged_on_users])
+    public_group.add(member)
+    logged_on_group.add(member)
+
+    expect(
+      search_for(
+        "mixedmember",
+        groups: [public_group, logged_on_group],
+        searching_user: Fabricate(:user),
+      ),
+    ).to eq(["mixedmember"])
+  end
+
+  it "does not let membership in one group grant visibility into a co-filtered hidden group" do
+    searcher = Fabricate(:user)
+    visible_group = Fabricate(:group, visibility_level: Group.visibility_levels[:public])
+    hidden_group = Fabricate(:group, visibility_level: Group.visibility_levels[:owners])
+    visible_group.add(searcher)
+    hidden_group.add(searcher)
+
+    expect {
+      search_for("searcher", groups: [visible_group, hidden_group], searching_user: searcher)
+    }.to raise_error(Discourse::InvalidAccess)
+  end
+
   context "with seed data" do
     fab!(:post1) { Fabricate :post, user: mr_b, topic: topic }
     fab!(:post2) { Fabricate :post, user: mr_blue, topic: topic2 }

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5919,6 +5919,46 @@ RSpec.describe UsersController do
           expect(users_found).to be_empty
         end
 
+        it "does not let an anon user enumerate members of a group it cannot see" do
+          hidden =
+            Fabricate(
+              :group,
+              visibility_level: Group.visibility_levels[:logged_on_users],
+              members_visibility_level: Group.visibility_levels[:public],
+            )
+          hidden.add(user)
+
+          get "/u/search/users.json", params: { group: hidden.name, term: user.username }
+
+          expect(response.status).to eq(403)
+        end
+
+        it "lets a signed-in user filter by a non-public group they can see" do
+          sign_in(user)
+          group =
+            Fabricate(
+              :group,
+              visibility_level: Group.visibility_levels[:logged_on_users],
+              members_visibility_level: Group.visibility_levels[:public],
+            )
+          member = Fabricate(:user, username: "visiblemember")
+          group.add(member)
+
+          get "/u/search/users.json", params: { group: group.name, term: "visiblemember" }
+
+          expect(response.status).to eq(200)
+          expect(users_found).to include("visiblemember")
+        end
+
+        it "returns no results rather than erroring for a group that does not exist" do
+          sign_in(user)
+
+          get "/u/search/users.json", params: { group: "does_not_exist", term: user.username }
+
+          expect(response.status).to eq(200)
+          expect(users_found).to be_empty
+        end
+
         def users_found
           response.parsed_body["users"].map { |u| u["username"] }
         end


### PR DESCRIPTION
Previously, filtering a user search by group (e.g. `/u/search/users?groups=admins`) only checked whether the requester could see the group's members, not the group itself. Because the default automatic groups are visible to logged-in users but expose their members publicly, an anonymous or non-member user could enumerate the members of a group hidden from them, even though every other path that lists users by group (the user directory, `/g/:name/members`, group topic lists) already required both checks.

This adds a `Guardian#can_see_group_and_members?` helper that requires both group and member visibility, and routes the user search, user directory, and plugin group-listing paths through it. This closes the leak, fixes a related all-or-nothing bug in `can_see_groups?` when several groups are filtered at once, and keeps the rule in one place so a caller can no longer reintroduce it by checking only half.
