### PR TITLE
DEV: Add usage metrics for workflows, automations, and data explorer

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3526,6 +3526,37 @@ ALTER SEQUENCE public.data_explorer_query_groups_id_seq OWNED BY public.data_exp
 
 
 --
+-- Name: data_explorer_query_stats; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.data_explorer_query_stats (
+    id bigint NOT NULL,
+    query_id bigint NOT NULL,
+    date date NOT NULL,
+    total_runs integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: data_explorer_query_stats_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.data_explorer_query_stats_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: data_explorer_query_stats_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.data_explorer_query_stats_id_seq OWNED BY public.data_explorer_query_stats.id;
+
+
+--
 -- Name: developers; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4583,6 +4614,37 @@ CREATE TABLE public.discourse_workflows_execution_data (
     data jsonb DEFAULT '{}'::jsonb NOT NULL,
     workflow_data jsonb DEFAULT '{}'::jsonb NOT NULL
 );
+
+
+--
+-- Name: discourse_workflows_execution_stats; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.discourse_workflows_execution_stats (
+    id bigint NOT NULL,
+    workflow_id bigint NOT NULL,
+    date date NOT NULL,
+    total_runs integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: discourse_workflows_execution_stats_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.discourse_workflows_execution_stats_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: discourse_workflows_execution_stats_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.discourse_workflows_execution_stats_id_seq OWNED BY public.discourse_workflows_execution_stats.id;
 
 
 --
@@ -12738,6 +12800,13 @@ ALTER TABLE ONLY public.data_explorer_query_groups ALTER COLUMN id SET DEFAULT n
 
 
 --
+-- Name: data_explorer_query_stats id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.data_explorer_query_stats ALTER COLUMN id SET DEFAULT nextval('public.data_explorer_query_stats_id_seq'::regclass);
+
+
+--
 -- Name: developers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -12945,6 +13014,13 @@ ALTER TABLE ONLY public.discourse_workflows_credentials ALTER COLUMN id SET DEFA
 --
 
 ALTER TABLE ONLY public.discourse_workflows_data_tables ALTER COLUMN id SET DEFAULT nextval('public.discourse_workflows_data_tables_id_seq'::regclass);
+
+
+--
+-- Name: discourse_workflows_execution_stats id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discourse_workflows_execution_stats ALTER COLUMN id SET DEFAULT nextval('public.discourse_workflows_execution_stats_id_seq'::regclass);
 
 
 --
@@ -15020,6 +15096,14 @@ ALTER TABLE ONLY public.data_explorer_query_groups
 
 
 --
+-- Name: data_explorer_query_stats data_explorer_query_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.data_explorer_query_stats
+    ADD CONSTRAINT data_explorer_query_stats_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: developers developers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -15265,6 +15349,14 @@ ALTER TABLE ONLY public.discourse_workflows_credentials
 
 ALTER TABLE ONLY public.discourse_workflows_data_tables
     ADD CONSTRAINT discourse_workflows_data_tables_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: discourse_workflows_execution_stats discourse_workflows_execution_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discourse_workflows_execution_stats
+    ADD CONSTRAINT discourse_workflows_execution_stats_pkey PRIMARY KEY (id);
 
 
 --
@@ -17295,6 +17387,13 @@ CREATE UNIQUE INDEX idx_dwf_execution_data_on_execution_id ON public.discourse_w
 
 
 --
+-- Name: idx_dwf_execution_stats_on_workflow_id_and_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_dwf_execution_stats_on_workflow_id_and_date ON public.discourse_workflows_execution_stats USING btree (workflow_id, date);
+
+
+--
 -- Name: idx_dwf_executions_on_resume_token; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -18776,6 +18875,13 @@ CREATE INDEX index_data_explorer_query_groups_on_query_id ON public.data_explore
 --
 
 CREATE UNIQUE INDEX index_data_explorer_query_groups_on_query_id_and_group_id ON public.data_explorer_query_groups USING btree (query_id, group_id);
+
+
+--
+-- Name: index_data_explorer_query_stats_on_query_id_and_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_data_explorer_query_stats_on_query_id_and_date ON public.data_explorer_query_stats USING btree (query_id, date);
 
 
 --
@@ -22472,6 +22578,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260708095336'),
 ('20260708080308'),
 ('20260707013407'),
+('20260703164430'),
+('20260703163425'),
 ('20260702102111'),
 ('20260701073045'),
 ('20260630034050'),

--- a/lib/period_count_helper.rb
+++ b/lib/period_count_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PeriodCountHelper
+  def period_counts(scope, column, count: true, &aggregate)
+    aggregate ||= ->(relation) { relation.count }
+    col = scope.arel_table[column]
+    result = {
+      last_day: aggregate.call(scope.where(col.gt(1.day.ago))),
+      "7_days": aggregate.call(scope.where(col.gt(7.days.ago))),
+      "30_days": aggregate.call(scope.where(col.gt(30.days.ago))),
+      previous_30_days: aggregate.call(scope.where(col.between(60.days.ago..30.days.ago))),
+    }
+    result[:count] = aggregate.call(scope) if count
+    result
+  end
+end

--- a/lib/plugin/instance.rb
+++ b/lib/plugin/instance.rb
@@ -1238,7 +1238,11 @@ class Plugin::Instance
   # }
   def register_stat(name, expose_via_api: false, stat_type: nil, &block)
     # We do not want to register and display the same group multiple times.
-    return if DiscoursePluginRegistry.stats.any? { |stat| stat.name == name }
+    if DiscoursePluginRegistry.stats.any? { |stat|
+         stat.name == name && stat.stat_type == stat_type
+       }
+      return
+    end
 
     stat = Stat.new(name, expose_via_api: expose_via_api, stat_type: stat_type, &block)
     DiscoursePluginRegistry.register_stat(stat, self)

--- a/plugins/automation/lib/discourse_automation/statistics.rb
+++ b/plugins/automation/lib/discourse_automation/statistics.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DiscourseAutomation
+  module Statistics
+    extend PeriodCountHelper
+
+    def self.total
+      { count: Automation.count }
+    end
+
+    def self.created
+      period_counts(Automation.all, :created_at, count: false)
+    end
+
+    def self.edited
+      period_counts(Automation.where("updated_at > created_at"), :updated_at, count: false)
+    end
+
+    def self.executed
+      period_counts(DiscourseAutomation::Stat.all, :date, count: false) do |scope|
+        scope.distinct.count(:automation_id)
+      end
+    end
+
+    def self.executions
+      period_counts(DiscourseAutomation::Stat.all, :date) { |scope| scope.sum(:total_runs) }
+    end
+  end
+end

--- a/plugins/automation/plugin.rb
+++ b/plugins/automation/plugin.rb
@@ -259,4 +259,12 @@ after_initialize do
   register_user_custom_field_type(DiscourseAutomation::AUTOMATION_IDS_CUSTOM_FIELD, :json)
   register_post_custom_field_type(DiscourseAutomation::AUTOMATION_IDS_CUSTOM_FIELD, :json)
   register_post_custom_field_type("stalled_wiki_triggered_at", :string)
+
+  register_stat("total", stat_type: :automations) { DiscourseAutomation::Statistics.total }
+  register_stat("created", stat_type: :automations) { DiscourseAutomation::Statistics.created }
+  register_stat("edited", stat_type: :automations) { DiscourseAutomation::Statistics.edited }
+  register_stat("executed", stat_type: :automations) { DiscourseAutomation::Statistics.executed }
+  register_stat("executions", stat_type: :automations) do
+    DiscourseAutomation::Statistics.executions
+  end
 end

--- a/plugins/automation/spec/lib/discourse_automation/statistics_spec.rb
+++ b/plugins/automation/spec/lib/discourse_automation/statistics_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAutomation::Statistics do
+  before { freeze_time(Time.utc(2026, 6, 15, 12, 0)) }
+
+  def create_stat(automation_id, date:, runs: 1)
+    DiscourseAutomation::Stat.create!(
+      automation_id: automation_id,
+      date: date,
+      last_run_at: date.to_time + 10.hours,
+      total_time: 1.0,
+      average_run_time: 1.0,
+      min_run_time: 1.0,
+      max_run_time: 1.0,
+      total_runs: runs,
+      total_errors: 0,
+    )
+  end
+
+  describe ".total" do
+    it "counts every automation" do
+      Fabricate(:automation)
+      Fabricate(:automation)
+
+      expect(described_class.total).to eq(count: 2)
+    end
+  end
+
+  describe ".created" do
+    it "counts automations created within each window" do
+      Fabricate(:automation)
+      Fabricate(:automation).update_columns(created_at: 10.days.ago)
+      Fabricate(:automation).update_columns(created_at: 45.days.ago)
+
+      expect(described_class.created).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 2,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".edited" do
+    it "counts automations modified after creation, ignoring never-edited ones" do
+      recently = Fabricate(:automation)
+      recently.update_columns(created_at: 3.days.ago, updated_at: Time.current)
+
+      previously = Fabricate(:automation)
+      previously.update_columns(created_at: 50.days.ago, updated_at: 45.days.ago)
+
+      never_edited = Fabricate(:automation)
+      never_edited.update_columns(created_at: 5.days.ago, updated_at: 5.days.ago)
+
+      expect(described_class.edited).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 1,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".executed" do
+    it "counts distinct automations with runs in each window" do
+      create_stat(1, date: Date.current, runs: 3)
+      create_stat(1, date: 10.days.ago.to_date, runs: 2)
+      create_stat(2, date: 45.days.ago.to_date, runs: 5)
+
+      expect(described_class.executed).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 1,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".executions" do
+    it "sums runs in each window plus a lifetime count" do
+      create_stat(1, date: Date.current, runs: 3)
+      create_stat(1, date: 10.days.ago.to_date, runs: 2)
+      create_stat(1, date: 45.days.ago.to_date, runs: 5)
+
+      expect(described_class.executions).to eq(
+        last_day: 3,
+        "7_days": 3,
+        "30_days": 5,
+        previous_30_days: 5,
+        count: 10,
+      )
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
+++ b/plugins/discourse-data-explorer/app/controllers/discourse_data_explorer/query_controller.rb
@@ -252,7 +252,7 @@ module DiscourseDataExplorer
       rate_limit_query_runs!
 
       query = Query.find(params[:id].to_i)
-      query.update!(last_run_at: Time.now)
+      query.record_run!
 
       explain = params[:explain] == "true"
       return run_download(query, explain:) if params[:download]

--- a/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query.rb
+++ b/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query.rb
@@ -30,6 +30,12 @@ module DiscourseDataExplorer
             )
           end
 
+    scope :user_queries, -> { where(hidden: false).where("id > 0") }
+
+    def self.is_default_query?(id)
+      id.to_i < 0
+    end
+
     def params
       @params ||= Parameter.create_from_sql(sql)
     end
@@ -46,8 +52,13 @@ module DiscourseDataExplorer
       Slug.for(name).presence || "query-#{id}"
     end
 
+    def record_run!
+      persisted? ? update_columns(last_run_at: Time.now) : update!(last_run_at: Time.now)
+      DiscourseDataExplorer::QueryStat.log(id) unless Query.is_default_query?(id)
+    end
+
     def self.find(id)
-      return super if id.to_i >= 0
+      return super unless is_default_query?(id)
       QueryFinder.find(id)
     end
 
@@ -75,7 +86,7 @@ module DiscourseDataExplorer
     # for `Query.unscoped.find`
     class ActiveRecord_Relation
       def find(id)
-        return super if id.to_i >= 0
+        return super unless Query.is_default_query?(id)
         QueryFinder.find(id)
       end
     end

--- a/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query_stat.rb
+++ b/plugins/discourse-data-explorer/app/models/discourse_data_explorer/query_stat.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DiscourseDataExplorer
+  class QueryStat < ActiveRecord::Base
+    self.table_name = "data_explorer_query_stats"
+
+    scope :for_user_queries, -> { where("query_id > 0") }
+
+    def self.log(query_id, date: Date.current)
+      DB.exec(<<~SQL, query_id: query_id, date: date)
+        INSERT INTO data_explorer_query_stats (query_id, date, total_runs)
+        VALUES (:query_id, :date, 1)
+        ON CONFLICT (query_id, date)
+        DO UPDATE SET total_runs = data_explorer_query_stats.total_runs + 1
+      SQL
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: data_explorer_query_stats
+#
+#  id         :bigint           not null, primary key
+#  date       :date             not null
+#  total_runs :integer          default(0), not null
+#  query_id   :bigint           not null
+#
+# Indexes
+#
+#  index_data_explorer_query_stats_on_query_id_and_date  (query_id,date) UNIQUE
+#

--- a/plugins/discourse-data-explorer/db/migrate/20260703164430_create_data_explorer_query_stats.rb
+++ b/plugins/discourse-data-explorer/db/migrate/20260703164430_create_data_explorer_query_stats.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class CreateDataExplorerQueryStats < ActiveRecord::Migration[8.0]
+  def change
+    create_table :data_explorer_query_stats do |t|
+      t.bigint :query_id, null: false
+      t.date :date, null: false
+      t.integer :total_runs, null: false, default: 0
+    end
+
+    add_index :data_explorer_query_stats, %i[query_id date], unique: true
+  end
+end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/report_generator.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/report_generator.rb
@@ -15,7 +15,7 @@ module DiscourseDataExplorer
       params = params_to_hash(query_params)
 
       result = DataExplorer.run_query(query, params)
-      query.update!(last_run_at: Time.now)
+      query.record_run!
 
       return [] if opts[:skip_empty] && result[:pg_result].values.empty?
       table =
@@ -31,7 +31,7 @@ module DiscourseDataExplorer
       params = params_to_hash(query_params)
 
       result = DataExplorer.run_query(query, params)
-      query.update!(last_run_at: Time.now)
+      query.record_run!
 
       return {} if opts[:skip_empty] && result[:pg_result].values.empty?
       table =

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/statistics.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/statistics.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DiscourseDataExplorer
+  module Statistics
+    extend PeriodCountHelper
+
+    def self.queries_total
+      { count: Query.user_queries.count }
+    end
+
+    def self.queries_created
+      period_counts(Query.user_queries, :created_at, count: false)
+    end
+
+    def self.queries_edited
+      period_counts(Query.user_queries.where("updated_at > created_at"), :updated_at, count: false)
+    end
+
+    def self.queries_executed
+      period_counts(QueryStat.for_user_queries, :date, count: false) do |scope|
+        scope.distinct.count(:query_id)
+      end
+    end
+
+    def self.executions
+      period_counts(QueryStat.for_user_queries, :date) { |scope| scope.sum(:total_runs) }
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/plugin.rb
+++ b/plugins/discourse-data-explorer/plugin.rb
@@ -219,4 +219,16 @@ after_initialize do
       plugin: self,
     )
   end
