### PR TITLE
UX: show emoji name when hovering post reactions

### DIFF
--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-list-emoji.gjs
@@ -106,7 +106,6 @@ export default class DiscourseReactionsListEmoji extends Component {
         {{#if @reaction.count}}
           {{dEmoji
             @reaction.id
-            skipTitle=true
             class=(if
               this.siteSettings.discourse_reactions_desaturated_reaction_panel
               "desaturated"

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -134,7 +134,7 @@ export default class DiscourseReactionsUsersMenu extends Component {
                 data-reaction-filter={{reaction.id}}
                 {{on "click" (fn this.selectFilter reaction.id)}}
               >
-                {{dEmoji reaction.id skipTitle=true}}
+                {{dEmoji reaction.id}}
                 <span>{{reaction.count}}</span>
               </button>
             {{/each}}
@@ -144,7 +144,7 @@ export default class DiscourseReactionsUsersMenu extends Component {
 
       <:reaction as |user|>
         {{#if user.reaction}}
-          {{dEmoji user.reaction skipTitle=true class="users-popup__reaction"}}
+          {{dEmoji user.reaction class="users-popup__reaction"}}
         {{else}}
           {{dIcon "d-liked" class="users-popup__reaction"}}
         {{/if}}

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
@@ -62,6 +62,20 @@ acceptance("Post", function (needs) {
       );
   });
 
+  test("Reaction emoji shows its name in the title on hover", async function (assert) {
+    await visit("/t/topic_with_reactions_and_likes/374");
+
+    assert
+      .dom(
+        "#post_1 .discourse-reactions-list .discourse-reactions-list-emoji img.emoji[alt='laughing']"
+      )
+      .hasAttribute(
+        "title",
+        "laughing",
+        "sets the emoji name as the title attribute"
+      );
+  });
+
   test("Current user has no reaction on post and can toggle", async function (assert) {
     await visit("/t/topic_with_reactions_and_likes/374");
 

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-post-test.js
@@ -66,9 +66,7 @@ acceptance("Post", function (needs) {
     await visit("/t/topic_with_reactions_and_likes/374");
 
     assert
-      .dom(
-        "#post_1 .discourse-reactions-list .discourse-reactions-list-emoji img.emoji[alt='laughing']"
-      )
+      .dom("#post_1 .discourse-reactions-list-emoji img[alt='laughing']")
       .hasAttribute(
         "title",
         "laughing",

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
@@ -95,6 +95,27 @@ acceptance(
       );
       assert.dom(".users-popup__item").exists({ count: 5 });
     });
+
+    test("emoji filters and list reactions show the emoji name in the title", async function (assert) {
+      await visit("/t/topic_with_reactions_and_likes/374");
+      await click("#post_1 .discourse-reactions-counter");
+
+      assert
+        .dom('[data-reaction-filter="laughing"] img.emoji')
+        .hasAttribute(
+          "title",
+          "laughing",
+          "the emoji filter shows the emoji name as its title"
+        );
+
+      assert
+        .dom(".users-popup__item .users-popup__reaction[alt='laughing']")
+        .hasAttribute(
+          "title",
+          "laughing",
+          "a reaction in the user list shows the emoji name as its title"
+        );
+    });
   }
 );
 


### PR DESCRIPTION
Adds the emoji name to the image title for the post reaction list and popup filter/reaction list.