### PR TITLE
SECURITY: Enforce chat message length before cooking it

### DIFF
--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -50,6 +50,7 @@ module Chat
 
       validates :chat_channel_id, presence: true
       validates :message, presence: true, if: -> { upload_ids.blank? && blocks.blank? }
+      validates :message, length: { maximum: -> { SiteSetting.chat_maximum_message_length } }
 
       after_validation do
         next if message.blank?

--- a/plugins/chat/app/services/chat/update_message.rb
+++ b/plugins/chat/app/services/chat/update_message.rb
@@ -35,6 +35,7 @@ module Chat
       validates :message_id, presence: true
       validates :channel_id, presence: true
       validates :message, presence: true, if: -> { upload_ids.blank? }
+      validates :message, length: { maximum: -> { SiteSetting.chat_maximum_message_length } }
 
       after_validation do
         next if message.blank?

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -220,6 +220,22 @@ RSpec.describe Chat::Api::ChannelMessagesController do
         end
       end
     end
+
+    context "when message is too long" do
+      let(:message) { "a" * 25_000 }
+
+      it "does not create the message" do
+        expect { post "/chat/#{channel.id}.json", params: params }.not_to change {
+          Chat::Message.count
+        }
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["errors"]).to eq(
+          [
+            "Message is too long (maximum is #{SiteSetting.chat_maximum_message_length} characters)",
+          ],
+        )
+      end
+    end
   end
 
   describe "#update" do
@@ -240,6 +256,25 @@ RSpec.describe Chat::Api::ChannelMessagesController do
           put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}"
 
           expect(response.status).to eq(400)
+        end
+      end
+
+      context "when message is too long" do
+        it "does not change the message" do
+          original_message = message_1.message
+
+          put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}",
+              params: {
+                message: "a" * 25_000,
+              }
+
+          expect(response.status).to eq(400)
+          expect(response.parsed_body["errors"]).to eq(
+            [
+              "Message is too long (maximum is #{SiteSetting.chat_maximum_message_length} characters)",
+            ],
+          )
+          expect(message_1.reload.message).to eq(original_message)
         end
       end
 

--- a/plugins/chat/spec/requests/chat/incoming_webhooks_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/incoming_webhooks_controller_spec.rb
@@ -31,12 +31,15 @@ RSpec.describe Chat::IncomingWebhooksController do
       expect(response.status).to eq(400)
     end
 
-    it "errors when the body is over chat_maximum_message_length characters" do
-      post "/chat/hooks/#{webhook.key}.json",
-           params: {
-             text: "$" * (SiteSetting.chat_maximum_message_length + 1),
-           }
-      expect(response.status).to eq(422)
+    it "rejects an over-length body" do
+      post "/chat/hooks/#{webhook.key}.json", params: { text: "a" * 25_000 }
+
+      expect(response.status).to eq(400)
+      expect(response.parsed_body["errors"]).to eq(
+        [
+          "You supplied invalid parameters to the request: [\"Message is too long (maximum is #{SiteSetting.chat_maximum_message_length} characters)\"]",
+        ],
+      )
     end
 
     it "creates a new chat message" do

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -492,10 +492,13 @@ RSpec.describe Chat::CreateMessage do
                 end
 
                 context "when nor thread nor reply is provided" do
-                  context "when message is not valid" do
+                  context "when message is too long" do
                     let(:content) { "a" * (SiteSetting.chat_maximum_message_length + 1) }
 
-                    it { is_expected.to fail_with_an_invalid_model(:message_instance) }
+                    it "fails the contract" do
+                      expect(result).to fail_a_contract
+                      expect(result.params.errors.of_kind?(:message, :too_long)).to eq(true)
+                    end
                   end
 
                   context "when message is valid" do

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -82,13 +82,13 @@ RSpec.describe Chat::UpdateMessage do
       expect(chat_message.reload.message).to eq(og_message)
     end
 
-    it "errors when length is greater than `chat_maximum_message_length`" do
+    it "rejects an over-length edit at the contract" do
       SiteSetting.chat_maximum_message_length = 100
       og_message = "This won't be changed!"
       chat_message = create_chat_message(user1, og_message, public_chat_channel)
       new_message = "2 long" * 100
 
-      expect do
+      result =
         described_class.call(
           guardian: guardian,
           params: {
@@ -97,14 +97,9 @@ RSpec.describe Chat::UpdateMessage do
             message: new_message,
           },
         )
-      end.to raise_error(ActiveRecord::RecordInvalid).with_message(
-        "Validation failed: " +
-          I18n.t(
-            "chat.errors.message_too_long",
-            { count: SiteSetting.chat_maximum_message_length },
-          ),
-      )
 
+      expect(result).to fail_a_contract
+      expect(result.params.errors.of_kind?(:message, :too_long)).to eq(true)
       expect(chat_message.reload.message).to eq(og_message)
     end
 


### PR DESCRIPTION
Chat::CreateMessage and Chat::UpdateMessage cooked the full,
attacker-controlled message (markdown-it rendering in V8) before the
chat_maximum_message_length limit was enforced at save!. A single
low-privilege request with an oversized body could burn tens of seconds
of worker CPU on rendering that was immediately discarded as too long,
enabling denial of service against the shared worker pool.

Validate the message length in the service contract, which runs before
the message is cooked, so oversized input is rejected without the
expensive rendering. The model-level length validation remains as
defense in depth. The guard covers the create, edit, and
Slack-compatible incoming-webhook paths, which all route through these
services.