### PR TITLE
FIX: Apply affiliate links to localized posts

### DIFF
--- a/plugins/discourse-affiliate/lib/affiliate_processor.rb
+++ b/plugins/discourse-affiliate/lib/affiliate_processor.rb
@@ -57,6 +57,10 @@ class AffiliateProcessor
     @rules = rules
   end
 
+  def self.apply_to_doc(doc)
+    doc.css("a[href]").each { |a| a["href"] = apply(a["href"]) }
+  end
+
   def self.apply(url)
     uri = URI.parse(url)
 

--- a/plugins/discourse-affiliate/plugin.rb
+++ b/plugins/discourse-affiliate/plugin.rb
@@ -14,8 +14,6 @@ register_svg_icon "handshake"
 after_initialize do
   require_relative "lib/affiliate_processor"
 
-  on(:post_process_cooked) do |doc, post|
-    doc.css("a[href]").each { |a| a["href"] = AffiliateProcessor.apply(a["href"]) }
-    true
-  end
+  on(:post_process_cooked) { |doc| AffiliateProcessor.apply_to_doc(doc) }
+  on(:post_process_localized_cooked) { |doc| AffiliateProcessor.apply_to_doc(doc) }
 end

--- a/plugins/discourse-affiliate/spec/integration/content_localization_spec.rb
+++ b/plugins/discourse-affiliate/spec/integration/content_localization_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe "Affiliate links on localized posts" do
+  fab!(:admin)
+  fab!(:localizer_group) { Fabricate(:group, users: [admin]) }
+
+  let(:amazon_url) { "https://www.amazon.de/gp/product/B0C3WGSSWC" }
+  let(:affiliate_tag) { "tag=discourse-21" }
+
+  before do
+    enable_current_plugin
+    stub_request(:get, /amazon\.de/).to_return(status: 200, body: "")
+    stub_request(:head, /amazon\.de/).to_return(status: 200, body: "")
+    Jobs.run_immediately!
+    SiteSetting.affiliate_amazon_de = "discourse-21"
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = localizer_group.id.to_s
+  end
+
+  def create_post_with_link
+    create_post(raw: "Great deal at #{amazon_url}", user: admin).reload
+  end
+
+  it "applies affiliate codes to a newly created localization" do
+    post = create_post_with_link
+
+    localization =
+      PostLocalizationCreator.create(
+        post: post,
+        locale: "ja",
+        raw: "お得な情報 #{amazon_url}",
+        user: admin,
+      )
+
+    expect(post.reload.cooked).to include(affiliate_tag)
+    expect(localization.reload.cooked).to include(affiliate_tag)
+  end
+
+  it "applies affiliate codes to an updated localization" do
+    post = create_post_with_link
+    PostLocalizationCreator.create(post: post, locale: "ja", raw: "お得な情報", user: admin)
+
+    localization =
+      PostLocalizationUpdater.update(
+        post: post,
+        locale: "ja",
+        raw: "更新されたお得な情報 #{amazon_url}",
+        user: admin,
+      )
+
+    expect(localization.reload.cooked).to include(affiliate_tag)
+  end
+
+  it "applies affiliate codes to an existing localization when it is recooked" do
+    post = create_post_with_link
+    localization =
+      PostLocalizationCreator.create(
+        post: post,
+        locale: "ja",
+        raw: "お得な情報 #{amazon_url}",
+        user: admin,
+      )
+    localization.update_column(:cooked, PrettyText.cook(localization.raw))
+    expect(localization.reload.cooked).not_to include(affiliate_tag)
+
+    Jobs::ProcessLocalizedCooked.new.execute(post_localization_id: localization.id, recook: true)
+
+    expect(localization.reload.cooked).to include(affiliate_tag)
+  end
+end


### PR DESCRIPTION
Previously, affiliate link rewriting only ran via the `:post_process_cooked` event, which fires exclusively when baking a post's original cooked HTML — so readers viewing a translated post were served untagged links.

This change subscribes the same rewrite to the `:post_process_localized_cooked` event fired by `LocalizedCookedPostProcessor`, so translated posts get affiliate links too. Existing localizations pick up the tags on their next rebake, since the recook path re-runs the localized post processor.

Reported at https://meta.discourse.org/t/407688