### PR TITLE
DEV: Allow rate limiters to return nil to skip rate limiting

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -476,6 +476,8 @@ class Middleware::RequestTracker
     rate_limiter = self.class.rate_limiters_stack.active_rate_limiter(request, cookie)
     return nil if rate_limiter.nil?
     rate_limit_key = rate_limiter.rate_limit_key
+    # Allow rate limiters to return nil to skip rate limiting entirely
+    return nil if rate_limit_key.nil?
     error_code_identifier = rate_limiter.error_code_identifier
     global = rate_limiter.rate_limit_globally?
 

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -1791,6 +1791,38 @@ RSpec.describe Middleware::RequestTracker do
         Error code: crawlers_60_secs_limit.
         MSG
       end
+
+      it "can return nil key to skip rate limiting entirely" do
+        global_setting :max_reqs_per_ip_per_minute, 1
+
+        plugin = Plugin::Instance.new
+
+        # Rate limiter that returns nil to skip rate limiting
+        plugin.add_request_rate_limiter(
+          identifier: :health_check,
+          key: ->(_request) { nil },
+          activate_when: ->(request) { request.path == "/srv/status" },
+        )
+
+        env1 = env("PATH_INFO" => "/srv/status")
+
+        app = lambda { |_| [200, {}, ["OK"]] }
+
+        # First request should succeed
+        middleware = Middleware::RequestTracker.new(app)
+        status, = middleware.call(env1)
+        expect(status).to eq(200)
+
+        # Second request should also succeed (not rate limited despite limit of 1)
+        middleware = Middleware::RequestTracker.new(app)
+        status, = middleware.call(env1)
+        expect(status).to eq(200)
+
+        # Third request should also succeed
+        middleware = Middleware::RequestTracker.new(app)
+        status, = middleware.call(env1)
+        expect(status).to eq(200)
+      end
     end
   end
 


### PR DESCRIPTION
This adds support for rate limiters registered via the `add_request_rate_limiter` plugin API to return nil as their key, which will cause rate limiting to be skipped entirely for that request.

This is useful for exempting specific request types (like health checks from internal infrastructure) from rate limiting without giving a blanket exemption to all requests from those IPs.