### PR TITLE
FIX: Serialize only a bookmark target's active assignment

### DIFF
--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -180,24 +180,30 @@ after_initialize do
 
   BookmarkQuery.on_preload do |bookmarks, _bookmark_query|
     if SiteSetting.assign_enabled?
-      topics =
-        Bookmark
-          .select_type(bookmarks, "Topic")
-          .map(&:bookmarkable)
-          .concat(Bookmark.select_type(bookmarks, "Post").map { |bm| bm.bookmarkable.topic })
-          .uniq
+      topics = Bookmark.select_type(bookmarks, "Topic").map(&:bookmarkable)
+      posts = Bookmark.select_type(bookmarks, "Post").map(&:bookmarkable)
+
       assignments =
         Assignment
           .strict_loading
-          .where(topic_id: topics)
+          .active
+          .where(topic_id: topics.map(&:id).concat(posts.map(&:topic_id)).uniq)
           .includes(:assigned_to)
-          .index_by(&:topic_id)
+
+      topic_assignments, post_assignments = assignments.partition { it.target_type == "Topic" }
+      topic_assignments_map = topic_assignments.index_by(&:target_id)
+      post_assignments_map = post_assignments.index_by(&:target_id)
 
       topics.each do |topic|
-        assignment = assignments[topic.id]
+        assignment = topic_assignments_map[topic.id]
         # NOTE: preloading to `nil` is necessary to avoid N+1 queries
         topic.preload_assigned_to(assignment&.assigned_to)
         topic.preload_assignment_status(assignment&.status)
+      end
+
+      posts.each do |post|
+        assignment = post_assignments_map[post.id]
+        post.preload_assigned_to(assignment&.assigned_to)
       end
     end
   end
@@ -516,6 +522,13 @@ after_initialize do
     @indirectly_assigned_to = indirectly_assigned_to
   end
 
