### PR TITLE
FEATURE: Support 'Happy Eyeballs' in `FinalDestination::HTTP`

### DIFF
--- a/lib/final_destination/connector.rb
+++ b/lib/final_destination/connector.rb
@@ -2,7 +2,7 @@
 
 class FinalDestination
   # FinalDestination resolves hostnames to allowed IPs, then encodes them in a
-  # pipe-separated format to be read by our patched versions of TCPSocket and 
+  # pipe-separated format to be read by our patched versions of TCPSocket and
   # Addrinfo in `freedom_patches/final_destination_connect.rb`.
   # This module exists to encode/decode that format.
   module Connector
@@ -24,9 +24,12 @@ class FinalDestination
       def addresses_for_family(ips, family)
         wanted =
           case family
-          when Integer then family
-          when :ipv6, "ipv6", :INET6, "INET6", "AF_INET6" then Socket::AF_INET6
-          when :ipv4, "ipv4", :INET, "INET", "AF_INET" then Socket::AF_INET
+          when Integer
+            family
+          when :ipv6, "ipv6", :INET6, "INET6", "AF_INET6"
+            Socket::AF_INET6
+          when :ipv4, "ipv4", :INET, "INET", "AF_INET"
+            Socket::AF_INET
           end
         return ips unless wanted
         ips.select { |ip| Addrinfo.ip(ip).afamily == wanted }

--- a/lib/final_destination/connector.rb
+++ b/lib/final_destination/connector.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class FinalDestination
+  # FinalDestination resolves hostnames to allowed IPs, then encodes them in a
+  # pipe-separated format to be read by our patched versions of TCPSocket and 
+  # Addrinfo in `freedom_patches/final_destination_connect.rb`.
+  # This module exists to encode/decode that format.
+  module Connector
+    TOKEN_SUFFIX = ".final-destination.invalid"
+
+    class << self
+      def encode(host, ips)
+        "#{host}|#{ips.join(",")}#{TOKEN_SUFFIX}"
+      end
+
+      def token?(name)
+        name.is_a?(String) && name.end_with?(TOKEN_SUFFIX)
+      end
+
+      def addresses(token)
+        token.delete_suffix(TOKEN_SUFFIX).rpartition("|").last.split(",")
+      end
+
+      def addresses_for_family(ips, family)
+        wanted =
+          case family
+          when Integer then family
+          when :ipv6, "ipv6", :INET6, "INET6", "AF_INET6" then Socket::AF_INET6
+          when :ipv4, "ipv4", :INET, "INET", "AF_INET" then Socket::AF_INET
+          end
+        return ips unless wanted
+        ips.select { |ip| Addrinfo.ip(ip).afamily == wanted }
+      end
+    end
+  end
+end

--- a/lib/final_destination/http.rb
+++ b/lib/final_destination/http.rb
@@ -1,42 +1,35 @@
 # frozen_string_literal: true
 
 class FinalDestination::HTTP < Net::HTTP
+  # Ruby's Happy Eyeballs implementation will try every IP address at 250ms intervals.
+  # Limit the total to avoid DoS via a high-ip-count DNS response.
+  MAX_ADDRESSES_PER_FAMILY = 5
+
   def connect
     raise ArgumentError.new("address cannot be nil or empty") if @address.blank?
-
-    original_open_timeout = @open_timeout
     return super if @ipaddr
 
-    timeout_at = current_time + @open_timeout
-
-    # This iteration through addresses would normally happen in Socket#tcp
-    # We do it here because we're tightly controlling addresses rather than
-    # handing Socket#tcp a hostname
     ips = FinalDestination::SSRFDetector.lookup_and_filter_ips(@address, timeout: @connect_timeout)
 
-    ips.each_with_index do |ip, index|
-      debug "[FinalDestination] Attempting connection to #{ip}..."
-      self.ipaddr = ip
-
-      remaining_time = timeout_at - current_time
-      if remaining_time <= 0
-        raise Net::OpenTimeout.new("Operation timed out - FinalDestination::HTTP")
-      end
-
-      @open_timeout = remaining_time
+    if proxy?
+      self.ipaddr = ips.first
       return super
