### PR TITLE
DEV: add `clean_up_inactive_users_query` modifier for plugins to extend query for inactive users

### DIFF
--- a/app/jobs/scheduled/clean_up_inactive_users.rb
+++ b/app/jobs/scheduled/clean_up_inactive_users.rb
@@ -7,23 +7,25 @@ module Jobs
     def execute(args)
       return if SiteSetting.clean_up_inactive_users_after_days <= 0
 
-      User
-        .where(
-          last_posted_at: nil,
-          trust_level: TrustLevel.levels[:newuser],
-          admin: false,
-          moderator: false,
-        )
-        .where("users.created_at < ?", SiteSetting.clean_up_inactive_users_after_days.days.ago)
-        .where(
-          "users.last_seen_at < ? OR users.last_seen_at IS NULL",
-          SiteSetting.clean_up_inactive_users_after_days.days.ago,
-        )
-        .where
-        .missing(:posts, :topics)
-        .limit(1000)
-        .pluck(:id)
-        .each_slice(50) { |slice| destroy(slice) }
+      inactive_days = SiteSetting.clean_up_inactive_users_after_days.days.ago
+
+      users_to_clean =
+        User
+          .where(
+            last_posted_at: nil,
+            trust_level: TrustLevel.levels[:newuser],
+            admin: false,
+            moderator: false,
+          )
+          .where("users.created_at < ?", inactive_days)
+          .where("users.last_seen_at < ? OR users.last_seen_at IS NULL", inactive_days)
+          .where
+          .missing(:posts, :topics)
+
+      users_to_clean =
+        DiscoursePluginRegistry.apply_modifier(:clean_up_inactive_users_query, users_to_clean)
+
+      users_to_clean.limit(1000).pluck(:id).each_slice(50) { |slice| destroy(slice) }
     end
 
     private

--- a/app/jobs/scheduled/clean_up_inactive_users.rb
+++ b/app/jobs/scheduled/clean_up_inactive_users.rb
@@ -20,7 +20,17 @@ module Jobs
           .where("users.created_at < ?", inactive_days)
           .where("users.last_seen_at < ? OR users.last_seen_at IS NULL", inactive_days)
           .where
-          .missing(:posts, :topics)
+          .missing(:posts, :topics, :bookmarks)
+          .where(
+            "NOT EXISTS (
+              SELECT 1 FROM post_actions pa
+              INNER JOIN posts p ON p.id = pa.post_id
+              WHERE pa.user_id = users.id
+                AND pa.post_action_type_id = #{PostActionType::LIKE_POST_ACTION_ID}
+                AND pa.deleted_at IS NULL
+                AND p.deleted_at IS NULL
+            )",
+          )
 
       users_to_clean =
         DiscoursePluginRegistry.apply_modifier(:clean_up_inactive_users_query, users_to_clean)

--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -275,4 +275,9 @@ after_initialize do
     # Expected business-logic failures (poll closed, group-restricted, etc.)
     # — silently drop. Unexpected exceptions still bubble to AnonymousAction.consume.
   end
+
+  # Protect users who have cast poll votes from the inactive user cleanup job.
+  register_modifier(:clean_up_inactive_users_query) do |relation|
+    relation.where("NOT EXISTS (SELECT 1 FROM poll_votes WHERE poll_votes.user_id = users.id)")
+  end
 end

--- a/plugins/poll/spec/jobs/scheduled/clean_up_inactive_users_spec.rb
+++ b/plugins/poll/spec/jobs/scheduled/clean_up_inactive_users_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe Jobs::CleanUpInactiveUsers do
+  before { SiteSetting.clean_up_inactive_users_after_days = 4 }
+
+  def inactive_user
+    Fabricate(
+      :user,
+      created_at: 5.days.ago,
+      last_seen_at: 5.days.ago,
+      trust_level: TrustLevel.levels[:newuser],
+    )
+  end
+
+  it "does not delete users who have cast poll votes" do
+    user = inactive_user
+    poll = Fabricate(:poll)
+    option = Fabricate(:poll_option, poll: poll)
+    Fabricate(:poll_vote, poll: poll, poll_option: option, user: user)
+
+    expect { described_class.new.execute({}) }.not_to change { User.count }
+    expect(User.exists?(user.id)).to eq(true)
+  end
+
+  it "deletes inactive users who have never voted in a poll" do
+    user = inactive_user
+
+    expect { described_class.new.execute({}) }.to change { User.count }.by(-1)
+    expect(User.exists?(user.id)).to eq(false)
+  end
+end

