### PR TITLE
PERF: avoid duplicating the defaults hash in SiteSettings::DefaultsProvider#get

### DIFF
--- a/lib/discourse_plugin_registry.rb
+++ b/lib/discourse_plugin_registry.rb
@@ -291,6 +291,10 @@ class DiscoursePluginRegistry
     modifiers_for_name.delete_at(i)
   end
 
+  def self.modifiers_registered?(name)
+    @modifiers&.[](name).present?
+  end
+
   def self.apply_modifier(name, arg, *more_args)
     return arg if !@modifiers
 

--- a/lib/site_settings/defaults_provider.rb
+++ b/lib/site_settings/defaults_provider.rb
@@ -84,7 +84,22 @@ class SiteSettings::DefaultsProvider
   end
 
   def get(name, locale = DEFAULT_LOCALE)
-    all(locale)[name.to_sym]
+    if DiscoursePluginRegistry.modifiers_registered?(:site_setting_defaults)
+      return all(locale)[name.to_sym]
+    end
+
+    name = name.to_sym
+
+    if (override = @site_setting.upcoming_change_default_overrides[name]) &&
+         @active_upcoming_change_overrides.include?(override[:upcoming_change])
+      return override[:new_default]
+    end
+
+    if locale && (locale_defaults = @defaults[locale.to_sym]) && locale_defaults.key?(name)
+      return locale_defaults[name]
+    end
+
+    @defaults[DEFAULT_LOCALE.to_sym][name]
   end
   alias [] get
 


### PR DESCRIPTION
This PR rewrites `SiteSettings::DefaultsProvider#get` as a direct lookup instead of materializing the entire merged defaults hash per call, removing ~287KB of avoidable allocations per topic-list request — measured below as **−210MB (−17.9%) total PSS on a production-shaped pitchfork cluster, in isolation**.

`get` (also aliased as `[]`) answered a single-setting lookup with `all(locale)[name.to_sym]`, and `#all` builds a fresh merged copy of the whole defaults hash — over 1,000 entries duplicated to read one value. `get` runs in request hot paths (~5 times per topic-list request), so every request paid five full-hash copies for five scalar reads. On forked web servers the churn also dirties copy-on-write pages, so it costs resident memory in every worker process, not just GC time.

Key changes:

* Rewrite `get` as a three-step direct lookup mirroring `#all`'s exact precedence — upcoming-change override, then locale value, then default-locale value — so the result is identical without building the merged hash. Equivalence is verified against `all(locale)[name]` for every setting under en/de/zh_CN locales (script below).
* Skip the fast path when a `site_setting_defaults` plugin modifier is registered, because such a modifier can rewrite the whole defaults hash inside `#all` and a direct lookup would bypass it. This adds a small `DiscoursePluginRegistry.modifiers_registered?` predicate; no core or bundled plugin registers that modifier, so the fast path is the common case and third-party plugins using the modifier keep today's behavior exactly.

## Cluster memory impact

The per-call numbers below are the mechanism; the number that matters in production is resident memory across a forked cluster. Method: `script/bench.rb` (`RAILS_ENV=profile`, pitchfork monitor + mold + service + 3 web workers, `-i 100` over the benched pages), summing PSS across every process in the cluster from `/proc/<pid>/smaps_rollup` after the run — stock bench.rb reports only the ~23MB monitor process, so it was locally patched to report the full cluster breakdown. Environment: dedicated idle 4 vCPU / 15GB droplet, `discourse_dev` container, Ruby 3.4.9, populated profile DB. Batches per tree with a sacrificial warm-up run after every tree switch (bootsnap cache); the control was re-measured at the end of the session to rule out ambient drift (control medians 19MB apart across the day).

| tree | cluster PSS samples (KB) | median (KB) |
|---|---|---|
| base = `main` + bench patch (two batches bracketing the session) | 1,197,299 / 1,147,265 / 1,190,199 and 1,068,412 / 1,170,828 / 1,200,572 / 1,172,210 | 1,172,210 (pooled, n=7) |
| base + **this PR only** | 969,514 / 913,096 / 958,987 / 966,040 | **962,513** |

**−209.7MB total cluster PSS (−17.9%), zero overlap**: the highest candidate sample (969,514) is ~99MB below the lowest of the seven control samples (1,068,412). The mold's PSS is unchanged (this PR doesn't touch boot); the reduction is all in worker memory — the copy-on-write signature of removing per-request allocation churn. The effect is far larger than the raw ~287KB/req would suggest; repeatedly materializing a 1,000+ entry hash is large, malloc-backed churn that drives GC activity and CoW page dirtying disproportionately. The isolated back-to-back A/B above is the measurement this PR stands on.

Measured together with its two sibling per-request-allocation PRs (#41386, #41388), the series totals **−227MB (−19.4%)**, also zero overlap (median 945,046 vs 1,172,210); this PR is the dominant contributor.

<details>
<summary>Reproduction script and results (per-call mechanism)</summary>

The old implementation is reconstructed inline from the unchanged public `#all`, so both sides run in the same process. Save as `bench.rb` in the Discourse root and run `bundle exec rails runner bench.rb` (memory_profiler is already in the bundle).

```ruby
# frozen_string_literal: true
require "memory_profiler"

provider = SiteSetting.defaults

names = provider.all.keys
locales = %i[en de zh_CN]
mismatches = []
locales.each do |locale|
  all = provider.all(locale)
  names.each { |name| mismatches << [locale, name] if provider.get(name, locale) != all[name] }
end
puts "equivalence over #{names.size} settings x #{locales.size} locales: " \
       "#{mismatches.empty? ? "OK" : mismatches.first(5).inspect}"

old_get = ->(name) { provider.all(:en)[name.to_sym] }
5.times { old_get.call(:title) }
5.times { provider.get(:title) }
r_old = MemoryProfiler.report { 5.times { old_get.call(:title) } }
r_new = MemoryProfiler.report { 5.times { provider.get(:title) } }
puts "before: #{r_old.total_allocated_memsize} bytes / #{r_old.total_allocated} objects per 5 calls"
puts "after:  #{r_new.total_allocated_memsize} bytes / #{r_new.total_allocated} objects per 5 calls"
```

Output on Ruby 3.4.9 (5 = `get` calls observed during one `/latest.json` request under memory_profiler):

```
equivalence over 1057 settings x 3 locales: OK
before: 287320 bytes / 10 objects per 5 calls
after:  0 bytes / 0 objects per 5 calls
```

`spec/lib/site_settings/defaults_provider_spec.rb` and `spec/lib/discourse_plugin_registry_spec.rb` pass unchanged — including the "plugin modifier can change defaults" example, which fails if the fast path forgets the modifier guard (that is exactly the regression it caught during development).

</details>