### PR TITLE
UX: Remove new height variables from foundation modernization

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -10,79 +10,8 @@
   --d-button-default-text-color: var(--primary-900);
   --d-button-default-icon-color: var(--primary-900);
 
-  .btn-default,
-  .btn-icon-text,
-  .btn-icon,
-  .btn-danger,
-  .btn-primary,
-  .btn.no-text,
-  .view-all-drafts,
-  .discourse-reactions-counter .reactions-counter,
-  #topic-progress-wrapper {
-    &:not(
-      .topic-voting-menu-trigger,
-      .sidebar-footer-actions-button,
-      #search-button,
-      .btn-sidebar-toggle,
-      .topic-map__views-trigger,
-      .topic-map__likes-trigger,
-      .topic-map__users-trigger,
-      .topic-map__links-trigger,
-      .user,
-      .notifications-tracking-btn,
-      .user-menu-tab,
-      .--with-description,
-      .chat-message-react-btn,
-      .profile-tab-btn,
-      .back-button,
-      .composer-actions-btn,
-      .language-switcher-trigger,
-      .d-multi-select-trigger__expand-btn,
-      .emoji-picker-trigger,
-      .topic-list-header-tab,
-      .reviewable-action-dropdown,
-      .sidebar-section-header,
-      .chat-message-creator__member,
-      .tag-choice
-    ) {
-      padding-block: 0;
-      height: var(--d-control-height);
-      padding-inline: var(--space-2);
-    }
-  }
-
-  .btn.no-text.btn-icon {
-    &:not(
-      .topic-voting-menu-trigger,
-      .voting-wrapper__button,
-      .user-menu-tab,
-      .user-menu-tab-active,
-      .composer-actions-btn,
-      .dropdown-select-box-header,
-      .d-multi-select-trigger__expand-btn,
-      .emoji-picker-trigger
-    ) {
-      width: var(--d-control-height);
-    }
-  }
-
-  .form-kit__control-password-wrapper {
-    height: unset;
-  }
-
   .sidebar-section-header-dropdown-btn {
     --d-button-default-border: none;
-  }
-
-  .c-footer button {
-    padding-block: 0.75rem !important;
-    height: unset !important;
-  }
-
-  .topic-replies-toggle-wrapper .topics-replies-toggle {
-    border-radius: var(--d-border-radius);
-    height: var(--d-control-height);
-    padding: 0 0.65em;
   }
 
   .topic-replies-toggle-wrapper .topics-replies-toggle.active:hover {
@@ -102,37 +31,6 @@
     align-items: center;
   }
 
-  .search-container .search-bar input.search-query {
-    height: var(--d-control-height);
-  }
-
-  .search-input,
-  input[type="text"],
-  input[type="password"],
-  input[type="datetime"],
-  input[type="datetime-local"],
-  input[type="date"],
-  input[type="month"],
-  input[type="time"],
-  input[type="week"],
-  input[type="number"],
-  input[type="email"],
-  input[type="url"],
-  input[type="search"],
-  input[type="tel"],
-  input[type="color"] {
-    height: var(--d-control-height);
-    padding-block: 0;
-  }
-
-  .search-input {
-    .search-context {
-      height: calc(
-        var(--d-control-height) - var(--space-2)
-      ) !important; // overrides very specific btn selector at the top of this file
-    }
-  }
-
   // button on /my/badges
   .favorite-btn {
     border-color: var(--primary-low);
@@ -142,70 +40,6 @@
     &:hover {
       border-bottom: none;
       border-right: none;
-    }
-  }
-
-  .login-fullpage,
-  .signup-fullpage,
-  .invites-show,
-  .password-reset-page {
-    .input-group {
-      label.alt-placeholder,
-      .user-field.text label.control-label {
-        top: 8px;
-      }
-
-      .user-field.dropdown label.control-label,
-      .user-field.multiselect label.control-label,
-      .user-field.date label.control-label {
-        top: -8px;
-      }
-    }
-  }
-
-  .invite-page,
-  .signup-fullpage {
-    .user-fields .input-group {
-      .user-field.text,
-      .user-field.textarea {
-        &:not(.value-entered, :focus-within)
-          label.alt-placeholder.control-label {
-          top: 8px;
-        }
-      }
-    }
-  }
-
-  @include viewport.until(md) {
-    .login-form,
-    #login-form,
-    .invite-form {
-      .input-group {
-        input {
-          height: var(--d-control-height);
-        }
-
-        label.alt-placeholder,
-        .user-field.text label.control-label,
-        .user-field.textarea label.control-label {
-          top: 7px;
-        }
-
-        input:focus + label,
-        input.value-entered + label.alt-placeholder,
-        div.user-field:not(.dropdown)
-          .controls
-          input:focus
-          + label.alt-placeholder.control-label,
-        div.user-field.value-entered:not(.dropdown)
-          .controls
-          label.alt-placeholder.control-label,
-        .user-field.dropdown label.control-label,
-        .user-field.multiselect label.control-label,
-        .user-field.date label.control-label {
-          top: -9px;
-        }
-      }
     }
   }
 }

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/buttons-controls.scss
@@ -14,23 +14,6 @@
     --d-button-default-border: none;
   }
 
