### PR TITLE
FEATURE: Persist "Activity by category" dashboard filter selection

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -4,7 +4,12 @@ class Admin::DashboardController < Admin::StaffController
   BULK_REPORTS_FILTER_KEYS = %i[start_date end_date].freeze
 
   before_action :ensure_admin,
-                only: %i[available_reports update_reports_section update_configuration]
+                only: %i[
+                  available_reports
+                  update_reports_section
+                  update_configuration
+                  update_section_settings
+                ]
 
   def index
     if dashboard_improvements?
@@ -23,6 +28,20 @@ class Admin::DashboardController < Admin::StaffController
   def update_configuration
     sections = params.permit(sections: %i[id visible])[:sections] || []
     AdminDashboardSectionConfiguration.update(sections, actor: current_user)
+    head :no_content
+  end
+
+  def update_section_settings
+    section_id = params.require(:section_id)
+    key = params.require(:setting_key)
+
+    definition = AdminDashboardSectionConfiguration.setting_definition(section_id, key)
+
+    AdminDashboardSectionConfiguration.update_setting(
+      section_id:,
+      key:,
+      attrs: params.permit(*(definition&.dig(:permit) || [])),
+    )
     head :no_content
   end
 

--- a/app/models/admin_dashboard_section.rb
+++ b/app/models/admin_dashboard_section.rb
@@ -12,6 +12,7 @@ end
 #
 #  id         :bigint           not null, primary key
 #  position   :integer          not null
+#  settings   :jsonb            not null
 #  visible    :boolean          default(TRUE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/services/admin_dashboard_engagement.rb
+++ b/app/services/admin_dashboard_engagement.rb
@@ -123,12 +123,12 @@ class AdminDashboardEngagement
   def build_activity_by_category
     args = { start_date: start_date, end_date: end_date, current_user: current_user }
 
-    category_ids =
+    selected_category_ids =
       AdminDashboardSectionConfiguration.settings_for("engagement").dig(
         "activity_by_category",
         "category_ids",
       )
-    args[:filters] = { category_ids: } if category_ids.present?
+    args[:filters] = { category_ids: selected_category_ids } if selected_category_ids.present?
 
     report = Report.find_cached("activity_by_category", args)
     if report.nil?
@@ -141,7 +141,13 @@ class AdminDashboardEngagement
     {
       rows: report_data(report),
       total: report.is_a?(Hash) ? report[:total] : report.total,
-      category_ids: category_ids,
+      category_ids: visible_category_ids(selected_category_ids),
     }
+  end
+
+  def visible_category_ids(category_ids)
+    return category_ids if category_ids.blank?
+
+    Category.secured(Guardian.new(current_user)).in_order_of(:id, category_ids).pluck(:id)
   end
 end

--- a/app/services/admin_dashboard_engagement.rb
+++ b/app/services/admin_dashboard_engagement.rb
@@ -123,6 +123,13 @@ class AdminDashboardEngagement
   def build_activity_by_category
     args = { start_date: start_date, end_date: end_date, current_user: current_user }
 
+    category_ids =
+      AdminDashboardSectionConfiguration.settings_for("engagement").dig(
+        "activity_by_category",
+        "category_ids",
+      )
+    args[:filters] = { category_ids: } if category_ids.present?
+
     report = Report.find_cached("activity_by_category", args)
     if report.nil?
       report = Report.find("activity_by_category", args)
@@ -131,6 +138,10 @@ class AdminDashboardEngagement
 
     return nil if report.nil? || report_error?(report)
 
-    { rows: report_data(report), total: report.is_a?(Hash) ? report[:total] : report.total }
+    {
+      rows: report_data(report),
+      total: report.is_a?(Hash) ? report[:total] : report.total,
+      category_ids: category_ids,
+    }
   end
 end

--- a/app/services/admin_dashboard_section_configuration.rb
+++ b/app/services/admin_dashboard_section_configuration.rb
@@ -3,6 +3,33 @@
 class AdminDashboardSectionConfiguration
   KNOWN_SECTIONS = %w[highlights reports traffic engagement search].freeze
 
