### PR TITLE
FIX: Argument error for problem checks overriding translation_data

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -198,10 +198,7 @@ class ProblemCheck
     if problem.blank?
       tracker.no_problem!(next_run_at:)
     else
-      tracker.problem!(
-        next_run_at:,
-        details: translation_data.merge(problem.details).merge(base_path: Discourse.base_path),
-      )
+      tracker.problem!(next_run_at:, details: problem.details.merge(base_path: Discourse.base_path))
     end
   end
 
@@ -217,21 +214,19 @@ class ProblemCheck
 
   def problem(target = nil, override_key: nil, override_data: {}, details: {})
     target_identifier = target.kind_of?(ActiveRecord::Base) ? target.id : target
+    problem_details =
+      override_data.merge(
+        target.present? ? translation_data(target) : translation_data,
+      ).symbolize_keys
 
     Problem.new(
       SiteSettings::LabelFormatter.expand_setting_links(
-        I18n.t(
-          override_key || translation_key,
-          base_path: Discourse.base_path,
-          **override_data.merge(
-            target.present? ? translation_data(target) : translation_data,
-          ).symbolize_keys,
-        ),
+        I18n.t(override_key || translation_key, base_path: Discourse.base_path, **problem_details),
       ),
       priority: config.priority,
       identifier:,
       target: target_identifier,
-      details:,
+      details: problem_details.merge(details),
     )
   end
 

--- a/spec/services/problem_check_spec.rb
+++ b/spec/services/problem_check_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe ProblemCheck do
     PluginCheck = Class.new(described_class)
     DisabledCheck = Class.new(described_class) { self.enabled = false }
     MultiTargetCheck = Class.new(described_class) { self.targets = -> { %w[foo bar] } }
+    TargetedFailingCheck =
+      Class.new(described_class) do
+        self.targets = -> { %w[foo] }
+
+        def call
+          problem(target, override_data: { error: "Bad target" })
+        end
+
+        private
+
+        def translation_data(target)
+          { target_name: target }
+        end
+      end
     FailingCheck =
       Class.new(described_class) do
         def call
@@ -50,6 +64,7 @@ RSpec.describe ProblemCheck do
         InlineCheck,
         DisabledCheck,
         MultiTargetCheck,
+        TargetedFailingCheck,
         FailingCheck,
         UnsafeDetailsCheck,
         PassingCheck,
@@ -62,6 +77,7 @@ RSpec.describe ProblemCheck do
     Object.send(:remove_const, InlineCheck.name)
     Object.send(:remove_const, DisabledCheck.name)
     Object.send(:remove_const, MultiTargetCheck.name)
+    Object.send(:remove_const, TargetedFailingCheck.name)
     Object.send(:remove_const, PluginCheck.name)
     Object.send(:remove_const, FailingCheck.name)
     Object.send(:remove_const, UnsafeDetailsCheck.name)
@@ -74,6 +90,7 @@ RSpec.describe ProblemCheck do
   let(:enabled_check) { RealtimeCheck }
   let(:disabled_check) { DisabledCheck }
   let(:multi_target_check) { MultiTargetCheck }
+  let(:targeted_failing_check) { TargetedFailingCheck }
   let(:plugin_check) { PluginCheck }
   let(:failing_check) { FailingCheck }
   let(:unsafe_details_check) { UnsafeDetailsCheck }
@@ -211,6 +228,33 @@ RSpec.describe ProblemCheck do
 
       it "deletes the tracker" do
         expect { multi_target_check.new("baz").run }.to change { ProblemCheckTracker.count }.by(-1)
+      end
+    end
+
+    context "when targeted check is failing" do
+      before do
+        I18n.backend.store_translations(
+          :en,
+          dashboard: {
+            problem: {
+              targeted_failing_check: "Problem with %{target_name}: %{error}",
+            },
+          },
+        )
+      end
+
+      it "stores target translation data and override data in the tracker" do
+        targeted_failing_check.new("foo").run
+
+        tracker = ProblemCheckTracker.find_by!(identifier: "targeted_failing_check", target: "foo")
+        notice = AdminNotice.find_by!(identifier: "targeted_failing_check")
+
+        expect(tracker.details).to include(
+          "target_name" => "foo",
+          "error" => "Bad target",
+          "base_path" => Discourse.base_path,
+        )
+        expect(notice.message).to eq("Problem with foo: Bad target")
       end
     end
   end


### PR DESCRIPTION
ProblemCheck#run was calling translation_data with no args while
persisting tracker/admin notice details. For targeted checks like
`group_email_credentials` and `upcoming_change_stable_opted_out`,
`translation_data` requires the target, so scheduled runs crashed after
call returned a problem. This was causing an error like this in
production:

```
A scheduled admin dashboard problem check (group_email_credentials) errored. : ArgumentError : wrong number of arguments (given 0, expected 1)
/var/www/discourse/app/services/problem_check/group_email_credentials.rb:35:in 'translation_data'
/var/www/discourse/app/models/problem_check.rb:203:in 'ProblemCheck#run'
/var/www/discourse/app/jobs/regular/run_problem_check.rb:23:in 'Jobs::RunProblemCheck#execute'
/var/www/discourse/app/jobs/base.rb:313:in 'block (2 levels) in Jobs::Base#perform'
```

The intended flow after the fix now:

* targets provides the scheduler/tracker key.
* problem(target) is where target-specific translation data is computed.
* Problem#details carries that computed translation data plus override_data.
* run persists problem.details instead of recalculating translation_data.

c.f. https://meta.discourse.org/t/argumenterror-wrong-number-of-arguments-given-0-expected-1-in-upcoming-change-stable-opted-out-problem-check-flooding-logs/407351
