### PR TITLE
DEV: Spike Sorbet typing for admin dashboard reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,11 @@ gem "railties", "~> 8.0.0"
 gem "propshaft"
 gem "json"
 
+# Spike: gradual typing for lib/admin_dashboard. Runtime component must be in
+# the default group so T::Sig/T::Struct are available wherever the typed code
+# loads.
+gem "sorbet-runtime"
+
 # this will eventually be added to rails,
 # allows us to precompile all our templates in the app server master
 gem "actionview_precompiler", require: false
@@ -168,6 +173,7 @@ group :development do
   gem "ruby-lsp", require: false
   gem "ruby-lsp-rails", require: false
   gem "ruby-lsp-rspec", require: false
+  gem "sorbet", require: false
 end
 
 if ENV["ALLOW_DEV_POPULATE"] == "1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -723,6 +723,12 @@ GEM
     snaky_hash (2.0.4)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
+    sorbet (0.6.13328)
+      sorbet-static (= 0.6.13328)
+    sorbet-runtime (0.6.13328)
+    sorbet-static (0.6.13328-aarch64-linux)
+    sorbet-static (0.6.13328-universal-darwin)
+    sorbet-static (0.6.13328-x86_64-linux)
     sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-aarch64-linux-musl)
     sqlite3 (2.9.5-arm64-darwin)
@@ -958,6 +964,8 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq (>= 7.3.10)
   simplecov
+  sorbet
+  sorbet-runtime
   sqlite3
   sshkey
   stackprof
@@ -1276,6 +1284,11 @@ CHECKSUMS
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   snaky_hash (2.0.4) sha256=2b12758c57defa6796341a1620f84b1a23737421d8d7e2575d0550b53cc4fece
+  sorbet (0.6.13328) sha256=f3606f88efcc7a623e53d73810803a681db528f71439ece4b51784c77b15b186
+  sorbet-runtime (0.6.13328) sha256=f30118d2f3c1b6bad90a5f54393b764dfa144f38b827e8399e2407aa097da0c4
+  sorbet-static (0.6.13328-aarch64-linux) sha256=e47a69cc7abd00a215f89ca8cdc46990d0d1bd02ef128acc874833794290fd1d
+  sorbet-static (0.6.13328-universal-darwin) sha256=1875a746e364f8fd26274694a25d5ead5e62382997ad1476da8f92f9fd832066
+  sorbet-static (0.6.13328-x86_64-linux) sha256=1755356c8ebcebae9ed39f34202e26f0724443d6c65d2f95819a4d610a4ce1eb
   sqlite3 (2.9.5-aarch64-linux-gnu) sha256=78075b6337d3d182c6d2b4691049ed45cd220826160c9ea18946bf6a1de200dc
   sqlite3 (2.9.5-aarch64-linux-musl) sha256=18c801185deb4adc01ddb281e8f672a39e3d1729979ca91e39439cd3eac0402d
   sqlite3 (2.9.5-arm64-darwin) sha256=d0cf444a70fc9395d513cfbcc1e6719e224aa645314e3824cb0474c721425aa2

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
+# typed: true
 
 class Admin::DashboardController < Admin::StaffController
+  extend T::Sig
+
   BULK_REPORTS_FILTER_KEYS = %i[start_date end_date].freeze
 
   before_action :ensure_admin,
@@ -131,10 +134,12 @@ class Admin::DashboardController < Admin::StaffController
 
   private
 
+  sig { returns(T.untyped) }
   def serialized_problems
     serialize_data(AdminNotice.problem.order(:id), AdminNoticeSerializer)
   end
 
