### PR TITLE
MT: Only use INSERT OR IGNORE for tables that want it in the shard merge

### DIFF
--- a/migrations/core/lib/migrations/conversion/consolidator.rb
+++ b/migrations/core/lib/migrations/conversion/consolidator.rb
@@ -53,7 +53,9 @@ module Migrations
       end
 
       def merge(shard_path)
-        @fork_mutex.synchronize { @connection.merge_database(shard_path, tables: mergeable_tables) }
+        @fork_mutex.synchronize do
+          @connection.merge_database(shard_path, tables: mergeable_tables, dedupe_tables:)
+        end
       rescue StandardError => e
         @errors << e
       ensure
@@ -64,6 +66,16 @@ module Migrations
       # shard, so they're left out of the merge.
       def mergeable_tables
         @mergeable_tables ||= @connection.tables - %w[config schema_migrations]
+      end
+
+      # The mergeable tables whose model opts into `INSERT OR IGNORE`; the rest
+      # raise on a duplicate. Derived from the models, so adding a table needs no
+      # change here (see `IntermediateDB.conflict_strategy_for`).
+      def dedupe_tables
+        @dedupe_tables ||=
+          mergeable_tables.select do |table|
+            Database::IntermediateDB.conflict_strategy_for(table) == :ignore
+          end
       end
     end
   end

--- a/migrations/core/lib/migrations/conversion/shard_manager.rb
+++ b/migrations/core/lib/migrations/conversion/shard_manager.rb
@@ -13,10 +13,9 @@ module Migrations
     # them.
     #
     # The template is a fresh, empty database migrated from the same schema as the
-    # run DB — not a copy of the run DB. That keeps a shard cheap to copy, and —
-    # importantly — means a run against an existing IntermediateDB doesn't drag the
-    # existing rows into every shard; the merge just adds each shard's new rows
-    # with `INSERT OR IGNORE`.
+    # run DB — not a copy of the run DB. That keeps a shard cheap to copy, and
+    # means a run against an existing IntermediateDB doesn't drag the existing rows
+    # into every shard; the merge just adds each shard's new rows.
     class ShardManager
       # @param canonical_path [String] the run's IntermediateDB; the shards and
       #   their template are placed next to it

--- a/migrations/core/lib/migrations/database/connection.rb
+++ b/migrations/core/lib/migrations/database/connection.rb
@@ -87,13 +87,20 @@ module Migrations
       end
 
       # `ATTACH` can't run inside a transaction, so commit any open batch first.
-      def merge_database(other_path, tables:)
+      # `dedupe_tables` merge with `INSERT OR IGNORE`; the rest raise on a
+      # duplicate row (see `Consolidator`).
+      def merge_database(other_path, tables:, dedupe_tables: [])
         commit_transaction
         @db.execute("ATTACH DATABASE ? AS merge_source", other_path)
         begin
           tables.each do |table|
             quoted = quote_identifier(table)
-            @db.execute("INSERT OR IGNORE INTO main.#{quoted} SELECT * FROM merge_source.#{quoted}")
+            conflict_clause = dedupe_tables.include?(table) ? "OR IGNORE " : ""
+            @db.execute(
+              "INSERT #{conflict_clause}INTO main.#{quoted} SELECT * FROM merge_source.#{quoted}",
+            )
+          rescue Extralite::Error => e
+            raise "Failed to merge table #{table.inspect}: #{e.message}"
           end
         ensure
           @db.execute("DETACH DATABASE merge_source")

--- a/migrations/core/lib/migrations/database/intermediate_db.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db.rb
@@ -23,6 +23,18 @@ module Migrations
         @db.insert(sql, parameters)
       end
 
+      # How the shard merge should handle a duplicate row in `table`: `:ignore`
+      # for a model that inserts with `INSERT OR IGNORE`, else `:raise` — so a
+      # genuine duplicate is an error, not a silently dropped row. Read from the
+      # model, so a new table needs no change here.
+      def self.conflict_strategy_for(table)
+        module_name = table.to_s.singularize.camelize
+        return :raise unless const_defined?(module_name, false)
+
+        model = const_get(module_name, false)
+        model.respond_to?(:conflict_strategy) ? model.conflict_strategy : :raise
+      end
+
       def self.close
         @db.close if @db
       end

