### PR TITLE
DEV: Use bundler module resolution for `@discourse/types` consumers

### DIFF
--- a/frontend/discourse-types/tsconfig-plugin.json
+++ b/frontend/discourse-types/tsconfig-plugin.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es2021",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
     "experimentalDecorators": true,
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
The declarations in `@discourse/types` are emitted by core under `moduleResolution: bundler`, so their relative re-exports are extensionless (`truth-helpers/index.d.ts` re-exports `./helpers/or`, no extension). Plugins and themes extend `tsconfig-plugin.json`, which was still on `nodenext`; in a `type: module` package nodenext cannot resolve an extensionless relative re-export, so every symbol reached through a barrel resolved to `any` for consumers.

`discourse/truth-helpers` is the most visible case (a pure re-export barrel, imported in hundreds of places), but this affects every barrel in the shipped declarations.

For example, in a plugin:

```gts
import { gt } from "discourse/truth-helpers";

<template>
  {{! @label is typed as a string; gt returns a boolean }}
  <SomeComponent @label={{gt @count 5}} />
</template>
```

This still builds and runs identically; types are stripped at build, so there is no runtime change. Only type-checking differs. `gt` returns a boolean and `@label` expects a string, so this is a type error, but under `nodenext` it went unreported because `gt` had degraded to `any`. Under `bundler`, `gt` resolves to its real signature and `pnpm lint:types` (and the editor) flag it:

```
Type 'boolean' is not assignable to type 'string'.
```

Editor hover and autocomplete are restored, and `or`/`and` recover the precise return types that motivated backing truth-helpers with the package.

The fix points consumer resolution at the same mode the declarations are produced under: `moduleResolution: bundler` and `module`/`target` `es2022`, matching `tsconfig-base.json`. Core and Embroider already resolve this way.

Verified by repointing every in-repo plugin and theme at the workspace `@discourse/types` and running the full `ember-tsc -b` build: it stays green, with nothing previously masked by `any` surfacing. External plugins and themes carry no type-checked TypeScript that depends on nodenext.

Because barrels now resolve to real types, a consumer that type-checks its own code may surface a pre-existing mistake that `any` was hiding after it upgrades; that is the intended effect, not a regression.