### PR TITLE
UX: Fix padding of pm small action in mobile view of horizon theme

### DIFF
--- a/themes/horizon/scss/mobile-stuff.scss
+++ b/themes/horizon/scss/mobile-stuff.scss
@@ -142,37 +142,39 @@
     }
   }
 
-  .container.posts {
-    @include viewport.until(sm) {
-      .main-avatar .avatar {
-        width: 40px;
-        height: 40px;
-      }
+  body:not(.archetype-private_message) {
+    .container.posts {
+      @include viewport.until(sm) {
+        .main-avatar .avatar {
+          width: 40px;
+          height: 40px;
+        }
 
-      .topic-body {
-        .topic-meta-data {
-          .username {
-            font-size: var(--font-0-rem);
+        .topic-body {
+          .topic-meta-data {
+            .username {
+              font-size: var(--font-0-rem);
+            }
+          }
+
+          .contents {
+            padding-top: var(--space-4);
           }
         }
 
-        .contents {
-          padding-top: var(--space-4);
-        }
-      }
+        .small-action {
+          &-desc {
+            padding: var(--space-1) 0;
+          }
 
-      .small-action {
-        &-desc {
-          padding: var(--space-1) 0;
-        }
+          // for core eventually, better way imo
+          .topic-avatar {
+            padding-top: 0;
+            align-items: center;
 
-        // for core eventually, better way imo
-        .topic-avatar {
-          padding-top: 0;
-          align-items: center;
-
-          .d-icon {
-            font-size: var(--font-up-1);
+            .d-icon {
+              font-size: var(--font-up-1);
+            }
           }
         }
       }


### PR DESCRIPTION
There exists a UX bug in mobile view of the horizon theme. In PM, the padding of `small-action` is misaligned, causing the "x" in "x month later" to be invisible.

This is caused by the body redesign, and this commit exclude that to align behaviors.

Before:

<img width="1197" height="833" alt="image" src="https://github.com/user-attachments/assets/73395c89-7f6d-42fd-b73b-68c0ca71ba69" />

After:

<img width="1197" height="837" alt="image" src="https://github.com/user-attachments/assets/88ec003d-8ab8-472b-b722-16c57219f320" />
