### PR TITLE
SECURITY: /solution/by_user leaks whisper/hidden accepted-answer post

### DIFF
--- a/plugins/discourse-solved/app/controllers/discourse_solved/solved_topics_controller.rb
+++ b/plugins/discourse-solved/app/controllers/discourse_solved/solved_topics_controller.rb
@@ -37,7 +37,7 @@ class DiscourseSolved::SolvedTopicsController < ::ApplicationController
     posts = guardian.filter_hidden_posts(posts)
 
     unless guardian.is_admin?
-      current_user_id = current_user&.id || -1
+      current_user_id = current_user&.id || Discourse.system_user.id
       posts =
         posts.where(
           "posts.user_id = :current_user_id OR posts.post_type IN (:visible_post_types)",

--- a/plugins/discourse-solved/app/controllers/discourse_solved/solved_topics_controller.rb
+++ b/plugins/discourse-solved/app/controllers/discourse_solved/solved_topics_controller.rb
@@ -34,6 +34,17 @@ class DiscourseSolved::SolvedTopicsController < ::ApplicationController
         )
 
     posts = posts.where(topics: { visible: true }) unless include_unlisted_topics
+    posts = guardian.filter_hidden_posts(posts)
+
+    unless guardian.is_admin?
+      current_user_id = current_user&.id || -1
+      posts =
+        posts.where(
+          "posts.user_id = :current_user_id OR posts.post_type IN (:visible_post_types)",
+          current_user_id:,
+          visible_post_types: Topic.visible_post_types(current_user),
+        )
+    end
 
     posts =
       posts
@@ -41,6 +52,8 @@ class DiscourseSolved::SolvedTopicsController < ::ApplicationController
         .order("discourse_solved_topic_answers.created_at DESC")
         .offset(offset)
         .limit(limit)
+
+    posts = posts.select { |post| guardian.can_see_post?(post) }
 
     render_serialized(posts, DiscourseSolved::SolvedPostSerializer, root: "user_solved_posts")
   end

--- a/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
+++ b/plugins/discourse-solved/spec/requests/solved_topics_controller_spec.rb
@@ -145,24 +145,45 @@ describe DiscourseSolved::SolvedTopicsController do
         expect(result["user_solved_posts"]).to be_empty
       end
 
-      context "with hidden posts" do
+      context "with posts hidden from the current user" do
         before do
-          answer_post.update!(
+          answer_post.update_columns(
+            raw: "secret hidden accepted answer raw",
+            cooked: "<p>secret hidden accepted answer cooked</p>",
             hidden: true,
             hidden_at: Time.zone.now,
             hidden_reason_id: Post.hidden_reasons[:flag_threshold_reached],
           )
+          answer_post.reload
         end
 
-        it "returns hidden posts when the topic is visible" do
-          sign_in(another_user)
+        it "does not return hidden posts or whispers" do
+          whisper_answer_post =
+            Fabricate(
+              :post,
+              topic: Fabricate(:topic),
+              user:,
+              raw: "secret whisper accepted answer raw",
+            )
+          whisper_answer_post.update_columns(
+            post_type: Post.types[:whisper],
+            cooked: "<p>secret whisper accepted answer cooked</p>",
+          )
+          Fabricate(
+            :solved_topic,
+            topic: whisper_answer_post.topic,
+            answer_post: whisper_answer_post,
+          )
 
           get "/solution/by_user.json", params: { username: user.username }
 
           expect(response.status).to eq(200)
           result = response.parsed_body
-          expect(result["user_solved_posts"].length).to eq(1)
-          expect(result["user_solved_posts"][0]["post_id"]).to eq(answer_post.id)
+          expect(result["user_solved_posts"]).to be_empty
+          expect(response.body).not_to include(answer_post.raw)
+          expect(response.body).not_to include(answer_post.cooked)
+          expect(response.body).not_to include(whisper_answer_post.raw)
+          expect(response.body).not_to include(whisper_answer_post.cooked)
         end
       end
 


### PR DESCRIPTION
## Summary

Prevent the unauthorized disclosure of hidden or whisper posts through the `/solution/by_user` endpoint. The patch ensures that only posts visible to the current visitor are returned by applying post-level visibility filters and guardian authorization checks during serialization.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1400

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>