### PR TITLE
FIX: use available channel for /chat/new-channel MessageBus event

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-subscriptions-manager.js
@@ -449,28 +449,28 @@ export default class ChatSubscriptionsManager extends Service {
 
   @bind
   _onNewChannelSubscription(data) {
-    this.chatChannelsManager.find(data.channel.id).then((channel) => {
-      // we need to refresh here to have correct last message ids
-      channel.meta = data.channel.meta;
-      channel.currentUserMembership = data.channel.current_user_membership;
+    const channel = this.chatChannelsManager.store(data.channel);
 
-      if (!this.currentUser) {
-        if (channel.isCategoryChannel) {
-          this.startChannelSubscription(channel, { readOnly: true });
-        }
+    // we need to refresh here to have correct last message ids
+    channel.meta = data.channel.meta;
+    channel.currentUserMembership = data.channel.current_user_membership;
 
-        return;
+    if (!this.currentUser) {
+      if (channel.isCategoryChannel) {
+        this.startChannelSubscription(channel, { readOnly: true });
       }
 
-      if (
-        channel.isDirectMessageChannel &&
-        !channel.currentUserMembership.following
-      ) {
-        channel.tracking.unreadCount = 1;
-      }
+      return;
+    }
 
-      this.chatChannelsManager.follow(channel);
-    });
+    if (
+      channel.isDirectMessageChannel &&
+      !channel.currentUserMembership.following
+    ) {
+      channel.tracking.unreadCount = 1;
+    }
+
+    this.chatChannelsManager.follow(channel);
   }
 
   _startChannelsMetadataChangesSubscription(lastId) {

--- a/plugins/chat/test/javascripts/unit/services/chat-subscriptions-manager-test.js
+++ b/plugins/chat/test/javascripts/unit/services/chat-subscriptions-manager-test.js
@@ -68,4 +68,19 @@ module("Unit | Service | chat-subscriptions-manager", function (hooks) {
     assert.strictEqual(channel.lastMessage, message);
     assert.strictEqual(channel.tracking.unreadCount, 0);
   });
+
+  test("new channel subscriptions use the channel from the event", async function (assert) {
+    const channel = this.fabricators.directMessageChannel({ id: 46 });
+    channel.current_user_membership = { following: true };
+    sinon.stub(this.chatChannelsManager.chatApi, "channel").throws();
+
+    this.subject._onNewChannelSubscription({ channel });
+
+    const storedChannel = await this.chatChannelsManager.find(channel.id, {
+      fetchIfNotFound: false,
+    });
+
+    assert.strictEqual(storedChannel, channel);
+    assert.true(storedChannel.currentUserMembership.following);
+  });
 });


### PR DESCRIPTION
Previously, the client received the serialized channel, ignored it, and called the channel API. For helper-bot onboarding, that event is published before the database transaction commits, so the API request could briefly return 404.

Now the client stores and uses the channel data included in the event itself, including its membership and MessageBus metadata.

/t/158243