### PR TITLE
UX: Minor fix for combo button

### DIFF
--- a/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/misc.scss
+++ b/app/assets/stylesheets/common/base/uc-modernize-foundation-theme/misc.scss
@@ -2,4 +2,9 @@
   .discourse-reactions-counter .reactions-counter {
     align-items: center;
   }
+
+  .d-combo-button.--has-menu .topic-dismiss-buttons__menu {
+    margin-left: -1px;
+    border-left-color: var(--primary-300);
+  }
 }


### PR DESCRIPTION
Changes to the default button style in the modernization efforts caused the gap present in the combo-button to be visually odd. This PR addresses that.

| Before | After | 
| - | - |
|<img width="966" height="314" alt="CleanShot 2026-07-06 at 16 09 12@2x" src="https://github.com/user-attachments/assets/4901902a-914f-4f72-b928-63d21cec238c" />|<img width="974" height="336" alt="CleanShot 2026-07-06 at 16 06 53@2x" src="https://github.com/user-attachments/assets/4b5d57cd-4909-4e92-8198-2ad59280a197" />|