### PR TITLE
SECURITY: Removed channel member can edit and trash their own chat messages

### DIFF
--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -273,6 +273,8 @@ module Chat
     end
 
     def can_edit_chat?(message)
+      return false if !can_preview_chat_channel?(message.chat_channel)
+
       (message.user_id == @user.id && !@user.silenced?) || is_admin?
     end
 

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -279,6 +279,37 @@ RSpec.describe Chat::Api::ChannelMessagesController do
         end
       end
 
+      context "when the user no longer has access to a private category channel" do
+        fab!(:group)
+        fab!(:private_category) { Fabricate(:private_category, group:) }
+        fab!(:private_channel) { Fabricate(:chat_channel, chatable: private_category) }
+        fab!(:message) do
+          Fabricate(
+            :chat_message,
+            chat_channel: private_channel,
+            user: current_user,
+            message: "original message",
+          )
+        end
+
+        before do
+          group.add(current_user)
+          private_channel.add(current_user)
+          GroupUser.where(group:, user: current_user).destroy_all
+        end
+
+        it "does not update their own message" do
+          put "/chat/api/channels/#{private_channel.id}/messages/#{message.id}",
+              params: {
+                message: "edited message",
+              }
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["failed"]).to eq("FAILED")
+          expect(message.reload.message).to eq("original message")
+        end
+      end
+
       context "when message belongs to a different channel" do
         fab!(:other_channel, :category_channel)
         fab!(:other_message) { Fabricate(:chat_message, chat_channel: other_channel) }


### PR DESCRIPTION
## Summary

Prevent users from editing chat messages in channels they can no longer access by requiring channel preview permissions in the authorization check. This fix addresses an authorization gap where stale chat memberships allowed users to modify their previous messages after losing access to a private category.

Patch Triage: https://patch.discourse.org/patch-triage/1403

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>