### PR TITLE
SECURITY: Prevent HTML injection in discourse-local-dates rendering

### DIFF
--- a/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
+++ b/plugins/discourse-local-dates/assets/javascripts/initializers/discourse-local-dates.js
@@ -43,8 +43,12 @@ export function applyLocalDates(dates, siteSettings, timezone) {
     element.insertAdjacentHTML(
       "beforeend",
       `${iconHTML("earth-americas")}
-        <span class="relative-time">${localDateBuilder.formatted}</span>`
+        `
     );
+    const relativeTime = document.createElement("span");
+    relativeTime.classList.add("relative-time");
+    relativeTime.textContent = localDateBuilder.formatted;
+    element.appendChild(relativeTime);
     element.setAttribute("aria-label", localDateBuilder.textPreview);
 
     const classes = ["cooked-date"];

--- a/plugins/discourse-local-dates/spec/system/local_dates_format_injection_spec.rb
+++ b/plugins/discourse-local-dates/spec/system/local_dates_format_injection_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe "Local dates" do
+  fab!(:topic)
+  fab!(:attacker) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:victim) { Fabricate(:user, refresh_auto_groups: true) }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:xss_probe) { "<img src=x class=xss-probe>" }
+
+  before { SiteSetting.discourse_local_dates_enabled = true }
+
+  it "renders a crafted data-format as literal text for viewers, injecting no markup" do
+    create_post(
+      user: attacker,
+      topic: topic,
+      raw:
+        %(<span class="discourse-local-date" data-date="2025-01-01" data-time="05:00:00" data-format="[#{CGI.escapeHTML(xss_probe)}]"></span>),
+    )
+    sign_in(victim)
+    topic_page.visit_topic(topic)
+
+    expect(page).to have_css(".discourse-local-date.cooked-date")
+    expect(page).to have_no_css(".cooked img.xss-probe")
+    expect(page).to have_css(".discourse-local-date .relative-time", text: xss_probe)
+  end
+
+  it "shows the hover preview without injecting markup from a crafted data-format" do
+    create_post(
+      user: attacker,
+      topic: topic,
+      raw:
+        %(<span class="discourse-local-date" data-date="2025-01-01" data-time="05:00:00" data-format="[#{CGI.escapeHTML(xss_probe)}]"></span>),
+    )
+    sign_in(victim)
+    topic_page.visit_topic(topic)
+
+    expect(page).to have_css(".discourse-local-date.cooked-date")
+    find(".discourse-local-date").click
+
+    expect(page).to have_css("[data-content] .current .date-time")
+    expect(page).to have_no_css("[data-content] img.xss-probe")
+  end
+end

--- a/plugins/discourse-local-dates/test/javascripts/unit/discourse-local-dates-test.js
+++ b/plugins/discourse-local-dates/test/javascripts/unit/discourse-local-dates-test.js
@@ -122,4 +122,95 @@ module("Unit | discourse-local-dates", function (hooks) {
       }
     );
   });
+
+  test("applyLocalDates renders a crafted data-format as literal text without injecting HTML", function (assert) {
+    const element = createElementFromHTML(
+      "<span " +
+        'data-date="2022-10-06" ' +
+        'data-time="17:21:00" ' +
+        'class="discourse-local-date" ' +
+        'data-timezone="Asia/Singapore" ' +
+        'data-format="[<img src=x class=xss-probe>]">' +
+        "</span>"
+    );
+
+    freezeTime(
+      { date: "2022-10-06T10:10:10", timezone: "Asia/Singapore" },
+      () => {
+        applyLocalDates([element], { discourse_local_dates_enabled: true });
+
+        assert.dom("img", element).doesNotExist();
+        assert
+          .dom(".relative-time", element)
+          .includesText("<img src=x class=xss-probe>");
+      }
+    );
+  });
+
+  test("applyLocalDates renders a crafted data-displayed-timezone as literal text without injecting HTML", function (assert) {
+    const element = createElementFromHTML(
+      "<span " +
+        'data-date="2022-10-06" ' +
+        'data-time="17:21:00" ' +
+        'class="discourse-local-date" ' +
+        'data-timezone="Asia/Singapore" ' +
+        'data-displayed-timezone="<img src=x class=xss-probe>">' +
+        "</span>"
+    );
+
+    freezeTime(
+      { date: "2022-10-06T10:10:10", timezone: "Asia/Singapore" },
+      () => {
+        applyLocalDates([element], { discourse_local_dates_enabled: true });
+
+        assert.dom("img", element).doesNotExist();
+        assert
+          .dom(".relative-time", element)
+          .includesText("<img src=x class=xss-probe>");
+      }
+    );
+  });
+
+  test("applyLocalDates renders a crafted data-timezone as literal text without injecting HTML", function (assert) {
+    const element = createElementFromHTML(
+      "<span " +
+        'data-date="2022-10-06" ' +
+        'class="discourse-local-date" ' +
+        'data-timezone="<img src=x class=xss-probe>">' +
+        "</span>"
+    );
+
+    freezeTime(
+      { date: "2022-10-06T10:10:10", timezone: "Asia/Singapore" },
+      () => {
+        applyLocalDates([element], { discourse_local_dates_enabled: true });
+
+        assert.dom("img", element).doesNotExist();
+        assert
+          .dom(".relative-time", element)
+          .includesText("<img src=x class=xss-probe>");
+      }
+    );
+  });
+
+  test("applyLocalDates preserves legitimate bracketed moment literals as text", function (assert) {
+    const element = createElementFromHTML(
+      "<span " +
+        'data-date="2022-10-06" ' +
+        'data-time="17:21:00" ' +
+        'class="discourse-local-date" ' +
+        'data-timezone="Asia/Singapore" ' +
+        'data-format="[at] LL">' +
+        "</span>"
+    );
+
+    freezeTime(
+      { date: "2022-10-06T10:10:10", timezone: "Asia/Singapore" },
+      () => {
+        applyLocalDates([element], { discourse_local_dates_enabled: true });
+
+        assert.dom(".relative-time", element).hasText("at October 6, 2022");
+      }
+    );
+  });
 });


### PR DESCRIPTION
This PR fixes a stored HTML-injection / DOM-XSS in the default-enabled `discourse-local-dates` plugin.

`applyLocalDates` interpolated `LocalDateBuilder#formatted` into an `insertAdjacentHTML` string. On the raw-HTML cook path, three attacker-controlled attributes reach that string unsanitized: `data-format` (via moment's `[...]` literal syntax) and `data-displayed-timezone` / `data-timezone` (via the trailing `(zone)` suffix `_formatWithZone` appends). As a result, attacker-controlled markup is injected into the cooked content every viewer renders.

The default CSP sets `script-src` without `unsafe-inline`, so it blocks the injected inline event handler and script execution does not fire under default settings. It becomes full stored XSS only where CSP has been disabled. Either way the sanitizer guarantee is broken: no attacker markup should reach cooked content. So we fix it at the source.

Key changes:
  * Render the date via `textContent` on a created `.relative-time` span instead of interpolating it into HTML. `formatted` is always plain text, so this is lossless and closes all three attributes at one sink. We preferred this over input validation, which cannot cover the timezone suffix and would break legitimate `[...]` formats.
  * Leave the sanitizer allowlist and the hover-preview sink unchanged. The preview value is built only from fixed format constants and is not reachable by these attributes, and a test guards that.

Custom formats that emitted HTML via `[...]` now render as literal text, which is intended. Covered by qunit (one case per attribute plus a legitimate `[at] LL`) and a system spec that drives the full cook to render path.