### PR TITLE
FIX: Stop asset-processor build from loading tsconfig

### DIFF
--- a/frontend/asset-processor/build.mjs
+++ b/frontend/asset-processor/build.mjs
@@ -5,6 +5,7 @@ const local = (p) => fileURLToPath(import.meta.resolve(p));
 
 const bundle = await rolldown({
   input: local("./transpiler.js"),
+  tsconfig: false,
   platform: "browser",
   moduleTypes: { ".wasm": "binary" },
   transform: {


### PR DESCRIPTION
Our tsconfig is designed for development use only, and is not needed for a successful asset-processor build.

In most cases, it didn't cause a problem. However, if someone does `rm -rf` on a core plugin, then it causes core's tscconfig to become invalid, which then breaks the asset-processor build.