### PR TITLE
FIX: Bring shared setting-field renderers to parity with admin controls

### DIFF
--- a/frontend/discourse/admin/components/site-settings/group-list.gjs
+++ b/frontend/discourse/admin/components/site-settings/group-list.gjs
@@ -3,59 +3,11 @@ import Component from "@ember/component";
 import { action, computed } from "@ember/object";
 import { service } from "@ember/service";
 import { tagName } from "@ember-decorators/component";
-import { AUTO_GROUPS } from "discourse/lib/constants";
+import {
+  mapEveryoneToLoggedInUsersIds,
+  mapLoggedInUsersToEveryoneForStorage,
+} from "discourse/lib/group-list-setting-aliasing";
 import ListSetting from "discourse/select-kit/components/list-setting";
-
-// TODO (martin) Remove all this indirection when
-// granular_anonymous_and_logged_in_groups_permissions is Permanent
-const EVERYONE_ID = AUTO_GROUPS.everyone.id.toString();
-const LOGGED_IN_USERS_ID = AUTO_GROUPS.logged_in_users.id.toString();
-
-function normalizeIds(ids) {
-  return ids.map((id) => id.toString());
-}
-
-function mapEveryoneToLoggedInUsersIds(ids, granularPermissionsEnabled) {
-  ids = normalizeIds(ids);
-
-  if (!granularPermissionsEnabled || !ids.includes(EVERYONE_ID)) {
-    return ids;
-  }
-
-  return [
-    ...new Set(ids.map((id) => (id === EVERYONE_ID ? LOGGED_IN_USERS_ID : id))),
-  ];
-}
-
-function mapLoggedInUsersToEveryoneForStorage(
-  ids,
-  granularPermissionsEnabled,
-  storedValue,
-  tokenSeparator
-) {
-  if (!granularPermissionsEnabled) {
-    return normalizeIds(ids);
-  }
-
-  const storedIds = normalizeIds(
-    (storedValue || "").split(tokenSeparator).filter(Boolean)
-  );
-
-  if (
-    !storedIds.includes(EVERYONE_ID) ||
-    storedIds.includes(LOGGED_IN_USERS_ID)
-  ) {
-    return normalizeIds(ids);
-  }
-
-  return [
-    ...new Set(
-      normalizeIds(ids).map((id) =>
-        id === LOGGED_IN_USERS_ID ? EVERYONE_ID : id
-      )
-    ),
-  ];
-}
 
 @tagName("")
 export default class GroupList extends Component {

--- a/frontend/discourse/admin/models/site-setting.js
+++ b/frontend/discourse/admin/models/site-setting.js
@@ -165,6 +165,11 @@ export default class SiteSetting extends EmberObject {
       max: this.max,
       choices: this.choices,
       valid_values: this.validValues,
+      allows_none: !!this.allowsNone,
+      allow_any: this.allow_any,
+      mandatory_values: this.mandatory_values,
+      disallowed_groups: this.disallowed_groups,
+      currentSavedValue: this.value,
     };
   }
 

