### PR TITLE
FIX: Strip Word Online's language tags when pasting

### DIFF
--- a/frontend/discourse/app/static/prosemirror/extensions/word-paste.js
+++ b/frontend/discourse/app/static/prosemirror/extensions/word-paste.js
@@ -320,9 +320,15 @@ const WORD_REVIEW_SELECTORS = [
   "del",
 ].join(", ");
 
+// Word for the web has no mso-* markers; it uses these class names and
+// data-ccp-* attributes. Anchored to class/attribute form so unrelated HTML
+// that merely mentions the words isn't misread as Word.
+const WAC_MARKERS =
+  /class=["'][^"']*\b(?:OutlineElement|NormalTextRun|WACImageContainer)\b|data-ccp-[\w-]*=/;
+
 /**
- * Detects whether an HTML string originated from Microsoft Word, so that
- * Word-only cleanup (e.g. review markup) is not applied to other sources.
+ * Detects whether an HTML string originated from Microsoft Word (desktop or
+ * Word for the web), so that Word-only cleanup is not applied to other sources.
  *
  * @param {string} html - The HTML string to inspect
  * @returns {boolean}
@@ -331,7 +337,8 @@ function isWordHtml(html) {
   return (
     html.includes("mso-") ||
     html.includes("urn:schemas-microsoft-com") ||
-    /class=["']?Mso/.test(html)
+    /class=["']?Mso/.test(html) ||
+    WAC_MARKERS.test(html)
   );
 }
 
@@ -345,6 +352,17 @@ export function stripWordReviewMarkup(container) {
   container
     .querySelectorAll(WORD_REVIEW_SELECTORS)
     .forEach((el) => el.remove());
+}
+
+// Word for the web stamps lang on every text span (<span class="TextRun" lang>),
+// which the editor keeps and surfaces as literal <span lang> markup. Strip it
+// from Word's own spans only, so a lang the user added on purpose survives.
+const WORD_LANG_RUN_SELECTOR = "span[class*='TextRun'][lang]";
+
+export function stripWordLangAttributes(container) {
+  container
+    .querySelectorAll(WORD_LANG_RUN_SELECTOR)
+    .forEach((el) => el.removeAttribute("lang"));
 }
 
 /**
@@ -381,6 +399,7 @@ export function transformWordHtml(html) {
 
   if (isWord) {
     stripWordReviewMarkup(doc.body);
+    stripWordLangAttributes(doc.body);
   }
 
   return doc.body.innerHTML;

--- a/frontend/discourse/tests/unit/lib/to-markdown-test.js
+++ b/frontend/discourse/tests/unit/lib/to-markdown-test.js
@@ -444,6 +444,30 @@ helloWorld();</code>consectetur.`;
     assert.false(markdown.includes("old removed phrase"));
   });
 
+  test("drops the document-language spans Word for the web stamps on runs", async function (assert) {
+    const html = `<div class="OutlineElement"><p class="Paragraph">
+      <span class="TextRun" lang="EN-GB"><span class="NormalTextRun" lang="EN-GB">Note:</span></span>
+      <span class="TextRun" lang="EN-GB"><span class="NormalTextRun" lang="EN-GB"> materiality</span></span>
+    </p></div>`;
+
+    const markdown = await toMarkdown(html);
+
+    assert.strictEqual(markdown, "Note: materiality");
+    assert.false(markdown.includes("<span"));
+    assert.false(markdown.includes("lang="));
+  });
+
+  test("cleans a real Word for the web run (lang on TextRun, EOP marker)", async function (assert) {
+    // Trimmed from a real Word for the web clipboard.
+    const html = `<span data-contrast="auto" xml:lang="PT-BR" lang="PT-BR" class="TextRun SCXW1 BCX0"><span class="NormalTextRun SCXW1 BCX0">This</span><span class="NormalTextRun SCXW1 BCX0"><span> </span></span><span class="NormalTextRun SCXW1 BCX0">is something</span></span><span class="EOP SCXW1 BCX0" data-ccp-props="{}"> </span>`;
+
+    const markdown = await toMarkdown(html);
+
+    assert.strictEqual(markdown, "This is something");
+    assert.false(markdown.includes("<span"));
+    assert.false(markdown.includes("lang="));
+  });
+
   test("keeps mention/hash class", async function (assert) {
     const html = `
       <p>User mention: <a class="mention" href="/u/discourse">@discourse</a></p>

--- a/frontend/discourse/tests/unit/static/prosemirror/extensions/word-paste-test.js
+++ b/frontend/discourse/tests/unit/static/prosemirror/extensions/word-paste-test.js
@@ -1,5 +1,6 @@
 import { module, test } from "qunit";
 import {
+  stripWordLangAttributes,
   stripWordReviewMarkup,
   transformWordHtml,
   transformWordLists,
@@ -295,5 +296,52 @@ module("Unit | Static | ProseMirror | Extensions | word-paste", function () {
     stripWordReviewMarkup(doc.body);
 
     assert.strictEqual(doc.querySelectorAll("a.msocomanchor").length, 0);
+  });
+
+  test("strips the document-language lang attribute from Word for the web runs", function (assert) {
+    const html = `<div class="OutlineElement"><p class="Paragraph"><span
+      class="TextRun" lang="EN-GB"><span class="NormalTextRun"
+      lang="EN-GB">Hello</span></span></p></div>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("[lang]").length, 0);
+    assert.true(doc.body.textContent.includes("Hello"));
+  });
+
+  test("does not strip lang from non-Word HTML", function (assert) {
+    const html = `<p><span lang="ja">日本語</span></p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("span[lang='ja']").length, 1);
+  });
+
+  test("does not treat a generic TextRun class as Word (no content loss)", function (assert) {
+    const html = `<p class="TextRun">Keep <del>this</del> <span lang="fr">bonjour</span></p>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("del").length, 1);
+    assert.strictEqual(doc.querySelectorAll("span[lang='fr']").length, 1);
+  });
+
+  test("keeps an intentional lang span inside a Word paste", function (assert) {
+    const html = `<div class="OutlineElement"><p class="Paragraph">
+      <span class="TextRun" lang="EN-GB">Note </span>
+      <span lang="fr">bonjour</span>
+    </p></div>`;
+    const doc = createDoc(transformWordHtml(html));
+
+    assert.strictEqual(doc.querySelectorAll("span.TextRun[lang]").length, 0);
+    assert.strictEqual(doc.querySelectorAll("span[lang='fr']").length, 1);
+  });
+
+  test("stripWordLangAttributes modifies DOM in place", function (assert) {
+    const doc = createDoc(
+      `<p><span class="TextRun" lang="EN-GB">Text</span></p>`
+    );
+
+    stripWordLangAttributes(doc.body);
+
+    assert.strictEqual(doc.querySelectorAll("[lang]").length, 0);
+    assert.true(doc.body.textContent.includes("Text"));
   });
 });


### PR DESCRIPTION
Pasting from Word Online filled the post with `<span lang="EN-GB"> `tags. Word marks every run of text with its spellcheck language, and the editor preserves lang-spans (they're the valid way to tag a foreign phrase), so Word's tags came through as raw HTML.

This strips Word's language tags on paste, leaving a `<span lang>` added on purpose untouched.