### PR TITLE
DEV: Bump ember-curry-component to 0.5.0

### DIFF
--- a/frontend/discourse/app/lib/blocks/-internals/components/block-layout-wrapper.gjs
+++ b/frontend/discourse/app/lib/blocks/-internals/components/block-layout-wrapper.gjs
@@ -15,7 +15,7 @@ import cssIdentifier from "discourse/helpers/css-identifier";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 /**
- * @typedef {import("ember-curry-component").CurriedComponent} CurriedComponent
+ * @typedef {import("@glint/template").ComponentLike} CurriedComponent
  */
 
 /**

--- a/frontend/discourse/app/lib/blocks/-internals/entry-processing.js
+++ b/frontend/discourse/app/lib/blocks/-internals/entry-processing.js
@@ -111,7 +111,7 @@ function getOrCreateLeafBlockComponent(
  * @property {string} [__failureReason] - Custom failure reason message (debug mode only).
  *
  * @typedef {Object} ChildBlockResult
- * @property {import("ember-curry-component").CurriedComponent} Component - Curried component ready to render.
+ * @property {import("@glint/template").ComponentLike} Component - Curried component ready to render.
  * @property {Object} [containerArgs] - Values for parent container's childArgs schema.
  * @property {string} key - Stable unique key for list rendering.
  * @property {boolean} [isGhost] - True if this is a ghost block (debug mode only).

--- a/frontend/discourse/app/static/dev-tools/block-debug/ghost-block.gjs
+++ b/frontend/discourse/app/static/dev-tools/block-debug/ghost-block.gjs
@@ -21,7 +21,7 @@ import ConditionsTree from "./conditions-tree";
  * @property {Object} [Args.conditions] - Conditions that failed evaluation.
  * @property {string} [Args.failureType] - The failure type constant (FAILURE_TYPE value).
  * @property {string} [Args.failureReason] - Optional custom display message (overrides type-based default).
- * @property {Array<{Component: import("ember-curry-component").CurriedComponent}>} [Args.children] - Nested ghost children for containers.
+ * @property {Array<{Component: import("@glint/template").ComponentLike}>} [Args.children] - Nested ghost children for containers.
  */
 
 /**

--- a/frontend/discourse/app/static/dev-tools/block-debug/patch.js
+++ b/frontend/discourse/app/static/dev-tools/block-debug/patch.js
@@ -52,7 +52,7 @@ function makeDebugCallback(fn) {
  * @param {boolean} isLoggingEnabled - Whether logging is enabled (unused, kept for API compatibility)
  * @param {Function} resolveBlockFn - Function to resolve block references to classes
  * @param {number} [depth=0] - Current nesting depth for recursion limit checking.
- * @returns {Array<{Component: import("ember-curry-component").CurriedComponent, isGhost?: boolean, asGhost?: Function}>} Array of ghost component data
+ * @returns {Array<{Component: import("@glint/template").ComponentLike, isGhost?: boolean, asGhost?: Function}>} Array of ghost component data
  */
 function createGhostChildren(
   childEntries,

--- a/frontend/discourse/package.json
+++ b/frontend/discourse/package.json
@@ -63,7 +63,7 @@
     "codemirror": "^6.0.2",
     "decorator-transforms": "^2.3.2",
     "diff": "^9.0.0",
-    "ember-curry-component": "^0.4.0",
+    "ember-curry-component": "^0.5.0",
     "ember-resolver": "^13.2.0",
     "ember-route-template": "^1.0.3",
     "ember-source": "~6.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       ember-curry-component:
-        specifier: ^0.4.0
-        version: 0.4.0(@babel/core@7.29.7)
+        specifier: ^0.5.0
+        version: 0.5.0(@babel/core@7.29.7)(@glint/template@1.7.8)
       ember-resolver:
         specifier: ^13.2.0
         version: 13.2.0
@@ -4326,8 +4326,13 @@ packages:
     resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
-  ember-curry-component@0.4.0:
-    resolution: {integrity: sha512-mXtlgCA0eW5B4ZdIP4qqMeatFCxKni7uuLbo06UK1a9y/itL5nKQosHwbyx5N7TfXXQt8oQl0oXAliIvw2sdmA==}
+  ember-curry-component@0.5.0:
+    resolution: {integrity: sha512-8N1WWt1KuMntWvB+i9ShwXFMU0tliJO7XinLJB+fihSl/ip+72UWAW3UCRttpiirKuIXJPpwqt6VCmlKbL8C4A==}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
 
   ember-eslint-parser@0.14.3:
     resolution: {integrity: sha512-jU1HtVHqlbzqRDMwS4lxggjIY7u/wr+lij4bEvyC1CpNd5YqHK7anK3ubmVZLiB19VrFO6tH2/iYUQ+drpSYuA==}
@@ -12595,10 +12600,12 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-curry-component@0.4.0(@babel/core@7.29.7):
+  ember-curry-component@0.5.0(@babel/core@7.29.7)(@glint/template@1.7.8):
     dependencies:
       '@embroider/addon-shim': 1.10.3
       decorator-transforms: 2.3.2(@babel/core@7.29.7)
+    optionalDependencies:
+      '@glint/template': 1.7.8
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
It now includes proper type definitions, so we need a couple tweaks to our signatures