### PR TITLE
FEATURE: Allow chat integration rules to exclude categories

### DIFF
--- a/plugins/discourse-chat-integration/admin/assets/javascripts/discourse/components/modal/edit-rule.gjs
+++ b/plugins/discourse-chat-integration/admin/assets/javascripts/discourse/components/modal/edit-rule.gjs
@@ -5,7 +5,9 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import Form from "discourse/components/form";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import Category from "discourse/models/category";
 import CategoryChooser from "discourse/select-kit/components/category-chooser";
+import CategorySelector from "discourse/select-kit/components/category-selector";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import TagChooser from "discourse/select-kit/components/tag-chooser";
 import DModal from "discourse/ui-kit/d-modal";
@@ -21,9 +23,26 @@ export default class EditRule extends Component {
   @tracked category_id = this.args.model.rule.category_id || null;
   @tracked group_id = this.args.model.rule.group_id || null;
   @tracked tags = this.args.model.rule.tags || [];
+  @tracked excludedCategories = [];
+
+  constructor() {
+    super(...arguments);
+    this.loadExcludedCategories();
+  }
 
   get isNormalType() {
     return this.type === "normal";
+  }
+
+  get showExcludedCategories() {
+    return this.isNormalType && !this.category_id;
+  }
+
+  async loadExcludedCategories() {
+    const ids = this.args.model.rule.exclude_category_ids || [];
+    this.excludedCategories = ids.length
+      ? await Category.asyncFindByIds(ids)
+      : [];
   }
 
   get title() {
@@ -53,6 +72,11 @@ export default class EditRule extends Component {
   }
 
   @action
+  onExcludedCategoriesChange(categories) {
+    this.excludedCategories = categories || [];
+  }
+
+  @action
   onTagsChange(tags) {
     this.tags = tags;
   }
@@ -64,6 +88,9 @@ export default class EditRule extends Component {
       type: this.type,
       filter: this.filter,
       category_id: this.type === "normal" ? this.category_id : null,
+      exclude_category_ids: this.showExcludedCategories
+        ? this.excludedCategories.map((category) => category.id)
+        : [],
       group_id: this.type !== "normal" ? this.group_id : null,
       tags: this.tags.map((tag) => getTagName(tag)),
     });
@@ -172,6 +199,27 @@ export default class EditRule extends Component {
                 />
               </field.Control>
             </form.Field>
+
+            {{#if this.showExcludedCategories}}
+              <form.Field
+                @type="custom"
+                @name="exclude_category_ids"
+                @title={{i18n
+                  "chat_integration.edit_rule_modal.exclude_categories"
+                }}
+                @description={{i18n
+                  "chat_integration.edit_rule_modal.instructions.exclude_categories"
+                }}
+                as |field|
+              >
+                <field.Control>
+                  <CategorySelector
+                    @categories={{this.excludedCategories}}
+                    @onChange={{this.onExcludedCategoriesChange}}
+                  />
+                </field.Control>
+              </form.Field>
+            {{/if}}
           {{else}}
             <form.Field
               @type="custom"

--- a/plugins/discourse-chat-integration/admin/assets/javascripts/discourse/components/rule-row.gjs
+++ b/plugins/discourse-chat-integration/admin/assets/javascripts/discourse/components/rule-row.gjs
@@ -3,6 +3,7 @@ import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import Category from "discourse/models/category";
 import DButton from "discourse/ui-kit/d-button";
 import dCategoryLink from "discourse/ui-kit/helpers/d-category-link";
 import { i18n } from "discourse-i18n";
@@ -22,6 +23,12 @@ export default class RuleRow extends Component {
 
   get isMention() {
     return this.args.rule.type === "group_mention";
+  }
+
+  get excludedCategories() {
+    return (this.args.rule.exclude_category_ids || [])
+      .map((id) => Category.findById(id))
+      .filter(Boolean);
   }
 
   get displayTags() {
@@ -64,6 +71,18 @@ export default class RuleRow extends Component {
             }}
           {{else}}
             {{i18n "chat_integration.all_categories"}}
+            {{#if this.excludedCategories.length}}
+              <div class="rule-excluded-categories">
+                {{i18n "chat_integration.excluding_categories"}}
+                {{#each this.excludedCategories as |category|}}
+                  {{dCategoryLink
+                    category
+                    allowUncategorized="true"
+                    link="false"
+                  }}
+                {{/each}}
+              </div>
+            {{/if}}
           {{/if}}
         {{else if this.isMention}}
           {{i18n

--- a/plugins/discourse-chat-integration/admin/assets/javascripts/discourse/models/rule.js
+++ b/plugins/discourse-chat-integration/admin/assets/javascripts/discourse/models/rule.js
@@ -6,6 +6,7 @@ import { i18n } from "discourse-i18n";
 export default class Rule extends RestModel {
   @tracked type = "normal";
   @tracked category_id = null;
+  @tracked exclude_category_ids = null;
   @tracked tags = null;
   @tracked channel_id = null;
   @tracked filter = "watch";
@@ -76,6 +77,7 @@ export default class Rule extends RestModel {
     return this.getProperties([
       "type",
       "category_id",
+      "exclude_category_ids",
       "group_id",
       "tags",
       "filter",
@@ -87,6 +89,7 @@ export default class Rule extends RestModel {
       "type",
       "channel_id",
       "category_id",
+      "exclude_category_ids",
       "group_id",
       "tags",
       "filter",

--- a/plugins/discourse-chat-integration/app/controllers/discourse_chat_integration/chat_controller.rb
+++ b/plugins/discourse-chat-integration/app/controllers/discourse_chat_integration/chat_controller.rb
@@ -175,7 +175,15 @@ class DiscourseChatIntegration::ChatController < ApplicationController
 
   def create_rule
     hash =
-      params.require(:rule).permit(:channel_id, :type, :filter, :group_id, :category_id, tags: [])
+      params.require(:rule).permit(
+        :channel_id,
+        :type,
+        :filter,
+        :group_id,
+        :category_id,
+        tags: [],
+        exclude_category_ids: [],
+      )
     rule = DiscourseChatIntegration::Rule.new(hash)
 
     raise Discourse::InvalidParameters, "Rule is not valid" if !rule.save
@@ -187,7 +195,15 @@ class DiscourseChatIntegration::ChatController < ApplicationController
 
   def update_rule
     rule = DiscourseChatIntegration::Rule.find(params[:id].to_i)
-    hash = params.require(:rule).permit(:type, :filter, :group_id, :category_id, tags: [])
+    hash =
+      params.require(:rule).permit(
+        :type,
+        :filter,
+        :group_id,
+        :category_id,
+        tags: [],
+        exclude_category_ids: [],
+      )
 
     raise Discourse::InvalidParameters, "Rule is not valid" if !rule.update(hash)
 

--- a/plugins/discourse-chat-integration/app/models/rule.rb
+++ b/plugins/discourse-chat-integration/app/models/rule.rb
@@ -2,7 +2,9 @@
 
 class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
   # Setup ActiveRecord::Store to use the JSON field to read/write these values
-  store :value, accessors: %i[channel_id type group_id category_id tags filter], coder: JSON
+  store :value,
+        accessors: %i[channel_id type group_id category_id exclude_category_ids tags filter],
+        coder: JSON
 
   scope :with_type, ->(type) { where("value::json->>'type'=?", type.to_s) }
   scope :with_channel, ->(channel) { with_channel_id(channel.id) }
@@ -58,7 +60,11 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
               message: "%{value} is not a valid filter",
             }
 
-  validate :channel_valid?, :category_valid?, :group_valid?, :tags_valid?
+  validate :channel_valid?,
+           :category_valid?,
+           :exclude_categories_valid?,
+           :group_valid?,
+           :tags_valid?
 
   def self.key_prefix
     "rule:"
@@ -70,6 +76,14 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
       super(nil)
     else
       super(array)
+    end
+  end
+
+  def exclude_category_ids=(array)
+    if array.nil? || array.empty?
+      super(nil)
+    else
+      super(array.map(&:to_i))
     end
   end
 
@@ -111,6 +125,29 @@ class DiscourseChatIntegration::Rule < DiscourseChatIntegration::PluginModel
 
     if !(category_id.nil? || Category.where(id: category_id).exists?)
       errors.add(:category_id, "#{category_id} is not a valid category id")
+    end
+  end
+
+  def exclude_categories_valid?
+    return if exclude_category_ids.nil?
+
+    if type != "normal"
+      errors.add(:exclude_category_ids, "cannot be specified for that type of rule")
+      return
+    end
+
+    if !category_id.nil?
+      errors.add(
+        :exclude_category_ids,
+        "can only be specified when the rule applies to all categories",
+      )
+      return
+    end
+
+    exclude_category_ids.each do |id|
+      if !Category.where(id: id).exists?
+        errors.add(:exclude_category_ids, "#{id} is not a valid category id")
+      end
     end
   end
 

--- a/plugins/discourse-chat-integration/app/serializers/rule_serializer.rb
+++ b/plugins/discourse-chat-integration/app/serializers/rule_serializer.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class DiscourseChatIntegration::RuleSerializer < ApplicationSerializer
-  attributes :id, :channel_id, :type, :group_id, :group_name, :category_id, :tags, :filter
+  attributes :id,
+             :channel_id,
+             :type,
+             :group_id,
+             :group_name,
+             :category_id,
+             :exclude_category_ids,
+             :tags,
+             :filter
 
   def group_name
     if object.group_id

--- a/plugins/discourse-chat-integration/app/services/manager.rb
+++ b/plugins/discourse-chat-integration/app/services/manager.rb
@@ -57,6 +57,14 @@ module DiscourseChatIntegration
 
       matching_rules = matching_rules.select { |rule| rule.filter != "tag_added" } # ignore tag_added rules, now uses Automation
 
+      # Discard rules which explicitly exclude the topic's category
+      if topic.category_id
+        matching_rules =
+          matching_rules.select do |rule|
+            rule.exclude_category_ids.nil? || !rule.exclude_category_ids.include?(topic.category_id)
+          end
+      end
+
       # If tagging is enabled, thow away rules that don't apply to this topic
       if SiteSetting.tagging_enabled
         topic_tags = topic.tags.present? ? topic.tags.pluck(:name) : []

--- a/plugins/discourse-chat-integration/config/locales/client.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/client.en.yml
@@ -49,6 +49,7 @@ en:
       choose_group: "(Choose a group)"
       all_categories: "(All categories)"
       all_tags: "(All tags)"
+      excluding_categories: "Excluding:"
       create_rule: "Create rule"
       add_channel: "Add channel"
       delete_channel: "Delete"
@@ -95,12 +96,14 @@ en:
         channel: Channel
         filter: Filter
         category: Category
+        exclude_categories: Excluded categories
         group: Group
         tags: Tags
         instructions:
           type: "Change the type to trigger notifications for group messages or mentions"
           filter: "Notification level. Mute overrides other matching rules"
           category: "This rule will only apply to topics in the specified category"
+          exclude_categories: "If specified, this rule will not apply to topics in these categories"
           group: "This rule will apply to posts referencing this group"
           tags: "If specified, this rule will only apply to topics which have at least one of these tags"
 

--- a/plugins/discourse-chat-integration/spec/models/rule_spec.rb
+++ b/plugins/discourse-chat-integration/spec/models/rule_spec.rb
@@ -47,6 +47,17 @@ RSpec.describe DiscourseChatIntegration::Rule do
     expect(loadedRule.filter).to eq("watch")
   end
 
+  it "should save and load exclude_category_ids successfully" do
+    rule =
+      DiscourseChatIntegration::Rule.create!(
+        channel: channel,
+        exclude_category_ids: [category.id.to_s],
+      )
+
+    loaded_rule = DiscourseChatIntegration::Rule.find(rule.id)
+    expect(loaded_rule.exclude_category_ids).to contain_exactly(category.id)
+  end
+
   describe "general operations" do
     before do
       rule =
@@ -228,6 +239,39 @@ RSpec.describe DiscourseChatIntegration::Rule do
       rule.filter = ""
       expect(rule.valid?).to eq(false)
       rule.filter = "somerandomstring"
+      expect(rule.valid?).to eq(false)
+    end
+
+    it "validates exclude_category_ids correctly" do
+      rule.category_id = nil
+      expect(rule.valid?).to eq(true)
+
+      rule.exclude_category_ids = []
+      expect(rule.exclude_category_ids).to eq(nil)
+      expect(rule.valid?).to eq(true)
+
+      rule.exclude_category_ids = [category.id]
+      expect(rule.valid?).to eq(true)
+
+      rule.exclude_category_ids = [category.id, -99]
+      expect(rule.valid?).to eq(false)
+    end
+
+    it "doesn't allow exclude_category_ids when a category is specified" do
+      rule.exclude_category_ids = [category.id]
+      expect(rule.valid?).to eq(false)
+
+      rule.category_id = nil
+      expect(rule.valid?).to eq(true)
+    end
+
+    it "doesn't allow exclude_category_ids for group rules" do
+      rule.category_id = nil
+      rule.type = "group_message"
+      rule.group_id = group.id
+      expect(rule.valid?).to eq(true)
+
+      rule.exclude_category_ids = [category.id]
       expect(rule.valid?).to eq(false)
     end
 

--- a/plugins/discourse-chat-integration/spec/services/manager_spec.rb
+++ b/plugins/discourse-chat-integration/spec/services/manager_spec.rb
@@ -89,6 +89,32 @@ RSpec.describe DiscourseChatIntegration::Manager do
       expect(provider.sent_to_channel_ids).to contain_exactly(chan1.id, chan2.id)
     end
 
+    describe "with exclude_category_ids" do
+      let(:excluded_category) { Fabricate(:category) }
+      let(:excluded_topic) { Fabricate(:topic, category_id: excluded_category.id) }
+      let(:excluded_topic_post) { Fabricate(:post, topic: excluded_topic) }
+
+      before do
+        DiscourseChatIntegration::Rule.create!(
+          channel: chan1,
+          filter: "watch",
+          exclude_category_ids: [excluded_category.id],
+        )
+      end
+
+      it "should not notify for a topic in an excluded category" do
+        manager.trigger_notifications(excluded_topic_post.id)
+
+        expect(provider.sent_to_channel_ids).to contain_exactly
+      end
+
+      it "should notify for topics in other categories" do
+        manager.trigger_notifications(first_post.id)
+
+        expect(provider.sent_to_channel_ids).to contain_exactly(chan1.id)
+      end
+    end
+
     it "should send a notification only to watched for reply" do
       DiscourseChatIntegration::Rule.create!(
         channel: chan1,


### PR DESCRIPTION
Chat integration rules that apply to all categories currently notify for every topic on the site. There is no way to say "notify for everything except these categories" — you would have to create one rule per category and keep that list in sync as categories are added.

This adds an optional **Excluded categories** setting to chat-integration rules:

- A new `exclude_category_ids` value is stored on the rule (same JSON store as `category_id`/`tags`). When a rule has excluded categories, `Manager.trigger_notifications` skips that rule for topics in those categories; all other categories keep notifying.
- The edit-rule modal shows a category multi-select for the excluded categories. It is only shown for "normal" rules with **(All categories)** selected, since exclusions are meaningless when the rule already targets a single category — this mirrors how `category_id`/`group_id` are scoped per rule type, and the same constraints are validated server-side.
- The rule list shows the exclusions next to "(All categories)" so the configuration is visible without opening the modal.

Existing rules are unaffected (`exclude_category_ids` defaults to `nil`, and empty arrays are normalized to `nil` like `tags`).

Tests: model validations and store round-trip in `rule_spec.rb`, notification filtering in `manager_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)