### PR TITLE
SECURITY: Restrict user action removal messages

### DIFF
--- a/app/models/user_action.rb
+++ b/app/models/user_action.rb
@@ -360,7 +360,11 @@ class UserAction < ActiveRecord::Base
     )
     if action = UserAction.find_by(hash.except(:created_at))
       action.destroy
-      MessageBus.publish("/user/#{hash[:user_id]}", user_action_id: action.id, remove: true)
+      MessageBus.publish(
+        "/user/#{action.user_id}",
+        { user_action_id: action.id, remove: true },
+        user_ids: [action.user_id],
+      )
     end
 
     if !Topic.where(id: hash[:target_topic_id], archetype: Archetype.private_message).exists?

--- a/spec/models/user_action_spec.rb
+++ b/spec/models/user_action_spec.rb
@@ -8,6 +8,44 @@ RSpec.describe UserAction do
   it { is_expected.to validate_presence_of :action_type }
   it { is_expected.to validate_presence_of :user_id }
 
+  describe ".remove_action!" do
+    fab!(:user)
+    fab!(:target_post) { Fabricate(:post, user: user) }
+
+    it "scopes removal messages to the affected user", :aggregate_failures do
+      action =
+        described_class.log_action!(
+          action_type: UserAction::EDIT,
+          user_id: user.id,
+          acting_user_id: user.id,
+          target_topic_id: target_post.topic_id,
+          target_post_id: target_post.id,
+        )
+
+      messages =
+        MessageBus.track_publish("/user/#{user.id}") do
+          described_class.remove_action!(
+            action_type: UserAction::EDIT,
+            user_id: user.id,
+            acting_user_id: user.id,
+            target_topic_id: target_post.topic_id,
+            target_post_id: target_post.id,
+          )
+        end
+
+      expect(messages).to contain_exactly(
+        have_attributes(
+          data: {
+            user_action_id: action.id,
+            remove: true,
+          },
+          user_ids: [user.id],
+          group_ids: nil,
+        ),
+      )
+    end
+  end
+
   describe "#stream" do
     fab!(:public_post, :post)
     let(:public_topic) { public_post.topic }


### PR DESCRIPTION
Scope UserAction removal MessageBus publishes to the affected user so unrelated clients cannot receive removal metadata.