### PR TITLE
DEV: Improve RSpec test skill guidance

### DIFF
--- a/.skills/discourse-writing-rspec-tests/SKILL.md
+++ b/.skills/discourse-writing-rspec-tests/SKILL.md
@@ -5,79 +5,54 @@ description: Write and structure RSpec tests for Discourse core, plugins, themes
 
 # Writing RSpec Tests
 
-Discourse uses RSpec for testing. Follow these patterns for all test types.
+Discourse uses RSpec at every layer — models, requests, services, jobs, system tests. This skill is the *judgment* for writing them. Mechanical style rules (layout, naming, matchers, nesting) live in [references/rspec-style-guide.md](references/rspec-style-guide.md); read it before writing.
 
-## Testing Principles
+## The core idea: test the interface, not the innards
 
-- **Test behavior, not implementation** — test public interfaces; don't assert on internal state or private methods. Refactoring internals shouldn't break tests.
-- **One concept per test** — each `it` block verifies one behavior for clear failure diagnosis.
-- **Don't over-mock** — mock external boundaries (HTTP, third-party services), not internal collaborators. Too many mocks signals a design problem.
-- **Don't assert that internal methods are or aren't called** — assertions like `SomeService.expects(:some_method).never` (or `.once`, `.with(...)`) couple the test to internal implementation details that the caller shouldn't care about. Assert on the observable outcome instead: returned value, persisted state, emitted event, response body, rendered output. If the implementation is later refactored, inlined, or renamed, a behavior-focused test still passes when the behavior is correct.
-- **Prefer readability over DRYness** — tests are documentation. Some duplication is fine. Avoid deep `shared_examples`/`let` chains that hurt readability.
-- **Test edge cases** — nil inputs, empty collections, boundary values, permission failures — not just happy paths.
-- **Keep tests independent** — no test should depend on another test's execution or shared mutable state.
-- **Verify placement in parent context** — before adding a new test, always read the surrounding `describe`/`context` block to confirm the test belongs there. Check that the parent context's description, `let`/`fab!` setup, and `before` hooks match the scenario being tested. A misplaced test inherits the wrong setup and produces misleading results.
-- **Arrange-Act-Assert** — clear separation of setup, action, and verification in each test.
-- **Don't test framework behavior** — don't test that Rails validations work; test your business logic.
-- **Avoid redundant multi-layer testing** — if a model spec tests a validation, the controller spec doesn't need to re-verify that same validation logic.
-- **No single-letter block variables** — use descriptive names like `|vote|`, `|option|`, not `|v|`, `|o|`.
-- **Assert collections in a single assertion** — use `contain_exactly` or `eq` instead of multiple `include`/`not_to include` checks.
-- **Reference objects, not literal strings, in negative assertions** — `expect(response.body).not_to include("hidden data explorer excerpt")` silently passes if the literal has a typo or drifts from the source, giving a false sense of security. Reference the object directly (`expect(response.body).not_to include(private_post.raw)`) so the assertion stays in sync with the data under test. The same applies to any `not_to include`/`not_to match` against hardcoded strings.
-- **Optimise for human readability** — minimise context overload when reading an example. Avoid too many indirections.
-- **Limit nesting to 2 levels** — avoid more than 2 levels of `describe`/`context` nesting. Instead of deeply nested contexts, put the full scenario description in the `it` block itself. Flat tests are easier to read and maintain.
-- **Avoid double negatives in descriptions** — write test descriptions that state the positive condition. For example, prefer `"returns true when topic_approval_type is approval or pre_approval"` over `"returns true when topic_approval_type is not none"`. Be specific about the values being tested.
+A spec pins down a method's **public interface** — the messages you send it and what you observably get back — so the implementation underneath stays free to change. (Sandi Metz, *The Magic Tricks of Testing*.) Choose what to assert by the kind of message:
 