+
+  register_stat("queries_total", stat_type: :de) { DiscourseDataExplorer::Statistics.queries_total }
+  register_stat("queries_created", stat_type: :de) do
+    DiscourseDataExplorer::Statistics.queries_created
+  end
+  register_stat("queries_edited", stat_type: :de) do
+    DiscourseDataExplorer::Statistics.queries_edited
+  end
+  register_stat("queries_executed", stat_type: :de) do
+    DiscourseDataExplorer::Statistics.queries_executed
+  end
+  register_stat("executions", stat_type: :de) { DiscourseDataExplorer::Statistics.executions }
 end

--- a/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/statistics_spec.rb
+++ b/plugins/discourse-data-explorer/spec/lib/discourse_data_explorer/statistics_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseDataExplorer::Statistics do
+  before { freeze_time(Time.utc(2026, 6, 15, 12, 0)) }
+
+  fab!(:user)
+
+  def log_runs(query_id, date:, runs: 1)
+    DiscourseDataExplorer::QueryStat.create!(query_id: query_id, date: date, total_runs: runs)
+  end
+
+  describe ".queries_total" do
+    it "counts non-hidden user queries" do
+      Fabricate(:query)
+      Fabricate(:query)
+      Fabricate(:query, hidden: true)
+
+      expect(described_class.queries_total).to eq(count: 2)
+    end
+  end
+
+  describe ".queries_created" do
+    it "counts queries created within each window" do
+      Fabricate(:query)
+      Fabricate(:query).update_columns(created_at: 10.days.ago)
+      Fabricate(:query).update_columns(created_at: 45.days.ago)
+
+      expect(described_class.queries_created).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 2,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".queries_edited" do
+    it "counts queries modified after creation, ignoring never-edited ones" do
+      recently = Fabricate(:query)
+      recently.update_columns(created_at: 3.days.ago, updated_at: Time.current)
+
+      previously = Fabricate(:query)
+      previously.update_columns(created_at: 50.days.ago, updated_at: 45.days.ago)
+
+      never_edited = Fabricate(:query)
+      never_edited.update_columns(created_at: 5.days.ago, updated_at: 5.days.ago)
+
+      expect(described_class.queries_edited).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 1,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".queries_executed" do
+    it "counts distinct queries with runs in each window" do
+      log_runs(1, date: Date.current, runs: 3)
+      log_runs(1, date: 10.days.ago.to_date, runs: 2)
+      log_runs(2, date: 45.days.ago.to_date, runs: 5)
+
+      expect(described_class.queries_executed).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 1,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".executions" do
+    it "sums runs in each window plus a lifetime count" do
+      log_runs(1, date: Date.current, runs: 3)
+      log_runs(1, date: 10.days.ago.to_date, runs: 2)
+      log_runs(1, date: 45.days.ago.to_date, runs: 5)
+
+      expect(described_class.executions).to eq(
+        last_day: 3,
+        "7_days": 3,
+        "30_days": 5,
+        previous_30_days: 5,
+        count: 10,
+      )
+    end
+  end
+end

