### PR TITLE
FIX: Build plugin JS assets when there is no prebuilt bundle

### DIFF
--- a/script/assemble_ember_build.rb
+++ b/script/assemble_ember_build.rb
@@ -163,6 +163,11 @@ else
 end
 
 build_plugin_env = { "SKIP_DB_AND_REDIS" => "1" }
+
+# Plugin JS usually comes from a prebuilt bundle. When there's no bundle, e.g.
+# in a theme's CI running against a custom core ref, we build it here instead.
+build_plugin_env["LOAD_PLUGINS"] = ENV.fetch("LOAD_PLUGINS", "1")
+
 system(build_plugin_env, "bin/rake", "assets:precompile:build_plugins", exception: true)
 
 if ARGV.include?("--compress")


### PR DESCRIPTION
Plugin JS usually comes from a prebuilt bundle. When there's no bundle, e.g. in a theme's CI running against a custom core ref, we need to build it.