### PR TITLE
DEV: External IDs, and hidden groups to admins only. Allow moderators to see SSO when the moderators_view_sso_details site setting is enabled

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -324,8 +324,8 @@ class UsersController < ApplicationController
   def check_sso_email
     user = fetch_user_from_params(include_inactive: true)
 
-    unless user == current_user
-      guardian.ensure_can_check_sso_details!(user)
+    guardian.ensure_can_check_sso_email!(user)
+    if user != current_user
       StaffActionLogger.new(current_user).log_check_email(user, context: params[:context])
     end
 
@@ -340,7 +340,7 @@ class UsersController < ApplicationController
   def check_sso_payload
     user = fetch_user_from_params(include_inactive: true)
 
-    guardian.ensure_can_check_sso_details!(user)
+    guardian.ensure_can_check_sso_payload!(user)
     unless user == current_user
       StaffActionLogger.new(current_user).log_check_email(user, context: params[:context])
     end

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -153,6 +153,10 @@ class AdminDetailedUserSerializer < AdminUserSerializer
     object.api_keys.active.count
   end
 
+  def include_external_ids?
+    scope.can_check_sso_details?(object)
+  end
+
   def external_ids
     external_ids = {}
 
@@ -196,5 +200,9 @@ class AdminDetailedUserSerializer < AdminUserSerializer
 
   def include_upcoming_changes_stats?
     scope.is_staff?
+  end
+
+  def groups
+    object.groups.visible_groups(scope.user)
   end
 end

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -203,6 +203,6 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   end
 
   def groups
-    object.groups.visible_groups(scope.user)
+    scope.user.visible_groups
   end
 end

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -154,7 +154,7 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   end
 
   def include_external_ids?
-    scope.can_check_sso_details?(object)
+    scope.is_admin?
   end
 
   def external_ids

--- a/app/serializers/admin_detailed_user_serializer.rb
+++ b/app/serializers/admin_detailed_user_serializer.rb
@@ -203,6 +203,6 @@ class AdminDetailedUserSerializer < AdminUserSerializer
   end
 
   def groups
-    scope.user.visible_groups
+    object.groups.visible_groups(scope.user)
   end
 end

--- a/app/serializers/admin_user_serializer.rb
+++ b/app/serializers/admin_user_serializer.rb
@@ -14,6 +14,11 @@ class AdminUserSerializer < AdminUserListSerializer
 
   has_one :single_sign_on_record, serializer: SingleSignOnRecordSerializer, embed: :objects
 
+  def include_single_sign_on_record?
+    scope.can_check_sso_details?(object) ||
+      (scope.is_staff? && SiteSetting.moderators_view_sso_details)
+  end
+
   def can_approve
     scope.can_approve?(object)
   end

--- a/app/serializers/admin_user_serializer.rb
+++ b/app/serializers/admin_user_serializer.rb
@@ -15,8 +15,7 @@ class AdminUserSerializer < AdminUserListSerializer
   has_one :single_sign_on_record, serializer: SingleSignOnRecordSerializer, embed: :objects
 
   def include_single_sign_on_record?
-    scope.can_check_sso_details?(object) ||
-      (scope.is_staff? && SiteSetting.moderators_view_sso_details)
+    scope.can_check_sso_details?(object)
   end
 
   def can_approve

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2092,6 +2092,7 @@ en:
     top_page_default_timeframe: "Default top page time period for anonymous users (automatically adjusts for logged in users based on their last visit)."
     moderators_view_emails: "Allow moderators to view user email addresses."
     moderators_view_ips: "Allow moderators to view user ip addresses."
+    moderators_view_sso_details: "Allow moderators to view SSO records and external authentication provider IDs."
     moderators_change_trust_levels: "Allow moderators to change user trust levels."
     prioritize_username_in_ux: "Show username first on user page, user card and posts (when disabled name is shown first)"
     enable_rich_text_paste: "Enable automatic HTML to Markdown conversion when pasting text into the composer."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2092,7 +2092,7 @@ en:
     top_page_default_timeframe: "Default top page time period for anonymous users (automatically adjusts for logged in users based on their last visit)."
     moderators_view_emails: "Allow moderators to view user email addresses."
     moderators_view_ips: "Allow moderators to view user ip addresses."
