### PR TITLE
DEV: add upcoming change for Solved badges

### DIFF
--- a/plugins/discourse-solved/app/services/discourse_solved/enable_solved_badges_toggled.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/enable_solved_badges_toggled.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Reacts to the `enable_solved_badges` upcoming change being enabled or disabled
+# (manually or via auto-promotion). See the on(:upcoming_change_enabled) /
+# on(:upcoming_change_disabled) subscriptions in plugin.rb for the dispatch.
+#
+# Enabling turns on the four seeded Solved badges. Their prior `enabled` state is
+# snapshotted onto the change's UpcomingChangeEvent so that opting out restores
+# exactly what the site had before (a site may have manually enabled a subset).
+#
+# New sites are handled separately by the badge seed fixture
+# (db/fixtures/001_badges.rb): the promotion event does not fire on brand-new
+# sites (UpcomingChanges.should_notify_admins? is false there), so the seed is
+# what gives freshly provisioned sites their enabled-by-default badges.
+module DiscourseSolved
+  class EnableSolvedBadgesToggled < Service::ActionBase
+    UPCOMING_CHANGE = :enable_solved_badges
+    BADGE_NAMES = ["Solved 1", "Solved 2", "Solved 3", "Solved 4"].freeze
+    SNAPSHOT_EVENT_TYPES = %i[manual_opt_in automatically_promoted].freeze
+
+    option :enabled
+
+    def call
+      enabled ? enable : disable
+    end
+
+    private
+
+    def enable
+      ActiveRecord::Base.transaction do
+        capture_snapshot(Badge.where(name: BADGE_NAMES).pluck(:name, :enabled).to_h)
+        Badge.where(name: BADGE_NAMES).update_all(enabled: true)
+      end
+    end
+
+    def disable
+      snapshot = read_snapshot
+      return if snapshot.blank?
+
+      ActiveRecord::Base.transaction do
+        snapshot.each do |name, was_enabled|
+          Badge.where(name: name).update_all(enabled: was_enabled)
+        end
+      end
+    end
+
+    # Capture once: the first opt-in/promotion snapshot is the canonical
+    # pre-change state. Later opt-ins reuse it, and opt-out restores that state.
+    def capture_snapshot(snapshot)
+      return if snapshot_event.present?
+
+      UpcomingChangeEvent
+        .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
+        .order(created_at: :desc)
+        .first
+        &.update!(event_data: snapshot)
+    end
+
+    def read_snapshot
+      snapshot_event&.event_data
+    end
+
+    def snapshot_event
+      @snapshot_event ||=
+        UpcomingChangeEvent
+          .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
+          .where.not(event_data: nil)
+          .order(created_at: :desc)
+          .first
+    end
+  end
+end

--- a/plugins/discourse-solved/app/services/discourse_solved/enable_solved_badges_toggled.rb
+++ b/plugins/discourse-solved/app/services/discourse_solved/enable_solved_badges_toggled.rb
@@ -4,9 +4,7 @@
 # (manually or via auto-promotion). See the on(:upcoming_change_enabled) /
 # on(:upcoming_change_disabled) subscriptions in plugin.rb for the dispatch.
 #
-# Enabling turns on the four seeded Solved badges. Their prior `enabled` state is
-# snapshotted onto the change's UpcomingChangeEvent so that opting out restores
-# exactly what the site had before (a site may have manually enabled a subset).
+# Enabling turns on the four seeded Solved badges; disabling turns them back off.
 #
 # New sites are handled separately by the badge seed fixture
 # (db/fixtures/001_badges.rb): the promotion event does not fire on brand-new
@@ -14,59 +12,12 @@
 # what gives freshly provisioned sites their enabled-by-default badges.
 module DiscourseSolved
   class EnableSolvedBadgesToggled < Service::ActionBase
-    UPCOMING_CHANGE = :enable_solved_badges
     BADGE_NAMES = ["Solved 1", "Solved 2", "Solved 3", "Solved 4"].freeze
-    SNAPSHOT_EVENT_TYPES = %i[manual_opt_in automatically_promoted].freeze
 
     option :enabled
 
     def call
