### PR TITLE
FIX: Show flagged chat message uploads in the review queue

### DIFF
--- a/plugins/chat/app/serializers/chat/reviewable_message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/reviewable_message_serializer.rb
@@ -5,7 +5,7 @@ require_dependency "reviewable_serializer"
 module Chat
   class ReviewableMessageSerializer < ReviewableSerializer
     target_attributes :cooked
-    payload_attributes :transcript_topic_id, :message_cooked
+    payload_attributes :transcript_topic_id, :message_cooked, :message_uploads
     attributes :target_id
 
     has_one :chat_channel, serializer: Chat::ChannelSerializer, root: false, embed: :objects

--- a/plugins/chat/assets/javascripts/discourse/components/reviewable/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/reviewable/chat-message.gjs
@@ -2,14 +2,23 @@ import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import { array } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
+import { modifier } from "ember-modifier";
 import ReviewableCreatedBy from "discourse/components/reviewable/created-by";
 import ReviewableTopicLink from "discourse/components/reviewable/topic-link";
 import highlightWatchedWords from "discourse/lib/highlight-watched-words";
+import applyLightbox from "discourse/lib/lightbox";
 import { i18n } from "discourse-i18n";
 import ChannelTitle from "discourse/plugins/chat/discourse/components/channel-title";
+import ChatUpload from "discourse/plugins/chat/discourse/components/chat-upload";
 import ChatChannel from "discourse/plugins/chat/discourse/models/chat-channel";
 
 export default class ReviewableRefreshChatMessage extends Component {
+  lightbox = modifier((element) => {
+    if (element.querySelector(".lightbox")) {
+      applyLightbox(element);
+    }
+  });
+
   @cached
   get channel() {
     if (!this.args.reviewable.chat_channel) {
@@ -23,6 +32,10 @@ export default class ReviewableRefreshChatMessage extends Component {
       this.args.reviewable.payload?.message_cooked ||
       this.args.reviewable.cooked
     );
+  }
+
+  get uploads() {
+    return this.args.reviewable.payload?.message_uploads;
   }
 
   <template>
@@ -59,6 +72,14 @@ export default class ReviewableRefreshChatMessage extends Component {
       <div class="review-item__post-content-wrapper">
         <div class="review-item__post-content">
           {{highlightWatchedWords this.messageCooked @reviewable}}
+
+          {{#if this.uploads.length}}
+            <div class="chat-uploads" {{this.lightbox}}>
+              {{#each this.uploads key="id" as |upload|}}
+                <ChatUpload @upload={{upload}} />
+              {{/each}}
+            </div>
+          {{/if}}
 
           {{#if @reviewable.payload.transcript_topic_id}}
             <div class="transcript">

--- a/plugins/chat/assets/stylesheets/common/reviewable-chat-message.scss
+++ b/plugins/chat/assets/stylesheets/common/reviewable-chat-message.scss
@@ -2,4 +2,22 @@
   .transcript {
     margin: 0 0 1em 0;
   }
+
+  .chat-uploads {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    margin-top: 0.5em;
+
+    img,
+    video {
+      object-fit: contain;
+      max-height: 150px;
+      max-width: 100%;
+    }
+
+    .chat-img-upload {
+      cursor: pointer;
+    }
+  }
 }

--- a/plugins/chat/lib/chat/review_queue.rb
+++ b/plugins/chat/lib/chat/review_queue.rb
@@ -49,6 +49,9 @@ module Chat
       queued_for_review = !!ActiveRecord::Type::Boolean.new.deserialize(opts[:queue_for_review])
 
       if !is_notify_user_type
+        uploads = serialize_uploads(chat_message)
+        payload[:message_uploads] = uploads if uploads.present?
+
         reviewable =
           Chat::ReviewableMessage.needs_review!(
             created_by: guardian.user,
@@ -84,6 +87,14 @@ module Chat
     end
 
     private
+
+    def serialize_uploads(chat_message)
+      ActiveModel::ArraySerializer.new(
+        chat_message.uploads.includes(:optimized_videos),
+        each_serializer: UploadSerializer,
+        root: false,
+      ).as_json
+    end
 
     def enforce_auto_silence_threshold(reviewable)
       auto_silence_duration = SiteSetting.chat_auto_silence_from_flags_duration

--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -34,6 +34,27 @@ describe Chat::ReviewQueue do
       expect(reviewable.payload["message_cooked"]).to eq(message.cooked)
     end
 
+    it "stores the message uploads inside the reviewable" do
+      upload = Fabricate(:image_upload, user: message_poster)
+      message.uploads = [upload]
+
+      queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+      reviewable = Chat::ReviewableMessage.last
+
+      expect(reviewable.payload["message_uploads"].map { |upload_json| upload_json["id"] }).to eq(
+        [upload.id],
+      )
+    end
+
+    it "does not store an uploads key when the message has no uploads" do
+      queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])
+
+      reviewable = Chat::ReviewableMessage.last
+
+      expect(reviewable.payload).not_to have_key("message_uploads")
+    end
+
     context "when the user already flagged the post" do
       let(:second_flag_result) do
         queue.flag_message(message, guardian, ReviewableScore.types[:off_topic])

--- a/plugins/chat/test/javascripts/components/reviewable-chat-message-test.gjs
+++ b/plugins/chat/test/javascripts/components/reviewable-chat-message-test.gjs
@@ -1,0 +1,56 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ReviewableChatMessage from "discourse/plugins/chat/discourse/components/reviewable/chat-message";
+
+function reviewable(payload) {
+  return {
+    type: "ReviewableChatMessage",
+    target_id: 1,
+    cooked: "<p>flagged message</p>",
+    payload,
+  };
+}
+
+module("Integration | Component | Reviewable | chat-message", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders the message uploads captured in the payload", async function (assert) {
+    const item = reviewable({
+      message_cooked: "<p>look at this</p>",
+      message_uploads: [
+        {
+          id: 1,
+          original_filename: "flagged.png",
+          extension: "png",
+          width: 200,
+          height: 100,
+          url: "/uploads/default/original/1X/flagged.png",
+          short_url: "upload://flagged.png",
+          short_path: "/uploads/short-url/flagged.png",
+        },
+      ],
+    });
+
+    await render(
+      <template><ReviewableChatMessage @reviewable={{item}} /></template>
+    );
+
+    assert
+      .dom(".review-item__post-content .chat-uploads img.chat-img-upload")
+      .exists("renders the flagged upload as an image");
+  });
+
+  test("renders no uploads section when the payload has none", async function (assert) {
+    const item = reviewable({ message_cooked: "<p>just text</p>" });
+
+    await render(
+      <template><ReviewableChatMessage @reviewable={{item}} /></template>
+    );
+
+    assert
+      .dom(".review-item__post-content")
+      .containsText("just text", "still renders the cooked message");
+    assert.dom(".chat-uploads").doesNotExist("renders no uploads section");
+  });
+});


### PR DESCRIPTION
When a chat message containing an uploaded image, video, or file was flagged, the review queue showed only the message text: chat uploads are stored separately from the cooked message, so moderators had no way to see the actual reported content. This was especially concerning for direct messages, where staff cannot otherwise view the media.

This change snapshots the flagged message's uploads into the reviewable's payload and renders them in the review queue using the same component chat itself uses, so moderators now see the flagged image/video/attachment (with lightbox support) directly on the reviewable.