-    rescue OpenSSL::SSL::SSLError, SystemCallError, Net::OpenTimeout => e
-      debug "[FinalDestination] Error connecting to #{ip}... #{e.message}"
-      was_last_attempt = index == ips.length - 1
-      raise if was_last_attempt
     end
+
+    @final_destination_token = FinalDestination::Connector.encode(@address, capped_addresses(ips))
+    super
   ensure
-    @open_timeout = original_open_timeout
+    @final_destination_token = nil
+  end
+
+  def conn_address
+    @final_destination_token || super
   end
 
   private
 
-  def current_time
-    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  def capped_addresses(ips)
+    ipv6, ipv4 = ips.partition { |ip| ip.include?(":") }
+    ipv6.first(MAX_ADDRESSES_PER_FAMILY) + ipv4.first(MAX_ADDRESSES_PER_FAMILY)
   end
 end

--- a/lib/freedom_patches/final_destination_connect.rb
+++ b/lib/freedom_patches/final_destination_connect.rb
@@ -21,10 +21,6 @@ end
 # getaddrinfo patch. Instead, open the socket with `Socket.tcp`, then set up a `TCPSocket`
 # instance with the result.
 module FinalDestinationTCPSocketPatch
-  # open_timeout is read from kwargs rather than declared as a parameter so that
-  # `super` (below) forwards exactly the arguments the caller passed. Declaring it
-  # would make bare `super` re-inject open_timeout: nil into the real C
-  # TCPSocket.open, which rejects the keyword and breaks every non-token call.
   def open(host, port, local_host = nil, local_port = nil, **kwargs)
     return super unless FinalDestination::Connector.token?(host)
 

--- a/lib/freedom_patches/final_destination_connect.rb
+++ b/lib/freedom_patches/final_destination_connect.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Patch getaddrinfo to recognize `FinalDestination::Connector` tokens
+# and return their IPs instead of doing a true lookup.
+module FinalDestinationAddrinfoPatch
+  def getaddrinfo(nodename, service, family = nil, *args, **kwargs)
+    return super unless FinalDestination::Connector.token?(nodename)
+
+    ips =
+      FinalDestination::Connector.addresses_for_family(
+        FinalDestination::Connector.addresses(nodename),
+        family,
+      )
+    raise SocketError, "getaddrinfo: Address family for hostname not supported" if ips.empty?
+
+    ips.map { |ip| Addrinfo.tcp(ip, service.to_i) }
+  end
+end
+
+# TCPSocket.open uses a C-based implementation by default, which would bypass our
+# getaddrinfo patch. Instead, open the socket with `Socket.tcp`, then set up a `TCPSocket`
+# instance with the result.
+module FinalDestinationTCPSocketPatch
+  # open_timeout is read from kwargs rather than declared as a parameter so that
+  # `super` (below) forwards exactly the arguments the caller passed. Declaring it
+  # would make bare `super` re-inject open_timeout: nil into the real C
+  # TCPSocket.open, which rejects the keyword and breaks every non-token call.
+  def open(host, port, local_host = nil, local_port = nil, **kwargs)
+    return super unless FinalDestination::Connector.token?(host)
+
+    socket =
+      Socket.tcp(
+        host,
+        port,
+        local_host,
+        local_port,
+        connect_timeout: kwargs[:open_timeout],
+        fast_fallback: true,
+      )
+    socket.autoclose = false # Let the TCPSocket handle closing
+
+    TCPSocket.for_fd(socket.fileno)
+  end
+end
+
+Addrinfo.singleton_class.prepend(FinalDestinationAddrinfoPatch)
+TCPSocket.singleton_class.prepend(FinalDestinationTCPSocketPatch)

--- a/spec/lib/final_destination/connector_spec.rb
+++ b/spec/lib/final_destination/connector_spec.rb
@@ -41,7 +41,13 @@ describe FinalDestination::Connector do
   it "ignores delimiters smuggled into the host" do
     vetted = %w[1.2.3.4 2400:c800::1]
 
-    ["evil|9.9.9.9", "evil|0.001|9.9.9.9", "a|b|c|d", "", "9.9.9.9,6.6.6.6"].each do |malicious_host|
+    [
+      "evil|9.9.9.9",
+      "evil|0.001|9.9.9.9",
+      "a|b|c|d",
+      "",
+      "9.9.9.9,6.6.6.6",
+    ].each do |malicious_host|
       token = described_class.encode(malicious_host, vetted)
 
       expect(described_class.addresses(token)).to eq(vetted)