-      enabled ? enable : disable
-    end
-
-    private
-
-    def enable
-      ActiveRecord::Base.transaction do
-        capture_snapshot(Badge.where(name: BADGE_NAMES).pluck(:name, :enabled).to_h)
-        Badge.where(name: BADGE_NAMES).update_all(enabled: true)
-      end
-    end
-
-    def disable
-      snapshot = read_snapshot
-      return if snapshot.blank?
-
-      ActiveRecord::Base.transaction do
-        snapshot.each do |name, was_enabled|
-          Badge.where(name: name).update_all(enabled: was_enabled)
-        end
-      end
-    end
-
-    # Capture once: the first opt-in/promotion snapshot is the canonical
-    # pre-change state. Later opt-ins reuse it, and opt-out restores that state.
-    def capture_snapshot(snapshot)
-      return if snapshot_event.present?
-
-      UpcomingChangeEvent
-        .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
-        .order(created_at: :desc)
-        .first
-        &.update!(event_data: snapshot)
-    end
-
-    def read_snapshot
-      snapshot_event&.event_data
-    end
-
-    def snapshot_event
-      @snapshot_event ||=
-        UpcomingChangeEvent
-          .where(upcoming_change_name: UPCOMING_CHANGE.to_s, event_type: SNAPSHOT_EVENT_TYPES)
-          .where.not(event_data: nil)
-          .order(created_at: :desc)
-          .first
+      Badge.where(name: BADGE_NAMES).update_all(enabled:)
     end
   end
 end

--- a/plugins/discourse-solved/config/locales/server.en.yml
+++ b/plugins/discourse-solved/config/locales/server.en.yml
@@ -47,6 +47,7 @@ en:
     prioritize_solved_topics_in_search: "Prioritize solved topics in search results."
     enable_support_category_type_setup: "Enables the Support category type option during category creation setup."
     enable_solved_shared_issues: "Adds a “Me too” button to unsolved topics in support categories, letting members signal they’re experiencing the same issue and opt-in to notifications about the topic's solution."
+    enable_solved_badges: "Enables the Solved badges awarded to members when they provide solutions to others’ questions."
     show_who_marked_solved: "Show who marked the topic as solved. This is indicated in the topic's first post, and the answer post in a tooltip."
 
     keywords:

--- a/plugins/discourse-solved/config/settings.yml
+++ b/plugins/discourse-solved/config/settings.yml
@@ -78,6 +78,14 @@ discourse_solved:
       status: "beta"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/402498"
+  enable_solved_badges:
+    default: false
+    hidden: true
+    client: true
+    upcoming_change:
+      status: "alpha"
+      impact: "site_setting_default,all_members"
+      learn_more_url: "https://meta.discourse.org/t/-/406386"
   discourse_solved_admin_dashboard_seeded:
     default: false
     hidden: true

