### PR TITLE
FEAT: Remember the last used editor mode in Data Explorer

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-result.gjs
@@ -6,13 +6,13 @@ import { service } from "@ember/service";
 import { capitalize } from "@ember/string";
 import moment from "moment";
 import DSegmentedControl from "discourse/components/d-segmented-control";
-import KeyValueStore from "discourse/lib/key-value-store";
 import Badge from "discourse/models/badge";
 import Category from "discourse/models/category";
 import DButton from "discourse/ui-kit/d-button";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
 import { chartability, defaultView, looksLikeDate } from "../lib/chart-helpers";
+import { dataExplorerStore } from "../lib/data-explorer-store";
 import DataExplorerChart from "./data-explorer-chart";
 import QueryChartEmptyState from "./query-chart-empty-state";
 import QueryResultDownloadButtons from "./query-result-download-buttons";
@@ -29,8 +29,6 @@ import TextViewComponent from "./result-types/text";
 import TopicViewComponent from "./result-types/topic";
 import UrlViewComponent from "./result-types/url";
 import UserViewComponent from "./result-types/user";
-
-const store = new KeyValueStore("discourse_data_explorer_");
 
 const VIEW_COMPONENTS = {
   topic: TopicViewComponent,
@@ -62,7 +60,7 @@ export default class QueryResult extends Component {
     const queryId = this.args.query?.id;
 
     if (!this.args.view) {
-      const stored = queryId ? store.get(`view_${queryId}`) : null;
+      const stored = queryId ? dataExplorerStore.get(`view_${queryId}`) : null;
       if (stored === "chart" || stored === "table") {
         this.internalView = stored;
       } else {
@@ -70,7 +68,9 @@ export default class QueryResult extends Component {
       }
     }
 
-    const storedChartForm = queryId ? store.get(`chart_form_${queryId}`) : null;
+    const storedChartForm = queryId
+      ? dataExplorerStore.get(`chart_form_${queryId}`)
+      : null;
     if (CHART_FORMS.includes(storedChartForm)) {
       this.internalChartForm = storedChartForm;
     }
@@ -89,7 +89,7 @@ export default class QueryResult extends Component {
     this.internalView = value;
     const queryId = this.args.query?.id;
     if (queryId) {
-      store.set({ key: `view_${queryId}`, value });
+      dataExplorerStore.set({ key: `view_${queryId}`, value });
     }
   }
 
@@ -103,7 +103,7 @@ export default class QueryResult extends Component {
     this.internalChartForm = value;
     const queryId = this.args.query?.id;
     if (queryId) {
-      store.set({ key: `chart_form_${queryId}`, value });
+      dataExplorerStore.set({ key: `chart_form_${queryId}`, value });
     }
   }
 

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
@@ -7,15 +7,17 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { AUTO_GROUPS } from "discourse/lib/constants";
 import { bind } from "discourse/lib/decorators";
-import KeyValueStore from "discourse/lib/key-value-store";
 import { i18n } from "discourse-i18n";
 import QueryHelp from "discourse/plugins/discourse-data-explorer/discourse/components/modal/query-help";
 import { ParamValidationError } from "discourse/plugins/discourse-data-explorer/discourse/components/param-input-form";
 import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
 import { defaultView } from "discourse/plugins/discourse-data-explorer/discourse/lib/chart-helpers";
+import {
+  dataExplorerStore,
+  rememberMode,
+} from "discourse/plugins/discourse-data-explorer/discourse/lib/data-explorer-store";
 import Query from "discourse/plugins/discourse-data-explorer/discourse/models/query";
 
-const dataExplorerStore = new KeyValueStore("discourse_data_explorer_");
 const HIDE_SCHEMA_KEY = "hide_schema";
 
 export default class PluginsExplorerController extends Controller {
@@ -196,6 +198,7 @@ export default class PluginsExplorerController extends Controller {
   @action
   setMode(value) {
     this.mode = value;
+    rememberMode(value);
     if (value !== "ai") {
       this._teardownAi();
       this.aiPrompt = "";

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
@@ -4,12 +4,15 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import KeyValueStore from "discourse/lib/key-value-store";
 import I18n, { i18n } from "discourse-i18n";
 import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
 import { defaultView } from "discourse/plugins/discourse-data-explorer/discourse/lib/chart-helpers";
+import {
+  dataExplorerStore,
+  rememberedMode,
+  rememberMode,
+} from "discourse/plugins/discourse-data-explorer/discourse/lib/data-explorer-store";
 
-const dataExplorerStore = new KeyValueStore("discourse_data_explorer_");
 const HIDE_SCHEMA_KEY = "hide_schema";
 
 export default class AdminPluginsExplorerNew extends Controller {
@@ -26,7 +29,7 @@ export default class AdminPluginsExplorerNew extends Controller {
   @tracked generatedSql = "";
   @tracked generatedName = "";
   @tracked generatedDescription = "";
-  @tracked mode = "ai";
+  @tracked mode = rememberedMode() ?? "ai";
   @tracked schema = null;
   @tracked hideSchema = dataExplorerStore.get(HIDE_SCHEMA_KEY) === "true";
   @tracked manualSql = "SELECT 1";
@@ -96,6 +99,7 @@ export default class AdminPluginsExplorerNew extends Controller {
   @action
   setMode(value) {
     this.mode = value;
+    rememberMode(value);
   }
 
   @action
@@ -289,7 +293,7 @@ export default class AdminPluginsExplorerNew extends Controller {
     this.generatedSql = "";
     this.generatedName = "";
     this.generatedDescription = "";
-    this.mode = "ai";
+    this.mode = rememberedMode() ?? "ai";
     this.schema = null;
     this.hideSchema = dataExplorerStore.get(HIDE_SCHEMA_KEY) === "true";
     this.manualSql = "SELECT 1";

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/data-explorer-store.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/data-explorer-store.js
@@ -1,0 +1,14 @@
+import KeyValueStore from "discourse/lib/key-value-store";
+
+export const dataExplorerStore = new KeyValueStore("discourse_data_explorer_");
+
+const DEFAULT_MODE_KEY = "default_mode";
+
+export function rememberedMode() {
+  const stored = dataExplorerStore.get(DEFAULT_MODE_KEY);
+  return stored === "ai" || stored === "manual" ? stored : null;
+}
+
+export function rememberMode(value) {
+  dataExplorerStore.set({ key: DEFAULT_MODE_KEY, value });
+}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
@@ -1,6 +1,7 @@
 import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";
+import { rememberedMode } from "discourse/plugins/discourse-data-explorer/discourse/lib/data-explorer-store";
 
 export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
   @service siteSettings;
@@ -62,11 +63,10 @@ export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
     const cachedResult = model.model.cached_result;
     const shouldAutoRun = !!transition.to.queryParams.run;
     const showCachedResult = !!cachedResult && !shouldAutoRun;
-    const defaultMode =
+    const aiAvailable =
       this.siteSettings.data_explorer_ai_queries_enabled &&
-      !model.model.is_default
-        ? "ai"
-        : "manual";
+      !model.model.is_default;
+    const defaultMode = aiAvailable ? (rememberedMode() ?? "ai") : "manual";
 
     controller.setProperties({
       ...model,

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/new.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/new.js
@@ -9,6 +9,7 @@ export default class AdminPluginsExplorerNew extends DiscourseRoute {
   }
 
   setupController(controller, model) {
+    controller.resetState();
     controller.setProperties({ schema: model.schema });
   }
 

--- a/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
@@ -114,4 +114,30 @@ RSpec.describe "Data Explorer AI query generation" do
       expect(page).to have_no_css(".query-ai-prompt")
     end
   end
+
+  context "when remembering the last used mode" do
+    fab!(:query) { Fabricate(:query, name: "First query", sql: "SELECT 1", user: admin) }
+    fab!(:other_query) { Fabricate(:query, name: "Second query", sql: "SELECT 2", user: admin) }
+
+    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+
+    it "opens subsequent queries and the new query page in the last used mode" do
+      visit("/admin/plugins/discourse-data-explorer/queries/new")
+      expect(page).to have_css(".query-new__ai-section")
+
+      find(".query-new__top-bar .back-button").click
+      within(".discourse-data-explorer-query-list") { click_link("First query") }
+      find(".query-mode-switch .d-segmented-control__label", text: "Write SQL").click
+      expect(page).to have_no_css(".query-ai-prompt")
+
+      find(".back-button").click
+      find(".d-page-subheader .btn-primary").click
+      expect(page).to have_css(".query-new__manual-form")
+      expect(page).to have_no_css(".query-new__ai-section")
+
+      visit("/admin/plugins/discourse-data-explorer/queries/#{other_query.id}")
+      expect(page).to have_css(".query-editor")
+      expect(page).to have_no_css(".query-ai-prompt")
+    end
+  end
 end


### PR DESCRIPTION
Previously, Data Explorer opened every query in a fixed editor mode ("Generate with AI" whenever AI queries were enabled), so admins who prefer writing SQL had to switch modes on every query they opened or created.

This change stores the last used "Write SQL"/"Generate with AI" choice in localStorage and applies it as the default when opening or creating queries, following the same mechanism the plugin already uses to remember the per-query results view.

Demo




https://github.com/user-attachments/assets/8bfc6e4d-efd8-4d87-be99-00198824ab7a

