### PR TITLE
FIX: Prevent resurrection of approved queued reviewables when reusing flagged reviewables for the same target

### DIFF
--- a/app/models/reviewable.rb
+++ b/app/models/reviewable.rb
@@ -163,7 +163,8 @@ class Reviewable < ActiveRecord::Base
       update_args = {
         status: statuses[:pending],
         id: target.id,
-        type: target.class.polymorphic_name,
+        target_type: target.class.polymorphic_name,
+        reviewable_type: reviewable.type,
         potential_spam: potential_spam == true ? true : nil,
         potentially_illegal: potentially_illegal == true ? true : nil,
       }
@@ -175,7 +176,9 @@ class Reviewable < ActiveRecord::Base
           potentially_illegal = COALESCE(:potentially_illegal, reviewables.potentially_illegal)
         FROM reviewables AS old_reviewables
         WHERE reviewables.target_id = :id
-          AND reviewables.target_type = :type
+          AND reviewables.target_type = :target_type
+          AND reviewables.type = :reviewable_type
+          AND old_reviewables.id = reviewables.id
         RETURNING old_reviewables.status
       SQL
       old_status = row[0]

--- a/spec/models/reviewable_spec.rb
+++ b/spec/models/reviewable_spec.rb
@@ -103,6 +103,20 @@ RSpec.describe Reviewable, type: :model do
       r1 = ReviewableFlaggedPost.needs_review!(created_by: admin, target: r0.target)
       expect(r1.pending?).to eq(true)
     end
+
+    it "will not resurrect an approved queued reviewable when reusing a flagged reviewable for the same target" do
+      r0 = Fabricate(:reviewable_queued_post)
+      r0.perform(admin, :approve_post)
+      expect(r0.reload.status).to eq("approved")
+
+      r1 = ReviewableFlaggedPost.needs_review!(created_by: admin, target: r0.target)
+      expect(r1.pending?).to eq(true)
+
+      ReviewableFlaggedPost.needs_review!(created_by: admin, target: r0.target)
+
+      expect(r1.reload.pending?).to eq(true)
+      expect(r0.reload.status).to eq("approved")
+    end
   end
 
   describe ".list_for" do


### PR DESCRIPTION
For these steps:

1. Set a watched word.
2. A user triggered watched word, and the topic fall into the reviewables.
3. A staff approved the topic.
4. The topic is flagged by a user.

Then the original reviewables of "Approving this topic" will change its status from "Approved" back to "Pending", and there will be two reviewables in the queue (one for approving this topic, which approve/reject won't make any difference, and another for dealing with the flag), which shouldn't be that case.

This commit add logic to prevent that from being changed back, keeping only the flagged reviewables, and some specs are also added to it.