### PR TITLE
FIX: Scope group archive and inbox actions to the group's messages

### DIFF
--- a/app/models/group_archived_message.rb
+++ b/app/models/group_archived_message.rb
@@ -5,6 +5,8 @@ class GroupArchivedMessage < ActiveRecord::Base
   belongs_to :topic
 
   def self.move_to_inbox!(group_id, topic, opts = {})
+    return unless topic.private_message? && topic.topic_allowed_groups.exists?(group_id: group_id)
+
     topic_id = topic.id
 
     GroupArchivedMessage.where(group_id: group_id, topic_id: topic_id).destroy_all
@@ -22,6 +24,8 @@ class GroupArchivedMessage < ActiveRecord::Base
   end
 
   def self.archive!(group_id, topic, opts = {})
+    return unless topic.private_message? && topic.topic_allowed_groups.exists?(group_id: group_id)
+
     topic_id = topic.id
 
     GroupArchivedMessage.where(group_id: group_id, topic_id: topic_id).destroy_all

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -97,6 +97,8 @@ class TopicsBulkAction
     group = find_group
     topics.each do |t|
       if guardian.can_see?(t) && t.private_message?
+        next if group && !t.topic_allowed_groups.exists?(group_id: group.id)
+
         if group
           GroupArchivedMessage.move_to_inbox!(group.id, t, acting_user_id: @user.id)
         else
@@ -111,6 +113,8 @@ class TopicsBulkAction
     group = find_group
     topics.each do |t|
       if guardian.can_see?(t) && t.private_message?
+        next if group && !t.topic_allowed_groups.exists?(group_id: group.id)
+
         if group
           GroupArchivedMessage.archive!(group.id, t, acting_user_id: @user.id)
         else

--- a/plugins/discourse-assign/spec/integration/assign_spec.rb
+++ b/plugins/discourse-assign/spec/integration/assign_spec.rb
@@ -29,6 +29,7 @@ describe "integration tests" do
       add_to_assign_allowed_group(user2)
       group.add(user)
       group.add(user2)
+      pm.topic_allowed_groups.create!(group: group)
     end
 
     def assert_publish_topic_state(topic, user: nil, group: nil)

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -155,6 +155,26 @@ RSpec.describe TopicsBulkAction do
     end
   end
 
+  describe "group message operations" do
+    fab!(:other_user, :user)
+    fab!(:group) { Fabricate(:group).tap { |group| group.add(user) } }
+    fab!(:private_message) { Fabricate(:private_message_topic, user: user, recipient: other_user) }
+
+    %w[archive_messages move_messages_to_inbox].each do |operation|
+      it "rejects #{operation} when the selected group is not a message recipient" do
+        topic_ids =
+          TopicsBulkAction.new(
+            user,
+            [private_message.id],
+            { type: operation },
+            group: group.name,
+          ).perform!
+
+        expect(topic_ids).to be_empty
+      end
+    end
+  end
+
   describe "change_category" do
     fab!(:category)
     fab!(:first_post) { Fabricate(:post, topic: topic) }

--- a/spec/models/group_archived_message_spec.rb
+++ b/spec/models/group_archived_message_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe GroupArchivedMessage do
   fab!(:group) do
     Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone]).tap { |g| g.add(user_2) }
   end
+  fab!(:unrelated_group, :group)
+  fab!(:public_topic) { Fabricate(:topic, allowed_groups: [unrelated_group]) }
 
   fab!(:group_message) do
     create_post(
@@ -29,6 +31,29 @@ RSpec.describe GroupArchivedMessage do
 
       expect(GroupArchivedMessage.exists?(topic: group_message, group: group)).to eq(false)
     end
+
+    it "does nothing for topics outside the group's private message inbox" do
+      [group_message, public_topic].each do |invalid_topic|
+        described_class.create!(group: unrelated_group, topic: invalid_topic)
+        events = nil
+        messages = nil
+
+        expect do
+          events =
+            DiscourseEvent.track_events(:move_to_inbox) do
+              messages =
+                MessageBus.track_publish do
+                  described_class.move_to_inbox!(unrelated_group.id, invalid_topic)
+                end
+            end
+        end.to not_change {
+          described_class.where(group: unrelated_group, topic: invalid_topic).count
+        }.and not_change { Jobs::GroupPmUpdateSummary.jobs.size }
+
+        expect(events).to be_empty
+        expect(messages).to be_empty
+      end
+    end
   end
 
   describe ".archive!" do
@@ -41,6 +66,28 @@ RSpec.describe GroupArchivedMessage do
       expect(GroupArchivedMessage.exists?(topic: group_message, group: group)).to eq(true)
 
       expect(messages.present?).to eq(true)
+    end
+
+    it "does nothing for topics outside the group's private message inbox" do
+      [group_message, public_topic].each do |invalid_topic|
+        events = nil
+        messages = nil
+
+        expect do
+          events =
+            DiscourseEvent.track_events(:archive_message) do
+              messages =
+                MessageBus.track_publish do
+                  described_class.archive!(unrelated_group.id, invalid_topic)
+                end
+            end
+        end.to not_change {
+          described_class.where(group: unrelated_group, topic: invalid_topic).count
+        }.and not_change { Jobs::GroupPmUpdateSummary.jobs.size }
+
+        expect(events).to be_empty
+        expect(messages).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, `GroupArchivedMessage.archive!` and `.move_to_inbox!` did not validate the target topic against the given group before updating state and triggering events.

This change makes both methods no-ops unless the topic is a private message with the group as an allowed recipient, and applies the same check in `TopicsBulkAction`.