### PR TITLE
SECURITY: Limit Category search term and word count [backport 2026.1]

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -36,6 +36,8 @@ class CategoriesController < ApplicationController
   MIN_CATEGORIES_TOPICS = 5
   MAX_CATEGORIES_TOPICS = 100
   MAX_CATEGORIES_LIMIT = 25
+  MAX_CATEGORY_SEARCH_TERM_LENGTH = 250
+  MAX_CATEGORY_SEARCH_WORDS = 25
 
   def redirect
     return if handle_permalink("/category/#{params[:path]}")
@@ -359,7 +361,7 @@ class CategoriesController < ApplicationController
   end
 
   def search
-    term = params[:term].to_s.strip
+    term = params[:term].to_s.strip[0, MAX_CATEGORY_SEARCH_TERM_LENGTH]
     parent_category_id = params[:parent_category_id].to_i if params[:parent_category_id].present?
     include_uncategorized =
       (
@@ -402,7 +404,13 @@ class CategoriesController < ApplicationController
 
     categories = Category.secured(guardian)
 
-    if term.present? && words = term.split
+    if term.present?
+      words = []
+      term.scan(/\S+/) do |word|
+        words << word
+        break if words.size >= MAX_CATEGORY_SEARCH_WORDS
+      end
+
       words.each { |word| categories = categories.where("name ILIKE ?", "%#{word}%") }
     end
 

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -1639,6 +1639,30 @@ RSpec.describe CategoriesController do
           "Notfoo",
         )
       end
+
+      it "limits the number of term words used in SQL filters" do
+        long_term = 50.times.map { |index| "word#{index}" }.join(" ")
+
+        queries = track_sql_queries { post "/categories/search.json", params: { term: long_term } }
+
+        expect(response.status).to eq(200)
+
+        category_search_queries =
+          queries.select { |query| query.match?(/FROM "?categories"?/i) && query.match?(/ILIKE/i) }
+        ilike_counts = category_search_queries.map { |query| query.scan(/\bILIKE\b/i).size }
+
+        expect(ilike_counts).to be_present
+        expect(ilike_counts.max).to be <= 25
+      end
+
+      it "limits the term length used in SQL filters" do
+        long_term = "a" * 300
+
+        queries = track_sql_queries { post "/categories/search.json", params: { term: long_term } }
+
+        expect(response.status).to eq(200)
+        expect(queries.join("\n")).not_to include(long_term)
+      end
     end
 
     context "with parent_category_id" do


### PR DESCRIPTION
Backport of #41588 to release/2026.1.

---

#### Description

Category search accepted an unbounded term from anonymous requests and expanded every whitespace-separated word into an ILIKE predicate. Large terms could generate expensive SQL and tie up request workers.

#### Fix

Cap the total term length and the number of words used for SQL filters.

#### Notes

Resolved the 2026.1 conflict by applying the term/word caps to the older `name ILIKE ?` search implementation. The accented-name normalization context from main is not present on 2026.1 and was not backported here.
