### PR TITLE
SECURITY: Unsanitized TagLocalization Descriptions

### DIFF
--- a/app/models/tag_localization.rb
+++ b/app/models/tag_localization.rb
@@ -2,10 +2,12 @@
 
 class TagLocalization < ActiveRecord::Base
   include LocaleMatchable
+  include HasSanitizableFields
 
   belongs_to :tag
 
   before_validation :clean_name
+  before_save :sanitize_description
 
   validates :locale, presence: true, length: { maximum: 20 }
   validates :name, presence: true
@@ -16,6 +18,10 @@ class TagLocalization < ActiveRecord::Base
 
   def clean_name
     self.name = DiscourseTagging.clean_tag(name) if name.present?
+  end
+
+  def sanitize_description
+    self.description = sanitize_field(description) if description_changed?
   end
 end
 

--- a/spec/lib/tag_localization_creator_spec.rb
+++ b/spec/lib/tag_localization_creator_spec.rb
@@ -26,6 +26,18 @@ describe TagLocalizationCreator do
     )
   end
 
+  it "sanitizes unsafe description HTML", :aggregate_failures do
+    unsafe_description =
+      '<script>alert("xss")</script><a href="https://example.com" onclick="alert(1)">link</a>'
+    sanitized_description = Fabricate(:tag, description: unsafe_description).description
+
+    localization =
+      described_class.create(tag:, locale:, name:, description: unsafe_description, user:)
+
+    expect(localization.description).to eq(sanitized_description)
+    expect(localization.description).not_to match(/<script|onclick/i)
+  end
+
   it "creates localization without description" do
     localization = described_class.create(tag:, locale:, name:, user:)
 


### PR DESCRIPTION
## Summary

Ssanitize localized tag descriptions before persistence. The TagLocalization model now applies the standard HTML safelist to ensure consistency with primary tag sanitization.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1347

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>