### PR TITLE
DEV: Make `bin/qunit` browser runs reliable

### DIFF
--- a/bin/qunit
+++ b/bin/qunit
@@ -11,6 +11,18 @@ require "securerandom"
 require_relative "../lib/chrome_installed_checker"
 
 class QunitRunner
+  DEFAULT_BROWSER_START_TIMEOUT = 45
+  DEFAULT_BROWSER_INACTIVITY_TIMEOUT = 30
+  DEFAULT_BROWSER_START_ATTEMPTS = 3
+
+  # A browser-start failure means the browser never connected, so no tests ran and the
+  # whole attempt can safely be retried. Once a browser connects, any test failure is a
+  # real failure that must not be retried away (which would mask it, especially in parallel
+  # runs where one browser can fail to start while another reports a genuine failure).
+  def self.retry_browser_start?(start_failed:, test_failed:, attempt:, attempts:)
+    start_failed && !test_failed && attempt < attempts
+  end
+
   def initialize(args)
     @file_paths = []
     @verbose = ENV["ACTIONS_STEP_DEBUG"] == "true"
@@ -29,6 +41,13 @@ class QunitRunner
     @plugin_targets = []
 
     @headless = true
+    @browser_watchdog = boolean_env("QUNIT_BROWSER_WATCHDOG", default: true)
+    @browser_start_timeout =
+      positive_integer_env("QUNIT_BROWSER_START_TIMEOUT", DEFAULT_BROWSER_START_TIMEOUT)
+    @browser_inactivity_timeout =
+      positive_integer_env("QUNIT_BROWSER_INACTIVITY_TIMEOUT", DEFAULT_BROWSER_INACTIVITY_TIMEOUT)
+    @browser_start_attempts =
+      positive_integer_env("QUNIT_BROWSER_START_ATTEMPTS", DEFAULT_BROWSER_START_ATTEMPTS)
 
     parse_options(args)
   end
@@ -118,6 +137,33 @@ class QunitRunner
         opts.on("--[no-]headless", "Run tests in headless mode (env: QUNIT_HEADLESS)") do |h|
           @headless = h
         end
+
+        opts.on(
+          "--[no-]browser-watchdog",
+          "Detect stalled browser startup and test loading (env: QUNIT_BROWSER_WATCHDOG)",
+        ) { |enabled| @browser_watchdog = enabled }
+
+        opts.on(
+          "--browser-start-timeout SECONDS",
+          Integer,
+          "Browser connection timeout (default: 45; env: QUNIT_BROWSER_START_TIMEOUT)",
+        ) do |seconds|
+          @browser_start_timeout = positive_integer(seconds, "--browser-start-timeout")
+        end
+
+        opts.on(
+          "--browser-inactivity-timeout SECONDS",
+          Integer,
+          "Browser inactivity timeout outside active tests (default: 30; env: QUNIT_BROWSER_INACTIVITY_TIMEOUT)",
+        ) do |seconds|
+          @browser_inactivity_timeout = positive_integer(seconds, "--browser-inactivity-timeout")
+        end
+
+        opts.on(
+          "--browser-start-attempts COUNT",
+          Integer,
+          "Total browser start attempts (default: 3; env: QUNIT_BROWSER_START_ATTEMPTS)",
+        ) { |count| @browser_start_attempts = positive_integer(count, "--browser-start-attempts") }
 
         opts.on("-v", "--verbose", "Verbose output") { @verbose = true }
 
@@ -254,6 +300,10 @@ class QunitRunner
     env["TESTEM_DEFAULT_BROWSER"] = ENV["TESTEM_DEFAULT_BROWSER"] || detect_browser
     env["PLUGIN_TARGETS"] = @plugin_targets.join(",") if @plugin_targets.any?
     env["QUNIT_HEADLESS"] = "0" if !@headless
