### PR TITLE
UX: category slug isn't required on edit

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5175,7 +5175,7 @@ en:
       unsaved_changes: "You have unsaved changes"
       slug: "Category slug"
       parent: "Parent category"
-      slug_placeholder: "(Optional) dashed-words for url"
+      slug_placeholder: "Auto-generated if left blank"
       creation_error: There has been an error during the creation of the category.
       save_error: There was an error saving the category.
       errors:

--- a/frontend/discourse/admin/components/upsert-category/settings.gjs
+++ b/frontend/discourse/admin/components/upsert-category/settings.gjs
@@ -39,7 +39,6 @@ export default class UpsertCategorySettings extends Component {
       @title={{i18n "category.slug"}}
       @format="max"
       @type="input"
-      @validation="required"
       as |field|
     >
       <field.Control


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/category-slug-error-when-changing-allow-owner-to-edit-first-post-indefinitely/407105

We throw a validation error on category edit if you leave the slug field blank, but it's not actually required at all... we'll auto-generate one if it's blank. Also updated the placeholder text to clarify (we auto replaces spaces with dashes too, so that's unnecessary guidance) 