+  ACTIVITY_BY_CATEGORY_MAX = 10
+
+  SUPPORTED_SETTINGS = {
+    "engagement" => {
+      "activity_by_category" => {
+        permit: [{ category_ids: [] }],
+        validate: ->(attrs) do
+          ids = attrs[:category_ids]
+          raise Discourse::InvalidParameters.new(:category_ids) if !ids.is_a?(Array)
+
+          parsed = ids.map { |id| Integer(id, exception: false) }
+
+          if parsed.size > ACTIVITY_BY_CATEGORY_MAX || parsed.any?(&:nil?) ||
+               parsed.uniq.size != parsed.size
+            raise Discourse::InvalidParameters.new(:category_ids)
+          end
+
+          if parsed.present? && Category.where(id: parsed).count != parsed.size
+            raise Discourse::InvalidParameters.new(:category_ids)
+          end
+
+          { "category_ids" => parsed }
+        end,
+      },
+    },
+  }.freeze
+
   def self.available_plugin_section_ids
     DiscoursePluginRegistry
       .admin_dashboard_sections
@@ -30,6 +57,31 @@ class AdminDashboardSectionConfiguration
 
   def self.visible_section_ids
     sections.select { |s| s[:visible] }.map { |s| s[:id] }
+  end
+
+  def self.settings_for(section_id)
+    AdminDashboardSection.where(section_id: section_id.to_s).pick(:settings) || {}
+  end
+
+  def self.setting_definition(section_id, key)
+    SUPPORTED_SETTINGS.dig(section_id.to_s, key.to_s)
+  end
+
+  def self.update_setting(section_id:, key:, attrs:)
+    section_id = section_id.to_s
+    key = key.to_s
+
+    definition = setting_definition(section_id, key)
+    raise Discourse::InvalidParameters.new(:setting_key) if definition.nil?
+
+    value = definition[:validate].call(attrs.to_h.with_indifferent_access)
+
+    record = AdminDashboardSection.find_by(section_id:)
+    raise Discourse::InvalidParameters.new(:section_id) if record.nil?
+
+    record.with_lock { record.update!(settings: record.settings.to_h.deep_merge(key => value)) }
+
+    record.settings
   end
 
   def self.update(input_sections, actor:)

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7203,6 +7203,7 @@ en:
               share: "Share"
               vs_prior: "Vs Prior"
               empty: "No activity in the selected period."
+              save_error: "Couldn't save your selection for next time."
             whos_posting:
               title: "Who's posting?"
               all_categories: "All categories"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,6 +327,9 @@ Discourse::Application.routes.draw do
       get "dashboard" => "dashboard#index"
       put "dashboard/configuration" => "dashboard#update_configuration",
           :constraints => AdminConstraint.new
+      put "dashboard/sections/:section_id/settings/:setting_key" =>
+            "dashboard#update_section_settings",
+          :constraints => AdminConstraint.new
       get "dashboard/general" => "dashboard#general"
       get "dashboard/moderation" => "dashboard#moderation"
       get "dashboard/security" => "dashboard#security"

