### PR TITLE
FIX: Strip SET transaction_timeout when restoring backups

### DIFF
--- a/lib/backup_restore/database_restorer.rb
+++ b/lib/backup_restore/database_restorer.rb
@@ -102,6 +102,7 @@ module BackupRestore
         "CREATE SCHEMA", # PostgreSQL 11+
         "COMMENT ON SCHEMA", # PostgreSQL 11+
         "SET default_table_access_method", # PostgreSQL 12
+        "SET transaction_timeout", # PostgreSQL 17
         "CREATE EXTENSION",
         "COMMENT ON EXTENSION",
         "\\\\restrict",

--- a/spec/fixtures/db/restore/unwanted.sql
+++ b/spec/fixtures/db/restore/unwanted.sql
@@ -10,6 +10,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);

--- a/spec/lib/backup_restore/database_restorer_spec.rb
+++ b/spec/lib/backup_restore/database_restorer_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe BackupRestore::DatabaseRestorer do
 
         expect(log).to include("CREATE TABLE public.foo")
         expect(log).not_to be_blank
+        expect(log).not_to include("SET transaction_timeout")
         expect(log).not_to include("CREATE EXTENSION")
         expect(log).not_to include("COMMENT ON EXTENSION")
         expect(log).not_to include(


### PR DESCRIPTION
pg_dump 17 and later adds SET transaction_timeout = 0 to dumps, but the parameter only exists on PostgreSQL 17+ servers. Restoring such a dump on PostgreSQL 16 or older fails with:

`psql failed: ERROR: unrecognized configuration parameter "transaction_timeout"`

This is easy to hit because postgres client tools are commonly newer than the server they talk to (the discourse_docker base image ships the latest client alongside the default version, and pg_dump resolves to the newest one installed), so backups can quietly become un-restorable on the server that created them.

Strip the line during restore like the other version-specific SQL in the unwanted_sql list.