### PR TITLE
FIX: only show first paragraph of localized category descriptions

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -616,6 +616,12 @@ class Category < ActiveRecord::Base
     end
   end
 
+  def self.first_paragraph_description(cooked)
+    doc = Nokogiri::HTML5.fragment(cooked)
+    doc.css("img").remove
+    doc.css("p").first&.inner_html&.strip
+  end
+
   def description_text
     return nil unless description
 

--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -143,20 +143,7 @@ class CategoryList
 
   def find_categories
     query = Category.includes(CategoryList.included_associations).secured(@guardian)
-
-    if SiteSetting.content_localization_enabled
-      locale = I18n.locale.to_s
-      query =
-        query.joins(
-          ActiveRecord::Base.sanitize_sql_array(
-            [
-              "LEFT JOIN category_localizations cl ON cl.category_id = categories.id AND cl.locale = ?",
-              locale,
-            ],
-          ),
-        )
-    end
-
+    query = query.includes(:localizations) if SiteSetting.content_localization_enabled
     query = self.class.order_categories(query)
 
     paginate = paginate_results?
@@ -177,15 +164,6 @@ class CategoryList
     query =
       DiscoursePluginRegistry.apply_modifier(:category_list_find_categories_query, query, self)
 
-    if SiteSetting.content_localization_enabled
-      query =
-        query.group("categories.id").select(
-          "categories.*,
-           MAX(COALESCE(cl.name, categories.name)) AS name,
-           MAX(COALESCE(cl.description, categories.description)) AS description",
-        )
-    end
-
     @categories = query.to_a
 
     if paginate && @options[:parent_category_id].blank?
@@ -195,11 +173,19 @@ class CategoryList
           .select(:id, "ROW_NUMBER() OVER (PARTITION BY parent_category_id) rownum")
           .where(parent_category_id: @categories.map { |c| c.id })
 
-      @categories +=
+      subcategories_query =
         Category.includes(CategoryList.included_associations).where(
           "id IN (WITH cte AS (#{categories_with_rownum.to_sql}) SELECT id FROM cte WHERE rownum <= ?)",
           SUBCATEGORIES_PER_CATEGORY,
         )
+      if SiteSetting.content_localization_enabled
+        subcategories_query = subcategories_query.includes(:localizations)
+      end
+      @categories += subcategories_query
+    end
+
+    if SiteSetting.content_localization_enabled
+      @categories.each { |c| LocalizationAttributesReplacer.localize_category(c, I18n.locale) }
     end
 
     if Site.preloaded_category_custom_fields.any?

--- a/app/models/category_localization.rb
+++ b/app/models/category_localization.rb
@@ -11,6 +11,33 @@ class CategoryLocalization < ActiveRecord::Base
 
   after_commit :invalidate_site_cache
 
+  def description_first_paragraph
+    return if description.blank?
+
+    @@first_paragraph_cache ||= LruRedux::ThreadSafeCache.new(1000)
+    @@first_paragraph_cache.getset(description) do
+      Category.first_paragraph_description(PrettyText.cook(description))
+    end
+  end
+
+  def description_text
+    first_paragraph = description_first_paragraph
+    return if first_paragraph.blank?
+
+    @@description_text_cache ||= LruRedux::ThreadSafeCache.new(1000)
+    @@description_text_cache.getset(description) do
+      ERB::Util.html_escape(Nokogiri::HTML5.fragment(first_paragraph).text.strip).html_safe
+    end
+  end
+
+  def description_excerpt
+    first_paragraph = description_first_paragraph
+    return if first_paragraph.blank?
+
+    @@description_excerpt_cache ||= LruRedux::ThreadSafeCache.new(1000)
+    @@description_excerpt_cache.getset(description) { PrettyText.excerpt(first_paragraph, 300) }
+  end
+
   def invalidate_site_cache
     I18n.with_locale(locale) { Site.clear_cache }
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -575,10 +575,7 @@ class Post < ActiveRecord::Base
     category ||= Category.find_by(topic_id:)
     return unless category
 
-    doc = Nokogiri::HTML5.fragment(cooked)
-    doc.css("img").remove
-
-    if (html = doc.css("p").first&.inner_html&.strip)
+    if (html = Category.first_paragraph_description(cooked))
       new_description = html unless html.starts_with?(Category.post_template[..50])
       return category if category.description == new_description
       category.update_column(:description, new_description)

--- a/app/serializers/site_category_serializer.rb
+++ b/app/serializers/site_category_serializer.rb
@@ -46,14 +46,7 @@ class SiteCategorySerializer < BasicCategorySerializer
   def name
     return I18n.t("uncategorized_category_name") if object.uncategorized?
 
-    translated_name =
-      if ContentLocalization.show_translated_category?(object, scope)
-        object.get_localization&.name
-      else
-        object.name
-      end
-
-    translated_name || object.name
+    localization&.name.presence || object.name
   end
 
   def description