--- a/migrations/core/lib/migrations/database/intermediate_db/upload.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/upload.rb
@@ -20,6 +20,13 @@ module Migrations
         SQL
         private_constant :SQL
 
+        # Several steps can reference the same file, and rows are identical for a
+        # given `id` (a content hash), so a duplicate `id` is expected: keep the
+        # first, ignore the rest — both here (`SQL` above) and in the shard merge.
+        def self.conflict_strategy
+          :ignore
+        end
+
         def self.create_for_file(
           path:,
           filename: nil,

--- a/migrations/core/spec/lib/conversion/consolidator_spec.rb
+++ b/migrations/core/spec/lib/conversion/consolidator_spec.rb
@@ -18,9 +18,21 @@ RSpec.describe Migrations::Conversion::Consolidator do
     errors = consolidator.drain
 
     # `config` and `schema_migrations` are excluded from the merge
-    expect(connection).to have_received(:merge_database).with("a.db", tables: %w[topics])
-    expect(connection).to have_received(:merge_database).with("b.db", tables: %w[topics])
-    expect(connection).to have_received(:merge_database).with("c.db", tables: %w[topics])
+    expect(connection).to have_received(:merge_database).with(
+      "a.db",
+      tables: %w[topics],
+      dedupe_tables: [],
+    )
+    expect(connection).to have_received(:merge_database).with(
+      "b.db",
+      tables: %w[topics],
+      dedupe_tables: [],
+    )
+    expect(connection).to have_received(:merge_database).with(
+      "c.db",
+      tables: %w[topics],
+      dedupe_tables: [],
+    )
     expect(shard_manager).to have_received(:discard).with("a.db")
     expect(shard_manager).to have_received(:discard).with("c.db")
     expect(errors).to be_empty
@@ -28,7 +40,11 @@ RSpec.describe Migrations::Conversion::Consolidator do
 
   it "collects a merge error and still discards the shard" do
     boom = StandardError.new("merge boom")
-    allow(connection).to receive(:merge_database).with("bad.db", tables: anything).and_raise(boom)
+    allow(connection).to receive(:merge_database).with(
+      "bad.db",
+      tables: anything,
+      dedupe_tables: anything,
+    ).and_raise(boom)
 
     consolidator = described_class.new(shard_manager, connection, fork_mutex)
     consolidator.enqueue(%w[bad.db])
@@ -36,5 +52,31 @@ RSpec.describe Migrations::Conversion::Consolidator do
 
     expect(errors).to eq([boom])
     expect(shard_manager).to have_received(:discard).with("bad.db")
+  end
+
+  it "merges `OR IGNORE` for the tables whose model declares it, and plain for the rest" do
+    # A fake model that opts into `OR IGNORE`, resolved by table name exactly like
+    # a real one — so the merge clause is derived from the models, not hard-coded.
+    fake_model =
+      Module.new do
+        def self.conflict_strategy
+          :ignore
+        end
+      end
+    stub_const("Migrations::Database::IntermediateDB::FakeThing", fake_model)
+
+    allow(connection).to receive(:tables).and_return(
+      %w[uploads topics fake_things config schema_migrations],
+    )
+
+    consolidator = described_class.new(shard_manager, connection, fork_mutex)
+    consolidator.enqueue(%w[a.db])
+    consolidator.drain
+
+    expect(connection).to have_received(:merge_database).with(
+      "a.db",
+      tables: %w[uploads topics fake_things],
+      dedupe_tables: %w[uploads fake_things],
+    )
   end
 end

--- a/migrations/core/spec/lib/conversion/scheduler_integration_spec.rb
+++ b/migrations/core/spec/lib/conversion/scheduler_integration_spec.rb
@@ -535,7 +535,25 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     Object.send(:remove_const, "TempIntegrationSteps")
   end
 
-  it "adds new rows to an existing IntermediateDB without dropping or overwriting" do
+  # Runs `TempIntegrationSteps::Keyed`, whose processor writes each item into the
+  # `keyed` table. `keyed` has no `INSERT OR IGNORE` model, so its shard merges
+  # with a plain, raising `INSERT`.
+  def run_keyed_step
+    step_classes = [TempIntegrationSteps::Keyed]
+    reporter = Migrations::Reporting::Factory.build(titles: step_classes.map(&:title))
+    Migrations::Conversion::StepScheduler.new(
+      step_classes:,
+      budget: 2,
+      reporter:,
+      step_factory: ->(step_class) { step_class.new },
+      shard_manager: @shard_manager,
+      writer: @writer,
+    ).run
+  ensure
+    reporter&.close
+  end
+
+  it "adds new, non-colliding rows to an existing IntermediateDB" do
     # A row from a previous run already lives in the DB.
     Migrations::Database::IntermediateDB.insert("INSERT INTO keyed VALUES (?, ?)", 1, "existing")
 
@@ -547,8 +565,8 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
           Class.new(Migrations::Conversion::Step) do
             source do
               def items
-                # id 1 collides with the existing row; id 2 is new
-                [{ id: 1, label: "new" }, { id: 2, label: "added" }]
+                # both ids are new; neither collides with the existing row
+                [{ id: 2, label: "added" }, { id: 3, label: "more" }]
               end
             end
 
@@ -566,25 +584,52 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
       end,
     )
 
