### PR TITLE
DEV: Fix stylesheet watcher file matching

### DIFF
--- a/lib/stylesheet/watcher.rb
+++ b/lib/stylesheet/watcher.rb
@@ -4,6 +4,9 @@ require "listen"
 
 module Stylesheet
   class Watcher
+    CORE_TARGETS = %w[admin desktop mobile publish wizard wcag]
+    SPECIAL_CORE_TARGETS = %w[color_definitions]
+
     def self.watch(paths = nil)
       watcher = new(paths)
       watcher.start
@@ -60,24 +63,8 @@ module Stylesheet
 
           listener =
             Listen.to(*@paths, listener_opts) do |modified, added, _|
-              paths = [modified, added].flatten
-              paths.compact!
-              paths.map! do |long|
-                plugin_name = nil
-                plugins_paths.each do |plugin_path|
-                  if long.include?("#{plugin_path}/")
-                    plugin_name = File.basename(plugin_path)
-                    break
-                  end
-                end
-
-                target = nil
-                target_match =
-                  long.match(/admin|desktop|mobile|publish|wizard|wcag|color_definitions/)
-                target = target_match[0] if target_match&.length
-
-                { basename: File.basename(long), target: target, plugin_name: plugin_name }
-              end
+              paths = [modified, added].flatten.compact
+              paths.map! { |path| path_data(path, plugins_paths) }
 
               process_change(paths)
             end
@@ -87,6 +74,39 @@ module Stylesheet
         listener.start
         sleep
       end
+    end
+
+    def path_data(path, plugins_paths)
+      plugin_name = nil
+      expanded_path = File.expand_path(path)
+
+      plugins_paths.each do |plugin_path|
+        next if !expanded_path.start_with?("#{plugin_path}/")
+
+        plugin_name = File.basename(plugin_path)
+        break
+      end
+
+      target = plugin_name ? nil : core_target(path)
+
+      { basename: File.basename(path), target: target, plugin_name: plugin_name }
+    end
+
+    def core_target(path)
+      relative_path =
+        Pathname.new(File.expand_path(path)).relative_path_from(
+          Rails.root.join("app/assets/stylesheets"),
+        )
+      path_parts = relative_path.each_filename.to_a
+      target = path_parts[0...-1].find { |path_part| CORE_TARGETS.include?(path_part) }
+      basename_target = File.basename(path_parts.last, ".scss")
+
+      target ||
+        if path_parts.one? && (CORE_TARGETS + SPECIAL_CORE_TARGETS).include?(basename_target)
+          basename_target
+        end
+    rescue ArgumentError
+      nil
     end
 
     def core_assets_refresh(target)

--- a/spec/lib/stylesheet/watcher_spec.rb
+++ b/spec/lib/stylesheet/watcher_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "stylesheet/watcher"
+
+RSpec.describe Stylesheet::Watcher do
+  subject(:watcher) { described_class.new([]) }
+
+  describe "#path_data" do
+    it "does not infer a core target from the filename" do
+      path =
+        Rails.root.join("app/assets/stylesheets/common/components/admin-onboarding-banner.scss")
+
+      expect(watcher.path_data(path.to_s, [])).to include(target: nil, plugin_name: nil)
+    end
+
+    it "infers core targets from stylesheet directories" do
+      path = Rails.root.join("app/assets/stylesheets/admin/dashboard.scss")
+
+      expect(watcher.path_data(path.to_s, [])).to include(target: "admin", plugin_name: nil)
+    end
+
+    it "infers core targets from top-level stylesheet filenames" do
+      path = Rails.root.join("app/assets/stylesheets/mobile.scss")
+
+      expect(watcher.path_data(path.to_s, [])).to include(target: "mobile", plugin_name: nil)
+    end
+
+    it "infers special core targets from top-level filenames" do
+      path = Rails.root.join("app/assets/stylesheets/color_definitions.scss")
+
+      expect(watcher.path_data(path.to_s, [])).to include(
+        target: "color_definitions",
+        plugin_name: nil,
+      )
+    end
+  end
+end

--- a/spec/lib/stylesheet/watcher_spec.rb
+++ b/spec/lib/stylesheet/watcher_spec.rb
@@ -33,5 +33,57 @@ RSpec.describe Stylesheet::Watcher do
         plugin_name: nil,
       )
     end
+
+    it "infers plugin names from stylesheet paths under plugins" do
+      plugin_path = Rails.root.join("plugins/discourse-calendar").to_s
+      path = Rails.root.join("plugins/discourse-calendar/assets/stylesheets/admin/calendar.scss")
+
+      expect(watcher.path_data(path.to_s, [plugin_path])).to include(
+        target: nil,
+        plugin_name: "discourse-calendar",
+      )
+    end
+  end
+
+  describe "#plugin_assets_refresh" do
+    let(:plugin_name) { "test-plugin" }
+    let(:manager) { instance_double(Stylesheet::Manager) }
+
+    before do
+      DiscoursePluginRegistry.stylesheets[plugin_name] = Set.new(["stylesheets/common.scss"])
+      DiscoursePluginRegistry.desktop_stylesheets[plugin_name] = Set.new(
+        ["stylesheets/desktop.scss"],
+      )
+      DiscoursePluginRegistry.mobile_stylesheets[plugin_name] = Set.new(["stylesheets/mobile.scss"])
+      DiscoursePluginRegistry.admin_stylesheets[plugin_name] = Set.new(["stylesheets/admin.scss"])
+
+      allow(Stylesheet::Manager).to receive(:new).and_return(manager)
+      allow(manager).to receive(:stylesheet_data) do |target|
+        [{ target: target, new_href: "/stylesheets/#{target}.css" }]
+      end
+    end
+
+    after { DiscoursePluginRegistry.reset! }
+
+    it "publishes changes for every registered plugin target" do
+      messages =
+        MessageBus.track_publish("/file-change") { watcher.plugin_assets_refresh(plugin_name) }
+
+      expect(messages.first.data).to contain_exactly(
+        { target: :"test-plugin", new_href: "/stylesheets/test-plugin.css" },
+        { target: :"test-plugin_desktop", new_href: "/stylesheets/test-plugin_desktop.css" },
+        { target: :"test-plugin_mobile", new_href: "/stylesheets/test-plugin_mobile.css" },
+        { target: :"test-plugin_admin", new_href: "/stylesheets/test-plugin_admin.css" },
+      )
+    end
+
+    it "skips publishing when the plugin has no registered stylesheets" do
+      DiscoursePluginRegistry.reset!
+
+      messages =
+        MessageBus.track_publish("/file-change") { watcher.plugin_assets_refresh(plugin_name) }
+
+      expect(messages).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Previously a file with `admin` in the name, would match the admin
stylesheet. Now this doesn't happen.

Found this out by editing the admin-onboarding-banner file and not
seeing live updates in the browser.