### PR TITLE
FIX: iOS text selection regression with locked composer

### DIFF
--- a/frontend/discourse/app/lib/composer/composer-position.js
+++ b/frontend/discourse/app/lib/composer/composer-position.js
@@ -32,12 +32,25 @@ export function setupComposerPosition(editor) {
     ].filter(Boolean);
   }
 
+  function selectionTouchmoveGuard(event) {
+    if (editor.selectionStart !== editor.selectionEnd) {
+      event.stopImmediatePropagation();
+    }
+  }
+
   function refreshScrollLock() {
     if (shouldLockScroll() && !scrollLocked) {
       scrollLockTargets = getAllowedScrollTargets();
+      editor.addEventListener("touchmove", selectionTouchmoveGuard, {
+        capture: true,
+        passive: false,
+      });
       lock(scrollLockTargets);
       scrollLocked = true;
     } else if (!shouldLockScroll() && scrollLocked) {
+      editor.removeEventListener("touchmove", selectionTouchmoveGuard, {
+        capture: true,
+      });
       unlock(scrollLockTargets);
       scrollLockTargets = null;
       scrollLocked = false;
@@ -101,6 +114,9 @@ export function setupComposerPosition(editor) {
       editor.removeEventListener("blur", onBlur);
 
       if (scrollLocked) {
+        editor.removeEventListener("touchmove", selectionTouchmoveGuard, {
+          capture: true,
+        });
         unlock(scrollLockTargets);
         scrollLockTargets = null;
         scrollLocked = false;


### PR DESCRIPTION
PR #41366 introduced a regression on iOS where text-selection gestures in the composer would get canceled. The scroll-lock added there routes composer touchmove events through body-scroll-lock, which calls `preventDefault` at scroll boundaries -- and a short textarea is always at its boundary -- so iOS never got a chance to handle the selection-handle drag.

Add a capture-phase touchmove listener on the editor that stops propagation when the editor has a selection, so the event never reaches body-scroll-lock's handlers and iOS handles the gesture natively.

[Meta Topic](https://meta.discourse.org/t/ios-markdown-composer-editor-freezes-when-selecting-text-a-second-time/407258)