### PR TITLE
Add db command to open PostgreSQL console

### DIFF
--- a/script/discourse
+++ b/script/discourse
@@ -352,6 +352,12 @@ class DiscourseCLI < Thor
     puts "", "Done", ""
   end
 
+  desc "db", "Open the database console"
+  def db
+    puts "Entering PostgreSQL console for Discourse..."
+    exec("sudo -u postgres psql discourse")
+  end
+
   private
 
   def confirm!(message, prompt = "ARE YOU SURE (type YES):")


### PR DESCRIPTION
Added db command to `script/discourse` to easily enter the PostgreSQL console.

This uses `sudo -u postgres psql discourse` to enter the SQL console when logged in as `root` inside the standard Docker container.

Example Usage:

```bash
cd /var/discourse
./launcher enter app
```
```bash
discourse db
```
```sql
discourse=> SELECT count(*) FROM users;
discourse=> \q
```