### PR TITLE
DEV: Remove jquery from select-kit-helper and category-badge-test

### DIFF
--- a/frontend/discourse/tests/helpers/select-kit-helper.js
+++ b/frontend/discourse/tests/helpers/select-kit-helper.js
@@ -1,7 +1,5 @@
-/* eslint-disable ember/no-jquery */
 import { click, fillIn, findAll, triggerEvent } from "@ember/test-helpers";
 import { isEmpty } from "@ember/utils";
-import $ from "jquery";
 import { exists, query } from "discourse/tests/helpers/qunit-helpers";
 
 function checkSelectKitIsNotExpanded(selector) {
@@ -64,32 +62,23 @@ async function selectKitSelectRowByIndex(index, selector) {
 async function keyboardHelper(value, target, selector) {
   target = query(selector).querySelector(target || ".filter-input");
 
-  if (value === "selectAll") {
-    // special casing the only one not working with triggerEvent
-    const event = $.Event("keydown");
-    event.key = "A";
-    event.keyCode = 65;
-    event.metaKey = true;
-    $(target).trigger(event);
-  } else {
-    const mapping = {
-      enter: { key: "Enter", keyCode: 13 },
-      backspace: { key: "Backspace", keyCode: 8 },
-      escape: { key: "Escape", keyCode: 27 },
-      down: { key: "ArrowDown", keyCode: 40 },
-      up: { key: "ArrowUp", keyCode: 38 },
-      tab: { key: "Tab", keyCode: 9 },
-    };
+  const mapping = {
+    enter: { key: "Enter", keyCode: 13 },
+    backspace: { key: "Backspace", keyCode: 8 },
+    escape: { key: "Escape", keyCode: 27 },
+    down: { key: "ArrowDown", keyCode: 40 },
+    up: { key: "ArrowUp", keyCode: 38 },
+    tab: { key: "Tab", keyCode: 9 },
+  };
 
-    await triggerEvent(
-      target,
-      "keydown",
-      mapping[value.toLowerCase()] || {
-        key: value,
-        keyCode: value.charCodeAt(0),
-      }
-    );
-  }
+  await triggerEvent(
+    target,
+    "keydown",
+    mapping[value.toLowerCase()] || {
+      key: value,
+      keyCode: value.charCodeAt(0),
+    }
+  );
 }
 
 function rowHelper(row) {

--- a/frontend/discourse/tests/unit/lib/category-badge-test.js
+++ b/frontend/discourse/tests/unit/lib/category-badge-test.js
@@ -1,8 +1,7 @@
-/* eslint-disable ember/no-jquery */
 import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
-import $ from "jquery";
 import { module, test } from "qunit";
+import domFromString from "discourse/lib/dom-from-string";
 import { helperContext } from "discourse/lib/helpers";
 import { categoryBadgeHTML } from "discourse/ui-kit/helpers/d-category-link";
 
@@ -22,7 +21,7 @@ module("Unit | Utility | category-badge", function (hooks) {
       color: "ff0",
       text_color: "f00",
     });
-    const tag = $.parseHTML(categoryBadgeHTML(category))[0];
+    const tag = domFromString(categoryBadgeHTML(category))[0];
 
     assert.strictEqual(tag.tagName, "A", "creates a `a` wrapper tag");
     assert.strictEqual(
@@ -41,7 +40,7 @@ module("Unit | Utility | category-badge", function (hooks) {
   test("undefined color", function (assert) {
     const store = getOwner(this).lookup("service:store");
     const noColor = store.createRecord("category", { name: "hello", id: 123 });
-    const tag = $.parseHTML(categoryBadgeHTML(noColor))[0];
+    const tag = domFromString(categoryBadgeHTML(noColor))[0];
 
     assert.blank(
       tag.attributes["style"],
@@ -102,12 +101,12 @@ module("Unit | Utility | category-badge", function (hooks) {
       id: 234,
     });
 
-    let tag = $.parseHTML(categoryBadgeHTML(rtlCategory))[0];
+    let tag = domFromString(categoryBadgeHTML(rtlCategory))[0];
 
     let dirSpan = tag.children[0].children[0];
     assert.strictEqual(dirSpan.dir, "auto");
 
-    tag = $.parseHTML(categoryBadgeHTML(ltrCategory))[0];
+    tag = domFromString(categoryBadgeHTML(ltrCategory))[0];
     dirSpan = tag.children[0].children[0];
     assert.strictEqual(dirSpan.dir, "auto");
   });


### PR DESCRIPTION
- The 'selectAll' path in the select-kit-helper is completely unused, so we can just drop it

- Update HTML parsing in category-badge-test