-## Style Guide Reference
+- **Query (returns a value, changes nothing)** — assert the **return value**.
+- **Command (changes state)** — assert the **direct public side effect** it owns: persisted columns, an enqueued job, an emitted event, a response body, rendered DOM. Drive the public entry point and check the state it left behind; that entry point names the spec's group — `describe "#execute"` for a job, `".call"` for a service, `"#expire!"` for a model command.
+- **Private method (a message to self)** — don't test it, don't assert it was called. `expects(:internal)` / `.to receive(:internal)` on the object under test freezes tomorrow's refactor. This is the anti-pattern.
+- **Outgoing query (to a collaborator)** — don't assert on it; the collaborator's own spec owns it.
+- **Outgoing command (to a collaborator)** — the only observable fact is *that it was sent*, so assert that with the capture helpers `DiscourseEvent.track_events` / `MessageBus.track_publish`, never `expects(:trigger)` / `expects(:publish)`.
 
-Before writing any RSpec code, read [references/rspec-style-guide.md](references/rspec-style-guide.md) and apply those conventions alongside the Discourse-specific patterns below.
+The throughline: **test the messages crossing the public boundary; ignore what happens inside.** A test that breaks only because you renamed a private method or reordered internal calls — with no change to the return value or persisted state — is testing the wrong thing.
 
-## Test Data with Fabricators
+## Principles that follow
 
-Use `fab!` for shared test data, or `Fabricate` inline within the test example:
+- **One behavior per example** — a failure should name its cause. (Batch assertions about the *same* state; see Cost.)
+- **Assert observable outcomes, including edge cases** — nil, empty, boundary, permission failures, not just the happy path. Don't test framework behavior (Rails validations work; your logic is what's under test).
+- **Each layer asserts what it owns** — models own validations/scopes/persisted state; services own orchestration/authorization/return values; request specs own HTTP status and response shape; jobs own enqueue/idempotency. Don't re-assert a lower layer's contract from above — trust it. (Callbacks belong to the model that defines them: drive the public op that fires them; never `describe "after_commit :x"`.)
+- **Readable beats DRY; flat beats nested** — tests are documentation. Some duplication is fine; deep `shared_examples`/`let` chains and more than two levels of `describe`/`context` nesting are not — push the scenario into the `it` description instead.
+- **Keep assertions in sync with the data** — match collections exactly (`contain_exactly`/`eq`, not a pile of `include`s), and reference the object under test, not a copied string literal that silently rots (`not_to include(private_post.raw)`, not a hardcoded `"..."`).
+- **Place each test where its setup fits** — read the surrounding `describe`/`before`/`fab!` before adding an example; a misplaced test inherits the wrong world.
 
-```rb
-fab!(:user)
-fab!(:category)
-fab!(:tag)
-fab!(:topic) { Fabricate(:topic, category: category, tags: [tag]) }
+## Test data: fabricators
 
-it "displays the topic" do
-  sign_in(user)
-  visit("/")
-end
+`fab!` for shared data, `Fabricate` inline for one-off data — **never** a `before` block to fabricate; `let!` only when truly needed. Fabricators live in `spec/fabricators/` (core and each plugin) — grep before assuming none exists or hand-rolling setup.
 
-it "creates a new topic" do
-  new_category = Fabricate(:category, name: "Special")
-  # ... test using new_category
-end
-```
+Name a fixture for the role it plays at the call site (`fab!(:topic_creator)`, not `fab!(:user)`). For a recurring non-default variant, declare a derived fabricator (`Fabricator(:variant, from: :base)`) named for its *data state* — reusable across tests — rather than an ad-hoc helper named after one test's scenario.
 
-Never use `before` blocks for Fabricate calls. Use `let!` only when absolutely necessary.
+## Cost: the cheapest test that proves the behavior
 
-## Test Efficiency
+Every example has setup cost; system tests cost orders of magnitude more.
 
-Tests have setup overhead. **Optimize for the fewest test examples possible:**
+- Batch assertions about the same page/state into one example; don't split trivial variations.
+- **One system test per user flow, not per internal code path.** If two scenarios look the same to the user but differ only in internals, test the flow once and cover the branches with cheaper unit/component tests.
 
