### PR TITLE
SECURITY: detailed_404 Security Setting Bypassed

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -40,6 +40,18 @@ class TopicsController < ApplicationController
   before_action :set_embed_class, only: :show
   after_action :allow_embed_mode, only: :show
 
+  around_action :hide_inaccessible_topic_when_detailed_404_disabled,
+                only: %i[
+                  archive_message
+                  move_to_inbox
+                  post_ids
+                  posts
+                  publish
+                  set_notifications
+                  set_slow_mode
+                  wordpress
+                ]
+
   skip_before_action :check_xhr, only: %i[show feed]
 
   def id_for_slug
@@ -1362,6 +1374,29 @@ class TopicsController < ApplicationController
   end
 
   private
+
+  def hide_inaccessible_topic_when_detailed_404_disabled
+    yield
+  rescue ActiveRecord::RecordNotFound
+    raise Discourse::NotFound
+  rescue Discourse::InvalidAccess => exception
+    raise exception if SiteSetting.detailed_404
+    raise exception if !requested_topic_hidden_from_user?(exception)
+
+    raise Discourse::NotFound
+  end
+
+  def requested_topic_hidden_from_user?(exception)
+    topic = exception.obj if exception.obj.is_a?(Topic)
+    topic ||= Topic.find_by(id: requested_topic_id)
+
+    topic.present? && !guardian.can_see?(topic)
+  end
+
+  def requested_topic_id
+    topic_id = params[:topic_id].presence || params[:id].presence
+    topic_id.to_s if topic_id.to_s.match?(/\A\d+\z/)
+  end
 
   def render_topic_with_tags(topic)
     payload = serialize_data(topic, BasicTopicSerializer)

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -4565,6 +4565,54 @@ RSpec.describe TopicsController do
     end
   end
 
+  describe "topic access errors with detailed_404 disabled" do
+    it "returns not found for inaccessible and nonexistent topics on secondary topic endpoints" do
+      SiteSetting.detailed_404 = false
+      sign_in(user)
+
+      private_message =
+        create_post(
+          user: admin,
+          archetype: Archetype.private_message,
+          target_usernames: [moderator.username],
+        ).topic
+      nonexistent_topic_id = Topic.maximum(:id) + 10_000
+      requests = {
+        "GET /t/:topic_id/wordpress.json" => ->(topic_id) do
+          get "/t/#{topic_id}/wordpress.json", params: { best: 1 }
+        end,
+        "GET /t/:topic_id/post_ids.json" => ->(topic_id) { get "/t/#{topic_id}/post_ids.json" },
+        "GET /t/:topic_id/posts.json" => ->(topic_id) { get "/t/#{topic_id}/posts.json" },
+        "PUT /t/:id/archive-message.json" => ->(topic_id) do
+          put "/t/#{topic_id}/archive-message.json"
+        end,
+        "PUT /t/:id/move-to-inbox.json" => ->(topic_id) { put "/t/#{topic_id}/move-to-inbox.json" },
+        "PUT /t/:id/publish.json" => ->(topic_id) do
+          put "/t/#{topic_id}/publish.json", params: { destination_category_id: category.id }
+        end,
+        "PUT /t/:topic_id/slow_mode.json" => ->(topic_id) do
+          put "/t/#{topic_id}/slow_mode.json", params: { seconds: "3600" }
+        end,
+        "POST /t/:topic_id/notifications.json" => ->(topic_id) do
+          post "/t/#{topic_id}/notifications.json",
+               params: {
+                 notification_level: NotificationLevels.topic_levels[:watching],
+               }
+        end,
+      }
+
+      requests.each do |description, perform_request|
+        perform_request.call(private_message.id)
+        expect(response.status).to eq(404), description
+        expect(response.parsed_body["error_type"]).to eq("not_found"), description
+
+        perform_request.call(nonexistent_topic_id)
+        expect(response.status).to eq(404), description
+        expect(response.parsed_body["error_type"]).to eq("not_found"), description
+      end
+    end
+  end
+
   describe "#post_ids" do
     fab!(:post) { Fabricate(:post, user: post_author1) }
     fab!(:topic) { post.topic }
@@ -7714,11 +7762,12 @@ RSpec.describe TopicsController do
       expect(body["group_name"]).to eq(group.name)
     end
 
-    it "rejects a user who is not a participant of the message" do
+    it "returns not found for a user who is not a participant of the message" do
       sign_in(user_2)
 
       put "/t/#{group_message.id}/archive-message.json"
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
     end
   end
 
@@ -7735,11 +7784,12 @@ RSpec.describe TopicsController do
       ).topic
     end
 
-    it "rejects a user who is not a participant of the message" do
+    it "returns not found for a user who is not a participant of the message" do
       sign_in(user_2)
 
       put "/t/#{group_message.id}/move-to-inbox.json"
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
     end
   end
 
@@ -7821,7 +7871,7 @@ RSpec.describe TopicsController do
       end
     end
 
-    it "does not allow a regular user to set notifications on a private message they cannot see" do
+    it "returns not found when a regular user sets notifications on a private message they cannot see" do
       sign_in(user)
 
       post "/t/#{pm.id}/notifications.json",
@@ -7829,11 +7879,12 @@ RSpec.describe TopicsController do
              notification_level: NotificationLevels.topic_levels[:watching],
            }
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
       expect(TopicUser.find_by(user: user, topic: pm)).to be_blank
     end
 
-    it "does not allow a regular user to set notifications on a topic in a restricted category" do
+    it "returns not found when a regular user sets notifications on a topic in a restricted category" do
       restricted_topic = Fabricate(:topic, category: staff_category)
       sign_in(user)
 
@@ -7842,7 +7893,8 @@ RSpec.describe TopicsController do
              notification_level: NotificationLevels.topic_levels[:watching],
            }
 
-      expect(response.status).to eq(403)
+      expect(response.status).to eq(404)
+      expect(response.parsed_body["error_type"]).to eq("not_found")
       expect(TopicUser.find_by(user: user, topic: restricted_topic)).to be_blank
     end
   end


### PR DESCRIPTION
## Summary

Prevent information disclosure of topic existence by ensuring secondary topic endpoints respect the 'detailed_404' security setting. The patch implements a normalization handler for several TopicsController actions—including post retrieval and notification updates—to return a consistent 404 status code for inaccessible topics when the setting is disabled.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1384

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>