### PR TITLE
DEV: Minor fixes to everyone-based permissions for granular_anonymous_and_logged_in_groups_permissions

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -480,6 +480,7 @@ basic:
     allow_any: false
     refresh: true
     disallowed_groups: "4"
+    mandatory_values: "1|2" # auto groups admins & moderators
     area: "group_permissions"
   push_notifications_prompt:
     default: true

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -102,6 +102,10 @@ class Guardian
     end
 
     def in_any_groups?(group_ids)
+      if !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
+        return group_ids.include?(Group::AUTO_GROUPS[:everyone])
+      end
+
       group_ids.include?(Group::AUTO_GROUPS[:anonymous_users])
     end
 

--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -662,8 +662,7 @@ class Guardian
   end
 
   def can_lazy_load_categories?
-    SiteSetting.lazy_load_categories_groups_map.include?(Group::AUTO_GROUPS[:everyone]) ||
-      @user.in_any_groups?(SiteSetting.lazy_load_categories_groups_map)
+    in_any_groups?(SiteSetting.lazy_load_categories_groups_map)
   end
 
   def is_me?(other)

--- a/lib/guardian/post_guardian.rb
+++ b/lib/guardian/post_guardian.rb
@@ -342,20 +342,19 @@ module PostGuardian
   end
 
   def can_see_all_hidden_posts?(category = nil)
-    hidden_post_visible_groups = SiteSetting.hidden_post_visible_groups_map
+    # TODO (martin) Remove this when granular_anonymous_and_logged_in_groups_permissions is
+    # permanent, as the check is covered inside guardian.in_any_groups? for anon
+    return false if anonymous? && !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
 
-    return true if hidden_post_visible_groups.include?(Group::AUTO_GROUPS[:everyone])
-    return false if anonymous?
-    return true if is_staff?
-    return true if is_category_group_moderator?(category)
-
-    @user.in_any_groups?(hidden_post_visible_groups)
+    in_any_groups?(SiteSetting.hidden_post_visible_groups_map) ||
+      is_category_group_moderator?(category)
   end
 
   def can_see_hidden_post?(post)
     return true if can_see_all_hidden_posts?
-    return false if anonymous?
-
+    # TODO (martin) Remove this when granular_anonymous_and_logged_in_groups_permissions is
+    # permanent, as the check is covered inside guardian.in_any_groups? for anon
+    return false if anonymous? && !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
     is_my_own?(post)
   end
 

--- a/plugins/styleguide/app/controllers/styleguide/styleguide_controller.rb
+++ b/plugins/styleguide/app/controllers/styleguide/styleguide_controller.rb
@@ -6,17 +6,7 @@ module Styleguide
     skip_before_action :check_xhr
 
     def index
-      allowed_group_ids = SiteSetting.styleguide_allowed_groups_map
-      anonymous_allowed =
-        allowed_group_ids.include?(Group::AUTO_GROUPS[:anonymous_users]) ||
-          (
-            !SiteSetting.granular_anonymous_and_logged_in_groups_permissions &&
-              allowed_group_ids.include?(Group::AUTO_GROUPS[:everyone])
-          )
-
-      return raise Discourse::NotFound if !current_user && !anonymous_allowed
-
-      if current_user && !current_user.in_any_groups?(allowed_group_ids)
+      if !guardian.in_any_groups?(SiteSetting.styleguide_allowed_groups_map)
         return raise Discourse::NotFound
       end
 

--- a/plugins/styleguide/spec/integration/access_spec.rb
+++ b/plugins/styleguide/spec/integration/access_spec.rb
@@ -24,6 +24,35 @@ RSpec.describe "SiteSetting.styleguide_allowed_groups" do
       end
     end
   end
+
+  context "when user is anonymous" do
+    context "when styleguide_allowed_groups is set to everyone" do
+      before { SiteSetting.styleguide_allowed_groups = Group::AUTO_GROUPS[:everyone] }
+
+      it "does not show the styleguide" do
+        get "/styleguide"
+        expect(response.status).to eq(404)
+      end
+
+      context "when styleguide_allowed_groups includes anonymous_users" do
+        before { SiteSetting.styleguide_allowed_groups = "#{Group::AUTO_GROUPS[:anonymous_users]}" }
+
+        it "shows the styleguide" do
+          get "/styleguide"
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when granular_anonymous_and_logged_in_groups_permissions is not enabled" do
+        before { SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false }
+
+        it "shows the styleguide" do
+          get "/styleguide"
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
 end
 
 RSpec.describe "SiteSetting.styleguide_enabled" do


### PR DESCRIPTION
Some minor changes based on findings in https://meta.discourse.org/t/granular-group-based-permissions-for-anonymous-and-logged-in-users/402273/12?u=martin , see individual commits for details.

- **DEV: Cleanup hidden_post_visible_groups usage**
- **DEV: Cleanup can_lazy_load_categories?**
- **FIX: Access check for styleguide_allowed_groups in styleguide**
