### PR TITLE
FIX: Make auto pseudogroups visible to logged on users

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -695,11 +695,10 @@ class GroupsController < ApplicationController
       (params[:include_everyone] == "true" || params[:include_pseudogroups] == "true") &&
         !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
     include_pseudogroups = params[:include_pseudogroups] == "true"
-    order = ["name"]
     groups =
       Group.visible_groups(
         current_user,
-        order,
+        ["name"],
         include_everyone: include_everyone,
         include_pseudogroups: include_pseudogroups,
       ).includes(:flair_upload)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -692,7 +692,8 @@ class GroupsController < ApplicationController
 
   def search
     include_everyone =
-      params[:include_everyone] == "true" || params[:include_pseudogroups] == "true"
+      (params[:include_everyone] == "true" || params[:include_pseudogroups] == "true") &&
+        !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
     include_pseudogroups = params[:include_pseudogroups] == "true"
     order = ["name"]
     groups =

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -190,6 +190,8 @@ class Group < ActiveRecord::Base
                 "groups.id NOT IN (:ids)",
                 ids: [Group::AUTO_GROUPS[:anonymous_users], Group::AUTO_GROUPS[:logged_in_users]],
               )
+          else
+            groups = groups.where("groups.id > 0") unless opts[:include_everyone]
           end
 
           if !user&.admin
@@ -254,6 +256,8 @@ class Group < ActiveRecord::Base
                 "groups.id NOT IN (:ids)",
                 ids: [Group::AUTO_GROUPS[:anonymous_users], Group::AUTO_GROUPS[:logged_in_users]],
               )
+          else
+            groups = groups.where("groups.id > 0") unless opts[:include_everyone]
           end
 
           if !user&.admin
@@ -569,12 +573,12 @@ class Group < ActiveRecord::Base
     group.full_name =
       I18n.t("groups.default_full_names.#{name}", locale: SiteSetting.default_locale)
 
-    # the everyone, anonymous_users, and logged_in_users groups are special — they
+    # the everyone, anonymous_users, and logged_in_users groups are special - they
     # represent implicit populations (unauthenticated visitors, or all logged-in
     # users) that cannot be enumerated via group_users rows.
     case name
     when :everyone, :anonymous_users, :logged_in_users
-      group.visibility_level = Group.visibility_levels[:staff]
+      group.visibility_level = Group.visibility_levels[:logged_on_users]
       group.save!
       return group
     when :moderators

--- a/db/fixtures/002_groups.rb
+++ b/db/fixtures/002_groups.rb
@@ -5,4 +5,10 @@ if g = Group.find_by(name: "trust_level_5", id: 15)
   g.destroy!
 end
 
-Group.where(name: "everyone").update_all(visibility_level: Group.visibility_levels[:staff])
+Group.where(
+  id: [
+    Group::AUTO_GROUPS[:everyone],
+    Group::AUTO_GROUPS[:anonymous_users],
+    Group::AUTO_GROUPS[:logged_in_users],
+  ],
+).update_all(visibility_level: Group.visibility_levels[:logged_on_users])

--- a/db/migrate/20260707013407_set_automatic_pseudogroups_visibility_to_logged_on_users.rb
+++ b/db/migrate/20260707013407_set_automatic_pseudogroups_visibility_to_logged_on_users.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SetAutomaticPseudogroupsVisibilityToLoggedOnUsers < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE groups
+      SET visibility_level = 1
+      WHERE id IN (0, 4, 5)
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22469,6 +22469,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260707013407'),
 ('20260702102111'),
 ('20260701073045'),
 ('20260630034050'),

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -449,20 +449,20 @@ RSpec.describe Group do
       end
     end
 
-    it "makes sure the everyone group is not visible except to staff" do
+    it "makes sure the everyone group is visible to logged in users" do
       g = Group.refresh_automatic_group!(:everyone)
-      expect(g.visibility_level).to eq(Group.visibility_levels[:staff])
+      expect(g.visibility_level).to eq(Group.visibility_levels[:logged_on_users])
     end
 
-    it "makes sure the anonymous_users and logged_in_users pseudogroups are hidden and have no members" do
+    it "makes sure pseudogroups are visible and have no members" do
       anon = Group.refresh_automatic_group!(:anonymous_users)
       expect(anon.id).to eq(Group::AUTO_GROUPS[:anonymous_users])
-      expect(anon.visibility_level).to eq(Group.visibility_levels[:staff])
+      expect(anon.visibility_level).to eq(Group.visibility_levels[:logged_on_users])
       expect(GroupUser.where(group_id: anon.id).count).to eq(0)
 
       logged_in = Group.refresh_automatic_group!(:logged_in_users)
       expect(logged_in.id).to eq(Group::AUTO_GROUPS[:logged_in_users])
