### PR TITLE
DEV: Toggle the workflow editor reference pill property picker on re-click

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-input.gjs
@@ -35,6 +35,7 @@ export default class ExpressionInput extends Component {
   #focusOutTimer = null;
   #pickerDismiss = null;
   #pickerEditorElement = null;
+  #pickerTrigger = null;
 
   willDestroy() {
     super.willDestroy(...arguments);
@@ -132,6 +133,14 @@ export default class ExpressionInput extends Component {
 
   @action
   openReferencePicker({ trigger, properties, current, onSelect, onEdit }) {
+    // Re-triggering on the same pill toggles the dropdown shut rather than
+    // closing and reopening it.
+    if (this.#pickerTrigger === trigger) {
+      this.#closeReferencePicker();
+      return;
+    }
+
+    this.#pickerTrigger = trigger;
     this.menu.show(trigger, {
       identifier: REFERENCE_PICKER_IDENTIFIER,
       component: ReferencePropertyPicker,
@@ -151,6 +160,15 @@ export default class ExpressionInput extends Component {
               onEdit();
             }
           : null,
+        // Fires however the menu closes (incl. float-kit's own outside-click),
+        // so our open-state can't go stale. Scoped to this trigger so a menu
+        // being replaced by another pill's doesn't clear the new one.
+        onClose: () => {
+          if (this.#pickerTrigger === trigger) {
+            this.#pickerTrigger = null;
+            this.#teardownPickerDismiss();
+          }
+        },
       },
     });
     this.#armPickerDismiss();
@@ -165,7 +183,19 @@ export default class ExpressionInput extends Component {
       return;
     }
     this.#pickerEditorElement = editor;
-    this.#pickerDismiss = () => this.#closeReferencePicker();
+    this.#pickerDismiss = (event) => {
+      // A pointerdown on the pill that owns the open dropdown is left to the
+      // pill's own click handler, which toggles it shut — closing here too
+      // would make it close and immediately reopen.
+      const openPill = this.#pickerTrigger?.closest?.(".cm-wf-reference-pill");
+      if (
+        openPill &&
+        event.target?.closest?.(".cm-wf-reference-pill") === openPill
+      ) {
+        return;
+      }
+      this.#closeReferencePicker();
+    };
     editor.addEventListener("pointerdown", this.#pickerDismiss, {
       capture: true,
     });
@@ -184,6 +214,7 @@ export default class ExpressionInput extends Component {
   }
 
   #closeReferencePicker() {
+    this.#pickerTrigger = null;
     this.menu.close(REFERENCE_PICKER_IDENTIFIER);
     this.#teardownPickerDismiss();
   }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/reference-property-picker.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/variable/reference-property-picker.gjs
@@ -24,6 +24,11 @@ export default class ReferencePropertyPicker extends Component {
     this.activeIndex = index >= 0 ? index : 0;
   }
 
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.args.data?.onClose?.();
+  }
+
   get current() {
     return this.args.data?.current;
   }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-extensions/reference-pills.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-extensions/reference-pills.js
@@ -5,7 +5,6 @@ import { dragSource } from "./drag-source";
 import { parseReference, referenceLabel } from "./reference-label";
 import { propertyAccessor, referencePickerData } from "./reference-properties";
 
