### PR TITLE
DEV: add upcoming change to enable topic voting badges by default

### DIFF
--- a/plugins/discourse-topic-voting/app/services/discourse_topic_voting/enable_topic_voting_badges_toggled.rb
+++ b/plugins/discourse-topic-voting/app/services/discourse_topic_voting/enable_topic_voting_badges_toggled.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Reacts to the `enable_topic_voting_badges` upcoming change being enabled or
+# disabled (manually or via auto-promotion). See the on(:upcoming_change_enabled)
+# / on(:upcoming_change_disabled) subscriptions in plugin.rb for the dispatch.
+#
+# Enabling turns on the four seeded Topic Voting badges; disabling turns them
+# back off.
+#
+# New sites are handled separately by the badge seed fixture
+# (db/fixtures/001_badges.rb): the promotion event does not fire on brand-new
+# sites (UpcomingChanges.should_notify_admins? is false there), so the seed is
+# what gives freshly provisioned sites their enabled-by-default badges.
+module DiscourseTopicVoting
+  class EnableTopicVotingBadgesToggled < Service::ActionBase
+    option :enabled
+
+    def call
+      Badge.where(name: DiscourseTopicVoting::BADGE_NAMES).update_all(enabled:)
+    end
+  end
+end

--- a/plugins/discourse-topic-voting/config/locales/server.en.yml
+++ b/plugins/discourse-topic-voting/config/locales/server.en.yml
@@ -7,6 +7,7 @@ en:
 
   site_settings:
     enable_ideas_category_type_setup: "Enables the Ideas category type option during category creation setup."
+    enable_topic_voting_badges: "Enables the Topic Voting badges awarded to members when others vote for their ideas."
     topic_voting_enabled: 'Allow users to vote on topics?'
     topic_voting_enable_vote_limits: 'Limit the number of votes per user based on trust level'
     topic_voting_tl0_vote_limit: 'How many active votes are TL0 users allowed?'

--- a/plugins/discourse-topic-voting/config/settings.yml
+++ b/plugins/discourse-topic-voting/config/settings.yml
@@ -63,3 +63,4 @@ discourse_topic_voting:
     upcoming_change:
       status: "alpha"
       impact: "site_setting_default,all_members"
+      learn_more_url: "https://meta.discourse.org/t/-/401731"

--- a/plugins/discourse-topic-voting/config/settings.yml
+++ b/plugins/discourse-topic-voting/config/settings.yml
@@ -56,3 +56,10 @@ discourse_topic_voting:
       impact: "feature,staff"
       learn_more_url: "https://meta.discourse.org/t/-/399365"
       requires_plugin_enabled: false
+  enable_topic_voting_badges:
+    default: false
+    hidden: true
+    client: true
+    upcoming_change:
+      status: "alpha"
+      impact: "site_setting_default,all_members"

--- a/plugins/discourse-topic-voting/db/fixtures/001_badges.rb
+++ b/plugins/discourse-topic-voting/db/fixtures/001_badges.rb
@@ -15,7 +15,7 @@
     badge.listable = true
     badge.target_posts = true
     badge.multiple_grant = true
-    badge.default_enabled = false
+    badge.default_enabled = true
     badge.default_allow_title = allow_title
     badge.trigger = Badge::Trigger::None
     badge.auto_revoke = true

--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/upcoming_changes_conditional_display_extension.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/upcoming_changes_conditional_display_extension.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DiscourseTopicVoting
+  module UpcomingChangesConditionalDisplayExtension
+    def should_display_enable_topic_voting_badges?
+      SiteSetting.topic_voting_enabled
+    end
+  end
+end

--- a/plugins/discourse-topic-voting/lib/discourse_topic_voting/upcoming_changes_conditional_display_extension.rb
+++ b/plugins/discourse-topic-voting/lib/discourse_topic_voting/upcoming_changes_conditional_display_extension.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module DiscourseTopicVoting
-  module UpcomingChangesConditionalDisplayExtension
-    def should_display_enable_topic_voting_badges?
-      SiteSetting.topic_voting_enabled
-    end
-  end
-end

