### PR TITLE
FIX: avoid double arrow key nav for select-kit-filter

### DIFF
--- a/frontend/discourse/select-kit/components/select-kit/select-kit-filter.gjs
+++ b/frontend/discourse/select-kit/components/select-kit/select-kit-filter.gjs
@@ -96,7 +96,11 @@ export default class SelectKitFilter extends Component {
     }
 
     if (event.key === "ArrowUp") {
-      this.selectKit.highlightLast();
+      if (this.selectKit.highlighted) {
+        this.selectKit.highlightPrevious();
+      } else {
+        this.selectKit.highlightLast();
+      }
       event.preventDefault();
       return false;
     }
@@ -105,7 +109,11 @@ export default class SelectKitFilter extends Component {
       if (!this.selectKit.isExpanded) {
         this.selectKit.open(event);
       }
-      this.selectKit.highlightFirst();
+      if (this.selectKit.highlighted) {
+        this.selectKit.highlightNext();
+      } else {
+        this.selectKit.highlightFirst();
+      }
       event.preventDefault();
       return false;
     }

--- a/frontend/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/mini-tag-chooser-test.gjs
@@ -56,6 +56,37 @@ module(
       assert.strictEqual(this.subject.header().name(), "foo,bar,monkey");
     });
 
+    test("navigating results with arrow keys after filtering", async function (assert) {
+      await render(
+        <template><MiniTagChooser @options={{hash allowAny=true}} /></template>
+      );
+
+      await this.subject.expand();
+      await this.subject.fillInFilter("mon");
+
+      assert.strictEqual(
+        this.subject.highlightedRow().name(),
+        "mon",
+        "the create-tag row is highlighted after filtering"
+      );
+
+      await this.subject.keyboard("down");
+
+      assert.strictEqual(
+        this.subject.highlightedRow().name(),
+        "monkey",
+        "a single down arrow press highlights the next row"
+      );
+
+      await this.subject.keyboard("up");
+
+      assert.strictEqual(
+        this.subject.highlightedRow().name(),
+        "mon",
+        "a single up arrow press highlights the previous row"
+      );
+    });
+
     test("max_tags_per_topic", async function (assert) {
       this.set("value", [
         { id: "foo", name: "foo", slug: "foo" },

--- a/plugins/discourse-assign/spec/system/page_objects/modals/assign.rb
+++ b/plugins/discourse-assign/spec/system/page_objects/modals/assign.rb
@@ -13,8 +13,7 @@ module PageObjects
         assignee = assignee.is_a?(Group) ? assignee.name : assignee.username
         input = find(".control-group input")
         input.fill_in(with: assignee)
-        find("li[data-value='#{assignee}']")
-        input.send_keys(:down)
+        find("li[data-value='#{assignee}'].is-highlighted")
         input.send_keys(:enter)
       end
 


### PR DESCRIPTION
Currently when you search for a tag in the composer, it requires two arrow key presses to reach the second option, even though the first option is already highlighted. 

This is because the create option (first row) is pre-highlighted... so arrow down in select-kit calls `this.selectKit.highlightFirst()` and you end up re-highlighting it on the first arrow press.

This checks if a row is pre-highlighted to avoid `highlightFirst` and instead fires `highlightNext` (and the opposite for up arrow cases) 