### PR TITLE
DEV: Decouple the site setting change tracker from row internals

### DIFF
--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -74,6 +74,7 @@ export default class SiteSettingComponent extends Component {
   @tracked status = null;
   @tracked progress = null;
   updateExistingUsers = null;
+  trackChanges = true;
 
   constructor() {
     super(...arguments);
@@ -98,11 +99,12 @@ export default class SiteSettingComponent extends Component {
     }
   }
 
-  canSubscribeToSettingsJobs() {
-    const settingName = this.setting.setting;
+  get canSubscribeToSettingsJobs() {
+    const settingName = this.setting?.setting;
+
     return (
-      settingName.includes("default_categories") ||
-      settingName.includes("default_tags")
+      settingName?.includes("default_categories") ||
+      settingName?.includes("default_tags")
     );
   }
 
@@ -284,10 +286,12 @@ export default class SiteSettingComponent extends Component {
 
     const dirty = !this.#valuesEqual(bufferVal, settingVal, setting);
 
-    if (dirty) {
-      this.siteSettingChangeTracker.add(setting);
-    } else {
-      this.siteSettingChangeTracker.remove(setting);
+    if (this.trackChanges) {
+      if (dirty) {
+        this.siteSettingChangeTracker.add(setting);
+      } else {
+        this.siteSettingChangeTracker.remove(setting);
+      }
     }
 
     return dirty;
@@ -476,8 +480,7 @@ export default class SiteSettingComponent extends Component {
 
       const refreshParams = {};
       settings.forEach((setting) => {
-        setting.validationMessage = null;
-        setting.buffered.applyChanges();
+        setting.commit();
 
         if (setting.requiresReload) {
           refreshParams[setting.setting] = setting.value;
@@ -527,7 +530,7 @@ export default class SiteSettingComponent extends Component {
   @action
   cancel() {
     this.dirtySettings.forEach((setting) => {
-      setting.buffered.discardChanges();
+      setting.rollback();
       setting.validationMessage = null;
     });
   }

--- a/frontend/discourse/admin/components/theme-setting-editor.js
+++ b/frontend/discourse/admin/components/theme-setting-editor.js
@@ -5,6 +5,8 @@ import SiteSettingComponent from "./site-setting";
 export default class ThemeSettingEditor extends SiteSettingComponent {
   @service toasts;
 
+  trackChanges = false;
+
   _save() {
     return this.setting
       .updateSetting(this.args.model.id, this.buffered.get("value"))

--- a/frontend/discourse/admin/components/theme-setting-relatives-selector.js
+++ b/frontend/discourse/admin/components/theme-setting-relatives-selector.js
@@ -1,6 +1,8 @@
 import SiteSettingComponent from "./site-setting";
 
 export default class ThemeSettingRelativesSelectorComponent extends SiteSettingComponent {
+  trackChanges = false;
+
   _save() {
     return this.args.model.save({
       [this.args.setting.setting]: this.convertNamesToIds(),

--- a/frontend/discourse/admin/components/theme-site-setting-editor.gjs
+++ b/frontend/discourse/admin/components/theme-site-setting-editor.gjs
@@ -5,6 +5,8 @@ import SiteSettingComponent from "./site-setting";
 export default class ThemeSiteSettingEditor extends SiteSettingComponent {
   @service toasts;
 
+  trackChanges = false;
+
   get staffLogFilter() {
     return {
       subject: `${this.args.model.name}: ${this.setting.setting}`,

--- a/frontend/discourse/admin/components/theme-translation.js
+++ b/frontend/discourse/admin/components/theme-translation.js
@@ -4,6 +4,7 @@ import SiteSettingComponent from "./site-setting";
 
 export default class ThemeTranslation extends SiteSettingComponent {
   type = "string";
+  trackChanges = false;
 
   get setting() {
     return this.args.translation;

--- a/frontend/discourse/admin/models/site-setting.js
+++ b/frontend/discourse/admin/models/site-setting.js
@@ -168,6 +168,19 @@ export default class SiteSetting extends EmberObject {
     };
   }
 
+  get pendingValue() {
+    return this.buffered.get("value");
+  }
+
+  commit() {
+    this.validationMessage = null;
+    this.buffered.applyChanges();
+  }
+
+  rollback() {
+    this.buffered.discardChanges();
+  }
+
   get requiresConfirmation() {
     switch (this.requires_confirmation) {
       case SITE_SETTING_REQUIRES_CONFIRMATION_TYPES.simple:

--- a/frontend/discourse/admin/services/site-setting-change-tracker.js
+++ b/frontend/discourse/admin/services/site-setting-change-tracker.js
@@ -31,7 +31,6 @@ export default class SiteSettingChangeTracker extends Service {
     this.#startSaving();
 
     try {
-      let reload = false;
       let confirm = true;
 
       // Settings with custom confirmation messages.
@@ -56,27 +55,29 @@ export default class SiteSettingChangeTracker extends Service {
       }
 
       this.dirtySiteSettings.forEach((setting) => {
-        params[setting.buffered.get("setting")] = {
-          value: setting.buffered.get("value"),
+        params[setting.setting] = {
+          value: setting.pendingValue,
           backfill: !!setting.updateExistingUsers,
         };
       });
 
       await SiteSetting.bulkUpdate(params);
 
+      const refreshParams = {};
+
       this.dirtySiteSettings.forEach((setting) => {
-        setting.validationMessage = null;
-        setting.buffered.applyChanges();
+        setting.commit();
+
         if (setting.requiresReload) {
-          reload = setting.afterSave;
+          refreshParams[setting.setting] = setting.value;
         }
       });
 
       this.#stopSaving();
       this.dirtySiteSettings.clear();
 
-      if (reload) {
-        reload();
+      if (Object.keys(refreshParams).length > 0) {
+        this.refreshPage(refreshParams);
       }
     } catch (error) {
       this.#stopSaving();
@@ -85,14 +86,12 @@ export default class SiteSettingChangeTracker extends Service {
   }
 
   discard() {
-    this.dirtySiteSettings.forEach((setting) =>
-      setting.buffered.discardChanges()
-    );
+    this.dirtySiteSettings.forEach((setting) => setting.rollback());
     this.dirtySiteSettings.clear();
   }
 
   async confirmChanges(setting) {
-    const settingKey = setting.buffered.get("setting");
+    const settingKey = setting.setting;
 
     return new Promise((resolve) => {
       // Fallback is needed in case the setting does not have a custom confirmation
@@ -150,10 +149,10 @@ export default class SiteSettingChangeTracker extends Service {
   }
 
   async configureBackfill(setting) {
-    const key = setting.buffered.get("setting");
+    const key = setting.setting;
 
     const data = {
-      [key]: setting.buffered.get("value"),
+      [key]: setting.pendingValue,
     };
 
     const result = await ajax(`/admin/site_settings/${key}/user_count.json`, {

--- a/frontend/discourse/tests/integration/components/site-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-setting-test.gjs
@@ -1,7 +1,17 @@
-import { click, fillIn, render, triggerEvent } from "@ember/test-helpers";
+import {
+  click,
+  fillIn,
+  render,
+  settled,
+  triggerEvent,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import SiteSettingComponent from "discourse/admin/components/site-setting";
+import ThemeSiteSettingEditor from "discourse/admin/components/theme-site-setting-editor";
+import ThemeTranslation from "discourse/admin/components/theme-translation";
 import SiteSetting from "discourse/admin/models/site-setting";
+import ThemeSettings from "discourse/admin/models/theme-settings";
+import ThemeSiteSettings from "discourse/admin/models/theme-site-settings";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
@@ -293,6 +303,87 @@ module("Integration | Component | SiteSetting", function (hooks) {
       status: "completed",
     });
     assert.dom(".desc.site-setting").doesNotExist();
+  });
+
+  test("doesn't listen for job progress on unrelated settings", async function (assert) {
+    this.set(
+      "setting",
+      SiteSetting.create({
+        setting: "title",
+        value: "",
+        type: "string",
+      })
+    );
+
+    await render(
+      <template><SiteSettingComponent @setting={{this.setting}} /></template>
+    );
+
+    await publishToMessageBus("/site_setting/title/process", {
+      status: "enqueued",
+    });
+
+    assert.dom(".desc.site-setting").doesNotExist();
+  });
+
+  test("theme rows don't register in the site setting change tracker", async function (assert) {
+    const tracker = this.owner.lookup("service:site-setting-change-tracker");
+
+    const themeSetting = ThemeSiteSettings.create({
+      setting: "enable_welcome_banner",
+      value: "true",
+      default: "true",
+      type: "bool",
+    });
+    this.setProperties({
+      themeSetting,
+      theme: { id: 1, name: "Horizon" },
+    });
+
+    await render(
+      <template>
+        <ThemeSiteSettingEditor
+          @setting={{this.themeSetting}}
+          @model={{this.theme}}
+        />
+      </template>
+    );
+
+    themeSetting.buffered.set("value", "false");
+    await settled();
+
+    assert
+      .dom(".setting-controls .ok")
+      .exists("the row itself still shows its save button");
+    assert.strictEqual(
+      tracker.count,
+      0,
+      "the dirty theme setting is not picked up by the site settings banner"
+    );
+  });
+
+  test("renders theme translation rows without a setting name", async function (assert) {
+    const translation = ThemeSettings.create({
+      key: "theme_metadata.description",
+      value: "A theme",
+      default: "A theme",
+      textarea: true,
+    });
+    this.setProperties({
+      translation,
+      theme: { id: 1, locale: "en" },
+    });
+
+    await render(
+      <template>
+        <ThemeTranslation
+          @translation={{this.translation}}
+          @model={{this.theme}}
+        />
+      </template>
+    );
+
+    assert.dom(".setting textarea").hasValue("A theme");
   });
 
   test("doesn't display the save/cancel buttons when the selected value is returned to the current value", async function (assert) {

--- a/frontend/discourse/tests/unit/services/site-setting-change-tracker-test.js
+++ b/frontend/discourse/tests/unit/services/site-setting-change-tracker-test.js
@@ -1,0 +1,124 @@
+import { getOwner } from "@ember/owner";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+
+function stubHandle(overrides = {}) {
+  return {
+    setting: "title",
+    value: "old",
+    pendingValue: "new",
+    updateExistingUsers: false,
+    requiresConfirmation: false,
+    affectsExistingUsers: false,
+    requiresReload: false,
+    isSaving: false,
+    validationMessage: null,
+    committed: false,
+    rolledBack: false,
+    commit() {
+      this.committed = true;
+      this.value = this.pendingValue;
+    },
+    rollback() {
+      this.rolledBack = true;
+    },
+    ...overrides,
+  };
+}
+
+module("Unit | Service | site-setting-change-tracker", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.tracker = getOwner(this).lookup("service:site-setting-change-tracker");
+  });
+
+  test("save sends every dirty setting in one bulk update and commits on success", async function (assert) {
+    let body;
+    pretender.put("/admin/site_settings/bulk_update.json", (request) => {
+      body = request.requestBody;
+      return response({ success: "OK" });
+    });
+
+    const title = stubHandle();
+    const backfilled = stubHandle({
+      setting: "default_email_digest_frequency",
+      pendingValue: "10080",
+      updateExistingUsers: true,
+    });
+
+    this.tracker.add(title);
+    this.tracker.add(backfilled);
+
+    await this.tracker.save();
+
+    const params = new URLSearchParams(body);
+    assert.strictEqual(params.get("settings[title][value]"), "new");
+    assert.strictEqual(params.get("settings[title][backfill]"), "false");
+    assert.strictEqual(
+      params.get("settings[default_email_digest_frequency][value]"),
+      "10080"
+    );
+    assert.strictEqual(
+      params.get("settings[default_email_digest_frequency][backfill]"),
+      "true"
+    );
+    assert.true(title.committed);
+    assert.true(backfilled.committed);
+    assert.false(title.isSaving);
+    assert.strictEqual(this.tracker.count, 0);
+  });
+
+  test("a failed bulk update leaves settings dirty and uncommitted", async function (assert) {
+    pretender.put("/admin/site_settings/bulk_update.json", () =>
+      response(422, { errors: ["nope"] })
+    );
+
+    const title = stubHandle();
+    this.tracker.add(title);
+
+    await this.tracker.save();
+
+    assert.false(title.committed);
+    assert.false(title.isSaving);
+    assert.strictEqual(this.tracker.count, 1);
+  });
+
+  test("save refreshes page state for settings that require a reload", async function (assert) {
+    pretender.put("/admin/site_settings/bulk_update.json", () =>
+      response({ success: "OK" })
+    );
+    const refreshPage = sinon.stub(this.tracker, "refreshPage");
+
+    const font = stubHandle({
+      setting: "base_font",
+      pendingValue: "arial",
+      requiresReload: true,
+    });
+    this.tracker.add(font);
+    this.tracker.add(stubHandle());
+
+    await this.tracker.save();
+
+    assert.true(
+      refreshPage.calledWith({ base_font: "arial" }),
+      "refreshes with the committed value of reload-requiring settings only"
+    );
+  });
+
+  test("discard rolls every dirty setting back", function (assert) {
+    const title = stubHandle();
+    const description = stubHandle({ setting: "site_description" });
+
+    this.tracker.add(title);
+    this.tracker.add(description);
+
+    this.tracker.discard();
+
+    assert.true(title.rolledBack);
+    assert.true(description.rolledBack);
+    assert.strictEqual(this.tracker.count, 0);
+  });
+});


### PR DESCRIPTION
Previously, the change tracker reached directly into each setting's buffered proxy, which couples the "unsaved changes" banner to one specific row implementation — and hid two bugs: the banner's save-all never triggered the live page refresh for reload-requiring settings (it read `setting.afterSave`, which nothing ever assigns), and every setting row subscribed to a backfill MessageBus channel because `if (this.canSubscribeToSettingsJobs)` tested a method reference instead of calling it.

This change narrows the tracker to a small handle interface (`pendingValue` / `commit()` / `rollback()`) so that FormKit-based rows can register alongside buffered rows during the site settings conversion (t/179889), makes save-all refresh fonts/logos live like a row-level save does, subscribes only `default_categories_*`/`default_tags_*` rows to job progress, and keeps theme rows out of the tracker so an abandoned theme edit can no longer leak into the site settings bulk save.