### PR TITLE
FIX: Remove Permanent dropdown filter from upcoming changes page

### DIFF
--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-changes.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-changes.gjs
@@ -54,11 +54,6 @@ export default class AdminConfigAreasUpcomingChanges extends Component {
           value: "stable",
           filterFn: (change) => change.upcoming_change.status === "stable",
         },
-        {
-          label: i18n("admin.upcoming_changes.filter.status_permanent"),
-          value: "permanent",
-          filterFn: (change) => change.upcoming_change.status === "permanent",
-        },
       ],
       type: [
         {


### PR DESCRIPTION
Permanent changes show on `/whats-new` but not the upcoming changes page.
This PR removes the Permanent filter from the dropdown on the upcoming
changes page to avoid confusion.
