### PR TITLE
FIX: In-memory state desynchronization leads to corrupt post revisions

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -362,6 +362,8 @@ class PostRevisor
 
       revise_topic
       advance_draft_sequence if !opts[:keep_existing_draft]
+
+      raise ActiveRecord::Rollback if !successfully_saved_post_and_topic
     end
 
     # bail out if the post or topic failed to save

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -346,6 +346,8 @@ class PostRevisor
     @silent = @opts[:silent] if @opts.has_key?(:silent)
     @topic_changes.silent = @silent
 
+    @previous_last_editor_id = @post.last_editor_id
+
     old_raw = @post.raw
 
     Post.transaction do
@@ -368,6 +370,8 @@ class PostRevisor
 
     # bail out if the post or topic failed to save
     return false if !successfully_saved_post_and_topic
+
+    bump_topic if @version_changed
 
     # Lock the post by default if the appropriate setting is true
     if SiteSetting.staff_edit_locks_post? && !@post.wiki? && @fields.has_key?("raw") &&
@@ -546,8 +550,7 @@ class PostRevisor
     @post.last_version_at = @revised_at
 
     revise
-    perform_edit
-    bump_topic
+    perform_edit if successfully_saved_post_and_topic
   end
 
   def revise
@@ -693,10 +696,14 @@ class PostRevisor
   def create_revision
     modifications = post_changes.merge(topic_diff)
 
-    modifications["raw"][0] = cached_original_raw || modifications["raw"][0] if modifications["raw"]
+    if use_cached_original_for_created_revision?
+      if modifications["raw"]
+        modifications["raw"][0] = cached_original_raw || modifications["raw"][0]
+      end
 
-    if modifications["cooked"]
-      modifications["cooked"][0] = cached_original_cooked || modifications["cooked"][0]
+      if modifications["cooked"]
+        modifications["cooked"][0] = cached_original_cooked || modifications["cooked"][0]
+      end
     end
 
     @post_revision =
@@ -709,6 +716,11 @@ class PostRevisor
       )
     @post_revision.silent = @silent
     @post_revision.save!
+  end
+
+  def use_cached_original_for_created_revision?
+    @previous_last_editor_id == @editor.id &&
+      !PostRevision.exists?(post_id: @post.id, number: @post.version - 1)
   end
 
   def update_revision

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -350,6 +350,8 @@ class PostRevisor
 
     old_raw = @post.raw
 
+    @should_bump_topic = false
+
     Post.transaction do
       revise_post
 
@@ -364,6 +366,7 @@ class PostRevisor
 
       revise_topic
       advance_draft_sequence if !opts[:keep_existing_draft]
+      @should_bump_topic = @version_changed && successfully_saved_post_and_topic && should_bump?
 
       raise ActiveRecord::Rollback if !successfully_saved_post_and_topic
     end
@@ -371,7 +374,7 @@ class PostRevisor
     # bail out if the post or topic failed to save
     return false if !successfully_saved_post_and_topic
 
-    bump_topic if @version_changed
+    bump_topic if @should_bump_topic
 
     # Lock the post by default if the appropriate setting is true
     if SiteSetting.staff_edit_locks_post? && !@post.wiki? && @fields.has_key?("raw") &&
@@ -773,7 +776,6 @@ class PostRevisor
   end
 
   def bump_topic
-    return if !should_bump?
     @topic.update_column(:bumped_at, Time.now)
     TopicTrackingState.publish_muted(@topic)
     TopicTrackingState.publish_unmuted(@topic)

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -364,9 +364,9 @@ class PostRevisor
       # false positive.
       plugin_callbacks
 
+      @should_bump_topic = @version_changed && successfully_saved_post_and_topic && should_bump?
       revise_topic
       advance_draft_sequence if !opts[:keep_existing_draft]
-      @should_bump_topic = @version_changed && successfully_saved_post_and_topic && should_bump?
 
       raise ActiveRecord::Rollback if !successfully_saved_post_and_topic
     end
