### PR TITLE
FIX: store method in route matcher

### DIFF
--- a/lib/route_matcher.rb
+++ b/lib/route_matcher.rb
@@ -100,7 +100,7 @@ class RouteMatcher
       # We store the result of `recognize_path` in a custom env key, so that we don't change
       # some Rails behavior by accident.
       request.env[PATH_PARAMETERS] ||= begin
-        Rails.application.routes.recognize_path(request.path_info)
+        Rails.application.routes.recognize_path(request.path_info, method: request.request_method)
       rescue ActionController::RoutingError
         {}
       end

--- a/spec/integration/api_keys_spec.rb
+++ b/spec/integration/api_keys_spec.rb
@@ -15,6 +15,35 @@ RSpec.describe "api keys" do
     expect(response.status).to eq(404)
   end
 
+  it "does not allow overloaded requests to bypass granular API key scopes" do
+    global_setting :reject_anonymous_min_queue_seconds, 1.0
+
+    admin = Fabricate(:admin)
+    topic = Fabricate(:topic)
+    Fabricate(:post, topic: topic)
+    scoped_api_key =
+      Fabricate(
+        :api_key,
+        user: admin,
+        api_key_scopes: [Fabricate.build(:api_key_scope, resource: "topics", action: "read")],
+      )
+
+    put "/t/#{topic.id}.json",
+        params: {
+          title: "This is an unauthorized title change",
+        },
+        headers: {
+          HTTP_API_KEY: scoped_api_key.key,
+          HTTP_X_REQUEST_START: "t=0",
+        }
+
+    expect(response.status).to eq(503)
+    expect(response.body).to eq(
+      "Server is currently experiencing high load. Please try again later.",
+    )
+    expect(topic.reload.title).not_to eq("This is an unauthorized title change")
+  end
+
   it "allows parameters on ics routes" do
     get "/u/#{user.username}/bookmarks.ics?api_key=#{api_key.key}&api_username=#{user.username.downcase}"
     expect(response.status).to eq(200)


### PR DESCRIPTION
This ensures that the parameters stored include the method, that way there is no caching collision between different methods.