### PR TITLE
UX: Normalize automatic membership email domains

### DIFF
--- a/app/controllers/admin/groups_controller.rb
+++ b/app/controllers/admin/groups_controller.rb
@@ -78,11 +78,7 @@ class Admin::GroupsController < Admin::StaffController
 
   def automatic_membership_count
     guardian.ensure_can_create_group!
-    invalid_domains = []
-    domains =
-      Group.get_valid_email_domains(params.require(:automatic_membership_email_domains)) do |domain|
-        invalid_domains << domain
-      end
+    domains = Group.get_valid_email_domains(params.require(:automatic_membership_email_domains))
     group_id = params[:id]
     user_count = 0
 
@@ -104,7 +100,7 @@ class Admin::GroupsController < Admin::StaffController
       end
     end
 
-    render json: { user_count:, invalid_domains: invalid_domains.uniq }
+    render json: { user_count: }
   end
 
   protected

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -143,7 +143,7 @@ class Group < ActiveRecord::Base
     everyone: 99,
   }
 
-  VALID_DOMAIN_REGEX = /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,24}(:[0-9]{1,5})?(\/.*)?\Z/i
+  VALID_DOMAIN_REGEX = /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,24}\Z/i
 
   def self.visibility_levels
     @visibility_levels = Enum.new(public: 0, logged_on_users: 1, members: 2, staff: 3, owners: 4)
@@ -1189,8 +1189,16 @@ class Group < ActiveRecord::Base
     value
       .split("|")
       .each do |domain|