--- a/spec/lib/final_destination/connector_spec.rb
+++ b/spec/lib/final_destination/connector_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe FinalDestination::Connector do
+  describe "round-trip" do
+    it "recovers the addresses it encoded" do
+      token = described_class.encode("example.com", %w[1.2.3.4 2400:c800::1])
+
+      expect(described_class.token?(token)).to eq(true)
+      expect(described_class.addresses(token)).to eq(%w[1.2.3.4 2400:c800::1])
+    end
+
+    it "does not treat an ordinary hostname as a token" do
+      expect(described_class.token?("example.com")).to eq(false)
+    end
+  end
+
+  describe ".addresses_for_family" do
+    let(:ips) { %w[1.2.3.4 5.6.7.8 2400:c800::1] }
+
+    it "returns only IPv4 addresses for AF_INET" do
+      expect(described_class.addresses_for_family(ips, Socket::AF_INET)).to contain_exactly(
+        "1.2.3.4",
+        "5.6.7.8",
+      )
+    end
+
+    it "returns only IPv6 addresses for AF_INET6" do
+      expect(described_class.addresses_for_family(ips, Socket::AF_INET6)).to contain_exactly(
+        "2400:c800::1",
+      )
+    end
+
+    it "returns every address when the family is unspecified" do
+      expect(described_class.addresses_for_family(ips, nil)).to eq(ips)
+    end
+  end
+
+  # The host is attacker-controlled (it comes from the URL) and rides in the token
+  # only for readable errors. It must not be able to smuggle addresses past the
+  # SSRF filter by embedding the token's delimiters.
+  it "ignores delimiters smuggled into the host" do
+    vetted = %w[1.2.3.4 2400:c800::1]
+
+    ["evil|9.9.9.9", "evil|0.001|9.9.9.9", "a|b|c|d", "", "9.9.9.9,6.6.6.6"].each do |malicious_host|
+      token = described_class.encode(malicious_host, vetted)
+
+      expect(described_class.addresses(token)).to eq(vetted)
+    end
+  end
+end

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -153,9 +153,9 @@ describe FinalDestination::HTTP do
         # 192.0.2.1 (RFC 5737 TEST-NET-1) silently drops SYNs. Happy Eyeballs must
         # step past it to the reachable loopback address; the previous design pinned
         # the first address and would burn the whole open_timeout here.
-        FinalDestination::SSRFDetector
-          .stubs(:lookup_and_filter_ips)
-          .returns(%w[192.0.2.1 127.0.0.1])
+        FinalDestination::SSRFDetector.stubs(:lookup_and_filter_ips).returns(
+          %w[192.0.2.1 127.0.0.1],
+        )
 
         body = nil
         duration =

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
+require "webrick"
+
 describe FinalDestination::HTTP do
   before do
     # We need to test low-level stuff, switch off WebMock for FinalDestination::HTTP
     WebMock.enable!(except: [:final_destination])
-    Socket.stubs(:tcp).never
-    TCPSocket.stubs(:open).never
-    Addrinfo.stubs(:getaddrinfo).never
-
     FinalDestination::SSRFDetector.allow_ip_lookups_in_test!
   end
 
@@ -16,106 +14,254 @@ describe FinalDestination::HTTP do
     FinalDestination::SSRFDetector.disallow_ip_lookups_in_test!
   end
 
-  def expect_tcp_and_abort(stub_addr, &blk)
-    success = Class.new(StandardError)
-    TCPSocket.stubs(:open).with { |addr| stub_addr == addr }.once.raises(success)
+  # Runs `blk` and returns the addresses FinalDestination handed to the socket
+  # layer, without letting it actually connect. The vetted, SSRF-filtered
+  # addresses ride inside a Connector token; decode it and abort.
+  def addresses_offered_to_socket
+    offered = nil
+    aborted = Class.new(StandardError)
+    Socket
+      .stubs(:tcp)
+      .with do |host, *|
+        next false unless FinalDestination::Connector.token?(host)
+        offered = FinalDestination::Connector.addresses(host)
+        true
+      end
+      .raises(aborted)
     begin
       yield