-// "value" means it resolves against authoring data, not a runtime guarantee.
 function referenceState(scope, inner) {
   const resolved = walkScope(scope, inner);
   if (resolved === undefined) {
@@ -50,9 +49,9 @@ export function buildReferencePills(
     return true;
   }
 
+  // Anchor to the pill, not the caret, for left-edge alignment.
   function selectedPillAnchor(view) {
-    const pill = view.dom.querySelector(".cm-wf-reference-pill.--selected");
-    return pill?.querySelector(".cm-wf-reference-pill__drill") || pill;
+    return view.dom.querySelector(".cm-wf-reference-pill.--selected");
   }
 
   function applyPickedProperty(view, range, baseExpr, name) {
@@ -156,6 +155,10 @@ export function buildReferencePills(
       );
     }
 
+    destroy(dom) {
+      clearTimeout(dom.__openTimer);
+    }
+
     toDOM(view) {
       const pill = document.createElement("span");
       pill.className = `cm-wf-reference-pill --source-${this.label.sourceType} --${this.state}${
@@ -164,19 +167,28 @@ export function buildReferencePills(
       pill.title = this.raw;
 
       // "click" not "mousedown", so preventDefault doesn't cancel a drag.
+      // First click selects; second opens the dropdown on a timer, so a
+      // double-click (edit) isn't misread as two selects.
       pill.addEventListener("click", (event) => {
         event.preventDefault();
         const range = expressionRangeAt(view, view.posAtDOM(pill));
-        if (range) {
-          view.dispatch({
-            selection: { anchor: range.from, head: range.to },
-          });
+        if (!range) {
+          return;
+        }
+        if (rangeIsSelected(view.state.selection.main, range)) {
+          clearTimeout(pill.__openTimer);
+          pill.__openTimer = setTimeout(() => {
+            openDropdown(view, range, pill);
+          }, 250);
+        } else {
+          view.dispatch({ selection: { anchor: range.from, head: range.to } });
           view.focus();
         }
       });
 
       pill.addEventListener("dblclick", (event) => {
         event.preventDefault();
+        clearTimeout(pill.__openTimer);
         const range = expressionRangeAt(view, view.posAtDOM(pill));
         if (range) {
           enterEditMode(view, range);
@@ -229,13 +241,12 @@ export function buildReferencePills(
         drill.title = i18n("discourse_workflows.reference_pill.pick_property");
         drill.innerHTML = iconHTML("angle-down");
         drill.addEventListener("mousedown", (event) => {
-          // mousedown, not click: the editor's selection handling would
-          // otherwise collapse the menu first.
+          // mousedown, not click — click lets the editor collapse the menu first.
           event.preventDefault();
           event.stopPropagation();
           const range = expressionRangeAt(view, view.posAtDOM(pill));
           if (range) {
-            openDropdown(view, range, drill);
+            openDropdown(view, range, pill);
           }
         });
         drill.addEventListener("click", (event) => event.stopPropagation());
@@ -315,8 +326,7 @@ export function buildReferencePills(
         this.view = view;
         this.decorations = buildDecorations(view);
 
-        // DModal and CodeMirror grab Escape on capture and stop propagation,
-        // so cancelling pill-edit mode has to happen on capture too.
+        // DModal and CodeMirror grab Escape on capture, so pill-edit cancel must too.
         this.handleEscape = (event) => {
           if (
             event.key !== "Escape" ||

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-extensions/reference-pills.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/expression-extensions/reference-pills.js
@@ -5,6 +5,10 @@ import { dragSource } from "./drag-source";
 import { parseReference, referenceLabel } from "./reference-label";
 import { propertyAccessor, referencePickerData } from "./reference-properties";
 
+// Delay before a selected pill's second click opens the dropdown, so a
+// double-click (which edits) isn't misread as two single clicks.
+const PILL_OPEN_DELAY = 250;
+
 function referenceState(scope, inner) {
   const resolved = walkScope(scope, inner);
   if (resolved === undefined) {
@@ -155,8 +159,8 @@ export function buildReferencePills(
       );
     }
 
-    destroy(dom) {
-      clearTimeout(dom.__openTimer);
+    destroy() {
+      clearTimeout(this.openTimer);
     }
 
     toDOM(view) {
@@ -176,10 +180,11 @@ export function buildReferencePills(
           return;
         }
         if (rangeIsSelected(view.state.selection.main, range)) {
-          clearTimeout(pill.__openTimer);
-          pill.__openTimer = setTimeout(() => {
-            openDropdown(view, range, pill);
-          }, 250);
+          clearTimeout(this.openTimer);
+          this.openTimer = setTimeout(
+            () => openDropdown(view, range, pill),
+            PILL_OPEN_DELAY
+          );
         } else {
           view.dispatch({ selection: { anchor: range.from, head: range.to } });
           view.focus();
@@ -188,7 +193,7 @@ export function buildReferencePills(
 
       pill.addEventListener("dblclick", (event) => {
         event.preventDefault();
-        clearTimeout(pill.__openTimer);
+        clearTimeout(this.openTimer);
         const range = expressionRangeAt(view, view.posAtDOM(pill));
         if (range) {
           enterEditMode(view, range);

--- a/plugins/discourse-workflows/assets/stylesheets/common/variable/variable-input.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/variable/variable-input.scss
@@ -12,8 +12,10 @@
   .cm-editor {
     flex: 1 1 auto;
 
+    // Text cursor over the whole field, so the empty area reads as editable.
     .cm-scroller {
       flex: 1 1 auto;
+      cursor: text;
     }
   }
 


### PR DESCRIPTION
Follow-up to #41442.

Clicking the pill that already owns the open property picker now toggles the dropdown shut, instead of closing and immediately reopening it. The component tracks the active trigger and drives its open-state off the menu's `onClose`, so the state can't go stale when float-kit closes on an outside click; a `pointerdown` on the owning pill is left to the pill's own click handler.

A short timer on the pill click distinguishes a second click (open) from a double-click (edit), and the dropdown now anchors to the pill's left edge rather than the drill button. The field also shows a text cursor across its whole width so the empty area reads as editable.
