### PR TITLE
UX: fix topic title edit aligments

### DIFF
--- a/app/assets/stylesheets/common/base/topic.scss
+++ b/app/assets/stylesheets/common/base/topic.scss
@@ -257,6 +257,15 @@
     .select-kit .category-row {
       max-width: unset;
     }
+
+    .editing-localization-indicator {
+      display: flex;
+      align-items: center;
+      gap: var(--space-1);
+      font-size: var(--font-down-1);
+      color: var(--primary-medium);
+      margin-bottom: -0.5em; // matches the flex gap of the edit-title__wrapper
+    }
   }
 
   .edit-title__wrapper {
@@ -265,15 +274,6 @@
     #edit-title {
       width: 100%;
       margin: 0;
-    }
-
-    .editing-localization-indicator {
-      display: flex;
-      align-items: center;
-      gap: var(--space-1);
-      margin: var(--space-1);
-      font-size: var(--font-down-1);
-      color: var(--primary-medium);
     }
   }
 

--- a/frontend/discourse/app/components/topic-title-editor.gjs
+++ b/frontend/discourse/app/components/topic-title-editor.gjs
@@ -16,16 +16,16 @@ export default class TopicTitleEditor extends Component {
   }
 
   <template>
+    {{#if @isEditingLocalization}}
+      <div class="editing-localization-indicator">
+        {{dIcon "language"}}
+        {{i18n
+          "topic.localizations.editing_translation"
+          language=this.translationLocaleName
+        }}
+      </div>
+    {{/if}}
     <div class="edit-title__wrapper">
-      {{#if @isEditingLocalization}}
-        <span class="editing-localization-indicator">
-          {{dIcon "language"}}
-          {{i18n
-            "topic.localizations.editing_translation"
-            language=this.translationLocaleName
-          }}
-        </span>
-      {{/if}}
       <PluginOutlet
         @name="edit-topic-title"
         @outletArgs={{lazyHash model=@model buffered=@buffered}}

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-helper/common/ai-helper.scss
@@ -251,13 +251,6 @@
   }
 }
 
-.edit-title__wrapper {
-  &:has(.ai-title-suggester-trigger) {
-    display: flex;
-    gap: var(--space-1);
-  }
-}
-
 .edit-title__wrapper,
 .edit-category__wrapper,
 .edit-tags__wrapper {


### PR DESCRIPTION
The translation info increased the size of the `edit-title__wrapper`, which in turn broke the absolute positioning (necessary evil) of the AI helper button.

This commit moves `editing-localization-indicator` a parent up, to `edit-topic-title`, so it's just part of the flex layout and no longer interferes with the wrapper.

| Then | Now |
|--------|--------|
| <img width="822" height="203" alt="CleanShot 2026-07-03 at 11 44 09" src="https://github.com/user-attachments/assets/ce525ab1-2028-43a3-86cd-61be5ae66779" /> | <img width="822" height="203" alt="CleanShot 2026-07-03 at 11 43 35" src="https://github.com/user-attachments/assets/58aa1c28-2f65-469c-9769-08279062ad16" /> | 