--- a/db/migrate/20260714152340_add_settings_to_admin_dashboard_sections.rb
+++ b/db/migrate/20260714152340_add_settings_to_admin_dashboard_sections.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddSettingsToAdminDashboardSections < ActiveRecord::Migration[8.0]
+  def change
+    add_column :admin_dashboard_sections, :settings, :jsonb, null: false, default: {}
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -340,7 +340,8 @@ CREATE TABLE public.admin_dashboard_sections (
     "position" integer NOT NULL,
     visible boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    settings jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -22651,6 +22652,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260715090434'),
 ('20260715090355'),
 ('20260715064155'),
+('20260714152340'),
 ('20260713180615'),
 ('20260708095336'),
 ('20260708080308'),

--- a/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
@@ -1,10 +1,11 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn } from "@ember/helper";
+import { fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { LinkTo } from "@ember/routing";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -16,7 +17,12 @@ import dCategoryBadge from "discourse/ui-kit/helpers/d-category-badge";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
 
+const MAX_CATEGORIES = 10;
+
 export default class ActivityByCategory extends Component {
+  @service currentUser;
+  @service toasts;
+
   @tracked selectedCategories = [];
   @tracked overrideActivity = null;
   @tracked loading = false;
@@ -26,8 +32,12 @@ export default class ActivityByCategory extends Component {
   constructor() {
     super(...arguments);
 
-    this.selectedCategories = (this.args.activity?.rows ?? [])
-      .map((row) => Category.findById(row.category_id))
+    const ids =
+      this.args.activity?.category_ids ??
+      (this.args.activity?.rows ?? []).map((row) => row.category_id);
+
+    this.selectedCategories = ids
+      .map((id) => Category.findById(id))
       .filter(Boolean);
   }
 
@@ -68,6 +78,33 @@ export default class ActivityByCategory extends Component {
   onCategoriesChange(categories) {
     this.selectedCategories = categories;
     this.refetch();
+    this.#persistSelection();
+  }
+
+  #persistSelection() {
+    if (!this.currentUser?.admin) {
+      return;
+    }
+
+    ajax(
+      "/admin/dashboard/sections/engagement/settings/activity_by_category.json",
+      {
+        type: "PUT",
+        contentType: "application/json",
+        data: JSON.stringify({
+          category_ids: this.selectedCategories.map((c) => c.id),
+        }),
+      }
+    ).catch(() => {
+      this.toasts.error({
+        duration: "short",
+        data: {
+          message: i18n(
+            "admin.dashboard.sections.engagement.activity_by_category.save_error"
+          ),
+        },
+      });
+    });
   }
 
   @action
@@ -136,6 +173,7 @@ export default class ActivityByCategory extends Component {
         <CategorySelector
           @categories={{this.selectedCategories}}
           @onChange={{this.onCategoriesChange}}
+          @options={{hash maximum=MAX_CATEGORIES}}
         />
       </div>
 

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -753,6 +753,110 @@ RSpec.describe Admin::DashboardController do
     end
   end
 
+  describe "#update_section_settings" do
+    fab!(:category)
+    fab!(:category_2, :category)
+    fab!(:category_3, :category)
+
+    before { SiteSetting.dashboard_improvements = true }
+
+    it "persists the selected category ids and returns 204 for admins" do
+      sign_in(admin)
+
+      put "/admin/dashboard/sections/engagement/settings/activity_by_category.json",
+          params: {
+            category_ids: [category_3.id, category.id, category_2.id],
+          }
+
+      expect(response.status).to eq(204)
+      expect(AdminDashboardSectionConfiguration.settings_for("engagement")).to eq(
+        {
+          "activity_by_category" => {
+            "category_ids" => [category_3.id, category.id, category_2.id],
+          },
+        },
+      )
+    end
+
+    it "returns 400 when more than ten categories are given" do
+      sign_in(admin)
+
+      put "/admin/dashboard/sections/engagement/settings/activity_by_category.json",
+          params: {
+            category_ids: (1..11).to_a,
+          }
+
+      expect(response.status).to eq(400)
+      expect(AdminDashboardSectionConfiguration.settings_for("engagement")).to eq({})
+    end
+
+    it "returns 400 when a category with the given id does not exist" do
+      sign_in(admin)
+
+      put "/admin/dashboard/sections/engagement/settings/activity_by_category.json",
+          params: {
+            category_ids: [category.id, Category.maximum(:id) + 1],
+          }
+
+      expect(response.status).to eq(400)
+      expect(AdminDashboardSectionConfiguration.settings_for("engagement")).to eq({})
+    end
+
+    it "returns 400 for an unknown section id" do
+      sign_in(admin)
+
+      put "/admin/dashboard/sections/frobnitz/settings/activity_by_category.json",
+          params: {
+            category_ids: [1],
+          }
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns 400 for a known section that does not support this setting" do
+      sign_in(admin)
+
+      put "/admin/dashboard/sections/traffic/settings/activity_by_category.json",
+          params: {
+            category_ids: [1],
+          }
+
+      expect(response.status).to eq(400)
+      expect(AdminDashboardSectionConfiguration.settings_for("traffic")).to eq({})
+    end
+
+    it "returns 400 for an unknown setting key" do
+      sign_in(admin)
+
+      put "/admin/dashboard/sections/engagement/settings/not_a_real_setting.json",
+          params: {
+            category_ids: [1],
+          }
+
+      expect(response.status).to eq(400)
+    end
+
+    it "returns 404 for moderators" do
+      sign_in(moderator)
+
+      put "/admin/dashboard/sections/engagement/settings/activity_by_category.json",
+          params: {
+            category_ids: [1],
+          }
+
+      expect(response.status).to eq(404)
+    end
+
+    it "returns 404 for anonymous users" do
+      put "/admin/dashboard/sections/engagement/settings/activity_by_category.json",
+          params: {
+            category_ids: [1],
+          }
+
+      expect(response.status).to eq(404)
+    end
+  end
+
   describe "#problems" do
     before { ProblemCheck.stubs(:realtime).returns(stub(run_all: [])) }
 

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -210,6 +210,26 @@ describe AdminDashboardEngagement do
         ids = result[:activity_by_category][:rows].map { |r| r[:category_id] }
         expect(ids).to include(private_cat.id)
       end
+
+      it "restricts rows to the persisted category selection" do
+        selected = Fabricate(:category)
+        other = Fabricate(:category)
+        Fabricate(:topic, category: selected, created_at: Time.zone.local(2026, 4, 10))
+        Fabricate(:topic, category: other, created_at: Time.zone.local(2026, 4, 10))
+
+        AdminDashboardSectionConfiguration.update_setting(
+          section_id: "engagement",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [selected.id],
+          },
+        )
+
+        result = described_class.build(start_date: "2026-04-01", end_date: "2026-04-28")
+
+        ids = result[:activity_by_category][:rows].map { |r| r[:category_id] }
+        expect(ids).to contain_exactly(selected.id)
+      end
     end
 
     describe "trust_level_pipeline" do

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -230,6 +230,57 @@ describe AdminDashboardEngagement do
         ids = result[:activity_by_category][:rows].map { |r| r[:category_id] }
         expect(ids).to contain_exactly(selected.id)
       end
+
+      it "omits categories the current user cannot see from the persisted selection" do
+        moderator = Fabricate(:moderator)
+        visible = Fabricate(:category)
+        private_group = Fabricate(:group)
+        restricted = Fabricate(:private_category, group: private_group, read_restricted: true)
+
+        AdminDashboardSectionConfiguration.update_setting(
+          section_id: "engagement",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [visible.id, restricted.id],
+          },
+        )
+
+        result =
+          described_class.build(
+            start_date: "2026-04-01",
+            end_date: "2026-04-28",
+            current_user: moderator,
+          )
+
+        expect(result[:activity_by_category][:category_ids]).to contain_exactly(visible.id)
+      end
+
+      it "keeps restricted categories in the persisted selection for an admin" do
+        admin = Fabricate(:admin)
+        visible = Fabricate(:category)
+        private_group = Fabricate(:group)
+        restricted = Fabricate(:private_category, group: private_group, read_restricted: true)
+
+        AdminDashboardSectionConfiguration.update_setting(
+          section_id: "engagement",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [visible.id, restricted.id],
+          },
+        )
+
+        result =
+          described_class.build(
+            start_date: "2026-04-01",
+            end_date: "2026-04-28",
+            current_user: admin,
+          )
+
+        expect(result[:activity_by_category][:category_ids]).to contain_exactly(
+          visible.id,
+          restricted.id,
+        )
+      end
     end
 
     describe "trust_level_pipeline" do

--- a/spec/services/admin_dashboard_section_configuration_spec.rb
+++ b/spec/services/admin_dashboard_section_configuration_spec.rb
@@ -2,6 +2,8 @@
 
 describe AdminDashboardSectionConfiguration do
   fab!(:admin)
+  fab!(:category)
+  fab!(:category_2, :category)
 
   describe ".sections" do
     it "returns every seeded section, all visible, in canonical order by default" do
@@ -161,6 +163,161 @@ describe AdminDashboardSectionConfiguration do
         )
 
       expect(result.first).to eq({ id: "engagement", visible: true })
