### PR TITLE
FIX: Prevent error when a reviewable claim is broadcast for a topicless reviewable

### DIFF
--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -366,7 +366,7 @@ export default class ReviewableItem extends Component {
 
   @bind
   _updateClaimedBy(data) {
-    if (data.topic_id !== this.reviewable.topic.id) {
+    if (data.topic_id !== this.topicId) {
       return;
     }
 

--- a/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
+++ b/frontend/discourse/tests/integration/components/reviewable/item-test.gjs
@@ -1,7 +1,9 @@
+import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import ReviewableItem from "discourse/components/reviewable/item";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
 
 module("Integration | Component | Reviewable | Item", function (hooks) {
   setupRenderingTest(hooks);
@@ -59,5 +61,74 @@ module("Integration | Component | Reviewable | Item", function (hooks) {
     assert
       .dom(".review-item__resources")
       .doesNotExist("does not render the help content");
+  });
+
+  test("does not error when a claim is broadcast for a reviewable without a topic", async function (assert) {
+    // e.g. ReviewableUser / a queued new topic have no associated topic object
+    const topiclessReviewable = {
+      id: 456,
+      type: "ReviewableUser",
+      topic: null,
+      reviewable_scores: [],
+      payload: { username: "flagged-user" },
+    };
+
+    await render(
+      <template>
+        <ReviewableItem @reviewable={{topiclessReviewable}} />
+      </template>
+    );
+
+    await publishToMessageBus("/reviewable_claimed", {
+      topic_id: 123,
+      user: { id: 7, username: "admin" },
+      claimed: true,
+    });
+
+    assert
+      .dom(".reviewable-user-info")
+      .exists("the item still renders and the broadcast is ignored");
+  });
+
+  test("updates claimed_by when a claim is broadcast for its topic", async function (assert) {
+    const claimable = getOwner(this)
+      .lookup("service:store")
+      .createRecord("reviewable", {
+        id: 789,
+        type: "topic",
+        topic: { id: 123, fancyTitle: "Test Topic Title" },
+        target_url: "/t/test-topic/123",
+        reviewable_scores: [],
+        reviewable_histories: [],
+        claimed_by: null,
+      });
+
+    await render(
+      <template><ReviewableItem @reviewable={{claimable}} /></template>
+    );
+
+    await publishToMessageBus("/reviewable_claimed", {
+      topic_id: 123,
+      user: { id: 7, username: "admin" },
+      claimed: true,
+    });
+
+    assert.strictEqual(
+      claimable.claimed_by?.user?.username,
+      "admin",
+      "the reviewable is marked as claimed"
+    );
+
+    await publishToMessageBus("/reviewable_claimed", {
+      topic_id: 999,
+      user: { id: 8, username: "other-admin" },
+      claimed: true,
+    });
+
+    assert.strictEqual(
+      claimable.claimed_by?.user?.username,
+      "admin",
+      "a claim for a different topic is ignored"
+    );
   });
 });


### PR DESCRIPTION
Previously, claiming a topic in the review queue threw `Cannot read properties of null (reading 'id')` in every `ReviewableItem` whose reviewable had no associated topic (e.g. `ReviewableUser` or a queued new topic), because `_updateClaimedBy` dereferenced `this.reviewable.topic.id` on the `/reviewable_claimed` broadcast.

This change compares against the existing `topicId` getter, which safely resolves the topic id and lets topicless reviewables ignore the broadcast instead of erroring.