### PR TITLE
FIX: Trailing small actions could appear perpetually unread

### DIFF
--- a/app/controllers/nested_topics_controller.rb
+++ b/app/controllers/nested_topics_controller.rb
@@ -244,15 +244,10 @@ class NestedTopicsController < ApplicationController
       next if user.blank? || topic.blank?
       next unless topic.nested_view?
 
-      highest =
-        if user.whisperer?
-          [topic.highest_staff_post_number.to_i, topic.highest_post_number.to_i].max
-        else
-          topic.highest_post_number.to_i
-        end
+      highest = Topic.highest_post_number_in_stream(topic_id, whisperer: user.whisperer?).to_i
       next if highest < 1
 
-      TopicUser.update_last_read(user, topic_id, highest, 0, 0)
+      TopicUser.update_last_read(user, topic_id, highest, 0, 0, max_post_number: highest)
       Notification.mark_posts_read(user, topic_id, (1..highest).to_a)
     end
   end

--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -635,9 +635,12 @@ class PostMover
       ON CONFLICT (topic_id, user_id) DO UPDATE
         SET posted                   = excluded.posted,
             last_read_post_number    = CASE
-                                         WHEN topic_users.last_read_post_number = :old_highest_staff_post_number OR (
+                                         WHEN (
+                                             :old_highest_staff_post_number > 0
+                                             AND topic_users.last_read_post_number >= :old_highest_staff_post_number
+                                           ) OR (
                                              :old_highest_post_number < :old_highest_staff_post_number
-                                             AND topic_users.last_read_post_number = :old_highest_post_number
+                                             AND topic_users.last_read_post_number >= :old_highest_post_number
                                              AND NOT EXISTS(SELECT 1
                                                             FROM users u
                                                             WHERE u.id = topic_users.user_id
@@ -647,9 +650,12 @@ class PostMover
                                                     excluded.last_read_post_number)
                                          ELSE topic_users.last_read_post_number END,
             last_emailed_post_number = CASE
-                                         WHEN topic_users.last_emailed_post_number = :old_highest_staff_post_number OR (
+                                         WHEN (
+                                             :old_highest_staff_post_number > 0
+                                             AND topic_users.last_emailed_post_number >= :old_highest_staff_post_number
+                                           ) OR (
                                              :old_highest_post_number < :old_highest_staff_post_number
-                                             AND topic_users.last_emailed_post_number = :old_highest_post_number
+                                             AND topic_users.last_emailed_post_number >= :old_highest_post_number
                                              AND NOT EXISTS(SELECT 1
                                                             FROM users u
                                                             WHERE u.id = topic_users.user_id

--- a/app/models/post_timing.rb
+++ b/app/models/post_timing.rb
@@ -154,12 +154,8 @@ class PostTiming < ActiveRecord::Base
   MAX_READ_TIME_PER_BATCH = 60 * 1000.0
 
   def self.process_timings(current_user, topic_id, topic_time, timings, opts = {})
-    lookup_column = current_user.whisperer? ? "highest_staff_post_number" : "highest_post_number"
-    highest_post_number = DB.query_single(<<~SQL, topic_id: topic_id).first
-          SELECT #{lookup_column}
-          FROM topics
-          WHERE id = :topic_id
-        SQL
+    highest_post_number =
+      Topic.highest_post_number_in_stream(topic_id, whisperer: current_user.whisperer?)
 
     # does not exist log nothing
     return if highest_post_number.nil?
@@ -237,7 +233,7 @@ SQL
       highest_seen,
       new_posts_read,
       topic_time,
-      opts,
+      opts.merge(max_post_number: highest_post_number),
     )
     TopicGroup.update_last_read(current_user, topic_id, highest_seen)
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -945,6 +945,20 @@ class Topic < ActiveRecord::Base
     "post_type <> #{Post.types[:small_action]}"
   end
 
+  def self.stream_post_types_sql(whisperer:)
+    whisperer ? "TRUE" : "post_type <> #{Post.types[:whisper]}"
+  end
+
+  def self.highest_post_number_in_stream(topic_id, whisperer:)
+    DB.query_single(<<~SQL, topic_id:).first
+      SELECT MAX(post_number)
+      FROM posts
+      WHERE topic_id = :topic_id
+        AND deleted_at IS NULL
+        AND #{stream_post_types_sql(whisperer:)}
+    SQL
+  end
+
   # Atomically creates the next post number
   def self.next_post_number(topic_id, opts = {})
     highest =
@@ -1085,11 +1099,13 @@ class Topic < ActiveRecord::Base
 
     highest = result.first.to_i
 
-    DB.exec(<<~SQL, highest:, topic_id:)
+    max_post_number = highest_post_number_in_stream(topic_id, whisperer: true).to_i
+
+    DB.exec(<<~SQL, topic_id:, max_post_number:)
       UPDATE topic_users
-         SET last_read_post_number = :highest
+         SET last_read_post_number = :max_post_number
        WHERE topic_id = :topic_id
-         AND last_read_post_number > :highest
+         AND last_read_post_number > :max_post_number
     SQL
 
     highest

--- a/app/models/topic_tracking_state.rb
+++ b/app/models/topic_tracking_state.rb
@@ -575,7 +575,7 @@ class TopicTrackingState
     user_id,
     write_event
   )
-    return unless last_read_post_number == topic.highest_post_number
+    return if last_read_post_number < topic.highest_post_number
     message = { topic_id: topic.id, show_indicator: write_event }.as_json
     groups_to_update = []
 

--- a/app/models/topic_user.rb
+++ b/app/models/topic_user.rb
@@ -281,13 +281,7 @@ class TopicUser < ActiveRecord::Base
       UPDATE topic_users
       SET
         last_read_post_number =
-          LEAST(
-            CASE WHEN :whisperer
-              THEN highest_staff_post_number
-              ELSE highest_post_number END
-            ,
-            GREATEST(:post_number, tu.last_read_post_number)
-          ),
+          LEAST(:max_post_number, GREATEST(:post_number, tu.last_read_post_number)),
         total_msecs_viewed = LEAST(tu.total_msecs_viewed + :msecs,86400000),
         notification_level =
            case when tu.notifications_reason_id is null and (tu.total_msecs_viewed + :msecs) >
@@ -328,6 +322,10 @@ class TopicUser < ActiveRecord::Base
       return if post_number.blank?
       msecs = 0 if msecs.to_i < 0
 
+      max_post_number =
+        opts[:max_post_number] ||
+          Topic.highest_post_number_in_stream(topic_id, whisperer: user.whisperer?).to_i
+
       args = {
         user_id: user.id,
         topic_id: topic_id,
@@ -336,7 +334,7 @@ class TopicUser < ActiveRecord::Base
         msecs: msecs,
         tracking: notification_levels[:tracking],
         threshold: SiteSetting.default_other_auto_track_topics_after_msecs,
-        whisperer: user.whisperer?,
+        max_post_number: max_post_number,
       }
 
       rows = DB.query(UPDATE_TOPIC_USER_SQL, args)

--- a/app/services/topic_status_updater.rb
+++ b/app/services/topic_status_updater.rb
@@ -110,7 +110,11 @@ TopicStatusUpdater =
       if (status.autoclosed? && status.enabled?) || (status.closed? && silent_tracking)
         # let's pretend all the people that read up to the autoclose message
         # actually read the topic
-        PostTiming.pretend_read(topic.id, old_highest_read, topic.highest_post_number)
+        PostTiming.pretend_read(
+          topic.id,
+          old_highest_read,
+          Topic.highest_post_number_in_stream(topic.id, whisperer: false),
+        )
       end
 
       if status.closed? && status.enabled?
@@ -124,7 +128,12 @@ TopicStatusUpdater =
         user_ids = DB.query_single(sql_query, topic_id: topic.id)
 
         if user_ids.present?
-          PostTiming.pretend_read(topic.id, old_highest_read, topic.highest_post_number, user_ids)
+          PostTiming.pretend_read(
+            topic.id,
+            old_highest_read,
+            Topic.highest_post_number_in_stream(topic.id, whisperer: false),
+            user_ids,
+          )
         end
       end
     end

--- a/frontend/discourse/app/models/topic-tracking-state.js
+++ b/frontend/discourse/app/models/topic-tracking-state.js
@@ -306,7 +306,7 @@ export default class TopicTrackingState extends EmberObject {
       // the highest post number is equal to last read post number here
       // because the state has already been modified based on the /unread
       // messageBus message
-      if (!old || old.highest_post_number === old.last_read_post_number) {
+      if (!old || old.last_read_post_number >= old.highest_post_number) {
         this._addIncoming(data.topic_id);
       }
     }

--- a/frontend/discourse/app/models/topic.js
+++ b/frontend/discourse/app/models/topic.js
@@ -13,7 +13,7 @@ import deprecated from "discourse/lib/deprecated";
 import { longDate } from "discourse/lib/formatter";
 import getURL from "discourse/lib/get-url";
 import { applyModelTransformations } from "discourse/lib/model-transformers";
-import { deepEqual, deepMerge } from "discourse/lib/object";
+import { deepMerge } from "discourse/lib/object";
 import PreloadStore from "discourse/lib/preload-store";
 import { serializeTags } from "discourse/lib/serialize-tags";
 import { emojiUnescape } from "discourse/lib/text";
@@ -430,12 +430,15 @@ export default class Topic extends RestModel {
 
   @dependentKeyCompat
   get readLastPost() {
-    return deepEqual(this.last_read_post_number, this.highest_post_number);
+    deprecated("`readLastPost` is deprecated, use `visited` instead", {
+      id: "discourse.topic.readLastPost",
+    });
+    return this.visited;
   }
 
-  @computed("pinned", "readLastPost")
+  @computed("pinned", "visited")
   get canClearPin() {
-    return this.pinned && this.readLastPost;
+    return this.pinned && this.visited;
   }
 
   @computed("details.can_edit", "details.can_edit_tags")

--- a/lib/topics_bulk_action.rb
+++ b/lib/topics_bulk_action.rb
@@ -126,14 +126,16 @@ class TopicsBulkAction
   end
 
   def dismiss_posts
-    highest_number_source_column =
-      @user.whisperer? ? "highest_staff_post_number" : "highest_post_number"
-
     sql = <<~SQL
       UPDATE topic_users tu
-      SET last_read_post_number = t.#{highest_number_source_column}
-      FROM topics t
-      WHERE t.id = tu.topic_id AND tu.user_id = :user_id AND t.id IN (:topic_ids)
+      SET last_read_post_number = (
+        SELECT COALESCE(MAX(post_number), 0)
+        FROM posts
+        WHERE topic_id = tu.topic_id
+          AND deleted_at IS NULL
+          AND #{Topic.stream_post_types_sql(whisperer: @user.whisperer?)}
+      )
+      WHERE tu.user_id = :user_id AND tu.topic_id IN (:topic_ids)
     SQL
 
     DB.exec(sql, user_id: @user.id, topic_ids: @topic_ids)

--- a/spec/lib/topics_bulk_action_spec.rb
+++ b/spec/lib/topics_bulk_action_spec.rb
@@ -119,6 +119,19 @@ RSpec.describe TopicsBulkAction do
       expect(tu.last_read_post_number).to eq(3)
     end
 
+    it "dismisses up to a trailing small action" do
+      post1 = create_post
+      create_post(topic_id: post1.topic_id)
+      small_action =
+        Fabricate(:post, topic: post1.topic, post_type: Post.types[:small_action], post_number: 3)
+
+      TopicsBulkAction.new(post1.user, [post1.topic_id], type: "dismiss_posts").perform!
+
+      tu = TopicUser.find_by(user_id: post1.user_id, topic_id: post1.topic_id)
+
+      expect(tu.last_read_post_number).to eq(small_action.post_number)
+    end
+
     context "when the user is staff" do
       fab!(:user, :admin)
 

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -1108,6 +1108,51 @@ RSpec.describe PostMover do
               )
             end
 
+            it "advances a reader caught up to a trailing small action in the destination" do
+              Fabricate(:post, topic: destination_topic)
+              Fabricate(
+                :post,
+                topic: destination_topic,
+                post_type: Post.types[:small_action],
+                post_number: 3,
+              )
+
+              destination_topic.reload
+              expect(destination_topic.highest_post_number).to eq(2)
+              expect(
+                Topic.highest_post_number_in_stream(destination_topic.id, whisperer: false),
+              ).to eq(3)
+
+              create_topic_user(user2, topic, last_read_post_number: 3, last_emailed_post_number: 3)
+              create_topic_user(
+                user2,
+                destination_topic,
+                last_read_post_number: 3,
+                last_emailed_post_number: 3,
+              )
+
+              create_topic_user(user3, topic, last_read_post_number: 3, last_emailed_post_number: 3)
+              create_topic_user(
+                user3,
+                destination_topic,
+                last_read_post_number: 2,
+                last_emailed_post_number: 2,
+              )
+
+              moved_to_topic =
+                topic.move_posts(user, [p1.id, p2.id], destination_topic_id: destination_topic.id)
+
+              expect(TopicUser.find_by(topic: moved_to_topic, user: user2)).to have_attributes(
+                last_read_post_number: 5,
+                last_emailed_post_number: 5,
+              )
+
+              expect(TopicUser.find_by(topic: moved_to_topic, user: user3)).to have_attributes(
+                last_read_post_number: 5,
+                last_emailed_post_number: 5,
+              )
+            end
+
             it "correctly updates existing topic_user records" do
               destination_topic.update!(created_at: 1.day.ago)
 

--- a/spec/models/post_timing_spec.rb
+++ b/spec/models/post_timing_spec.rb
@@ -110,6 +110,24 @@ RSpec.describe PostTiming do
       expect(user_visit.reload.posts_read).to eq(5)
     end
 
+    it "advances last_read_post_number onto a trailing small action" do
+      Fabricate(:post, topic: post.topic, post_number: 2)
+      small_action =
+        Fabricate(:post, topic: post.topic, post_type: Post.types[:small_action], post_number: 3)
+      Topic.reset_highest(post.topic_id)
+
+      expect(post.topic.reload.highest_post_number).to eq(2)
+
+      PostTiming.process_timings(
+        post.user,
+        post.topic_id,
+        1,
+        [[1, 100], [2, 100], [small_action.post_number, 100]],
+      )
+
+      expect(TopicUser.get(post.topic, post.user).last_read_post_number).to eq(3)
+    end
+
     it "does not count private message posts read" do
       pm = Fabricate(:private_message_topic, user: Fabricate(:admin))
       user1, user2 = pm.topic_allowed_users.map(&:user)

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -3681,6 +3681,15 @@ RSpec.describe Topic do
       expect(Topic.reset_highest(topic.id)).to eq(2)
       expect(topic.reload.highest_staff_post_number).to eq(2)
     end
+
+    it "does not pull a user's last_read_post_number back below a trailing small action" do
+      third_post.update!(post_type: Post.types[:small_action])
+      topic_user = Fabricate(:topic_user, topic:, user:, last_read_post_number: 3)
+
+      Topic.reset_highest(topic.id)
+
+      expect(topic_user.reload.last_read_post_number).to eq(3)
+    end
   end
 
   describe "#update_statistics!" do

--- a/spec/models/topic_user_spec.rb
+++ b/spec/models/topic_user_spec.rb
@@ -237,6 +237,45 @@ RSpec.describe TopicUser do
       end
     end
 
+    context "with trailing small actions and whispers" do
+      it "lets last_read_post_number advance onto a trailing small action" do
+        Fabricate(:post, topic: topic, post_number: 1)
+        Fabricate(:post, topic: topic, post_number: 2)
+        small_action =
+          Fabricate(:post, topic: topic, post_type: Post.types[:small_action], post_number: 3)
+
+        TopicUser.update_last_read(user, topic.id, 2, 1, 0)
+        TopicUser.update_last_read(user, topic.id, small_action.post_number, 1, 0)
+
+        expect(topic_user.last_read_post_number).to eq(3)
+      end
+
+      it "does not let a non-whisperer's last_read advance onto a trailing whisper" do
+        SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+        Fabricate(:post, topic: topic, post_number: 1)
+        Fabricate(:post, topic: topic, post_number: 2)
+        whisper = Fabricate(:post, topic: topic, post_type: Post.types[:whisper], post_number: 3)
+
+        TopicUser.update_last_read(user, topic.id, 2, 1, 0)
+        TopicUser.update_last_read(user, topic.id, whisper.post_number, 1, 0)
+
+        expect(topic_user.last_read_post_number).to eq(2)
+      end
+
+      it "lets a whisperer's last_read advance onto a trailing whisper" do
+        SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
+        whisperer = Fabricate(:admin)
+        Fabricate(:post, topic: topic, post_number: 1)
+        Fabricate(:post, topic: topic, post_number: 2)
+        whisper = Fabricate(:post, topic: topic, post_type: Post.types[:whisper], post_number: 3)
+
+        TopicUser.update_last_read(whisperer, topic.id, 2, 1, 0)
+        TopicUser.update_last_read(whisperer, topic.id, whisper.post_number, 1, 0)
+
+        expect(TopicUser.get(topic, whisperer).last_read_post_number).to eq(3)
+      end
+    end
+
     context "with private messages" do
       fab!(:target_user) { Fabricate(:user, refresh_auto_groups: true) }
 

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -1357,6 +1357,19 @@ RSpec.describe NestedTopicsController, type: :request do
         expect(topic_user.last_read_post_number).to eq(2)
       end
 
+      it "advances past a trailing small action for a nested topic" do
+        Fabricate(:post, topic: topic, post_type: Post.types[:small_action], post_number: 3)
+
+        sign_in(reader)
+        get show_url(topic), params: { track_visit: true }
+        expect(response.status).to eq(200)
+
+        Scheduler::Defer.do_all_work
+
+        topic_user = TopicUser.find_by(topic: topic, user: reader)
+        expect(topic_user.last_read_post_number).to eq(3)
+      end
+
       it "marks the topic's unread notifications as read" do
         reply_notification =
           Fabricate(

--- a/spec/services/topic_status_updater_spec.rb
+++ b/spec/services/topic_status_updater_spec.rb
@@ -24,7 +24,27 @@ RSpec.describe TopicStatusUpdater do
     expect(post.topic.posts.count).to eq(2)
 
     tu = TopicUser.find_by(user_id: user.id)
-    expect(tu.last_read_post_number).to eq(1)
+    expect(tu.last_read_post_number).to eq(2)
+  end
+
+  it "advances a caught-up reader past a trailing autoclose small action" do
+    post =
+      PostCreator.create(user, raw: "this is the original post here", title: "hello world title")
+    topic = post.topic
+    reader = Fabricate(:user, refresh_auto_groups: true)
+
+    PostTiming.process_timings(reader, topic.id, 1, [[1, 1000]])
+    expect(TopicUser.get(topic, reader).last_read_post_number).to eq(1)
+
+    topic.set_or_create_timer(TopicTimer.types[:close], "10")
+    topic.reload
+    TopicStatusUpdater.new(topic, admin).update!("autoclosed", true)
+
+    small_action = topic.posts.order(:post_number).last
+    expect(small_action.post_type).to eq(Post.types[:small_action])
+    expect(small_action.post_number).to eq(2)
+
+    expect(TopicUser.get(topic, reader).last_read_post_number).to eq(2)
   end
 
   it "respects topics_unread_when_closed preference for private messages" do
@@ -54,13 +74,13 @@ RSpec.describe TopicStatusUpdater do
     # Should have 2 posts (original + close action)
     expect(post.topic.posts.count).to eq(2)
 
-    # In PMs, close small_action posts only bump highest_staff_post_number,
-    # so neither user's last_read_post_number advances past the original post.
+    # user_wants_read opts out of "unread when closed", so they are advanced past
+    # the close small action; user_wants_unread keeps their prior read position.
     tu_wants_unread = TopicUser.find_by(user: user_wants_unread, topic: post.topic)
     expect(tu_wants_unread.last_read_post_number).to eq(1)
 
     tu_wants_read = TopicUser.find_by(user: user_wants_read, topic: post.topic)
-    expect(tu_wants_read.last_read_post_number).to eq(1)
+    expect(tu_wants_read.last_read_post_number).to eq(2)
   end
 
   it "adds an autoclosed message" do


### PR DESCRIPTION
Excluding small actions from a topic's counters (#40481) also excluded them from `highest_post_number` / `highest_staff_post_number`, which are the ceiling that `topic_users.last_read_post_number` is clamped to. As a result, a topic whose last post is a small action (a close, pin, archive, etc. notice) could never be read past that notice: the "last visit" line stayed above it on every visit and the topic never read as fully caught up ([meta](https://meta.discourse.org/t/-/404058)).

The root cause is that `highest_post_number` quietly served two roles — the highest post worth *notifying* about, and the highest post a user can *see* (the read-position ceiling). Those were only ever the same value because small actions used to count toward both. Dropping them from the columns is correct for the first role but wrong for the second: small actions are visible to everyone and occupy real stream positions that get read.

This keeps the columns meaning "highest notify-worthy post" — so `/unread`, the unread badge, and watched notifications stay correct and cheap — and derives "highest post in the visible stream" wherever a read position is written. That value includes small actions (and whispers only for whisperers) and lives in `Topic.highest_post_number_in_stream`; every read-tracking path now goes through it: recording timings, the `last_read` clamp, `reset_highest`, `dismiss_posts`, the close/auto-close `pretend_read` target, nested-topic catch-up, and the post-merge caught-up detection.

Because `last_read_post_number` can now legitimately exceed the notify counter, a few checks that assumed the two were equal became `>=` (the private-message read indicator, the topic model's `visited` / `canClearPin`, and the client-side tracking state).

Finally, `process_timings` computes the visible-stream ceiling once and threads it into `update_last_read`, so the clamp no longer re-derives it and the hottest read path stays a single index-backed `MAX(post_number)`.
