### PR TITLE
DEV: Fix failing admin dashboard spec [backport 2026.6]

### DIFF
--- a/spec/system/admin_dashboard_redesign/search_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/search_section_spec.rb
@@ -212,8 +212,7 @@ describe "Admin Dashboard Redesign | Search section" do
     expect(search).to have_no_kpis
   end
 
-  it "asks moderators to contact an admin when search logging is disabled",
-     time: Time.zone.local(2026, 5, 14, 12, 0, 0) do
+  it "asks moderators to contact an admin when search logging is disabled" do
     SiteSetting.log_search_queries = false
     sign_in(moderator)
 


### PR DESCRIPTION
Backport of #41660 to release/2026.6.

---

The example `spec/system/admin_dashboard_redesign/search_section_spec.rb` freezes time at 2026-05-14, then signs in the moderator inside the example. That creates an authentication cookie expiring 1,440 hours (exactly 60 days) later, i.e. **2026-07-13 12:00 UTC**. After that moment the real browser discards the already-expired cookie, `/admin` sees an anonymous visitor, and the spec times out (45s `SpecTimeoutError`).


Fixes the `core system` failure currently blocking the #41668 security backport (#41671) on this branch.