### PR TITLE
SECURITY: Bind shared session key to auth token and enforce user gates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,8 +82,11 @@ module ApplicationHelper
       sk = "shared_session_key"
       return request.env[sk] if request.env[sk]
 
+      token = request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY]
+      return if !token || token.user != current_user
+
       request.env[sk] = key = (session[sk] ||= SecureRandom.hex)
-      Discourse.redis.setex "#{sk}_#{key}", 7.days, current_user.id.to_s
+      Auth::DefaultCurrentUserProvider.store_shared_session_key(key, token.id.to_s)
       key
     end
   end

--- a/app/models/user_auth_token.rb
+++ b/app/models/user_auth_token.rb
@@ -8,6 +8,8 @@ class UserAuthToken < ActiveRecord::Base
   # overriding `#user` later in the class definition.
   alias_method :acting_user, :user
 
+  scope :unexpired, -> { where("rotated_at > ?", SiteSetting.maximum_session_age.hours.ago) }
+
   ROTATE_TIME_MINS = 10
   ROTATE_TIME = ROTATE_TIME_MINS.minutes
   # used when token did not arrive at client
@@ -144,15 +146,8 @@ class UserAuthToken < ActiveRecord::Base
     mark_seen = opts && opts[:seen]
 
     token = hash_token(unhashed_token)
-    expire_before = SiteSetting.maximum_session_age.hours.ago
 
-    user_token =
-      where(
-        "(auth_token = :token OR
-                          prev_auth_token = :token) AND rotated_at > :expire_before",
-        token: token,
-        expire_before: expire_before,
-      )
+    user_token = unexpired.where("auth_token = :token OR prev_auth_token = :token", token: token)
 
     if SiteSetting.verbose_auth_token_logging && path = opts.dig(:path)
       user_token = user_token.annotate("path:#{path}")

--- a/lib/auth/default_current_user_provider.rb
+++ b/lib/auth/default_current_user_provider.rb
@@ -44,6 +44,14 @@ class Auth::DefaultCurrentUserProvider
 
   TOKEN_SIZE = 32
 
+  def self.shared_session_redis_key(key)
+    "shared_session_user_auth_token_id:#{key}"
+  end
+
+  def self.store_shared_session_key(key, token_id)
+    Discourse.redis.setex(shared_session_redis_key(key), 7.days, token_id)
+  end
+
   PARAMETER_API_PATTERNS = [
     RouteMatcher.new(
       methods: :get,
@@ -101,9 +109,13 @@ class Auth::DefaultCurrentUserProvider
 
     # bypass if we have the shared session header
     if shared_key = @env["HTTP_X_SHARED_SESSION_KEY"]
-      uid = Discourse.redis.get("shared_session_key_#{shared_key}")
+      token_id = Discourse.redis.get(self.class.shared_session_redis_key(shared_key))
       user = nil
-      user = User.find_by(id: uid.to_i) if uid
+      if token_id
+        token = UserAuthToken.unexpired.find_by(id: token_id)
+        user = token&.user
+        user = nil if user && (user.suspended? || !user.active)
+      end
       @env[CURRENT_USER_KEY] = user
       return user
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1332,4 +1332,76 @@ RSpec.describe ApplicationHelper do
       expect(result).to include('itemtype="http://schema.org/Comment"')
     end
   end
+
+  describe "#shared_session_key" do
+    fab!(:user)
+
+    before { SiteSetting.long_polling_base_url = "https://mb.example.com/" }
+
+    context "when the request carries an auth token" do
+      let(:auth_token) { UserAuthToken.generate!(user_id: user.id) }
+
+      before do
+        helper.stubs(:current_user).returns(user)
+        helper.request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY] = auth_token
+      end
+
+      it "binds the stored value to the auth token" do
+        key = helper.shared_session_key
+        expect(
+          Discourse.redis.get(Auth::DefaultCurrentUserProvider.shared_session_redis_key(key)),
+        ).to eq(auth_token.id.to_s)
+      end
+    end
+
+    context "when the auth token does not belong to the current user" do
+      fab!(:other_user, :user)
+
+      before do
+        helper.stubs(:current_user).returns(user)
+        helper.request.env[
+          Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY
+        ] = UserAuthToken.generate!(user_id: other_user.id)
+      end
+
+      it "returns no shared session key" do
+        expect(helper.shared_session_key).to eq(nil)
+      end
+    end
+
+    context "when the auth token is impersonating the current user" do
+      fab!(:admin)
+
+      let(:auth_token) do
+        UserAuthToken
+          .generate!(user_id: admin.id)
+          .tap do |token|
+            token.update!(impersonated_user_id: user.id, impersonation_expires_at: 1.hour.from_now)
+          end
+      end
+
+      before do
+        helper.stubs(:current_user).returns(user)
+        helper.request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY] = auth_token
+      end
+
+      it "binds the stored value to the impersonating token" do
+        key = helper.shared_session_key
+        expect(
+          Discourse.redis.get(Auth::DefaultCurrentUserProvider.shared_session_redis_key(key)),
+        ).to eq(auth_token.id.to_s)
+      end
+    end
+
+    context "when the request carries no auth token" do
+      before do
+        helper.stubs(:current_user).returns(user)
+        helper.request.env[Auth::DefaultCurrentUserProvider::USER_TOKEN_KEY] = nil
+      end
+
+      it "returns no shared session key" do
+        expect(helper.shared_session_key).to eq(nil)
+      end
+    end
+  end
 end

