### PR TITLE
A11Y: include read status, last visit, unread count

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4301,6 +4301,7 @@ en:
       read_more_in_category: "Want to read more? Browse other topics in %{categoryLink} or <a href='%{latestLink}'>view latest topics</a>."
       read_more: "Want to read more? <a href='%{categoryLink}'>Browse all categories</a> or <a href='%{latestLink}'>view latest topics</a>."
       unread_indicator: "No member has read the last post of this topic yet."
+      sr_read: "read"
       participant_groups: "Participant groups"
 
       # This string uses the ICU Message Format. See https://meta.discourse.org/t/7035 for translation guidelines.

--- a/frontend/discourse/app/components/post/visited-line.gjs
+++ b/frontend/discourse/app/components/post/visited-line.gjs
@@ -10,7 +10,7 @@ const PostVisitedLine = <template>
         (concat "post-" @post.post_number)
       }}
     >
-      <span class="topic-post-visited-message">
+      <span class="topic-post-visited-message" role="heading" aria-level="2">
         {{i18n "topics.new_messages_marker"}}
       </span>
     </div>

--- a/frontend/discourse/app/components/topic-list/topic-link.gjs
+++ b/frontend/discourse/app/components/topic-list/topic-link.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { trustHTML } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
+import { i18n } from "discourse-i18n";
 
 export default class TopicLink extends Component {
   get url() {
@@ -19,7 +20,13 @@ export default class TopicLink extends Component {
         data-topic-id={{@topic.id}}
         class="title"
         ...attributes
-      >{{trustHTML @topic.fancyTitle}}{{yield}}</a>
+      >
+        {{trustHTML @topic.fancyTitle}}
+        {{#if @topic.visited}}
+          <span class="sr-only">&nbsp;{{i18n "topic.sr_read"}}</span>
+        {{/if}}
+        {{yield}}
+      </a>
       {{~! no whitespace ~}}
     </PluginOutlet>
     {{~! no whitespace ~}}

--- a/frontend/discourse/app/components/topic-list/unread-indicator.gjs
+++ b/frontend/discourse/app/components/topic-list/unread-indicator.gjs
@@ -32,7 +32,7 @@ export default class UnreadIndicator extends Component {
         title={{i18n "topic.unread_indicator"}}
         class="badge badge-notification unread-indicator"
       >
-        {{~dIcon "asterisk"~}}
+        {{~dIcon "asterisk" label=(i18n "topic.unread_indicator")~}}
       </span>
     {{~/if~}}
   </template>

--- a/frontend/discourse/app/components/topic-post-badges.gjs
+++ b/frontend/discourse/app/components/topic-post-badges.gjs
@@ -22,6 +22,7 @@ export default class TopicPostBadges extends Component {
         &nbsp;<a
           href={{@url}}
           title={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
+          aria-label={{i18n "topic.unread_posts" count=this.displayUnreadPosts}}
           class="badge badge-notification unread-posts"
         >{{this.displayUnreadPosts}}</a>
       {{~/if~}}
@@ -30,6 +31,7 @@ export default class TopicPostBadges extends Component {
         &nbsp;<a
           href={{@url}}
           title={{i18n "topic.new"}}
+          aria-label={{i18n "topic.new"}}
           class="badge badge-notification new-topic"
         >{{this.newDotText}}</a>
       {{~/if~}}

--- a/frontend/discourse/app/routes/topic.js
+++ b/frontend/discourse/app/routes/topic.js
@@ -23,10 +23,12 @@ import topicTitleToken from "discourse/lib/topic-title-token";
 import DiscourseURL from "discourse/lib/url";
 import { ID_CONSTRAINT } from "discourse/models/topic";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
 const SCROLL_DELAY = 500;
 
 export default class TopicRoute extends DiscourseRoute {
+  @service a11y;
   @service composer;
   @service screenTrack;
   @service currentUser;
@@ -34,10 +36,8 @@ export default class TopicRoute extends DiscourseRoute {
   @service router;
 
   scheduledReplace = null;
-
   lastScrollPos = null;
   isTransitioning = false;
-
   queryParams = {
     filter: { replace: true },
     username_filters: { replace: true },
@@ -45,6 +45,7 @@ export default class TopicRoute extends DiscourseRoute {
     context: { refreshModel: true },
     collapseReplies: { replace: true },
   };
+  #announcedUnreadForTopicId = null;
 
   buildRouteInfoMetadata() {
     return {
@@ -351,8 +352,23 @@ export default class TopicRoute extends DiscourseRoute {
     }
   }
 
+  announceUnreadPosts(topic) {
+    if (this.#announcedUnreadForTopicId === topic.id) {
+      return;
+    }
+    this.#announcedUnreadForTopicId = topic.id;
+
+    const lastRead = topic.last_read_post_number;
+    const unread = topic.highest_post_number - lastRead;
+    if (lastRead && unread > 0) {
+      this.a11y.announce(i18n("topic.unread_posts", { count: unread }));
+    }
+  }
+
   deactivate() {
     super.deactivate(...arguments);
+
+    this.#announcedUnreadForTopicId = null;
 
     this.searchService.searchContext = null;
 

--- a/frontend/discourse/app/routes/topic/from-params.js
+++ b/frontend/discourse/app/routes/topic/from-params.js
@@ -22,7 +22,6 @@ import { registerPostInTopicPostStream } from "discourse/lib/process-node";
 import DiscourseURL from "discourse/lib/url";
 import Draft from "discourse/models/draft";
 import DiscourseRoute from "discourse/routes/discourse";
-import { i18n } from "discourse-i18n";
 
 export function nestedQueryString(params) {
   const query = new URLSearchParams();
@@ -38,7 +37,6 @@ export function nestedQueryString(params) {
 
 // This route is used for retrieving a topic based on params
 export default class TopicFromParams extends DiscourseRoute {
-  @service a11y;
   @service appEvents;
   @service composer;
   @service header;
@@ -49,8 +47,6 @@ export default class TopicFromParams extends DiscourseRoute {
   @service site;
   @service siteSettings;
   @service store;
-
-  #announcedUnreadForTopicId = null;
 
   buildRouteInfoMetadata() {
     return {
@@ -119,8 +115,6 @@ export default class TopicFromParams extends DiscourseRoute {
 
   deactivate() {
     super.deactivate(...arguments);
-
-    this.#announcedUnreadForTopicId = null;
 
     const topicController = this.controllerFor("topic");
     const nestedController = this.controllerFor("nested");
@@ -328,19 +322,8 @@ export default class TopicFromParams extends DiscourseRoute {
     return `nested-view-scroll:${cacheKey}`;
   }
 
-  // Announce once per topic entry so re-navigating between posts
-  // within the topic stays quiet.
   #announceUnreadPosts(topic) {
-    if (this.#announcedUnreadForTopicId === topic.id) {
-      return;
-    }
-    this.#announcedUnreadForTopicId = topic.id;
-
-    const lastRead = topic.last_read_post_number;
-    const unread = topic.highest_post_number - lastRead;
-    if (lastRead && unread > 0) {
-      this.a11y.announce(i18n("topic.unread_posts", { count: unread }));
-    }
+    getOwner(this).lookup("route:topic").announceUnreadPosts(topic);
   }
 
   #loadScrollAnchor(cacheKey) {

--- a/frontend/discourse/app/routes/topic/from-params.js
+++ b/frontend/discourse/app/routes/topic/from-params.js
@@ -22,6 +22,7 @@ import { registerPostInTopicPostStream } from "discourse/lib/process-node";
 import DiscourseURL from "discourse/lib/url";
 import Draft from "discourse/models/draft";
 import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
 
 export function nestedQueryString(params) {
   const query = new URLSearchParams();
@@ -37,6 +38,7 @@ export function nestedQueryString(params) {
 
 // This route is used for retrieving a topic based on params
 export default class TopicFromParams extends DiscourseRoute {
+  @service a11y;
   @service appEvents;
   @service composer;
   @service header;
@@ -47,6 +49,8 @@ export default class TopicFromParams extends DiscourseRoute {
   @service site;
   @service siteSettings;
   @service store;
+
+  #announcedUnreadForTopicId = null;
 
   buildRouteInfoMetadata() {
     return {
@@ -116,6 +120,8 @@ export default class TopicFromParams extends DiscourseRoute {
   deactivate() {
     super.deactivate(...arguments);
 
+    this.#announcedUnreadForTopicId = null;
+
     const topicController = this.controllerFor("topic");
     const nestedController = this.controllerFor("nested");
     this.#saveNestedToCache(nestedController);
@@ -175,6 +181,7 @@ export default class TopicFromParams extends DiscourseRoute {
     });
 
     this.appEvents.trigger("page:topic-loaded", topic);
+    this.#announceUnreadPosts(topic);
     topicController.subscribe();
     if (wasNestedView) {
       this.screenTrack.start(topic.id, topicController);
@@ -321,6 +328,21 @@ export default class TopicFromParams extends DiscourseRoute {
     return `nested-view-scroll:${cacheKey}`;
   }
 
+  // Announce once per topic entry so re-navigating between posts
+  // within the topic stays quiet.
+  #announceUnreadPosts(topic) {
+    if (this.#announcedUnreadForTopicId === topic.id) {
+      return;
+    }
+    this.#announcedUnreadForTopicId = topic.id;
+
+    const lastRead = topic.last_read_post_number;
+    const unread = topic.highest_post_number - lastRead;
+    if (lastRead && unread > 0) {
+      this.a11y.announce(i18n("topic.unread_posts", { count: unread }));
+    }
+  }
+
   #loadScrollAnchor(cacheKey) {
     try {
       const value = sessionStorage.getItem(this.#scrollAnchorKey(cacheKey));
@@ -404,6 +426,7 @@ export default class TopicFromParams extends DiscourseRoute {
     }
 
     this.appEvents.trigger("page:topic-loaded", model.topic);
+    this.#announceUnreadPosts(model.topic);
     topicController.subscribe();
     nestedController.subscribe();
     this.screenTrack.start(model.topic.id, nestedController);

--- a/frontend/discourse/app/ui-kit/helpers/d-topic-link.js
+++ b/frontend/discourse/app/ui-kit/helpers/d-topic-link.js
@@ -1,7 +1,12 @@
 import { trustHTML } from "@ember/template";
+import { escapeExpression } from "discourse/lib/utilities";
+import { i18n } from "discourse-i18n";
 
 export default function dTopicLink(topic, args = {}) {
   const title = topic.get("fancyTitle");
+  const readIndicator = topic.get("visited")
+    ? `<span class="sr-only">&nbsp;${escapeExpression(i18n("topic.sr_read"))}</span>`
+    : "";
 
   const url = topic.linked_post_number
     ? topic.urlForPostNumber(topic.linked_post_number)
@@ -16,6 +21,6 @@ export default function dTopicLink(topic, args = {}) {
   return trustHTML(
     `<a href='${url}'
         class='${classes.join(" ")}'
-        data-topic-id='${topic.id}'>${title}</a>`
+        data-topic-id='${topic.id}'>${title}${readIndicator}</a>`
   );
 }

--- a/frontend/discourse/tests/acceptance/topic-test.js
+++ b/frontend/discourse/tests/acceptance/topic-test.js
@@ -571,6 +571,15 @@ acceptance(`Topic last visit line`, function (needs) {
       .dom(".topic-post-visited-line.post-10")
       .exists("shows the last visited line on the right post");
 
+    assert
+      .dom(".topic-post-visited-line.post-10 .topic-post-visited-message")
+      .hasAria("level", "2", "the marker is part of heading navigation")
+      .hasAttribute(
+        "role",
+        "heading",
+        "the marker is part of heading navigation"
+      );
+
     await visit("/t/-/9");
 
     assert

--- a/frontend/discourse/tests/acceptance/topic-unread-posts-announcement-test.js
+++ b/frontend/discourse/tests/acceptance/topic-unread-posts-announcement-test.js
@@ -1,0 +1,87 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import sinon from "sinon";
+import { cloneJSON } from "discourse/lib/object";
+import { disableClearA11yAnnouncementsInTests } from "discourse/services/a11y";
+import topicFixtures from "discourse/tests/fixtures/topic";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
+
+acceptance("Topic - unread posts announcement", function (needs) {
+  needs.user();
+
+  let topicJson;
+
+  needs.hooks.beforeEach(function () {
+    disableClearA11yAnnouncementsInTests();
+
+    topicJson = cloneJSON(topicFixtures["/t/280/1.json"]);
+    topicJson.last_read_post_number = 15;
+    topicJson.highest_post_number = 20;
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/t/280.json", () => helper.response(topicJson));
+    server.get("/t/280/:post_number.json", () => helper.response(topicJson));
+  });
+
+  test("announces the unread post count when entering a topic", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText(
+        i18n("topic.unread_posts", { count: 5 }),
+        "politely announces highest_post_number - last_read_post_number"
+      );
+  });
+
+  test("stays silent when the topic has never been read", async function (assert) {
+    topicJson.last_read_post_number = null;
+
+    await visit("/t/internationalization-localization/280");
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText("", "no announcement without a last read post number");
+  });
+
+  test("stays silent when the topic is fully read", async function (assert) {
+    topicJson.last_read_post_number = 20;
+
+    await visit("/t/internationalization-localization/280");
+
+    assert
+      .dom("#a11y-announcements-polite")
+      .hasText("", "no announcement when there are no unread posts");
+  });
+
+  test("does not repeat while moving between posts of the same topic", async function (assert) {
+    const announce = sinon.spy(this.owner.lookup("service:a11y"), "announce");
+    const message = i18n("topic.unread_posts", { count: 5 });
+
+    await visit("/t/internationalization-localization/280");
+    await visit("/t/internationalization-localization/280/2");
+
+    assert.strictEqual(
+      announce.withArgs(message).callCount,
+      1,
+      "announced only once for the same topic entry"
+    );
+  });
+
+  test("announces again after leaving and re-entering the topic", async function (assert) {
+    const announce = sinon.spy(this.owner.lookup("service:a11y"), "announce");
+    const message = i18n("topic.unread_posts", { count: 5 });
+
+    await visit("/t/internationalization-localization/280");
+    await visit("/latest");
+    await visit("/t/internationalization-localization/280");
+
+    assert.strictEqual(
+      announce.withArgs(message).callCount,
+      2,
+      "each fresh topic entry announces"
+    );
+  });
+});


### PR DESCRIPTION
This fills in some gaps for the screenreader experience around read status. 

It adds:

* "read" to items in the topic list that have been read — currently we rely on "visited" and "unvisited" links according to the browser, which is inconsistent across devices 

* adds a heading role to the "last visit" line between posts within topics, so it's a part of the navigation flow... currently the lack of a heading omits it

* upon entering a topic, reads the count of new posts with a polite announcement 

* adds labels to existing unread and new topic badges 