### PR TITLE
DEV: Rename AdminFilterControls to DFilterControls

### DIFF
--- a/.skills/discourse-upcoming-changes-authoring/SKILL.md
+++ b/.skills/discourse-upcoming-changes-authoring/SKILL.md
@@ -65,7 +65,7 @@ All services use `Service::Base`. They're organized under `app/services/upcoming
 **Admin page** — `admin/templates/admin-config/upcoming-changes.gjs` renders the page header, `admin/components/admin-config-areas/upcoming-changes.gjs` is the container with filtering, and `admin/components/admin-config-areas/upcoming-change-item.gjs` renders each row.
 
 **Key frontend patterns:**
-- Filtering by status, impact type, impact role, and enabled/disabled state via `AdminFilterControls`
+- Filtering by status, impact type, impact role, and enabled/disabled state via `DFilterControls`
 - Group selection uses a multi-select dropdown with debounced API saves
 - Toast notifications for all toggle/group changes
 - Lightbox integration for preview images

--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -1287,7 +1287,6 @@ a.inline-editable-field {
 @import "admin/admin_dashboard";
 @import "admin/admin-dashboard-skeleton";
 @import "admin/admin_filter";
-@import "admin/admin_filter_controls";
 @import "admin/admin_reports";
 @import "admin/admin_report";
 @import "admin/admin_report_counters";

--- a/app/assets/stylesheets/admin/badges.scss
+++ b/app/assets/stylesheets/admin/badges.scss
@@ -25,7 +25,7 @@
   }
 
   .content-list {
-    .admin-filter-controls {
+    .d-filter-controls {
       border: 1px solid var(--content-border-color);
       border-bottom: none;
       padding: 0.5em;

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -20,6 +20,7 @@
 @import "composer-toggle-switch";
 @import "convert-to-public-topic-modal";
 @import "d-autocomplete";
+@import "d-filter-controls";
 @import "docked-composer";
 @import "d-toggle-switch";
 @import "date-input";

--- a/app/assets/stylesheets/common/components/d-filter-controls.scss
+++ b/app/assets/stylesheets/common/components/d-filter-controls.scss
@@ -1,4 +1,4 @@
-.admin-filter-controls {
+.d-filter-controls {
   display: flex;
   gap: var(--space-2);
   margin-block: var(--space-2);

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3215,6 +3215,10 @@ en:
     filter_input:
       clear: "Clear filter"
 
+    filter_controls:
+      reset: "Reset filter"
+      toggle: "Toggle dropdown filters"
+
     d_icon_grid_picker:
       select_icon: "Select icon"
       search_placeholder: "Search icons..."
@@ -6479,8 +6483,6 @@ en:
     # This is a text input placeholder, keep the translation short
     type_to_filter: "Type to filter…"
     settings: "Settings"
-    reset_filter: "Reset filter"
-    toggle_filters: "Toggle dropdown filters"
 
     admin:
       title: "Discourse Admin"

--- a/frontend/discourse/admin/components/admin-badges-list.gjs
+++ b/frontend/discourse/admin/components/admin-badges-list.gjs
@@ -1,8 +1,8 @@
 import Component from "@glimmer/component";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import DBadgeButton from "discourse/ui-kit/d-badge-button";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import { i18n } from "discourse-i18n";
 
 export default class AdminBadgesList extends Component {
@@ -24,7 +24,7 @@ export default class AdminBadgesList extends Component {
 
   <template>
     <div class="content-list">
-      <AdminFilterControls
+      <DFilterControls
         @array={{@badges}}
         @searchableProps={{this.searchableProps}}
         @textFilterQueryParam="filter"
@@ -47,7 +47,7 @@ export default class AdminBadgesList extends Component {
             {{/each}}
           </ul>
         </:content>
-      </AdminFilterControls>
+      </DFilterControls>
     </div>
     {{outlet}}
   </template>

--- a/frontend/discourse/admin/components/admin-category-management-list.gjs
+++ b/frontend/discourse/admin/components/admin-category-management-list.gjs
@@ -4,7 +4,6 @@ import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { ajax } from "discourse/lib/ajax";
@@ -13,6 +12,7 @@ import discourseDebounce from "discourse/lib/debounce";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import dCategoryBadge from "discourse/ui-kit/helpers/d-category-badge";
@@ -203,7 +203,7 @@ export default class AdminCategoryManagementList extends Component {
       {{/unless}}
 
       {{#if (availableCategoryType @categoryType)}}
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.categories}}
           @dropdownOptions={{VISIBILITY_FILTER_OPTIONS}}
           @inputPlaceholder={{i18n
@@ -378,7 +378,7 @@ export default class AdminCategoryManagementList extends Component {
               </DLoadMore>
             {{/if}}
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       {{/if}}
     </div>
   </template>

--- a/frontend/discourse/admin/components/admin-config-areas/components.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/components.gjs
@@ -7,7 +7,6 @@ import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import AdminConfigAreaEmptyList from "discourse/admin/components/admin-config-area-empty-list";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import InstallComponentModal from "discourse/admin/components/modal/install-theme";
 import { COMPONENTS } from "discourse/admin/models/theme";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -23,6 +22,7 @@ import { searchParamsFromPath } from "discourse/lib/url";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
@@ -261,7 +261,7 @@ export default class AdminConfigAreasComponents extends Component {
     </DPageSubheader>
     <div class="container">
       {{#if this.hasComponents}}
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.components}}
           @dropdownOptions={{STATUS_FILTER_OPTIONS}}
           @initialTextFilter={{this.nameFilter}}
@@ -315,7 +315,7 @@ export default class AdminConfigAreasComponents extends Component {
               <DConditionalLoadingSpinner @condition={{this.loadingMore}} />
             </DLoadMore>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       {{/if}}
       <DConditionalLoadingSpinner @condition={{this.loading}}>
         {{#unless this.hasComponents}}

--- a/frontend/discourse/admin/components/admin-config-areas/upcoming-changes.gjs
+++ b/frontend/discourse/admin/components/admin-config-areas/upcoming-changes.gjs
@@ -6,8 +6,8 @@ import { trackedObject } from "@ember/reactive/collections";
 import { service } from "@ember/service";
 import AdminConfigAreaEmptyList from "discourse/admin/components/admin-config-area-empty-list";
 import UpcomingChangeItem from "discourse/admin/components/admin-config-areas/upcoming-change-item";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import { AUTO_GROUPS } from "discourse/lib/constants";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import { i18n } from "discourse-i18n";
 
 export default class AdminConfigAreasUpcomingChanges extends Component {
@@ -159,7 +159,7 @@ export default class AdminConfigAreasUpcomingChanges extends Component {
   }
 
   <template>
-    <AdminFilterControls
+    <DFilterControls
       @array={{this.upcomingChanges}}
       @searchableProps={{array
         "humanized_name"
@@ -206,7 +206,7 @@ export default class AdminConfigAreasUpcomingChanges extends Component {
           </tbody>
         </table>
       </:content>
-    </AdminFilterControls>
+    </DFilterControls>
 
     {{#unless this.upcomingChanges}}
       <AdminConfigAreaEmptyList

--- a/frontend/discourse/admin/components/admin-filter-controls.gjs
+++ b/frontend/discourse/admin/components/admin-filter-controls.gjs
@@ -45,6 +45,8 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
  * @param {Function} [onDropdownChange] - Callback for dropdown selection changes
  * @param {Function} [onResetFilters] - Callback for reset action (server-side mode)
  * @param {String} [initialTextFilter] - Initial value to seed the text filter input on mount
+ * @param {Boolean} [showCustomEmptyState] - Whether to show a custom empty state when no results found,
+ *                                           if minItemsForFilter is set and the array is empty
  */
 
 export default class AdminFilterControls extends Component {
@@ -494,7 +496,11 @@ export default class AdminFilterControls extends Component {
         </div>
       {{/if}}
     {{else}}
-      {{yield this.array to="content"}}
+      {{#if @showCustomEmptyState}}
+        {{yield to="customEmptyState"}}
+      {{else}}
+        {{yield this.array to="content"}}
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/frontend/discourse/admin/components/admin-reports.gjs
+++ b/frontend/discourse/admin/components/admin-reports.gjs
@@ -1,12 +1,12 @@
 import Component from "@glimmer/component";
 import { array } from "@ember/helper";
 import { service } from "@ember/service";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import AdminSectionLandingItem from "discourse/admin/components/admin-section-landing-item";
 import AdminSectionLandingWrapper from "discourse/admin/components/admin-section-landing-wrapper";
 import { ajax } from "discourse/lib/ajax";
 import { bind } from "discourse/lib/decorators";
 import DAsyncContent from "discourse/ui-kit/d-async-content";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import { i18n } from "discourse-i18n";
 
 const REPORT_GROUPS = {
@@ -173,7 +173,7 @@ export default class AdminReports extends Component {
   <template>
     <DAsyncContent @asyncData={{this.loadReports}}>
       <:content as |reports|>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.filterReports reports}}
           @searchableProps={{array "title" "description"}}
           @dropdownOptions={{this.groupDropdownOptions reports}}
@@ -199,7 +199,7 @@ export default class AdminReports extends Component {
               </section>
             {{/each}}
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </:content>
     </DAsyncContent>
   </template>

--- a/frontend/discourse/admin/components/admin-user-upcoming-changes.gjs
+++ b/frontend/discourse/admin/components/admin-user-upcoming-changes.gjs
@@ -1,12 +1,12 @@
 import Component from "@glimmer/component";
 import { array } from "@ember/helper";
 import { trustHTML } from "@ember/template";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import { UPCOMING_CHANGES_USER_ENABLED_REASONS } from "discourse/lib/constants";
 import { bind } from "discourse/lib/decorators";
 import getUrl from "discourse/lib/get-url";
 import { escapeExpression } from "discourse/lib/utilities";
 import { and, eq } from "discourse/truth-helpers";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DModal from "discourse/ui-kit/d-modal";
 import dEmoji from "discourse/ui-kit/helpers/d-emoji";
 import { i18n } from "discourse-i18n";
@@ -49,7 +49,7 @@ export default class AdminUserUpcomingChanges extends Component {
           class="admin-user-upcoming-changes-modal__description"
         >{{this.description}}</p>
 
-        <AdminFilterControls
+        <DFilterControls
           @array={{@model.user.upcoming_changes_stats}}
           @searchableProps={{array "humanized_name" "description"}}
           @inputPlaceholder={{i18n
@@ -129,7 +129,7 @@ export default class AdminUserUpcomingChanges extends Component {
               </tbody>
             </table>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </:body>
     </DModal>
   </template>

--- a/frontend/discourse/admin/components/theme-site-settings.gjs
+++ b/frontend/discourse/admin/components/theme-site-settings.gjs
@@ -4,12 +4,12 @@ import { array } from "@ember/helper";
 import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { ajax } from "discourse/lib/ajax";
 import { currentThemeId, listThemes } from "discourse/lib/theme-selector";
 import { eq } from "discourse/truth-helpers";
 import DAsyncContent from "discourse/ui-kit/d-async-content";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import dBasePath from "discourse/ui-kit/helpers/d-base-path";
 import { i18n } from "discourse-i18n";
@@ -92,7 +92,7 @@ export default class ThemeSiteSettings extends Component {
 
       <DAsyncContent @asyncData={{this.loadThemeSiteSettings}}>
         <:content as |content|>
-          <AdminFilterControls
+          <DFilterControls
             @array={{this.filterableSettings content}}
             @searchableProps={{array
               "humanized_name"
@@ -162,7 +162,7 @@ export default class ThemeSiteSettings extends Component {
                 </tbody>
               </table>
             </:content>
-          </AdminFilterControls>
+          </DFilterControls>
         </:content>
       </DAsyncContent>
     </div>

--- a/frontend/discourse/admin/components/themes-grid.gjs
+++ b/frontend/discourse/admin/components/themes-grid.gjs
@@ -1,10 +1,10 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
 import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import DButton from "discourse/ui-kit/d-button";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ThemesGridCard from "./themes-grid-card";
@@ -61,7 +61,7 @@ export default class ThemesGrid extends Component {
   }
 
   <template>
-    <AdminFilterControls
+    <DFilterControls
       @array={{this.sortedThemes}}
       @minItemsForFilter={{FILTER_MINIMUM}}
       @searchableProps={{this.searchableProps}}
@@ -109,6 +109,6 @@ export default class ThemesGrid extends Component {
           />
         </div>
       </:content>
-    </AdminFilterControls>
+    </DFilterControls>
   </template>
 }

--- a/frontend/discourse/admin/templates/admin-config/color-palettes/index.gjs
+++ b/frontend/discourse/admin/templates/admin-config/color-palettes/index.gjs
@@ -1,10 +1,10 @@
 import { trustHTML } from "@ember/template";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import ColorPaletteListItem from "discourse/admin/components/color-palette-list-item";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import getUrl from "discourse/lib/get-url";
 import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DPageHeader from "discourse/ui-kit/d-page-header";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import { i18n } from "discourse-i18n";
@@ -64,7 +64,7 @@ export default <template>
     </p>
   {{/if}}
 
-  <AdminFilterControls
+  <DFilterControls
     @array={{@controller.displayedPalettes}}
     @minItemsForFilter={{FILTER_MINIMUM}}
     @searchableProps={{@controller.searchableProps}}
@@ -91,5 +91,5 @@ export default <template>
         {{/each}}
       </ul>
     </:content>
-  </AdminFilterControls>
+  </DFilterControls>
 </template>

--- a/frontend/discourse/admin/templates/admin-email-templates/index.gjs
+++ b/frontend/discourse/admin/templates/admin-email-templates/index.gjs
@@ -1,15 +1,15 @@
 import { array } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import DButton from "discourse/ui-kit/d-button";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import { i18n } from "discourse-i18n";
 
 export default <template>
   <PluginOutlet @name="admin-email-templates-index" @connectorTagName="div">
-    <AdminFilterControls
+    <DFilterControls
       @array={{@controller.shownTemplates}}
       @searchableProps={{array "title" "id"}}
       @textFilterQueryParam="filter"
@@ -76,6 +76,6 @@ export default <template>
           </tbody>
         </table>
       </:content>
-    </AdminFilterControls>
+    </DFilterControls>
   </PluginOutlet>
 </template>

--- a/frontend/discourse/admin/templates/admin-plugins/index.gjs
+++ b/frontend/discourse/admin/templates/admin-plugins/index.gjs
@@ -1,10 +1,10 @@
 import { concat } from "@ember/helper";
 import { trustHTML } from "@ember/template";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import AdminPluginsList from "discourse/admin/components/admin-plugins-list";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DNavItem from "discourse/ui-kit/d-nav-item";
 import DPageHeader from "discourse/ui-kit/d-page-header";
 import { i18n } from "discourse-i18n";
@@ -54,7 +54,7 @@ export default <template>
     </DPageHeader>
 
     {{#if @controller.model.length}}
-      <AdminFilterControls
+      <DFilterControls
         @array={{@controller.model}}
         @searchableProps={{@controller.searchableProps}}
         @dropdownOptions={{@controller.dropdownOptions}}
@@ -64,7 +64,7 @@ export default <template>
         <:content as |filteredPlugins|>
           <AdminPluginsList @plugins={{filteredPlugins}} />
         </:content>
-      </AdminFilterControls>
+      </DFilterControls>
     {{else}}
       <p>{{i18n "admin.plugins.none_installed"}}</p>
     {{/if}}

--- a/frontend/discourse/app/ui-kit/d-filter-controls.gjs
+++ b/frontend/discourse/app/ui-kit/d-filter-controls.gjs
@@ -21,12 +21,12 @@ import DSelect from "discourse/ui-kit/d-select";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 /**
- * admin filter controls component that support both client-side and server-side filtering
+ * filter controls component that support both client-side and server-side filtering
  *
  * client: provide searchableProps and filterFn in dropdownOptions
  * server: provide onTextFilterChange or onDropdownFilterChange callbacks
  *
- * @component AdminFilterControls
+ * @component DFilterControls
  * @param {Array} array - The dataset to display
  * @param {Array} [searchableProps] - Property names to search for client-side text filtering, can be dot-separated
  *                                for nested properties (e.g. "user.name")
@@ -49,7 +49,7 @@ import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
  *                                           if minItemsForFilter is set and the array is empty
  */
 
-export default class AdminFilterControls extends Component {
+export default class DFilterControls extends Component {
   @service router;
 
   @tracked dropdownFilter = "all";
@@ -383,7 +383,7 @@ export default class AdminFilterControls extends Component {
     }
 
     schedule("afterRender", () => {
-      document.querySelector(".admin-filter-controls__input")?.focus();
+      document.querySelector(".d-filter-controls__input")?.focus();
     });
   }
 
@@ -398,7 +398,7 @@ export default class AdminFilterControls extends Component {
     {{#if this.showFilters}}
       <div
         class={{dConcatClass
-          "admin-filter-controls"
+          "d-filter-controls"
           (if this.hasMultipleDropdowns "--multiple-dropdowns")
         }}
         {{didInsert this.applyDropdownsFromUrl}}
@@ -408,34 +408,34 @@ export default class AdminFilterControls extends Component {
           @dropdownValue
         }}
       >
-        <div class="admin-filter-controls__inputs">
+        <div class="d-filter-controls__inputs">
           <DFilterInput
             placeholder={{@inputPlaceholder}}
             @filterAction={{this.onTextFilterChange}}
             @value={{this.textFilter}}
-            class="admin-filter-controls__input"
+            class="d-filter-controls__input"
             @icons={{hash left="magnifying-glass"}}
           />
 
           {{#if this.hasMultipleDropdowns}}
             <DButton
-              class="btn-transparent admin-filter-controls__toggle-filters"
+              class="btn-transparent d-filter-controls__toggle-filters"
               @icon="filter"
-              @title="toggle_filters"
+              @title="filter_controls.toggle"
               @action={{this.toggleFilters}}
             />
           {{/if}}
         </div>
 
         {{#if this.showDropdownFilter}}
-          <div class="admin-filter-controls__dropdowns">
+          <div class="d-filter-controls__dropdowns">
             {{#if this.hasMultipleDropdowns}}
               {{#each-in this.dropdownOptions as |key options|}}
                 <DSelect
                   @value={{get this.dropdownFilters key}}
                   @includeNone={{false}}
                   @onChange={{fn this.onDropdownFilterChange key}}
-                  class="admin-filter-controls__dropdown admin-filter-controls__dropdown--{{key}}"
+                  class="d-filter-controls__dropdown d-filter-controls__dropdown--{{key}}"
                   data-dropdown-key={{key}}
                   as |select|
                 >
@@ -451,7 +451,7 @@ export default class AdminFilterControls extends Component {
                 @value={{this.dropdownFilter}}
                 @includeNone={{false}}
                 @onChange={{this.onDropdownFilterChange}}
-                class="admin-filter-controls__dropdown"
+                class="d-filter-controls__dropdown"
                 as |select|
               >
                 {{#each this.dropdownOptions as |option|}}
@@ -467,9 +467,9 @@ export default class AdminFilterControls extends Component {
         {{#if (and this.hasActiveFilters (not @loading))}}
           <DButton
             @icon="arrow-rotate-left"
-            @label="reset_filter"
+            @label="filter_controls.reset"
             @action={{this.resetFilters}}
-            class="btn-default admin-filter-controls__reset"
+            class="btn-default d-filter-controls__reset"
           />
         {{/if}}
 
@@ -483,15 +483,15 @@ export default class AdminFilterControls extends Component {
       {{yield this.filteredData to="content"}}
     {{else if this.showFilters}}
       {{#if (and this.hasActiveFilters (not @loading))}}
-        <div class="admin-filter-controls__no-results">
+        <div class="d-filter-controls__no-results">
           {{#if @noResultsMessage}}
             <p>{{@noResultsMessage}}</p>
           {{/if}}
           <DButton
             @icon="arrow-rotate-left"
-            @label="reset_filter"
+            @label="filter_controls.reset"
             @action={{this.resetFilters}}
-            class="btn-default admin-filter-controls__reset"
+            class="btn-default d-filter-controls__reset"
           />
         </div>
       {{/if}}

--- a/frontend/discourse/tests/acceptance/admin-customize-components-config-area-test.gjs
+++ b/frontend/discourse/tests/acceptance/admin-customize-components-config-area-test.gjs
@@ -127,10 +127,10 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
       "the first request includes the status filter from the URL"
     );
     assert
-      .dom(".admin-filter-controls__input")
+      .dom(".d-filter-controls__input")
       .hasValue("air", "prefills the search input from the URL");
     assert
-      .dom(".admin-filter-controls__dropdown")
+      .dom(".d-filter-controls__dropdown")
       .hasValue("unused", "preselects the status dropdown from the URL");
     assert.dom(".admin-config-components__component-row").exists({ count: 1 });
   });
@@ -144,7 +144,7 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
       "does not send the invalid status to the server"
     );
     assert
-      .dom(".admin-filter-controls__dropdown")
+      .dom(".d-filter-controls__dropdown")
       .hasValue("all", "the status dropdown falls back to the default value");
     assert.dom(".admin-config-components__component-row").exists({ count: 2 });
   });
@@ -152,7 +152,7 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
   test("reflects the search in the URL as the user types", async function (assert) {
     await visit("/admin/config/customize/components");
 
-    await fillIn(".admin-filter-controls__input", "air");
+    await fillIn(".d-filter-controls__input", "air");
 
     assert.strictEqual(
       requests.at(-1).name,
@@ -166,10 +166,10 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
     );
     assert.dom(".admin-config-components__component-row").exists({ count: 1 });
     assert
-      .dom(".admin-filter-controls__input")
+      .dom(".d-filter-controls__input")
       .isFocused("keeps focus while the URL updates");
 
-    await fillIn(".admin-filter-controls__input", "");
+    await fillIn(".d-filter-controls__input", "");
 
     assert.strictEqual(
       currentURL(),
@@ -182,7 +182,7 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
   test("reflects the status dropdown in the URL", async function (assert) {
     await visit("/admin/config/customize/components");
 
-    await select(".admin-filter-controls__dropdown", "used");
+    await select(".d-filter-controls__dropdown", "used");
 
     assert.strictEqual(
       requests.at(-1).status,
@@ -196,7 +196,7 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
     );
     assert.dom(".admin-config-components__component-row").exists({ count: 1 });
 
-    await select(".admin-filter-controls__dropdown", "all");
+    await select(".d-filter-controls__dropdown", "all");
 
     assert.strictEqual(
       currentURL(),
@@ -209,15 +209,15 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
   test("resetting the filters clears the params from the URL", async function (assert) {
     await visit("/admin/config/customize/components?filter=air&status=unused");
 
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
 
     assert.strictEqual(
       currentURL(),
       "/admin/config/customize/components",
       "removes both params in a single URL update"
     );
-    assert.dom(".admin-filter-controls__input").hasValue("");
-    assert.dom(".admin-filter-controls__dropdown").hasValue("all");
+    assert.dom(".d-filter-controls__input").hasValue("");
+    assert.dom(".d-filter-controls__dropdown").hasValue("all");
     assert.strictEqual(
       requests.at(-1).name,
       "",
@@ -235,14 +235,14 @@ acceptance("Admin - Config areas - Components - filters", function (needs) {
     await visit("/admin/config/customize/components?filter=nomatch");
 
     assert
-      .dom(".admin-filter-controls")
+      .dom(".d-filter-controls")
       .exists("the filter controls render despite the empty filtered result");
     assert
-      .dom(".admin-filter-controls__input")
+      .dom(".d-filter-controls__input")
       .hasValue("nomatch", "prefills the search input from the URL");
     assert.dom(".admin-config-components__component-row").doesNotExist();
     assert
-      .dom(".admin-filter-controls__no-results .admin-filter-controls__reset")
+      .dom(".d-filter-controls__no-results .d-filter-controls__reset")
       .exists("a reset button renders alongside the no-results message");
     assert
       .dom(".admin-config-area-empty-list")

--- a/frontend/discourse/tests/acceptance/admin-email-templates-test.js
+++ b/frontend/discourse/tests/acceptance/admin-email-templates-test.js
@@ -36,11 +36,11 @@ acceptance("Admin - Email Templates - URL filters", function (needs) {
   test("seeds and updates the URL filters", async function (assert) {
     await visit("/admin/email/templates?filter=login&overridden=true");
 
-    assert.dom(".admin-filter-controls__input").hasValue("login");
+    assert.dom(".d-filter-controls__input").hasValue("login");
     assert.dom("#toggle-overridden").isChecked();
     assert.dom("tr.email-templates-list__row").exists({ count: 1 });
 
-    await fillIn(".admin-filter-controls__input", "sign");
+    await fillIn(".d-filter-controls__input", "sign");
     assert.strictEqual(
       currentURL(),
       "/admin/email/templates?filter=sign&overridden=true"

--- a/frontend/discourse/tests/acceptance/admin-sidebar-section-test.js
+++ b/frontend/discourse/tests/acceptance/admin-sidebar-section-test.js
@@ -168,7 +168,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       .dom(".admin-reports-list .admin-section-landing-item__content")
       .exists({ count: 1 });
 
-    await fillIn(".admin-filter-controls__input", "flags");
+    await fillIn(".d-filter-controls__input", "flags");
 
     assert
       .dom(".admin-reports-list .admin-section-landing-item__content")
@@ -181,7 +181,7 @@ acceptance("Admin Sidebar - Sections", function (needs) {
       .dom(".admin-reports-list .admin-section-landing-item__content")
       .exists({ count: 1 }, "navigating back and forth resets filter");
 
-    await fillIn(".admin-filter-controls__input", "activities");
+    await fillIn(".d-filter-controls__input", "activities");
 
     assert
       .dom(".admin-reports-list .admin-section-landing-item__content")

--- a/frontend/discourse/tests/acceptance/admin-upcoming-changes-test.js
+++ b/frontend/discourse/tests/acceptance/admin-upcoming-changes-test.js
@@ -61,11 +61,11 @@ acceptance("Admin - Upcoming Changes - URL filters", function (needs) {
     );
 
     assert
-      .dom(".admin-filter-controls__input")
+      .dom(".d-filter-controls__input")
       .hasValue("alpha_composer,beta_sidebar");
     assert.dom(".upcoming-change-row").exists({ count: 2 });
 
-    await fillIn(".admin-filter-controls__input", "beta_sidebar");
+    await fillIn(".d-filter-controls__input", "beta_sidebar");
     assert.strictEqual(
       currentURL(),
       "/admin/config/upcoming-changes?changeNamesFilter=beta_sidebar"
@@ -78,8 +78,8 @@ acceptance("Admin - Upcoming Changes - URL filters", function (needs) {
     );
     await visit("/admin/config/upcoming-changes?status=stable");
 
-    assert.dom(".admin-filter-controls__input").hasValue("");
-    assert.dom(".admin-filter-controls__dropdown--status").hasValue("stable");
+    assert.dom(".d-filter-controls__input").hasValue("");
+    assert.dom(".d-filter-controls__dropdown--status").hasValue("stable");
     assert
       .dom(".upcoming-change-row[data-upcoming-change='stable_defaults']")
       .exists();
@@ -91,11 +91,11 @@ acceptance("Admin - Upcoming Changes - URL filters", function (needs) {
     );
 
     assert.dom(".upcoming-change-row").exists({ count: 1 });
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
 
     assert.strictEqual(currentURL(), "/admin/config/upcoming-changes");
-    assert.dom(".admin-filter-controls__input").hasValue("");
-    assert.dom(".admin-filter-controls__dropdown--status").hasValue("all");
+    assert.dom(".d-filter-controls__input").hasValue("");
+    assert.dom(".d-filter-controls__dropdown--status").hasValue("all");
     assert.dom(".upcoming-change-row").exists({ count: 3 });
   });
 });

--- a/frontend/discourse/tests/acceptance/reports-test.js
+++ b/frontend/discourse/tests/acceptance/reports-test.js
@@ -109,7 +109,7 @@ acceptance("Reports | Filter query params", function (needs) {
   test("typing in the filter box reflects the search in the URL", async function (assert) {
     await visit("/admin/reports");
 
-    await fillIn(".admin-filter-controls__input", "signups");
+    await fillIn(".d-filter-controls__input", "signups");
 
     assert.strictEqual(
       currentURL(),
@@ -121,10 +121,10 @@ acceptance("Reports | Filter query params", function (needs) {
       .dom(".admin-section-landing-item__title")
       .hasHtml("Signups", "only shows the matching report");
     assert
-      .dom(".admin-filter-controls__input")
+      .dom(".d-filter-controls__input")
       .isFocused("keeps focus while the URL updates");
 
-    await fillIn(".admin-filter-controls__input", "");
+    await fillIn(".d-filter-controls__input", "");
 
     assert.strictEqual(
       currentURL(),
@@ -137,7 +137,7 @@ acceptance("Reports | Filter query params", function (needs) {
   test("selecting a group reflects it in the URL", async function (assert) {
     await visit("/admin/reports");
 
-    await select(".admin-filter-controls__dropdown", "moderation_and_security");
+    await select(".d-filter-controls__dropdown", "moderation_and_security");
 
     assert.strictEqual(
       currentURL(),
@@ -147,7 +147,7 @@ acceptance("Reports | Filter query params", function (needs) {
     assert.dom(".admin-reports-group").exists({ count: 1 });
     assert.dom(".admin-section-landing-item__content").exists({ count: 1 });
 
-    await select(".admin-filter-controls__dropdown", "all");
+    await select(".d-filter-controls__dropdown", "all");
 
     assert.strictEqual(
       currentURL(),
@@ -161,7 +161,7 @@ acceptance("Reports | Filter query params", function (needs) {
     await visit("/admin/reports?group=content");
 
     assert.strictEqual(currentURL(), "/admin/reports?group=content");
-    assert.dom(".admin-filter-controls__dropdown").hasValue("content");
+    assert.dom(".d-filter-controls__dropdown").hasValue("content");
     assert.dom(".admin-reports-group").exists({ count: 1 });
     assert
       .dom(".admin-section-landing-item__title")
@@ -174,12 +174,12 @@ acceptance("Reports | Filter query params", function (needs) {
     // same-route transition to the bare URL fires no route event at all
     await visit("/admin/reports?group=content");
 
-    assert.dom(".admin-filter-controls__dropdown").hasValue("content");
+    assert.dom(".d-filter-controls__dropdown").hasValue("content");
 
     await visit("/admin/reports?group=moderation_and_security");
 
     assert
-      .dom(".admin-filter-controls__dropdown")
+      .dom(".d-filter-controls__dropdown")
       .hasValue(
         "moderation_and_security",
         "re-selects the dropdown from the new URL"
@@ -192,7 +192,7 @@ acceptance("Reports | Filter query params", function (needs) {
   test("falls back to all groups when the URL group is unknown", async function (assert) {
     await visit("/admin/reports?group=nonsense");
 
-    assert.dom(".admin-filter-controls__dropdown").hasValue("all");
+    assert.dom(".d-filter-controls__dropdown").hasValue("all");
     assert.dom(".admin-reports-group").exists({ count: 3 });
     assert.dom(".admin-section-landing-item__content").exists({ count: 3 });
   });
@@ -200,8 +200,8 @@ acceptance("Reports | Filter query params", function (needs) {
   test("reset button clears both params from the URL", async function (assert) {
     await visit("/admin/reports");
 
-    await fillIn(".admin-filter-controls__input", "signups");
-    await select(".admin-filter-controls__dropdown", "engagement");
+    await fillIn(".d-filter-controls__input", "signups");
+    await select(".d-filter-controls__dropdown", "engagement");
 
     assert.strictEqual(
       currentURL(),
@@ -209,15 +209,15 @@ acceptance("Reports | Filter query params", function (needs) {
       "both filters are in the URL"
     );
 
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
 
     assert.strictEqual(
       currentURL(),
       "/admin/reports",
       "clears both params in one write"
     );
-    assert.dom(".admin-filter-controls__input").hasValue("");
-    assert.dom(".admin-filter-controls__dropdown").hasValue("all");
+    assert.dom(".d-filter-controls__input").hasValue("");
+    assert.dom(".d-filter-controls__dropdown").hasValue("all");
     assert.dom(".admin-section-landing-item__content").exists({ count: 3 });
   });
 });

--- a/frontend/discourse/tests/integration/components/admin-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-filter-controls-test.gjs
@@ -916,4 +916,29 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
       .dom(".item")
       .exists({ count: 2 }, "applies the dropdown filter from the new URL");
   });
+
+  test("shows a custom empty state in a yield when showEmptyState is true and the array is empty", async function (assert) {
+    this.set("data", []);
+
+    await render(
+      <template>
+        <AdminFilterControls
+          @array={{this.data}}
+          @showCustomEmptyState={{true}}
+          @minItemsForFilter={{1}}
+        >
+          <:content>
+            N/A
+          </:content>
+          <:customEmptyState>
+            <div class="custom-empty-state">Custom Empty State</div>
+          </:customEmptyState>
+        </AdminFilterControls>
+      </template>
+    );
+
+    assert
+      .dom(".custom-empty-state")
+      .exists("renders the custom empty state when array is empty");
+  });
 });

--- a/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
@@ -3,8 +3,8 @@ import Evented from "@ember/object/evented";
 import Service from "@ember/service";
 import { click, fillIn, render, select, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 
 const SAMPLE_DATA = [
   {
@@ -53,7 +53,7 @@ class RouterStub extends Service.extend(Evented) {
   }
 }
 
-module("Integration | Component | AdminFilterControls", function (hooks) {
+module("Integration | ui-kit | DFilterControls", function (hooks) {
   setupRenderingTest(hooks);
 
   test("renders text filter input", async function (assert) {
@@ -61,7 +61,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls @array={{this.data}} @inputPlaceholder="Search...">
+        <DFilterControls @array={{this.data}} @inputPlaceholder="Search...">
           <:content as |filteredData|>
             <div class="results">
               {{#each filteredData as |item|}}
@@ -69,13 +69,11 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
-    assert
-      .dom(".admin-filter-controls__input")
-      .exists("renders text filter input");
+    assert.dom(".d-filter-controls__input").exists("renders text filter input");
     assert
       .dom(".filter-input")
       .hasAttribute("placeholder", "Search...", "has correct placeholder");
@@ -87,7 +85,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @inputPlaceholder="Search..."
@@ -99,7 +97,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -119,7 +117,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
         >
@@ -130,12 +128,12 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert
-      .dom(".admin-filter-controls__dropdown")
+      .dom(".d-filter-controls__dropdown")
       .exists("renders dropdown filter");
   });
 
@@ -145,7 +143,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
         >
@@ -156,13 +154,13 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert.dom(".item").exists({ count: 3 }, "shows all items initially");
 
-    await select(".admin-filter-controls__dropdown", "feature");
+    await select(".d-filter-controls__dropdown", "feature");
 
     assert
       .dom(".item")
@@ -181,7 +179,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @dropdownOptions={{this.dropdownOptions}}
@@ -193,13 +191,13 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert.dom(".item").exists({ count: 3 }, "shows all items initially");
 
-    await select(".admin-filter-controls__dropdown", "feature");
+    await select(".d-filter-controls__dropdown", "feature");
 
     assert
       .dom(".item")
@@ -219,7 +217,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
         >
@@ -230,21 +228,21 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert
-      .dom(".admin-filter-controls__reset")
+      .dom(".d-filter-controls__reset")
       .doesNotExist("no reset button initially");
 
     await fillIn(".filter-input", "nonexistent");
 
     assert
-      .dom(".admin-filter-controls__no-results")
+      .dom(".d-filter-controls__no-results")
       .exists("shows no results message");
     assert
-      .dom(".admin-filter-controls__reset")
+      .dom(".d-filter-controls__reset")
       .exists("shows reset button after filtering");
   });
 
@@ -254,7 +252,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
         >
@@ -265,7 +263,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -278,7 +276,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
       .dom(".item")
       .doesNotExist("does not show any results when filters find none");
 
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
 
     assert.dom(".item").exists({ count: 3 }, "shows all items after reset");
     assert.dom(".filter-input").hasValue("", "clears text input");
@@ -290,7 +288,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
         >
@@ -301,13 +299,13 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     await fillIn(".filter-input", "first");
     assert
-      .dom(".admin-filter-controls > .admin-filter-controls__reset")
+      .dom(".d-filter-controls > .d-filter-controls__reset")
       .exists("shows reset button after filter controls");
   });
 
@@ -316,7 +314,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls @array={{this.data}} @minItemsForFilter={{2}}>
+        <DFilterControls @array={{this.data}} @minItemsForFilter={{2}}>
           <:content as |filteredData|>
             <div class="results">
               {{#each filteredData as |item|}}
@@ -324,12 +322,12 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert
-      .dom(".admin-filter-controls")
+      .dom(".d-filter-controls")
       .doesNotExist("hides filters when items below minimum");
     assert
       .dom(".item")
@@ -344,7 +342,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @onTextFilterChange={{this.textFilterCallback}}
         >
@@ -355,7 +353,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -376,7 +374,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
           @onDropdownFilterChange={{this.dropdownFilterCallback}}
@@ -388,11 +386,11 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
-    await select(".admin-filter-controls__dropdown", "feature");
+    await select(".d-filter-controls__dropdown", "feature");
 
     assert.verifySteps(
       ["dropdown-filter:feature"],
@@ -409,7 +407,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @onResetFilters={{this.resetCallback}}
@@ -421,12 +419,12 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     await fillIn(".filter-input", "test");
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
 
     assert.verifySteps(["reset-filters"], "calls reset callback");
   });
@@ -438,7 +436,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @onTextFilterChange={{this.textFilterCallback}}
@@ -450,7 +448,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -469,7 +467,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls @array={{this.data}}>
+        <DFilterControls @array={{this.data}}>
           <:actions>
             <button type="button" class="custom-action">Custom Action</button>
           </:actions>
@@ -480,7 +478,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -494,7 +492,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls @array={{this.data}}>
+        <DFilterControls @array={{this.data}}>
           <:aboveContent>
             <div class="above-content">Above Content Area</div>
           </:aboveContent>
@@ -505,7 +503,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -520,7 +518,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @noResultsMessage="No items found matching your criteria"
@@ -532,14 +530,14 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     await fillIn(".filter-input", "nonexistent");
 
     assert
-      .dom(".admin-filter-controls__no-results p")
+      .dom(".d-filter-controls__no-results p")
       .hasText(
         "No items found matching your criteria",
         "shows custom no results message"
@@ -552,7 +550,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
         >
@@ -563,12 +561,12 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert
-      .dom(".admin-filter-controls__dropdown")
+      .dom(".d-filter-controls__dropdown")
       .doesNotExist("hides dropdown when only one option");
   });
 
@@ -587,7 +585,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
         >
@@ -598,18 +596,18 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert
-      .dom(".admin-filter-controls__dropdown")
+      .dom(".d-filter-controls__dropdown")
       .exists({ count: 2 }, "renders two dropdowns");
     assert
-      .dom(".admin-filter-controls__dropdown--category")
+      .dom(".d-filter-controls__dropdown--category")
       .exists("renders category dropdown");
     assert
-      .dom(".admin-filter-controls__dropdown--enabled")
+      .dom(".d-filter-controls__dropdown--enabled")
       .exists("renders enabled dropdown");
   });
 
@@ -636,7 +634,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
         >
@@ -647,19 +645,19 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert.dom(".item").exists({ count: 3 }, "shows all items initially");
 
-    await select(".admin-filter-controls__dropdown--category", "feature");
+    await select(".d-filter-controls__dropdown--category", "feature");
 
     assert
       .dom(".item")
       .exists({ count: 2 }, "shows only feature items after category filter");
 
-    await select(".admin-filter-controls__dropdown--enabled", "enabled");
+    await select(".d-filter-controls__dropdown--enabled", "enabled");
 
     assert
       .dom(".item")
@@ -687,7 +685,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @dropdownOptions={{this.dropdownOptions}}
@@ -699,17 +697,17 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
-    await select(".admin-filter-controls__dropdown--category", "feature");
+    await select(".d-filter-controls__dropdown--category", "feature");
     await fillIn(".filter-input", "first");
 
     assert.dom(".item").exists({ count: 1 }, "shows filtered results");
 
     await fillIn(".filter-input", "firstblah");
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
 
     assert.dom(".item").exists({ count: 3 }, "shows all items after reset");
   });
@@ -732,7 +730,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
           @onDropdownFilterChange={{this.dropdownFilterCallback}}
@@ -744,12 +742,12 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
-    await select(".admin-filter-controls__dropdown--category", "feature");
-    await select(".admin-filter-controls__dropdown--enabled", "enabled");
+    await select(".d-filter-controls__dropdown--category", "feature");
+    await select(".d-filter-controls__dropdown--enabled", "enabled");
 
     assert.verifySteps(
       ["dropdown-filter:category:feature", "dropdown-filter:enabled:enabled"],
@@ -773,7 +771,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
           @defaultDropdownValue={{this.defaultDropdownValue}}
@@ -785,7 +783,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
@@ -796,7 +794,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
         "shows only feature items initially because of defaultDropdownValue"
       );
 
-    await select(".admin-filter-controls__dropdown--category", "all");
+    await select(".d-filter-controls__dropdown--category", "all");
 
     assert
       .dom(".item")
@@ -812,7 +810,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @dropdownOptions={{this.dropdownOptions}}
@@ -826,21 +824,21 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert.dom(".item").exists({ count: 3 }, "renders all items");
 
-    await fillIn(".admin-filter-controls__input", "second");
+    await fillIn(".d-filter-controls__input", "second");
     assert.dom(".item").exists({ count: 1 }, "text filtering still works");
 
-    await select(".admin-filter-controls__dropdown", "feature");
+    await select(".d-filter-controls__dropdown", "feature");
     assert
       .dom(".item")
       .doesNotExist("dropdown filtering still combines with text");
 
-    await click(".admin-filter-controls__reset");
+    await click(".d-filter-controls__reset");
     assert.dom(".item").exists({ count: 3 }, "reset still works");
   });
 
@@ -850,7 +848,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @searchableProps={{this.searchableProps}}
           @textFilterQueryParam="filter"
@@ -863,11 +861,11 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
-    assert.dom(".admin-filter-controls__input").hasValue("third");
+    assert.dom(".d-filter-controls__input").hasValue("third");
     assert.dom(".item").exists({ count: 1 }, "applies the seeded filter");
   });
 
@@ -883,7 +881,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @dropdownOptions={{this.dropdownOptions}}
           @dropdownFilterQueryParams={{this.dropdownFilterQueryParams}}
@@ -896,12 +894,12 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
               {{/each}}
             </div>
           </:content>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 
     assert
-      .dom(".admin-filter-controls__dropdown--category")
+      .dom(".d-filter-controls__dropdown--category")
       .doesNotExist("keeps inactive dropdown filters collapsed initially");
 
     this.owner
@@ -910,7 +908,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
     await settled();
 
     assert
-      .dom(".admin-filter-controls__dropdown--category")
+      .dom(".d-filter-controls__dropdown--category")
       .hasValue("feature", "reveals the URL-owned active dropdown");
     assert
       .dom(".item")
@@ -922,7 +920,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
 
     await render(
       <template>
-        <AdminFilterControls
+        <DFilterControls
           @array={{this.data}}
           @showCustomEmptyState={{true}}
           @minItemsForFilter={{1}}
@@ -933,7 +931,7 @@ module("Integration | Component | AdminFilterControls", function (hooks) {
           <:customEmptyState>
             <div class="custom-empty-state">Custom Empty State</div>
           </:customEmptyState>
-        </AdminFilterControls>
+        </DFilterControls>
       </template>
     );
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-list-editor.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-agent-list-editor.gjs
@@ -5,7 +5,6 @@ import { action } from "@ember/object";
 import { LinkTo } from "@ember/routing";
 import { service } from "@ember/service";
 import AdminConfigAreaEmptyList from "discourse/admin/components/admin-config-area-empty-list";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import DMenu from "discourse/float-kit/components/d-menu";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -14,6 +13,7 @@ import { gt } from "discourse/truth-helpers";
 import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
 import DButton from "discourse/ui-kit/d-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -219,7 +219,7 @@ export default class AiAgentListEditor extends Component {
           </:actions>
         </DPageSubheader>
         {{#if @agents.content}}
-          <AdminFilterControls
+          <DFilterControls
             @array={{@agents.content}}
             @searchableProps={{this.searchableProps}}
             @dropdownOptions={{this.dropdownOptions}}
@@ -346,7 +346,7 @@ export default class AiAgentListEditor extends Component {
                 </tbody>
               </table>
             </:content>
-          </AdminFilterControls>
+          </DFilterControls>
         {{else}}
           <AdminConfigAreaEmptyList
             @ctaLabel="discourse_ai.ai_agent.new"

--- a/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
+++ b/plugins/discourse-data-explorer/admin/assets/javascripts/admin/templates/admin-plugins/show/explorer/index.gjs
@@ -1,9 +1,9 @@
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
-import AdminFilterControls from "discourse/admin/components/admin-filter-controls";
 import { not } from "discourse/truth-helpers";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DPickFilesButton from "discourse/ui-kit/d-pick-files-button";
@@ -38,7 +38,7 @@ export default <template>
         </:actions>
       </DPageSubheader>
 
-      <AdminFilterControls
+      <DFilterControls
         @array={{@controller.model.content}}
         @inputPlaceholder={{i18n "explorer.search_placeholder"}}
         @noResultsMessage={{i18n "explorer.no_search_results"}}
@@ -229,7 +229,7 @@ export default <template>
             <div class="explorer-pad-bottom"></div>
           {{/if}}
         </:content>
-      </AdminFilterControls>
+      </DFilterControls>
     {{/if}}
   </div>
 </template>

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/list-queries-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/list-queries-test.js
@@ -61,7 +61,7 @@ acceptance("List Queries", function (needs) {
     await visit("/admin/plugins/discourse-data-explorer/queries");
 
     assert
-      .dom(".admin-filter-controls__input")
+      .dom(".d-filter-controls__input")
       .hasAttribute(
         "placeholder",
         i18n("explorer.search_placeholder"),

--- a/spec/system/admin_color_palettes_config_area_spec.rb
+++ b/spec/system/admin_color_palettes_config_area_spec.rb
@@ -101,13 +101,13 @@ describe "Admin Color Palettes Config Area Page" do
     it "shows filters when there are more than 8 color schemes" do
       config_area.visit
 
-      expect(page).to have_css(".admin-filter-controls__input")
+      expect(page).to have_css(".d-filter-controls__input")
     end
 
     it "can filter by text search" do
       config_area.visit
 
-      find(".admin-filter-controls__input").fill_in(with: user_selectable_palette.name)
+      find(".d-filter-controls__input").fill_in(with: user_selectable_palette.name)
 
       expect(page).to have_css("[data-palette-id='#{user_selectable_palette.id}']")
       expect(page).to have_no_css("[data-palette-id='#{regular_palette.id}']")
@@ -127,10 +127,10 @@ describe "Admin Color Palettes Config Area Page" do
     it "shows no results state" do
       config_area.visit
 
-      find(".admin-filter-controls__input").fill_in(with: "bananas")
+      find(".d-filter-controls__input").fill_in(with: "bananas")
 
-      expect(page).to have_css(".admin-filter-controls__no-results")
-      expect(page).to have_css("button", text: I18n.t("admin_js.reset_filter"))
+      expect(page).to have_css(".d-filter-controls__no-results")
+      expect(page).to have_css("button", text: I18n.t("js.filter_controls.reset"))
     end
   end
 

--- a/spec/system/d_filter_controls_spec.rb
+++ b/spec/system/d_filter_controls_spec.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-describe "AdminFilterControls" do
+describe "DFilterControls" do
   fab!(:admin)
 
-  let(:filter_controls) do
-    PageObjects::Components::AdminFilterControls.new(".admin-filter-controls")
-  end
+  let(:filter_controls) { PageObjects::Components::DFilterControls.new(".d-filter-controls") }
 
   before do
     sign_in(admin)
@@ -22,7 +20,7 @@ describe "AdminFilterControls" do
     it "filters plugins by text input" do
       page.visit("/admin/plugins")
 
-      expect(page).to have_css(".admin-filter-controls")
+      expect(page).to have_css(".d-filter-controls")
       expect(page).to have_css(".admin-plugins-list__row", count: 2)
 
       filter_controls.type_in_search("poll")
@@ -37,7 +35,7 @@ describe "AdminFilterControls" do
     it "filters plugins by dropdown selection" do
       page.visit("/admin/plugins")
 
-      expect(page).to have_css(".admin-filter-controls")
+      expect(page).to have_css(".d-filter-controls")
 
       filter_controls.select_dropdown_option("Enabled")
       expect(page).to have_css(".admin-plugins-list__row", count: 2)
@@ -54,7 +52,7 @@ describe "AdminFilterControls" do
     it "shows reset button when filters are active and no results" do
       page.visit("/admin/plugins")
 
-      expect(page).to have_css(".admin-filter-controls")
+      expect(page).to have_css(".d-filter-controls")
 
       expect(filter_controls).to have_no_no_results_reset_button
       filter_controls.type_in_search("xyznonexistent")
@@ -69,7 +67,7 @@ describe "AdminFilterControls" do
     it "also shows reset button when there are results and active filters" do
       page.visit("/admin/plugins")
 
-      expect(page).to have_css(".admin-filter-controls")
+      expect(page).to have_css(".d-filter-controls")
 
       expect(filter_controls).to have_no_reset_button
       filter_controls.type_in_search("poll")
@@ -86,7 +84,7 @@ describe "AdminFilterControls" do
     it "shows configurable no results message" do
       page.visit("/admin/plugins")
 
-      expect(page).to have_css(".admin-filter-controls")
+      expect(page).to have_css(".d-filter-controls")
 
       filter_controls.type_in_search("xyznonexistent")
       expect(page).to have_css(".admin-plugins-list__row", count: 0)

--- a/spec/system/page_objects/components/d_filter_controls.rb
+++ b/spec/system/page_objects/components/d_filter_controls.rb
@@ -2,7 +2,7 @@
 
 module PageObjects
   module Components
-    class AdminFilterControls < PageObjects::Components::Base
+    class DFilterControls < PageObjects::Components::Base
       def initialize(component_selector, has_multiple_dropdowns: false)
         @component_selector = component_selector
         @has_multiple_dropdowns = has_multiple_dropdowns
@@ -13,69 +13,69 @@ module PageObjects
       end
 
       def type_in_search(input)
-        component.find(".admin-filter-controls__input").send_keys(input)
+        component.find(".d-filter-controls__input").send_keys(input)
       end
 
       def clear_search
-        component.find(".admin-filter-controls__input").set("")
+        component.find(".d-filter-controls__input").set("")
       end
 
       def select_dropdown_option(text, dropdown_id: nil)
-        selector = ".admin-filter-controls__dropdown"
+        selector = ".d-filter-controls__dropdown"
         selector += "#{selector}--#{dropdown_id}" if dropdown_id
         component.find(selector).select(text)
       end
 
       def select_all_dropdown_option(dropdown_id: nil)
-        selector = ".admin-filter-controls__dropdown"
+        selector = ".d-filter-controls__dropdown"
         selector += "#{selector}--#{dropdown_id}" if dropdown_id
         find(selector).find("option[value='all']").select_option
       end
 
       def toggle_dropdown_filters
-        component.find(".admin-filter-controls__toggle-filters").click
+        component.find(".d-filter-controls__toggle-filters").click
       end
 
       def has_no_results_reset_button?
-        page.has_css?(".admin-filter-controls__no-results .admin-filter-controls__reset")
+        page.has_css?(".d-filter-controls__no-results .d-filter-controls__reset")
       end
 
       def has_reset_button?
-        component.has_css?("> .admin-filter-controls__reset")
+        component.has_css?("> .d-filter-controls__reset")
       end
 
       def click_reset_button
-        component.find("> .admin-filter-controls__reset").click
+        component.find("> .d-filter-controls__reset").click
       end
 
       def click_no_results_reset_button
-        page.find(".admin-filter-controls__no-results .admin-filter-controls__reset").click
+        page.find(".d-filter-controls__no-results .d-filter-controls__reset").click
       end
 
       def has_no_no_results_reset_button?
-        page.has_no_css?(".admin-filter-controls__no-results .admin-filter-controls__reset")
+        page.has_no_css?(".d-filter-controls__no-results .d-filter-controls__reset")
       end
 
       def has_no_reset_button?
-        component.has_no_css?("> .admin-filter-controls__reset")
+        component.has_no_css?("> .d-filter-controls__reset")
       end
 
       def has_no_results_message?
-        page.has_css?(".admin-filter-controls__no-results")
+        page.has_css?(".d-filter-controls__no-results")
       end
 
       def search_input_value
-        component.find(".admin-filter-controls__input").value
+        component.find(".d-filter-controls__input").value
       end
 
       def has_dropdown_value?(text, dropdown_id: nil)
-        selector = ".admin-filter-controls__dropdown"
+        selector = ".d-filter-controls__dropdown"
         selector += "#{selector}--#{dropdown_id}" if dropdown_id
         component.has_css?("#{selector} option:checked", text: text)
       end
 
       def dropdown_value
-        component.find(".admin-filter-controls__dropdown option:checked").text
+        component.find(".d-filter-controls__dropdown option:checked").text
       end
     end
   end

--- a/spec/system/page_objects/pages/admin_badges.rb
+++ b/spec/system/page_objects/pages/admin_badges.rb
@@ -22,7 +22,7 @@ module PageObjects
       end
 
       def filter_badges(text)
-        page.fill_in(class: "admin-filter-controls__input", with: text)
+        page.fill_in(class: "d-filter-controls__input", with: text)
         self
       end
 
@@ -35,7 +35,7 @@ module PageObjects
       end
 
       def has_no_badges_found_message?
-        page.has_css?(".admin-filter-controls__no-results")
+        page.has_css?(".d-filter-controls__no-results")
       end
 
       def has_saved_form?

--- a/spec/system/page_objects/pages/admin_category_management.rb
+++ b/spec/system/page_objects/pages/admin_category_management.rb
@@ -14,7 +14,7 @@ module PageObjects
       end
 
       def filter_controls
-        PageObjects::Components::AdminFilterControls.new(".admin-filter-controls")
+        PageObjects::Components::DFilterControls.new(".d-filter-controls")
       end
 
       def filter_by_name(name)

--- a/spec/system/page_objects/pages/admin_customize_components_config_area.rb
+++ b/spec/system/page_objects/pages/admin_customize_components_config_area.rb
@@ -133,11 +133,11 @@ module PageObjects
       end
 
       def status_selector
-        PageObjects::Components::DSelect.new(find(".admin-filter-controls__dropdown"))
+        PageObjects::Components::DSelect.new(find(".d-filter-controls__dropdown"))
       end
 
       def name_filter_input
-        find(".admin-filter-controls__input")
+        find(".d-filter-controls__input")
       end
 
       def has_no_components?
@@ -159,19 +159,19 @@ module PageObjects
       end
 
       def has_name_filter_input?
-        has_css?(".admin-filter-controls__input")
+        has_css?(".d-filter-controls__input")
       end
 
       def has_status_selector?
-        has_css?(".admin-filter-controls__dropdown")
+        has_css?(".d-filter-controls__dropdown")
       end
 
       def has_no_name_filter_input?
-        has_no_css?(".admin-filter-controls__input")
+        has_no_css?(".d-filter-controls__input")
       end
 
       def has_no_status_selector?
-        has_no_css?(".admin-filter-controls__dropdown")
+        has_no_css?(".d-filter-controls__dropdown")
       end
 
       def has_no_components_installed_text?

--- a/spec/system/page_objects/pages/admin_email_templates_index.rb
+++ b/spec/system/page_objects/pages/admin_email_templates_index.rb
@@ -31,7 +31,7 @@ module PageObjects
       end
 
       def filter_controls
-        PageObjects::Components::AdminFilterControls.new(".admin-filter-controls")
+        PageObjects::Components::DFilterControls.new(".d-filter-controls")
       end
 
       def only_overridden_checkbox

--- a/spec/system/page_objects/pages/admin_report.rb
+++ b/spec/system/page_objects/pages/admin_report.rb
@@ -37,7 +37,7 @@ module PageObjects
       end
 
       def filter_controls
-        PageObjects::Components::AdminFilterControls.new(".admin-filter-controls")
+        PageObjects::Components::DFilterControls.new(".d-filter-controls")
       end
 
       def has_group?(name)

--- a/spec/system/page_objects/pages/admin_upcoming_changes.rb
+++ b/spec/system/page_objects/pages/admin_upcoming_changes.rb
@@ -25,7 +25,7 @@ module PageObjects
       end
 
       def filter_controls
-        PageObjects::Components::AdminFilterControls.new(
+        PageObjects::Components::DFilterControls.new(
           ".upcoming-changes",
           has_multiple_dropdowns: true,
         )


### PR DESCRIPTION
The `AdminFilterControls` component isn't really admin specific,
and I want to use it in more places. Renaming to `DFilterControls`.
No backwards compat needed, it's only used in core + core plugins.

Also add `customEmptyState` to `DFilterControls`, which
allows caller to show a custom empty state for `DFilterControls`
in a yield when the array of result items is empty, for cases
where you might want to show e.g. a different message and CTA
when the filter is empty.

E.g. used in Kanban:

<img width="1107" height="439" alt="image" src="https://github.com/user-attachments/assets/1466e4d9-ac4d-4c59-81e5-6e0e3e259c6f" />
