### PR TITLE
Revert "DEV: Remove alternate `dashboard_improvements` dashboard response"

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -7,7 +7,7 @@ class Admin::DashboardController < Admin::StaffController
                 only: %i[available_reports update_reports_section update_configuration]
 
   def index
-    if UpcomingChanges.enabled_for_user?(:dashboard_improvements, current_user)
+    if dashboard_improvements?
       data = dashboard_sections_payload
     else
       data = AdminDashboardIndexData.fetch_cached_stats
@@ -155,6 +155,21 @@ class Admin::DashboardController < Admin::StaffController
 
   def mark_new_features_as_seen
     DiscourseUpdates.mark_new_features_as_seen(current_user.id)
+  end
+
+  def ensure_dashboard_improvements_enabled
+    raise Discourse::NotFound if !dashboard_improvements?
+  end
+
+  def dashboard_improvements?
+    dashboard_improvements_enabled =
+      UpcomingChanges.enabled_for_user?(:dashboard_improvements, current_user)
+
+    if params[:version] == "alt"
+      !dashboard_improvements_enabled
+    else
+      dashboard_improvements_enabled
+    end
   end
 
   def parse_reports_items_payload

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -369,6 +369,25 @@ RSpec.describe Admin::DashboardController do
         expect(response.parsed_body["configuration"]).to be_present
       end
 
+      it "is returned with version=alt when the admin is not included" do
+        group = Fabricate(:group)
+        Fabricate(:site_setting_group, name: "dashboard_improvements", group_ids: group.id.to_s)
+
+        get "/admin/dashboard.json", params: { version: "alt" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["sections"]).to be_present
+        expect(response.parsed_body["configuration"]).to be_present
+      end
+
+      it "is omitted with version=alt when enabled for the admin" do
+        get "/admin/dashboard.json", params: { version: "alt" }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["sections"]).to be_nil
+        expect(response.parsed_body["configuration"]).to be_nil
+      end
+
       it "falls back to default dates when date params are malformed" do
         get "/admin/dashboard.json", params: { start_date: "garbage", end_date: "also-garbage" }
 


### PR DESCRIPTION
Reverts discourse/discourse#41106