### PR TITLE
MT: Keep the real created_at for category moderation groups

### DIFF
--- a/migrations/converters/lib/migrations/converters/discourse/steps/category_moderation_groups.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/category_moderation_groups.rb
@@ -11,6 +11,7 @@ module Migrations
             IntermediateDB::CategoryModerationGroup.create(
               category_id: item[:category_id],
               group_id: item[:group_id],
+              created_at: item[:created_at],
             )
           end
         end

--- a/migrations/core/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/core/db/intermediate_db_schema/100-base-schema.sql
@@ -100,8 +100,9 @@ CREATE TABLE category_custom_fields
 
 CREATE TABLE category_moderation_groups
 (
-    category_id NUMERIC NOT NULL,
-    group_id    NUMERIC NOT NULL,
+    category_id NUMERIC  NOT NULL,
+    group_id    NUMERIC  NOT NULL,
+    created_at  DATETIME,
     PRIMARY KEY (category_id, group_id)
 );
 

--- a/migrations/core/lib/migrations/database/intermediate_db/category_moderation_group.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/category_moderation_group.rb
@@ -11,10 +11,11 @@ module Migrations
         SQL = <<~SQL
           INSERT INTO category_moderation_groups (
             category_id,
-            group_id
+            group_id,
+            created_at
           )
           VALUES (
-            ?, ?
+            ?, ?, ?
           )
         SQL
         private_constant :SQL
@@ -23,10 +24,16 @@ module Migrations
         #
         # @param category_id   [Integer, String]
         # @param group_id      [Integer, String]
+        # @param created_at    [Time, nil]
         #
         # @return [void]
-        def self.create(category_id:, group_id:)
-          Migrations::Database::IntermediateDB.insert(SQL, category_id, group_id)
+        def self.create(category_id:, group_id:, created_at: nil)
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            category_id,
+            group_id,
+            Migrations::Database.format_datetime(created_at),
+          )
         end
       end
     end

--- a/migrations/importer/lib/migrations/importer/steps/categories/category_moderation_groups.rb
+++ b/migrations/importer/lib/migrations/importer/steps/categories/category_moderation_groups.rb
@@ -6,7 +6,7 @@ module Migrations
       class CategoryModerationGroups < CopyStep
         depends_on :categories, :groups
 
-        column_names %i[category_id group_id]
+        column_names %i[category_id group_id created_at updated_at]
 
         requires_set :existing_category_moderation_groups,
                      "SELECT category_id, group_id FROM category_moderation_groups WHERE group_id > 0"

--- a/migrations/tooling/config/schema/intermediate_db/tables/category_moderation_groups.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/category_moderation_groups.rb
@@ -3,5 +3,5 @@
 Migrations::Tooling::Schema.table :category_moderation_groups do
   primary_key :category_id, :group_id
 
-  ignore :created_at, :id
+  ignore :id
 end


### PR DESCRIPTION
Importing `category_moderation_groups` crashed — its `created_at`/`updated_at` are `NOT NULL`, but the importer copied only `category_id`/`group_id`.

`group_users` already carries `created_at` through the IntermediateDB; this table just ignored it. Now it's kept and carried through, the importer writes it (`updated_at` derived from it), and a source without one falls back to the import time.