### PR TITLE
DEV: Speed up CI annotation and structure checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,7 +214,7 @@ jobs:
             directories="$(script/list_bundled_plugins | xargs -I{} find {} -type d -path '*/app/models' -maxdepth 3)"
           fi
 
-          # annotate:clean runs the seed + annotaterb in a temporary postgres so it
+          # annotate:clean runs index setup + annotaterb in a temporary postgres so it
           # doesn't pollute the rspec test DB.
           MODEL_DIR="$(echo "${directories}" | tr '\n' ',')" bin/rake annotate:clean
 

--- a/lib/tasks/annotate.rake
+++ b/lib/tasks/annotate.rake
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
-# Runs annotaterb in a TemporaryDb so the seed topics that
-# `annotate:ensure_all_indexes` creates don't leak into the persistent test DB.
+# Runs annotaterb in a TemporaryDb so the index setup performed by
+# `annotate:ensure_all_indexes` does not leak into the persistent test DB.
 def annotate_in_temp_db(load_plugins:, annotaterb_args: [])
-  env = { "RAILS_ENV" => "test", "LOAD_PLUGINS" => load_plugins }
+  env = {
+    "RAILS_ENV" => "test",
+    "LOAD_PLUGINS" => load_plugins,
+    "SKIP_OPTIMIZE_ICONS" => "1",
+    "SKIP_SEED_FU" => "1",
+  }
   db = TemporaryDb.new
   db.start
   db.with_env do
-    system(env, "bin/rails", "db:migrate", exception: true)
-    system(env, "bin/rails", "annotate:ensure_all_indexes", exception: true)
+    system(env, "bin/rails", "db:migrate", "annotate:ensure_all_indexes", exception: true)
     system(env, "bin/annotaterb", "models", "--force", *annotaterb_args, exception: true)
   end
 ensure
@@ -31,11 +35,25 @@ end
 
 desc "ensure the asynchronously-created post_search_data index is present"
 task "annotate:ensure_all_indexes" => :environment do |task, args|
-  # One of the indexes on post_search_data is created by a sidekiq job
-  # We need to do some acrobatics to create it on-demand
-  SeedData::Topics.with_default_locale.create
-  SiteSetting.search_enable_recent_regular_posts_offset_size = 1
-  Jobs::CreateRecentPostSearchIndexes.new.execute([])
+  recent_posts_size = SiteSetting.search_recent_posts_size
+  offset_size = SiteSetting.search_enable_recent_regular_posts_offset_size
+  offset_post_id = SiteSetting.search_recent_regular_posts_offset_post_id
+  inserted_synthetic_row = false
+
+  # One of the indexes on post_search_data is created by a sidekiq job.
+  # Add the minimum data needed to create it on demand.
+  begin
+    PostSearchData.insert_all!([{ post_id: 0, private_message: false }])
+    inserted_synthetic_row = true
+    SiteSetting.search_enable_recent_regular_posts_offset_size = 1
+    SiteSetting.search_recent_posts_size = 1
+    Jobs::CreateRecentPostSearchIndexes.new.execute([])
+  ensure
+    PostSearchData.where(post_id: 0).delete_all if inserted_synthetic_row
+    SiteSetting.search_enable_recent_regular_posts_offset_size = offset_size
+    SiteSetting.search_recent_posts_size = recent_posts_size
+    SiteSetting.search_recent_regular_posts_offset_post_id = offset_post_id
+  end
 end
 
 desc "regenerate core model annotations using a temporary database"

--- a/lib/temporary_db.rb
+++ b/lib/temporary_db.rb
@@ -96,7 +96,7 @@ class TemporaryDb
 
   def start
     init_data_directory
-    configure_ports
+    configure_database
 
     puts "Starting postgres on port: #{pg_port}"
     @previous_discourse_pg_port = ENV["DISCOURSE_PG_PORT"]
@@ -192,11 +192,21 @@ class TemporaryDb
     )
   end
 
-  def configure_ports
+  def configure_database
     FileUtils.mkdir(@pg_sock_path)
     FileUtils.chown(@pg_system_user, nil, @pg_sock_path) if running_as_root?
     conf = File.read(@pg_conf)
-    File.write(@pg_conf, conf + "\nport = #{pg_port}\nunix_socket_directories = '#{@pg_sock_path}'")
+    conf << <<~CONF
+
+      port = #{pg_port}
+      unix_socket_directories = '#{@pg_sock_path}'
+      fsync = off
+      synchronous_commit = off
+      full_page_writes = off
+      wal_level = minimal
+      max_wal_senders = 0
+    CONF
+    File.write(@pg_conf, conf)
   end
 
   def start_server


### PR DESCRIPTION
Previously, CI annotation checks seeded unnecessary data and ran migration and index setup in separate Rails processes, while annotation and structure checks used durable PostgreSQL settings for disposable databases.

Before: https://github.com/discourse/discourse/actions/runs/29068299457/job/86284449983

<img width="2616" height="82" alt="Screenshot 2026-07-10 at 3 22 51 PM" src="https://github.com/user-attachments/assets/45959267-af44-433a-ba4b-3230987550b1" />

After: https://github.com/discourse/discourse/actions/runs/29076405986/job/86308887427?pr=41614

<img width="2601" height="77" alt="Screenshot 2026-07-10 at 3 23 26 PM" src="https://github.com/user-attachments/assets/6efac54c-1579-4a2b-9add-38256adfa975" />

