### PR TITLE
SECURITY: Apply category tag visibility to full-text search

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -1200,16 +1200,14 @@ class Search
   def tags_search
     return unless SiteSetting.tagging_enabled
     tags =
-      Tag
+      DiscourseTagging
+        .visible_tags(@guardian)
         .includes(:tag_search_data)
         .where("tag_search_data.search_data @@ #{ts_query}")
         .references(:tag_search_data)
         .order("name asc")
         .limit(limit)
-
-    hidden_tag_names = DiscourseTagging.hidden_tag_names(@guardian)
-
-    tags.each { |tag| @results.add(tag) if !hidden_tag_names.include?(tag.name) }
+        .each { |tag| @results.add(tag) }
   end
 
   def exclude_topics_search

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -1876,7 +1876,7 @@ RSpec.describe Search do
         expect(search.tags.map(&:name)).to eq([tag.name, "#{tag.name}9"])
       end
 
-      it "includes category-restricted tags" do
+      it "filters category-restricted tags based on category access" do
         category_tag = Fabricate(:tag, name: "#{tag.name}9")
         tag_group.tags = [category_tag]
         category.set_permissions(admins: :full)
@@ -1886,7 +1886,7 @@ RSpec.describe Search do
         expect(Search.execute(tag.name, guardian: Guardian.new(admin)).tags).to eq(
           [tag, category_tag],
         )
-        expect(search.tags).to eq([tag, category_tag])
+        expect(search.tags).to eq([tag])
       end
     end
   end

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -153,6 +153,78 @@ RSpec.describe SearchController do
       expect(data["users"][0]["id"]).to eq(user.id)
     end
 
+    context "with category-restricted tags" do
+      fab!(:tag_access_group, :group)
+      fab!(:private_category) { Fabricate(:private_category, group: tag_access_group) }
+      fab!(:category_tag) do
+        Fabricate(:tag, name: "classified-category-tag", description: "Category tag description")
+      end
+      fab!(:category_tag_group_tag) do
+        Fabricate(
+          :tag,
+          name: "classified-category-tag-group",
+          description: "Category tag group description",
+        )
+      end
+      fab!(:tag_group) { Fabricate(:tag_group, tags: [category_tag_group_tag]) }
+      fab!(:regular_user, :user)
+      fab!(:authorized_user, :user)
+      fab!(:admin)
+
+      before do
+        SiteSetting.tagging_enabled = true
+        CategoryTag.create!(category: private_category, tag: category_tag)
+        CategoryTagGroup.create!(category: private_category, tag_group: tag_group)
+        tag_access_group.add(authorized_user)
+        SearchIndexer.index(category_tag, force: true)
+        SearchIndexer.index(category_tag_group_tag, force: true)
+      end
+
+      it "does not expose either restriction type to anonymous users" do
+        get "/search/query.json", params: { term: "classified" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["tags"]).to be_empty
+      end
+
+      it "does not expose either restriction type to unauthorized regular users" do
+        sign_in(regular_user)
+
+        get "/search/query.json", params: { term: "classified" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["tags"]).to be_empty
+      end
+
+      it "exposes both restriction types to users who can access the category" do
+        sign_in(authorized_user)
+
+        get "/search/query.json", params: { term: "classified" }
+
+        expect(response).to have_http_status(:ok)
+        expect(
+          response.parsed_body["tags"].map { |tag| tag.values_at("name", "description") },
+        ).to contain_exactly(
+          [category_tag.name, category_tag.description],
+          [category_tag_group_tag.name, category_tag_group_tag.description],
+        )
+      end
+
+      it "exposes both restriction types to admins" do
+        sign_in(admin)
+
+        get "/search/query.json", params: { term: "classified" }
+
+        expect(response).to have_http_status(:ok)
+        expect(
+          response.parsed_body["tags"].map { |tag| tag.values_at("name", "description") },
+        ).to contain_exactly(
+          [category_tag.name, category_tag.description],
+          [category_tag_group_tag.name, category_tag_group_tag.description],
+        )
+      end
+    end
+
     context "when searching by topic id" do
       it "should not be restricted by minimum search term length" do
         SiteSetting.min_search_term_length = 20_000


### PR DESCRIPTION
Full-text search (`Search#tags_search`, which powers the anonymous `/search/query.json` endpoint) filtered matching tags through `DiscourseTagging.hidden_tag_names`. That helper only accounts for tag-group permissions, so tags restricted to a private category via `CategoryTag` or `CategoryTagGroup` were never filtered out. An anonymous or unauthorized user could search for a term and receive the restricted tag's name, slug, and description (including localized descriptions) in the `tags` array, even with no access to the category itself. Because the search term can be swept, this allowed enumeration of otherwise-hidden tag metadata.

This came from Patch Triage: https://patch.discourse.org/patch-triage/1434