### PR TITLE
UX: Keep bot conversation URL in sync with selected agent and LLM

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-agent-llm-selector.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-agent-llm-selector.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
+import { slugify } from "discourse/lib/utilities";
 import DropdownSelectBox from "discourse/select-kit/components/dropdown-select-box";
 import { i18n } from "discourse-i18n";
 
@@ -25,6 +26,7 @@ export default class AiAgentLlmSelector extends Component {
 
       next(() => {
         this.resetTargetRecipients();
+        this.notifySelectionChanged();
       });
     }
   }
@@ -81,6 +83,7 @@ export default class AiAgentLlmSelector extends Component {
     this.args.setAgentId(newValue);
     this.setAllowLLMSelector();
     this.resetTargetRecipients();
+    this.notifySelectionChanged();
   }
 
   setAllowLLMSelector() {
@@ -110,6 +113,29 @@ export default class AiAgentLlmSelector extends Component {
     );
     this.args.setLlmId?.(bot?.llm_model_id);
     this.resetTargetRecipients();
+    this.notifySelectionChanged();
+  }
+
+  notifySelectionChanged() {
+    if (!this.args.onSelectionChanged) {
+      return;
+    }
+
+    let agentName = null;
+    if (this.showAgentSelector) {
+      agentName = this.enabledAgents.find(
+        (agent) => agent.id === this._value
+      )?.name;
+    }
+
+    let llmName = null;
+    if (this.showLLMSelector) {
+      llmName = this.currentUser.ai_enabled_chat_bots.find(
+        (bot) => bot.id === this.llm
+      )?.display_name;
+    }
+
+    this.args.onSelectionChanged({ agentName, llmName });
   }
 
   resetTargetRecipients() {
@@ -152,7 +178,10 @@ export default class AiAgentLlmSelector extends Component {
   #getAgentIdFromAttrs() {
     const agentName = this.args?.agentName;
     if (agentName) {
-      const agent = this.botOptions.find((p) => p.name === agentName);
+      const slug = slugify(agentName);
+      const agent = this.botOptions.find(
+        (p) => p.name === agentName || (slug && slugify(p.name) === slug)
+      );
       if (agent) {
         return agent.id;
       }
@@ -162,7 +191,10 @@ export default class AiAgentLlmSelector extends Component {
   #getLlmIdFromAttrs() {
     const llmName = this.args?.llmName;
     if (llmName) {
-      const llm = this.llmOptions.find((l) => l.name === llmName);
+      const slug = slugify(llmName);
+      const llm = this.llmOptions.find(
+        (l) => l.name === llmName || (slug && slugify(l.name) === slug)
+      );
       if (llm) {
         return llm.id;
       }

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -27,7 +27,7 @@ import {
   initUserStatusHtml,
   renderUserStatusHtml,
 } from "discourse/lib/user-status-on-autocomplete";
-import { clipboardHelpers } from "discourse/lib/utilities";
+import { clipboardHelpers, slugify } from "discourse/lib/utilities";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dAutocomplete from "discourse/ui-kit/modifiers/d-autocomplete";
@@ -207,6 +207,16 @@ export default class AiBotConversations extends Component {
       // Fail open - allow usage if credit check fails
       this.creditStatus = null;
     }
+  }
+
+  @action
+  onSelectionChanged({ agentName, llmName }) {
+    if (!this.controller) {
+      return;
+    }
+
+    this.controller.agent = agentName ? slugify(agentName) || agentName : null;
+    this.controller.llm = llmName ? slugify(llmName) || llmName : null;
   }
 
   @action
@@ -396,6 +406,7 @@ export default class AiBotConversations extends Component {
         @setTargetRecipient={{this.setTargetRecipient}}
         @agentName={{@controller.agent}}
         @llmName={{@controller.llm}}
+        @onSelectionChanged={{this.onSelectionChanged}}
       />
 
       <div class="ai-bot-conversations__content-wrapper">

--- a/plugins/discourse-ai/assets/javascripts/discourse/routes/discourse-ai-bot-conversations.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/routes/discourse-ai-bot-conversations.js
@@ -4,6 +4,11 @@ import DiscourseRoute from "discourse/routes/discourse";
 export default class DiscourseAiBotConversationsRoute extends DiscourseRoute {
   @service currentUser;
 
+  queryParams = {
+    agent: { replace: true },
+    llm: { replace: true },
+  };
+
   beforeModel(transition) {
     if (!this.currentUser) {
       transition.send("showLogin");

--- a/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
+++ b/plugins/discourse-ai/spec/system/ai_bot/homepage_spec.rb
@@ -256,6 +256,26 @@ RSpec.describe "AI Bot - Homepage" do
       expect(ai_pm_homepage.llm_selector).to have_selected_name(claude_2_dup.display_name)
     end
 
+    it "allows navigating to a specific LLM and agent with slugified names" do
+      visit "/discourse-ai/ai-bot/conversations?agent=test-agent&llm=duplicate"
+
+      expect(ai_pm_homepage.agent_selector).to have_selected_name(agent.name)
+      expect(ai_pm_homepage.llm_selector).to have_selected_name(claude_2_dup.display_name)
+    end
+
+    it "keeps the URL in sync with the selected agent and LLM" do
+      ai_pm_homepage.visit
+
+      ai_pm_homepage.agent_selector.expand
+      ai_pm_homepage.agent_selector.select_row_by_name(agent.name)
+      expect(page).to have_current_path(/agent=test-agent/)
+
+      ai_pm_homepage.llm_selector.expand
+      ai_pm_homepage.llm_selector.select_row_by_name(claude_2_dup.display_name)
+      expect(page).to have_current_path(/agent=test-agent/)
+      expect(page).to have_current_path(/llm=duplicate/)
+    end
+
     it "removes agent from selector when allow_personal_messages is disabled" do
       agent.update!(allow_personal_messages: false)
       ai_pm_homepage.visit


### PR DESCRIPTION
Previously, the agent and LLM selected on the AI bot conversations page were not reflected in the URL, and deep links only worked with exact URL-encoded names (e.g. `?agent=Data+Explorer+Query+Generator`).

This change keeps the `agent` and `llm` query params in sync with the dropdown selections and accepts slugified names (e.g. `?agent=data-explorer-query-generator`), so the current state can be copied from the address bar and shared as a direct link to a specific bot. The URL is updated with `replace: true` to avoid polluting browser history.