### PR TITLE
FIX: Validate early for input length in username field on registration

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -682,6 +682,15 @@ class UsersController < ApplicationController
       return fail_with("login.password_too_long")
     end
 
+    if params[:username].length > UsernameValidator::MAX_CHARS * 3
+      message =
+        User.new.errors.full_message(
+          :username,
+          I18n.t("user.username.long", count: SiteSetting.max_username_length),
+        )
+      return render json: { success: false, message: message }
+    end
+
     return fail_with("login.email_too_long") if params[:email].length > 254 + 1 + 253
 
     if SiteSetting.require_invite_code &&

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -1646,6 +1646,19 @@ RSpec.describe UsersController do
       include_examples "failed signup"
     end
 
+    context "when username is too long" do
+      let(:oversized_username) { "a" * 50_000 }
+
+      it "rejects signup without reflecting the username", :aggregate_failures do
+        expect { post_user(username: oversized_username) }.not_to change { User.count }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq(false)
+        expect(response.body.bytesize).to be < 1_000
+        expect(response.body).not_to include(oversized_username)
+      end
+    end
+
     context "when password param is missing" do
       let(:create_params) { { name: @user.name, username: @user.username, email: @user.email } }
       include_examples "failed signup"


### PR DESCRIPTION
We do the same on the username-change endpoint, worth enforcing this at registration as well.