-    step_classes = [TempIntegrationSteps::Keyed]
-    reporter = Migrations::Reporting::Factory.build(titles: step_classes.map(&:title))
-    Migrations::Conversion::StepScheduler.new(
-      step_classes:,
-      budget: 2,
-      reporter:,
-      step_factory: ->(step_class) { step_class.new },
-      shard_manager: @shard_manager,
-      writer: @writer,
-    ).run
-    reporter.close
+    run_keyed_step
 
     Migrations::Database::IntermediateDB.close
 
     db = Extralite::Database.new(@db_path)
     keyed = db.query_array("SELECT id, label FROM keyed ORDER BY id")
     db.close
-    # the existing row is kept as-is (not overwritten), and the new row is added
-    expect(keyed).to eq([[1, "existing"], [2, "added"]])
+    # the existing row is kept and the new, non-colliding rows are appended
+    expect(keyed).to eq([[1, "existing"], [2, "added"], [3, "more"]])
+  ensure
+    Object.send(:remove_const, "TempIntegrationSteps")
+  end
+
+  it "fails the run, naming the table, when a shard row collides with an existing one" do
+    # `keyed` merges with a plain `INSERT`, so a shard row that duplicates a row
+    # already in the run DB is a genuine double-write: it fails the run loudly
+    # instead of being silently dropped, matching the single-writer contract.
+    Migrations::Database::IntermediateDB.insert("INSERT INTO keyed VALUES (?, ?)", 1, "existing")
+
+    Object.const_set(
+      "TempIntegrationSteps",
+      Module.new do
+        const_set(
+          "Keyed",
+          Class.new(Migrations::Conversion::Step) do
+            source do
+              def items
+                [{ id: 1, label: "collides" }] # id 1 already lives in the run DB
+              end
+            end
+
+            processor do
+              def process(item)
+                Migrations::Database::IntermediateDB.insert(
+                  "INSERT INTO keyed VALUES (?, ?)",
+                  item[:id],
+                  item[:label],
+                )
+              end
+            end
+          end,
+        )
+      end,
+    )
+
+    expect { run_keyed_step }.to raise_error(Migrations::Conversion::ConvertError, /keyed/)
   ensure
     Object.send(:remove_const, "TempIntegrationSteps")
   end

--- a/migrations/core/spec/lib/database/connection_spec.rb
+++ b/migrations/core/spec/lib/database/connection_spec.rb
@@ -125,6 +125,90 @@ RSpec.describe Migrations::Database::Connection do
     end
   end
 