-- Combine related assertions in a single `it` block when testing the same page/state
-- Avoid separate tests for trivial variations
-- Each `it` block incurs setup overhead; batch checks where logical
-
-## Running Tests
+## Running tests
 
 ```sh
-# Run specific file
-bin/rspec spec/models/topic_spec.rb
-
-# Run specific line
-bin/rspec spec/models/topic_spec.rb:15
+bin/rspec spec/models/topic_spec.rb        # a file
+bin/rspec spec/models/topic_spec.rb:15     # one example
+SELENIUM_HEADLESS=0 bin/rspec spec/system/my_spec.rb   # visible browser
 ```
 
-## Specialized Test Types
+## Where to go next
 
-- **Request specs**: See [references/request-specs.md](references/request-specs.md) for controller/request spec structure, action-based `describe` grouping, and what to assert.
-- **System tests**: See [references/system-tests.md](references/system-tests.md) for file naming, test structure, page objects, and scoping patterns.
-- **Theme/component tests**: See [references/theme-tests.md](references/theme-tests.md) for theme upload helpers, settings, and directory structure.
-
-## Tracking Helpers
-
-See [references/tracking-helpers.md](references/tracking-helpers.md) for `DiscourseEvent.track_events`, `MessageBus.track_publish`, and `track_sql_queries` — block helpers that capture events, message-bus publishes, and SQL queries so tests can assert on side effects.
+- Request specs → [references/request-specs.md](references/request-specs.md)
+- System tests → [references/system-tests.md](references/system-tests.md)
+- Theme / component tests → [references/theme-tests.md](references/theme-tests.md)
+- Capturing events / publishes / SQL → [references/tracking-helpers.md](references/tracking-helpers.md)
+- General RSpec style → [references/rspec-style-guide.md](references/rspec-style-guide.md)

--- a/.skills/discourse-writing-rspec-tests/references/request-specs.md
+++ b/.skills/discourse-writing-rspec-tests/references/request-specs.md
@@ -1,6 +1,6 @@
 # Request Specs
 
-Discourse uses **request specs** (`spec/requests/`) rather than controller specs to test controllers. They drive real HTTP requests against the Rails router, so they verify routing, middleware, controller actions, and response payloads end-to-end.
+Discourse uses **request specs** (`spec/requests/`) rather than controller specs to exercise controllers. They drive real HTTP requests against the Rails router, so they verify routing, middleware, controller actions, and response payloads end-to-end.
 
 ## File and Top-Level Naming
 

--- a/.skills/discourse-writing-rspec-tests/references/rspec-style-guide.md
+++ b/.skills/discourse-writing-rspec-tests/references/rspec-style-guide.md
@@ -1,6 +1,7 @@
 # RSpec Style Guide
 
-> Adapted from: https://rspec.rubystyle.guide/
+> Source: https://rspec.rubystyle.guide/
+> Last updated: 2026-02-24
 
 ## Layout
 
@@ -39,11 +40,13 @@
 
 ## Example Group Structure
 
-- **Declaration order**: `subject` → `fab!`/`let!`/`let` → `before` → `after`
+- **First level of nesting is the method under test** — inside `RSpec.describe SomeClass`, group examples by public method: `describe "#instance_method"` / `describe ".class_method"`. Scenario `describe`/`context` blocks nest *below* the method group, never directly under the class.
+- **Declaration order**: `subject` → `let!`/`let` → `before` → `after`
 - **Use `context` blocks** to organize test conditions; avoid conditional logic in example descriptions
 - **Pair context cases** — include both positive and negative contexts (e.g. "when present" and "when not present")
-- **Use `fab!`** for shared test data, `let` for computed values or non-persisted objects
+- **Use `let`** for shared data, `let!` when the value must exist even if unused in specific examples
 - **Prefer `let` over instance variables** — `let(:name) { "John" }` not `before { @name = "John" }`
