### PR TITLE
DEV: Apply different first-day limits for TL0 and TL1

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -210,12 +210,7 @@ class Post < ActiveRecord::Base
 
   def limit_posts_per_day
     if user && user.new_user_posting_on_first_day? && post_number && post_number > 1
-      RateLimiter.new(
-        user,
-        "first-day-replies-per-day",
-        SiteSetting.max_replies_in_first_day,
-        1.day.to_i,
-      )
+      RateLimiter.new(user, "first-day-replies-per-day", user.first_day_replies_limit, 1.day.to_i)
     end
   end
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -2293,7 +2293,7 @@ class Topic < ActiveRecord::Base
   end
 
   def limit_first_day_topics_per_day
-    apply_per_day_rate_limit_for("first-day-topics", :max_topics_in_first_day)
+    RateLimiter.new(user, "first-day-topics-per-day", user.first_day_topics_limit, 1.day.to_i)
   end
 
   def apply_per_day_rate_limit_for(key, method_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1047,8 +1047,24 @@ class User < ActiveRecord::Base
   def new_user_posting_on_first_day?
     return false if staff?
     return false if trust_level >= TrustLevel[2]
-    return false if first_post_created_at.present? && first_post_created_at <= 24.hours.ago
+    return false if created_at <= 24.hours.ago
     true
+  end
+
+  def first_day_topics_limit
+    if trust_level == TrustLevel[1]
+      SiteSetting.tl1_max_topics_in_first_day
+    else
+      SiteSetting.max_topics_in_first_day
+    end
+  end
+
+  def first_day_replies_limit
+    if trust_level == TrustLevel[1]
+      SiteSetting.tl1_max_replies_in_first_day
+    else
+      SiteSetting.max_replies_in_first_day
+    end
   end
 
   def new_user?

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2000,8 +2000,10 @@ en:
 
     cooldown_minutes_after_hiding_posts: "Number of minutes a user must wait before they can edit a post hidden via community flagging"
 
-    max_topics_in_first_day: "The maximum number of topics a user is allowed to create in the 24 hour period after creating their first post"
-    max_replies_in_first_day: "The maximum number of replies a user is allowed to create in the 24 hour period after creating their first post"
+    max_topics_in_first_day: "The maximum number of topics a trust level 0 user is allowed to create in the 24 hour period after account creation"
+    max_replies_in_first_day: "The maximum number of replies a trust level 0 user is allowed to create in the 24 hour period after account creation"
+    tl1_max_topics_in_first_day: "The maximum number of topics a trust level 1 user is allowed to create in the 24 hour period after account creation"
+    tl1_max_replies_in_first_day: "The maximum number of replies a trust level 1 user is allowed to create in the 24 hour period after account creation"
 
     tl2_additional_likes_per_day_multiplier: "Increase limit of likes per day for tl2 (member) by multiplying with this number"
     tl3_additional_likes_per_day_multiplier: "Increase limit of likes per day for tl3 (regular) by multiplying with this number"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3256,6 +3256,8 @@ rate_limits:
   max_topic_invitations_per_minute: 5
   max_topics_in_first_day: 3
   max_replies_in_first_day: 10
+  tl1_max_topics_in_first_day: 6
+  tl1_max_replies_in_first_day: 30
   tl2_additional_likes_per_day_multiplier: 1.5
   tl3_additional_likes_per_day_multiplier: 2
   tl4_additional_likes_per_day_multiplier: 3

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -2980,17 +2980,20 @@ RSpec.describe Topic do
     before do
       SiteSetting.max_topics_in_first_day = 1
       SiteSetting.max_replies_in_first_day = 1
+      SiteSetting.tl1_max_topics_in_first_day = 2
+      SiteSetting.tl1_max_replies_in_first_day = 2
       SiteSetting.stubs(:client_settings_json).returns(SiteSetting.client_settings_json_uncached)
       RateLimiter.stubs(:rate_limit_create_topic).returns(100)
       RateLimiter.enable
     end
 
-    it "limits new users to max_topics_in_first_day and max_posts_in_first_day" do
+    it "limits TL0 users to max_topics_in_first_day and max_replies_in_first_day" do
       start = Time.now.tomorrow.beginning_of_day
 
       freeze_time(start)
 
-      user = Fabricate(:user, refresh_auto_groups: true)
+      user =
+        Fabricate(:user, created_at: start, trust_level: TrustLevel[0], refresh_auto_groups: true)
       topic_id = create_post(user: user).topic_id
 
       freeze_time(start + 10.minutes)
@@ -3005,26 +3008,52 @@ RSpec.describe Topic do
       )
     end
 
