### PR TITLE
DEV: Re-enable human activity tracker interaction test

### DIFF
--- a/frontend/discourse/tests/unit/services/human-activity-tracker-test.js
+++ b/frontend/discourse/tests/unit/services/human-activity-tracker-test.js
@@ -1,6 +1,6 @@
 import { triggerEvent } from "@ember/test-helpers";
 import { setupTest } from "ember-qunit";
-import { module, skip, test } from "qunit";
+import { module, test } from "qunit";
 import sinon from "sinon";
 import { processBrowserAttentionChange } from "discourse/lib/user-presence";
 
@@ -67,11 +67,10 @@ module("Unit | Service | human-activity-tracker", function (hooks) {
     assert.strictEqual(this.sent.length, 0);
   });
 
-  // TODO: Flaky, skipped while investigating a global getBoundingClientRect error.
-  skip("counts interaction events and reports them on flush", async function (assert) {
-    await triggerEvent(document.body, "keydown");
-    await triggerEvent(document.body, "mousedown");
-    await triggerEvent(document.body, "scroll");
+  test("counts interaction events and reports them on flush", function (assert) {
+    window.dispatchEvent(new Event("keydown"));
+    window.dispatchEvent(new Event("mousedown"));
+    window.dispatchEvent(new Event("scroll"));
     pagehide();
 
     const payload = this.sent.at(-1);


### PR DESCRIPTION
Re-enables the `counts interaction events and reports them on flush` QUnit test.

The test now dispatches interaction events directly on `window`, matching the target used by the `human-activity-tracker` service.

The previous version used `triggerEvent(document.body, ...)`, including a synthetic bubbling `scroll` event. That could trigger unrelated global listeners and make the test fail with global errors from outside the service under test.