-    moderators_view_sso_details: "Allow moderators to view SSO records and external authentication provider IDs."
+    moderators_view_sso_details: "Allow moderators to view SSO records"
     moderators_change_trust_levels: "Allow moderators to change user trust levels."
     prioritize_username_in_ux: "Show username first on user page, user card and posts (when disabled name is shown first)"
     enable_rich_text_paste: "Enable automatic HTML to Markdown conversion when pasting text into the composer."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2940,6 +2940,9 @@ security:
   moderators_view_ips:
     default: true
     client: true
+  moderators_view_sso_details:
+    default: false
+    client: true
   moderators_change_trust_levels:
     default: true
   non_crawler_user_agents:

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -105,6 +105,14 @@ module UserGuardian
   end
 
   def can_check_sso_details?(user)
+    user && (is_admin? || (is_staff? && SiteSetting.moderators_view_sso_details))
+  end
+
+  def can_check_sso_email?(user)
+    user && is_admin?
+  end
+
+  def can_check_sso_payload?(user)
     user && is_admin?
   end
 

--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -105,7 +105,7 @@ module UserGuardian
   end
 
   def can_check_sso_details?(user)
-    user && (is_admin? || (is_staff? && SiteSetting.moderators_view_sso_details))
+    user && (is_admin? || (is_moderator? && SiteSetting.moderators_view_sso_details))
   end
 
   def can_check_sso_email?(user)

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -825,4 +825,51 @@ RSpec.describe UserGuardian do
       expect(Guardian.new(user).can_upload_external?).to eq(false)
     end
   end
+
+  describe "#can_check_sso_details?" do
+    it "is always true for admins" do
+      expect(Guardian.new(admin).can_check_sso_details?(user)).to eq(true)
+    end
+
+    it "is false for moderators by default" do
+      expect(Guardian.new(moderator).can_check_sso_details?(user)).to eq(false)
+    end
+
+    it "is true for moderators when moderators_view_sso_details is enabled" do
+      SiteSetting.moderators_view_sso_details = true
+      expect(Guardian.new(moderator).can_check_sso_details?(user)).to eq(true)
+    end
+
+    it "is false for regular users" do
+      expect(Guardian.new(user).can_check_sso_details?(user)).to eq(false)
+    end
+
+    it "is false for anonymous users" do
+      expect(Guardian.new.can_check_sso_details?(user)).to eq(false)
+    end
+  end
+
+  describe "#can_check_sso_email?" do
+    it "is true for admins" do
+      expect(Guardian.new(admin).can_check_sso_email?(user)).to eq(true)
+    end
+
+    it "is false for moderators when moderators_view_sso_details is enabled" do
+      SiteSetting.moderators_view_sso_details = true
+
+      expect(Guardian.new(moderator).can_check_sso_email?(user)).to eq(false)
+    end
+  end
+
+  describe "#can_check_sso_payload?" do
+    it "is true for admins" do
+      expect(Guardian.new(admin).can_check_sso_payload?(user)).to eq(true)
+    end
+
+    it "is false for moderators when moderators_view_sso_details is enabled" do
+      SiteSetting.moderators_view_sso_details = true
+
+      expect(Guardian.new(moderator).can_check_sso_payload?(user)).to eq(false)
+    end
+  end
 end

--- a/spec/lib/plugin/instance_spec.rb
+++ b/spec/lib/plugin/instance_spec.rb
@@ -460,10 +460,12 @@ TEXT
       DiscoursePluginRegistry.serialized_current_user_fields << "has_car"
       user = Fabricate(:user)
       user.custom_fields["has_car"] = "true"
+      user.custom_fields["has_bike"] = "true"
       user.save!
 
       payload = JSON.parse(CurrentUserSerializer.new(user, scope: Guardian.new(user)).to_json)
       expect(payload["current_user"]["custom_fields"]["has_car"]).to eq("true")
+      expect(payload["current_user"]["custom_fields"]).not_to have_key("has_bike")
 
       payload = JSON.parse(UserSerializer.new(user, scope: Guardian.new(user)).to_json)
       expect(payload["user"]["custom_fields"]["has_car"]).to eq("true")

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -269,6 +269,28 @@ RSpec.describe Admin::UsersController do
         expect(response.parsed_body["id"]).to eq(user.id)
       end
 
+      it "returns SSO details when moderators can view them" do
+        sso_record =
+          Fabricate(:single_sign_on_record, user: user, external_id: "discourse_connect_user")
+        SiteSetting.moderators_view_sso_details = true
+
+        get "/admin/users/#{user.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("single_sign_on_record", "external_id")).to eq(
+          sso_record.external_id,
+        )
+      end
+
+      it "hides SSO details by default" do
+        Fabricate(:single_sign_on_record, user: user)
+
+        get "/admin/users/#{user.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).not_to have_key("single_sign_on_record")
+      end
+
       it "includes count of similar users" do
         Fabricate(:user, ip_address: "88.88.88.88")
         Fabricate(:admin, ip_address: user.ip_address)

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4390,6 +4390,15 @@ RSpec.describe UsersController do
         expect(response).to be_forbidden
       end
 