--- a/plugins/discourse-data-explorer/spec/models/discourse_data_explorer/query_stat_spec.rb
+++ b/plugins/discourse-data-explorer/spec/models/discourse_data_explorer/query_stat_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseDataExplorer::QueryStat do
+  fab!(:query)
+
+  describe ".log" do
+    it "creates a row with a single run" do
+      described_class.log(query.id)
+
+      expect(described_class.find_by(query_id: query.id, date: Date.current).total_runs).to eq(1)
+    end
+
+    it "increments total_runs for the same query and day" do
+      3.times { described_class.log(query.id) }
+
+      expect(described_class.where(query_id: query.id).count).to eq(1)
+      expect(described_class.find_by(query_id: query.id).total_runs).to eq(3)
+    end
+  end
+
+  describe "DiscourseDataExplorer::Query#record_run!" do
+    it "bumps last_run_at without touching updated_at and records a run" do
+      query.update_columns(
+        created_at: 10.days.ago,
+        updated_at: 10.days.ago,
+        last_run_at: 10.days.ago,
+      )
+      original_updated_at = query.reload.updated_at
+
+      freeze_time
+
+      expect { query.record_run! }.to change {
+        described_class.where(query_id: query.id).sum(:total_runs)
+      }.by(1)
+
+      query.reload
+      expect(query.last_run_at).to be_within(1.second).of(Time.current)
+      expect(query.updated_at).to be_within(1.second).of(original_updated_at)
+    end
+
+    it "persists a default (unpersisted) query on run without recording a stat" do
+      default_query = DiscourseDataExplorer::Query.new(id: -100, name: "Default", sql: "SELECT 1")
+
+      expect { default_query.record_run! }.not_to change { described_class.count }
+      expect(default_query.reload.last_run_at).to be_present
+    end
+  end
+end

