### PR TITLE
DEV: Drop JQuery from discourse-topic and modernize click-track

### DIFF
--- a/frontend/discourse/app/components/discourse-topic.js
+++ b/frontend/discourse/app/components/discourse-topic.js
@@ -1,4 +1,4 @@
-/* eslint-disable ember/no-classic-components, ember/no-jquery, ember/no-observers, ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components, ember/no-observers, ember/require-tagless-components */
 import Component from "@ember/component";
 import { computed, set } from "@ember/object";
 import { getOwner } from "@ember/owner";
@@ -7,7 +7,6 @@ import { service } from "@ember/service";
 import { isBlank } from "@ember/utils";
 import { classNameBindings } from "@ember-decorators/component";
 import { observes } from "@ember-decorators/object";
-import $ from "jquery";
 import ClickTrack from "discourse/lib/click-track";
 import { bind } from "discourse/lib/decorators";
 import { highlightPost } from "discourse/lib/utilities";
@@ -80,11 +79,7 @@ export default class DiscourseTopic extends Component {
 
     this.scrollManager.bindScrolling(this);
     window.addEventListener("resize", this.scrolled);
-    $(this.element).on(
-      "click.discourse-redirect",
-      ".cooked a, a.track-link",
-      (e) => ClickTrack.trackClick(e, getOwner(this))
-    );
+    this.element.addEventListener("click", this._trackLinkClick);
   }
 
   willDestroyElement() {
@@ -94,7 +89,14 @@ export default class DiscourseTopic extends Component {
     window.removeEventListener("resize", this.scrolled);
 
     // Unbind link tracking
-    $(this.element).off("click.discourse-redirect", ".cooked a, a.track-link");
+    this.element.removeEventListener("click", this._trackLinkClick);
+  }
+
+  @bind
+  _trackLinkClick(event) {
+    if (event.target.closest(".cooked a, a.track-link")) {
+      ClickTrack.trackClick(event, getOwner(this));
+    }
   }
 
   gotFocus(hasFocus) {

--- a/frontend/discourse/app/components/links-redirect.js
+++ b/frontend/discourse/app/components/links-redirect.js
@@ -5,7 +5,7 @@ import ClickTrack from "discourse/lib/click-track";
 
 export default class LinksRedirect extends Component {
   click(event) {
-    if (event?.target?.tagName === "A") {
+    if (event.target.closest("a")) {
       return ClickTrack.trackClick(event, getOwner(this));
     }
   }

--- a/frontend/discourse/app/components/user-stream.gjs
+++ b/frontend/discourse/app/components/user-stream.gjs
@@ -175,7 +175,7 @@ export default class UserStreamComponent extends Component {
       return;
     }
 
-    if (event.target.matches(".excerpt a")) {
+    if (event.target.closest(".excerpt a")) {
       return ClickTrack.trackClick(event, getOwner(this));
     }
   }

--- a/frontend/discourse/app/lib/click-track.js
+++ b/frontend/discourse/app/lib/click-track.js
@@ -79,7 +79,13 @@ export default {
       return true;
     }
 
-    const link = e.currentTarget;
+    // Resolve the clicked link from the event target. This lets callers bind a
+    // single listener on a container element instead of delegating per-link.
+    const link = e.target?.closest("a");
+    if (!link) {
+      return true;
+    }
+
     const tracking = isValidLink(link);
 
     // Return early for mentions and group mentions. This is not in
@@ -106,7 +112,7 @@ export default {
       ) {
         const dialog = getOwnerWithFallback(this).lookup("service:dialog");
         dialog.alert(i18n("post.errors.attachment_download_requires_login"));
-      } else if (wantsNewWindow(e)) {
+      } else if (wantsNewWindow(e, link)) {
         const newWindow = window.open(href, "_blank");
         newWindow.opener = null;
         newWindow.focus();
@@ -161,7 +167,7 @@ export default {
       }
     }
 
-    if (!wantsNewWindow(e)) {
+    if (!wantsNewWindow(e, link)) {
       if (shouldOpenInNewTab(href)) {
         openLinkInNewTab(e, link);
       } else {

--- a/frontend/discourse/app/lib/intercept-click.js
+++ b/frontend/discourse/app/lib/intercept-click.js
@@ -2,7 +2,7 @@ import DiscourseURL from "discourse/lib/url";
 
 const MOUSE_EVENT_PRIMARY_BUTTON_ID = 0;
 
-export function wantsNewWindow(e) {
+export function wantsNewWindow(e, link = e.currentTarget) {
   return (
     e.defaultPrevented ||
     e.isDefaultPrevented?.() ||
@@ -10,7 +10,7 @@ export function wantsNewWindow(e) {
     e.metaKey ||
     e.ctrlKey ||
     (e.button && e.button !== MOUSE_EVENT_PRIMARY_BUTTON_ID) ||
-    e.currentTarget?.target === "_blank"
+    link?.target === "_blank"
   );
 }
 

--- a/frontend/discourse/tests/unit/lib/click-track-test.js
+++ b/frontend/discourse/tests/unit/lib/click-track-test.js
@@ -12,7 +12,7 @@ const track = ClickTrack.trackClick;
 
 function generateClickEventOn(selector) {
   const event = new MouseEvent("click");
-  sinon.stub(event, "currentTarget").get(() => fixture(selector));
+  sinon.stub(event, "target").get(() => fixture(selector));
   return event;
 }
 
@@ -97,6 +97,26 @@ module("Unit | Utility | click-track", function (hooks) {
 
   test("does not track elements with no href", async function (assert) {
     assert.true(track(generateClickEventOn(".a-without-href")));
+  });
+
+  test("resolves the link when the click lands on a nested element", async function (assert) {
+    sinon.stub(DiscourseURL, "origin").get(() => "http://discuss.domain.com");
+
+    const done = assert.async();
+    pretender.post("/clicks/track", (request) => {
+      assert.strictEqual(
+        request.requestBody,
+        "url=http%3A%2F%2Fwww.google.de&post_id=42&topic_id=1337"
+      );
+      done();
+      return [200, {}, ""];
+    });
+
+    // Target the badge <span> inside the "#with-badge" anchor: trackClick must
+    // still walk up to the enclosing <a> via closest().
+    const event = new MouseEvent("click");
+    sinon.stub(event, "target").get(() => fixture("#with-badge span.badge"));
+    assert.false(track(event));
   });
 
   test("does not track attachments", async function (assert) {


### PR DESCRIPTION
click-track was relying on `e.currentTarget`, which may not be the actual link in a vanilla-js event. It worked in JQuery because listeners could be set with filters like `"a"`, and `currentTarget` would be set accordingly. But in vanilla JS, `currentTarget` is the wrapper element with the event-listener attached.

Instead, we can use `event.target.closest("a")` to find the actual link element.