--- a/plugins/discourse-solved/db/fixtures/001_badges.rb
+++ b/plugins/discourse-solved/db/fixtures/001_badges.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-# When the "Enable Solved badges by default" upcoming change is active, newly
-# seeded sites get the Solved badges enabled out of the box. `default_enabled`
-# only applies to new badge records, so existing sites are left untouched.
-solved_badges_default_enabled = UpcomingChanges.enabled?(:enable_solved_badges)
-
 first_solution_query = <<~SQL
   SELECT post_id, user_id, created_at AS granted_at
   FROM (
@@ -28,7 +23,7 @@ Badge.seed(:name) do |badge|
   badge.query = first_solution_query
   badge.listable = true
   badge.target_posts = true
-  badge.default_enabled = solved_badges_default_enabled
+  badge.default_enabled = true
   badge.trigger = Badge::Trigger::PostRevision
   badge.auto_revoke = true
   badge.show_posts = true
@@ -63,7 +58,7 @@ end
     badge.listable = true
     badge.default_allow_title = true
     badge.target_posts = false
-    badge.default_enabled = solved_badges_default_enabled
+    badge.default_enabled = true
     badge.trigger = Badge::Trigger::PostRevision
     badge.auto_revoke = true
     badge.show_posts = false

--- a/plugins/discourse-solved/db/fixtures/001_badges.rb
+++ b/plugins/discourse-solved/db/fixtures/001_badges.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# When the "Enable Solved badges by default" upcoming change is active, newly
+# seeded sites get the Solved badges enabled out of the box. `default_enabled`
+# only applies to new badge records, so existing sites are left untouched.
+solved_badges_default_enabled = UpcomingChanges.enabled?(:enable_solved_badges)
+
 first_solution_query = <<~SQL
   SELECT post_id, user_id, created_at AS granted_at
   FROM (
@@ -23,7 +28,7 @@ Badge.seed(:name) do |badge|
   badge.query = first_solution_query
   badge.listable = true
   badge.target_posts = true
-  badge.default_enabled = false
+  badge.default_enabled = solved_badges_default_enabled
   badge.trigger = Badge::Trigger::PostRevision
   badge.auto_revoke = true
   badge.show_posts = true
@@ -58,7 +63,7 @@ end
     badge.listable = true
     badge.default_allow_title = true
     badge.target_posts = false
-    badge.default_enabled = false
+    badge.default_enabled = solved_badges_default_enabled
     badge.trigger = Badge::Trigger::PostRevision
     badge.auto_revoke = true
     badge.show_posts = false

--- a/plugins/discourse-solved/lib/discourse_solved/upcoming_changes_conditional_display_extension.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/upcoming_changes_conditional_display_extension.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DiscourseSolved
+  module UpcomingChangesConditionalDisplayExtension
+    def should_display_enable_solved_badges?
+      SiteSetting.solved_enabled
+    end
+  end
+end

--- a/plugins/discourse-solved/lib/discourse_solved/upcoming_changes_conditional_display_extension.rb
+++ b/plugins/discourse-solved/lib/discourse_solved/upcoming_changes_conditional_display_extension.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module DiscourseSolved
-  module UpcomingChangesConditionalDisplayExtension
-    def should_display_enable_solved_badges?
-      SiteSetting.solved_enabled
-    end
-  end
-end

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -57,6 +57,9 @@ after_initialize do
     ::PostSerializer.prepend(DiscourseSolved::PostSerializerExtension)
     ::PostMover.prepend(DiscourseSolved::PostMoverExtension)
     ::UserSummary.prepend(DiscourseSolved::UserSummaryExtension)
+    ::UpcomingChanges::ConditionalDisplay.extend(
+      DiscourseSolved::UpcomingChangesConditionalDisplayExtension,
+    )
 
     ::Topic.attr_accessor(:accepted_answer_user_ids)
     ::TopicPostersSummary.alias_method(:old_user_ids, :user_ids)
@@ -284,6 +287,18 @@ after_initialize do
   end
   add_to_serializer(:topic_view, :shared_issue_visible) do
     scope.shared_issue_visible?(object.topic)
+  end
+
+  on(:upcoming_change_enabled) do |setting_name|
+    if setting_name == :enable_solved_badges
+      DiscourseSolved::EnableSolvedBadgesToggled.call(enabled: true)
+    end
+  end
+
+  on(:upcoming_change_disabled) do |setting_name|
+    if setting_name == :enable_solved_badges
+      DiscourseSolved::EnableSolvedBadgesToggled.call(enabled: false)
+    end
   end
 
   on(:post_destroyed) do |post|

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -57,9 +57,6 @@ after_initialize do
     ::PostSerializer.prepend(DiscourseSolved::PostSerializerExtension)
     ::PostMover.prepend(DiscourseSolved::PostMoverExtension)
     ::UserSummary.prepend(DiscourseSolved::UserSummaryExtension)
-    ::UpcomingChanges::ConditionalDisplay.extend(
-      DiscourseSolved::UpcomingChangesConditionalDisplayExtension,
-    )
 
     ::Topic.attr_accessor(:accepted_answer_user_ids)
     ::TopicPostersSummary.alias_method(:old_user_ids, :user_ids)
@@ -288,6 +285,8 @@ after_initialize do
   add_to_serializer(:topic_view, :shared_issue_visible) do
     scope.shared_issue_visible?(object.topic)
   end
+
+  register_upcoming_change_conditional_display(:enable_solved_badges) { SiteSetting.solved_enabled }
 
   on(:upcoming_change_enabled) do |setting_name|
     if setting_name == :enable_solved_badges

--- a/plugins/discourse-solved/plugin.rb
+++ b/plugins/discourse-solved/plugin.rb
@@ -286,8 +286,6 @@ after_initialize do
     scope.shared_issue_visible?(object.topic)
   end
 
-  register_upcoming_change_conditional_display(:enable_solved_badges) { SiteSetting.solved_enabled }
-
   on(:upcoming_change_enabled) do |setting_name|
     if setting_name == :enable_solved_badges
       DiscourseSolved::EnableSolvedBadgesToggled.call(enabled: true)

--- a/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
+++ b/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
@@ -9,20 +9,10 @@ RSpec.describe "Enable Solved badges by default upcoming change" do
   end
 
   describe "seeding the Solved badges on a new site" do
-    it "enables the badges by default when the upcoming change is enabled" do
-      SiteSetting.enable_solved_badges = true
-
+    it "enables the badges by default" do
       reseed_solved_badges
 
       expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(true))
-    end
-
-    it "leaves the badges disabled by default when the upcoming change is disabled" do
-      SiteSetting.enable_solved_badges = false
-
-      reseed_solved_badges
-
-      expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(false))
     end
   end
 