+  describe "#merge_database" do
+    def create_schema(db)
+      db.execute(<<~SQL)
+        CREATE TABLE topic_tags (topic_id INTEGER, tag_id INTEGER, PRIMARY KEY (topic_id, tag_id))
+      SQL
+      db.execute("CREATE TABLE uploads (id TEXT PRIMARY KEY, filename TEXT)")
+    end
+
+    # Yields a run-DB `connection` and a closed shard database at `source_path`,
+    # both carrying the same schema. The block seeds each and runs the merge.
+    def with_merge_dbs
+      Dir.mktmpdir do |dir|
+        source_path = File.join(dir, "source.db")
+        connection = described_class.new(path: File.join(dir, "main.db"))
+        create_schema(connection.db)
+
+        source = described_class.open_database(path: source_path)
+        create_schema(source)
+
+        yield connection, source, source_path
+      ensure
+        connection&.close
+      end
+    end
+
+    it "merges non-colliding rows from every listed table" do
+      with_merge_dbs do |connection, source, source_path|
+        connection.db.execute("INSERT INTO topic_tags VALUES (1, 10)")
+        source.execute("INSERT INTO topic_tags VALUES (2, 20)")
+        source.execute("INSERT INTO uploads VALUES ('a', 'a.png')")
+        source.close
+
+        connection.merge_database(source_path, tables: %w[topic_tags uploads])
+
+        expect(connection.db.query("SELECT topic_id, tag_id FROM topic_tags")).to contain_exactly(
+          { topic_id: 1, tag_id: 10 },
+          { topic_id: 2, tag_id: 20 },
+        )
+        expect(connection.db.query_splat("SELECT id FROM uploads")).to contain_exactly("a")
+      end
+    end
+
+    it "dedups an `OR IGNORE` table across shards, keeping the first writer's row" do
+      with_merge_dbs do |connection, source, source_path|
+        connection.db.execute("INSERT INTO uploads VALUES ('x', 'first.png')")
+        source.execute("INSERT INTO uploads VALUES ('x', 'second.png')")
+        source.close
+
+        connection.merge_database(source_path, tables: %w[uploads], dedupe_tables: %w[uploads])
+
+        expect(connection.db.query("SELECT id, filename FROM uploads")).to contain_exactly(
+          { id: "x", filename: "first.png" },
+        )
+      end
+    end
+
+    it "raises, naming the table, when a plain table has a cross-shard duplicate" do
+      with_merge_dbs do |connection, source, source_path|
+        connection.db.execute("INSERT INTO topic_tags VALUES (1, 10)")
+        source.execute("INSERT INTO topic_tags VALUES (1, 10)")
+        source.close
+
+        expect { connection.merge_database(source_path, tables: %w[topic_tags]) }.to raise_error(
+          /topic_tags/,
+        )
+      end
+    end
+
+    it "detaches the merge source even when a merge raises, so the next merge works" do
+      with_merge_dbs do |connection, source, source_path|
+        connection.db.execute("INSERT INTO topic_tags VALUES (1, 10)")
+        source.execute("INSERT INTO topic_tags VALUES (1, 10)")
+        source.close
+
+        expect { connection.merge_database(source_path, tables: %w[topic_tags]) }.to raise_error(
+          /topic_tags/,
+        )
+
+        # A leaked `merge_source` attachment would make this second merge raise.
+        expect { connection.merge_database(source_path, tables: %w[uploads]) }.not_to raise_error
+      end
+    end
+  end
+
   context "when `Migrations::ForkManager.fork` is used" do
     it "temporarily closes the connection while a process fork is created" do
       create_connection do |connection|

--- a/migrations/core/spec/lib/database/intermediate_db_spec.rb
+++ b/migrations/core/spec/lib/database/intermediate_db_spec.rb
@@ -57,6 +57,32 @@ RSpec.describe Migrations::Database::IntermediateDB do
     end
   end
 
+  describe ".conflict_strategy_for" do
+    it "returns `:ignore` for a table whose model declares it" do
+      expect(described_class.conflict_strategy_for("uploads")).to eq(:ignore)
+    end
+
+    it "returns `:raise` for a table whose model does not declare a strategy" do
+      expect(described_class.conflict_strategy_for("topic_tags")).to eq(:raise)
+    end
+
+    it "returns `:raise` for a table without a model" do
+      expect(described_class.conflict_strategy_for("schema_migrations")).to eq(:raise)
+    end
+
+    it "reads the strategy from the model, so a new `OR IGNORE` model flips it" do
+      model =
+        Module.new do
+          def self.conflict_strategy
+            :ignore
+          end
+        end
+      stub_const("#{described_class}::Widget", model)
+
+      expect(described_class.conflict_strategy_for("widgets")).to eq(:ignore)
+    end
+  end
+
   describe ".with_connection" do
     let(:previous_connection) { create_connection_double }
     let(:temporary_connection) { create_connection_double }

--- a/migrations/tooling/lib/migrations/tooling/schema.rb
+++ b/migrations/tooling/lib/migrations/tooling/schema.rb
@@ -14,7 +14,12 @@ module Migrations
           :primary_key_column_names,
           :constraints,
           :model_mode,
+          :conflict_strategy,
         ) do
