### PR TITLE
SECURITY: Respect group member visibility for counts

### DIFF
--- a/app/controllers/composer_controller.rb
+++ b/app/controllers/composer_controller.rb
@@ -46,9 +46,10 @@ class ComposerController < ApplicationController
         .values
         .each_with_object({}) do |group, hash|
           name = group.name.downcase
-          serialized_group = { user_count: group.user_count }
+          members_visible = members_visible_group_ids.include?(group.id)
+          serialized_group = members_visible ? { user_count: group.user_count } : {}
 
-          if group_reasons[name] == :not_allowed && members_visible_group_ids.include?(group.id) &&
+          if group_reasons[name] == :not_allowed && members_visible &&
                (@topic&.private_message? || @allowed_names.present?)
             notified_count = already_notified_member_count(group)
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -46,15 +46,14 @@ class GroupsController < ApplicationController
       raise Discourse::InvalidAccess.new(:enable_group_directory)
     end
 
-    order = %w[name user_count].delete(params[:order])
+    requested_order = %w[name user_count].delete(params[:order])
     dir = params[:asc].to_s == "true" ? "ASC" : "DESC"
-    sort = order ? "#{order} #{dir}" : nil
-    groups = Group.visible_groups(current_user, sort)
+    groups = Group.visible_groups(current_user)
     type_filters = TYPE_FILTERS.keys
 
     if (username = params[:username]).present?
       raise Discourse::NotFound unless user = User.find_by_username(username)
-      groups = TYPE_FILTERS[:my].call(groups.members_visible_groups(current_user, sort), user)
+      groups = TYPE_FILTERS[:my].call(groups.members_visible_groups(current_user), user)
       type_filters = type_filters - %i[my owner]
     end
 
@@ -90,6 +89,9 @@ class GroupsController < ApplicationController
 
     type_filters.delete(:non_automatic)
 
+    order = group_directory_order(groups, requested_order)
+    groups = apply_group_directory_order(groups, order, dir)
+
     # count the total before doing pagination
     total = groups.count
 
@@ -110,7 +112,13 @@ class GroupsController < ApplicationController
       },
       total_rows_groups: total,
       load_more_groups:
-        groups_path(page: page + 1, type: type, order: order, asc: params[:asc], filter: filter),
+        groups_path(
+          page: page + 1,
+          type: type,
+          order: order,
+          asc: order ? params[:asc] : nil,
+          filter: filter,
+        ),
     )
   end
 
@@ -786,6 +794,28 @@ class GroupsController < ApplicationController
   end
 
   private
+
+  def group_directory_order(groups, requested_order)
+    return requested_order if requested_order != "user_count"
+
+    member_visible_group_ids =
+      Group.members_visible_groups(current_user).unscope(:order).select(:id)
+
+    requested_order if !groups.unscope(:order).where.not(id: member_visible_group_ids).exists?
+  end
+
+  def apply_group_directory_order(groups, order, dir)
+    return groups if order.blank?
+
+    sort =
+      if order == "user_count"
+        "groups.user_count #{dir}, groups.name ASC"
+      else
+        "groups.name #{dir}"
+      end
+
+    groups.reorder(sort)
+  end
 
   def add_users_to_group(group, users, notify = false)
     user_ids = users.map(&:id)

--- a/app/serializers/basic_group_serializer.rb
+++ b/app/serializers/basic_group_serializer.rb
@@ -101,7 +101,12 @@ class BasicGroupSerializer < ApplicationSerializer
   end
 
   def can_see_members
-    scope.can_see_group_members?(object)
+    @can_see_members = scope.can_see_group_members?(object) if !defined?(@can_see_members)
+    @can_see_members
+  end
+
+  def include_user_count?
+    can_see_members
   end
 
   private

--- a/spec/requests/api/schemas/json/group_response.json
+++ b/spec/requests/api/schemas/json/group_response.json
@@ -271,7 +271,6 @@
         "id",
         "automatic",
         "name",
-        "user_count",
         "mentionable_level",
         "messageable_level",
         "visibility_level",

--- a/spec/requests/api/schemas/json/groups_list_response.json
+++ b/spec/requests/api/schemas/json/groups_list_response.json
@@ -143,7 +143,6 @@
             "automatic",
             "name",
             "display_name",
-            "user_count",
             "mentionable_level",
             "messageable_level",
             "visibility_level",

--- a/spec/requests/composer_controller_spec.rb
+++ b/spec/requests/composer_controller_spec.rb
@@ -238,6 +238,24 @@ RSpec.describe ComposerController do
       end
     end
 
+    context "with a group with hidden members" do
+      fab!(:hidden_members_group) do
+        Fabricate(
+          :group,
+          mentionable_level: Group::ALIAS_LEVELS[:everyone],
+          members_visibility_level: Group.visibility_levels[:owners],
+          users: [Fabricate(:user)],
+        )
+      end
+
+      it "does not return the member count" do
+        get "/composer/mentions.json", params: { names: [hidden_members_group.name] }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["groups"]).to eq(hidden_members_group.name => {})
+      end
+    end
+
     context "with invalid allowed_names parameter" do
       it "returns 400 when allowed_names is not an array" do
         get "/composer/mentions.json",

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -186,6 +186,26 @@ RSpec.describe GroupsController do
       )
     end
 
+    it "does not expose member counts for groups with hidden members" do
+      hidden_members_group =
+        Fabricate(
+          :group,
+          members_visibility_level: Group.visibility_levels[:owners],
+          users: [Fabricate(:user)],
+        )
+
+      get "/groups.json"
+
+      expect(response.status).to eq(200)
+
+      group_json =
+        response.parsed_body["groups"].find { |group| group["id"] == hidden_members_group.id }
+
+      expect(group_json).to be_present
+      expect(group_json["can_see_members"]).to eq(false)
+      expect(group_json).not_to have_key("user_count")
+    end
+
     context "when viewing groups of another user" do
       describe "when an invalid username is given" do
         it "should return the right response" do

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -132,6 +132,27 @@ RSpec.describe GroupsController do
 
           expect(body["load_more_groups"]).to eq("/groups?order=user_count&page=1")
         end
+
+        it "does not sort by hidden member counts" do
+          hidden_members_group =
+            Fabricate(
+              :group,
+              name: "zzz_hidden_group",
+              members_visibility_level: Group.visibility_levels[:owners],
+              users: [Fabricate(:user), Fabricate(:user), Fabricate(:user)],
+            )
+
+          get "/groups.json", params: { order: "user_count" }
+
+          expect(response.status).to eq(200)
+
+          body = response.parsed_body
+          group_ids = body["groups"].map { |group| group["id"] }
+
+          expect(group_ids.index(hidden_members_group.id)).to be >
+            group_ids.index(group_with_2_users.id)
+          expect(body["load_more_groups"]).to eq("/groups?page=1")
+        end
       end
 
       context "with ascending order" do


### PR DESCRIPTION
When a group is visible but its members are hidden, some group payloads still included the exact member count.

This PR serializes group member counts when the requester can see group members, and we update the public API schemas to match the conditional field.