### PR TITLE
FEATURE: Add `selectable_avatars_random_on_signup` site setting

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1764,7 +1764,8 @@ class User < ActiveRecord::Base
   end
 
   def set_random_avatar
-    if SiteSetting.selectable_avatars_mode != "disabled"
+    if SiteSetting.selectable_avatars_random_on_signup &&
+         SiteSetting.selectable_avatars_mode != "disabled"
       if upload = SiteSetting.selectable_avatars.sample
         update_column(:uploaded_avatar_id, upload.id)
         UserAvatar.create!(user_id: id, custom_upload_id: upload.id)

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2284,6 +2284,7 @@ en:
     restrict_letter_avatar_colors: "A list of 6-digit hexadecimal color values to be used for letter avatar background."
     enable_listing_suspended_users_on_search: "Enable regular users to find suspended users."
     selectable_avatars_mode: "Allow users to select an avatar from the {{setting:selectable_avatars}} list and limit custom avatar uploads to the selected trust level."
+    selectable_avatars_random_on_signup: "Assign new users a random avatar from {{setting:selectable_avatars}}."
     selectable_avatars: "Specify a collection of avatars from which users can select their profile picture. The choice will appear during user profile creation or when updating the profile avatar."
 
     allow_all_attachments_for_group_messages: "Allow all email attachments for group messages."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2579,6 +2579,8 @@ files:
       - staff
       - no_one
     validator: "SelectableAvatarsModeValidator"
+  selectable_avatars_random_on_signup:
+    default: true
   selectable_avatars:
     default: ""
     client: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3065,6 +3065,16 @@ RSpec.describe User do
       expect([avatar1.id, avatar2.id]).to include(user.uploaded_avatar_id)
       expect(user.user_avatar.custom_upload_id).to eq(user.uploaded_avatar_id)
     end
+
+    it "does not set a random avatar when selectable avatar assignment on signup is disabled" do
+      SiteSetting.selectable_avatars = [Fabricate(:upload), Fabricate(:upload)]
+      SiteSetting.selectable_avatars_mode = "everyone"
+      SiteSetting.selectable_avatars_random_on_signup = false
+
+      user = Fabricate(:user)
+
+      expect(user.uploaded_avatar_id).to be_nil
+    end
   end
 
   describe "ensure_consistency!" do


### PR DESCRIPTION
When using the selectable avatars feature with other sources of avatars (for example, OIDC or OAuth inherited avatars), this setting allows site admins to let users pick a selectable avatar without having to have a random one assigned on account creation.