### PR TITLE
DEV: set enable_gifs to true in migrate gifs rake task

### DIFF
--- a/lib/tasks/migrate_discourse_gifs_to_core.rake
+++ b/lib/tasks/migrate_discourse_gifs_to_core.rake
@@ -275,7 +275,7 @@ module DiscourseGifsMigration
           Discourse.system_user,
           "Migrated from #{DiscourseGifs::COMPONENT_NAME} theme component",
         )
-        success("enable_gifs: true (auto-enabled per task argument)")
+        success("enable_gifs: true (auto-enabled after migration)")
         migrated += 1
       rescue StandardError => e
         errors << e
@@ -339,9 +339,9 @@ module DiscourseGifsMigration
 end
 
 desc "Migrate #{DiscourseGifs::COMPONENT_NAME} theme component settings to core site settings. " \
-       "Set ENABLE_GIFS=1 to also flip enable_gifs to true after migration."
+       "enable_gifs is flipped to true after migration by default; set ENABLE_GIFS=0 to skip that."
 task "themes:discourse_gifs:migrate" => :environment do
-  enable_gifs = %w[true yes 1].include?(ENV["ENABLE_GIFS"].to_s.strip.downcase)
+  enable_gifs = !%w[false no 0].include?(ENV["ENABLE_GIFS"].to_s.strip.downcase)
 
   DiscourseGifsMigration.migrate_all(enable_gifs: enable_gifs)
 end

--- a/spec/tasks/migrate_discourse_gifs_to_core_spec.rb
+++ b/spec/tasks/migrate_discourse_gifs_to_core_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe "tasks/migrate_discourse_gifs_to_core" do
     end
 
     context "with the enable_gifs keyword" do
-      it "leaves enable_gifs untouched by default" do
+      it "leaves enable_gifs untouched when enable_gifs: false is passed" do
         SiteSetting.enable_gifs = false
         add_overrides(component, api_provider: "klipy", klipy_api_key: "key")
 
@@ -397,6 +397,29 @@ RSpec.describe "tasks/migrate_discourse_gifs_to_core" do
         ).last
       expect(log).to be_present
       expect(log.details).to include("Migrated from discourse-gifs theme component")
+    end
+  end
+
+  describe "the themes:discourse_gifs:migrate task" do
+    def run_task
+      capture_stdout { Rake::Task["themes:discourse_gifs:migrate"].invoke }
+    end
+
+    before { allow(DiscourseGifsMigration).to receive(:migrate_all) }
+
+    it "enables gifs by default" do
+      run_task
+
+      expect(DiscourseGifsMigration).to have_received(:migrate_all).with(enable_gifs: true)
+    end
+
+    it "skips enabling gifs when ENABLE_GIFS is set to a falsey value" do
+      ENV["ENABLE_GIFS"] = "0"
+      run_task
+
+      expect(DiscourseGifsMigration).to have_received(:migrate_all).with(enable_gifs: false)
+    ensure
+      ENV.delete("ENABLE_GIFS")
     end
   end
 end


### PR DESCRIPTION
Auto enables the site setting `enable_gifs` when running the migration script, making it easier for self hosted sites.

Before running the script the site admin should get their own [Klipy API key](https://docs.klipy.com/getting-started).

After running the script the admin needs to and add their key to: `Admin -> Appearance -> GIFs -> Klipy API key` and remove/disable the theme component.