### PR TITLE
UX: add placeholder text for Klipy gifs search

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3229,6 +3229,7 @@ en:
     gifs:
       modal_title: "Search GIFs"
       composer_title: "Insert GIF"
+      placeholder: "Search KLIPY"
       powered_by: "Powered by Klipy"
       no_results: "Enter a keyword above to search for GIFs."
       browse_categories: "Browse by category"

--- a/frontend/discourse/app/components/modal/gifs.gjs
+++ b/frontend/discourse/app/components/modal/gifs.gjs
@@ -260,6 +260,7 @@ export default class GifsModal extends Component {
             @type="text"
             @value={{this.query}}
             name="query"
+            placeholder={{i18n "gifs.placeholder"}}
             autofocus
           />
 


### PR DESCRIPTION
The API Usage & Attribution Guidelines for KLIPY ([see here](https://docs.klipy.com/attribution)) requires us to add attribution placeholder text on the GIFs search field.

We didn't have this placeholder text in the original theme component that we ported this feature over from but we should add clear attribution to comply since this is now a core feature.