### PR TITLE
FIX: Don't swallow errors in the backup store and S3 downloads

### DIFF
--- a/lib/backup_restore/s3_backup_store.rb
+++ b/lib/backup_restore/s3_backup_store.rb
@@ -119,12 +119,12 @@ module BackupRestore
         s3_helper.list.each do |obj|
           objects << create_file_from_object(obj) if obj.key.match?(file_regex)
         end
-      rescue StandardError
-        NoMethodError
-      end #fired when s3_helper.list is nil - wont respond to .nil?
+      rescue NoMethodError
+        # s3_helper.list can return nil which won't respond to .each
+      end
 
       objects
-    rescue Aws::Errors::ServiceError => e
+    rescue Aws::Errors::ServiceError, Seahorse::Client::NetworkingError => e
       Rails.logger.warn("Failed to list backups from S3: #{e.message.presence || e.class.name}")
       raise StorageError.new(e.message.presence || e.class.name)
     end

--- a/lib/s3_helper.rb
+++ b/lib/s3_helper.rb
@@ -330,8 +330,8 @@ class S3Helper
   def download_file(filename, destination_path, failure_message = nil)
     object(filename).download_file(destination_path)
   rescue => err
-    raise failure_message&.to_s ||
-            "Failed to download #{filename} because #{err.message.length > 0 ? err.message : err.class.to_s}"
+    detail = err.message.presence || err.class.to_s
+    raise "#{failure_message.presence || "Failed to download #{filename}"} (#{detail})"
   end
 
   def s3_client

--- a/spec/lib/backup_restore/s3_backup_store_spec.rb
+++ b/spec/lib/backup_restore/s3_backup_store_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe BackupRestore::S3BackupStore do
     before { create_backups }
     after { remove_backups }
 
+    describe "#files" do
+      it "raises StorageError when the S3 listing fails instead of returning an empty list" do
+        @s3_client.stub_responses(:list_objects_v2, "AccessDenied")
+
+        expect { store.files }.to raise_error(BackupRestore::BackupStore::StorageError)
+      end
+    end
+
     describe "#delete_old" do
       it "doesn't delete files when cleanup is disabled" do
         SiteSetting.maximum_backups = 1

--- a/spec/lib/backup_restore/shared_examples_for_backup_store.rb
+++ b/spec/lib/backup_restore/shared_examples_for_backup_store.rb
@@ -170,11 +170,22 @@ RSpec.shared_examples "backup store" do
         expect(store.files).to eq([backup1])
       end
 
+      let(:empty_list_body) { <<~XML }
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Name>s3-backup-bucket</Name>
+          <Prefix>default/</Prefix>
+          <KeyCount>0</KeyCount>
+          <MaxKeys>1000</MaxKeys>
+          <IsTruncated>false</IsTruncated>
+        </ListBucketResult>
+      XML
+
       it "runs if SiteSetting.backup_frequency is configured" do
         base_backup_s3_url = "https://s3-backup-bucket.s3.dualstack.us-west-1.amazonaws.com"
         stub_request(:get, "#{base_backup_s3_url}/?list-type=2&prefix=default/").to_return(
           status: 200,
-          body: "",
+          body: empty_list_body,
           headers: {
           },
         )
@@ -190,7 +201,7 @@ RSpec.shared_examples "backup store" do
         base_backup_s3_url = "https://s3-backup-bucket.s3.dualstack.us-west-1.amazonaws.com"
         stub_request(:get, "#{base_backup_s3_url}/?list-type=2&prefix=default/").to_return(
           status: 200,
-          body: "",
+          body: empty_list_body,
           headers: {
           },
         )

--- a/spec/lib/s3_helper_spec.rb
+++ b/spec/lib/s3_helper_spec.rb
@@ -77,6 +77,29 @@ RSpec.describe "S3Helper" do
     end
   end
 
+  describe "#download_file" do
+    let(:s3_helper) { S3Helper.new("bucket", "", client: client) }
+
+    before do
+      Aws::S3::Object
+        .any_instance
+        .expects(:download_file)
+        .raises(Aws::S3::Errors::NoSuchKey.new(nil, "The specified key does not exist."))
+    end
+
+    it "includes the underlying error when a failure message is given" do
+      expect {
+        s3_helper.download_file("key", "destination", "Failed to download archive.")
+      }.to raise_error("Failed to download archive. (The specified key does not exist.)")
+    end
+
+    it "includes the underlying error when no failure message is given" do
+      expect { s3_helper.download_file("key", "destination") }.to raise_error(
+        "Failed to download key (The specified key does not exist.)",
+      )
+    end
+  end
+
   it "should prefix bucket folder path only if not exists" do
     s3_helper = S3Helper.new("bucket/folder_path", "", client: client)
 


### PR DESCRIPTION
Two error-swallowing bugs in the backup path made S3 failures invisible:

* S3Helper#download_file discarded the underlying exception whenever a failure_message was given, so restores failed with a generic "Failed to download archive to tmp directory." regardless of the actual cause (access denied, missing key, out of disk space). The message now includes the original error.

* S3BackupStore#unsorted_files wrapped the listing in a bare rescue StandardError meant to guard against a nil list, which also ate every AWS service error and made #files silently return an empty list. The intended error handling (log and raise StorageError, which callers already rescue) was unreachable. The rescue is narrowed to NoMethodError and the StorageError conversion now also covers Seahorse::Client::NetworkingError.

The scheduled backup shared example relied on the swallowed error: its webmock stub returned an empty body for the list request, which the AWS SDK rejects as an incomplete response. The stub now returns a valid empty ListBucketResult.