### PR TITLE
FIX: Do not surface upcoming changes owned by unavailable plugins

### DIFF
--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -16,6 +16,8 @@ module UpcomingChanges
   # have selected, so caching may be appropriate at times.
   class ConditionalDisplay
     def self.should_display?(upcoming_change_name)
+      return false if !UpcomingChanges.owning_plugin_configurable?(upcoming_change_name)
+
       if respond_to?("should_display_#{upcoming_change_name}?")
         return public_send("should_display_#{upcoming_change_name}?")
       end
@@ -156,6 +158,22 @@ module UpcomingChanges
     change_metadata(change_setting_name.to_sym).present?
   end
 
+  # An upcoming change owned by a plugin that is not configurable on this site,
+  # is never available. It must not be displayed, notified about, or enabled.
+  #
+  # This is deliberately broader than the guard in SiteSettingExtension#setting,
+  # which only forces a plugin's own enabled_site_setting to false. A change
+  # gating a sub-feature of an unavailable plugin is equally unavailable.
+  #
+  # Core changes have no owning plugin and return early, so the common case
+  # never reaches #configurable? and adds no cost to callers on hot paths like
+  # .settings_hidden_while_enabled.
+  def self.owning_plugin_configurable?(change_setting_name)
+    plugin_name = settings_provider.plugins[change_setting_name.to_sym]
+    return true if plugin_name.nil?
+    Discourse.plugins_by_name[plugin_name]&.configurable? != false
+  end
+
   # We dynamically determine if an upcoming change is enabled
   # or disabled based on the current status of the change as well
   # as whether the admin has manually toggled the change.
@@ -168,6 +186,11 @@ module UpcomingChanges
     if !exists?(change_setting_name)
       raise ArgumentError, "Unknown upcoming change: #{change_setting_name}"
     end
+
+    # The owning plugin is not available on this site, so neither is the change.
+    # This intentionally takes precedence over the :permanent status below, since
+    # a permanent change to an unavailable plugin still cannot take effect.
+    return false if !owning_plugin_configurable?(change_setting_name)
 
     # An admin has modified the setting and a value is stored
     # in the database, since the default for upcoming changes

--- a/spec/jobs/scheduled/notify_admins_of_available_upcoming_changes_spec.rb
+++ b/spec/jobs/scheduled/notify_admins_of_available_upcoming_changes_spec.rb
@@ -328,6 +328,27 @@ RSpec.describe Jobs::NotifyAdminsOfAvailableUpcomingChanges do
     end
   end
 
+  context "when an upcoming change is owned by a plugin that is not configurable" do
+    before do
+      UpcomingChanges.stubs(:owning_plugin_configurable?).with(anything).returns(true)
+      UpcomingChanges.stubs(:owning_plugin_configurable?).with(:test_upcoming_change).returns(false)
+    end
+
+    it "does not create a notification for the unavailable change but still notifies for others" do
+      result
+      data =
+        JSON.parse(
+          Notification
+            .where(notification_type: Notification.types[:upcoming_change_available])
+            .last
+            .data,
+          symbolize_names: true,
+        )
+      expect(data[:upcoming_change_names]).to eq(%w[test_upcoming_change_b])
+      expect(data[:count]).to eq(1)
+    end
+  end
+
   context "when an upcoming change should not be displayed on this site" do
     before do
       UpcomingChanges::ConditionalDisplay.stubs(:should_display_test_upcoming_change?).returns(

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -1091,6 +1091,28 @@ RSpec.describe SiteSettingExtension do
     end
   end
 
+  describe "upcoming changes owned by a non-configurable plugin" do
+    let(:setting_name) { :enable_experimental_sample_plugin_feature }
+
+    before do
+      SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+      SiteSetting.promote_upcoming_changes_on_status = :alpha
+    end
+
+    after do
+      SiteSetting.promote_upcoming_changes_on_status = :stable
+      UpcomingChanges.clear_caches!
+    end
+
+    it "reports the change as disabled even though it has been promoted" do
+      expect(UpcomingChanges.enabled?(setting_name)).to eq(false)
+    end
+
+    it "keeps the setting getter in agreement with UpcomingChanges.enabled?" do
+      expect(SiteSetting.public_send(setting_name)).to eq(UpcomingChanges.enabled?(setting_name))
+    end
+  end
+
   describe ".all_settings" do
     describe "non-configurable plugin filtering" do
       it "includes plugin site settings when the plugin is configurable" do

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -399,11 +399,64 @@ RSpec.describe UpcomingChanges do
     end
   end
 
+  describe ".owning_plugin_configurable?" do
+    let(:plugin_setting_name) { :enable_experimental_sample_plugin_feature }
+
+    it "returns true for a core change with no owning plugin" do
+      expect(described_class.owning_plugin_configurable?(setting_name)).to eq(true)
+    end
+
+    it "returns true when the owning plugin is configurable" do
+      SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(true)
+
+      expect(described_class.owning_plugin_configurable?(plugin_setting_name)).to eq(true)
+    end
+
+    it "returns false when the owning plugin is not configurable" do
+      SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+
+      expect(described_class.owning_plugin_configurable?(plugin_setting_name)).to eq(false)
+    end
+
+    it "returns true when the owning plugin has not been loaded yet" do
+      Discourse.stubs(:plugins_by_name).returns({})
+
+      expect(described_class.owning_plugin_configurable?(plugin_setting_name)).to eq(true)
+    end
+  end
+
   describe ".enabled?" do
     after do
       SiteSetting.remove_override!(setting_name)
       SiteSetting.promote_upcoming_changes_on_status = :stable
       UpcomingChanges.clear_caches!
+    end
+
+    context "when the owning plugin is not configurable" do
+      let(:plugin_setting_name) { :enable_experimental_sample_plugin_feature }
+
+      before { SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false) }
+
+      it "returns false even when the change has been promoted" do
+        SiteSetting.promote_upcoming_changes_on_status = :alpha
+
+        expect(described_class.enabled?(plugin_setting_name)).to eq(false)
+      end
+
+      it "returns false even when the change is permanent" do
+        mock_upcoming_change_metadata(
+          { enable_experimental_sample_plugin_feature: { status: :permanent } },
+        )
+
+        expect(described_class.enabled?(plugin_setting_name)).to eq(false)
+      end
+
+      it "returns true again once the plugin becomes configurable" do
+        SiteSetting.promote_upcoming_changes_on_status = :alpha
+        SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(true)
+
+        expect(described_class.enabled?(plugin_setting_name)).to eq(true)
+      end
     end
 
     context "when the change is not registered" do