--- a/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
+++ b/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
@@ -22,17 +22,5 @@ RSpec.describe "Enable Solved badges by default upcoming change" do
 
       expect(UpcomingChanges::ConditionalDisplay.should_display?(:enable_solved_badges)).to eq(true)
     end
-
-    it "is hidden on sites where the Solved plugin is disabled" do
-      pending(
-        "DiscoursePluginRegistry filters out conditional display callbacks from disabled plugins, so the change is still displayed. Needs a core fix.",
-      )
-
-      SiteSetting.solved_enabled = false
-
-      expect(UpcomingChanges::ConditionalDisplay.should_display?(:enable_solved_badges)).to eq(
-        false,
-      )
-    end
   end
 end

--- a/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
+++ b/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
@@ -15,12 +15,4 @@ RSpec.describe "Enable Solved badges by default upcoming change" do
       expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(true))
     end
   end
-
-  describe "conditional display" do
-    it "is displayed on sites where the Solved plugin is enabled" do
-      SiteSetting.solved_enabled = true
-
-      expect(UpcomingChanges::ConditionalDisplay.should_display?(:enable_solved_badges)).to eq(true)
-    end
-  end
 end

--- a/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
+++ b/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "Enable Solved badges by default upcoming change" do
+  let(:badge_names) { ["Solved 1", "Solved 2", "Solved 3", "Solved 4"] }
+
+  def reseed_solved_badges
+    Badge.where(name: badge_names).delete_all
+    load Rails.root.join("plugins/discourse-solved/db/fixtures/001_badges.rb") # rubocop:disable Discourse/Plugins/UseRequireRelative
+  end
+
+  describe "seeding the Solved badges on a new site" do
+    it "enables the badges by default when the upcoming change is enabled" do
+      SiteSetting.enable_solved_badges = true
+
+      reseed_solved_badges
+
+      expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(true))
+    end
+
+    it "leaves the badges disabled by default when the upcoming change is disabled" do
+      SiteSetting.enable_solved_badges = false
+
+      reseed_solved_badges
+
+      expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(false))
+    end
+  end
+
+  describe "conditional display" do
+    it "is displayed only on sites where the Solved plugin is enabled" do
+      SiteSetting.solved_enabled = true
+      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_solved_badges?).to eq(true)
+
+      SiteSetting.solved_enabled = false
+      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_solved_badges?).to eq(false)
+    end
+  end
+end

--- a/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
+++ b/plugins/discourse-solved/spec/integration/enable_solved_badges_spec.rb
@@ -17,12 +17,22 @@ RSpec.describe "Enable Solved badges by default upcoming change" do
   end
 
   describe "conditional display" do
-    it "is displayed only on sites where the Solved plugin is enabled" do
+    it "is displayed on sites where the Solved plugin is enabled" do
       SiteSetting.solved_enabled = true
-      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_solved_badges?).to eq(true)
+
+      expect(UpcomingChanges::ConditionalDisplay.should_display?(:enable_solved_badges)).to eq(true)
+    end
+
+    it "is hidden on sites where the Solved plugin is disabled" do
+      pending(
+        "DiscoursePluginRegistry filters out conditional display callbacks from disabled plugins, so the change is still displayed. Needs a core fix.",
+      )
 
       SiteSetting.solved_enabled = false
-      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_solved_badges?).to eq(false)
+
+      expect(UpcomingChanges::ConditionalDisplay.should_display?(:enable_solved_badges)).to eq(
+        false,
+      )
     end
   end
 end

