### PR TITLE
UX: Name the failing repository in GitHub setting validation errors

### DIFF
--- a/plugins/discourse-github/app/lib/github_badges_repo_setting_validator.rb
+++ b/plugins/discourse-github/app/lib/github_badges_repo_setting_validator.rb
@@ -7,15 +7,21 @@ class GithubBadgesRepoSettingValidator
 
   def valid_value?(val)
     return true if val.blank?
-    val
-      .split("|")
-      .all? do |repo|
-        repo.match?(DiscourseGithubPlugin::GithubRepo::VALID_URL_BASED_REPO_REGEX) ||
-          repo.match?(DiscourseGithubPlugin::GithubRepo::VALID_USER_BASED_REPO_REGEX)
-      end
+    @invalid_repo =
+      val
+        .split("|")
+        .find do |repo|
+          !repo.match?(DiscourseGithubPlugin::GithubRepo::VALID_URL_BASED_REPO_REGEX) &&
+            !repo.match?(DiscourseGithubPlugin::GithubRepo::VALID_USER_BASED_REPO_REGEX)
+        end
+    @invalid_repo.nil?
   end
 
   def error_message
-    I18n.t("site_settings.errors.invalid_badge_repo")
+    if @invalid_repo.present?
+      I18n.t("site_settings.errors.invalid_badge_repo_value", repo: @invalid_repo)
+    else
+      I18n.t("site_settings.errors.invalid_badge_repo")
+    end
   end
 end

--- a/plugins/discourse-github/app/lib/github_linkback_access_token_setting_validator.rb
+++ b/plugins/discourse-github/app/lib/github_linkback_access_token_setting_validator.rb
@@ -9,14 +9,22 @@ class GithubLinkbackAccessTokenSettingValidator
     return true if val.blank?
     client = Discourse::GithubApi.new(val)
     DiscourseGithubPlugin::GithubRepo.repos.each do |repo|
+      @failing_repo = repo.name
       client.get("/repos/#{repo.name}/branches")
     end
     true
-  rescue Discourse::GithubApi::Unauthorized
+  rescue Discourse::GithubApi::Unauthorized, Discourse::GithubApi::NotFound
     false
   end
 
   def error_message
-    I18n.t("site_settings.errors.invalid_github_linkback_access_token")
+    if @failing_repo.present?
+      I18n.t(
+        "site_settings.errors.invalid_github_linkback_access_token_for_repo",
+        repo: @failing_repo,
+      )
+    else
+      I18n.t("site_settings.errors.invalid_github_linkback_access_token")
+    end
   end
 end

--- a/plugins/discourse-github/config/locales/server.en.yml
+++ b/plugins/discourse-github/config/locales/server.en.yml
@@ -16,7 +16,9 @@ en:
 
     errors:
       invalid_badge_repo: "You must provide a GitHub URL or the repository name in the format github_user/repository_name"
+      invalid_badge_repo_value: "'%{repo}' is not a valid GitHub URL or repository name. Use the format github_user/repository_name."
       invalid_github_linkback_access_token: "You must provide a valid GitHub linkback access token which has access to the badge repositories you have provided."
+      invalid_github_linkback_access_token_for_repo: "The GitHub linkback access token could not access the '%{repo}' repository. Make sure the token is valid and that the repository name is correct and accessible."
 
   github_linkback:
     commit_template: |

--- a/plugins/discourse-github/spec/lib/github_badges_repo_setting_validator_spec.rb
+++ b/plugins/discourse-github/spec/lib/github_badges_repo_setting_validator_spec.rb
@@ -46,4 +46,19 @@ describe GithubBadgesRepoSettingValidator do
       end
     end
   end
+
+  describe "#error_message" do
+    it "returns the generic message when no specific repo failed" do
+      expect(validator.error_message).to eq(I18n.t("site_settings.errors.invalid_badge_repo"))
+    end
+
+    it "names the first invalid repo in a list" do
+      value = "discourse/discourse-github|https://github.com/discourse/discourse/|bad-dog|nope"
+
+      expect(validator.valid_value?(value)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t("site_settings.errors.invalid_badge_repo_value", repo: "bad-dog"),
+      )
+    end
+  end
 end