+  add_to_class(:post, :assigned_to) do
+    return @assigned_to if defined?(@assigned_to)
+    @assigned_to = assignment.assigned_to if assignment&.active
+  end
+
+  add_to_class(:post, :preload_assigned_to) { |assigned_to| @assigned_to = assigned_to }
+
   # TopicList serializer
   add_to_serializer(
     :topic_list,
@@ -713,8 +726,7 @@ after_initialize do
   register_permitted_bulk_action_parameter :note
 
   add_to_class(:user_bookmark_base_serializer, :assigned_to) do
-    @assigned_to ||=
-      bookmarkable_type == "Topic" ? bookmarkable.assigned_to : bookmarkable.topic.assigned_to
+    @assigned_to ||= bookmarkable.assigned_to
   end
 
   add_to_class(:user_bookmark_base_serializer, :can_have_assignment?) do

--- a/plugins/discourse-assign/spec/requests/users_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/users_controller_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+RSpec.describe UsersController do
+  fab!(:admin)
+  fab!(:assignee) { Fabricate(:user, username: "assigneduser") }
+
+  before do
+    SiteSetting.assign_enabled = true
+    SiteSetting.assign_allowed_on_groups = Group::AUTO_GROUPS[:staff].to_s
+    sign_in(admin)
+  end
+
+  describe "#bookmarks" do
+    fab!(:topic) { Fabricate(:read_topic, current_user: admin) }
+
+    context "when a bookmarked topic has an active assignment" do
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic) }
+      fab!(:assignment) { Fabricate(:topic_assignment, topic: topic, assigned_to: assignee) }
+
+      it "includes the user assigned to the topic" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body.dig("user_bookmark_list", "bookmarks", 0, "assigned_to_user", "id"),
+        ).to eq(assignee.id)
+      end
+    end
+
+    context "when a bookmarked topic's assignment is inactive" do
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic) }
+
+      fab!(:assignment) do
+        Fabricate(:topic_assignment, topic: topic, assigned_to: assignee, active: false)
+      end
+
+      it "does not include an assigned user" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("user_bookmark_list", "bookmarks", 0)).not_to have_key(
+          "assigned_to_user",
+        )
+      end
+    end
+
+    context "when only a post in the bookmarked topic is assigned" do
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic) }
+
+      fab!(:assignment) do
+        Fabricate(:post_assignment, post: topic.first_post, assigned_to: assignee)
+      end
+
+      it "does not include an assigned user" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("user_bookmark_list", "bookmarks", 0)).not_to have_key(
+          "assigned_to_user",
+        )
+      end
+    end
+
+    context "when a bookmarked post has an active assignment" do
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic.first_post) }
+
+      fab!(:assignment) do
+        Fabricate(:post_assignment, post: topic.first_post, assigned_to: assignee)
+      end
+
+      it "includes the user assigned to the post" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body.dig("user_bookmark_list", "bookmarks", 0, "assigned_to_user", "id"),
+        ).to eq(assignee.id)
+      end
+    end
+
+    context "when a bookmarked post's assignment is inactive" do
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic.first_post) }
+
+      fab!(:assignment) do
+        Fabricate(:post_assignment, post: topic.first_post, assigned_to: assignee, active: false)
+      end
+
+      it "does not include an assigned user" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("user_bookmark_list", "bookmarks", 0)).not_to have_key(
+          "assigned_to_user",
+        )
+      end
+    end
+
+    context "when only the topic of a bookmarked post is assigned" do
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic.first_post) }
+      fab!(:assignment) { Fabricate(:topic_assignment, topic: topic, assigned_to: assignee) }
+
+      it "does not include an assigned user" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("user_bookmark_list", "bookmarks", 0)).not_to have_key(
+          "assigned_to_user",
+        )
+      end
+    end
+
+    context "when a different post in the bookmarked post's topic is assigned" do
+      fab!(:other_post) { Fabricate(:post, topic: topic) }
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic.first_post) }
+      fab!(:assignment) { Fabricate(:post_assignment, post: other_post, assigned_to: assignee) }
+
+      it "does not include an assigned user" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("user_bookmark_list", "bookmarks", 0)).not_to have_key(
+          "assigned_to_user",
+        )
+      end
+    end
+
+    context "when a bookmarked post and its topic are both assigned" do
+      fab!(:topic_assignee) { Fabricate(:user, username: "topicassignee") }
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic.first_post) }
+
+      fab!(:topic_assignment) do
+        Fabricate(:topic_assignment, topic: topic, assigned_to: topic_assignee)
+      end
+
+      fab!(:post_assignment) do
+        Fabricate(:post_assignment, post: topic.first_post, assigned_to: assignee)
+      end
+
+      it "includes the user assigned to the post" do
+        get "/u/#{admin.username}/bookmarks.json"
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body.dig("user_bookmark_list", "bookmarks", 0, "assigned_to_user", "id"),
+        ).to eq(assignee.id)
+      end
+    end
+  end
+
+  describe "#user_menu_bookmarks" do
+    context "when a bookmarked topic's assignment is inactive" do
+      fab!(:topic) { Fabricate(:read_topic, current_user: admin) }
+      fab!(:bookmark) { Fabricate(:bookmark, user: admin, bookmarkable: topic) }
+
+      fab!(:assignment) do
+        Fabricate(:topic_assignment, topic: topic, assigned_to: assignee, active: false)
+      end
+
+      it "does not include an assigned user" do
+        get "/u/#{admin.username}/user-menu-bookmarks"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("bookmarks", 0)).not_to have_key("assigned_to_user")
+      end
+    end
+  end
+end

--- a/plugins/discourse-assign/spec/serializers/user_bookmark_base_serializer_spec.rb
+++ b/plugins/discourse-assign/spec/serializers/user_bookmark_base_serializer_spec.rb
@@ -39,7 +39,7 @@ describe UserBookmarkBaseSerializer do
   context "for Post bookmarkable" do
     let!(:bookmark) { Fabricate(:bookmark, user: user, bookmarkable: post) }
     it "includes assigned user in serializer" do
-      Assigner.new(topic, user).assign(user)
+      Assigner.new(post, user).assign(user)
       serializer = UserPostBookmarkSerializer.new(bookmark, scope: guardian)
       bookmark = serializer.as_json[:user_post_bookmark]
 
@@ -48,7 +48,7 @@ describe UserBookmarkBaseSerializer do
     end
 
     it "includes assigned group in serializer" do