--- a/spec/jobs/clean_up_inactive_users_spec.rb
+++ b/spec/jobs/clean_up_inactive_users_spec.rb
@@ -112,4 +112,40 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
 
     expect { described_class.new.execute({}) }.to change { User.count }.by(-1)
   end
+
+  it "supports plugins extending eligibility via the clean_up_inactive_users_query modifier" do
+    SiteSetting.clean_up_inactive_users_after_days = 4
+
+    eligible_user =
+      Fabricate(
+        :user,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
+    protected_user =
+      Fabricate(
+        :user,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
+
+    modifier_proc = Proc.new { |relation| relation.where.not(id: protected_user.id) }
+
+    plugin_instance = Plugin::Instance.new
+    plugin_instance.register_modifier(:clean_up_inactive_users_query, &modifier_proc)
+
+    begin
+      expect { described_class.new.execute({}) }.to change { User.count }.by(-1)
+      expect(User.exists?(eligible_user.id)).to eq(false)
+      expect(User.exists?(protected_user.id)).to eq(true)
+    ensure
+      DiscoursePluginRegistry.unregister_modifier(
+        plugin_instance,
+        :clean_up_inactive_users_query,
+        &modifier_proc
+      )
+    end
+  end
 end

--- a/spec/jobs/clean_up_inactive_users_spec.rb
+++ b/spec/jobs/clean_up_inactive_users_spec.rb
@@ -113,6 +113,56 @@ RSpec.describe Jobs::CleanUpInactiveUsers do
     expect { described_class.new.execute({}) }.to change { User.count }.by(-1)
   end
 
+  it "doesn't delete a user who has liked a post" do
+    SiteSetting.clean_up_inactive_users_after_days = 4
+    user =
+      Fabricate(
+        :user,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
+    Fabricate(:post_action, user: user, post_action_type_id: PostActionType.types[:like])
+
+    expect { described_class.new.execute({}) }.not_to change { User.count }
+    expect(User.exists?(user.id)).to eq(true)
+  end
+
+  it "deletes a user whose only like was on a deleted post" do
+    SiteSetting.clean_up_inactive_users_after_days = 4
+    user =
+      Fabricate(
+        :user,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
+    Fabricate(
+      :post_action,
+      user: user,
+      post_action_type_id: PostActionType.types[:like],
+      post: Fabricate(:post, deleted_at: Time.now),
+    )
+
+    expect { described_class.new.execute({}) }.to change { User.count }.by(-1)
+    expect(User.exists?(user.id)).to eq(false)
+  end
+
+  it "doesn't delete a user who has a bookmark" do
+    SiteSetting.clean_up_inactive_users_after_days = 4
+    user =
+      Fabricate(
+        :user,
+        created_at: 5.days.ago,
+        last_seen_at: 5.days.ago,
+        trust_level: TrustLevel.levels[:newuser],
+      )
+    Fabricate(:bookmark, user: user)
+
+    expect { described_class.new.execute({}) }.not_to change { User.count }
+    expect(User.exists?(user.id)).to eq(true)
+  end
+
   it "supports plugins extending eligibility via the clean_up_inactive_users_query modifier" do
     SiteSetting.clean_up_inactive_users_after_days = 4
 


### PR DESCRIPTION
This PR adds Bookmarks and PostActions (likes) to the query for `CleanUpInactiveUsers` to fetch qualified users.

This PR also allows plugins to modify the `CleanUpInactiveUsers` job query for selecting which users to destroy. The modifier is given the AR relation as the argument. Plugins should avoid executing the query, as it expects a builder style pattern.

Implementation:
```ruby
register_modifier(:clean_up_inactive_users_query) do |relation|
  relation.where.missing(:table_name)
end
```