### PR TITLE
DEV: Make `DDateTimeInput` test timezone-independent

### DIFF
--- a/frontend/discourse/tests/integration/ui-kit/d-date-time-input-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-date-time-input-test.gjs
@@ -42,7 +42,11 @@ module("Integration | ui-kit | DDateTimeInput", function (hooks) {
     await fillIn(".date-picker", "2019-01-02");
     await triggerEvent(".date-picker", "change");
 
-    assert.true(this.date.isSame(moment("2019-01-02 14:45")));
+    assert.strictEqual(
+      this.date.format("YYYY-MM-DD HH:mm"),
+      "2019-01-02 14:45",
+      "it preserves the original time when changing the date"
+    );
   });
 
   test("can hide time", async function (assert) {


### PR DESCRIPTION
Previously, the `DDateTimeInput` mutation test compared Moment instances as absolute instants, causing it to fail in timezones with historical daylight-saving offsets while passing in UTC CI.

This change asserts the preserved date and time as a wall-clock value, keeping the test focused on the component contract.
