### PR TITLE
FIX: Roll up browser pageviews from each day's active source

### DIFF
--- a/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
+++ b/app/jobs/scheduled/maintain_browser_pageview_rollups.rb
@@ -20,18 +20,48 @@ module Jobs
       start_date, end_date = pageview_aggregation_window
       return if start_date.nil?
 
-      BrowserPageviewCountryDailyRollup.aggregate(start_date: start_date, end_date: end_date)
-      BrowserPageviewReferrerDailyRollup.aggregate(start_date: start_date, end_date: end_date)
+      source_windows(start_date, end_date) do |window_start, window_end, source|
+        BrowserPageviewCountryDailyRollup.aggregate(
+          start_date: window_start,
+          end_date: window_end,
+          source:,
+        )
+        BrowserPageviewReferrerDailyRollup.aggregate(
+          start_date: window_start,
+          end_date: window_end,
+          source:,
+        )
+      end
     end
 
     def aggregate_engagement
       start_date, end_date = engagement_aggregation_window
       return if start_date.nil?
 
-      BrowserPageviewSessionEngagementDailyRollup.aggregate(
-        start_date: start_date,
-        end_date: end_date,
-      )
+      source_windows(start_date, end_date) do |window_start, window_end, source|
+        BrowserPageviewSessionEngagementDailyRollup.aggregate(
+          start_date: window_start,
+          end_date: window_end,
+          source:,
+        )
+      end
+    end
+
+    # A window spanning the piggyback-to-beacon cutover must be split so each
+    # day is aggregated from the source that fully covers it; a single-source
+    # pass would rebuild days on the other side of the boundary from a stream
+    # that wasn't recording (or only partially recording) on those days.
+    def source_windows(start_date, end_date)
+      beacon_start_date = BrowserPageviewEvent.beacon_rollup_start_date
+
+      if beacon_start_date.nil? || beacon_start_date > end_date
+        yield start_date, end_date, BrowserPageviewEvent::SOURCE_PIGGYBACK
+      elsif beacon_start_date <= start_date
+        yield start_date, end_date, BrowserPageviewEvent::SOURCE_BEACON
+      else
+        yield start_date, beacon_start_date - 1, BrowserPageviewEvent::SOURCE_PIGGYBACK
+        yield beacon_start_date, end_date, BrowserPageviewEvent::SOURCE_BEACON
+      end
     end
 
     def engagement_aggregation_window
@@ -48,11 +78,9 @@ module Jobs
       end_date = Time.zone.today
 
       if BrowserPageviewCountryDailyRollup.none? && BrowserPageviewReferrerDailyRollup.none?
-        earliest_event_date =
-          BrowserPageviewEvent
-            .where(source: BrowserPageviewEvent.rollup_source)
-            .minimum(:created_at)
-            &.to_date
+        # Not filtered by source: the backfill can span the piggyback-to-beacon
+        # cutover, and each day aggregates from whichever source covers it.
+        earliest_event_date = BrowserPageviewEvent.minimum(:created_at)&.to_date
         [earliest_event_date, end_date]
       else
         [1.day.ago.to_date, end_date]
@@ -71,11 +99,11 @@ module Jobs
     end
 
     def next_batch
-      params = {
-        source: BrowserPageviewEvent.rollup_source,
-        version: BrowserPageviewReferrerInspector::VERSION,
-        limit: batch_size,
-      }
+      params =
+        rollup_source_params.merge(
+          version: BrowserPageviewReferrerInspector::VERSION,
+          limit: batch_size,
+        )
 
       retention_clause = ""
       if SiteSetting.clean_up_browser_pageview_events
@@ -90,7 +118,7 @@ module Jobs
         SELECT id, referrer
         FROM browser_pageview_events
         WHERE referrer IS NOT NULL
