### PR TITLE
DEV: Add resolve_group_membership for theme object settings of group type

### DIFF
--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -856,19 +856,11 @@ class Theme < ActiveRecord::Base
   end
 
   def resolve_group_settings_for_user(settings_hash, guardian)
-    resolved_hash = settings_hash.dup
-
-    (cached_settings["theme_setting_type_info"] || []).each do |name, info|
-      next unless info[:type] == "list"
-      next unless info[:resolve_group_membership]
-
-      # Replace group list with user_in_ prefixed boolean (prevents leaking group IDs)
-      group_ids = settings_hash[name].to_s.split("|").map(&:to_i)
-      resolved_hash.delete(name)
-      resolved_hash[:"user_in_#{name}"] = guardian.in_any_groups?(group_ids)
-    end
-
-    resolved_hash
+    ThemeSettingsGroupResolver.resolve(
+      settings_hash:,
+      type_info: cached_settings["theme_setting_type_info"],
+      guardian:,
+    )
   end
 
   # Retrieves a theme setting

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -149,6 +149,7 @@ en:
         other: "Value must be at most %{count} characters long."
       resolve_group_membership_requires_list: "resolve_group_membership can only be used with type: list"
       resolve_group_membership_requires_group_list: "resolve_group_membership requires list_type: group"
+      resolve_group_membership_requires_groups_property: "resolve_group_membership can only be used with type: groups in object schemas. Invalid property: %{property}"
       objects:
         humanize_required: "The property at JSON Pointer '%{property_json_pointer}' must be present."
         required: "must be present"

