### PR TITLE
FEATURE: Bump newuser_max_embedded_media to a default of 5

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -1581,7 +1581,7 @@ posting:
     area: "posts_and_topics"
   newuser_max_embedded_media:
     client: true
-    default: 1
+    default: 5
     area: "posts_and_topics"
   newuser_max_attachments:
     client: true

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1564,6 +1564,7 @@ RSpec.describe PostsController do
         end
 
         it "does not silence when the post cannot be queued" do
+          SiteSetting.newuser_max_embedded_media = 1
           topic = Fabricate(:topic)
           user.change_trust_level!(TrustLevel[0])
 


### PR DESCRIPTION
New users can now upload up to 5 media items in a post. Previously this was limited to 1 as a spam-prevention measure but it was adding too much friction for legitimate users. With the current spam handling and review queue options in Discourse (especially hosted), this low limit is no longer necessary

internal ticket: /t/187161