### PR TITLE
SECURITY: Shared conversations and artifacts remain accessible

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/artifacts_controller.rb
@@ -13,6 +13,8 @@ module DiscourseAi
         artifact = AiArtifact.find(params[:id])
 
         post = Post.find_by(id: artifact.post_id)
+        raise Discourse::NotFound if post.blank? || post.topic.blank?
+
         if artifact.public?
           # no guardian needed
         else

--- a/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/ai_bot/shared_ai_conversations_controller.rb
@@ -39,7 +39,9 @@ module DiscourseAi
 
       def show
         @shared_conversation = SharedAiConversation.find_by(share_key: params[:share_key])
-        raise Discourse::NotFound if @shared_conversation.blank?
+        if @shared_conversation.blank? || !@shared_conversation.publicly_visible?
+          raise Discourse::NotFound
+        end
 
         expires_in 1.minute, public: true
         response.headers["X-Robots-Tag"] = "noindex"

--- a/plugins/discourse-ai/app/jobs/regular/shared_conversation_adjust_upload_security.rb
+++ b/plugins/discourse-ai/app/jobs/regular/shared_conversation_adjust_upload_security.rb
@@ -23,7 +23,10 @@ module Jobs
       # NOTE: Only Topics are supported for now, in future we will need a more flexible
       # way of doing this.
       if conversation.target_type == "Topic"
-        rebaked_posts = TopicUploadSecurityManager.new(conversation.target).run
+        topic = conversation.target_topic
+        return if topic.blank?
+
+        rebaked_posts = TopicUploadSecurityManager.new(topic).run
 
         if rebaked_posts.any?
           new_context =
@@ -42,8 +45,9 @@ module Jobs
       # NOTE: Only Topics are supported for now, in future we will need a more flexible
       # way of doing this.
       if target_type == "Topic"
-        topic = target_type.constantize.find_by(id: target_id)
+        topic = Topic.with_deleted.find_by(id: target_id)
         return if topic.blank?
+
         TopicUploadSecurityManager.new(topic).run
       end
     end

--- a/plugins/discourse-ai/app/models/shared_ai_conversation.rb
+++ b/plugins/discourse-ai/app/models/shared_ai_conversation.rb
@@ -37,19 +37,22 @@ class SharedAiConversation < ActiveRecord::Base
   end
 
   def self.destroy_conversation(conversation)
+    target_id = conversation.target_id
+    target_type = conversation.target_type
+    target_topic = conversation.target_topic(with_deleted: true)
+
     conversation.destroy
 
