### PR TITLE
FIX: Linkify site setting references in dashboard problem messages

### DIFF
--- a/app/models/admin_notice.rb
+++ b/app/models/admin_notice.rb
@@ -2,7 +2,8 @@
 
 class AdminNotice < ActiveRecord::Base
   MESSAGE_ALLOWED_TAGS = %w[a pre ul li].freeze
-  MESSAGE_ALLOWED_ATTRIBUTES = %w[href target rel].freeze
+  MESSAGE_ALLOWED_ATTRIBUTES =
+    (%w[href target rel] + SiteSettings::LabelFormatter::LINK_ATTRIBUTES).freeze
   MESSAGE_SANITIZER = Rails::Html::SafeListSanitizer.new
 
   validates :identifier, presence: true
@@ -11,11 +12,14 @@ class AdminNotice < ActiveRecord::Base
   enum :subject, %i[problem].freeze
 
   def message
-    MESSAGE_SANITIZER.sanitize(
+    translated =
       I18n.t(
         "dashboard.#{subject}.#{identifier}",
         **details.symbolize_keys.merge(base_path: Discourse.base_path),
-      ),
+      )
+
+    MESSAGE_SANITIZER.sanitize(
+      SiteSettings::LabelFormatter.expand_setting_links(translated),
       tags: MESSAGE_ALLOWED_TAGS,
       attributes: MESSAGE_ALLOWED_ATTRIBUTES,
     )

--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -220,9 +220,7 @@ class ProblemCheck
       ).symbolize_keys
 
     Problem.new(
-      SiteSettings::LabelFormatter.expand_setting_links(
-        I18n.t(override_key || translation_key, base_path: Discourse.base_path, **problem_details),
-      ),
+      I18n.t(override_key || translation_key, base_path: Discourse.base_path, **problem_details),
       priority: config.priority,
       identifier:,
       target: target_identifier,

--- a/frontend/discourse/admin/components/admin-notice.gjs
+++ b/frontend/discourse/admin/components/admin-notice.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 
@@ -19,7 +20,7 @@ export default class AdminNotice extends Component {
 
   <template>
     <div class="notice">
-      <div class="message">
+      <div class="message" {{linkifySettingLinks @problem.message}}>
         {{if @icon (dIcon @icon)}}
         {{trustHTML @problem.message}}
       </div>

--- a/frontend/discourse/admin/components/dashboard/site-advice.gjs
+++ b/frontend/discourse/admin/components/dashboard/site-advice.gjs
@@ -5,6 +5,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import { compare } from "@ember/utils";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
 import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -79,7 +80,10 @@ export default class DashboardSiteAdvice extends Component {
                 class=(concat "db-site-advice__icon --" problem.priority)
               }}
 
-              <div class="db-site-advice__message">
+              <div
+                class="db-site-advice__message"
+                {{linkifySettingLinks problem.message}}
+              >
                 {{trustHTML problem.message}}
               </div>
 

--- a/frontend/discourse/tests/integration/components/admin-notice-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-notice-test.gjs
@@ -1,0 +1,38 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import AdminNotice from "discourse/admin/components/admin-notice";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  logIn,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+
+module("Integration | Component | AdminNotice", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    logIn(getOwner(this));
+    updateCurrentUser({ admin: true });
+  });
+
+  test("rewrites setting links in the problem message via the modifier", async function (assert) {
+    const rewrittenURL =
+      "/admin/config/onebox?filter=github_onebox_access_tokens";
+    const dataSource = this.owner.lookup("service:admin-search-data-source");
+    dataSource.urlForSetting = ({ setting }) =>
+      setting === "github_onebox_access_tokens" ? rewrittenURL : null;
+
+    const problem = {
+      message:
+        'Configuring <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=github_onebox_access_tokens" data-setting-name="github_onebox_access_tokens" data-setting-category="onebox">GitHub onebox access tokens</a> raises the limit.',
+    };
+
+    await render(<template><AdminNotice @problem={{problem}} /></template>);
+
+    assert
+      .dom(".message a.site-setting-link")
+      .hasText("GitHub onebox access tokens")
+      .hasAttribute("href", rewrittenURL);
+  });
+});

