### PR TITLE
FIX: Live rendering replies to max level post

### DIFF
--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -34,6 +34,7 @@ export default class NestedController extends Controller {
   @service nestedViewCache;
   @service router;
   @service site;
+  @service siteSettings;
 
   @tracked topic;
   @tracked opPost;
@@ -811,7 +812,7 @@ export default class NestedController extends Controller {
         this.appEvents.trigger("nested-replies:child-created", {
           topicId,
           post: node.post,
-          parentPostNumber: replyTo,
+          parentPostNumber: this.#visibleParentPostNumber(postData),
           isOwnPost: data.user_id === this.currentUser?.id,
         });
       }
@@ -834,6 +835,28 @@ export default class NestedController extends Controller {
       return false;
     }
     return true;
+  }
+
+  #visibleParentPostNumber(postData) {
+    const replyTo = postData.reply_to_post_number;
+    if (!this.siteSettings.nested_replies_cap_nesting_depth) {
+      return replyTo;
+    }
+
+    const ancestors = [];
+    let postNumber = replyTo;
+
+    while (postNumber && postNumber !== 1) {
+      ancestors.unshift(postNumber);
+      const post = this.postRegistry.get(postNumber);
+      if (!post) {
+        return replyTo;
+      }
+      postNumber = post.reply_to_post_number;
+    }
+
+    const maxDepth = this.siteSettings.nested_replies_max_depth;
+    return ancestors.length > maxDepth ? ancestors[maxDepth - 1] : replyTo;
   }
 
   #isPostKnown(postId) {

--- a/spec/system/nested_replying_spec.rb
+++ b/spec/system/nested_replying_spec.rb
@@ -192,4 +192,87 @@ RSpec.describe "Nested view replying" do
       expect(nested_view).to have_children_visible_for(child_reply)
     end
   end
+
+  describe "replying to a capped-depth post with hidden replies" do
+    fab!(:root_reply) { Fabricate(:post, topic: topic, user: Fabricate(:user), raw: "Root reply") }
+
+    fab!(:second_level_reply) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Second-level reply",
+        reply_to_post_number: root_reply.post_number,
+      )
+    end
+
+    fab!(:third_level_reply) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Third-level reply",
+        reply_to_post_number: second_level_reply.post_number,
+      )
+    end
+
+    fab!(:fourth_level_reply) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Fourth-level reply",
+        reply_to_post_number: third_level_reply.post_number,
+      )
+    end
+
+    fab!(:fifth_level_reply) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Fifth-level reply",
+        reply_to_post_number: third_level_reply.post_number,
+      )
+    end
+
+    fab!(:sixth_level_reply) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Sixth-level reply",
+        reply_to_post_number: third_level_reply.post_number,
+      )
+    end
+
+    fab!(:seventh_level_reply) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Seventh-level reply",
+        reply_to_post_number: third_level_reply.post_number,
+      )
+    end
+
+    before do
+      SiteSetting.nested_replies_cap_nesting_depth = true
+      SiteSetting.nested_replies_max_depth = 3
+      SiteSetting.nested_replies_default_sort = "old"
+    end
+
+    it "shows a reply to a capped-depth post without expanding hidden replies" do
+      nested_view.visit_nested(topic)
+      expect(nested_view).to have_post(fourth_level_reply)
+      expect(nested_view).to have_load_more_children_for(third_level_reply)
+
+      nested_view.click_reply_on_post(fourth_level_reply)
+      composer.fill_content("Reply shown immediately at the capped depth")
+      composer.submit
+
+      expect(composer).to be_closed
+      expect(nested_view).to have_post_text("Reply shown immediately at the capped depth")
+    end
+  end
 end


### PR DESCRIPTION
At the moment, replying to a capped-depth post with hidden replies messed up live rendering. The post is only loaded after you expand replies. It makes it feel like you _didn't_ post. This fixes that :)