### PR TITLE
UX: a little margin at the bottom of category cards

### DIFF
--- a/app/assets/stylesheets/admin/admin_new_category_setup.scss
+++ b/app/assets/stylesheets/admin/admin_new_category_setup.scss
@@ -5,7 +5,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-6);
-    margin-top: var(--space-8);
+    margin-block: var(--space-8);
 
     &__card {
       position: relative;


### PR DESCRIPTION
With a short viewport, when you create a new category the last "type" card can be a little too close to the bottom of the page. This little margin at the bottom, to match the top, helps. 