### PR TITLE
FEATURE: Add {username} template param to BotContext

### DIFF
--- a/plugins/discourse-ai/lib/agents/bot_context.rb
+++ b/plugins/discourse-ai/lib/agents/bot_context.rb
@@ -103,6 +103,7 @@ module DiscourseAi
         site_title
         site_description
         participants
+        username
         resource_url
         inferred_concepts
         user_language
@@ -136,6 +137,10 @@ module DiscourseAi
 
       def private_message?
         @private_message
+      end
+
+      def username
+        @user&.username
       end
 
       def top_categories

--- a/plugins/discourse-ai/spec/lib/agents/agent_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/agent_spec.rb
@@ -45,6 +45,7 @@ class TestAgent < DiscourseAi::Agents::Agent
       {site_title}
       {site_description}
       {participants}
+      {username}
       {time}
       {date}
       {resource_url}
@@ -65,6 +66,8 @@ RSpec.describe DiscourseAi::Agents::Agent do
   let(:resource_url) { "https://path-to-resource" }
   let(:inferred_concepts) { %w[bulbassaur charmander squirtle].join(", ") }
 
+  let(:context_user) { User.new(username: "alice") }
+
   let(:context) do
     DiscourseAi::Agents::BotContext.new(
       site_url: Discourse.base_url,
@@ -72,6 +75,7 @@ RSpec.describe DiscourseAi::Agents::Agent do
       site_description: "test site description",
       time: Time.zone.now,
       participants: topic_with_users.allowed_users.map(&:username).join(", "),
+      user: context_user,
       resource_url: resource_url,
       inferred_concepts: inferred_concepts,
     )
@@ -98,6 +102,8 @@ RSpec.describe DiscourseAi::Agents::Agent do
     expect(system_message).to include("test site title")
     expect(system_message).to include("test site description")
     expect(system_message).to include("joe, jane")
+    expect(system_message).to include("alice")
+    expect(system_message).not_to include("{username}")
     expect(system_message).to include(Time.zone.now.to_s)
     expect(system_message).to include(resource_url)
     expect(system_message).to include(inferred_concepts)
@@ -109,6 +115,24 @@ RSpec.describe DiscourseAi::Agents::Agent do
 
     # needs to be configured so it is not available
     expect(tools.find { |t| t.name == "image" }).to be_nil
+  end
+
+  it "leaves {username} literal when no user is present" do
+    context_without_user =
+      DiscourseAi::Agents::BotContext.new(
+        site_url: Discourse.base_url,
+        site_title: "test site title",
+        site_description: "test site description",
+        time: Time.zone.now,
+        participants: topic_with_users.allowed_users.map(&:username).join(", "),
+        resource_url: resource_url,
+        inferred_concepts: inferred_concepts,
+      )
+
+    rendered = agent.craft_prompt(context_without_user)
+    system_message = rendered.messages.first[:content]
+
+    expect(system_message).to include("{username}")
   end
 
   it "can parse string that are wrapped in quotes" do


### PR DESCRIPTION
`BotContext` already tracks the authenticated user who triggered the bot via `@user` and exposes `username` in `to_json`. This PR makes it available as a system prompt template variable, consistent with the existing params like `{participants}` and `{site_url}`.

**What this enables**

Persona authors can now use `{username}` in a system prompt to get the current user's Discourse username substituted before the prompt reaches the LLM. The substitution happens on the server, from the authenticated Discourse session, not from text in the conversation.

One concrete case: a persona that proxies requests to an external service needs to identify the caller reliably. Without `{username}`, the LLM has to infer the username from post metadata, which is fragile and introduces an injection surface. With `{username}`, the persona author gets the actual authenticated username directly.

**Behavior when no user is present**

When `@user` is nil (report runners, automated pipelines, etc.), `{username}` is left as a literal token in the prompt. This matches how `{participants}` and `{resource_url}` behave in contexts where they have no value. An explicit test covers this.

**Backwards compatibility**

Any persona prompt containing the literal string `{username}` would have passed through unchanged before this change and will now be substituted. In practice, no existing persona would have relied on that token staying literal.

**Changes**

- `lib/agents/bot_context.rb`: add `username` to `TEMPLATE_PARAMS` and add a `username` method
- `spec/lib/agents/agent_spec.rb`: assert substitution in the existing render test; add a test covering the no-user case

---

I'm a paying Discourse customer (Pro, Andrea Ross / RnL Solar Inc., `community.ripplesandleaves.ca`) and hit this gap building an integration that needs to pass a verified user identity from Discourse to an external service. Happy to answer questions.