### PR TITLE
FIX: Prevent stray list marker when quoting a quote containing a list

### DIFF
--- a/frontend/discourse/app/lib/selection/preserve-list-structure.js
+++ b/frontend/discourse/app/lib/selection/preserve-list-structure.js
@@ -322,8 +322,15 @@ export function preserveListStructureInClonedContent(container, range) {
     annotateOrphanListItemsWithOriginalInfo(container, range);
   }
 
-  if (originalListItem) {
-    const parentList = originalListItem.parentElement;
+  // When the list's wrapper is itself inside the clone (e.g. a list nested in a
+  // fully-selected quote), the structure is intact and must not be re-wrapped.
+  const parentList = originalListItem?.parentElement;
+  const listWrapperInClone =
+    parentList &&
+    parentList !== range.commonAncestorContainer &&
+    range.commonAncestorContainer.contains(parentList);
+
+  if (originalListItem && !listWrapperInClone) {
     const isParentAList =
       parentList?.tagName === "OL" || parentList?.tagName === "UL";
 

--- a/frontend/discourse/tests/unit/lib/selection/preserve-list-structure-test.js
+++ b/frontend/discourse/tests/unit/lib/selection/preserve-list-structure-test.js
@@ -167,10 +167,11 @@ module("Unit | Lib | selection | preserve-list-structure", function () {
       const original = createContainer("<ul><li>Hello world</li></ul>");
       document.body.appendChild(original);
 
-      // Simulate selecting just the text node inside the LI
+      // A partial selection within a single text node has that text node as its
+      // common ancestor, so the <li>/<ul> wrapper is not part of the clone.
       const textNode = original.querySelector("li").firstChild;
       const container = createContainer("world");
-      const range = mockRange(original, textNode, 6);
+      const range = mockRange(textNode, textNode, 6);
 
       preserveListStructureInClonedContent(container, range);
 
@@ -182,6 +183,43 @@ module("Unit | Lib | selection | preserve-list-structure", function () {
       assert.strictEqual(
         container.querySelector("ul").querySelectorAll("li").length,
         1
+      );
+
+      document.body.removeChild(original);
+    });
+
+    test("does not re-wrap when the start list is nested in a fully-selected quote", function (assert) {
+      // Selection starts inside the nested <li>, but the whole quote (and its
+      // list) is selected, so the cloned fragment already has the list wrapper.
+      const original = createContainer(
+        '<aside class="quote"><blockquote><ul><li>Mark wish</li></ul></blockquote></aside>' +
+          "<p>And signup abuse</p>"
+      );
+      document.body.appendChild(original);
+
+      const startTextNode = original.querySelector("li").firstChild;
+      const container = createContainer(
+        '<aside class="quote"><blockquote><ul><li>Mark wish</li></ul></blockquote></aside>' +
+          "<p>And signup abuse</p>"
+      );
+      const range = mockRange(original, startTextNode, 0);
+
+      preserveListStructureInClonedContent(container, range);
+
+      assert.strictEqual(
+        container.querySelectorAll(":scope > ul, :scope > ol").length,
+        0,
+        "no stray top-level list is introduced around the quote"
+      );
+      assert.strictEqual(
+        container.firstElementChild?.tagName,
+        "ASIDE",
+        "the quote remains the first top-level node"
+      );
+      assert.strictEqual(
+        container.querySelector("aside ul li")?.textContent.trim(),
+        "Mark wish",
+        "the list stays nested inside the quote"
       );
 
       document.body.removeChild(original);


### PR DESCRIPTION
Quoting a post whose selection began inside a list nested in a quote wrapped the whole selection in a stray list item, producing a broken `* [quote=…]` line in the composer.

This change leaves the list untouched when its wrapper is already contained in the cloned selection, so the nested quote serializes correctly.