### PR TITLE
FIX: Render the error page title in the user's interface language

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -312,26 +312,27 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    message = title = nil
+    message = nil
     with_resolved_locale(check_current_user: false) do
-      if opts[:custom_message]
-        title = message = I18n.t(opts[:custom_message], opts[:custom_message_params] || {})
-      else
-        message = I18n.t(type)
-        if status_code == 403
-          title = I18n.t("page_forbidden.title")
+      message =
+        if opts[:custom_message]
+          I18n.t(opts[:custom_message], opts[:custom_message_params] || {})
         else
-          title = I18n.t("page_not_found.title")
+          I18n.t(type)
         end
-      end
     end
 
-    error_page_opts = { title: title, status: status_code, group: opts[:group] }
+    error_page_opts = {
+      status: status_code,
+      group: opts[:group],
+      custom_message: opts[:custom_message],
+      custom_message_params: opts[:custom_message_params],
+    }
 
     if show_json_errors
       opts = { type: type, status: status_code }
 
-      with_resolved_locale(check_current_user: false) do
+      with_resolved_locale do
         # Include error in HTML format for topics#show.
         if (request.params[:controller] == "topics" && request.params[:action] == "show") ||
              (
@@ -921,7 +922,14 @@ class ApplicationController < ActionController::Base
 
     @container_class = "wrap not-found-container"
     @page_title = I18n.t("page_not_found.page_title")
-    @title = opts[:title] || I18n.t("page_not_found.title")
+    @title =
+      if opts[:custom_message]
+        I18n.t(opts[:custom_message], opts[:custom_message_params] || {})
+      elsif opts[:status] == 403
+        I18n.t("page_forbidden.title")
+      else
+        I18n.t("page_not_found.title")
+      end
     @subtitle = opts[:subtitle] || I18n.t("page_not_found.subtitle")
     @group = opts[:group]
     @hide_search = true if SiteSetting.login_required

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1404,6 +1404,55 @@ RSpec.describe ApplicationController do
       end
     end
 
+    context "with a logged in user whose interface language differs from the default locale" do
+      let(:user) { Fabricate(:user, locale: :ja) }
+
+      before do
+        SiteSetting.allow_user_locale = true
+        SiteSetting.default_locale = "en"
+        sign_in(user)
+      end
+
+      it "serves the whole not-found page, including the title, in the user's locale" do
+        get "/missingroute"
+        expect(response.status).to eq(404)
+
+        # the body is rendered in the user's interface language...
+        expect(response.body).to include(I18n.t("page_not_found.home", locale: :ja))
+        expect(response.body).to include(I18n.t("page_not_found.search_title", locale: :ja))
+
+        # ...and so is the <h1> title
+        expect(response.body).to include(
+          ActionController::Base.helpers.sanitize(
+            I18n.t("page_not_found.title", locale: :ja),
+            tags: %w[a],
+            attributes: %w[href class target rel],
+          ),
+        )
+      end
+
+      it "serves the forbidden page title in the user's locale" do
+        SiteSetting.detailed_404 = true
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+
+        get "/c/#{private_category.slug}/l/latest"
+        expect(response.status).to eq(403)
+        expect(response.body).to include(I18n.t("page_forbidden.title", locale: :ja))
+      end
+
+      it "serves the SPA-injected error panel (JSON extras) in the user's locale" do
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+        private_topic = Fabricate(:topic, category: private_category)
+
+        get "/t/#{private_topic.slug}/#{private_topic.id}.json"
+        expect(response.status).to eq(404)
+
+        extras = response.parsed_body["extras"]
+        expect(extras["title"]).to eq(I18n.t("page_not_found.page_title", locale: :ja))
+        expect(extras["html"]).to include(I18n.t("page_not_found.title", locale: :ja))
+      end
+    end
+
     context "with set_locale_from_cookie enabled" do
       context "when cookie locale differs from default locale" do
         before do


### PR DESCRIPTION
Previously, the title on the not-found/private (404) and forbidden (403) pages was resolved using the site's default locale while the rest of the page used the visitor's interface language, so the heading could appear in a different language than the rest of the page.

This change resolves the title in the same locale as the page it appears on — on both the full-page render and the SPA-injected error panel (`topics#show` / `categories#find_by_slug`) — so the whole page renders consistently.