-    rescue success
+    rescue aborted
+    end
+    offered
+  end
+
+  # A minimal HTTP server on `bind`:<ephemeral> that answers every request with "hi".
+  def with_http_server(bind = "127.0.0.1")
+    server =
+      WEBrick::HTTPServer.new(
+        BindAddress: bind,
+        Port: 0,
+        Logger: WEBrick::Log.new(File::NULL),
+        AccessLog: [],
+      )
+    server.mount_proc("/") { |_req, res| res.body = "hi" }
+    thread = Thread.new { server.start }
+    yield server.config[:Port]
+  ensure
+    server&.shutdown
+    thread&.join
+  end
+
+  def elapsed
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+  end
+
+  describe "SSRF filtering" do
+    it "offers only the non-private addresses to the socket layer" do
+      stub_ip_lookup("example.com", %w[0.0.0.0 93.184.216.34])
+
+      offered =
+        addresses_offered_to_socket { FinalDestination::HTTP.get(URI("https://example.com")) }
+
+      expect(offered).to eq(%w[93.184.216.34])
+    end
+
+    it "offers otherwise-blocked addresses when the host is allowlisted" do
+      SiteSetting.allowed_internal_hosts = "internal.example.com"
+      stub_ip_lookup("internal.example.com", %w[10.0.0.5])
+
+      offered =
+        addresses_offered_to_socket do
+          FinalDestination::HTTP.get(URI("https://internal.example.com"))
+        end
+
+      expect(offered).to eq(%w[10.0.0.5])
+    end
+
+    it "caps how many addresses are offered to the socket, per family" do
+      # a hostname's DNS response is attacker-controlled; a huge one must not turn
+      # into an unbounded fan-out of concurrent connection attempts
+      cap = FinalDestination::HTTP::MAX_ADDRESSES_PER_FAMILY
+      ipv4 = Array.new(100) { |n| "93.184.216.#{n}" }
+      ipv6 = Array.new(100) { |n| "2606:2800:220:1:248:1893:25c8:#{n.to_s(16)}" }
+      FinalDestination::SSRFDetector.stubs(:lookup_and_filter_ips).returns(ipv6 + ipv4)
+
+      offered =
+        addresses_offered_to_socket { FinalDestination::HTTP.get(URI("https://example.com")) }
+
+      expect(offered.count { |ip| ip.include?(":") }).to eq(cap)
+      expect(offered.count { |ip| !ip.include?(":") }).to eq(cap)
+    end
+
+    it "raises DisallowedIpError when every address is private" do
+      stub_ip_lookup("example.com", %w[0.0.0.0 127.0.0.1])
+
+      expect { FinalDestination::HTTP.get(URI("https://example.com")) }.to raise_error(
+        FinalDestination::SSRFDetector::DisallowedIpError,
+      )
+    end
+
+    it "raises DisallowedIpError when every address is blocked by site setting" do
+      SiteSetting.blocked_ip_blocks = "98.0.0.0/8|9001:82f3::/32"
+      stub_ip_lookup("ip4.example.com", %w[98.23.19.111])
+      stub_ip_lookup("ip6.example.com", %w[9001:82f3:8873::3])
+
+      expect { FinalDestination::HTTP.get(URI("https://ip4.example.com")) }.to raise_error(
+        FinalDestination::SSRFDetector::DisallowedIpError,
+      )
+      expect { FinalDestination::HTTP.get(URI("https://ip6.example.com")) }.to raise_error(
+        FinalDestination::SSRFDetector::DisallowedIpError,
+      )
+    end
+
+    it "handles short IPs" do
+      stub_ip_lookup("0", %w[0.0.0.0])
+
+      expect { FinalDestination::HTTP.get(URI("https://0/path")) }.to raise_error(
+        FinalDestination::SSRFDetector::DisallowedIpError,
+      )
+    end
+
+    it "raises SocketError on nxdomain" do
+      FinalDestination::SSRFDetector
+        .stubs(:lookup_ips)
+        .with { |addr| addr == "example.com" }
+        .raises(SocketError)
+
+      expect { FinalDestination::HTTP.get(URI("https://example.com")) }.to raise_error(SocketError)
     end
   end
 