-      expect(logged_in.visibility_level).to eq(Group.visibility_levels[:staff])
+      expect(logged_in.visibility_level).to eq(Group.visibility_levels[:logged_on_users])
       expect(GroupUser.where(group_id: logged_in.id).count).to eq(0)
     end
 
@@ -987,13 +987,7 @@ RSpec.describe Group do
       ).to eq(false)
     end
 
-    it "includes logged_in_users, anonymous_users and everyone groups when include_pseudogroups is true" do
-      expect(
-        Group
-          .visible_groups(admin, [], include_pseudogroups: true)
-          .where(id: Group::AUTO_GROUPS[:everyone])
-          .exists?,
-      ).to eq(true)
+    it "includes logged_in_users and anonymous_users groups when include_pseudogroups is true, and everyone when that is also requested" do
       expect(
         Group
           .visible_groups(admin, [], include_pseudogroups: true)
@@ -1006,6 +1000,44 @@ RSpec.describe Group do
           .where(id: Group::AUTO_GROUPS[:logged_in_users])
           .exists?,
       ).to eq(true)
+      expect(
+        Group
+          .visible_groups(admin, [], include_pseudogroups: true)
+          .where(id: Group::AUTO_GROUPS[:everyone])
+          .exists?,
+      ).to eq(false)
+      expect(
+        Group
+          .visible_groups(admin, [], include_pseudogroups: true, include_everyone: true)
+          .where(id: Group::AUTO_GROUPS[:everyone])
+          .exists?,
+      ).to eq(true)
+    end
+
+    it "includes pseudogroups for regular users when requested" do
+      regular_user = Fabricate(:user)
+      Group.refresh_automatic_groups!(:everyone, :anonymous_users, :logged_in_users)
+
+      visible_group_ids =
+        Group.visible_groups(regular_user, [], include_pseudogroups: true).pluck(:id)
+
+      expect(visible_group_ids).to include(
+        Group::AUTO_GROUPS[:anonymous_users],
+        Group::AUTO_GROUPS[:logged_in_users],
+      )
+      expect(visible_group_ids).to_not include(Group::AUTO_GROUPS[:everyone])
+      expect(
+        Group
+          .visible_groups(nil, [], include_pseudogroups: true)
+          .where(
+            id: [
+              Group::AUTO_GROUPS[:everyone],
+              Group::AUTO_GROUPS[:anonymous_users],
+              Group::AUTO_GROUPS[:logged_in_users],
+            ],
+          )
+          .exists?,
+      ).to eq(false)
     end
 
     it "does not include logged_in_users, anonymous_users and everyone groups by default" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Site do
     color_scheme = Fabricate(:color_scheme)
 
     anon_guardian = Guardian.new
-    user_guardian = Guardian.new(Fabricate(:user))
+    user_guardian = Fabricate(:user).guardian
 
     expect_correct_themes(anon_guardian)
     expect_correct_themes(user_guardian)
@@ -70,7 +70,7 @@ RSpec.describe Site do
   describe "#categories" do
     fab!(:category)
     fab!(:user)