--- a/plugins/discourse-workflows/app/models/discourse_workflows/execution.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/execution.rb
@@ -20,6 +20,8 @@ module DiscourseWorkflows
          { pending: 0, running: 1, success: 2, error: 3, waiting: 4, rate_limited: 5, skipped: 6 }
     enum :execution_mode, { normal: 0, error_mode: 1, manual: 2 }
 
+    after_create { ExecutionStat.log(workflow_id) unless rate_limited? }
+
     scope :for_workflow, ->(workflow_id) { workflow_id ? where(workflow_id: workflow_id) : all }
     scope :recent, ->(period = 7.days) { where("created_at >= ?", period.ago) }
     scope :successful, -> { where(status: :success) }

--- a/plugins/discourse-workflows/app/models/discourse_workflows/execution_stat.rb
+++ b/plugins/discourse-workflows/app/models/discourse_workflows/execution_stat.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DiscourseWorkflows
+  class ExecutionStat < ActiveRecord::Base
+    self.table_name = "discourse_workflows_execution_stats"
+
+    def self.log(workflow_id, date: Date.current)
+      DB.exec(<<~SQL, workflow_id: workflow_id, date: date)
+        INSERT INTO discourse_workflows_execution_stats (workflow_id, date, total_runs)
+        VALUES (:workflow_id, :date, 1)
+        ON CONFLICT (workflow_id, date)
+        DO UPDATE SET total_runs = discourse_workflows_execution_stats.total_runs + 1
+      SQL
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: discourse_workflows_execution_stats
+#
+#  id          :bigint           not null, primary key
+#  date        :date             not null
+#  total_runs  :integer          default(0), not null
+#  workflow_id :bigint           not null
+#
+# Indexes
+#
+#  idx_dwf_execution_stats_on_workflow_id_and_date  (workflow_id,date) UNIQUE
+#

