### PR TITLE
FIX: firefox draggable bug

### DIFF
--- a/app/assets/stylesheets/common/base/sidebar.scss
+++ b/app/assets/stylesheets/common/base/sidebar.scss
@@ -229,7 +229,6 @@
     display: grid;
     grid-template-columns: 2em 4.5em repeat(2, 1fr) 2em;
     padding: 0.55em 0 0.7em;
-    -webkit-user-drag: none;
     cursor: default;
     border-top: 2px solid transparent;
     border-bottom: 2px solid transparent;

--- a/frontend/discourse/app/components/sidebar/section-form-link.gjs
+++ b/frontend/discourse/app/components/sidebar/section-form-link.gjs
@@ -79,7 +79,6 @@ export default class SectionFormLink extends Component {
 
   <template>
     <div
-      {{on "dragstart" this.dragHasStarted}}
       {{on "dragover" this.dragOver}}
       {{on "dragenter" this.dragEnter}}
       {{on "dragleave" this.dragLeave}}
@@ -87,7 +86,6 @@ export default class SectionFormLink extends Component {
       {{on "drop" this.dropItem}}
       role="row"
       data-row-id={{@link.objectId}}
-      draggable="true"
       class={{dConcatClass
         "sidebar-section-form-link"
         "row-wrapper"
@@ -95,7 +93,12 @@ export default class SectionFormLink extends Component {
       }}
     >
       {{#if this.site.desktopView}}
-        <div class="draggable" data-link-name={{@link.name}}>
+        <div
+          {{on "dragstart" this.dragHasStarted}}
+          class="draggable"
+          data-link-name={{@link.name}}
+          draggable="true"
+        >
           {{dIcon "grip-lines"}}
         </div>
       {{/if}}


### PR DESCRIPTION
The implementation relies on a WebKit-only CSS property to suppress draggable="true" from the row. Firefox correctly applies the HTML spec — draggable="true" on the parent means the element and its children initiate a drag on mouse-down, while ignoring `-webkit-user-drag: none`, so intercepting any attempt to interact with the <Input> fields.

This commit moves the `dragStart` & ` draggable="true"` to the drag icon. This only appears on desktop, but mobile drag wasn't working anyway since the used native HTML5 drag-n-drop API doesn't fire on touch input so no functionality was changed.