### PR TITLE
A11Y: relative post dates for screenreaders

### DIFF
--- a/frontend/discourse/app/components/post/meta-data/date.gjs
+++ b/frontend/discourse/app/components/post/meta-data/date.gjs
@@ -3,13 +3,24 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import ShareTopicModal from "discourse/components/modal/share-topic";
+import { relativeAge } from "discourse/lib/formatter";
 import { and } from "discourse/truth-helpers";
 import DRelativeDate from "discourse/ui-kit/d-relative-date";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 export default class PostMetaDataDate extends Component {
+  @service a11y;
   @service modal;
+
+  get srDate() {
+    if (this.a11y.autoUpdatingRelativeDateRef && this.args.post.displayDate) {
+      return relativeAge(new Date(this.args.post.displayDate), {
+        format: "medium-with-ago",
+        wrapInSpan: false,
+      });
+    }
+  }
 
   @action
   showShareModal(evt) {
@@ -32,9 +43,12 @@ export default class PostMetaDataDate extends Component {
         }}
         href={{@post.shareUrl}}
         title={{i18n "post.sr_date"}}
+        aria-label={{this.srDate}}
         {{on "click" this.showShareModal}}
       >
-        <DRelativeDate @date={{@post.displayDate}} />
+        <span aria-hidden="true">
+          <DRelativeDate @date={{@post.displayDate}} />
+        </span>
       </a>
     </div>
   </template>

--- a/frontend/discourse/app/ui-kit/d-post-accordion-item.gjs
+++ b/frontend/discourse/app/ui-kit/d-post-accordion-item.gjs
@@ -2,9 +2,11 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import PostCookedHtml from "discourse/components/post/cooked-html";
 import userPrioritizedName from "discourse/helpers/user-prioritized-name";
+import { relativeAge } from "discourse/lib/formatter";
 import DiscourseURL from "discourse/lib/url";
 import DButton from "discourse/ui-kit/d-button";
 import DRelativeDate from "discourse/ui-kit/d-relative-date";
@@ -15,6 +17,8 @@ import dOnResize from "discourse/ui-kit/modifiers/d-on-resize";
 import { i18n } from "discourse-i18n";
 
 export default class DPostAccordionItem extends Component {
+  @service a11y;
+
   @tracked measured = false;
   @tracked isOverflowing = false;
 
@@ -28,6 +32,15 @@ export default class DPostAccordionItem extends Component {
 
   get hasContent() {
     return !!this.post?.cooked;
+  }
+
+  get srDate() {
+    if (this.a11y.autoUpdatingRelativeDateRef && this.post.created_at) {
+      return relativeAge(new Date(this.post.created_at), {
+        format: "medium-with-ago",
+        wrapInSpan: false,
+      });
+    }
   }
 
   get userDisplayName() {
@@ -108,8 +121,11 @@ export default class DPostAccordionItem extends Component {
                 href={{this.post.url}}
                 class="date-link"
                 title={{i18n "post.sr_date"}}
+                aria-label={{this.srDate}}
               >
-                <DRelativeDate @date={{this.post.created_at}} />
+                <span aria-hidden="true">
+                  <DRelativeDate @date={{this.post.created_at}} />
+                </span>
               </a>
             {{/if}}
           </div>

--- a/frontend/discourse/tests/integration/components/post-accordion-test.gjs
+++ b/frontend/discourse/tests/integration/components/post-accordion-test.gjs
@@ -1,6 +1,7 @@
 import { click, render, waitFor } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 import DPostAccordion from "discourse/ui-kit/d-post-accordion";
 
 module("Integration | Component | DPostAccordion", function (hooks) {
@@ -53,6 +54,27 @@ module("Integration | Component | DPostAccordion", function (hooks) {
     assert
       .dom(":nth-child(2 of .d-post-accordion-item) .date-link")
       .hasAttribute("href", posts[1].url);
+  });
+
+  test("date link is announced with an abbreviated date instead of the full date and time", async function (assert) {
+    const clock = fakeTime("2026-07-13T12:00:00", null, true);
+
+    try {
+      const recentPosts = [
+        { ...posts[0], created_at: moment().subtract(2, "days").toISOString() },
+      ];
+
+      await render(
+        <template><DPostAccordion @posts={{recentPosts}} /></template>
+      );
+
+      assert.dom(".date-link").hasAria("label", "2 days ago");
+      assert
+        .dom(".date-link > span[aria-hidden=true] .relative-date")
+        .exists("the relative date and its tooltip are accessibility-hidden");
+    } finally {
+      clock.restore();
+    }
   });
 
   test("yields custom header", async function (assert) {

--- a/frontend/discourse/tests/integration/components/post/meta-data/date-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/meta-data/date-test.gjs
@@ -1,9 +1,9 @@
 import { getOwner } from "@ember/owner";
-import { render } from "@ember/test-helpers";
+import { render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import PostMetaDataDate from "discourse/components/post/meta-data/date";
-import { relativeAge } from "discourse/lib/formatter";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { fakeTime } from "discourse/tests/helpers/qunit-helpers";
 
 function renderComponent(post) {
   return render(<template><PostMetaDataDate @post={{post}} /></template>);
@@ -12,33 +12,64 @@ function renderComponent(post) {
 module("Integration | Component | Post | PostMetaDataDate", function (hooks) {
   setupRenderingTest(hooks);
 
+  let clock;
+
   hooks.beforeEach(function () {
+    clock = fakeTime("2026-07-13T12:00:00", null, true);
+
     this.store = getOwner(this).lookup("service:store");
     const topic = this.store.createRecord("topic", { id: 1 });
-    const post = this.store.createRecord("post", {
+    this.post = this.store.createRecord("post", {
       id: 123,
       post_number: 1,
       topic,
-      created_at: "2025-06-01T00:31:24.008Z",
     });
-
-    this.post = post;
   });
 
-  test("uses an abbreviated date for the accessible label", async function (assert) {
+  hooks.afterEach(function () {
+    clock?.restore();
+  });
+
+  test("announces recent posts with a relative label instead of the full date and time", async function (assert) {
+    this.post.created_at = moment().subtract(20, "minutes").toISOString();
+
     await renderComponent(this.post);
 
-    assert.dom("a.post-date").hasAria(
-      "label",
-      relativeAge(new Date(this.post.created_at), {
-        format: "medium-with-ago",
-        wrapInSpan: false,
-      }),
-      "the link is announced with an abbreviated date instead of the full date and time"
-    );
+    assert.dom("a.post-date").hasAria("label", "20 mins ago");
 
     assert
       .dom("a.post-date > span[aria-hidden=true] .relative-date")
       .exists("the relative date and its tooltip are accessibility-hidden");
+  });
+
+  test("refreshes the label as time passes", async function (assert) {
+    this.post.created_at = moment().subtract(2, "days").toISOString();
+
+    await renderComponent(this.post);
+
+    assert.dom("a.post-date").hasAria("label", "2 days ago");
+
+    clock.tick(24 * 60 * 60 * 1000);
+    getOwner(this).lookup("service:a11y").autoUpdatingRelativeDateRef =
+      new Date();
+    await settled();
+
+    assert.dom("a.post-date").hasAria("label", "3 days ago");
+  });
+
+  test("announces older posts with a short absolute date", async function (assert) {
+    this.post.created_at = moment().subtract(31, "days").toISOString();
+
+    await renderComponent(this.post);
+
+    assert.dom("a.post-date").hasAria("label", "Jun 12");
+  });
+
+  test("includes the year for posts from previous years", async function (assert) {
+    this.post.created_at = moment().subtract(1, "year").toISOString();
+
+    await renderComponent(this.post);
+
+    assert.dom("a.post-date").hasAria("label", "Jul 13, 2025");
   });
 });

--- a/frontend/discourse/tests/integration/components/post/meta-data/date-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/meta-data/date-test.gjs
@@ -1,0 +1,44 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import PostMetaDataDate from "discourse/components/post/meta-data/date";
+import { relativeAge } from "discourse/lib/formatter";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+function renderComponent(post) {
+  return render(<template><PostMetaDataDate @post={{post}} /></template>);
+}
+
+module("Integration | Component | Post | PostMetaDataDate", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = getOwner(this).lookup("service:store");
+    const topic = this.store.createRecord("topic", { id: 1 });
+    const post = this.store.createRecord("post", {
+      id: 123,
+      post_number: 1,
+      topic,
+      created_at: "2025-06-01T00:31:24.008Z",
+    });
+
+    this.post = post;
+  });
+
+  test("uses an abbreviated date for the accessible label", async function (assert) {
+    await renderComponent(this.post);
+
+    assert.dom("a.post-date").hasAria(
+      "label",
+      relativeAge(new Date(this.post.created_at), {
+        format: "medium-with-ago",
+        wrapInSpan: false,
+      }),
+      "the link is announced with an abbreviated date instead of the full date and time"
+    );
+
+    assert
+      .dom("a.post-date > span[aria-hidden=true] .relative-date")
+      .exists("the relative date and its tooltip are accessibility-hidden");
+  });
+});


### PR DESCRIPTION
Currently screenreaders hear the title attribute on post dates, which is meant as an affordance for sighted readers to have access to the full date... for example "Jul 13, 2026 3:04 pm" — this is much more verbose than the relative date shown to sighted readers "9m" or "2d"

This change hides the visible relative date with the verbose title attribute from screenreaders entirely using `aria-hidden`, and adds an accessible relative date to the parent link "20 mins ago", "2 days ago", "Jul 1" (this year), "Jul 1 2025" (previous years) which is much more aligned with the sighted experience. The experience is unchanged for sighted users.

