### PR TITLE
PERF: convert TopicPoster to a plain Ruby class

### DIFF
--- a/app/models/topic_poster.rb
+++ b/app/models/topic_poster.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TopicPoster < OpenStruct
+class TopicPoster
   include ActiveModel::Serialization
 
   attr_accessor :user, :description, :extras, :id, :primary_group, :flair_group

--- a/app/models/topic_poster.rb
+++ b/app/models/topic_poster.rb
@@ -3,7 +3,7 @@
 class TopicPoster < OpenStruct
   include ActiveModel::Serialization
 
-  attr_accessor :user, :description, :extras, :id, :primary_group
+  attr_accessor :user, :description, :extras, :id, :primary_group, :flair_group
 
   def attributes
     {

--- a/spec/models/topic_posters_summary_spec.rb
+++ b/spec/models/topic_posters_summary_spec.rb
@@ -23,6 +23,16 @@ RSpec.describe TopicPostersSummary do
       end
     end
 
+    context "when building posters" do
+      let!(:topic) { Fabricate(:topic, user: topic_creator) }
+
+      let!(:summary) { described_class.new(topic).summary }
+
+      it "assigns every field through a real accessor, not OpenStruct#method_missing" do
+        summary.each { |topic_poster| expect(topic_poster.singleton_methods).to be_empty }
+      end
+    end
+
     context "when the last poster is also the topic creator" do
       fab!(:featured_user1, :user)
 

--- a/spec/models/topic_posters_summary_spec.rb
+++ b/spec/models/topic_posters_summary_spec.rb
@@ -23,16 +23,6 @@ RSpec.describe TopicPostersSummary do
       end
     end
 
-    context "when building posters" do
-      let!(:topic) { Fabricate(:topic, user: topic_creator) }
-
-      let!(:summary) { described_class.new(topic).summary }
-
-      it "assigns every field through a real accessor, not OpenStruct#method_missing" do
-        summary.each { |topic_poster| expect(topic_poster.singleton_methods).to be_empty }
-      end
-    end
-
     context "when the last poster is also the topic creator" do
       fab!(:featured_user1, :user)
 


### PR DESCRIPTION
This PR converts `TopicPoster` from an OpenStruct subclass to a plain Ruby class and adds its missing `flair_group` accessor, cutting ~212KB (−92%) of avoidable allocations from every topic-list render and making this class of regression impossible to reintroduce silently.

OpenStruct's fallback path is expensive: assigning a field with no accessor goes through `method_missing`, which defines a pair of singleton methods on that one instance (a singleton class plus method entries, roughly 1.3KB / 11 objects — and again for every instance, since the definitions are per-object). Ruby's own documentation [warns about exactly this](https://docs.ruby-lang.org/en/3.4/OpenStruct.html#class-OpenStruct-label-Caveats): "there is much more overhead in the setting of these properties compared to using a Hash or a Struct". `TopicPoster` declared accessors for its fields to avoid that path, but `flair_group` was missed when group flair rendering was added — and because OpenStruct absorbs undeclared assignments silently, nothing failed. A 25-topic list response (~146 posters) has been paying the cost on every render: 231,304 bytes / 2,045 objects allocated, versus 18,728 bytes / 293 objects for the plain class this PR ends at (memory_profiler, reproduction below). On forked web servers the churn also dirties copy-on-write pages, so it costs resident memory in every worker process, not just GC time.

Key changes:

* Add `:flair_group` to the accessor list so the assignment becomes a plain ivar write instead of `method_missing` singleton-method definition — the bulk of the win (231,304 → 42,088 bytes per response).
* Drop the OpenStruct superclass so a future field added without an accessor raises `NoMethodError` immediately instead of silently allocating; that is what lets this regression never land unnoticed again. It also removes OpenStruct's per-instance bookkeeping, a further ~23KB per response (42,088 → 18,728 bytes). `TopicPoster` uses no OpenStruct behavior: its only construction sites (`TopicPostersSummary` and `TopicParticipantsSummary`) call `TopicPoster.new` and assign declared accessors, and no core or bundled-plugin code uses hash construction, `[]`, `to_h`, or `each_pair` on it. 219 examples across the poster summaries, serializers, and `ListController` request specs pass unchanged.

## Cluster memory impact

Measured on a production-shaped pitchfork cluster (monitor + mold + service + 3 workers, `script/bench.rb -i 100`, total PSS summed across all cluster processes; full methodology and batch table in #41389): in isolation this PR's batch median came out 51MB below control (1,121,022 vs pooled control 1,172,210 KB), but the sample ranges overlap — a single ~212KB/req change is below what that rig resolves cleanly (~±50MB batch noise), so no individual cluster number is claimed beyond directional consistency with the verified allocation mechanism. Measured together with its sibling per-request-allocation PRs (#41388, #41389), the series totals **−227MB (−19.4%) total cluster PSS with zero overlap** (median 945,046 vs 1,172,210). #41389 isolates cleanly at −210MB; this PR and #41388 contribute the remainder.

<details>
<summary>Reproduction script and results (per-call mechanism)</summary>

The cost is pure OpenStruct mechanics, so it can be demonstrated without booting the app. The script compares the old class (OpenStruct, missing accessor), the intermediate fix (OpenStruct plus accessor), and the plain class this PR ships. It mirrors `TopicPostersSummary#new_topic_poster_for`'s assignment sequence and builds 146 posters (one 25-topic topic-list response's worth). Run with `bundle exec ruby bench.rb` from the Discourse root (memory_profiler is already in the bundle).

```ruby
# frozen_string_literal: true
require "ostruct"
require "memory_profiler"

class PosterBefore < OpenStruct
  attr_accessor :user, :description, :extras, :id, :primary_group
end

class PosterAfter < OpenStruct
  attr_accessor :user, :description, :extras, :id, :primary_group, :flair_group
end

class PosterPlain
  attr_accessor :user, :description, :extras, :id, :primary_group, :flair_group
end

N = 146 # posters built for one 25-topic /latest.json response

def build(klass, n)
  Array.new(n) do
    poster = klass.new
    poster.user = "user"
    poster.description = "Original Poster"
    poster.primary_group = nil
    poster.flair_group = nil
    poster.extras = +"latest"
    poster
  end
end

[PosterBefore, PosterAfter, PosterPlain].each do |klass|
  build(klass, 10) # warm method caches
  report = MemoryProfiler.report { build(klass, N) }
  sample = build(klass, 1).first
  puts "#{klass}: #{report.total_allocated_memsize} bytes / " \
         "#{report.total_allocated} objects allocated for #{N} posters"
  puts "  singleton methods on an instance: #{sample.singleton_methods.inspect}"
end
```

Results on Ruby 3.4.9:

| variant | allocated bytes | allocated objects | singleton methods per instance |
|---|---:|---:|---|
| before: OpenStruct, missing accessor | 231,304 | 2,045 | `[:flair_group, :flair_group=]` |
| OpenStruct + accessor | 42,088 | 439 | `[]` |
| **after: plain class (this PR)** | **18,728** | **293** | `[]` |

Net: **−212,576 bytes (−92%) / −1,752 objects per topic-list response.** The singleton-methods column can be checked independently of any profiler: before the fix, every `TopicPoster` instance carries its own privately-defined `flair_group`/`flair_group=` methods; after, none.

</details>