### PR TITLE
FIX: Validate the length of chat draft data

### DIFF
--- a/plugins/chat/app/services/chat/upsert_draft.rb
+++ b/plugins/chat/app/services/chat/upsert_draft.rb
@@ -30,6 +30,7 @@ module Chat
       attribute :data, :string
 
       validates :channel_id, presence: true
+      validates :data, length: { maximum: -> { SiteSetting.max_chat_draft_length } }
     end
 
     model :channel

--- a/plugins/chat/spec/services/chat/upsert_draft_spec.rb
+++ b/plugins/chat/spec/services/chat/upsert_draft_spec.rb
@@ -2,7 +2,10 @@
 
 RSpec.describe Chat::UpsertDraft do
   describe described_class::Contract, type: :model do
+    subject(:contract) { described_class.new(channel_id: 1) }
+
     it { is_expected.to validate_presence_of :channel_id }
+    it { is_expected.to validate_length_of(:data).is_at_most(SiteSetting.max_chat_draft_length) }
   end
 
   describe ".call" do


### PR DESCRIPTION
## Summary

Correctly validate the length of chat draft data at the service contract layer using the max_chat_draft_length site setting. This ensures that oversized payloads are rejected early in the request lifecycle before reaching the model persistence layer.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1362

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>