### PR TITLE
FIX: Omit inaccessible reply target post numbers from post revision history

### DIFF
--- a/app/serializers/post_revision_serializer.rb
+++ b/app/serializers/post_revision_serializer.rb
@@ -380,13 +380,12 @@ class PostRevisionSerializer < ApplicationSerializer
   def reply_to_info(post_number)
     return nil if post_number.blank?
 
-    target = Post.where(topic_id: topic.id, post_number: post_number).first
-    info = { post_number: post_number }
+    target = Post.with_deleted.where(topic_id: topic.id, post_number: post_number).first
+    return nil if target.blank? || !scope.can_see?(target)
 
-    # Only enrich with the target's author if the current viewer can see
-    # that post. Deleted posts, whispers, and posts in restricted
-    # categories must not leak their author through the revision history.
-    if target && scope.can_see?(target) && target.user
+    info = { post_number: target.post_number }
+
+    if target.user
       info[:username] = target.user.username_lower
       info[:display_username] = target.user.username
       info[:avatar_template] = target.user.avatar_template

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -3031,6 +3031,44 @@ RSpec.describe PostsController do
         expect(response.status).to eq(200)
       end
 
+      it "omits unseen reply target post numbers" do
+        SiteSetting.editing_grace_period = 0
+        SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff]
+
+        topic = Fabricate(:topic)
+        Fabricate(:post, topic: topic, post_number: 1)
+        visible_parent = Fabricate(:post, topic: topic, post_number: 2)
+        whisper = Fabricate(:post, topic: topic, post_number: 3, post_type: Post.types[:whisper])
+        revised_post =
+          Fabricate(
+            :post,
+            topic: topic,
+            post_number: 4,
+            reply_to_post_number: visible_parent.post_number,
+            reply_to_user_id: visible_parent.user_id,
+          )
+
+        sign_in(admin)
+        put "/posts/#{revised_post.id}.json",
+            params: {
+              post: {
+                raw: revised_post.raw,
+                reply_to_post_number: whisper.post_number,
+              },
+            }
+        expect(response.status).to eq(200)
+        delete "/session/#{admin.username}.json"
+
+        revision = revised_post.reload.revisions.last
+        get "/posts/#{revised_post.id}/revisions/#{revision.number}.json"
+
+        expect(response.status).to eq(200)
+        expect(
+          response.parsed_body["reply_to_post_number_changes"]["previous"]["post_number"],
+        ).to eq(visible_parent.post_number)
+        expect(response.parsed_body["reply_to_post_number_changes"]["current"]).to eq(nil)
+      end
+
       context "when names are disabled" do
         before { SiteSetting.enable_names = false }
 

--- a/spec/serializers/post_revision_serializer_spec.rb
+++ b/spec/serializers/post_revision_serializer_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe PostRevisionSerializer do
       expect(json).not_to have_key(:reply_to_post_number_changes)
     end
 
-    it "does not leak author info for a target the viewer cannot see" do
+    it "omits target info for a reply target the viewer cannot see" do
       SiteSetting.whispers_allowed_groups = Group::AUTO_GROUPS[:staff]
       whisper =
         Fabricate(
@@ -278,9 +278,10 @@ RSpec.describe PostRevisionSerializer do
           root: false,
         ).as_json
 
-      expect(json[:reply_to_post_number_changes][:current][:post_number]).to eq(whisper.post_number)
-      expect(json[:reply_to_post_number_changes][:current]).not_to have_key(:username)
-      expect(json[:reply_to_post_number_changes][:current]).not_to have_key(:avatar_template)
+      expect(json[:reply_to_post_number_changes][:previous][:post_number]).to eq(
+        other_parent.post_number,
+      )
+      expect(json[:reply_to_post_number_changes][:current]).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

Prevent the disclosure of inaccessible reply targets in post revision history. The serializer now correctly omits metadata for target posts, such as whispers or deleted posts, if the current user does not have permission to view them.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1359

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>