### PR TITLE
DEV: Drop unused `decorateCooked` from discourse-details

### DIFF
--- a/plugins/discourse-details/assets/javascripts/initializers/apply-details.js
+++ b/plugins/discourse-details/assets/javascripts/initializers/apply-details.js
@@ -1,14 +1,8 @@
-/* eslint-disable ember/no-jquery */
-import $ from "jquery";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { i18n } from "discourse-i18n";
 import richEditorExtension from "../lib/rich-editor-extension";
 
 function initializeDetails(api) {
-  api.decorateCooked(($elem) => $("details", $elem), {
-    id: "discourse-details",
-  });
-
   api.addComposerToolbarPopupMenuOption({
     action: function (toolbarEvent) {
       toolbarEvent.applySurround(


### PR DESCRIPTION
This has been a no-op since 8f2f9e6afa0 in 2020, when we removed the JS polyfill of `<details>`