### PR TITLE
A11Y: ensure post avatars are hidden when paired with usernames

### DIFF
--- a/frontend/discourse/app/components/post/avatar.gjs
+++ b/frontend/discourse/app/components/post/avatar.gjs
@@ -86,7 +86,6 @@ export default class PostAvatar extends Component {
             {{else}}
               <DUserAvatar
                 class="main-avatar"
-                tabindex="-1"
                 @hideTitle={{true}}
                 @lazy={{true}}
                 @size={{this.size}}

--- a/frontend/discourse/app/components/post/menu/liked-users-list.gjs
+++ b/frontend/discourse/app/components/post/menu/liked-users-list.gjs
@@ -174,6 +174,7 @@ export default class LikedUsersList extends Component {
                     >
                       <DUserAvatar
                         class="trigger-user-card"
+                        @ariaHidden={{false}}
                         @user={{user}}
                         @size="small"
                       />
@@ -200,6 +201,7 @@ export default class LikedUsersList extends Component {
                       >
                         <DUserAvatar
                           class="trigger-user-card"
+                          @ariaHidden={{false}}
                           @user={{user}}
                           @size="small"
                         />

--- a/frontend/discourse/app/components/post/meta-data/poster-name.gjs
+++ b/frontend/discourse/app/components/post/meta-data/poster-name.gjs
@@ -172,7 +172,10 @@ export default class PostMetaDataPosterName extends Component {
                 user=this.user
               }}
             >
-              <DUserLink @user={{this.user}}>
+              <DUserLink
+                @ariaLabel={{i18n "user.profile_possessive" username=this.name}}
+                @user={{this.user}}
+              >
                 {{this.name}}
                 {{#if this.showGlyph}}
                   {{#if (or this.user.moderator @post.group_moderator)}}
@@ -204,7 +207,7 @@ export default class PostMetaDataPosterName extends Component {
                     user=this.user
                   }}
                 >
-                  <DUserLink @user={{this.user}}>
+                  <DUserLink @ariaHidden={{true}} @user={{this.user}}>
                     {{#if this.nameFirst}}
                       {{formatUsername this.user.username}}
                     {{else}}

--- a/frontend/discourse/app/ui-kit/d-user-avatar.gjs
+++ b/frontend/discourse/app/ui-kit/d-user-avatar.gjs
@@ -10,7 +10,7 @@ export default class DUserAvatar extends Component {
   @service siteSettings;
 
   get ariaHidden() {
-    if (this.args.ariaHidden !== null) {
+    if (this.args.ariaHidden != null) {
       return this.args.ariaHidden;
     }
 
@@ -20,7 +20,7 @@ export default class DUserAvatar extends Component {
 
     // often avatars are paired with usernames, making them redundant for screen readers so we hide the avatar from
     // screen readers by default
-    return this.args.ariaHidden ?? true;
+    return true;
   }
 
   get hideFromAnonUser() {
@@ -32,7 +32,7 @@ export default class DUserAvatar extends Component {
   <template>
     <DUserLink
       ...attributes
-      @ariaHidden={{@ariaHidden}}
+      @ariaHidden={{this.ariaHidden}}
       @ariaLabel={{@ariaLabel}}
       @href={{@href}}
       @user={{@user}}

--- a/frontend/discourse/tests/integration/components/post/meta-data/poster-name-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/meta-data/poster-name-test.gjs
@@ -46,6 +46,32 @@ module(
       assert.dom(".user-title").hasText("Trout Master");
     });
 
+    test("screen readers only announce one name", async function (assert) {
+      this.siteSettings.display_name_on_posts = true;
+      this.siteSettings.prioritize_username_in_ux = false;
+      this.post.user_id = 1;
+      this.post.username = "eviltrout";
+      this.post.name = "Robin Ward";
+
+      await renderComponent(this.post);
+
+      assert
+        .dom(".first a")
+        .hasAttribute(
+          "aria-label",
+          "Robin Ward's profile",
+          "the first link is announced with the displayed name"
+        );
+      assert
+        .dom(".second a")
+        .hasAttribute(
+          "aria-hidden",
+          "true",
+          "the second name is redundant and hidden from screen readers"
+        )
+        .hasAttribute("tabindex", "-1");
+    });
+
     test("extra classes and glyphs", async function (assert) {
       this.post.user_id = 1;
       this.post.username = "eviltrout";

--- a/frontend/discourse/tests/integration/ui-kit/d-user-avatar-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-user-avatar-test.gjs
@@ -1,0 +1,61 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DUserAvatar from "discourse/ui-kit/d-user-avatar";
+
+module("Integration | ui-kit | DUserAvatar", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.user = {
+      username: "eviltrout",
+      avatar_template: "/letter_avatar_proxy/v4/letter/e/8797f3/{size}.png",
+    };
+  });
+
+  test("is hidden from screen readers by default", async function (assert) {
+    const user = this.user;
+
+    await render(<template><DUserAvatar @user={{user}} /></template>);
+
+    assert
+      .dom("a[data-user-card='eviltrout']")
+      .hasAttribute(
+        "aria-hidden",
+        "true",
+        "avatars are usually paired with usernames, so the link is redundant for screen readers"
+      )
+      .hasAttribute("tabindex", "-1", "the hidden link is not focusable")
+      .doesNotHaveAttribute("aria-label");
+  });
+
+  test("@ariaHidden={{false}} keeps the link accessible", async function (assert) {
+    const user = this.user;
+
+    await render(
+      <template><DUserAvatar @ariaHidden={{false}} @user={{user}} /></template>
+    );
+
+    assert
+      .dom("a[data-user-card='eviltrout']")
+      .doesNotHaveAttribute("aria-hidden")
+      .hasAttribute("tabindex", "0")
+      .hasAttribute("aria-label", "eviltrout's profile");
+  });
+
+  test("@ariaLabel keeps the link accessible and overrides the label", async function (assert) {
+    const user = this.user;
+
+    await render(
+      <template>
+        <DUserAvatar @ariaLabel="Robin Ward" @user={{user}} />
+      </template>
+    );
+
+    assert
+      .dom("a[data-user-card='eviltrout']")
+      .doesNotHaveAttribute("aria-hidden")
+      .hasAttribute("tabindex", "0")
+      .hasAttribute("aria-label", "Robin Ward");
+  });
+});

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/group-timezones/timezone.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/group-timezones/timezone.gjs
@@ -32,6 +32,7 @@ export default class GroupTimezone extends Component {
             }}
           >
             <DUserAvatar
+              @ariaHidden={{false}}
               @user={{member}}
               @size="small"
               class="group-timezones-member-avatar"

--- a/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-state-panel-reaction.gjs
+++ b/plugins/discourse-reactions/assets/javascripts/discourse/components/discourse-reactions-state-panel-reaction.gjs
@@ -78,6 +78,7 @@ export default class DiscourseReactionsStatePanelReaction extends Component {
               <span>
                 <DUserAvatar
                   class="trigger-user-card"
+                  @ariaHidden={{false}}
                   @size="tiny"
                   @user={{user}}
                 />
@@ -103,6 +104,7 @@ export default class DiscourseReactionsStatePanelReaction extends Component {
                 <span>
                   <DUserAvatar
                     class="trigger-user-card"
+                    @ariaHidden={{false}}
                     @size="tiny"
                     @user={{user}}
                   />


### PR DESCRIPTION
Currently screen reader users are hearing the username twice (one for the avatar and again for the text). There were some minor regressions after moving to the glimmer post stream that caused avatars to be read again. 

This gets us back to where avatars are hidden with `aria-hidden` when there's a username immediately next to them, and adds some tests so we can catch regressions earlier next time. Places where avatars don't accompany the text username are preserved. 

