### PR TITLE
UX: Long press chat channel rows to open the actions menu on touch

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-row.gjs
@@ -5,11 +5,13 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { LinkTo } from "@ember/routing";
+import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { modifier as modifierFn } from "ember-modifier";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
+import discourseLater from "discourse/lib/later";
 import { and, eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -18,13 +20,16 @@ import { i18n } from "discourse-i18n";
 import ChannelIcon from "discourse/plugins/chat/discourse/components/channel-icon";
 import ChannelName from "discourse/plugins/chat/discourse/components/channel-name";
 import ChatChannelMetadata from "discourse/plugins/chat/discourse/components/chat-channel-metadata";
+import ChatChannelSidebarContextMenu from "discourse/plugins/chat/discourse/components/chat-channel-sidebar-context-menu";
 import ToggleChannelMembershipButton from "discourse/plugins/chat/discourse/components/toggle-channel-membership-button";
+import ChatOnLongPress from "discourse/plugins/chat/discourse/modifiers/chat/on-long-press";
 
 const FADEOUT_CLASS = "-fade-out";
 
 export default class ChatChannelRow extends Component {
   @service capabilities;
   @service chat;
+  @service menu;
   @service site;
 
   @tracked isAtThreshold = false;
@@ -34,6 +39,7 @@ export default class ChatChannelRow extends Component {
   @tracked shouldReset = false;
   @tracked diff = 0;
   @tracked rowStyle = null;
+  @tracked isLongPressing = false;
 
   registerSwipableRow = modifierFn((element) => {
     this.swipableRow = element;
@@ -84,6 +90,12 @@ export default class ChatChannelRow extends Component {
     };
   });
 
+  willDestroy() {
+    super.willDestroy(...arguments);
+    cancel(this._longPressActivationHandler);
+    cancel(this._removeClickSuppressorHandler);
+  }
+
   @bind
   onSwipeStart(event) {
     this._initialX = event.changedTouches[0].screenX;
@@ -121,6 +133,56 @@ export default class ChatChannelRow extends Component {
     } else {
       this.shouldReset = true;
     }
+  }
+
+  @bind
+  suppressEvent(event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  @action
+  onLongPressStart(element) {
+    // suppress the native context menu during the press
+    element.addEventListener("contextmenu", this.suppressEvent);
+
+    this._longPressActivationHandler = discourseLater(() => {
+      this.isLongPressing = true;
+    }, 125);
+  }
+
+  @action
+  onLongPressCancel(element) {
+    cancel(this._longPressActivationHandler);
+    this.isLongPressing = false;
+
+    element.removeEventListener("contextmenu", this.suppressEvent);
+
+    this._removeClickSuppressorHandler = discourseLater(() => {
+      element.removeEventListener("click", this.suppressEvent, {
+        capture: true,
+      });
+    }, 200);
+  }
+
+  @action
+  onLongPressEnd(element) {
+    cancel(this._longPressActivationHandler);
+    this.isLongPressing = false;
+
+    // stop the release from clicking through to the channel link
+    element.addEventListener("click", this.suppressEvent, { capture: true });
+
+    document.activeElement?.blur();
+
+    this.menu.show(element, {
+      identifier: this.args.channel.isDirectMessageChannel
+        ? "chat-direct-message-channel-menu"
+        : "chat-channel-menu",
+      component: ChatChannelSidebarContextMenu,
+      modalForMobile: true,
+      data: { channel: this.args.channel },
+    });
   }
 
   get shouldHandleSwipe() {
@@ -175,12 +237,18 @@ export default class ChatChannelRow extends Component {
         (if @options.leaveButton "can-leave")
         (if (eq this.chat.activeChannel.id @channel.id) "active")
         (if this.channelHasUnread "has-unread")
+        (if this.isLongPressing "is-long-pressed")
       }}
       tabindex="0"
       data-chat-channel-id={{@channel.id}}
       {{didInsert this.startTrackingStatus}}
       {{willDestroy this.stopTrackingStatus}}
       {{(if this.shouldRemoveChannel (modifier this.onRemoveChannel))}}
+      {{ChatOnLongPress
+        this.onLongPressStart
+        this.onLongPressEnd
+        this.onLongPressCancel
+      }}
     >
       <div
         class={{dConcatClass

--- a/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-row.scss
@@ -8,6 +8,10 @@
   color: var(--primary);
 
   @media (hover: none) {
+    // avoid the native long-press callout/selection on the row link
+    -webkit-touch-callout: none;
+    user-select: none;
+
     &:hover,
     &:focus {
       background: transparent;
@@ -56,6 +60,12 @@
 
   &.muted {
     opacity: 0.65;
+  }
+
+  &.is-long-pressed {
+    .chat-channel-row__content {
+      background: var(--d-hover);
+    }
   }
 
   &__content {

--- a/plugins/chat/spec/system/list_channels/mobile_spec.rb
+++ b/plugins/chat/spec/system/list_channels/mobile_spec.rb
@@ -152,6 +152,57 @@ RSpec.describe "List channels | mobile", mobile: true do
         end
       end
     end
+
+    context "when long pressing a channel row" do
+      fab!(:category_channel_1, :category_channel)
+
+      let(:channel_row) { PageObjects::Components::Chat::ChannelRow.new(category_channel_1.id) }
+
+      before { category_channel_1.add(current_user) }
+
+      it "opens the channel menu" do
+        visit("/chat/channels")
+
+        channel_row.long_press
+
+        expect(page).to have_css(".fk-d-menu-modal .chat-channel-sidebar-link-menu")
+      end
+
+      it "leaves the channel using the menu" do
+        visit("/chat/channels")
+
+        channel_row.long_press
+        find(".chat-channel-sidebar-link-menu__leave-channel").click
+
+        expect(channel_row).to be_non_existent
+      end
+
+      it "changes the notification level from the menu submenu" do
+        visit("/chat/channels")
+
+        channel_row.long_press
+        find(".chat-channel-sidebar-link-menu__open-notification-settings").click
+        find(".chat-channel-sidebar-link-menu__notification-level-never").click
+
+        expect(category_channel_1.membership_for(current_user).reload.notification_level).to eq(
+          "never",
+        )
+      end
+
+      context "when direct message channel" do
+        fab!(:dm_channel_1) { Fabricate(:direct_message_channel, users: [current_user]) }
+
+        let(:dm_channel_row) { PageObjects::Components::Chat::ChannelRow.new(dm_channel_1.id) }
+
+        it "opens the channel menu" do
+          visit("/chat/direct-messages")
+
+          dm_channel_row.long_press
+
+          expect(page).to have_css(".fk-d-menu-modal .chat-channel-sidebar-link-menu")
+        end
+      end
+    end
   end
 
   context "when no category channels" do

--- a/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
+++ b/plugins/chat/spec/system/page_objects/chat/components/channel_row.rb
@@ -28,6 +28,28 @@ module PageObjects
           btn.click
         end
 
+        def long_press
+          page.execute_script(<<-JS, component)
+            arguments[0].dispatchEvent(new TouchEvent("touchstart", {
+              cancelable: true,
+              bubbles: true,
+              touches: [
+                new Touch({ identifier: Date.now(), target: arguments[0] })
+              ],
+            }));
+
+            setTimeout(() => {
+              arguments[0].dispatchEvent(new TouchEvent("touchend", {
+                cancelable: true,
+                bubbles: true,
+                touches: [
+                  new Touch({ identifier: Date.now(), target: arguments[0] })
+                ],
+              }));
+            }, 600);
+          JS
+        end
+
         def component(**args)
           find(build_selector(**args))
         end


### PR DESCRIPTION
Touch users had no way to reach the channel actions menu that desktop exposes through the hover ellipsis. Long pressing a channel or direct message row now opens that same menu, rendered as a bottom-sheet modal on mobile.

Long press is gated on the mobile view, consistent with the existing chat message long press.