### PR TITLE
FIX: Normalize tag-chooser tags to names in RSS polling and chat archive

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat/modal/archive-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/modal/archive-channel.gjs
@@ -86,7 +86,9 @@ export default class ChatModalArchiveChannel extends Component {
     if (this.newTopic) {
       data.title = this.topicTitle;
       data.category_id = this.categoryId;
-      data.tags = this.tags;
+      data.tags = (this.tags ?? []).map((tag) =>
+        typeof tag === "string" ? tag : tag.name
+      );
     }
     if (this.existingTopic) {
       data.topic_id = this.selectedTopicId;

--- a/plugins/chat/spec/system/archive_channel_spec.rb
+++ b/plugins/chat/spec/system/archive_channel_spec.rb
@@ -54,14 +54,29 @@ RSpec.describe "Archive channel" do
 
       context "when archiving" do
         it "works" do
+          SiteSetting.tagging_enabled = true
+          tag = Fabricate(:tag, name: "archived")
           Jobs.run_immediately!
 
           chat.visit_channel_settings(channel_1)
           click_button(I18n.t("js.chat.channel_settings.archive_channel"))
           find("#split-topic-name").fill_in(with: "An interesting topic for cats")
+
+          tag_chooser =
+            PageObjects::Components::SelectKit.new(".chat-to-topic-selector .tag-chooser")
+          tag_chooser.expand
+          tag_chooser.search(tag.name)
+          tag_chooser.select_row_by_name(tag.name)
+          tag_chooser.collapse
+
           click_button(I18n.t("js.chat.channel_archive.title"))
 
           expect(page).to have_css(".chat-channel-archive-status", wait: 15)
+
+          try_until_success do
+            archive = Chat::ChannelArchive.find_by(chat_channel: channel_1)
+            expect(archive&.destination_tags).to eq([tag.name])
+          end
         end
 
         context "when archived channels had unreads" do

--- a/plugins/discourse-rss-polling/admin/assets/javascripts/discourse/components/rss-polling-feed-form.gjs
+++ b/plugins/discourse-rss-polling/admin/assets/javascripts/discourse/components/rss-polling-feed-form.gjs
@@ -169,7 +169,9 @@ export default class RssPollingFeedForm extends Component {
       });
     }
 
-    const feedTags = data.discourse_tags ?? [];
+    const feedTags = (data.discourse_tags ?? []).map((tag) =>
+      typeof tag === "string" ? tag : tag.name
+    );
 
     this.categoryRequirements.forEach((group) => {
       const matched = group.tags.filter((tag) => feedTags.includes(tag)).length;

--- a/plugins/discourse-rss-polling/spec/system/admin_spec.rb
+++ b/plugins/discourse-rss-polling/spec/system/admin_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe "Rss Polling - admin" do
   it "tests a feed and saves the configuration" do
     stub_request(:get, url).to_return(status: 200, body: file_from_fixtures("feed.rss", "feed"))
 
+    tag_group = Fabricate(:tag_group, tags: [tag_1])
+    CategoryRequiredTagGroup.create!(category: category_1, tag_group:, min_count: 1)
+
     visit("/admin/plugins/discourse-rss-polling/feeds")
 
     find(".rss-polling-feeds__add").click


### PR DESCRIPTION
### What

Since #36678, `tag-chooser`/`mini-tag-chooser` emit an array of tag **objects** instead of tag name strings. Two consumers still assumed name strings and broke:

1. **RSS polling feed form** — the client-side required-tag validation compared the category's required tag *names* against the selected tag *objects*, so the comparison always failed. A feed pointed at a category with a required tag group could never be saved from the UI, even when the required tag was selected (reported on meta).

2. **Chat "archive channel → new topic"** — the selected tags were POSTed as objects, which the controller's `tags: []` strong parameter rejects, so the destination topic was created without any of the chosen tags.

### Fix

Both consumers now map the tag objects to their `.name` before comparing / submitting, matching what the server (`normalize_tags`) and select-kit's own `validateCreate` already do.

### Tests

Extended the existing system specs rather than adding new ones:
- RSS polling admin spec: the "saves the configuration" test's category now requires the tag it selects, so the save exercises the required-tag validation.
- Chat archive spec: the "works" test now selects a tag and asserts it reaches the archive (`destination_tags`).
