### PR TITLE
UX: Restrict active reviewable notifications and badges to moderators

### DIFF
--- a/app/controllers/reviewables_controller.rb
+++ b/app/controllers/reviewables_controller.rb
@@ -94,6 +94,9 @@ class ReviewablesController < ApplicationController
   end
 
   def user_menu_list
+    unless current_user.moderator?
+      return render_json_dump({ reviewables: [], reviewable_count: 0 }, rest_serializer: true)
+    end
     json = {
       reviewables:
         Reviewable.basic_serializers_for_list(

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -666,7 +666,7 @@ class Reviewable < ActiveRecord::Base
   end
 
   def notify_users(result, guardian)
-    group_ids = Set.new([Group::AUTO_GROUPS[:staff]])
+    group_ids = Set.new([Group::AUTO_GROUPS[:moderators]])
 
     if SiteSetting.enable_category_group_moderation? && category
       group_ids.merge(category.moderating_group_ids)

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -628,6 +628,7 @@ class Reviewable < ActiveRecord::Base
   end
 
   def self.user_menu_list_for(user, limit: 30)
+    return [] unless user.moderator?
     list_for(user, limit: limit, status: :pending, include_claimed_by_others: false).to_a
   end
 

--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -478,6 +478,7 @@ class Reviewable < ActiveRecord::Base
   end
 
   def self.unseen_reviewable_count(user)
+    return 0 unless user.moderator?
     unseen_list_for(user).count
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -867,8 +867,8 @@ class User < ActiveRecord::Base
 
   def publish_reviewable_counts(extra_data = nil)
     data = {
-      reviewable_count: reviewable_count,
-      unseen_reviewable_count: Reviewable.unseen_reviewable_count(self),
+      reviewable_count: moderator? ? reviewable_count : 0,
+      unseen_reviewable_count: moderator? ? Reviewable.unseen_reviewable_count(self) : 0,
     }
     data.merge!(extra_data) if extra_data.present?
     MessageBus.publish("/reviewable_counts/#{id}", data, user_ids: [id])

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -366,8 +366,14 @@ class CurrentUserSerializer < BasicUserSerializer
   def featured_topic
     BasicTopicSerializer.new(object.user_profile.featured_topic, scope: scope, root: false).as_json
   end
+  
+  def reviewable_count
+    return 0 unless object.moderator?
+    object.reviewable_count
+  end
 
   def unseen_reviewable_count
+    return 0 unless object.moderator?
     Reviewable.unseen_reviewable_count(object)
   end
 

--- a/spec/jobs/refresh_users_reviewable_counts_spec.rb
+++ b/spec/jobs/refresh_users_reviewable_counts_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Jobs::RefreshUsersReviewableCounts do
       user_message = messages.find { |m| m.user_ids == [user.id] }
 
       expect(admin_message.channel).to eq("/reviewable_counts/#{admin.id}")
-      expect(admin_message.data).to eq(reviewable_count: 3, unseen_reviewable_count: 3)
+      expect(admin_message.data).to eq(reviewable_count: 3, unseen_reviewable_count: 0)
 
       expect(moderator_message.channel).to eq("/reviewable_counts/#{moderator.id}")
       expect(moderator_message.data).to eq(reviewable_count: 2, unseen_reviewable_count: 2)

--- a/spec/jobs/refresh_users_reviewable_counts_spec.rb
+++ b/spec/jobs/refresh_users_reviewable_counts_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Jobs::RefreshUsersReviewableCounts do
       user_message = messages.find { |m| m.user_ids == [user.id] }
 
       expect(admin_message.channel).to eq("/reviewable_counts/#{admin.id}")
-      expect(admin_message.data).to eq(reviewable_count: 3, unseen_reviewable_count: 0)
+      expect(admin_message.data).to eq(reviewable_count: 0, unseen_reviewable_count: 0)
 
       expect(moderator_message.channel).to eq("/reviewable_counts/#{moderator.id}")
       expect(moderator_message.data).to eq(reviewable_count: 2, unseen_reviewable_count: 2)

--- a/spec/requests/reviewables_controller_spec.rb
+++ b/spec/requests/reviewables_controller_spec.rb
@@ -474,6 +474,9 @@ RSpec.describe ReviewablesController do
     end
 
     describe "#user_menu_list" do
+      fab!(:moderator) { Fabricate(:moderator) }
+      before { sign_in(moderator) }
+      
       it "renders each reviewable using its basic serializers" do
         reviewable_user = Fabricate(:reviewable_user, payload: { username: "someb0dy" })
         reviewable_flagged_post = Fabricate(:reviewable_flagged_post)


### PR DESCRIPTION
## What is the purpose of this Pull Request?
Currently, Discourse broadcasts review queue notifications (flags, queued posts) to the entire `staff` group. This results in significant notification noise for "pure Admins" who are not members of the Moderator group, and thus, not involved in the day-to-day moderation of the community. 

Following the discussion on Meta here: https://meta.discourse.org/t/add-setting-to-not-show-flag-notification-to-admins-who-are-not-moderators/383964/5

This PR makes flags only notify the Moderators group instead of staff; thus, Admins not in the moderators group are not notified of flags nor see a review queue count indicator in sidebar (they can still go to the review queue manually as usual). That is, it mutes the active UI elements for pure Admins while preserving their underlying permission to access and action the review queue if they choose to. 

### Technical Implementation:
This PR intercepts the reviewable counts at the Model and Serializer layers to securely silence the frontend without modifying underlying database permissions or the core `/review` route.

1. **Websockets & Live Updates:** 
   * Scoped `notify_users` to `moderators` instead of `staff` to prevent live browser "pops" for admins.
   * Updated `publish_reviewable_counts` to push `0` counts to pure admins.
2. **UI Badges & Preloaders:**
   * Overrode `unseen_reviewable_count` and `reviewable_count` in `CurrentUserSerializer` to clear the red avatar flag, the blue menu badge, and the sidebar count for pure admins.
   * Intercepted `Reviewable.user_menu_list_for` to return an empty array for non-moderators, effectively silencing the `<meta>` tag preloader and the user menu dropdown API.
3. **Tests:** Updated `refresh_users_reviewable_counts_spec` to expect `0` for admin payloads. *(Note: CI is running, will update any other strictly `staff`-scoped spec expectations as needed!)*

### Testing Performed:
Manually verified on a live development install with three distinct user roles:
- [x] **Pure Admin (Admin = true, Moderator = false):** Receives 0 websocket pops, no red avatar badge, no blue menu badge, and an empty menu dropdown. Can still successfully manually navigate to `/review` and action pending flags.
- [x] **Pure Moderator (Admin = false, Moderator = true):** Behavior remains exactly as it was. Fully receives websockets, badges, and dropdown items.
- [x] **Hybrid Staff (Admin = true, Moderator = true):** Behavior remains exactly as it was (receives all notifications).
- [ ] **Category Moderators:** not tested yet.

### Files Touched:
* app/models/reviewable.rb
* app/models/user.rb
* app/serializers/current_user_serializer.rb
* app/controllers/reviewables_controller.rb
* spec/jobs/refresh_users_reviewable_counts_spec.rb
* spec/requests/reviewables_controller_spec.rb
