### PR TITLE
FIX: apply featured-links treatment to topics even when they have content

### DIFF
--- a/frontend/discourse/app/components/composer-title.gjs
+++ b/frontend/discourse/app/components/composer-title.gjs
@@ -150,12 +150,6 @@ export default class ComposerTitle extends Component {
       return;
     }
 
-    if (!this.bodyIsDefault()) {
-      this.set("autoPosted", true);
-      this.set("composer.featuredLink", this.get("composer.title"));
-      return;
-    }
-
     // Try to onebox. If success, update post body and title.
     this.set("composer.loading", true);
 

--- a/frontend/discourse/app/components/composer-title.gjs
+++ b/frontend/discourse/app/components/composer-title.gjs
@@ -137,50 +137,58 @@ export default class ComposerTitle extends Component {
       return;
     }
 
-    if (this.isAbsoluteUrl && this.bodyIsDefault()) {
-      // only feature links to external sites
-      if (
-        this.get("composer.title").match(
-          new RegExp("^https?:\\/\\/" + window.location.hostname, "i")
-        )
-      ) {
-        return;
-      }
+    if (!this.isAbsoluteUrl) {
+      return;
+    }
 
-      // Try to onebox. If success, update post body and title.
-      this.set("composer.loading", true);
+    // only feature links to external sites
+    if (
+      this.get("composer.title").match(
+        new RegExp("^https?:\\/\\/" + window.location.hostname, "i")
+      )
+    ) {
+      return;
+    }
 
-      const link = document.createElement("a");
-      link.href = this.get("composer.title");
+    if (!this.bodyIsDefault()) {
+      this.set("autoPosted", true);
+      this.set("composer.featuredLink", this.get("composer.title"));
+      return;
+    }
 
-      const loadOnebox = load({
-        elem: link,
-        refresh: false,
-        ajax,
-        synchronous: true,
-        categoryId: this.get("composer.category.id"),
-        topicId: this.get("composer.topic.id"),
-      });
+    // Try to onebox. If success, update post body and title.
+    this.set("composer.loading", true);
 
-      if (loadOnebox && loadOnebox.then) {
-        loadOnebox
-          .then(() => {
-            const v = lookupCache(this.get("composer.title"));
-            this._updatePost(v ? v : link);
-          })
-          .finally(() => {
-            this.set("composer.loading", false);
-            schedule("afterRender", () => {
-              putCursorAtEnd(this.element.querySelector("input"));
-            });
+    const link = document.createElement("a");
+    link.href = this.get("composer.title");
+
+    const loadOnebox = load({
+      elem: link,
+      refresh: false,
+      ajax,
+      synchronous: true,
+      categoryId: this.get("composer.category.id"),
+      topicId: this.get("composer.topic.id"),
+    });
+
+    if (loadOnebox && loadOnebox.then) {
+      loadOnebox
+        .then(() => {
+          const v = lookupCache(this.get("composer.title"));
+          this._updatePost(v ? v : link);
+        })
+        .finally(() => {
+          this.set("composer.loading", false);
+          schedule("afterRender", () => {
+            putCursorAtEnd(this.element.querySelector("input"));
           });
-      } else {
-        this._updatePost(loadOnebox);
-        this.set("composer.loading", false);
-        schedule("afterRender", () => {
-          putCursorAtEnd(this.element.querySelector("input"));
         });
-      }
+    } else {
+      this._updatePost(loadOnebox);
+      this.set("composer.loading", false);
+      schedule("afterRender", () => {
+        putCursorAtEnd(this.element.querySelector("input"));
+      });
     }
   }
 

--- a/frontend/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/frontend/discourse/tests/acceptance/composer-topic-links-test.js
@@ -1,6 +1,7 @@
 import { click, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
 
 acceptance("Composer topic featured links", function (needs) {
   needs.user();
@@ -23,6 +24,37 @@ acceptance("Composer topic featured links", function (needs) {
     assert
       .dom(".title-input input")
       .hasValue("An interesting article", "title is from the oneboxed article");
+  });
+
+  test("featured link after body content is entered", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await fillIn("#reply-title", "Existing topic title");
+    await selectKit(".category-chooser").expand();
+    await selectKit(".category-chooser").selectRowByValue(2);
+    await fillIn(".d-editor-input", "this is the content of a new topic post");
+    await fillIn("#reply-title", "http://www.example.com/has-title.html");
+
+    assert
+      .dom(".title-input input")
+      .hasValue(
+        "http://www.example.com/has-title.html",
+        "title remains the pasted link"
+      );
+    assert
+      .dom(".d-editor-input")
+      .hasValue(
+        "this is the content of a new topic post",
+        "link is not appended to existing body content"
+      );
+
+    const composer = this.owner.lookup("service:composer");
+
+    assert.strictEqual(
+      composer.model.featuredLink,
+      "http://www.example.com/has-title.html",
+      "featured link is set"
+    );
   });
 
   test("onebox result doesn't include a title", async function (assert) {

--- a/frontend/discourse/tests/acceptance/composer-topic-links-test.js
+++ b/frontend/discourse/tests/acceptance/composer-topic-links-test.js
@@ -37,16 +37,16 @@ acceptance("Composer topic featured links", function (needs) {
 
     assert
       .dom(".title-input input")
-      .hasValue(
-        "http://www.example.com/has-title.html",
-        "title remains the pasted link"
-      );
+      .hasValue("An interesting article", "title is from the oneboxed article");
     assert
       .dom(".d-editor-input")
       .hasValue(
-        "this is the content of a new topic post",
-        "link is not appended to existing body content"
+        "this is the content of a new topic post\n\nhttp://www.example.com/has-title.html",
+        "link is appended to existing body content"
       );
+    assert
+      .dom(".d-editor-preview")
+      .includesHtml("onebox", "appended link previews as a onebox");
 
     const composer = this.owner.lookup("service:composer");
 


### PR DESCRIPTION
Previously, a link pasted in the title field would be treated as a featured link only if the topic had no content.

With this change, this applies even if topic has content. Pasting a link in the title will assign it as a featured link and append the link to the topic content. 