### PR TITLE
FIX: Prevent secret & themeable  site settings from entering AI approvals

### DIFF
--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -955,6 +955,8 @@ en:
           not_found: "Site setting '%{setting_name}' does not exist."
           not_allowed: "You are not allowed to change site settings."
           hidden: "Site setting '%{setting_name}' is hidden and cannot be changed here."
+          secret: "Site setting '%{setting_name}' contains a secret and cannot be changed here."
+          themeable: "Site setting '%{setting_name}' requires a theme and cannot be changed here."
           deprecated: "Site setting '%{setting_name}' is deprecated; use '%{new_name}' instead."
           shadowed: "Site setting '%{setting_name}' is overridden globally and cannot be changed."
           unconfigurable: "Site setting '%{setting_name}' belongs to a plugin that cannot be configured."

--- a/plugins/discourse-ai/lib/agents/tools/change_site_setting.rb
+++ b/plugins/discourse-ai/lib/agents/tools/change_site_setting.rb
@@ -114,6 +114,28 @@ module DiscourseAi
             )
           end
 
+          if SiteSetting.secret_settings.include?(setting_sym)
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.secret",
+                  setting_name: setting_name,
+                ),
+              )
+            )
+          end
+
+          if SiteSetting.themeable[setting_sym]
+            return(
+              error_response(
+                I18n.t(
+                  "discourse_ai.ai_bot.change_site_setting.errors.themeable",
+                  setting_name: setting_name,
+                ),
+              )
+            )
+          end
+
           if SiteSetting.shadowed_settings.include?(setting_sym)
             return(
               error_response(

--- a/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
@@ -877,6 +877,47 @@ RSpec.describe DiscourseAi::Agents::Bot do
       expect(SiteSetting.min_post_length).not_to eq(42)
     end
 
+    it "rejects a secret site setting change before queueing it" do
+      toggle_enabled_bots(bots: [fake])
+      Group.refresh_automatic_groups!
+
+      approval_agent =
+        AiAgent.create!(
+          name: "SecretSettingApprovalAgent",
+          system_prompt: "test",
+          description: "test",
+          allowed_group_ids: [Group::AUTO_GROUPS[:trust_level_0]],
+          require_approval: true,
+          tools: [["ChangeSiteSetting", nil, false]],
+        )
+
+      agent_class = approval_agent.class_instance
+      test_bot_user = DiscourseAi::AiBot::EntryPoint.find_user_from_model(fake.name)
+      bot = described_class.as(test_bot_user, agent: agent_class.new)
+      secret_value = "new-discourse-connect-secret"
+      tool =
+        DiscourseAi::Agents::Tools::ChangeSiteSetting.new(
+          { setting_name: "discourse_connect_secret", value: secret_value, reason: "Testing" },
+          bot_user: test_bot_user,
+          llm: bot.llm,
+          context: DiscourseAi::Agents::BotContext.new(user: admin),
+        )
+
+      result = nil
+      expect { result = bot.send(:invoke_tool, tool, tool.context) { |*args| } }.not_to change {
+        [AiToolAction.count, ReviewableAiToolAction.count]
+      }
+
+      expect(result[:status]).to eq("error")
+      expect(result[:error]).to eq(
+        I18n.t(
+          "discourse_ai.ai_bot.change_site_setting.errors.secret",
+          setting_name: "discourse_connect_secret",
+        ),
+      )
+      expect(result[:error]).not_to include(secret_value)
+    end
+
     it "executes immediately when require_approval is false" do
       toggle_enabled_bots(bots: [fake])
       Group.refresh_automatic_groups!

--- a/plugins/discourse-ai/spec/lib/agents/tools/change_site_setting_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/change_site_setting_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe DiscourseAi::Agents::Tools::ChangeSiteSetting do
     expect(result[:error]).to include("hidden")
   end
 
+  it "returns an error for a themeable setting" do
+    result = tool(setting_name: "enable_welcome_banner", value: "false", reason: "Test").invoke
+
+    expect(result[:status]).to eq("error")
+    expect(result[:error]).to eq(
+      I18n.t(
+        "discourse_ai.ai_bot.change_site_setting.errors.themeable",
+        setting_name: "enable_welcome_banner",
+      ),
+    )
+  end
+
   it "points at the replacement for a hard-deprecated setting" do
     old_name, new_name, _override, _version =
       SiteSettings::DeprecatedSettings::SETTINGS.find { |_, _, override, _| !override }


### PR DESCRIPTION
Previously, the AI change site-setting tool allowed secret and themeable values to go to `/review`. This should not happen

This change rejects secret and theme-controlled settings before they can be queued for approval. Similar to what we do in Read Site Settings:

https://github.com/discourse/discourse/blob/main/plugins/discourse-ai/lib/agents/tools/read_site_setting.rb#L44-L86