### PR TITLE
FEATURE: Support bulk user search in the admin users list

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2882,7 +2882,7 @@ en:
     created: "Created"
     created_lowercase: "created"
     trust_level: "Trust Level"
-    search_hint: "username, email or IP address"
+    search_hint: "usernames or emails (comma or space separated), or an IP address"
 
     create_account:
       header_title: "Welcome!"

--- a/frontend/discourse/admin/controllers/admin-users-list/show.js
+++ b/frontend/discourse/admin/controllers/admin-users-list/show.js
@@ -11,6 +11,7 @@ import CanCheckEmailsHelper from "discourse/lib/can-check-emails-helper";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
 import { INPUT_DELAY } from "discourse/lib/environment";
+import DiscourseURL from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
 
 const MAX_BULK_SELECT_LIMIT = 100;
@@ -148,7 +149,22 @@ export default class AdminUsersListShowController extends Controller {
   @action
   onListFilterChange(event) {
     this.set("listFilter", event.target.value);
-    discourseDebounce(this, this.resetFilters, INPUT_DELAY);
+    discourseDebounce(this, this._listFilterChanged, INPUT_DELAY);
+  }
+
+  _listFilterChanged() {
+    // `filter` is deliberately not a registered query param (its name would
+    // clash with the :filter segment), so sync the URL without a transition
+    const url = new URL(window.location.href);
+    url.searchParams.delete("username");
+    if (this.listFilter) {
+      url.searchParams.set("filter", this.listFilter);
+    } else {
+      url.searchParams.delete("filter");
+    }
+    DiscourseURL.replaceState(url.pathname + url.search);
+
+    this.resetFilters();
   }
 
   @action

--- a/frontend/discourse/admin/routes/admin-users-list/show.js
+++ b/frontend/discourse/admin/routes/admin-users-list/show.js
@@ -22,7 +22,12 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
         controller.setProperties({
           order: transition.to.queryParams.order,
           asc: transition.to.queryParams.asc,
-          listFilter: transition.to.queryParams.username,
+          // `filter` is deliberately not a registered query param (its name
+          // would clash with the :filter segment); `username` is kept as a
+          // legacy fallback for old links
+          listFilter:
+            transition.to.queryParams.filter ??
+            transition.to.queryParams.username,
           query: params.filter,
           activation:
             params.filter === "new"

--- a/frontend/discourse/admin/templates/admin-users-list/show.gjs
+++ b/frontend/discourse/admin/templates/admin-users-list/show.gjs
@@ -53,6 +53,7 @@ export default <template>
         class="admin-filter__input"
         type="text"
         dir="auto"
+        value={{@controller.listFilter}}
         placeholder={{@controller.searchHint}}
         title={{@controller.searchHint}}
         {{on "input" @controller.onListFilterChange}}

--- a/frontend/discourse/tests/acceptance/admin-users-list-test.js
+++ b/frontend/discourse/tests/acceptance/admin-users-list-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, visit } from "@ember/test-helpers";
+import { click, currentURL, fillIn, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import { i18n } from "discourse-i18n";
@@ -180,5 +180,104 @@ acceptance("Admin - Users List", function (needs) {
     assert
       .dom(".users-list .user:nth-child(1) .username")
       .includesText("notactivated");
+  });
+});
+
+acceptance("Admin - Users List - bulk search", function (needs) {
+  needs.user();
+
+  let lastFilter;
+
+  needs.pretender((server, helper) => {
+    const respond = (request) => {
+      lastFilter = request.queryParams.filter;
+
+      const users = [
+        { id: 2, username: "sam" },
+        { id: 3, username: "bob" },
+      ];
+
+      if (!lastFilter) {
+        return helper.response(users);
+      }
+
+      const terms = lastFilter.split(/[,\s]+/).filter(Boolean);
+      return helper.response(
+        users.filter((user) =>
+          terms.some((term) => user.username.includes(term))
+        )
+      );
+    };
+
+    server.get("/admin/users/list/active.json", respond);
+    server.get("/admin/users/list/new.json", respond);
+  });
+
+  test("searches multiple users at once and reflects the search in the URL", async function (assert) {
+    await visit("/admin/users/list/active");
+
+    await fillIn(".admin-users-list__search input", "sam,bob");
+
+    assert.strictEqual(
+      lastFilter,
+      "sam,bob",
+      "sends the whole list to the server"
+    );
+    assert.dom(".users-list .user").exists({ count: 2 });
+    assert.true(
+      decodeURIComponent(currentURL()).includes("filter=sam,bob"),
+      "reflects the search in the URL"
+    );
+    assert
+      .dom(".admin-users-list__search input")
+      .isFocused("keeps focus while the URL updates");
+
+    await fillIn(".admin-users-list__search input", "");
+
+    assert.false(
+      currentURL().includes("filter="),
+      "clearing the search removes it from the URL"
+    );
+  });
+
+  test("prefills and applies the search from the URL", async function (assert) {
+    await visit("/admin/users/list/active?filter=sam");
+
+    assert.dom(".admin-users-list__search input").hasValue("sam");
+    assert.strictEqual(lastFilter, "sam", "sends the filter from the URL");
+    assert.dom(".users-list .user").exists({ count: 1 });
+  });
+
+  test("prefills the search from the legacy username query param", async function (assert) {
+    await visit("/admin/users/list/active?username=sam");
+
+    assert.dom(".admin-users-list__search input").hasValue("sam");
+    assert.strictEqual(lastFilter, "sam", "sends the filter from the URL");
+  });
+
+  test("clears the search when switching tabs", async function (assert) {
+    await visit("/admin/users/list/active");
+
+    await fillIn(".admin-users-list__search input", "sam");
+    assert.dom(".users-list .user").exists({ count: 1 });
+
+    await click('a[href="/admin/users/list/new"]');
+
+    assert.dom(".admin-users-list__search input").hasValue("");
+    assert.strictEqual(
+      lastFilter,
+      undefined,
+      "does not filter the new tab results"
+    );
+
+    await click('a[href="/admin/users/list/active"]');
+
+    assert
+      .dom(".admin-users-list__search input")
+      .hasValue("", "does not restore the search when returning to the tab");
+    assert.false(
+      currentURL().includes("filter="),
+      "does not restore the search in the URL"
+    );
   });
 });

--- a/lib/admin_user_index_query.rb
+++ b/lib/admin_user_index_query.rb
@@ -34,6 +34,9 @@ class AdminUserIndexQuery
 
   SAME_IP_ADDRESS_COLUMNS = { "last" => :ip_address, "registration" => :registration_ip_address }
 
+  FILTER_SPLIT_REGEX = /[,\s]+/
+  MAX_FILTER_TERMS = 100
+
   def find_users(limit = 100)
     page = params[:page].to_i - 1
     page = 0 if page < 0
@@ -113,17 +116,46 @@ class AdminUserIndexQuery
     end
 
     filter = params[:filter]
-    if filter.present?
-      filter = filter.strip
-      if ip = parse_ip(filter)
+    return if filter.blank?
+
+    terms = filter.split(FILTER_SPLIT_REGEX).reject(&:blank?)
+    return if terms.empty?
+    raise Discourse::InvalidParameters.new(:filter) if terms.size > MAX_FILTER_TERMS
+
+    if terms.size == 1
+      term = terms.first
+      if ip = parse_ip(term)
         return if params[:same_ip_user_id].present?
         return @query.none unless can_see_ip?
 
         @query.where("ip_address <<= :ip OR registration_ip_address <<= :ip", ip: ip.to_cidr_s)
       else
-        @query.filter_by_username_or_email(filter)
+        @query.filter_by_username_or_email(term)
       end
+    else
+      filter_by_multiple_terms(terms.map(&:downcase))
     end
+  end
+
+  # per-term semantics match the single-term search: substring match on
+  # username and primary email, exact match on any email (secondary
+  # included) for terms that look like emails
+  def filter_by_multiple_terms(terms)
+    patterns = terms.map { |term| "%#{term}%" }
+
+    sql = +<<~SQL
+      username_lower ILIKE ANY (ARRAY[:patterns])
+      OR lower(user_emails.email) ILIKE ANY (ARRAY[:patterns])
+    SQL
+    binds = { patterns: patterns }
+
+    exact_emails = terms.select { |term| term =~ /.+@.+/ }
+    if exact_emails.present?
+      sql << "OR users.id IN (SELECT user_id FROM user_emails WHERE lower(user_emails.email) IN (:exact_emails))"
+      binds[:exact_emails] = exact_emails
+    end
+
+    @query.joins(:primary_email).where(sql, binds)
   end
 
   def filter_by_ip

--- a/spec/lib/admin_user_index_query_spec.rb
+++ b/spec/lib/admin_user_index_query_spec.rb
@@ -280,5 +280,81 @@ RSpec.describe AdminUserIndexQuery do
         expect(query.find_users.count()).to eq(1)
       end
     end
+
+    context "with multiple terms" do
+      fab!(:user_one) { Fabricate(:user, username: "bulk_user_1", email: "first@example.com") }
+      fab!(:user_two) { Fabricate(:user, username: "bulk_user_2", email: "second@example.com") }
+
+      it "matches usernames separated by commas" do
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1,bulk_user_2")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+      end
+
+      it "matches usernames separated by whitespace" do
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1 bulk_user_2")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1\nbulk_user_2")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+      end
+
+      it "matches a mix of usernames and emails" do
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1, second@example.com")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+      end
+
+      it "matches a list of emails" do
+        query = ::AdminUserIndexQuery.new(filter: "first@example.com,second@example.com")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+
+        query = ::AdminUserIndexQuery.new(filter: "first@example.com second@example.com")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+      end
+
+      it "matches secondary emails exactly" do
+        Fabricate(:secondary_email, user: user_two, email: "extra@elsewhere.com")
+
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1,extra@elsewhere.com")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+      end
+
+      it "ignores blank tokens" do
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1, ,,  bulk_user_2,")
+        expect(query.find_users).to contain_exactly(user_one, user_two)
+      end
+
+      it "treats like and regex metacharacters literally" do
+        query = ::AdminUserIndexQuery.new(filter: "bulk_user_1,foo(")
+        expect(query.find_users).to contain_exactly(user_one)
+
+        query = ::AdminUserIndexQuery.new(filter: "a|b,zzz%")
+        expect(query.find_users).to be_empty
+      end
+
+      it "still uses the exact email bypass for a single term with a trailing comma" do
+        query = ::AdminUserIndexQuery.new(filter: "first@example.com,").find_users_query
+        expect(query.to_sql.downcase).not_to include("ilike")
+        expect(query).to contain_exactly(user_one)
+      end
+
+      it "does not search by ip address when multiple terms are given" do
+        Fabricate(:user, ip_address: "117.207.94.9")
+
+        query =
+          ::AdminUserIndexQuery.new(
+            filter: "117.207.94.9,117.207.94.10",
+            guardian: Fabricate(:admin).guardian,
+          )
+        expect(query.find_users).to be_empty
+      end
+
+      it "raises when there are too many terms" do
+        filter = (0..AdminUserIndexQuery::MAX_FILTER_TERMS).map { |i| "user#{i}" }.join(",")
+
+        expect { ::AdminUserIndexQuery.new(filter: filter).find_users }.to raise_error(
+          Discourse::InvalidParameters,
+        )
+      end
+    end
   end
 end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -79,6 +79,24 @@ RSpec.describe Admin::UsersController do
         expect(ids).not_to include(admin.id)
       end
 
