### PR TITLE
FIX: Record `feature_name` for streamed bot replies

### DIFF
--- a/plugins/discourse-ai/lib/ai_bot/response_http_streamer.rb
+++ b/plugins/discourse-ai/lib/ai_bot/response_http_streamer.rb
@@ -111,7 +111,11 @@ module DiscourseAi
 
           DiscourseAi::AiBot::Playground
             .new(bot)
-            .reply_to(post, custom_instructions: custom_instructions) do |partial|
+            .reply_to(
+              post,
+              custom_instructions: custom_instructions,
+              feature_name: "bot",
+            ) do |partial|
               next if partial.empty?
 
               write_chunk(io, { partial: partial })

--- a/plugins/discourse-ai/lib/ai_bot/stream_reply_custom_tools_session.rb
+++ b/plugins/discourse-ai/lib/ai_bot/stream_reply_custom_tools_session.rb
@@ -195,6 +195,7 @@ module DiscourseAi
           temperature: @temperature,
           top_p: @top_p,
           execution_context: execution_context,
+          feature_name: "bot",
         }
 
         # Pre-check: if budget already exhausted on resume, force a final


### PR DESCRIPTION
Previously, LLM calls made through `ResponseHttpStreamer` — both the standard `Playground#reply_to` path and the custom-tools streaming session — passed a nil `feature_name`, so these requests appeared in the AI usage logs without feature attribution.

This change passes `feature_name: "bot"` on both paths, matching the attribution used by regular bot replies via `Jobs::CreateAiReply`.