### PR TITLE
DEV: Show depends_on site settings for upcoming changes

### DIFF
--- a/app/assets/stylesheets/admin/upcoming-changes.scss
+++ b/app/assets/stylesheets/admin/upcoming-changes.scss
@@ -26,6 +26,12 @@
     margin-top: var(--space-2);
   }
 
+  &__depends-on-notice {
+    font-size: var(--font-down-1);
+    color: var(--danger);
+    margin-top: var(--space-2);
+  }
+
   &__opt-in-groups-label {
     display: block;
     font-size: var(--font-down-1);

--- a/app/services/upcoming_changes/list.rb
+++ b/app/services/upcoming_changes/list.rb
@@ -60,8 +60,11 @@ class UpcomingChanges::List
           :value,
           :upcoming_change,
           :plugin,
+          :depends_on,
+          :depends_on_humanized_names,
         ).merge(
           dependents: UpcomingChanges.find_dependents_for_change(setting[:setting]),
+          depends_on_met: UpcomingChanges.change_dependencies_met?(setting[:setting]),
           overriding_defaults:
             SiteSetting.upcoming_change_default_overrides.values.any? do |override|
               override[:upcoming_change] == setting[:setting]

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6537,6 +6537,7 @@ en:
         enabled_for_throttle: "You have modified who this change is enabled for too quickly. Please wait a few seconds before trying again."
         change_enabled_for_success: "You have enabled this change for %{enabledFor}"
         change_disabled: "You have opted-out of this change"
+        depends_on_notice: "This change requires %{dependencyLinks} to be enabled."
         permanent_notice: "This change is now permanent and it will soon be removed. You are no longer able to opt-out."
         permanent_soon_notice: "This change will become permanent soon. You will no longer be able to opt-out."
         permanent_no_group_selection: "N/A, permanent changes apply to all groups."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2163,7 +2163,7 @@ en:
 
     enable_local_logins: "Enable local username and password login based accounts. WARNING: if disabled, you may be unable to log in if you have not previously configured at least one alternate login method."
     enable_local_logins_via_email: "Allow users to request a one-click login link to be sent to them via email."
-    enable_local_logins_via_code: "Allow members to sign up and log in faster using one-time email codes (OTPs). Requires 'enable local logins via email'."
+    enable_local_logins_via_code: "Allow members to sign up and log in faster using one-time email codes (OTPs)."
     allow_passkeys_for_2fa: "Allow users to use a passkey to satisfy two-factor authentication when confirming a sensitive action."
     allow_new_registrations: "Allow new user registrations. Uncheck this to prevent anyone from creating a new account."
     enable_signup_cta: "Show a notice to returning anonymous users prompting them to sign up for an account."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -699,6 +699,9 @@ login:
     hidden: true
     validator: "EnableLocalLoginsViaCodeValidator"
     area: "login"
+    depends_on:
+      - enable_local_logins
+      - enable_local_logins_via_email
     upcoming_change:
       status: "alpha"
       impact: "feature,all_members"

--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-change-item.gjs
@@ -20,10 +20,12 @@ import { AUTO_GROUPS } from "discourse/lib/constants";
 import { bind } from "discourse/lib/decorators";
 import discourseLater from "discourse/lib/later";
 import lightbox from "discourse/lib/lightbox";
+import { sanitize } from "discourse/lib/text";
 import Group from "discourse/models/group";
 import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DSelect from "discourse/ui-kit/d-select";
+import dBasePath from "discourse/ui-kit/helpers/d-base-path";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
@@ -97,6 +99,32 @@ export default class UpcomingChangeItem extends Component {
     return (
       this.args.change.upcoming_change.status === "stable" &&
       this.args.change.upcoming_change.impact_type !== "site_setting_default"
+    );
+  }
+
+  get showDependsOnNotice() {
+    return (
+      this.args.change.depends_on?.length > 0 &&
+      !this.args.change.depends_on_met
+    );
+  }
+
+  get dependsOnNoticeText() {
+    const path = dBasePath();
+    const links = this.args.change.depends_on
+      .map((name, index) => {
+        const label = sanitize(
+          this.args.change.depends_on_humanized_names?.[index] ||
+            name.replaceAll("_", " ")
+        );
+        return `<a href="${path}/admin/site_settings/category/all_results?filter=${encodeURIComponent(name)}">${label}</a>`;
+      })
+      .join(", ");
+
+    return trustHTML(
+      i18n("admin.upcoming_changes.depends_on_notice", {
+        dependencyLinks: links,
+      })
     );
   }
 
@@ -337,6 +365,13 @@ export default class UpcomingChangeItem extends Component {
                 </span>
               {{/if}}
             </div>
+          </div>
+        {{/if}}
+
+        {{#if this.showDependsOnNotice}}
+          <div class="upcoming-change__depends-on-notice">
+            {{dIcon "triangle-exclamation"}}
+            {{this.dependsOnNoticeText}}
           </div>
         {{/if}}
 

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -482,6 +482,25 @@ module UpcomingChanges
     settings_provider.type_supervisor.dependencies.dependents(change_setting_name.to_s)
   end
 
+  # Whether the settings the change itself depends_on (in site_settings.yml)
+  # currently hold the values the change needs. Used by the admin UI to warn
+  # admins when a change's prerequisites are not met, since enabling the change
+  # would have no effect (or be rejected by a validator) until they are.
+  def self.change_dependencies_met?(change_setting_name)
+    dependencies = settings_provider.type_supervisor.dependencies[change_setting_name.to_sym]
+    return true if dependencies.blank?
+
+    allowed_values = settings_provider.dependency_values[change_setting_name.to_sym]
+    dependencies.all? do |dependency|
+      value = settings_provider.public_send(dependency)
+      if (allowed = allowed_values&.dig(dependency))
+        allowed.include?(value.to_s)
+      else
+        value == true
+      end
+    end
+  end
+
   def self.including_css
     settings_provider.upcoming_change_site_settings.filter_map do |upcoming_change|
       upcoming_change if settings_provider.upcoming_change_metadata[upcoming_change][:body_class]

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -555,6 +555,50 @@ RSpec.describe UpcomingChanges do
     end
   end
 
+  describe ".change_dependencies_met?" do
+    it "returns true for a change with no dependencies" do
+      expect(described_class.change_dependencies_met?(:enable_upload_debug_mode)).to eq(true)
+    end
+
+    it "returns false when a boolean dependency is disabled" do
+      SiteSetting.allow_user_locale = false
+
+      expect(described_class.change_dependencies_met?(:set_locale_from_cookie)).to eq(false)
+    end
+
+    it "returns true when all boolean dependencies are enabled" do
+      SiteSetting.allow_user_locale = true
+
+      expect(described_class.change_dependencies_met?(:set_locale_from_cookie)).to eq(true)
+    end
+
+    context "with depends_on_values for a non-boolean dependency" do
+      before do
+        SiteSetting
+          .type_supervisor
+          .dependencies
+          .stubs(:[])
+          .with(:fake_change)
+          .returns([:desktop_category_page_style])
+        SiteSetting.stubs(:dependency_values).returns(
+          { fake_change: { desktop_category_page_style: %w[categories_only] } },
+        )
+      end
+
+      it "returns true when the dependency matches an allowed value" do
+        SiteSetting.desktop_category_page_style = "categories_only"
+
+        expect(described_class.change_dependencies_met?(:fake_change)).to eq(true)
+      end
+
+      it "returns false when the dependency does not match an allowed value" do
+        SiteSetting.desktop_category_page_style = "categories_and_latest_topics"
+
+        expect(described_class.change_dependencies_met?(:fake_change)).to eq(false)
+      end
+    end
+  end
+
   describe ".settings_hidden_while_enabled" do
     # `enable_upload_debug_mode` stands in for the change; the two real settings
     # below stand in for the legacy settings it would hide.

--- a/spec/services/upcoming_changes/list_spec.rb
+++ b/spec/services/upcoming_changes/list_spec.rb
@@ -114,6 +114,69 @@ RSpec.describe UpcomingChanges::List do
         end
       end
 
+      describe "depends_on settings" do
+        before do
+          # This replaces the metadata mocked in the outer `before` block, so
+          # enable_upload_debug_mode must be re-mocked here.
+          mock_upcoming_change_metadata(
+            {
+              set_locale_from_cookie: {
+                impact: "feature,all_members",
+                status: :experimental,
+                impact_type: "feature",
+                impact_role: "all_members",
+              },
+              enable_upload_debug_mode: {
+                impact: "other,developers",
+                status: :experimental,
+                impact_type: "other",
+                impact_role: "developers",
+              },
+            },
+          )
+        end
+
+        it "includes the settings the change depends on and their humanized names" do
+          results = result.upcoming_changes
+          mock_setting = results.find { |change| change[:setting] == :set_locale_from_cookie }
+
+          expect(mock_setting[:depends_on]).to eq([:allow_user_locale])
+          expect(mock_setting[:depends_on_humanized_names]).to eq(["Allow user locale"])
+        end
+
+        it "includes depends_on_met as false when a dependency is not enabled" do
+          SiteSetting.allow_user_locale = false
+
+          results = result.upcoming_changes
+          mock_setting = results.find { |change| change[:setting] == :set_locale_from_cookie }
+
+          expect(mock_setting[:depends_on_met]).to eq(false)
+        end
+
+        it "includes depends_on_met as true when all dependencies are enabled" do
+          SiteSetting.allow_user_locale = true
+
+          results = result.upcoming_changes
+          mock_setting = results.find { |change| change[:setting] == :set_locale_from_cookie }
+
+          expect(mock_setting[:depends_on_met]).to eq(true)
+        end
+
+        it "includes depends_on_met as true for changes with no dependencies" do
+          results = result.upcoming_changes
+          mock_setting = results.find { |change| change[:setting] == :enable_upload_debug_mode }
+
+          expect(mock_setting[:depends_on_met]).to eq(true)
+        end
+
+        it "includes an empty depends_on for changes with no dependencies" do
+          results = result.upcoming_changes
+          mock_setting = results.find { |change| change[:setting] == :enable_upload_debug_mode }
+
+          expect(mock_setting[:depends_on]).to eq([])
+        end
+      end
+
       describe "conditional display" do
         context "when the upcoming change should display" do
           before do

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -90,6 +90,53 @@ describe "Admin upcoming changes" do
     ).to have_no_permanent_soon_notice
   end
 
+  describe "when the change depends on other settings" do
+    before do
+      mock_upcoming_change_metadata(
+        {
+          set_locale_from_cookie: {
+            impact: "feature,all_members",
+            status: :experimental,
+            impact_type: "feature",
+            impact_role: "all_members",
+          },
+          enable_upload_debug_mode: {
+            impact: "other,developers",
+            status: :experimental,
+            impact_type: "other",
+            impact_role: "developers",
+          },
+        },
+      )
+    end
+
+    it "shows a warning notice with links when the dependencies are not met" do
+      SiteSetting.allow_user_locale = false
+      upcoming_changes_page.visit
+
+      change_item = upcoming_changes_page.change_item(:set_locale_from_cookie)
+      expect(change_item).to have_depends_on_notice(
+        "This change requires Allow user locale to be enabled.",
+      )
+      expect(change_item.find_item(:set_locale_from_cookie)).to have_link(
+        "Allow user locale",
+        href: "/admin/site_settings/category/all_results?filter=allow_user_locale",
+      )
+      expect(
+        upcoming_changes_page.change_item(:enable_upload_debug_mode),
+      ).to have_no_depends_on_notice
+    end
+
+    it "does not show the notice when the dependencies are met" do
+      SiteSetting.allow_user_locale = true
+      upcoming_changes_page.visit
+
+      expect(
+        upcoming_changes_page.change_item(:set_locale_from_cookie),
+      ).to have_no_depends_on_notice
+    end
+  end
+
   it "does not show permanent upcoming changes" do
     mock_upcoming_change_metadata(
       {

--- a/spec/system/page_objects/pages/admin_upcoming_change_item.rb
+++ b/spec/system/page_objects/pages/admin_upcoming_change_item.rb
@@ -47,6 +47,14 @@ module PageObjects
         find_item(@setting_name).has_no_css?(".upcoming-change__status-notice")
       end
 
+      def has_depends_on_notice?(text)
+        find_item(@setting_name).has_css?(".upcoming-change__depends-on-notice", text: text)
+      end
+
+      def has_no_depends_on_notice?
+        find_item(@setting_name).has_no_css?(".upcoming-change__depends-on-notice")
+      end
+
       def select_enabled_for(option)
         enabled_for_dropdown.select(option)
       end


### PR DESCRIPTION
Sometimes for upcoming changes we need to tell the admin about
some settings that must be enabled for the change to take effect.
Currently the only way to do this is with a note in the change
description which is not ideal.

This commit introduces a way to display the depends_on settings
for the upcoming change in the admin upcoming changes page. The
warning only shows if any of the settings are not enabled, if all
dependencies are satisfied we do not show the warning to the admin.

There is a link to each setting from the upcoming changes list
to make it easy for the admin to enable the setting if needed.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/724762a9-cc40-45b4-b080-d6ee87dc57ca" />
