### PR TITLE
FIX: return empty string for invalid date

### DIFF
--- a/frontend/discourse/app/lib/formatter.js
+++ b/frontend/discourse/app/lib/formatter.js
@@ -72,7 +72,7 @@ export function updateRelativeAge(elems) {
 }
 
 export function autoUpdatingRelativeAge(date, options) {
-  if (!date) {
+  if (!date || isNaN(date.getTime())) {
     return "";
   }
   if (+date === +new Date(0)) {

--- a/frontend/discourse/tests/unit/lib/formatter-test.js
+++ b/frontend/discourse/tests/unit/lib/formatter-test.js
@@ -260,6 +260,17 @@ module("Unit | Utility | formatter", function (hooks) {
 
     elem = domFromString(autoUpdatingRelativeAge(d, { prefix: "test" }))[0];
     assert.dom(elem).hasHtml("test 1d");
+
+    assert.strictEqual(
+      autoUpdatingRelativeAge(null),
+      "",
+      "it returns an empty string for a missing date"
+    );
+    assert.strictEqual(
+      autoUpdatingRelativeAge(new Date(undefined), { format: "medium" }),
+      "",
+      "it returns an empty string for an invalid date"
+    );
   });
 
   test("updateRelativeAge", function (assert) {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/group-members-last-visited-and-last-posted-date-of-hidden-profiles/406816

When someone's profile is hidden, `last_seen_at` and `last_posted_at` are hidden. The group user directory calls `{{dAgeWithTooltip m.last_seen_at format="medium"}}`, which does `new Date(undefined)` resulting in `Invalid Date`, which is truthy! This passes the `!date` check in `autoUpdatingRelativeAge` and results in a broken translation: 

<img width="886" height="86" alt="image" src="https://github.com/user-attachments/assets/6e18cc82-82cd-429e-8c92-a4351051ac2e" />
 
Adding `isNaN(date.getTime())` avoids the case where we attempt to process a `new Date()` result that's not a date. 