### PR TITLE
FIX: Restore nested post moderation affordances

### DIFF
--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -812,6 +812,7 @@ export default class Nested extends Component {
           @grantBadge={{@grantBadge}}
           @lockPost={{@lockPost}}
           @recoverPost={{@recoverPost}}
+          @showFlags={{@showFlags}}
           @unlockPost={{@unlockPost}}
           @permanentlyDeletePost={{@permanentlyDeletePost}}
           @rebakePost={{@rebakePost}}

--- a/frontend/discourse/app/components/nested/op.gjs
+++ b/frontend/discourse/app/components/nested/op.gjs
@@ -10,6 +10,7 @@ import PostCookedHtml from "discourse/components/post/cooked-html";
 import PostLinks from "discourse/components/post/links";
 import PostMenu from "discourse/components/post/menu";
 import PostMetaData from "discourse/components/post/meta-data";
+import PostNotice from "discourse/components/post/notice";
 import TopicMap from "discourse/components/topic-map";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -19,6 +20,7 @@ import nestedPostUrl from "discourse/lib/nested-post-url";
 import postActionFeedback from "discourse/lib/post-action-feedback";
 import { nativeShare } from "discourse/lib/pwa-utils";
 import { clipboardCopy } from "discourse/lib/utilities";
+import { and, or } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 export default class NestedOp extends Component {
@@ -26,6 +28,7 @@ export default class NestedOp extends Component {
   @service currentUser;
   @service modal;
   @service site;
+  @service siteSettings;
 
   get nestedShareUrl() {
     return nestedPostUrl(this.args.topic, this.args.post.post_number);
@@ -123,6 +126,13 @@ export default class NestedOp extends Component {
                 "boxed"
                 (if this.selected "selected")
                 (if @post.deleted "is-deleted deleted")
+                (if
+                  (or
+                    @post.isModeratorAction
+                    (and @post.isWarning @post.firstPost)
+                  )
+                  "post--moderator moderator"
+                )
               }}
               data-post-id={{@post.id}}
               data-post-number={{@post.post_number}}
@@ -132,6 +142,9 @@ export default class NestedOp extends Component {
                 @name="post-article-content"
                 @outletArgs={{postOutletArgs}}
               >
+                {{#if (PostNotice.shouldRender @post this.siteSettings)}}
+                  <PostNotice @post={{@post}} />
+                {{/if}}
                 <div class="nested-view__op-row">
                   <PostAvatar @post={{@post}} />
                   <div class="nested-view__op-body">
@@ -150,7 +163,7 @@ export default class NestedOp extends Component {
                         @togglePostSelection={{this.togglePostSelection}}
                       />
                     </PluginOutlet>
-                    <div class="nested-view__op-content">
+                    <div class="nested-view__op-content regular">
                       <PluginOutlet
                         @name="post-content-cooked-html"
                         @outletArgs={{postOutletArgs}}
@@ -171,6 +184,7 @@ export default class NestedOp extends Component {
                           @deletePost={{fn @deletePost @post}}
                           @editPost={{fn @editPost @post}}
                           @recoverPost={{fn @recoverPost @post}}
+                          @showFlags={{fn @showFlags @post}}
                           @changeNotice={{fn @changeNotice @post}}
                           @changePostOwner={{fn @changePostOwner @post}}
                           @grantBadge={{fn @grantBadge @post}}

--- a/frontend/discourse/app/components/nested/post.gjs
+++ b/frontend/discourse/app/components/nested/post.gjs
@@ -15,6 +15,7 @@ import PostCookedHtml from "discourse/components/post/cooked-html";
 import PostLinks from "discourse/components/post/links";
 import PostMenu from "discourse/components/post/menu";
 import PostMetaData from "discourse/components/post/meta-data";
+import PostNotice from "discourse/components/post/notice";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -583,6 +584,10 @@ export default class NestedPost extends Component {
         (if this.effectiveCollapsed "nested-post--collapsed")
         (if @isPinned "nested-post--pinned")
         (if @post.isWhisper "nested-post--whisper")
+        (if
+          (or @post.isModeratorAction (and @post.isWarning @post.firstPost))
+          "post--moderator moderator"
+        )
         (if @post.hidden "nested-post--hidden post--hidden post-hidden")
         (if (or @post.deleted @post.user_deleted) "nested-post--deleted")
         (if this.cloakingData.active "nested-post--cloaked")
@@ -749,6 +754,9 @@ export default class NestedPost extends Component {
                     @name="post-article-content"
                     @outletArgs={{postOutletArgs}}
                   >
+                    {{#if (PostNotice.shouldRender @post this.siteSettings)}}
+                      <PostNotice @post={{@post}} />
+                    {{/if}}
                     <div class="nested-post__header">
                       <PluginOutlet
                         @name="post-metadata"
@@ -776,7 +784,7 @@ export default class NestedPost extends Component {
                           }}</span>
                       {{/if}}
                     </div>
-                    <div class="nested-post__content">
+                    <div class="nested-post__content regular">
                       <PluginOutlet
                         @name="post-content-cooked-html"
                         @outletArgs={{postOutletArgs}}

--- a/frontend/discourse/app/components/post/notice.gjs
+++ b/frontend/discourse/app/components/post/notice.gjs
@@ -14,7 +14,7 @@ const POST_NOTICE_COMPONENTS = {
 
 export default class PostNotice extends Component {
   static shouldRender(post, siteSettings) {
-    if (!post.notice || post.deletedAt) {
+    if (!post.notice?.type || post.deletedAt) {
       return false;
     }
 

--- a/lib/nested_replies/post_tree_serializer.rb
+++ b/lib/nested_replies/post_tree_serializer.rb
@@ -38,6 +38,7 @@ module NestedReplies
       post.topic = @topic
       serializer = PostSerializer.new(post, scope: @guardian, root: false)
       serializer.topic_view = @topic_view
+      serializer.notice_created_by_users = post_notice_created_by_users if @guardian.is_staff?
       json = serializer.as_json
 
       json[:direct_reply_count] = reply_counts[post.post_number] || 0
@@ -86,6 +87,20 @@ module NestedReplies
     def topic_view_json
       @topic_view_json ||=
         TopicViewSerializer.new(@topic_view, scope: @guardian, root: false).as_json
+    end
+
+    def post_notice_created_by_users
+      @post_notice_created_by_users ||=
+        begin
+          user_ids =
+            (@topic_view.post_custom_fields || {})
+              .filter_map do |_, custom_fields|
+                custom_fields.dig(Post::NOTICE, "created_by_user_id")
+              end
+              .uniq
+
+          User.real.where(id: user_ids).to_a
+        end
     end
 
     # Filters mirror Guardian#can_see_post? so the boolean does not leak

--- a/spec/services/nested_topic/list_roots_spec.rb
+++ b/spec/services/nested_topic/list_roots_spec.rb
@@ -60,6 +60,47 @@ RSpec.describe NestedTopic::ListRoots do
       end
     end
 
+    context "when staff views root posts with official notices" do
+      fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
+      fab!(:root_post) { Fabricate(:post, topic: topic, user: user, reply_to_post_number: 1) }
+
+      let(:topic_view) do
+        TopicView.new(topic.id, admin, skip_custom_fields: true, skip_post_loading: true)
+      end
+      let(:dependencies) { { guardian: admin.guardian, topic_view: topic_view } }
+
+      before do
+        root_post.custom_fields[Post::NOTICE] = {
+          type: Post.notices[:custom],
+          raw: "Official reply notice",
+          cooked: "<p>Official reply notice</p>",
+          created_by_user_id: admin.id,
+        }
+        root_post.save_custom_fields
+      end
+
+      it "serializes the official notice creator for nested posts" do
+        root_json = result[:response][:roots].first
+
+        expect(root_json[:notice]).to eq(
+          {
+            cooked: "<p>Official reply notice</p>",
+            created_by_user_id: admin.id,
+            raw: "Official reply notice",
+            type: Post.notices[:custom],
+          }.with_indifferent_access,
+        )
+        expect(root_json[:notice_created_by_user]).to eq(
+          {
+            id: admin.id,
+            username: admin.username,
+            name: admin.name,
+            avatar_template: admin.avatar_template,
+          },
+        )
+      end
+    end
+
     context "when page is greater than 0" do
       let(:params) { { sort: "top", page: 1 } }
 

--- a/spec/system/nested_post_admin_menu_spec.rb
+++ b/spec/system/nested_post_admin_menu_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe "Nested view post admin menu" do
   fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:flagger) { Fabricate(:user, refresh_auto_groups: true) }
   fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
   fab!(:topic) { Fabricate(:topic, user: user) }
   fab!(:op) do
@@ -16,6 +17,7 @@ RSpec.describe "Nested view post admin menu" do
   fab!(:reply) { Fabricate(:post, topic: topic, user: user, raw: "Some reply body here") }
 
   let(:nested_view) { PageObjects::Pages::NestedView.new }
+  let(:flag_modal) { PageObjects::Modals::Flag.new }
 
   before do
     SiteSetting.nested_replies_enabled = true
@@ -24,10 +26,31 @@ RSpec.describe "Nested view post admin menu" do
 
   def open_admin_menu_for(post)
     selector = "[data-post-number='#{post.post_number}']"
+    page.execute_script(
+      "document.querySelector(#{selector.to_json})?.scrollIntoView({ block: 'center', inline: 'nearest' })",
+    )
+
     within(selector) do
-      find(".show-more-actions").click if has_css?(".show-more-actions", wait: 2)
+      all(".show-more-actions", minimum: 0, wait: 0).first&.click
       find(".post-action-menu__admin").click
     end
+  end
+
+  def add_official_notice(post, raw)
+    post.custom_fields[Post::NOTICE] = {
+      type: Post.notices[:custom],
+      raw: raw,
+      cooked: PrettyText.cook(raw),
+      created_by_user_id: admin.id,
+    }
+    post.save_custom_fields
+  end
+
+  def set_official_notice(raw)
+    expect(page).to have_css(".change-post-notice-modal")
+    find(".change-post-notice-modal textarea").fill_in(with: raw)
+    find(".change-post-notice-modal .btn-primary").click
+    expect(page).to have_no_css(".change-post-notice-modal")
   end
 
   context "as an admin" do
@@ -51,12 +74,74 @@ RSpec.describe "Nested view post admin menu" do
       try_until_success { expect(op.reload.locked_by_id).to eq(admin.id) }
     end
 
+    it "shows staff-only OP admin controls" do
+      nested_view.visit_nested(topic)
+      open_admin_menu_for(op)
+
+      expect(page).to have_css("[data-content][data-identifier='admin-post-menu'] .add-notice")
+      expect(page).to have_css(
+        "[data-content][data-identifier='admin-post-menu'] .toggle-post-type",
+      )
+    end
+
+    it "applies staff color and official notice from the OP admin controls" do
+      nested_view.visit_nested(topic)
+      open_admin_menu_for(op)
+      find("[data-content][data-identifier='admin-post-menu'] .toggle-post-type").click
+
+      expect(page).to have_css(
+        "[data-post-number='#{op.post_number}'].moderator .nested-view__op-content.regular > .cooked",
+        text: op.raw,
+      )
+
+      open_admin_menu_for(op)
+      find("[data-content][data-identifier='admin-post-menu'] .add-notice").click
+      set_official_notice("Official OP notice")
+
+      expect(page).to have_css(
+        "[data-post-number='#{op.post_number}'] .post-notice.custom",
+        text: "Official OP notice",
+      )
+    end
+
+    it "renders staff color and official notices on nested replies" do
+      reply.update!(post_type: Post.types[:moderator_action])
+      add_official_notice(reply, "Official reply notice")
+
+      nested_view.visit_nested(topic)
+
+      expect(page).to have_css(
+        ".nested-post.moderator [data-post-number='#{reply.post_number}'] .nested-post__content.regular > .cooked",
+        text: reply.raw,
+      )
+      expect(page).to have_css(
+        "[data-post-number='#{reply.post_number}'] .post-notice.custom",
+        text: "Official reply notice",
+      )
+    end
+
     it "opens the change-owner modal when clicking the admin menu item" do
       nested_view.visit_nested(topic)
       open_admin_menu_for(reply)
       find("[data-content][data-identifier='admin-post-menu'] .change-owner").click
 
       expect(page).to have_css(".change-ownership-modal")
+    end
+  end
+
+  context "as a regular user" do
+    before do
+      SiteSetting.post_menu = "like|copyLink|share|flag|edit|bookmark|delete|admin|reply"
+      SiteSetting.post_menu_hidden_items = ""
+      sign_in(flagger)
+    end
+
+    it "opens the flag modal from the OP menu" do
+      nested_view.visit_nested(topic)
+
+      within("[data-post-number='#{op.post_number}']") { find(".post-action-menu__flag").click }
+
+      expect(flag_modal).to be_open
     end
   end
 end


### PR DESCRIPTION
### What changed

Nested replies now restore the moderation affordances reported in the bug https://meta.discourse.org/t/nested-replies-flagging-and-staff-color-has-no-effect/406636?u=markvanlan:

- wires the OP flag action into `PostMenu`, so the OP / first post can open the regular flag modal from nested view
- renders official post notices in nested OP and nested reply posts
- applies the existing staff-color/moderator post styling in nested OP and nested reply posts
- includes staff notice creator data in nested post serialization, matching flat topic serialization
- makes `PostNotice.shouldRender` ignore transient non-object notice values while a notice save is in flight