--- a/plugins/discourse-workflows/db/migrate/20260703163425_create_discourse_workflows_execution_stats.rb
+++ b/plugins/discourse-workflows/db/migrate/20260703163425_create_discourse_workflows_execution_stats.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class CreateDiscourseWorkflowsExecutionStats < ActiveRecord::Migration[8.0]
+  def change
+    create_table :discourse_workflows_execution_stats do |t|
+      t.bigint :workflow_id, null: false
+      t.date :date, null: false
+      t.integer :total_runs, null: false, default: 0
+    end
+
+    add_index :discourse_workflows_execution_stats,
+              %i[workflow_id date],
+              unique: true,
+              name: "idx_dwf_execution_stats_on_workflow_id_and_date"
+  end
+end

--- a/plugins/discourse-workflows/lib/discourse_workflows/statistics.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/statistics.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module DiscourseWorkflows
+  module Statistics
+    extend PeriodCountHelper
+
+    def self.total
+      { count: Workflow.count }
+    end
+
+    def self.created
+      period_counts(Workflow.all, :created_at, count: false)
+    end
+
+    def self.edited
+      period_counts(
+        WorkflowVersion.where("version_number > 1"),
+        :created_at,
+        count: false,
+      ) { |scope| scope.distinct.count(:workflow_id) }
+    end
+
+    def self.executed
+      period_counts(ExecutionStat.all, :date, count: false) do |scope|
+        scope.distinct.count(:workflow_id)
+      end
+    end
+
+    def self.executions
+      period_counts(ExecutionStat.all, :date) { |scope| scope.sum(:total_runs) }
+    end
+  end
+end

