### PR TITLE
FIX: Regenerate existing reply when retrying AI bot posts in public topics

### DIFF
--- a/plugins/discourse-ai/lib/ai_bot/playground.rb
+++ b/plugins/discourse-ai/lib/ai_bot/playground.rb
@@ -513,6 +513,16 @@ module DiscourseAi
           reply_user = User.find_by(id: bot.agent.class.user_id) || reply_user
         end
 
+        if existing_reply_post
+          if existing_reply_post.topic_id != post.topic_id
+            raise Discourse::InvalidParameters.new(:reply_post_id)
+          end
+
+          if existing_reply_post.user_id != reply_user.id
+            raise Discourse::InvalidParameters.new(:reply_post_id)
+          end
+        end
+
         stream_reply = post.topic.private_message? if stream_reply.nil?
 
         # we need to ensure agent user is allowed to reply to the pm
@@ -536,14 +546,6 @@ module DiscourseAi
           reply_post = existing_reply_post
 
           if reply_post
-            if reply_post.topic_id != post.topic_id
-              raise Discourse::InvalidParameters.new(:reply_post_id)
-            end
-
-            if reply_post.user_id != reply_user.id
-              raise Discourse::InvalidParameters.new(:reply_post_id)
-            end
-
             reply_post.update_columns(raw: "", cooked: "")
             reply_post.post_custom_prompt = nil
           else
@@ -564,16 +566,7 @@ module DiscourseAi
               )
           end
 
-          reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD] = bot
-            .llm
-            .llm_model
-            .display_name
-          reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD] = bot
-            .llm
-            .llm_model
-            .id
-          reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD] = bot.agent.id
-          reply_post.save_custom_fields
+          save_ai_custom_fields(reply_post)
 
           publish_update(reply_post, { raw: "" })
 
@@ -655,6 +648,16 @@ module DiscourseAi
             skip_validations: true,
             skip_revision: true,
           )
+        elsif existing_reply_post
+          reply_post = existing_reply_post
+          reply_post.post_custom_prompt = nil
+          reply_post.revise(
+            bot.bot_user,
+            { raw: reply },
+            skip_validations: true,
+            force_new_version: true,
+          )
+          save_ai_custom_fields(reply_post)
         else
           reply_post =
             PostCreator.create!(
@@ -761,6 +764,19 @@ module DiscourseAi
       end
 
       private
+
+      def save_ai_custom_fields(reply_post)
+        reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_NAME_FIELD] = bot
+          .llm
+          .llm_model
+          .display_name
+        reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD] = bot
+          .llm
+          .llm_model
+          .id
+        reply_post.custom_fields[DiscourseAi::AiBot::POST_AI_AGENT_ID_FIELD] = bot.agent.id
+        reply_post.save_custom_fields
+      end
 
       def should_stop_thinking?(partial:, context:, type:, started_thinking:, placeholder:)
         return false if context.skip_show_thinking

--- a/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/ai_bot/playground_spec.rb
@@ -1578,4 +1578,43 @@ RSpec.describe DiscourseAi::AiBot::Playground do
       end
     }.not_to raise_error
   end
+
+  describe "retrying a reply in a public topic" do
+    fab!(:public_topic, :topic)
+    fab!(:prompt_post) do
+      Fabricate(:post, topic: public_topic, user: user, raw: "Hello bot, can you help me?")
+    end
+    fab!(:bot_reply) do
+      Fabricate(:post, topic: public_topic, user: bot_user, raw: "This is the first answer")
+    end
+
+    it "revises the existing reply keeping a revision instead of creating a duplicate post" do
+      expect {
+        DiscourseAi::Completions::Llm.with_prepared_responses(["This is the second answer"]) do
+          playground.reply_to(prompt_post, existing_reply_post: bot_reply)
+        end
+      }.not_to change { public_topic.reload.posts.count }
+
+      bot_reply.reload
+      expect(bot_reply.raw).to eq("This is the second answer")
+      expect(bot_reply.revisions.count).to eq(1)
+      expect(bot_reply.custom_fields[DiscourseAi::AiBot::POST_AI_LLM_MODEL_ID_FIELD].to_i).to eq(
+        claude_2.id,
+      )
+    end
+
+    it "raises when the existing reply belongs to a different topic" do
+      other_topic_reply = Fabricate(:post, user: bot_user)
+
+      expect {
+        playground.reply_to(prompt_post, existing_reply_post: other_topic_reply)
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "raises when the existing reply belongs to a different user" do
+      expect { playground.reply_to(prompt_post, existing_reply_post: prompt_post) }.to raise_error(
+        Discourse::InvalidParameters,
+      )
+    end
+  end
 end


### PR DESCRIPTION
Previously, clicking retry on an AI bot reply in a public (non-PM) topic appended a brand-new bot post, because `Playground#reply_to` only honored `existing_reply_post` in the streaming path used by PMs.

This change revises the existing reply in place in the non-streaming path as well, keeping an edit revision so the previous answer remains visible in the post history, and refreshes the post's LLM/agent custom fields on retry.

Reported at https://meta.discourse.org/t/407562