### PR TITLE
DEV: Allow browser to cache stylesheets in development

### DIFF
--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -81,13 +81,9 @@ class StylesheetsController < ApplicationController
       end
     end
 
-    if Rails.env.development?
-      response.headers["Last-Modified"] = Time.zone.now.httpdate
-      immutable_for(1.second)
-    else
-      response.headers["Last-Modified"] = stylesheet_time.httpdate if stylesheet_time
-      immutable_for(1.year)
-    end
+    response.headers["Last-Modified"] = stylesheet_time.httpdate if stylesheet_time
+    immutable_for(1.year)
+
     send_file(location, disposition: :inline)
   end
 


### PR DESCRIPTION
Stylesheets are all served with digests in their URL, so there's no need for browsers to re-request identical files every time