### PR TITLE
UX: trim topic list whitespace for badges

### DIFF
--- a/frontend/discourse/app/components/topic-list/topic-link.gjs
+++ b/frontend/discourse/app/components/topic-list/topic-link.gjs
@@ -21,11 +21,11 @@ export default class TopicLink extends Component {
         class="title"
         ...attributes
       >
-        {{trustHTML @topic.fancyTitle}}
-        {{#if @topic.visited}}
+        {{~trustHTML @topic.fancyTitle~}}
+        {{~#if @topic.visited~}}
           <span class="sr-only">&nbsp;{{i18n "topic.sr_read"}}</span>
-        {{/if}}
-        {{yield}}
+        {{~/if~}}
+        {{~yield~}}
       </a>
       {{~! no whitespace ~}}
     </PluginOutlet>


### PR DESCRIPTION
introduced some whitespace in 4fa0393783a that causes unwanted wrapping, this removes it again 

before
<img width="450" alt="image" src="https://github.com/user-attachments/assets/c287feba-9934-495a-80ae-3e2a8969584a" />

after
<img width="450"  alt="image" src="https://github.com/user-attachments/assets/a475b89b-c73a-49dd-a1fc-f62f4a1dfc4e" />
