### PR TITLE
FIX: Classify Yeti user agents as crawlers

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2980,7 +2980,7 @@ security:
     list_type: compact
   crawler_user_agents:
     hidden: true
-    default: "rss|bot|spider|crawler|facebook|archive|wayback|ping|monitor|lighthouse|google-inspectiontool|gptbot|claudebot|anthropic-ai|brightbot|googleother"
+    default: "rss|bot|spider|crawler|facebook|archive|wayback|ping|monitor|lighthouse|google-inspectiontool|gptbot|claudebot|anthropic-ai|brightbot|googleother|yeti"
     type: list
     list_type: compact
   browser_update_user_agents:

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -201,10 +201,7 @@ RSpec.describe Middleware::RequestTracker do
     it "can log requests correctly" do
       data =
         Middleware::RequestTracker.get_data(
-          env(
-            "HTTP_USER_AGENT" =>
-              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Yeti/1.1; +https://naver.me/spd) Chrome/144.0.0.0 Safari/537.36",
-          ),
+          env("HTTP_USER_AGENT" => "AdsBot-Google (+http://www.google.com/adsbot.html)"),
           ["200", { "Content-Type" => "text/html" }],
           0.1,
         )

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -201,7 +201,10 @@ RSpec.describe Middleware::RequestTracker do
     it "can log requests correctly" do
       data =
         Middleware::RequestTracker.get_data(
-          env("HTTP_USER_AGENT" => "AdsBot-Google (+http://www.google.com/adsbot.html)"),
+          env(
+            "HTTP_USER_AGENT" =>
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Yeti/1.1; +https://naver.me/spd) Chrome/144.0.0.0 Safari/537.36",
+          ),
           ["200", { "Content-Type" => "text/html" }],
           0.1,
         )


### PR DESCRIPTION
Previously, request tracking did not correctly classify Yeti requests such as the following as crawlers:

```text
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Yeti/1.1; +https://naver.me/spd) Chrome/144.0.0.0 Safari/537.36
```

This change adds `yeti` to the default `crawler_user_agents` list so its pageviews are counted as crawler traffic.