### PR TITLE
FIX: Target editor button bar instead of wrapper

### DIFF
--- a/frontend/discourse/app/lib/composer/composer-position.js
+++ b/frontend/discourse/app/lib/composer/composer-position.js
@@ -28,7 +28,7 @@ export function setupComposerPosition(editor) {
     return [
       editor,
       replyControl?.querySelector(".d-editor-preview-wrapper"),
-      replyControl?.querySelector(".d-editor-button-bar__wrap"),
+      replyControl?.querySelector(".d-editor-button-bar"),
     ].filter(Boolean);
   }
 


### PR DESCRIPTION
PR #41366 targeted the wrong element for the composer toolbar leading to a frozen state that cannot be scrolled. Change to the actual toolbar instead of the wrapper.