### PR TITLE
FIX: add missing length validation to chat channel `emoji`

### DIFF
--- a/plugins/chat/app/models/chat/channel.rb
+++ b/plugins/chat/app/models/chat/channel.rb
@@ -43,6 +43,7 @@ module Chat
     validates :chatable_type, length: { maximum: 100 }
     validates :type, length: { maximum: 100 }
     validates :slug, length: { maximum: 100 }
+    validates :emoji, length: { maximum: 100 }
     validate :ensure_slug_ok, if: :slug_changed?
     before_validation :generate_auto_slug
 

--- a/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
@@ -530,6 +530,30 @@ RSpec.describe Chat::Api::ChannelsController do
       end
     end
 
+    context "when user provides an emoji that is too long" do
+      fab!(:user, :admin)
+      fab!(:channel, :category_channel)
+
+      before { sign_in(user) }
+
+      it "rejects the update" do
+        long_emoji = "a" * 2800
+        expected_error = "Emoji #{I18n.t("errors.messages.too_long", count: 100)}"
+
+        put "/chat/api/channels/#{channel.id}",
+            params: {
+              channel: {
+                emoji: long_emoji,
+              },
+            },
+            as: :json
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to contain_exactly(expected_error)
+        expect(channel.reload.emoji).to be_nil
+      end
+    end
+
     context "when user provided an empty name" do
       fab!(:user, :admin)
       fab!(:channel) do


### PR DESCRIPTION
Previously, the `emoji` attribute on chat channels had no length validation, unlike `slug`, `name`, and `description`, so a channel editor could persist arbitrarily long strings through the create/update API.

This change adds a `maximum: 100` length validation to `emoji` on `Chat::Channel`, rejecting oversized values with a 422 and keeping it consistent with the other channel fields.