+  sig { returns(T::Hash[Symbol, T.untyped]) }
   def dashboard_sections_payload
     visible_ids = AdminDashboardSectionConfiguration.visible_section_ids
     data = {
@@ -153,14 +158,17 @@ class Admin::DashboardController < Admin::StaffController
     data
   end
 
+  sig { void }
   def mark_new_features_as_seen
     DiscourseUpdates.mark_new_features_as_seen(current_user.id)
   end
 
+  sig { void }
   def ensure_dashboard_improvements_enabled
     raise Discourse::NotFound if !dashboard_improvements?
   end
 
+  sig { returns(T::Boolean) }
   def dashboard_improvements?
     dashboard_improvements_enabled =
       UpcomingChanges.enabled_for_user?(:dashboard_improvements, current_user)
@@ -172,6 +180,10 @@ class Admin::DashboardController < Admin::StaffController
     end
   end
 
+  # Boundary between untyped ActionController params and the typed
+  # AdminDashboard::Reports classes: the sig runtime-checks that only
+  # String-valued {source:, identifier:} hashes flow onward.
+  sig { returns(T::Array[T::Hash[Symbol, String]]) }
   def parse_reports_items_payload
     raise Discourse::InvalidParameters.new(:items) if !params[:items].is_a?(Array)
     if params[:items].size > AdminDashboardReport::VISIBLE_CAP

--- a/lib/admin_dashboard/reports/bulk_fetch.rb
+++ b/lib/admin_dashboard/reports/bulk_fetch.rb
@@ -1,22 +1,34 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
     class BulkFetch
+      extend T::Sig
+
+      sig do
+        params(
+          items: T::Array[T::Hash[Symbol, String]],
+          filters: T::Hash[Symbol, T.untyped],
+          guardian: Guardian,
+        ).returns(T::Hash[Symbol, T.untyped])
+      end
       def self.call(items:, filters:, guardian:)
         per_source =
           AdminDashboard::Reports::Registry.dispatch_per_source(items) do |provider, group|
-            identifiers = group.map { |i| i[:identifier] }
+            identifiers = group.map { |i| i.fetch(:identifier) }
             provider.fetch_many(identifiers, guardian:, filters:)
           end
 
         results =
           items.map do |item|
+            source = item.fetch(:source)
+            identifier = item.fetch(:identifier)
             {
-              source: item[:source],
-              identifier: item[:identifier],
-              key: "#{item[:source]}:#{item[:identifier]}",
-              data: per_source.dig(item[:source], item[:identifier]),
+              source: source,
+              identifier: identifier,
+              key: "#{source}:#{identifier}",
+              data: per_source.dig(source, identifier),
             }
           end
 

--- a/lib/admin_dashboard/reports/core_report_provider.rb
+++ b/lib/admin_dashboard/reports/core_report_provider.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
     class CoreReportProvider < SourceProvider
-      SOURCE_NAME = "core_report"
+      extend T::Sig
 
+      SOURCE_NAME = T.let("core_report", String)
+
+      sig { override.returns(String) }
       def self.source_name
         SOURCE_NAME
       end
@@ -12,10 +16,16 @@ module AdminDashboard
       # The standard/default provider intentionally has no label, so its
       # reports render without a pill. Labels exist only to distinguish
       # non-standard (plugin-contributed) sources.
+      sig { override.returns(T.nilable(String)) }
       def self.label
         nil
       end
 
+      sig do
+        override
+          .params(identifiers: T::Array[String], guardian: T.nilable(Guardian))
+          .returns(T::Hash[String, ResolvedReport])
+      end
       def self.resolve_many(identifiers, guardian:)
         return {} if guardian.nil?
 
@@ -28,6 +38,15 @@ module AdminDashboard
         end
       end
 
+      sig do
+        override
+          .params(
+            identifiers: T::Array[String],
+            guardian: T.nilable(Guardian),
+            filters: T::Hash[Symbol, T.untyped],
+          )
+          .returns(T::Hash[String, T.untyped])
+      end
       def self.fetch_many(identifiers, guardian:, filters: {})
         accessible = accessible_ids(identifiers, guardian: guardian)
         opts = build_opts(filters, guardian)
@@ -50,17 +69,28 @@ module AdminDashboard
         end
       end
 
+      sig { params(payload: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
       def self.with_empty_flag(payload)
         payload.merge(empty: payload[:data].blank?)
       end
       private_class_method :with_empty_flag
 
+      sig do
+        override
+          .params(
+            search: T.nilable(String),
+            after: T.nilable(T::Hash[Symbol, String]),
+            limit: T.nilable(Integer),
+          )
+          .returns(T::Array[ResolvedReport])
+      end
       def self.list_all(search: nil, after: nil, limit: nil)
         entries = dashboard_entries(Guardian.new(Discourse.system_user))
         entries = filter_by_search(entries, search) if search.present?
         seek(entries.map { |entry| build_resolved(entry) }, after: after, limit: limit)
       end
 
+      sig { params(guardian: Guardian).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
       def self.dashboard_entries(guardian)
         ::Reports::ListQuery
           .call(guardian: guardian)
@@ -68,6 +98,7 @@ module AdminDashboard
       end
       private_class_method :dashboard_entries
 
+      sig { params(entry: T::Hash[Symbol, T.untyped]).returns(ResolvedReport) }
       def self.build_resolved(entry)
         AdminDashboard::Reports::ResolvedReport.new(
           source: SOURCE_NAME,
@@ -80,6 +111,11 @@ module AdminDashboard
       end
       private_class_method :build_resolved
 
+      sig do
+        params(filters: T::Hash[Symbol, T.untyped], guardian: T.nilable(Guardian)).returns(
+          T::Hash[Symbol, T.untyped],
+        )
+      end
       def self.build_opts(filters, guardian)
         filters = filters.symbolize_keys if filters.respond_to?(:symbolize_keys)
         opts = { current_user: guardian&.user }
@@ -92,6 +128,7 @@ module AdminDashboard
       end
       private_class_method :build_opts
 
+      sig { params(value: T.untyped).returns(T.untyped) }
       def self.parse_date(value)
         Time.zone.parse(value.to_s)
       rescue ArgumentError, TypeError
@@ -99,6 +136,11 @@ module AdminDashboard
       end
       private_class_method :parse_date
 
+      sig do
+        params(entries: T::Array[T::Hash[Symbol, T.untyped]], search: T.nilable(String)).returns(
+          T::Array[T::Hash[Symbol, T.untyped]],
+        )
+      end
       def self.filter_by_search(entries, search)
         query = search.to_s.downcase
         entries.select do |entry|

--- a/lib/admin_dashboard/reports/layout_updater.rb
+++ b/lib/admin_dashboard/reports/layout_updater.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
     class LayoutUpdater
+      extend T::Sig
+
+      sig do
+        params(items: T::Array[T::Hash[Symbol, String]], guardian: Guardian).void
+      end
       def self.call(items:, guardian:)
         items
-          .group_by { |item| item[:source] }
+          .group_by { |item| item.fetch(:source) }
           .each do |source, group|
             provider = Registry.provider_for(source)
             raise Discourse::InvalidParameters.new(:items) if provider.nil?
 
-            requested = group.map { |item| item[:identifier] }.to_set
+            requested = group.map { |item| item.fetch(:identifier) }.to_set
             accessible = provider.accessible_ids(requested.to_a, guardian: guardian)
             raise Discourse::InvalidAccess unless requested.subset?(accessible)
           end
@@ -21,8 +27,8 @@ module AdminDashboard
           rows =
             items.each_with_index.map do |item, index|
               {
-                source: item[:source],
-                identifier: item[:identifier],
+                source: item.fetch(:source),
+                identifier: item.fetch(:identifier),
                 position: index,
                 created_at: now,
                 updated_at: now,

--- a/lib/admin_dashboard/reports/listing.rb
+++ b/lib/admin_dashboard/reports/listing.rb
@@ -1,19 +1,27 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
     class Listing
+      extend T::Sig
+
       PAGE_SIZE = 30
 
+      sig do
+        params(cursor: T.untyped, search: T.nilable(String)).returns(T::Hash[Symbol, T.untyped])
+      end
       def self.call(cursor:, search:)
         new(cursor: cursor, search: search).call
       end
 
+      sig { params(cursor: T.untyped, search: T.nilable(String)).void }
       def initialize(cursor:, search:)
-        @cursor = normalize_cursor(cursor)
-        @search = search.presence
+        @cursor = T.let(normalize_cursor(cursor), T.nilable(T::Hash[Symbol, String]))
+        @search = T.let(search.presence, T.nilable(String))
       end
 
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def call
         merged =
           Registry
@@ -21,7 +29,7 @@ module AdminDashboard
             .flat_map do |provider|
               provider.list_all(search: @search, after: @cursor, limit: PAGE_SIZE + 1)
             end
-            .sort_by { |report| [report.title.to_s.downcase, report.key] }
+            .sort_by { |report| [report.title.downcase, report.key] }
 
         has_more = merged.size > PAGE_SIZE
         page = merged.first(PAGE_SIZE)
@@ -30,18 +38,20 @@ module AdminDashboard
           providers: provider_summaries,
           items: page.map(&:to_h),
           has_more: has_more,
-          cursor: has_more ? cursor_for(page.last) : nil,
+          cursor: has_more ? cursor_for(T.must(page.last)) : nil,
         }
       end
 
       private
 
+      sig { returns(T::Array[T::Hash[Symbol, T.nilable(String)]]) }
       def provider_summaries
         Registry.providers.map do |provider|
           { source: provider.source_name, label: provider.label }
         end
       end
 
+      sig { params(raw: T.untyped).returns(T.nilable(T::Hash[Symbol, String])) }
       def normalize_cursor(raw)
         return nil if raw.blank?
 
@@ -52,6 +62,7 @@ module AdminDashboard
         { title: title.to_s, key: key.to_s }
       end
 
+      sig { params(report: ResolvedReport).returns(T::Hash[Symbol, String]) }
       def cursor_for(report)
         { title: report.title, key: report.key }
       end

--- a/lib/admin_dashboard/reports/registry.rb
+++ b/lib/admin_dashboard/reports/registry.rb
@@ -1,19 +1,37 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
     class Registry
-      CORE_PROVIDERS = [CoreReportProvider].freeze
+      extend T::Sig
 
+      CORE_PROVIDERS =
+        T.let([CoreReportProvider].freeze, T::Array[T.class_of(SourceProvider)])
+
+      sig { returns(T::Array[T.class_of(SourceProvider)]) }
       def self.providers
         CORE_PROVIDERS + DiscoursePluginRegistry.admin_dashboard_report_sources
       end
 
+      sig { params(source_name: T.untyped).returns(T.nilable(T.class_of(SourceProvider))) }
       def self.provider_for(source_name)
         providers.find { |klass| klass.source_name.to_s == source_name.to_s }
       end
 
-      def self.dispatch_per_source(items)
+      # `items` only needs to respond to `[](:source)` — both permitted-params
+      # hashes and AdminDashboardReport rows flow through here, which is why
+      # the element type stays untyped.
+      sig do
+        params(
+          items: T::Array[T.untyped],
+          blk:
+            T.proc.params(provider: T.class_of(SourceProvider), group: T::Array[T.untyped]).returns(
+              T.untyped,
+            ),
+        ).returns(T::Hash[String, T.untyped])
+      end
+      def self.dispatch_per_source(items, &blk)
         items
           .group_by { |item| item[:source] }
           .each_with_object({}) do |(source, group), result|

--- a/lib/admin_dashboard/reports/resolved_report.rb
+++ b/lib/admin_dashboard/reports/resolved_report.rb
@@ -1,16 +1,44 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
-    ResolvedReport =
-      Data.define(:source, :identifier, :title, :description, :label, :url) do
-        def key
-          "#{source}:#{identifier}"
-        end
+    # Immutable value object describing a mountable report. Previously a
+    # Data.define; now a T::Struct so field types are enforced on
+    # construction. Keeps the Data semantics providers and specs rely on:
+    # keyword construction, value equality, and `to_h` including the
+    # composite key.
+    class ResolvedReport < T::Struct
+      extend T::Sig
 
-        def to_h
-          super.merge(key: key)
-        end
+      const :source, String
+      const :identifier, String
+      const :title, String
+      const :description, T.nilable(String)
+      const :label, T.nilable(String)
+      const :url, T.nilable(String)
+
+      sig { returns(String) }
+      def key
+        "#{source}:#{identifier}"
       end
+
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      def to_h
+        { source:, identifier:, title:, description:, label:, url:, key: }
+      end
+
+      sig { params(other: T.untyped).returns(T::Boolean) }
+      def ==(other)
+        !!(other.is_a?(ResolvedReport) && other.to_h == to_h)
+      end
+
+      alias eql? ==
+
+      sig { returns(Integer) }
+      def hash
+        to_h.hash
+      end
+    end
   end
 end

--- a/lib/admin_dashboard/reports/section.rb
+++ b/lib/admin_dashboard/reports/section.rb
@@ -1,30 +1,42 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
     class Section
+      extend T::Sig
+
+      sig do
+        params(guardian: Guardian, search: T.nilable(String)).returns(T::Hash[Symbol, T.untyped])
+      end
       def self.build(guardian:, search: nil)
         new(guardian: guardian, search: search).build
       end
 
+      sig { params(guardian: Guardian, search: T.nilable(String)).void }
       def initialize(guardian:, search: nil)
-        @guardian = guardian
-        @search = search.presence
+        @guardian = T.let(guardian, Guardian)
+        @search = T.let(search.presence, T.nilable(String))
       end
 
+      sig { returns(T::Hash[Symbol, T.untyped]) }
       def build
         items = visible_items.map { |_row, resolved| serialize(resolved) }
-        items = filter_by_search(items) if @search
+        if (search = @search)
+          items = filter_by_search(items, search)
+        end
 
         { items: items }
       end
 
       private
 
+      sig { returns(Guardian) }
       attr_reader :guardian
 
+      sig { returns(T::Array[[AdminDashboardReport, ResolvedReport]]) }
       def visible_items
-        rows = AdminDashboardReport.order(created_at: :desc).to_a
+        rows = T.let(AdminDashboardReport.order(created_at: :desc).to_a, T::Array[AdminDashboardReport])
         resolved_by_row_id = resolve_rows(rows)
 
         # When more rows resolve than VISIBLE_CAP allows, the older overflow
@@ -36,6 +48,11 @@ module AdminDashboard
           .sort_by { |row, _obj| row.position }
       end
 
+      sig do
+        params(rows: T::Array[AdminDashboardReport]).returns(
+          T::Hash[Integer, T.nilable(ResolvedReport)],
+        )
+      end
       def resolve_rows(rows)
         per_source =
           AdminDashboard::Reports::Registry.dispatch_per_source(rows) do |provider, group|
@@ -47,12 +64,18 @@ module AdminDashboard
         end
       end
 
+      sig { params(resolved: ResolvedReport).returns(T::Hash[Symbol, T.untyped]) }
       def serialize(resolved)
         resolved.to_h
       end
 
-      def filter_by_search(items)
-        query = @search.downcase
+      sig do
+        params(items: T::Array[T::Hash[Symbol, T.untyped]], search: String).returns(
+          T::Array[T::Hash[Symbol, T.untyped]],
+        )
+      end
+      def filter_by_search(items, search)
+        query = search.downcase
         items.select do |item|
           item[:title].to_s.downcase.include?(query) ||
             item[:description].to_s.downcase.include?(query)

--- a/lib/admin_dashboard/reports/source_provider.rb
+++ b/lib/admin_dashboard/reports/source_provider.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# typed: strict
 
 module AdminDashboard
   module Reports
@@ -10,43 +11,58 @@ module AdminDashboard
     #
     # Every method on the provider is batch-shaped to keep the dashboard
     # render path bounded — never one-by-one resolution.
+    #
+    # The contract is expressed as abstract sigs: sorbet-runtime raises
+    # NotImplementedError for missing overrides (same behaviour as the old
+    # `raise NotImplementedError` bodies) and validates the batch shapes at
+    # the plugin boundary.
     class SourceProvider
-      # @return [String] the value stored in admin_dashboard_reports.source for
-      #                  rows this provider owns. Examples: "core_report",
-      #                  "data_explorer_query".
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
+      # The value stored in admin_dashboard_reports.source for rows this
+      # provider owns. Examples: "core_report", "data_explorer_query".
+      sig { abstract.returns(String) }
       def self.source_name
-        raise NotImplementedError
       end
 
-      # @return [String, nil] a short, translated label rendered as a tag pill
-      #                  in the UI to distinguish this provider's reports from
-      #                  the standard ones. Return nil for the standard/default
-      #                  provider so its reports render without a pill.
+      # A short, translated label rendered as a tag pill in the UI to
+      # distinguish this provider's reports from the standard ones. Return nil
+      # for the standard/default provider so its reports render without a
+      # pill.
+      sig { abstract.returns(T.nilable(String)) }
       def self.label
-        raise NotImplementedError
       end
 
       # Cheap metadata resolution. Called server-side on dashboard render and
       # by the Manage Reports modal to populate its enabled list.
       #
-      # @param identifiers [Array<String>]
-      # @param guardian [Guardian]
-      # @return [Hash{String => AdminDashboard::Reports::ResolvedReport}]
-      #         identifiers that cannot be resolved (deleted, hidden, no
-      #         permission) are simply absent from the hash.
+      # Identifiers that cannot be resolved (deleted, hidden, no permission)
+      # are simply absent from the returned hash.
+      sig do
+        abstract
+          .params(identifiers: T::Array[String], guardian: T.nilable(Guardian))
+          .returns(T::Hash[String, ResolvedReport])
+      end
       def self.resolve_many(identifiers, guardian:)
-        raise NotImplementedError
       end
 
       # Expensive data fetch. Called by the bulk endpoint to load chart/table
-      # content. Providers own their own caching.
-      #
-      # @param identifiers [Array<String>]
-      # @param guardian [Guardian]
-      # @param filters [Hash] dashboard-level filter values (date range, etc).
-      # @return [Hash{String => Object}] identifier -> report data payload.
+      # content. Providers own their own caching. Returns identifier -> report
+      # data payload; `filters` carries dashboard-level filter values (date
+      # range, etc).
+      sig do
+        abstract
+          .params(
+            identifiers: T::Array[String],
+            guardian: T.nilable(Guardian),
+            filters: T::Hash[Symbol, T.untyped],
+          )
+          .returns(T::Hash[String, T.untyped])
+      end
       def self.fetch_many(identifiers, guardian:, filters: {})
-        raise NotImplementedError
       end
 
       # Universe of items of this source. Powers the Manage Reports modal's
@@ -57,21 +73,31 @@ module AdminDashboard
       # provider into one globally title-sorted stream without loading the
       # whole universe. Items must come back sorted by
       # [title.downcase, key] (key being "source:identifier") and limited to
-      # those strictly after `after`.
-      #
-      # @param search [String, nil] optional name/description filter.
-      # @param after [Hash, nil] cursor of the last item from the previous
-      #              page: { title:, key: }. nil for the first page.
-      # @param limit [Integer, nil] maximum number of items to return.
-      # @return [Array<AdminDashboard::Reports::ResolvedReport>]
+      # those strictly after `after` — a cursor of the last item from the
+      # previous page: { title:, key: }, nil for the first page.
+      sig do
+        abstract
+          .params(
+            search: T.nilable(String),
+            after: T.nilable(T::Hash[Symbol, String]),
+            limit: T.nilable(Integer),
+          )
+          .returns(T::Array[ResolvedReport])
+      end
       def self.list_all(search: nil, after: nil, limit: nil)
-        raise NotImplementedError
       end
 
       # Sort + keyset-filter an in-memory set of resolved reports for
       # `list_all`. Suitable for providers small enough to materialise their
       # whole set (e.g. core reports); SQL-backed providers should push the
       # keyset into the query instead.
+      sig do
+        params(
+          reports: T::Array[ResolvedReport],
+          after: T.nilable(T::Hash[Symbol, String]),
+          limit: T.nilable(Integer),
+        ).returns(T::Array[ResolvedReport])
+      end
       def self.seek(reports, after:, limit:)
         reports = reports.sort_by { |report| sort_key(report) }
         if after
@@ -81,18 +107,20 @@ module AdminDashboard
         limit ? reports.first(limit) : reports
       end
 
+      sig { params(report: ResolvedReport).returns([String, String]) }
       def self.sort_key(report)
-        [report.title.to_s.downcase, report.key]
+        [report.title.downcase, report.key]
       end
 
       # Identifiers from the input that the guardian is allowed to mount /
       # interact with. Default implementation is a subset of `resolve_many`
       # keys, which works for any provider whose access check is identical
       # to its resolution check.
-      #
-      # @param identifiers [Array<String>]
-      # @param guardian [Guardian]
-      # @return [Set<String>]
+      sig do
+        params(identifiers: T::Array[String], guardian: T.nilable(Guardian)).returns(
+          T::Set[String],
+        )
+      end
       def self.accessible_ids(identifiers, guardian:)
         resolve_many(identifiers, guardian: guardian).keys.to_set
       end

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,0 +1,3 @@
+lib/admin_dashboard
+app/controllers/admin/dashboard_controller.rb
+sorbet/rbi

--- a/sorbet/rbi/shims/discourse.rbi
+++ b/sorbet/rbi/shims/discourse.rbi
@@ -1,0 +1,68 @@
+# typed: true
+
+# Hand-written shims for the slice of Discourse/Rails that the typed
+# lib/admin_dashboard code touches. A full adoption would generate these with
+# Tapioca; for the spike we declare only what we call, mostly untyped, so the
+# type boundary sits inside lib/admin_dashboard itself.
+
+class Guardian
+  def initialize(user = nil, request = nil); end
+  def user; end
+end
+
+module Discourse
+  class InvalidParameters < StandardError
+    def initialize(name = nil); end
+  end
+
+  class InvalidAccess < StandardError
+  end
+
+  class NotFound < StandardError
+  end
+
+  def self.system_user; end
+end
+
+class Report
+  def self.find_cached(type, opts = nil); end
+  def self.find(type, opts = nil); end
+  def self.cache(report); end
+
+  sig { returns(T::Array[String]) }
+  def self.dashboard_excluded_report_types; end
+end
+
+module Reports
+  class ListQuery
+    def self.call(guardian:); end
+  end
+end
+
+class DiscoursePluginRegistry
+  sig { returns(T::Array[T.untyped]) }
+  def self.admin_dashboard_report_sources; end
+end
+
+class AdminDashboardReport
+  VISIBLE_CAP = T.let(T.unsafe(nil), Integer)
+
+  def self.order(*args, **kwargs); end
+  def self.delete_all; end
+  def self.insert_all(rows); end
+  def self.transaction(&blk); end
+
+  sig { returns(Integer) }
+  def id; end
+
+  sig { returns(String) }
+  def source; end
+
+  sig { returns(String) }
+  def identifier; end
+
+  sig { returns(Integer) }
+  def position; end
+
+  def [](key); end
+end

--- a/sorbet/rbi/shims/gem_fixes.rbi
+++ b/sorbet/rbi/shims/gem_fixes.rbi
@@ -1,0 +1,17 @@
+# typed: true
+
+# Gems that ship their own RBIs (prism, pdf-reader) reference constants that
+# don't resolve without the rest of their dependency graph in the payload.
+# Declare the missing names so `srb tc` stays green.
+
+module Prism
+  module LexCompat
+    class Result < Prism::Result
+    end
+  end
+end
+
+module TTFunk
+  class File
+  end
+end

--- a/sorbet/rbi/shims/rails.rbi
+++ b/sorbet/rbi/shims/rails.rbi
@@ -1,0 +1,120 @@
+# typed: true
+
+# ActiveSupport core extensions and the controller surface used by the typed
+# admin dashboard code. Untyped on purpose — these are boundaries, not the
+# subject of the spike.
+
+class Object
+  sig { returns(T::Boolean) }
+  def blank?; end
+
+  sig { returns(T::Boolean) }
+  def present?; end
+
+  sig { returns(T.nilable(T.self_type)) }
+  def presence; end
+
+  def as_json(options = nil); end
+end
+
+module Enumerable
+  def index_by(&blk); end
+
+  sig { params(object: T.untyped).returns(T::Boolean) }
+  def exclude?(object); end
+end
+
+class Hash
+  def symbolize_keys; end
+end
+
+class Time
+  def self.zone; end
+  def self.current; end
+end
+
+class Numeric
+  def minute; end
+  def minutes; end
+end
+
+module Admin
+end
+
+class Admin::StaffController
+  def self.before_action(*args, **kwargs, &blk); end
+
+  def params; end
+  def render(*args); end
+  def head(status); end
+  def guardian; end
+  def current_user; end
+  def hijack(*args, &blk); end
+  def render_json_dump(*args); end
+  def serialize_data(*args, **kwargs); end
+  def service_params; end
+  def success_json; end
+  def failed_json; end
+
+  # Service DSL methods (UpcomingChanges::Toggle.call block) are instance
+  # -exec'd; Sorbet sees them as self calls, so they are declared here.
+  def on_success(&blk); end
+  def on_failure(&blk); end
+  def on_failed_policy(name, &blk); end
+  def on_failed_contract(&blk); end
+end
+
+class AdminDashboardIndexData
+  def self.fetch_cached_stats; end
+end
+
+class AdminDashboardGeneralData
+  def self.fetch_cached_stats; end
+end
+
+class AdminDashboardSectionConfiguration
+  def self.update(sections, actor:); end
+  def self.visible_section_ids; end
+  def self.sections; end
+end
+
+class AdminDashboardSectionLoader
+  def self.build(section_ids:, current_user:, start_date:, end_date:); end
+end
+
+class SiteSetting
+  def self.version_checks?; end
+end
+
+module DiscourseUpdates
+  def self.check_version; end
+  def self.new_features(force_refresh: false); end
+  def self.merge_new_features_with_upcoming_changes(features); end
+  def self.bump_last_viewed_feature_date(user_id, date); end
+  def self.has_unseen_features?(user_id); end
+  def self.mark_new_features_as_seen(user_id); end
+end
+
+class ProblemCheck
+  def self.realtime; end
+end
+
+class RateLimiter
+  def initialize(user, key, max, secs, **opts); end
+  def performed!; end
+end
+
+module UpcomingChanges
+  def self.enabled_for_user?(change, user); end
+
+  class Toggle
+    def self.call(params, &blk); end
+  end
+end
+
+class AdminNotice
+  def self.problem; end
+end
+
+class AdminNoticeSerializer
+end


### PR DESCRIPTION
## Spike — not intended to merge as-is

Explores how reliable the admin dashboard reports code can become if we adopted Sorbet, using `lib/admin_dashboard/reports` as a well-bounded, recently built test bed.

## What's typed

- All of `lib/admin_dashboard/reports/` at `typed: strict`; `Admin::DashboardController` at `typed: true`.
- `ResolvedReport`: `Data.define` → `T::Struct` with typed fields. Keyword construction, value equality, and `to_h`-with-key semantics preserved — no caller or spec changes needed. Constructing a report with a nil title now fails fast at the source instead of surfacing later as a broken sort in `Listing`.
- `SourceProvider`: the `raise NotImplementedError` contract moves from YARD comments to `abstract` sigs, so the batch shapes (`Hash[String, ResolvedReport]` returns, nilable guardian, keyset cursor) are machine-enforced at the plugin boundary.
- `Registry.providers` returns `T::Array[T.class_of(SourceProvider)]` — a plugin registering the wrong class is caught immediately.
- `parse_reports_items_payload` in the controller is the typed boundary between untyped ActionController params and the lib classes.
- `sorbet/config` is scoped to just this namespace with hand-written RBI shims (`sorbet/rbi/shims/`) for the external surface. Tapioca was deliberately skipped — generating RBIs for all of Discourse isn't needed to evaluate the approach.

## Verification

- `bundle exec srb tc`: clean.
- `spec/lib/admin_dashboard` + model specs (36), `spec/requests/admin/dashboard_controller_spec.rb` (80), and data-explorer plugin provider specs (19): all pass with runtime sig checks enabled.

## Findings

**Wins:** the plugin boundary is where Sorbet pays off most — third-party providers now get their inputs/outputs validated with immediate, well-located exceptions instead of silently corrupting dashboard rendering. Typing also forced explicit nil-narrowing in `Section#build` and let defensive `.to_s` calls in sort paths be dropped.

**Limitations:** `Registry.dispatch_per_source` stays `T.untyped` because it accepts both param hashes and AR rows (a shared struct would be the natural next step); static checking is only as strong as the hand-shimmed boundaries; the service DSL (`UpcomingChanges::Toggle.call` block) `instance_exec`s methods Sorbet can't model, requiring shims; and sigs default to always-checked, so production adoption would want `T::Configuration` set to log-don't-raise or tests-only checking. Two gems (prism, pdf-reader) ship broken RBIs that needed shim fixes.