+    env["QUNIT_BROWSER_WATCHDOG"] = @browser_watchdog ? "1" : "0"
+    env["QUNIT_BROWSER_START_TIMEOUT"] = @browser_start_timeout.to_s
+    env["QUNIT_BROWSER_INACTIVITY_TIMEOUT"] = @browser_inactivity_timeout.to_s
+    env["QUNIT_BROWSER_START_ATTEMPTS"] = @browser_start_attempts.to_s
 
     parallel = !@plugin_targets.any? && present_string(@parallel)
     reuse_build = ENV["QUNIT_REUSE_BUILD"] == "1" || !@standalone_mode
@@ -287,8 +337,40 @@ class QunitRunner
       exit 0
     end
 
-    system(env, *args, chdir: dir)
-    exit $?.exitstatus
+    browser_start_failure_file =
+      File.join(rails_root, "tmp", "qunit_browser_start_failure_#{Process.pid}.marker")
+    browser_test_failure_file =
+      File.join(rails_root, "tmp", "qunit_browser_test_failure_#{Process.pid}.marker")
+    env["QUNIT_BROWSER_START_FAILURE_FILE"] = browser_start_failure_file
+    env["QUNIT_BROWSER_TEST_FAILURE_FILE"] = browser_test_failure_file
+    attempts = @browser_watchdog ? @browser_start_attempts : 1
+    exit_status = nil
+
+    begin
+      1.upto(attempts) do |attempt|
+        FileUtils.rm_f(browser_start_failure_file)
+        FileUtils.rm_f(browser_test_failure_file)
+        system(env, *args, chdir: dir)
+        exit_status = $?.exitstatus
+        break if exit_status == 0
+
+        unless self.class.retry_browser_start?(
+                 start_failed: File.exist?(browser_start_failure_file),
+                 test_failed: File.exist?(browser_test_failure_file),
+                 attempt: attempt,
+                 attempts: attempts,
+               )
+          break
+        end
+
+        warn "Browser failed to connect; retrying (attempt #{attempt + 1}/#{attempts})"
+      end
+    ensure
+      FileUtils.rm_f(browser_start_failure_file)
+      FileUtils.rm_f(browser_test_failure_file)
+    end
+
+    exit exit_status
   end
 
   def convert_to_ember_relative_path(file_path)
@@ -624,6 +706,28 @@ class QunitRunner
     str.empty? ? nil : str
   end
 
+  def boolean_env(name, default:)
+    value = ENV[name]
+    return default if value.nil?
+    return true if %w[1 true].include?(value.downcase)
+    return false if %w[0 false].include?(value.downcase)
+
+    abort "Error: #{name} must be one of: 1, 0, true, false"
+  end
+
+  def positive_integer_env(name, default)
+    value = ENV[name]
+    return default if value.nil?
+
+    positive_integer(Integer(value, exception: false), name)
+  end
+
+  def positive_integer(value, name)
+    abort "Error: #{name} must be greater than 0" if !value || value <= 0
+
+    value
+  end
+
   def resolve_plugin_namespace(directory_name)
     @plugin_namespace_cache ||= {}
     return @plugin_namespace_cache[directory_name] if @plugin_namespace_cache.key?(directory_name)
@@ -668,4 +772,4 @@ class QunitRunner
   end
 end
 
-QunitRunner.new(ARGV).run
+QunitRunner.new(ARGV).run if __FILE__ == $PROGRAM_NAME