-  def stub_tcp_to_raise(stub_addr, exception)
-    TCPSocket.stubs(:open).with { |addr| addr == stub_addr }.once.raises(exception)
-  end
+  describe "connecting" do
+    it "fetches over a real connection" do
+      with_http_server do |port|
+        FinalDestination::SSRFDetector.stubs(:lookup_and_filter_ips).returns(%w[127.0.0.1])
 
-  it "works through each IP address until success" do
-    stub_ip_lookup("example.com", %w[1.1.1.1 2.2.2.2 3.3.3.3])
-    stub_tcp_to_raise("1.1.1.1", Errno::ETIMEDOUT)
-    stub_tcp_to_raise("2.2.2.2", Errno::EPIPE)
-    expect_tcp_and_abort("3.3.3.3") { FinalDestination::HTTP.get(URI("https://example.com")) }
-  end
+        body =
+          FinalDestination::HTTP.start("test.invalid", port, open_timeout: 5) do |http|
+            http.get("/").body
+          end
 
-  it "handles nxdomain with SocketError" do
-    FinalDestination::SSRFDetector
-      .stubs(:lookup_ips)
-      .with { |addr| addr == "example.com" }
-      .raises(SocketError)
-    expect { FinalDestination::HTTP.get(URI("https://example.com")) }.to raise_error(SocketError)
-  end
-
-  it "raises the normal error when all IPs fail" do
-    stub_ip_lookup("example.com", %w[1.1.1.1 2.2.2.2])
-    stub_tcp_to_raise("1.1.1.1", Errno::ETIMEDOUT)
-    stub_tcp_to_raise("2.2.2.2", Errno::EPIPE)
-    expect { FinalDestination::HTTP.get(URI("https://example.com")) }.to raise_error(Errno::EPIPE)
-  end
-
-  it "ignores private IPs" do
-    stub_ip_lookup("example.com", %w[0.0.0.0 2.2.2.2])
-    expect_tcp_and_abort("2.2.2.2") { FinalDestination::HTTP.get(URI("https://example.com")) }
-  end
-
-  it "raises DisallowedIpError if all IPs are private" do
-    stub_ip_lookup("example.com", %w[0.0.0.0 127.0.0.1])
-    expect { FinalDestination::HTTP.get(URI("https://example.com")) }.to raise_error(
-      FinalDestination::SSRFDetector::DisallowedIpError,
-    )
-    expect(FinalDestination::SSRFDetector::DisallowedIpError.new).to be_a(SocketError)
-  end
-
-  it "handles short IPs" do
-    stub_ip_lookup("0", %w[0.0.0.0])
-    expect { FinalDestination::HTTP.get(URI("https://0/path")) }.to raise_error(
-      FinalDestination::SSRFDetector::DisallowedIpError,
-    )
-    expect(FinalDestination::SSRFDetector::DisallowedIpError.new).to be_a(SocketError)
-  end
-
-  it "raises DisallowedIpError if all IPs are blocked" do
-    SiteSetting.blocked_ip_blocks = "98.0.0.0/8|78.13.47.0/24|9001:82f3::/32"
-    stub_ip_lookup("ip6.example.com", %w[9001:82f3:8873::3])
-    stub_ip_lookup("ip4.example.com", %w[98.23.19.111])
-    expect { FinalDestination::HTTP.get(URI("https://ip4.example.com")) }.to raise_error(
-      FinalDestination::SSRFDetector::DisallowedIpError,
-    )
-    expect { FinalDestination::HTTP.get(URI("https://ip6.example.com")) }.to raise_error(
-      FinalDestination::SSRFDetector::DisallowedIpError,
-    )
-  end
-
-  it "allows specified hosts to bypass IP checks" do
-    SiteSetting.blocked_ip_blocks = "98.0.0.0/8|78.13.47.0/24|9001:82f3::/32"
-    SiteSetting.allowed_internal_hosts = "internal.example.com|blocked-ip.example.com"
-    stub_ip_lookup("internal.example.com", %w[0.0.0.0 127.0.0.1])
-    stub_ip_lookup("blocked-ip.example.com", %w[98.23.19.111])
-    expect_tcp_and_abort("0.0.0.0") do
-      FinalDestination::HTTP.get(URI("https://internal.example.com"))
+        expect(body).to eq("hi")
+      end
     end