--- a/plugins/discourse-workflows/plugin.rb
+++ b/plugins/discourse-workflows/plugin.rb
@@ -148,4 +148,10 @@ after_initialize do
 
     DiscourseWorkflows::PluginEnableHandler.handle!
   end
+
+  register_stat("total", stat_type: :workflows) { DiscourseWorkflows::Statistics.total }
+  register_stat("created", stat_type: :workflows) { DiscourseWorkflows::Statistics.created }
+  register_stat("edited", stat_type: :workflows) { DiscourseWorkflows::Statistics.edited }
+  register_stat("executed", stat_type: :workflows) { DiscourseWorkflows::Statistics.executed }
+  register_stat("executions", stat_type: :workflows) { DiscourseWorkflows::Statistics.executions }
 end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/statistics_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/statistics_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::Statistics do
+  before { freeze_time(Time.utc(2026, 6, 15, 12, 0)) }
+
+  fab!(:user)
+
+  def log_runs(workflow, date:, runs: 1)
+    DiscourseWorkflows::ExecutionStat.create!(
+      workflow_id: workflow.id,
+      date: date,
+      total_runs: runs,
+    )
+  end
+
+  describe ".total" do
+    it "counts every workflow" do
+      Fabricate(:discourse_workflows_workflow)
+      Fabricate(:discourse_workflows_workflow)
+
+      expect(described_class.total).to eq(count: 2)
+    end
+  end
+
+  describe ".created" do
+    it "counts workflows created within each window" do
+      Fabricate(:discourse_workflows_workflow)
+      Fabricate(:discourse_workflows_workflow).update_columns(created_at: 10.days.ago)
+      Fabricate(:discourse_workflows_workflow).update_columns(created_at: 45.days.ago)
+
+      expect(described_class.created).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 2,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".edited" do
+    it "counts distinct workflows edited beyond their initial snapshot" do
+      recently_edited = Fabricate(:discourse_workflows_workflow, created_by: user)
+      recently_edited.snapshot!(user: user)
+
+      previously_edited = Fabricate(:discourse_workflows_workflow, created_by: user)
+      previously_edited.snapshot!(user: user)
+      DiscourseWorkflows::WorkflowVersion
+        .where(workflow_id: previously_edited.id)
+        .where("version_number > 1")
+        .update_all(created_at: 45.days.ago)
+
+      # never edited beyond creation - must not be counted
+      Fabricate(:discourse_workflows_workflow, created_by: user)
+
+      expect(described_class.edited).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 1,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".executed" do
+    it "counts distinct workflows with runs in each window" do
+      one = Fabricate(:discourse_workflows_workflow)
+      two = Fabricate(:discourse_workflows_workflow)
+
+      log_runs(one, date: Date.current, runs: 3)
+      log_runs(one, date: 10.days.ago.to_date, runs: 2)
+      log_runs(two, date: 45.days.ago.to_date, runs: 5)
+
+      expect(described_class.executed).to eq(
+        last_day: 1,
+        "7_days": 1,
+        "30_days": 1,
+        previous_30_days: 1,
+      )
+    end
+  end
+
+  describe ".executions" do
+    it "sums runs in each window plus a lifetime count" do
+      workflow = Fabricate(:discourse_workflows_workflow)
+
+      log_runs(workflow, date: Date.current, runs: 3)
+      log_runs(workflow, date: 10.days.ago.to_date, runs: 2)
+      log_runs(workflow, date: 45.days.ago.to_date, runs: 5)
+
+      expect(described_class.executions).to eq(
+        last_day: 3,
+        "7_days": 3,
+        "30_days": 5,
+        previous_30_days: 5,
+        count: 10,
+      )
+    end
+  end
+end