+          def initialize(conflict_strategy: :raise, **args)
+            super(conflict_strategy:, **args)
+          end
+
           def sorted_columns
             pk_position = primary_key_column_names.each_with_index.to_h
             columns.sort_by { |c| [c.is_primary_key ? 0 : 1, pk_position.fetch(c.name, 0), c.name] }

--- a/migrations/tooling/lib/migrations/tooling/schema/dsl/schema_resolver.rb
+++ b/migrations/tooling/lib/migrations/tooling/schema/dsl/schema_resolver.rb
@@ -56,6 +56,7 @@ module Migrations
               primary_key_column_names: resolved_pk_names,
               constraints:,
               model_mode: table_def.model_mode,
+              conflict_strategy: table_def.conflict_strategy,
             )
           end
 

--- a/migrations/tooling/lib/migrations/tooling/schema/dsl/table_builder.rb
+++ b/migrations/tooling/lib/migrations/tooling/schema/dsl/table_builder.rb
@@ -24,6 +24,7 @@ module Migrations
             :ignore_plugin_columns,
             :ignore_plugin_names,
             :model_mode,
+            :conflict_strategy,
           ) do
             def column_options_for(col)
               column_options[col.to_s]
@@ -43,6 +44,7 @@ module Migrations
           end
 
         VALID_MODEL_MODES = %i[extended manual].freeze
+        VALID_CONFLICT_STRATEGIES = %i[raise ignore].freeze
 
         class TableBuilder
           def initialize(name)
@@ -60,6 +62,7 @@ module Migrations
             @ignore_plugin_columns = false
             @ignore_plugin_names = nil
             @model_mode = nil
+            @conflict_strategy = :raise
           end
 
           def copy_structure_from(table)
@@ -148,6 +151,18 @@ module Migrations
             @model_mode = mode
           end
 
+          # How the model's inserts and the shard merge handle a duplicate row.
+          # `:raise` (the default) uses a plain `INSERT`; `:ignore` uses `INSERT OR
+          # IGNORE`, keeping the first row and dropping later duplicates.
+          def conflict_strategy(strategy)
+            strategy = strategy.to_sym
+            if VALID_CONFLICT_STRATEGIES.exclude?(strategy)
+              raise ConfigError,
+                    "Invalid conflict strategy :#{strategy} for table :#{@name}. Valid: #{VALID_CONFLICT_STRATEGIES.join(", ")}"
+            end
+            @conflict_strategy = strategy
+          end
+
           def build
             if @source_table_name && @included_columns.nil? && !@include_all &&
                  @ignored_columns.empty?
@@ -186,6 +201,7 @@ module Migrations
               ignore_plugin_columns: @ignore_plugin_columns,
               ignore_plugin_names: @ignore_plugin_names&.freeze,
               model_mode: @model_mode,
+              conflict_strategy: @conflict_strategy,
             )
           end
 

--- a/migrations/tooling/lib/migrations/tooling/schema/model_writer.rb
+++ b/migrations/tooling/lib/migrations/tooling/schema/model_writer.rb
@@ -28,7 +28,7 @@ module Migrations
           @namespace_parts.each { |part| emit "module #{part}" }
           emit "  module #{module_name}"
           emit "    SQL = <<~SQL"
-          emit "      INSERT INTO #{escape_identifier(table.name)} ("
+          emit "      #{insert_statement(table)} INTO #{escape_identifier(table.name)} ("
           emit column_names(columns)
           emit "      )"
           emit "      VALUES ("
@@ -37,6 +37,8 @@ module Migrations
           emit "    SQL"
           emit "    private_constant :SQL"
           emit
+
+          emit_conflict_strategy(table)
 
           if table.model_mode == :extended
             emit "    # -- custom code --"
@@ -69,6 +71,22 @@ module Migrations
               @out.puts(line.empty? ? "" : "#{@base_indent}#{line}")
             end
           end
+        end
+
+        def insert_statement(table)
+          table.conflict_strategy == :ignore ? "INSERT OR IGNORE" : "INSERT"
+        end
+
+        # Only `:ignore` needs a declaration; the absent method reads back as
+        # `:raise` via `IntermediateDB.conflict_strategy_for`, so a plain model's
+        # output is unchanged.
+        def emit_conflict_strategy(table)
+          return unless table.conflict_strategy == :ignore
+
+          emit "    def self.conflict_strategy"
+          emit "      :ignore"
+          emit "    end"
+          emit
         end
 
         def column_names(columns)

