### PR TITLE
UX: add mobile horizontal swipe to see all emoji filters

### DIFF
--- a/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
+++ b/app/assets/stylesheets/common/modal/discourse-reactions-popup.scss
@@ -53,6 +53,16 @@
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 
+    // signals that the row continues past its edges; the ramps sit over the
+    // padding, so a row too short to scroll has nothing under them to fade
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black var(--space-4),
+      black calc(100% - var(--space-6)),
+      transparent 100%
+    );
+
     @include viewport.from(sm) {
       padding: var(--space-2) var(--space-3);
       border-bottom: 1px solid var(--primary-low);

--- a/frontend/discourse/app/lib/body-scroll-lock.js
+++ b/frontend/discourse/app/lib/body-scroll-lock.js
@@ -122,6 +122,45 @@ function getLockState(options) {
 }
 getLockState.lockState = initialLockState;
 
+// The locked element is not necessarily the one under the finger: its content can
+// hold nested scrollers, which are read as sitting at both of their edges on the
+// axis they don't scroll, and so never get to move. Resolve the scroller the
+// gesture would actually travel on instead. Scrollers with no room left in the
+// gesture's direction are skipped so the gesture still chains outwards to the
+// locked element, matching how a swipe is deferred to scrollable modal content.
+function scrollerUnderTouch(
+  event,
+  targetElement,
+  isVertical,
+  clientX,
+  clientY
+) {
+  let element = event.target instanceof Element ? event.target : null;
+
+  while (element && element !== targetElement) {
+    const { overflowX, overflowY } = window.getComputedStyle(element);
+    const overflow = isVertical ? overflowY : overflowX;
+
+    if (overflow === "auto" || overflow === "scroll") {
+      const hasRoomToScroll = isVertical
+        ? clientY > 0
+          ? element.scrollTop > 0
+          : element.scrollTop + element.clientHeight + 1 < element.scrollHeight
+        : clientX > 0
+          ? element.scrollLeft > 0
+          : element.scrollLeft + element.clientWidth + 1 < element.scrollWidth;
+
+      if (hasRoomToScroll) {
+        return element;
+      }
+    }
+
+    element = element.parentElement;
+  }
+
+  return targetElement;
+}
+
 function handleScroll(
   event,
   targetElement,
@@ -132,6 +171,16 @@ function handleScroll(
   }
 ) {
   if (targetElement) {
+    const clientX = event.targetTouches[0].clientX - initialClientPos.clientX;
+    const clientY = event.targetTouches[0].clientY - initialClientPos.clientY;
+    const isVertical = Math.abs(clientY) > Math.abs(clientX);
+    const scroller = scrollerUnderTouch(
+      event,
+      targetElement,
+      isVertical,
+      clientX,
+      clientY
+    );
     const {
       scrollTop,
       scrollLeft,
@@ -139,11 +188,12 @@ function handleScroll(
       scrollHeight,
       clientWidth,
       clientHeight,
-    } = targetElement;
-    const { reverseColumn = false, reverseRow = false } = options;
-    const clientX = event.targetTouches[0].clientX - initialClientPos.clientX;
-    const clientY = event.targetTouches[0].clientY - initialClientPos.clientY;
-    const isVertical = Math.abs(clientY) > Math.abs(clientX);
+    } = scroller;
+    // the reverse flags describe the locked element's own layout, so they no
+    // longer hold once the gesture resolves to a nested scroller
+    const isLockedElement = scroller === targetElement;
+    const reverseColumn = isLockedElement && (options.reverseColumn ?? false);
+    const reverseRow = isLockedElement && (options.reverseRow ?? false);
     let isOnTop, isOnBottom, isOnLeft, isOnRight;
     if (reverseColumn) {
       isOnTop = clientY > 0 && scrollTop + clientHeight + 1 >= scrollHeight;


### PR DESCRIPTION
Allows horizontal swipe on mobile to see more reaction/emojis in the filter area.

Previously if there were more reactions that fitted on screen on mobile — we couldn't filter by them due to body scroll lock.