### PR TITLE
SECURITY: Authorization bypass in wiki edit presence leaks editor identities

### DIFF
--- a/plugins/discourse-presence/plugin.rb
+++ b/plugins/discourse-presence/plugin.rb
@@ -58,11 +58,19 @@ after_initialize do
         config.allowed_user_ids += topic.allowed_users.pluck(:id)
         config.allowed_group_ids += topic.allowed_groups.pluck(:id)
       elsif post.wiki
-        config.allowed_group_ids += SiteSetting.edit_wiki_post_allowed_groups_map
+        wiki_post_allowed_group_ids = SiteSetting.edit_wiki_post_allowed_groups_map
+        if secure_group_ids = topic.secure_group_ids
+          wiki_post_allowed_group_ids &= secure_group_ids
+        end
+        config.allowed_group_ids += wiki_post_allowed_group_ids
       end
 
       if !topic.private_message? && SiteSetting.edit_all_post_groups_map.present?
-        config.allowed_group_ids += SiteSetting.edit_all_post_groups_map
+        edit_all_post_group_ids = SiteSetting.edit_all_post_groups_map
+        if secure_group_ids = topic.secure_group_ids
+          edit_all_post_group_ids &= secure_group_ids
+        end
+        config.allowed_group_ids += edit_all_post_group_ids
       end
 
       if SiteSetting.enable_category_group_moderation? && topic.category

--- a/plugins/discourse-presence/spec/integration/presence_spec.rb
+++ b/plugins/discourse-presence/spec/integration/presence_spec.rb
@@ -280,4 +280,40 @@ RSpec.describe "discourse-presence" do
       end
     end
   end
+
+  describe "PresenceController#get" do
+    fab!(:editor, :trust_level_1)
+    fab!(:attacker, :trust_level_1)
+
+    fab!(:private_group) { Fabricate(:group).tap { |private_group| private_group.add(editor) } }
+
+    fab!(:private_category) { Fabricate(:private_category, group: private_group) }
+    fab!(:private_topic) { Fabricate(:topic, category: private_category, user: editor) }
+    fab!(:wiki_post) { Fabricate(:post, topic: private_topic, user: editor, wiki: true) }
+
+    before do
+      PresenceChannel.clear_all!
+      SiteSetting.edit_wiki_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
+    end
+
+    after { PresenceChannel.clear_all! }
+
+    it "hides private wiki edit presence from outsiders" do
+      channel_name = "/discourse-presence/edit/#{wiki_post.id}"
+
+      sign_in(editor)
+      post "/presence/update.json",
+           params: {
+             client_id: SecureRandom.hex,
+             present_channels: [channel_name],
+           }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body).to eq(channel_name => true)
+
+      sign_in(attacker)
+      get "/presence/get", params: { channels: [channel_name] }
+      expect(response.status).to eq(200)
+      expect(response.parsed_body[channel_name]).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Correctly restrict wiki edit presence information to authorized users by intersecting global edit permissions with topic-level security groups. This prevents users outside of a private category from observing editor identities via the presence API.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1402

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>