### PR TITLE
FEATURE: Change Site Settings AI Tool

### DIFF
--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -631,6 +631,7 @@ en:
         setting_context: "Look up site setting context"
         schema: "Look up database schema"
         search_settings: "Searching site settings"
+        change_site_setting: "Change site setting"
         dall_e: "Generate image"
         search_meta_discourse: "Search Meta Discourse"
         javascript_evaluator: "Evaluate JavaScript"
@@ -681,6 +682,7 @@ en:
         setting_context: "Look up site setting context"
         schema: "Look up database schema"
         search_settings: "Search site settings"
+        change_site_setting: "Change the value of a site setting"
         dall_e: "Generate image using DALL-E 3"
         search_meta_discourse: "Search Meta Discourse"
         javascript_evaluator: "Evaluate JavaScript"
@@ -750,6 +752,7 @@ en:
         search_settings:
           one: "Found %{count} result for '%{query}'"
           other: "Found %{count} results for '%{query}'"
+        change_site_setting: "Changing site setting %{setting_name} to '%{value}'"
       discoveries:
         continue_conversation:
           title: "Discovery conversation: Search for %{query}"
@@ -917,6 +920,20 @@ en:
           no_note: "A note is required to add a note to a review queue item"
           failed: "Failed to add the note"
         success: "Successfully added a note to review queue item %{reviewable_id}"
+
+      change_site_setting:
+        errors:
+          no_reason: "A reason is required to change a site setting."
+          not_found: "Site setting '%{setting_name}' does not exist."
+          not_allowed: "You are not allowed to change site settings."
+          hidden: "Site setting '%{setting_name}' is hidden and cannot be changed here."
+          deprecated: "Site setting '%{setting_name}' is deprecated; use '%{new_name}' instead."
+          shadowed: "Site setting '%{setting_name}' is overridden globally and cannot be changed."
+          unconfigurable: "Site setting '%{setting_name}' belongs to a plugin that cannot be configured."
+          unsupported_type: "Site settings of type '%{type}' cannot be changed by the AI bot."
+          invalid_value: "Invalid value: %{error}"
+          failed: "Failed to change the site setting."
+        success: "Site setting %{setting_name} has been changed to '%{value}'."
 
     reviewables:
       ai_tool_action:

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -636,6 +636,7 @@ en:
         setting_context: "Look up site setting context"
         schema: "Look up database schema"
         search_settings: "Searching site settings"
+        change_site_setting: "Change site setting"
         dall_e: "Generate image"
         search_meta_discourse: "Search Meta Discourse"
         javascript_evaluator: "Evaluate JavaScript"
@@ -686,6 +687,7 @@ en:
         setting_context: "Look up site setting context"
         schema: "Look up database schema"
         search_settings: "Search site settings"
+        change_site_setting: "Change the value of a site setting"
         dall_e: "Generate image using DALL-E 3"
         search_meta_discourse: "Search Meta Discourse"
         javascript_evaluator: "Evaluate JavaScript"
@@ -755,6 +757,7 @@ en:
         search_settings:
           one: "Found %{count} result for '%{query}'"
           other: "Found %{count} results for '%{query}'"
+        change_site_setting: "Changing site setting %{setting_name} to '%{value}'"
       discoveries:
         continue_conversation:
           title: "Discovery conversation: Search for %{query}"
@@ -922,6 +925,20 @@ en:
           no_note: "A note is required to add a note to a review queue item"
           failed: "Failed to add the note"
         success: "Successfully added a note to review queue item %{reviewable_id}"
