### PR TITLE
UX: chart legend styling

### DIFF
--- a/frontend/discourse/admin/components/admin-report-stacked-chart.gjs
+++ b/frontend/discourse/admin/components/admin-report-stacked-chart.gjs
@@ -1,7 +1,9 @@
 import Component from "@glimmer/component";
 import Report from "discourse/admin/models/report";
+import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
 import { number } from "discourse/lib/formatter";
 import { makeArray } from "discourse/lib/helpers";
+import { remToPx } from "discourse/lib/rem-to-px";
 import I18n, { i18n } from "discourse-i18n";
 import Chart from "./chart";
 
@@ -141,9 +143,8 @@ export default class AdminReportStackedChart extends Component {
             },
             labels: {
               usePointStyle: true,
-              pointStyle: "rectRounded",
-              boxWidth: 10,
-              boxHeight: 10,
+              padding: remToPx(1),
+              font: { size: remToPx(0.75) },
               generateLabels: (chart) => {
                 const textColor = getCSSColor("--primary-high");
                 return chart.data.datasets.map((dataset, i) => {
@@ -151,12 +152,9 @@ export default class AdminReportStackedChart extends Component {
                   return {
                     text: dataset.label,
                     fontColor: textColor,
-                    fillStyle: isVisible ? dataset._baseColor : "transparent",
-                    strokeStyle: dataset._baseColor,
-                    lineWidth: 2,
                     hidden: false,
                     datasetIndex: i,
-                    pointStyle: "rectRounded",
+                    pointStyle: buildLegendIcon(dataset._baseColor, isVisible),
                   };
                 });
               },

--- a/frontend/discourse/admin/components/admin-report-stacked-chart.gjs
+++ b/frontend/discourse/admin/components/admin-report-stacked-chart.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import Report from "discourse/admin/models/report";
-import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
+import { buildLegendIcon, dimColor } from "discourse/lib/chart-legend-icon";
 import { number } from "discourse/lib/formatter";
 import { makeArray } from "discourse/lib/helpers";
 import { remToPx } from "discourse/lib/rem-to-px";
@@ -151,7 +151,7 @@ export default class AdminReportStackedChart extends Component {
                   const isVisible = chart.isDatasetVisible(i);
                   return {
                     text: dataset.label,
-                    fontColor: textColor,
+                    fontColor: isVisible ? textColor : dimColor(textColor),
                     hidden: false,
                     datasetIndex: i,
                     pointStyle: buildLegendIcon(dataset._baseColor, isVisible),

--- a/frontend/discourse/app/lib/chart-legend-icon.js
+++ b/frontend/discourse/app/lib/chart-legend-icon.js
@@ -1,5 +1,7 @@
 import { remToPx } from "discourse/lib/rem-to-px";
 
+export const INACTIVE_ALPHA = 0.6;
+
 export function buildLegendIcon(color, isVisible, size = remToPx(1)) {
   const canvas = document.createElement("canvas");
   canvas.width = size;
@@ -8,6 +10,7 @@ export function buildLegendIcon(color, isVisible, size = remToPx(1)) {
 
   const borderWidth = 2;
   const half = borderWidth / 2;
+  ctx.globalAlpha = isVisible ? 1 : INACTIVE_ALPHA;
   ctx.strokeStyle = color;
   ctx.lineWidth = borderWidth;
   ctx.beginPath();
@@ -23,4 +26,33 @@ export function buildLegendIcon(color, isVisible, size = remToPx(1)) {
   }
 
   return canvas;
+}
+
+export function dimColor(color, alpha = INACTIVE_ALPHA) {
+  const value = color?.trim();
+  if (!value) {
+    return color;
+  }
+
+  if (value.startsWith("#")) {
+    let hex = value.slice(1);
+    if (hex.length === 3) {
+      hex = hex
+        .split("")
+        .map((char) => char + char)
+        .join("");
+    }
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  const rgbMatch = value.match(/^rgba?\(([^)]+)\)$/);
+  if (rgbMatch) {
+    const [r, g, b] = rgbMatch[1].split(",").map((part) => part.trim());
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  return value;
 }

--- a/frontend/discourse/app/lib/chart-legend-icon.js
+++ b/frontend/discourse/app/lib/chart-legend-icon.js
@@ -1,0 +1,26 @@
+import { remToPx } from "discourse/lib/rem-to-px";
+
+export function buildLegendIcon(color, isVisible, size = remToPx(1)) {
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+
+  const borderWidth = 2;
+  const half = borderWidth / 2;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = borderWidth;
+  ctx.beginPath();
+  ctx.roundRect(half, half, size - borderWidth, size - borderWidth, 4);
+  ctx.stroke();
+
+  if (isVisible) {
+    const inset = 4;
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.roundRect(inset, inset, size - inset * 2, size - inset * 2, 2);
+    ctx.fill();
+  }
+
+  return canvas;
+}

--- a/frontend/discourse/app/lib/rem-to-px.js
+++ b/frontend/discourse/app/lib/rem-to-px.js
@@ -1,0 +1,6 @@
+export function remToPx(rem) {
+  const rootFontSize = parseFloat(
+    getComputedStyle(document.documentElement).fontSize
+  );
+  return rem * rootFontSize;
+}

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/doughnut-chart.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/doughnut-chart.gjs
@@ -1,5 +1,7 @@
 import Component from "@glimmer/component";
 import Chart from "discourse/admin/components/chart";
+import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
+import { remToPx } from "discourse/lib/rem-to-px";
 
 export default class DoughnutChart extends Component {
   get config() {
@@ -25,6 +27,28 @@ export default class DoughnutChart extends Component {
           legend: {
             display: this.args.displayLegend || false,
             position: "bottom",
+            labels: {
+              usePointStyle: true,
+              padding: remToPx(1),
+              font: { size: remToPx(0.75) },
+              generateLabels: (chart) => {
+                const textColor = getComputedStyle(document.documentElement)
+                  .getPropertyValue("--primary-high")
+                  .trim();
+                const backgroundColor =
+                  chart.data.datasets[0]?.backgroundColor || [];
+                return chart.data.labels.map((label, index) => ({
+                  text: label,
+                  fontColor: textColor,
+                  hidden: false,
+                  index,
+                  pointStyle: buildLegendIcon(
+                    backgroundColor[index],
+                    chart.getDataVisibility(index)
+                  ),
+                }));
+              },
+            },
           },
         },
       },

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/doughnut-chart.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/doughnut-chart.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import Chart from "discourse/admin/components/chart";
-import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
+import { buildLegendIcon, dimColor } from "discourse/lib/chart-legend-icon";
 import { remToPx } from "discourse/lib/rem-to-px";
 
 export default class DoughnutChart extends Component {
@@ -37,16 +37,19 @@ export default class DoughnutChart extends Component {
                   .trim();
                 const backgroundColor =
                   chart.data.datasets[0]?.backgroundColor || [];
-                return chart.data.labels.map((label, index) => ({
-                  text: label,
-                  fontColor: textColor,
-                  hidden: false,
-                  index,
-                  pointStyle: buildLegendIcon(
-                    backgroundColor[index],
-                    chart.getDataVisibility(index)
-                  ),
-                }));
+                return chart.data.labels.map((label, index) => {
+                  const isVisible = chart.getDataVisibility(index);
+                  return {
+                    text: label,
+                    fontColor: isVisible ? textColor : dimColor(textColor),
+                    hidden: false,
+                    index,
+                    pointStyle: buildLegendIcon(
+                      backgroundColor[index],
+                      isVisible
+                    ),
+                  };
+                });
               },
             },
           },

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-chart.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-chart.gjs
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
-import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
+import { buildLegendIcon, dimColor } from "discourse/lib/chart-legend-icon";
 import { bind } from "discourse/lib/decorators";
 import loadChartJS from "discourse/lib/load-chart-js";
 import { remToPx } from "discourse/lib/rem-to-px";
@@ -188,16 +188,16 @@ export default class DataExplorerChart extends Component {
               padding: remToPx(1),
               font: { size: remToPx(0.75) },
               generateLabels: (chart) =>
-                chart.data.datasets.map((dataset, i) => ({
-                  text: dataset.label,
-                  fontColor: labelColor,
-                  hidden: false,
-                  datasetIndex: i,
-                  pointStyle: buildLegendIcon(
-                    dataset.borderColor,
-                    chart.isDatasetVisible(i)
-                  ),
-                })),
+                chart.data.datasets.map((dataset, i) => {
+                  const isVisible = chart.isDatasetVisible(i);
+                  return {
+                    text: dataset.label,
+                    fontColor: isVisible ? labelColor : dimColor(labelColor),
+                    hidden: false,
+                    datasetIndex: i,
+                    pointStyle: buildLegendIcon(dataset.borderColor, isVisible),
+                  };
+                }),
             },
           },
           tooltip: this._multiSeriesTooltipOptions(stacked),

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-chart.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/data-explorer-chart.gjs
@@ -2,8 +2,10 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
 import { bind } from "discourse/lib/decorators";
 import loadChartJS from "discourse/lib/load-chart-js";
+import { remToPx } from "discourse/lib/rem-to-px";
 import I18n, { i18n } from "discourse-i18n";
 import { formatChartDateLabel, SERIES_COLORS } from "../lib/chart-helpers";
 import themeColor from "../lib/themeColor";
@@ -178,7 +180,26 @@ export default class DataExplorerChart extends Component {
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
-          legend: { display: true, position: "bottom" },
+          legend: {
+            display: true,
+            position: "bottom",
+            labels: {
+              usePointStyle: true,
+              padding: remToPx(1),
+              font: { size: remToPx(0.75) },
+              generateLabels: (chart) =>
+                chart.data.datasets.map((dataset, i) => ({
+                  text: dataset.label,
+                  fontColor: labelColor,
+                  hidden: false,
+                  datasetIndex: i,
+                  pointStyle: buildLegendIcon(
+                    dataset.borderColor,
+                    chart.isDatasetVisible(i)
+                  ),
+                })),
+            },
+          },
           tooltip: this._multiSeriesTooltipOptions(stacked),
         },
         scales,

--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-pie.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-pie.gjs
@@ -31,6 +31,7 @@ export default class PollResultsPieComponent extends Component {
 
         const li = document.createElement("li");
         li.classList.add("legend");
+        li.style.opacity = isVisible ? 1.0 : 0.4;
         li.onclick = () => {
           chart.toggleDataVisibility(item.index);
           chart.update();

--- a/plugins/poll/assets/javascripts/discourse/components/poll-results-pie.gjs
+++ b/plugins/poll/assets/javascripts/discourse/components/poll-results-pie.gjs
@@ -3,6 +3,7 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { trustHTML } from "@ember/template";
 import { modifier } from "ember-modifier";
+import { buildLegendIcon } from "discourse/lib/chart-legend-icon";
 import loadChartJS from "discourse/lib/load-chart-js";
 import {
   applyHtmlDecorators,
@@ -26,6 +27,8 @@ export default class PollResultsPieComponent extends Component {
 
       const items = chart.options.plugins.legend.labels.generateLabels(chart);
       items.forEach((item) => {
+        const isVisible = chart.getDataVisibility(item.index);
+
         const li = document.createElement("li");
         li.classList.add("legend");
         li.onclick = () => {
@@ -33,21 +36,14 @@ export default class PollResultsPieComponent extends Component {
           chart.update();
         };
 
-        const boxSpan = document.createElement("span");
-        boxSpan.classList.add("swatch");
-        boxSpan.style.background = item.fillStyle;
+        const icon = buildLegendIcon(item.fillStyle, isVisible);
+        icon.classList.add("swatch");
 
         const textContainer = document.createElement("span");
         textContainer.style.color = item.fontColor;
         textContainer.innerHTML = item.text;
 
-        if (!chart.getDataVisibility(item.index)) {
-          li.style.opacity = 0.2;
-        } else {
-          li.style.opacity = 1.0;
-        }
-
-        li.appendChild(boxSpan);
+        li.appendChild(icon);
         li.appendChild(textContainer);
 
         ul.appendChild(li);


### PR DESCRIPTION
Restyle the chart.js legend to be more clearly toggled on or off by changing the design to an inset box when checked and apply opacity when unchecked.

This commit adds 2 small reusable libs to achieve this across the different chart implementations.

| What | Then | Now |
|--------|--------|--------|
| Unchecked | <img width="485" height="334" alt="CleanShot 2026-07-14 at 10 59 43" src="https://github.com/user-attachments/assets/04ace368-ea4e-44ec-8270-74174dd8f602" /> | <img width="488" height="347" alt="CleanShot 2026-07-14 at 10 58 10" src="https://github.com/user-attachments/assets/ad8a2150-003e-405c-a93a-192956c25c59" /> |
| Checked | <img width="485" height="334" alt="CleanShot 2026-07-14 at 10 59 29" src="https://github.com/user-attachments/assets/128439c9-009b-4d09-9c07-93219abdf959" /> | <img width="488" height="347" alt="CleanShot 2026-07-14 at 10 58 24" src="https://github.com/user-attachments/assets/a9f40a03-5cec-4991-95f2-ec1fc35a126c" /> | 