--- a/frontend/discourse/app/components/setting-field/category-list.gjs
+++ b/frontend/discourse/app/components/setting-field/category-list.gjs
@@ -11,20 +11,30 @@ export default class SettingFieldCategoryList extends Component {
 
   constructor() {
     super(...arguments);
-    this.loadCategories();
+    this.pendingCategoriesRequest = Promise.resolve();
+    this.valueChanged();
   }
 
   get categoryIds() {
     return splitString(this.args.field.value, "|");
   }
 
+  async updateSelectedCategories(previousRequest) {
+    const categories = await Category.asyncFindByIds(this.categoryIds);
+
+    // This is to prevent a race. We want to ensure that the update to
+    // selectedCategories for this request happens after the update for the
+    // previous request.
+    await previousRequest;
+
+    this.selectedCategories = categories;
+  }
+
   @action
-  async loadCategories() {
-    if (this.categoryIds.length) {
-      this.selectedCategories = await Category.asyncFindByIds(this.categoryIds);
-    } else {
-      this.selectedCategories = [];
-    }
+  valueChanged() {
+    const previousRequest = this.pendingCategoriesRequest;
+    this.pendingCategoriesRequest =
+      this.updateSelectedCategories(previousRequest);
   }
 
   @action
@@ -34,7 +44,7 @@ export default class SettingFieldCategoryList extends Component {
 
   <template>
     <@field.Control>
-      <div {{didUpdate this.loadCategories @field.value}}>
+      <div {{didUpdate this.valueChanged @field.value}}>
         <CategorySelector
           @categories={{this.selectedCategories}}
           @onChange={{this.onChangeCategories}}

--- a/frontend/discourse/app/components/setting-field/compact-list.gjs
+++ b/frontend/discourse/app/components/setting-field/compact-list.gjs
@@ -1,12 +1,29 @@
 import Component from "@glimmer/component";
-import { fn } from "@ember/helper";
-import { bind } from "discourse/lib/decorators";
-import { splitString } from "discourse/lib/utilities";
+import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { uniqueItemsFromArray } from "discourse/lib/array-tools";
+import { makeArray } from "discourse/lib/helpers";
 import ListSetting from "discourse/select-kit/components/list-setting";
 
+const TOKEN_SEPARATOR = "|";
+
 export default class SettingFieldCompactList extends Component {
+  @tracked createdChoices = null;
+
   get hasEnumChoices() {
     return this.args.definition.valid_values?.length > 0;
+  }
+
+  get allowAny() {
+    return this.args.definition.allow_any !== false;
+  }
+
+  get settingValue() {
+    return (this.args.field.value ?? "")
+      .toString()
+      .split(TOKEN_SEPARATOR)
+      .filter(Boolean);
   }
 
   get choices() {
@@ -16,23 +33,39 @@ export default class SettingFieldCompactList extends Component {
         value: String(v.value),
       }));
     }
-    return this.args.definition.choices;
+
+    return uniqueItemsFromArray([
+      ...this.settingValue,
+      ...makeArray(this.args.definition.choices),
+      ...makeArray(this.createdChoices),
+    ]);
   }
 
-  @bind
-  setList(field, values) {
-    field.set(Array.isArray(values) ? values.join("|") : values);
+  @action
+  onChange(values) {
+    this.args.field.set(makeArray(values).join(TOKEN_SEPARATOR));
+  }
+
+  @action
+  onChangeChoices(choices) {
+    this.createdChoices = uniqueItemsFromArray([
+      ...makeArray(this.createdChoices),
+      ...makeArray(choices),
+    ]);
   }
 
   <template>
     <@field.Control>
       <ListSetting
-        @value={{splitString @field.value "|"}}
+        @value={{this.settingValue}}
         @choices={{this.choices}}
         @settingName={{@definition.key}}
         @nameProperty={{if this.hasEnumChoices "name"}}
         @valueProperty={{if this.hasEnumChoices "value"}}
-        @onChange={{fn this.setList @field}}
+        @onChange={{this.onChange}}
+        @onChangeChoices={{this.onChangeChoices}}
+        @options={{hash allowAny=this.allowAny}}
+        @mandatoryValues={{@definition.mandatory_values}}
       />
     </@field.Control>
   </template>

--- a/frontend/discourse/app/components/setting-field/enum.gjs
+++ b/frontend/discourse/app/components/setting-field/enum.gjs
@@ -1,11 +1,50 @@
-import { or } from "discourse/truth-helpers";
+import Component from "@glimmer/component";
+import { i18n } from "discourse-i18n";
 
-export default <template>
-  <@field.Control as |select|>
-    {{#each (or @definition.valid_values @definition.choices) as |choice|}}
-      <select.Option @value={{choice.value}}>
-        {{choice.name}}
-      </select.Option>
-    {{/each}}
-  </@field.Control>
-</template>
+export default class SettingFieldEnum extends Component {
+  get rawChoices() {
+    return (
+      this.args.definition.valid_values ?? this.args.definition.choices ?? []
+    );
+  }
+
+  get hasBlankChoice() {
+    return this.rawChoices.includes("");
+  }
+
+  get includeNone() {
+    if (this.hasBlankChoice) {
+      return true;
+    }
+
+    return this.args.definition.allows_none;
+  }
+
+  get choices() {
+    return this.rawChoices
+      .filter((choice) => choice != null && choice !== "")
+      .map((choice) =>
+        typeof choice === "object"
+          ? { value: String(choice.value), name: choice.name }
+          : { value: String(choice), name: String(choice) }
+      );
+  }
+
+  get selectedValue() {
+    return String(this.args.field.value ?? "");
+  }
+
+  <template>
+    <@field.Control
+      @includeNone={{this.includeNone}}
+      @nonePlaceholder={{if this.includeNone (i18n "admin.settings.none")}}
+      as |select|
+    >
+      {{#each this.choices as |choice|}}
+        <select.Option @value={{choice.value}} @selected={{this.selectedValue}}>
+          {{choice.name}}
+        </select.Option>
+      {{/each}}
+    </@field.Control>
+  </template>
+}

--- a/frontend/discourse/app/components/setting-field/group-list.gjs
+++ b/frontend/discourse/app/components/setting-field/group-list.gjs
@@ -1,36 +1,88 @@
 import Component from "@glimmer/component";
-import { fn } from "@ember/helper";
 import { service } from "@ember/service";
 import { bind } from "discourse/lib/decorators";
+import {
+  mapEveryoneToLoggedInUsersIds,
+  mapLoggedInUsersToEveryoneForStorage,
+} from "discourse/lib/group-list-setting-aliasing";
 import { splitString } from "discourse/lib/utilities";
-import GroupChooser from "discourse/select-kit/components/group-chooser";
+import ListSetting from "discourse/select-kit/components/list-setting";
+
+const TOKEN_SEPARATOR = "|";
 
 export default class SettingFieldGroupList extends Component {
   @service site;
+  @service siteSettings;
 
-  get groupContent() {
-    return this.site.groups;
+  get granularPermissionsEnabled() {
+    return this.siteSettings
+      .granular_anonymous_and_logged_in_groups_permissions;
   }
 
-  toGroupIdArray(value) {
-    if (Array.isArray(value)) {
-      return value.map(Number);
+  get groupChoices() {
+    const disallowed = splitString(
+      this.args.definition.disallowed_groups,
+      TOKEN_SEPARATOR
+    );
+    const groups = (this.site.groups || []).filter(
+      (group) => !disallowed.includes(group.id.toString())
+    );
+    const groupsById = Object.fromEntries(
+      groups.map((group) => [group.id.toString(), group])
+    );
+
+    return mapEveryoneToLoggedInUsersIds(
+      groups.map((group) => group.id.toString()),
+      this.granularPermissionsEnabled
+    )
+      .map((id) => {
+        const group = groupsById[id];
+        return group ? { name: group.name, id } : null;
+      })
+      .filter(Boolean);
+  }
+
+  get selectedIds() {
+    const value = this.args.field.value;
+    const ids = Array.isArray(value)
+      ? value.map(String)
+      : splitString(value, TOKEN_SEPARATOR);
+
+    return mapEveryoneToLoggedInUsersIds(ids, this.granularPermissionsEnabled);
+  }
+
+  get storedValueReference() {
+    const saved = this.args.definition.currentSavedValue;
+    if (saved !== undefined) {
+      return saved;
     }
-    return splitString(value, "|").map(Number);
+
+    const value = this.args.field.value;
+    return Array.isArray(value) ? value.join(TOKEN_SEPARATOR) : value;
   }
 
   @bind
-  setGroupIdString(field, ids) {
-    field.set((ids ?? []).join("|"));
+  onChange(ids) {
+    const storedIds = mapLoggedInUsersToEveryoneForStorage(
+      ids ?? [],
+      this.granularPermissionsEnabled,
+      this.storedValueReference,
+      TOKEN_SEPARATOR
+    );
+
+    this.args.field.set(storedIds.join(TOKEN_SEPARATOR));
   }
 
   <template>
     <@field.Control>
-      <GroupChooser
-        @content={{this.groupContent}}
-        @value={{this.toGroupIdArray @field.value}}
-        @labelProperty="name"
-        @onChange={{fn this.setGroupIdString @field}}
+      <ListSetting
+        @value={{this.selectedIds}}
+        @choices={{this.groupChoices}}
+        @settingName={{@definition.key}}
+        @mandatoryValues={{@definition.mandatory_values}}
+        @nameProperty="name"
+        @valueProperty="id"
+        @onChange={{this.onChange}}
       />
     </@field.Control>
   </template>

--- a/frontend/discourse/app/lib/group-list-setting-aliasing.js
+++ b/frontend/discourse/app/lib/group-list-setting-aliasing.js
@@ -1,0 +1,52 @@
+import { AUTO_GROUPS } from "discourse/lib/constants";
+
+// TODO (martin) Remove all this indirection when
+// granular_anonymous_and_logged_in_groups_permissions is Permanent
+const EVERYONE_ID = AUTO_GROUPS.everyone.id.toString();
+const LOGGED_IN_USERS_ID = AUTO_GROUPS.logged_in_users.id.toString();
+
+function normalizeIds(ids) {
+  return ids.map((id) => id.toString());
+}
+
+export function mapEveryoneToLoggedInUsersIds(ids, granularPermissionsEnabled) {
+  ids = normalizeIds(ids);
+
+  if (!granularPermissionsEnabled || !ids.includes(EVERYONE_ID)) {
+    return ids;
+  }
+
+  return [
+    ...new Set(ids.map((id) => (id === EVERYONE_ID ? LOGGED_IN_USERS_ID : id))),
+  ];
+}
+
+export function mapLoggedInUsersToEveryoneForStorage(
+  ids,
+  granularPermissionsEnabled,
+  storedValue,
+  tokenSeparator
+) {
+  if (!granularPermissionsEnabled) {
+    return normalizeIds(ids);
+  }
+
+  const storedIds = normalizeIds(
+    (storedValue || "").split(tokenSeparator).filter(Boolean)
+  );
+
+  if (
+    !storedIds.includes(EVERYONE_ID) ||
+    storedIds.includes(LOGGED_IN_USERS_ID)
+  ) {
+    return normalizeIds(ids);
+  }
+
+  return [
+    ...new Set(
+      normalizeIds(ids).map((id) =>
+        id === LOGGED_IN_USERS_ID ? EVERYONE_ID : id
+      )
+    ),
+  ];
+}

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -1,8 +1,9 @@
-import { array, hash } from "@ember/helper";
+import { array, concat, hash } from "@ember/helper";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import Form from "discourse/components/form";
 import SettingDefinitionField from "discourse/components/setting-definition-field";
+import Site from "discourse/models/site";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
@@ -169,7 +170,7 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
       </template>
     );
 
-    const groups = selectKit("[data-name='my_groups'] .group-chooser");
+    const groups = selectKit("[data-name='my_groups'] .list-setting");
     assert.strictEqual(
       groups.header().value(),
       "1",
@@ -177,11 +178,153 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
     );
 
     await groups.expand();
-    await groups.selectRowByValue(2);
+    await groups.selectRowByValue("2");
 
     assert
       .dom(".value-probe")
       .hasText("1|2", "serializes the selection back to a pipe string");
+  });
+
+  test("group_list swaps everyone for logged_in_users when granular permissions are enabled", async function (assert) {
+    this.siteSettings.granular_anonymous_and_logged_in_groups_permissions = true;
+
+    this.site.groups = [
+      { id: 1, name: "Donuts" },
+      { id: 5, name: "logged_in_users" },
+      { id: 11, name: "trust_level_1" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash my_groups="0|11"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_groups"
+              type="group_list"
+              label="My groups"
+              currentSavedValue="0|11"
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_groups}}</span>
+        </Form>
+      </template>
+    );
+
+    const groups = selectKit("[data-name='my_groups'] .list-setting");
+    assert.strictEqual(
+      groups.header().value(),
+      "5,11",
+      "displays logged_in_users instead of everyone"
+    );
+    assert
+      .dom(".value-probe")
+      .hasText("0|11", "does not rewrite the form value just by rendering");
+
+    await groups.expand();
+    await groups.selectRowByValue("1");
+
+    assert
+      .dom(".value-probe")
+      .hasText("0|11|1", "maps logged_in_users back to everyone on write");
+  });
+
+  test("group_list keeps everyone in the value even when the definition has no saved-value reference", async function (assert) {
+    this.siteSettings.granular_anonymous_and_logged_in_groups_permissions = true;
+
+    this.site.groups = [
+      { id: 1, name: "Donuts" },
+      { id: 5, name: "logged_in_users" },
+      { id: 11, name: "trust_level_1" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash my_groups="0|11"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_groups"
+              type="group_list"
+              label="My groups"
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_groups}}</span>
+        </Form>
+      </template>
+    );
+
+    const groups = selectKit("[data-name='my_groups'] .list-setting");
+    await groups.expand();
+    await groups.selectRowByValue("1");
+
+    assert
+      .dom(".value-probe")
+      .hasText(
+        "0|11|1",
+        "falls back to the current value to keep everyone stored as everyone"
+      );
+  });
+
+  test("group_list filters out disallowed groups from the choices", async function (assert) {
+    this.site.groups = [
+      { id: 0, name: "everyone" },
+      { id: 1, name: "Donuts" },
+      { id: 2, name: "Cheese cake" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash my_groups=""}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_groups"
+              type="group_list"
+              label="My groups"
+              disallowed_groups="0"
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    const groups = selectKit("[data-name='my_groups'] .list-setting");
+    await groups.expand();
+
+    assert.false(groups.rowByValue("0").exists(), "disallowed group is hidden");
+    assert.true(groups.rowByValue("1").exists());
+    assert.true(groups.rowByValue("2").exists());
+  });
+
+  test("group_list marks mandatory values as non-removable", async function (assert) {
+    this.site.groups = [
+      { id: 1, name: "Donuts" },
+      { id: 2, name: "Cheese cake" },
+    ];
+
+    await render(
+      <template>
+        <Form @data={{hash my_groups="1"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_groups"
+              type="group_list"
+              label="My groups"
+              mandatory_values="1"
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    const groups = selectKit("[data-name='my_groups'] .list-setting");
+    await groups.expand();
+
+    assert
+      .dom("[data-name='my_groups'] .selected-content button")
+      .hasClass("disabled");
   });
 
   test("enum prefers valid_values over a raw string choices array (site setting shape)", async function (assert) {
@@ -211,6 +354,234 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
       .dom("[data-name='my_enum'] select option[value='b']")
       .hasText("Banana");
     assert.form().field("my_enum").hasValue("a");
+  });
+
+  test("enum normalizes scalar choices into options", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum="a"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              choices=(array "a" "b")
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert.dom("[data-name='my_enum'] select option[value='a']").hasText("a");
+    assert.dom("[data-name='my_enum'] select option[value='b']").hasText("b");
+    assert.form().field("my_enum").hasValue("a");
+  });
+
+  test("enum only offers a none option when the setting allows a blank value", async function (assert) {
+    await render(
+      <template>
+        <Form
+          @data={{hash with_none="a" without_none="a" no_allows_none_key="a"}}
+          as |form|
+        >
+          <SettingDefinitionField
+            @definition={{hash
+              key="with_none"
+              type="enum"
+              label="With none"
+              valid_values=(array
+                "" (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+          <SettingDefinitionField
+            @definition={{hash
+              key="without_none"
+              type="enum"
+              label="Without none"
+              allows_none=false
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+          <SettingDefinitionField
+            @definition={{hash
+              key="no_allows_none_key"
+              type="enum"
+              label="Consumer default"
+              valid_values=(array
+                (hash value="a" name="Apple") (hash value="b" name="Banana")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='with_none'] select option[value='__NONE__']")
+      .exists("the blank valid value becomes a none option");
+    assert
+      .dom("[data-name='with_none'] select option")
+      .exists({ count: 3 }, "the raw blank entry does not render as an option");
+    assert
+      .dom("[data-name='without_none'] select option[value='__NONE__']")
+      .doesNotExist(
+        "a setting that does not allow a blank value cannot be cleared"
+      );
+    assert
+      .dom("[data-name='no_allows_none_key'] select option[value='__NONE__']")
+      .exists(
+        "definitions without allows_none keep the optional-field default"
+      );
+  });
+
+  test("enum matches the selected option when values are not strings", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_enum=5}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_enum"
+              type="enum"
+              label="My enum"
+              valid_values=(array
+                (hash value=5 name="Five") (hash value=6 name="Six")
+              )
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert
+      .dom("[data-name='my_enum'] select option[value='5']")
+      .hasAttribute("selected");
+  });
+
+  test("compact_list offers created entries again after they are removed", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_list="a"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_list"
+              type="compact_list"
+              label="My list"
+              choices=(array "a" "b")
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_list}}</span>
+        </Form>
+      </template>
+    );
+
+    const list = selectKit("[data-name='my_list'] .list-setting");
+    await list.expand();
+    await list.fillInFilter("custom");
+    await list.keyboard("Enter");
+
+    assert.dom(".value-probe").hasText("a|custom");
+
+    await list.deselectItemByValue("custom");
+    assert.dom(".value-probe").hasText("a");
+
+    await list.collapse();
+    await list.expand();
+    assert.true(
+      list.rowByValue("custom").exists(),
+      "the created entry stays available as a choice"
+    );
+  });
+
+  test("compact_list does not allow arbitrary entries when allow_any is false", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_list="a"}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_list"
+              type="compact_list"
+              label="My list"
+              choices=(array "a" "b")
+              allow_any=false
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_list}}</span>
+        </Form>
+      </template>
+    );
+
+    const list = selectKit("[data-name='my_list'] .list-setting");
+    await list.expand();
+    await list.fillInFilter("custom");
+    await list.keyboard("Enter");
+
+    assert.dom(".value-probe").hasText("a");
+  });
+
+  test("compact_list marks mandatory values as non-removable", async function (assert) {
+    await render(
+      <template>
+        <Form @data={{hash my_list="admin|moderator"}} as |form|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_list"
+              type="compact_list"
+              label="My list"
+              choices=(array "admin" "moderator")
+              mandatory_values="admin"
+            }}
+            @form={{form}}
+          />
+        </Form>
+      </template>
+    );
+
+    const list = selectKit("[data-name='my_list'] .list-setting");
+    await list.expand();
+
+    assert
+      .dom("[data-name='my_list'] .selected-content button")
+      .hasClass("disabled");
+  });
+
+  test("category_list clears every selection", async function (assert) {
+    const categoryId = Site.current().categories[0].id;
+
+    await render(
+      <template>
+        <Form @data={{hash my_categories=(concat categoryId)}} as |form data|>
+          <SettingDefinitionField
+            @definition={{hash
+              key="my_categories"
+              type="category_list"
+              label="My categories"
+            }}
+            @form={{form}}
+          />
+          <span class="value-probe">{{data.my_categories}}</span>
+        </Form>
+      </template>
+    );
+
+    const categories = selectKit(
+      "[data-name='my_categories'] .category-selector"
+    );
+    await categories.expand();
+    await categories.deselectItemByValue(categoryId);
+
+    assert
+      .dom(".value-probe")
+      .hasText("", "removing the last category clears the value");
   });
 
   test("list + list_type collapses to the compact_list control", async function (assert) {

--- a/frontend/discourse/tests/unit/lib/group-list-setting-aliasing-test.js
+++ b/frontend/discourse/tests/unit/lib/group-list-setting-aliasing-test.js
@@ -1,0 +1,74 @@
+import { module, test } from "qunit";
+import {
+  mapEveryoneToLoggedInUsersIds,
+  mapLoggedInUsersToEveryoneForStorage,
+} from "discourse/lib/group-list-setting-aliasing";
+
+module("Unit | Lib | group-list-setting-aliasing", function () {
+  test("mapEveryoneToLoggedInUsersIds is an identity when granular permissions are disabled", function (assert) {
+    assert.deepEqual(mapEveryoneToLoggedInUsersIds(["0", "11"], false), [
+      "0",
+      "11",
+    ]);
+  });
+
+  test("mapEveryoneToLoggedInUsersIds normalizes numeric ids to strings", function (assert) {
+    assert.deepEqual(mapEveryoneToLoggedInUsersIds([1, 2], true), ["1", "2"]);
+  });
+
+  test("mapEveryoneToLoggedInUsersIds swaps everyone for logged_in_users", function (assert) {
+    assert.deepEqual(mapEveryoneToLoggedInUsersIds(["0", "11"], true), [
+      "5",
+      "11",
+    ]);
+  });
+
+  test("mapEveryoneToLoggedInUsersIds dedupes when both everyone and logged_in_users are present", function (assert) {
+    assert.deepEqual(mapEveryoneToLoggedInUsersIds(["0", "5", "11"], true), [
+      "5",
+      "11",
+    ]);
+  });
+
+  test("mapLoggedInUsersToEveryoneForStorage is an identity when granular permissions are disabled", function (assert) {
+    assert.deepEqual(
+      mapLoggedInUsersToEveryoneForStorage(["5", "1"], false, "0|1", "|"),
+      ["5", "1"]
+    );
+  });
+
+  test("mapLoggedInUsersToEveryoneForStorage keeps logged_in_users when the stored value never contained everyone", function (assert) {
+    assert.deepEqual(
+      mapLoggedInUsersToEveryoneForStorage(["5", "1"], true, "1", "|"),
+      ["5", "1"]
+    );
+  });
+
+  test("mapLoggedInUsersToEveryoneForStorage keeps logged_in_users when the stored value already distinguishes both groups", function (assert) {
+    assert.deepEqual(
+      mapLoggedInUsersToEveryoneForStorage(["5", "1"], true, "0|5", "|"),
+      ["5", "1"]
+    );
+  });
+
+  test("mapLoggedInUsersToEveryoneForStorage maps logged_in_users back to everyone when the stored value contained everyone", function (assert) {
+    assert.deepEqual(
+      mapLoggedInUsersToEveryoneForStorage(["5", "1"], true, "0|1", "|"),
+      ["0", "1"]
+    );
+  });
+
+  test("mapLoggedInUsersToEveryoneForStorage handles a blank stored value", function (assert) {
+    assert.deepEqual(
+      mapLoggedInUsersToEveryoneForStorage(["5"], true, undefined, "|"),
+      ["5"]
+    );
+  });
+
+  test("mapLoggedInUsersToEveryoneForStorage dedupes when the selection contains both groups", function (assert) {
+    assert.deepEqual(
+      mapLoggedInUsersToEveryoneForStorage(["0", "5"], true, "0", "|"),
+      ["0"]
+    );
+  });
+});

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/routes/admin-plugins/show/discourse-ai-features/edit.js
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/routes/admin-plugins/show/discourse-ai-features/edit.js
@@ -33,13 +33,6 @@ export default class AdminPluginsShowDiscourseAiFeaturesEdit extends DiscourseRo
         value = value === "true" || value === true;
       }
 
-      if (setting.type === "enum" && typeof value === "string") {
-        const numValue = parseInt(value, 10);
-        if (!isNaN(numValue) && numValue.toString() === value) {
-          value = numValue;
-        }
-      }
-
       currentFeature.formData[setting.setting] = value;
     });
 

--- a/plugins/discourse-ai/spec/system/admin_ai_features_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_features_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Admin AI features configuration" do
     expect(page).to have_css(".ai-feature-editor")
 
     field = form.field("ai_bot_allowed_groups")
-    expect(field.component).to have_css(".group-chooser")
+    expect(field.component).to have_css(".list-setting")
     expect(field.component).to have_content(group_1.name)
     expect(field.component).to have_content(group_2.name)
   end


### PR DESCRIPTION
Previously, the shared `SettingDefinitionField` renderers lacked behaviors their legacy `site-settings/*` counterparts enforce — most notably `group_list` skipped the everyone/logged_in_users aliasing and `disallowed_groups`/`mandatory_values`, so the AI feature settings page could silently store the wrong group.

This change ports those behaviors into the shared renderers — group aliasing (extracted to `discourse/lib/group-list-setting-aliasing` so there is a single implementation), `compact_list` custom entries / `allow_any` / `mandatory_values`, `enum` none-gating and non-string value matching, and the `category_list` concurrent-lookup guard — so they can back the admin site settings pages next (t/179889).