### PR TITLE
FEATURE: Add category scope for AI translations

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22469,6 +22469,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260708080308'),
 ('20260707013407'),
 ('20260702102111'),
 ('20260701073045'),

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -11,6 +11,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Category from "discourse/models/category";
 import CategorySelector from "discourse/select-kit/components/category-selector";
+import ComboBox from "discourse/select-kit/components/combo-box";
 import MultiSelect from "discourse/select-kit/components/multi-select";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
@@ -48,24 +49,25 @@ export default class AiTranslations extends Component {
   @tracked isTogglingTranslation = false;
   @tracked creditStatus = null;
   @tracked creditCheckComplete = false;
-  @tracked excludedCategories = [];
-  @tracked
-  originalExcludedCategoryIds = this.args.model?.excluded_category_ids || [];
+  @tracked categoryScope = this.args.model?.category_scope || "public";
+  @tracked originalCategoryScope = this.args.model?.category_scope || "public";
+  @tracked categories = [];
+  @tracked originalCategoryIds = this.args.model?.category_ids || [];
   hourlyRate = this.args.model?.hourly_rate || 0;
 
   constructor() {
     super(...arguments);
     this._checkCredits();
-    this._loadExcludedCategories();
+    this._loadCategories();
     if (this.enabled) {
       this._loadProgress();
     }
   }
 
-  async _loadExcludedCategories() {
-    const ids = this.args.model?.excluded_category_ids || [];
+  async _loadCategories() {
+    const ids = this.args.model?.category_ids || [];
     if (ids.length) {
-      this.excludedCategories = await Category.asyncFindByIds(ids);
+      this.categories = await Category.asyncFindByIds(ids);
     }
   }
 
@@ -129,11 +131,33 @@ export default class AiTranslations extends Component {
   }
 
   get categoriesChanged() {
-    const current = [...this.excludedCategories.map((c) => c.id)]
+    const current = [...this.categories.map((category) => category.id)]
       .sort()
       .join("|");
-    const original = [...this.originalExcludedCategoryIds].sort().join("|");
-    return current !== original;
+    const original = [...this.originalCategoryIds].sort().join("|");
+    return (
+      this.categoryScope !== this.originalCategoryScope || current !== original
+    );
+  }
+
+  get categoryScopeOptions() {
+    return [
+      "all",
+      "public",
+      "include",
+      "include_strict",
+      "exclude",
+      "exclude_strict",
+    ].map((value) => ({
+      value,
+      name: i18n(`category_scope.${value}`),
+    }));
+  }
+
+  get showCategorySelector() {
+    return ["include", "include_strict", "exclude", "exclude_strict"].includes(
+      this.categoryScope
+    );
   }
 
   get isToggleDisabled() {
@@ -221,22 +245,31 @@ export default class AiTranslations extends Component {
   }
 
   @action
-  updateExcludedCategories(categories) {
-    this.excludedCategories = categories;
+  updateCategoryScope(scope) {
+    this.categoryScope = scope;
+  }
+
+  @action
+  updateCategories(categories) {
+    this.categories = categories;
   }
 
   @action
   async saveCategories() {
     this.isSavingCategories = true;
     try {
-      const ids = this.excludedCategories.map((c) => c.id);
-      await ajax("/admin/site_settings/ai_translation_excluded_categories", {
+      const ids = this.categories.map((category) => category.id);
+      await ajax("/admin/site_settings/bulk_update", {
         type: "PUT",
         data: {
-          ai_translation_excluded_categories: ids.join("|"),
+          settings: {
+            ai_translation_category_scope: { value: this.categoryScope },
+            ai_translation_categories: { value: ids.join("|") },
+          },
         },
       });
-      this.originalExcludedCategoryIds = ids;
+      this.originalCategoryScope = this.categoryScope;
+      this.originalCategoryIds = ids;
     } catch (e) {
       popupAjaxError(e);
     } finally {
@@ -246,14 +279,14 @@ export default class AiTranslations extends Component {
 
   @action
   async cancelCategories() {
-    this.excludedCategories = await Category.asyncFindByIds(
-      this.originalExcludedCategoryIds
-    );
+    this.categoryScope = this.originalCategoryScope;
+    this.categories = await Category.asyncFindByIds(this.originalCategoryIds);
   }
 
   @action
   resetCategories() {
-    this.excludedCategories = [];
+    this.categoryScope = "public";
+    this.categories = [];
   }
 
   @action
@@ -577,43 +610,83 @@ export default class AiTranslations extends Component {
             <div class="setting">
               <div class="setting-label">
                 <label>{{i18n
-                    "discourse_ai.translations.excluded_categories"
+                    "discourse_ai.translations.category_scope"
                   }}</label>
               </div>
               <div class="setting-value">
                 <div class="ai-translations__category-input-row">
-                  <CategorySelector
-                    @categories={{this.excludedCategories}}
-                    @onChange={{this.updateExcludedCategories}}
-                  />
-                  {{#if this.categoriesChanged}}
-                    <div class="setting-controls">
-                      <DButton
-                        @action={{this.saveCategories}}
-                        @icon="check"
-                        @isLoading={{this.isSavingCategories}}
-                        @ariaLabel="save"
-                        class="ok setting-controls__ok"
-                      />
-                      <DButton
-                        @action={{this.cancelCategories}}
-                        @icon="xmark"
-                        @isLoading={{this.isSavingCategories}}
-                        @ariaLabel="cancel"
-                        class="cancel setting-controls__cancel"
-                      />
-                    </div>
-                  {{else if this.excludedCategories.length}}
-                    <DButton
-                      @action={{this.resetCategories}}
-                      @icon="arrow-rotate-left"
-                      @label="admin.settings.reset"
-                      class="undo setting-controls__undo"
+                  <div class="ai-translations__category-scope-row">
+                    <ComboBox
+                      @value={{this.categoryScope}}
+                      @content={{this.categoryScopeOptions}}
+                      @onChange={{this.updateCategoryScope}}
+                      @valueProperty="value"
+                      @nameProperty="name"
                     />
+                    {{#unless this.showCategorySelector}}
+                      {{#if this.categoriesChanged}}
+                        <div class="setting-controls">
+                          <DButton
+                            @action={{this.saveCategories}}
+                            @icon="check"
+                            @isLoading={{this.isSavingCategories}}
+                            @ariaLabel="save"
+                            class="ok setting-controls__ok"
+                          />
+                          <DButton
+                            @action={{this.cancelCategories}}
+                            @icon="xmark"
+                            @isLoading={{this.isSavingCategories}}
+                            @ariaLabel="cancel"
+                            class="cancel setting-controls__cancel"
+                          />
+                        </div>
+                      {{else if this.categories.length}}
+                        <DButton
+                          @action={{this.resetCategories}}
+                          @icon="arrow-rotate-left"
+                          @label="admin.settings.reset"
+                          class="undo setting-controls__undo"
+                        />
+                      {{/if}}
+                    {{/unless}}
+                  </div>
+                  {{#if this.showCategorySelector}}
+                    <div class="ai-translations__category-selector-row">
+                      <CategorySelector
+                        @categories={{this.categories}}
+                        @onChange={{this.updateCategories}}
+                      />
+                      {{#if this.categoriesChanged}}
+                        <div class="setting-controls">
+                          <DButton
+                            @action={{this.saveCategories}}
+                            @icon="check"
+                            @isLoading={{this.isSavingCategories}}
+                            @ariaLabel="save"
+                            class="ok setting-controls__ok"
+                          />
+                          <DButton
+                            @action={{this.cancelCategories}}
+                            @icon="xmark"
+                            @isLoading={{this.isSavingCategories}}
+                            @ariaLabel="cancel"
+                            class="cancel setting-controls__cancel"
+                          />
+                        </div>
+                      {{else if this.categories.length}}
+                        <DButton
+                          @action={{this.resetCategories}}
+                          @icon="arrow-rotate-left"
+                          @label="admin.settings.reset"
+                          class="undo setting-controls__undo"
+                        />
+                      {{/if}}
+                    </div>
                   {{/if}}
                 </div>
                 <div class="desc">{{i18n
-                    "discourse_ai.translations.excluded_categories_description"
+                    "discourse_ai.translations.category_scope_description"
                   }}</div>
               </div>
             </div>

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -39,7 +39,8 @@ module DiscourseAi
           translation_enabled: SiteSetting.ai_translation_enabled,
           hourly_rate: SiteSetting.ai_translation_backfill_hourly_rate,
           backfill_max_age_days: SiteSetting.ai_translation_backfill_max_age_days,
-          excluded_category_ids: DiscourseAi::Translation.excluded_category_ids,
+          category_scope: SiteSetting.ai_translation_category_scope,
+          category_ids: DiscourseAi::Translation.category_ids,
         }
       end
     end

--- a/plugins/discourse-ai/app/jobs/regular/detect_translate_post.rb
+++ b/plugins/discourse-ai/app/jobs/regular/detect_translate_post.rb
@@ -37,7 +37,7 @@ module Jobs
           return
         end
       else
-        return if DiscourseAi::Translation.category_excluded?(topic.category_id)
+        return if !DiscourseAi::Translation.category_allowed?(topic.category)
       end
 
       # the user may fill locale in manually

--- a/plugins/discourse-ai/app/jobs/regular/detect_translate_topic.rb
+++ b/plugins/discourse-ai/app/jobs/regular/detect_translate_topic.rb
@@ -34,7 +34,7 @@ module Jobs
           return
         end
       else
-        return if DiscourseAi::Translation.category_excluded?(topic.category_id)
+        return if !DiscourseAi::Translation.category_allowed?(topic.category)
       end
 
       if (detected_locale = topic.locale).blank?

--- a/plugins/discourse-ai/app/jobs/scheduled/categories_locale_detection_backfill.rb
+++ b/plugins/discourse-ai/app/jobs/scheduled/categories_locale_detection_backfill.rb
@@ -19,9 +19,7 @@ module Jobs
         return
       end
 
-      categories = Category.where(locale: nil)
-      excluded_category_ids = DiscourseAi::Translation.excluded_category_ids
-      categories = categories.where.not(id: excluded_category_ids) if excluded_category_ids.present?
+      categories = DiscourseAi::Translation::CategoryCandidates.get.where(locale: nil)
 
       limit = SiteSetting.ai_translation_backfill_hourly_rate
       categories = categories.limit(limit)

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-feature-setting-groups.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-feature-setting-groups.js
@@ -177,7 +177,8 @@ export const AI_FEATURE_SETTING_GROUPS = {
         "discourse_ai.features.translation.setting_groups.backfill_and_limits",
       settings: [
         "ai_translation_backfill_hourly_rate",
-        "ai_translation_excluded_categories",
+        "ai_translation_category_scope",
+        "ai_translation_categories",
         "ai_translation_personal_messages",
         "ai_translation_include_bot_content",
         "ai_translation_max_post_length",

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -12,7 +12,8 @@
   &__category-input-row {
     display: flex;
     align-items: center;
-    gap: 0.5em;
+    flex-wrap: wrap;
+    gap: var(--space-2);
 
     .multi-select,
     .category-selector {
@@ -21,11 +22,16 @@
 
     .setting-controls {
       float: none;
+      margin-inline-start: auto;
+    }
+
+    .setting-controls__undo {
+      margin-inline-start: auto;
     }
   }
 
   .settings .setting {
-    padding: 0.5em;
+    padding: var(--space-2);
 
     .setting-label,
     .setting-value {
@@ -41,6 +47,39 @@
       .select-kit {
         // Not ideal, but upstream .select-kit gets a width: 100% !important that is too eager
         max-width: calc(100% - 100px);
+      }
+    }
+  }
+
+  &__category-input-row {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    .setting-controls {
+      display: flex;
+      gap: var(--space-1);
+    }
+  }
+
+  &__category-scope-row,
+  &__category-selector-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+
+    .combo-box,
+    .category-selector {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+  }
+
+  .settings .setting .setting-value {
+    .ai-translations__category-scope-row,
+    .ai-translations__category-selector-row {
+      .select-kit {
+        max-width: 100%;
       }
     }
   }

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -411,8 +411,8 @@ en:
         description: "Automatically translate all content on your forum to the user's preferred language"
         supported_locales: "Supported languages"
         supported_locales_description: "This site setting also allows visitors to contribute post translations."
-        excluded_categories: "Excluded categories"
-        excluded_categories_description: "Content in these categories will not be translated. Leave empty to translate content in all categories, including private categories."
+        category_scope: "Categories"
+        category_scope_description: "Choose whether automatic translations use all categories, public categories, or selected categories."
         admin_actions:
           translation_settings: "Translation settings"
           localization_settings: "Localization settings"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -153,7 +153,8 @@ en:
     ai_discord_allowed_guilds: "Discord guilds (servers) where the bot is allowed to search"
 
     ai_translation_enabled: "Enable the AI translation feature"
-    ai_translation_excluded_categories: "Content in these categories will not be translated. Leave empty to translate content in all categories, including private categories."
+    ai_translation_category_scope: "Choose which categories AI translation can use. Include and exclude options use {{setting:ai_translation_categories}}. Personal messages are controlled by {{setting:ai_translation_personal_messages}}."
+    ai_translation_categories: "Categories used when the AI translation category scope is set to <strong>include</strong> or <strong>exclude</strong>."
     ai_translation_personal_messages: "Controls which personal messages are translated. 'none' disables PM translation. 'group' translates only group PMs. 'all' translates all PMs."
     ai_translation_include_bot_content: "When enabled, content written by bots (user IDs below 0) will also be sent for translation."
     ai_translation_max_post_length: "The maximum number of characters for a post to be translated. Posts longer than this will not be translated."

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -504,11 +504,27 @@ discourse_ai:
     max: 100000
     client: false
     area: "ai-features/translation"
-  ai_translation_excluded_categories:
+  ai_translation_category_scope:
+    type: enum
+    default: "public"
+    enum: "CategoryScopeSiteSetting"
+    client: false
+    area: "ai-features/translation"
+  ai_translation_categories:
     type: category_list
     default: ""
     client: false
     area: "ai-features/translation"
+    depends_on:
+      - ai_translation_category_scope
+    depends_on_values:
+      ai_translation_category_scope:
+        - include
+        - include_strict
+        - exclude
+        - exclude_strict
+    depends_behavior: "hidden"
+    dependent_setting_display: "inline"
   ai_translation_personal_messages:
     type: enum
     default: "none"

--- a/plugins/discourse-ai/db/migrate/20260708080308_convert_ai_translation_excluded_categories_to_category_scope.rb
+++ b/plugins/discourse-ai/db/migrate/20260708080308_convert_ai_translation_excluded_categories_to_category_scope.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class ConvertAiTranslationExcludedCategoriesToCategoryScope < ActiveRecord::Migration[8.0]
+  OLD_SETTING = "ai_translation_excluded_categories"
+  ENABLED_SETTING = "ai_translation_enabled"
+  SCOPE_SETTING = "ai_translation_category_scope"
+  CATEGORIES_SETTING = "ai_translation_categories"
+  ENUM_DATA_TYPE = 7
+  CATEGORY_LIST_DATA_TYPE = 11
+
+  def up
+    excluded_category_ids =
+      DB.query_single("SELECT value FROM site_settings WHERE name = '#{OLD_SETTING}' LIMIT 1").first
+
+    if excluded_category_ids.present?
+      execute <<~SQL
+        INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+        VALUES ('#{SCOPE_SETTING}', #{ENUM_DATA_TYPE}, 'exclude_strict', NOW(), NOW())
+      SQL
+
+      execute <<~SQL
+        INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+        VALUES ('#{CATEGORIES_SETTING}', #{CATEGORY_LIST_DATA_TYPE}, '#{excluded_category_ids}', NOW(), NOW())
+      SQL
+    elsif ai_translation_enabled?
+      execute <<~SQL
+        INSERT INTO site_settings (name, data_type, value, created_at, updated_at)
+        VALUES ('#{SCOPE_SETTING}', #{ENUM_DATA_TYPE}, 'all', NOW(), NOW())
+      SQL
+    end
+
+    execute "DELETE FROM site_settings WHERE name = '#{OLD_SETTING}'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def ai_translation_enabled?
+    DB.query_single(
+      "SELECT value FROM site_settings WHERE name = '#{ENABLED_SETTING}' LIMIT 1",
+    ).first == "t"
+  end
+end

--- a/plugins/discourse-ai/lib/translation.rb
+++ b/plugins/discourse-ai/lib/translation.rb
@@ -38,16 +38,90 @@ module DiscourseAi
         SiteSetting.ai_translation_backfill_max_age_days > 0
     end
 
-    # AI translation intentionally treats every category, including read-restricted
-    # categories, as eligible unless admins add it to the exclusion setting.
-    def self.excluded_category_ids
-      SiteSetting.ai_translation_excluded_categories.to_s.split("|").map(&:to_i)
+    def self.category_ids
+      SiteSetting.ai_translation_categories.to_s.split("|").filter_map { |id| id.presence&.to_i }
     end
 
-    def self.category_excluded?(category_id)
-      return true if category_id.blank?
+    def self.category_ids_with_subcategories
+      category_ids.flat_map { |category_id| Category.subcategory_ids(category_id) }.uniq
+    end
 
-      excluded_category_ids.include?(category_id)
+    def self.category_scope_cache_key
+      ids =
+        case SiteSetting.ai_translation_category_scope
+        when "include", "exclude"
+          category_ids_with_subcategories
+        else
+          category_ids
+        end
+
+      "#{SiteSetting.ai_translation_category_scope}:#{ids.sort.join("|")}"
+    end
+
+    def self.category_scope_condition(category_column:)
+      case SiteSetting.ai_translation_category_scope
+      when "all"
+        ["#{category_column} IS NOT NULL", {}]
+      when "include"
+        ids = category_ids_with_subcategories
+        return "1 = 0", {} if ids.blank?
+
+        ["#{category_column} IN (:category_ids)", { category_ids: ids }]
+      when "include_strict"
+        ids = category_ids
+        return "1 = 0", {} if ids.blank?
+
+        ["#{category_column} IN (:category_ids)", { category_ids: ids }]
+      when "exclude"
+        ids = category_ids_with_subcategories
+        return "#{category_column} IS NOT NULL", {} if ids.blank?
+
+        [
+          "#{category_column} IS NOT NULL AND #{category_column} NOT IN (:category_ids)",
+          { category_ids: ids },
+        ]
+      when "exclude_strict"
+        ids = category_ids
+        return "#{category_column} IS NOT NULL", {} if ids.blank?
+
+        [
+          "#{category_column} IS NOT NULL AND #{category_column} NOT IN (:category_ids)",
+          { category_ids: ids },
+        ]
+      else
+        [
+          "#{category_column} IS NOT NULL AND EXISTS (
+            SELECT 1 FROM categories category_scope_categories
+            WHERE category_scope_categories.id = #{category_column}
+              AND category_scope_categories.read_restricted = false
+          )",
+          {},
+        ]
+      end
+    end
+
+    def self.category_allowed?(category)
+      category_id = category.respond_to?(:id) ? category.id : category
+      return false if category_id.blank?
+
+      case SiteSetting.ai_translation_category_scope
+      when "all"
+        true
+      when "include"
+        category_ids_with_subcategories.include?(category_id)
+      when "include_strict"
+        category_ids.include?(category_id)
+      when "exclude"
+        !category_ids_with_subcategories.include?(category_id)
+      when "exclude_strict"
+        !category_ids.include?(category_id)
+      else
+        if category.respond_to?(:read_restricted)
+          !category.read_restricted
+        else
+          Category.where(id: category_id, read_restricted: false).exists?
+        end
+      end
     end
 
     def self.llm_model_for_agent(agent_id)

--- a/plugins/discourse-ai/lib/translation/category_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/category_candidates.rb
@@ -9,10 +9,20 @@ module DiscourseAi
       # including those without locale detected yet.
       def self.get
         categories = Category.all
-        excluded_category_ids = DiscourseAi::Translation.excluded_category_ids
-        categories =
-          categories.where.not(id: excluded_category_ids) if excluded_category_ids.present?
-        categories
+        case SiteSetting.ai_translation_category_scope
+        when "public"
+          categories.where(read_restricted: false)
+        when "include"
+          categories.where(id: DiscourseAi::Translation.category_ids_with_subcategories)
+        when "include_strict"
+          categories.where(id: DiscourseAi::Translation.category_ids)
+        when "exclude"
+          categories.where.not(id: DiscourseAi::Translation.category_ids_with_subcategories)
+        when "exclude_strict"
+          categories.where.not(id: DiscourseAi::Translation.category_ids)
+        else
+          categories
+        end
       end
 
       def self.calculate_completion_per_locale(locale)

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -59,25 +59,15 @@ module DiscourseAi
 
         posts = posts.joins(:topic)
 
-        # if no categories are excluded, posts from all categories will be sent for translation
-        # private categories need to be explicitly excluded
-        excluded_category_ids = DiscourseAi::Translation.excluded_category_ids
         pm_scope = SiteSetting.ai_translation_personal_messages
+        category_condition, category_params =
+          DiscourseAi::Translation.category_scope_condition(category_column: "topics.category_id")
 
-        if excluded_category_ids.present?
-          posts =
-            posts.where(
-              "topics.category_id NOT IN (:cats) OR topics.archetype = :pm",
-              cats: excluded_category_ids,
-              pm: Archetype.private_message,
-            )
-        else
-          posts =
-            posts.where(
-              "topics.category_id IS NOT NULL OR topics.archetype = :pm",
-              pm: Archetype.private_message,
-            )
-        end
+        posts =
+          posts.where(
+            "topics.archetype = :pm OR (#{category_condition})",
+            category_params.merge(pm: Archetype.private_message),
+          )
 
         # PM scope filter
         case pm_scope
@@ -116,7 +106,7 @@ module DiscourseAi
           SiteSetting.ai_translation_include_bot_content,
           SiteSetting.ai_translation_max_post_length,
           SiteSetting.ai_translation_personal_messages,
-          DiscourseAi::Translation.excluded_category_ids.sort.join(","),
+          DiscourseAi::Translation.category_scope_cache_key,
         ].join(":")
       end
 

--- a/plugins/discourse-ai/lib/translation/topic_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/topic_candidates.rb
@@ -45,23 +45,15 @@ module DiscourseAi
         topics =
           topics.where("topics.user_id > 0") unless SiteSetting.ai_translation_include_bot_content
 
-        excluded_category_ids = DiscourseAi::Translation.excluded_category_ids
         pm_scope = SiteSetting.ai_translation_personal_messages
+        category_condition, category_params =
+          DiscourseAi::Translation.category_scope_condition(category_column: "topics.category_id")
 
-        if excluded_category_ids.present?
-          topics =
-            topics.where(
-              "topics.category_id NOT IN (:cats) OR topics.archetype = :pm",
-              cats: excluded_category_ids,
-              pm: Archetype.private_message,
-            )
-        else
-          topics =
-            topics.where(
-              "topics.category_id IS NOT NULL OR topics.archetype = :pm",
-              pm: Archetype.private_message,
-            )
-        end
+        topics =
+          topics.where(
+            "topics.archetype = :pm OR (#{category_condition})",
+            category_params.merge(pm: Archetype.private_message),
+          )
 
         # PM scope filter
         case pm_scope

--- a/plugins/discourse-ai/spec/db/migrate/20260708080308_convert_ai_translation_excluded_categories_to_category_scope_spec.rb
+++ b/plugins/discourse-ai/spec/db/migrate/20260708080308_convert_ai_translation_excluded_categories_to_category_scope_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "plugins/discourse-ai/db/migrate/20260708080308_convert_ai_translation_excluded_categories_to_category_scope",
+        )
+
+describe ConvertAiTranslationExcludedCategoriesToCategoryScope do
+  subject(:migration) { described_class.new }
+
+  let(:connection) { ActiveRecord::Base.connection }
+
+  fab!(:category_1, :category)
+  fab!(:category_2, :category)
+
+  around { |example| ActiveRecord::Migration.suppress_messages { example.run } }
+
+  before do
+    enable_current_plugin
+    delete_settings
+  end
+
+  after { delete_settings }
+
+  def delete_settings
+    connection.execute(
+      "DELETE FROM site_settings WHERE name IN ('ai_translation_excluded_categories', 'ai_translation_enabled', 'ai_translation_category_scope', 'ai_translation_categories')",
+    )
+  end
+
+  def store_setting(name, val, data_type:)
+    connection.execute <<~SQL
+      INSERT INTO site_settings(name, data_type, value, created_at, updated_at)
+      VALUES ('#{name}', #{data_type}, '#{val}', NOW(), NOW())
+    SQL
+  end
+
+  def setting_value(name)
+    DB.query_single("SELECT value FROM site_settings WHERE name = '#{name}'").first
+  end
+
+  def setting_exists?(name)
+    DB.query_single("SELECT COUNT(*) FROM site_settings WHERE name = '#{name}'").first > 0
+  end
+
+  describe "#up" do
+    it "converts excluded categories to an exact exclude category scope" do
+      store_setting(
+        "ai_translation_excluded_categories",
+        "#{category_1.id}|#{category_2.id}",
+        data_type: 11,
+      )
+
+      migration.up
+
+      expect(setting_value("ai_translation_category_scope")).to eq("exclude_strict")
+      expect(setting_value("ai_translation_categories")).to eq("#{category_1.id}|#{category_2.id}")
+      expect(setting_exists?("ai_translation_excluded_categories")).to eq(false)
+    end
+
+    it "preserves all categories for enabled sites with empty excluded categories" do
+      store_setting("ai_translation_enabled", "t", data_type: 5)
+      store_setting("ai_translation_excluded_categories", "", data_type: 11)
+
+      migration.up
+
+      expect(setting_value("ai_translation_category_scope")).to eq("all")
+      expect(setting_value("ai_translation_categories")).to be_nil
+      expect(setting_exists?("ai_translation_excluded_categories")).to eq(false)
+    end
+
+    it "preserves all categories for enabled sites without stored excluded categories" do
+      store_setting("ai_translation_enabled", "t", data_type: 5)
+
+      migration.up
+
+      expect(setting_value("ai_translation_category_scope")).to eq("all")
+      expect(setting_value("ai_translation_categories")).to be_nil
+    end
+
+    it "uses the public categories default for disabled sites with empty excluded categories" do
+      store_setting("ai_translation_enabled", "f", data_type: 5)
+      store_setting("ai_translation_excluded_categories", "", data_type: 11)
+
+      migration.up
+
+      expect(setting_value("ai_translation_category_scope")).to be_nil
+      expect(setting_value("ai_translation_categories")).to be_nil
+      expect(setting_exists?("ai_translation_excluded_categories")).to eq(false)
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/jobs/regular/detect_translate_post_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/detect_translate_post_spec.rb
@@ -18,7 +18,8 @@ describe Jobs::DetectTranslatePost do
     enable_current_plugin
     SiteSetting.ai_translation_enabled = true
     SiteSetting.content_localization_supported_locales = locales.join("|")
-    SiteSetting.ai_translation_excluded_categories = ""
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   it "does nothing when translator is disabled" do
@@ -144,7 +145,7 @@ describe Jobs::DetectTranslatePost do
     expect { job.execute({ post_id: post.id }) }.not_to raise_error
   end
 
-  describe "with excluded categories and PM scope" do
+  describe "with category scope and PM scope" do
     fab!(:included_category, :category)
     fab!(:excluded_category, :category)
     fab!(:included_topic) { Fabricate(:topic, category: included_category) }
@@ -160,9 +161,12 @@ describe Jobs::DetectTranslatePost do
     end
     fab!(:group_pm_post) { Fabricate(:post, topic: group_pm_topic) }
 
-    before { SiteSetting.ai_translation_excluded_categories = excluded_category.id.to_s }
+    before do
+      SiteSetting.ai_translation_category_scope = "exclude"
+      SiteSetting.ai_translation_categories = excluded_category.id.to_s
+    end
 
-    it "skips posts in excluded categories" do
+    it "skips posts outside the category scope" do
       DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(excluded_post).never
       job.execute({ post_id: excluded_post.id })
     end
@@ -170,6 +174,20 @@ describe Jobs::DetectTranslatePost do
     it "processes posts in included categories" do
       DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(included_post).once
       job.execute({ post_id: included_post.id })
+    end
+
+    it "processes posts from selected subcategories" do
+      subcategory = Fabricate(:category, parent_category: included_category)
+      subcategory_post = Fabricate(:post, topic: Fabricate(:topic, category: subcategory))
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = included_category.id.to_s
+
+      DiscourseAi::Translation::PostLocaleDetector
+        .expects(:detect_locale)
+        .with(subcategory_post)
+        .once
+
+      job.execute({ post_id: subcategory_post.id })
     end
 
     context "when pm_translation_scope is none" do

--- a/plugins/discourse-ai/spec/jobs/regular/detect_translate_topic_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/detect_translate_topic_spec.rb
@@ -12,7 +12,8 @@ describe Jobs::DetectTranslateTopic do
     enable_current_plugin
     SiteSetting.ai_translation_enabled = true
     SiteSetting.content_localization_supported_locales = locales.join("|")
-    SiteSetting.ai_translation_excluded_categories = ""
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   it "does nothing when translator is disabled" do
@@ -139,7 +140,7 @@ describe Jobs::DetectTranslateTopic do
     expect { job.execute({ topic_id: topic.id }) }.not_to raise_error
   end
 
-  describe "with excluded categories and PM scope" do
+  describe "with category scope and PM scope" do
     fab!(:included_category, :category)
     fab!(:excluded_category, :category)
     fab!(:included_topic) { Fabricate(:topic, category: included_category) }
@@ -151,9 +152,12 @@ describe Jobs::DetectTranslateTopic do
       Fabricate(:group_private_message_topic, recipient_group: Fabricate(:group))
     end
 
-    before { SiteSetting.ai_translation_excluded_categories = excluded_category.id.to_s }
+    before do
+      SiteSetting.ai_translation_category_scope = "exclude"
+      SiteSetting.ai_translation_categories = excluded_category.id.to_s
+    end
 
-    it "skips topics in excluded categories" do
+    it "skips topics outside the category scope" do
       DiscourseAi::Translation::TopicLocaleDetector
         .expects(:detect_locale)
         .with(excluded_topic)
@@ -171,8 +175,9 @@ describe Jobs::DetectTranslateTopic do
       job.execute({ topic_id: included_topic.id })
     end
 
-    it "processes regular topics when excluded categories is empty" do
-      SiteSetting.ai_translation_excluded_categories = ""
+    it "processes regular topics when all categories are configured" do
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
 
       DiscourseAi::Translation::TopicLocaleDetector
         .expects(:detect_locale)
@@ -180,6 +185,20 @@ describe Jobs::DetectTranslateTopic do
         .once
 
       job.execute({ topic_id: included_topic.id })
+    end
+
+    it "skips subcategory topics in strict include mode" do
+      subcategory = Fabricate(:category, parent_category: included_category)
+      subcategory_topic = Fabricate(:topic, category: subcategory)
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      SiteSetting.ai_translation_categories = included_category.id.to_s
+
+      DiscourseAi::Translation::TopicLocaleDetector
+        .expects(:detect_locale)
+        .with(subcategory_topic)
+        .never
+
+      job.execute({ topic_id: subcategory_topic.id })
     end
 
     context "when pm_translation_scope is none" do

--- a/plugins/discourse-ai/spec/jobs/regular/localize_categories_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/localize_categories_spec.rb
@@ -15,6 +15,8 @@ describe Jobs::LocalizeCategories do
     SiteSetting.ai_translation_enabled = true
     SiteSetting.default_locale = "pt_BR"
     SiteSetting.content_localization_supported_locales = "pt_BR|zh_CN"
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
 
     Jobs.run_immediately!
   end
@@ -66,7 +68,6 @@ describe Jobs::LocalizeCategories do
   end
 
   it "translates categories to the configured locales" do
-    SiteSetting.ai_translation_excluded_categories = ""
     Category.update_all(locale: "en")
     number_of_categories = Category.count
 
@@ -95,7 +96,6 @@ describe Jobs::LocalizeCategories do
     SiteSetting.content_localization_supported_locales = "pt"
 
     6.times { Fabricate(:category) }
-    SiteSetting.ai_translation_excluded_categories = ""
     Category.update_all(locale: "en")
 
     DiscourseAi::Translation::CategoryLocalizer
@@ -111,7 +111,6 @@ describe Jobs::LocalizeCategories do
   end
 
   it "skips categories that already have localizations" do
-    SiteSetting.ai_translation_excluded_categories = ""
     localize_all_categories("pt", "zh_CN")
 
     DiscourseAi::Translation::CategoryLocalizer
@@ -135,7 +134,6 @@ describe Jobs::LocalizeCategories do
   end
 
   it "handles translation errors gracefully" do
-    SiteSetting.ai_translation_excluded_categories = ""
     localize_all_categories("pt", "zh_CN")
 
     category1 = Fabricate(:category, name: "First", description: "First description", locale: "en")
@@ -161,10 +159,11 @@ describe Jobs::LocalizeCategories do
     expect { job.execute({ limit: 10 }) }.not_to raise_error
   end
 
-  it "does not translate excluded categories" do
+  it "does not translate categories excluded by the category scope" do
     included = Fabricate(:category, locale: "en")
     excluded = Fabricate(:category, locale: "en")
-    SiteSetting.ai_translation_excluded_categories = excluded.id.to_s
+    SiteSetting.ai_translation_category_scope = "exclude"
+    SiteSetting.ai_translation_categories = excluded.id.to_s
 
     DiscourseAi::Translation::CategoryLocalizer
       .expects(:localize)
@@ -179,7 +178,6 @@ describe Jobs::LocalizeCategories do
   end
 
   it "skips creating localizations in the same language as the category's locale" do
-    SiteSetting.ai_translation_excluded_categories = ""
     Category.update_all(locale: "pt")
 
     DiscourseAi::Translation::CategoryLocalizer
@@ -203,7 +201,6 @@ describe Jobs::LocalizeCategories do
   end
 
   it "deletes existing localizations that match the category's locale" do
-    SiteSetting.ai_translation_excluded_categories = ""
     # update all categories to portuguese
     Category.update_all(locale: "pt")
 
@@ -217,7 +214,6 @@ describe Jobs::LocalizeCategories do
   it "doesn't process categories with nil locale" do
     # Add a category with nil locale
     nil_locale_category = Fabricate(:category, name: "No Locale", locale: nil)
-    SiteSetting.ai_translation_excluded_categories = ""
 
     # Make sure our query for categories with non-null locales excludes it
     DiscourseAi::Translation::CategoryLocalizer

--- a/plugins/discourse-ai/spec/jobs/scheduled/categories_locale_detection_backfill_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/scheduled/categories_locale_detection_backfill_spec.rb
@@ -11,8 +11,8 @@ describe Jobs::CategoriesLocaleDetectionBackfill do
     SiteSetting.ai_translation_enabled = true
     SiteSetting.ai_translation_backfill_hourly_rate = 100
     SiteSetting.content_localization_supported_locales = "en"
-    SiteSetting.ai_translation_excluded_categories =
-      Category.where.not(id: category.id).pluck(:id).join("|")
+    SiteSetting.ai_translation_category_scope = "include"
+    SiteSetting.ai_translation_categories = category.id.to_s
   end
 
   it "does nothing when AI is disabled" do
@@ -43,22 +43,22 @@ describe Jobs::CategoriesLocaleDetectionBackfill do
     job.execute({})
   end
 
-  it "does nothing when all categories are excluded" do
-    SiteSetting.ai_translation_excluded_categories = Category.pluck(:id).join("|")
+  it "does nothing when no categories are included" do
+    SiteSetting.ai_translation_category_scope = "include"
+    SiteSetting.ai_translation_categories = ""
     DiscourseAi::Translation::CategoryLocaleDetector.expects(:detect_locale).never
 
     job.execute({})
   end
 
-  it "detects locale for categories with nil locale when they are not excluded" do
-    excluded = Fabricate(:category, locale: nil)
-    SiteSetting.ai_translation_excluded_categories = excluded.id.to_s
-    SiteSetting.ai_translation_excluded_categories =
-      Category.where.not(id: category.id).pluck(:id).join("|")
+  it "detects locale for selected categories with nil locale" do
+    unselected = Fabricate(:category, locale: nil)
+    SiteSetting.ai_translation_category_scope = "include"
+    SiteSetting.ai_translation_categories = category.id.to_s
 
     DiscourseAi::Translation::CategoryLocaleDetector.expects(:detect_locale).with(category).once
 
-    DiscourseAi::Translation::CategoryLocaleDetector.expects(:detect_locale).with(excluded).never
+    DiscourseAi::Translation::CategoryLocaleDetector.expects(:detect_locale).with(unselected).never
 
     job.execute({})
   end
@@ -85,8 +85,8 @@ describe Jobs::CategoriesLocaleDetectionBackfill do
   it "limits processing to the backfill rate" do
     SiteSetting.ai_translation_backfill_hourly_rate = 1
     extra = Fabricate(:category, locale: nil)
-    SiteSetting.ai_translation_excluded_categories =
-      Category.where.not(id: [category.id, extra.id]).pluck(:id).join("|")
+    SiteSetting.ai_translation_category_scope = "include"
+    SiteSetting.ai_translation_categories = "#{category.id}|#{extra.id}"
 
     DiscourseAi::Translation::CategoryLocaleDetector.expects(:detect_locale).once
 

--- a/plugins/discourse-ai/spec/jobs/scheduled/post_localization_backfill_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/scheduled/post_localization_backfill_spec.rb
@@ -10,7 +10,8 @@ describe Jobs::PostLocalizationBackfill do
     SiteSetting.ai_translation_backfill_max_age_days = 100
     SiteSetting.content_localization_supported_locales = "en"
     SiteSetting.ai_translation_enabled = true
-    SiteSetting.ai_translation_excluded_categories = ""
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   it "does not enqueue post translation when translator disabled" do

--- a/plugins/discourse-ai/spec/jobs/scheduled/posts_locale_detection_backfill_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/scheduled/posts_locale_detection_backfill_spec.rb
@@ -12,7 +12,8 @@ describe Jobs::PostsLocaleDetectionBackfill do
     SiteSetting.ai_translation_enabled = true
     SiteSetting.ai_translation_backfill_hourly_rate = 100
     SiteSetting.content_localization_supported_locales = "en"
-    SiteSetting.ai_translation_excluded_categories = ""
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   it "does nothing when translator is disabled" do
@@ -97,7 +98,7 @@ describe Jobs::PostsLocaleDetectionBackfill do
     job.execute({})
   end
 
-  describe "with excluded categories" do
+  describe "with selected categories" do
     fab!(:included_category, :category)
     fab!(:excluded_category, :category)
     fab!(:included_topic) { Fabricate(:topic, category: included_category) }
@@ -113,12 +114,12 @@ describe Jobs::PostsLocaleDetectionBackfill do
     fab!(:pm_post) { Fabricate(:post, topic: pm_topic, locale: nil) }
 
     before do
-      SiteSetting.ai_translation_excluded_categories =
-        Category.where.not(id: included_category.id).pluck(:id).join("|")
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = included_category.id.to_s
       SiteSetting.ai_translation_personal_messages = "none"
     end
 
-    it "does not process posts from excluded categories" do
+    it "only processes posts from selected categories" do
       DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(included_post).once
       DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(excluded_post).never
       DiscourseAi::Translation::PostLocaleDetector.expects(:detect_locale).with(group_pm_post).never

--- a/plugins/discourse-ai/spec/jobs/scheduled/topic_localization_backfill_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/scheduled/topic_localization_backfill_spec.rb
@@ -10,7 +10,8 @@ describe Jobs::TopicLocalizationBackfill do
     SiteSetting.ai_translation_backfill_max_age_days = 100
     SiteSetting.content_localization_supported_locales = "en"
     SiteSetting.ai_translation_enabled = true
-    SiteSetting.ai_translation_excluded_categories = ""
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   it "does not enqueue topic translation when translator disabled" do

--- a/plugins/discourse-ai/spec/jobs/scheduled/topics_locale_detection_backfill_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/scheduled/topics_locale_detection_backfill_spec.rb
@@ -12,7 +12,8 @@ describe Jobs::TopicsLocaleDetectionBackfill do
     SiteSetting.ai_translation_enabled = true
     SiteSetting.ai_translation_backfill_hourly_rate = 100
     SiteSetting.content_localization_supported_locales = "en"
-    SiteSetting.ai_translation_excluded_categories = ""
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   it "does nothing when translator is disabled" do
@@ -82,7 +83,7 @@ describe Jobs::TopicsLocaleDetectionBackfill do
     job.execute({ limit: 10 })
   end
 
-  describe "with excluded categories" do
+  describe "with selected categories" do
     fab!(:included_category, :category)
     fab!(:excluded_category, :category)
     fab!(:included_topic) { Fabricate(:topic, category: included_category, locale: nil) }
@@ -94,12 +95,12 @@ describe Jobs::TopicsLocaleDetectionBackfill do
     fab!(:pm_topic, :private_message_topic)
 
     before do
-      SiteSetting.ai_translation_excluded_categories =
-        Category.where.not(id: included_category.id).pluck(:id).join("|")
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = included_category.id.to_s
       SiteSetting.ai_translation_personal_messages = "none"
     end
 
-    it "does not process topics from excluded categories" do
+    it "only processes topics from selected categories" do
       DiscourseAi::Translation::TopicLocaleDetector
         .expects(:detect_locale)
         .with(included_topic)

--- a/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
@@ -2,10 +2,14 @@
 
 describe DiscourseAi::Translation::CategoryCandidates do
   describe ".get" do
-    it "returns all categories when no excluded categories are set" do
+    before do
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
+    end
+
+    it "returns all categories when all categories are configured" do
       category_1 = Fabricate(:category)
       category_2 = Fabricate(:category)
-      SiteSetting.ai_translation_excluded_categories = ""
 
       categories = DiscourseAi::Translation::CategoryCandidates.get
       expect(categories).to include(category_1, category_2)
@@ -13,26 +17,51 @@ describe DiscourseAi::Translation::CategoryCandidates do
 
     it "returns private categories by default" do
       private_category = Fabricate(:private_category, group: Fabricate(:group))
-      SiteSetting.ai_translation_excluded_categories = ""
 
       expect(DiscourseAi::Translation::CategoryCandidates.get).to include(private_category)
     end
 
-    it "does not return excluded categories" do
-      included = Fabricate(:category)
-      excluded = Fabricate(:category)
-      SiteSetting.ai_translation_excluded_categories = excluded.id.to_s
+    it "returns only public categories when configured" do
+      public_category = Fabricate(:category)
+      private_category = Fabricate(:private_category, group: Fabricate(:group))
+      SiteSetting.ai_translation_category_scope = "public"
 
       categories = DiscourseAi::Translation::CategoryCandidates.get
-      expect(categories).to include(included)
-      expect(categories).not_to include(excluded)
+      expect(categories).to include(public_category)
+      expect(categories).not_to include(private_category)
+    end
+
+    it "includes selected categories and subcategories" do
+      parent_category = Fabricate(:category)
+      subcategory = Fabricate(:category, parent_category:)
+      unselected_category = Fabricate(:category)
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = parent_category.id.to_s
+
+      categories = DiscourseAi::Translation::CategoryCandidates.get
+      expect(categories).to include(parent_category, subcategory)
+      expect(categories).not_to include(unselected_category)
+    end
+
+    it "excludes only selected categories in strict mode" do
+      parent_category = Fabricate(:category)
+      subcategory = Fabricate(:category, parent_category:)
+      SiteSetting.ai_translation_category_scope = "exclude_strict"
+      SiteSetting.ai_translation_categories = parent_category.id.to_s
+
+      categories = DiscourseAi::Translation::CategoryCandidates.get
+      expect(categories).to include(subcategory)
+      expect(categories).not_to include(parent_category)
     end
   end
 
   describe ".calculate_completion_per_locale" do
     fab!(:target_category, :category)
 
-    before { SiteSetting.ai_translation_excluded_categories = "" }
+    before do
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
+    end
 
     context "when (scenario A) completion determined by category's locale" do
       it "returns done = total if all categories are in the locale" do
@@ -90,7 +119,8 @@ describe DiscourseAi::Translation::CategoryCandidates do
     end
 
     it "returns 0 for done and total when no categories match" do
-      SiteSetting.ai_translation_excluded_categories = Category.pluck(:id).join("|")
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = ""
 
       completion =
         DiscourseAi::Translation::CategoryCandidates.calculate_completion_per_locale("pt")

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 describe DiscourseAi::Translation::PostCandidates do
-  before { SiteSetting.ai_translation_excluded_categories = "" }
+  before do
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
+  end
 
   describe ".get" do
     it "does not return bot posts" do
@@ -69,19 +72,44 @@ describe DiscourseAi::Translation::PostCandidates do
         expect(DiscourseAi::Translation::PostCandidates.get).to include(private_post)
       end
 
-      it "does not include posts from excluded categories" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+      it "includes only posts from public categories when configured" do
+        private_category = Fabricate(:private_category, group:)
+        private_post = Fabricate(:post, topic: Fabricate(:topic, category: private_category))
+        SiteSetting.ai_translation_category_scope = "public"
         SiteSetting.ai_translation_personal_messages = "none"
 
         posts = DiscourseAi::Translation::PostCandidates.get
         expect(posts).to include(target_post)
+        expect(posts).not_to include(private_post)
+      end
+
+      it "includes posts from selected categories and subcategories" do
+        subcategory = Fabricate(:category, parent_category: target_category)
+        subcategory_post = Fabricate(:post, topic: Fabricate(:topic, category: subcategory))
+        SiteSetting.ai_translation_category_scope = "include"
+        SiteSetting.ai_translation_categories = target_category.id.to_s
+        SiteSetting.ai_translation_personal_messages = "none"
+
+        posts = DiscourseAi::Translation::PostCandidates.get
+        expect(posts).to include(target_post, subcategory_post)
         expect(posts).not_to include(non_target_post)
-        expect(posts).not_to include(pm_post)
-        expect(posts).not_to include(group_pm_post)
+      end
+
+      it "excludes selected categories and subcategories" do
+        subcategory = Fabricate(:category, parent_category: non_target_category)
+        subcategory_post = Fabricate(:post, topic: Fabricate(:topic, category: subcategory))
+        SiteSetting.ai_translation_category_scope = "exclude"
+        SiteSetting.ai_translation_categories = non_target_category.id.to_s
+        SiteSetting.ai_translation_personal_messages = "none"
+
+        posts = DiscourseAi::Translation::PostCandidates.get
+        expect(posts).to include(target_post)
+        expect(posts).not_to include(non_target_post, subcategory_post, pm_post, group_pm_post)
       end
 
       it "includes group PMs but not personal PMs when pm_translation_scope is group" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+        SiteSetting.ai_translation_category_scope = "exclude"
+        SiteSetting.ai_translation_categories = non_target_category.id.to_s
         SiteSetting.ai_translation_personal_messages = "group"
 
         posts = DiscourseAi::Translation::PostCandidates.get
@@ -91,7 +119,8 @@ describe DiscourseAi::Translation::PostCandidates do
       end
 
       it "includes all PMs when pm_translation_scope is all" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+        SiteSetting.ai_translation_category_scope = "exclude"
+        SiteSetting.ai_translation_categories = non_target_category.id.to_s
         SiteSetting.ai_translation_personal_messages = "all"
 
         posts = DiscourseAi::Translation::PostCandidates.get
@@ -108,7 +137,8 @@ describe DiscourseAi::Translation::PostCandidates do
     before do
       SiteSetting.ai_translation_backfill_max_age_days = 100
       SiteSetting.content_localization_supported_locales = "en|ja|de"
-      SiteSetting.ai_translation_excluded_categories = ""
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
       SiteSetting.ai_translation_personal_messages = "none"
     end
 
@@ -193,7 +223,8 @@ describe DiscourseAi::Translation::PostCandidates do
       Discourse.cache.clear
       SiteSetting.content_localization_supported_locales = "en_GB|pt|es"
       SiteSetting.ai_translation_backfill_max_age_days = 30
-      SiteSetting.ai_translation_excluded_categories = ""
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
       SiteSetting.ai_translation_personal_messages = "group"
     end
 
@@ -208,17 +239,34 @@ describe DiscourseAi::Translation::PostCandidates do
       expect(result[:posts_with_detected_locale]).to eq(0)
     end
 
-    it "uses excluded categories in the cache key" do
+    it "uses category scope in the cache key" do
       Post.delete_all
-      excluded_category = Fabricate(:category)
+      scoped_category = Fabricate(:category)
       Fabricate(:post, locale: "en_GB", topic: Fabricate(:topic, category: target_category))
-      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: excluded_category))
+      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: scoped_category))
 
-      SiteSetting.ai_translation_excluded_categories = ""
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
       expect(described_class.get_completion_all_locales[:total]).to eq(2)
 
-      SiteSetting.ai_translation_excluded_categories = excluded_category.id.to_s
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = scoped_category.id.to_s
       expect(described_class.get_completion_all_locales[:total]).to eq(1)
+    end
+
+    it "uses expanded subcategory ids in the cache key" do
+      Post.delete_all
+      parent_category = Fabricate(:category)
+      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: parent_category))
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = parent_category.id.to_s
+
+      expect(described_class.get_completion_all_locales[:total]).to eq(1)
+
+      subcategory = Fabricate(:category, parent_category:)
+      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: subcategory))
+
+      expect(described_class.get_completion_all_locales[:total]).to eq(2)
     end
 
     it "returns progress grouped by base locale (of en_GB) and correct totals" do

--- a/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 describe DiscourseAi::Translation::TopicCandidates do
-  before { SiteSetting.ai_translation_excluded_categories = "" }
+  before do
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
+  end
 
   describe ".get" do
     it "does not return bot topics" do
@@ -43,8 +46,9 @@ describe DiscourseAi::Translation::TopicCandidates do
       expect(DiscourseAi::Translation::TopicCandidates.get).to include(banner_topic)
     end
 
-    it "returns banner topics even when all categories are excluded" do
-      SiteSetting.ai_translation_excluded_categories = Category.pluck(:id).join("|")
+    it "returns banner topics even when no regular categories are included" do
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = ""
       SiteSetting.ai_translation_personal_messages = "none"
 
       banner_topic = Fabricate(:topic, archetype: Archetype.banner)
@@ -80,16 +84,30 @@ describe DiscourseAi::Translation::TopicCandidates do
         expect(DiscourseAi::Translation::TopicCandidates.get).to include(private_topic)
       end
 
-      it "does not include excluded categories" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+      it "includes only topics from public categories when configured" do
+        private_category = Fabricate(:private_category, group:)
+        private_topic = Fabricate(:topic, category: private_category)
+        SiteSetting.ai_translation_category_scope = "public"
 
         topics = DiscourseAi::Translation::TopicCandidates.get
         expect(topics).to include(target_topic)
+        expect(topics).not_to include(private_topic)
+      end
+
+      it "includes topics from selected categories and subcategories" do
+        subcategory = Fabricate(:category, parent_category: target_category)
+        subcategory_topic = Fabricate(:topic, category: subcategory)
+        SiteSetting.ai_translation_category_scope = "include"
+        SiteSetting.ai_translation_categories = target_category.id.to_s
+
+        topics = DiscourseAi::Translation::TopicCandidates.get
+        expect(topics).to include(target_topic, subcategory_topic)
         expect(topics).not_to include(non_target_topic)
       end
 
-      it "returns no regular topics when all categories are excluded" do
-        SiteSetting.ai_translation_excluded_categories = Category.pluck(:id).join("|")
+      it "returns no regular topics when no categories are included" do
+        SiteSetting.ai_translation_category_scope = "include"
+        SiteSetting.ai_translation_categories = ""
         SiteSetting.ai_translation_personal_messages = "none"
 
         topics = DiscourseAi::Translation::TopicCandidates.get
@@ -100,7 +118,8 @@ describe DiscourseAi::Translation::TopicCandidates do
       end
 
       it "excludes all PMs when pm_translation_scope is none" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+        SiteSetting.ai_translation_category_scope = "exclude"
+        SiteSetting.ai_translation_categories = non_target_category.id.to_s
         SiteSetting.ai_translation_personal_messages = "none"
 
         topics = DiscourseAi::Translation::TopicCandidates.get
@@ -110,7 +129,8 @@ describe DiscourseAi::Translation::TopicCandidates do
       end
 
       it "includes group PMs but not personal PMs when pm_translation_scope is group" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+        SiteSetting.ai_translation_category_scope = "exclude"
+        SiteSetting.ai_translation_categories = non_target_category.id.to_s
         SiteSetting.ai_translation_personal_messages = "group"
 
         topics = DiscourseAi::Translation::TopicCandidates.get
@@ -120,7 +140,8 @@ describe DiscourseAi::Translation::TopicCandidates do
       end
 
       it "includes all PMs when pm_translation_scope is all" do
-        SiteSetting.ai_translation_excluded_categories = non_target_category.id.to_s
+        SiteSetting.ai_translation_category_scope = "exclude"
+        SiteSetting.ai_translation_categories = non_target_category.id.to_s
         SiteSetting.ai_translation_personal_messages = "all"
 
         topics = DiscourseAi::Translation::TopicCandidates.get
@@ -137,7 +158,8 @@ describe DiscourseAi::Translation::TopicCandidates do
     before do
       SiteSetting.ai_translation_backfill_max_age_days = 100
       SiteSetting.content_localization_supported_locales = "en|ja|de"
-      SiteSetting.ai_translation_excluded_categories = ""
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
       SiteSetting.ai_translation_personal_messages = "none"
     end
 
@@ -205,7 +227,10 @@ describe DiscourseAi::Translation::TopicCandidates do
   end
 
   describe ".calculate_completion_per_locale" do
-    before { SiteSetting.ai_translation_excluded_categories = "" }
+    before do
+      SiteSetting.ai_translation_category_scope = "all"
+      SiteSetting.ai_translation_categories = ""
+    end
 
     context "when (scenario A) 'done' determined by topic's locale" do
       it "returns total = done if all topics are in the locale" do

--- a/plugins/discourse-ai/spec/lib/translation/translation_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/translation_spec.rb
@@ -5,6 +5,8 @@ describe DiscourseAi::Translation do
     assign_fake_provider_to(:ai_default_llm_model)
     enable_current_plugin
     SiteSetting.ai_translation_enabled = true
+    SiteSetting.ai_translation_category_scope = "all"
+    SiteSetting.ai_translation_categories = ""
   end
 
   describe ".locales" do
@@ -13,6 +15,64 @@ describe DiscourseAi::Translation do
       SiteSetting.default_locale = "en"
 
       expect(described_class.locales).to eq(SiteSetting.content_localization_locales)
+    end
+  end
+
+  describe ".category_scope_condition" do
+    it "filters categories for all and public scopes", :aggregate_failures do
+      public_category = Fabricate(:category)
+      private_category = Fabricate(:private_category, group: Fabricate(:group))
+      categories = Category.where(id: [public_category.id, private_category.id])
+
+      SiteSetting.ai_translation_category_scope = "all"
+      sql, params = described_class.category_scope_condition(category_column: "categories.id")
+      expect(categories.where(sql, params)).to contain_exactly(public_category, private_category)
+
+      SiteSetting.ai_translation_category_scope = "public"
+      sql, params = described_class.category_scope_condition(category_column: "categories.id")
+      expect(categories.where(sql, params)).to contain_exactly(public_category)
+    end
+
+    it "filters categories with selected category scopes", :aggregate_failures do
+      parent_category = Fabricate(:category)
+      subcategory = Fabricate(:category, parent_category:)
+      unselected_category = Fabricate(:category)
+      categories = Category.where(id: [parent_category.id, subcategory.id, unselected_category.id])
+
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = parent_category.id.to_s
+      sql, params = described_class.category_scope_condition(category_column: "categories.id")
+      expect(categories.where(sql, params)).to contain_exactly(parent_category, subcategory)
+
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      sql, params = described_class.category_scope_condition(category_column: "categories.id")
+      expect(categories.where(sql, params)).to contain_exactly(parent_category)
+
+      SiteSetting.ai_translation_category_scope = "exclude"
+      sql, params = described_class.category_scope_condition(category_column: "categories.id")
+      expect(categories.where(sql, params)).to contain_exactly(unselected_category)
+
+      SiteSetting.ai_translation_category_scope = "exclude_strict"
+      sql, params = described_class.category_scope_condition(category_column: "categories.id")
+      expect(categories.where(sql, params)).to contain_exactly(subcategory, unselected_category)
+    end
+  end
+
+  describe ".category_allowed?" do
+    it "allows categories according to the configured scope", :aggregate_failures do
+      parent_category = Fabricate(:category)
+      subcategory = Fabricate(:category, parent_category:)
+      private_category = Fabricate(:private_category, group: Fabricate(:group))
+
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = parent_category.id.to_s
+      expect(described_class.category_allowed?(subcategory)).to eq(true)
+
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      expect(described_class.category_allowed?(subcategory)).to eq(false)
+
+      SiteSetting.ai_translation_category_scope = "public"
+      expect(described_class.category_allowed?(private_category.id)).to eq(false)
     end
   end
 end

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -11,14 +11,15 @@ describe DiscourseAi::Admin::AiTranslationsController do
 
   describe "#show" do
     context "when logged in as admin" do
-      fab!(:excluded_category, :category)
+      fab!(:selected_category, :category)
 
       before do
         sign_in(admin)
         SiteSetting.discourse_ai_enabled = true
         SiteSetting.ai_translation_enabled = true
         SiteSetting.content_localization_supported_locales = "en|fr|es"
-        SiteSetting.ai_translation_excluded_categories = excluded_category.id.to_s
+        SiteSetting.ai_translation_category_scope = "include"
+        SiteSetting.ai_translation_categories = selected_category.id.to_s
       end
 
       it "returns base configuration data without progress" do
@@ -97,27 +98,28 @@ describe DiscourseAi::Admin::AiTranslationsController do
         expect(response.parsed_body["backfill_enabled"]).to eq(false)
       end
 
-      it "returns excluded_category_ids from ai_translation_excluded_categories" do
+      it "returns category scope settings" do
         other_category = Fabricate(:category)
-        SiteSetting.ai_translation_excluded_categories =
-          "#{excluded_category.id}|#{other_category.id}"
+        SiteSetting.ai_translation_category_scope = "include"
+        SiteSetting.ai_translation_categories = "#{selected_category.id}|#{other_category.id}"
 
         get "/admin/plugins/discourse-ai/ai-translations.json"
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["excluded_category_ids"]).to contain_exactly(
-          excluded_category.id,
+        expect(response.parsed_body["category_scope"]).to eq("include")
+        expect(response.parsed_body["category_ids"]).to contain_exactly(
+          selected_category.id,
           other_category.id,
         )
       end
 
-      it "returns an empty array when no excluded categories are configured" do
-        SiteSetting.ai_translation_excluded_categories = ""
+      it "returns an empty array when no categories are configured" do
+        SiteSetting.ai_translation_categories = ""
 
         get "/admin/plugins/discourse-ai/ai-translations.json"
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["excluded_category_ids"]).to eq([])
+        expect(response.parsed_body["category_ids"]).to eq([])
       end
 
       it "correctly indicates if feature is enabled" do
@@ -188,7 +190,8 @@ describe DiscourseAi::Admin::AiTranslationsController do
         SiteSetting.discourse_ai_enabled = true
         SiteSetting.ai_translation_enabled = true
         SiteSetting.content_localization_supported_locales = "en|fr|es"
-        SiteSetting.ai_translation_excluded_categories = ""
+        SiteSetting.ai_translation_category_scope = "all"
+        SiteSetting.ai_translation_categories = ""
       end
 
       it "returns translation progress data" do

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe "Admin AI translations" do
       SiteSetting.discourse_ai_enabled = true
       SiteSetting.ai_translation_enabled = false
       SiteSetting.content_localization_supported_locales = "en|fr|es"
-      SiteSetting.ai_translation_excluded_categories = category.id.to_s
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = category.id.to_s
       SiteSetting.ai_translation_backfill_max_age_days = 30
 
       translations_page.visit
@@ -111,10 +112,10 @@ RSpec.describe "Admin AI translations" do
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.supported_locales"))
     end
 
-    it "displays the category selector alongside the locale selector" do
+    it "displays the category scope selector alongside the locale selector" do
       expect(page).to have_css(".alert.alert-info")
-      expect(page).to have_content(I18n.t("js.discourse_ai.translations.excluded_categories"))
-      expect(page).to have_css(".category-selector")
+      expect(page).to have_content(I18n.t("js.discourse_ai.translations.category_scope"))
+      expect(page).to have_css(".ai-translations__category-input-row .combo-box")
     end
 
     it "allows adding and saving languages" do
@@ -130,14 +131,15 @@ RSpec.describe "Admin AI translations" do
     end
   end
 
-  describe "when categories are not excluded" do
+  describe "when selected categories are configured" do
     fab!(:category)
 
     before do
       SiteSetting.discourse_ai_enabled = true
       SiteSetting.ai_translation_enabled = false
       SiteSetting.content_localization_supported_locales = "en|fr"
-      SiteSetting.ai_translation_excluded_categories = ""
+      SiteSetting.ai_translation_category_scope = "include"
+      SiteSetting.ai_translation_categories = ""
       SiteSetting.ai_translation_backfill_max_age_days = 30
 
       visit "/admin/plugins/discourse-ai/ai-translations"
@@ -145,18 +147,19 @@ RSpec.describe "Admin AI translations" do
 
     it "displays the setup alert with the category selector" do
       expect(page).to have_css(".alert.alert-info")
-      expect(page).to have_content(I18n.t("js.discourse_ai.translations.excluded_categories"))
+      expect(page).to have_content(I18n.t("js.discourse_ai.translations.category_scope"))
       expect(page).to have_css(".category-selector")
     end
 
-    it "allows adding and saving excluded categories" do
+    it "allows adding and saving selected categories" do
       find(".category-selector").click
       find(".category-row[data-value='#{category.id}']").click
 
       within(".ai-translations__category-input-row") { find(".setting-controls__ok").click }
 
       expect(page).to have_no_css(".ai-translations__category-input-row .setting-controls__ok")
-      expect(SiteSetting.ai_translation_excluded_categories).to eq(category.id.to_s)
+      expect(SiteSetting.ai_translation_category_scope).to eq("include")
+      expect(SiteSetting.ai_translation_categories).to eq(category.id.to_s)
     end
   end
 


### PR DESCRIPTION
We have switched AI translations settings first from public categories, to "include" categories, then to "exclude" categories.

This is not great. Some admins prefer one, and some prefer others. 

This PR allows admins to do either. This also updates default categories to be "public" only, when the original default was "all" (public + private). 

The migration covers moving existing users to 
- if has selected categories -> "exclude strict" + their selected categories
- if no selected categories + feature enabled -> "all" to maintain status quo


https://github.com/user-attachments/assets/607f2340-8fa6-4059-b13d-07d1938ad74f

