### PR TITLE
SECURITY: Harden `ListController` top period query against SQL injection

### DIFF
--- a/app/controllers/list_controller.rb
+++ b/app/controllers/list_controller.rb
@@ -510,6 +510,10 @@ class ListController < ApplicationController
           SiteSetting.top_page_default_timeframe
       ).to_sym
 
+    default_period = SiteSetting.top_page_default_timeframe.to_sym if TopTopic.periods.exclude?(
+      default_period,
+    )
+
     best_period_with_topics_for(previous_visit_at, category_id, default_period) || default_period
   end
 
@@ -519,7 +523,7 @@ class ListController < ApplicationController
     default_period = SiteSetting.top_page_default_timeframe
   )
     best_periods_for(previous_visit_at, default_period.to_sym).find do |period|
-      top_topics = TopTopic.where("#{period}_score > 0")
+      top_topics = TopTopic.where("#{TopTopic.score_column_for_period(period)} > 0")
       top_topics =
         top_topics.joins(:topic).where("topics.category_id = ?", category_id) if category_id
       top_topics = top_topics.limit(SiteSetting.topics_per_period_in_top_page)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -135,6 +135,8 @@ class Category < ActiveRecord::Base
   validates :color, format: { with: /\A(\h{6}|\h{3})\z/ }
   validates :text_color, format: { with: /\A(\h{6}|\h{3})\z/ }
 
+  before_validation :normalize_default_top_period
+
   before_save :apply_permissions
   before_save :downcase_email
   before_save :downcase_name
@@ -1379,6 +1381,10 @@ class Category < ActiveRecord::Base
 
   def ensure_category_setting
     build_category_setting if category_setting.blank?
+  end
+
+  def normalize_default_top_period
+    self.default_top_period = nil if TopTopic.periods.exclude?(default_top_period&.to_sym)
   end
 
   def group_based_posting_review_mode?(post_type)

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -31,6 +31,26 @@ RSpec.describe Category do
     expect(category.errors.to_hash.keys).to contain_exactly(:search_priority)
   end
 
+  describe "#default_top_period" do
+    it "keeps a supported period" do
+      category = Fabricate(:category, user: user, default_top_period: "weekly")
+
+      expect(category.reload.default_top_period).to eq("weekly")
+    end
+
+    it "is nil for an unsupported period" do
+      category = Fabricate(:category, user: user, default_top_period: "hourly")
+
+      expect(category.reload.default_top_period).to be_nil
+    end
+
+    it "is nil for a blank period" do
+      category = Fabricate(:category, user: user, default_top_period: "")
+
+      expect(category.reload.default_top_period).to be_nil
+    end
+  end
+
   it "validates uniqueness in case insensitive way" do
     Fabricate(:category_with_definition, name: "Cats")
     cats = Fabricate.build(:category, name: "cats")

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1107,6 +1107,18 @@ RSpec.describe ListController do
           expect(json["topic_list"]["for_period"]).to eq("monthly")
         end
 
+        it "falls back to the site default period when default_top_period is an unsupported value" do
+          SiteSetting.top_page_default_timeframe = "monthly"
+          category.update!(default_view: "top")
+          category.update_column(:default_top_period, "user~'^d'AND all")
+
+          get "/c/#{category.slug}/#{category.id}.json"
+
+          expect(response.status).to eq(200)
+          json = response.parsed_body
+          expect(json["topic_list"]["for_period"]).to eq("monthly")
+        end
+
         it "has a default view of nil" do
           category.update!(default_view: nil)
           get "/c/#{category.slug}/#{category.id}.json"


### PR DESCRIPTION
A category's `default_top_period` was interpolated raw into the top-topic
score predicate in `ListController` before the period was validated against
the allowlist. For anonymous requests to a category whose default view is
`top`, an attacker-planted value reached the SQL predicate directly. The
response never returns the query's data, but it changes depending on whether
an injected condition holds, so an attacker can read data one yes/no answer at
a time.

This is hardening rather than a critical fix because the column is
`varchar(20)`: PostgreSQL rejects an over-long value, leaving no room for a
subquery or a second statement. An attacker could only probe one value at a
time, for example reading the PostgreSQL session role character by character,
not perform arbitrary reads or writes.

Harden the path in depth:

- Sanitise the category-derived period in `best_period_for`, falling back to
  the site default when it is not a known period, so the untrusted value never
  reaches SQL.
- Build the score column in `best_period_with_topics_for` through the
  validating `TopTopic.score_column_for_period` helper instead of raw string
  interpolation.
- Clear `Category#default_top_period` on validation when it is not a known
  period, so an invalid value is never stored and the category falls back to
  the site default at read time.