### PR TITLE
FIX: composer actions fix z-index for firefox touch tablets

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -39,7 +39,7 @@ html.composer-open:not(.has-full-page-chat) {
 
 .composer-toggles-menu-content,
 .composer-actions-dropdown {
-  z-index: z("composer", "dropdown") + 1;
+  z-index: z("mobile-composer");
 }
 
 #reply-control {


### PR DESCRIPTION
In Firefox, with touch mode enabled, the new composer post type actions are hidden behind the composer. This generally affects tablet devices that are using the Firefox browser.

Note: To see the new post type actions, enable **Enable new post reactions menu** in Upcoming changes

See Meta topic ``/t/403635/9``

**Before:** Post type actions modal is hidden behind composer

<img width="916" height="699" alt="CleanShot 2026-07-02 at 19 12 12" src="https://github.com/user-attachments/assets/87c13880-644e-44a1-90f1-3d050870e6c2" />

**After: Visible**

<img width="785" height="870" alt="CleanShot 2026-07-02 at 19 11 09" src="https://github.com/user-attachments/assets/f1d5c678-085d-403b-a1f7-b1210e2838b7" />