-        domain.sub!(%r{\Ahttps?://}, "")
-        domain.sub!(%r{/.*\z}, "")
+        domain =
+          domain
+            .strip
+            .downcase
+            .sub(%r{\Ahttps?://}, "")
+            .sub(%r{/.*\z}, "")
+            .sub(/\A.*@/, "")
+            .sub(/:\d+\z/, "")
+
+        next if domain.blank?
 
         if domain =~ Group::VALID_DOMAIN_REGEX
           valid_domains << domain
@@ -1199,7 +1207,7 @@ class Group < ActiveRecord::Base
         end
       end
 
-    valid_domains
+    valid_domains.uniq
   end
 
   private

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7459,10 +7459,7 @@ en:
             effects: Effects
             trust_levels_none: "None"
             automatic_membership_email_domains: "Users who register with an email domain that exactly matches one in this list will be automatically added to this group:"
-            automatic_membership_email_domains_instructions: "Enter each domain on its own, without the @ symbol, for example discourse.org."
-            automatic_membership_email_domains_invalid:
-              one: "%{domains} isn't a valid domain. Enter a bare domain, for example discourse.org."
-              other: "These aren't valid domains: %{domains}. Enter each as a bare domain, for example discourse.org."
+            automatic_membership_email_domains_instructions: "Enter each domain on its own, for example discourse.org."
             automatic_membership_user_count:
               one: "%{count} user has the new email domains and will be added to the group."
               other: "%{count} users have the new email domains and will be added to the group."

--- a/frontend/discourse/app/services/group-automatic-members-dialog.js
+++ b/frontend/discourse/app/services/group-automatic-members-dialog.js
@@ -27,19 +27,6 @@ export default class GroupAutomaticMembersDialog extends Service {
         }
       );
 
-      if (result.invalid_domains?.length) {
-        this.dialog.alert(
-          i18n(
-            "admin.groups.manage.membership.automatic_membership_email_domains_invalid",
-            {
-              count: result.invalid_domains.length,
-              domains: result.invalid_domains.join(", "),
-            }
-          )
-        );
-        return false;
-      }
-
       const count = result.user_count;
 
       if (count === null) {

--- a/frontend/discourse/tests/acceptance/group-manage-membership-test.js
+++ b/frontend/discourse/tests/acceptance/group-manage-membership-test.js
@@ -33,14 +33,9 @@ acceptance("Managing Group Membership", function (needs) {
       return helper.response({ success: "OK" });
     });
 
-    server.put("/admin/groups/automatic_membership_count.json", (request) => {
-      const domains = (
-        helper.parsePostData(request.requestBody)
-          .automatic_membership_email_domains || ""
-      ).split("|");
-      const invalid_domains = domains.filter((domain) => domain.includes("@"));
-      return helper.response({ user_count: 0, invalid_domains });
-    });
+    server.put("/admin/groups/automatic_membership_count.json", () =>
+      helper.response({ user_count: 0 })
+    );
   });
 
   needs.hooks.beforeEach(() => (savedGroup = null));
@@ -110,7 +105,7 @@ acceptance("Managing Group Membership", function (needs) {
     assert.strictEqual(emailDomains.header().value(), "foo.com");
   });
 
-  test("warns and blocks the save when a domain includes '@'", async function (assert) {
+  test("saves silently when a domain includes '@' (the server normalizes it)", async function (assert) {
     updateCurrentUser({ can_create_group: true });
 
     await visit("/g/alternative-group/manage/membership");
@@ -126,15 +121,8 @@ acceptance("Managing Group Membership", function (needs) {
 
     assert
       .dom(".dialog-body")
-      .hasText(
-        i18n(
-          "admin.groups.manage.membership.automatic_membership_email_domains_invalid",
-          { count: 1, domains: "@harness.io" }
-        ),
-        "shows the invalid-domain warning"
-      );
-
-    assert.strictEqual(savedGroup, null, "does not save the group");
+      .doesNotExist("does not warn about the leading @");
+    assert.notStrictEqual(savedGroup, null, "saves the group");
   });
 
   test("the join method constrains the group's visibility options", async function (assert) {
@@ -320,7 +308,7 @@ acceptance(
     needs.user();
     needs.pretender((server, helper) => {
       server.put("/admin/groups/automatic_membership_count.json", () =>
-        helper.response({ user_count: null, invalid_domains: [] })
+        helper.response({ user_count: null })
       );
 
       server.put("/groups/57", (request) => {

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -174,13 +174,19 @@ RSpec.describe Group do
     end
 
     it "is invalid for poorly formatted domains" do
-      group.automatic_membership_email_domains = "wikipedia.org|*@example.com"
+      group.automatic_membership_email_domains = "wikipedia.org|not a domain"
       expect(group.valid?).to eq false
     end
 
     it "is valid for proper domains" do
       group.automatic_membership_email_domains = "discourse.org|wikipedia.org"
       expect(group.valid?).to eq true
+    end
+
+    it "normalizes domains that include an @ or surrounding whitespace" do
+      group.automatic_membership_email_domains = " @discourse.org | jane@wikipedia.org "
+      expect(group.valid?).to eq true
+      expect(group.automatic_membership_email_domains).to eq("discourse.org|wikipedia.org")
     end
 
     it "is invalid for too many domains" do
@@ -243,6 +249,36 @@ RSpec.describe Group do
 
         expect(group.valid?).to eq(true)
       end
+    end
+  end
+
+  describe ".get_valid_email_domains" do
+    it "normalizes URLs, emails, ports, case, and surrounding whitespace to bare domains" do
+      expect(Group.get_valid_email_domains("HTTPS://Discourse.ORG/path")).to eq(["discourse.org"])
+      expect(Group.get_valid_email_domains("@discourse.org")).to eq(["discourse.org"])
+      expect(Group.get_valid_email_domains("jane@discourse.org")).to eq(["discourse.org"])
+      expect(Group.get_valid_email_domains("a@b@discourse.org")).to eq(["discourse.org"])
+      expect(Group.get_valid_email_domains("  discourse.org  ")).to eq(["discourse.org"])
+      expect(Group.get_valid_email_domains("discourse.org:8080")).to eq(["discourse.org"])
+    end
+
+    it "collapses entries that normalize to the same domain, ignoring case" do
+      expect(Group.get_valid_email_domains("sales@acme.io|support@acme.io")).to eq(["acme.io"])
+      expect(Group.get_valid_email_domains("Acme.io|acme.io")).to eq(["acme.io"])
+    end
+
+    it "skips blank entries left by stray pipes or a bare @" do
+      invalid = []
+      valid = Group.get_valid_email_domains("acme.io||jane@") { |d| invalid << d }
+      expect(valid).to eq(["acme.io"])
+      expect(invalid).to be_empty
+    end
+
+    it "yields the normalized value for genuinely invalid domains" do
+      invalid = []
+      valid = Group.get_valid_email_domains("@discourse.org|not a domain") { |d| invalid << d }
+      expect(valid).to eq(["discourse.org"])
+      expect(invalid).to eq(["not a domain"])
     end
   end
 

--- a/spec/requests/admin/groups_controller_spec.rb
+++ b/spec/requests/admin/groups_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Admin::GroupsController do
       end
 
       context "with automatic membership email domains" do
-        it "surfaces a clear validation error when a domain includes '@'" do
+        it "normalizes a domain that includes '@' and creates the group" do
           post "/admin/groups.json",
                params: {
                  group: {
@@ -109,9 +109,22 @@ RSpec.describe Admin::GroupsController do
                  },
                }
 
+          expect(response.status).to eq(200)
+          expect(Group.last.automatic_membership_email_domains).to eq("harness.io")
+        end
+
+        it "surfaces a clear validation error for a genuinely invalid domain" do
+          post "/admin/groups.json",
+               params: {
+                 group: {
+                   name: "harness-staff",
+                   automatic_membership_email_domains: "not a domain",
+                 },
+               }
+
           expect(response.status).to eq(422)
           expect(response.parsed_body["errors"]).to include(
-            I18n.t("groups.errors.invalid_domain", domain: "@harness.io"),
+            I18n.t("groups.errors.invalid_domain", domain: "not a domain"),
           )
           expect(response.parsed_body["failed"]).to be_nil
         end
@@ -464,6 +477,14 @@ RSpec.describe Admin::GroupsController do
   end
 
   describe "#automatic_membership_count" do
+    def count_domains(domains)
+      put "/admin/groups/automatic_membership_count.json",
+          params: {
+            automatic_membership_email_domains: domains,
+            id: group.id,
+          }
+    end
+
     context "when logged in as admin" do
       before { sign_in(admin) }
 
@@ -471,79 +492,42 @@ RSpec.describe Admin::GroupsController do
         Fabricate(:user, email: "user1@somedomain.org")
         Fabricate(:user, email: "user1@somedomain.com")
         Fabricate(:user, email: "user1@notsomedomain.com")
-        group = Fabricate(:group)
 
-        put "/admin/groups/automatic_membership_count.json",
-            params: {
-              automatic_membership_email_domains: "somedomain.org|somedomain.com",
-              id: group.id,
-            }
+        count_domains("somedomain.org|somedomain.com")
+
         expect(response.status).to eq(200)
         expect(response.parsed_body["user_count"]).to eq(2)
       end
 
-      it "skips the count but still responds for a long list of valid domains" do
-        put "/admin/groups/automatic_membership_count.json",
-            params: {
-              automatic_membership_email_domains: 1.upto(11).map { |n| "domain#{n}.com" }.join("|"),
-              id: group.id,
-            }
+      it "returns a null count for a long list of domains" do
+        count_domains(1.upto(11).map { |n| "domain#{n}.com" }.join("|"))
+
         expect(response.status).to eq(200)
         expect(response.parsed_body["user_count"]).to be_nil
-        expect(response.parsed_body["invalid_domains"]).to be_empty
       end
 
-      it "still reports invalid domains when the count is skipped" do
-        domains = (1.upto(11).map { |n| "domain#{n}.com" } + ["@bad.io"]).join("|")
-
-        put "/admin/groups/automatic_membership_count.json",
-            params: {
-              automatic_membership_email_domains: domains,
-              id: group.id,
-            }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["user_count"]).to be_nil
-        expect(response.parsed_body["invalid_domains"]).to contain_exactly("@bad.io")
-      end
-
-      it "doesn't respond with 500 if domain is invalid and reports the invalid domains" do
-        group = Fabricate(:group)
-
-        put "/admin/groups/automatic_membership_count.json",
-            params: {
-              automatic_membership_email_domains: "@somedomain.org|@somedomain.com",
-              id: group.id,
-            }
-        expect(response.status).to eq(200)
-        expect(response.parsed_body["user_count"]).to eq(0)
-        expect(response.parsed_body["invalid_domains"]).to contain_exactly(
-          "@somedomain.org",
-          "@somedomain.com",
-        )
-      end
-
-      it "reports invalid domains alongside the valid count" do
+      it "ignores invalid domains when counting the matches" do
         Fabricate(:user, email: "user1@somedomain.org")
-        group = Fabricate(:group)
 
-        put "/admin/groups/automatic_membership_count.json",
-            params: {
-              automatic_membership_email_domains: "somedomain.org|@bad.com",
-              id: group.id,
-            }
+        count_domains("somedomain.org|not a domain")
+
         expect(response.status).to eq(200)
         expect(response.parsed_body["user_count"]).to eq(1)
-        expect(response.parsed_body["invalid_domains"]).to contain_exactly("@bad.com")
+      end
+
+      it "normalizes domains that include '@' before counting" do
+        Fabricate(:user, email: "user1@somedomain.org")
+
+        count_domains("@somedomain.org")
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["user_count"]).to eq(1)
       end
     end
 
     shared_examples "automatic membership count inaccessible" do
       it "denies access with a 404 response" do
-        put "/admin/groups/automatic_membership_count.json",
-            params: {
-              automatic_membership_email_domains: "somedomain.org|somedomain.com",
-              id: group.id,
-            }
+        count_domains("somedomain.org|somedomain.com")
 
         expect(response.status).to eq(404)
         expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
@@ -559,11 +543,7 @@ RSpec.describe Admin::GroupsController do
         it "returns count of users whose emails match the domain" do
           Fabricate(:user, email: "user1@somedomain.org")
 
-          put "/admin/groups/automatic_membership_count.json",
-              params: {
-                automatic_membership_email_domains: "somedomain.org",
-                id: group.id,
-              }
+          count_domains("somedomain.org")
 
           expect(response.status).to eq(200)
           expect(response.parsed_body["user_count"]).to eq(1)
@@ -574,11 +554,7 @@ RSpec.describe Admin::GroupsController do
         before { SiteSetting.moderators_manage_groups = false }
 
         it "denies access with a 403 response" do
-          put "/admin/groups/automatic_membership_count.json",
-              params: {
-                automatic_membership_email_domains: "somedomain.org",
-                id: group.id,
-              }
+          count_domains("somedomain.org")
 
           expect(response.status).to eq(403)
         end


### PR DESCRIPTION
Previously, entering an automatic membership email domain that included an `@` (such as `@acme.io` or a pasted email or URL) warned the admin and blocked the save until they hand-edited it down to a bare domain.

This change quietly normalizes those entries to the bare domain — stripping any scheme, path, port, `@` prefix, casing, and surrounding whitespace — so common paste mistakes just work, while the server still rejects genuinely invalid domains on save.

Follow up to #41233