+      it "prevents moderators from checking sso email" do
+        SiteSetting.moderators_view_sso_details = true
+        sign_in(moderator)
+
+        get "/u/#{user1.username}/sso-email.json"
+
+        expect(response).to be_forbidden
+      end
+
       it "returns emails and associated_accounts when you're allowed to see them" do
         user1.single_sign_on_record =
           SingleSignOnRecord.create(
@@ -4420,6 +4429,15 @@ RSpec.describe UsersController do
       it "raises an error when you aren't allowed to check sso payload" do
         sign_in(Fabricate(:user))
         get "/u/#{user1.username}/sso-payload.json"
+        expect(response).to be_forbidden
+      end
+
+      it "prevents moderators from checking sso payload" do
+        SiteSetting.moderators_view_sso_details = true
+        sign_in(moderator)
+
+        get "/u/#{user1.username}/sso-payload.json"
+
         expect(response).to be_forbidden
       end
 

--- a/spec/serializers/admin_detailed_user_serializer_spec.rb
+++ b/spec/serializers/admin_detailed_user_serializer_spec.rb
@@ -26,4 +26,77 @@ RSpec.describe AdminDetailedUserSerializer do
       expect(serializer.as_json[:latest_export]).to be_nil
     end
   end
+
+  describe "#single_sign_on_record" do
+    fab!(:sso_record) do
+      Fabricate(:single_sign_on_record, user: user, external_id: "external_user_id")
+    end
+
+    it "is always included for admins" do
+      serializer = described_class.new(user, scope: Guardian.new(admin), root: false)
+      expect(serializer.as_json[:single_sign_on_record][:external_id]).to eq("external_user_id")
+    end
+
+    it "is not included for moderators by default" do
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json).not_to have_key(:single_sign_on_record)
+    end
+
+    it "is included for moderators when site setting is enabled" do
+      SiteSetting.moderators_view_sso_details = true
+
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json[:single_sign_on_record][:external_id]).to eq("external_user_id")
+    end
+  end
+
+  describe "#external_ids" do
+    fab!(:associated_account) do
+      Fabricate(:user_associated_account, user: user, provider_name: "google_oauth2")
+    end
+
+    it "is only included for admins" do
+      serializer = described_class.new(user, scope: Guardian.new(admin), root: false)
+      expect(serializer.as_json[:external_ids]["google_oauth2"]).to eq(
+        associated_account.provider_uid,
+      )
+
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json).not_to have_key(:external_ids)
+    end
+
+    it "is not included for moderators even with site setting enabled" do
+      SiteSetting.moderators_view_sso_details = true
+
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      expect(serializer.as_json).not_to have_key(:external_ids)
+    end
+  end
+
+  describe "#groups" do
+    fab!(:public_group) { Fabricate(:group, visibility_level: Group.visibility_levels[:public]) }
+    fab!(:owner_only_group) do
+      Fabricate(:group, visibility_level: Group.visibility_levels[:owners])
+    end
+
+    before do
+      public_group.add(user)
+      owner_only_group.add_owner(user)
+    end
+
+    it "filters groups based on visibility for moderators" do
+      serializer = described_class.new(user, scope: Guardian.new(moderator), root: false)
+      group_names = serializer.as_json[:groups].map { |g| g[:name] }
+
+      expect(group_names).to include(public_group.name)
+      expect(group_names).not_to include(owner_only_group.name)
+    end
+
+    it "shows all groups for admins" do
+      serializer = described_class.new(user, scope: Guardian.new(admin), root: false)
+      group_names = serializer.as_json[:groups].map { |g| g[:name] }
+
+      expect(group_names).to include(public_group.name, owner_only_group.name)
+    end
+  end
 end


### PR DESCRIPTION
#### Description

Moderators could access admin-only SSO, external identity and hidden groups data via GET /admin/users/:id.json — the single_sign_on_record field, external_ids field and hidden groups were serialized unconditionally for all staff members instead of being restricted to admins. This PR restricts External IDs, and hidden group to admins only but allows moderators to see SSO information when the `moderators_view_sso_details` SiteSetting is enabled

Context: `t/180409`