--- a/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/generator_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/generator_spec.rb
@@ -3,9 +3,10 @@
 RSpec.describe Migrations::Tooling::Schema::DSL::Generator do
   after { Migrations::Tooling::Schema.reset! }
 
-  def make_table(name, model_mode: nil)
+  def make_table(name, model_mode: nil, conflict_strategy: :raise)
     Migrations::Tooling::Schema::TableDefinition.new(
       name:,
+      conflict_strategy:,
       columns: [
         Migrations::Tooling::Schema::ColumnDefinition.new(
           name: "id",
@@ -155,6 +156,37 @@ RSpec.describe Migrations::Tooling::Schema::DSL::Generator do
         described_class.new(Migrations::Tooling::Schema).generate
 
         expect(Dir[File.join(paths[:models], "*.rb")]).to be_empty
+      end
+    end
+
+    it "generates a plain `INSERT` and no conflict strategy for the default `:raise`" do
+      Dir.mktmpdir do |tmpdir|
+        paths = configure_output(tmpdir)
+        stub_validation_and_resolution(resolved_definition)
+
+        described_class.new(Migrations::Tooling::Schema).generate
+
+        model_content = File.read(File.join(paths[:models], "user.rb"))
+        expect(model_content).to include("INSERT INTO users")
+        expect(model_content).not_to include("INSERT OR IGNORE")
+        expect(model_content).not_to include("def self.conflict_strategy")
+      end
+    end
+
+    it "generates `INSERT OR IGNORE` and a conflict strategy for `:ignore`" do
+      Dir.mktmpdir do |tmpdir|
+        paths = configure_output(tmpdir)
+
+        table = make_table("users", conflict_strategy: :ignore)
+        definition = Migrations::Tooling::Schema::Definition.new(tables: [table], enums: [])
+        stub_validation_and_resolution(definition)
+
+        described_class.new(Migrations::Tooling::Schema).generate
+
+        model_content = File.read(File.join(paths[:models], "user.rb"))
+        expect(model_content).to include("INSERT OR IGNORE INTO users")
+        expect(model_content).to include("def self.conflict_strategy")
+        expect(model_content).to include(":ignore")
       end
     end
 

--- a/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/table_builder_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/table_builder_spec.rb
@@ -36,6 +36,37 @@ RSpec.describe Migrations::Tooling::Schema::DSL::TableBuilder do
       end.to raise_error(Migrations::Tooling::Schema::ConfigError, /Invalid model mode :invalid/)
     end
 
+    it "defaults the conflict strategy to `:raise`" do
+      Migrations::Tooling::Schema.table :users do
+        primary_key :id
+        include :id
+      end
+
+      expect(Migrations::Tooling::Schema.tables["users"].conflict_strategy).to eq(:raise)
+    end
+
+    it "records a declared conflict strategy" do
+      Migrations::Tooling::Schema.table :uploads do
+        conflict_strategy :ignore
+        synthetic!
+        primary_key :id
+        add_column :id, :text
+      end
+
+      expect(Migrations::Tooling::Schema.tables["uploads"].conflict_strategy).to eq(:ignore)
+    end
+
+    it "raises on an invalid conflict strategy" do
+      expect do
+        Migrations::Tooling::Schema.table :users do
+          conflict_strategy :maybe
+        end
+      end.to raise_error(
+        Migrations::Tooling::Schema::ConfigError,
+        /Invalid conflict strategy :maybe/,
+      )
+    end
+
     it "raises when synthetic table uses include or include_all" do
       %i[include include_all].each do |method|
         expect do


### PR DESCRIPTION
Follow-up to #41262. The shard merge used `INSERT OR IGNORE` for every table, so a genuine duplicate row on any table other than `uploads` got silently dropped instead of raising like the single-writer path would.

Now the merge clause comes from the model: only `upload` declares `conflict_strategy :ignore`, everything else raises. No current step hits this, so a real run is unchanged — it just fails loudly if a future step ever double-writes a key.

Second commit wires this into the schema DSL too: a generated model can declare `conflict_strategy :ignore` in its table config and `ModelWriter` emits both the `OR IGNORE` SQL and the `conflict_strategy` method. It defaults to `:raise`, so every existing generated model regenerates byte-for-byte. `uploads` stays a manual model and keeps declaring it by hand.