@@ -62,23 +55,26 @@ class SiteCategorySerializer < BasicCategorySerializer
 
   def description_text
     return super if object.uncategorized?
-    return ERB::Util.html_escape(localized_description).html_safe if localized_description
+    return localization.description_text if localized_description
     object.description_text
   end
 
   def description_excerpt
     return super if object.uncategorized?
-    return PrettyText.excerpt(localized_description, 300) if localized_description
+    return localization.description_excerpt if localized_description
     object.description_excerpt
   end
 
   private
 
+  def localization
+    return @localization if defined?(@localization)
+    @localization =
+      (object.get_localization if ContentLocalization.show_translated_category?(object, scope))
+  end
+
   def localized_description
     return @localized_description if defined?(@localized_description)
-    @localized_description =
-      if ContentLocalization.show_translated_category?(object, scope)
-        object.get_localization&.description.presence
-      end
+    @localized_description = localization&.description_first_paragraph.presence
   end
 end

--- a/lib/localization_attributes_replacer.rb
+++ b/lib/localization_attributes_replacer.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 module LocalizationAttributesReplacer
-  def self.replace_category_attributes(category, crawl_locale)
-    if loc = get_localization(category, crawl_locale)
+  def self.localize_category(category, locale)
+    if loc = get_localization(category, locale)
       category.name = loc.name if loc.name.present?
       localized_description = loc.description_first_paragraph
       category.description = localized_description if localized_description.present?
     end
+  end
+
+  def self.replace_category_attributes(category, crawl_locale)
+    localize_category(category, crawl_locale)
 
     while category = category.parent_category
-      replace_category_attributes(category, crawl_locale)
+      localize_category(category, crawl_locale)
     end
   end
 

--- a/lib/localization_attributes_replacer.rb
+++ b/lib/localization_attributes_replacer.rb
@@ -4,7 +4,8 @@ module LocalizationAttributesReplacer
   def self.replace_category_attributes(category, crawl_locale)
     if loc = get_localization(category, crawl_locale)
       category.name = loc.name if loc.name.present?
-      category.description = loc.description if loc.description.present?
+      localized_description = loc.description_first_paragraph
+      category.description = localized_description if localized_description.present?
     end
 
     while category = category.parent_category

--- a/spec/lib/localization_attributes_replacer_spec.rb
+++ b/spec/lib/localization_attributes_replacer_spec.rb
@@ -18,6 +18,23 @@ describe LocalizationAttributesReplacer do
       expect(subcategory.parent_category.description).to eq(ja_category.description)
     end
 
+    it "only uses the first paragraph of a localized description" do
+      ja_category.update!(description: "最初の段落\n\n二番目の段落")
+
+      LocalizationAttributesReplacer.replace_category_attributes(category, "ja")
+
+      expect(category.description).to eq("最初の段落")
+    end
+
+    it "keeps the untranslated description when the localized description has no paragraph" do
+      ja_category.update!(description: "- 一つ\n- 二つ")
+      original_description = category.description
+
+      LocalizationAttributesReplacer.replace_category_attributes(category, "ja")
+
+      expect(category.description).to eq(original_description)
+    end
+
     it "does not change the name if the locale is the same" do
       LocalizationAttributesReplacer.replace_category_attributes(category, "en")
 

--- a/spec/models/category_list_spec.rb
+++ b/spec/models/category_list_spec.rb
@@ -500,7 +500,9 @@ RSpec.describe CategoryList do
   end
 
   context "with content_localization_enabled enabled" do
-    fab!(:category) { Fabricate(:category, name: "Original Name", description: "Original Desc") }
+    fab!(:category) do
+      Fabricate(:category, name: "Original Name", description: "Original Desc", locale: "en")
+    end
     fab!(:category_localization) { Fabricate(:category_localization, category:, locale: "ja") }
 
     let(:locale) { "ja" }
@@ -514,7 +516,21 @@ RSpec.describe CategoryList do
       cl = CategoryList.new(Guardian.new)
       cat = cl.categories.find { |c| c.id == category.id }
       expect(cat.name).to eq(category_localization.name)
-      expect(cat.description).to eq(category_localization.description)
+      expect(cat.description).to eq(category_localization.description_first_paragraph)
+    end
+
+    it "only uses the first paragraph of a multi-paragraph localized description" do
+      category_localization.update!(description: "最初の段落\n\n二番目の段落")
+      cl = CategoryList.new(Guardian.new)
+      cat = cl.categories.find { |c| c.id == category.id }
+      expect(cat.description).to eq("最初の段落")
+    end
+
+    it "keeps the untranslated description when the localized description has no paragraph" do
+      category_localization.update!(description: "- 一つ\n- 二つ")
+      cl = CategoryList.new(Guardian.new)
+      cat = cl.categories.find { |c| c.id == category.id }
+      expect(cat.description).to eq("Original Desc")
     end
 
     it "falls back to the original name and description if no localization exists" do

