### PR TITLE
DEV: Introduce a category scope enum for flexible category selection

### DIFF
--- a/app/assets/stylesheets/admin/settings.scss
+++ b/app/assets/stylesheets/admin/settings.scss
@@ -68,6 +68,27 @@
       }
     }
 
+    .inline-dependent-settings {
+      margin-top: var(--space-3);
+
+      .setting.inline-dependent-setting {
+        padding-bottom: var(--space-2);
+
+        .setting-label,
+        .setting-value,
+        .setting-controls {
+          float: none;
+          width: 100%;
+          padding-right: 0;
+        }
+
+        .setting-label h3 {
+          margin-top: 0;
+          margin-bottom: var(--space-1);
+        }
+      }
+    }
+
     .setting-override-warning {
       font-size: var(--font-down-1);
       color: var(--primary-medium);

--- a/app/models/category_scope_site_setting.rb
+++ b/app/models/category_scope_site_setting.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "enum_site_setting"
+
+class CategoryScopeSiteSetting < EnumSiteSetting
+  def self.valid_value?(val)
+    values.any? { |value| value[:value] == val }
+  end
+
+  def self.values
+    @values ||= [
+      { name: "category_scope.all", value: "all" },
+      { name: "category_scope.public", value: "public" },
+      { name: "category_scope.include", value: "include" },
+      { name: "category_scope.include_strict", value: "include_strict" },
+      { name: "category_scope.exclude", value: "exclude" },
+      { name: "category_scope.exclude_strict", value: "exclude_strict" },
+    ]
+  end
+
+  def self.translate_names?
+    true
+  end
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9540,6 +9540,9 @@ en:
         depends_on_notice:
           one: "This setting is only applied when %{dependencyLinks} is enabled."
           other: "This setting is only applied when %{dependencyLinks} are enabled."
+        depends_on_values_notice:
+          one: "This setting only applies when %{dependencyLinks} is set to a compatible value."
+          other: "This setting only applies when %{dependencyLinks} are set to compatible values."
         discard:
           one: "Discard change"
           other: "Discard changes"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3101,6 +3101,13 @@ en:
       disabled: "Do not display"
       sidebar_footer: "Display in sidebar footer"
       header: "Display in header"
+    category_scope:
+      all: "All categories"
+      public: "Public categories"
+      include: "Include selected categories (with subcategories)"
+      include_strict: "Include selected categories (without subcategories)"
+      exclude: "Exclude selected categories (with subcategories)"
+      exclude_strict: "Exclude selected categories (without subcategories)"
     welcome_banner_location:
       above_topic_content: "Above topic content"
       below_site_header: "Below site header"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3102,7 +3102,7 @@ en:
       sidebar_footer: "Display in sidebar footer"
       header: "Display in header"
     category_scope:
-      all: "All categories"
+      all: "All public and private categories"
       public: "Public categories"
       include: "Include selected categories (with subcategories)"
       include_strict: "Include selected categories (without subcategories)"

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -46,9 +46,13 @@
 #                            Omit the key to allow all four options (the default permissive
 #                            behavior).
 # depends_on            - One or more boolean settings that must be true for this setting to take effect.
+# depends_on_values     - Optional hash of depends_on setting names to values that make this setting take effect.
+#                         Use this when the parent setting is not boolean, for example an enum setting.
 # depends_behavior      - The behavior of the dependent setting. Only currently supported behaviour is "hidden"
-#                         to hide the setting if the dependent setting is false. If left blank, no special behavior
-#                         is applied and the setting is shown as normal.
+#                         to hide the setting if the dependent setting is false or does not match depends_on_values.
+#                         If left blank, no special behavior is applied and the setting is shown as normal.
+# dependent_setting_display - Optional display mode for hidden dependent settings. "inline" renders the setting
+#                         under its parent instead of as a separate row.
 #
 #
 #

--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -24,7 +24,7 @@ import { bind } from "discourse/lib/decorators";
 import { deepEqual } from "discourse/lib/object";
 import { sanitize } from "discourse/lib/text";
 import { splitString } from "discourse/lib/utilities";
-import { and } from "discourse/truth-helpers";
+import { and, not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dBasePath from "discourse/ui-kit/helpers/d-base-path";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -146,7 +146,21 @@ export default class SiteSettingComponent extends Component {
   }
 
   get overridden() {
-    return !this.#valuesEqual(this.setting.default, this.buffered.get("value"));
+    return this.settingIsOverridden(this.setting);
+  }
+
+  get groupedOverridden() {
+    return [this.setting, ...this.inlineDependentSettings].some((setting) =>
+      this.settingIsOverridden(setting)
+    );
+  }
+
+  settingIsOverridden(setting) {
+    return !this.#valuesEqual(
+      setting.default,
+      setting.buffered.get("value"),
+      setting
+    );
   }
 
   get displayDescription() {
@@ -176,9 +190,13 @@ export default class SiteSettingComponent extends Component {
         return `<a href="${path}/admin/site_settings/category/all_results?filter=${encodeURIComponent(name)}">${label}</a>`;
       })
       .join(", ");
+    const translationKey =
+      Object.keys(this.setting.depends_on_values ?? {}).length > 0
+        ? "admin.site_settings.depends_on_values_notice"
+        : "admin.site_settings.depends_on_notice";
 
     return trustHTML(
-      i18n("admin.site_settings.depends_on_notice", {
+      i18n(translationKey, {
         count: this.setting.depends_on.length,
         dependencyLinks: links,
       })
@@ -235,8 +253,26 @@ export default class SiteSettingComponent extends Component {
   }
 
   get dirty() {
+    return this.settingIsDirty(this.setting);
+  }
+
+  get groupedDirty() {
+    return this.dirtySettings.length > 0;
+  }
+
+  get dirtySettings() {
+    return [this.setting, ...this.inlineDependentSettings].filter((setting) =>
+      this.settingIsDirty(setting)
+    );
+  }
+
+  settingIsDirty(setting) {
     let bufferVal = this.buffered.get("value");
-    let settingVal = this.setting?.value;
+    let settingVal = setting?.value;
+
+    if (setting !== this.setting) {
+      bufferVal = setting.buffered.get("value");
+    }
 
     if (isNone(bufferVal)) {
       bufferVal = "";
@@ -246,12 +282,12 @@ export default class SiteSettingComponent extends Component {
       settingVal = "";
     }
 
-    const dirty = !this.#valuesEqual(bufferVal, settingVal);
+    const dirty = !this.#valuesEqual(bufferVal, settingVal, setting);
 
     if (dirty) {
-      this.siteSettingChangeTracker.add(this.setting);
+      this.siteSettingChangeTracker.add(setting);
     } else {
-      this.siteSettingChangeTracker.remove(this.setting);
+      this.siteSettingChangeTracker.remove(setting);
     }
 
     return dirty;
@@ -369,7 +405,9 @@ export default class SiteSettingComponent extends Component {
   }
 
   get disableControls() {
-    return !!this.setting.isSaving;
+    return [this.setting, ...this.inlineDependentSettings].some(
+      (setting) => setting.isSaving
+    );
   }
 
   get staffLogFilter() {
@@ -405,37 +443,49 @@ export default class SiteSettingComponent extends Component {
 
   @action
   async update() {
-    if (this.setting.requiresConfirmation) {
-      const confirm = await this.siteSettingChangeTracker.confirmChanges(
-        this.setting
-      );
+    const dirtySettings = this.dirtySettings;
+
+    for (const setting of dirtySettings) {
+      if (!setting.requiresConfirmation) {
+        continue;
+      }
+
+      const confirm =
+        await this.siteSettingChangeTracker.confirmChanges(setting);
 
       if (!confirm) {
         return;
       }
     }
 
-    if (this.setting.affectsExistingUsers) {
-      await this.siteSettingChangeTracker.configureBackfill(this.setting);
+    for (const setting of dirtySettings) {
+      if (setting.affectsExistingUsers) {
+        await this.siteSettingChangeTracker.configureBackfill(setting);
+      }
     }
 
-    await this.save();
+    await this.save(dirtySettings);
   }
 
   @action
-  async save() {
+  async save(settings = [this.setting]) {
+    settings.forEach((setting) => (setting.isSaving = true));
+
     try {
-      this.setting.isSaving = true;
+      await this._save(settings);
 
-      await this._save();
+      const refreshParams = {};
+      settings.forEach((setting) => {
+        setting.validationMessage = null;
+        setting.buffered.applyChanges();
 
-      this.setting.validationMessage = null;
-      this.buffered.applyChanges();
+        if (setting.requiresReload) {
+          refreshParams[setting.setting] = setting.value;
+        }
+      });
 
-      if (this.setting.requiresReload) {
-        this.siteSettingChangeTracker.refreshPage({
-          [this.setting.setting]: this.setting.value,
-        });
+      if (Object.keys(refreshParams).length > 0) {
+        this.siteSettingChangeTracker.refreshPage(refreshParams);
       }
     } catch (e) {
       const json = e.jqXHR?.responseJSON;
@@ -446,14 +496,18 @@ export default class SiteSettingComponent extends Component {
           errorString = trustHTML(errorString);
         }
 
-        this.setting.validationMessage = errorString;
+        settings.forEach(
+          (setting) => (setting.validationMessage = errorString)
+        );
       } else {
         // eslint-disable-next-line no-console
         console.error(e);
-        this.setting.validationMessage = i18n("generic_error");
+        settings.forEach(
+          (setting) => (setting.validationMessage = i18n("generic_error"))
+        );
       }
     } finally {
-      this.setting.isSaving = false;
+      settings.forEach((setting) => (setting.isSaving = false));
     }
   }
 
@@ -472,17 +526,25 @@ export default class SiteSettingComponent extends Component {
 
   @action
   cancel() {
-    this.buffered.discardChanges();
-    this.setting.validationMessage = null;
+    this.dirtySettings.forEach((setting) => {
+      setting.buffered.discardChanges();
+      setting.validationMessage = null;
+    });
   }
 
   @action
   resetDefault() {
-    this.buffered.set("value", this.setting.default);
-    this.setting.validationMessage = null;
-    if (isSettingValueTrue(this.setting.default)) {
-      this.adminSiteSettingStore.reveal(this.setting.setting);
-    }
+    [this.setting, ...this.inlineDependentSettings].forEach((setting) => {
+      if (!this.settingIsOverridden(setting)) {
+        return;
+      }
+
+      setting.buffered.set("value", setting.default);
+      setting.validationMessage = null;
+      if (isSettingValueTrue(setting.default)) {
+        this.adminSiteSettingStore.reveal(setting.setting);
+      }
+    });
   }
 
   @action
@@ -501,19 +563,27 @@ export default class SiteSettingComponent extends Component {
     this.setting.validationMessage = null;
   }
 
-  _save() {
-    const setting = this.buffered;
-    return SiteSetting.update(setting.get("setting"), setting.get("value"), {
-      updateExistingUsers: this.setting.updateExistingUsers,
+  _save(settings) {
+    if (settings.length === 1) {
+      const setting = settings[0].buffered;
+      return SiteSetting.update(setting.get("setting"), setting.get("value"), {
+        updateExistingUsers: settings[0].updateExistingUsers,
+      });
+    }
+
+    const params = {};
+    settings.forEach((setting) => {
+      params[setting.buffered.get("setting")] = {
+        value: setting.buffered.get("value"),
+        backfill: !!setting.updateExistingUsers,
+      };
     });
+
+    return SiteSetting.bulkUpdate(params);
   }
 
-  #valuesEqual(a, b) {
-    if (
-      this.setting.json_schema ||
-      this.setting.schema ||
-      this.setting.objects_schema
-    ) {
+  #valuesEqual(a, b, setting = this.setting) {
+    if (setting.json_schema || setting.schema || setting.objects_schema) {
       return deepEqual(a, b);
     } else {
       return a?.toString() === b?.toString();
@@ -636,7 +706,7 @@ export default class SiteSettingComponent extends Component {
         {{/if}}
       </div>
 
-      {{#if (and this.dirty this.canUpdate)}}
+      {{#if (and this.groupedDirty this.canUpdate (not @inline))}}
         <div class="setting-controls">
           <DButton
             @action={{this.update}}
@@ -653,7 +723,7 @@ export default class SiteSettingComponent extends Component {
             class="cancel setting-controls__cancel"
           />
         </div>
-      {{else if (and this.overridden this.canUpdate)}}
+      {{else if (and this.groupedOverridden this.canUpdate (not @inline))}}
         {{#if this.setting.secret}}
           <DButton
             @action={{this.toggleSecret}}

--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -141,6 +141,10 @@ export default class SiteSettingComponent extends Component {
     return `site-settings/${this.typeClass}`;
   }
 
+  get siteSettingComponent() {
+    return getOwner(this).resolveRegistration("component:site-setting");
+  }
+
   get overridden() {
     return !this.#valuesEqual(this.setting.default, this.buffered.get("value"));
   }
@@ -273,6 +277,14 @@ export default class SiteSettingComponent extends Component {
     return this.args.setting;
   }
 
+  get inlineDependentSettings() {
+    if (this.args.inline) {
+      return [];
+    }
+
+    return this.adminSiteSettingStore.inlineDependentSettings(this.setting);
+  }
+
   get settingName() {
     return this.setting.label || this.setting.humanized_name;
   }
@@ -376,12 +388,7 @@ export default class SiteSettingComponent extends Component {
     if (this.setting.depends_behavior !== "hidden") {
       return false;
     }
-    return (
-      this.setting.depends_on?.some((name) => {
-        const parent = this.adminSiteSettingStore.get(name);
-        return parent && !isSettingValueTrue(parent.buffered.get("value"));
-      }) ?? false
-    );
+    return !this.adminSiteSettingStore.dependenciesSatisfied(this.setting);
   }
 
   get canUpdate() {
@@ -520,7 +527,8 @@ export default class SiteSettingComponent extends Component {
         {{this.typeClass}}
         {{if this.overridden 'overridden'}}
         {{if this.isDisabled 'disabled'}}
-        {{if this.isDisabledByDependency 'disabled-by-dependency'}}"
+        {{if this.isDisabledByDependency 'disabled-by-dependency'}}
+        {{if @inline 'inline-dependent-setting'}}"
       ...attributes
     >
       <div class="setting-label">
@@ -584,6 +592,16 @@ export default class SiteSettingComponent extends Component {
           {{#if this.displayDescription}}
             <Description @description={{this.setting.description}} />
             <JobStatus @status={{this.status}} @progress={{this.progress}} />
+          {{/if}}
+          {{#if this.inlineDependentSettings.length}}
+            <div class="inline-dependent-settings">
+              {{#each this.inlineDependentSettings as |dependentSetting|}}
+                <this.siteSettingComponent
+                  @setting={{dependentSetting}}
+                  @inline={{true}}
+                />
+              {{/each}}
+            </div>
           {{/if}}
           <PluginOutlet
             @name="site-setting-after-description"

--- a/frontend/discourse/admin/lib/site-setting-filter.js
+++ b/frontend/discourse/admin/lib/site-setting-filter.js
@@ -66,7 +66,7 @@ export default class SiteSettingFilter {
     this.siteSettings.forEach((settingsCategory) => {
       let fuzzyMatches = [];
 
-      const siteSettings = settingsCategory.siteSettings.filter(
+      const matchedSiteSettings = settingsCategory.siteSettings.filter(
         (siteSetting) => {
           siteSetting.weight = 0;
 
@@ -127,6 +127,9 @@ export default class SiteSettingFilter {
           return false;
         }
       );
+      const siteSettings = opts.dependsOn
+        ? matchedSiteSettings
+        : this.displaySettingsFor(matchedSiteSettings);
 
       if (siteSettings.length > 0) {
         matches.push(...siteSettings);
@@ -160,5 +163,50 @@ export default class SiteSettingFilter {
     return settings.sort((a, b) => {
       return (b.weight || 0) - (a.weight || 0);
     });
+  }
+
+  displaySettingsFor(settings) {
+    const displaySettings = [];
+
+    settings.forEach((setting) => {
+      const displaySetting = this.displaySettingFor(setting);
+
+      if (displaySetting !== setting) {
+        displaySetting.weight = Math.max(
+          displaySetting.weight || 0,
+          setting.weight || 0
+        );
+      }
+
+      if (!displaySettings.includes(displaySetting)) {
+        displaySettings.push(displaySetting);
+      }
+    });
+
+    return displaySettings;
+  }
+
+  displaySettingFor(setting) {
+    if (
+      setting.depends_behavior !== "hidden" ||
+      setting.dependent_setting_display !== "inline" ||
+      !setting.depends_on?.length
+    ) {
+      return setting;
+    }
+
+    return this.findSetting(setting.depends_on[0]) || setting;
+  }
+
+  findSetting(name) {
+    for (const settingsCategory of this.siteSettings) {
+      const setting = settingsCategory.siteSettings.find(
+        (siteSetting) => siteSetting.setting === name
+      );
+
+      if (setting) {
+        return setting;
+      }
+    }
   }
 }

--- a/frontend/discourse/admin/services/admin-site-setting-store.js
+++ b/frontend/discourse/admin/services/admin-site-setting-store.js
@@ -22,25 +22,69 @@ export default class AdminSiteSettingStore extends Service {
   }
 
   isRevealed(setting) {
-    return this.#revealed.has(setting.setting);
+    if (this.#hasValueDependencies(setting)) {
+      return this.dependenciesSatisfied(setting);
+    }
+
+    return (
+      this.#revealed.has(setting.setting) || this.dependenciesSatisfied(setting)
+    );
   }
 
   isVisible(setting, activeFilter = "") {
+    const filter = normalize(activeFilter);
+
+    if (this.#isInlineDependent(setting)) {
+      return filter !== "" && filter === normalize(setting.setting);
+    }
+
     if (setting.depends_behavior !== "hidden") {
       return true;
     }
-    if (this.#revealed.has(setting.setting)) {
+    if (this.isRevealed(setting)) {
       return true;
     }
-    const filter = normalize(activeFilter);
     return filter !== "" && filter === normalize(setting.setting);
+  }
+
+  inlineDependentSettings(setting) {
+    return Array.from(this.byName.values()).filter(
+      (dependentSetting) =>
+        this.#isInlineDependent(dependentSetting) &&
+        dependentSetting.depends_on?.includes(setting.setting) &&
+        this.dependenciesSatisfied(dependentSetting)
+    );
+  }
+
+  dependenciesSatisfied(setting) {
+    if (!setting.depends_on?.length) {
+      return true;
+    }
+
+    return setting.depends_on.every((name) => {
+      const parent = this.byName.get(name);
+
+      if (!parent) {
+        return true;
+      }
+
+      const parentValue = parent.buffered?.get("value") ?? parent.value;
+      const allowedValues = setting.depends_on_values?.[name];
+
+      if (allowedValues) {
+        return allowedValues.map(String).includes(String(parentValue));
+      }
+
+      return isSettingValueTrue(parentValue);
+    });
   }
 
   reveal(name) {
     this.byName.forEach((setting) => {
       if (
         setting.depends_behavior === "hidden" &&
-        setting.depends_on?.includes(name)
+        setting.depends_on?.includes(name) &&
+        !this.#hasValueDependencies(setting)
       ) {
         this.#revealed.add(setting.setting);
       }
@@ -55,15 +99,24 @@ export default class AdminSiteSettingStore extends Service {
       ) {
         return;
       }
-      const allTrue = setting.depends_on.every((name) => {
-        const parent = this.byName.get(name);
-        return parent ? isSettingValueTrue(parent.value) : true;
-      });
-      if (allTrue) {
+      if (this.#hasValueDependencies(setting)) {
+        this.#revealed.delete(setting.setting);
+      } else if (this.dependenciesSatisfied(setting)) {
         this.#revealed.add(setting.setting);
       } else {
         this.#revealed.delete(setting.setting);
       }
     });
+  }
+
+  #hasValueDependencies(setting) {
+    return Object.keys(setting.depends_on_values ?? {}).length > 0;
+  }
+
+  #isInlineDependent(setting) {
+    return (
+      setting.depends_behavior === "hidden" &&
+      setting.dependent_setting_display === "inline"
+    );
   }
 }

--- a/frontend/discourse/admin/services/admin-site-setting-store.js
+++ b/frontend/discourse/admin/services/admin-site-setting-store.js
@@ -35,7 +35,7 @@ export default class AdminSiteSettingStore extends Service {
     const filter = normalize(activeFilter);
 
     if (this.#isInlineDependent(setting)) {
-      return filter !== "" && filter === normalize(setting.setting);
+      return false;
     }
 
     if (setting.depends_behavior !== "hidden") {

--- a/frontend/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/frontend/discourse/tests/acceptance/admin-site-settings-test.js
@@ -148,7 +148,7 @@ acceptance("Admin - Site Settings", function (needs) {
               setting: "highlight_scope",
               humanized_name: "Highlight scope",
               description: "Choose a scope.",
-              default: "public",
+              default: "include",
               value: "include",
               category: "required",
               preview: null,
@@ -159,13 +159,14 @@ acceptance("Admin - Site Settings", function (needs) {
               setting: "highlight_categories",
               humanized_name: "Highlight categories",
               description: "Choose categories.",
-              default: "",
+              default: "default",
               value: "",
               category: "required",
               preview: null,
               secret: false,
               type: "string",
               depends_on: ["highlight_scope"],
+              depends_on_humanized_names: ["Highlight scope"],
               depends_on_values: {
                 highlight_scope: ["include", "exclude"],
               },
@@ -189,6 +190,184 @@ acceptance("Admin - Site Settings", function (needs) {
       .doesNotExist(
         "dependent setting is not rendered as a separate top-level row"
       );
+    assert
+      .dom(
+        '[data-setting="highlight_scope"] [data-setting="highlight_categories"] .setting-controls'
+      )
+      .doesNotExist("dependent setting does not render its own controls");
+    assert
+      .dom('[data-setting="highlight_scope"] > .setting-controls__undo')
+      .exists("parent setting renders controls for an overridden dependent");
+
+    await click('[data-setting="highlight_scope"] > .setting-controls__undo');
+
+    assert
+      .dom('[data-setting="highlight_categories"] .input-setting-string')
+      .hasValue("default", "parent controls reset the dependent setting");
+    assert
+      .dom(".setting-depends-on-notice")
+      .includesText(
+        "This setting only applies when Highlight scope is set to a compatible value.",
+        "value-based dependencies do not use enabled copy"
+      );
+  });
+
+  test("filtering by an inline dependent site setting shows its parent setting", async function (assert) {
+    pretender.get("/admin/site_settings", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        JSON.stringify({
+          site_settings: [
+            {
+              setting: "highlight_scope",
+              humanized_name: "Highlight scope",
+              description: "Choose a scope.",
+              default: "include",
+              value: "include",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+            },
+            {
+              setting: "highlight_categories",
+              humanized_name: "Highlight categories",
+              description: "Choose categories.",
+              default: "",
+              value: "",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+              depends_on: ["highlight_scope"],
+              depends_on_humanized_names: ["Highlight scope"],
+              depends_on_values: {
+                highlight_scope: ["include", "exclude"],
+              },
+              depends_behavior: "hidden",
+              dependent_setting_display: "inline",
+            },
+          ],
+        }),
+      ];
+    });
+
+    await visit("/admin/site_settings?filter=highlight_categories");
+
+    assert
+      .dom('section.settings > [data-setting="highlight_scope"]')
+      .exists("the parent setting is rendered as the top-level row");
+    assert
+      .dom(
+        '[data-setting="highlight_scope"] [data-setting="highlight_categories"]'
+      )
+      .exists("the matched dependent setting is rendered inline");
+    assert
+      .dom('section.settings > [data-setting="highlight_categories"]')
+      .doesNotExist("the dependent setting is not rendered as its own row");
+  });
+
+  test("inline dependent site settings use their parent setting controls", async function (assert) {
+    const updatedSettings = [];
+
+    pretender.get("/admin/site_settings", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        JSON.stringify({
+          site_settings: [
+            {
+              setting: "highlight_scope",
+              humanized_name: "Highlight scope",
+              description: "Choose a scope.",
+              default: "public",
+              value: "public",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+            },
+            {
+              setting: "highlight_categories",
+              humanized_name: "Highlight categories",
+              description: "Choose categories.",
+              default: "",
+              value: "",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+              depends_on: ["highlight_scope"],
+              depends_on_values: {
+                highlight_scope: ["include", "exclude"],
+              },
+              depends_behavior: "hidden",
+              dependent_setting_display: "inline",
+            },
+            {
+              setting: "unrelated_setting",
+              humanized_name: "Unrelated setting",
+              description: "Choose something else.",
+              default: "",
+              value: "",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+            },
+          ],
+        }),
+      ];
+    });
+    pretender.put("/admin/site_settings/bulk_update.json", (request) => {
+      updatedSettings.push("bulk_update");
+      const params = new URLSearchParams(request.requestBody);
+
+      assert.strictEqual(
+        params.get("settings[highlight_scope][value]"),
+        "include",
+        "saves the parent scope value"
+      );
+      assert.strictEqual(
+        params.get("settings[highlight_categories][value]"),
+        "selected categories",
+        "saves the inline dependent value"
+      );
+      assert.false(
+        params.has("settings[unrelated_setting][value]"),
+        "does not save unrelated dirty settings"
+      );
+
+      return [204, {}, ""];
+    });
+    pretender.put("/admin/site_settings/unrelated_setting", () => {
+      updatedSettings.push("unrelated_setting");
+      return [204, {}, ""];
+    });
+
+    await visit("/admin/site_settings");
+
+    await fillIn(
+      '[data-setting="highlight_scope"] .input-setting-string',
+      "include"
+    );
+    await fillIn(
+      '[data-setting="highlight_categories"] .input-setting-string',
+      "selected categories"
+    );
+    await fillIn(
+      '[data-setting="unrelated_setting"] .input-setting-string',
+      "do not save me"
+    );
+
+    await click('[data-setting="highlight_scope"] > .setting-controls .ok');
+
+    assert.deepEqual(
+      updatedSettings,
+      ["bulk_update"],
+      "only the inline group is saved"
+    );
   });
 
   test("category name is preserved", async function (assert) {

--- a/frontend/discourse/tests/acceptance/admin-site-settings-test.js
+++ b/frontend/discourse/tests/acceptance/admin-site-settings-test.js
@@ -137,6 +137,60 @@ acceptance("Admin - Site Settings", function (needs) {
     assert.dom(".row.setting").exists({ count: 0 });
   });
 
+  test("renders inline dependent site settings under their parent setting", async function (assert) {
+    pretender.get("/admin/site_settings", () => {
+      return [
+        200,
+        { "Content-Type": "application/json" },
+        JSON.stringify({
+          site_settings: [
+            {
+              setting: "highlight_scope",
+              humanized_name: "Highlight scope",
+              description: "Choose a scope.",
+              default: "public",
+              value: "include",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+            },
+            {
+              setting: "highlight_categories",
+              humanized_name: "Highlight categories",
+              description: "Choose categories.",
+              default: "",
+              value: "",
+              category: "required",
+              preview: null,
+              secret: false,
+              type: "string",
+              depends_on: ["highlight_scope"],
+              depends_on_values: {
+                highlight_scope: ["include", "exclude"],
+              },
+              depends_behavior: "hidden",
+              dependent_setting_display: "inline",
+            },
+          ],
+        }),
+      ];
+    });
+
+    await visit("/admin/site_settings");
+
+    assert
+      .dom(
+        '[data-setting="highlight_scope"] [data-setting="highlight_categories"]'
+      )
+      .exists("dependent setting is rendered inside its parent setting");
+    assert
+      .dom('section.settings > [data-setting="highlight_categories"]')
+      .doesNotExist(
+        "dependent setting is not rendered as a separate top-level row"
+      );
+  });
+
   test("category name is preserved", async function (assert) {
     await visit("/admin/site_settings/category/basic?filter=menu");
     assert.strictEqual(

--- a/frontend/discourse/tests/unit/services/admin-site-setting-store-test.js
+++ b/frontend/discourse/tests/unit/services/admin-site-setting-store-test.js
@@ -64,6 +64,78 @@ module("Unit | Service | admin-site-setting-store", function (hooks) {
         "case + whitespace"
       );
     });
+
+    test("hidden value-dependent settings are visible only when the parent has a matching value", function (assert) {
+      const parent = build({ setting: "category_scope", value: "public" });
+      const child = build({
+        setting: "highlight_categories",
+        depends_on: ["category_scope"],
+        depends_on_values: {
+          category_scope: ["include", "exclude"],
+        },
+        depends_behavior: "hidden",
+      });
+      this.store.register([parent, child]);
+
+      assert.false(this.store.isVisible(child));
+
+      parent.buffered.set("value", "include");
+      assert.true(this.store.isVisible(child));
+
+      parent.buffered.set("value", "public");
+      assert.false(
+        this.store.isVisible(child),
+        "the dependent setting is hidden again when the parent value no longer matches"
+      );
+    });
+
+    test("inline dependent settings are hidden from the top-level list unless directly filtered", function (assert) {
+      const child = build({
+        setting: "highlight_categories",
+        depends_on: ["category_scope"],
+        depends_on_values: {
+          category_scope: ["include"],
+        },
+        depends_behavior: "hidden",
+        dependent_setting_display: "inline",
+      });
+      this.store.register([
+        build({ setting: "category_scope", value: "include" }),
+        child,
+      ]);
+
+      assert.false(this.store.isVisible(child));
+      assert.true(this.store.isVisible(child, "highlight_categories"));
+    });
+  });
+
+  module("inlineDependentSettings", function () {
+    test("returns matching inline dependents for a setting", function (assert) {
+      const parent = build({ setting: "category_scope", value: "public" });
+      const child = build({
+        setting: "highlight_categories",
+        depends_on: ["category_scope"],
+        depends_on_values: {
+          category_scope: ["include"],
+        },
+        depends_behavior: "hidden",
+        dependent_setting_display: "inline",
+      });
+      const separateChild = build({
+        setting: "separate_categories",
+        depends_on: ["category_scope"],
+        depends_on_values: {
+          category_scope: ["include"],
+        },
+        depends_behavior: "hidden",
+      });
+      this.store.register([parent, child, separateChild]);
+
+      assert.deepEqual(this.store.inlineDependentSettings(parent), []);
+
+      parent.buffered.set("value", "include");
+      assert.deepEqual(this.store.inlineDependentSettings(parent), [child]);
+    });
   });
 
   module("register", function () {
@@ -127,6 +199,24 @@ module("Unit | Service | admin-site-setting-store", function (hooks) {
         oneOff,
       ]);
       assert.false(this.store.isRevealed(oneOff));
+    });
+
+    test("value-dependent settings are not latched as revealed", function (assert) {
+      const parent = build({ setting: "scope", value: "include" });
+      const child = build({
+        setting: "categories",
+        depends_on: ["scope"],
+        depends_on_values: {
+          scope: ["include"],
+        },
+        depends_behavior: "hidden",
+      });
+      this.store.register([parent, child]);
+
+      assert.true(this.store.isRevealed(child));
+
+      parent.buffered.set("value", "public");
+      assert.false(this.store.isRevealed(child));
     });
   });
 

--- a/frontend/discourse/tests/unit/services/admin-site-setting-store-test.js
+++ b/frontend/discourse/tests/unit/services/admin-site-setting-store-test.js
@@ -89,7 +89,7 @@ module("Unit | Service | admin-site-setting-store", function (hooks) {
       );
     });
 
-    test("inline dependent settings are hidden from the top-level list unless directly filtered", function (assert) {
+    test("inline dependent settings are hidden from the top-level list", function (assert) {
       const child = build({
         setting: "highlight_categories",
         depends_on: ["category_scope"],
@@ -105,7 +105,7 @@ module("Unit | Service | admin-site-setting-store", function (hooks) {
       ]);
 
       assert.false(this.store.isVisible(child));
-      assert.true(this.store.isVisible(child, "highlight_categories"));
+      assert.false(this.store.isVisible(child, "highlight_categories"));
     });
   });
 

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -154,6 +154,14 @@ module SiteSettingExtension
     @requires_confirmation_settings ||= {}
   end
 
+  def dependency_values
+    @dependency_values ||= {}
+  end
+
+  def dependent_setting_display
+    @dependent_setting_display ||= {}
+  end
+
   # Valid upcoming change metadata looks like this
   # in site_settings.yml:
   #
@@ -519,6 +527,10 @@ module SiteSettingExtension
             opts_data[:depends_on] = depends_on
             opts_data[:depends_on_humanized_names] = depends_on.map { |dep| humanized_names(dep) }
             opts_data[:depends_behavior] = type_supervisor.dependencies.behaviors[s]
+            opts_data[:depends_on_values] = dependency_values[s] if dependency_values[s]
+            if display = dependent_setting_display[s]
+              opts_data[:dependent_setting_display] = display
+            end
           end
 
           if upcoming_change_default_override_metadata
@@ -1308,6 +1320,20 @@ module SiteSettingExtension
           opts[:requires_confirmation]
         end
       )
+
+      if opts[:depends_on_values]
+        dependency_values[name] = opts[:depends_on_values]
+          .transform_keys(&:to_sym)
+          .transform_values { |values| Array(values).map(&:to_s) }
+      else
+        dependency_values.delete(name)
+      end
+
+      if opts[:dependent_setting_display]
+        dependent_setting_display[name] = opts[:dependent_setting_display].to_s
+      else
+        dependent_setting_display.delete(name)
+      end
 
       if opts[:upcoming_change]
         upcoming_change_metadata[name] ||= {}

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -775,6 +775,31 @@ RSpec.describe SiteSettingExtension do
         end
       end
 
+      context "when the dependent setting declares depends_on_values" do
+        before do
+          settings.setting(:cool_thing_scope, "public")
+          settings.setting(
+            :cool_thing_categories,
+            "",
+            depends_on: [:cool_thing_scope],
+            depends_on_values: {
+              cool_thing_scope: %w[include exclude],
+            },
+            depends_behavior: :hidden,
+            dependent_setting_display: :inline,
+          )
+          settings.refresh!
+        end
+
+        it "serializes the values and display mode for the dependent setting" do
+          setting = settings.all_settings.find { |s| s[:setting] == :cool_thing_categories }
+
+          expect(setting[:depends_on]).to eq([:cool_thing_scope])
+          expect(setting[:depends_on_values]).to eq(cool_thing_scope: %w[include exclude])
+          expect(setting[:dependent_setting_display]).to eq("inline")
+        end
+      end
+
       context "when the depends_on setting is false" do
         before do
           settings.setting(:enable_cool_thing, false)

--- a/spec/models/category_scope_site_setting_spec.rb
+++ b/spec/models/category_scope_site_setting_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe CategoryScopeSiteSetting do
+  it "returns translated category scope values" do
+    expect(described_class.values).to contain_exactly(
+      { name: "category_scope.all", value: "all" },
+      { name: "category_scope.public", value: "public" },
+      { name: "category_scope.include", value: "include" },
+      { name: "category_scope.include_strict", value: "include_strict" },
+      { name: "category_scope.exclude", value: "exclude" },
+      { name: "category_scope.exclude_strict", value: "exclude_strict" },
+    )
+    expect(described_class.translate_names?).to eq(true)
+  end
+
+  it "validates category scope values" do
+    expect(described_class.valid_value?("all")).to eq(true)
+    expect(described_class.valid_value?("include_strict")).to eq(true)
+    expect(described_class.valid_value?("invalid")).to eq(false)
+  end
+end


### PR DESCRIPTION
This PR adds a shared `CategoryScopeSiteSetting` enum for category-scope dropdowns.

The enum keeps the stored values short (`all`, `public`, `include`, `include_strict`, `exclude`, `exclude_strict`) while letting the admin UI show clearer labels like “Include selected categories (with subcategories)”. This gives category-list settings a reusable way to explain include/exclude and strict/non-strict behavior without making the setting description do all the work.

Example usage:

```yaml
feature_name_category_scope:
    type: enum
    default: "public" # public categories
    enum: "CategoryScopeSiteSetting"
    client: false
    area: "feature-name"
feature_name_categories:
    type: category_list
    default: ""
    client: false
    area: "feature-name"
    depends_on:
      - feature_name_category_scope
    depends_on_values:
      feature_name_category_scope:
        - include
        - include_strict
        - exclude
        - exclude_strict
    depends_behavior: "hidden" # this settting will be hidden based on the depends_on_values
    dependent_setting_display: "inline" # this setting will be displayed inline to the above
```

And suitable descriptions in `server.en.yml`

```yaml
feature_name_category_scope: "Choose which categories this feature can use. Include and exclude options use {{setting:feature_name_categories}}."   
feature_name_categories: "Categories used when the category scope is set to <strong>include</strong> or <strong>exclude</strong>."
```
https://github.com/user-attachments/assets/d5255687-e995-4123-951b-2c784b315c0b