--- a/docs/developer-guides/docs/05-themes-components/09-theme-settings.md
+++ b/docs/developer-guides/docs/05-themes-components/09-theme-settings.md
@@ -264,7 +264,7 @@ export default apiInitializer((api) => {
 });
 ```
 
-The generated boolean also works with automatic groups such as `logged_in_users` and `anonymous_users`.
+The generated boolean also works with automatic groups such as `logged_in_users` and `anonymous_users`. Object theme settings can use the same option on `type: groups` properties. See [objects type for theme settings](./10-objects-for-theme-settings.md#resolving-group-membership) for details.
 
 ## :link: Related Topics
 

--- a/docs/developer-guides/docs/05-themes-components/10-objects-for-theme-settings.md
+++ b/docs/developer-guides/docs/05-themes-components/10-objects-for-theme-settings.md
@@ -160,6 +160,42 @@ links:
 - `min`: Minimum number of records for the property. Value of the keyword has to be an integer.
 - `max`: Maximum number of records for the property. Value of the keyword has to be an integer.
 
+#### Resolving group membership
+
+Object settings can resolve `type: groups` properties to a boolean for the current user. This is useful when theme code only needs to know whether the current user is in one of the configured groups, because `currentUser.groups` only includes groups that are visible to the user.
+
+Add `resolve_group_membership: true` to the `groups` property:
+
+```yaml
+menu_sections:
+  type: objects
+  default:
+    - name: section 1
+      groups:
+        - 1
+        - 3
+  schema:
+    name: menu section
+    properties:
+      name:
+        type: string
+      groups:
+        type: groups
+        resolve_group_membership: true
+```
+
+The admin UI and stored setting value still use the original `groups` array. In the frontend runtime `settings` object, Discourse removes the group IDs from each object and adds a boolean with the same property name prefixed by `user_in_`:
+
+```gjs
+for (const section of settings.menu_sections) {
+  if (section.user_in_groups) {
+    // User is in at least one selected group for this section.
+  }
+}
+```
+
+This option is only valid on object schema properties with `type: groups`. It also works on nested object schemas and with automatic groups such as `logged_in_users` and `anonymous_users`.
+
 #### Nested objects structure
 
 An object can also have a property which contains an array of objects. In order to create a nested objects structure, a property can also be annotated with `type: objects` and the associated `schema` definition.

--- a/lib/theme_settings_group_resolver.rb
+++ b/lib/theme_settings_group_resolver.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "theme_settings_group_resolver/list_setting"
+require_relative "theme_settings_group_resolver/object_setting"
+
+# Rewrites theme settings that opted into server-side group membership resolution,
+# via the resolve_group_membership property in the theme settings schema.
+#
+# Example:
+#   settings_hash: { allowed_groups: "1|2", title: "Welcome" }
+#   type_info: { allowed_groups: { type: "list", resolve_group_membership: true } }
+#   output: { user_in_allowed_groups: true, title: "Welcome" }
+class ThemeSettingsGroupResolver
+  RESOLVERS = [ThemeSettingsGroupResolver::ListSetting, ThemeSettingsGroupResolver::ObjectSetting]
+
+  def self.resolve(settings_hash:, type_info:, guardian:)
+    new(settings_hash:, type_info:, guardian:).resolve
+  end
+
+  def initialize(settings_hash:, type_info:, guardian:)
+    @settings_hash = settings_hash
+    @type_info = type_info || {}
+    @guardian = guardian
+  end
+
+  def resolve
+    @type_info.each_with_object(@settings_hash.dup) do |(setting_name, setting_info), settings|
+      resolver_class = RESOLVERS.find { |resolver| resolver.applies?(setting_info) }
+      next if !resolver_class
+
+      resolver_class.new(setting_name:, setting_info:, guardian: @guardian).resolve!(settings)
+    end
+  end
+end

--- a/lib/theme_settings_group_resolver/list_setting.rb
+++ b/lib/theme_settings_group_resolver/list_setting.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ThemeSettingsGroupResolver
+  # Resolves one top-level group list setting into a boolean and removes the
+  # original group IDs from the frontend payload.
+  #
+  # c.f. ThemeSettingsGroupResolver.resolve
+  #
+  # Example:
+  #   input: { allowed_groups: "1|2" }
+  #   output: { user_in_allowed_groups: true }
+  class ListSetting
+    def self.applies?(setting_info)
+      setting_info[:type] == "list" && setting_info[:resolve_group_membership]
+    end
+
+    def initialize(setting_name:, setting_info:, guardian:)
+      @setting_name = setting_name
+      @guardian = guardian
+    end
+
+    def resolve!(settings)
+      group_ids = settings.delete(@setting_name).to_s.split("|").map(&:to_i)
+      settings[:"user_in_#{@setting_name}"] = @guardian.in_any_groups?(group_ids)
+    end
+  end
+end

--- a/lib/theme_settings_group_resolver/object_setting.rb
+++ b/lib/theme_settings_group_resolver/object_setting.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class ThemeSettingsGroupResolver
+  # Resolves opted-in `type: groups` properties inside object settings while
+  # leaving stored/admin values untouched.
+  #
+  # c.f. ThemeSettingsGroupResolver.resolve
+  #
+  # Example:
+  #   input: { menu_sections: [{ "groups" => [1, 2], "name" => "Main" }] }
+  #   output: { menu_sections: [{ "user_in_groups" => true, "name" => "Main" }] }
+  class ObjectSetting
+    def self.applies?(setting_info)
+      setting_info[:type] == "objects"
+    end
+
+    def initialize(setting_name:, setting_info:, guardian:)
+      @setting_name = setting_name
+      @schema = setting_info[:schema]
+      @guardian = guardian
+    end
+
+    def resolve!(settings)
+      objects = settings[@setting_name]
+      return if !objects.is_a?(Array) || !resolves_groups?(@schema)
+
+      settings[@setting_name] = objects.deep_dup.each { |object| resolve_object!(object, @schema) }
+    end
+
+    private
+
+    def resolves_groups?(schema)
+      return false if schema.blank?
+
+      schema[:properties].any? do |_, property|
+        (property[:type] == "groups" && property[:resolve_group_membership]) ||
+          (property[:type] == "objects" && resolves_groups?(property[:schema]))
+      end
+    end
+
+    def resolve_object!(object, schema)
+      schema[:properties].each do |property_name, property|
+        if property[:type] == "groups" && property[:resolve_group_membership]
+          resolve_group_property!(object, property_name)
+        elsif property[:type] == "objects"
+          resolve_nested_objects!(object, property_name, property[:schema])
+        end
+      end
+    end
+
+    def resolve_group_property!(object, property_name)
+      key = object_key(object, property_name)
+      group_ids = Array(object.delete(key)).map(&:to_i)
+      object[resolved_key(key, property_name)] = @guardian.in_any_groups?(group_ids)
+    end
+
+    def resolve_nested_objects!(object, property_name, schema)
+      nested_objects = object[object_key(object, property_name)]
+      return if !nested_objects.is_a?(Array)
+
+      nested_objects.each { |nested_object| resolve_object!(nested_object, schema) }
+    end
+
+    def object_key(object, property_name)
+      string_key = property_name.to_s
+      return string_key if object.key?(string_key)
+
+      property_name.to_sym
+    end
+
+    def resolved_key(original_key, property_name)
+      original_key.is_a?(String) ? "user_in_#{property_name}" : :"user_in_#{property_name}"
+    end
+  end
+end

--- a/lib/theme_settings_validator.rb
+++ b/lib/theme_settings_validator.rb
@@ -71,6 +71,11 @@ class ThemeSettingsValidator
           errors << I18n.t("themes.settings_errors.resolve_group_membership_requires_group_list")
         end
       end
+
+      if type == types[:objects]
+        errors.concat(validate_object_schema_resolve_group_membership(opts[:schema]))
+      end
+
       errors
     end
 
@@ -78,6 +83,28 @@ class ThemeSettingsValidator
 
     def types
       ThemeSetting.types
+    end
+
+    def validate_object_schema_resolve_group_membership(schema)
+      errors = []
+      return errors if schema.blank?
+
+      schema[:properties].each do |property_name, property_attributes|
+        if property_attributes[:resolve_group_membership] && property_attributes[:type] != "groups"
+          errors << I18n.t(
+            "themes.settings_errors.resolve_group_membership_requires_groups_property",
+            property: property_name,
+          )
+        end
+
+        if property_attributes[:type] == "objects"
+          errors.concat(
+            validate_object_schema_resolve_group_membership(property_attributes[:schema]),
+          )
+        end
+      end
+
+      errors
     end
 
     def validate_value_in_range!(value, min:, max:, errors:, translation_prefix:)

--- a/spec/lib/application_layout_preloader_spec.rb
+++ b/spec/lib/application_layout_preloader_spec.rb
@@ -106,6 +106,29 @@ RSpec.describe ApplicationLayoutPreloader do
           list_type: group
           resolve_group_membership: true
           default: "#{other_group.id}"
+        menu_sections:
+          type: objects
+          default:
+            - name: "member section"
+              groups:
+                - #{group.id}
+              visible_groups:
+                - #{other_group.id}
+            - name: "other section"
+              groups:
+                - #{other_group.id}
+              visible_groups:
+                - #{group.id}
+          schema:
+            name: "section"
+            properties:
+              name:
+                type: string
+              groups:
+                type: groups
+                resolve_group_membership: true
+              visible_groups:
+                type: groups
       YAML
 
       component.set_field(target: :settings, name: :yaml, value: <<~YAML)
@@ -138,6 +161,18 @@ RSpec.describe ApplicationLayoutPreloader do
               "color" => "red",
               "user_in_allowed_groups" => true,
               "user_in_other_allowed_groups" => false,
+              "menu_sections" => [
+                {
+                  "name" => "member section",
+                  "user_in_groups" => true,
+                  "visible_groups" => [other_group.id],
+                },
+                {
+                  "name" => "other section",
+                  "user_in_groups" => false,
+                  "visible_groups" => [group.id],
+                },
+              ],
             },
           },
           component.id.to_s => {

--- a/spec/lib/theme_settings_group_resolver/list_setting_spec.rb
+++ b/spec/lib/theme_settings_group_resolver/list_setting_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe ThemeSettingsGroupResolver::ListSetting do
+  fab!(:user)
+  fab!(:group)
+  fab!(:other_group, :group)
+
+  before { group.add(user) }
+
+  describe ".applies?" do
+    it "applies only to opted-in list settings" do
+      expect(described_class.applies?(type: "list", resolve_group_membership: true)).to eq(true)
+      expect(described_class.applies?(type: "list", resolve_group_membership: false)).to eq(false)
+      expect(described_class.applies?(type: "objects", resolve_group_membership: true)).to eq(false)
+    end
+  end
+
+  describe "#resolve!" do
+    it "replaces the group list with a user_in boolean" do
+      settings = { allowed_groups: "#{group.id}|#{other_group.id}" }
+
+      described_class.new(
+        setting_name: :allowed_groups,
+        setting_info: {
+        },
+        guardian: user.guardian,
+      ).resolve!(settings)
+
+      expect(settings).to eq(user_in_allowed_groups: true)
+    end
+
+    it "returns false for empty group lists and anonymous users" do
+      settings = { allowed_groups: "" }
+
+      described_class.new(
+        setting_name: :allowed_groups,
+        setting_info: {
+        },
+        guardian: Guardian.new,
+      ).resolve!(settings)
+
+      expect(settings).to eq(user_in_allowed_groups: false)
+    end
+  end
+end

--- a/spec/lib/theme_settings_group_resolver/object_setting_spec.rb
+++ b/spec/lib/theme_settings_group_resolver/object_setting_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+RSpec.describe ThemeSettingsGroupResolver::ObjectSetting do
+  fab!(:user)
+  fab!(:group)
+  fab!(:other_group, :group)
+
+  before { group.add(user) }
+
+  describe ".applies?" do
+    it "applies only to object settings" do
+      expect(described_class.applies?(type: "objects")).to eq(true)
+      expect(described_class.applies?(type: "list")).to eq(false)
+    end
+  end
+
+  describe "#resolve!" do
+    it "replaces opted-in group properties with user_in booleans" do
+      settings = {
+        menu_sections: [
+          {
+            "name" => "member section",
+            "groups" => [group.id],
+            "visible_groups" => [other_group.id],
+          },
+          {
+            "name" => "other section",
+            "groups" => [other_group.id],
+            "visible_groups" => [group.id],
+          },
+        ],
+      }
+
+      resolve!(settings, schema: section_schema)
+
+      expect(settings[:menu_sections]).to eq(
+        [
+          {
+            "name" => "member section",
+            "user_in_groups" => true,
+            "visible_groups" => [other_group.id],
+          },
+          { "name" => "other section", "user_in_groups" => false, "visible_groups" => [group.id] },
+        ],
+      )
+    end
+
+    it "resolves nested object group properties" do
+      settings = {
+        menu_sections: [
+          {
+            "name" => "section",
+            "links" => [
+              { "name" => "member link", "groups" => [group.id] },
+              { "name" => "other link", "groups" => [other_group.id] },
+            ],
+          },
+        ],
+      }
+
+      resolve!(settings, schema: nested_groups_schema)
+
+      expect(settings[:menu_sections]).to eq(
+        [
+          {
+            "name" => "section",
+            "links" => [
+              { "name" => "member link", "user_in_groups" => true },
+              { "name" => "other link", "user_in_groups" => false },
+            ],
+          },
+        ],
+      )
+    end
+
+    it "does not mutate the original object value" do
+      original_objects = [{ "name" => "section", "groups" => [group.id] }]
+      settings = { menu_sections: original_objects }
+
+      resolve!(settings, schema: section_schema)
+
+      expect(original_objects).to eq([{ "name" => "section", "groups" => [group.id] }])
+      expect(settings[:menu_sections]).not_to equal(original_objects)
+    end
+
+    it "preserves symbol keys when resolving symbol-keyed objects" do
+      settings = { menu_sections: [{ name: "section", groups: [group.id] }] }
+
+      resolve!(settings, schema: section_schema)
+
+      expect(settings[:menu_sections]).to eq([{ name: "section", user_in_groups: true }])
+    end
+
+    it "leaves settings unchanged when no group properties opt in" do
+      original_objects = [{ "name" => "section", "groups" => [group.id] }]
+      settings = { menu_sections: original_objects }
+      schema = { name: "section", properties: { groups: { type: "groups" } } }
+
+      resolve!(settings, schema:)
+
+      expect(settings[:menu_sections]).to equal(original_objects)
+    end
+
+    it "handles anonymous users, auto-groups, empty arrays, and multiple groups" do
+      settings = {
+        menu_sections: [
+          { "name" => "logged in", "groups" => [Group::AUTO_GROUPS[:logged_in_users]] },
+          { "name" => "anonymous", "groups" => [Group::AUTO_GROUPS[:anonymous_users]] },
+          { "name" => "empty", "groups" => [] },
+          { "name" => "multiple", "groups" => [group.id, other_group.id] },
+        ],
+      }
+
+      resolve!(settings, schema: section_schema, guardian: Guardian.new)
+
+      expect(settings[:menu_sections].pluck("user_in_groups")).to eq([false, true, false, false])
+    end
+  end
+
+  def resolve!(settings, schema:, guardian: user.guardian)
+    described_class.new(
+      setting_name: :menu_sections,
+      setting_info: {
+        schema:,
+      },
+      guardian:,
+    ).resolve!(settings)
+  end
+
+  def section_schema
+    {
+      name: "section",
+      properties: {
+        groups: {
+          type: "groups",
+          resolve_group_membership: true,
+        },
+        visible_groups: {
+          type: "groups",
+        },
+        links: {
+          type: "objects",
+          schema: {
+            name: "link",
+            properties: {
+              groups: {
+                type: "groups",
+                resolve_group_membership: true,
+              },
+            },
+          },
+        },
+      },
+    }
+  end
+
+  def nested_groups_schema
+    {
+      name: "section",
+      properties: {
+        links: {
+          type: "objects",
+          schema: {
+            name: "link",
+            properties: {
+              groups: {
+                type: "groups",
+                resolve_group_membership: true,
+              },
+            },
+          },
+        },
+      },
+    }
+  end
+end

--- a/spec/lib/theme_settings_group_resolver_spec.rb
+++ b/spec/lib/theme_settings_group_resolver_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe ThemeSettingsGroupResolver do
+  fab!(:user)
+  fab!(:group)
+
+  before { group.add(user) }
+
+  describe ".resolve" do
+    it "resolves list and object group memberships from type metadata" do
+      settings = {
+        allowed_groups: group.id.to_s,
+        menu_sections: [{ "name" => "section", "groups" => [group.id] }],
+        title: "Welcome",
+      }
+      type_info = {
+        allowed_groups: {
+          type: "list",
+          resolve_group_membership: true,
+        },
+        menu_sections: {
+          type: "objects",
+          schema: {
+            name: "section",
+            properties: {
+              groups: {
+                type: "groups",
+                resolve_group_membership: true,
+              },
+            },
+          },
+        },
+        title: {
+          type: "string",
+        },
+      }
+
+      expect(
+        described_class.resolve(settings_hash: settings, type_info:, guardian: user.guardian),
+      ).to eq(
+        {
+          user_in_allowed_groups: true,
+          menu_sections: [{ "name" => "section", "user_in_groups" => true }],
+          title: "Welcome",
+        },
+      )
+    end
+  end
+end

--- a/spec/lib/theme_settings_validator_spec.rb
+++ b/spec/lib/theme_settings_validator_spec.rb
@@ -82,5 +82,95 @@ RSpec.describe ThemeSettingsValidator do
 
       expect(errors).to eq([])
     end
+
+    it "returns no errors when resolve_group_membership is true on an object groups property" do
+      errors =
+        described_class.validate_value(
+          [{ groups: [Group::AUTO_GROUPS[:admins]] }],
+          ThemeSetting.types[:objects],
+          {
+            schema: {
+              name: "section",
+              properties: {
+                groups: {
+                  type: "groups",
+                  resolve_group_membership: true,
+                },
+              },
+            },
+          },
+        )
+
+      expect(errors).to eq([])
+    end
+
+    it "returns an error when resolve_group_membership is true on a non-groups object property" do
+      errors =
+        described_class.validate_value(
+          [{ name: "section", category_ids: [] }],
+          ThemeSetting.types[:objects],
+          {
+            schema: {
+              name: "section",
+              properties: {
+                name: {
+                  type: "string",
+                  resolve_group_membership: true,
+                },
+                category_ids: {
+                  type: "categories",
+                  resolve_group_membership: true,
+                },
+              },
+            },
+          },
+        )
+
+      expect(errors).to contain_exactly(
+        I18n.t(
+          "themes.settings_errors.resolve_group_membership_requires_groups_property",
+          property: :name,
+        ),
+        I18n.t(
+          "themes.settings_errors.resolve_group_membership_requires_groups_property",
+          property: :category_ids,
+        ),
+      )
+    end
+
+    it "returns an error when resolve_group_membership is true on a nested objects property" do
+      errors =
+        described_class.validate_value(
+          [{ links: [] }],
+          ThemeSetting.types[:objects],
+          {
+            schema: {
+              name: "section",
+              properties: {
+                links: {
+                  type: "objects",
+                  resolve_group_membership: true,
+                  schema: {
+                    name: "link",
+                    properties: {
+                      groups: {
+                        type: "groups",
+                        resolve_group_membership: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        )
+
+      expect(errors).to contain_exactly(
+        I18n.t(
+          "themes.settings_errors.resolve_group_membership_requires_groups_property",
+          property: :links,
+        ),
+      )
+    end
   end
 end


### PR DESCRIPTION
Followup 7e77ce4bd3889820d67b52a5788357ac6f7b2f58

We need to automatically resolve group membership into a boolean
for theme object type settings which are of the group type, similar
to what we did in the original commit above for group list type
settings.

This behaves in the same way -- for an object setting schema like this:

```
menu_sections:
  type: objects
  default:
    - name: section 1
      groups:
        - 1
        - 3
  schema:
    name: menu section
    properties:
      name:
        type: string
      groups:
        type: groups
        resolve_group_membership: true
```

We replace `groups` with a boolean `user_in_groups` (groups is just
the property name, it could be foo_bar etc.) and then you can
do this on the client:

```
for (const section of settings.menu_sections) {
  if (section.user_in_groups) {
    // User is in at least one selected group for this section.
  }
}
```

Rather than inspecting the `currentUser.groups`, which only includes
visible groups, not all groups the user is a member of. This allows
for more accurate permission checks for theme settings that are group
based.

Also c.f. https://meta.discourse.org/t/granular-group-based-permissions-for-anonymous-and-logged-in-users/402273/18?u=martin
