### PR TITLE
DEV: Fix failing admin dashboard spec

### DIFF
--- a/spec/system/admin_dashboard_redesign/search_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/search_section_spec.rb
@@ -222,8 +222,7 @@ describe "Admin Dashboard Redesign | Search section" do
     expect(search).to have_no_kpis
   end
 
-  it "asks moderators to contact an admin when search logging is disabled",
-     time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+  it "asks moderators to contact an admin when search logging is disabled" do
     SiteSetting.log_search_queries = false
     sign_in(moderator)
 


### PR DESCRIPTION
The example freezes time at May 14, then signs in the moderator inside the example: spec/system/ admin_dashboard_redesign/search_section_spec.rb:225. That creates an authentication cookie expiring 1,440 hours— exactly 60 days—later, based on lib/auth/default_current_user_provider.rb:304 and config/site_settings.yml:971.

That cookie expired on July 13 at 12:00 UTC. The browser therefore discards it, and /admin sees an anonymous visitor. The screenshot’s “Log In” button confirms this.

cc @tgxworld (FYI, there are May timestamps in other specs in this file)