### PR TITLE
FEAT: Allow unsilencing after author deletes flagged post

### DIFF
--- a/app/models/reviewable_flagged_post.rb
+++ b/app/models/reviewable_flagged_post.rb
@@ -9,6 +9,7 @@ class ReviewableFlaggedPost < Reviewable
   def self.action_aliases
     {
       agree_and_keep_hidden: :agree_and_keep,
+      agree_and_keep_deleted: :agree_and_keep,
       agree_and_silence: :agree_and_keep,
       agree_and_suspend: :agree_and_keep,
       agree_and_edit: :agree_and_keep,
@@ -55,24 +56,31 @@ class ReviewableFlaggedPost < Reviewable
     agree_bundle =
       actions.add_bundle("#{id}-agree", icon: "thumbs-up", label: "reviewables.actions.agree.title")
 
-    if !post.user_deleted? && !post.hidden?
-      build_action(actions, :agree_and_hide, icon: "far-eye-slash", bundle: agree_bundle)
-    end
-
-    if post.hidden?
-      build_action(actions, :agree_and_keep_hidden, icon: "far-eye-slash", bundle: agree_bundle)
+    if post.user_deleted?
+      build_action(actions, :agree_and_keep_deleted, icon: "far-eye-slash", bundle: agree_bundle)
     else
-      build_action(actions, :agree_and_keep, icon: "far-eye", bundle: agree_bundle)
-      build_action(
-        actions,
-        :agree_and_edit,
-        icon: "pencil",
-        bundle: agree_bundle,
-        client_action: "edit",
-      )
+      if !post.hidden?
+        build_action(actions, :agree_and_hide, icon: "far-eye-slash", bundle: agree_bundle)
+      end
+
+      if post.hidden?
+        build_action(actions, :agree_and_keep_hidden, icon: "far-eye-slash", bundle: agree_bundle)
+      else
+        build_action(actions, :agree_and_keep, icon: "far-eye", bundle: agree_bundle)
+        build_action(
+          actions,
+          :agree_and_edit,
+          icon: "pencil",
+          bundle: agree_bundle,
+          client_action: "edit",
+        )
+      end
     end
 
-    if guardian.can_delete_post_or_topic?(post)
+    can_delete_post_or_topic = guardian.can_delete_post_or_topic?(post)
+    can_delete_existing_post_or_topic = can_delete_post_or_topic && !post.user_deleted?
+
+    if can_delete_existing_post_or_topic
       build_action(actions, :delete_and_agree, icon: "trash-can", bundle: agree_bundle)
 
       if post.reply_count > 0
@@ -87,13 +95,16 @@ class ReviewableFlaggedPost < Reviewable
     end
 
     if guardian.can_suspend?(target_created_by)
-      build_action(
-        actions,
-        :agree_and_silence,
-        icon: "microphone-slash",
-        bundle: agree_bundle,
-        client_action: "silence",
-      )
+      if !target_created_by.silenced?
+        build_action(
+          actions,
+          :agree_and_silence,
+          icon: "microphone-slash",
+          bundle: agree_bundle,
+          client_action: "silence",
+        )
+      end
+
       build_action(
         actions,
         :agree_and_suspend,
@@ -107,13 +118,11 @@ class ReviewableFlaggedPost < Reviewable
       delete_user_actions(actions, agree_bundle)
     end
 
-    if post.user_deleted?
+    if post.user_deleted? && !user_penalized_for_deleted_post?
       build_action(actions, :agree_and_restore, icon: "far-eye", bundle: agree_bundle)
     end
 
     post_visible_or_system_user = !post.hidden? || guardian.user.is_system_user?
-    can_delete_post_or_topic = guardian.can_delete_post_or_topic?(post)
-
     # We must return early in this case otherwise we can end up with a bundle
     # with no associated actions, which is not valid on the client.
     return if !can_delete_post_or_topic && !post_visible_or_system_user && post.hidden?
@@ -125,16 +134,25 @@ class ReviewableFlaggedPost < Reviewable
         label: "reviewables.actions.disagree_bundle.title",
       )
 
-    if post.hidden?
-      build_action(actions, :disagree_and_restore, icon: "far-eye", bundle: disagree_bundle)
-    else
-      build_action(actions, :disagree, icon: "far-eye", bundle: disagree_bundle)
+    if user_silenced_for_post?
+      build_action(
+        actions,
+        :unsilence_user_and_ignore,
+        icon: "microphone-slash",
+        bundle: disagree_bundle,
+      )
+    elsif !user_penalized_for_deleted_post?
+      if post.hidden?
+        build_action(actions, :disagree_and_restore, icon: "far-eye", bundle: disagree_bundle)
+      else
+        build_action(actions, :disagree, icon: "far-eye", bundle: disagree_bundle)
+      end
     end
 
-    if post_visible_or_system_user
+    if post_visible_or_system_user || user_penalized_for_deleted_post?
       build_action(actions, :ignore_and_do_nothing, icon: "xmark", bundle: disagree_bundle)
     end
-    if can_delete_post_or_topic
+    if can_delete_existing_post_or_topic
       build_action(actions, :delete_and_ignore, icon: "trash-can", bundle: disagree_bundle)
       if post.reply_count > 0
         build_action(
@@ -152,8 +170,26 @@ class ReviewableFlaggedPost < Reviewable
     perform_ignore_and_do_nothing(performed_by, args)
   end
 
+  def perform_unsilence_user_and_ignore(performed_by, args)
+    UserSilencer.unsilence(post.user, performed_by, reviewable_id: id) if user_silenced_for_post?
+    perform_ignore_and_do_nothing(performed_by, args)
+  end
+
   def post_action_type_view
     @post_action_type_view ||= PostActionTypeView.new
+  end
+
+  def user_silenced_for_post?
+    post.user_deleted? && post.user&.silenced? && UserSilencer.was_silenced_for?(post)
+  end
+
+  def user_penalized_for_deleted_post?
+    return false if !post.user_deleted? || (!post.user&.silenced? && !post.user&.suspended?)
+
+    UserHistory.exists?(
+      action: [UserHistory.actions[:silence_user], UserHistory.actions[:suspend_user]],
+      post: post,
+    )
   end
 
   def perform_ignore_and_do_nothing(performed_by, args)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6046,6 +6046,8 @@ en:
     already_handled: "Thanks, but we've already reviewed that post and determined it does not need to be flagged again."
     already_handled_and_user_not_exist: "Thanks, but someone already reviewed and that user no longer exists."
     post_restored_by_author: "Post was restored by the author"
+    post_deleted_by_author_after_penalty: >-
+      Post was deleted by the author after the user was penalized for it. Review the penalty without restoring the post.
     priorities:
       low: "Low"
       medium: "Medium"
@@ -6095,6 +6097,10 @@ en:
         title: "Keep post hidden"
         description: "Agree with flag and keep the post hidden."
         complete: "Post kept hidden."
+      agree_and_keep_deleted:
+        title: "Keep post deleted"
+        description: "Agree with flag and keep the post deleted."
+        complete: "Post kept deleted."
       agree_and_suspend:
         title: "Suspend user"
         description: "Agree with flag and suspend the user."
@@ -6160,6 +6166,10 @@ en:
         title: "Do nothing"
         description: "Ignore the flag by removing it from the queue without taking any action. Hidden posts will stay hidden and be handled by the auto-tools."
         complete: "Flag ignored."
+      unsilence_user_and_ignore:
+        title: "Unsilence user and ignore"
+        description: "Unsilence the user and remove the flag from the queue without restoring the deleted post."
+        complete: "User unsilenced and flag ignored."
       approve:
         title: "Yes"
         complete: "Post approved."

--- a/lib/post_destroyer.rb
+++ b/lib/post_destroyer.rb
@@ -560,12 +560,19 @@ class PostDestroyer
   end
 
   def resolve_reviewables_for_author_deletion
-    # Don't auto-ignore if user was penalized for this post - staff should review the penalty.
-    return if user_penalized_for_post?
+    reviewables = Reviewable.where(target: @post, status: Reviewable.statuses[:pending])
 
-    Reviewable
-      .where(target: @post, status: Reviewable.statuses[:pending])
-      .find_each { |reviewable| reviewable.transition_to(:ignored, Discourse.system_user) }
+    if user_penalized_for_post?
+      reviewables.find_each do |reviewable|
+        note = I18n.t("reviewables.post_deleted_by_author_after_penalty")
+        next if reviewable.reviewable_notes.exists?(user: Discourse.system_user, content: note)
+
+        reviewable.reviewable_notes.create!(user: Discourse.system_user, content: note)
+      end
+      return
+    end
+
+    reviewables.find_each { |reviewable| reviewable.transition_to(:ignored, Discourse.system_user) }
   end
 
   def user_penalized_for_post?

--- a/spec/lib/post_destroyer_spec.rb
+++ b/spec/lib/post_destroyer_spec.rb
@@ -576,6 +576,9 @@ RSpec.describe PostDestroyer do
 
       expect(reply.reload.user_deleted).to eq(true)
       expect(reviewable.reload).to be_pending
+      expect(reviewable.reviewable_notes.last.content).to eq(
+        I18n.t("reviewables.post_deleted_by_author_after_penalty"),
+      )
 
       PostDestroyer.new(reply.user, reply).recover
 

--- a/spec/models/reviewable_flagged_post_spec.rb
+++ b/spec/models/reviewable_flagged_post_spec.rb
@@ -68,9 +68,50 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         expect(actions.has?(:agree_and_keep_hidden)).to eq(true)
       end
 
-      it "returns `agree_and_restore` if the post is user deleted" do
-        post.update(user_deleted: true)
-        expect(reviewable.actions_for(guardian).has?(:agree_and_restore)).to eq(true)
+      it "does not return post visibility or delete actions if the post is user deleted" do
+        post.update!(user_deleted: true, reply_count: 3)
+
+        actions = reviewable.actions_for(guardian)
+
+        expect(actions.has?(:agree_and_keep_deleted)).to eq(true)
+        expect(actions.has?(:agree_and_keep)).to eq(false)
+        expect(actions.has?(:agree_and_keep_hidden)).to eq(false)
+        expect(actions.has?(:agree_and_edit)).to eq(false)
+        expect(actions.has?(:delete_and_agree)).to eq(false)
+        expect(actions.has?(:delete_and_agree_replies)).to eq(false)
+        expect(actions.has?(:delete_and_ignore)).to eq(false)
+        expect(actions.has?(:delete_and_ignore_replies)).to eq(false)
+      end
+
+      it "returns an unsilence action without restore actions if a silenced user deleted the flagged post" do
+        post.update!(hidden: true, user_deleted: true)
+        UserSilencer.silence(post.user, moderator, post_id: post.id)
+
+        actions = reviewable.actions_for(guardian)
+
+        expect(actions.has?(:agree_and_keep_deleted)).to eq(true)
+        expect(actions.has?(:unsilence_user_and_ignore)).to eq(true)
+        expect(actions.has?(:agree_and_silence)).to eq(false)
+        expect(actions.has?(:agree_and_keep_hidden)).to eq(false)
+        expect(actions.has?(:agree_and_restore)).to eq(false)
+        expect(actions.has?(:disagree_and_restore)).to eq(false)
+      end
+
+      it "returns ignore without restore actions if a suspended user deleted the flagged post" do
+        post.update!(hidden: true, user_deleted: true)
+        UserSuspender.new(
+          post.user,
+          suspended_till: 5.days.from_now,
+          reason: "spam",
+          by_user: moderator,
+          post_id: post.id,
+        ).suspend
+
+        actions = reviewable.actions_for(guardian)
+
+        expect(actions.has?(:ignore_and_do_nothing)).to eq(true)
+        expect(actions.has?(:agree_and_restore)).to eq(false)
+        expect(actions.has?(:disagree_and_restore)).to eq(false)
       end
 
       it "returns delete replies options if there are replies" do
@@ -88,6 +129,15 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
         post.user.update(moderator: true)
         expect(reviewable.actions_for(guardian).has?(:agree_and_silence)).to eq(false)
         expect(reviewable.actions_for(guardian).has?(:agree_and_suspend)).to eq(false)
+      end
+
+      it "doesn't return the silence action if the user is already silenced" do
+        UserSilencer.silence(post.user, moderator, post_id: post.id)
+
+        actions = reviewable.actions_for(guardian)
+
+        expect(actions.has?(:agree_and_silence)).to eq(false)
+        expect(actions.has?(:agree_and_suspend)).to eq(true)
       end
 
       it "doesn't end up with an empty ignore bundle when the post is already hidden and deleted" do
@@ -493,6 +543,22 @@ RSpec.describe ReviewableFlaggedPost, type: :model do
       flagged_post.perform(moderator, :delete_and_agree_replies)
 
       expect(flagged_reply.reload).to be_ignored
+    end
+  end
+
+  describe "#perform_unsilence_user_and_ignore" do
+    it "unsilences the user and resolves the reviewable without restoring the deleted post" do
+      reviewable = Fabricate(:reviewable_flagged_post)
+      flagged_post = reviewable.post
+      target_user = flagged_post.user
+      flagged_post.update!(hidden: true, user_deleted: true)
+      UserSilencer.silence(target_user, moderator, post_id: flagged_post.id)
+
+      reviewable.perform(moderator, :unsilence_user_and_ignore)
+
+      expect(target_user.reload.silenced?).to eq(false)
+      expect(flagged_post.reload.user_deleted?).to eq(true)
+      expect(reviewable.reload).to be_ignored
     end
   end
 


### PR DESCRIPTION
When an author deletes a flagged post that caused a silence or suspension, we keep the reviewable pending so staff can review the penalty. However, the available review actions could still encourage staff to restore or delete the already user-deleted post.

This change adds clearer review handling for that case:

- adds a note explaining that the author deleted the post after being penalized
- adds a "Keep post deleted" action for agreeing with the flag while respecting the deletion
- hides restore/delete/edit/visibility actions for user-deleted posts
- adds an "Unsilence user and ignore" action when the user was silenced for the deleted post
- avoids showing "Silence user" when the user is already silenced
- prevents restore actions when the deleted post caused a suspension

This lets staff resolve the reviewable and lift an incorrect silence without overturning the author’s decision to delete their post.

<img width="1412" height="943" alt="Screenshot 2026-07-15 at 1 59 21 pm" src="https://github.com/user-attachments/assets/07cc769d-3fb2-4d33-bc87-6cc93cb4221d" />
<img width="1297" height="936" alt="Screenshot 2026-07-15 at 1 59 25 pm" src="https://github.com/user-attachments/assets/2b515506-fa65-4b32-bf16-5c639550c416" />
