### PR TITLE
FIX: Refresh chat reviewable payload when re-flagging an edited message

### DIFF
--- a/plugins/chat/lib/chat/review_queue.rb
+++ b/plugins/chat/lib/chat/review_queue.rb
@@ -31,7 +31,7 @@ module Chat
         return result
       end
 
-      payload = { message_cooked: chat_message.cooked }
+      payload = { "message_cooked" => chat_message.cooked }
 
       if opts[:message].present? && !is_dm && is_notify_type
         creator = companion_pm_creator(chat_message, guardian.user, flag_type_id, opts)
@@ -43,14 +43,14 @@ module Chat
         end
       elsif is_dm
         transcript = find_or_create_transcript(chat_message, guardian.user, existing_reviewable)
-        payload[:transcript_topic_id] = transcript.topic_id if transcript
+        payload["transcript_topic_id"] = transcript.topic_id if transcript
       end
 
       queued_for_review = !!ActiveRecord::Type::Boolean.new.deserialize(opts[:queue_for_review])
 
       if !is_notify_user_type
         uploads = serialize_uploads(chat_message)
-        payload[:message_uploads] = uploads if uploads.present?
+        payload["message_uploads"] = uploads if uploads.present?
 
         reviewable =
           Chat::ReviewableMessage.needs_review!(
@@ -60,7 +60,10 @@ module Chat
             potential_spam: flag_type_id == ReviewableScore.types[:spam],
             payload: payload,
           )
-        reviewable.update(target_created_by: chat_message.user)
+        reviewable.update(
+          target_created_by: chat_message.user,
+          payload: (reviewable.payload || {}).merge(payload),
+        )
         score =
           reviewable.add_score(
             guardian.user,

--- a/plugins/chat/spec/lib/chat/review_queue_spec.rb
+++ b/plugins/chat/spec/lib/chat/review_queue_spec.rb
@@ -143,6 +143,26 @@ describe Chat::ReviewQueue do
         expect(second_flag_result).to include success: true
       end
 
+      it "refreshes the reviewable payload when re-flagging an edited message" do
+        upload = Fabricate(:upload, user: message_poster)
+        update_message!(
+          message,
+          user: message_poster,
+          text: "Now with an image ![#{upload.original_filename}](#{upload.short_url})",
+          upload_ids: [upload.id],
+        )
+        message.reload
+
+        expect(second_flag_result).to include success: true
+
+        payload = Chat::ReviewableMessage.find_by(target: message).payload
+        expect(payload["message_cooked"]).to eq(message.cooked)
+        expect(payload["message_cooked"]).to include(upload.url)
+        expect(payload["message_uploads"].map { |upload_json| upload_json["id"] }).to eq(
+          [upload.id],
+        )
+      end
+
       it "ignores the cooldown window when using the notify_moderators flag type" do
         notify_moderators_result =
           queue.flag_message(


### PR DESCRIPTION
When a chat message is re-flagged after being edited (via the `edited_since_last_review` path), `Reviewable.needs_review!` keeps the existing reviewable and discards the freshly built payload. Moderators then review a stale snapshot: text changes or uploads added in the edit are never reflected in the review queue, which renders `message_cooked` and `message_uploads` from the payload.

Refresh the payload on the existing reviewable so the queue reflects the current cooked content and uploads.