--- a/frontend/discourse/patch-testem-browser-watchdog.js
+++ b/frontend/discourse/patch-testem-browser-watchdog.js
@@ -1,0 +1,112 @@
+const BrowserTestRunner = require("testem/lib/runners/browser_test_runner");
+const fs = require("fs");
+
+const patchedRunnerClasses = new WeakSet();
+
+function installBrowserWatchdog(
+  RunnerClass,
+  {
+    inactivityTimeout,
+    setTimeout: setTimer = setTimeout,
+    clearTimeout: clearTimer = clearTimeout,
+  }
+) {
+  if (patchedRunnerClasses.has(RunnerClass)) {
+    return;
+  }
+  patchedRunnerClasses.add(RunnerClass);
+
+  function clearWatchdog(runner) {
+    if (runner.browserWatchdogTimer) {
+      clearTimer(runner.browserWatchdogTimer);
+      runner.browserWatchdogTimer = undefined;
+    }
+  }
+
+  function scheduleWatchdog(runner) {
+    clearWatchdog(runner);
+    runner.browserWatchdogTimer = setTimer(() => {
+      runner.browserWatchdogTimer = undefined;
+      if (runner.finished) {
+        return;
+      }
+
+      runner.reportResults(
+        new Error(
+          `Browser made no test progress for ${inactivityTimeout} seconds outside an active test`
+        ),
+        0
+      );
+    }, inactivityTimeout * 1000);
+  }
+
+  const originalTryAttach = RunnerClass.prototype.tryAttach;
+  RunnerClass.prototype.tryAttach = function (browser, id, socket) {
+    const result = originalTryAttach.call(this, browser, id, socket);
+    if (result === false) {
+      return result;
+    }
+
+    scheduleWatchdog(this);
+    socket.on("tests-start", () => clearWatchdog(this));
+    socket.on("test-result", () => scheduleWatchdog(this));
+    socket.on("all-test-results", () => clearWatchdog(this));
+    socket.on("after-tests-complete", () => clearWatchdog(this));
+    socket.on("disconnect", () => clearWatchdog(this));
+
+    return result;
+  };
+
+  const originalFinish = RunnerClass.prototype.finish;
+  RunnerClass.prototype.finish = function (...args) {
+    clearWatchdog(this);
+    return originalFinish.apply(this, args);
+  };
+}
+
+function patchTestemBrowserWatchdog() {
+  if (process.env.QUNIT_BROWSER_WATCHDOG !== "1") {
+    return;
+  }
+
+  installBrowserWatchdog(BrowserTestRunner, {
+    inactivityTimeout: parseInt(
+      process.env.QUNIT_BROWSER_INACTIVITY_TIMEOUT,
+      10
+    ),
+  });
+}
+
+function isBrowserStartFailure(result) {
+  // testem's to-result.js reports synthetic runner failures (including the browser-start
+  // timeout) with `name: "error"`; a real per-test result carries the test name. Requiring
+  // both the name and the message keeps an assertion whose text happens to contain the
+  // phrase from being misclassified as a retryable start failure.
+  return (
+    result.name === "error" &&
+    !!result.error?.message?.includes("Browser failed to connect within")
+  );
+}
+
+function markBrowserStartFailure(result, markerPath) {
+  if (markerPath && isBrowserStartFailure(result)) {
+    fs.writeFileSync(markerPath, "");
+    return true;
+  }
+
+  return false;
+}
+
+function markBrowserTestFailure(result, markerPath) {
+  if (markerPath && result.failed && !isBrowserStartFailure(result)) {
+    fs.writeFileSync(markerPath, "");
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = patchTestemBrowserWatchdog;
+module.exports.installBrowserWatchdog = installBrowserWatchdog;
+module.exports.markBrowserStartFailure = markBrowserStartFailure;
+module.exports.markBrowserTestFailure = markBrowserTestFailure;

--- a/frontend/discourse/testem.js
+++ b/frontend/discourse/testem.js
@@ -4,6 +4,9 @@ const displayUtils = require("testem/lib/utils/displayutils");
 const colors = require("@colors/colors/safe");
 
 require("./patch-testem-output")();
+const patchTestemBrowserWatchdog = require("./patch-testem-browser-watchdog");
+
+patchTestemBrowserWatchdog();
 
 const SANDBOX_DISABLE_VALUES = ["1", "true"];
 const sandboxDisabled =
@@ -52,6 +55,18 @@ class Reporter extends TapReporter {
   }
 
   report(prefix, data) {
+    // Record browser-start failures and real test failures under separate markers so the
+    // retry loop can retry only when the browser never connected, without masking a genuine
+    // test failure that occurred in the same (parallel) run.
+    patchTestemBrowserWatchdog.markBrowserStartFailure(
+      data,
+      process.env.QUNIT_BROWSER_START_FAILURE_FILE
+    );
+    patchTestemBrowserWatchdog.markBrowserTestFailure(
+      data,
+      process.env.QUNIT_BROWSER_TEST_FAILURE_FILE
+    );
+
     if (data.failed) {
       this.failReports.push([prefix, data, this.id]);
     }
@@ -269,7 +284,10 @@ module.exports = {
   socket_server_options: {
     maxHttpBufferSize: 1e8, // 100MB
   },
-  browser_start_timeout: 120,
+  browser_start_timeout:
+    process.env.QUNIT_BROWSER_WATCHDOG === "1"
+      ? parseInt(process.env.QUNIT_BROWSER_START_TIMEOUT, 10)
+      : 120,
   browser_disconnect_timeout: 30,
   browser_args: {
     Chromium: [

--- a/frontend/discourse/tests-node/patch-testem-browser-watchdog-test.js
+++ b/frontend/discourse/tests-node/patch-testem-browser-watchdog-test.js
@@ -1,0 +1,234 @@
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const {
+  installBrowserWatchdog,
+  markBrowserStartFailure,
+  markBrowserTestFailure,
+} = require("../patch-testem-browser-watchdog");
+
+function setupWatchdog() {
+  let pendingTimer;
+  let clearedTimers = 0;
+
+  class BrowserTestRunner {
+    finish() {
+      this.finished = true;
+    }
+
+    reportResults(error) {
+      this.reportedError = error;
+      this.finish();
+    }
+
+    tryAttach() {
+      return true;
+    }
+  }
+
+  installBrowserWatchdog(BrowserTestRunner, {
+    inactivityTimeout: 30,
+    setTimeout(callback) {
+      pendingTimer = () => {
+        pendingTimer = undefined;
+        callback();
+      };
+      return pendingTimer;
+    },
+    clearTimeout(timer) {
+      if (timer) {
+        clearedTimers += 1;
+      }
+      if (pendingTimer === timer) {
+        pendingTimer = undefined;
+      }
+    },
+  });
+
+  const runner = new BrowserTestRunner();
+  const socket = new EventEmitter();
+  runner.tryAttach("TestBrowser", 1, socket);
+
+  return {
+    get clearedTimers() {
+      return clearedTimers;
+    },
+    get pendingTimer() {
+      return pendingTimer;
+    },
+    runner,
+    socket,
+  };
+}
+
+test("reports a browser that connects but does not start a test", () => {
+  const watchdog = setupWatchdog();
+
+  watchdog.pendingTimer();
+
+  assert.match(watchdog.runner.reportedError.message, /30 seconds/);
+  assert.equal(watchdog.runner.finished, true);
+  assert.equal(watchdog.pendingTimer, undefined);
+});
+
+test("suspends the timer during a test and restarts it after the result", () => {
+  const watchdog = setupWatchdog();
+
+  watchdog.socket.emit("tests-start");
+  assert.equal(watchdog.pendingTimer, undefined);
+
+  watchdog.socket.emit("test-result", {});
+  assert.equal(typeof watchdog.pendingTimer, "function");
+});
+
+test("does not treat browser console output as test progress", () => {
+  const watchdog = setupWatchdog();
+  const initialTimer = watchdog.pendingTimer;
+
+  watchdog.socket.emit("browser-console", "log", "still running");
+
+  assert.equal(watchdog.pendingTimer, initialTimer);
+  assert.equal(watchdog.clearedTimers, 0);
+});
+
+test("clears the timer when the runner finishes", () => {
+  const watchdog = setupWatchdog();
+
+  watchdog.runner.finish();
+
+  assert.equal(watchdog.pendingTimer, undefined);
+  assert.equal(watchdog.clearedTimers, 1);
+});
+
+test("marks only browser connection timeouts as retryable", () => {
+  const markerPath = path.join(
+    os.tmpdir(),
+    `qunit-browser-start-failure-${process.pid}`
+  );
+
+  try {
+    assert.equal(
+      markBrowserStartFailure(
+        {
+          name: "error",
+          error: { message: "Error: Browser failed to connect within 45s" },
+        },
+        markerPath
+      ),
+      true
+    );
+    assert.equal(fs.existsSync(markerPath), true);
+
+    fs.rmSync(markerPath);
+    assert.equal(
+      markBrowserStartFailure(
+        { name: "error", error: { message: "Expected true to equal false" } },
+        markerPath
+      ),
+      false
+    );
+    assert.equal(fs.existsSync(markerPath), false);
+  } finally {
+    fs.rmSync(markerPath, { force: true });
+  }
+});
+
+test("does not treat a test whose failure text mentions the timeout as a start failure", () => {
+  const markerPath = path.join(
+    os.tmpdir(),
+    `qunit-browser-start-failure-name-${process.pid}`
+  );
+
+  try {
+    // A real per-test result carries the test name, not "error", even if its assertion
+    // message happens to contain the browser-start phrase.
+    assert.equal(
+      markBrowserStartFailure(
+        {
+          name: "asserts Browser failed to connect within 45s",
+          failed: 1,
+          error: { message: "Browser failed to connect within 45s" },
+        },
+        markerPath
+      ),
+      false
+    );
+    assert.equal(fs.existsSync(markerPath), false);
+  } finally {
+    fs.rmSync(markerPath, { force: true });
+  }
+});
+
+test("marks a genuine test failure under the test-failure marker", () => {
+  const markerPath = path.join(
+    os.tmpdir(),
+    `qunit-browser-test-failure-${process.pid}`
+  );
+
+  try {
+    assert.equal(
+      markBrowserTestFailure(
+        {
+          name: "renders the button",
+          failed: 1,
+          error: { message: "Expected true to equal false" },
+        },
+        markerPath
+      ),
+      true
+    );
+    assert.equal(fs.existsSync(markerPath), true);
+  } finally {
+    fs.rmSync(markerPath, { force: true });
+  }
+});
+
+test("does not mark a browser-start failure as a test failure", () => {
+  const markerPath = path.join(
+    os.tmpdir(),
+    `qunit-browser-test-failure-start-${process.pid}`
+  );
+
+  try {
+    // The browser-start result is reported as a failure too, but it belongs to the
+    // start-failure marker, not the test-failure marker.
+    assert.equal(
+      markBrowserTestFailure(
+        {
+          name: "error",
+          failed: 1,
+          error: { message: "Error: Browser failed to connect within 45s" },
+        },
+        markerPath
+      ),
+      false
+    );
+    assert.equal(fs.existsSync(markerPath), false);
+  } finally {
+    fs.rmSync(markerPath, { force: true });
+  }
+});
+
+test("does not mark a passing result as a test failure", () => {
+  const markerPath = path.join(
+    os.tmpdir(),
+    `qunit-browser-test-failure-pass-${process.pid}`
+  );
+
+  try {
+    assert.equal(
+      markBrowserTestFailure(
+        { name: "renders the button", failed: 0 },
+        markerPath
+      ),
+      false
+    );
+    assert.equal(fs.existsSync(markerPath), false);
+  } finally {
+    fs.rmSync(markerPath, { force: true });
+  }
+});

--- a/spec/tasks/qunit_cli_spec.rb
+++ b/spec/tasks/qunit_cli_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe "bin/qunit" do
-  def run(*args)
-    out, err, status = Open3.capture3("bin/qunit", "--dry-run", *args, chdir: Rails.root.to_s)
+  def run(*args, env: {})
+    out, err, status = Open3.capture3(env, "bin/qunit", "--dry-run", *args, chdir: Rails.root.to_s)
 
     parsed_args, parsed_env =
       if parsed_result = out.match(/Executing: (?<args>\[.+?\])\nwith env: (?<env>\{.+?\})/m)
@@ -31,6 +31,15 @@ describe "bin/qunit" do
 
   let(:chat_test_file) { Dir.glob("#{Rails.root.join("plugins/chat/test/**/*-test.js")}").first }
 
+  let(:default_watchdog_env) do
+    {
+      "QUNIT_BROWSER_WATCHDOG" => "1",
+      "QUNIT_BROWSER_START_TIMEOUT" => "45",
+      "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "30",
+      "QUNIT_BROWSER_START_ATTEMPTS" => "3",
+    }
+  end
+
   it "runs all core tests by default" do
     result = run
     expect(result.status).to eq(0)
@@ -50,9 +59,11 @@ describe "bin/qunit" do
       ],
     )
     expect(result.env).to match(
-      "UNICORN_PORT" => a_truthy_value,
-      "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
-      "LOAD_PLUGINS" => "0",
+      default_watchdog_env.merge(
+        "UNICORN_PORT" => a_truthy_value,
+        "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
+        "LOAD_PLUGINS" => "0",
+      ),
     )
   end
 
@@ -77,9 +88,11 @@ describe "bin/qunit" do
       ],
     )
     expect(result.env).to match(
-      "UNICORN_PORT" => a_truthy_value,
-      "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
-      "LOAD_PLUGINS" => "0",
+      default_watchdog_env.merge(
+        "UNICORN_PORT" => a_truthy_value,
+        "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
+        "LOAD_PLUGINS" => "0",
+      ),
     )
   end
 
@@ -102,10 +115,12 @@ describe "bin/qunit" do
       ],
     )
     expect(result.env).to match(
-      "UNICORN_PORT" => a_truthy_value,
-      "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
-      "LOAD_PLUGINS" => "1",
-      "PLUGIN_TARGETS" => a_string_matching(/,/),
+      default_watchdog_env.merge(
+        "UNICORN_PORT" => a_truthy_value,
+        "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
+        "LOAD_PLUGINS" => "1",
+        "PLUGIN_TARGETS" => a_string_matching(/,/),
+      ),
     )
   end
 
