### PR TITLE
FIX: Render pasted emoji in the composer's markdown mode

### DIFF
--- a/frontend/discourse/app/lib/to-markdown.js
+++ b/frontend/discourse/app/lib/to-markdown.js
@@ -15,6 +15,20 @@ async function ensureDefaultExtensions() {
   );
 }
 
+// Chrome and Safari copy the space next to an inline element as a non-breaking
+// space, which stops a pasted emoji from cooking. Restore just the copy
+// artifact - a lone nbsp in a bare span - so an author's own nbsp is kept.
+function restoreReplacedSpaces(root) {
+  const spans = root.querySelectorAll(
+    "span:not([class]):not([style]), span.Apple-converted-space"
+  );
+  for (const span of spans) {
+    if (span.childNodes.length === 1 && span.textContent === "\u00a0") {
+      span.replaceWith(root.ownerDocument.createTextNode(" "));
+    }
+  }
+}
+
 // Deprecated no-ops - kept for backward compatibility
 function deprecationWarning(name) {
   deprecated(
@@ -78,6 +92,8 @@ export default async function toMarkdown(html) {
       processedHtml,
       "text/html"
     );
+
+    restoreReplacedSpaces(parsedDoc.body);
 
     for (const ext of extensions) {
       if (typeof ext.transformParsedHTML === "function") {

--- a/frontend/discourse/tests/unit/lib/to-markdown-test.js
+++ b/frontend/discourse/tests/unit/lib/to-markdown-test.js
@@ -518,6 +518,14 @@ helloWorld();</code>consectetur.`;
     assert.strictEqual(await toMarkdown(html), markdown);
   });
 
+  test("restores clipboard non-breaking spaces around inline nodes", async function (assert) {
+    // The copied nbsp beside the emoji must become a regular space or it won't
+    // cook; an author-typed nbsp (in "to keep") is left alone.
+    const html = `<span style="color: rgb(0,0,0)">use the<span>&nbsp;</span></span><img class="emoji" title=":heart:" alt=":heart:" /><span style="color: rgb(0,0,0)"><span>&nbsp;</span>to&nbsp;keep</span>`;
+
+    assert.strictEqual(await toMarkdown(html), `use the :heart: to\u00a0keep`);
+  });
+
   test("converts image lightboxes to markdown", async function (assert) {
     let html = `
     <a class="lightbox" href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/original/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba.jpeg" data-download-href="https://d11a6trkgmumsb.cloudfront.net/uploads/default/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba" title="sherlock3_sig.jpg" rel="nofollow noopener"><img src="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg" alt="sherlock3_sig" width="689" height="459" class="d-lazyload" srcset="https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_689x459.jpeg, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1033x688.jpeg 1.5x, https://d11a6trkgmumsb.cloudfront.net/uploads/default/optimized/1X/8hkjhk7692f6afed3cb99d43ab2abd4e30aa8cba_2_1378x918.jpeg 2x"><div class="meta">


### PR DESCRIPTION
Copying an emoji from a post and pasting into the composer in markdown mode showed it as literal text (`:heart:`) instead of the image. Chrome and Safari copy the space next to an inline element as a non-breaking space, and the emoji rule doesn't treat U+00A0 as a boundary, so it isn't cooked.

Restore the copied non-breaking space in `toMarkdown`, as the rich-text editor already does for pasted HTML. Mentions and hashtags were affected too.