### PR TITLE
FIX: Make a11y.announce safe to call during render

### DIFF
--- a/frontend/discourse/app/services/a11y.js
+++ b/frontend/discourse/app/services/a11y.js
@@ -1,6 +1,6 @@
 import { tracked } from "@glimmer/tracking";
 import { trackedMap } from "@ember/reactive/collections";
-import { cancel } from "@ember/runloop";
+import { cancel, next } from "@ember/runloop";
 import Service from "@ember/service";
 import { isRailsTesting, isTesting } from "discourse/lib/environment";
 import discourseLater from "discourse/lib/later";
@@ -194,15 +194,26 @@ export default class A11y extends Service {
       throw new Error("The clearDelay must be a positive number");
     }
 
-    switch (type) {
-      case "assertive":
-      case "polite":
-        this.#state.setMessage(type, message.trim(), clearDelay);
-        break;
-      default:
-        throw new Error(
-          `Invalid announcement type: ${type}. Expected 'polite' or 'assertive'.`
-        );
+    if (type !== "assertive" && type !== "polite") {
+      throw new Error(
+        `Invalid announcement type: ${type}. Expected 'polite' or 'assertive'.`
+      );
     }
+
+    const trimmed = message.trim();
+
+    // Defer the tracked-state write out of the current render. `announce` is often
+    // called from a render-driven data load (e.g. an async content resolution), and
+    // writing tracked state synchronously during render trips Ember's
+    // backtracking-rerender assertion. `next` runs after the render completes and is
+    // awaited by `settled()`; a live region is polled asynchronously, so the one-tick
+    // delay is imperceptible.
+    next(() => {
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
+      this.#state.setMessage(type, trimmed, clearDelay);
+    });
   }
 }

--- a/frontend/discourse/tests/integration/components/a11y/live-regions-test.gjs
+++ b/frontend/discourse/tests/integration/components/a11y/live-regions-test.gjs
@@ -1,4 +1,6 @@
+import Component from "@glimmer/component";
 import { getOwner } from "@ember/owner";
+import { service } from "@ember/service";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import A11yLiveRegions from "discourse/components/a11y/live-regions";
@@ -59,5 +61,39 @@ module("Integration | Component | A11y | LiveRegions", function (hooks) {
     assert
       .dom("#a11y-announcements-polite")
       .hasText("Test polite message", "displays polite message");
+  });
+
+  test("announce called during render does not trigger a backtracking assertion", async function (assert) {
+    disableClearA11yAnnouncementsInTests();
+
+    // Mirrors DIconGridPickerContent: a getter read during render calls `announce`.
+    // <A11yLiveRegions /> renders first and reads the tracked message map, so a
+    // synchronous announce (write) later in the same render trips Ember's
+    // backtracking-rerender assertion and breaks the render. The announcer is placed
+    // AFTER the live regions to establish that read-before-write ordering.
+    class RenderTimeAnnouncer extends Component {
+      @service a11y;
+
+      get announced() {
+        this.a11y.announce("Announced during render", "polite", 500);
+        return "";
+      }
+
+      <template>{{this.announced}}</template>
+    }
+
+    await render(
+      <template>
+        <A11yLiveRegions />
+        <RenderTimeAnnouncer />
+      </template>
+    );
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText(
+        "Announced during render",
+        "the render-time announcement is shown without a backtracking error"
+      );
   });
 });


### PR DESCRIPTION
`a11y.announce` updated its tracked announcement map synchronously, so calling it during render — for example from an async data resolution that announces its result count — tripped Ember's backtracking-rerender assertion ("attempted to update … already used in the same computation") and broke the render.

This defers the tracked write to the runloop with `next`, so it lands after the current render. Validation (message / type / delay) still throws synchronously, and `settled()` still awaits the deferred update, so callers and tests observe the announcement as before. A live region is polled asynchronously by screen readers, so the one-tick delay is imperceptible.

Adds a regression test that announces from a getter read during render (alongside `<A11yLiveRegions />`) and asserts the announcement renders without a backtracking error.