@@ -128,10 +143,12 @@ describe "bin/qunit" do
       ],
     )
     expect(result.env).to match(
-      "UNICORN_PORT" => a_truthy_value,
-      "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
-      "LOAD_PLUGINS" => "1",
-      "PLUGIN_TARGETS" => "chat,discourse-local-dates",
+      default_watchdog_env.merge(
+        "UNICORN_PORT" => a_truthy_value,
+        "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
+        "LOAD_PLUGINS" => "1",
+        "PLUGIN_TARGETS" => "chat,discourse-local-dates",
+      ),
     )
   end
 
@@ -159,9 +176,11 @@ describe "bin/qunit" do
       ],
     )
     expect(result.env).to match(
-      "UNICORN_PORT" => a_truthy_value,
-      "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
-      "LOAD_PLUGINS" => "1",
+      default_watchdog_env.merge(
+        "UNICORN_PORT" => a_truthy_value,
+        "TESTEM_DEFAULT_BROWSER" => a_truthy_value,
+        "LOAD_PLUGINS" => "1",
+      ),
     )
   end
 
@@ -204,5 +223,129 @@ describe "bin/qunit" do
 
     expect(result.status).to eq(1)
     expect(result.err).to include("Use either --filter or --filter-regex, not both")
+  end
+
+  it "enables the browser watchdog with default settings" do
+    result = run
+
+    expect(result.env).to include(
+      "QUNIT_BROWSER_WATCHDOG" => "1",
+      "QUNIT_BROWSER_START_TIMEOUT" => "45",
+      "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "30",
+      "QUNIT_BROWSER_START_ATTEMPTS" => "3",
+    )
+  end
+
+  it "allows browser watchdog settings to be configured through the environment" do
+    result =
+      run(
+        env: {
+          "QUNIT_BROWSER_WATCHDOG" => "0",
+          "QUNIT_BROWSER_START_TIMEOUT" => "60",
+          "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "40",
+          "QUNIT_BROWSER_START_ATTEMPTS" => "2",
+        },
+      )
+
+    expect(result.env).to include(
+      "QUNIT_BROWSER_WATCHDOG" => "0",
+      "QUNIT_BROWSER_START_TIMEOUT" => "60",
+      "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "40",
+      "QUNIT_BROWSER_START_ATTEMPTS" => "2",
+    )
+  end
+
+  it "gives browser watchdog CLI settings precedence over the environment" do
+    result =
+      run(
+        "--browser-watchdog",
+        "--browser-start-timeout",
+        "70",
+        "--browser-inactivity-timeout",
+        "50",
+        "--browser-start-attempts",
+        "1",
+        env: {
+          "QUNIT_BROWSER_WATCHDOG" => "0",
+          "QUNIT_BROWSER_START_TIMEOUT" => "60",
+          "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "40",
+          "QUNIT_BROWSER_START_ATTEMPTS" => "2",
+        },
+      )
+
+    expect(result.env).to include(
+      "QUNIT_BROWSER_WATCHDOG" => "1",
+      "QUNIT_BROWSER_START_TIMEOUT" => "70",
+      "QUNIT_BROWSER_INACTIVITY_TIMEOUT" => "50",
+      "QUNIT_BROWSER_START_ATTEMPTS" => "1",
+    )
+  end
+
+  it "rejects non-positive browser watchdog settings" do
+    result = run("--browser-inactivity-timeout", "0")
+
+    expect(result.status).to eq(1)
+    expect(result.err).to include("--browser-inactivity-timeout must be greater than 0")
+  end
+
+  describe "QunitRunner.retry_browser_start?" do
+    # Load the script so `QunitRunner` is defined without executing its runner (the
+    # bottom-line invocation is guarded by `__FILE__ == $PROGRAM_NAME`).
+    load Rails.root.join("bin/qunit").to_s
+
+    it "retries when only a browser-start failure occurred" do
+      expect(
+        QunitRunner.retry_browser_start?(
+          start_failed: true,
+          test_failed: false,
+          attempt: 1,
+          attempts: 3,
+        ),
+      ).to eq(true)
+    end
+
+    it "does not retry when a test failure also occurred in the same attempt" do
+      expect(
+        QunitRunner.retry_browser_start?(
+          start_failed: true,
+          test_failed: true,
+          attempt: 1,
+          attempts: 3,
+        ),
+      ).to eq(false)
+    end
+
+    it "does not retry when only a test failure occurred" do
+      expect(
+        QunitRunner.retry_browser_start?(
+          start_failed: false,
+          test_failed: true,
+          attempt: 1,
+          attempts: 3,
+        ),
+      ).to eq(false)
+    end
+
+    it "does not retry when no failure marker is present" do
+      expect(
+        QunitRunner.retry_browser_start?(
+          start_failed: false,
+          test_failed: false,
+          attempt: 1,
+          attempts: 3,
+        ),
+      ).to eq(false)
+    end
+
+    it "does not retry on the final attempt" do
+      expect(
+        QunitRunner.retry_browser_start?(
+          start_failed: true,
+          test_failed: false,
+          attempt: 3,
+          attempts: 3,
+        ),
+      ).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
Stacked on #41912 (base branch `dev-qunit-filter-modes`); review that first.

Previously, `bin/qunit` could wait indefinitely for a headless browser that connected without ever making test progress, freezing the run.

This adds configurable startup and inactivity watchdogs backed by bounded browser-start retries. A testem patch reports a browser that connects but never begins a test, and `bin/qunit` retries only when the browser genuinely failed to connect: browser-start failures and real test failures are recorded under separate marker files, so a failing test in a parallel run is never retried into a green result. The watchdog and its timeouts and attempt count are configurable through flags and environment variables (`--browser-watchdog`, `--browser-start-timeout`, `--browser-inactivity-timeout`, `--browser-start-attempts`).

Coverage spans the watchdog timer and failure classification (node) and the retry-eligibility decision and CLI wiring (RSpec).