### PR TITLE
UX: Focus dashboard search analytics on member searches

### DIFF
--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -8,6 +8,8 @@ class SearchLog < ActiveRecord::Base
 
   belongs_to :user
 
+  scope :non_staff, -> { joins(:user).where(users: { admin: false, moderator: false }) }
+
   def ctr
     return 0 if click_through == 0 || searches == 0
 
@@ -86,8 +88,8 @@ class SearchLog < ActiveRecord::Base
     details = []
 
     result =
-      SearchLog.select("COUNT(*) AS count, created_at::date AS date").where(
-        "lower(term) = ? AND created_at > ?",
+      SearchLog.select("COUNT(*) AS count, search_logs.created_at::date AS date").where(
+        "lower(search_logs.term) = ? AND search_logs.created_at > ?",
         term.downcase,
         start_of(period),
       )
@@ -95,11 +97,11 @@ class SearchLog < ActiveRecord::Base
     result = result.where("search_type = ?", search_types[search_type]) if search_type == :header ||
       search_type == :full_page
     result = result.where.not(search_result_id: nil) if search_type == :click_through_only
-    result = result.where.not(user_id: nil) if search_type == :logged_in_only
+    result = result.non_staff if search_type == :non_staff_only
 
     result
       .order("date")
-      .group("date")
+      .group("search_logs.created_at::date")
       .each { |record| details << { x: Date.parse(record["date"].to_s), y: record["count"] } }
 
     {
@@ -130,12 +132,12 @@ class SearchLog < ActiveRecord::Base
            END) AS click_through
     SQL
 
-    result = SearchLog.select(select_sql).where("created_at > ?", start_date)
+    result = SearchLog.select(select_sql).where("search_logs.created_at > ?", start_date)
 
-    result = result.where("created_at < ?", end_date) if end_date
+    result = result.where("search_logs.created_at < ?", end_date) if end_date
 
-    if search_type == :logged_in_only
-      result = result.where.not(user_id: nil)
+    if search_type == :non_staff_only
+      result = result.non_staff
     elsif search_type != :all
       result = result.where("search_type = ?", search_types[search_type])
     end

--- a/app/services/admin_dashboard_search.rb
+++ b/app/services/admin_dashboard_search.rb
@@ -105,17 +105,16 @@ class AdminDashboardSearch
   end
 
   def trending
-    rows = DB.query(<<~SQL, window_start: start_date, window_end: end_date, limit: TOP_TERMS_LIMIT)
-          SELECT lower(term) AS term,
-                 COUNT(*) AS searches,
-                 SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
-          FROM search_logs
-          WHERE created_at >= :window_start AND created_at <= :window_end
-            AND user_id IS NOT NULL
-          GROUP BY lower(term)
-          ORDER BY searches DESC, clicks DESC, term ASC
-          LIMIT :limit
+    rows =
+      non_staff_search_logs_in(window_start: start_date, window_end: end_date)
+        .select(<<~SQL)
+          lower(search_logs.term) AS term,
+          COUNT(*) AS searches,
+          SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
         SQL
+        .group("lower(search_logs.term)")
+        .order("searches DESC, clicks DESC, term ASC")
+        .limit(TOP_TERMS_LIMIT)
 
     rows.map { |row| { term: row.term, searches: row.searches } }
   end
@@ -130,51 +129,48 @@ class AdminDashboardSearch
 
   def content_gaps
     rows =
-      DB.query(
-        <<~SQL,
-          SELECT lower(term) AS term,
-                 COUNT(*) AS searches,
-                 SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
-          FROM search_logs
-          WHERE created_at >= :window_start AND created_at <= :window_end
-            AND user_id IS NOT NULL
-          GROUP BY lower(term)
-          HAVING SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) * 100 <=
-            COUNT(*) * :max_ctr_percent
-          ORDER BY searches DESC, term ASC
-          LIMIT :limit
+      non_staff_search_logs_in(window_start: start_date, window_end: end_date)
+        .select(<<~SQL)
+          lower(search_logs.term) AS term,
+          COUNT(*) AS searches,
+          SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
         SQL
-        window_start: start_date,
-        window_end: end_date,
-        max_ctr_percent: POOR_MATCH_MAX_CTR_PERCENT,
-        limit: TOP_TERMS_LIMIT,
-      )
+        .group("lower(search_logs.term)")
+        .having(<<~SQL, POOR_MATCH_MAX_CTR_PERCENT)
+          SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) * 100 <=
+            COUNT(*) * ?
+        SQL
+        .order("searches DESC, term ASC")
+        .limit(TOP_TERMS_LIMIT)
 
     rows.map do |row|
       {
         term: row.term,
         searches: row.searches,
-        status: row.clicks.zero? ? "no_match" : "poor_match",
+        status: row.clicks.to_i.zero? ? "no_match" : "poor_match",
       }
     end
   end
 
   def window_stats(window_start:, window_end:)
