### PR TITLE
Update tag-list.gjs (correct the multiplication sign: not the letter …

### DIFF
--- a/frontend/discourse/app/components/tag-list.gjs
+++ b/frontend/discourse/app/components/tag-list.gjs
@@ -84,7 +84,7 @@ export default class TagList extends Component {
           {{/if}}
           {{#if tag.totalCount}}
             <span class="tag-count">
-              x
+              ×
               {{tag.totalCount}}
             </span>
           {{/if}}


### PR DESCRIPTION
…x but ×)

I hope this is the right file to correct what we see at https://meta.discourse.org/tags

<img width="473" height="213" alt="Capture d’écran 2026-07-03 à 23 49 19" src="https://github.com/user-attachments/assets/12028918-0040-4a65-9c22-4f08b7d73f5c" />