-    let(:guardian) { Guardian.new(user) }
+    let(:guardian) { user.guardian }
 
     it "omits read restricted categories" do
       expect(Site.new(guardian).categories.map { |c| c[:id] }).to contain_exactly(
@@ -96,7 +96,7 @@ RSpec.describe Site do
 
       group.add(user)
 
-      expect(Site.new(Guardian.new(user)).categories.map { |c| c[:id] }).to contain_exactly(
+      expect(Site.new(user.guardian).categories.map { |c| c[:id] }).to contain_exactly(
         SiteSetting.uncategorized_category_id,
         category.id,
       )
@@ -108,7 +108,7 @@ RSpec.describe Site do
       category.set_permissions(everyone: :create_post)
       category.save!
 
-      guardian = Guardian.new(user)
+      guardian = user.guardian
 
       expect(
         Site.new(guardian).categories.keep_if { |c| c[:name] == category.name }.first[:permission],
@@ -149,13 +149,13 @@ RSpec.describe Site do
 
       expect(categories.map { |c| c[:can_edit] }).to contain_exactly(false, false)
 
-      site = Site.new(Guardian.new(Fabricate(:moderator)))
+      site = Site.new(Fabricate(:moderator).guardian)
 
       expect(site.categories.map { |c| c[:can_edit] }).to contain_exactly(false, false)
 
       SiteSetting.moderators_manage_categories = true
 
-      site = Site.new(Guardian.new(Fabricate(:moderator)))
+      site = Site.new(Fabricate(:moderator).guardian)
 
       expect(site.categories.map { |c| c[:can_edit] }).to contain_exactly(true, true)
     end
@@ -165,7 +165,7 @@ RSpec.describe Site do
       fab!(:boring_category) { Fabricate(:category, name: "Boring category") }
 
       it "allows changing the query" do
-        prefetched_categories = Site.new(Guardian.new(user)).categories.map { |c| c[:id] }
+        prefetched_categories = Site.new(user.guardian).categories.map { |c| c[:id] }
         expect(prefetched_categories).to include(cool_category.id, boring_category.id)
 
         # we need to clear the cache to ensure that the categories list will be updated
@@ -175,7 +175,7 @@ RSpec.describe Site do
         modifier_block = Proc.new { |query| query.where("categories.name LIKE 'Cool%'") }
         plugin_instance.register_modifier(:site_all_categories_cache_query, &modifier_block)
 
-        prefetched_categories = Site.new(Guardian.new(user)).categories.map { |c| c[:id] }
+        prefetched_categories = Site.new(user.guardian).categories.map { |c| c[:id] }
 
         expect(prefetched_categories).to include(cool_category.id)
         expect(prefetched_categories).not_to include(boring_category.id)
@@ -206,7 +206,7 @@ RSpec.describe Site do
         category.update!(parent_category: parent_category)
         Fabricate(:category_sidebar_section_link, linkable: category, user: user)
 
-        site = Site.new(Guardian.new(user))
+        site = Site.new(user.guardian)
 
         expect(site.categories.map { |c| c[:id] }).to contain_exactly(
           grandfather_category.id,
@@ -219,7 +219,7 @@ RSpec.describe Site do
         Fabricate(:category_sidebar_section_link, linkable: category, user: user)
         category.update!(read_restricted: true)
 
-        site = Site.new(Guardian.new(user))
+        site = Site.new(user.guardian)
 
         expect(site.categories).to eq([])
       end
@@ -228,7 +228,7 @@ RSpec.describe Site do
 
   it "omits groups user can not see" do
     user = Fabricate(:user)
-    site = Site.new(Guardian.new(user))
+    site = Site.new(user.guardian)
 
     staff_group = Fabricate(:group, visibility_level: Group.visibility_levels[:staff])
     expect(site.groups.pluck(:name)).not_to include(staff_group.name)
@@ -237,8 +237,13 @@ RSpec.describe Site do
     expect(site.groups.pluck(:name)).to include(public_group.name)
 
     admin = Fabricate(:admin)
-    site = Site.new(Guardian.new(admin))
-    expect(site.groups.pluck(:name)).to include(staff_group.name, public_group.name, "everyone")
+    site = Site.new(admin.guardian)
+    expect(site.groups.pluck(:name)).to include(
+      staff_group.name,
+      public_group.name,
+      "logged_in_users",
+      "anonymous_users",
+    )
   end
 
   describe "site_groups_query modifier" do
@@ -247,7 +252,7 @@ RSpec.describe Site do
     fab!(:boring_group) { Fabricate(:group, name: "boring-group") }
 
     it "allows changing the query" do
-      prefetched_groups = Site.new(Guardian.new(user)).groups.map { |c| c[:id] }
+      prefetched_groups = Site.new(user.guardian).groups.map { |c| c[:id] }
       expect(prefetched_groups).to include(cool_group.id, boring_group.id)
 
       # we need to clear the cache to ensure that the groups list will be updated
@@ -257,7 +262,7 @@ RSpec.describe Site do
       modifier_block = Proc.new { |query| query.where("groups.name LIKE 'cool%'") }
       plugin_instance.register_modifier(:site_groups_query, &modifier_block)
 
-      prefetched_groups = Site.new(Guardian.new(user)).groups.map { |c| c[:id] }
+      prefetched_groups = Site.new(user.guardian).groups.map { |c| c[:id] }
 
       expect(prefetched_groups).to include(cool_group.id)
       expect(prefetched_groups).not_to include(boring_group.id)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -3064,6 +3064,7 @@ RSpec.describe GroupsController do
           ),
         )
 
+        SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false
         get "/groups/search.json?include_everyone=true"
 
         expect(response.status).to eq(200)

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -640,7 +640,7 @@ RSpec.describe SiteSerializer do
           :groups
         ]
 
-      expect(serialized_groups.find { |g| g["name"] == "everyone" }["automatic"]).to eq(true)
+      expect(serialized_groups.find { |g| g["name"] == "trust_level_1" }["automatic"]).to eq(true)
       expect(serialized_groups.find { |g| g["name"] == group.name }["automatic"]).to eq(false)
     end
   end


### PR DESCRIPTION
With the ACL changes that are ongoing, regular users
need to be able to see the pseudogroups in certain situations,
like the ACL group selection dropdown. Pseudogroups are the
everyone, logged_in_users, and anonymous_users groups. They
are currently limited to staff only, but this change will allow
all logged on users to see them as well.

This commit also does some minor fixes related to granular_anonymous_and_logged_in_groups_permissions
upcoming change. If this is enabled, the everyone group should not
be selectable in Site.groups in the UI, that will just lead to
confusion in the long term especially because this upcoming change
will eventually remove the everyone group.
