### PR TITLE
FIX: Surface an error when enabling notifications fails

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1747,6 +1747,7 @@ en:
         perm_denied_expl: "You denied permission for notifications. Allow notifications via your browser settings."
         disable: "Disable notifications"
         enable: "Enable notifications"
+        enable_failed: "Could not enable notifications. Your browser blocked the request or its push service is unavailable."
         each_browser_note: "Note: You have to change this setting on every browser you use. All notifications will be disabled if you pause notifications from user menu, regardless of this setting."
         consent_prompt: "Do you want live notifications when people reply to your posts?"
       dismiss: "Dismiss"

--- a/frontend/discourse/app/services/desktop-notifications.js
+++ b/frontend/discourse/app/services/desktop-notifications.js
@@ -14,6 +14,7 @@ import {
   unsubscribe as unsubscribePushNotification,
   userSubscriptionKey as pushNotificationUserSubscriptionKey,
 } from "discourse/lib/push-notifications";
+import { i18n } from "discourse-i18n";
 
 const keyValueStore = new KeyValueStore(context);
 const DISABLED = "disabled";
@@ -25,6 +26,7 @@ export default class DesktopNotificationsService extends Service {
   @service currentUser;
   @service site;
   @service siteSettings;
+  @service toasts;
 
   @tracked isEnabledBrowser = false;
   @tracked isEnabledPush = false;
@@ -127,11 +129,20 @@ export default class DesktopNotificationsService extends Service {
   @action
   async enable() {
     if (this.isPushNotificationsPreferred) {
-      await subscribePushNotification(() => {
+      const subscribed = await subscribePushNotification(() => {
         this.setIsEnabledPush(true);
       }, this.siteSettings.vapid_public_key_bytes);
 
-      return true;
+      if (!subscribed) {
+        this.toasts.error({
+          duration: "short",
+          data: {
+            message: i18n("user.desktop_notifications.enable_failed"),
+          },
+        });
+      }
+
+      return subscribed;
     } else {
       await Notification.requestPermission((permission) => {
         confirmNotification(this.siteSettings);


### PR DESCRIPTION
Clicking "Enable notifications" did nothing when push subscription registration failed (e.g. a browser with its push service disabled or unreachable). `enable()` discarded the result of the subscribe call and always returned true, so no feedback ever reached the user.

Return the real subscription result and show an error toast on failure.