-    expect_tcp_and_abort("98.23.19.111") do
-      FinalDestination::HTTP.get(URI("https://blocked-ip.example.com"))
+
+    it "connects to a reachable address even when a blackholed one is offered first" do
+      with_http_server do |port|
+        # 192.0.2.1 (RFC 5737 TEST-NET-1) silently drops SYNs. Happy Eyeballs must
+        # step past it to the reachable loopback address; the previous design pinned
+        # the first address and would burn the whole open_timeout here.
+        FinalDestination::SSRFDetector
+          .stubs(:lookup_and_filter_ips)
+          .returns(%w[192.0.2.1 127.0.0.1])
+
+        body = nil
+        duration =
+          elapsed do
+            FinalDestination::HTTP.start("test.invalid", port, open_timeout: 30) do |http|
+              body = http.get("/").body
+            end
+          end
+
+        expect(body).to eq("hi")
+        expect(duration).to be < 10 # steps past the blackhole in ~250ms, nowhere near 30s
+      end
+    end
+
+    it "raises when the offered address refuses the connection" do
+      # nothing is listening here: bind an ephemeral port then release it
+      closed = TCPServer.new("127.0.0.1", 0)
+      closed_port = closed.addr[1]
+      closed.close
+      FinalDestination::SSRFDetector.stubs(:lookup_and_filter_ips).returns(%w[127.0.0.1])
+
+      expect do
+        FinalDestination::HTTP.start("test.invalid", closed_port, open_timeout: 5) do |http|
+          http.get("/")
+        end
+      end.to raise_error(SystemCallError)
+    end
+
+    it "forwards net-http's open_timeout to the socket as a connect deadline" do
+      # Some Ruby/net-http versions call TCPSocket.open(..., open_timeout:) with no
+      # Timeout.timeout wrapper, so we must pass that deadline on to Socket.tcp;
+      # dropping it would let a blackholed address hang on the OS TCP timeout.
+      captured = nil
+      aborted = Class.new(StandardError)
+      Socket
+        .stubs(:tcp)
+        .with do |host, *_rest, **kwargs|
+          next false unless FinalDestination::Connector.token?(host)
+          captured = kwargs[:connect_timeout]
+          true
+        end
+        .raises(aborted)
+
+      token = FinalDestination::Connector.encode("test.invalid", %w[203.0.113.1])
+
+      expect { TCPSocket.open(token, 443, nil, nil, open_timeout: 7) }.to raise_error(aborted)
+      expect(captured).to eq(7)
     end
   end
 
-  it "stops iterating over DNS records once timeout reached" do
-    stub_ip_lookup("example.com", %w[1.1.1.1 2.2.2.2 3.3.3.3 4.4.4.4])
-    TCPSocket.stubs(:open).with { |addr| addr == "1.1.1.1" }.raises(Errno::ECONNREFUSED)
-    TCPSocket.stubs(:open).with { |addr| addr == "2.2.2.2" }.raises(Errno::ECONNREFUSED)
-    TCPSocket
-      .stubs(:open)
-      .with { |*args, **kwargs| kwargs[:open_timeout] == 0 }
-      .raises(Errno::ETIMEDOUT)
-    FinalDestination::HTTP.any_instance.stubs(:current_time).returns(0, 1, 5)
-    expect do
-      FinalDestination::HTTP.start("example.com", 80, open_timeout: 5) {}
-    end.to raise_error(Net::OpenTimeout)
+  describe "the socket patch" do
+    it "leaves ordinary (non-token) TCPSocket.open calls untouched" do
+      # the patch is installed globally; every non-FinalDestination socket in the
+      # process must still open normally, with no injected keyword arguments
+      with_http_server do |port|
+        socket = TCPSocket.open("127.0.0.1", port)
+        expect(socket).to be_a(TCPSocket)
+        socket.close
+      end
+    end
   end
 