-    row = DB.query(<<~SQL, window_start: window_start, window_end: window_end).first
-      WITH term_stats AS (
-        SELECT COUNT(*) AS searches,
-               SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
-        FROM search_logs
-        WHERE created_at >= :window_start AND created_at <= :window_end
-          AND user_id IS NOT NULL
-        GROUP BY lower(term)
-      )
-      SELECT COALESCE(SUM(searches), 0)::bigint AS total,
-             COALESCE(SUM(CASE WHEN clicks = 0 THEN searches ELSE 0 END), 0)::bigint AS no_match
-      FROM term_stats
-    SQL
+    term_stats =
+      non_staff_search_logs_in(window_start: window_start, window_end: window_end).select(
+        <<~SQL,
+          COUNT(*) AS searches,
+          SUM(CASE WHEN search_result_id IS NOT NULL THEN 1 ELSE 0 END) AS clicks
+        SQL
+      ).group("lower(search_logs.term)")
+
+    row = SearchLog.from("(#{term_stats.to_sql}) term_stats").select(<<~SQL).take
+          COALESCE(SUM(searches), 0)::bigint AS total,
+          COALESCE(SUM(CASE WHEN clicks = 0 THEN searches ELSE 0 END), 0)::bigint AS no_match
+        SQL
 
     { total: row.total, no_match: row.no_match }
+  end
+
+  def non_staff_search_logs_in(window_start:, window_end:)
+    SearchLog.non_staff.where(created_at: window_start..window_end)
   end
 
   def parse_date(value)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8870,7 +8870,7 @@ en:
             header: "Header"
             full_page: "Full page"
             click_through_only: "All (click through only)"
-            logged_in_only: "Logged in only"
+            non_staff_only: "Non-staff users"
           header_search_results: "Header search results"
         logster:
           title: "Error logs"