--- a/plugins/discourse-github/spec/lib/github_linkback_access_token_setting_validator_spec.rb
+++ b/plugins/discourse-github/spec/lib/github_linkback_access_token_setting_validator_spec.rb
@@ -21,6 +21,19 @@ describe GithubLinkbackAccessTokenSettingValidator do
       end
     end
 
+    context "when a repo is missing or private (404)" do
+      before do
+        setup_repos
+        stub_request(:get, "https://api.github.com/repos/discourse/discourse/branches").to_return(
+          status: 404,
+        )
+      end
+
+      it "should fail" do
+        expect(validator.valid_value?(value)).to eq(false)
+      end
+    end
+
     context "when the token is accepted" do
       it "should pass, without repos defined" do
         expect(validator.valid_value?(value)).to eq(true)
@@ -42,8 +55,48 @@ describe GithubLinkbackAccessTokenSettingValidator do
     end
   end
 
-  def setup_repos
-    SiteSetting.github_badges_repos = "discourse/discourse"
+  describe "#error_message" do
+    it "returns the generic message when no specific repo failed" do
+      expect(validator.error_message).to eq(
+        I18n.t("site_settings.errors.invalid_github_linkback_access_token"),
+      )
+    end
+
+    it "names the failing repo when access is unauthorized (401)" do
+      setup_repos("discourse/discourse|acme/private-repo|foo/bar")
+      stub_branches("discourse/discourse", status: 200)
+      stub_branches("acme/private-repo", status: 401)
+
+      expect(validator.valid_value?(value)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t(
+          "site_settings.errors.invalid_github_linkback_access_token_for_repo",
+          repo: "acme/private-repo",
+        ),
+      )
+    end
+
+    it "names the failing repo when it is missing or private (404)" do
+      setup_repos("discourse/discourse|acme/typo-repo")
+      stub_branches("discourse/discourse", status: 200)
+      stub_branches("acme/typo-repo", status: 404)
+
+      expect(validator.valid_value?(value)).to eq(false)
+      expect(validator.error_message).to eq(
+        I18n.t(
+          "site_settings.errors.invalid_github_linkback_access_token_for_repo",
+          repo: "acme/typo-repo",
+        ),
+      )
+    end
+  end
+
+  def setup_repos(repos = "discourse/discourse")
+    SiteSetting.github_badges_repos = repos
     DiscourseGithubPlugin::GithubRepo.repos
+  end
+
+  def stub_branches(repo, status:)
+    stub_request(:get, "https://api.github.com/repos/#{repo}/branches").to_return(status:)
   end
 end


### PR DESCRIPTION
### Why

Saving `github_linkback_access_token` validates the token against every repository listed in `github_badges_repos`, and saving `github_badges_repos` validates the format of each entry. When one entry failed, both validators returned a generic error:

- _"You must provide a valid GitHub linkback access token which has access to the badge repositories you have provided."_
- _"You must provide a GitHub URL or the repository name in the format github_user/repository_name"_

Neither message said **which** repository was at fault. On a site with a long list of repositories, an admin had no way to identify the offending entry from the UI and had to run a console script to find it.

### What changed

Both validators now capture the first failing entry and interpolate its name into the error message, so the problem repository can be fixed straight from the settings page, e.g.:

> The GitHub linkback access token could not access the 'acme/private-repo' repository. Make sure the token is valid and that the repository name is correct and accessible.

> 'not a repo' is not a valid GitHub URL or repository name. Use the format github_user/repository_name.

The generic messages are kept as a fallback.

While reworking the token validator, a repository that is missing or private (GitHub answers both with a `404`) was previously left unrescued and turned the save into a `500`. That case is now treated as a validation failure, alongside an unauthorized (`401`) token, and reported with the same repository-naming message.

### Testing

Added specs covering the `401` and `404` paths for the token validator and the "name the first invalid entry" path for the badges-repo validator, plus the generic-message fallback for both.