--- a/frontend/discourse/tests/integration/components/dashboard/site-advice-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/site-advice-test.gjs
@@ -1,0 +1,44 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DashboardSiteAdvice from "discourse/admin/components/dashboard/site-advice";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import {
+  logIn,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+
+module("Integration | Component | DashboardSiteAdvice", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    logIn(getOwner(this));
+    updateCurrentUser({ admin: true });
+  });
+
+  test("rewrites setting links in problem messages via the modifier", async function (assert) {
+    const rewrittenURL =
+      "/admin/config/onebox?filter=github_onebox_access_tokens";
+    const dataSource = this.owner.lookup("service:admin-search-data-source");
+    dataSource.urlForSetting = ({ setting }) =>
+      setting === "github_onebox_access_tokens" ? rewrittenURL : null;
+
+    const problems = [
+      {
+        id: 1,
+        priority: "low",
+        message:
+          'Configuring <a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=github_onebox_access_tokens" data-setting-name="github_onebox_access_tokens" data-setting-category="onebox">GitHub onebox access tokens</a> raises the limit.',
+      },
+    ];
+
+    await render(
+      <template><DashboardSiteAdvice @problems={{problems}} /></template>
+    );
+
+    assert
+      .dom(".db-site-advice__message a.site-setting-link")
+      .hasText("GitHub onebox access tokens")
+      .hasAttribute("href", rewrittenURL);
+  });
+});

--- a/lib/site_settings/label_formatter.rb
+++ b/lib/site_settings/label_formatter.rb
@@ -132,6 +132,14 @@ module SiteSettings
 
     SETTING_LINK_PATTERN = /\{\{setting:([a-z][a-z0-9_]*)\}\}/
 
+    LINK_ATTRIBUTES = %w[
+      class
+      data-setting-name
+      data-setting-area
+      data-setting-category
+      data-setting-plugin
+    ].freeze
+
     class << self
       def description(setting)
         desc = I18n.t("site_settings.#{setting}", base_path: Discourse.base_path, default: "")

--- a/spec/models/admin_notice_spec.rb
+++ b/spec/models/admin_notice_spec.rb
@@ -4,25 +4,22 @@ RSpec.describe AdminNotice do
   it { is_expected.to validate_presence_of(:identifier) }
 
   describe "#message" do
-    let(:notice) do
-      Fabricate(
-        :admin_notice,
-        identifier: "test",
-        subject: "problem",
-        priority: "high",
-        details: {
-          thing: "world",
-        },
-      )
+    def store_problem_translation(text)
+      I18n.backend.store_translations(:en, { "dashboard" => { "problem" => { "test" => text } } })
     end
 
-    before do
-      I18n.backend.store_translations(
-        :en,
-        { "dashboard" => { "problem" => { "test" => "Something is wrong with the %{thing}" } } },
-      )
+    it "interpolates the notice details into the translation" do
+      store_problem_translation("Something is wrong with the %{thing}")
+      notice = Fabricate(:admin_notice, identifier: "test", details: { thing: "world" })
+      expect(notice.message).to eq("Something is wrong with the world")
     end
 
-    it { expect(notice.message).to eq("Something is wrong with the world") }
+    it "expands setting markers into links that survive sanitization" do
+      store_problem_translation("Configure {{setting:title}} to fix this")
+      notice = Fabricate(:admin_notice, identifier: "test")
+      expect(notice.message).to eq(
+        "Configure #{SiteSettings::LabelFormatter.linkify(:title)} to fix this",
+      )
+    end
   end
 end


### PR DESCRIPTION
Previously, the admin dashboard rendered `{{setting:...}}` references in problem messages as raw text, because `AdminNotice#message` re-translated each notice without expanding the markers and its sanitizer stripped the `class`/`data-setting-*` attributes the frontend needs to link each setting.

This change expands the markers at that render seam (widening the sanitizer allowlist via a shared constant on `SiteSettings::LabelFormatter` so it can't drift from what `linkify` emits) and applies the `linkifySettingLinks` modifier in both the classic and redesigned dashboards, so setting references resolve to their own config pages.

Ref - t/148687

**BEFORE**

<img width="1958" height="1380" alt="2026-07-16 @ 09 02 12" src="https://github.com/user-attachments/assets/4a83deba-ae10-40e3-a91b-ca66d5178c08" />

**AFTER**


<img width="1958" height="1380" alt="2026-07-16 @ 09 01 53" src="https://github.com/user-attachments/assets/8cd71db8-95d7-445a-9dde-f49af21b3446" />
