### PR TITLE
UX: Prevent wide tables from breaking the dashboard

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -435,11 +435,11 @@ $db-bar-height: var(--space-2);
 
     &.--grid {
       display: grid;
-      grid-template-columns: 1fr 1fr;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: var(--space-4);
 
       @include viewport.until(sm) {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
       }
     }
 

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/admin-dashboard-card.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/admin-dashboard-card.gjs
@@ -12,6 +12,10 @@ export default class DataExplorerAdminDashboardCard extends Component {
     return this.args.payload?.columns ?? [];
   }
 
+  get columnLabels() {
+    return this.columns.map((col) => col.replaceAll("_", " "));
+  }
+
   get chartability() {
     return chartability(this.args.payload);
   }
@@ -41,7 +45,7 @@ export default class DataExplorerAdminDashboardCard extends Component {
 
   get chartDatasets() {
     return this.chartability.numericIndices.map((colIdx) => ({
-      label: this.columns[colIdx],
+      label: this.columnLabels[colIdx],
       values: this.rows.map((row) => Number(row[colIdx])),
     }));
   }
@@ -60,7 +64,7 @@ export default class DataExplorerAdminDashboardCard extends Component {
           <table class="de-dashboard-card__table">
             <thead>
               <tr>
-                {{#each this.columns as |col|}}
+                {{#each this.columnLabels as |col|}}
                   <th>{{col}}</th>
                 {{/each}}
               </tr>


### PR DESCRIPTION
Previously, the reports section used `1fr` grid tracks, which cannot shrink below a grid item's min-content width — a table-style report with many columns (e.g. a wide Data Explorer query) forced its column to grow and blew the whole section out of the page.

This change caps the tracks with `minmax(0, 1fr)`, so cards keep equal widths and wide tables are clipped at the card edge; admins can click into the report to see the full table.

Before:
<img width="1112" height="874" alt="Screenshot 2026-07-13 at 1 44 04 pm" src="https://github.com/user-attachments/assets/e0778374-ff29-4964-872f-7dcab9bf1ce0" />


After:
<img width="1087" height="850" alt="Screenshot 2026-07-13 at 1 44 40 pm" src="https://github.com/user-attachments/assets/7a47e04d-4983-4051-84f3-b9ef48c79d5d" />

