### PR TITLE
SECURITY: Reject too many tags during post creation

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostsController < ApplicationController
+  include TagParamLimit
+
   # Bug with Rails 7+
   # see https://github.com/rails/rails/issues/44867
   self._flash_types -= [:notice]
@@ -190,6 +192,8 @@ class PostsController < ApplicationController
   end
 
   def create
+    return if reject_too_many_tags!(:tags)
+
     manager_params = create_params
     manager_params[:first_post_checks] = !is_api?
     manager_params[:advance_draft] = !is_api?

--- a/app/controllers/tag_param_limit.rb
+++ b/app/controllers/tag_param_limit.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module TagParamLimit
+  private
+
+  def reject_too_many_tags!(*param_names)
+    param_names.each do |param_name|
+      next if !params.has_key?(param_name)
+      next if tag_param_count(params[param_name]) <= SiteSetting.max_tags_per_topic
+
+      render_json_error(
+        I18n.t("tags.too_many_tags_for_topic", count: SiteSetting.max_tags_per_topic),
+      )
+      return true
+    end
+
+    false
+  end
+
+  def tag_param_count(tags)
+    return tags.length if tags.is_a?(Array)
+    return tags.keys.length if tags.is_a?(ActionController::Parameters)
+
+    0
+  end
+end

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TopicsController < ApplicationController
+  include TagParamLimit
   include EmbedModeHandler
 
   requires_login only: %i[
@@ -401,7 +402,7 @@ class TopicsController < ApplicationController
     topic = Topic.find_by(id: params[:topic_id])
 
     guardian.ensure_can_edit!(topic)
-    return if reject_oversized_tag_params!(:tags, :original_tags)
+    return if reject_too_many_tags!(:tags, :original_tags)
 
     original_title = params[:original_title]
     if original_title.present? && original_title != topic.title
@@ -527,7 +528,7 @@ class TopicsController < ApplicationController
   def update_tags
     topic = Topic.find_by(id: params[:topic_id])
     guardian.ensure_can_edit_tags!(topic)
-    return if reject_oversized_tag_params!(:tags)
+    return if reject_too_many_tags!(:tags)
 
     tags =
       if params[:tags].is_a?(ActionController::Parameters)
@@ -1368,27 +1369,6 @@ class TopicsController < ApplicationController
       .visible_tags(guardian)
       .map { |t| { id: t.id, name: t.name, slug: t.slug_for_url } }
     render_json_dump(payload)
-  end
-
-  def reject_oversized_tag_params!(*param_names)
-    param_names.each do |param_name|
-      next if !params.has_key?(param_name)
-      next if tag_param_size(params[param_name]) <= SiteSetting.max_tags_per_topic
-
-      render_json_error(
-        I18n.t("tags.too_many_tags_for_topic", count: SiteSetting.max_tags_per_topic),
-      )
-      return true
-    end
-
-    false
-  end
-
-  def tag_param_size(tags)
-    return tags.length if tags.is_a?(Array)
-    return tags.keys.length if tags.is_a?(ActionController::Parameters)
-
-    0
   end
 
   def resolve_tag_names(topic)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1822,6 +1822,26 @@ RSpec.describe PostsController do
         expect(Post.last.topic.tags).to contain_exactly(tag)
       end
 
+      it "rejects tag arrays exceeding the configured per-topic limit" do
+        SiteSetting.tagging_enabled = true
+        SiteSetting.max_tags_per_topic = 5
+        tags = 25.times.map { |index| Fabricate(:tag, name: "tag-#{index}") }
+
+        expect do
+          post "/posts.json",
+               params: {
+                 raw: "this is the test content",
+                 title: "this is the test title for the topic",
+                 tags: tags.map { |tag| { id: tag.id, name: tag.name } },
+               }
+        end.not_to change { Post.count }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          I18n.t("tags.too_many_tags_for_topic", count: 5),
+        )
+      end
+
       context "with content localization enabled" do
         fab!(:japanese_user) { Fabricate(:user, locale: "ja", refresh_auto_groups: true) }
         fab!(:localized_tag) { Fabricate(:tag, name: "strategy", locale: "en") }


### PR DESCRIPTION
Reuse the topic tag limit check when creating posts so tag payloads over the configured per-topic limit return the existing validation error before post creation continues.