-          AND source = :source
+          AND #{rollup_source_condition}
           AND (
             normalized_referrer_version IS NULL
             OR normalized_referrer_version < :version
@@ -117,11 +145,8 @@ module Jobs
     end
 
     def recomputable_dates(ids)
-      params = {
-        ids: ids,
-        source: BrowserPageviewEvent.rollup_source,
-        version: BrowserPageviewReferrerInspector::VERSION,
-      }
+      params =
+        rollup_source_params.merge(ids: ids, version: BrowserPageviewReferrerInspector::VERSION)
 
       retention_clause = ""
       if SiteSetting.clean_up_browser_pageview_events
@@ -145,7 +170,7 @@ module Jobs
           FROM browser_pageview_events e
           WHERE e.created_at >= touched_dates.date
             AND e.created_at < touched_dates.date + 1
-            AND e.source = :source
+            AND #{rollup_source_condition("e.")}
             AND e.referrer IS NOT NULL
             AND NOT EXISTS (
               SELECT 1
@@ -159,6 +184,27 @@ module Jobs
             #{retention_clause}
         )
       SQL
+    end
+
+    # Matches each event against the rollup source for its own day, so a batch
+    # spanning the piggyback-to-beacon cutover backfills the right rows on both
+    # sides. When there is no cutover, :beacon_start_date is NULL and the
+    # comparison falls through to piggyback.
+    def rollup_source_condition(prefix = "")
+      <<~SQL
+        #{prefix}source = CASE
+          WHEN #{prefix}created_at >= :beacon_start_date THEN :source_beacon
+          ELSE :source_piggyback
+        END
+      SQL
+    end
+
+    def rollup_source_params
+      {
+        beacon_start_date: BrowserPageviewEvent.beacon_rollup_start_date,
+        source_beacon: BrowserPageviewEvent::SOURCE_BEACON,
+        source_piggyback: BrowserPageviewEvent::SOURCE_PIGGYBACK,
+      }
     end
 
     def stamp_version(ids)

--- a/app/models/browser_pageview_country_daily_rollup.rb
+++ b/app/models/browser_pageview_country_daily_rollup.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class BrowserPageviewCountryDailyRollup < ActiveRecord::Base
-  def self.aggregate(start_date:, end_date:, source: BrowserPageviewEvent.rollup_source)
+  def self.aggregate(
+    start_date:,
+    end_date:,
+    source: BrowserPageviewEvent.rollup_source_for(start_date)
+  )
     start_date = start_date.to_date
     end_date = end_date.to_date + 1
 

--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -189,12 +189,26 @@ class BrowserPageviewEvent < ActiveRecord::Base
     RETENTION_PERIOD.ago.beginning_of_day
   end
 
-  def self.rollup_source
-    if UpcomingChanges.enabled?(:dashboard_improvements)
-      SOURCE_BEACON
-    else
-      SOURCE_PIGGYBACK
-    end
+  # Rollups switch from piggyback to beacon the day AFTER the upcoming change
+  # is enabled: beacon events only cover the part of the enablement day after
+  # the toggle, while piggyback keeps recording in parallel, so the enablement
+  # day itself (and everything before it) must keep aggregating from piggyback
+  # or those days would be rebuilt from a partial or empty beacon stream.
+  def self.beacon_rollup_start_date
+    return if !UpcomingChanges.enabled?(:dashboard_improvements)
+
+    enabled_at =
+      UpcomingChangeEvent.where(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: %i[manual_opt_in automatically_promoted],
+      ).maximum(:created_at)
+
+    enabled_at && enabled_at.to_date + 1
+  end
+
+  def self.rollup_source_for(date)
+    start_date = beacon_rollup_start_date
+    start_date && date.to_date >= start_date ? SOURCE_BEACON : SOURCE_PIGGYBACK
   end
 
   before_save :truncate_fields

--- a/app/models/browser_pageview_referrer_daily_rollup.rb
+++ b/app/models/browser_pageview_referrer_daily_rollup.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class BrowserPageviewReferrerDailyRollup < ActiveRecord::Base
-  def self.aggregate(start_date:, end_date:, source: BrowserPageviewEvent.rollup_source)
+  def self.aggregate(
+    start_date:,
+    end_date:,
+    source: BrowserPageviewEvent.rollup_source_for(start_date)
+  )
     start_date = start_date.to_date
     end_date = end_date.to_date + 1
 
@@ -27,32 +31,34 @@ class BrowserPageviewReferrerDailyRollup < ActiveRecord::Base
     dates = Array(dates).map(&:to_date).uniq
     return if dates.empty?
 
-    source = BrowserPageviewEvent.rollup_source
+    sources = dates.map { |date| BrowserPageviewEvent.rollup_source_for(date) }
 
     # The rollups are the permanent record, but their source events are pruned
     # after a retention period (CleanUpBrowserPageviewEvents). Only rebuild
     # dates that still have events so we never delete a rollup we can no longer
     # reconstruct from events.
-    dates = DB.query_single(<<~SQL, dates:, source:)
-      SELECT d.date
-      FROM unnest(ARRAY[:dates]::date[]) AS d(date)
+    rebuildable = DB.query(<<~SQL, dates:, sources:)
+      SELECT d.date, d.source
+      FROM unnest(ARRAY[:dates]::date[], ARRAY[:sources]::int[]) AS d(date, source)
       WHERE EXISTS (
         SELECT 1
         FROM browser_pageview_events e
         WHERE e.created_at >= d.date
           AND e.created_at < d.date + 1
-          AND e.source = :source
+          AND e.source = d.source
       )
     SQL
-    return if dates.empty?
+    return if rebuildable.empty?
 
     transaction do
-      DB.exec(<<~SQL, dates: dates)
+      DB.exec(<<~SQL, dates: rebuildable.map(&:date))
         DELETE FROM browser_pageview_referrer_daily_rollups
         WHERE date IN (:dates)
       SQL
 
-      dates.each { |date| aggregate(start_date: date, end_date: date, source:) }
+      rebuildable.each do |row|
+        aggregate(start_date: row.date, end_date: row.date, source: row.source)
+      end
     end
   end
 end

--- a/app/models/browser_pageview_session_engagement_daily_rollup.rb
+++ b/app/models/browser_pageview_session_engagement_daily_rollup.rb
@@ -5,7 +5,11 @@ class BrowserPageviewSessionEngagementDailyRollup < ActiveRecord::Base
   MIN_SESSION_AGE = 10.minutes
   private_constant :BOUNCE_ENGAGED_SECONDS_THRESHOLD, :MIN_SESSION_AGE
 
-  def self.aggregate(start_date:, end_date:, source: BrowserPageviewEvent.rollup_source)
+  def self.aggregate(
+    start_date:,
+    end_date:,
+    source: BrowserPageviewEvent.rollup_source_for(start_date)
+  )
     start_date = start_date.to_date
     end_date = end_date.to_date + 1
 

--- a/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
+++ b/plugins/discourse-ai/lib/admin_dashboard/admin_dashboard_facts.rb
@@ -463,7 +463,10 @@ module DiscourseAi
               AND e.created_at < (:end_date::date + 1)
               AND e.topic_id IS NOT NULL
               AND e.normalized_referrer IS NOT NULL
-              AND e.source = :source
+              AND e.source = CASE
+                WHEN e.created_at >= :beacon_start_date THEN :source_beacon
+                ELSE :source_piggyback
+              END
               AND #{topic_conditions}
             GROUP BY e.topic_id, t.title
             ORDER BY visits DESC
@@ -471,7 +474,9 @@ module DiscourseAi
           SQL
             start_date: @start_date,
             end_date: @end_date,
-            source: BrowserPageviewEvent.rollup_source,
+            beacon_start_date: BrowserPageviewEvent.beacon_rollup_start_date,
+            source_beacon: BrowserPageviewEvent::SOURCE_BEACON,
+            source_piggyback: BrowserPageviewEvent::SOURCE_PIGGYBACK,
             category_ids: scoped_category_ids,
           ).first
         return if row.nil? || row.visits.to_i < 50

