### PR TITLE
FIX: Restore enabled checkboxes for similar users in penalty modals

### DIFF
--- a/app/serializers/similar_admin_user_serializer.rb
+++ b/app/serializers/similar_admin_user_serializer.rb
@@ -7,6 +7,10 @@ class SimilarAdminUserSerializer < AdminUserListSerializer
     scope.can_suspend?(object)
   end
 
+  def include_can_be_suspended?
+    true
+  end
+
   def can_be_silenced
     scope.can_silence_user?(object)
   end

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -326,6 +326,17 @@ RSpec.describe Admin::UsersController do
       expect(response.status).to eq(200)
       expect(response.parsed_body["users"].map { |u| u["id"] }).to contain_exactly(similar_user.id)
     end
+
+    it "includes penalizability of each similar user" do
+      Fabricate(:user, ip_address: user.ip_address)
+
+      get "/admin/users/#{user.id}/similar-users.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["users"]).to all(
+        include("can_be_suspended" => true, "can_be_silenced" => true),
+      )
+    end
   end
 
   describe "#approve" do

--- a/spec/system/admin_user_spec.rb
+++ b/spec/system/admin_user_spec.rb
@@ -230,14 +230,16 @@ describe "Admin User Page" do
         )
       end
 
-      it "suspends and unsuspends the user" do
+      it "suspends the user along with selected similar users and unsuspends the user" do
         admin_user_page.click_suspend_button
+        suspend_user_modal.select_similar_user(similar_user.username)
         suspend_user_modal.fill_in_suspend_reason("spamming")
         suspend_user_modal.set_future_date("tomorrow")
         suspend_user_modal.perform
         expect(suspend_user_modal).to be_closed
 
         expect(page).to have_css(".suspension-info")
+        expect(similar_user.reload).to be_suspended
 
         admin_user_page.click_unsuspend_button
         expect(page).not_to have_css(".suspension-info")

--- a/spec/system/page_objects/modals/penalize_user.rb
+++ b/spec/system/page_objects/modals/penalize_user.rb
@@ -11,6 +11,10 @@ module PageObjects
         modal.all("table tbody tr td:nth-child(2)").map(&:text)
       end
 
+      def select_similar_user(username)
+        modal.find("table tbody tr", text: username).check
+      end
+
       def modal
         find(".d-modal.#{@penalty_type}-user-modal")
       end


### PR DESCRIPTION
The suspend user modal lists other accounts sharing the same IP address, with a checkbox next to each so staff can penalize them in the same action. Since #41227, every one of those checkboxes was disabled, making it impossible to select anyone.

The modal enables a checkbox only when the user's `can_be_suspended` attribute is `true` in the similar-users response. That attribute regressed as a side effect of #41227: it added `can_be_suspended` to the parent `AdminUserListSerializer` behind an `include_can_be_suspended?` opt-in guard for the admin users list. `SimilarAdminUserSerializer` inherited that guard, and since the similar-users endpoint never passes the opt-in option, the attribute was silently dropped from its response — and a missing attribute reads as "cannot be suspended", disabling the checkbox.

This change overrides the guard in `SimilarAdminUserSerializer` so the attribute is always serialized, as it was before. It also adds a request spec pinning `can_be_suspended`/`can_be_silenced` in the response, and extends the suspend system spec to tick a similar user's checkbox and verify both accounts get suspended — closing the coverage gap that let this regress unnoticed.