+
+      change_site_setting:
+        errors:
+          no_reason: "A reason is required to change a site setting."
+          not_found: "Site setting '%{setting_name}' does not exist."
+          not_allowed: "You are not allowed to change site settings."
+          hidden: "Site setting '%{setting_name}' is hidden and cannot be changed here."
+          deprecated: "Site setting '%{setting_name}' is deprecated; use '%{new_name}' instead."
+          shadowed: "Site setting '%{setting_name}' is overridden globally and cannot be changed."
+          unconfigurable: "Site setting '%{setting_name}' belongs to a plugin that cannot be configured."
+          unsupported_type: "Site settings of type '%{type}' cannot be changed by the AI bot."
+          invalid_value: "Invalid value: %{error}"
+          failed: "Failed to change the site setting."
+        success: "Site setting %{setting_name} has been changed to '%{value}'."
 
     reviewables:
       ai_tool_action:

--- a/plugins/discourse-ai/lib/agents/agent.rb
+++ b/plugins/discourse-ai/lib/agents/agent.rb
@@ -115,6 +115,7 @@ module DiscourseAi
             Tools::DbSchema,
             Tools::SearchSettings,
             Tools::SettingContext,
+            Tools::ChangeSiteSetting,
             Tools::RandomPicker,
             Tools::DiscourseMetaSearch,
             Tools::GithubFileContent,

