### PR TITLE
DEV: Remove unnecessary flakey agent setup

### DIFF
--- a/plugins/discourse-ai/spec/jobs/regular/generate_post_image_captions_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/regular/generate_post_image_captions_spec.rb
@@ -17,10 +17,6 @@ describe Jobs::GeneratePostImageCaptions do
     enable_current_plugin
     llm_model = assign_fake_provider_to(:ai_default_llm_model)
     llm_model.update!(vision_enabled: true)
-    AiAgent.find_by(id: SiteSetting.ai_image_caption_agent).update!(
-      enabled: true,
-      vision_enabled: true,
-    )
     SiteSetting.ai_post_image_captions_enabled = true
     SiteSetting.ai_helper_enabled = true
     SearchIndexer.enable

--- a/plugins/discourse-ai/spec/jobs/scheduled/post_image_captions_backfill_spec.rb
+++ b/plugins/discourse-ai/spec/jobs/scheduled/post_image_captions_backfill_spec.rb
@@ -17,10 +17,6 @@ describe Jobs::PostImageCaptionsBackfill do
     enable_current_plugin
     llm_model = assign_fake_provider_to(:ai_default_llm_model)
     llm_model.update!(vision_enabled: true)
-    AiAgent.find_by(id: SiteSetting.ai_image_caption_agent).update!(
-      enabled: true,
-      vision_enabled: true,
-    )
     SiteSetting.ai_post_image_captions_enabled = true
     SiteSetting.ai_helper_enabled = true
     post.update_column(:cooked, post.cook(post.raw, topic_id: post.topic_id))


### PR DESCRIPTION
```
rspec ./spec/serializers/site_serializer_spec.rb:331 # SiteSerializer#anonymous_sidebar_sections eager loads sidebar_urls
rspec ./spec/serializers/current_user_serializer_spec.rb:333 # CurrentUserSerializer#sidebar_sections eager loads sidebar_urls
```

These are randomly failing due to `AiAgent.find_by ... update` which is unneeded now.