### PR TITLE
FIX: Make user field checkboxes usable on the code login page

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -607,7 +607,7 @@ body.signup-page {
   }
 }
 
-// Signup, invite, and code login pages (share the user-fields step)
+// Signup, invite, and code login pages share the user-fields step
 .invite-page,
 .signup-fullpage,
 .login-fullpage {

--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -607,9 +607,10 @@ body.signup-page {
   }
 }
 
-// Signup and invite page
+// Signup, invite, and code login pages (share the user-fields step)
 .invite-page,
-.signup-fullpage {
+.signup-fullpage,
+.login-fullpage {
   .password-confirmation {
     display: none;
   }

--- a/spec/system/code_login_spec.rb
+++ b/spec/system/code_login_spec.rb
@@ -100,6 +100,48 @@ describe "Login via email code" do
     expect(page).to have_css(".header-dropdown-toggle.current-user")
   end
 
+  context "with a required checkbox user field" do
+    fab!(:user_field) do
+      Fabricate(:user_field, name: "Terms", field_type: "confirm", required: true)
+    end
+
+    it "renders the checkbox at a usable size and lets it be toggled" do
+      new_email = "new.person@example.com"
+
+      visit("/login")
+      expect(page).to have_css("#login-account-name")
+      find("#one-time-code-link").click
+      expect(page).to have_css(".code-login-form__email-step")
+
+      find(".code-login-form__email-step input[type='email']").fill_in(with: new_email)
+      find(".code-login-form__continue").click
+      expect(page).to have_css(".code-login-form__code-step")
+
+      fill_code(latest_emailed_code(new_email))
+
+      expect(page).to have_css(".code-login-form__user-fields-step")
+      screenshot_marker(label: "code-login-user-fields-step")
+
+      checkbox = find(".user-field.confirm input[type='checkbox']")
+
+      # Regression: the shared `.input-group input` rule stretches inputs to
+      # `min-width: 250px; width: 100%`. Without the checkbox override applying
+      # to `.login-fullpage`, the checkbox renders as a full-width bar. Assert it
+      # stays small.
+      expect(checkbox.evaluate_script("this.offsetWidth")).to be < 50
+
+      checkbox.click
+      expect(checkbox).to be_checked
+
+      find(".code-login-form__user-fields-step .code-login-form__verify").click
+
+      expect(page).to have_css(".code-login-form__complete-step")
+
+      user = User.find_by_email(new_email)
+      expect(user.custom_fields["user_field_#{user_field.id}"]).to eq("true")
+    end
+  end
+
   context "when the setting is disabled" do
     before { SiteSetting.enable_local_logins_via_code = false }
 


### PR DESCRIPTION
**Previously**, required checkbox (`confirm`) user fields shown during the email-code login flow were stretched to full width by the shared `.input-group input` rule, rendering them as an unclickable bar because the checkbox size override was scoped only to `.signup-fullpage`/`.invite-page`.

**In this update**, extended the override to `.login-fullpage` so checkbox user fields render at their correct size on the code login page.

Added a system spec covering the scenario (required `confirm` field → `/login` → email code → user-fields step), which asserts the checkbox renders at a usable width, is toggleable, and persists. Verified as a true regression test: it fails (checkbox width 404px) without the CSS change and passes with it.