--- a/plugins/discourse-workflows/spec/models/discourse_workflows/execution_stat_spec.rb
+++ b/plugins/discourse-workflows/spec/models/discourse_workflows/execution_stat_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseWorkflows::ExecutionStat do
+  fab!(:workflow, :discourse_workflows_workflow)
+
+  describe ".log" do
+    it "creates a row with a single run" do
+      described_class.log(workflow.id)
+
+      stat = described_class.find_by(workflow_id: workflow.id, date: Date.current)
+      expect(stat.total_runs).to eq(1)
+    end
+
+    it "increments total_runs for the same workflow and day" do
+      3.times { described_class.log(workflow.id) }
+
+      expect(described_class.where(workflow_id: workflow.id).count).to eq(1)
+      expect(described_class.find_by(workflow_id: workflow.id).total_runs).to eq(3)
+    end
+
+    it "keeps separate rows per day" do
+      described_class.log(workflow.id, date: 2.days.ago.to_date)
+      described_class.log(workflow.id, date: Date.current)
+
+      expect(described_class.where(workflow_id: workflow.id).count).to eq(2)
+    end
+  end
+
+  describe "recording executions" do
+    it "logs a run when an execution is created" do
+      expect { Fabricate(:discourse_workflows_execution, workflow: workflow) }.to change {
+        described_class.where(workflow_id: workflow.id).sum(:total_runs)
+      }.by(1)
+    end
+
+    it "does not log rate limited executions" do
+      expect {
+        Fabricate(:discourse_workflows_execution, workflow: workflow, status: :rate_limited)
+      }.not_to change { described_class.count }
+    end
+  end
+end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -1073,6 +1073,18 @@ TEXT
       plugin.register_stat("some_group") { stats }
       expect(DiscoursePluginRegistry.stats.count).to eq(1)
     end
