### PR TITLE
DEV: Add `full-page-refresh-on-navigation` value transformer

### DIFF
--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -69,6 +69,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "flag-custom-placeholder",
   "flag-description",
   "flag-formatted-name",
+  "full-page-refresh-on-navigation",
   "hamburger-dropdown-click-outside-exceptions",
   "header-notifications-avatar-size",
   "home-logo-href",

--- a/frontend/discourse/app/lib/url.js
+++ b/frontend/discourse/app/lib/url.js
@@ -248,11 +248,14 @@ class DiscourseURL extends EmberObject {
       }
     }
 
-    const shouldRefresh = applyValueTransformer(
+    let shouldRefresh =
+      Session.currentProp("requiresRefresh") && !this.isComposerOpen;
+    shouldRefresh = applyValueTransformer(
       "full-page-refresh-on-navigation",
-      Session.currentProp("requiresRefresh") && !this.isComposerOpen,
+      shouldRefresh,
       { url: path }
     );
+
     if (shouldRefresh) {
       return this.redirectTo(path);
     }

--- a/frontend/discourse/app/lib/url.js
+++ b/frontend/discourse/app/lib/url.js
@@ -248,7 +248,13 @@ class DiscourseURL extends EmberObject {
       }
     }
 
-    if (Session.currentProp("requiresRefresh") && !this.isComposerOpen) {
+    if (
+      Session.currentProp("requiresRefresh") &&
+      !this.isComposerOpen &&
+      applyValueTransformer("full-page-refresh-on-navigation", true, {
+        url: path,
+      })
+    ) {
       return this.redirectTo(path);
     }
 

--- a/frontend/discourse/app/lib/url.js
+++ b/frontend/discourse/app/lib/url.js
@@ -248,13 +248,12 @@ class DiscourseURL extends EmberObject {
       }
     }
 
-    if (
-      Session.currentProp("requiresRefresh") &&
-      !this.isComposerOpen &&
-      applyValueTransformer("full-page-refresh-on-navigation", true, {
-        url: path,
-      })
-    ) {
+    const shouldRefresh = applyValueTransformer(
+      "full-page-refresh-on-navigation",
+      Session.currentProp("requiresRefresh") && !this.isComposerOpen,
+      { url: path }
+    );
+    if (shouldRefresh) {
       return this.redirectTo(path);
     }
 

--- a/frontend/discourse/app/ui-kit/d-nav-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-nav-item.gjs
@@ -6,6 +6,7 @@ import { trustHTML } from "@ember/template";
 import { isPresent } from "@ember/utils";
 import getURL from "discourse/lib/get-url";
 import { iconHTML } from "discourse/lib/icon-library";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
@@ -77,9 +78,15 @@ export default class DNavItem extends Component {
       return null;
     }
     try {
-      return this.args.routeParam
+      const href = this.args.routeParam
         ? getURL(this.router.urlFor(this.args.route, this.args.routeParam))
         : getURL(this.router.urlFor(this.args.route));
+
+      return applyValueTransformer("full-page-refresh-on-navigation", true, {
+        url: href,
+      })
+        ? href
+        : null;
     } catch {
       return null;
     }

--- a/frontend/discourse/app/ui-kit/d-nav-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-nav-item.gjs
@@ -74,7 +74,7 @@ export default class DNavItem extends Component {
   }
 
   get refreshHref() {
-    if (!this.session.requiresRefresh || !this.args.route) {
+    if (!this.args.route) {
       return null;
     }
     try {
@@ -82,11 +82,12 @@ export default class DNavItem extends Component {
         ? getURL(this.router.urlFor(this.args.route, this.args.routeParam))
         : getURL(this.router.urlFor(this.args.route));
 
-      return applyValueTransformer("full-page-refresh-on-navigation", true, {
-        url: href,
-      })
-        ? href
-        : null;
+      const shouldRefresh = applyValueTransformer(
+        "full-page-refresh-on-navigation",
+        this.session.requiresRefresh,
+        { url: href }
+      );
+      return shouldRefresh ? href : null;
     } catch {
       return null;
     }

--- a/frontend/discourse/tests/unit/lib/url-test.js
+++ b/frontend/discourse/tests/unit/lib/url-test.js
@@ -2,6 +2,7 @@ import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import { setPrefix } from "discourse/lib/get-url";
+import { withPluginApi } from "discourse/lib/plugin-api";
 import DiscourseURL, {
   getCanonicalUrl,
   getCategoryAndTagUrl,
@@ -9,6 +10,7 @@ import DiscourseURL, {
   prefixProtocol,
   userPath,
 } from "discourse/lib/url";
+import Session from "discourse/models/session";
 import { logIn } from "discourse/tests/helpers/qunit-helpers";
 
 module("Unit | Utility | url", function (hooks) {
@@ -326,6 +328,43 @@ module("Unit | Utility | url", function (hooks) {
         DiscourseURL.redirectTo.calledWith(route),
         `${route} is redirected to server`
       );
+    }
+  });
+
+  test("routeTo full page loads when a refresh is required", async function (assert) {
+    sinon.stub(DiscourseURL, "isComposerOpen").get(() => false);
+    sinon.stub(DiscourseURL, "redirectTo");
+    sinon.stub(DiscourseURL, "handleURL");
+
+    try {
+      Session.currentProp("requiresRefresh", true);
+
+      DiscourseURL.routeTo("/t/some-topic/123");
+      assert.true(
+        DiscourseURL.redirectTo.calledWith("/t/some-topic/123"),
+        "does a full page load when a refresh is required"
+      );
+
+      DiscourseURL.redirectTo.resetHistory();
+
+      withPluginApi((api) => {
+        api.registerValueTransformer(
+          "full-page-refresh-on-navigation",
+          () => false
+        );
+      });
+
+      DiscourseURL.routeTo("/t/some-topic/123");
+      assert.false(
+        DiscourseURL.redirectTo.called,
+        "the transformer can defer the full page load"
+      );
+      assert.true(
+        DiscourseURL.handleURL.calledWith("/t/some-topic/123"),
+        "navigates within the app instead"
+      );
+    } finally {
+      Session.resetCurrent(null);
     }
   });
 


### PR DESCRIPTION
Previously, when a new client version was deployed, the next navigation always became a full page load, which destroyed long-lived client state — for example dropping users out of an ongoing voice call.

This change wraps that decision (in `DiscourseURL#routeTo` and `DNavItem`) in a new `full-page-refresh-on-navigation` value transformer, so plugins can defer the reload while such state is active; the refresh then happens on the first navigation after the transformer stops deferring it.