### PR TITLE
Revert "FEATURE: Bump enable_unified_new upcoming change to beta (#41253)"

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4540,7 +4540,7 @@ experimental:
     client: true
     refresh: true
     upcoming_change:
-      status: "beta"
+      status: "alpha"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/404728"
   enable_rich_text_paste:


### PR DESCRIPTION
This reverts commit a0a46c15ae90203d18bea8af153da443c2991dd9.

Since Beta is now the point where everything is enabled for self-hosters, we
need to fix specs for this first