### PR TITLE
DEV: auto-silence only if a post is queued

### DIFF
--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -173,7 +173,7 @@ class NewPostManager
 
     result = manager.enqueue(reason)
 
-    if result.success?
+    if result.success? || (reason == :email_spam && is_first_post?(manager))
       I18n.with_locale(SiteSetting.default_locale) do
         if is_fast_typer?(manager)
           UserSilencer.auto_silence(

--- a/lib/new_post_manager.rb
+++ b/lib/new_post_manager.rb
@@ -173,28 +173,30 @@ class NewPostManager
 
     result = manager.enqueue(reason)
 
-    I18n.with_locale(SiteSetting.default_locale) do
-      if is_fast_typer?(manager)
-        UserSilencer.auto_silence(
-          manager.user,
-          Discourse.system_user,
-          keep_posts: true,
-          reason: I18n.t("user.new_user_typed_too_fast"),
-        )
-      elsif auto_silence?(manager) || matches_auto_silence_regex?(manager)
-        UserSilencer.auto_silence(
-          manager.user,
-          Discourse.system_user,
-          keep_posts: true,
-          reason: I18n.t("user.content_matches_auto_silence_regex"),
-        )
-      elsif reason == :email_spam && is_first_post?(manager)
-        UserSilencer.auto_silence(
-          manager.user,
-          Discourse.system_user,
-          keep_posts: true,
-          reason: I18n.t("user.email_in_spam_header"),
-        )
+    if result.success?
+      I18n.with_locale(SiteSetting.default_locale) do
+        if is_fast_typer?(manager)
+          UserSilencer.auto_silence(
+            manager.user,
+            Discourse.system_user,
+            keep_posts: true,
+            reason: I18n.t("user.new_user_typed_too_fast"),
+          )
+        elsif auto_silence?(manager) || matches_auto_silence_regex?(manager)
+          UserSilencer.auto_silence(
+            manager.user,
+            Discourse.system_user,
+            keep_posts: true,
+            reason: I18n.t("user.content_matches_auto_silence_regex"),
+          )
+        elsif reason == :email_spam && is_first_post?(manager)
+          UserSilencer.auto_silence(
+            manager.user,
+            Discourse.system_user,
+            keep_posts: true,
+            reason: I18n.t("user.email_in_spam_header"),
+          )
+        end
       end
     end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1521,6 +1521,27 @@ RSpec.describe PostsController do
           expect(user).not_to be_silenced
         end
 
+        it "does not silence when the post cannot be queued" do
+          topic = Fabricate(:topic)
+          user.change_trust_level!(TrustLevel[0])
+
+          post "/posts.json",
+               params: {
+                 raw:
+                   "this is the test content\n\n<img src='https://example.com/first.png'>\n\n<img src='https://example.com/second.png'>",
+                 topic_id: topic.id,
+                 composer_open_duration_msecs: 204,
+                 typing_duration_msecs: 100,
+               }
+
+          expect(response).not_to be_successful
+          expect(response.parsed_body["errors"]).to be_present
+          expect(ReviewableQueuedPost.find_by(target_created_by: user)).to be_blank
+
+          user.reload
+          expect(user).not_to be_silenced
+        end
+
         it "doesn't enqueue posts when user first creates a topic" do
           topic = Fabricate(:post, user: user).topic
 


### PR DESCRIPTION
A new user could previously get in a permanent silenced state by simply uploading 2 or more media items in their first post by uploading quickly and not adding any content. Our code would silence them (via fast typing detection) and not queue the reviewable because the post would be rejected, from `newuser_max_embedded_media`.

This fix ensures that the silence only happens if the post is queued for review.