### PR TITLE
PERF: make UpcomingChanges.exists? allocation-free

### DIFF
--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -147,7 +147,7 @@ module UpcomingChanges
   end
 
   def self.exists?(change_setting_name)
-    change_metadata(change_setting_name.to_sym).present?
+    settings_provider.upcoming_change_metadata.key?(change_setting_name.to_sym)
   end
 
   # We dynamically determine if an upcoming change is enabled


### PR DESCRIPTION
This PR makes `UpcomingChanges.exists?` allocation-free, removing ~249KB / 1,555 objects of avoidable allocations per topic-list request.

Every generated `SiteSetting` reader checks whether its setting has an upcoming change, so `UpcomingChanges.exists?` runs ~1,555 times per topic-list request. It answered via `change_metadata(name).present?`, and `change_metadata` returns `settings_provider.upcoming_change_metadata[name] || {}` — allocating a fresh empty Hash on every miss. Misses are the overwhelming case, since only a handful of settings have upcoming changes registered. On forked web servers the churn also dirties copy-on-write pages, so it costs resident memory in every worker process, not just GC time.

Key changes:

* Answer with `key?` on the metadata hash instead of materializing per-name metadata and asking `present?` — the same question ("is an upcoming change registered under this name?") with zero allocations. `change_metadata` keeps its `|| {}` contract for its other callers.

## Cluster memory impact

Measured on a production-shaped pitchfork cluster (monitor + mold + service + 3 workers, `script/bench.rb -i 100`, total PSS summed across all cluster processes; full methodology and batch table in #41389): in isolation this PR's batch median came out 61MB below control (1,111,073 vs pooled control 1,172,210 KB), but the sample ranges overlap — a single ~250KB/req change is below what that rig resolves cleanly (~±50MB batch noise), so no individual cluster number is claimed beyond directional consistency with the verified allocation mechanism. Measured together with its sibling per-request-allocation PRs (#41386, #41389), the series totals **−227MB (−19.4%) total cluster PSS with zero overlap** (median 945,046 vs 1,172,210). #41389 isolates cleanly at −210MB; this PR and #41386 contribute the remainder.

<details>
<summary>Reproduction script and results (per-call mechanism)</summary>

The old implementation is reconstructed inline from the unchanged public `change_metadata`, so both sides run in the same process. Save as `bench.rb` in the Discourse root and run `bundle exec rails runner bench.rb` (memory_profiler is already in the bundle).

```ruby
# frozen_string_literal: true
require "memory_profiler"

old_exists = ->(name) { UpcomingChanges.change_metadata(name).present? }

probes = SiteSetting.upcoming_change_metadata.keys + %i[title enable_discourse_connect not_a_real_change]
mismatches = probes.select { |name| old_exists.call(name) != UpcomingChanges.exists?(name) }
puts "equivalence over #{probes.size} names: #{mismatches.empty? ? "OK" : mismatches.inspect}"

1555.times { old_exists.call(:title) }
1555.times { UpcomingChanges.exists?(:title) }
r_old = MemoryProfiler.report { 1555.times { old_exists.call(:title) } }
r_new = MemoryProfiler.report { 1555.times { UpcomingChanges.exists?(:title) } }
puts "before: #{r_old.total_allocated_memsize} bytes / #{r_old.total_allocated} objects per 1555 calls"
puts "after:  #{r_new.total_allocated_memsize} bytes / #{r_new.total_allocated} objects per 1555 calls"
```

Output on Ruby 3.4.9 (1,555 = `exists?` calls observed during one `/latest.json` request under memory_profiler):

```
equivalence over 20 names: OK
before: 248800 bytes / 1555 objects per 1555 calls
after:  0 bytes / 0 objects per 1555 calls
```

Equivalence covers every registered upcoming change plus absent names (regular settings and an unknown name). `spec/lib/upcoming_changes_spec.rb` passes unchanged.

</details>