+- **Extract shared examples** — use `shared_examples` with `it_behaves_like` to reduce duplicated test blocks
 - **Omit `:each`/`:example`** scope on `before`/`after`/`around` hooks (they're the default)
 - **Use `:context` over `:all`** when specifying hook scope
 - **Minimize `:context`-scoped hooks** to prevent state leakage
@@ -59,9 +62,11 @@
 - **Don't generate tests via iteration** — write each test explicitly
 - **Avoid incidental state** — use matchers like `change` instead of depending on shared state
 - **Balance DRY with clarity** — some duplication in tests is preferable to fragile shared setup
+- **Use factories** (`FactoryBot.create`) for test data in integration tests; avoid `Model.create` and fixtures
 - **Load only needed data** — minimum objects required for the test
-- **Freeze time with `freeze_time`** — don't stub `Time.now` or `Date.today`
-- **Stub HTTP requests** with WebMock
+- **Use verifying doubles** — `instance_double`, `class_double`, `object_double` over plain `double`
+- **Freeze time with Timecop** — don't stub `Time.now` or `Date.today`
+- **Stub HTTP requests** with WebMock or VCR
 - **Don't define classes in example groups** (they leak to global scope) — use `stub_const` or `Class.new`
 - **Use explicit block expectations** — `expect { do_something }.to change(...)` not implicit block subjects
 
@@ -72,6 +77,8 @@
 - **Keep descriptions under 60 characters**
 - **Avoid "should"** — use third-person present tense: `it "returns the summary"` not `it "should return the summary"`
 - **Describe methods**: `.method_name` for class methods, `#method_name` for instance methods
+- **Avoid double negatives** — state the positive condition: `"returns true when status is approved or pre_approval"`, not `"returns true when status is not none"`. Be specific about the values being tested.
+- **No single-letter block variables** — `|vote|`, `|option|`, not `|v|`, `|o|`.
 
 ## Expectations
 
@@ -84,7 +91,39 @@
 - **Avoid bare `be`** — use `be_truthy`, `be_nil`, `be_an(Type)` etc.
 - **Extract custom matchers** for repeated expectation patterns
 - **Avoid `any_instance_of`** — mock injected dependencies directly
+- **Use matcher libraries** (e.g. Shoulda Matchers) for common validation checks
 
 ## Capybara
 
 - **Use negative selectors** — `have_no_selector` not `to_not have_selector`
+
+## Rails: Controllers
+
+- **Mock models** in controller specs
+- **Test only controller responsibilities** — method execution, assigns, render/redirect
+- **Use `context` blocks** for different controller behaviors
+
+## Rails: Models
+
+- **Don't mock the model under test**
+- **Use `FactoryBot.create`** or `subject` with new instances
+- **Mocking associations is acceptable**
+- **Define model once** via `let` for reuse
+- **Verify factory validity** — `expect(article).to be_valid`
+- **Test validations via `errors[:attribute].size`** not just `be_valid`/`not_to be_valid`
+- **Separate `describe` blocks** per validated attribute
+- **Name alternate objects** `another_*` for uniqueness tests
+
+## Rails: Mailers
+
+- **Mock models** in mailer specs
+- **Verify subject, sender, recipient, and body content**
+
+## Rails: Views
+
+- **Mirror `app/views` structure** in `spec/views`
+- **Append `_spec.rb`** to the view filename
+- **Use relative view path** as outer `describe` string
+- **Mock models** in view specs
+- **Use `assign`** for instance variables
+- **Stub helpers** on the `template` object

--- a/.skills/discourse-writing-rspec-tests/references/system-tests.md
+++ b/.skills/discourse-writing-rspec-tests/references/system-tests.md
@@ -18,6 +18,39 @@ expect(Post.count).to eq(1)
 
 Only reach into the database when no UI signal exists for the behavior being tested, which should be rare. If you find yourself needing database assertions, consider whether the feature is missing user-visible feedback.
 
+## Don't Assert on Transient States
+
+**Do not assert on transient UI states in system tests** — loading spinners, in-flight error banners, optimistic UI mid-flip, skeleton placeholders, or any state that resolves on its own as the page settles. By the time Capybara polls for the assertion, the state has usually already changed, producing flaky tests. Even when they pass, they exercise timing-dependent code paths that drift with unrelated network and perf shifts.
+
+Route transient-state verification to the layer that lets you pin the state without racing the runner:
+
+- **qunit component tests** — state can be stubbed or held in a known value while the assertion runs. This is the right home for `{{#if loading}}` / `{{#if error}}` guards and other mid-flight branches.
+- **Code review** — for simple structural guards (e.g., a button that's only rendered when a chart has loaded), reading the template is more reliable than racing a test against the transition.
+
+System tests own the **stable outcomes**: the final rendered state after the flow completes, persisted changes the user can see, navigation results. Mid-flight is qunit's job.
+
+## URL Assertions
+
+**Use exact-string matches with `have_current_path`.** Do not pass a regex unless the URL genuinely contains a value you cannot predict (a UUID, an auto-generated slug, a server-assigned id).
+
+```rb
+# Good - exact match: catches extra params, wrong separators, encoding bugs
+expect(page).to have_current_path(
+  "/admin/reports/site_traffic?end_date=2026-05-31&start_date=2026-05-01"
+)
+
+# Bad - regex tolerates extra params, wrong path prefixes, and encoding bugs
+expect(page).to have_current_path(
+  %r{\A/admin/reports/site_traffic\?.*start_date=2026-05-01}
+)
+```
+
+Regex assertions look like a clean fix for query-param ordering surprises, but they trade away the test's strongest property — it stops asserting **the exact URL the user sees**. A regex passes when extra params get silently appended, when the path prefix drifts, when the separator is wrong, when encoding breaks. An exact match catches all of those.
+
+**When the framework produces a URL ordering that surprises you, update the expected string — don't soften the matcher.** Ember sorts query params alphabetically on navigation, so a link declared as `?start_date=…&end_date=…` lands on `?end_date=…&start_date=…`. The correct response is to spell the expected URL in the order the framework actually produces. If the ordering is non-obvious, add a one-line comment explaining why — but keep the assertion exact.
+
+Reach for regex only when the URL genuinely contains a value you can't predict at write time (UUID, generated token). Even then, anchor the regex (`\A...\z`) and pin everything except the unpredictable segment, so the matcher still catches the failures it would have caught with an exact string.
+
 **Verify persistence by refreshing the page.** After a save action, refresh (or revisit) the current page and assert the saved state is still visible. This is what a real user would do to confirm their changes persisted.
 
 ```rb
@@ -168,6 +201,8 @@ Because the addon strips these in production, never use `data-test-*` for stylin
 ## Page Objects
 
 **Always use page objects** - never write raw selectors or Capybara finders directly in test files. Encapsulate all selectors and interactions in page object classes. Only add methods that are actually used by your tests - don't add methods speculatively.
+
+**Design page object APIs from the call site.** Page object methods should make the spec read in product/user language. Prefer explicit methods and named arguments that describe the behavior being exercised over generic helpers that require the spec to know implementation details. If a test has to pass route/query param names, internal identifiers, selector fragments, enum values, or serialized keys, the page object abstraction has leaked. Keep that translation inside the page object so the spec remains stable when implementation details change.
 
 **Prefer passing entire objects** to page object methods instead of just attributes. Let the page object extract what it needs:
 


### PR DESCRIPTION
This PR upstreams improved guidance into the `discourse-writing-rspec-tests` agent skill.

Key changes:
  * Reframe `SKILL.md` around testing the public interface — the query vs. command message distinction (assert return values for queries, observable side effects for commands, never assert private methods were called) — instead of an unstructured list of principles.
  * Expand `references/rspec-style-guide.md`, `references/request-specs.md`, and `references/system-tests.md` with sharper rules: don't assert on transient UI states in system tests, use exact-string `have_current_path` matches over regex, and design page object APIs from the call site.
  * Keep this repo's `pnpm build` / `bin/dev` build commands in `system-tests.md`, since this repo migrated its JS build to Rolldown.