### PR TITLE
DEV: Remove duplication in the new admin dashboard

### DIFF
--- a/frontend/discourse/admin/components/dashboard/engagement/headline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/headline.gjs
@@ -1,27 +1,19 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
+import {
+  formatDeltaPercent,
+  formatKpiValue,
+} from "discourse/admin/lib/dashboard-format";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { eq } from "discourse/truth-helpers";
-import I18n, { i18n } from "discourse-i18n";
+import { i18n } from "discourse-i18n";
 
 const PRESET_PERIODS = ["last_7_days", "last_30_days", "last_3_months"];
-const PERCENTAGE_KPIS = ["dau_mau"];
 
 class MetricItem extends Component {
-  get isPercentage() {
-    return PERCENTAGE_KPIS.includes(this.args.metric.type);
-  }
-
   get displayValue() {
-    const value = this.args.metric.value;
-    if (value == null) {
-      return "—";
-    }
-    if (this.isPercentage) {
-      return `${I18n.toNumber(value, { precision: 1 })}%`;
-    }
-    return I18n.toNumber(value, { precision: 0 });
+    return formatKpiValue(this.args.metric.type, this.args.metric.value);
   }
 
   get hasDelta() {
@@ -39,17 +31,7 @@ class MetricItem extends Component {
   }
 
   get deltaText() {
-    const value = this.args.metric.percent_change;
-    const abs = Math.abs(value);
-
-    if (abs > 0 && abs < 1) {
-      const sign = value > 0 ? "+" : "-";
-      return `${sign}${I18n.toNumber(abs, { precision: 1 })}%`;
-    }
-
-    const rounded = Math.round(value);
-    const sign = rounded > 0 ? "+" : "";
-    return `${sign}${I18n.toNumber(rounded, { precision: 0 })}%`;
+    return formatDeltaPercent(this.args.metric.percent_change);
   }
 
   <template>

--- a/frontend/discourse/admin/components/dashboard/engagement/headline.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/headline.gjs
@@ -10,10 +10,17 @@ import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 const PRESET_PERIODS = ["last_7_days", "last_30_days", "last_3_months"];
+const PERCENTAGE_KPIS = ["dau_mau"];
 
 class MetricItem extends Component {
+  get isPercentage() {
+    return PERCENTAGE_KPIS.includes(this.args.metric.type);
+  }
+
   get displayValue() {
-    return formatKpiValue(this.args.metric.type, this.args.metric.value);
+    return formatKpiValue(this.args.metric.value, {
+      percentage: this.isPercentage,
+    });
   }
 
   get hasDelta() {

--- a/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
@@ -28,13 +28,21 @@ export default class WhosPosting extends Component {
     return (category?.subcategories?.length ?? 0) > 0;
   }
 
+  get #categoryFilters() {
+    if (!this.categoryId) {
+      return null;
+    }
+    const filters = { category: this.categoryId };
+    if (this.includeSubcategories) {
+      filters.include_subcategories = true;
+    }
+    return filters;
+  }
+
   get reportQuery() {
     const query = {};
-    if (this.categoryId) {
-      const filters = { category: this.categoryId };
-      if (this.includeSubcategories) {
-        filters.include_subcategories = true;
-      }
+    const filters = this.#categoryFilters;
+    if (filters) {
       query.filters = filters;
     }
     if (this.args.startDate) {
@@ -110,11 +118,9 @@ export default class WhosPosting extends Component {
       start_date: this.args.startDate?.toISOString().slice(0, 10),
       end_date: this.args.endDate?.toISOString().slice(0, 10),
     };
-    if (this.categoryId) {
-      data.filters = { category: this.categoryId };
-      if (this.includeSubcategories) {
-        data.filters.include_subcategories = true;
-      }
+    const filters = this.#categoryFilters;
+    if (filters) {
+      data.filters = filters;
     }
 
     try {

--- a/frontend/discourse/admin/components/dashboard/kpi-tile.gjs
+++ b/frontend/discourse/admin/components/dashboard/kpi-tile.gjs
@@ -3,26 +3,17 @@ import { concat, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
+import {
+  formatDeltaPercent,
+  formatKpiValue,
+} from "discourse/admin/lib/dashboard-format";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
-import I18n, { i18n } from "discourse-i18n";
-
-const PERCENTAGE_KPIS = ["dau_mau"];
+import { i18n } from "discourse-i18n";
 
 export default class KpiTile extends Component {
-  get isPercentage() {
-    return PERCENTAGE_KPIS.includes(this.args.type);
-  }
-
   get displayValue() {
-    const value = this.args.value;
-    if (value == null) {
-      return "—";
-    }
-    if (this.isPercentage) {
-      return `${I18n.toNumber(value, { precision: 1 })}%`;
-    }
-    return I18n.toNumber(value, { precision: 0 });
+    return formatKpiValue(this.args.type, this.args.value);
   }
 
   get label() {
@@ -42,17 +33,7 @@ export default class KpiTile extends Component {
   }
 
   get deltaText() {
-    const value = this.args.percentChange;
-    const abs = Math.abs(value);
-
-    if (abs > 0 && abs < 1) {
-      const sign = value > 0 ? "+" : "-";
-      return `${sign}${I18n.toNumber(abs, { precision: 1 })}%`;
-    }
-
-    const rounded = Math.round(value);
-    const sign = rounded > 0 ? "+" : "";
-    return `${sign}${I18n.toNumber(rounded, { precision: 0 })}%`;
+    return formatDeltaPercent(this.args.percentChange);
   }
 
   get ariaLabel() {

--- a/frontend/discourse/admin/components/dashboard/kpi-tile.gjs
+++ b/frontend/discourse/admin/components/dashboard/kpi-tile.gjs
@@ -11,9 +11,15 @@ import DTooltip from "discourse/float-kit/components/d-tooltip";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+const PERCENTAGE_KPIS = ["dau_mau"];
+
 export default class KpiTile extends Component {
+  get isPercentage() {
+    return PERCENTAGE_KPIS.includes(this.args.type);
+  }
+
   get displayValue() {
-    return formatKpiValue(this.args.type, this.args.value);
+    return formatKpiValue(this.args.value, { percentage: this.isPercentage });
   }
 
   get label() {

--- a/frontend/discourse/admin/components/dashboard/reports.gjs
+++ b/frontend/discourse/admin/components/dashboard/reports.gjs
@@ -20,8 +20,6 @@ import { i18n } from "discourse-i18n";
 
 const VISIBLE_CAP = 10;
 
-const rendererFor = (source) => lookupAdminDashboardReportRenderer(source);
-
 export default class DashboardReports extends Component {
   @service currentUser;
   @service modal;
@@ -37,6 +35,13 @@ export default class DashboardReports extends Component {
 
   get items() {
     return this.args.data?.items ?? [];
+  }
+
+  get layoutItems() {
+    return this.items.map(({ source, identifier }) => ({
+      source,
+      identifier,
+    }));
   }
 
   get canEdit() {
@@ -69,10 +74,7 @@ export default class DashboardReports extends Component {
     this.loading = true;
     try {
       const payloads = await loadDashboardReports({
-        items: this.items.map(({ source, identifier }) => ({
-          source,
-          identifier,
-        })),
+        items: this.layoutItems,
         filters: this.filters,
       });
       this.cards = this.items.map((item) => ({
@@ -95,11 +97,9 @@ export default class DashboardReports extends Component {
 
   @action
   async removeReport(item) {
-    const nextItems = this.items
-      .filter(
-        (i) => !(i.source === item.source && i.identifier === item.identifier)
-      )
-      .map(({ source, identifier }) => ({ source, identifier }));
+    const nextItems = this.layoutItems.filter(
+      (i) => !(i.source === item.source && i.identifier === item.identifier)
+    );
 
     try {
       await ajax("/admin/dashboard/reports/layout", {
@@ -155,7 +155,10 @@ export default class DashboardReports extends Component {
                 {{#if card.payload.empty}}
                   <DashboardReportEmptyState />
                 {{else}}
-                  {{#let (rendererFor card.source) as |Renderer|}}
+                  {{#let
+                    (lookupAdminDashboardReportRenderer card.source)
+                    as |Renderer|
+                  }}
                     {{#if Renderer}}
                       <Renderer
                         @item={{card}}

--- a/frontend/discourse/admin/components/dashboard/search.gjs
+++ b/frontend/discourse/admin/components/dashboard/search.gjs
@@ -4,6 +4,7 @@ import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import DashboardSection from "discourse/admin/components/dashboard/section";
+import { formatDeltaPercent } from "discourse/admin/lib/dashboard-format";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import dBasePath from "discourse/ui-kit/helpers/d-base-path";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -17,19 +18,6 @@ const COUNT_HEADLINE_KEYS = {
 
 function formatCount(value) {
   return I18n.toNumber(value, { precision: 0 });
-}
-
-function formatDelta(value) {
-  const abs = Math.abs(value);
-
-  if (abs > 0 && abs < 1) {
-    const sign = value > 0 ? "+" : "-";
-    return `${sign}${I18n.toNumber(abs, { precision: 1 })}%`;
-  }
-
-  const rounded = Math.round(value);
-  const sign = rounded > 0 ? "+" : "";
-  return `${sign}${I18n.toNumber(rounded, { precision: 0 })}%`;
 }
 
 function badgeLabel(status) {
@@ -84,7 +72,7 @@ export default class DashboardSearch extends Component {
     }
 
     return {
-      text: formatDelta(change),
+      text: formatDeltaPercent(change),
       className: change > 0 ? "--pos" : "--neg",
     };
   }
@@ -102,7 +90,7 @@ export default class DashboardSearch extends Component {
     }
 
     return {
-      text: formatDelta(change),
+      text: formatDeltaPercent(change),
       className: change > 0 ? "--neg" : "--pos",
     };
   }

--- a/frontend/discourse/admin/components/dashboard/traffic.gjs
+++ b/frontend/discourse/admin/components/dashboard/traffic.gjs
@@ -31,7 +31,7 @@ export default class DashboardTraffic extends Component {
   hiddenLabels = ["page_view_crawler"];
 
   get browserPageviews() {
-    return this.args.traffic?.kpis?.browser_pageviews?.value ?? 0;
+    return this.#kpiValue("browser_pageviews") ?? 0;
   }
 
   get headlineCount() {
@@ -87,21 +87,23 @@ export default class DashboardTraffic extends Component {
   }
 
   get showLoggedInShare() {
-    const loggedInShare = this.args.traffic?.kpis?.logged_in_share?.value;
-    return loggedInShare !== null && loggedInShare !== undefined;
+    return this.#kpiValue("logged_in_share") != null;
   }
 
   get loggedInShare() {
-    return `${this.args.traffic?.kpis?.logged_in_share?.value ?? 0}%`;
+    return `${this.#kpiValue("logged_in_share") ?? 0}%`;
   }
 
   get showDirectTraffic() {
-    const directTraffic = this.args.traffic?.kpis?.direct_traffic?.value;
-    return directTraffic !== null && directTraffic !== undefined;
+    return this.#kpiValue("direct_traffic") != null;
   }
 
   get directTraffic() {
-    return `${this.args.traffic?.kpis?.direct_traffic?.value ?? 0}%`;
+    return `${this.#kpiValue("direct_traffic") ?? 0}%`;
+  }
+
+  #kpiValue(key) {
+    return this.args.traffic?.kpis?.[key]?.value;
   }
 
   get chartModel() {
@@ -226,11 +228,6 @@ export default class DashboardTraffic extends Component {
                 </DTooltip>
               {{/if}}
             </h3>
-            {{! <p>
-              Placeholder: Logged-in traffic is growing steadily. Two spikes on
-              Mar 8-9 drove a burst of anonymous visitors who didn't log in,
-              pulling the logged-in share down slightly to 38%.
-            </p> }}
           </div>
 
           {{#if (or this.showLoggedInShare this.showDirectTraffic)}}
@@ -285,11 +282,6 @@ export default class DashboardTraffic extends Component {
             </div>
           {{/if}}
         </div>
-
-        {{! <div class="db-section__callout">
-          Placeholder: Spikes on Mar 8 and Mar 9 - a Hacker News post linking to
-          the plugin release docs drove a surge in anonymous pageviews.
-        </div> }}
 
         {{#if @fetchError}}
           <div class="db-section__traffic-chart">

--- a/frontend/discourse/admin/controllers/admin/dashboard.js
+++ b/frontend/discourse/admin/controllers/admin/dashboard.js
@@ -53,23 +53,24 @@ export default class AdminDashboardController extends Controller {
   }
 
   get startDate() {
-    if (this.safePeriod === PERIOD_CUSTOM && this.start_date) {
-      const parsed = moment(this.start_date, "YYYY-MM-DD", true);
-      if (parsed.isValid()) {
-        return parsed.startOf("day").toDate();
-      }
-    }
-    return calculatePresetStartDate(this.safePeriod);
+    return (
+      this.#customDate(this.start_date, "startOf") ??
+      calculatePresetStartDate(this.safePeriod)
+    );
   }
 
   get endDate() {
-    if (this.safePeriod === PERIOD_CUSTOM && this.end_date) {
-      const parsed = moment(this.end_date, "YYYY-MM-DD", true);
-      if (parsed.isValid()) {
-        return parsed.endOf("day").toDate();
-      }
+    return (
+      this.#customDate(this.end_date, "endOf") ?? moment().endOf("day").toDate()
+    );
+  }
+
+  #customDate(value, edge) {
+    if (this.safePeriod !== PERIOD_CUSTOM || !value) {
+      return null;
     }
-    return moment().endOf("day").toDate();
+    const parsed = moment(value, "YYYY-MM-DD", true);
+    return parsed.isValid() ? parsed[edge]("day").toDate() : null;
   }
 
   @action

--- a/frontend/discourse/admin/lib/dashboard-format.js
+++ b/frontend/discourse/admin/lib/dashboard-format.js
@@ -1,0 +1,26 @@
+import I18n from "discourse-i18n";
+
+const PERCENTAGE_KPIS = ["dau_mau"];
+
+export function formatKpiValue(type, value) {
+  if (value == null) {
+    return "—";
+  }
+  if (PERCENTAGE_KPIS.includes(type)) {
+    return `${I18n.toNumber(value, { precision: 1 })}%`;
+  }
+  return I18n.toNumber(value, { precision: 0 });
+}
+
+export function formatDeltaPercent(value) {
+  const abs = Math.abs(value);
+
+  if (abs > 0 && abs < 1) {
+    const sign = value > 0 ? "+" : "-";
+    return `${sign}${I18n.toNumber(abs, { precision: 1 })}%`;
+  }
+
+  const rounded = Math.round(value);
+  const sign = rounded > 0 ? "+" : "";
+  return `${sign}${I18n.toNumber(rounded, { precision: 0 })}%`;
+}

--- a/frontend/discourse/admin/lib/dashboard-format.js
+++ b/frontend/discourse/admin/lib/dashboard-format.js
@@ -1,12 +1,10 @@
 import I18n from "discourse-i18n";
 
-const PERCENTAGE_KPIS = ["dau_mau"];
-
-export function formatKpiValue(type, value) {
+export function formatKpiValue(value, { percentage = false } = {}) {
   if (value == null) {
     return "—";
   }
-  if (PERCENTAGE_KPIS.includes(type)) {
+  if (percentage) {
     return `${I18n.toNumber(value, { precision: 1 })}%`;
   }
   return I18n.toNumber(value, { precision: 0 });

--- a/frontend/discourse/tests/unit/admin/lib/dashboard-format-test.js
+++ b/frontend/discourse/tests/unit/admin/lib/dashboard-format-test.js
@@ -10,15 +10,19 @@ module("Unit | Admin | Lib | dashboard-format", function (hooks) {
 
   module("formatKpiValue", function () {
     test("returns an em dash when the value is null", function (assert) {
-      assert.strictEqual(formatKpiValue("new_signups", null), "—");
+      assert.strictEqual(formatKpiValue(null), "—");
+    });
+
+    test("returns an em dash when the value is undefined", function (assert) {
+      assert.strictEqual(formatKpiValue(undefined), "—");
     });
 
     test("formats a count with no decimals and a thousands separator", function (assert) {
-      assert.strictEqual(formatKpiValue("new_signups", 1100), "1,100");
+      assert.strictEqual(formatKpiValue(1100), "1,100");
     });
 
-    test("formats a percentage KPI with a percent suffix and one decimal", function (assert) {
-      assert.strictEqual(formatKpiValue("dau_mau", 21.6), "21.6%");
+    test("formats a percentage value with a percent suffix and one decimal", function (assert) {
+      assert.strictEqual(formatKpiValue(21.6, { percentage: true }), "21.6%");
     });
   });
 

--- a/frontend/discourse/tests/unit/admin/lib/dashboard-format-test.js
+++ b/frontend/discourse/tests/unit/admin/lib/dashboard-format-test.js
@@ -1,0 +1,46 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  formatDeltaPercent,
+  formatKpiValue,
+} from "discourse/admin/lib/dashboard-format";
+
+module("Unit | Admin | Lib | dashboard-format", function (hooks) {
+  setupTest(hooks);
+
+  module("formatKpiValue", function () {
+    test("returns an em dash when the value is null", function (assert) {
+      assert.strictEqual(formatKpiValue("new_signups", null), "—");
+    });
+
+    test("formats a count with no decimals and a thousands separator", function (assert) {
+      assert.strictEqual(formatKpiValue("new_signups", 1100), "1,100");
+    });
+
+    test("formats a percentage KPI with a percent suffix and one decimal", function (assert) {
+      assert.strictEqual(formatKpiValue("dau_mau", 21.6), "21.6%");
+    });
+  });
+
+  module("formatDeltaPercent", function () {
+    test("prefixes a positive delta with a plus and rounds to a whole percent", function (assert) {
+      assert.strictEqual(formatDeltaPercent(12.02), "+12%");
+    });
+
+    test("keeps one decimal for a sub-1% positive delta", function (assert) {
+      assert.strictEqual(formatDeltaPercent(0.4), "+0.4%");
+    });
+
+    test("keeps one decimal and a minus sign for a sub-1% negative delta", function (assert) {
+      assert.strictEqual(formatDeltaPercent(-0.4), "-0.4%");
+    });
+
+    test("renders an exact-zero delta without a sign", function (assert) {
+      assert.strictEqual(formatDeltaPercent(0), "0%");
+    });
+
+    test("rounds a larger negative delta and keeps the minus sign", function (assert) {
+      assert.strictEqual(formatDeltaPercent(-38.5), "-38%");
+    });
+  });
+});


### PR DESCRIPTION
This PR consolidates formatting and data-shaping logic that was duplicated across the redesigned admin dashboard components, with no change in behavior.

The redesign grew several sections (`kpi-tile`, `engagement/headline`, `search`, `traffic`, `reports`, `whos-posting`) that each re-implemented the same small pieces of logic, and the copies had already begun to drift. This pulls the shared pieces into one place before they diverge further.

Key changes:
* Extract the KPI value formatter (empty dash / count / percentage) and the delta-percent formatter (sub-1% keeps one decimal, otherwise rounded and signed) into a new `admin/lib/dashboard-format` module, replacing three byte-identical copies in `kpi-tile`, `engagement/headline`, and `search`. These are the only genuinely shared, testable units, so they get a dedicated unit test.
* Collapse the duplicated custom-range date parsing in `AdminDashboardController`'s `startDate`/`endDate` getters into one `#customDate(value, edge)` helper, so the two getters stay in sync.
* Reuse a `layoutItems` getter in the reports section instead of repeating the `{ source, identifier }` projection in two places, and drop the `rendererFor` wrapper that only forwarded to `lookupAdminDashboardReportRenderer`.
* Build the who's-posting category filter once (`#categoryFilters`) and share it between the report-link query and the refetch request, and route the traffic KPI lookups through a `#kpiValue` helper.

Every change is an internal getter/helper refactor: no public component args, rendered DOM, class names, or request payloads change, which is why the existing component and system tests pass unchanged.