--- a/spec/lib/auth/default_current_user_provider_spec.rb
+++ b/spec/lib/auth/default_current_user_provider_spec.rb
@@ -317,6 +317,81 @@ RSpec.describe Auth::DefaultCurrentUserProvider do
       expect(env[ActionDispatch::Http::Parameters::PARAMETERS_KEY]).to be_blank
       expect(provider.env[Auth::DefaultCurrentUserProvider::CURRENT_USER_KEY]).to eq(u)
     end
+
+    context "with the shared session key header" do
+      def authenticate_via_shared_key(stored_value)
+        key = SecureRandom.hex
+        Auth::DefaultCurrentUserProvider.store_shared_session_key(key, stored_value)
+        provider("/", "HTTP_X_SHARED_SESSION_KEY" => key).current_user
+      end
+
+      def expired_token(user)
+        UserAuthToken
+          .generate!(user_id: user.id)
+          .tap do |token|
+            token.update!(rotated_at: (SiteSetting.maximum_session_age.hours + 1.hour).ago)
+          end
+      end
+
+      it "authenticates the user of the bound auth token" do
+        token = UserAuthToken.generate!(user_id: user.id)
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(user)
+      end
+
+      it "returns nil once the bound user is suspended" do
+        token = UserAuthToken.generate!(user_id: user.id)
+        user.update!(suspended_at: Time.zone.now, suspended_till: 1.year.from_now)
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(nil)
+      end
+
+      it "returns nil once the bound user is deactivated" do
+        token = UserAuthToken.generate!(user_id: user.id)
+        user.update!(active: false)
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(nil)
+      end
+
+      it "returns nil after the bound auth token is destroyed" do
+        token = UserAuthToken.generate!(user_id: user.id)
+        stored_value = token.id.to_s
+        token.destroy!
+        expect(authenticate_via_shared_key(stored_value)).to eq(nil)
+      end
+
+      it "does not authenticate an expired token" do
+        token = expired_token(user)
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(nil)
+      end
+
+      it "authenticates the impersonated user while the bound token is impersonating" do
+        admin = Fabricate(:admin)
+        token = UserAuthToken.generate!(user_id: admin.id)
+        token.update!(impersonated_user_id: user.id, impersonation_expires_at: 1.hour.from_now)
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(user)
+      end
+
+      it "authenticates the acting user once impersonation has expired" do
+        admin = Fabricate(:admin)
+        token = UserAuthToken.generate!(user_id: admin.id)
+        token.update!(impersonated_user_id: user.id, impersonation_expires_at: 1.hour.ago)
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(admin)
+      end
+
+      it "returns nil when the bound token's user no longer exists" do
+        token = UserAuthToken.generate!(user_id: user.id)
+        user.delete
+        expect(authenticate_via_shared_key(token.id.to_s)).to eq(nil)
+      end
+
+      it "returns nil when the stored value is not a token id" do
+        expect(authenticate_via_shared_key("not-a-token-id")).to eq(nil)
+      end
+
+      it "returns nil for a value stored under the legacy namespace" do
+        key = SecureRandom.hex
+        Discourse.redis.setex("shared_session_key_#{key}", 7.days, user.id.to_s)
+        expect(provider("/", "HTTP_X_SHARED_SESSION_KEY" => key).current_user).to eq(nil)
+      end
+    end
   end
 
   it "should update last seen for non ajax" do

