### PR TITLE
UX: remove wrapping from relative time control

### DIFF
--- a/app/assets/stylesheets/common/components/relative-time-picker.scss
+++ b/app/assets/stylesheets/common/components/relative-time-picker.scss
@@ -1,6 +1,5 @@
 .relative-time-picker {
   display: flex;
-  flex-wrap: wrap;
 
   input[type="text"] {
     flex: 1;


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/unit-and-number-are-no-longer-in-one-line-in-relative-time-selection/407464

The wrapping here is awkward, previously it was on a single line — this adjustment gets us back there. 

Before:
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/94fc8d4b-b320-420a-b574-9e46c9f13dae" />



After: 
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/4258ddb2-85f5-4bdc-af01-74b46135b4b5" />