+      it "filters by multiple usernames or emails at once" do
+        user_one = Fabricate(:user, username: "bulk_user_1")
+        user_two = Fabricate(:user, email: "bulk2@example.com")
+
+        get "/admin/users/list.json", params: { filter: "bulk_user_1,bulk2@example.com" }
+        expect(response.status).to eq(200)
+
+        ids = response.parsed_body.map { |u| u["id"] }
+        expect(ids).to contain_exactly(user_one.id, user_two.id)
+      end
+
+      it "returns a 400 when the filter has too many terms" do
+        filter = (0..AdminUserIndexQuery::MAX_FILTER_TERMS).map { |i| "u#{i}" }.join(",")
+
+        get "/admin/users/list.json", params: { filter: filter }
+        expect(response.status).to eq(400)
+      end
+
       context "when showing emails" do
         it "returns email for all the users" do
           get "/admin/users/list.json", params: { show_emails: "true" }


### PR DESCRIPTION
Admins can now search for multiple users at once in `/admin/users/list` by
separating usernames or emails with commas or whitespace — useful for
support workflows where a list of users needs to be checked in one go
(e.g. pasted from a spreadsheet; spaces work because usernames and emails
can never contain them).

The search is also shareable via URL: typing keeps the address bar in sync
with a `filter` query param (`/admin/users/list/active?filter=sam,bob@example.com`),
and visiting such a URL prefills the search box and filters the list. The
old `username` query param keeps working as a read-only legacy fallback —
it was a misleading name, since searches also match emails.

## Demo:

https://github.com/user-attachments/assets/c85e4f30-3c06-493b-9fed-bb2057209c5d