@@ -601,6 +601,7 @@ class PostRevisor
     previous_reply_to_post_number = @post.reply_to_post_number_was
 
     @post_successfully_saved = @post.save(validate: @validate_post)
+    @post_changes = @post.previous_changes.slice(*POST_TRACKED_FIELDS) if @post_successfully_saved
     @post.link_post_uploads
 
     if @post_successfully_saved
@@ -759,7 +760,7 @@ class PostRevisor
   end
 
   def post_changes
-    @post.previous_changes.slice(*POST_TRACKED_FIELDS)
+    @post_changes || @post.previous_changes.slice(*POST_TRACKED_FIELDS)
   end
 
   def topic_diff

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1969,6 +1969,36 @@ describe PostRevisor do
           }.to change { post.topic.reload.bumped_at }
         end
 
+        it "keeps post changes available to the modifier before advancing the draft" do
+          DiscoursePluginRegistry.unregister_modifier(
+            plugin_instance,
+            :should_bump_topic,
+            &modifier_block
+          )
+
+          inspecting_modifier =
+            Proc.new do |value, modifier_post, modifier_post_changes, modifier_topic_changes, editor|
+              modifier_post.is_first_post? && modifier_post_changes.any?
+            end
+
+          plugin_instance.register_modifier(:should_bump_topic, &inspecting_modifier)
+
+          expect {
+            post_revisor.revise!(
+              post.user,
+              { raw: "updated body", title: "Updated topic title" },
+              revised_at: post.updated_at + SiteSetting.editing_grace_period + 1.second,
+            )
+          }.to change { post.topic.reload.bumped_at }
+        ensure
+          DiscoursePluginRegistry.unregister_modifier(
+            plugin_instance,
+            :should_bump_topic,
+            &inspecting_modifier
+          ) if defined?(inspecting_modifier)
+          plugin_instance.register_modifier(:should_bump_topic, &modifier_block)
+        end
+
         it "doesn't bump the topic when the title edit is invalid" do
           original_raw = post.raw
           post.topic.update!(bumped_at: 1.day.ago)

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1954,7 +1954,41 @@ describe PostRevisor do
               { raw: "updated body" },
               revised_at: post.updated_at + SiteSetting.editing_grace_period + 1.second,
             )
-          }.to change { post.topic.bumped_at }
+          }.to change { post.topic.reload.bumped_at }
+        end
+
+        it "bumps the persisted topic when editing raw and title" do
+          post.topic.update!(bumped_at: 1.day.ago)
+
+          expect {
+            post_revisor.revise!(
+              post.user,
+              { raw: "updated body", title: "This is an updated topic title" },
+              revised_at: post.updated_at + SiteSetting.editing_grace_period + 1.second,
+            )
+          }.to change { post.topic.reload.bumped_at }
+        end
+
+        it "doesn't bump the topic when the title edit is invalid" do
+          original_raw = post.raw
+          post.topic.update!(bumped_at: 1.day.ago)
+
+          messages =
+            MessageBus.track_publish(TopicTrackingState::LATEST_MESSAGE_BUS_CHANNEL) do
+              expect {
+                result =
+                  post_revisor.revise!(
+                    post.user,
+                    { raw: "updated body", title: "New Title" },
+                    revised_at: post.updated_at + SiteSetting.editing_grace_period + 1.second,
+                  )
+                expect(result).to eq(false)
+              }.not_to change { post.topic.reload.bumped_at }
+            end
+
+          expect(messages).to be_empty
+          expect(post.reload.raw).to eq(original_raw)
+          expect(post.version).to eq(1)
         end
       end
     end

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -1991,11 +1991,13 @@ describe PostRevisor do
             )
           }.to change { post.topic.reload.bumped_at }
         ensure
-          DiscoursePluginRegistry.unregister_modifier(
-            plugin_instance,
-            :should_bump_topic,
-            &inspecting_modifier
-          ) if defined?(inspecting_modifier)
+          if defined?(inspecting_modifier)
+            DiscoursePluginRegistry.unregister_modifier(
+              plugin_instance,
+              :should_bump_topic,
+              &inspecting_modifier
+            )
+          end
           plugin_instance.register_modifier(:should_bump_topic, &modifier_block)
         end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2725,6 +2725,52 @@ RSpec.describe PostsController do
       expect(response.status).to eq(400)
     end
 
