### PR TITLE
SECURITY: Reviewable conversations expose post-voting flag PM excerpts to category moderators outside the PM

### DIFF
--- a/app/serializers/reviewable_score_serializer.rb
+++ b/app/serializers/reviewable_score_serializer.rb
@@ -33,6 +33,10 @@ class ReviewableScoreSerializer < ApplicationSerializer
   has_one :reviewable_conversation, serializer: ReviewableConversationSerializer
   has_one :reviewed_by, serializer: BasicUserSerializer, root: "users"
 
+  def include_reviewable_conversation?
+    object.meta_topic.present? && scope&.can_see?(object.meta_topic)
+  end
+
   def agree_stats
     {
       agreed: user.user_stat.flags_agreed,

--- a/plugins/discourse-post-voting/lib/post_voting/comment_review_queue.rb
+++ b/plugins/discourse-post-voting/lib/post_voting/comment_review_queue.rb
@@ -117,7 +117,14 @@ module PostVoting
         create_args[:is_warning] = opts[:is_warning] if flagger.staff?
       else
         create_args[:subtype] = TopicSubtype.notify_moderators
-        create_args[:target_group_names] = [Group[:moderators].name]
+        group_names = Set[Group[:moderators].name]
+
+        if SiteSetting.enable_category_group_moderation? &&
+             (category = comment.post.topic&.category)
+          group_names.merge(category.moderating_groups.pluck(:name))
+        end
+
+        create_args[:target_group_names] = group_names.to_a
       end
 
       PostCreator.new(flagger, create_args)

--- a/plugins/discourse-post-voting/spec/lib/post_voting/comment_review_queue_spec.rb
+++ b/plugins/discourse-post-voting/spec/lib/post_voting/comment_review_queue_spec.rb
@@ -202,6 +202,28 @@ describe PostVoting::CommentReviewQueue do
         expect(pm_topic.title).to eq("A post voting comment requires staff attention")
       end
 
+      it "gives category moderation groups access to the companion PM" do
+        SiteSetting.enable_category_group_moderation = true
+
+        category = Fabricate(:category)
+        group = Fabricate(:group)
+        group.update!(messageable_level: Group::ALIAS_LEVELS[:nobody])
+        topic.update!(category: category)
+        Fabricate(:category_moderation_group, category: category, group: group)
+
+        queue.flag_comment(
+          comment,
+          guardian,
+          ReviewableScore.types[:notify_moderators],
+          comment: flag_comment,
+        )
+
+        pm_topic =
+          Topic.includes(:posts).find_by(user: guardian.user, archetype: Archetype.private_message)
+
+        expect(pm_topic.allowed_groups).to contain_exactly(Group[:moderators], group)
+      end
+
       it "creates a reviewable" do
         queue.flag_comment(comment, guardian, ReviewableScore.types[:notify_moderators])
 

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -604,6 +604,56 @@ RSpec.describe ReviewablesController do
           expect(reply["user_id"]).to eq(admin.id)
         end
       end
+
+      context "with an inaccessible conversation" do
+        it "does not serialize the conversation" do
+          SiteSetting.enable_category_group_moderation = true
+
+          category = Fabricate(:category)
+          group_user = Fabricate(:group_user)
+          Fabricate(:category_moderation_group, category: category, group: group_user.group)
+
+          flagger = Fabricate(:user, refresh_auto_groups: true)
+          topic = Fabricate(:topic, category: category)
+          post = Fabricate(:post, topic: topic)
+          meta_post =
+            PostCreator.create!(
+              flagger,
+              archetype: Archetype.private_message,
+              subtype: TopicSubtype.notify_moderators,
+              target_group_names: [Group[:moderators].name],
+              title: "A hidden flag conversation",
+              raw: "Sensitive flag reason for moderators only",
+            )
+          reviewable =
+            ReviewableFlaggedPost.needs_review!(
+              created_by: flagger,
+              target: post,
+              topic: topic,
+              reviewable_by_moderator: true,
+            )
+          reviewable_score =
+            reviewable.add_score(
+              flagger,
+              ReviewableScore.types[:notify_moderators],
+              meta_topic_id: meta_post.topic_id,
+            )
+
+          expect(Guardian.new(group_user.user).can_see?(meta_post.topic)).to eq(false)
+
+          sign_in(group_user.user)
+          get "/review/#{reviewable.id}.json"
+
+          expect(response.code).to eq("200")
+          json = response.parsed_body
+          score = json["reviewable_scores"].find { |item| item["id"] == reviewable_score.id }
+
+          expect(score).not_to have_key("reviewable_conversation_id")
+          expect(json["reviewable_conversations"]).to be_blank
+          expect(json["conversation_posts"]).to be_blank
+          expect(response.body).not_to include(meta_post.raw)
+        end
+      end
     end
 
     describe "#explain" do


### PR DESCRIPTION
## Summary

Prevent unauthorized access to private message excerpts in reviewable responses by ensuring companion conversations are only serialized when the viewer has permission to see the underlying topic. The patch also ensures category moderators receive legitimate access to post-voting flag conversations by including the relevant moderation groups in the private message recipient list.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1282

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>