### PR TITLE
FIX: Prevent empty top menu configuration

### DIFF
--- a/lib/validators/top_menu_validator.rb
+++ b/lib/validators/top_menu_validator.rb
@@ -6,21 +6,31 @@ class TopMenuValidator
   end
 
   def valid_value?(val)
-    return true if val.blank?
+    @error_message = "site_settings.errors.invalid_string"
+
+    if val.blank?
+      @error_message = "site_settings.errors.must_include_latest"
+      return false
+    end
+
     val_choices = val.split("|").map(&:strip).compact
+
+    if val_choices.include?("unread") && UpcomingChanges.enabled?(:enable_unified_new)
+      @error_message = "site_settings.errors.top_menu_unread_not_allowed_with_unified_new"
+      return false
+    end
 
     return false if !val_choices.all? { |choice| TopMenu.choices.include?(choice) }
 
-    return false if !val_choices.include?("latest")
-
-    val_choices.each do |choice|
-      return false if choice == "unread" && UpcomingChanges.enabled?(:enable_unified_new)
+    if !val_choices.include?("latest")
+      @error_message = "site_settings.errors.must_include_latest"
+      return false
     end
 
     true
   end
 
   def error_message
-    I18n.t("site_settings.errors.top_menu_unread_not_allowed_with_unified_new")
+    I18n.t(@error_message)
   end
 end

--- a/spec/lib/validators/top_menu_validator_spec.rb
+++ b/spec/lib/validators/top_menu_validator_spec.rb
@@ -4,13 +4,17 @@ RSpec.describe TopMenuValidator do
   describe "#valid_value?" do
     subject(:validator) { described_class.new }
 
-    it "returns true for blank values" do
-      expect(validator.valid_value?("")).to eq(true)
-      expect(validator.valid_value?(nil)).to eq(true)
+    it "returns false for blank values" do
+      expect(validator.valid_value?("")).to eq(false)
+      expect(validator.error_message).to eq(I18n.t("site_settings.errors.must_include_latest"))
+
+      expect(validator.valid_value?(nil)).to eq(false)
+      expect(validator.error_message).to eq(I18n.t("site_settings.errors.must_include_latest"))
     end
 
     it "returns false when latest is missing" do
       expect(validator.valid_value?("categories|new")).to eq(false)
+      expect(validator.error_message).to eq(I18n.t("site_settings.errors.must_include_latest"))
     end
 
     it "returns false when a choice is not in TopMenu.choices" do
@@ -25,22 +29,15 @@ RSpec.describe TopMenuValidator do
       SiteSetting.enable_unified_new = true
 
       expect(validator.valid_value?("latest|new|unread|hot|categories")).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t("site_settings.errors.top_menu_unread_not_allowed_with_unified_new"),
+      )
     end
 
     it "returns true when unread is included and unified new is disabled" do
       SiteSetting.enable_unified_new = false
 
       expect(validator.valid_value?("latest|new|unread|hot|categories")).to eq(true)
-    end
-  end
-
-  describe "#error_message" do
-    subject(:validator) { described_class.new }
-
-    it "returns the unread not allowed message" do
-      expect(validator.error_message).to eq(
-        I18n.t("site_settings.errors.top_menu_unread_not_allowed_with_unified_new"),
-      )
     end
   end
 end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe SiteSetting do
         )
       end
 
+      it "does not allow an empty menu" do
+        expect do SiteSetting.top_menu = "" end.to raise_error(Discourse::InvalidParameters)
+      end
+
       it "does not allow random text" do
         expect do SiteSetting.top_menu = "latest|random" end.to raise_error(
           Discourse::InvalidParameters,


### PR DESCRIPTION
The unified new view change replaced the top menu presence validator and allowed blank values. This let an admin clear the setting, causing homepage resolution to fail because it expects a first menu item.

Reject blank top menus again while preserving the unified new validation for the removed unread item.