### PR TITLE
FIX: Bind workflow modal responses to their target user

### DIFF
--- a/plugins/discourse-workflows/app/services/discourse_workflows/modal/respond.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/modal/respond.rb
@@ -17,7 +17,7 @@ module DiscourseWorkflows
 
     private
 
-    def fetch_resume_request(params:)
+    def fetch_resume_request(params:, guardian:)
       payload = DiscourseWorkflows::InteractiveResume.action_payload(params.action_id)
       return if payload.blank?
 
@@ -28,12 +28,18 @@ module DiscourseWorkflows
       waiting_node = execution.find_waiting_node
       return unless waiting_node && waiting_node["type"] == NODE_TYPE
 
-      DiscourseWorkflows::InteractiveResume.from_action_id(
-        params.action_id,
-        expected_node_type: NODE_TYPE,
-        allowed_actions:
-          DiscourseWorkflows::Nodes::Modal::V1.button_values(waiting_node["parameters"]),
-      )
+      resume_request =
+        DiscourseWorkflows::InteractiveResume.from_action_id(
+          params.action_id,
+          expected_node_type: NODE_TYPE,
+          allowed_actions:
+            DiscourseWorkflows::Nodes::Modal::V1.button_values(waiting_node["parameters"]),
+        )
+      return if resume_request.blank?
+      return if resume_request.target_user_id.blank?
+      return if resume_request.target_user_id != guardian.user&.id
+
+      resume_request
     end
 
     def resume(resume_request:, guardian:)

--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/node_execution_context.rb
@@ -378,11 +378,12 @@ module DiscourseWorkflows
         @runtime_state.request_wait(waiting_until, kind: kind, payload: payload)
       end
 
-      def resume_action_id(action)
+      def resume_action_id(action, target_user_id: nil)
         DiscourseWorkflows::InteractiveResume.action_id(
           execution_id: execution_id,
           resume_token: @resume_token,
           action: action,
+          target_user_id: target_user_id,
         )
       end
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/interactive_resume.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/interactive_resume.rb
@@ -3,11 +3,12 @@
 module DiscourseWorkflows
   class InteractiveResume
     class Request
-      attr_reader :action
+      attr_reader :action, :target_user_id
 
-      def initialize(execution:, action:)
+      def initialize(execution:, action:, target_user_id: nil)
         @execution = execution
         @action = action
+        @target_user_id = target_user_id
       end
 
       def claim
@@ -35,11 +36,12 @@ module DiscourseWorkflows
       end
     end
 
-    def self.action_id(execution_id:, resume_token:, action:)
+    def self.action_id(execution_id:, resume_token:, action:, target_user_id: nil)
       DiscourseWorkflows::WaitingExecution.action_token(
         execution_id: execution_id,
         resume_token: resume_token,
         action: action,
+        target_user_id: target_user_id,
       )
     end
 
@@ -67,7 +69,11 @@ module DiscourseWorkflows
         )
       return if execution.blank?
 
-      Request.new(execution: execution, action: payload["action"])
+      Request.new(
+        execution: execution,
+        action: payload["action"],
+        target_user_id: payload["target_user_id"],
+      )
     end
   end
 end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/modal/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/modal/v1.rb
@@ -92,7 +92,7 @@ module DiscourseWorkflows
 
         def execute(exec_ctx)
           target_user = resolve_target_user(exec_ctx)
-          buttons = build_buttons(exec_ctx)
+          buttons = build_buttons(exec_ctx, target_user)
 
           MessageBus.publish(
             self.class.user_channel(target_user.id),
@@ -132,7 +132,7 @@ module DiscourseWorkflows
           user
         end
 
-        def build_buttons(exec_ctx)
+        def build_buttons(exec_ctx, target_user)
           rows =
             DiscourseWorkflows::CollectionParameters.rows_from_value(
               exec_ctx.get_node_parameter("buttons", 0, default: []),
@@ -146,7 +146,7 @@ module DiscourseWorkflows
               "label" => row["label"].to_s.presence || value,
               "value" => value,
               "style" => normalize_style(row["style"]),
-              "action_id" => exec_ctx.resume_action_id(value),
+              "action_id" => exec_ctx.resume_action_id(value, target_user_id: target_user.id),
             }
           end
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/waiting_execution.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/waiting_execution.rb
@@ -118,19 +118,26 @@ module DiscourseWorkflows
       signed_url(path, signature, absolute: absolute)
     end
 
-    def self.action_token(execution_id:, resume_token:, action:)
+    def self.action_token(execution_id:, resume_token:, action:, target_user_id: nil)
       action = action.to_s
-      "#{execution_id.to_i}:#{action}:#{action_signature(execution_id:, resume_token:, action:)}"
+      signature = action_signature(execution_id:, resume_token:, action:, target_user_id:)
+      "#{execution_id.to_i}:#{target_user_id}:#{action}:#{signature}"
     end
 
     def self.action_token_payload(token)
       return if token.blank?
 
-      execution_id, action, signature = token.to_s.split(":", 3)
+      execution_id, target_user_id, action, signature = token.to_s.split(":", 4)
       return if execution_id.blank? || action.blank? || signature.blank?
       return unless execution_id.match?(/\A\d+\z/)
+      return unless target_user_id.blank? || target_user_id.match?(/\A\d+\z/)
 
-      { "execution_id" => execution_id.to_i, "action" => action, "signature" => signature }
+      {
+        "execution_id" => execution_id.to_i,
+        "target_user_id" => target_user_id.presence&.to_i,
+        "action" => action,
+        "signature" => signature,
+      }
     end
 
     def self.find_by_action_token(token, expected_node_type:)
@@ -174,6 +181,7 @@ module DiscourseWorkflows
           execution_id: execution.id,
           resume_token: execution.resume_token,
           action: payload["action"],
+          target_user_id: payload["target_user_id"],
         )
       return false if signature.bytesize != expected.bytesize
 