-    maybe_topic = conversation.target
-    if maybe_topic.is_a?(Topic)
-      AiArtifact.where(post: maybe_topic.posts).update_all(
+    if target_topic
+      AiArtifact.where(post: target_topic.posts.with_deleted).update_all(
         "metadata = jsonb_set(COALESCE(metadata, '{}'), '{public}', 'false')",
       )
     end
 
     ::Jobs.enqueue(
       :shared_conversation_adjust_upload_security,
-      target_id: conversation.target_id,
-      target_type: conversation.target_type,
+      target_id: target_id,
+      target_type: target_type,
     )
   end
 
@@ -89,6 +92,30 @@ class SharedAiConversation < ActiveRecord::Base
 
   def url
     "#{Discourse.base_uri}/discourse-ai/ai-bot/shared-ai-conversations/#{share_key}"
+  end
+
+  def publicly_visible?
+    topic = target_topic
+    return false if topic.blank?
+
+    source_guardian = user.guardian
+    return false if DiscourseAi::AiBot::EntryPoint.ai_share_error(topic, source_guardian)
+
+    context_post_ids = context.filter_map { |context_post| context_post["id"] }
+    return false if context_post_ids.blank?
+
+    posts_by_id = Post.where(id: context_post_ids, topic_id: topic.id).index_by(&:id)
+    context_post_ids.all? do |post_id|
+      post = posts_by_id[post_id]
+      post.present? && source_guardian.can_see?(post)
+    end
+  end
+
+  def target_topic(with_deleted: false)
+    return if target_type != "Topic"
+
+    scope = with_deleted ? Topic.with_deleted : Topic
+    scope.find_by(id: target_id)
   end
 
   def html_excerpt

--- a/plugins/discourse-ai/spec/jobs/shared_conversation_adjust_upload_security_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/shared_conversation_adjust_upload_security_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe Jobs::SharedConversationAdjustUploadSecurity do
       run_job
     end
 
-    it "doesn't attempt to run the topic upload security manager if the topic has been deleted" do
-      TopicUploadSecurityManager.any_instance.expects(:run).never
+    it "runs the topic upload security manager if the topic has been trashed" do
       topic.trash!
+      TopicUploadSecurityManager.any_instance.expects(:run).once
       run_job
     end
   end

--- a/plugins/discourse-ai/spec/requests/ai_bot/artifacts_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/artifacts_controller_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe DiscourseAi::AiBot::ArtifactsController do
         expect(response.status).to eq(200)
         expect(parse_srcdoc(response.body)).to include(artifact.html)
       end
+
+      it "returns 404 when the source topic has been trashed" do
+        topic.trash!
+
+        get "/discourse-ai/ai-bot/artifacts/#{artifact.id}"
+        expect(response.status).to eq(404)
+      end
     end
 
     it "sanitizes CSS to prevent style tag breakout" do

--- a/plugins/discourse-ai/spec/requests/ai_bot/shared_ai_conversations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/ai_bot/shared_ai_conversations_controller_spec.rb
@@ -281,6 +281,45 @@ RSpec.describe DiscourseAi::AiBot::SharedAiConversationsController do
           expect(shared_conversation.target.posts.second.reload.cooked).not_to eq(post_2_cooked)
           expect(shared_conversation.target.posts.second.reload.cooked).to include("secure-uploads")
         end
+
+        it "marks uploads back as secure when unsharing after the source topic was trashed" do
+          shared_conversation.target.trash!
+
+          delete "#{path}/#{shared_conversation.share_key}.json"
+          expect(response).to have_http_status(:success)
+          expect(upload_1.reload.secure).to eq(true)
+          expect(upload_2.reload.secure).to eq(true)
+        end
+      end
+
+      context "when ai artifacts are in lax mode" do
+        before { SiteSetting.ai_artifact_security = "lax" }
+
+        it "marks artifacts private when unsharing after the source topic was trashed" do
+          first_post = user_pm_share.posts.first
+          artifact =
+            AiArtifact.create!(
+              user: bot_user,
+              post: first_post,
+              name: "test",
+              html: "<div>test</div>",
+            )
+
+          first_post.update!(raw: <<~RAW)
+              This is a post with an artifact
+
+              <div class="ai-artifact" data-ai-artifact-id="#{artifact.id}"></div>
+            RAW
+
+          conversation = SharedAiConversation.share_conversation(user, user_pm_share)
+          expect(artifact.reload.public?).to eq(true)
+
+          user_pm_share.trash!
+
+          delete "#{path}/#{conversation.share_key}.json"
+          expect(response).to have_http_status(:success)
+          expect(artifact.reload.public?).to eq(false)
+        end
       end
     end
 
@@ -413,6 +452,22 @@ RSpec.describe DiscourseAi::AiBot::SharedAiConversationsController do
       get "#{path}/#{shared_conversation.share_key}.json"
       expect(response.parsed_body["llm_name"]).to eq("Claude-2")
       expect(response.headers["X-Robots-Tag"]).to eq("noindex")
+    end
+
+    it "returns not found when the source topic has been trashed" do
+      share_key = shared_conversation.share_key
+      user_pm_share.trash!
+
+      get "#{path}/#{share_key}.json"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns not found when a shared source post has been trashed" do
+      share_key = shared_conversation.share_key
+      user_pm_share.posts.last.trash!
+
+      get "#{path}/#{share_key}.json"
+      expect(response).to have_http_status(:not_found)
     end
 
     it "returns an error if the shared conversation is not found" do


### PR DESCRIPTION
## Summary

Prevent unauthorized access to shared AI conversations and artifacts by verifying the visibility of source topics and posts before rendering. The patch also ensures that destroying a shared conversation correctly restores privacy settings for artifacts and uploads even when the source topic has been trashed.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1398

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>