### PR TITLE
FIX: Print site setting descriptions and setting enums correctly

### DIFF
--- a/frontend/discourse/admin/models/site-setting.js
+++ b/frontend/discourse/admin/models/site-setting.js
@@ -1,5 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import EmberObject, { computed, set } from "@ember/object";
+import { trustHTML } from "@ember/template";
 import BufferedProxy from "ember-buffered-proxy/proxy";
 import {
   DEFAULT_USER_PREFERENCES,
@@ -157,13 +158,13 @@ export default class SiteSetting extends EmberObject {
     return {
       key: this.setting,
       label: this.humanized_name,
-      description: this.description,
+      description: trustHTML(this.description),
       type: this.type,
       list_type: this.list_type,
       min: this.min,
       max: this.max,
       choices: this.choices,
-      valid_values: this.valid_values,
+      valid_values: this.validValues,
     };
   }
 

--- a/frontend/discourse/tests/unit/models/site-setting-test.js
+++ b/frontend/discourse/tests/unit/models/site-setting-test.js
@@ -9,25 +9,39 @@ module("Unit | Model | site-setting", function (hooks) {
     const setting = SiteSetting.create({
       setting: "title",
       humanized_name: "Title",
-      description: "The name of the site",
+      description: "The <strong>name</strong> of the site",
       type: "string",
       list_type: null,
       min: 1,
       max: 100,
       choices: ["a", "b"],
-      valid_values: ["a", "b"],
+      valid_values: [
+        { name: "category_scope.all", value: "a" },
+        { name: "category_scope.public", value: "b" },
+      ],
+      translate_names: true,
     });
 
-    assert.deepEqual(setting.definition, {
-      key: "title",
-      label: "Title",
-      description: "The name of the site",
-      type: "string",
-      list_type: null,
-      min: 1,
-      max: 100,
-      choices: ["a", "b"],
-      valid_values: ["a", "b"],
-    });
+    const definition = setting.definition;
+
+    assert.strictEqual(definition.key, "title");
+    assert.strictEqual(definition.label, "Title");
+    assert.strictEqual(
+      definition.description.toString(),
+      "The <strong>name</strong> of the site"
+    );
+    assert.strictEqual(definition.type, "string");
+    assert.strictEqual(definition.list_type, null);
+    assert.strictEqual(definition.min, 1);
+    assert.strictEqual(definition.max, 100);
+    assert.deepEqual(definition.choices, ["a", "b"]);
+    assert.strictEqual(definition.valid_values.length, 2);
+    assert.strictEqual(
+      definition.valid_values[0].name,
+      "All public and private categories"
+    );
+    assert.strictEqual(definition.valid_values[0].value, "a");
+    assert.strictEqual(definition.valid_values[1].name, "Public categories");
+    assert.strictEqual(definition.valid_values[1].value, "b");
   });
 });


### PR DESCRIPTION
For site setting descriptions, we have the ability to link to another site setting via defining `{{setting. ... }}`  in the i18n description.

Presentation of this was not extended to AI settings, resulting in it being poorly displayed.

Also, setting enums were not being displayed properly either.

### before

<img width="685" height="263" alt="Screenshot 2026-07-10 at 4 49 14 PM" src="https://github.com/user-attachments/assets/5df400f6-dc8b-4b50-ad0b-fb7cc90a4e45" />

### after

<img width="666" height="127" alt="Screenshot 2026-07-10 at 4 50 50 PM" src="https://github.com/user-attachments/assets/8ff5071a-6c57-44d9-8fb3-cb1a5657870f" />
