### PR TITLE
FIX: Redirect upcoming change notifications to What's New when permanent

### DIFF
--- a/app/assets/stylesheets/admin/dashboard.scss
+++ b/app/assets/stylesheets/admin/dashboard.scss
@@ -798,6 +798,11 @@
   display: flex;
   align-items: flex-start;
   border-bottom: 1px solid var(--content-border-color);
+  transition: background-color 0.5s ease;
+
+  &.--highlighted {
+    background-color: var(--highlight-low);
+  }
 
   &:not(:first-child) {
     margin-top: var(--space-4);

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -54,6 +54,7 @@ class SiteSerializer < ApplicationSerializer
     :admin_config_login_routes,
     :email_configured,
     :upcoming_changes_with_css,
+    :permanent_upcoming_change_names,
     :access_control,
   )
 
@@ -454,6 +455,14 @@ class SiteSerializer < ApplicationSerializer
 
   def upcoming_changes_with_css
     UpcomingChanges.including_css
+  end
+
+  def permanent_upcoming_change_names
+    UpcomingChanges.permanent_upcoming_change_names
+  end
+
+  def include_permanent_upcoming_change_names?
+    scope.is_staff?
   end
 
   private

--- a/frontend/discourse/admin/components/dashboard-new-feature-item.gjs
+++ b/frontend/discourse/admin/components/dashboard-new-feature-item.gjs
@@ -6,14 +6,17 @@ import { i18n } from "discourse-i18n";
 
 export default class DiscourseNewFeatureItem extends Component {
   get identifier() {
-    return this.args.item.title ? dasherize(this.args.item.title) : null;
+    if (this.args.item.upcoming_change_setting_name) {
+      return `upcoming-change-${this.args.item.upcoming_change_setting_name}`;
+    }
+
+    return this.args.item.title
+      ? dasherize(this.args.item.title).toLowerCase()
+      : null;
   }
 
   <template>
-    <div
-      class="admin-new-feature-item"
-      data-new-feature-identifier={{this.identifier}}
-    >
+    <div class="admin-new-feature-item" id={{this.identifier}}>
       <div class="admin-new-feature-item__content">
         <div class="admin-new-feature-item__header">
           {{#if (and @item.emoji (not @item.screenshot_url))}}

--- a/frontend/discourse/admin/components/dashboard-new-features.gjs
+++ b/frontend/discourse/admin/components/dashboard-new-features.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
 import AdminConfigAreaEmptyList from "discourse/admin/components/admin-config-area-empty-list";
@@ -8,6 +9,7 @@ import DashboardNewFeatureItem from "discourse/admin/components/dashboard-new-fe
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
+import discourseLater from "discourse/lib/later";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import { i18n } from "discourse-i18n";
 
@@ -17,6 +19,8 @@ export default class DashboardNewFeatures extends Component {
   @tracked newFeatures = {};
   @tracked isLoading = true;
   @tracked feedError = false;
+
+  hasScrolledToTarget = false;
 
   constructor() {
     super(...arguments);
@@ -52,7 +56,30 @@ export default class DashboardNewFeatures extends Component {
       popupAjaxError(err);
     } finally {
       this.isLoading = false;
+      this.scrollToTarget();
     }
+  }
+
+  // When arriving from an "automatically enabled" notification for a change that
+  // has since become permanent, scroll to (and briefly highlight) its card. The
+  // features load asynchronously, so this runs after they've rendered.
+  scrollToTarget() {
+    const scrollTo = this.args.scrollTo;
+    if (!scrollTo || this.hasScrolledToTarget) {
+      return;
+    }
+
+    schedule("afterRender", () => {
+      const element = document.getElementById(`upcoming-change-${scrollTo}`);
+      if (!element) {
+        return;
+      }
+
+      this.hasScrolledToTarget = true;
+      element.scrollIntoView({ block: "center", behavior: "smooth" });
+      element.classList.add("--highlighted");
+      discourseLater(() => element.classList.remove("--highlighted"), 2000);
+    });
   }
 
   get groupedNewFeatures() {

--- a/frontend/discourse/admin/controllers/admin/whats-new.js
+++ b/frontend/discourse/admin/controllers/admin/whats-new.js
@@ -1,7 +1,11 @@
+import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 
 export default class AdminWhatsNewController extends Controller {
+  @tracked scrollTo = null;
+  queryParams = ["scrollTo"];
+
   @action
   checkForUpdates() {
     this.checkFeaturesCallback?.({ forceRefresh: true });

--- a/frontend/discourse/admin/templates/admin/whats-new.gjs
+++ b/frontend/discourse/admin/templates/admin/whats-new.gjs
@@ -29,6 +29,7 @@ export default <template>
     <div class="admin-config-area">
       <DashboardNewFeatures
         @onCheckForFeatures={{@controller.bindCheckFeatures}}
+        @scrollTo={{@controller.scrollTo}}
       />
     </div>
   </div>

--- a/frontend/discourse/app/lib/notification-types/upcoming-change-automatically-promoted.js
+++ b/frontend/discourse/app/lib/notification-types/upcoming-change-automatically-promoted.js
@@ -41,6 +41,17 @@ export default class extends NotificationTypeBase {
   get linkHref() {
     const data = this.notification.data;
     const names = data.upcoming_change_names || [data.upcoming_change_name];
+    const permanentNames = this.site.permanent_upcoming_change_names || [];
+    const nonPermanent = names.filter((n) => !permanentNames.includes(n));
+
+    // Once a change is permanent it no longer shows on the upcoming changes
+    // page, it's surfaced on the What's New page instead. If every change this
+    // notification references is now permanent, send the admin there and scroll
+    // to the relevant change. Otherwise keep the upcoming changes page, where
+    // the still non-permanent changes are actionable.
+    if (nonPermanent.length === 0 && names.length > 0) {
+      return getURL(`/admin/whats-new?scrollTo=${names[0]}`);
+    }
 
     return getURL(
       `/admin/config/upcoming-changes?changeNamesFilter=${names.join(",")}`

--- a/frontend/discourse/tests/acceptance/admin-whats-new-test.js
+++ b/frontend/discourse/tests/acceptance/admin-whats-new-test.js
@@ -1,5 +1,6 @@
 import { visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import sinon from "sinon";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 const RELEASE_SITE_URL = "https://releases.discourse.org/";
@@ -22,5 +23,58 @@ acceptance("Admin - What's New", function (needs) {
     assert
       .dom(`.admin-config-area-empty-list a[href="${RELEASE_SITE_URL}"]`)
       .exists();
+  });
+});
+
+acceptance("Admin - What's New - anchors and scroll", function (needs) {
+  needs.user();
+
+  needs.pretender((server, helper) => {
+    server.get("/admin/whats-new.json", () => {
+      return helper.response({
+        new_features: [
+          {
+            id: 1,
+            title: "New color palettes",
+            description: "New light and dark color palettes.",
+            created_at: "2021-01-18T19:59:29.666Z",
+          },
+          {
+            id: 2,
+            title: "Enable new editor",
+            description: "The new rich text editor.",
+            upcoming_change_setting_name: "enable_new_editor",
+            created_at: "2021-02-18T19:59:29.666Z",
+          },
+        ],
+        release_notes_link: RELEASE_SITE_URL,
+      });
+    });
+  });
+
+  test("each item has an id anchor", async function (assert) {
+    await visit("/admin/whats-new");
+
+    assert
+      .dom("#new-color-palettes")
+      .exists("regular items are anchored by their dasherized title");
+    assert
+      .dom("#upcoming-change-enable_new_editor")
+      .exists("upcoming change items are anchored by their setting name");
+  });
+
+  test("scrolls to the targeted upcoming change", async function (assert) {
+    const scrollIntoView = sinon.stub(HTMLElement.prototype, "scrollIntoView");
+
+    await visit("/admin/whats-new?scrollTo=enable_new_editor");
+
+    assert.true(
+      scrollIntoView
+        .getCalls()
+        .some(
+          (call) => call.thisValue.id === "upcoming-change-enable_new_editor"
+        ),
+      "scrolls the targeted change into view"
+    );
   });
 });

--- a/frontend/discourse/tests/unit/lib/notification-types/upcoming-change-automatically-promoted-test.js
+++ b/frontend/discourse/tests/unit/lib/notification-types/upcoming-change-automatically-promoted-test.js
@@ -1,6 +1,7 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import Notification from "discourse/models/notification";
+import Site from "discourse/models/site";
 import { createRenderDirector } from "discourse/tests/helpers/notification-types-helper";
 import { i18n } from "discourse-i18n";
 
@@ -24,6 +25,10 @@ module(
   "Unit | Notification Types | upcoming-change-automatically-promoted",
   function (hooks) {
     setupTest(hooks);
+
+    hooks.afterEach(function () {
+      Site.current().permanent_upcoming_change_names = [];
+    });
 
     test("description with single change", function (assert) {
       const notification = getNotification();
@@ -146,6 +151,57 @@ module(
       assert.strictEqual(
         director.linkHref,
         "/admin/config/upcoming-changes?changeNamesFilter=enable_feature_x,enable_feature_y,enable_feature_z"
+      );
+    });
+
+    test("linkHref redirects to What's New when the change is now permanent", function (assert) {
+      Site.current().permanent_upcoming_change_names = ["enable_feature_x"];
+      const notification = getNotification({
+        upcoming_change_names: ["enable_feature_x"],
+      });
+      const director = createRenderDirector(
+        notification,
+        "upcoming_change_automatically_promoted",
+        this.siteSettings
+      );
+      assert.strictEqual(
+        director.linkHref,
+        "/admin/whats-new?scrollTo=enable_feature_x"
+      );
+    });
+
+    test("linkHref redirects to What's New when every change is now permanent", function (assert) {
+      Site.current().permanent_upcoming_change_names = [
+        "enable_feature_x",
+        "enable_feature_y",
+      ];
+      const notification = getNotification({
+        upcoming_change_names: ["enable_feature_x", "enable_feature_y"],
+      });
+      const director = createRenderDirector(
+        notification,
+        "upcoming_change_automatically_promoted",
+        this.siteSettings
+      );
+      assert.strictEqual(
+        director.linkHref,
+        "/admin/whats-new?scrollTo=enable_feature_x"
+      );
+    });
+
+    test("linkHref stays on the upcoming changes page when only some changes are permanent", function (assert) {
+      Site.current().permanent_upcoming_change_names = ["enable_feature_x"];
+      const notification = getNotification({
+        upcoming_change_names: ["enable_feature_x", "enable_feature_y"],
+      });
+      const director = createRenderDirector(
+        notification,
+        "upcoming_change_automatically_promoted",
+        this.siteSettings
+      );
+      assert.strictEqual(
+        director.linkHref,
+        "/admin/config/upcoming-changes?changeNamesFilter=enable_feature_x,enable_feature_y"
       );
     });
 

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -440,6 +440,13 @@ module UpcomingChanges
       end
   end
 
+  # The setting names of all permanent upcoming changes. Used on the frontend
+  # to decide whether a notification should link to the upcoming changes page
+  # or to the What's New page (where permanent changes are surfaced).
+  def self.permanent_upcoming_change_names
+    permanent_upcoming_changes.map { |uc| uc[:setting].to_s }
+  end
+
   # No point in notifying admins on brand new sites, the upcoming change system
   # is more about notifying admins of changes to established sites.
   #

--- a/spec/requests/api/schemas/json/site_response.json
+++ b/spec/requests/api/schemas/json/site_response.json
@@ -977,6 +977,12 @@
         "mandatory_acl",
         "banned_acl"
       ]
+    },
+    "permanent_upcoming_change_names": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -699,4 +699,26 @@ RSpec.describe SiteSerializer do
       expect(serialized[:upcoming_changes_with_css]).not_to include(:enable_user_tips)
     end
   end
+
+  describe "#permanent_upcoming_change_names" do
+    before do
+      UpcomingChanges.stubs(:permanent_upcoming_change_names).returns(%w[enable_permanent_feature])
+    end
+
+    it "returns the permanent change names for staff" do
+      admin = Fabricate(:admin)
+      admin_guardian = Guardian.new(admin)
+      serialized =
+        described_class.new(Site.new(admin_guardian), scope: admin_guardian, root: false).as_json
+      expect(serialized[:permanent_upcoming_change_names]).to eq(%w[enable_permanent_feature])
+    end
+
+    it "is not included for non-staff users" do
+      user = Fabricate(:user)
+      user_guardian = Guardian.new(user)
+      serialized =
+        described_class.new(Site.new(user_guardian), scope: user_guardian, root: false).as_json
+      expect(serialized).not_to have_key(:permanent_upcoming_change_names)
+    end
+  end
 end

--- a/spec/system/page_objects/pages/admin_new_features.rb
+++ b/spec/system/page_objects/pages/admin_new_features.rb
@@ -15,9 +15,7 @@ module PageObjects
       end
 
       def within_new_feature_item(title, &block)
-        within find(
-                 ".admin-new-feature-item[data-new-feature-identifier='#{title.parameterize}']",
-               ) do
+        within find(".admin-new-feature-item##{title.parameterize.downcase}") do
           block.call
         end
       end


### PR DESCRIPTION
When an upcoming change was automatically enabled, the notification
linked admins to the upcoming changes config page. But once a change
reaches permanent status it no longer appears there (that page only
lists experimental through stable) and instead surfaces on the What's
New page. So if the notification was left unread until the change became
permanent, clicking it dropped the admin on an empty filtered list.

This resolves the change's status at click time rather than baking it
into the notification. The permanent change names are now exposed to
staff via the site serializer, and the notification's link checks them:
if every referenced change is now permanent, it sends the admin to
What's New scrolled to that change's card; otherwise it keeps the
existing upcoming changes page where the still non-permanent changes
remain actionable.

To support the scroll, every What's New item now has a stable id anchor,
and the page accepts a scrollTo query param that scrolls to and briefly
highlights the matching card once the feed loads.

<img width="1106" height="423" alt="image" src="https://github.com/user-attachments/assets/353304b3-1590-407a-b3f2-7d0a0c1d0a38" />

<img width="1163" height="782" alt="image" src="https://github.com/user-attachments/assets/26e2d8d2-173f-455b-83a8-a0f3fc907243" />