-  it "validates address argument against nil value" do
-    expect do FinalDestination::HTTP.start(nil) {} end.to raise_error(ArgumentError)
+  describe "via a proxy" do
+    # a fake CONNECT proxy that records the line the client tunnels with
+    def with_capturing_proxy
+      server = TCPServer.new("127.0.0.1", 0)
+      connect_line = Queue.new
+      acceptor =
+        Thread.new do
+          conn = server.accept
+          connect_line << conn.gets
+          conn.write("HTTP/1.1 200 Connection established\r\n\r\n")
+          conn.close
+        rescue IOError
+        end
+      yield server.addr[1], connect_line
+    ensure
+      server&.close
+      acceptor&.kill
+    end
+
+    it "has the proxy connect to a vetted IP, never the token or hostname" do
+      with_capturing_proxy do |proxy_port, connect_line|
+        FinalDestination::SSRFDetector.stubs(:lookup_and_filter_ips).returns(%w[93.184.216.34])
+
+        http = FinalDestination::HTTP.new("example.com", 443, "127.0.0.1", proxy_port)
+        http.use_ssl = true
+        http.open_timeout = 2
+        begin
+          http.start { |h| h.get("/") }
+        rescue StandardError
+          # the fake proxy never completes TLS; we only care about the CONNECT line
+        end
+
+        expect(connect_line.pop(timeout: 2)).to start_with("CONNECT 93.184.216.34:443")
+      end
+    end
   end
 
-  it "validates address argument against empty value" do
-    expect do FinalDestination::HTTP.start("") {} end.to raise_error(ArgumentError)
+  describe "argument validation" do
+    it "rejects a nil address" do
+      expect { FinalDestination::HTTP.start(nil) {} }.to raise_error(ArgumentError)
+    end
+
+    it "rejects an empty address" do
+      expect { FinalDestination::HTTP.start("") {} }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/lib/freedom_patches/fast_image_spec.rb
+++ b/spec/lib/freedom_patches/fast_image_spec.rb
@@ -21,7 +21,14 @@ RSpec.describe FastImage do
     stub_ip_lookup("example.com", %W[52.125.123.12])
 
     success = Class.new(StandardError)
-    TCPSocket.stubs(:open).with { |addr| "52.125.123.12" == addr }.once.raises(success)
+    TCPSocket
+      .stubs(:open)
+      .with do |addr|
+        FinalDestination::Connector.token?(addr) &&
+          FinalDestination::Connector.addresses(addr) == %w[52.125.123.12]
+      end
+      .once
+      .raises(success)
 
     expect { described_class.type("http://example.com") }.to raise_error(success)
   end

--- a/spec/lib/freedom_patches/web_push_spec.rb
+++ b/spec/lib/freedom_patches/web_push_spec.rb
@@ -41,7 +41,14 @@ RSpec.describe klass do
     stub_ip_lookup("example.com", %W[52.125.123.12])
 
     success = Class.new(StandardError)
-    TCPSocket.stubs(:open).with { |addr| "52.125.123.12" == addr }.once.raises(success)
+    TCPSocket
+      .stubs(:open)
+      .with do |addr|
+        FinalDestination::Connector.token?(addr) &&
+          FinalDestination::Connector.addresses(addr) == %w[52.125.123.12]
+      end
+      .once
+      .raises(success)
 
     expect do
       klass.payload_send(


### PR DESCRIPTION
Ruby 3.4 shipped support for happy eyeballs in `Socket.tcp` and `TCPSocket`. However, our `FinalDestination::HTTP` wrapper was performing a DNS lookup and passing IP addresses one at a time when opening the socket. That meant that we didn't benefit from the new Ruby feature in most Discourse features.

This commit factors the strategy. Now, `FinalDestination::HTTP` encodes the DNS result and passes it to the underlying implementation as a fake hostname string. A patch to `Addrinfo` detects this fake hostname and returns the given IPs instead of performing its own lookup.

For this Addrinfo patch to work, we also had to patch `TCPSocket` so that it uses the ruby-based `Socket.tcp` rather than its native C socket-opening code.

The result is that we now get the benefit of the native Ruby 'Happy Eyeballs' support for concurrent ipv4 and ipv6 connections.

All this patching of low-level ruby classes is not ideal, but there is no native way to control name resolution in `Net::HTTP` or its dependencies.