### PR TITLE
FIX: Recover AI structured output when models emit stray prefixes

### DIFF
--- a/plugins/discourse-ai/lib/utils/best_effort_json_parser.rb
+++ b/plugins/discourse-ai/lib/utils/best_effort_json_parser.rb
@@ -31,7 +31,9 @@ module DiscourseAi
         #     unclosed structures and strings.
         #  2. JsonCompleter over a control-character-escaped copy: recovers
         #     values containing real newlines/tabs.
-        #  3. SmarterJSON: lenient parsing for single quotes, unquoted keys,
+        #  3. JsonCompleter from the object brace preceding the schema key:
+        #     recovers documents with stray characters before the real object.
+        #  4. SmarterJSON: lenient parsing for single quotes, unquoted keys,
         #     prose-wrapped JSON, and other LLM formatting quirks.
         #
         # A candidate wins if it holds the schema key; a parseable document
@@ -40,6 +42,7 @@ module DiscourseAi
           attempts = [
             -> { JsonCompleter.parse(cleaned) },
             -> { JsonCompleter.parse(escape_control_characters(cleaned)) },
+            -> { parse_from_key_object(cleaned, key) },
             -> { SmarterJSON.process_one(cleaned) },
           ]
 
@@ -58,6 +61,23 @@ module DiscourseAi
           end
 
           fallback
+        end
+
+        # Models occasionally emit stray characters before the real JSON
+        # object (observed: a duplicated opening brace-quote). Restart parsing
+        # from the object brace that precedes the schema key.
+        def parse_from_key_object(cleaned, key)
+          ["\"#{key}\"", "'#{key}'"].each do |quoted_key|
+            key_idx = cleaned.index(quoted_key)
+            next if key_idx.nil?
+
+            start = cleaned.rindex("{", key_idx)
+            next if start.nil? || start.zero?
+
+            return JsonCompleter.parse(escape_control_characters(cleaned[start..]))
+          end
+
+          nil
         end
 
         def remove_markdown_fences(text)

--- a/plugins/discourse-ai/lib/utils/best_effort_json_parser.rb
+++ b/plugins/discourse-ai/lib/utils/best_effort_json_parser.rb
@@ -67,17 +67,13 @@ module DiscourseAi
         # object (observed: a duplicated opening brace-quote). Restart parsing
         # from the object brace that precedes the schema key.
         def parse_from_key_object(cleaned, key)
-          ["\"#{key}\"", "'#{key}'"].each do |quoted_key|
-            key_idx = cleaned.index(quoted_key)
-            next if key_idx.nil?
+          key_idx = cleaned.index("\"#{key}\"") || cleaned.index("'#{key}'")
+          return if key_idx.nil?
 
-            start = cleaned.rindex("{", key_idx)
-            next if start.nil? || start.zero?
+          start = cleaned.rindex("{", key_idx)
+          return if start.nil? || start.zero?
 
-            return JsonCompleter.parse(escape_control_characters(cleaned[start..]))
-          end
-
-          nil
+          JsonCompleter.parse(escape_control_characters(cleaned[start..]))
         end
 
         def remove_markdown_fences(text)

--- a/plugins/discourse-ai/spec/lib/utils/best_effort_json_parser_spec.rb
+++ b/plugins/discourse-ai/spec/lib/utils/best_effort_json_parser_spec.rb
@@ -183,6 +183,15 @@ RSpec.describe DiscourseAi::Utils::BestEffortJsonParser do
       it "casts values to numbers for integer schemas" do
         expect(described_class.extract_key('{"output": 42}', "integer", :output)).to eq(42)
       end
+
+      it "recovers when the model emits stray characters before the JSON object" do
+        content = "Olá a todos! 😊\nVeja \"aspas\" e `List<string>` aqui."
+        input = "{\"#{{ output: content }.to_json}"
+
+        result = described_class.extract_key(input, "string", :output)
+
+        expect(result).to eq(content)
+      end
     end
 
     context "when very broken JSON is entered" do


### PR DESCRIPTION
Follow-up to #41716, found by live-testing the new parsing chain against locally configured vLLM models (Jolteon/CDCK MoM, DeepSeek V4 Flash, Qwen3.6 35B).

## The bug

DeepSeek V4 Flash reproducibly prefixes its structured output with a stray brace-quote, so the streamed document looks like:

```
{"{"output":"Olá a todos! ..."}
```

The complete, correct translation is in there, but every parser in the best-effort chain rejects the document (the stray prefix parses as an object key with no value), and `extract_key` returned an empty string — so translations from this model came back blank.

## The fix

Add a recovery attempt to the chain, between the control-character re-escape and the lenient parser: locate the schema key in the text and re-parse (truncation-tolerant) from the object brace immediately preceding it. This is generic for any "garbage before the real object" response, not just the doubled brace-quote observed here.

## Verification

Live runs of the real `PostRawTranslator` pipeline (hazard-rich source: emoji, inline code with `<`/`&`, code fences, blockquote, quoted strings) against the three vLLM models:

| model | before | after |
|---|---|---|
| Jolteon (CDCK/MoM) | complete, clean stream | complete, clean stream |
| Qwen3.6 35B A3B | complete, clean stream | complete, clean stream |
| DeepSeek V4 Flash | **blank translation** | complete translation via fallback, warning logged |

All structure checks pass on the recovered output: no control characters, no literal escape artifacts, angle brackets/query strings/code fences/blockquote/emoji intact.

Plus a regression spec with the exact observed shape. Parser + structured output suites: 111 examples, 0 failures.