-      Assigner.new(topic, user).assign(assign_allowed_group)
+      Assigner.new(post, user).assign(assign_allowed_group)
       serializer = UserPostBookmarkSerializer.new(bookmark, scope: guardian)
       bookmark = serializer.as_json[:user_post_bookmark]
 

--- a/plugins/discourse-assign/spec/system/bookmark_assignment_badges_spec.rb
+++ b/plugins/discourse-assign/spec/system/bookmark_assignment_badges_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe "Assign | Bookmark assignment badges" do
+  fab!(:admin)
+  fab!(:assignee) { Fabricate(:user, username: "assigneduser") }
+
+  let(:bookmarks_page) { PageObjects::Pages::UserActivityBookmarks.new }
+  let(:bookmark_list) { bookmarks_page.bookmark_list }
+
+  before do
+    SiteSetting.assign_enabled = true
+    SiteSetting.assign_allowed_on_groups = Group::AUTO_GROUPS[:staff].to_s
+    sign_in(admin)
+  end
+
+  it "shows users only current assignment badges" do
+    active_topic = Fabricate(:read_topic, current_user: admin, title: "Topic still assigned")
+    Fabricate(:bookmark, user: admin, bookmarkable: active_topic)
+    Fabricate(:topic_assignment, topic: active_topic, assigned_to: assignee)
+
+    inactive_topic = Fabricate(:read_topic, current_user: admin, title: "Topic no longer assigned")
+    Fabricate(:bookmark, user: admin, bookmarkable: inactive_topic)
+    Fabricate(:topic_assignment, topic: inactive_topic, assigned_to: assignee, active: false)
+
+    bookmarks_page.visit(admin)
+
+    expect(bookmark_list).to have_assignee(active_topic, assignee)
+    expect(bookmark_list).to have_no_assignment(inactive_topic)
+  end
+end

--- a/plugins/discourse-assign/spec/system/viewing_assignments_in_the_bookmark_list_spec.rb
+++ b/plugins/discourse-assign/spec/system/viewing_assignments_in_the_bookmark_list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Assign | Bookmark assignment badges" do
+RSpec.describe "Assign | Viewing assignments in the bookmark list" do
   fab!(:admin)
   fab!(:assignee) { Fabricate(:user, username: "assigneduser") }
 

--- a/spec/system/page_objects/components/bookmark_list.rb
+++ b/spec/system/page_objects/components/bookmark_list.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class BookmarkList < PageObjects::Components::Base
+      SELECTOR = ".bookmark-list"
+
+      def has_assignee?(topic, assignee)
+        bookmark_row(topic).has_css?(".assigned-to", text: assignee.username)
+      end
+
+      def has_no_assignment?(topic)
+        bookmark_row(topic).has_no_css?(".assigned-to")
+      end
+
+      private
+
+      def bookmark_row(topic)
+        page.find("#{SELECTOR} .bookmark-list-item", text: topic.title)
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/user_activity_bookmarks.rb
+++ b/spec/system/page_objects/pages/user_activity_bookmarks.rb
@@ -51,6 +51,10 @@ module PageObjects
         has_no_content?(topic.title)
       end
 
+      def bookmark_list
+        PageObjects::Components::BookmarkList.new
+      end
+
       def submit_button
         page.find(".bookmark-search-form button")
       end


### PR DESCRIPTION
This PR makes a bookmark's "Assigned to …" badge reflect only the current, active assignment of the exact item that was bookmarked.

In discourse-assign, a topic or an individual post can be assigned to a user or group, and bookmark lists show a badge for it. Previously, `BookmarkQuery.on_preload` loaded every assignment belonging to a bookmarked topic — without filtering on `active`, and keyed by `topic_id` regardless of `target_type`. Bookmarks kept showing "Assigned to …" after an assignment was deactivated (for example by `unassign_on_close`), and when a topic carried both a direct assignment and post-level assignments, whichever row loaded last won, so a bookmark could show an assignee that was never assigned the bookmarked item at all. Post bookmarks had a second problem: the `UserBookmarkBaseSerializer` extension read the topic's assignment for them, so a bookmark on an assigned post never showed that post's own assignee.