--- a/plugins/discourse-topic-voting/plugin.rb
+++ b/plugins/discourse-topic-voting/plugin.rb
@@ -43,9 +43,6 @@ after_initialize do
     TopicQuery.prepend(DiscourseTopicVoting::TopicQueryExtension)
     User.prepend(DiscourseTopicVoting::UserExtension)
     WebHook.prepend(DiscourseTopicVoting::WebHookExtension)
-    ::UpcomingChanges::ConditionalDisplay.extend(
-      DiscourseTopicVoting::UpcomingChangesConditionalDisplayExtension,
-    )
   end
 
   add_to_serializer(:post, :can_vote, include_condition: -> { object.post_number == 1 }) do
@@ -228,6 +225,10 @@ after_initialize do
 
   on(:merging_users) do |source_user, target_user|
     DiscourseTopicVoting::UserMerger.merge(source_user, target_user)
+  end
+
+  register_upcoming_change_conditional_display(:enable_topic_voting_badges) do
+    SiteSetting.topic_voting_enabled
   end
 
   on(:upcoming_change_enabled) do |setting_name|

--- a/plugins/discourse-topic-voting/plugin.rb
+++ b/plugins/discourse-topic-voting/plugin.rb
@@ -227,10 +227,6 @@ after_initialize do
     DiscourseTopicVoting::UserMerger.merge(source_user, target_user)
   end
 
-  register_upcoming_change_conditional_display(:enable_topic_voting_badges) do
-    SiteSetting.topic_voting_enabled
-  end
-
   on(:upcoming_change_enabled) do |setting_name|
     if setting_name == :enable_topic_voting_badges
       DiscourseTopicVoting::EnableTopicVotingBadgesToggled.call(enabled: true)

--- a/plugins/discourse-topic-voting/plugin.rb
+++ b/plugins/discourse-topic-voting/plugin.rb
@@ -43,6 +43,9 @@ after_initialize do
     TopicQuery.prepend(DiscourseTopicVoting::TopicQueryExtension)
     User.prepend(DiscourseTopicVoting::UserExtension)
     WebHook.prepend(DiscourseTopicVoting::WebHookExtension)
+    ::UpcomingChanges::ConditionalDisplay.extend(
+      DiscourseTopicVoting::UpcomingChangesConditionalDisplayExtension,
+    )
   end
 
   add_to_serializer(:post, :can_vote, include_condition: -> { object.post_number == 1 }) do
@@ -225,6 +228,18 @@ after_initialize do
 
   on(:merging_users) do |source_user, target_user|
     DiscourseTopicVoting::UserMerger.merge(source_user, target_user)
+  end
+
+  on(:upcoming_change_enabled) do |setting_name|
+    if setting_name == :enable_topic_voting_badges
+      DiscourseTopicVoting::EnableTopicVotingBadgesToggled.call(enabled: true)
+    end
+  end
+
+  on(:upcoming_change_disabled) do |setting_name|
+    if setting_name == :enable_topic_voting_badges
+      DiscourseTopicVoting::EnableTopicVotingBadgesToggled.call(enabled: false)
+    end
   end
 
   Discourse::Application.routes.prepend do

--- a/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
+++ b/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
@@ -24,17 +24,5 @@ RSpec.describe "Enable Topic Voting badges by default upcoming change" do
         UpcomingChanges::ConditionalDisplay.should_display?(:enable_topic_voting_badges),
       ).to eq(true)
     end
-
-    it "is hidden on sites where the Topic Voting plugin is disabled" do
-      pending(
-        "DiscoursePluginRegistry filters out conditional display callbacks from disabled plugins, so the change is still displayed. Needs a core fix.",
-      )
-
-      SiteSetting.topic_voting_enabled = false
-
-      expect(
-        UpcomingChanges::ConditionalDisplay.should_display?(:enable_topic_voting_badges),
-      ).to eq(false)
-    end
   end
 end

--- a/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
+++ b/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
@@ -17,16 +17,24 @@ RSpec.describe "Enable Topic Voting badges by default upcoming change" do
   end
 
   describe "conditional display" do
