### PR TITLE
DEV: Enable Playwright soft reset on CI for all system tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 20
       MINIO_RUNNER_LOG_LEVEL: WARN
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && '1' }}
-      CAPYBARA_PLAYWRIGHT_SOFT_RESET: ${{ matrix.build_type == 'system' && (matrix.target == 'core' || matrix.target == 'chat') && '1' }}
+      CAPYBARA_PLAYWRIGHT_SOFT_RESET: ${{ matrix.build_type == 'system' && '1' }}
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner


### PR DESCRIPTION
This PR enables the Playwright soft reset optimization for every system test target on CI, not just `core` and `chat`.

The soft reset path (`PlaywrightSoftReset` in `spec/support/system/capybara_patches.rb`, gated on the `CAPYBARA_PLAYWRIGHT_SOFT_RESET` env var) reuses the browser context between examples instead of tearing it down, speeding up system specs. It was previously scoped to only the `core` and `chat` targets in `.github/workflows/tests.yml` while it was proven out; the other system targets still paid the full-reset cost.

Key changes:
  * Set `CAPYBARA_PLAYWRIGHT_SOFT_RESET` to `1` for all `system` build types, dropping the `core`/`chat` target condition, now that the approach has proven stable on those targets.