### PR TITLE
FIX: Correctly attribute edit to subsequent editor

### DIFF
--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -346,6 +346,8 @@ class PostRevisor
     @silent = @opts[:silent] if @opts.has_key?(:silent)
     @topic_changes.silent = @silent
 
+    @previous_last_editor_id = @post.last_editor_id
+
     old_raw = @post.raw
 
     Post.transaction do
@@ -691,10 +693,14 @@ class PostRevisor
   def create_revision
     modifications = post_changes.merge(topic_diff)
 
-    modifications["raw"][0] = cached_original_raw || modifications["raw"][0] if modifications["raw"]
+    if use_cached_original_for_created_revision?
+      if modifications["raw"]
+        modifications["raw"][0] = cached_original_raw || modifications["raw"][0]
+      end
 
-    if modifications["cooked"]
-      modifications["cooked"][0] = cached_original_cooked || modifications["cooked"][0]
+      if modifications["cooked"]
+        modifications["cooked"][0] = cached_original_cooked || modifications["cooked"][0]
+      end
     end
 
     @post_revision =
@@ -707,6 +713,11 @@ class PostRevisor
       )
     @post_revision.silent = @silent
     @post_revision.save!
+  end
+
+  def use_cached_original_for_created_revision?
+    @previous_last_editor_id == @editor.id &&
+      !PostRevision.exists?(post_id: @post.id, number: @post.version - 1)
   end
 
   def update_revision

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -2683,6 +2683,52 @@ RSpec.describe PostsController do
       expect(response.status).to eq(400)
     end
 
+    it "attributes coalesced grace-period edits to the correct editor" do
+      SiteSetting.edit_history_visible_to_public = true
+      SiteSetting.editing_grace_period = 1.minute
+      SiteSetting.editing_grace_period_max_diff = 1000
+
+      edited_post = Fabricate(:post, raw: "Original version")
+      first_editor = Fabricate(:user)
+      second_editor = Fabricate(:user)
+      first_body = "First editor first version"
+      coalesced_body = "First editor coalesced version"
+      second_body = "Second editor version"
+
+      PostRevisor.new(edited_post).revise!(
+        first_editor,
+        { raw: first_body },
+        revised_at: edited_post.updated_at + 2.minutes,
+      )
+      edited_post.reload
+      PostRevisor.new(edited_post).revise!(
+        first_editor,
+        { raw: coalesced_body },
+        revised_at: edited_post.last_version_at + 1.second,
+      )
+      edited_post.reload
+      PostRevisor.new(edited_post).revise!(
+        second_editor,
+        { raw: second_body },
+        revised_at: edited_post.last_version_at + 2.seconds,
+      )
+      edited_post.reload
+
+      get "/posts/#{edited_post.id}/revisions/2.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["username"]).to eq(first_editor.username_lower)
+      expect(response.parsed_body.dig("body_changes", "side_by_side_markdown")).to eq(
+        DiscourseDiff.new("Original version", coalesced_body).side_by_side_markdown,
+      )
+
+      get "/posts/#{edited_post.id}/revisions/3.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["username"]).to eq(second_editor.username_lower)
+      expect(response.parsed_body.dig("body_changes", "side_by_side_markdown")).to eq(
+        DiscourseDiff.new(coalesced_body, second_body).side_by_side_markdown,
+      )
+    end
+
     context "when the id is passed as an array" do
       fab!(:accessible_post) { Fabricate(:post, user: moderator) }
       fab!(:inaccessible_post, :private_message_post)


### PR DESCRIPTION
## Summary

Prevent content added by one user from being falsely attributed to a subsequent editor in the post revision history. The fix ensures that revisions created after a coalesced grace-period edit correctly use the post's immediate pre-edit state as the baseline for diffs.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1390

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>