### PR TITLE
FIX: Avoid 500 error on rare missing topic during MB publish

### DIFF
--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -369,13 +369,15 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   end
 
   def publish_change_to_clients!(post, reaction: nil, previous_reaction: nil)
+    return unless (topic = post.topic)
+
     message = { post_id: post.id, reactions: [reaction, previous_reaction].compact.uniq }
 
     opts = {}
-    secure_audience = post.topic.secure_audience_publish_messages
+    secure_audience = topic.secure_audience_publish_messages
     opts = secure_audience if secure_audience[:user_ids] != [] && secure_audience[:group_ids] != []
 
-    MessageBus.publish("/topic/#{post.topic.id}/reactions", message, opts)
+    MessageBus.publish("/topic/#{topic.id}/reactions", message, opts)
   end
 
   def secure_reaction_users!(reaction_users)

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -151,6 +151,13 @@ describe DiscourseReactions::CustomReactionsController do
       expect(user_1_messages).to eq(nil)
     end
 
+    it "does not publish MessageBus messages when the post topic is unavailable" do
+      post_1.stubs(:topic).returns(nil)
+      MessageBus.expects(:publish).never
+
+      described_class.new.send(:publish_change_to_clients!, post_1, reaction: "cry")
+    end
+
     it "errors when reaction is invalid" do
       sign_in(user_1)
       expect do


### PR DESCRIPTION
This shows up in logs from time to time, the refactor matches what we do in core in similar circumstances.