### PR TITLE
FIX: Respect the category subcategory filter for events

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/category-calendar.gjs
@@ -38,6 +38,14 @@ export default class CategoryCalendar extends Component {
     });
   }
 
+  get includeSubcategories() {
+    return !this.router.currentRoute?.attributes?.noSubcategories;
+  }
+
+  get refreshKey() {
+    return `${this.category.id}-${this.includeSubcategories}`;
+  }
+
   @bind
   async loadEvents(info) {
     try {
@@ -46,8 +54,11 @@ export default class CategoryCalendar extends Component {
         before: info.endStr,
         include_ongoing: true,
         category_id: this.category.id,
-        include_subcategories: true,
       };
+
+      if (this.includeSubcategories) {
+        params.include_subcategories = true;
+      }
 
       const events = await this.discoursePostEventService.fetchEvents(params);
       return this.formattedEvents(events);
@@ -148,7 +159,7 @@ export default class CategoryCalendar extends Component {
         @height="650px"
         @initialView={{this.categorySetting.defaultView}}
         @weekends={{this.renderWeekends}}
-        @refreshKey={{this.category.id}}
+        @refreshKey={{this.refreshKey}}
       />
     {{/if}}
   </template>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/upcoming-events-list.gjs
@@ -38,7 +38,6 @@ export default class UpcomingEventsList extends Component {
   timeFormat = this.args.params?.timeFormat ?? DEFAULT_TIME_FORMAT;
   count = this.args.params?.count ?? DEFAULT_COUNT;
   upcomingDays = this.args.params?.upcomingDays ?? DEFAULT_UPCOMING_DAYS;
-  includeSubcategories = this.args.params?.includeSubcategories ?? false;
 
   emptyMessage = i18n("discourse_post_event.upcoming_events_list.empty");
   allDayLabel = i18n("discourse_post_event.upcoming_events_list.all_day");
@@ -57,6 +56,16 @@ export default class UpcomingEventsList extends Component {
 
   get categoryId() {
     return this.router.currentRoute.attributes?.category?.id;
+  }
+
+  get includeSubcategories() {
+    const { attributes } = this.router.currentRoute;
+
+    if (attributes?.category) {
+      return !attributes.noSubcategories;
+    }
+
+    return this.args.params?.includeSubcategories ?? false;
   }
 
   get hasEmptyResponse() {

--- a/plugins/discourse-calendar/test/javascripts/acceptance/category-calendar-subcategories-test.js
+++ b/plugins/discourse-calendar/test/javascripts/acceptance/category-calendar-subcategories-test.js
@@ -1,0 +1,58 @@
+import { visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import { cloneJSON } from "discourse/lib/object";
+import { fixturesByUrl } from "discourse/tests/helpers/create-pretender";
+import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+
+acceptance("Category Events Calendar - subcategory filter", function (needs) {
+  needs.user();
+  needs.settings({
+    calendar_enabled: true,
+    discourse_post_event_enabled: true,
+    events_calendar_categories: "1",
+    calendar_categories: "",
+  });
+
+  let lastEventsParams;
+
+  needs.hooks.beforeEach(function () {
+    lastEventsParams = undefined;
+  });
+
+  needs.pretender((server, helper) => {
+    server.get("/discourse-post-event/events", (request) => {
+      lastEventsParams = request.queryParams;
+      return helper.response({ events: [] });
+    });
+
+    server.get("/c/bug/1/none/l/latest.json", () => {
+      return helper.response(
+        cloneJSON(fixturesByUrl["/c/bug/1/l/latest.json"])
+      );
+    });
+  });
+
+  test("follows the category list's subcategory filter", async function (assert) {
+    await visit("/c/bug/1");
+
+    assert.strictEqual(
+      lastEventsParams.include_subcategories,
+      "true",
+      "requests subcategory events when the list shows subcategory topics"
+    );
+
+    lastEventsParams = undefined;
+    await visit("/c/bug/1/none");
+
+    assert.strictEqual(
+      lastEventsParams?.category_id,
+      "1",
+      "refetches events when the subcategory filter changes"
+    );
+    assert.strictEqual(
+      lastEventsParams?.include_subcategories,
+      undefined,
+      "omits subcategory events when the list hides subcategory topics"
+    );
+  });
+});

--- a/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/upcoming-events-list-test.gjs
@@ -637,6 +637,46 @@ module("Integration | Component | UpcomingEventsList", function (hooks) {
     assert.true(eventTime.includes("8"), "contains end day");
     assert.true(eventTime.includes("2100"), "contains year");
   });
+
+  test("respects the category list's subcategory filter", async function (assert) {
+    let lastQuery;
+    pretender.get("/discourse-post-event/events", ({ queryParams }) => {
+      lastQuery = queryParams;
+      return response({ events: [] });
+    });
+
+    const router = this.owner.lookup("service:router");
+    const setNoSubcategories = (noSubcategories) => {
+      router.currentRoute = {
+        attributes: {
+          category: { id: 1, slug: "announcements" },
+          noSubcategories,
+        },
+      };
+    };
+
+    await render(<template><UpcomingEventsList /></template>);
+
+    setNoSubcategories(false);
+    this.appEvents.trigger("page:changed", { url: "/c/announcements/1" });
+    await waitFor(".loading-container .spinner", { count: 0 });
+
+    assert.strictEqual(
+      lastQuery.include_subcategories,
+      "true",
+      "includes subcategory events when the category list shows subcategory topics"
+    );
+
+    setNoSubcategories(true);
+    this.appEvents.trigger("page:changed", { url: "/c/announcements/1/none" });
+    await waitFor(".loading-container .spinner", { count: 0 });
+
+    assert.strictEqual(
+      lastQuery.include_subcategories,
+      undefined,
+      "excludes subcategory events when the category list hides subcategory topics"
+    );
+  });
 });
 
 function twoEventsResponseHandler({ queryParams }) {


### PR DESCRIPTION
Previously, the upcoming-events sidebar block and the category events calendar ignored a category's "subcategories"/"no subcategories" filter — the block was locked to a static per-site parameter, and the calendar always included subcategory events.

This change derives subcategory inclusion from the current category route (matching core's `includeSubcategories === !noSubcategories`), so both surfaces show exactly the events the list's filter implies.

Reported at https://meta.discourse.org/t/have-the-upcoming-events-block-respect-the-subcategory-filter-when-in-category-lists/407540
