### PR TITLE
FIX: Maintain rotation for video uploads to AWS

### DIFF
--- a/app/services/video_conversion/aws_media_convert_adapter.rb
+++ b/app/services/video_conversion/aws_media_convert_adapter.rb
@@ -428,6 +428,7 @@ module VideoConversion
               },
             },
             video_selector: {
+              rotate: "AUTO",
             },
           },
         ],

--- a/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
+++ b/spec/services/video_conversion/aws_media_convert_adapter_spec.rb
@@ -106,6 +106,18 @@ RSpec.describe VideoConversion::AwsMediaConvertAdapter do
     allow(OptimizedVideo).to receive(:create_for)
   end
 
+  describe ".build_conversion_settings" do
+    it "honors rotation metadata from uploaded videos" do
+      settings =
+        described_class.build_conversion_settings(
+          "s3://#{s3_bucket}/uploads/default/original/test.mp4",
+          new_sha1,
+        )
+
+      expect(settings[:inputs].first[:video_selector]).to eq(rotate: "AUTO")
+    end
+  end
+
   describe "#convert" do
     let(:output_path) do
       "/uploads/default/test_#{Discourse.test_env_number}/original/1X/#{new_sha1}"


### PR DESCRIPTION
Videos uploaded to AWS MediaConvert were losing their orientation after "conversion".

The original file can rely on rotation metadata from the device, but MediaConvert does not apply or preserve that metadata by default. 

So adding `rotate: "AUTO"` here, so MediaConvert will read the input rotation metadata and bake the correct orientation into the converted video.

<img width="342" height="253" alt="Screenshot 2026-07-16 at 6 21 35 PM" src="https://github.com/user-attachments/assets/30860c86-2c74-4cf7-958c-7833741ac1be" />
