### PR TITLE
UX: Chat channel empty and not yet joined state redesigns

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-preview-card.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-preview-card.gjs
@@ -45,13 +45,12 @@ export default class ChatChannelPreviewCard extends Component {
             {{dIcon "lock"}}
           </div>
 
-          <div class="chat-channel-preview-card__content">
-            <div class="chat-channel-preview-card__title">
-              {{this.guestTitle}}
-            </div>
-            <div class="chat-channel-preview-card__body">
-              {{i18n "chat.channel.preview_card.join_body"}}
-            </div>
+          <div class="chat-channel-preview-card__title">
+            {{this.guestTitle}}
+          </div>
+
+          <div class="chat-channel-preview-card__body">
+            {{i18n "chat.channel.preview_card.join_body"}}
           </div>
 
           <div class="chat-channel-preview-card__actions">
@@ -67,13 +66,12 @@ export default class ChatChannelPreviewCard extends Component {
             {{dIcon "lock"}}
           </div>
 
-          <div class="chat-channel-preview-card__content">
-            <div class="chat-channel-preview-card__title">
-              {{this.noAccessTitle}}
-            </div>
-            <div class="chat-channel-preview-card__body">
-              {{i18n "chat.channel.preview_card.no_access_body"}}
-            </div>
+          <div class="chat-channel-preview-card__title">
+            {{this.noAccessTitle}}
+          </div>
+
+          <div class="chat-channel-preview-card__body">
+            {{i18n "chat.channel.preview_card.no_access_body"}}
           </div>
         </div>
       {{/if}}
@@ -83,13 +81,12 @@ export default class ChatChannelPreviewCard extends Component {
           {{dIcon "lock"}}
         </div>
 
-        <div class="chat-channel-preview-card__content">
-          <div class="chat-channel-preview-card__title">
-            {{this.guestTitle}}
-          </div>
-          <div class="chat-channel-preview-card__body">
-            {{i18n "chat.channel.preview_card.guest_body"}}
-          </div>
+        <div class="chat-channel-preview-card__title">
+          {{this.guestTitle}}
+        </div>
+
+        <div class="chat-channel-preview-card__body">
+          {{i18n "chat.channel.preview_card.guest_body"}}
         </div>
 
         <div class="chat-channel-preview-card__actions">

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-preview-card.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-preview-card.gjs
@@ -1,10 +1,17 @@
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { getOwner } from "@ember/owner";
+import { service } from "@ember/service";
+import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ToggleChannelMembershipButton from "./toggle-channel-membership-button";
 
 export default class ChatChannelPreviewCard extends Component {
+  @service currentUser;
+
   get showJoinButton() {
     return this.args.channel?.isOpen && this.args.channel?.canJoin;
   }
@@ -15,23 +22,69 @@ export default class ChatChannelPreviewCard extends Component {
     });
   }
 
+  get guestTitle() {
+    return i18n("chat.channel.preview_card.guest_title", {
+      channelName: `#${this.args.channel.title}`,
+    });
+  }
+
+  @action
+  showLogin() {
+    getOwner(this).lookup("route:application").send("showLogin");
+  }
+
+  @action
+  showCreateAccount() {
+    getOwner(this).lookup("route:application").send("showCreateAccount");
+  }
+
   <template>
-    <div
-      class={{dConcatClass
-        "chat-channel-preview-card"
-        (unless this.showJoinButton "-no-button")
-      }}
-    >
-      {{#if this.showJoinButton}}
-        <div class="chat-channel__placeholder">
-          {{this.channelPlaceholder}}
+    {{#if this.currentUser}}
+      <div
+        class={{dConcatClass
+          "chat-channel-preview-card"
+          (unless this.showJoinButton "-no-button")
+        }}
+      >
+        {{#if this.showJoinButton}}
+          <div class="chat-channel__placeholder">
+            {{this.channelPlaceholder}}
+          </div>
+
+          <ToggleChannelMembershipButton
+            @channel={{@channel}}
+            @options={{hash joinClass="btn-primary" labelType="short"}}
+          />
+        {{/if}}
+      </div>
+    {{else}}
+      <div class="chat-channel-preview-card --anon">
+        <div class="chat-channel-preview-card__icon">
+          {{dIcon "lock"}}
         </div>
 
-        <ToggleChannelMembershipButton
-          @channel={{@channel}}
-          @options={{hash joinClass="btn-primary" labelType="short"}}
-        />
-      {{/if}}
-    </div>
+        <div class="chat-channel-preview-card__content">
+          <div class="chat-channel-preview-card__title">
+            {{this.guestTitle}}
+          </div>
+          <div class="chat-channel-preview-card__body">
+            {{i18n "chat.channel.preview_card.guest_body"}}
+          </div>
+        </div>
+
+        <div class="chat-channel-preview-card__actions">
+          <DButton
+            @action={{this.showLogin}}
+            @label="chat.channel.preview_card.log_in"
+            class="btn-transparent --primary"
+          />
+          <DButton
+            @action={{this.showCreateAccount}}
+            @label="chat.channel.preview_card.sign_up"
+            class="btn-primary"
+          />
+        </div>
+      </div>
+    {{/if}}
   </template>
 }

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel-preview-card.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel-preview-card.gjs
@@ -4,7 +4,6 @@ import { action } from "@ember/object";
 import { getOwner } from "@ember/owner";
 import { service } from "@ember/service";
 import DButton from "discourse/ui-kit/d-button";
-import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ToggleChannelMembershipButton from "./toggle-channel-membership-button";
@@ -16,14 +15,14 @@ export default class ChatChannelPreviewCard extends Component {
     return this.args.channel?.isOpen && this.args.channel?.canJoin;
   }
 
-  get channelPlaceholder() {
-    return i18n("chat.placeholder_channel", {
+  get guestTitle() {
+    return i18n("chat.channel.preview_card.guest_title", {
       channelName: `#${this.args.channel.title}`,
     });
   }
 
-  get guestTitle() {
-    return i18n("chat.channel.preview_card.guest_title", {
+  get noAccessTitle() {
+    return i18n("chat.channel.preview_card.no_access_title", {
       channelName: `#${this.args.channel.title}`,
     });
   }
@@ -40,23 +39,44 @@ export default class ChatChannelPreviewCard extends Component {
 
   <template>
     {{#if this.currentUser}}
-      <div
-        class={{dConcatClass
-          "chat-channel-preview-card"
-          (unless this.showJoinButton "-no-button")
-        }}
-      >
-        {{#if this.showJoinButton}}
-          <div class="chat-channel__placeholder">
-            {{this.channelPlaceholder}}
+      {{#if this.showJoinButton}}
+        <div class="chat-channel-preview-card --logged-in">
+          <div class="chat-channel-preview-card__icon">
+            {{dIcon "lock"}}
           </div>
 
-          <ToggleChannelMembershipButton
-            @channel={{@channel}}
-            @options={{hash joinClass="btn-primary" labelType="short"}}
-          />
-        {{/if}}
-      </div>
+          <div class="chat-channel-preview-card__content">
+            <div class="chat-channel-preview-card__title">
+              {{this.guestTitle}}
+            </div>
+            <div class="chat-channel-preview-card__body">
+              {{i18n "chat.channel.preview_card.join_body"}}
+            </div>
+          </div>
+
+          <div class="chat-channel-preview-card__actions">
+            <ToggleChannelMembershipButton
+              @channel={{@channel}}
+              @options={{hash joinClass="btn-primary" labelType="short"}}
+            />
+          </div>
+        </div>
+      {{else}}
+        <div class="chat-channel-preview-card --logged-in --no-access">
+          <div class="chat-channel-preview-card__icon">
+            {{dIcon "lock"}}
+          </div>
+
+          <div class="chat-channel-preview-card__content">
+            <div class="chat-channel-preview-card__title">
+              {{this.noAccessTitle}}
+            </div>
+            <div class="chat-channel-preview-card__body">
+              {{i18n "chat.channel.preview_card.no_access_body"}}
+            </div>
+          </div>
+        </div>
+      {{/if}}
     {{else}}
       <div class="chat-channel-preview-card --anon">
         <div class="chat-channel-preview-card__icon">

--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -32,6 +32,7 @@ import {
   scrollListToMessage,
 } from "discourse/plugins/chat/discourse/lib/scroll-helpers";
 import ChatMessage from "discourse/plugins/chat/discourse/models/chat-message";
+import ChatChannelEmptyState from "./chat/channel/empty-state";
 import ChatComposerChannel from "./chat/composer/channel";
 import ChatScrollToBottomArrow from "./chat/scroll-to-bottom-arrow";
 import ChatSelectionManager from "./chat/selection-manager";
@@ -86,6 +87,13 @@ export default class ChatChannel extends Component {
 
   get messagesManager() {
     return this.args.channel.messagesManager;
+  }
+
+  get isEmpty() {
+    return (
+      this.messagesLoader.fetchedOnce &&
+      this.messagesManager.messages.length === 0
+    );
   }
 
   get currentUserMembership() {
@@ -751,6 +759,7 @@ export default class ChatChannel extends Component {
         (if this.pane.sending "chat-channel--sending")
         (if this.hasSavedScrollPosition "chat-channel--saved-scroll-position")
         (if this.messagesLoader.fetchedOnce "--loaded")
+        (if this.isEmpty "is-empty")
       }}
       {{willDestroy this.teardown}}
       {{didInsert this.setup}}
@@ -782,14 +791,20 @@ export default class ChatChannel extends Component {
               @context="channel"
             />
           {{else}}
-            {{#unless this.messagesLoader.fetchedOnce}}
+            {{#if this.messagesLoader.fetchedOnce}}
+              <ChatChannelEmptyState @channel={{@channel}} />
+            {{else}}
               <ChatSkeleton />
-            {{/unless}}
+            {{/if}}
           {{/each}}
         </ChatMessagesContainer>
 
         {{! at bottom even if shown at top due to column-reverse  }}
-        {{#if this.messagesLoader.loadedPast}}
+        {{#if
+          (and
+            this.messagesLoader.loadedPast this.messagesManager.messages.length
+          )
+        }}
           <div class="all-loaded-message">
             {{i18n "chat.all_loaded"}}
           </div>

--- a/plugins/chat/assets/javascripts/discourse/components/chat/channel/empty-state.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/channel/empty-state.gjs
@@ -24,9 +24,7 @@ export default class ChatChannelEmptyState extends Component {
 
   @action
   loadMemberships() {
-    // Anonymous users can't list memberships, so skip the fetch and fall back
-    // to the count-only display for them.
-    if (!this.currentUser) {
+    if (!this.currentUser || !this.memberCount) {
       return;
     }
 
@@ -40,8 +38,9 @@ export default class ChatChannelEmptyState extends Component {
   }
 
   get memberCount() {
-    const count = this.args.channel.membershipsCount;
-    return this.args.channel.isFollowing ? count - 1 : count;
+    const total = this.args.channel.membershipsCount ?? 0;
+    const count = this.args.channel.isFollowing ? total - 1 : total;
+    return Math.max(0, count);
   }
 
   get channelIcon() {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/channel/empty-state.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/channel/empty-state.gjs
@@ -1,0 +1,87 @@
+import Component from "@glimmer/component";
+import { cached } from "@glimmer/tracking";
+import { service } from "@ember/service";
+import { trustHTML } from "@ember/template";
+import DEmptyState from "discourse/ui-kit/d-empty-state";
+import dAvatar from "discourse/ui-kit/helpers/d-avatar";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
+
+const MAX_AVATARS = 5;
+
+export default class ChatChannelEmptyState extends Component {
+  @service chatApi;
+  @service currentUser;
+
+  constructor() {
+    super(...arguments);
+
+    // Anonymous users can't list memberships, so skip the fetch and fall back
+    // to the count-only display for them.
+    if (this.currentUser) {
+      this.memberships.load({ limit: MAX_AVATARS }).catch(() => {
+        // A failed preview fetch degrades to count-only; not worth interrupting.
+      });
+    }
+  }
+
+  @cached
+  get memberships() {
+    return this.chatApi.listChannelMemberships(this.args.channel.id);
+  }
+
+  get title() {
+    return i18n("chat.channel.empty_state.title", {
+      channelName: `#${this.args.channel.title}`,
+    });
+  }
+
+  get tip() {
+    if (!this.currentUser) {
+      return i18n("chat.channel.empty_state.guest_tip");
+    }
+
+    return null;
+  }
+
+  <template>
+    <DEmptyState
+      @identifier="chat-channel"
+      @svgContent={{dIcon "comments"}}
+      @title={{this.title}}
+      @body={{@channel.description}}
+    >
+      <:tip>
+        {{#if this.tip}}
+          <p class="empty-state__tip-text">{{this.tip}}</p>
+        {{/if}}
+
+        {{#if @channel.membershipsCount}}
+          <div
+            class={{dConcatClass
+              "empty-state__members-facepile"
+              (if this.memberships.items.length "--with-avatars")
+            }}
+          >
+            {{#if this.memberships.items.length}}
+              <div class="empty-state__members-avatars">
+                {{#each this.memberships.items as |membership|}}
+                  {{dAvatar membership.user imageSize="small"}}
+                {{/each}}
+              </div>
+            {{/if}}
+            <span class="empty-state__members-count">
+              {{trustHTML
+                (i18n
+                  "chat.channel.empty_state.members_here"
+                  count=@channel.membershipsCount
+                )
+              }}
+            </span>
+          </div>
+        {{/if}}
+      </:tip>
+    </DEmptyState>
+  </template>
+}

--- a/plugins/chat/assets/javascripts/discourse/components/chat/channel/empty-state.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/channel/empty-state.gjs
@@ -1,11 +1,14 @@
 import Component from "@glimmer/component";
 import { cached } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import DEmptyState from "discourse/ui-kit/d-empty-state";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
+import dReplaceEmoji from "discourse/ui-kit/helpers/d-replace-emoji";
 import { i18n } from "discourse-i18n";
 
 const MAX_AVATARS = 5;
@@ -14,74 +17,132 @@ export default class ChatChannelEmptyState extends Component {
   @service chatApi;
   @service currentUser;
 
-  constructor() {
-    super(...arguments);
-
-    // Anonymous users can't list memberships, so skip the fetch and fall back
-    // to the count-only display for them.
-    if (this.currentUser) {
-      this.memberships.load({ limit: MAX_AVATARS }).catch(() => {
-        // A failed preview fetch degrades to count-only; not worth interrupting.
-      });
-    }
-  }
-
   @cached
   get memberships() {
     return this.chatApi.listChannelMemberships(this.args.channel.id);
   }
 
+  @action
+  loadMemberships() {
+    // Anonymous users can't list memberships, so skip the fetch and fall back
+    // to the count-only display for them.
+    if (!this.currentUser) {
+      return;
+    }
+
+    this.memberships.load({ limit: MAX_AVATARS }).catch(() => {});
+  }
+
+  get otherMemberships() {
+    return this.memberships.items.filter(
+      (membership) => membership.user.id !== this.currentUser?.id
+    );
+  }
+
+  get memberCount() {
+    const count = this.args.channel.membershipsCount;
+    return this.args.channel.isFollowing ? count - 1 : count;
+  }
+
+  get channelIcon() {
+    const { emoji, chatable } = this.args.channel;
+    const icon = emoji ? dReplaceEmoji(`:${emoji}:`) : dIcon("d-chat");
+
+    if (!chatable?.color) {
+      return icon;
+    }
+
+    return trustHTML(`<span style="color: #${chatable.color}">${icon}</span>`);
+  }
+
   get title() {
-    return i18n("chat.channel.empty_state.title", {
-      channelName: `#${this.args.channel.title}`,
-    });
+    const channelName = `#${this.args.channel.title}`;
+
+    if (this.args.channel.isFollowing) {
+      return i18n("chat.channel.empty_state.joined_title", { channelName });
+    }
+
+    return i18n("chat.channel.empty_state.title", { channelName });
   }
 
   get tip() {
-    if (!this.currentUser) {
-      return i18n("chat.channel.empty_state.guest_tip");
+    if (this.args.channel.isFollowing) {
+      return i18n("chat.channel.empty_state.joined_tip");
     }
 
-    return null;
+    return i18n("chat.channel.empty_state.guest_tip");
   }
 
   <template>
-    <DEmptyState
-      @identifier="chat-channel"
-      @svgContent={{dIcon "comments"}}
-      @title={{this.title}}
-      @body={{@channel.description}}
-    >
-      <:tip>
-        {{#if this.tip}}
-          <p class="empty-state__tip-text">{{this.tip}}</p>
-        {{/if}}
+    {{#if this.currentUser}}
+      <DEmptyState
+        @identifier="chat-channel"
+        @svgContent={{this.channelIcon}}
+        @title={{this.title}}
+        @body={{@channel.description}}
+      >
+        <:tip>
+          {{#if this.tip}}
+            <p class="empty-state__tip-text">{{this.tip}}</p>
+          {{/if}}
 
-        {{#if @channel.membershipsCount}}
           <div
             class={{dConcatClass
               "empty-state__members-facepile"
-              (if this.memberships.items.length "--with-avatars")
+              (if this.otherMemberships.length "--with-avatars")
             }}
+            {{didInsert this.loadMemberships}}
           >
-            {{#if this.memberships.items.length}}
+            {{#if this.otherMemberships.length}}
               <div class="empty-state__members-avatars">
-                {{#each this.memberships.items as |membership|}}
+                {{#each this.otherMemberships as |membership|}}
                   {{dAvatar membership.user imageSize="small"}}
                 {{/each}}
               </div>
             {{/if}}
             <span class="empty-state__members-count">
-              {{trustHTML
-                (i18n
-                  "chat.channel.empty_state.members_here"
-                  count=@channel.membershipsCount
-                )
-              }}
+              {{#if this.memberCount}}
+                {{trustHTML
+                  (i18n
+                    "chat.channel.empty_state.members_here"
+                    count=this.memberCount
+                  )
+                }}
+              {{else}}
+                {{i18n "chat.channel.empty_state.no_other_members"}}
+              {{/if}}
             </span>
           </div>
-        {{/if}}
-      </:tip>
-    </DEmptyState>
+        </:tip>
+      </DEmptyState>
+    {{/if}}
+    {{#unless this.currentUser}}
+      <DEmptyState
+        @identifier="chat-channel"
+        @svgContent={{this.channelIcon}}
+        @title={{this.title}}
+        @body={{@channel.description}}
+      >
+        <:tip>
+          {{#if this.tip}}
+            <p class="empty-state__tip-text">{{this.tip}}</p>
+          {{/if}}
+          <div class="empty-state__members-facepile">
+            <span class="empty-state__members-count">
+              {{#if this.memberCount}}
+                {{trustHTML
+                  (i18n
+                    "chat.channel.empty_state.members_here"
+                    count=this.memberCount
+                  )
+                }}
+              {{else}}
+                {{i18n "chat.channel.empty_state.no_other_members"}}
+              {{/if}}
+            </span>
+          </div>
+        </:tip>
+      </DEmptyState>
+    {{/unless}}
   </template>
 }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-empty-state.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-empty-state.scss
@@ -7,7 +7,6 @@
     max-width: 60ch;
     display: flex;
     flex-direction: column;
-    gap: var(--space-2);
 
     &__container {
       display: flex;
@@ -17,10 +16,11 @@
       padding: var(--space-4);
     }
 
-    &__image svg {
+    &__image svg,
+    &__image img {
       width: 4rem;
       height: 4rem;
-      color: var(--tertiary);
+      margin-bottom: var(--space-4);
     }
 
     &__title {
@@ -34,7 +34,6 @@
 
     &__tip {
       margin: 0;
-      font-size: var(--font-0);
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -64,10 +63,9 @@
 
       .avatar {
         border: 2px solid var(--secondary);
-        border-radius: 50%;
 
         &:not(:first-child) {
-          margin-inline-start: -0.5rem;
+          margin-inline-start: -8px;
         }
       }
     }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-empty-state.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-empty-state.scss
@@ -7,20 +7,18 @@
     max-width: 60ch;
     display: flex;
     flex-direction: column;
+    padding: var(--space-4);
+    margin-inline: auto;
 
-    &__container {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      padding: var(--space-4);
-    }
+    &__image {
+      margin-top: 0; // specific chat overrule for default Emptystate component
 
-    &__image svg,
-    &__image img {
-      width: 4rem;
-      height: 4rem;
-      margin-bottom: var(--space-4);
+      svg,
+      img {
+        width: 4rem;
+        height: 4rem;
+        margin-bottom: var(--space-4);
+      }
     }
 
     &__title {
@@ -33,6 +31,8 @@
     }
 
     &__tip {
+      position: relative; // overrule for core component being pos abs
+      bottom: 0; // overrule for core component being pos abs
       margin: 0;
       display: flex;
       flex-direction: column;

--- a/plugins/chat/assets/stylesheets/common/chat-channel-empty-state.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-empty-state.scss
@@ -1,0 +1,83 @@
+.chat-channel {
+  &.is-empty .chat-messages-scroller {
+    justify-content: center;
+  }
+
+  .empty-state {
+    max-width: 60ch;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+
+    &__container {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: var(--space-4);
+    }
+
+    &__image svg {
+      width: 4rem;
+      height: 4rem;
+      color: var(--tertiary);
+    }
+
+    &__title {
+      font-size: var(--font-up-3);
+      font-weight: 700;
+    }
+
+    &__body {
+      color: var(--primary-high);
+    }
+
+    &__tip {
+      margin: 0;
+      font-size: var(--font-0);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--space-3);
+    }
+
+    &__tip-text {
+      margin: 0;
+      color: var(--primary-medium);
+    }
+
+    &__members-facepile {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-1) var(--space-3);
+      border: 1px solid var(--primary-low);
+      border-radius: var(--d-border-radius-pill);
+
+      &.--with-avatars {
+        padding-inline-start: var(--space-1);
+      }
+    }
+
+    &__members-avatars {
+      display: flex;
+
+      .avatar {
+        border: 2px solid var(--secondary);
+        border-radius: 50%;
+
+        &:not(:first-child) {
+          margin-inline-start: -0.5rem;
+        }
+      }
+    }
+
+    &__members-count {
+      font-size: var(--font-down-1-rem);
+
+      strong {
+        color: var(--primary-high);
+      }
+    }
+  }
+}

--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -12,6 +12,13 @@
   width: max-content;
   min-width: 60%;
   gap: var(--space-3);
+  box-sizing: border-box;
+
+  .chat-drawer &,
+  .full-page-chat & {
+    margin-inline: var(--space-4);
+    max-width: calc(100% - var(--space-8));
+  }
 
   &__icon {
     display: flex;

--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,17 +1,49 @@
 .chat-channel-preview-card {
-  padding: 0.5rem;
+  padding: var(--space-4);
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
   z-index: 3;
-  border: 1px solid var(--d-chat-input-border-color);
-  background-color: var(--d-chat-input-bg-color);
+  border: 1px solid var(--tertiary-medium);
+  background: rgb(var(--tertiary-rgb), 0.075);
+  box-shadow: var(--shadow-card);
   border-radius: var(--d-border-radius-large);
-  margin: 1rem;
-  margin-top: 0.25rem;
+  margin: var(--space-4);
+  margin-top: var(--space-1);
 
   .chat-channel__placeholder {
     color: var(--primary-medium);
+  }
+
+  &.--anon {
+    gap: var(--space-3);
+  }
+
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background-color: var(--tertiary);
+    color: var(--secondary);
+  }
+
+  &__title {
+    font-weight: 700;
+  }
+
+  &__body {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,24 +1,17 @@
 .chat-channel-preview-card {
   padding: var(--space-4);
   display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content: space-between;
   z-index: 3;
   border: 1px solid var(--tertiary-medium);
   background: rgb(var(--tertiary-rgb), 0.075);
   box-shadow: var(--shadow-card);
   border-radius: var(--d-border-radius-large);
-  margin: var(--space-4);
+  margin: var(--space-4) auto;
   margin-top: var(--space-1);
-
-  .chat-channel__placeholder {
-    color: var(--primary-medium);
-  }
-
-  &.--anon {
-    gap: var(--space-3);
-  }
+  width: max-content;
+  min-width: 60%;
+  gap: var(--space-3);
 
   &__icon {
     display: flex;
@@ -43,6 +36,8 @@
 
   &__actions {
     display: flex;
+    margin-left: auto;
+    padding-left: var(--space-4);
     align-items: center;
     gap: var(--space-2);
   }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,10 +1,15 @@
 @use "lib/viewport";
 
 .chat-channel-preview-card {
-  padding: var(--space-4);
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas:
+    "icon title title"
+    ". body body"
+    "actions actions actions";
   align-items: center;
-  z-index: 3;
+  gap: var(--space-2) var(--space-3);
+  padding: var(--space-4);
   border: 1px solid var(--tertiary-medium);
   background: rgb(var(--tertiary-rgb), 0.075);
   box-shadow: var(--shadow-card);
@@ -13,8 +18,26 @@
   margin-top: var(--space-1);
   width: max-content;
   min-width: 60%;
-  gap: var(--space-3);
   box-sizing: border-box;
+
+  &.--no-access {
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "icon title"
+      "body body";
+  }
+
+  @include viewport.from(sm) {
+    grid-template-areas:
+      "icon title actions"
+      "icon body  actions";
+
+    &.--no-access {
+      grid-template-areas:
+        "icon title"
+        "icon body";
+    }
+  }
 
   .chat-drawer & {
     margin-inline: var(--space-4);
@@ -29,31 +52,52 @@
   }
 
   &__icon {
+    grid-area: icon;
     display: flex;
     align-items: center;
     justify-content: center;
     flex: 0 0 auto;
-    width: 2.5rem;
-    height: 2.5rem;
     border-radius: 50%;
     background-color: var(--tertiary);
     color: var(--secondary);
+    width: 2.5rem;
+    height: 2.5rem;
+
+    @include viewport.until(sm) {
+      width: 2rem;
+      height: 2rem;
+    }
   }
 
   &__title {
+    grid-area: title;
     font-weight: 700;
   }
 
   &__body {
+    grid-area: body;
     color: var(--primary-medium);
     font-size: var(--font-down-1);
   }
 
   &__actions {
+    grid-area: actions;
     display: flex;
-    margin-left: auto;
-    padding-left: var(--space-4);
     align-items: center;
     gap: var(--space-2);
+
+    @include viewport.until(sm) {
+      margin-top: var(--space-2);
+    }
+
+    .chat-channel-preview-card.--anon & {
+      justify-content: flex-end;
+    }
+  }
+
+  .toggle-channel-membership-button {
+    @include viewport.until(sm) {
+      width: 100%;
+    }
   }
 }

--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .chat-channel-preview-card {
   padding: var(--space-4);
   display: flex;
@@ -12,6 +14,19 @@
   width: max-content;
   min-width: 60%;
   gap: var(--space-3);
+  box-sizing: border-box;
+
+  .chat-drawer & {
+    margin-inline: var(--space-4);
+    max-width: calc(100% - var(--space-8));
+  }
+
+  .full-page-chat & {
+    @include viewport.until(sm) {
+      margin-inline: var(--space-4);
+      max-width: calc(100% - var(--space-8));
+    }
+  }
 
   &__icon {
     display: flex;

--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -6,6 +6,7 @@
 @import "chat-sidebar";
 @import "chat-channel";
 @import "chat-channel-card";
+@import "chat-channel-empty-state";
 @import "chat-channel-icon";
 @import "chat-channel-info";
 @import "chat-channel-name";

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -461,6 +461,17 @@ en:
         memberships_count:
           one: "%{count} member"
           other: "%{count} members"
+        empty_state:
+          title: "This is the start of %{channelName}"
+          guest_tip: "You're reading along as a guest. The conversation starts the moment members post — join in to be one of them."
+          members_here:
+            one: "<strong>%{count} member</strong> here"
+            other: "<strong>%{count} members</strong> here"
+        preview_card:
+          guest_title: "Join %{channelName} to start chatting"
+          guest_body: "Reading is free for everyone. Sign up to post, react, and reply — it takes about 30 seconds."
+          log_in: "Log in"
+          sign_up: "Sign up"
 
       create_channel:
         threading:

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -463,13 +463,19 @@ en:
           other: "%{count} members"
         empty_state:
           title: "This is the start of %{channelName}"
+          joined_title: "You're the first in %{channelName}"
           guest_tip: "You're reading along as a guest. The conversation starts the moment members post — join in to be one of them."
+          joined_tip: "Be the first to post and start the conversation."
           members_here:
             one: "<strong>%{count} member</strong> here"
             other: "<strong>%{count} members</strong> here"
+          no_other_members: "No other members yet"
         preview_card:
           guest_title: "Join %{channelName} to start chatting"
           guest_body: "Reading is free for everyone. Sign up to post, react, and reply — it takes about 30 seconds."
+          join_body: "You'll be able to post and reply, and it'll show up in your channel list."
+          no_access_title: "You can't join %{channelName}"
+          no_access_body: "This channel isn't open to new members right now."
           log_in: "Log in"
           sign_up: "Sign up"
 

--- a/plugins/chat/spec/system/anonymous_public_channels_spec.rb
+++ b/plugins/chat/spec/system/anonymous_public_channels_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe "Anonymous public chat channels" do
       id: existing_message.id,
       text: "Existing public channel update",
     )
-    expect(channel_page).to have_join_channel_button
+    expect(channel_page).to have_anonymous_preview_card
     expect(channel_page).to have_no_composer
     expect(channel_page).to have_no_search_button
     expect(channel_page).to have_no_star_button
 
-    channel_page.join_channel
+    channel_page.click_preview_card_login
 
     expect(login_page).to be_open
   end
@@ -60,7 +60,7 @@ RSpec.describe "Anonymous public chat channels" do
 
     expect(chat_drawer_page).to have_open_channel(public_channel)
 
-    chat_drawer_page.join_channel
+    chat_drawer_page.click_preview_card_login
     expect(login_page).to be_open
   end
 

--- a/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
+++ b/plugins/chat/spec/system/page_objects/chat/chat_channel.rb
@@ -52,6 +52,13 @@ module PageObjects
         find(".toggle-channel-membership-button.-join").click
       end
 
+      def click_preview_card_login
+        find(
+          ".chat-channel-preview-card .btn",
+          text: I18n.t("js.chat.channel.preview_card.log_in"),
+        ).click
+      end
+
       def message_by_id_selector(id)
         ".chat-channel .chat-messages-container .chat-message-container[data-id=\"#{id}\"]"
       end
@@ -237,6 +244,10 @@ module PageObjects
 
       def has_join_channel_button?
         has_css?(".toggle-channel-membership-button.-join")
+      end
+
+      def has_anonymous_preview_card?
+        has_css?(".chat-channel-preview-card.--anon")
       end
 
       def has_no_composer?

--- a/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
+++ b/plugins/chat/spec/system/page_objects/chat_drawer/chat_drawer.rb
@@ -70,6 +70,13 @@ module PageObjects
         find("#{VISIBLE_DRAWER} .toggle-channel-membership-button.-join").click
       end
 
+      def click_preview_card_login
+        find(
+          "#{VISIBLE_DRAWER} .chat-channel-preview-card .btn",
+          text: I18n.t("js.chat.channel.preview_card.log_in"),
+        ).click
+      end
+
       def open_channel_row(channel)
         find("#{VISIBLE_DRAWER} .chat-channel-row[data-chat-channel-id='#{channel.id}']").click
         has_no_css?(".chat-skeleton")

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "Visit channel" do
             it "allows to join it" do
               chat.visit_thread(thread)
 
-              expect(page).to have_content(I18n.t("js.chat.channel_settings.join"), count: 2)
+              expect(page).to have_css(".toggle-channel-membership-button.-join", count: 2)
             end
           end
         end


### PR DESCRIPTION
Providing a more attractive empty state and join CTA for chat channels.

| Scenario | Desktop | Drawer | Mobile |
|--------|--------|--------|--------|
| Anon | <img width="1746" height="1606" alt="CleanShot 2026-07-17 at 12 05 42@2x" src="https://github.com/user-attachments/assets/080d0785-fc5b-46ca-9cd7-1631ad8f0319" /> | <img width="1748" height="1628" alt="CleanShot 2026-07-17 at 12 07 32@2x" src="https://github.com/user-attachments/assets/d0ad65f1-ac7c-4365-88d9-88e30896f0b0" /> | <img width="736" height="1580" alt="CleanShot 2026-07-17 at 12 07 17@2x" src="https://github.com/user-attachments/assets/ae37e80c-db8e-49cd-8a24-79e5a05cb034" /> |
| Logged in, unjoined | <img width="1782" height="1622" alt="CleanShot 2026-07-17 at 12 09 09@2x" src="https://github.com/user-attachments/assets/f0adbe95-449b-43b7-92b2-3095a4ae9918" /> | <img width="1748" height="1628" alt="CleanShot 2026-07-17 at 12 08 01@2x" src="https://github.com/user-attachments/assets/a081a53b-5e14-403d-8eca-027b4b221add" /> | <img width="732" height="1582" alt="CleanShot 2026-07-17 at 12 09 19@2x" src="https://github.com/user-attachments/assets/f7f2348c-e84c-4386-806a-4a68437bc988" /> |
| Logged in, joined | <img width="1782" height="1622" alt="CleanShot 2026-07-17 at 12 08 48@2x" src="https://github.com/user-attachments/assets/59389f72-06e0-49a0-a50f-dd6f8fd3cd0a" /> | <img width="1748" height="1628" alt="CleanShot 2026-07-17 at 12 08 24@2x" src="https://github.com/user-attachments/assets/67ebdbae-3252-4472-ba0d-db8af59f02f2" /> | <img width="732" height="1582" alt="CleanShot 2026-07-17 at 12 09 30@2x" src="https://github.com/user-attachments/assets/8d5b893f-7fee-4368-982f-9d53bef400f4" /> | 