--- a/spec/models/user_auth_token_spec.rb
+++ b/spec/models/user_auth_token_spec.rb
@@ -73,6 +73,20 @@ RSpec.describe UserAuthToken do
     end
   end
 
+  describe ".unexpired" do
+    it "returns only tokens within maximum_session_age" do
+      SiteSetting.maximum_session_age = 1
+
+      fresh = UserAuthToken.generate!(user_id: user.id)
+      fresh.update!(rotated_at: 30.minutes.ago)
+
+      stale = UserAuthToken.generate!(user_id: user.id)
+      stale.update!(rotated_at: 2.hours.ago)
+
+      expect(UserAuthToken.unexpired).to contain_exactly(fresh)
+    end
+  end
+
   describe ".cleanup!" do
     it "can remove old expired tokens" do
       freeze_time Time.zone.now

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -3,6 +3,31 @@
 RSpec.describe ApplicationController do
   fab!(:user)
 
+  describe "shared session key" do
+    before { SiteSetting.long_polling_base_url = "https://mb.example.com/" }
+
+    it "renders the meta tag for a logged-in user" do
+      sign_in(user)
+
+      get "/latest"
+
+      expect(response.body).to match(/<meta name="shared_session_key" content="[^"]+">/)
+    end
+
+    it "authenticates a login-required route via the header" do
+      SiteSetting.login_required = true
+      token = UserAuthToken.generate!(user_id: user.id)
+      key = SecureRandom.hex
+      Auth::DefaultCurrentUserProvider.store_shared_session_key(key, token.id.to_s)
+
+      get "/latest.json"
+      expect(response.status).to eq(403)
+
+      get "/latest.json", headers: { "HTTP_X_SHARED_SESSION_KEY" => key }
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "for cache control headers" do
     it "sets the `no-cache, no-store` cache control response header when no error is raised" do
       get "/latest"


### PR DESCRIPTION
This PR binds the shared session key to the session's `UserAuthToken` so it can no longer be replayed after the session is revoked.

When the `long_polling_base_url` site setting points to an external origin, the auth cookie is not sent with message_bus requests, so each authenticated page render mints a shared session key: a random token that Discourse stores in Redis pointing at the user's id, embeds in the page, and the client replays on the `X-Shared-Session-Key` header. That Redis entry is given a 7-day TTL. On each request the key was resolved to its user id and returned before the suspended/active check ran, so a captured key kept authenticating for the full 7 days of its TTL. Logout, suspension, password change, and token revocation never touched the Redis entry, so none of them stopped it.

Key changes:

* Store the key as `shared_session_user_auth_token_id:<key> -> token.id`, building the Redis key name in one place (`Auth::DefaultCurrentUserProvider.shared_session_redis_key`). Legacy `shared_session_key_*` entries are never read, so every pre-deploy key fails closed with no migration; clients re-mint on their next page load.
* Resolve the user through the bound token, applying the same suspended/active and `maximum_session_age` checks as cookie auth, so the key revokes and expires with the session instead of outliving it on the Redis TTL.
* Mint against the token's effective user so admin impersonation keeps live updates; the key stays the admin's and reverts to them when impersonation ends.
* Rely on token destruction for revocation on every path rather than deleting the Redis entry, since a gone token already makes its key fail closed on lookup; orphaned entries expire on the 7-day TTL.