### PR TITLE
FEATURE: Add admin report group filter URLs

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6477,6 +6477,7 @@ en:
         sidebar_title: "Reports"
         back: "Back to all reports"
         back_to_dashboard: "Back to dashboard"
+        all_groups: "All groups"
         group_engagement: "Engagement"
         group_traffic: "Traffic"
         group_members: "Members"

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -278,15 +278,6 @@ export default class AdminFilterControls extends Component {
             @icons={{hash left="magnifying-glass"}}
           />
 
-          {{#if (and this.hasActiveFilters (not @loading))}}
-            <DButton
-              @icon="arrow-rotate-left"
-              @label="reset_filter"
-              @action={{this.resetFilters}}
-              class="btn-default admin-filter-controls__reset"
-            />
-          {{/if}}
-
           {{#if this.hasMultipleDropdowns}}
             <DButton
               class="btn-transparent admin-filter-controls__toggle-filters"
@@ -332,6 +323,15 @@ export default class AdminFilterControls extends Component {
               </DSelect>
             {{/if}}
           </div>
+        {{/if}}
+
+        {{#if (and this.hasActiveFilters (not @loading))}}
+          <DButton
+            @icon="arrow-rotate-left"
+            @label="reset_filter"
+            @action={{this.resetFilters}}
+            class="btn-default admin-filter-controls__reset"
+          />
         {{/if}}
 
         {{yield to="actions"}}

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -34,6 +34,7 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
  * @param {Function} [onTextFilterChange] - Callback for text changes (enables server-side mode)
  * @param {Function} [onDropdownFilterChange] - Callback for dropdown changes (enables server-side mode).
  *                                              For multiple dropdowns: receives (key, value)
+ * @param {Function} [onClientDropdownFilterChange] - Callback for client-side dropdown changes
  * @param {Function} [onResetFilters] - Callback for reset action (server-side mode)
  * @param {String} [initialTextFilter] - Initial value to seed the text filter input on mount
  */
@@ -206,9 +207,11 @@ export default class AdminFilterControls extends Component {
     if (this.hasMultipleDropdowns) {
       this.dropdownFilters[keyOrValue] = value;
       this.args.onDropdownFilterChange?.(keyOrValue, value);
+      this.args.onClientDropdownFilterChange?.(keyOrValue, value);
     } else {
       this.dropdownFilter = keyOrValue;
       this.args.onDropdownFilterChange?.(keyOrValue);
+      this.args.onClientDropdownFilterChange?.(keyOrValue);
     }
   }
 

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -36,7 +36,7 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
  * @param {Function} [onTextFilterChange] - Callback for text changes (enables server-side mode)
  * @param {Function} [onDropdownFilterChange] - Callback for dropdown changes (enables server-side mode).
  *                                              For multiple dropdowns: receives (key, value)
- * @param {Function} [onClientDropdownFilterChange] - Callback for client-side dropdown changes
+ * @param {Function} [onDropdownChange] - Callback for dropdown selection changes
  * @param {Function} [onResetFilters] - Callback for reset action (server-side mode)
  * @param {String} [initialTextFilter] - Initial value to seed the text filter input on mount
  */
@@ -219,11 +219,11 @@ export default class AdminFilterControls extends Component {
     if (this.hasMultipleDropdowns) {
       this.dropdownFilters[keyOrValue] = value;
       this.args.onDropdownFilterChange?.(keyOrValue, value);
-      this.args.onClientDropdownFilterChange?.(keyOrValue, value);
+      this.args.onDropdownChange?.(keyOrValue, value);
     } else {
       this.dropdownFilter = keyOrValue;
       this.args.onDropdownFilterChange?.(keyOrValue);
-      this.args.onClientDropdownFilterChange?.(keyOrValue);
+      this.args.onDropdownChange?.(keyOrValue);
     }
   }
 
@@ -233,10 +233,13 @@ export default class AdminFilterControls extends Component {
 
     if (this.hasMultipleDropdowns) {
       Object.keys(this.dropdownFilters).forEach((key) => {
-        this.dropdownFilters[key] = this.defaultValue(key);
+        const defaultValue = this.defaultValue(key);
+        this.dropdownFilters[key] = defaultValue;
+        this.args.onDropdownChange?.(key, defaultValue);
       });
     } else {
       this.dropdownFilter = this.defaultDropdownValue;
+      this.args.onDropdownChange?.(this.defaultDropdownValue);
     }
 
     if (this.args.onResetFilters) {

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -4,6 +4,7 @@ import { fn, get, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { schedule } from "@ember/runloop";
 import { isTesting } from "discourse/lib/environment";
 import { resettableTracked } from "discourse/lib/tracked-tools";
@@ -251,6 +252,7 @@ export default class AdminFilterControls extends Component {
           (if this.hasMultipleDropdowns "--multiple-dropdowns")
         }}
         {{didInsert this.setupComponent}}
+        {{didUpdate this.setupComponent @defaultDropdownValue}}
       >
         <div class="admin-filter-controls__inputs">
           <DFilterInput

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -29,6 +29,7 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
  * @param {String} [inputPlaceholder] - Placeholder text for search input
  * @param {String|Object} [defaultDropdownValue="all"] - Default dropdown value(s). For single dropdown: "all",
  *                                                       for multiple: { dropdown1: "all", dropdown2: "all" }
+ * @param {String|Object} [dropdownValue] - Current dropdown value(s), defaults to defaultDropdownValue
  * @param {String} [noResultsMessage] - Message shown when no results found
  * @param {Boolean} [loading] - Whether data is loading (hides reset button during loading)
  * @param {Number} [minItemsForFilter] - Minimum items before showing filters (default: always show)
@@ -54,7 +55,7 @@ export default class AdminFilterControls extends Component {
 
     if (this.hasMultipleDropdowns) {
       Object.keys(this.dropdownOptions).forEach((key) => {
-        this.dropdownFilters[key] = this.defaultValue(key);
+        this.dropdownFilters[key] = this.dropdownValueFor(key);
       });
     }
   }
@@ -95,6 +96,10 @@ export default class AdminFilterControls extends Component {
 
   get defaultDropdownValue() {
     return this.args.defaultDropdownValue || "all";
+  }
+
+  get dropdownValue() {
+    return this.args.dropdownValue || this.defaultDropdownValue;
   }
 
   get showFilters() {
@@ -185,14 +190,20 @@ export default class AdminFilterControls extends Component {
     return defaults[key] || "all";
   }
 
+  dropdownValueFor(key) {
+    const values =
+      typeof this.dropdownValue === "object" ? this.dropdownValue : {};
+    return values[key] || this.defaultValue(key);
+  }
+
   @action
   setupComponent() {
     if (this.hasMultipleDropdowns) {
       Object.keys(this.dropdownOptions).forEach((key) => {
-        this.dropdownFilters[key] = this.defaultValue(key);
+        this.dropdownFilters[key] = this.dropdownValueFor(key);
       });
     } else {
-      this.dropdownFilter = this.defaultDropdownValue;
+      this.dropdownFilter = this.dropdownValue;
     }
   }
 
@@ -253,6 +264,7 @@ export default class AdminFilterControls extends Component {
         }}
         {{didInsert this.setupComponent}}
         {{didUpdate this.setupComponent @defaultDropdownValue}}
+        {{didUpdate this.setupComponent @dropdownValue}}
       >
         <div class="admin-filter-controls__inputs">
           <DFilterInput

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -184,25 +184,13 @@ export default class AdminReports extends Component {
   }
 
   @bind
-  filterReportsByGroup(reports, availableReports) {
-    const selectedGroupKey = this.selectedGroupKey(availableReports);
-
-    if (selectedGroupKey === "all") {
-      return reports;
-    }
-
-    const group = this.groupReports(this.filterReports(availableReports)).find(
-      (reportGroup) => reportGroup.key === selectedGroupKey
-    );
-
-    return group?.reports
-      ? reports.filter((report) => group.reports.includes(report))
-      : reports;
+  updateGroupFilter(groupKey) {
+    this.args.onGroupChange?.(groupKey);
   }
 
   @bind
-  updateGroupFilter(groupKey) {
-    this.args.onGroupChange?.(groupKey);
+  resetGroupFilter() {
+    this.args.onGroupChange?.("all");
   }
 
   <template>
@@ -212,18 +200,14 @@ export default class AdminReports extends Component {
           @array={{this.filterReports reports}}
           @searchableProps={{array "title" "description"}}
           @dropdownOptions={{this.groupDropdownOptions reports}}
-          @defaultDropdownValue={{this.selectedGroupKey reports}}
+          @dropdownValue={{this.selectedGroupKey reports}}
           @inputPlaceholder={{i18n "admin.filter_reports"}}
           @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
           @onClientDropdownFilterChange={{this.updateGroupFilter}}
+          @onResetFilters={{this.resetGroupFilter}}
         >
           <:content as |filteredReports|>
-            {{#each
-              (this.groupReports
-                (this.filterReportsByGroup filteredReports reports)
-              )
-              as |group|
-            }}
+            {{#each (this.groupReports filteredReports) as |group|}}
               <section class="admin-reports-group">
                 <h2 class="admin-reports-group__title">{{group.name}}</h2>
                 <AdminSectionLandingWrapper class="admin-reports-list">

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -66,8 +66,6 @@ const REPORT_GROUPS = {
   other: [],
 };
 
-const CORE_REPORT_GROUP_KEYS = new Set(Object.keys(REPORT_GROUPS));
-
 export default class AdminReports extends Component {
   @service siteSettings;
 
@@ -160,9 +158,7 @@ export default class AdminReports extends Component {
 
   @bind
   groupDropdownOptions(reports) {
-    const groups = this.groupReports(reports).filter((group) =>
-      CORE_REPORT_GROUP_KEYS.has(group.key)
-    );
+    const groups = this.groupReports(reports);
 
     return [
       {

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -1,5 +1,4 @@
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 import { array } from "@ember/helper";
 import { service } from "@ember/service";
 import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
@@ -70,8 +69,6 @@ const REPORT_GROUPS = {
 export default class AdminReports extends Component {
   @service router;
   @service siteSettings;
-
-  @tracked selectedGroupKeyOverride;
 
   @bind
   async loadReports() {
@@ -162,7 +159,9 @@ export default class AdminReports extends Component {
 
   @bind
   groupDropdownOptions(reports) {
-    const groups = this.groupReports(reports);
+    const groups = this.groupReports(reports).filter(
+      (group) => !group.key.startsWith("plugin-")
+    );
 
     return [
       {
@@ -180,34 +179,32 @@ export default class AdminReports extends Component {
 
   @bind
   selectedGroupKey(reports) {
-    const requestedGroupKey =
-      this.selectedGroupKeyOverride || this.requestedGroupKey;
     const options = this.groupDropdownOptions(reports);
 
-    return options.some((option) => option.value === requestedGroupKey)
-      ? requestedGroupKey
+    return options.some((option) => option.value === this.requestedGroupKey)
+      ? this.requestedGroupKey
       : "all";
   }
 
   @bind
-  filterReportsByGroup(reports) {
-    const selectedGroupKey = this.selectedGroupKey(reports);
+  filterReportsByGroup(reports, availableReports) {
+    const selectedGroupKey = this.selectedGroupKey(availableReports);
 
     if (selectedGroupKey === "all") {
       return reports;
     }
 
-    const group = this.groupReports(reports).find(
+    const group = this.groupReports(availableReports).find(
       (reportGroup) => reportGroup.key === selectedGroupKey
     );
 
-    return group?.reports || reports;
+    return group?.reports
+      ? reports.filter((report) => group.reports.includes(report))
+      : reports;
   }
 
   @bind
   updateGroupFilter(groupKey) {
-    this.selectedGroupKeyOverride = groupKey;
-
     this.router.transitionTo({
       queryParams: { group: groupKey === "all" ? null : groupKey },
     });
@@ -216,40 +213,40 @@ export default class AdminReports extends Component {
   <template>
     <DAsyncContent @asyncData={{this.loadReports}}>
       <:content as |reports|>
-        <AdminFilterControls
-          @array={{this.filterReports reports}}
-          @searchableProps={{array "title" "description"}}
-          @dropdownOptions={{this.groupDropdownOptions
-            (this.filterReports reports)
-          }}
-          @defaultDropdownValue={{this.selectedGroupKey
-            (this.filterReports reports)
-          }}
-          @inputPlaceholder={{i18n "admin.filter_reports"}}
-          @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
-          @onClientDropdownFilterChange={{this.updateGroupFilter}}
-        >
-          <:content as |filteredReports|>
-            {{#each
-              (this.groupReports (this.filterReportsByGroup filteredReports))
-              as |group|
-            }}
-              <section class="admin-reports-group">
-                <h2 class="admin-reports-group__title">{{group.name}}</h2>
-                <AdminSectionLandingWrapper class="admin-reports-list">
-                  {{#each group.reports as |report|}}
-                    <AdminSectionLandingItem
-                      @titleLabelTranslated={{report.title}}
-                      @descriptionLabelTranslated={{report.description}}
-                      @titleRoute="adminReports.show"
-                      @titleRouteModel={{report.type}}
-                    />
-                  {{/each}}
-                </AdminSectionLandingWrapper>
-              </section>
-            {{/each}}
-          </:content>
-        </AdminFilterControls>
+        {{#let (this.filterReports reports) as |visibleReports|}}
+          <AdminFilterControls
+            @array={{visibleReports}}
+            @searchableProps={{array "title" "description"}}
+            @dropdownOptions={{this.groupDropdownOptions visibleReports}}
+            @defaultDropdownValue={{this.selectedGroupKey visibleReports}}
+            @inputPlaceholder={{i18n "admin.filter_reports"}}
+            @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
+            @onClientDropdownFilterChange={{this.updateGroupFilter}}
+          >
+            <:content as |filteredReports|>
+              {{#each
+                (this.groupReports
+                  (this.filterReportsByGroup filteredReports visibleReports)
+                )
+                as |group|
+              }}
+                <section class="admin-reports-group">
+                  <h2 class="admin-reports-group__title">{{group.name}}</h2>
+                  <AdminSectionLandingWrapper class="admin-reports-list">
+                    {{#each group.reports as |report|}}
+                      <AdminSectionLandingItem
+                        @titleLabelTranslated={{report.title}}
+                        @descriptionLabelTranslated={{report.description}}
+                        @titleRoute="adminReports.show"
+                        @titleRouteModel={{report.type}}
+                      />
+                    {{/each}}
+                  </AdminSectionLandingWrapper>
+                </section>
+              {{/each}}
+            </:content>
+          </AdminFilterControls>
+        {{/let}}
       </:content>
     </DAsyncContent>
   </template>

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -158,7 +158,7 @@ export default class AdminReports extends Component {
 
   @bind
   groupDropdownOptions(reports) {
-    const groups = this.groupReports(reports);
+    const groups = this.groupReports(this.filterReports(reports));
 
     return [
       {
@@ -191,7 +191,7 @@ export default class AdminReports extends Component {
       return reports;
     }
 
-    const group = this.groupReports(availableReports).find(
+    const group = this.groupReports(this.filterReports(availableReports)).find(
       (reportGroup) => reportGroup.key === selectedGroupKey
     );
 
@@ -208,40 +208,38 @@ export default class AdminReports extends Component {
   <template>
     <DAsyncContent @asyncData={{this.loadReports}}>
       <:content as |reports|>
-        {{#let (this.filterReports reports) as |visibleReports|}}
-          <AdminFilterControls
-            @array={{visibleReports}}
-            @searchableProps={{array "title" "description"}}
-            @dropdownOptions={{this.groupDropdownOptions visibleReports}}
-            @defaultDropdownValue={{this.selectedGroupKey visibleReports}}
-            @inputPlaceholder={{i18n "admin.filter_reports"}}
-            @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
-            @onClientDropdownFilterChange={{this.updateGroupFilter}}
-          >
-            <:content as |filteredReports|>
-              {{#each
-                (this.groupReports
-                  (this.filterReportsByGroup filteredReports visibleReports)
-                )
-                as |group|
-              }}
-                <section class="admin-reports-group">
-                  <h2 class="admin-reports-group__title">{{group.name}}</h2>
-                  <AdminSectionLandingWrapper class="admin-reports-list">
-                    {{#each group.reports as |report|}}
-                      <AdminSectionLandingItem
-                        @titleLabelTranslated={{report.title}}
-                        @descriptionLabelTranslated={{report.description}}
-                        @titleRoute="adminReports.show"
-                        @titleRouteModel={{report.type}}
-                      />
-                    {{/each}}
-                  </AdminSectionLandingWrapper>
-                </section>
-              {{/each}}
-            </:content>
-          </AdminFilterControls>
-        {{/let}}
+        <AdminFilterControls
+          @array={{this.filterReports reports}}
+          @searchableProps={{array "title" "description"}}
+          @dropdownOptions={{this.groupDropdownOptions reports}}
+          @defaultDropdownValue={{this.selectedGroupKey reports}}
+          @inputPlaceholder={{i18n "admin.filter_reports"}}
+          @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
+          @onClientDropdownFilterChange={{this.updateGroupFilter}}
+        >
+          <:content as |filteredReports|>
+            {{#each
+              (this.groupReports
+                (this.filterReportsByGroup filteredReports reports)
+              )
+              as |group|
+            }}
+              <section class="admin-reports-group">
+                <h2 class="admin-reports-group__title">{{group.name}}</h2>
+                <AdminSectionLandingWrapper class="admin-reports-list">
+                  {{#each group.reports as |report|}}
+                    <AdminSectionLandingItem
+                      @titleLabelTranslated={{report.title}}
+                      @descriptionLabelTranslated={{report.description}}
+                      @titleRoute="adminReports.show"
+                      @titleRouteModel={{report.type}}
+                    />
+                  {{/each}}
+                </AdminSectionLandingWrapper>
+              </section>
+            {{/each}}
+          </:content>
+        </AdminFilterControls>
       </:content>
     </DAsyncContent>
   </template>

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -188,11 +188,6 @@ export default class AdminReports extends Component {
     this.args.onGroupChange?.(groupKey);
   }
 
-  @bind
-  resetGroupFilter() {
-    this.args.onGroupChange?.("all");
-  }
-
   <template>
     <DAsyncContent @asyncData={{this.loadReports}}>
       <:content as |reports|>
@@ -203,8 +198,7 @@ export default class AdminReports extends Component {
           @dropdownValue={{this.selectedGroupKey reports}}
           @inputPlaceholder={{i18n "admin.filter_reports"}}
           @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
-          @onClientDropdownFilterChange={{this.updateGroupFilter}}
-          @onResetFilters={{this.resetGroupFilter}}
+          @onDropdownChange={{this.updateGroupFilter}}
         >
           <:content as |filteredReports|>
             {{#each (this.groupReports filteredReports) as |group|}}

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -66,6 +66,8 @@ const REPORT_GROUPS = {
   other: [],
 };
 
+const CORE_REPORT_GROUP_KEYS = new Set(Object.keys(REPORT_GROUPS));
+
 export default class AdminReports extends Component {
   @service siteSettings;
 
@@ -158,8 +160,8 @@ export default class AdminReports extends Component {
 
   @bind
   groupDropdownOptions(reports) {
-    const groups = this.groupReports(reports).filter(
-      (group) => !group.key.startsWith("plugin-")
+    const groups = this.groupReports(reports).filter((group) =>
+      CORE_REPORT_GROUP_KEYS.has(group.key)
     );
 
     return [

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -67,7 +67,6 @@ const REPORT_GROUPS = {
 };
 
 export default class AdminReports extends Component {
-  @service router;
   @service siteSettings;
 
   @bind
@@ -89,7 +88,7 @@ export default class AdminReports extends Component {
   }
 
   get requestedGroupKey() {
-    return this.router.currentRoute?.queryParams?.group || "all";
+    return this.args.group || "all";
   }
 
   @bind
@@ -205,9 +204,7 @@ export default class AdminReports extends Component {
 
   @bind
   updateGroupFilter(groupKey) {
-    this.router.transitionTo({
-      queryParams: { group: groupKey === "all" ? null : groupKey },
-    });
+    this.args.onGroupChange?.(groupKey);
   }
 
   <template>

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { array } from "@ember/helper";
 import { service } from "@ember/service";
 import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
@@ -67,7 +68,10 @@ const REPORT_GROUPS = {
 };
 
 export default class AdminReports extends Component {
+  @service router;
   @service siteSettings;
+
+  @tracked selectedGroupKeyOverride;
 
   @bind
   async loadReports() {
@@ -85,6 +89,10 @@ export default class AdminReports extends Component {
       .split("|")
       .filter(Boolean);
     return reports.filter((report) => !hiddenReports.includes(report.type));
+  }
+
+  get requestedGroupKey() {
+    return this.router.currentRoute?.queryParams?.group || "all";
   }
 
   @bind
@@ -152,17 +160,80 @@ export default class AdminReports extends Component {
     return groupedReports;
   }
 
+  @bind
+  groupDropdownOptions(reports) {
+    const groups = this.groupReports(reports);
+
+    return [
+      {
+        value: "all",
+        label: i18n("admin.reports.all_groups"),
+        filterFn: () => true,
+      },
+      ...groups.map((group) => ({
+        value: group.key,
+        label: group.name,
+        filterFn: (report) => group.reports.includes(report),
+      })),
+    ];
+  }
+
+  @bind
+  selectedGroupKey(reports) {
+    const requestedGroupKey =
+      this.selectedGroupKeyOverride || this.requestedGroupKey;
+    const options = this.groupDropdownOptions(reports);
+
+    return options.some((option) => option.value === requestedGroupKey)
+      ? requestedGroupKey
+      : "all";
+  }
+
+  @bind
+  filterReportsByGroup(reports) {
+    const selectedGroupKey = this.selectedGroupKey(reports);
+
+    if (selectedGroupKey === "all") {
+      return reports;
+    }
+
+    const group = this.groupReports(reports).find(
+      (reportGroup) => reportGroup.key === selectedGroupKey
+    );
+
+    return group?.reports || reports;
+  }
+
+  @bind
+  updateGroupFilter(groupKey) {
+    this.selectedGroupKeyOverride = groupKey;
+
+    this.router.transitionTo({
+      queryParams: { group: groupKey === "all" ? null : groupKey },
+    });
+  }
+
   <template>
     <DAsyncContent @asyncData={{this.loadReports}}>
       <:content as |reports|>
         <AdminFilterControls
           @array={{this.filterReports reports}}
           @searchableProps={{array "title" "description"}}
+          @dropdownOptions={{this.groupDropdownOptions
+            (this.filterReports reports)
+          }}
+          @defaultDropdownValue={{this.selectedGroupKey
+            (this.filterReports reports)
+          }}
           @inputPlaceholder={{i18n "admin.filter_reports"}}
           @noResultsMessage={{i18n "admin.filter_reports_no_results"}}
+          @onClientDropdownFilterChange={{this.updateGroupFilter}}
         >
           <:content as |filteredReports|>
-            {{#each (this.groupReports filteredReports) as |group|}}
+            {{#each
+              (this.groupReports (this.filterReportsByGroup filteredReports))
+              as |group|
+            }}
               <section class="admin-reports-group">
                 <h2 class="admin-reports-group__title">{{group.name}}</h2>
                 <AdminSectionLandingWrapper class="admin-reports-list">

--- a/frontend/discourse/admin/controllers/admin-reports.js
+++ b/frontend/discourse/admin/controllers/admin-reports.js
@@ -4,6 +4,9 @@ import { service } from "@ember/service";
 export default class AdminReportsController extends Controller {
   @service router;
 
+  queryParams = ["group"];
+  group = null;
+
   get showHeader() {
     return this.router.currentRouteName === "adminReports.index";
   }

--- a/frontend/discourse/admin/controllers/admin-reports.js
+++ b/frontend/discourse/admin/controllers/admin-reports.js
@@ -4,9 +4,6 @@ import { service } from "@ember/service";
 export default class AdminReportsController extends Controller {
   @service router;
 
-  queryParams = ["group"];
-  group = null;
-
   get showHeader() {
     return this.router.currentRouteName === "adminReports.index";
   }

--- a/frontend/discourse/admin/controllers/admin-reports/index.js
+++ b/frontend/discourse/admin/controllers/admin-reports/index.js
@@ -1,0 +1,12 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+
+export default class AdminReportsIndexController extends Controller {
+  queryParams = ["group"];
+  group = null;
+
+  @action
+  updateGroupFilter(groupKey) {
+    this.set("group", groupKey === "all" ? null : groupKey);
+  }
+}

--- a/frontend/discourse/admin/templates/admin-reports/index.gjs
+++ b/frontend/discourse/admin/templates/admin-reports/index.gjs
@@ -2,6 +2,9 @@ import AdminReports from "discourse/admin/components/admin-reports";
 
 export default <template>
   <div class="admin-config-area__full-width">
-    <AdminReports />
+    <AdminReports
+      @group={{@controller.group}}
+      @onGroupChange={{@controller.updateGroupFilter}}
+    />
   </div>
 </template>

--- a/frontend/discourse/tests/integration/components/admin-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-filter-controls-test.gjs
@@ -295,8 +295,8 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await fillIn(".filter-input", "first");
     assert
-      .dom(".admin-filter-controls__inputs .admin-filter-controls__reset")
-      .exists("shows reset button");
+      .dom(".admin-filter-controls > .admin-filter-controls__reset")
+      .exists("shows reset button after filter controls");
   });
 
   test("respects minItemsForFilter parameter", async function (assert) {

--- a/spec/system/admin_reports_spec.rb
+++ b/spec/system/admin_reports_spec.rb
@@ -2,6 +2,9 @@
 
 describe "Admin Reports" do
   fab!(:current_user, :admin)
+
+  let(:reports_page) { PageObjects::Pages::AdminReport.new }
+
   before { sign_in(current_user) }
 
   context "when use_legacy_pageviews is true" do
@@ -44,5 +47,114 @@ describe "Admin Reports" do
       ".alert.alert-info",
       text: I18n.t("admin_js.admin.reports.legacy_warning"),
     )
+  end
+
+  it "lets admins use report group filters from URLs and controls" do
+    Reports::ListQuery.stubs(:call).returns(
+      [
+        {
+          type: "signups",
+          title: I18n.t("reports.signups.title"),
+          description: I18n.t("reports.signups.description"),
+        },
+        {
+          type: "flags",
+          title: I18n.t("reports.flags.title"),
+          description: I18n.t("reports.flags.description"),
+        },
+        {
+          type: "alpha_report",
+          title: "Alpha report",
+          description: "From alpha plugin",
+          plugin: "alpha-plugin",
+          plugin_display_name: "Alpha Metrics",
+        },
+      ],
+    )
+
+    reports_page.visit_index(group: "plugin-missing")
+
+    expect(reports_page).to have_current_all_reports_path
+    expect(reports_page.filter_controls).to have_dropdown_value("All groups")
+    expect(reports_page).to have_group("Engagement")
+    expect(reports_page).to have_group("Moderation & Security")
+    expect(reports_page).to have_group("Alpha Metrics")
+    expect(reports_page).to have_no_group_link("Engagement")
+    expect(reports_page).to have_no_group_link("Alpha Metrics")
+
+    reports_page.visit_index(group: "engagement")
+
+    expect(reports_page).to have_current_reports_path(group: "engagement")
+    expect(reports_page.filter_controls).to have_dropdown_value("Engagement")
+    expect(reports_page).to have_group("Engagement")
+    expect(reports_page).to have_no_group_link("Engagement")
+    expect(reports_page).to have_no_group("Moderation & Security")
+    expect(reports_page).to have_no_group("Alpha Metrics")
+    expect(reports_page).to have_report(I18n.t("reports.signups.title"))
+    expect(reports_page).to have_no_report(I18n.t("reports.flags.title"))
+    expect(reports_page).to have_no_report("Alpha report")
+
+    reports_page.filter_controls.type_in_search(I18n.t("reports.flags.title"))
+
+    expect(reports_page.filter_controls).to have_no_results_message
+
+    reports_page.filter_controls.click_no_results_reset_button
+
+    expect(reports_page).to have_current_all_reports_path
+    expect(reports_page.filter_controls).to have_dropdown_value("All groups")
+    expect(reports_page.filter_controls.search_input_value).to eq("")
+    expect(reports_page).to have_group("Engagement")
+    expect(reports_page).to have_group("Moderation & Security")
+    expect(reports_page).to have_group("Alpha Metrics")
+
+    reports_page.filter_controls.select_dropdown_option("Moderation & Security")
+
+    expect(reports_page).to have_current_reports_path(group: "moderation_and_security")
+    expect(reports_page).to have_group("Moderation & Security")
+    expect(reports_page).to have_no_group("Engagement")
+    expect(reports_page).to have_no_group("Alpha Metrics")
+  end
+
+  it "lets admins open plugin report groups by stable slug" do
+    Reports::ListQuery.stubs(:call).returns(
+      [
+        {
+          type: "signups",
+          title: I18n.t("reports.signups.title"),
+          description: I18n.t("reports.signups.description"),
+        },
+        {
+          type: "zebra_report",
+          title: "Zebra report",
+          description: "From zebra plugin",
+          plugin: "zebra-plugin",
+          plugin_display_name: "Zebra Analytics",
+        },
+        {
+          type: "alpha_report",
+          title: "Alpha report",
+          description: "From alpha plugin",
+          plugin: "alpha-plugin",
+          plugin_display_name: "Alpha Metrics",
+        },
+      ],
+    )
+
+    reports_page.visit_index(group: "plugin-alpha-plugin")
+
+    expect(reports_page).to have_current_reports_path(group: "plugin-alpha-plugin")
+    expect(reports_page.filter_controls).to have_dropdown_value("Alpha Metrics")
+    expect(reports_page).to have_group("Alpha Metrics")
+    expect(reports_page).to have_no_group("Engagement")
+    expect(reports_page).to have_no_group("Zebra Analytics")
+    expect(reports_page).to have_report("Alpha report")
+    expect(reports_page).to have_no_report(I18n.t("reports.signups.title"))
+    expect(reports_page).to have_no_report("Zebra report")
+
+    reports_page.filter_controls.select_dropdown_option("Zebra Analytics")
+
+    expect(reports_page).to have_current_reports_path(group: "plugin-zebra-plugin")
+    expect(reports_page).to have_group("Zebra Analytics")
+    expect(reports_page).to have_no_group("Alpha Metrics")
   end
 end

--- a/spec/system/admin_reports_spec.rb
+++ b/spec/system/admin_reports_spec.rb
@@ -49,142 +49,26 @@ describe "Admin Reports" do
     )
   end
 
-  it "lets admins use report group filters from URLs and controls" do
-    Reports::ListQuery.stubs(:call).returns(
-      [
-        {
-          type: "signups",
-          title: I18n.t("reports.signups.title"),
-          description: I18n.t("reports.signups.description"),
-        },
-        {
-          type: "visits",
-          title: I18n.t("reports.visits.title"),
-          description: I18n.t("reports.visits.description"),
-        },
-        {
-          type: "flags",
-          title: I18n.t("reports.flags.title"),
-          description: I18n.t("reports.flags.description"),
-        },
-        {
-          type: "alpha_report",
-          title: "Alpha report",
-          description: "From alpha plugin",
-          plugin: "alpha-plugin",
-          plugin_display_name: "Alpha Metrics",
-        },
-      ],
-    )
-
-    reports_page.visit_index(group: "missing")
-
-    expect(reports_page).to have_current_all_reports_path
-    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
-    expect(reports_page.filter_controls).to have_dropdown_value("All groups")
-    expect(reports_page).to have_group("Engagement")
-    expect(reports_page).to have_group("Moderation & Security")
-    expect(reports_page).to have_group("Alpha Metrics")
-    expect(reports_page).to have_static_group_heading("Engagement")
-    expect(reports_page).to have_static_group_heading("Alpha Metrics")
-
-    reports_page.visit_index(group: "plugin-missing")
-
-    expect(reports_page).to have_current_all_reports_path
-    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
-    expect(reports_page.filter_controls).to have_dropdown_value("All groups")
-    expect(reports_page).to have_group("Engagement")
-    expect(reports_page).to have_group("Moderation & Security")
-    expect(reports_page).to have_group("Alpha Metrics")
-    expect(reports_page).to have_static_group_heading("Engagement")
-    expect(reports_page).to have_static_group_heading("Alpha Metrics")
-
+  it "lets admins filter report groups from URLs and controls" do
     reports_page.visit_index(group: "engagement")
 
     expect(reports_page).to have_current_reports_path(group: "engagement")
-    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
     expect(reports_page.filter_controls).to have_dropdown_value("Engagement")
     expect(reports_page).to have_group("Engagement")
-    expect(reports_page).to have_static_group_heading("Engagement")
-    expect(reports_page).to have_no_group("Moderation & Security")
-    expect(reports_page).to have_no_group("Alpha Metrics")
-    expect(reports_page).to have_report(I18n.t("reports.signups.title"))
-    expect(reports_page).to have_report(I18n.t("reports.visits.title"))
-    expect(reports_page).to have_no_report(I18n.t("reports.flags.title"))
-    expect(reports_page).to have_no_report("Alpha report")
+    expect(reports_page).to have_no_group("Traffic")
 
-    reports_page.filter_controls.type_in_search(I18n.t("reports.signups.title"))
+    reports_page.filter_controls.select_dropdown_option("Traffic")
 
-    expect(reports_page).to have_report(I18n.t("reports.signups.title"))
-    expect(reports_page).to have_no_report(I18n.t("reports.visits.title"))
-    expect(reports_page.filter_controls).to have_no_no_results_reset_button
+    expect(reports_page).to have_current_reports_path(group: "traffic")
+    expect(reports_page.filter_controls).to have_dropdown_value("Traffic")
+    expect(reports_page).to have_group("Traffic")
+    expect(reports_page).to have_no_group("Engagement")
 
-    reports_page.filter_controls.clear_search
-    reports_page.filter_controls.type_in_search(I18n.t("reports.flags.title"))
-
-    expect(reports_page.filter_controls).to have_no_results_message(
-      I18n.t("admin_js.admin.filter_reports_no_results"),
-    )
-
-    reports_page.filter_controls.click_no_results_reset_button
+    reports_page.filter_controls.select_all_dropdown_option
 
     expect(reports_page).to have_current_all_reports_path
     expect(reports_page.filter_controls).to have_dropdown_value("All groups")
-    expect(reports_page.filter_controls.search_input_value).to eq("")
     expect(reports_page).to have_group("Engagement")
-    expect(reports_page).to have_group("Moderation & Security")
-    expect(reports_page).to have_group("Alpha Metrics")
-    expect(reports_page).to have_report(I18n.t("reports.visits.title"))
-
-    reports_page.filter_controls.select_dropdown_option("Moderation & Security")
-
-    expect(reports_page).to have_current_reports_path(group: "moderation_and_security")
-    expect(reports_page).to have_group("Moderation & Security")
-    expect(reports_page).to have_no_group("Engagement")
-    expect(reports_page).to have_no_group("Alpha Metrics")
-  end
-
-  it "lets admins open plugin report groups by stable slug" do
-    Reports::ListQuery.stubs(:call).returns(
-      [
-        {
-          type: "signups",
-          title: I18n.t("reports.signups.title"),
-          description: I18n.t("reports.signups.description"),
-        },
-        {
-          type: "zebra_report",
-          title: "Zebra report",
-          description: "From zebra plugin",
-          plugin: "zebra-plugin",
-          plugin_display_name: "Zebra Analytics",
-        },
-        {
-          type: "alpha_report",
-          title: "Alpha report",
-          description: "From alpha plugin",
-          plugin: "alpha-plugin",
-          plugin_display_name: "Alpha Metrics",
-        },
-      ],
-    )
-
-    reports_page.visit_index(group: "plugin-alpha-plugin")
-
-    expect(reports_page).to have_current_reports_path(group: "plugin-alpha-plugin")
-    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
-    expect(reports_page.filter_controls).to have_dropdown_value("Alpha Metrics")
-    expect(reports_page).to have_group("Alpha Metrics")
-    expect(reports_page).to have_no_group("Engagement")
-    expect(reports_page).to have_no_group("Zebra Analytics")
-    expect(reports_page).to have_report("Alpha report")
-    expect(reports_page).to have_no_report(I18n.t("reports.signups.title"))
-    expect(reports_page).to have_no_report("Zebra report")
-
-    reports_page.filter_controls.select_dropdown_option("Zebra Analytics")
-
-    expect(reports_page).to have_current_reports_path(group: "plugin-zebra-plugin")
-    expect(reports_page).to have_group("Zebra Analytics")
-    expect(reports_page).to have_no_group("Alpha Metrics")
+    expect(reports_page).to have_group("Traffic")
   end
 end

--- a/spec/system/admin_reports_spec.rb
+++ b/spec/system/admin_reports_spec.rb
@@ -58,6 +58,11 @@ describe "Admin Reports" do
           description: I18n.t("reports.signups.description"),
         },
         {
+          type: "visits",
+          title: I18n.t("reports.visits.title"),
+          description: I18n.t("reports.visits.description"),
+        },
+        {
           type: "flags",
           title: I18n.t("reports.flags.title"),
           description: I18n.t("reports.flags.description"),
@@ -72,31 +77,54 @@ describe "Admin Reports" do
       ],
     )
 
-    reports_page.visit_index(group: "plugin-missing")
+    reports_page.visit_index(group: "missing")
 
     expect(reports_page).to have_current_all_reports_path
+    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
     expect(reports_page.filter_controls).to have_dropdown_value("All groups")
     expect(reports_page).to have_group("Engagement")
     expect(reports_page).to have_group("Moderation & Security")
     expect(reports_page).to have_group("Alpha Metrics")
-    expect(reports_page).to have_no_group_link("Engagement")
-    expect(reports_page).to have_no_group_link("Alpha Metrics")
+    expect(reports_page).to have_static_group_heading("Engagement")
+    expect(reports_page).to have_static_group_heading("Alpha Metrics")
+
+    reports_page.visit_index(group: "plugin-missing")
+
+    expect(reports_page).to have_current_all_reports_path
+    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
+    expect(reports_page.filter_controls).to have_dropdown_value("All groups")
+    expect(reports_page).to have_group("Engagement")
+    expect(reports_page).to have_group("Moderation & Security")
+    expect(reports_page).to have_group("Alpha Metrics")
+    expect(reports_page).to have_static_group_heading("Engagement")
+    expect(reports_page).to have_static_group_heading("Alpha Metrics")
 
     reports_page.visit_index(group: "engagement")
 
     expect(reports_page).to have_current_reports_path(group: "engagement")
+    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
     expect(reports_page.filter_controls).to have_dropdown_value("Engagement")
     expect(reports_page).to have_group("Engagement")
-    expect(reports_page).to have_no_group_link("Engagement")
+    expect(reports_page).to have_static_group_heading("Engagement")
     expect(reports_page).to have_no_group("Moderation & Security")
     expect(reports_page).to have_no_group("Alpha Metrics")
     expect(reports_page).to have_report(I18n.t("reports.signups.title"))
+    expect(reports_page).to have_report(I18n.t("reports.visits.title"))
     expect(reports_page).to have_no_report(I18n.t("reports.flags.title"))
     expect(reports_page).to have_no_report("Alpha report")
 
+    reports_page.filter_controls.type_in_search(I18n.t("reports.signups.title"))
+
+    expect(reports_page).to have_report(I18n.t("reports.signups.title"))
+    expect(reports_page).to have_no_report(I18n.t("reports.visits.title"))
+    expect(reports_page.filter_controls).to have_no_no_results_reset_button
+
+    reports_page.filter_controls.clear_search
     reports_page.filter_controls.type_in_search(I18n.t("reports.flags.title"))
 
-    expect(reports_page.filter_controls).to have_no_results_message
+    expect(reports_page.filter_controls).to have_no_results_message(
+      I18n.t("admin_js.admin.filter_reports_no_results"),
+    )
 
     reports_page.filter_controls.click_no_results_reset_button
 
@@ -106,6 +134,7 @@ describe "Admin Reports" do
     expect(reports_page).to have_group("Engagement")
     expect(reports_page).to have_group("Moderation & Security")
     expect(reports_page).to have_group("Alpha Metrics")
+    expect(reports_page).to have_report(I18n.t("reports.visits.title"))
 
     reports_page.filter_controls.select_dropdown_option("Moderation & Security")
 
@@ -143,6 +172,7 @@ describe "Admin Reports" do
     reports_page.visit_index(group: "plugin-alpha-plugin")
 
     expect(reports_page).to have_current_reports_path(group: "plugin-alpha-plugin")
+    expect(reports_page.filter_controls).to have_dropdown_accessible_name("Report group")
     expect(reports_page.filter_controls).to have_dropdown_value("Alpha Metrics")
     expect(reports_page).to have_group("Alpha Metrics")
     expect(reports_page).to have_no_group("Engagement")

--- a/spec/system/page_objects/components/admin_filter_controls.rb
+++ b/spec/system/page_objects/components/admin_filter_controls.rb
@@ -41,11 +41,11 @@ module PageObjects
       end
 
       def has_reset_button?
-        page.has_css?(".admin-filter-controls__inputs .admin-filter-controls__reset")
+        component.has_css?("> .admin-filter-controls__reset")
       end
 
       def click_reset_button
-        page.find(".admin-filter-controls__inputs .admin-filter-controls__reset").click
+        component.find("> .admin-filter-controls__reset").click
       end
 
       def click_no_results_reset_button
@@ -57,7 +57,7 @@ module PageObjects
       end
 
       def has_no_reset_button?
-        component.has_no_css?(".admin-filter-controls__inputs .admin-filter-controls__reset")
+        component.has_no_css?("> .admin-filter-controls__reset")
       end
 
       def has_no_results_message?

--- a/spec/system/page_objects/components/admin_filter_controls.rb
+++ b/spec/system/page_objects/components/admin_filter_controls.rb
@@ -68,6 +68,12 @@ module PageObjects
         component.find(".admin-filter-controls__input").value
       end
 
+      def has_dropdown_value?(text, dropdown_id: nil)
+        selector = ".admin-filter-controls__dropdown"
+        selector += "#{selector}--#{dropdown_id}" if dropdown_id
+        component.has_css?("#{selector} option:checked", text: text)
+      end
+
       def dropdown_value
         component.find(".admin-filter-controls__dropdown option:checked").text
       end

--- a/spec/system/page_objects/components/admin_filter_controls.rb
+++ b/spec/system/page_objects/components/admin_filter_controls.rb
@@ -60,12 +60,23 @@ module PageObjects
         component.has_no_css?(".admin-filter-controls__inputs .admin-filter-controls__reset")
       end
 
-      def has_no_results_message?
-        page.has_css?(".admin-filter-controls__no-results")
+      def has_no_results_message?(message = nil)
+        if message
+          page.has_css?(".admin-filter-controls__no-results", text: message)
+        else
+          page.has_css?(".admin-filter-controls__no-results")
+        end
       end
 
       def search_input_value
         component.find(".admin-filter-controls__input").value
+      end
+
+      def has_dropdown_accessible_name?(name, dropdown_id: nil)
+        selector = ".admin-filter-controls__dropdown"
+        selector += "#{selector}--#{dropdown_id}" if dropdown_id
+
+        component.has_select?(name) || component.has_css?("#{selector}[aria-label='#{name}']")
       end
 
       def has_dropdown_value?(text, dropdown_id: nil)

--- a/spec/system/page_objects/components/admin_filter_controls.rb
+++ b/spec/system/page_objects/components/admin_filter_controls.rb
@@ -60,23 +60,12 @@ module PageObjects
         component.has_no_css?(".admin-filter-controls__inputs .admin-filter-controls__reset")
       end
 
-      def has_no_results_message?(message = nil)
-        if message
-          page.has_css?(".admin-filter-controls__no-results", text: message)
-        else
-          page.has_css?(".admin-filter-controls__no-results")
-        end
+      def has_no_results_message?
+        page.has_css?(".admin-filter-controls__no-results")
       end
 
       def search_input_value
         component.find(".admin-filter-controls__input").value
-      end
-
-      def has_dropdown_accessible_name?(name, dropdown_id: nil)
-        selector = ".admin-filter-controls__dropdown"
-        selector += "#{selector}--#{dropdown_id}" if dropdown_id
-
-        component.has_select?(name) || component.has_css?("#{selector}[aria-label='#{name}']")
       end
 
       def has_dropdown_value?(text, dropdown_id: nil)

--- a/spec/system/page_objects/pages/admin_report.rb
+++ b/spec/system/page_objects/pages/admin_report.rb
@@ -48,21 +48,6 @@ module PageObjects
         page.has_no_css?(".admin-reports-group__title", text: name)
       end
 
-      def has_static_group_heading?(name)
-        page.has_css?("h2.admin-reports-group__title", text: name) &&
-          page.has_no_css?(
-            "a.admin-reports-group__title, " \
-              "a .admin-reports-group__title, " \
-              ".admin-reports-group__title a, " \
-              "button.admin-reports-group__title, " \
-              "button .admin-reports-group__title, " \
-              ".admin-reports-group__title button, " \
-              ".admin-reports-group__title[role='button'], " \
-              ".admin-reports-group__title[tabindex]",
-            text: name,
-          )
-      end
-
       def has_report?(title)
         page.has_css?(".admin-section-landing-item__title", text: title)
       end

--- a/spec/system/page_objects/pages/admin_report.rb
+++ b/spec/system/page_objects/pages/admin_report.rb
@@ -3,6 +3,11 @@
 module PageObjects
   module Pages
     class AdminReport < PageObjects::Pages::Base
+      def visit_index(group: nil)
+        page.visit("/admin/reports#{group ? "?group=#{group}" : ""}")
+        self
+      end
+
       def visit_default_dashboard_report
         page.visit(
           "/admin/reports/#{SeedData::AdminDashboardReports::DEFAULT_BUILTIN_REPORTS.first}",
@@ -31,8 +36,36 @@ module PageObjects
         self
       end
 
+      def filter_controls
+        PageObjects::Components::AdminFilterControls.new(".admin-filter-controls")
+      end
+
+      def has_group?(name)
+        page.has_css?(".admin-reports-group__title", text: name)
+      end
+
+      def has_no_group?(name)
+        page.has_no_css?(".admin-reports-group__title", text: name)
+      end
+
+      def has_no_group_link?(name)
+        page.has_no_link?(name, href: %r{/admin/reports})
+      end
+
+      def has_report?(title)
+        page.has_css?(".admin-section-landing-item__title", text: title)
+      end
+
+      def has_no_report?(title)
+        page.has_no_css?(".admin-section-landing-item__title", text: title)
+      end
+
       def has_current_all_reports_path?
         page.has_current_path?("/admin/reports")
+      end
+
+      def has_current_reports_path?(group: nil)
+        page.has_current_path?("/admin/reports#{group ? "?group=#{group}" : ""}")
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_report.rb
+++ b/spec/system/page_objects/pages/admin_report.rb
@@ -48,8 +48,19 @@ module PageObjects
         page.has_no_css?(".admin-reports-group__title", text: name)
       end
 
-      def has_no_group_link?(name)
-        page.has_no_link?(name, href: %r{/admin/reports})
+      def has_static_group_heading?(name)
+        page.has_css?("h2.admin-reports-group__title", text: name) &&
+          page.has_no_css?(
+            "a.admin-reports-group__title, " \
+              "a .admin-reports-group__title, " \
+              ".admin-reports-group__title a, " \
+              "button.admin-reports-group__title, " \
+              "button .admin-reports-group__title, " \
+              ".admin-reports-group__title button, " \
+              ".admin-reports-group__title[role='button'], " \
+              ".admin-reports-group__title[tabindex]",
+            text: name,
+          )
       end
 
       def has_report?(title)


### PR DESCRIPTION
This PR lets admins open the existing reports index with a report group selected from the URL.

Previously, `/admin/reports` grouped reports visually, but the selected group could not be represented in a bookmarkable URL. This keeps the existing reports index and filter controls while adding URL-backed group selection for any report group, including groups provided by plugins.

Key changes:
* Add a report group dropdown to `AdminReports` so groups can be selected from the existing filter controls and reflected in `?group=`.
* Keep the `group` query param owned by the `admin-reports/index` controller and pass the selected value down to `AdminReports`.
* Include plugin-provided report groups in the same group filter as core groups.
* Update `AdminFilterControls` so a URL-controlled dropdown value can still use client-side filtering, no-results, reset, and browser navigation correctly.
* Move the reset button after dropdowns so the controls read as search, group filter, then reset.
* Cover the direct URL, group dropdown, and clear-filter flow with a system test.

https://github.com/user-attachments/assets/2493025a-92c3-4843-853d-b5567af7a2cc
