### PR TITLE
DEV: Remove unused `d-hover` class reference

### DIFF
--- a/app/assets/stylesheets/wcag.scss
+++ b/app/assets/stylesheets/wcag.scss
@@ -28,7 +28,6 @@ html.discourse-no-touch {
     }
   }
 
-  .btn-flat.delete.d-hover,
   .btn-flat.delete:hover {
     background: var(--danger);
   }


### PR DESCRIPTION
This was used in the old widget system, but none of our templates use this class name any more.