-  .topic-replies-toggle-wrapper .topics-replies-toggle.active:hover {
-    background-color: var(--d-nav-bg-color--active);
-    color: var(--d-nav-color--active);
-  }
-
-  .bookmark-menu-content .bookmark-menu__title,
-  .bookmark-menu-content .bookmark-menu__row-title {
-    padding-block: 0;
-    padding-inline: var(--d-sidebar-row-horizontal-padding);
-    height: var(--d-sidebar-row-height);
-  }
-
-  .bookmark-menu-content .bookmark-menu__row-title {
-    display: flex;
-    align-items: center;
-  }
-
   // button on /my/badges
   .favorite-btn {
     border-color: var(--primary-low);

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/header.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/header.scss
@@ -5,10 +5,6 @@
     height: 3.25em;
   }
 
-  .d-header {
-    --d-control-height: var(--space-8);
-  }
-
   .d-header .title {
     @include viewport.from(sm) {
       --d-logo-height: 2.3em;

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/select-kit.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/select-kit.scss
@@ -1,16 +1,6 @@
 .uc-modernize-foundation-theme {
-  .select-kit .select-kit-header:not(.composer-actions-btn),
-  .d-date-input .date-picker {
-    height: var(--d-control-height);
-  }
-
   .select-kit.is-expanded .select-kit-filter.is-expanded {
     border: none;
-  }
-
-  .select-kit.is-expanded .select-kit-filter.is-expanded {
-    height: var(--d-control-height);
-    padding-block: 0;
   }
 
   .select-kit .caret-icon {
@@ -18,8 +8,6 @@
   }
 
   .list-controls .combo-box .combo-box-header {
-    height: var(--d-control-height);
-
     &:hover {
       background-color: var(--primary-100);
     }

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/variables.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/variables.scss
@@ -1,7 +1,6 @@
 .uc-modernize-foundation-theme {
   // New Variables
   --webkit-font-smoothing: antialiased;
-  --d-control-height: var(--space-9);
   --welcome-banner-text-align: center;
   --welcome-banner-search-menu-margin-inline: auto;
   -webkit-font-smoothing: var(--webkit-font-smoothing);

--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/welcome-banner.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/welcome-banner.scss
@@ -3,6 +3,7 @@
 
   &__wrap .search-menu {
     align-items: center;
+    margin-inline: var(--welcome-banner-search-menu-margin-inline);
   }
 
   &__subheader {
@@ -13,9 +14,5 @@
     font-size: var(--font-up-5);
     font-weight: 500;
     text-align: var(--welcome-banner-text-align);
-  }
-
-  &__wrap .search-menu {
-    margin-inline: var(--welcome-banner-search-menu-margin-inline);
   }
 }


### PR DESCRIPTION
The changes to button and input height in this upcoming change are too complex and deserve their own upcoming change for better styling, targeting, button markup cleanup & refactoring. Removing this section will allow this upcoming change to be pushed into a stable state.

| Before | After |
| -- | -- |
|<img width="2736" height="1854" alt="CleanShot 2026-07-03 at 13 00 08@2x" src="https://github.com/user-attachments/assets/8b9094b6-4b16-43b1-824b-1d80fb80aafe" />|<img width="2744" height="1854" alt="CleanShot 2026-07-03 at 12 59 45@2x" src="https://github.com/user-attachments/assets/837af700-d724-4f95-ace2-e954797ac479" />|

The change is mostly seen in the welcome banner search, elsewhere it is very subtle.

**Search**
<img width="1310" height="269" alt="CleanShot 2026-07-03 at 13 00 53@2x" src="https://github.com/user-attachments/assets/b92bb13b-d3dd-4ee7-945a-d6bcefef1dff" />

**Button**
<img width="386" height="182" alt="CleanShot 2026-07-03 at 13 04 19@2x" src="https://github.com/user-attachments/assets/46f7a6d7-30d4-41f7-ab83-6f9b089b6f69" />

