### PR TITLE
FIX: Bust cache so that group additions to AI helper can take effect

### DIFF
--- a/plugins/discourse-ai/app/models/ai_agent.rb
+++ b/plugins/discourse-ai/app/models/ai_agent.rb
@@ -168,6 +168,8 @@ class AiAgent < ActiveRecord::Base
 
   def bump_cache
     self.class.agent_cache.flush!
+    return if !DiscourseAi::AiHelper::Assistant.prompt_agent_ids.include?(id)
+    DiscourseAi::AiHelper::Assistant.clear_prompt_cache!
   end
 
   def tools_can_not_be_duplicated

--- a/plugins/discourse-ai/lib/ai_helper/assistant.rb
+++ b/plugins/discourse-ai/lib/ai_helper/assistant.rb
@@ -23,6 +23,10 @@ module DiscourseAi
         prompt_cache.flush!
       end
 
+      def self.prompt_agent_ids
+        agents_prompt_map.keys.compact.uniq
+      end
+
       def initialize(helper_llm: nil, image_caption_llm: nil)
         @helper_llm = helper_llm
         @image_caption_llm = image_caption_llm
@@ -348,7 +352,7 @@ module DiscourseAi
         end
       end
 
-      def agents_prompt_map(include_image_caption: false)
+      def self.agents_prompt_map(include_image_caption: false)
         map = {
           SiteSetting.ai_helper_translator_agent.to_i => TRANSLATE,
           SiteSetting.ai_helper_title_suggestions_agent.to_i => GENERATE_TITLES,
@@ -366,6 +370,10 @@ module DiscourseAi
         end
 
         map
+      end
+
+      def agents_prompt_map(include_image_caption: false)
+        self.class.agents_prompt_map(include_image_caption:)
       end
 
       def all_prompts

--- a/plugins/discourse-ai/spec/models/ai_agent_spec.rb
+++ b/plugins/discourse-ai/spec/models/ai_agent_spec.rb
@@ -54,6 +54,31 @@ RSpec.describe AiAgent do
     expect(AiAgent.find(general_id).thinking_effort).to eq("high") # admin choice preserved
   end
 
+  it "clears AI helper prompt permissions after changes" do
+    agent = AiAgent.find(SiteSetting.ai_helper_proofreader_agent)
+    DiscourseAi::AiHelper::Assistant.prompt_cache[:value] = "cached prompts"
+
+    agent.update!(allowed_group_ids: [Group::AUTO_GROUPS[:staff]])
+
+    expect(DiscourseAi::AiHelper::Assistant.prompt_cache[:value]).to be_nil
+  end
+
+  it "keeps AI helper prompt permissions after unrelated changes" do
+    agent =
+      AiAgent.create!(
+        name: "unrelated agent",
+        description: "test",
+        system_prompt: "test",
+        tools: [],
+        allowed_group_ids: [],
+      )
+    DiscourseAi::AiHelper::Assistant.prompt_cache[:value] = "cached prompts"
+
+    agent.update!(allowed_group_ids: [Group::AUTO_GROUPS[:staff]])
+
+    expect(DiscourseAi::AiHelper::Assistant.prompt_cache[:value]).to eq("cached prompts")
+  end
+
   it "validates context settings" do
     expect(basic_agent.valid?).to eq(true)
 


### PR DESCRIPTION
Adding new groups to `Composer AI helper allowed groups` setting was not taking effect due to a cache on agents.

This PR busts the agent cache when the the updated agent is AI helper related.