### PR TITLE
FIX: Return database connections to the pool after dashboard builds 

### DIFF
--- a/app/services/admin_dashboard_section_loader.rb
+++ b/app/services/admin_dashboard_section_loader.rb
@@ -36,7 +36,9 @@ class AdminDashboardSectionLoader
 
     section_ids.each do |id|
       self.class.thread_pool.post do
-        results << { id: id, data: section_data(id, current_user) }
+        ActiveRecord::Base.with_connection(prevent_permanent_checkout: true) do
+          results << { id: id, data: section_data(id, current_user) }
+        end
       rescue StandardError => e
         results << { id: id, error: e }
       end

--- a/spec/services/admin_dashboard_section_loader_spec.rb
+++ b/spec/services/admin_dashboard_section_loader_spec.rb
@@ -99,3 +99,39 @@ describe AdminDashboardSectionLoader do
     end
   end
 end
+
+describe AdminDashboardSectionLoader do
+  self.use_transactional_tests = false
+
+  after do
+    if thread_pool = described_class.instance_variable_get(:@thread_pool)
+      thread_pool.shutdown
+      thread_pool.wait_for_termination(timeout: 1)
+      described_class.remove_instance_variable(:@thread_pool)
+    end
+  end
+
+  it "returns database connections to the pool once a section finishes building" do
+    worker_thread = nil
+    loader = ->(start_date:, end_date:, current_user:) do
+      worker_thread = Thread.current
+      ActiveRecord::Base.connection.execute("SELECT 1")
+      { value: "leaky" }
+    end
+    DiscoursePluginRegistry.stubs(:admin_dashboard_sections).returns(
+      [{ id: "leaky", enabled: -> { true }, loader: loader }],
+    )
+
+    described_class.build(
+      section_ids: ["leaky"],
+      current_user: Discourse.system_user,
+      start_date: "2026-05-01",
+      end_date: "2026-05-07",
+    )
+
+    expect(worker_thread).not_to eq(Thread.current)
+    wait_for do
+      ActiveRecord::Base.connection_pool.connections.none? { |c| c.owner == worker_thread }
+    end
+  end
+end


### PR DESCRIPTION
Previously, AdminDashboardSectionLoader worker threads leased a database connection on their first query and held it while idling in the shared thread pool, which exhausted the connection pool (sized 5 in development) and made subsequent requests fail with "could not obtain a connection from the pool within 5.000 seconds".

This change wraps each section build in
ActiveRecord::Base.with_connection(prevent_permanent_checkout: true) so the connection is checked back in as soon as the section finishes building - the flag is required because sections use ActiveRecord::Base.connection internally, which would otherwise mark the connection as permanently checked out for the thread. The regression spec lives in a separate describe block with use_transactional_tests = false because both transactional tests and fab!'s before(:all) transaction pin a single shared connection across threads, which masks the leak.