### PR TITLE
DEV: report full Pitchfork cluster memory in `script/bench.rb`

### DIFF
--- a/script/bench.rb
+++ b/script/bench.rb
@@ -304,6 +304,37 @@ begin
     YAML.safe_load `ruby script/memstats.rb #{pid} --yaml`
   end
 
+  # Workers are forked from the mold, so most of their pages are shared
+  # copy-on-write. Summing RSS across processes counts every shared page once
+  # per process; PSS divides shared pages by the number of sharers, so the sum
+  # of PSS across the cluster is the true aggregate footprint.
+  memory = {}
+  `pgrep -fa pitchfork`.lines.each do |line|
+    proc_pid, title = line.strip.split(" ", 2)
+    role =
+      case title
+      when /worker\[(\d+)\]/
+        "worker[#{$1}]"
+      when /mold/
+        "mold"
+      when /service/
+        "service"
+      when /monitor/
+        "monitor"
+      end
+    next if !role
+
+    stats = get_mem(proc_pid)
+    memory[role] = { "rss_kb" => stats["rss_kb"], "pss_kb" => stats["pss_kb"] }
+  end
+
+  worker_rss = memory.filter_map { |k, v| v["rss_kb"] if k.start_with?("worker") }
+  cluster_rss = memory.values.sum { |v| v["rss_kb"].to_i }
+  cluster_pss = memory.values.sum { |v| v["pss_kb"].to_i }
+  memory["worker_avg_rss_kb"] = worker_rss.sum / worker_rss.size if worker_rss.any?
+  memory["cluster_rss_kb"] = cluster_rss
+  memory["cluster_pss_kb"] = cluster_pss
+
   mem = get_mem(pid)
 
   results =
@@ -313,6 +344,7 @@ begin
       "yjit" => RubyVM::YJIT.enabled?,
       "rss_kb" => mem["rss_kb"],
       "pss_kb" => mem["pss_kb"],
+      "memory" => memory,
     ).merge(facts)
 
   puts results.to_yaml

--- a/script/bench.rb
+++ b/script/bench.rb
@@ -335,15 +335,11 @@ begin
   memory["cluster_rss_kb"] = cluster_rss
   memory["cluster_pss_kb"] = cluster_pss
 
-  mem = get_mem(pid)
-
   results =
     results.merge(
       "timings" => @timings,
       "ruby-version" => "#{RUBY_DESCRIPTION}",
       "yjit" => RubyVM::YJIT.enabled?,
-      "rss_kb" => mem["rss_kb"],
-      "pss_kb" => mem["pss_kb"],
       "memory" => memory,
     ).merge(facts)
 

--- a/script/bench.rb
+++ b/script/bench.rb
@@ -300,10 +300,6 @@ begin
 
   run("RAILS_ENV=profile bundle exec rake assets:clean")
 
-  def get_mem(pid)
-    YAML.safe_load `ruby script/memstats.rb #{pid} --yaml`
-  end
-
   # Workers are forked from the mold, so most of their pages are shared
   # copy-on-write. Summing RSS across processes counts every shared page once
   # per process; PSS divides shared pages by the number of sharers, so the sum
@@ -326,7 +322,7 @@ begin
       end
     next if !role
 
-    stats = get_mem(proc_pid)
+    stats = YAML.safe_load `ruby script/memstats.rb #{proc_pid} --yaml`
     memory[role] = { "rss_kb" => stats["rss_kb"], "pss_kb" => stats["pss_kb"] }
   end
 

--- a/script/bench.rb
+++ b/script/bench.rb
@@ -309,8 +309,10 @@ begin
   # per process; PSS divides shared pages by the number of sharers, so the sum
   # of PSS across the cluster is the true aggregate footprint.
   memory = {}
-  `pgrep -fa pitchfork`.lines.each do |line|
+  processes = `ps -p #{pid} -o pid=,args=`.lines
+  processes.each do |line|
     proc_pid, title = line.strip.split(" ", 2)
+    processes.concat(`pgrep -P #{proc_pid} -fa pitchfork`.lines)
     role =
       case title
       when /worker\[(\d+)\]/
@@ -329,8 +331,8 @@ begin
   end
 
   worker_rss = memory.filter_map { |k, v| v["rss_kb"] if k.start_with?("worker") }
-  cluster_rss = memory.values.sum { |v| v["rss_kb"].to_i }
-  cluster_pss = memory.values.sum { |v| v["pss_kb"].to_i }
+  cluster_rss = memory.values.sum { |v| v["rss_kb"] }
+  cluster_pss = memory.values.sum { |v| v["pss_kb"] }
   memory["worker_avg_rss_kb"] = worker_rss.sum / worker_rss.size if worker_rss.any?
   memory["cluster_rss_kb"] = cluster_rss
   memory["cluster_pss_kb"] = cluster_pss


### PR DESCRIPTION
The memory figures from `script/bench.rb` describe only Pitchfork's monitor process, omitting the mold, service worker, and web workers that hold the application in memory.

This commit reports per-process RSS and PSS under `memory`, plus cluster totals and average worker RSS. PSS apportions shared pages across processes, avoiding the repeated counting in summed RSS. Collection stays within the spawned cluster so another running Pitchfork server cannot distort the results.

The monitor-only top-level `rss_kb` and `pss_kb` fields are replaced by the `memory` section; no in-tree consumer uses them. Unavailable measurements remain `NaN`, allowing completed benchmark results to be reported if a process exits during collection.

### Reviewer notes

Example memory output using values captured from one running development cluster. Timing and host fields are omitted; this illustrates the output format, not a before/after performance comparison.

Before, only the monitor's memory was reported:

```yaml
rss_kb: 24340
pss_kb: 19292
```

After, the report includes each cluster process and the aggregates:

```yaml
memory:
  monitor:
    rss_kb: 24340
    pss_kb: 19292
  mold:
    rss_kb: 393404
    pss_kb: 145166
  service:
    rss_kb: 371720
    pss_kb: 196756
  worker[0]:
    rss_kb: 408692
    pss_kb: 160728
  worker[1]:
    rss_kb: 408632
    pss_kb: 160459
  worker[2]:
    rss_kb: 408684
    pss_kb: 160073
  worker_avg_rss_kb: 408669
  cluster_rss_kb: 2015472
  cluster_pss_kb: 842474
```