+    end
+  end
+
+  describe ".settings_for" do
+    it "returns an empty hash when nothing is persisted" do
+      expect(described_class.settings_for("engagement")).to eq({})
+    end
+
+    it "returns the persisted settings for the section" do
+      described_class.update_setting(
+        section_id: "engagement",
+        key: "activity_by_category",
+        attrs: {
+          category_ids: [category.id, category_2.id],
+        },
+      )
+
+      expect(described_class.settings_for("engagement")).to eq(
+        { "activity_by_category" => { "category_ids" => [category.id, category_2.id] } },
+      )
+    end
+  end
+
+  describe ".update_setting" do
+    it "persists a valid selection under its key" do
+      described_class.update_setting(
+        section_id: "engagement",
+        key: "activity_by_category",
+        attrs: {
+          category_ids: [category.id, category_2.id],
+        },
+      )
+
+      expect(described_class.settings_for("engagement")).to eq(
+        { "activity_by_category" => { "category_ids" => [category.id, category_2.id] } },
+      )
+    end
+
+    it "raises when a category with the given id does not exist" do
+      expect {
+        described_class.update_setting(
+          section_id: "engagement",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [category.id, Category.maximum(:id) + 1],
+          },
+        )
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "raises when more than the allowed number of categories are given" do
+      expect {
+        described_class.update_setting(
+          section_id: "engagement",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: (1..11).to_a,
+          },
+        )
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "raises when category ids are duplicated" do
+      expect {
+        described_class.update_setting(
+          section_id: "engagement",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [1, 1, 2],
+          },
+        )
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "deep-merges so pre-existing settings keys are preserved" do
+      AdminDashboardSection.find_by(section_id: "engagement").update!(
+        settings: {
+          "legacy" => {
+            "kept" => true,
+          },
+        },
+      )
+
+      described_class.update_setting(
+        section_id: "engagement",
+        key: "activity_by_category",
+        attrs: {
+          category_ids: [category.id],
+        },
+      )
+
+      expect(described_class.settings_for("engagement")).to eq(
+        {
+          "legacy" => {
+            "kept" => true,
+          },
+          "activity_by_category" => {
+            "category_ids" => [category.id],
+          },
+        },
+      )
+    end
+
+    it "raises for an unknown section id" do
+      expect {
+        described_class.update_setting(
+          section_id: "frobnitz",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [1],
+          },
+        )
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "raises for a known section that supports no settings" do
+      expect {
+        described_class.update_setting(
+          section_id: "traffic",
+          key: "activity_by_category",
+          attrs: {
+            category_ids: [1],
+          },
+        )
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "raises for a setting key not supported by the section" do
+      expect {
+        described_class.update_setting(
+          section_id: "engagement",
+          key: "not_a_real_setting",
+          attrs: {
+          },
+        )
+      }.to raise_error(Discourse::InvalidParameters)
+    end
+
+    it "leaves settings untouched when the section is reordered or hidden" do
+      described_class.update_setting(
+        section_id: "engagement",
+        key: "activity_by_category",
+        attrs: {
+          category_ids: [category.id, category_2.id],
+        },
+      )
+
+      described_class.update(
+        [{ id: "engagement", visible: false }, { id: "reports", visible: true }],
+        actor: admin,
+      )
+
+      expect(described_class.settings_for("engagement")).to eq(
+        { "activity_by_category" => { "category_ids" => [category.id, category_2.id] } },
+      )
     end
   end
 

--- a/spec/system/admin_dashboard_redesign/engagement_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/engagement_section_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+describe "Admin Dashboard Redesign | Engagement section" do
+  fab!(:current_user, :admin)
+  fab!(:moderator)
+
+  fab!(:category_alpha) { Fabricate(:category, name: "Category Alpha") }
+  fab!(:category_bravo) { Fabricate(:category, name: "Category Bravo") }
+  fab!(:category_dormant) { Fabricate(:category, name: "Category Dormant") }
+
+  let(:dashboard) { PageObjects::Pages::AdminDashboard.new }
+  let(:engagement) { dashboard.engagement }
+
+  before do
+    SiteSetting.dashboard_improvements = true
+    AdminDashboardSectionConfiguration.update(
+      [
+        { id: "engagement", visible: true },
+        { id: "highlights", visible: false },
+        { id: "reports", visible: false },
+        { id: "traffic", visible: false },
+        { id: "search", visible: false },
+      ],
+      actor: current_user,
+    )
+    Fabricate(:topic, category: category_alpha, created_at: "2026-06-12")
+    Fabricate(:topic, category: category_bravo, created_at: "2026-06-12")
+    sign_in(current_user)
+  end
+
+  it "persists an admin's 'Activity by category' selection per-site across a refresh",
+     time: Time.zone.local(2026, 6, 15, 12, 0, 0) do
+    dashboard.visit
+    expect(dashboard).to have_section("engagement")
+    expect(engagement).to have_activity_row(category_alpha)
+
+    engagement.deselect_category(category_alpha)
+
+    expect(engagement).to have_no_activity_row(category_alpha)
+    expect(engagement).to have_activity_row(category_bravo)
+
+    dashboard.visit
+
+    expect(engagement).to have_activity_row(category_bravo)
+    expect(engagement).to have_no_activity_row(category_alpha)
+  end
+
+  it "does not persist a moderator's 'Activity by category' selection",
+     time: Time.zone.local(2026, 6, 15, 12, 0, 0) do
+    sign_in(moderator)
+
+    dashboard.visit
+    expect(engagement).to have_activity_row(category_alpha)
+
+    engagement.deselect_category(category_alpha)
+
+    expect(engagement).to have_no_activity_row(category_alpha)
+
+    dashboard.visit
+
+    expect(engagement).to have_activity_row(category_alpha)
+    expect(engagement).to have_activity_row(category_bravo)
+  end
+
+  it "keeps a persisted category selected even when it has no activity in the period",
+     time: Time.zone.local(2026, 6, 15, 12, 0, 0) do
+    AdminDashboardSectionConfiguration.update_setting(
+      section_id: "engagement",
+      key: "activity_by_category",
+      attrs: {
+        category_ids: [category_alpha.id, category_dormant.id],
+      },
+    )
+
+    dashboard.visit
+    expect(dashboard).to have_section("engagement")
+
+    expect(engagement).to have_activity_row(category_alpha)
+    expect(engagement).to have_no_activity_row(category_dormant)
+
+    engagement.expand_category_filter
+
+    expect(engagement).to have_selected_category(category_alpha)
+    expect(engagement).to have_selected_category(category_dormant)
+  end
+end

--- a/spec/system/page_objects/components/admin_dashboard_engagement.rb
+++ b/spec/system/page_objects/components/admin_dashboard_engagement.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class AdminDashboardEngagement < PageObjects::Components::Base
+      SECTION = "[data-section-id='engagement']"
+      CATEGORY_FILTER = "#{SECTION} .category-selector"
+      ACTIVITY_CATEGORY_CELL = "#{SECTION} .db-activity-table__cell-category"
+
+      def category_filter
+        PageObjects::Components::SelectKit.new(CATEGORY_FILTER)
+      end
+
+      def expand_category_filter
+        category_filter.expand
+        self
+      end
+
+      def deselect_category(category)
+        expand_category_filter
+        find("#{CATEGORY_FILTER} .selected-choice[data-value='#{category.id}']").click
+        self
+      end
+
+      def has_activity_row?(category)
+        has_css?(ACTIVITY_CATEGORY_CELL, text: category.name)
+      end
+
+      def has_no_activity_row?(category)
+        has_no_css?(ACTIVITY_CATEGORY_CELL, text: category.name)
+      end
+
+      def has_selected_category?(category)
+        has_css?("#{CATEGORY_FILTER} .selected-choice[data-value='#{category.id}']")
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/admin_dashboard.rb
+++ b/spec/system/page_objects/pages/admin_dashboard.rb
@@ -169,6 +169,10 @@ module PageObjects
         PageObjects::Components::AdminDashboardSearch.new
       end
 
+      def engagement
+        PageObjects::Components::AdminDashboardEngagement.new
+      end
+
       def section_ids_in_order
         all(".db-main [data-section-id]").map { |el| el["data-section-id"] }
       end


### PR DESCRIPTION
Admins can choose which categories appear in the admin dashboard's "Activity by category" section. That choice now sticks for everyone across refreshes instead of resetting to the defaults on each visit.

The selection is stored through a generic per-section settings storage system. Any dashboard section can declare the settings it supports, so future section configuration and filters can reuse the same storage, endpoint, and validation without new plumbing.