--- a/plugins/discourse-solved/spec/services/discourse_solved/enable_solved_badges_toggled_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/enable_solved_badges_toggled_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseSolved::EnableSolvedBadgesToggled do
+  let(:badge_names) { DiscourseSolved::EnableSolvedBadgesToggled::BADGE_NAMES }
+
+  def solved_badges
+    Badge.where(name: badge_names)
+  end
+
+  before { solved_badges.update_all(enabled: false) }
+
+  describe "enabling" do
+    it "enables all four Solved badges" do
+      described_class.call(enabled: true)
+
+      expect(solved_badges.where(enabled: true).count).to eq(4)
+    end
+
+    it "snapshots the prior enabled state onto the existing opt-in event" do
+      Badge.where(name: "Solved 1").update_all(enabled: true)
+      event =
+        UpcomingChangeEvent.create!(
+          event_type: :manual_opt_in,
+          upcoming_change_name: "enable_solved_badges",
+        )
+
+      described_class.call(enabled: true)
+
+      expect(event.reload.event_data).to eq(
+        "Solved 1" => true,
+        "Solved 2" => false,
+        "Solved 3" => false,
+        "Solved 4" => false,
+      )
+    end
+
+    it "captures the snapshot only once" do
+      event =
+        UpcomingChangeEvent.create!(
+          event_type: :automatically_promoted,
+          upcoming_change_name: "enable_solved_badges",
+          event_data: {
+            "Solved 1" => true,
+          },
+        )
+
+      described_class.call(enabled: true)
+
+      expect(event.reload.event_data).to eq("Solved 1" => true)
+    end
+  end
+
+  describe "disabling" do
+    it "restores each badge to its snapshotted state" do
+      UpcomingChangeEvent.create!(
+        event_type: :manual_opt_in,
+        upcoming_change_name: "enable_solved_badges",
+        event_data: {
+          "Solved 1" => true,
+          "Solved 2" => false,
+          "Solved 3" => false,
+          "Solved 4" => false,
+        },
+      )
+      solved_badges.update_all(enabled: true)
+
+      described_class.call(enabled: false)
+
+      expect(Badge.find_by(name: "Solved 1").enabled).to eq(true)
+      expect(Badge.where(name: ["Solved 2", "Solved 3", "Solved 4"], enabled: false).count).to eq(3)
+    end
+
+    it "does nothing when there is no snapshot" do
+      solved_badges.update_all(enabled: true)
+
+      described_class.call(enabled: false)
+
+      expect(solved_badges.where(enabled: true).count).to eq(4)
+    end
+  end
+end

--- a/plugins/discourse-solved/spec/services/discourse_solved/enable_solved_badges_toggled_spec.rb
+++ b/plugins/discourse-solved/spec/services/discourse_solved/enable_solved_badges_toggled_spec.rb
@@ -7,75 +7,23 @@ RSpec.describe DiscourseSolved::EnableSolvedBadgesToggled do
     Badge.where(name: badge_names)
   end
 
-  before { solved_badges.update_all(enabled: false) }
-
   describe "enabling" do
+    before { solved_badges.update_all(enabled: false) }
+
     it "enables all four Solved badges" do
       described_class.call(enabled: true)
 
       expect(solved_badges.where(enabled: true).count).to eq(4)
     end
-
-    it "snapshots the prior enabled state onto the existing opt-in event" do
-      Badge.where(name: "Solved 1").update_all(enabled: true)
-      event =
-        UpcomingChangeEvent.create!(
-          event_type: :manual_opt_in,
-          upcoming_change_name: "enable_solved_badges",
-        )
-
-      described_class.call(enabled: true)
-
-      expect(event.reload.event_data).to eq(
-        "Solved 1" => true,
-        "Solved 2" => false,
-        "Solved 3" => false,
-        "Solved 4" => false,
-      )
-    end
-
-    it "captures the snapshot only once" do
-      event =
-        UpcomingChangeEvent.create!(
-          event_type: :automatically_promoted,
-          upcoming_change_name: "enable_solved_badges",
-          event_data: {
-            "Solved 1" => true,
-          },
-        )
-
-      described_class.call(enabled: true)
-
-      expect(event.reload.event_data).to eq("Solved 1" => true)
-    end
   end
 
   describe "disabling" do
-    it "restores each badge to its snapshotted state" do
-      UpcomingChangeEvent.create!(
-        event_type: :manual_opt_in,
-        upcoming_change_name: "enable_solved_badges",
-        event_data: {
-          "Solved 1" => true,
-          "Solved 2" => false,
-          "Solved 3" => false,
-          "Solved 4" => false,
-        },
-      )
-      solved_badges.update_all(enabled: true)
+    before { solved_badges.update_all(enabled: true) }
 
+    it "disables all four Solved badges" do
       described_class.call(enabled: false)
 
-      expect(Badge.find_by(name: "Solved 1").enabled).to eq(true)
-      expect(Badge.where(name: ["Solved 2", "Solved 3", "Solved 4"], enabled: false).count).to eq(3)
-    end
-
-    it "does nothing when there is no snapshot" do
-      solved_badges.update_all(enabled: true)
-
-      described_class.call(enabled: false)
-
-      expect(solved_badges.where(enabled: true).count).to eq(4)
+      expect(solved_badges.where(enabled: false).count).to eq(4)
     end
   end
 end


### PR DESCRIPTION
We want to enable the Solved badges by default so that communities can more easily acknowledge their engaged and contributing members.

For sites that have the Solved plugin enabled — we will show an upcoming change labelled "Enabled Solved Badges".

When the upcoming change is enabled (either manually or via auto-promotion) we will update all 4 solved badges to enabled. When opting out of this upcoming change we will disable all 4 solved badges.