### PR TITLE
FIX: close post reaction menu on route change

### DIFF
--- a/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-menu.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UsersPopup from "discourse/components/user/users-popup";
 import lazyHash from "discourse/helpers/lazy-hash";
@@ -9,6 +10,8 @@ import { i18n } from "discourse-i18n";
 const LIKE_ACTION = 2;
 
 export default class PostLikedUsersMenu extends Component {
+  @service router;
+
   fetchUsers = async (page, pageSize) => {
     const result = await ajax("/post_action_users", {
       data: {
@@ -24,6 +27,16 @@ export default class PostLikedUsersMenu extends Component {
       newUsers.length >= pageSize && !!result.total_rows_post_action_users;
     return { users: newUsers, canLoadMore };
   };
+
+  constructor() {
+    super(...arguments);
+    this.router.on("routeWillChange", this.args.close);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.router.off("routeWillChange", this.args.close);
+  }
 
   get post() {
     return this.args.data.post;

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-users-menu.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import UsersPopup from "discourse/components/user/users-popup";
 import { eq } from "discourse/truth-helpers";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -12,6 +13,8 @@ import { i18n } from "discourse-i18n";
 import CustomReaction from "../models/discourse-reactions-custom-reaction";
 
 export default class DiscourseReactionsUsersMenu extends Component {
+  @service router;
+
   @tracked activeFilter = null;
 
   fetchUsers = async (page, pageSize) => {
@@ -58,8 +61,20 @@ export default class DiscourseReactionsUsersMenu extends Component {
 
     return { users, canLoadMore };
   };
+
   #resetCallback = null;
+
   #tabCache = new Map();
+
+  constructor() {
+    super(...arguments);
+    this.router.on("routeWillChange", this.args.close);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.router.off("routeWillChange", this.args.close);
+  }
 
   get post() {
     return this.args.data.post;

--- a/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
+++ b/plugins/discourse-reactions/test/javascripts/acceptance/discourse-reactions-users-menu-test.js
@@ -96,6 +96,19 @@ acceptance(
       assert.dom(".users-popup__item").exists({ count: 5 });
     });
 
+    test("closes the users menu when navigating away", async function (assert) {
+      await visit("/t/topic_with_reactions_and_likes/374");
+      await click("#post_1 .discourse-reactions-counter");
+
+      assert.dom(".users-popup").exists("the reactions menu is open");
+
+      await visit("/");
+
+      assert
+        .dom(".users-popup")
+        .doesNotExist("the reactions menu closes when navigating away");
+    });
+
     test("emoji filters and list reactions show the emoji name in the title", async function (assert) {
       await visit("/t/topic_with_reactions_and_likes/374");
       await click("#post_1 .discourse-reactions-counter");


### PR DESCRIPTION
When the reaction menu is open and the user navigates to a new page — we should force close the menu.