### PR TITLE
DEV: Stabilize event card system test

### DIFF
--- a/plugins/discourse-calendar/spec/system/event_card_spec.rb
+++ b/plugins/discourse-calendar/spec/system/event_card_spec.rb
@@ -14,20 +14,25 @@ describe "Event card" do
     sign_in(admin)
   end
 
-  it "links the hero image to the topic" do
+  it "links the hero image to the topic", time: Time.zone.parse("2026-07-13 12:00:00") do
     post =
       PostCreator.create!(
         admin,
         title: "Boat party with a banner",
         category: category.id,
-        raw: "[event start=\"#{2.hours.from_now.iso8601}\"]\n[/event]",
+        raw:
+          "[event start=\"#{2.hours.from_now.iso8601}\" end=\"#{3.hours.from_now.iso8601}\"]\n[/event]",
       )
     DiscoursePostEvent::Event.find(post.id).update!(image_upload: upload)
 
     category_page.visit(category)
 
     expect(page).to have_css("#category-events-calendar .fc")
-    find(".fc-daygrid-event-harness .fc-event-title", text: "Boat party with a banner").click
+    find(
+      ".fc-daygrid-event-harness .fc-event-title",
+      text: "Boat party with a banner",
+      match: :first,
+    ).click
 
     expect(page).to have_css(".discourse-post-event .event-image img")
     # the hero image links to the topic, not to the upload file (lightbox)


### PR DESCRIPTION
This PR stabilizes the event-card system test when its generated event crosses midnight.

The test previously created an event two hours from the current wall clock without an explicit end. When CI ran late in the day, the serializer supplied a one-hour duration that crossed midnight, so FullCalendar rendered the event in two day cells and Capybara rejected the title selector as ambiguous before testing the hero-image link.