+    it "attributes coalesced grace-period edits to the correct editor" do
+      SiteSetting.edit_history_visible_to_public = true
+      SiteSetting.editing_grace_period = 1.minute
+      SiteSetting.editing_grace_period_max_diff = 1000
+
+      edited_post = Fabricate(:post, raw: "Original version")
+      first_editor = Fabricate(:user)
+      second_editor = Fabricate(:user)
+      first_body = "First editor first version"
+      coalesced_body = "First editor coalesced version"
+      second_body = "Second editor version"
+
+      PostRevisor.new(edited_post).revise!(
+        first_editor,
+        { raw: first_body },
+        revised_at: edited_post.updated_at + 2.minutes,
+      )
+      edited_post.reload
+      PostRevisor.new(edited_post).revise!(
+        first_editor,
+        { raw: coalesced_body },
+        revised_at: edited_post.last_version_at + 1.second,
+      )
+      edited_post.reload
+      PostRevisor.new(edited_post).revise!(
+        second_editor,
+        { raw: second_body },
+        revised_at: edited_post.last_version_at + 2.seconds,
+      )
+      edited_post.reload
+
+      get "/posts/#{edited_post.id}/revisions/2.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["username"]).to eq(first_editor.username_lower)
+      expect(response.parsed_body.dig("body_changes", "side_by_side_markdown")).to eq(
+        DiscourseDiff.new("Original version", coalesced_body).side_by_side_markdown,
+      )
+
+      get "/posts/#{edited_post.id}/revisions/3.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["username"]).to eq(second_editor.username_lower)
+      expect(response.parsed_body.dig("body_changes", "side_by_side_markdown")).to eq(
+        DiscourseDiff.new(coalesced_body, second_body).side_by_side_markdown,
+      )
+    end
+
     context "when the id is passed as an array" do
       fab!(:accessible_post) { Fabricate(:post, user: moderator) }
       fab!(:inaccessible_post, :private_message_post)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -696,6 +696,48 @@ RSpec.describe PostsController do
         expect(post.raw).to eq("edited body")
       end
 
+      it "rolls back post changes when a first-post title edit is invalid" do
+        Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "blockedword")
+
+        first_post = create_post(user:, title: "Original topic title", raw: "Original topic body")
+        original_title = first_post.topic.title
+        original_raw = first_post.raw
+
+        put "/posts/#{first_post.id}.json",
+            params: {
+              title: "A blockedword topic title",
+              post: {
+                raw: "Body from failed title edit",
+                edit_reason: "moderator edit",
+              },
+            }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"].join).to include("blockedword")
+        expect(first_post.reload.raw).to eq(original_raw)
+        expect(first_post.version).to eq(1)
+        expect(PostRevision.where(post_id: first_post.id).pluck(:number)).to eq([])
+
+        put "/posts/#{first_post.id}.json",
+            params: {
+              title: original_title,
+              post: {
+                raw: "Body from valid title edit",
+                edit_reason: "moderator edit",
+              },
+            }
+
+        expect(response.status).to eq(200)
+        expect(first_post.reload.raw).to eq("Body from valid title edit")
+        expect(first_post.version).to eq(2)
+        expect(PostRevision.where(post_id: first_post.id).pluck(:number)).to eq([2])
+
+        get "/posts/#{first_post.id}/revisions/2.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["current_revision"]).to eq(2)
+      end
+
       it "won't update bump date if post is a whisper" do
         created_at = freeze_time 1.day.ago
         post = Fabricate(:post, post_type: Post.types[:whisper], user: user)


### PR DESCRIPTION
## Summary

Correctly maintain post revision integrity by rolling back the transaction if a topic validation fails during a first-post edit. This ensures that post body updates and version increments remain synchronized with the revision history, preventing broken audit logs and 404 errors when viewing post history.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1392

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>