### PR TITLE
FIX: Don't fail the dashboard when one section errors

### DIFF
--- a/app/assets/stylesheets/admin/admin_dashboard.scss
+++ b/app/assets/stylesheets/admin/admin_dashboard.scss
@@ -212,6 +212,14 @@ $db-bar-height: var(--space-2);
   border-radius: var(--d-border-radius);
 }
 
+.db-main__error {
+  padding: var(--space-8);
+  text-align: center;
+  color: var(--primary-medium);
+  background: var(--primary-very-low);
+  border-radius: var(--d-border-radius);
+}
+
 .db-link-arrow {
   position: absolute;
   opacity: 0;
@@ -250,6 +258,17 @@ $db-bar-height: var(--space-2);
   &__intro {
     max-width: 60ch;
     margin: 0;
+  }
+
+  &__error {
+    grid-column: 1 / -1;
+    flex: 1;
+    padding: var(--space-8);
+    text-align: center;
+    color: var(--primary-medium);
+    background: var(--primary-very-low);
+    border-radius: var(--d-border-radius);
+    font-size: var(--font-down-1-rem);
   }
 
   &__subheader {

--- a/app/services/admin_dashboard_section_loader.rb
+++ b/app/services/admin_dashboard_section_loader.rb
@@ -48,7 +48,17 @@ class AdminDashboardSectionLoader
 
     section_ids.size.times do
       result = results.pop
-      raise result[:error] if result[:error]
+
+      if result[:error]
+        Discourse.warn_exception(
+          result[:error],
+          message: "Failed to build admin dashboard section",
+          env: {
+            section_id: result[:id],
+          },
+        )
+        result = { id: result[:id], data: nil, error: true }
+      end
 
       results_by_id[result[:id]] = result
     end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7135,6 +7135,7 @@ en:
         not_found_error: Sorry, this report doesn’t exist
         custom_date_range: Custom date range
         loading: "Loading dashboard…"
+        fetch_error: "Couldn't load the dashboard. Try refreshing the page."
         stable: "stable"
 
         sections:
@@ -7142,6 +7143,7 @@ en:
             title: "Highlights"
           reports:
             title: "Reports"
+            fetch_error: "Couldn't load reports. Try refreshing the page."
           traffic:
             title: "Site traffic"
           engagement:

--- a/frontend/discourse/admin/components/dashboard/highlights.gjs
+++ b/frontend/discourse/admin/components/dashboard/highlights.gjs
@@ -40,7 +40,7 @@ export default class Highlights extends Component {
       </:intro>
       <:default>
         {{#if @fetchError}}
-          <div class="db-highlights__error" role="alert">
+          <div class="db-section__error" role="alert">
             {{i18n "admin.dashboard.highlights.fetch_error"}}
           </div>
         {{else}}

--- a/frontend/discourse/admin/components/dashboard/reports.gjs
+++ b/frontend/discourse/admin/components/dashboard/reports.gjs
@@ -132,59 +132,68 @@ export default class DashboardReports extends Component {
       @endDate={{@endDate}}
       ...attributes
     >
-      <div
-        class="db-reports"
-        {{didUpdate this.loadPayloads @data @startDate @endDate}}
-      >
-        {{#each this.cards key="key" as |card|}}
-          <div class="db-report__card" data-identifier={{card.key}}>
-            <div class="db-report__header">
-              <a href={{card.url}} class="db-report__name">{{card.title}}</a>
-              {{#if card.label}}
-                <div
-                  class={{dConcatClass
-                    "db-report__label"
-                    (concat "--" card.source)
-                  }}
-                  data-source={{card.source}}
-                >{{card.label}}</div>
-              {{/if}}
-            </div>
-            <div class="db-report__chart">
-              {{#if card.payload}}
-                {{#if card.payload.empty}}
-                  <DashboardReportEmptyState />
-                {{else}}
-                  {{#let
-                    (lookupAdminDashboardReportRenderer card.source)
-                    as |Renderer|
-                  }}
-                    {{#if Renderer}}
-                      <Renderer
-                        @item={{card}}
-                        @payload={{card.payload}}
-                        @filters={{hash startDate=@startDate endDate=@endDate}}
-                      />
-                    {{/if}}
-                  {{/let}}
+      {{#if @fetchError}}
+        <div class="db-section__error" role="alert">
+          {{i18n "admin.dashboard.sections.reports.fetch_error"}}
+        </div>
+      {{else}}
+        <div
+          class="db-reports"
+          {{didUpdate this.loadPayloads @data @startDate @endDate}}
+        >
+          {{#each this.cards key="key" as |card|}}
+            <div class="db-report__card" data-identifier={{card.key}}>
+              <div class="db-report__header">
+                <a href={{card.url}} class="db-report__name">{{card.title}}</a>
+                {{#if card.label}}
+                  <div
+                    class={{dConcatClass
+                      "db-report__label"
+                      (concat "--" card.source)
+                    }}
+                    data-source={{card.source}}
+                  >{{card.label}}</div>
                 {{/if}}
-              {{/if}}
+              </div>
+              <div class="db-report__chart">
+                {{#if card.payload}}
+                  {{#if card.payload.empty}}
+                    <DashboardReportEmptyState />
+                  {{else}}
+                    {{#let
+                      (lookupAdminDashboardReportRenderer card.source)
+                      as |Renderer|
+                    }}
+                      {{#if Renderer}}
+                        <Renderer
+                          @item={{card}}
+                          @payload={{card.payload}}
+                          @filters={{hash
+                            startDate=@startDate
+                            endDate=@endDate
+                          }}
+                        />
+                      {{/if}}
+                    {{/let}}
+                  {{/if}}
+                {{/if}}
+              </div>
             </div>
-          </div>
-        {{/each}}
+          {{/each}}
 
-        {{#if this.addTileVisible}}
-          <button
-            type="button"
-            class="db-report__add-report"
-            aria-label={{i18n "admin.dashboard.reports_section.add"}}
-            {{on "click" this.openReportsConfig}}
-          >
-            <span>{{dIcon "plus"}}
-              {{i18n "admin.dashboard.reports_section.add"}}</span>
-          </button>
-        {{/if}}
-      </div>
+          {{#if this.addTileVisible}}
+            <button
+              type="button"
+              class="db-report__add-report"
+              aria-label={{i18n "admin.dashboard.reports_section.add"}}
+              {{on "click" this.openReportsConfig}}
+            >
+              <span>{{dIcon "plus"}}
+                {{i18n "admin.dashboard.reports_section.add"}}</span>
+            </button>
+          {{/if}}
+        </div>
+      {{/if}}
 
       <PluginOutlet
         @name="admin-dashboard-reports-section-after"

--- a/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
+++ b/frontend/discourse/admin/components/redesigned-admin-dashboard.gjs
@@ -78,7 +78,11 @@ export default class RedesignedAdminDashboard extends Component {
     />
 
     <div class="db-main">
-      {{#if @loadedSections}}
+      {{#if @sectionsFetchError}}
+        <div class="db-main__error" role="alert">
+          {{i18n "admin.dashboard.fetch_error"}}
+        </div>
+      {{else if @loadedSections}}
         <DashboardSiteAdvice
           @problems={{@problems}}
           @onRefresh={{@onRefreshProblems}}
@@ -93,7 +97,7 @@ export default class RedesignedAdminDashboard extends Component {
               @highlights={{section.data}}
               @period={{@loadedSections.period}}
               @loading={{@loadingSections}}
-              @fetchError={{@sectionsFetchError}}
+              @fetchError={{section.error}}
               @startDate={{@loadedSections.startDate}}
               @endDate={{@loadedSections.endDate}}
             />
@@ -105,6 +109,7 @@ export default class RedesignedAdminDashboard extends Component {
               @startDate={{@loadedSections.startDate}}
               @endDate={{@loadedSections.endDate}}
               @refreshSections={{@refreshSections}}
+              @fetchError={{section.error}}
             />
           {{else if (eq section.id "traffic")}}
             <DashboardTraffic
@@ -113,7 +118,7 @@ export default class RedesignedAdminDashboard extends Component {
               @traffic={{section.data}}
               @period={{@loadedSections.period}}
               @loading={{@loadingSections}}
-              @fetchError={{@sectionsFetchError}}
+              @fetchError={{section.error}}
               @startDate={{@loadedSections.startDate}}
               @endDate={{@loadedSections.endDate}}
             />
@@ -124,7 +129,7 @@ export default class RedesignedAdminDashboard extends Component {
               @engagement={{section.data}}
               @period={{@loadedSections.period}}
               @loading={{@loadingSections}}
-              @fetchError={{@sectionsFetchError}}
+              @fetchError={{section.error}}
               @startDate={{@loadedSections.startDate}}
               @endDate={{@loadedSections.endDate}}
             />
@@ -135,7 +140,7 @@ export default class RedesignedAdminDashboard extends Component {
               @search={{section.data}}
               @period={{@loadedSections.period}}
               @loading={{@loadingSections}}
-              @fetchError={{@sectionsFetchError}}
+              @fetchError={{section.error}}
               @startDate={{@loadedSections.startDate}}
               @endDate={{@loadedSections.endDate}}
             />
@@ -148,7 +153,7 @@ export default class RedesignedAdminDashboard extends Component {
                   @data={{section.data}}
                   @period={{@loadedSections.period}}
                   @loading={{@loadingSections}}
-                  @fetchError={{@sectionsFetchError}}
+                  @fetchError={{section.error}}
                   @startDate={{@loadedSections.startDate}}
                   @endDate={{@loadedSections.endDate}}
                 />

--- a/frontend/discourse/tests/integration/components/dashboard/highlights-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/highlights-test.gjs
@@ -139,7 +139,7 @@ module("Integration | Component | Dashboard | Highlights", function (hooks) {
       </template>
     );
 
-    assert.dom(".db-highlights__error").exists();
+    assert.dom(".db-section__error").exists();
     assert.dom(".db-kpi").doesNotExist();
   });
 });

--- a/frontend/discourse/tests/integration/components/dashboard/reports-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/reports-test.gjs
@@ -1,0 +1,28 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DashboardReports from "discourse/admin/components/dashboard/reports";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+module("Integration | Component | DashboardReports", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("displays an error when the section failed to load", async function (assert) {
+    await render(
+      <template>
+        <DashboardReports @data={{null}} @fetchError={{true}} />
+      </template>
+    );
+
+    assert
+      .dom(".db-section__error")
+      .hasText(
+        i18n("admin.dashboard.sections.reports.fetch_error"),
+        "the fetch error is shown"
+      );
+    assert.dom(".db-reports").doesNotExist("the reports grid is not rendered");
+    assert
+      .dom(".db-report__add-report")
+      .doesNotExist("the add report button is not rendered");
+  });
+});

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -412,6 +412,39 @@ RSpec.describe Admin::DashboardController do
         expect(ids).to eq(%w[reports highlights])
       end
 
+      it "returns successful sections when another section fails to build" do
+        error = StandardError.new("boom")
+        configure_dashboard_sections(%w[highlights search])
+        AdminDashboardHighlights.stubs(:build).returns({ value: "highlights" })
+        AdminDashboardSearch.stubs(:build).raises(error)
+        Discourse.expects(:warn_exception).with(
+          error,
+          message: "Failed to build admin dashboard section",
+          env: {
+            section_id: "search",
+          },
+        )
+
+        get "/admin/dashboard.json"
+
+        expect(response.status).to eq(200)
+        expect(section_payloads).to eq(
+          "highlights" => {
+            "id" => "highlights",
+            "data" => {
+              "value" => "highlights",
+            },
+          },
+          "search" => {
+            "id" => "search",
+            "data" => nil,
+            "error" => true,
+          },
+        )
+        expect(response.parsed_body["configuration"]).to be_present
+        expect(response.parsed_body).to have_key("problems")
+      end
+
       it "omits hidden sections from the data payload" do
         configure_dashboard_sections(%w[highlights reports])
 

--- a/spec/services/admin_dashboard_section_loader_spec.rb
+++ b/spec/services/admin_dashboard_section_loader_spec.rb
@@ -44,6 +44,30 @@ describe AdminDashboardSectionLoader do
         ],
       )
     end
+
+    it "returns partial section data when a section fails to build" do
+      error = StandardError.new("boom")
+      AdminDashboardSiteTraffic.stubs(:build).returns({ value: "traffic" })
+      AdminDashboardSearch.stubs(:build).raises(error)
+      Discourse.expects(:warn_exception).with(
+        error,
+        message: "Failed to build admin dashboard section",
+        env: {
+          section_id: "search",
+        },
+      )
+
+      expect(
+        described_class.build(
+          section_ids: %w[traffic search],
+          current_user: admin,
+          start_date: "2026-05-01",
+          end_date: "2026-05-07",
+        ),
+      ).to eq(
+        [{ id: "traffic", data: { value: "traffic" } }, { id: "search", data: nil, error: true }],
+      )
+    end
   end
 
   describe "plugin sections" do


### PR DESCRIPTION
Previously, an exception in a single section's loader failed the entire admin dashboard request, so one broken section left admins with no dashboard at all.

This change rescues and logs per-section build errors in `AdminDashboardSectionLoader` and returns `error: true` for the affected section, so the rest of the dashboard renders normally while the failed section shows an inline "couldn't load" message.

Dashboard when the whole endpoint is 404
<img width="1388" height="1307" alt="Screenshot 2026-07-15 at 10 17 25 am" src="https://github.com/user-attachments/assets/a6a0c0ea-53eb-402f-b940-ecf4015e1757" />

Dashboard when 2 sections are broken
<img width="1456" height="1489" alt="Screenshot 2026-07-15 at 10 43 14 am" src="https://github.com/user-attachments/assets/46e11855-bcc3-41b1-ad45-aa3a80dd367a" />

