### PR TITLE
UX: simplify ai conversations topic map styles, alignment

### DIFF
--- a/app/assets/stylesheets/common/components/docked-composer.scss
+++ b/app/assets/stylesheets/common/components/docked-composer.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .docked-composer {
   --docked-composer-input-min-height: 2.5em;
   --docked-composer-max-width: 100%;
@@ -78,8 +80,6 @@
     gap: 0.5em;
     width: 100%;
     max-width: var(--docked-composer-max-width);
-    padding-left: var(--docked-composer-content-offset);
-    margin: 0 auto;
     box-sizing: border-box;
   }
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/common.scss
@@ -95,17 +95,11 @@ body.has-ai-conversations-sidebar {
 
   #topic-title {
     display: flex;
-    justify-content: center;
 
     .title-wrapper {
       width: 100%;
       max-width: 960px;
     }
-  }
-
-  .small-action,
-  .onscreen-post .row {
-    justify-content: center;
   }
 
   #topic-footer-buttons {
@@ -122,7 +116,7 @@ body.has-ai-conversations-sidebar {
     display: none;
   }
 
-  @include viewport.until(sm) {
+  @include viewport.until(lg) {
     #topic-progress-wrapper,
     .topic-navigation.with-topic-progress {
       display: none;
@@ -406,11 +400,6 @@ body.has-ai-conversations-sidebar {
   }
 
   .topic-map {
-    box-sizing: border-box;
-    width: 100%;
-    margin: 0 auto;
-    padding-block: 0.5em;
-
     .topic-map__views-trigger,
     .topic-map__likes-trigger,
     .summarization-button,
@@ -423,19 +412,6 @@ body.has-ai-conversations-sidebar {
     // conversation page — the docked composer sits where it would render.
     &.--bottom {
       display: none;
-    }
-
-    section {
-      background: transparent;
-      border-block: 1px solid var(--primary-low);
-    }
-
-    &__contents {
-      padding: 0.5em 1.25em;
-
-      @include viewport.from(sm) {
-        padding: 0.5em 0.5em 0.5em 1.9em;
-      }
     }
 
     &__stats {

--- a/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/ai-bot-conversations/docked-composer.scss
@@ -37,14 +37,9 @@ body.has-ai-bot-docked-composer {
 
 // AI-bot variant of the docked composer: align with the PM post body's
 // visible bordered box.
-// - max-width matches the full topic-post row width (avatar + body + padding)
-// - content offset is topic-avatar-width minus the --pm-padding negative
-//   margin that personal-message.scss applies to `.regular.contents`,
-//   which pulls the bordered body 1.25em to the left.
 .docked-composer.ai-bot-docked-composer {
   --docked-composer-max-width: calc(
-    var(--topic-avatar-width) + var(--topic-body-width) +
-      (var(--topic-body-width-padding) * 2)
+    var(--topic-avatar-width) + var(--topic-body-width)
   );
   --docked-composer-content-offset: calc(
     var(--topic-avatar-width) - var(--pm-padding, 1.25em)
@@ -64,6 +59,10 @@ body.has-ai-bot-docked-composer {
   @include viewport.until(sm) {
     --docked-composer-content-offset: 0px;
     --docked-composer-max-width: 100%;
+  }
+
+  @include viewport.from(sm) {
+    margin-left: calc(var(--topic-avatar-width) - var(--pm-padding));
   }
 
   &.docked-composer--keyboard-open {


### PR DESCRIPTION
Core topic map styles for PMs were cleaned up a bit, and custom AI conversation styles for it needed a little cleaning up as a result. Fortunately this is mostly removing custom styles. 

I've also removed some centering styles we had for PM conversations... it was nice, but it was only a minor difference and it brought along some inconsistency and fragility. 

Before:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/f2bcbfdd-8186-4652-b344-5a8c344da6d3" />


After: 
<img width="800" alt="image" src="https://github.com/user-attachments/assets/20e040e3-2c4d-4479-a8c1-230319cb3553" />


Before:
<img width="1495"  alt="image" src="https://github.com/user-attachments/assets/e50db39f-3fc0-4f6c-9d67-f382ef4c5815" />



After:
<img width="1495"  alt="image" src="https://github.com/user-attachments/assets/67345e90-8dae-4d22-8cb7-b3afd6686d79" />
