### PR TITLE
UX: update review queue icon to link

### DIFF
--- a/frontend/discourse/app/components/reviewable/item.gjs
+++ b/frontend/discourse/app/components/reviewable/item.gjs
@@ -769,7 +769,7 @@ export default class ReviewableItem extends Component {
                 title={{i18n "review.copy_permalink_title"}}
                 class="btn btn-transparent reviewable-permalink-copy"
               >
-                {{dIcon "d-post-share"}}
+                {{dIcon "link"}}
               </button>
 
               {{newReviewableStatus


### PR DESCRIPTION
This icon got caught up in other updates, it should remain a link rather than the share icon, as it copies the link

before
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/b086070f-d7d7-436b-b939-f4aec7930ed3" />



after
<img width="800"  alt="image" src="https://github.com/user-attachments/assets/9c51048e-495f-4542-b93f-050684aa77cb" />