-    it "starts counting when they make their first post/topic" do
+    it "limits TL1 users to TL1 first day limits" do
       start = Time.now.tomorrow.beginning_of_day
 
       freeze_time(start)
 
-      user = Fabricate(:user, refresh_auto_groups: true)
+      user =
+        Fabricate(:user, created_at: start, trust_level: TrustLevel[1], refresh_auto_groups: true)
+      topic_id = create_post(user: user).topic_id
+
+      freeze_time(start + 10.minutes)
+      create_post(user: user)
+
+      freeze_time(start + 20.minutes)
+      expect { create_post(user: user) }.to raise_error(RateLimiter::LimitExceeded)
+
+      freeze_time(start + 30.minutes)
+      create_post(user: user, topic_id: topic_id)
+
+      freeze_time(start + 40.minutes)
+      create_post(user: user, topic_id: topic_id)
+
+      freeze_time(start + 50.minutes)
+      expect { create_post(user: user, topic_id: topic_id) }.to raise_error(
+        RateLimiter::LimitExceeded,
+      )
+    end
+
+    it "starts counting when the account is created" do
+      start = Time.now.tomorrow.beginning_of_day
+
+      freeze_time(start)
+
+      user =
+        Fabricate(:user, created_at: start, trust_level: TrustLevel[0], refresh_auto_groups: true)
 
       freeze_time(start + 25.hours)
       topic_id = create_post(user: user).topic_id
 
       freeze_time(start + 26.hours)
-      expect { create_post(user: user) }.to raise_error(RateLimiter::LimitExceeded)
+      create_post(user: user)
 
       freeze_time(start + 27.hours)
       create_post(user: user, topic_id: topic_id)
 
       freeze_time(start + 28.hours)
-      expect { create_post(user: user, topic_id: topic_id) }.to raise_error(
-        RateLimiter::LimitExceeded,
-      )
+      create_post(user: user, topic_id: topic_id)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1782,16 +1782,33 @@ RSpec.describe User do
       )
     end
 
-    it "is true for a user who posted less than 24 hours ago but was created over 1 day ago" do
-      u = create_test_user(created_at: 28.hours.ago)
-      u.user_stat.update!(first_post_created_at: 1.hour.ago)
-      expect(u.new_user_posting_on_first_day?).to eq(true)
+    it "is true for a TL1 user created less than 24 hours ago" do
+      expect(create_test_user(trust_level: TrustLevel[1]).new_user_posting_on_first_day?).to eq(
+        true,
+      )
     end
 
-    it "is false if first post was more than 24 hours ago" do
-      u = create_test_user(created_at: 28.hours.ago)
-      u.user_stat.update!(first_post_created_at: 25.hours.ago)
+    it "is false if account was created more than 24 hours ago" do
+      u = create_test_user(created_at: 25.hours.ago)
       expect(u.new_user_posting_on_first_day?).to eq(false)
+    end
+  end
+
+  describe "#first_day_topics_limit" do
+    it "returns the TL1 limit for TL1 users" do
+      SiteSetting.max_topics_in_first_day = 3
+      SiteSetting.tl1_max_topics_in_first_day = 6
+
+      expect(Fabricate(:user, trust_level: TrustLevel[1]).first_day_topics_limit).to eq(6)
+    end
+  end
+
+  describe "#first_day_replies_limit" do
+    it "returns the TL1 limit for TL1 users" do
+      SiteSetting.max_replies_in_first_day = 10
+      SiteSetting.tl1_max_replies_in_first_day = 30
+
+      expect(Fabricate(:user, trust_level: TrustLevel[1]).first_day_replies_limit).to eq(30)
     end
   end
 


### PR DESCRIPTION
Two changes here: 

- the first-day limits clock now starts when user account is created (previously, it was starting when the first post was created)
- TL1 gets its own limits, by default 6 topics and 30 replies, configurable via its own site settings `tl1_max_topics_in_first_day`, `tl1_max_replies_in_first_day`

I'm not thrilled to add yet another site setting here, but this change is useful, it allows better separation between TL0 and TL1 in a critical first day of use. 

Context in https://meta.discourse.org/t/bootstrap-mode-is-legacy/402468/17?u=pmusaraj 