### PR TITLE
FIX: Prevent stale Floating UI trigger errors in tests

### DIFF
--- a/frontend/discourse/float-kit/modifiers/apply-floating-ui.js
+++ b/frontend/discourse/float-kit/modifiers/apply-floating-ui.js
@@ -31,15 +31,13 @@ export default class FloatKitApplyFloatingUi extends Modifier {
 
   @bind
   async update() {
-    if (this.instance.trigger?.isConnected === false) {
+    const { trigger, content } = this.instance;
+
+    if (!trigger?.isConnected || !content?.isConnected) {
       return;
     }
 
-    await updatePosition(
-      this.instance.trigger,
-      this.instance.content,
-      this.options
-    );
+    await updatePosition(trigger, content, this.options);
   }
 
   teardown() {

--- a/frontend/discourse/tests/unit/services/human-activity-tracker-test.js
+++ b/frontend/discourse/tests/unit/services/human-activity-tracker-test.js
@@ -1,6 +1,6 @@
 import { triggerEvent } from "@ember/test-helpers";
 import { setupTest } from "ember-qunit";
-import { module, skip, test } from "qunit";
+import { module, test } from "qunit";
 import sinon from "sinon";
 import { processBrowserAttentionChange } from "discourse/lib/user-presence";
 
@@ -67,11 +67,10 @@ module("Unit | Service | human-activity-tracker", function (hooks) {
     assert.strictEqual(this.sent.length, 0);
   });
 
-  // TODO: Flaky, skipped while investigating a global getBoundingClientRect error.
-  skip("counts interaction events and reports them on flush", async function (assert) {
-    await triggerEvent(document.body, "keydown");
-    await triggerEvent(document.body, "mousedown");
-    await triggerEvent(document.body, "scroll");
+  test("counts interaction events and reports them on flush", function (assert) {
+    window.dispatchEvent(new Event("keydown"));
+    window.dispatchEvent(new Event("mousedown"));
+    window.dispatchEvent(new Event("scroll"));
     pagehide();
 
     const payload = this.sent.at(-1);


### PR DESCRIPTION
Guard Floating UI position updates when the trigger or content element is no longer connected. This prevents stale autoUpdate callbacks from calling computePosition with an invalid reference element, which could surface as a global getBoundingClientRect error.

Re-enable the human activity tracker interaction-counting test, and dispatch events directly on window to match the service listener target instead of using synthetic bubbling events from document.body.