@@ -181,11 +189,11 @@ module DiscourseWorkflows
     end
     private_class_method :valid_action_signature?
 
-    def self.action_signature(execution_id:, resume_token:, action:)
+    def self.action_signature(execution_id:, resume_token:, action:, target_user_id: nil)
       OpenSSL::HMAC.hexdigest(
         "SHA256",
         action_token_key,
-        "#{execution_id.to_i}:#{action}:#{resume_token}",
+        "#{execution_id.to_i}:#{target_user_id}:#{action}:#{resume_token}",
       )
     end
     private_class_method :action_signature

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/interactive_resume_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/interactive_resume_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe DiscourseWorkflows::InteractiveResume do
         ),
       ).to be_nil
     end
+
+    it "returns nil when the bound target user id in the token is altered" do
+      bound_action_id =
+        DiscourseWorkflows::InteractiveResume.action_id(
+          execution_id: execution.id,
+          resume_token: execution.resume_token,
+          action: "resume",
+          target_user_id: user.id,
+        )
+      _execution_id, _target_user_id, action, signature = bound_action_id.split(":", 4)
+      tampered = [execution.id, user.id + 1, action, signature].join(":")
+
+      expect(
+        described_class.from_action_id(
+          tampered,
+          expected_node_type: "flow:wait",
+          allowed_actions: %w[resume],
+        ),
+      ).to be_nil
+    end
   end
 
   describe DiscourseWorkflows::InteractiveResume::Request do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/modal_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/modal_spec.rb
@@ -62,8 +62,24 @@ RSpec.describe DiscourseWorkflows::Nodes::Modal::V1 do
           execution_id: 7,
           resume_token: "tok-7",
           action: "approve",
+          target_user_id: user.id,
         ),
       )
+    end
+
+    it "binds the target user into the action ids so another user's token differs" do
+      configuration = config.merge("target_user" => other_user.username)
+      exec_ctx = build_exec_ctx(configuration, ctx_user: user)
+
+      messages =
+        MessageBus.track_publish(described_class.user_channel(other_user.id)) do
+          described_class.new(parameters: configuration).execute(exec_ctx)
+        end
+
+      action_id = messages.first.data[:buttons].first["action_id"]
+      payload = DiscourseWorkflows::InteractiveResume.action_payload(action_id)
+      expect(payload["target_user_id"]).to eq(other_user.id)
+      expect(payload["target_user_id"]).not_to eq(user.id)
     end
 
     it "sends the modal to a configured target user instead of the triggering user" do

--- a/plugins/discourse-workflows/spec/services/discourse_workflows/modal/respond_spec.rb
+++ b/plugins/discourse-workflows/spec/services/discourse_workflows/modal/respond_spec.rb
@@ -47,11 +47,12 @@ RSpec.describe DiscourseWorkflows::Modal::Respond do
       ).run
     end
 
-    def action_id(action)
+    def action_id(action, target_user_id: user.id)
       DiscourseWorkflows::InteractiveResume.action_id(
         execution_id: execution.id,
         resume_token: execution.resume_token,
         action: action,
+        target_user_id: target_user_id,
       )
     end
 
@@ -87,6 +88,20 @@ RSpec.describe DiscourseWorkflows::Modal::Respond do
       let(:params) { { action_id: action_id("delete") } }
 
       it { is_expected.to fail_to_find_a_model(:resume_request) }
+    end
+
+    context "when a user other than the modal target holds the token" do
+      fab!(:other_user, :user)
+
+      let(:dependencies) { { guardian: other_user.guardian } }
+
+      it { is_expected.to fail_to_find_a_model(:resume_request) }
+
+      it "leaves the execution waiting instead of resuming it" do
+        described_class.call(params:, **dependencies)
+
+        expect(execution.reload.status).to eq("waiting")
+      end
     end
 
     context "when the execution was already resumed" do


### PR DESCRIPTION
Modal nodes publish an approve/reject modal to a single resolved target user over a per-user MessageBus channel. Each button carried an HMAC-signed action token, but the token only proved it was issued by the server, not who it was for: any logged-in user who obtained a valid token could POST it and resume the execution under their own account.

In practice this was hard to pull off as only the valid user would get the message bus event (and the modal to show), but this is an important defense in depth fix to apply.