@@ -900,6 +953,36 @@ RSpec.describe UpcomingChanges do
       expect(UpcomingChanges::ConditionalDisplay.should_display?(:enable_upload_debug_mode)).to eq(
         true,
       )
+    end
+
+    context "when the owning plugin is not configurable" do
+      let(:plugin_setting_name) { :enable_experimental_sample_plugin_feature }
+
+      it "returns false" do
+        SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+
+        expect(UpcomingChanges::ConditionalDisplay.should_display?(plugin_setting_name)).to eq(
+          false,
+        )
+      end
+
+      it "returns false without consulting the change's conditional display method" do
+        SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+        UpcomingChanges::ConditionalDisplay.define_singleton_method(
+          :should_display_enable_experimental_sample_plugin_feature?,
+        ) { raise "should not be called" }
+
+        begin
+          expect(UpcomingChanges::ConditionalDisplay.should_display?(plugin_setting_name)).to eq(
+            false,
+          )
+        ensure
+          UpcomingChanges::ConditionalDisplay.singleton_class.send(
+            :remove_method,
+            :should_display_enable_experimental_sample_plugin_feature?,
+          )
+        end
+      end
     end
 
     context "when the conditional display method is defined for an upcoming change" do

--- a/spec/services/upcoming_changes/notify_promotion_spec.rb
+++ b/spec/services/upcoming_changes/notify_promotion_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe UpcomingChanges::NotifyPromotion do
       it { is_expected.to fail_a_policy(:meets_or_exceeds_status) }
     end
 
+    context "when the change is owned by a plugin that is not configurable" do
+      let(:setting_name) { :enable_experimental_sample_plugin_feature }
+
+      before do
+        SiteSetting::SAMPLE_TEST_PLUGIN.stubs(:configurable?).returns(false)
+        mock_upcoming_change_metadata(
+          enable_experimental_sample_plugin_feature: {
+            impact: "feature,admins",
+            status: :stable,
+          },
+        )
+      end
+
+      it { is_expected.to fail_a_policy(:change_should_be_displayed) }
+
+      it "does not fire the upcoming_change_enabled event" do
+        events = DiscourseEvent.track_events(:upcoming_change_enabled) { result }
+
+        expect(events).to be_empty
+      end
+    end
+
     context "when the change should not be displayed on this site" do
       before do
         UpcomingChanges::ConditionalDisplay.stubs(


### PR DESCRIPTION
Upcoming changes can be registered by plugins, but nothing in the
upcoming changes framework knew whether the owning plugin was actually
configurable on a given site.

For unavailble plugins on our hosting, `SiteSettingExtension#setting` already
forces the plugin's `enabled_site_setting` to false, and `all_settings`
already filters the change out of the Upcoming Changes page.

The notification paths for upcoming changes did not
follow suit...`UpcomingChanges::NotifyPromotion` and
`Jobs::NotifyAdminsOfAvailableUpcomingChanges` both gate only on
`ConditionalDisplay`, so admins were told a change had been enabled by
default for a plugin they cannot use and that is in fact still off.

`UpcomingChanges.enabled?` had the same blind spot for a different
reason, in that it reads the settings provider directly, bypassing the getter's
configurability guard, so it returned true where the setting itself read
false.

Adds `UpcomingChanges.owning_plugin_configurable?` and short-circuits
both `ConditionalDisplay.should_display?` and `UpcomingChanges.enabled?`
on it. Core changes have no owning plugin and return early, so hot paths
such as `settings_hidden_while_enabled` are unaffected.

The gate keys on `configurable?` alone rather than mirroring the getter's
narrower `enabled_site_setting == name` condition, a change gating a
sub-feature of an unavailable plugin is equally unavailable.