--- a/frontend/discourse/admin/components/dashboard/search.gjs
+++ b/frontend/discourse/admin/components/dashboard/search.gjs
@@ -243,7 +243,7 @@ export default class DashboardSearch extends Component {
                           @query={{hash
                             term=row.term
                             period=this.trendingTermPeriod
-                            searchType="logged_in_only"
+                            searchType="non_staff_only"
                           }}
                           title={{row.term}}
                         >

--- a/frontend/discourse/admin/controllers/admin-search-logs/index.js
+++ b/frontend/discourse/admin/controllers/admin-search-logs/index.js
@@ -13,8 +13,8 @@ export default class AdminSearchLogsIndexController extends Controller {
       name: i18n("admin.logs.search_logs.types.all_search_types"),
     },
     {
-      id: "logged_in_only",
-      name: i18n("admin.logs.search_logs.types.logged_in_only"),
+      id: "non_staff_only",
+      name: i18n("admin.logs.search_logs.types.non_staff_only"),
     },
     { id: "header", name: i18n("admin.logs.search_logs.types.header") },
     {

--- a/frontend/discourse/admin/controllers/admin-search-logs/term.js
+++ b/frontend/discourse/admin/controllers/admin-search-logs/term.js
@@ -13,8 +13,8 @@ export default class AdminSearchLogsTermController extends Controller {
       name: i18n("admin.logs.search_logs.types.all_search_types"),
     },
     {
-      id: "logged_in_only",
-      name: i18n("admin.logs.search_logs.types.logged_in_only"),
+      id: "non_staff_only",
+      name: i18n("admin.logs.search_logs.types.non_staff_only"),
     },
     { id: "header", name: i18n("admin.logs.search_logs.types.header") },
     {

--- a/spec/models/search_log_spec.rb
+++ b/spec/models/search_log_spec.rb
@@ -228,15 +228,18 @@ RSpec.describe SearchLog, type: :model do
       expect(term_click_through_details[:data][0][:y]).to eq(1)
     end
 
-    it "counts only logged-in members' searches with the logged_in_only search type" do
+    it "returns only non-staff users' searches with the non_staff_only search type" do
       member = Fabricate(:user)
-      Fabricate.times(2, :search_log, term: "ruby", user: member)
-      Fabricate.times(3, :search_log, term: "ruby")
+      admin = Fabricate(:admin)
+      moderator = Fabricate(:moderator)
+      Fabricate(:search_log, term: "ruby", user: member)
+      Fabricate(:search_log, term: "ruby", user: admin)
+      Fabricate(:search_log, term: "ruby", user: moderator)
+      Fabricate(:search_log, term: "ruby", user: nil)
 
-      expect(SearchLog.term_details("ruby")[:data].sum { |point| point[:y] }).to eq(5)
       expect(
-        SearchLog.term_details("ruby", :weekly, :logged_in_only)[:data].sum { |point| point[:y] },
-      ).to eq(2)
+        SearchLog.term_details("ruby", :weekly, :non_staff_only)[:data].sum { |point| point[:y] },
+      ).to eq(1)
     end
   end
 
@@ -271,8 +274,14 @@ RSpec.describe SearchLog, type: :model do
       expect(top_trending.click_through).to eq(3)
     end
 
-    it "counts only logged-in members' searches with the logged_in_only search type" do
-      results = SearchLog.trending(:all, :logged_in_only).to_a
+    it "returns only non-staff users' searches with the non_staff_only search type" do
+      admin = Fabricate(:admin)
+      moderator = Fabricate(:moderator)
+      Fabricate(:search_log, term: "admin-search", user: admin)
+      Fabricate(:search_log, term: "moderator-search", user: moderator)
+      Fabricate(:search_log, term: "anonymous-search", user: nil)
+
+      results = SearchLog.trending(:all, :non_staff_only).to_a
 
       expect(results.map { |trend| [trend.term, trend.searches] }).to eq([["ruby", 1]])
     end

--- a/spec/requests/admin/search_logs_spec.rb
+++ b/spec/requests/admin/search_logs_spec.rb
@@ -38,14 +38,17 @@ RSpec.describe Admin::SearchLogsController do
         expect(row["searches"]).to eq(3)
       end
 
-      it "counts only logged-in members' searches with the logged_in_only search type" do
-        Fabricate(:search_log, term: "discobot", user: user)
-        Fabricate.times(2, :search_log, term: "discobot")
+      it "returns only non-staff users' searches with the non_staff_only search type" do
+        Fabricate(:search_log, term: "member-search", user: user)
+        Fabricate(:search_log, term: "admin-search", user: admin)
+        Fabricate(:search_log, term: "moderator-search", user: moderator)
+        Fabricate(:search_log, term: "anonymous-search", user: nil)
 
-        get "/admin/logs/search_logs.json", params: { search_type: "logged_in_only" }
+        get "/admin/logs/search_logs.json", params: { search_type: "non_staff_only" }
 
-        row = response.parsed_body.find { |entry| entry["term"] == "discobot" }
-        expect(row["searches"]).to eq(1)
+        expect(response.parsed_body.map { |entry| [entry["term"], entry["searches"]] }).to eq(
+          [["member-search", 1]],
+        )
       end
     end
 
@@ -85,17 +88,16 @@ RSpec.describe Admin::SearchLogsController do
 
       include_examples "search log term accessible"
 
-      it "excludes anonymous searches from the graph with the logged_in_only search type" do
+      it "returns only non-staff users' searches with the non_staff_only search type" do
         Fabricate(:search_log, term: "discobot", user: user)
-        Fabricate.times(4, :search_log, term: "discobot")
-
-        get "/admin/logs/search_logs/term.json", params: { term: "discobot" }
-        expect(response.parsed_body["term"]["data"].sum { |point| point["y"] }).to eq(5)
+        Fabricate(:search_log, term: "discobot", user: admin)
+        Fabricate(:search_log, term: "discobot", user: moderator)
+        Fabricate(:search_log, term: "discobot", user: nil)
 
         get "/admin/logs/search_logs/term.json",
             params: {
               term: "discobot",
-              search_type: "logged_in_only",
+              search_type: "non_staff_only",
             }
         expect(response.parsed_body["term"]["data"].sum { |point| point["y"] }).to eq(1)
       end

--- a/spec/services/admin_dashboard_search_spec.rb
+++ b/spec/services/admin_dashboard_search_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe AdminDashboardSearch do
   before { freeze_time(Time.zone.local(2026, 5, 14, 12, 0, 0)) }
 
   describe ".build" do
-    it "returns KPIs, trending terms, and content gaps for the selected dates, counting only logged-in members" do
+    it "returns KPIs, trending terms, and content gaps for the selected dates, counting only non-staff users" do
+      admin = Fabricate(:admin)
+      moderator = Fabricate(:moderator)
+
       Fabricate.times(
         3,
         :clicked_search_log,
@@ -60,6 +63,14 @@ RSpec.describe AdminDashboardSearch do
       Fabricate.times(10, :search_log, term: "ruby", created_at: "2026-05-02 09:00")
       Fabricate.times(20, :search_log, term: "crawler-bait", created_at: "2026-04-26 09:00")
 
+      Fabricate(:search_log, term: "admin-search", user: admin, created_at: "2026-05-05 12:00")
+      Fabricate(:clicked_search_log, term: "ruby", user: moderator, created_at: "2026-05-05 13:00")
+      Fabricate(
+        :search_log,
+        term: "moderator-prior-search",
+        user: moderator,
+        created_at: "2026-04-26 12:00",
+      )
       expect(described_class.build(start_date: "2026-05-01", end_date: "2026-05-07")).to eq(
         logging_enabled: true,
         headline_state: "content_gaps",

--- a/spec/system/admin_dashboard_redesign/search_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/search_section_spec.rb
@@ -22,7 +22,7 @@ describe "Admin Dashboard Redesign | Search section" do
     sign_in(current_user)
   end
 
-  it "lets staff review logged-in search health, inspect tooltips, and drill into terms",
+  it "lets staff review non-staff search health, inspect tooltips, and drill into terms",
      time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
     Fabricate.times(
       15,
@@ -68,6 +68,15 @@ describe "Admin Dashboard Redesign | Search section" do
     )
     Fabricate.times(20, :search_log, term: "ruby", user: user, created_at: "2026-03-20 11:00")
 
+    Fabricate(:search_log, term: "admin-search", user: current_user, created_at: "2026-05-10 08:00")
+    Fabricate(:clicked_search_log, term: "ruby", user: moderator, created_at: "2026-05-10 08:30")
+    Fabricate(
+      :search_log,
+      term: "admin-prior-search",
+      user: current_user,
+      created_at: "2026-03-20 08:00",
+    )
+
     # Anonymous searches (likely crawlers) must be excluded from every metric. If they
     # were counted, "crawlerbot" would top trending and the no-result rate would spike.
     Fabricate.times(100, :search_log, term: "crawlerbot", created_at: "2026-05-10 09:00")
@@ -108,6 +117,7 @@ describe "Admin Dashboard Redesign | Search section" do
         { term: "discobot", searches: 2 },
       ],
     )
+    expect(search).to have_no_trending_term("admin-search")
     expect(search).to have_no_trending_term("crawlerbot")
 
     expect(search).to have_content_gap_rows(
@@ -141,7 +151,7 @@ describe "Admin Dashboard Redesign | Search section" do
 
     expect(page).to have_current_path("/admin/logs/search_logs/term", ignore_query: true)
     expect(Rack::Utils.parse_query(URI.parse(page.current_url).query)).to eq(
-      "searchType" => "logged_in_only",
+      "searchType" => "non_staff_only",
       "period" => "weekly",
       "term" => "ruby",
     )
@@ -250,7 +260,7 @@ describe "Admin Dashboard Redesign | Search section" do
 
     expect(page).to have_current_path("/admin/logs/search_logs/term", ignore_query: true)
     expect(Rack::Utils.parse_query(URI.parse(page.current_url).query)).to eq(
-      "searchType" => "logged_in_only",
+      "searchType" => "non_staff_only",
       "period" => "all",
       "term" => "ruby",
     )


### PR DESCRIPTION
This PR removes searches by admins and moderators from the new dashboard’s Search section. This helps staff focus on what community members are searching for.

Staff often search for personal or work-related topics. Including those searches adds noise and makes it harder to see what members need and what content may be missing.

Key changes:

* Exclude admin and moderator searches from totals, changes over time, trending searches, and content gaps.
* On the Search Logs pages, rename the “Logged in only” filter to “Non-staff users” because the old filter still included admins and moderators.
* Use the non-staff filter when someone clicks a trending search, so the details also leave out staff searches.