### PR TITLE
DEV: Fix JS error in modal when selected avatars is misconfigured

### DIFF
--- a/frontend/discourse/app/components/modal/avatar-selector.gjs
+++ b/frontend/discourse/app/components/modal/avatar-selector.gjs
@@ -44,7 +44,11 @@ export default class AvatarSelectorModal extends Component {
   get selectableAvatars() {
     const mode = this.siteSettings.selectable_avatars_mode;
     const list = this.siteSettings.selectable_avatars;
-    return mode !== "disabled" ? (list ? list.split("|") : []) : null;
+    return mode !== "disabled"
+      ? Array.isArray(list)
+        ? list
+        : list?.split("|") || []
+      : null;
   }
 
   get showSelectableAvatars() {

--- a/frontend/discourse/tests/acceptance/user-preferences-account-test.js
+++ b/frontend/discourse/tests/acceptance/user-preferences-account-test.js
@@ -156,6 +156,18 @@ acceptance("User Preferences - Account", function (needs) {
       .exists("avatar selection modal includes option to upload");
   });
 
+  test("avatar selector handles an empty selectable avatars list", async function (assert) {
+    this.siteSettings.selectable_avatars_mode = "everyone";
+    this.siteSettings.selectable_avatars = [];
+
+    await visit("/u/eviltrout/preferences/account");
+    await click(".pref-avatar .btn");
+
+    assert
+      .dom(".avatar-choice")
+      .exists("opens the avatar selection modal without selectable avatars");
+  });
+
   test("avatars are not selectable for non-staff user when `selectable_avatars_mode` site setting is set to `staff`", async function (assert) {
     this.siteSettings.selectable_avatars_mode = "staff";
 


### PR DESCRIPTION
See https://meta.discourse.org/t/-/407452

When an admin mistakenly misconfigures, it results in a broken modal. This change ensure that modal still works even if selected avatars is misconfigured.