### PR TITLE
FEATURE: Support category-scoped upcoming events calendars

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-calendar.gjs
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import moment from "moment";
+import Category from "discourse/models/category";
 import { i18n } from "discourse-i18n";
 import { normalizeViewForRoute } from "../lib/calendar-view-helper";
 import formatEventForCalendar from "../lib/format-event-for-calendar";
@@ -35,7 +36,9 @@ export default class UpcomingEventsCalendar extends Component {
       currentUser: this.currentUser,
       siteSettings: this.siteSettings,
       info,
-      category: null,
+      category: this.args.categoryId
+        ? (Category.findById(this.args.categoryId) ?? null)
+        : null,
     });
   }
 
@@ -72,12 +75,22 @@ export default class UpcomingEventsCalendar extends Component {
 
   @action
   async loadEvents(info) {
-    const events = await this.discoursePostEventService.fetchEvents({
+    const params = {
       after: info.startStr,
       before: info.endStr,
       include_ongoing: true,
       attending_user: this.args.mine ? this.currentUser?.username : null,
-    });
+    };
+
+    if (this.args.categoryId) {
+      params.category_id = this.args.categoryId;
+    }
+
+    if (this.args.includeSubcategories !== undefined) {
+      params.include_subcategories = this.args.includeSubcategories;
+    }
+
+    const events = await this.discoursePostEventService.fetchEvents(params);
 
     const timezone = this.currentUser?.user_option?.timezone;
 
@@ -88,6 +101,14 @@ export default class UpcomingEventsCalendar extends Component {
         timezone
       )
     );
+  }
+
+  get refreshKey() {
+    return [
+      this.currentUser?.id,
+      this.args.categoryId,
+      this.args.includeSubcategories,
+    ].join("-");
   }
 
   get leftHeaderToolbar() {
@@ -125,6 +146,10 @@ export default class UpcomingEventsCalendar extends Component {
   @action
   async onDatesChange(info) {
     this.applyCustomButtonsState();
+
+    if (this.args.updateRouteOnDatesChange === false) {
+      return;
+    }
 
     const localDate = moment(info.view.currentStart)
       .clone()
@@ -172,7 +197,7 @@ export default class UpcomingEventsCalendar extends Component {
         @leftHeaderToolbar={{this.leftHeaderToolbar}}
         @centerHeaderToolbar={{this.centerHeaderToolbar}}
         @rightHeaderToolbar={{this.rightHeaderToolbar}}
-        @refreshKey={{this.currentUser?.id}}
+        @refreshKey={{this.refreshKey}}
       />
     </div>
   </template>

--- a/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-calendar-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-calendar-test.gjs
@@ -1,0 +1,78 @@
+import { render, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import UpcomingEventsCalendar from "../../discourse/components/upcoming-events-calendar";
+
+module("Integration | Component | UpcomingEventsCalendar", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  test("renders events from the requested category", async function (assert) {
+    const requests = [];
+
+    pretender.get("/discourse-post-event/events", ({ queryParams }) => {
+      requests.push(queryParams);
+
+      if (queryParams.category_id === "2") {
+        return response({ events: [eventForCategory(2, "Beauty event")] });
+      }
+
+      return response({ events: [] });
+    });
+
+    await render(
+      <template>
+        <UpcomingEventsCalendar
+          @categoryId={{2}}
+          @includeSubcategories={{true}}
+          @initialDate="2026-07-01"
+          @initialView="dayGridMonth"
+          @updateRouteOnDatesChange={{false}}
+        />
+      </template>
+    );
+
+    await waitFor(".fc-event-title");
+
+    assert
+      .dom(".fc-event-title")
+      .hasText(
+        "Beauty event",
+        "renders the event returned for the selected category"
+      );
+
+    assert.strictEqual(
+      requests[0].category_id,
+      "2",
+      "category id is passed through to the event API"
+    );
+    assert.strictEqual(
+      requests[0].include_subcategories,
+      "true",
+      "include subcategories is passed through to the event API"
+    );
+  });
+});
+
+function eventForCategory(categoryId, name) {
+  return {
+    id: categoryId,
+    name,
+    category_id: categoryId,
+    timezone: "UTC",
+    post: {
+      id: categoryId,
+      post_number: 1,
+      topic: {
+        id: categoryId,
+        title: name,
+      },
+    },
+    occurrences: [
+      {
+        starts_at: "2026-07-10T10:00:00.000Z",
+        ends_at: "2026-07-10T11:00:00.000Z",
+      },
+    ],
+  };
+}


### PR DESCRIPTION
Previously, embedded upcoming events calendars always fetched all visible events and created events without a category.

This change lets callers pass a category scope to `UpcomingEventsCalendar`, uses it for event fetching and composer defaults, and lets embedded callers opt out of the calendar's existing route/date syncing via `@updateRouteOnDatesChange={{false}}`. The default preserves the existing `/upcoming-events` behavior for backwards compatibility.