### PR TITLE
UX: Add filetype warning for apple_touch_icon

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6710,7 +6710,7 @@ en:
             apple_touch_icon:
               title: "Apple touch icon"
               description: "Icon used for Apple touch devices. If left blank, large_icon will be used."
-              help_text: "Recommended size is 180 x 180 pixels. A transparent background is not recommended."
+              help_text: "Recommended size is 180 x 180 pixels. Don't use an SVG image. A transparent background is not recommended."
             digest_logo:
               title: "Digest logo"
               description: "The alternate logo image used at the top of your site's email summary. If left blank, the image from the `logo` setting will be used."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1968,7 +1968,7 @@ en:
     manifest_screenshots: "Screenshots that showcase your instance features and functionality on its install prompt page. All images should be local uploads and of the same dimensions."
     favicon: "A favicon for your site, see <a href='https://en.wikipedia.org/wiki/Favicon' target='_blank'>https://en.wikipedia.org/wiki/Favicon</a>. To work correctly over a CDN it must be a png. Will be resized to 32x32. If left blank, {{setting:large_icon}} will be used."
     generate_topic_og_image: "Automatically generate OpenGraph preview images for topics that don't have an image. Uses topic title, category, and site colors."
-    apple_touch_icon: "Icon used for Apple touch devices. A transparent background is not recommended. Will be automatically resized to 180x180. If left blank, {{setting:large_icon}} will be used."
+    apple_touch_icon: "Icon used for Apple touch devices. Don't use an SVG image. A transparent background is not recommended. Will be automatically resized to 180x180. If left blank, {{setting:large_icon}} will be used."
     opengraph_image: "Default opengraph image, used when the page has no other suitable image. If left blank, {{setting:large_icon}} will be used"
     x_summary_large_image: "Twitter card 'summary large image' (should be at least 280 in width, and at least 150 in height, cannot be .svg). If left blank, regular card metadata is generated using the {{setting:opengraph_image}}, as long as that is not also a .svg"
 


### PR DESCRIPTION
The `digest_logo` setting already warns admins not to use SVG images, but a similar warning is missing from the `apple_touch_icon` site setting, which can lead to confusing issues like logos not appearing in DiscourseHub.

This PR adds matching SVG warnings.

Related discussion: https://meta.discourse.org/t/adding-svg-warnings-to-apple-touch-icon-setting/407481