### PR TITLE
FIX: keep private message conversion limited to staff

### DIFF
--- a/lib/guardian/topic_guardian.rb
+++ b/lib/guardian/topic_guardian.rb
@@ -321,6 +321,9 @@ module TopicGuardian
     if new_archetype == Archetype.banner || topic.archetype == Archetype.banner
       return can_banner_topic?(topic)
     end
+    if new_archetype == Archetype.private_message || topic.private_message?
+      return can_convert_topic?(topic)
+    end
     true
   end
 

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe TopicConverter do
 
     context "with success" do
       it "converts regular topic to private message" do
-        private_message = topic.convert_to_private_message(post.user)
+        private_message = topic.convert_to_private_message(admin)
         expect(private_message).to be_valid
         expect(topic.archetype).to eq("private_message")
         expect(topic.category_id).to eq(nil)
@@ -180,7 +180,7 @@ RSpec.describe TopicConverter do
 
       it "converts unlisted topic to private message" do
         topic.update_status("visible", false, admin)
-        private_message = topic.convert_to_private_message(post.user)
+        private_message = topic.convert_to_private_message(admin)
 
         expect(private_message).to be_valid
         expect(topic.archetype).to eq("private_message")

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -2209,6 +2209,41 @@ RSpec.describe TopicsController do
         expect(topic.archetype).to eq(Archetype.default)
       end
 
+      it "does not allow a regular user to convert a private message to a public topic" do
+        private_message = Fabricate(:private_message_topic, user: user, recipient: user_2)
+        Fabricate(:post, topic: private_message, user: user)
+        victim_reply = Fabricate(:post, topic: private_message, user: user_2, raw: "private reply")
+
+        sign_in(post_author2)
+        get "/t/#{private_message.slug}/#{private_message.id}.json"
+        blocked_status = response.status
+        expect(blocked_status).to be_in([403, 404])
+        expect(response.body).not_to include(victim_reply.raw)
+
+        sign_in(user)
+        put "/t/#{private_message.slug}/#{private_message.id}.json",
+            params: {
+              archetype: Archetype.default,
+              category_id: category.id,
+            }
+        update_status = response.status
+        update_body = response.parsed_body
+
+        sign_in(post_author2)
+        get "/t/#{private_message.slug}/#{private_message.id}.json"
+
+        aggregate_failures do
+          expect(update_status).to eq(422)
+          expect(update_body["errors"]).to include(
+            I18n.t("activerecord.errors.models.topic.attributes.base.unable_to_update"),
+          )
+          expect(private_message.reload).to be_private_message
+          expect(private_message.category_id).to be_nil
+          expect(response.status).to eq(blocked_status)
+          expect(response.body).not_to include(victim_reply.raw)
+        end
+      end
+
       describe "without permission" do
         it "raises an exception when the user doesn't have permission to update the topic" do
           topic.update!(archived: true)


### PR DESCRIPTION
Converting a topic between a private message and a regular topic is meant to go through the dedicated staff-only conversion flow. The generic topic update path did not apply that same restriction, so the topic's archetype could be changed there without it.

Route archetype changes involving private messages through the same `can_convert_topic?` permission the conversion flow already uses, so both paths behave consistently.