### PR TITLE
FIX: Ignore title parameter during public signup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -700,7 +700,7 @@ class UsersController < ApplicationController
       if current_user&.admin? && is_api?
         user_params.except(:timezone)
       else
-        user_params.except(:timezone, :primary_group_id, :flair_group_id)
+        user_params.except(:timezone, :title, :primary_group_id, :flair_group_id)
       end
 
     user = User.where(staged: true).with_email(new_user_params[:email].strip.downcase).first

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -906,18 +906,26 @@ RSpec.describe UsersController do
         end
       end
 
-      context "when signup params include group assignments" do
+      context "when signup params include protected profile attributes" do
         fab!(:whisperers_group, :group)
 
         let(:created_user) { User.find(response.parsed_body["user_id"]) }
 
         before { SiteSetting.whispers_allowed_groups = whisperers_group.id.to_s }
 
-        it "ignores primary_group_id and flair_group_id on unauthenticated signup" do
-          post_user(primary_group_id: whisperers_group.id, flair_group_id: whisperers_group.id)
+        it "ignores protected profile attributes on unauthenticated signup" do
+          post_user(
+            title: "Moderator",
+            primary_group_id: whisperers_group.id,
+            flair_group_id: whisperers_group.id,
+          )
 
           expect(response).to have_http_status(:ok)
-          expect(created_user).to have_attributes(primary_group_id: nil, flair_group_id: nil)
+          expect(created_user).to have_attributes(
+            title: nil,
+            primary_group_id: nil,
+            flair_group_id: nil,
+          )
           expect(created_user).not_to be_a_whisperer
         end
       end


### PR DESCRIPTION
Public account creation accepted `title` from non-admin signup requests, allowing a new user to assign themselves an arbitrary visible profile title before normal title authorization checks could apply.

Ignore `title` for non-admin account creation, matching the existing treatment of primary/flair group parameters. Admin API user creation remains unchanged.

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>