### PR TITLE
UX: minor padding fix for mobile PM topic map

### DIFF
--- a/app/assets/stylesheets/common/base/personal-message.scss
+++ b/app/assets/stylesheets/common/base/personal-message.scss
@@ -161,7 +161,7 @@
 
   .topic-map {
     margin-top: var(--space-2);
-    padding: var(--space-3) var(--space-3) var(--space-3) var(--space-8);
+    padding: var(--space-3);
     display: grid;
     grid-template-areas: "contents additional" "pm-map pm-map";
     grid-template-columns: 1fr auto;
@@ -172,6 +172,7 @@
     );
 
     @include viewport.from(sm) {
+      padding-left: var(--space-8);
       margin-left: calc(var(--pm-padding) + var(--space-1));
     }
 


### PR DESCRIPTION
Too much left padding on mobile in the PM topic map 


before
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fb5354a8-a01c-4d7d-9e18-a122ea51594c" />


after
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f39cb8fa-6035-43e2-ba3a-e97b8eb75a83" />