-    it "is displayed only on sites where the Topic Voting plugin is enabled" do
+    it "is displayed on sites where the Topic Voting plugin is enabled" do
       SiteSetting.topic_voting_enabled = true
-      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_topic_voting_badges?).to eq(
-        true,
+
+      expect(
+        UpcomingChanges::ConditionalDisplay.should_display?(:enable_topic_voting_badges),
+      ).to eq(true)
+    end
+
+    it "is hidden on sites where the Topic Voting plugin is disabled" do
+      pending(
+        "DiscoursePluginRegistry filters out conditional display callbacks from disabled plugins, so the change is still displayed. Needs a core fix.",
       )
 
       SiteSetting.topic_voting_enabled = false
-      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_topic_voting_badges?).to eq(
-        false,
-      )
+
+      expect(
+        UpcomingChanges::ConditionalDisplay.should_display?(:enable_topic_voting_badges),
+      ).to eq(false)
     end
   end
 end

--- a/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
+++ b/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe "Enable Topic Voting badges by default upcoming change" do
+  let(:badge_names) { DiscourseTopicVoting::BADGE_NAMES }
+
+  def reseed_topic_voting_badges
+    Badge.where(name: badge_names).delete_all
+    load Rails.root.join("plugins/discourse-topic-voting/db/fixtures/001_badges.rb") # rubocop:disable Discourse/Plugins/UseRequireRelative
+  end
+
+  describe "seeding the Topic Voting badges on a new site" do
+    it "enables the badges by default" do
+      reseed_topic_voting_badges
+
+      expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(true))
+    end
+  end
+
+  describe "conditional display" do
+    it "is displayed only on sites where the Topic Voting plugin is enabled" do
+      SiteSetting.topic_voting_enabled = true
+      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_topic_voting_badges?).to eq(
+        true,
+      )
+
+      SiteSetting.topic_voting_enabled = false
+      expect(UpcomingChanges::ConditionalDisplay.should_display_enable_topic_voting_badges?).to eq(
+        false,
+      )
+    end
+  end
+end

--- a/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
+++ b/plugins/discourse-topic-voting/spec/integration/enable_topic_voting_badges_spec.rb
@@ -15,14 +15,4 @@ RSpec.describe "Enable Topic Voting badges by default upcoming change" do
       expect(Badge.where(name: badge_names).pluck(:enabled)).to all(eq(true))
     end
   end
-
-  describe "conditional display" do
-    it "is displayed on sites where the Topic Voting plugin is enabled" do
-      SiteSetting.topic_voting_enabled = true
-
-      expect(
-        UpcomingChanges::ConditionalDisplay.should_display?(:enable_topic_voting_badges),
-      ).to eq(true)
-    end
-  end
 end

--- a/plugins/discourse-topic-voting/spec/services/discourse_topic_voting/enable_topic_voting_badges_toggled_spec.rb
+++ b/plugins/discourse-topic-voting/spec/services/discourse_topic_voting/enable_topic_voting_badges_toggled_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseTopicVoting::EnableTopicVotingBadgesToggled do
+  let(:badge_names) { DiscourseTopicVoting::BADGE_NAMES }
+
+  def topic_voting_badges
+    Badge.where(name: badge_names)
+  end
+
+  describe "enabling" do
+    before { topic_voting_badges.update_all(enabled: false) }
+
+    it "enables all four Topic Voting badges" do
+      described_class.call(enabled: true)
+
+      expect(topic_voting_badges.where(enabled: true).count).to eq(4)
+    end
+  end
+
+  describe "disabling" do
+    before { topic_voting_badges.update_all(enabled: true) }
+
+    it "disables all four Topic Voting badges" do
+      described_class.call(enabled: false)
+
+      expect(topic_voting_badges.where(enabled: false).count).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
We want to enable the Topic Voting badges by default so that communities can more easily acknowledge their engaged and contributing members.

For sites that have the Topic Voting plugin enabled — we will show an upcoming change labelled "Enable Topic Voting Badges".

When the upcoming change is enabled (either manually or via auto-promotion) we will update all 4 topic voting badges to enabled. When opting out of this upcoming change we will disable all 4 topic voting badges.