--- a/spec/jobs/maintain_browser_pageview_rollups_spec.rb
+++ b/spec/jobs/maintain_browser_pageview_rollups_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
 
   before { SiteSetting.persist_browser_pageview_events = true }
 
+  def enable_dashboard_improvements(enabled_at:)
+    SiteSetting.dashboard_improvements = true
+    UpcomingChangeEvent.create!(
+      upcoming_change_name: "dashboard_improvements",
+      event_type: :manual_opt_in,
+      created_at: enabled_at,
+    )
+  end
+
   describe "#execute" do
     it "does nothing when persist_browser_pageview_events is disabled" do
       SiteSetting.persist_browser_pageview_events = false
@@ -34,8 +43,9 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
         ).to eq(1)
       end
 
-      it "uses beacon source for rollups when dashboard_improvements is enabled" do
-        SiteSetting.dashboard_improvements = false
+      it "keeps aggregating from piggyback on the day dashboard_improvements is enabled" do
+        freeze_time
+        enable_dashboard_improvements(enabled_at: Time.zone.now)
         Fabricate(
           :browser_pageview_event,
           country_code: "US",
@@ -55,8 +65,68 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
         expect(BrowserPageviewReferrerDailyRollup.pluck(:normalized_referrer, :count)).to eq(
           [["google.com", 1]],
         )
+      end
 
-        SiteSetting.dashboard_improvements = true
+      it "aggregates from beacon for days after the enablement day" do
+        freeze_time
+        enable_dashboard_improvements(enabled_at: 2.days.ago)
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "US",
+          normalized_referrer: "google.com",
+          source: BrowserPageviewEvent::SOURCE_PIGGYBACK,
+        )
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "GB",
+          normalized_referrer: "reddit.com",
+          source: BrowserPageviewEvent::SOURCE_BEACON,
+        )
+
+        job.execute({})
+
+        expect(BrowserPageviewCountryDailyRollup.pluck(:country_code, :count)).to eq([["GB", 1]])
+        expect(BrowserPageviewReferrerDailyRollup.pluck(:normalized_referrer, :count)).to eq(
+          [["reddit.com", 1]],
+        )
+      end
+
+      it "backfills each day from the source that was active on that day" do
+        freeze_time
+        enable_dashboard_improvements(enabled_at: 1.day.ago)
+        Fabricate(:browser_pageview_event, country_code: "US", created_at: 5.days.ago)
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "GB",
+          source: BrowserPageviewEvent::SOURCE_BEACON,
+        )
+        Fabricate(:browser_pageview_event, country_code: "DE")
+
+        job.execute({})
+
+        expect(BrowserPageviewCountryDailyRollup.pluck(:country_code)).to contain_exactly(
+          "US",
+          "GB",
+        )
+      end
+
+      it "keeps piggyback-built rollups for days before the cutover after the change is enabled" do
+        freeze_time
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "US",
+          normalized_referrer: "google.com",
+          created_at: 1.day.ago,
+        )
+        job.execute({})
+
+        enable_dashboard_improvements(enabled_at: 1.day.ago)
+        Fabricate(
+          :browser_pageview_event,
+          country_code: "GB",
+          normalized_referrer: "reddit.com",
+          source: BrowserPageviewEvent::SOURCE_BEACON,
+        )
         job.execute({})
 
         expect(BrowserPageviewCountryDailyRollup.pluck(:country_code, :count)).to contain_exactly(
@@ -183,8 +253,15 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
         expect(event.normalized_referrer_version).to eq(BrowserPageviewReferrerInspector::VERSION)
       end
 
-      it "only backfills referrers from the active source" do
-        SiteSetting.dashboard_improvements = true
+      it "backfills referrers from each day's rollup source" do
+        freeze_time
+        enable_dashboard_improvements(enabled_at: 2.days.ago)
+        pre_cutover_piggyback =
+          Fabricate(
+            :browser_pageview_event_with_unnormalized_referrer,
+            referrer: "https://www.bing.com/",
+            created_at: 3.days.ago,
+          )
         piggyback_event =
           Fabricate(
             :browser_pageview_event_with_unnormalized_referrer,
@@ -200,6 +277,7 @@ RSpec.describe Jobs::MaintainBrowserPageviewRollups do
 
         job.execute({})
 
+        expect(pre_cutover_piggyback.reload.normalized_referrer).to eq("bing.com")
         expect(piggyback_event.reload.normalized_referrer_version).to be_nil
         expect(beacon_event.reload.normalized_referrer).to eq("reddit.com")
         expect(beacon_event.normalized_referrer_version).to eq(

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -144,4 +144,76 @@ RSpec.describe BrowserPageviewEvent do
       expect(Discourse.redis.ttl(described_class::REDIS_QUEUE_KEY)).to be > 0
     end
   end
+
+  describe ".beacon_rollup_start_date" do
+    def record_enablement(event_type, created_at)
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type:,
+        created_at:,
+      )
+    end
+
+    it "is nil when dashboard_improvements is disabled" do
+      SiteSetting.dashboard_improvements = false
+      record_enablement(:manual_opt_in, 2.days.ago)
+
+      expect(described_class.beacon_rollup_start_date).to be_nil
+    end
+
+    it "is nil when the change is enabled but no enablement event was recorded" do
+      SiteSetting.dashboard_improvements = true
+
+      expect(described_class.beacon_rollup_start_date).to be_nil
+    end
+
+    it "is the day after the change was manually enabled" do
+      SiteSetting.dashboard_improvements = true
+      record_enablement(:manual_opt_in, Time.zone.parse("2026-07-10 15:00"))
+
+      expect(described_class.beacon_rollup_start_date).to eq(Date.new(2026, 7, 11))
+    end
+
+    it "is the day after an automatic promotion" do
+      SiteSetting.dashboard_improvements = true
+      record_enablement(:automatically_promoted, Time.zone.parse("2026-07-10 15:00"))
+
+      expect(described_class.beacon_rollup_start_date).to eq(Date.new(2026, 7, 11))
+    end
+
+    it "uses the latest enablement when the change was toggled off and on again" do
+      SiteSetting.dashboard_improvements = true
+      record_enablement(:manual_opt_in, Time.zone.parse("2026-07-01 09:00"))
+      record_enablement(:manual_opt_out, Time.zone.parse("2026-07-05 09:00"))
+      record_enablement(:manual_opt_in, Time.zone.parse("2026-07-10 09:00"))
+
+      expect(described_class.beacon_rollup_start_date).to eq(Date.new(2026, 7, 11))
+    end
+  end
+
+  describe ".rollup_source_for" do
+    it "is piggyback for every date when there is no cutover" do
+      SiteSetting.dashboard_improvements = false
+
+      expect(described_class.rollup_source_for(Time.zone.today)).to eq(
+        described_class::SOURCE_PIGGYBACK,
+      )
+    end
+
+    it "flips from piggyback to beacon at the cutover date" do
+      SiteSetting.dashboard_improvements = true
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: :manual_opt_in,
+        created_at: Time.zone.parse("2026-07-10 15:00"),
+      )
+
+      expect(described_class.rollup_source_for(Date.new(2026, 7, 10))).to eq(
+        described_class::SOURCE_PIGGYBACK,
+      )
+      expect(described_class.rollup_source_for(Date.new(2026, 7, 11))).to eq(
+        described_class::SOURCE_BEACON,
+      )
+    end
+  end
 end

--- a/spec/models/browser_pageview_session_engagement_daily_rollup_spec.rb
+++ b/spec/models/browser_pageview_session_engagement_daily_rollup_spec.rb
@@ -157,6 +157,11 @@ RSpec.describe BrowserPageviewSessionEngagementDailyRollup do
 
     it "counts only rollup-source pageviews, even within a single session" do
       SiteSetting.dashboard_improvements = true
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: :manual_opt_in,
+        created_at: Time.utc(2026, 5, 20),
+      )
       beacon_event =
         Fabricate(:browser_pageview_event, source: :beacon, created_at: Time.utc(2026, 6, 10, 9))
       Fabricate(


### PR DESCRIPTION
Previously, once `dashboard_improvements` was enabled the pageview rollup jobs treated beacon as the only source for every date, so re-aggregating or backfilling piggyback-era days rebuilt them from a beacon stream that was not recording on those days, wiping their data.

This change flips the rollup source to beacon only for days after the upcoming change was enabled (derived from `upcoming_change_events`), so earlier days — including the enablement day itself, where beacon coverage is only partial — keep aggregating from the piggyback stream, which continues recording in parallel.

Follow-up to https://github.com/discourse/discourse/pull/40934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)