### PR TITLE
UX: Do not include `upgrade-insecure-requests` in report-only CSP

### DIFF
--- a/lib/content_security_policy.rb
+++ b/lib/content_security_policy.rb
@@ -4,8 +4,8 @@ require "content_security_policy/extension"
 
 class ContentSecurityPolicy
   class << self
-    def policy(theme_id = nil, base_url: Discourse.base_url, path_info: "/")
-      new.build(theme_id, base_url: base_url, path_info: path_info)
+    def policy(theme_id = nil, base_url: Discourse.base_url, path_info: "/", report_only: false)
+      new.build(theme_id, base_url: base_url, path_info: path_info, report_only: report_only)
     end
 
     def nonce_placeholder(response_headers)
@@ -15,8 +15,8 @@ class ContentSecurityPolicy
     end
   end
 
-  def build(theme_id, base_url:, path_info: "/")
-    builder = Builder.new(base_url: base_url)
+  def build(theme_id, base_url:, path_info: "/", report_only: false)
+    builder = Builder.new(base_url: base_url, report_only: report_only)
 
     Extension.theme_extensions(theme_id).each { |extension| builder << extension }
     Extension.plugin_extensions.each { |extension| builder << extension }

--- a/lib/content_security_policy/builder.rb
+++ b/lib/content_security_policy/builder.rb
@@ -25,8 +25,8 @@ class ContentSecurityPolicy
       style_src
     ].freeze
 
-    def initialize(base_url:)
-      @directives = Default.new.directives
+    def initialize(base_url:, report_only: false)
+      @directives = Default.new(report_only: report_only).directives
       @base_url = base_url
     end
 

--- a/lib/content_security_policy/default.rb
+++ b/lib/content_security_policy/default.rb
@@ -5,10 +5,13 @@ class ContentSecurityPolicy
   class Default
     attr_reader :directives
 
-    def initialize
+    def initialize(report_only: false)
       @directives =
         {}.tap do |directives|
-          directives[:upgrade_insecure_requests] = [] if SiteSetting.force_https
+          # `upgrade-insecure-requests` is ignored in a report-only policy, and
+          # browsers log a console warning when it is present there, so only
+          # emit it for the enforced policy.
+          directives[:upgrade_insecure_requests] = [] if SiteSetting.force_https && !report_only
           directives[:base_uri] = [:self]
           directives[:object_src] = [:none]
           directives[:script_src] = script_src

--- a/lib/content_security_policy/middleware.rb
+++ b/lib/content_security_policy/middleware.rb
@@ -29,6 +29,7 @@ class ContentSecurityPolicy
         theme_id,
         base_url: base_url,
         path_info: env["PATH_INFO"],
+        report_only: true,
       ) if SiteSetting.content_security_policy_report_only
 
       response

--- a/spec/lib/content_security_policy_spec.rb
+++ b/spec/lib/content_security_policy_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe ContentSecurityPolicy do
       SiteSetting.force_https = true
       expect(parse(policy)["upgrade-insecure-requests"]).to eq([])
     end
+
+    it "is omitted from a report-only policy since browsers ignore it there" do
+      SiteSetting.force_https = true
+      expect(parse(policy(report_only: true))["upgrade-insecure-requests"]).to eq(nil)
+    end
   end
 
   describe "strict-dynamic script-src and worker-src" do
@@ -145,7 +150,7 @@ RSpec.describe ContentSecurityPolicy do
       .to_h
   end
 
-  def policy(theme_id = nil, path_info: "/")
-    ContentSecurityPolicy.policy(theme_id, path_info: path_info)
+  def policy(theme_id = nil, path_info: "/", report_only: false)
+    ContentSecurityPolicy.policy(theme_id, path_info: path_info, report_only: report_only)
   end
 end


### PR DESCRIPTION
This directive is not supported in report-only CSP, and causes confusing errors to be logged to the browser console. Omit it in report-only mode.