### PR TITLE
UX: Sort assignment notification menu by topic bump date

### DIFF
--- a/plugins/discourse-assign/assets/javascripts/discourse/components/user-menu/assigns-list.js
+++ b/plugins/discourse-assign/assets/javascripts/discourse/components/user-menu/assigns-list.js
@@ -64,7 +64,7 @@ class SortedItems {
   @tracked
   itemsSorting = [
     "notification.read",
-    "notification.data.message:desc",
+    "notification.topic_bumped_at:desc",
     "notification.created_at:desc",
   ];
 

--- a/plugins/discourse-assign/plugin.rb
+++ b/plugins/discourse-assign/plugin.rb
@@ -69,6 +69,14 @@ after_initialize do
   add_to_serializer(:user, :reminders_frequency) { RemindAssignsFrequencySiteSettings.values }
 
   add_to_serializer(
+    :notification,
+    :topic_bumped_at,
+    include_condition: -> do
+      object.notification_type == Notification.types[:assigned] && object.topic.present?
+    end,
+  ) { object.topic.bumped_at }
+
+  add_to_serializer(
     :group_show,
     :assignment_count,
     include_condition: -> { scope.can_assign_globally? },

--- a/plugins/discourse-assign/spec/system/user_menu_spec.rb
+++ b/plugins/discourse-assign/spec/system/user_menu_spec.rb
@@ -11,30 +11,31 @@ RSpec.describe "Assign | User Menu" do
   end
 
   describe "Assign tab ordering" do
-    let!(:unread_user_assign) { Fabricate(:assignment_notification, user: admin) }
-    let!(:unread_user_assign_2) { Fabricate(:assignment_notification, user: admin) }
-    let!(:read_user_assign) { Fabricate(:assignment_notification, user: admin, read: true) }
-    let!(:read_user_assign_2) { Fabricate(:assignment_notification, user: admin, read: true) }
-    let!(:unread_group_assign) { Fabricate(:assignment_notification, user: admin, group: true) }
-    let!(:read_group_assign) do
-      Fabricate(:assignment_notification, user: admin, read: true, group: true)
-    end
-    let(:expected_order) do
-      [
-        unread_user_assign_2,
-        unread_user_assign,
-        unread_group_assign,
-        read_user_assign_2,
-        read_user_assign,
-        read_group_assign,
-      ].map { it.topic.fancy_title }
+    fab!(:newest_topic) { Fabricate(:topic, bumped_at: 1.hour.ago) }
+    fab!(:middle_topic) { Fabricate(:topic, bumped_at: 2.hours.ago) }
+    fab!(:oldest_topic) { Fabricate(:topic, bumped_at: 3.hours.ago) }
+
+    fab!(:older_unread_assign) do
+      Fabricate(:assignment_notification, user: admin, topic: oldest_topic)
     end
 
-    it "orders the items properly" do
+    fab!(:newer_read_assign) do
+      Fabricate(:assignment_notification, user: admin, topic: newest_topic, read: true)
+    end
+
+    fab!(:middle_unread_group_assign) do
+      Fabricate(:assignment_notification, user: admin, topic: middle_topic, group: true)
+    end
+
+    it "keeps unread items first and orders them by topic bump date" do
       visit "/"
       user_menu.open
       user_menu.click_assignments_tab
-      expect(user_menu).to have_assignments_in_order(expected_order)
+      expect(user_menu).to have_assignments_in_order(
+        [middle_unread_group_assign, older_unread_assign, newer_read_assign].map do
+          it.topic.fancy_title
+        end,
+      )
     end
   end
 end

--- a/plugins/discourse-assign/test/javascripts/acceptance/assigns-tab-user-menu-test.js
+++ b/plugins/discourse-assign/test/javascripts/acceptance/assigns-tab-user-menu-test.js
@@ -15,6 +15,7 @@ const USER_MENU_ASSIGN_RESPONSE = {
       read: false,
       high_priority: true,
       created_at: "2022-08-11T21:32:32.404Z",
+      topic_bumped_at: "2022-08-11T21:32:32.404Z",
       post_number: 1,
       topic_id: 227,
       fancy_title: "Test poll topic please bear with me :heart:",
@@ -33,6 +34,7 @@ const USER_MENU_ASSIGN_RESPONSE = {
       read: true,
       high_priority: true,
       created_at: "2022-08-11T21:32:32.404Z",
+      topic_bumped_at: "2022-08-12T21:32:32.404Z",
       post_number: 1,
       topic_id: 228,
       fancy_title: "Test poll topic please bear with me 2 :ok_hand:",
@@ -161,7 +163,7 @@ acceptance("user menu", function (needs) {
     );
   });
 
-  test("displays unread assign notifications on top and fills the remaining space with read assigns", async function (assert) {
+  test("displays unread assign notifications first, ordered by topic bump date", async function (assert) {
     await visit("/");
     await click(".d-header-icons .current-user button");
     await click("#user-menu-button-assign-list");


### PR DESCRIPTION
Currently the /u/username/activity/assigns list sorts by
topic bump date for assignments, whereas the user menu for
assigns list sorts by read/unread and then the created_at
date for the notification.

The latter doesn't make much sense, most of the time when
you are working on assignments the ones you are working on
now which are being bumped somewhat frequently are the
ones you want to see first, not in created_at order.

This commit keeps the unread assignments at the top of the
list, but sorts the rest by topic bump date.
