### PR TITLE
DEV: Bump `dashboard_improvements` upcoming change to alpha

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4634,7 +4634,7 @@ experimental:
     hidden: true
     client: true
     upcoming_change:
-      status: "experimental"
+      status: "alpha"
       impact: "feature,admins"
       learn_more_url: "https://meta.discourse.org/t/-/404528"
   admin_dashboard_reports_seeded:


### PR DESCRIPTION
Previously, the `dashboard_improvements` upcoming change was marked as `experimental`.

This change promotes it to `alpha`.