+
+    it "allows the same name under different stat_types" do
+      stats = { count: 1 }
+      plugin.register_stat("total", stat_type: :foo) { stats }
+      plugin.register_stat("total", stat_type: :bar) { stats }
+      plugin.register_stat("total", stat_type: :foo) { stats }
+
+      expect(DiscoursePluginRegistry.stats.count).to eq(2)
+      expect(Stat.all_stats.with_indifferent_access).to match(
+        hash_including(foo: { total_count: 1 }, bar: { total_count: 1 }),
+      )
+    end
   end
 
   describe "#register_user_destroyer_on_content_deletion_callback" do


### PR DESCRIPTION
Adds basic usage metrics for **workflows**, **automations**, and **data explorer** so we can measure adoption across all sites, following the pattern established for Kanban (dev topic `t/185911`).

Each plugin registers stats via the freeform `stat_type` API, so the values flow automatically into our site statistics pipeline. No infrastructure changes are needed.

## Metrics

For each feature: `total` (running count), `created`, `edited`, `executed` (distinct objects run), and `executions` (total run count) — each windowed over `last_day / 7_days / 30_days / previous_30_days`, with a lifetime `count` on `total` and `executions`. Resulting columns:

| | Workflows | Automations | Data Explorer |
|---|---|---|---|
| total | `workflows_total_count` | `automations_total_count` | `de_queries_total_count` |
| created | `workflows_created_*` | `automations_created_*` | `de_queries_created_*` |
| edited | `workflows_edited_*` | `automations_edited_*` | `de_queries_edited_*` |
| executed | `workflows_executed_*` | `automations_executed_*` | `de_queries_executed_*` |
| executions | `workflows_executions_*` | `automations_executions_*` | `de_executions_*` |

## How executions are counted

Automations already have a daily rollup (`discourse_automation_stats`), so they reuse it.

Workflows and Data Explorer get a small daily rollup table each (`discourse_workflows_execution_stats`, `data_explorer_query_stats`) recording `total_runs` per object per day. This deliberately avoids two traps:

- **Workflow executions are purged** after `workflow_executions_retention_days` (default 30), and the purged rows carry heavy payloads (full node-graph snapshot + step I/O). Counting from a lightweight rollup keeps `previous_30_days`/lifetime metrics valid without retaining those payloads, and decouples the metrics from a per-site retention setting.
- **Data Explorer has no run log** — only a single `last_run_at`. The rollup gives us real execution counts and a durable `previous_30_days` window.

Workflow runs are recorded via an `after_create` on `Execution` (one row per execution, rate-limited executions excluded). Data Explorer runs go through a new `Query#record_run!` used by the three run sites.

## Data Explorer `updated_at` fix

Query runs previously did `query.update!(last_run_at:)`, which bumped `updated_at` on every run and made "edited" indistinguishable from "executed". `record_run!` now uses `update_columns`, so `updated_at` reflects genuine edits again. Default (unpersisted) queries are still persisted on first run as before, and the `DeleteHiddenQueries` job is unaffected (it also gates on `last_run_at`).

## Core change

`register_stat` deduplicated by name only, so the three plugins couldn't all register generic names like `total`/`executions` — whichever activated first won and the rest were silently dropped. The identity check now includes `stat_type`, so a name can be reused across stat types (columns stay unique because they are prefixed with the stat type). Kanban avoided this only because its names happened to be globally unique.

## Notes for review

- **Single `de` stat_type** (yielding `de_queries_*` and `de_executions_*`) rather than splitting into `de_queries`/`de_executions` — happy to change if you'd rather query by two separate `stat_type_freeform` values. cc measurement folks.
- `structure.sql` and model annotations were hand-updated (local box is on PG17, which can't run the temp-DB dump/annotate tasks); CI will verify.

## Tests

- New specs for all three `Statistics` modules and both rollup models (`.log`, the `after_create`/`record_run!` hooks, the `updated_at` behavior).
- New core spec covering same-name/different-`stat_type` registration.
