### PR TITLE
FIX: Control characters injected into AI translations

### DIFF
--- a/plugins/discourse-ai/lib/translation/base_translator.rb
+++ b/plugins/discourse-ai/lib/translation/base_translator.rb
@@ -26,16 +26,28 @@ module DiscourseAi
 
         bot = DiscourseAi::Agents::Bot.as(translation_user, agent:, model:)
 
-        ContentSplitter
-          .split(content: @text, chunk_size: model.max_output_tokens)
-          .map { |text| get_translation(text:, bot:, translation_user:, model:) }
-          .join("")
+        translated =
+          ContentSplitter
+            .split(content: @text, chunk_size: model.max_output_tokens)
+            .map { |text| get_translation(text:, bot:, translation_user:, model:) }
+            .join("")
+
+        strip_control_characters(translated)
       end
 
       private
 
       def formatted_content(content)
-        { content:, target_locale: @target_locale }.to_json
+        # JSON.generate over to_json: ActiveSupport HTML-escapes <, >, and & into
+        # \uXXXX sequences, which models can mis-copy into control characters
+        JSON.generate({ content:, target_locale: @target_locale })
+      end
+
+      # control characters are never valid in a translation, but models
+      # occasionally emit them by mangling unicode escapes (e.g. \u003c
+      # coming back as \u001c)
+      def strip_control_characters(text)
+        text.gsub(/[\u0000-\u0008\u000B-\u001F\u007F\u0080-\u009F]/, "")
       end
 
       def get_translation(text:, bot:, translation_user:, model:)

--- a/plugins/discourse-ai/spec/lib/translation/base_translator_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/base_translator_spec.rb
@@ -73,5 +73,41 @@ describe DiscourseAi::Translation::BaseTranslator do
         ).to eq "hur dur hur dur!"
       end
     end
+
+    it "sends the content to the model without HTML entity escaping" do
+      html_text = "List<string> and ?a=1&b=2"
+      post_translator =
+        DiscourseAi::Translation::PostRawTranslator.new(text: html_text, target_locale:, post:)
+
+      bot_context = instance_double(DiscourseAi::Agents::BotContext)
+      allow(DiscourseAi::Agents::BotContext).to receive(:new).and_return(bot_context)
+      mock_bot = instance_double(DiscourseAi::Agents::Bot)
+      allow(DiscourseAi::Agents::Bot).to receive(:as).and_return(mock_bot)
+      allow(mock_bot).to receive(:reply).and_yield(llm_response, nil, nil)
+
+      post_translator.translate
+
+      expect(DiscourseAi::Agents::BotContext).to have_received(:new).with(
+        user: an_instance_of(User),
+        skip_show_thinking: true,
+        feature_name: "translation",
+        messages: [
+          {
+            type: :user,
+            content: "{\"content\":\"List<string> and ?a=1&b=2\",\"target_locale\":\"de\"}",
+          },
+        ],
+        topic: nil,
+        post: post,
+      )
+    end
+
+    it "strips control characters from the model response but keeps newlines" do
+      DiscourseAi::Completions::Llm.with_prepared_responses(["hur\u001Cdur \u001Ehur\ndur!"]) do
+        expect(
+          DiscourseAi::Translation::PostRawTranslator.new(text:, target_locale:).translate,
+        ).to eq "hurdur hur\ndur!"
+      end
+    end
   end
 end


### PR DESCRIPTION
Follow-up to #41716, addressing the first issue from a user report: AI translations coming back with control characters (U+001C, U+001E, U+0016, ...) that were never in the source post, concentrated on posts containing `<`, `>`, or `&` (inline code, generic types, URLs with query strings).

## Root cause

`Translation::BaseTranslator#formatted_content` serialized the prompt payload with `to_json`, and Rails' default `escape_html_entities_in_json = true` HTML-escapes `<` `>` `&` into unicode escape sequences in the text the model receives:

```ruby
{ content: "List<string> and ?a=1&b=2", target_locale: "es" }.to_json
# => {"content":"List\u003cstring\u003e and ?a=1\u0026b=2","target_locale":"es"}
```

Some models (reported with gpt-4o-mini) mis-copy those escapes into their output, typically dropping a hex digit -- U+003C's escape comes back as U+001C -- and `PostLocalizer` persisted the decoded control characters verbatim into the localization's raw and cooked.

The reporter measured ~2% of localizations affected, dropping to 0 with the escaping disabled.

## Fix

- Serialize the payload with `JSON.generate`: it's an API argument, not HTML output, so there's nothing to HTML-escape. This removes the trigger entirely.
- Defense in depth: strip C0/C1 control characters (keeping newlines and tabs) from translator output before it's persisted. This covers all localizers (posts, topic titles, categories, tags) against any model that emits control characters for other reasons.

## Tests

New specs assert the prompt payload keeps `<`/`&` literal and that control characters are stripped from responses while newlines survive. Translation suite: 189 examples, 0 failures.