--- a/spec/models/category_localization_spec.rb
+++ b/spec/models/category_localization_spec.rb
@@ -1,6 +1,42 @@
 # frozen_string_literal: true
 
 describe CategoryLocalization do
+  describe "#description_first_paragraph" do
+    it "cooks the description and keeps only the first paragraph" do
+      localization =
+        Fabricate(
+          :category_localization,
+          description: "un [enlace](https://example.com)\n\notro párrafo",
+        )
+
+      expect(localization.description_first_paragraph).to eq(
+        "un <a href=\"https://example.com\" rel=\"noopener nofollow ugc\">enlace</a>",
+      )
+    end
+
+    it "returns nil when the cooked description has no paragraph" do
+      localization = Fabricate(:category_localization, description: "- uno\n- dos")
+
+      expect(localization.description_first_paragraph).to be_nil
+    end
+  end
+
+  describe "#description_text and #description_excerpt" do
+    it "derives plain text and excerpt from the first paragraph" do
+      localization = Fabricate(:category_localization, description: "un **texto**\n\notro párrafo")
+
+      expect(localization.description_text).to eq("un texto")
+      expect(localization.description_excerpt).to eq("un texto")
+    end
+
+    it "returns nil when there is no first paragraph" do
+      localization = Fabricate(:category_localization, description: "- uno\n- dos")
+
+      expect(localization.description_text).to be_nil
+      expect(localization.description_excerpt).to be_nil
+    end
+  end
+
   context "when commit" do
     it "clears the site cache for the locale" do
       category = Fabricate(:category, name: "yy")

--- a/spec/serializers/category_serializer_spec.rb
+++ b/spec/serializers/category_serializer_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe CategorySerializer do
       expect(json[:description]).to eq("Original Description")
     end
 
-    it "returns translated attributes for SiteCategorySerializer when enabled" do
+    it "returns only the first paragraph of the translated description for SiteCategorySerializer when enabled" do
       SiteSetting.content_localization_enabled = true
       user.update!(locale: "ja")
       I18n.with_locale("ja") do
@@ -164,9 +164,50 @@ RSpec.describe CategorySerializer do
             root: false,
           ).as_json
         expect(json[:name]).to eq("日本語名")
-        expect(json[:description]).to eq("<p>最初の段落</p><p>二番目の段落</p>")
-        expect(json[:description_text]).to eq("&lt;p&gt;最初の段落&lt;/p&gt;&lt;p&gt;二番目の段落&lt;/p&gt;")
-        expect(json[:description_excerpt]).to eq("最初の段落 二番目の段落")
+        expect(json[:description]).to eq("最初の段落")
+        expect(json[:description_text]).to eq("最初の段落")
+        expect(json[:description_excerpt]).to eq("最初の段落")
+      end
+    end
+
+    it "keeps only the first paragraph of a plain text translated description" do
+      SiteSetting.content_localization_enabled = true
+      category_with_localization
+        .category_localizations
+        .find_by(locale: "ja")
+        .update!(description: "最初の段落\n\n二番目の段落")
+      user.update!(locale: "ja")
+      I18n.with_locale("ja") do
+        json =
+          SiteCategorySerializer.new(
+            category_with_localization,
+            scope: Guardian.new(user),
+            root: false,
+          ).as_json
+        expect(json[:description]).to eq("最初の段落")
+        expect(json[:description_text]).to eq("最初の段落")
+        expect(json[:description_excerpt]).to eq("最初の段落")
+      end
+    end
+
+    it "falls back to the untranslated description when the translated description has no paragraph" do
+      SiteSetting.content_localization_enabled = true
+      category_with_localization
+        .category_localizations
+        .find_by(locale: "ja")
+        .update!(description: "- 一つ\n- 二つ")
+      user.update!(locale: "ja")
+      I18n.with_locale("ja") do
+        json =
+          SiteCategorySerializer.new(
+            category_with_localization,
+            scope: Guardian.new(user),
+            root: false,
+          ).as_json
+        expect(json[:name]).to eq("日本語名")
+        expect(json[:description]).to eq("Original Description")
+        expect(json[:description_text]).to eq(category_with_localization.description_text)
+        expect(json[:description_excerpt]).to eq(category_with_localization.description_excerpt)
       end
     end
 


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/category-description-truncates-to-first-paragraph-for-primary-base-language-but-not-for-localizations-panel-languages/406801

In a number of places we only show the first paragraph of a category description by default, but when someone manually adds a category description translation we show the full content. This results in translated content being much longer in some places where only a single paragraph is expected (/categories pages, category headers, etc). 

This change cooks the translated description and applies the same single paragraph rule where relevant.

`Category.first_paragraph_description` has been extracted to be used in both the default and translated descriptions so the behavior remains consistent.  