### PR TITLE
PERF: Precompile search advanced-filter matchers once

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -388,7 +388,8 @@ class Search
   end
 
   def self.advanced_filter(trigger, name: nil, enabled: -> { true }, &block)
-    advanced_filters[trigger] = { block:, name:, enabled: }
+    case_insensitive_matcher = Regexp.new(trigger.source, trigger.options | Regexp::IGNORECASE)
+    advanced_filters[trigger] = { block:, name:, enabled:, case_insensitive_matcher: }
   end
 
   def self.advanced_filters
@@ -990,16 +991,14 @@ class Search
 
         found = false
 
-        Search.advanced_filters.each do |matcher, options|
+        cleaned = word.gsub(/["']/, "")
+
+        Search.advanced_filters.each_value do |options|
           block = options[:block]
           name = options[:name]
           next unless options[:enabled].call
 
-          case_insensitive_matcher =
-            Regexp.new(matcher.source, matcher.options | Regexp::IGNORECASE)
-
-          cleaned = word.gsub(/["']/, "")
-          if cleaned =~ case_insensitive_matcher
+          if cleaned =~ options[:case_insensitive_matcher]
             (@filters ||= []) << [block, $1]
             @matched_advanced_filter_names << name if name
             found = true


### PR DESCRIPTION
This PR removes redundant per-token regexp compilation from advanced search-term processing.

`Search#process_advanced_search!` runs inside `Search.new`, before any query, and splits the search term into whitespace-delimited tokens. For every token it looped over all ~50 registered advanced filters (`in:title`, `status:open`, `category:...`, and friends) and rebuilt each filter's case-insensitive matcher with `Regexp.new(matcher.source, matcher.options | Regexp::IGNORECASE)`. The advanced-filter set is fixed at boot, so a multi-token term recompiled the same regexes once per token. This precompiles each filter's case-insensitive matcher once at registration and reuses it, and hoists the per-token quote stripping out of the filter loop.

### Benchmark

Run from the Discourse root with `bundle exec ruby bench_search_filters.rb`:

```ruby
require "benchmark"
require "./config/environment"

guardian = Guardian.new

[100, 500, 1000, 2000].each do |n|
  term = (["abcd"] * n).join(" ")
  Search.new(term, guardian:)                       # warmup
  ms = Benchmark.realtime { Search.new(term, guardian:) } * 1000
  puts format("%d tokens: %.1f ms", n, ms)
end
```

Timing `Search.new` on a term of N repeated tokens:

| Tokens | Before | After |
|--------|--------|-------|
| 100 | 62.5 ms | 1.6 ms |
| 500 | 336.0 ms | 8.6 ms |
| 1000 | 671.2 ms | 16.9 ms |
| 2000 | 1201.1 ms | 36.7 ms |