--- a/plugins/discourse-ai/lib/agents/tools/change_site_setting.rb
+++ b/plugins/discourse-ai/lib/agents/tools/change_site_setting.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Agents
+    module Tools
+      class ChangeSiteSetting < Tool
+        # Upload-backed values cannot be expressed reliably as a string
+        # parameter (an unknown URL silently resolves to an empty value),
+        # so they stay admin-UI only.
+        UNSUPPORTED_TYPES = %i[upload uploaded_image_list].freeze
+
+        UPDATE_POLICIES = %i[
+          settings_are_not_deprecated
+          settings_are_unshadowed_globally
+          settings_are_visible
+          settings_are_configurable
+        ].freeze
+
+        def self.signature
+          {
+            name: name,
+            description:
+              "Changes the value of a site setting. Look up the exact setting name first (e.g. with the search_settings tool); never guess it.",
+            parameters: [
+              {
+                name: "setting_name",
+                description: "The exact name of the site setting to change",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "value",
+                description:
+                  "The new value for the setting, as a string. Use 'true' or 'false' for boolean settings, plain digits for numeric settings, and pipe-delimited entries (one|two|three) for list settings.",
+                type: "string",
+                required: true,
+              },
+              {
+                name: "reason",
+                description: "Short explanation of why the setting is being changed",
+                type: "string",
+                required: true,
+              },
+            ],
+          }
+        end
+
+        def self.name
+          "change_site_setting"
+        end
+
+        def self.requires_approval?
+          true
+        end
+
+        def self.attribute_to_approver?
+          true
+        end
+
+        def invoke
+          if (error = validation_error)
+            return error
+          end
+          perform_update
+        end
+
+        # Mirrors the SiteSetting::Update policies (which stay authoritative at
+        # write time) so an unknown, hidden, or otherwise unchangeable setting
+        # never creates a review item that could only fail on approval.
+        def validation_error
+          if reason.blank?
+            return(
+              error_response(I18n.t("discourse_ai.ai_bot.change_site_setting.errors.no_reason"))
+            )
+          end
+
+          if (deprecation = hard_deprecation)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.deprecated",
+                  setting_name: setting_name,
+                  new_name: deprecation[1],
+                ),
+              )
+            )
+          end
+
+          if !SiteSetting.has_setting?(setting_name)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.not_found",
+                  setting_name: setting_name,
+                ),
+              )
+            )
+          end
+
+          if SiteSetting.hidden_settings.include?(setting_sym)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.hidden",
+                  setting_name: setting_name,
+                ),
+              )
+            )
+          end
+
+          if SiteSetting.shadowed_settings.include?(setting_sym)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.shadowed",
+                  setting_name: setting_name,
+                ),
+              )
+            )
+          end
+
+          if unconfigurable_plugin_setting?
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.unconfigurable",
+                  setting_name: setting_name,
+                ),
+              )
+            )
+          end
+
+          if UNSUPPORTED_TYPES.include?(setting_type)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.unsupported_type",
+                  type: setting_type,
+                ),
+              )
+            )
+          end
+
+          if (error_message = invalid_value_message)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.invalid_value",
+                  error: error_message,
+                ),
+              )
+            )
+          end
+
+          nil
+        end
+
+        def description_args
+          { setting_name: setting_name, value: new_value }
+        end
+
+        private
+
+        def setting_name
+          parameters[:setting_name].to_s.strip
+        end
+
+        def setting_sym
+          setting_name.to_sym
+        end
+
+        def new_value
+          parameters[:value].to_s.strip
+        end
+
+        def setting_type
+          SiteSetting.type_supervisor.get_type(setting_sym)
+        end
+
+        def hard_deprecation
+          SiteSettings::DeprecatedSettings::SETTINGS.find do |old_name, _new_name, override, _|
+            old_name.to_sym == setting_sym && !override
+          end
+        end
+
+        def unconfigurable_plugin_setting?
+          plugin_name = SiteSetting.plugins[setting_sym]
+          plugin_name && !Discourse.plugins_by_name[plugin_name].configurable?
+        end
+
+        # Runs the same coercion + validation the SiteSetting::Update service
+        # applies at write time, without writing anything.
+        def invalid_value_message
+          coerced =
+            case setting_type
+            when :integer
+              new_value.tr("^-0-9", "").to_i
+            when :file_size_restriction
+              new_value.tr("^0-9", "").to_i
+            else
+              new_value
+            end
+
+          SiteSetting.type_supervisor.to_db_value(setting_sym, coerced)
+          nil
+        rescue Discourse::InvalidParameters => e
+          e.message
+        end
+
+        def perform_update
+          if !guardian.is_admin?
+            return(
+              error_response(I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed"))
+            )
+          end
+
+          result =
+            begin
+              SiteSetting::Update.call(
+                guardian: guardian,
+                params: {
+                  settings: [{ setting_name: setting_name, value: new_value }],
+                },
+              )
+            rescue Discourse::InvalidParameters => e
+              return(
+                error_response(
+                  I18n.t(
+                    "discourse_ai.ai_bot.change_site_setting.errors.invalid_value",
+                    error: e.message,
+                  ),
+                )
+              )
+            end
+
+          return error_response(update_error_message(result)) if result.failure?
+
+          {
+            status: "success",
+            message:
+              I18n.t(
+                "discourse_ai.ai_bot.change_site_setting.success",
+                setting_name: setting_name,
+                value: new_value,
+              ),
+          }
+        end
+
+        def update_error_message(result)
+          contract_result = result["result.contract.default"]
+          return contract_result.errors.full_messages.to_sentence if contract_result&.failure?
+
+          if result["result.policy.current_user_is_admin"]&.failure?
+            return I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed")
+          end
+
+          UPDATE_POLICIES.each do |policy_name|
+            policy_result = result["result.policy.#{policy_name}"]
+            next if !policy_result&.failure?
+            return policy_result.reason if policy_result.reason.present?
+            return I18n.t("discourse_ai.ai_bot.change_site_setting.errors.failed")
+          end
+
+          save_error = result["result.step.save"]&.exception&.message
+          return save_error if save_error.present?
+
+          I18n.t("discourse_ai.ai_bot.change_site_setting.errors.failed")
+        end
+      end
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/agents/tools/change_site_setting.rb
+++ b/plugins/discourse-ai/lib/agents/tools/change_site_setting.rb
@@ -68,6 +68,12 @@ module DiscourseAi
         # write time) so an unknown, hidden, or otherwise unchangeable setting
         # never creates a review item that could only fail on approval.
         def validation_error
+          if !guardian.is_admin?
+            return(
+              error_response(I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed"))
+            )
+          end
+
           if reason.blank?
             return(
               error_response(I18n.t("discourse_ai.ai_bot.change_site_setting.errors.no_reason"))

--- a/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
@@ -746,6 +746,44 @@ RSpec.describe DiscourseAi::Agents::Bot do
       expect(ReviewableAiToolAction.count).to eq(1)
     end
 
+    it "rejects a site setting change requested by a moderator before queueing it" do
+      toggle_enabled_bots(bots: [fake])
+      Group.refresh_automatic_groups!
+      moderator = Fabricate(:moderator)
+
+      approval_agent =
+        AiAgent.create!(
+          name: "ModeratorApprovalAgent",
+          system_prompt: "test",
+          description: "test",
+          allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
+          require_approval: true,
+          tools: [["ChangeSiteSetting", nil, false]],
+        )
+
+      agent_class = approval_agent.class_instance
+      test_bot_user = DiscourseAi::AiBot::EntryPoint.find_user_from_model(fake.name)
+      bot = described_class.as(test_bot_user, agent: agent_class.new)
+      tool =
+        DiscourseAi::Agents::Tools::ChangeSiteSetting.new(
+          { setting_name: "min_post_length", value: "42", reason: "Testing" },
+          bot_user: test_bot_user,
+          llm: bot.llm,
+          context: DiscourseAi::Agents::BotContext.new(user: moderator),
+        )
+
+      result = nil
+      expect { result = bot.send(:invoke_tool, tool, tool.context) { |*args| } }.not_to change {
+        [AiToolAction.count, ReviewableAiToolAction.count]
+      }
+
+      expect(result[:status]).to eq("error")
+      expect(result[:error]).to eq(
+        I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed"),
+      )
+      expect(SiteSetting.min_post_length).not_to eq(42)
+    end
+
     it "executes immediately when require_approval is false" do
       toggle_enabled_bots(bots: [fake])
       Group.refresh_automatic_groups!

--- a/plugins/discourse-ai/spec/lib/agents/tools/change_site_setting_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/change_site_setting_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DiscourseAi::Agents::Tools::ChangeSiteSetting do
     expect(SiteSetting.default_locale).not_to eq("zz_INVALID")
   end
 
-  it "refuses upload-backed settings" do
+  it "does not update upload-backed settings" do
     result =
       tool(setting_name: "logo", value: "https://example.com/logo.png", reason: "Test").invoke
 

--- a/plugins/discourse-ai/spec/lib/agents/tools/change_site_setting_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/change_site_setting_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseAi::Agents::Tools::ChangeSiteSetting do
+  fab!(:llm_model)
+  let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
+  let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }
+  let(:context) { DiscourseAi::Agents::BotContext.new }
+
+  before do
+    enable_current_plugin
+    SiteSetting.ai_bot_enabled = true
+  end
+
+  def tool(params = nil, **kwargs)
+    params ||= kwargs
+    described_class.new(params, bot_user: bot_user, llm: llm, context: context)
+  end
+
+  it "changes the setting and logs a staff action" do
+    result = tool(setting_name: "min_post_length", value: "42", reason: "Testing").invoke
+
+    expect(result[:status]).to eq("success")
+    expect(SiteSetting.min_post_length).to eq(42)
+    expect(
+      UserHistory.where(
+        action: UserHistory.actions[:change_site_setting],
+        subject: "min_post_length",
+      ).count,
+    ).to eq(1)
+  end
+
+  it "coerces boolean values from strings" do
+    result = tool(setting_name: "enable_badges", value: "false", reason: "Testing").invoke
+
+    expect(result[:status]).to eq("success")
+    expect(SiteSetting.enable_badges).to eq(false)
+  end
+
+  it "returns an error when reason is blank" do
+    result = tool(setting_name: "min_post_length", value: "42", reason: " ").invoke
+
+    expect(result[:status]).to eq("error")
+    expect(SiteSetting.min_post_length).not_to eq(42)
+  end
+
+  it "returns an error for an unknown setting" do
+    result = tool(setting_name: "definitely_not_a_setting", value: "42", reason: "Test").invoke
+
+    expect(result[:status]).to eq("error")
+    expect(result[:error]).to include("definitely_not_a_setting")
+  end
+
+  it "returns an error for a hidden setting" do
+    hidden_setting = SiteSetting.hidden_settings.first
+
+    result = tool(setting_name: hidden_setting.to_s, value: "x", reason: "Test").invoke
+
+    expect(result[:status]).to eq("error")
+    expect(result[:error]).to include("hidden")
+  end
+
+  it "points at the replacement for a hard-deprecated setting" do
+    old_name, new_name, _override, _version =
+      SiteSettings::DeprecatedSettings::SETTINGS.find { |_, _, override, _| !override }
+    skip "no hard-deprecated settings to test with" if old_name.nil?
+
+    result = tool(setting_name: old_name, value: "x", reason: "Test").invoke
+
+    expect(result[:status]).to eq("error")
+    expect(result[:error]).to include(new_name)
+  end
+
+  it "returns an error for an invalid value" do
+    result = tool(setting_name: "default_locale", value: "zz_INVALID", reason: "Test").invoke
+
+    expect(result[:status]).to eq("error")
+    expect(SiteSetting.default_locale).not_to eq("zz_INVALID")
+  end
+
+  it "refuses upload-backed settings" do
+    result =
+      tool(setting_name: "logo", value: "https://example.com/logo.png", reason: "Test").invoke
+
+    expect(result[:status]).to eq("error")
+  end
+
+  it "returns an error when the acting user is not an admin" do
+    regular_user = Fabricate(:user)
+    ctx = DiscourseAi::Agents::BotContext.new(user: regular_user)
+    t =
+      described_class.new(
+        { setting_name: "min_post_length", value: "42", reason: "Test" },
+        bot_user: bot_user,
+        llm: llm,
+        context: ctx,
+      )
+
+    result = t.invoke
+
+    expect(result[:status]).to eq("error")
+    expect(result[:error]).to include("not allowed")
+    expect(SiteSetting.min_post_length).not_to eq(42)
+  end
+
+  describe "#validation_error" do
+    it "returns nil for a valid request without changing the setting" do
+      t = tool(setting_name: "min_post_length", value: "42", reason: "Test")
+
+      expect(t.validation_error).to be_nil
+      expect(SiteSetting.min_post_length).not_to eq(42)
+    end
+
+    it "returns an error for an unknown setting and for an out-of-range value" do
+      expect(
+        tool(setting_name: "definitely_not_a_setting", value: "1", reason: "Test").validation_error[
+          :status
+        ],
+      ).to eq("error")
+      expect(
+        tool(setting_name: "min_post_length", value: "0", reason: "Test").validation_error[:status],
+      ).to eq("error")
+    end
+  end
+end

--- a/plugins/discourse-ai/spec/models/reviewable_ai_tool_action_spec.rb
+++ b/plugins/discourse-ai/spec/models/reviewable_ai_tool_action_spec.rb
@@ -247,6 +247,49 @@ RSpec.describe ReviewableAiToolAction do
       expect(silence_history.target_user_id).to eq(target_user.id)
       expect(silence_history.reviewable_id).to eq(reviewable.id)
     end
+
+    it "applies a change_site_setting approval credited to the approving admin" do
+      tool_action =
+        create_tool_action(
+          tool_name: "change_site_setting",
+          params: {
+            setting_name: "min_post_length",
+            value: "42",
+            reason: "Testing",
+          },
+        )
+      reviewable = create_reviewable(tool_action)
+
+      result = reviewable.perform(admin, :approve)
+
+      expect(result.success?).to eq(true)
+      expect(SiteSetting.min_post_length).to eq(42)
+
+      change_history =
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "min_post_length",
+        ).last
+      expect(change_history.acting_user_id).to eq(admin.id)
+    end
+
+    it "raises and stays pending when a non-admin moderator approves a change_site_setting action" do
+      tool_action =
+        create_tool_action(
+          tool_name: "change_site_setting",
+          params: {
+            setting_name: "min_post_length",
+            value: "42",
+            reason: "Testing",
+          },
+        )
+      reviewable = create_reviewable(tool_action)
+      moderator = Fabricate(:moderator)
+
+      expect { reviewable.perform(moderator, :approve) }.to raise_error(Discourse::InvalidAccess)
+      expect(reviewable.reload).to be_pending
+      expect(SiteSetting.min_post_length).not_to eq(42)
+    end
   end
 
   describe "#perform_reject" do

--- a/plugins/discourse-ai/spec/system/ai_bot/site_setting_permissions_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/site_setting_permissions_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe "AI bot site setting permissions" do
+  include ThemeScreenshotMarker
+
+  fab!(:regular_user, :user)
+  fab!(:moderator)
+  fab!(:bot_agent) do
+    agent = Fabricate(:ai_agent)
+    agent.create_user!
+    agent
+  end
+  fab!(:regular_user_channel) do
+    Fabricate(:direct_message_channel, users: [regular_user, bot_agent.user])
+  end
+  fab!(:moderator_channel) do
+    Fabricate(:direct_message_channel, users: [moderator, bot_agent.user])
+  end
+
+  let(:chat_page) { PageObjects::Pages::Chat.new }
+  let(:chat_channel_page) { PageObjects::Pages::ChatChannel.new }
+
+  before do
+    enable_current_plugin
+    SiteSetting.chat_enabled = true
+    SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:everyone]
+    Group.refresh_automatic_groups!
+  end
+
+  def post_rejected_site_setting_request(channel:, user:)
+    ChatSDK::Message.create(
+      raw: "Change the site setting min_post_length to 42",
+      channel_id: channel.id,
+      guardian: Guardian.new(user),
+    )
+
+    ChatSDK::Message.create(
+      raw:
+        "**Change site setting**\n#{I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed")}",
+      channel_id: channel.id,
+      guardian: Guardian.new(bot_agent.user),
+    )
+  end
+
+  it "shows a regular user that they cannot change a site setting" do
+    rejection =
+      post_rejected_site_setting_request(channel: regular_user_channel, user: regular_user)
+
+    sign_in(regular_user)
+    chat_page.prefers_full_page
+    chat_page.visit_channel(regular_user_channel)
+
+    expect(chat_channel_page.messages).to have_message(
+      id: rejection.id,
+      text: I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed"),
+    )
+    screenshot_marker(label: "ai-site-setting-permission-regular-user")
+  end
+
+  it "shows a moderator that they cannot request a site setting change" do
+    rejection = post_rejected_site_setting_request(channel: moderator_channel, user: moderator)
+
+    sign_in(moderator)
+    chat_page.prefers_full_page
+    chat_page.visit_channel(moderator_channel)
+
+    expect(chat_channel_page.messages).to have_message(
+      id: rejection.id,
+      text: I18n.t("discourse_ai.ai_bot.change_site_setting.errors.not_allowed"),
+    )
+    screenshot_marker(label: "ai-site-setting-permission-moderator")
+  end
+end


### PR DESCRIPTION
Previously, AI agents could look up site settings (`search_settings`, `setting_context`) but had no way to change them.

This change adds a `change_site_setting` tool that requires admin approval before anything is applied: the proposed change shows up as an inline review card in the bot conversation, and on approval it is applied through the `SiteSetting::Update` service — keeping all of its guardrails (no hidden, deprecated, globally shadowed, or unconfigurable settings) — credited to the approving admin in the staff action log.


## Demo:


https://github.com/user-attachments/assets/6782d8f4-0182-47dc-92b5-1db77b7a1ee1

