### PR TITLE
FIX: Do not load `tsconfig` during core assets build

### DIFF
--- a/frontend/discourse/rolldown.config.mjs
+++ b/frontend/discourse/rolldown.config.mjs
@@ -73,6 +73,7 @@ export function buildConfig({ devMode } = {}) {
   }
 
   return {
+    tsconfig: false,
     resolve: {
       extensions,
     },


### PR DESCRIPTION
Similar to 2d34d84d: we don't need this, and loading it can cause problems if people mess with core plugins