### PR TITLE
FIX: re-validate permissions when running CSV export job

### DIFF
--- a/app/jobs/regular/export_csv_file.rb
+++ b/app/jobs/regular/export_csv_file.rb
@@ -67,6 +67,8 @@ module Jobs
       entity[:method] = :"#{entity[:name]}_export"
       raise Discourse::InvalidParameters.new(:entity) unless respond_to?(entity[:method])
 
+      Guardian.new(@current_user).ensure_can_export_entity!(@entity, nil, @extra)
+
       @timestamp ||= Time.now.strftime("%y%m%d-%H%M%S")
       entity[:filename] = if entity[:name] == "report" && @extra[:name].present?
         "#{@extra[:name].dasherize}-#{@timestamp}"

--- a/plugins/discourse-calendar/lib/discourse_post_event/export_csv_file_extension.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/export_csv_file_extension.rb
@@ -34,4 +34,19 @@ module DiscoursePostEvent
       end
     end
   end
+
+  module GuardianExtension
+    def can_export_entity?(entity, entity_id = nil, args = nil)
+      if entity == "post_event"
+        return false if !SiteSetting.discourse_post_event_enabled
+
+        event_id = args&.[](:id) || args&.[]("id")
+        event = DiscoursePostEvent::Event.find_by(id: event_id)
+
+        return event.present? && can_act_on_discourse_post_event?(event)
+      end
+
+      super
+    end
+  end
 end

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -222,6 +222,7 @@ after_initialize do
   reloadable_patch do
     ExportCsvController.prepend(DiscoursePostEvent::ExportCsvControllerExtension)
     Jobs::ExportCsvFile.prepend(DiscoursePostEvent::ExportPostEventCsvReportExtension)
+    Guardian.prepend(DiscoursePostEvent::GuardianExtension)
     Post.prepend(DiscoursePostEvent::PostExtension)
     ::WebHook.prepend(DiscoursePostEvent::WebHookExtension)
     Topic.prepend(DiscoursePostEvent::TopicExtension)

--- a/spec/jobs/export_csv_file_spec.rb
+++ b/spec/jobs/export_csv_file_spec.rb
@@ -12,6 +12,43 @@ RSpec.describe Jobs::ExportCsvFile do
       )
     end
 
+    context "when re-validating permissions at execution time" do
+      it "exports the user list for an admin" do
+        expect do
+          Jobs::ExportCsvFile.new.execute(user_id: admin.id, entity: "user_list")
+        end.to change { Upload.count }.by(1)
+      ensure
+        admin.uploads.each(&:destroy!)
+      end
+
+      it "raises an error when the admin was demoted after enqueueing" do
+        admin.revoke_admin!
+
+        expect do
+          Jobs::ExportCsvFile.new.execute(user_id: admin.id, entity: "user_list")
+        end.to raise_error(Discourse::InvalidAccess)
+        expect(UserExport.where(user_id: admin.id)).to be_empty
+      end
+
+      it "raises an error when a regular user attempts a privileged export" do
+        user = Fabricate(:user)
+
+        expect do
+          Jobs::ExportCsvFile.new.execute(user_id: user.id, entity: "user_list")
+        end.to raise_error(Discourse::InvalidAccess)
+        expect(UserExport.where(user_id: user.id)).to be_empty
+      end
+
+      it "raises an error when a moderator attempts an admin-only export" do
+        moderator = Fabricate(:moderator)
+
+        expect do
+          Jobs::ExportCsvFile.new.execute(user_id: moderator.id, entity: "user_list")
+        end.to raise_error(Discourse::InvalidAccess)
+        expect(UserExport.where(user_id: moderator.id)).to be_empty
+      end
+    end
+
     it "works" do
       action_log
 


### PR DESCRIPTION
Authorization for a CSV export was only checked when the export was requested, not when the background job actually ran. This adds a permission check inside `Jobs::ExportCsvFile` so that access always reflects the user's current privileges at the time the data is generated. If the user is not allowed to export the entity, the job stops before any data is produced.

The discourse-calendar plugin is updated with a matching `Guardian#can_export_entity?` extension so that legitimate `post_event` exports keep working under the new check.