### PR TITLE
DEV: Parse TypeScript test modules in wrap-test-modules plugin

### DIFF
--- a/frontend/discourse/lib/wrap-test-modules-plugin.mjs
+++ b/frontend/discourse/lib/wrap-test-modules-plugin.mjs
@@ -6,7 +6,8 @@ export default function wrapTestModulesPlugin() {
     transform: {
       filter: { id: TEST_FILE_RE },
       handler(code, id, { magicString }) {
-        const ast = this.parse(code);
+        const isTypeScript = id.endsWith(".ts") || id.endsWith(".gts");
+        const ast = this.parse(code, isTypeScript ? { lang: "ts" } : undefined);
 
         let lastImportEnd = 0;
         for (const node of ast.body) {

--- a/frontend/discourse/lib/wrap-test-modules-plugin.mjs
+++ b/frontend/discourse/lib/wrap-test-modules-plugin.mjs
@@ -5,10 +5,7 @@ export default function wrapTestModulesPlugin() {
     name: "wrap-test-modules",
     transform: {
       filter: { id: TEST_FILE_RE },
-      handler(code, id, { magicString }) {
-        const isTypeScript = id.endsWith(".ts") || id.endsWith(".gts");
-        const ast = this.parse(code, isTypeScript ? { lang: "ts" } : undefined);
-
+      handler(code, id, { ast, magicString }) {
         let lastImportEnd = 0;
         for (const node of ast.body) {
           if (node.type === "ImportDeclaration") {

--- a/frontend/discourse/rolldown.config.mjs
+++ b/frontend/discourse/rolldown.config.mjs
@@ -84,6 +84,8 @@ export function buildConfig({ devMode } = {}) {
     },
     moduleTypes: {
       ".wasm": "asset",
+      ".gjs": "js",
+      ".gts": "ts",
     },
     input: {
       discourse: "discourse.js",


### PR DESCRIPTION
The `wrap-test-modules` build plugin finds the end of a test file's imports and wraps the remaining body in the test loader's default-export function. Its file filter already accepted `.ts`/`.gts`, but the handler called `this.parse(code)`, which runs with rolldown's default `lang: "js"`. The first TypeScript-only token (a type import, a parameter annotation) then failed to parse and the standalone build aborted.

The handler now reuses the AST rolldown already built for the module (`ast` from the transform context) instead of re-parsing, so each file is parsed under the language rolldown assigned it. `rolldown.config.mjs` maps `.gjs` to `js` and `.gts` to `ts` under `moduleTypes` so those extensions get the right parser.

No `.ts`/`.gts` test files exist in the tree yet, so this path was never exercised. It is a prerequisite for authoring or converting any test file to TypeScript.