### PR TITLE
FEATURE: exclude groups from /filter route

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3182,6 +3182,7 @@ en:
       group: "Filter topics by groups"
       groups_any: "Show topics with any of the specified groups (comma-separated)"
       groups_all: "Show topics with all of the specified groups (plus-separated)"
+      exclude_group: "Exclude topics with participants from specific groups"
       locale: "Filter topics by original language"
       locale_any: "Show topics originally written in any of the specified languages (comma-separated)"
       exclude_locale: "Exclude topics originally written in a specific language"

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -613,13 +613,13 @@ class TopicsFilter
           .pluck(:id)
 
       if group_ids.empty?
-        @scope = @scope.none
+        @scope = @scope.none if prefix != "-"
         next
       end
 
       if require_all
         if group_ids.length < group_names.length
-          @scope = @scope.none
+          @scope = @scope.none if prefix != "-"
           next
         end
 

--- a/lib/topics_filter.rb
+++ b/lib/topics_filter.rb
@@ -89,7 +89,7 @@ class TopicsFilter
       when "users"
         filter_users(values: key_prefixes.zip(filter_values))
       when "group"
-        filter_groups(values: filter_values)
+        filter_groups(values: key_prefixes.zip(filter_values))
       when "posts-min"
         filter_by_number_of_posts(min: filter_values)
       when "posts-max"
@@ -376,6 +376,7 @@ class TopicsFilter
         description: I18n.t("filter.description.group"),
         type: "group",
         priority: 1,
+        prefixes: [{ name: "-", description: I18n.t("filter.description.exclude_group") }],
         delimiters: [
           { name: ",", description: I18n.t("filter.description.groups_any") },
           { name: "+", description: I18n.t("filter.description.groups_all") },
@@ -593,8 +594,10 @@ class TopicsFilter
 
   # group:staff,moderators => any of the groups have participation
   # group:staff+moderators => both groups have participation
+  # -group:staff,moderators => none of the groups have participation
+  # -group:staff+moderators => at least one of the groups has no participation
   def filter_groups(values:)
-    values.each do |value|
+    values.each do |prefix, value|
       require_all, group_names = calculate_all_or_any(value)
 
       if group_names.empty?
@@ -620,7 +623,7 @@ class TopicsFilter
           next
         end
 
-        group_ids.each_with_index { |gid, idx| @scope = @scope.where(<<~SQL) }
+        exists_clauses = group_ids.each_with_index.map { |gid, idx| <<~SQL }
             EXISTS (
               SELECT 1
               FROM posts pg#{idx}
@@ -631,13 +634,21 @@ class TopicsFilter
               #{whisper_condition("pg#{idx}")}
             )
           SQL
+
+        if prefix == "-"
+          @scope = @scope.where("NOT (#{exists_clauses.join(" AND ")})")
+        else
+          exists_clauses.each { |exists_clause| @scope = @scope.where(exists_clause) }
+        end
       else
+        not_sql = prefix == "-" ? "NOT" : ""
         @scope = @scope.where(<<~SQL, group_ids:)
-              topics.id IN (
-                SELECT DISTINCT p.topic_id
+              #{not_sql} EXISTS (
+                SELECT 1
                 FROM posts p
                 JOIN group_users gu ON gu.user_id = p.user_id
-                WHERE gu.group_id IN (:group_ids)
+                WHERE p.topic_id = topics.id
+                AND gu.group_id IN (:group_ids)
                 AND p.deleted_at IS NULL
                 #{whisper_condition("p")}
               )

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe TopicsFilter do
       expect(tag_options).not_to be_nil
     end
 
+    it "should advertise the - prefix for the group: option" do
+      group_option = options.find { |o| o[:name] == "group:" }
+
+      expect(group_option[:prefixes]).to contain_exactly(
+        { name: "-", description: I18n.t("filter.description.exclude_group") },
+      )
+    end
+
     it "should not include user-specific options for anonymous users" do
       anon_options = TopicsFilter.option_info(Guardian.new)
       logged_in_options = TopicsFilter.option_info(user.guardian)

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -195,6 +195,47 @@ RSpec.describe TopicsFilter do
         expect(ids).to contain_exactly(topic_by_u1_and_u2.id)
       end
 
+      it "-group:group1 returns topics without participants from the group" do
+        topic_by_u3 = Fabricate(:post, user: u3).topic
+        ids =
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-group:group1")
+            .pluck(:id)
+        expect(ids).to contain_exactly(topic_by_u2.id, topic_by_u3.id)
+      end
+
+      it "-groups:group1,group2 returns topics with participants from neither group" do
+        topic_by_u3 = Fabricate(:post, user: u3).topic
+        ids =
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-groups:group1,group2")
+            .pluck(:id)
+        expect(ids).to contain_exactly(topic_by_u3.id)
+      end
+
+      it "-group:group1+group2 returns topics where both groups are not represented together" do
+        ids =
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-group:group1+group2")
+            .pluck(:id)
+        expect(ids).to contain_exactly(topic_by_u1.id, topic_by_u2.id)
+      end
+
+      it "-group:group1 returns topics where the only post from a group member is deleted" do
+        topic = Fabricate(:topic)
+        Fabricate(:post, topic:, user: u1).update_column(:deleted_at, Time.zone.now)
+
+        ids =
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-group:group1")
+            .pluck(:id)
+        expect(ids).to include(topic.id)
+      end
+
       it "group:group1 should not return topics where the only post from a group member is deleted" do
         topic = Fabricate(:topic)
         post = Fabricate(:post, topic:, user: u1)

--- a/spec/lib/topics_filter_spec.rb
+++ b/spec/lib/topics_filter_spec.rb
@@ -224,6 +224,24 @@ RSpec.describe TopicsFilter do
         expect(ids).to contain_exactly(topic_by_u1.id, topic_by_u2.id)
       end
 
+      it "-group:missing is a no-op when the group cannot be resolved" do
+        ids =
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-group:missing")
+            .pluck(:id)
+        expect(ids).to contain_exactly(topic_by_u1.id, topic_by_u2.id, topic_by_u1_and_u2.id)
+      end
+
+      it "-group:group1+missing is a no-op when any group cannot be resolved" do
+        ids =
+          TopicsFilter
+            .new(guardian: Guardian.new)
+            .filter_from_query_string("-group:group1+missing")
+            .pluck(:id)
+        expect(ids).to contain_exactly(topic_by_u1.id, topic_by_u2.id, topic_by_u1_and_u2.id)
+      end
+
       it "-group:group1 returns topics where the only post from a group member is deleted" do
         topic = Fabricate(:topic)
         Fabricate(:post, topic:, user: u1).update_column(:deleted_at, Time.zone.now)


### PR DESCRIPTION
Requested here: https://meta.discourse.org/t/allow-to-exclude-groups-in-filter/407466

This adds the ability to exclude groups from filter on the `/filter` route using `-group:` similar to the `-users:` exclusion 

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/06a657f2-21ac-4011-91b1-27e1bbcd9c18" />
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/b939be6d-73d4-4c63-b264-2ad30045d6ae" />
