### PR TITLE
PERF: Improve user participation default query

### DIFF
--- a/app/models/topic_view_item.rb
+++ b/app/models/topic_view_item.rb
@@ -75,6 +75,7 @@ end
 #
 # Indexes
 #
+#  index_topic_views_for_user_participation     (viewed_at,user_id,topic_id) WHERE (user_id IS NOT NULL)
 #  index_topic_views_on_topic_id_and_viewed_at  (topic_id,viewed_at)
 #  index_topic_views_on_user_id_and_viewed_at   (user_id,viewed_at)
 #  index_topic_views_on_viewed_at_and_topic_id  (viewed_at,topic_id)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -21307,6 +21307,13 @@ CREATE INDEX index_topic_view_stats_on_viewed_at_and_topic_id ON public.topic_vi
 
 
 --
+-- Name: index_topic_views_for_user_participation; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_topic_views_for_user_participation ON public.topic_views USING btree (viewed_at, user_id, topic_id) WHERE (user_id IS NOT NULL);
+
+
+--
 -- Name: index_topic_views_on_topic_id_and_viewed_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -22575,6 +22582,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260713180615'),
 ('20260708095336'),
 ('20260708080308'),
 ('20260707013407'),

--- a/plugins/discourse-data-explorer/db/post_migrate/20260713180615_add_topic_views_user_participation_index.rb
+++ b/plugins/discourse-data-explorer/db/post_migrate/20260713180615_add_topic_views_user_participation_index.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+class AddTopicViewsUserParticipationIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :topic_views,
+                 name: "index_topic_views_for_user_participation",
+                 algorithm: :concurrently,
+                 if_exists: true
+
+    add_index :topic_views,
+              %i[viewed_at user_id topic_id],
+              where: "user_id IS NOT NULL",
+              name: "index_topic_views_for_user_participation",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :topic_views,
+                 name: "index_topic_views_for_user_participation",
+                 algorithm: :concurrently,
+                 if_exists: true
+  end
+end

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/queries.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/queries.rb
@@ -411,21 +411,18 @@ module DiscourseDataExplorer
               user_id
       ),
       pc AS (
-          SELECT user_id, COUNT(1) AS posts_created
-          FROM posts, t
-          WHERE
-              created_at > t.START
-              AND created_at < t.
-              END
+          SELECT p.user_id, COUNT(1) AS posts_created
+          FROM posts p
+          JOIN t ON p.created_at > t.START AND p.created_at < t.END
+          JOIN pr ON p.user_id = pr.user_id
           GROUP BY
-              user_id
+              p.user_id
       ),
       ttopics AS (
-          SELECT user_id, posts_count
-          FROM topics, t
-          WHERE created_at > t.START
-              AND created_at < t.
-              END
+          SELECT topics.user_id, topics.posts_count
+          FROM topics
+          JOIN t ON topics.created_at > t.START AND topics.created_at < t.END
+          JOIN pr ON topics.user_id = pr.user_id
       ),
       tc AS (
           SELECT user_id, COUNT(1) AS topics_created
@@ -439,27 +436,26 @@ module DiscourseDataExplorer
           GROUP BY user_id
       ),
       tv AS (
-          SELECT user_id,
-              COUNT(DISTINCT(topic_id)) AS topics_viewed
-          FROM topic_views, t
-          WHERE viewed_at > t.START
-              AND viewed_at < t.
-              END
-          GROUP BY user_id
+          SELECT topic_views.user_id,
+              COUNT(DISTINCT(topic_views.topic_id)) AS topics_viewed
+          FROM topic_views
+          JOIN t ON topic_views.viewed_at > t.START AND topic_views.viewed_at < t.END
+          JOIN pr ON topic_views.user_id = pr.user_id
+          WHERE topic_views.user_id IS NOT NULL
+          GROUP BY topic_views.user_id
       ),
       likes AS (
           SELECT post_actions.user_id AS given_by_user_id,
               posts.user_id AS received_by_user_id
-          FROM t,
-              post_actions
-              LEFT JOIN
-              posts
-              ON post_actions.post_id = posts.id
+          FROM post_actions
+          JOIN t ON post_actions.created_at > t.START AND post_actions.created_at < t.END
+          LEFT JOIN posts ON post_actions.post_id = posts.id
           WHERE
-              post_actions.created_at > t.START
-              AND post_actions.created_at < t.
-              END
-              AND post_action_type_id = 2
+              post_action_type_id = 2
+              AND (
+                  post_actions.user_id IN (SELECT user_id FROM pr)
+                  OR posts.user_id IN (SELECT user_id FROM pr)
+              )
       ),
       lg AS (
           SELECT given_by_user_id AS user_id,
@@ -472,11 +468,6 @@ module DiscourseDataExplorer
               COUNT(1) AS likes_received
           FROM likes
           GROUP BY user_id
-      ),
-      e AS (
-          SELECT email, user_id
-          FROM user_emails u
-          WHERE u.PRIMARY = TRUE
       )
       SELECT
           pr.user_id,
@@ -498,7 +489,7 @@ module DiscourseDataExplorer
       LEFT JOIN twr USING (user_id)
       LEFT JOIN lg USING (user_id)
       LEFT JOIN lr USING (user_id)
-      LEFT JOIN e USING (user_id)
+      LEFT JOIN user_emails e ON e.user_id = pr.user_id AND e.PRIMARY = TRUE
       LEFT JOIN users ON pr.user_id = users.id
       ORDER BY
           visits DESC,


### PR DESCRIPTION
- Adds a more targeted partial index
- Rewrote the user-participation query to calculate posts, topics, views, and emails only for users active in pr

This should improve perf considerably, since it hits the index instead of a table fetch for the topic views.