### PR TITLE
PERF: Only recompile stylesheets when required

### DIFF
--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -72,14 +72,7 @@ class StylesheetsController < ApplicationController
       return head :not_modified
     end
 
-    unless File.exist?(location)
-      if current = query.pick(source_map ? :source_map : :content)
-        FileUtils.mkdir_p(cache_path)
-        Discourse::Utils.atomic_write_file(location, current)
-      else
-        raise Discourse::NotFound
-      end
-    end
+    raise Discourse::NotFound if !StylesheetCache.write_to_disk(query, location, source_map:)
 
     if Rails.env.development?
       response.headers["Last-Modified"] = Time.zone.now.httpdate

--- a/app/models/stylesheet_cache.rb
+++ b/app/models/stylesheet_cache.rb
@@ -34,6 +34,17 @@ class StylesheetCache < ActiveRecord::Base
     ActiveRecord::Base.logger = old_logger if Rails.env.development? && old_logger
   end
 
+  def self.write_to_disk(relation, location, source_map: false)
+    return true if File.exist?(location)
+
+    content = relation.pick(source_map ? :source_map : :content)
+    return false if content.nil?
+
+    FileUtils.mkdir_p(File.dirname(location))
+    Discourse::Utils.atomic_write_file(location, content)
+    true
+  end
+
   def self.clean_up
     StylesheetCache.where("created_at < ?", CLEANUP_AFTER_DAYS.days.ago).delete_all
   end

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -69,9 +69,14 @@ class Stylesheet::Manager
       )
 
     targets.each do |target|
-      $stderr.puts "precompile target: #{target}"
+      builder = Stylesheet::Manager::Builder.new(target: target, manager: nil)
 
-      Stylesheet::Manager::Builder.new(target: target, manager: nil).compile(force: true)
+      if builder.hydrate_from_cache!
+        $stderr.puts "precompile target: #{target} (cached)"
+      else
+        $stderr.puts "precompile target: #{target}"
+        builder.compile
+      end
     end
   end
 
@@ -108,8 +113,13 @@ class Stylesheet::Manager
               Stylesheet::Manager::Builder.new(target: target, theme: theme, manager: manager)
 
             next if !scss_checker.has_scss(theme.id)
-            $stderr.puts "precompile target: #{target} #{theme.name}"
-            builder.compile(force: true)
+
+            if builder.hydrate_from_cache!
+              $stderr.puts "precompile target: #{target} #{theme.name} (cached)"
+            else
+              $stderr.puts "precompile target: #{target} #{theme.name}"
+              builder.compile
+            end
             compiled << "#{target}_#{theme.id}"
           end
       end
@@ -118,13 +128,20 @@ class Stylesheet::Manager
       theme_dark_color_scheme = ColorScheme.find_by_id(dark_color_scheme_id)
       theme = manager.get_theme(theme_id)
       [theme_color_scheme, theme_dark_color_scheme, *color_schemes].compact.uniq.each do |scheme|
-        $stderr.puts "precompile target: #{COLOR_SCHEME_STYLESHEET} #{theme.name} (#{scheme.name})"
-        Stylesheet::Manager::Builder.new(
-          target: COLOR_SCHEME_STYLESHEET,
-          theme: theme,
-          color_scheme: scheme,
-          manager: manager,
-        ).compile(force: true)
+        builder =
+          Stylesheet::Manager::Builder.new(
+            target: COLOR_SCHEME_STYLESHEET,
+            theme: theme,
+            color_scheme: scheme,
+            manager: manager,
+          )
+
+        if builder.hydrate_from_cache!
+          $stderr.puts "precompile target: #{COLOR_SCHEME_STYLESHEET} #{theme.name} (#{scheme.name}) (cached)"
+        else
+          $stderr.puts "precompile target: #{COLOR_SCHEME_STYLESHEET} #{theme.name} (#{scheme.name})"
+          builder.compile
+        end
       end
 
       clear_color_scheme_cache!

--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -74,6 +74,15 @@ class Stylesheet::Manager::Builder
     css
   end
 
+  def hydrate_from_cache!
+    relation = StylesheetCache.where(target: qualified_target, digest: digest)
+    return false if !relation.exists?
+
+    StylesheetCache.write_to_disk(relation, stylesheet_fullpath)
+    StylesheetCache.write_to_disk(relation, source_map_fullpath, source_map: true)
+    true
+  end
+
   def current_hostname
     Discourse.current_hostname
   end

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -924,6 +924,31 @@ RSpec.describe Stylesheet::Manager do
       expect(StylesheetCache.pluck(:target)).to contain_exactly(*core_targets)
     end
 
+    it "hydrates core CSS to disk from StylesheetCache without recompiling" do
+      capture_output(:stderr) { Stylesheet::Manager.precompile_css }
+      Stylesheet::Manager.rm_cache_folder
+      expect(Dir["#{Stylesheet::Manager.cache_fullpath}/*.css"]).to be_empty
+
+      Stylesheet::Compiler.expects(:compile_asset).never
+      output = capture_output(:stderr) { Stylesheet::Manager.precompile_css }
+
+      expect(output.scan(/\(cached\)/).length).to eq(core_targets.length)
+      expect(Dir["#{Stylesheet::Manager.cache_fullpath}/*.css"].length).to eq(core_targets.length)
+    end
+
+    it "hydrates theme CSS to disk from StylesheetCache without recompiling" do
+      capture_output(:stderr) { Stylesheet::Manager.precompile_theme_css }
+      cached_count = StylesheetCache.count
+      Stylesheet::Manager.rm_cache_folder
+      expect(Dir["#{Stylesheet::Manager.cache_fullpath}/*.css"]).to be_empty
+
+      Stylesheet::Compiler.expects(:compile_asset).never
+      output = capture_output(:stderr) { Stylesheet::Manager.precompile_theme_css }
+
+      expect(output).to include("(cached)")
+      expect(Dir["#{Stylesheet::Manager.cache_fullpath}/*.css"].length).to eq(cached_count)
+    end
+
     it "generates precompiled CSS - only themes" do
       output = capture_output(:stderr) { Stylesheet::Manager.precompile_theme_css }
 


### PR DESCRIPTION
When precompiling stylesheets, we were forcibly recompiling, even if we already had the correct stylesheet in the cache. This commit updates the precompile job so that it tries to pull an already-compiled copy from the database and cache it on disk, rather than doing a full recompile.