### PR TITLE
DEV: Drop jquery in patreon plugin

### DIFF
--- a/plugins/discourse-patreon/assets/javascripts/discourse/connectors/topic-above-footer-buttons/patreon.gjs
+++ b/plugins/discourse-patreon/assets/javascripts/discourse/connectors/topic-above-footer-buttons/patreon.gjs
@@ -1,10 +1,9 @@
-/* eslint-disable ember/no-classic-components, ember/no-jquery, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/require-tagless-components */
 import Component from "@ember/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { trustHTML } from "@ember/template";
 import { classNames, tagName } from "@ember-decorators/component";
-import $ from "jquery";
 import cookie from "discourse/lib/cookie";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
@@ -44,7 +43,7 @@ export default class Patreon extends Component {
     cookie(cookieName, "t", {
       expires,
     });
-    $(this.element).fadeOut(700);
+    this.set("showDonationPrompt", false);
   }
 
   <template>


### PR DESCRIPTION
This was doing direct manipulation of ember-rendered DOM, which is risky. This commit changes it to be a simple non-animated closure, which is safer, and more in line with other Discourse UX.