### PR TITLE
DEV: Add a spec to assert flag post tool doesn't require approval

### DIFF
--- a/plugins/discourse-ai/spec/lib/agents/tools/flag_post_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/tools/flag_post_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe DiscourseAi::Agents::Tools::FlagPost do
+  it "does not require separate approval before adding a post to the review queue" do
+    expect(described_class.requires_approval?).to eq(false)
+  end
+
   fab!(:llm_model)
   let(:bot_user) { DiscourseAi::AiBot::EntryPoint.find_user_from_model(llm_model.name) }
   let(:llm) { DiscourseAi::Completions::Llm.proxy(llm_model) }


### PR DESCRIPTION
## Summary

We don't want tool approval for this tool. The flagged item is always added to the review queue, so any action taken by the bot will be reviewed by staff regardless.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1143

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>