### PR TITLE
SECURITY: Private UserField value disclosure via directory_items `order` sort side-channel

### DIFF
--- a/app/controllers/directory_items_controller.rb
+++ b/app/controllers/directory_items_controller.rb
@@ -37,16 +37,18 @@ class DirectoryItemsController < ApplicationController
           .where.not(users: { username: params[:exclude_usernames].split(",") })
     end
 
-    order = params[:order] || DirectoryColumn.automatic_column_names.first
+    default_order = DirectoryColumn.automatic_column_names.first
+    order = params[:order] || default_order
     dir = params[:asc] ? "ASC" : "DESC"
     active_directory_column_names = DirectoryColumn.active_column_names
     if active_directory_column_names.include?(order.to_sym)
       result = result.order("directory_items.#{order} #{dir}, directory_items.id")
-    elsif params[:order] === "username"
+    elsif order == "username"
       result = result.order("users.#{order} #{dir}, directory_items.id")
     else
       # Ordering by user field value
-      user_field = UserField.find_by(name: params[:order])
+      user_field_scope = guardian.is_staff? ? UserField.all : UserField.public_fields
+      user_field = user_field_scope.find_by(name: order)
       if user_field
         result =
           result
@@ -57,6 +59,8 @@ class DirectoryItemsController < ApplicationController
             .order(
               "user_custom_fields.name = 'user_field_#{user_field.id}' ASC, user_custom_fields.value #{dir}",
             )
+      else
+        result = result.order("directory_items.#{default_order} #{dir}, directory_items.id")
       end
     end
 

--- a/spec/requests/directory_items_controller_spec.rb
+++ b/spec/requests/directory_items_controller_spec.rb
@@ -314,6 +314,48 @@ RSpec.describe DirectoryItemsController do
       end
     end
 
+    it "does not order anonymous users by private user fields" do
+      group.add(walter_white)
+      private_field = Fabricate(:user_field, show_on_profile: false, show_on_user_card: false)
+
+      [
+        { user: evil_trout, field_value: "Alpha", likes_received: 3 },
+        { user: walter_white, field_value: "Mike", likes_received: 2 },
+        { user: stage_user, field_value: "Zulu", likes_received: 1 },
+      ].each do |data|
+        DirectoryItem.find_by!(
+          period_type: DirectoryItem.period_types[:all],
+          user: data[:user],
+        ).update!(likes_received: data[:likes_received])
+        UserCustomField.create!(
+          user_id: data[:user].id,
+          name: "user_field_#{private_field.id}",
+          value: data[:field_value],
+        )
+      end
+
+      get "/directory_items.json", params: { period: "all", group: group.name, asc: true }
+      expect(response.status).to eq(200)
+      baseline_usernames =
+        response.parsed_body["directory_items"].map { |item| item["user"]["username"] }
+
+      get "/directory_items.json",
+          params: {
+            period: "all",
+            group: group.name,
+            order: private_field.name,
+            asc: true,
+          }
+      expect(response.status).to eq(200)
+      ordered_usernames =
+        response.parsed_body["directory_items"].map { |item| item["user"]["username"] }
+
+      expect(baseline_usernames).to eq(
+        [stage_user.username, walter_white.username, evil_trout.username],
+      )
+      expect(ordered_usernames).to eq(baseline_usernames)
+    end
+
     it "searches users by user field value" do
       field1 = Fabricate(:user_field, searchable: true, show_on_profile: true)
       field2 = Fabricate(:user_field, searchable: true, show_on_profile: true)


### PR DESCRIPTION
## Summary

Prevent unauthenticated disclosure of private user custom field values via the directory items sort order. The fix restricts the `order` parameter to public fields for non-staff users and falls back to default sorting when an unauthorized field is requested.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1334

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>