### PR TITLE
DEV: Turn on AI data explorer queries by default

### DIFF
--- a/plugins/discourse-data-explorer/config/settings.yml
+++ b/plugins/discourse-data-explorer/config/settings.yml
@@ -3,7 +3,7 @@ discourse_data_explorer:
     default: false
     client: true
   data_explorer_ai_queries_enabled:
-    default: false
+    default: true
     client: true
     depends_on:
       - discourse_ai_enabled

--- a/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
+++ b/plugins/discourse-data-explorer/spec/requests/query_controller_spec.rb
@@ -1120,8 +1120,6 @@ describe DiscourseDataExplorer::QueryController do
     end
 
     describe "#generate_with_ai" do
-      before { SiteSetting.data_explorer_ai_queries_enabled = true }
-
       it "returns 404 when AI queries are disabled" do
         SiteSetting.data_explorer_ai_queries_enabled = false
         post "/admin/plugins/discourse-data-explorer/queries/generate.json",
@@ -1144,7 +1142,7 @@ describe DiscourseDataExplorer::QueryController do
         expect(response.status).to eq(400)
       end
 
-      it "enqueues a generation job and returns generation_id" do
+      it "enqueues a generation job by default and returns generation_id" do
         post "/admin/plugins/discourse-data-explorer/queries/generate.json",
              params: {
                ai_description: "show me users",

--- a/plugins/discourse-data-explorer/spec/system/new_query_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/new_query_spec.rb
@@ -7,6 +7,7 @@ describe "Data explorer new query" do
 
   before do
     SiteSetting.data_explorer_enabled = true
+    SiteSetting.data_explorer_ai_queries_enabled = false
     sign_in admin
   end
 

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/new-query-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/new-query-test.js
@@ -8,7 +8,10 @@ import {
 
 acceptance("New Query", function (needs) {
   needs.user();
-  needs.settings({ data_explorer_enabled: true });
+  needs.settings({
+    data_explorer_enabled: true,
+    data_explorer_ai_queries_enabled: false,
+  });
 
   const dataExplorerStore = new KeyValueStore("discourse_data_explorer_");
 


### PR DESCRIPTION
Now that we've reached a certain level of confidence for data explorer query generation using AI, we can turn it on by default.