### PR TITLE
FIX: Keep quotes around wrap bbcode attribute values with spaces

### DIFF
--- a/frontend/discourse/app/lib/wrap-utils.js
+++ b/frontend/discourse/app/lib/wrap-utils.js
@@ -1,3 +1,6 @@
+import { buildBBCodeAttrs, serializeBBCodeAttr } from "discourse/lib/text";
+import { parseBBCodeTag } from "discourse-markdown-it/features/bbcode-block";
+
 /**
  * Parse an attributes string into flat object (matches server behavior)
  * @param {string} attrsString - The attributes string to parse
@@ -8,19 +11,16 @@ export function parseAttributesString(attrsString) {
     return {};
   }
 
-  const attrs = {};
-  const parts = attrsString.trim().split(/\s+/);
+  // Reuse the markdown-it parser so quoting stays in parity with the server
+  const source = `[wrap${attrsString}]`;
+  const parsed = parseBBCodeTag(source, 0, source.length);
 
-  for (const part of parts) {
-    if (part.startsWith("=")) {
-      attrs.wrap = part.slice(1);
-    } else if (part.includes("=")) {
-      const [key, ...valueParts] = part.split("=");
-      attrs[key] = valueParts.join("=");
-    }
+  if (!parsed?.attrs) {
+    return {};
   }
 
-  return attrs;
+  const { _default: wrap, ...rest } = parsed.attrs;
+  return wrap ? { wrap, ...rest } : rest;
 }
 
 /**
@@ -33,28 +33,15 @@ export function serializeAttributes(data) {
     return "";
   }
 
-  let result = "";
+  // An empty name serializes the wrap as the nameless `=value` default
+  const wrapName = data.wrap ? serializeBBCodeAttr(data.wrap, "").trim() : "";
+  const otherAttrs = buildBBCodeAttrs(data, { skipAttrs: ["wrap"] });
 
-  // Handle wrap name first
-  if (data.wrap) {
-    result = `=${data.wrap}`;
+  if (wrapName && otherAttrs) {
+    return `${wrapName} ${otherAttrs}`;
   }
 
-  // Handle other attributes
-  const otherAttrs = Object.entries(data)
-    .filter(([key]) => key !== "wrap")
-    .map(([key, value]) => `${key}=${value}`)
-    .join(" ");
-
-  if (otherAttrs) {
-    if (result) {
-      result += ` ${otherAttrs}`;
-    } else {
-      result = ` ${otherAttrs}`;
-    }
-  }
-
-  return result;
+  return wrapName || (otherAttrs ? ` ${otherAttrs}` : "");
 }
 
 /**

--- a/frontend/discourse/tests/unit/lib/wrap-utils-test.js
+++ b/frontend/discourse/tests/unit/lib/wrap-utils-test.js
@@ -1,0 +1,90 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  parseAttributesString,
+  serializeAttributes,
+} from "discourse/lib/wrap-utils";
+
+module("Unit | lib | wrap-utils", function (hooks) {
+  setupTest(hooks);
+
+  test("parseAttributesString", function (assert) {
+    assert.deepEqual(parseAttributesString(""), {});
+    assert.deepEqual(parseAttributesString("   "), {});
+    assert.deepEqual(parseAttributesString("=toc"), { wrap: "toc" });
+    assert.deepEqual(parseAttributesString("=toc id=123"), {
+      wrap: "toc",
+      id: "123",
+    });
+    assert.deepEqual(
+      parseAttributesString("=toc url=https://example.com/a/b"),
+      { wrap: "toc", url: "https://example.com/a/b" },
+      "keeps unquoted values containing = and /"
+    );
+  });
+
+  test("parseAttributesString with quoted values containing spaces", function (assert) {
+    assert.deepEqual(
+      parseAttributesString(
+        `=theme-install-button repo-name="Homepage Feature"`
+      ),
+      { wrap: "theme-install-button", "repo-name": "Homepage Feature" },
+      "reads a double-quoted value with spaces"
+    );
+    assert.deepEqual(
+      parseAttributesString(` repo-name='Homepage Feature'`),
+      { "repo-name": "Homepage Feature" },
+      "reads a single-quoted value with spaces"
+    );
+    assert.deepEqual(
+      parseAttributesString(` repo-name=“Homepage Feature”`),
+      { "repo-name": "Homepage Feature" },
+      "reads other quotation marks in parity with the markdown-it parser"
+    );
+  });
+
+  test("serializeAttributes", function (assert) {
+    assert.strictEqual(serializeAttributes({}), "");
+    assert.strictEqual(serializeAttributes({ wrap: "toc" }), "=toc");
+    assert.strictEqual(
+      serializeAttributes({ wrap: "toc", id: "123" }),
+      "=toc id=123"
+    );
+    assert.strictEqual(
+      serializeAttributes({ id: "123" }),
+      " id=123",
+      "leading space when there is no wrap name"
+    );
+  });
+
+  test("serializeAttributes quotes values containing spaces", function (assert) {
+    assert.strictEqual(
+      serializeAttributes({
+        wrap: "theme-install-button",
+        "repo-name": "Homepage Feature",
+      }),
+      `=theme-install-button repo-name="Homepage Feature"`,
+      "wraps a value with spaces in double quotes"
+    );
+    assert.strictEqual(
+      serializeAttributes({ wrap: "quote", title: `Design "Gems"` }),
+      `=quote title='Design "Gems"'`,
+      "picks a non-conflicting quote pair when the value contains quotes"
+    );
+  });
+
+  test("round-trips a value containing spaces", function (assert) {
+    const attrs = {
+      wrap: "theme-install-button",
+      "repo-name": "Homepage Feature",
+      "repo-url":
+        "https://github.com/discourse/discourse-homepage-feature-component",
+    };
+
+    assert.deepEqual(
+      parseAttributesString(serializeAttributes(attrs)),
+      attrs,
+      "serialize then parse preserves a spaced value"
+    );
+  });
+});


### PR DESCRIPTION
The rich text editor's wrap serialize/parse helpers are meant to mirror the server bbcode parser, but they never handled quoting: `serializeAttributes` emitted bare `key=value` pairs and `parseAttributesString` split on whitespace. So a value containing spaces such as `repo-name="Homepage Feature"` was rewritten as `repo-name=Homepage Feature` on the next markdown/RTE toggle, breaking the bbcode.

`serializeAttributes` now wraps values that contain whitespace in double quotes, matching how `[quote=...]` already serializes. `parseAttributesString` reconstructs the tag and delegates to the markdown-it `parseBBCodeTag`, so it reads quoted values back in full parity with the server (every supported quotation mark, not just double quotes), keeping the round-trip lossless.