### PR TITLE
DEV: Bump prettier-plugin-ember-template-tag and reformat

### DIFF
--- a/frontend/discourse/admin/components/admin-interpolation-keys.gjs
+++ b/frontend/discourse/admin/components/admin-interpolation-keys.gjs
@@ -23,7 +23,7 @@ function pillTitle(item) {
   return i18n("admin.site_text.interpolation_key_insert");
 }
 
-<template>
+export default <template>
   {{#if @keys.length}}
     <div class="interpolation-keys">
       {{#each @keys as |item|}}

--- a/frontend/discourse/admin/components/admin-report-body.gjs
+++ b/frontend/discourse/admin/components/admin-report-body.gjs
@@ -13,7 +13,7 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <div
     class={{dConcatClass "admin-report" @report.reportClasses}}
     {{didUpdate

--- a/frontend/discourse/admin/components/dashboard/engagement.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement.gjs
@@ -5,7 +5,7 @@ import WhosPosting from "discourse/admin/components/dashboard/engagement/whos-po
 import DashboardSection from "discourse/admin/components/dashboard/section";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <DashboardSection
     @title={{i18n "admin.dashboard.sections.engagement.title"}}
     @startDate={{@startDate}}

--- a/frontend/discourse/admin/components/dashboard/report-cards/core-report.gjs
+++ b/frontend/discourse/admin/components/dashboard/report-cards/core-report.gjs
@@ -1,6 +1,6 @@
 import AdminReport from "discourse/admin/components/admin-report";
 
-<template>
+export default <template>
   <AdminReport
     @dataSourceName={{@item.identifier}}
     @preloadedData={{@payload}}

--- a/frontend/discourse/admin/components/dashboard/report-empty-state.gjs
+++ b/frontend/discourse/admin/components/dashboard/report-empty-state.gjs
@@ -1,7 +1,7 @@
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <div class="db-report__empty">
     {{dIcon "chart-pie"}}
     <span>{{i18n "admin.dashboard.reports_section.no_data"}}</span>

--- a/frontend/discourse/admin/components/dashboard/skeleton.gjs
+++ b/frontend/discourse/admin/components/dashboard/skeleton.gjs
@@ -6,7 +6,7 @@ const TRAFFIC_LIST_ROWS = Array.from({ length: 5 });
 const METRICS = Array.from({ length: 3 });
 const ENGAGEMENT_ACTIVITY_ROWS = Array.from({ length: 4 });
 
-<template>
+export default <template>
   <div
     class="db-skeleton --animation"
     role="status"

--- a/frontend/discourse/admin/components/schema-setting/editor/child-tree-node.gjs
+++ b/frontend/discourse/admin/components/schema-setting/editor/child-tree-node.gjs
@@ -1,7 +1,7 @@
 import { on } from "@ember/modifier";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
-<template>
+export default <template>
   <li
     role="link"
     class="schema-setting-editor__tree-node --child"

--- a/frontend/discourse/admin/components/schema-setting/editor/tree.gjs
+++ b/frontend/discourse/admin/components/schema-setting/editor/tree.gjs
@@ -5,7 +5,7 @@ import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
-<template>
+export default <template>
   <ul class="schema-setting-editor__tree">
     {{#if @backButtonText}}
       <li

--- a/frontend/discourse/admin/components/schema-setting/field-input-description.gjs
+++ b/frontend/discourse/admin/components/schema-setting/field-input-description.gjs
@@ -1,4 +1,4 @@
-<template>
+export default <template>
   <div class="schema-field__input-description">
     {{@description}}
   </div>

--- a/frontend/discourse/admin/components/site-settings/description.gjs
+++ b/frontend/discourse/admin/components/site-settings/description.gjs
@@ -1,7 +1,7 @@
 import { trustHTML } from "@ember/template";
 import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
 
-<template>
+export default <template>
   <div class="desc" {{linkifySettingLinks @description}}>{{trustHTML
       @description
     }}</div>

--- a/frontend/discourse/admin/components/site-settings/job-status.gjs
+++ b/frontend/discourse/admin/components/site-settings/job-status.gjs
@@ -1,7 +1,7 @@
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   {{#if @status}}
     <div class="job desc site-setting">
       {{#if (eq @status "enqueued")}}

--- a/frontend/discourse/admin/templates/admin-config/color-palettes.gjs
+++ b/frontend/discourse/admin/templates/admin-config/color-palettes.gjs
@@ -1,1 +1,1 @@
-<template>{{outlet}}</template>
+export default <template>{{outlet}}</template>

--- a/frontend/discourse/admin/templates/admin-customize-form-templates.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-form-templates.gjs
@@ -1,1 +1,1 @@
-<template>{{outlet}}</template>
+export default <template>{{outlet}}</template>

--- a/frontend/discourse/admin/templates/admin-search-logs.gjs
+++ b/frontend/discourse/admin/templates/admin-search-logs.gjs
@@ -1,1 +1,1 @@
-<template>{{outlet}}</template>
+export default <template>{{outlet}}</template>

--- a/frontend/discourse/admin/templates/admin-search.gjs
+++ b/frontend/discourse/admin/templates/admin-search.gjs
@@ -1,1 +1,1 @@
-<template>{{outlet}}</template>
+export default <template>{{outlet}}</template>

--- a/frontend/discourse/app/components/back-button.gjs
+++ b/frontend/discourse/app/components/back-button.gjs
@@ -4,7 +4,7 @@ import { or } from "discourse/truth-helpers";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <LinkTo
     class="btn btn-transparent back-button"
     @route={{@route}}

--- a/frontend/discourse/app/components/reviewable/created-by.gjs
+++ b/frontend/discourse/app/components/reviewable/created-by.gjs
@@ -17,7 +17,7 @@ import { i18n } from "discourse-i18n";
  *
  * @param {User} [user] - The user that created the reviewable item
  */
-<template>
+export default <template>
   <div class="created-by">
     {{#if @user}}
       <DUserLink @user={{@user}}>{{dAvatar @user imageSize="small"}}</DUserLink>

--- a/frontend/discourse/app/components/reviewable/flagged-post.gjs
+++ b/frontend/discourse/app/components/reviewable/flagged-post.gjs
@@ -1,7 +1,7 @@
 import ReviewablePost from "discourse/components/reviewable/post";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <ReviewablePost
     @reviewable={{@reviewable}}
     @userLabel={{i18n "review.flagged_user"}}

--- a/frontend/discourse/app/components/reviewable/topic-link.gjs
+++ b/frontend/discourse/app/components/reviewable/topic-link.gjs
@@ -25,7 +25,7 @@ import { i18n } from "discourse-i18n";
  *
  * @param {Reviewable} reviewable - The reviewable object containing topic information
  */
-<template>
+export default <template>
   <div class="reviewable-topic-link">
     {{#if @reviewable.topic}}
       <div class="reviewable-topic-link__title-wrapper">

--- a/frontend/discourse/app/components/search-menu/advanced-button.gjs
+++ b/frontend/discourse/app/components/search-menu/advanced-button.gjs
@@ -1,7 +1,7 @@
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <DButton
     class="show-advanced-search btn-transparent"
     title={{i18n "search.open_advanced"}}

--- a/frontend/discourse/app/components/search-menu/clear-button.gjs
+++ b/frontend/discourse/app/components/search-menu/clear-button.gjs
@@ -2,7 +2,7 @@ import { on } from "@ember/modifier";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <a
     class="clear-search"
     aria-label="clear_input"

--- a/frontend/discourse/app/components/setting-field/bool.gjs
+++ b/frontend/discourse/app/components/setting-field/bool.gjs
@@ -1,3 +1,3 @@
-<template>
+export default <template>
   <@field.Control>{{@definition.description}}</@field.Control>
 </template>

--- a/frontend/discourse/app/components/setting-field/duration.gjs
+++ b/frontend/discourse/app/components/setting-field/duration.gjs
@@ -1,6 +1,6 @@
 import DRelativeTimePicker from "discourse/ui-kit/d-relative-time-picker";
 
-<template>
+export default <template>
   <DRelativeTimePicker
     @durationHours={{@field.value}}
     @durationOutputUnit="hours"

--- a/frontend/discourse/app/components/setting-field/enum.gjs
+++ b/frontend/discourse/app/components/setting-field/enum.gjs
@@ -1,6 +1,6 @@
 import { or } from "discourse/truth-helpers";
 
-<template>
+export default <template>
   <@field.Control as |select|>
     {{#each (or @definition.valid_values @definition.choices) as |choice|}}
       <select.Option @value={{choice.value}}>

--- a/frontend/discourse/app/components/setting-field/integer.gjs
+++ b/frontend/discourse/app/components/setting-field/integer.gjs
@@ -1,3 +1,3 @@
-<template>
+export default <template>
   <@field.Control min={{@definition.min}} max={{@definition.max}} />
 </template>

--- a/frontend/discourse/app/components/setting-field/radio-group.gjs
+++ b/frontend/discourse/app/components/setting-field/radio-group.gjs
@@ -1,6 +1,6 @@
 import { or } from "discourse/truth-helpers";
 
-<template>
+export default <template>
   <@field.Control as |radioGroup|>
     {{#each (or @definition.valid_values @definition.choices) as |choice|}}
       <radioGroup.Radio @value={{choice.value}}>

--- a/frontend/discourse/app/components/site-skeleton.gjs
+++ b/frontend/discourse/app/components/site-skeleton.gjs
@@ -1,7 +1,7 @@
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
 // Decorative, inert loading skeleton — content is placeholder bars, not text.
-<template>
+export default <template>
   <div class="site-skeleton" aria-hidden="true">
     <div class="site-skeleton__header">
       <div class="site-skeleton__brand">

--- a/frontend/discourse/app/components/topic-metadata.gjs
+++ b/frontend/discourse/app/components/topic-metadata.gjs
@@ -5,7 +5,7 @@ import CategoryChooser from "discourse/select-kit/components/category-chooser";
 import MiniTagChooser from "discourse/select-kit/components/mini-tag-chooser";
 import DButton from "discourse/ui-kit/d-button";
 
-<template>
+export default <template>
   {{#if @showCategoryChooser}}
     <div class="edit-category__wrapper">
       <PluginOutlet

--- a/frontend/discourse/app/static/wizard/components/discourse-logo.gjs
+++ b/frontend/discourse/app/static/wizard/components/discourse-logo.gjs
@@ -1,4 +1,4 @@
-<template>
+export default <template>
   {{! prettier-ignore }}
   <div class="discourse-logo">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 385 104">

--- a/frontend/discourse/app/templates/review/index.gjs
+++ b/frontend/discourse/app/templates/review/index.gjs
@@ -8,7 +8,7 @@ import DNavItem from "discourse/ui-kit/d-nav-item";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <DHorizontalOverflowNav @ariaLabel="Review" class="reviewable-title">
     <DNavItem @route="review.index" @label="review.view_all" />
     <DNavItem @route="review.topics" @label="review.grouped_by_topic" />

--- a/frontend/discourse/app/templates/tag/edit/tab.gjs
+++ b/frontend/discourse/app/templates/tag/edit/tab.gjs
@@ -1,6 +1,6 @@
 import TagSettings from "discourse/components/tag-settings";
 
-<template>
+export default <template>
   <TagSettings
     @tag={{@model}}
     @selectedTab={{@controller.selectedTab}}

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-card.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-card.gjs
@@ -8,7 +8,7 @@ import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
 import { i18n } from "discourse-i18n";
 import ToggleChannelMembershipButton from "./toggle-channel-membership-button";
 
-<template>
+export default <template>
   {{#if @channel}}
     <div
       class={{dConcatClass

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-sidebar-empty-state.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-sidebar-empty-state.gjs
@@ -1,6 +1,6 @@
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <div class="ai-bot-sidebar-empty-state">
     {{i18n "discourse_ai.ai_bot.sidebar_empty"}}
   </div>

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/modal/ai-mcp-server-tools-modal.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/modal/ai-mcp-server-tools-modal.gjs
@@ -1,7 +1,7 @@
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <DModal
     @title={{i18n
       "discourse_ai.mcp_servers.tools_modal.title"

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/reviewable/ai-post.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/reviewable/ai-post.gjs
@@ -2,7 +2,7 @@ import ReviewablePost from "discourse/components/reviewable/post";
 import { i18n } from "discourse-i18n";
 import ModelAccuracies from "../model-accuracies";
 
-<template>
+export default <template>
   <ReviewablePost
     @reviewable={{@reviewable}}
     @userLabel={{i18n "review.flagged_user"}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/chat-channel.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/chat-channel.gjs
@@ -4,7 +4,7 @@ import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-ti
   discourseImport: "optional",
 };
 
-<template>
+export default <template>
   {{#if (and @event.channel ChannelTitle)}}
     <section class="event__section event-chat-channel">
       <span></span>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/image.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/image.gjs
@@ -9,7 +9,7 @@ const setupLightbox = modifier((element, _positional, { post }) => {
   return () => window.pswp?.close();
 });
 
-<template>
+export default <template>
   {{#if @imageUpload}}
     <section class="event__section event-image">
       {{#if @linkToPost}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/connectors/calendar-subscriptions-feeds/event-feeds.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/connectors/calendar-subscriptions-feeds/event-feeds.gjs
@@ -1,7 +1,7 @@
 import CalendarSubscriptionUrl from "discourse/components/calendar-subscription-url";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   {{#if @outletArgs.urls.all_events}}
     <CalendarSubscriptionUrl
       @label={{i18n "discourse_calendar.preferences.all_events"}}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/connectors/admin-dashboard-manage-reports-footer/data-explorer-hint.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/connectors/admin-dashboard-manage-reports-footer/data-explorer-hint.gjs
@@ -2,7 +2,7 @@ import { LinkTo } from "@ember/routing";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <LinkTo
     @route="adminPlugins.show.explorer.new"
     @model="discourse-data-explorer"

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/templates/group/reports.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/templates/group/reports.gjs
@@ -1,1 +1,1 @@
-<template>{{outlet}}</template>
+export default <template>{{outlet}}</template>

--- a/plugins/discourse-gamification/assets/javascripts/discourse/templates/gamification-leaderboard.gjs
+++ b/plugins/discourse-gamification/assets/javascripts/discourse/templates/gamification-leaderboard.gjs
@@ -1,1 +1,1 @@
-<template>{{outlet}}</template>
+export default <template>{{outlet}}</template>

--- a/plugins/discourse-solved/assets/javascripts/discourse/connectors/user-card-metadata/accepted-answers.gjs
+++ b/plugins/discourse-solved/assets/javascripts/discourse/connectors/user-card-metadata/accepted-answers.gjs
@@ -1,6 +1,6 @@
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   <div class="user-card-metadata-outlet accepted-answers" ...attributes>
     {{#if @outletArgs.user.accepted_answers}}
       <span class="desc">{{i18n "solutions"}}</span>

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/header-topic-info__before/header-topic-voting.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/header-topic-info__before/header-topic-voting.gjs
@@ -1,6 +1,6 @@
 import VoteBox from "../../components/vote-box";
 
-<template>
+export default <template>
   {{#if @outletArgs.topic.can_vote}}
     <div class="voting header-title-voting">
       <VoteBox @topic={{@outletArgs.topic}} />

--- a/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/topic-title/topic-title-voting.gjs
+++ b/plugins/discourse-topic-voting/assets/javascripts/discourse/connectors/topic-title/topic-title-voting.gjs
@@ -1,7 +1,7 @@
 import { and, or } from "discourse/truth-helpers";
 import VoteBox from "../../components/vote-box";
 
-<template>
+export default <template>
   {{#let @outletArgs.model as |topic|}}
     {{#if
       (and

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/connection-entry.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/connection-entry.gjs
@@ -7,7 +7,7 @@ const SVG_STYLE = trustHTML(
   "overflow:visible;position:absolute;pointer-events:none;width:9999px;height:9999px"
 );
 
-<template>
+export default <template>
   <svg
     class={{dConcatClass "workflow-connection" (if @entry.isPseudo "--pseudo")}}
     style={{SVG_STYLE}}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/connection-toolbar.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/connection-toolbar.gjs
@@ -10,7 +10,7 @@ function stopAndCall(callback, e) {
   callback?.();
 }
 
-<template>
+export default <template>
   <CanvasHoverToolbar
     @hoverQuery=".workflow-connection__hit"
     @visibilityQuery=".workflow-connection__toolbar-fo"

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/controls.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/controls.gjs
@@ -12,7 +12,7 @@ function redoTitle() {
   return `${i18n("discourse_workflows.canvas.redo")} [${translateModKey("Meta+Y")}]`;
 }
 
-<template>
+export default <template>
   <div class="workflows-canvas__controls">
     <DTooltip @identifier="workflow-canvas-undo" @content={{(undoTitle)}}>
       <:trigger>

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/hover-toolbar.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/hover-toolbar.gjs
@@ -43,7 +43,7 @@ const hoverVisibility = modifier(function (element, _, named) {
   };
 });
 
-<template>
+export default <template>
   <div
     class={{dConcatClass "workflow-canvas-toolbar" (if @inline "--inline")}}
     {{hoverVisibility

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/loop-back-connection.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/canvas/loop-back-connection.gjs
@@ -12,7 +12,7 @@ function handleAdd(callback, loopNodeClientId, e) {
   callback?.(loopNodeClientId);
 }
 
-<template>
+export default <template>
   <svg class="workflow-loop-back" style={{SVG_STYLE}}>
     <path
       class="workflow-loop-back__path"

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/default-input-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/default-input-control.gjs
@@ -1,6 +1,6 @@
 import ExpressionWrapper from "./expression-wrapper";
 
-<template>
+export default <template>
   <ExpressionWrapper
     @field={{@field}}
     @schema={{@schema}}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/icon-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/icon-control.gjs
@@ -1,6 +1,6 @@
 import ExpressionWrapper from "./expression-wrapper";
 
-<template>
+export default <template>
   <ExpressionWrapper
     @field={{@field}}
     @schema={{@schema}}

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/empty-state.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/empty-state.gjs
@@ -1,7 +1,7 @@
 import DButton from "discourse/ui-kit/d-button";
 import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 
-<template>
+export default <template>
   <div class="workflows-empty-state">
     {{#if @emoji}}
       <span class="workflows-empty-state__icon">{{dEmoji @emoji}}</span>

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/in-use-dialog.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/in-use-dialog.gjs
@@ -1,7 +1,7 @@
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
 
-<template>
+export default <template>
   <p>{{@model.description}}</p>
 
   <ul>

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/stats.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/stats.gjs
@@ -1,7 +1,7 @@
 import DStatTiles from "discourse/ui-kit/d-stat-tiles";
 import { i18n } from "discourse-i18n";
 
-<template>
+export default <template>
   {{#if @stats.total}}
     <DStatTiles
       title={{i18n "discourse_workflows.stats.period"}}

--- a/plugins/discourse-workflows/assets/javascripts/discourse/templates/workflows-form-test.gjs
+++ b/plugins/discourse-workflows/assets/javascripts/discourse/templates/workflows-form-test.gjs
@@ -1,6 +1,6 @@
 import WorkflowsForm from "../components/workflows-form";
 
-<template>
+export default <template>
   <div class="workflows-form-page">
     <WorkflowsForm @model={{@model}} />
   </div>

--- a/plugins/discourse-workflows/assets/javascripts/discourse/templates/workflows-form.gjs
+++ b/plugins/discourse-workflows/assets/javascripts/discourse/templates/workflows-form.gjs
@@ -1,6 +1,6 @@
 import WorkflowsForm from "../components/workflows-form";
 
-<template>
+export default <template>
   <div class="workflows-form-page">
     <WorkflowsForm @model={{@model}} />
   </div>

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/atoms/00-typography.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/atoms/00-typography.gjs
@@ -1,7 +1,7 @@
 import { i18n } from "discourse-i18n";
 import StyleguideExample from "../../styleguide-example";
 
-<template>
+export default <template>
   <StyleguideExample @title="h1">
     <h1>{{i18n "styleguide.sections.typography.example"}}</h1>
   </StyleguideExample>

--- a/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/02-post-oneboxes.gjs
+++ b/plugins/styleguide/assets/javascripts/discourse/components/sections/organisms/02-post-oneboxes.gjs
@@ -1,7 +1,7 @@
 import Post from "discourse/components/post";
 import StyleguideExample from "discourse/plugins/styleguide/discourse/components/styleguide-example";
 
-<template>
+export default <template>
   <StyleguideExample @title="Wikipedia onebox">
     <Post @post={{@dummy.oneboxPosts.wikipedia}} @canCreatePost={{true}} />
   </StyleguideExample>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6641,8 +6641,8 @@ packages:
   pretender@3.4.7:
     resolution: {integrity: sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==}
 
-  prettier-plugin-ember-template-tag@2.1.3:
-    resolution: {integrity: sha512-FfAvkU+fqDC3Zs8+qGhBHYuwq1DED+UTPMH33QXxivZxRekkItBNXfi1Y+YkIbhCnu6UeTE2aYdbQSLlkOC2bA==}
+  prettier-plugin-ember-template-tag@2.1.7:
+    resolution: {integrity: sha512-NQS/a03LCefDbOJ1o0NeN+4VdfZRJt6NBp6/5yLMXTQ2TNT4fkcbhfXkvcgl7lN9nmssm6GweX51G/CAEvtazg==}
     engines: {node: 18.* || >= 20}
     peerDependencies:
       prettier: '>= 3.0.0'
@@ -9337,7 +9337,7 @@ snapshots:
       eslint-plugin-sort-class-members: 1.22.1(eslint@10.6.0(jiti@2.6.1))
       globals: 17.7.0
       prettier: 3.8.1
-      prettier-plugin-ember-template-tag: 2.1.3(prettier@3.8.1)
+      prettier-plugin-ember-template-tag: 2.1.7(prettier@3.8.1)
       stylelint: 17.5.0(typescript@5.9.3)
       stylelint-config-standard: 40.0.0(stylelint@17.5.0(typescript@5.9.3))
       stylelint-config-standard-scss: 17.0.0(postcss@8.5.15)(stylelint@17.5.0(typescript@5.9.3))
@@ -15138,7 +15138,7 @@ snapshots:
       fake-xml-http-request: 2.1.2
       route-recognizer: 0.3.4
 
-  prettier-plugin-ember-template-tag@2.1.3(prettier@3.8.1):
+  prettier-plugin-ember-template-tag@2.1.7(prettier@3.8.1):
     dependencies:
       '@babel/traverse': 7.29.7
       content-tag: 4.2.0


### PR DESCRIPTION
As of 2.1.7 the plugin correctly enforces the `templateExportDefault: true` option.