### PR TITLE
FIX: Preserve emphasis when it borders punctuation in rich editor output

### DIFF
--- a/frontend/discourse/app/static/prosemirror/core/serializer.js
+++ b/frontend/discourse/app/static/prosemirror/core/serializer.js
@@ -2,6 +2,7 @@ import {
   defaultMarkdownSerializer,
   MarkdownSerializerState,
 } from "prosemirror-markdown";
+import expelBoundaryPunctuation from "../lib/expel-boundary-punctuation";
 
 export default class Serializer {
   #afterSerializers;
@@ -23,7 +24,7 @@ export default class Serializer {
 
   convert(doc) {
     const state = new MarkdownSerializerState(this.nodes, this.marks, {});
-    state.renderContent(doc.content);
+    state.renderContent(expelBoundaryPunctuation(doc).content);
 
     if (this.#afterSerializers) {
       for (const afterSerializer of this.#afterSerializers) {

--- a/frontend/discourse/app/static/prosemirror/lib/expel-boundary-punctuation.ts
+++ b/frontend/discourse/app/static/prosemirror/lib/expel-boundary-punctuation.ts
@@ -1,0 +1,78 @@
+import {
+  type Fragment,
+  type MarkType,
+  Node,
+  type Slice,
+} from "prosemirror-model";
+import { Transform } from "prosemirror-transform";
+
+const FLANKING_SENSITIVE_MARKS = ["strong", "em", "strikethrough"];
+
+// Matches markdown-it's `isPunctChar` (P || S).
+const PUNCTUATION = /[\p{P}\p{S}]/u;
+const LEADING_PUNCTUATION = new RegExp(`^${PUNCTUATION.source}+`, "u");
+const TRAILING_PUNCTUATION = new RegExp(`${PUNCTUATION.source}+$`, "u");
+
+function isWordChar(char: string | undefined): boolean {
+  return !!char && !PUNCTUATION.test(char) && !/\s/u.test(char);
+}
+
+// Punctuation counterpart to prosemirror-markdown's `expelEnclosingWhitespace`:
+// `**text.**text` reparses as literal, so serialize as `**text**.text` instead.
+// Slices/fragments from selection serialization pass through untouched.
+export default function expelBoundaryPunctuation(
+  content: Node | Slice | Fragment
+): Node | Slice | Fragment {
+  if (!(content instanceof Node)) {
+    return content;
+  }
+
+  const tr = new Transform(content);
+  const markTypes = FLANKING_SENSITIVE_MARKS.map(
+    (name) => content.type.schema.marks[name]
+  ).filter((markType): markType is MarkType => Boolean(markType));
+
+  // RemoveMarkStep doesn't shift positions, so no mapping is needed.
+  content.descendants((node, pos) => {
+    if (!node.isTextblock) {
+      return;
+    }
+
+    node.forEach((child, offset, index) => {
+      const text = child.text;
+      if (text === undefined) {
+        return;
+      }
+
+      const start = pos + 1 + offset;
+      const end = start + text.length;
+      const next = index + 1 < node.childCount ? node.child(index + 1) : null;
+      const prev = index > 0 ? node.child(index - 1) : null;
+      const nextChar = next?.text?.[0];
+      const prevText = prev?.text;
+      const prevChar = prevText?.[prevText.length - 1];
+
+      for (const markType of markTypes) {
+        if (!markType.isInSet(child.marks)) {
+          continue;
+        }
+
+        if ((!next || !markType.isInSet(next.marks)) && isWordChar(nextChar)) {
+          const trailing = text.match(TRAILING_PUNCTUATION);
+          if (trailing) {
+            tr.removeMark(end - trailing[0].length, end, markType);
+          }
+        }
+
+        if ((!prev || !markType.isInSet(prev.marks)) && isWordChar(prevChar)) {
+          const leading = text.match(LEADING_PUNCTUATION);
+          if (leading) {
+            tr.removeMark(start, start + leading[0].length, markType);
+          }
+        }
+      }
+    });
+  });
+
+  return tr.doc;
+}

--- a/frontend/discourse/tests/unit/static/prosemirror/expel-boundary-punctuation-test.js
+++ b/frontend/discourse/tests/unit/static/prosemirror/expel-boundary-punctuation-test.js
@@ -1,0 +1,88 @@
+import { module, test } from "qunit";
+import { createSchema } from "discourse/static/prosemirror/core/schema";
+import Serializer from "discourse/static/prosemirror/core/serializer";
+import strikethrough from "discourse/static/prosemirror/extensions/strikethrough";
+
+module(
+  "Unit | Static | ProseMirror | expel-boundary-punctuation",
+  function (hooks) {
+    let schema, serializer;
+
+    hooks.beforeEach(function () {
+      // strikethrough supplies its `~~` mark alongside the strong/em defaults
+      schema = createSchema([strikethrough]);
+      serializer = new Serializer([strikethrough]);
+    });
+
+    // Builds these doc states directly since no markdown source produces them.
+    function paragraph(...runs) {
+      const content = runs.map(([text, ...marks]) =>
+        schema.text(
+          text,
+          marks.map((name) => schema.marks[name].create())
+        )
+      );
+      return schema.node("doc", null, [
+        schema.node("paragraph", null, content),
+      ]);
+    }
+
+    function serialize(...runs) {
+      return serializer.convert(paragraph(...runs));
+    }
+
+    test("expels trailing punctuation that would break the closing delimiter", function (assert) {
+      assert.strictEqual(
+        serialize(["text.", "strong"], ["text"]),
+        "**text**.text"
+      );
+      assert.strictEqual(serialize(["text.", "em"], ["text"]), "*text*.text");
+      assert.strictEqual(
+        serialize(["text.", "strikethrough"], ["text"]),
+        "~~text~~.text"
+      );
+    });
+
+    test("expels leading punctuation that would break the opening delimiter", function (assert) {
+      assert.strictEqual(
+        serialize(["text"], [".word", "strong"]),
+        "text.**word**"
+      );
+    });
+
+    test("expels a run of consecutive boundary punctuation", function (assert) {
+      assert.strictEqual(
+        serialize(["text..", "strong"], ["text"]),
+        "**text**..text"
+      );
+    });
+
+    test("leaves valid boundaries untouched", function (assert) {
+      assert.strictEqual(serialize(["Hello.", "strong"]), "**Hello.**");
+      assert.strictEqual(
+        serialize(["Hello.", "strong"], [" world"]),
+        "**Hello.** world"
+      );
+      assert.strictEqual(serialize(["Hello", "strong"], ["!"]), "**Hello**!");
+      assert.strictEqual(
+        serialize(["text", "strong"], ["text"]),
+        "**text**text"
+      );
+    });
+
+    test("handles nested strong/em ending in punctuation", function (assert) {
+      assert.strictEqual(
+        serialize(["text.", "strong", "em"], ["text"]),
+        "***text***.text"
+      );
+    });
+
+    test("passes selection slices through untouched", function (assert) {
+      const doc = paragraph(["text.", "strong"], ["text"]);
+      assert.strictEqual(
+        serializer.convert(doc.slice(0, doc.content.size)),
+        "**text.**text"
+      );
+    });
+  }
+);


### PR DESCRIPTION
The rich editor serializes strong/em/strikethrough marks with prosemirror-markdown's default delimiters, which ignore CommonMark's flanking rules. A mark whose text ends in punctuation immediately followed by a word character (e.g. bold `text.` directly followed by plain `text`, easily produced by the `**text.**` input rule then typing on) serializes to `**text.**text`. That closing delimiter is not right-flanking, so it reparses as literal text, silently dropping the mark on round-trip.

prosemirror-markdown already handles the whitespace variant of this via `expelEnclosingWhitespace`, which relocates boundary whitespace outside the delimiters. This adds the punctuation analogue: before serializing, shrink flanking marks off any boundary punctuation that would otherwise produce a non-flanking delimiter, yielding round-trippable `**text**.text`.