### PR TITLE
FIX: Correctly close fully merged topics containing whispers

### DIFF
--- a/app/models/post_mover.rb
+++ b/app/models/post_mover.rb
@@ -90,23 +90,7 @@ class PostMover
 
     ensure_acting_user_is_allowed_in_destination
 
-    # when a topic contains some posts after moving posts to another topic we shouldn't close it
-    # two types of posts should prevent a topic from closing:
-    #   1. regular posts
-    #   2. almost all whispers
-    # we should only exclude whispers with action_code: 'split_topic'
-    # because we use such whispers as a small-action posts when moving posts to the secret message
-    # (in this case we don't want everyone to see that posts were moved, that's why we use whispers)
-    original_topic_posts_count =
-      @original_topic
-        .posts
-        .where(
-          "post_type = ? or (post_type = ? and action_code != 'split_topic')",
-          Post.types[:regular],
-          Post.types[:whisper],
-        )
-        .count
-    @full_move = original_topic_posts_count == posts.length
+    @full_move = (posts_preventing_close.pluck(:id) - posts.map(&:id)).empty?
 
     @first_post_number_moved =
       posts.first.is_first_post? ? posts[1]&.post_number : posts.first.post_number
@@ -729,6 +713,14 @@ class PostMover
         .where.not(raw: "")
         .order(:created_at)
         .tap { |posts| raise Discourse::InvalidParameters.new(:post_ids) if posts.empty? }
+  end
+
+  def posts_preventing_close
+    @original_topic
+      .posts
+      .where(post_type: [Post.types[:regular], Post.types[:whisper]])
+      .where.not(raw: "")
+      .where("action_code IS DISTINCT FROM 'split_topic'")
   end
 
   def update_last_post_stats

--- a/plugins/discourse-topic-voting/spec/lib/topic_merger_spec.rb
+++ b/plugins/discourse-topic-voting/spec/lib/topic_merger_spec.rb
@@ -114,6 +114,29 @@ describe DiscourseTopicVoting::TopicMerger do
       expect(merged_post.raw).to include(I18n.t("topic_voting.duplicated_votes", count: 2))
     end
 
+    it "moves votes when the source topic has an action whisper with no content" do
+      Fabricate(
+        :post,
+        topic: topic_0,
+        user: user_0,
+        post_type: Post.types[:whisper],
+        action_code: "some_action",
+      ).update_columns(raw: "", cooked: "")
+
+      topic_0.move_posts(
+        Discourse.system_user,
+        topic_0.posts.pluck(:id),
+        destination_topic_id: topic_1.id,
+      )
+
+      expect(topic_0.reload).to be_closed
+      expect(topic_0.vote_count).to eq(0)
+      expect(topic_1.reload.vote_count).to eq(5)
+
+      users[0].reload
+      expect(users[0].topics_with_vote.pluck(:topic_id)).to contain_exactly(topic_1.id)
+    end
+
     it "does not move votes when not all posts are moved and the original topic does not get closed" do
       topic_0.move_posts(
         Discourse.system_user,

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -781,6 +781,75 @@ RSpec.describe PostMover do
             expect(topic).to_not be_closed
           end
 
+          context "with an action whisper that has no content" do
+            fab!(:action_whisper) do
+              Fabricate(
+                :post,
+                topic:,
+                user:,
+                post_type: Post.types[:whisper],
+                action_code: "some_action",
+              ).tap { |post| post.update_columns(raw: "", cooked: "") }
+            end
+
+            it "closes the topic when all other posts were moved" do
+              posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+              topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+
+              topic.reload
+              expect(topic).to be_closed
+            end
+
+            it "closes the topic when the whisper id is included in the move" do
+              posts_to_move = [p1.id, p2.id, p3.id, p4.id, action_whisper.id]
+              topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+
+              topic.reload
+              expect(topic).to be_closed
+              expect(action_whisper.reload.topic_id).to eq(topic.id)
+            end
+          end
+
+          context "with a whisper that has content" do
+            fab!(:content_whisper) do
+              Fabricate(:post, topic:, user:, post_type: Post.types[:whisper])
+            end
+
+            it "closes the topic when the whisper is moved along with all posts" do
+              posts_to_move = [p1.id, p2.id, p3.id, p4.id, content_whisper.id]
+              topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+
+              topic.reload
+              expect(topic).to be_closed
+              expect(content_whisper.reload.topic_id).to eq(destination_topic.id)
+            end
+
+            it "doesn't close the topic when the whisper is left behind" do
+              posts_to_move = [p1.id, p2.id, p3.id, p4.id]
+              topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+
+              topic.reload
+              expect(topic).to_not be_closed
+            end
+          end
+
+          it "closes the topic when moving all posts and a whisper from an earlier move to a message" do
+            split_topic_whisper =
+              Fabricate(
+                :post,
+                topic:,
+                user:,
+                post_type: Post.types[:whisper],
+                action_code: "split_topic",
+              )
+
+            posts_to_move = [p1.id, p2.id, p3.id, p4.id, split_topic_whisper.id]
+            topic.move_posts(user, posts_to_move, destination_topic_id: destination_topic.id)
+
+            topic.reload
+            expect(topic).to be_closed
+          end
+
           it "schedules topic deleting when all posts were moved" do
             SiteSetting.delete_merged_stub_topics_after_days = 7
             freeze_time


### PR DESCRIPTION
Previously, `PostMover` detected a full merge by comparing the sizes of two differently-filtered post sets — a topic-wide census (`regular OR (whisper AND action_code != 'split_topic')`, with no content filter and a NULL-unsafe `!=`) against the movable set (which excludes `small_action` and blank-`raw` posts). Any post the two filters classified differently threw the counts off, so a topic that had ever been assigned (its blank-`raw` tracking whisper is counted but never movable) would never close on a full merge, was never scheduled for deletion, and — via discourse-topic-voting, which only transfers votes once the source topic closes — left its votes stranded. The same asymmetry ran the other way for ordinary content whispers (dropped from the census by the NULL comparison), so one left behind could wrongly close and delete the source with its content still inside.

This change computes `@full_move` directly as "no close-preventing post is left out of the move" — a set difference between the close-preventing posts and the moved posts — using a single NULL-safe predicate (`regular`/`whisper`, `raw <> ''`, `action_code IS DISTINCT FROM 'split_topic'`). Fully merged topics now reliably close and transfer their votes, while a topic still holding whisper content correctly stays open.
