### PR TITLE
FIX: Handle a member disabling chat in their preferences

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/chat-route-map.js
+++ b/plugins/chat/assets/javascripts/discourse/chat-route-map.js
@@ -1,6 +1,7 @@
 /* eslint-disable ember/routes-segments-snake-case */
 export default function () {
   this.route("chat", function () {
+    this.route("disabled");
     this.route("search");
 
     this.route("channel", { path: "/c/:channelTitle/:channelId" }, function () {

--- a/plugins/chat/assets/javascripts/discourse/components/chat/disabled.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/disabled.gjs
@@ -1,0 +1,20 @@
+import getUrl from "discourse/lib/get-url";
+import DEmptyState from "discourse/ui-kit/d-empty-state";
+import { i18n } from "discourse-i18n";
+import ChatZero from "../svg/chat-zero";
+
+const ChatDisabled = <template>
+  <div class="chat-disabled">
+    <DEmptyState
+      @identifier="chat-disabled"
+      @svgContent={{ChatZero}}
+      @title={{i18n "chat.disabled.title"}}
+      @body={{i18n "chat.disabled.body"}}
+      @ctaLabel={{i18n "chat.disabled.cta"}}
+      @ctaHref={{getUrl "/my/preferences/chat"}}
+      @ctaIcon="gear"
+    />
+  </div>
+</template>;
+
+export default ChatDisabled;

--- a/plugins/chat/assets/javascripts/discourse/controllers/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/controllers/chat.js
@@ -10,6 +10,10 @@ export default class ChatController extends Controller {
   @service router;
 
   get shouldUseChatSidebar() {
+    if (this.chat.chatDisabledInPreferences) {
+      return false;
+    }
+
     if (this.site.mobileView) {
       return false;
     }

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-user-menu.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-user-menu.js
@@ -11,10 +11,6 @@ export default {
     withPluginApi((api) => {
       const chat = container.lookup("service:chat");
 
-      if (!chat.userCanChat) {
-        return;
-      }
-
       if (api.registerNotificationTypeRenderer) {
         api.registerNotificationTypeRenderer(
           "chat_invitation",
@@ -141,6 +137,10 @@ export default {
             };
           }
         );
+      }
+
+      if (!chat.userCanChat) {
+        return;
       }
 
       if (api.registerUserMenuTab) {

--- a/plugins/chat/assets/javascripts/discourse/routes/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat.js
@@ -22,6 +22,14 @@ export default class ChatRoute extends DiscourseRoute {
   }
 
   beforeModel(transition) {
+    if (this.chat.chatDisabledInPreferences) {
+      if (transition.to.name === "chat.disabled") {
+        return;
+      }
+
+      return this.router.replaceWith("chat.disabled");
+    }
+
     if (!this.chat.userCanChat && !this.chat.anonymousUserCanViewPublicChat) {
       return this.router.transitionTo(`discovery.${defaultHomepage()}`);
     }
@@ -77,6 +85,10 @@ export default class ChatRoute extends DiscourseRoute {
   }
 
   activate() {
+    if (this.chat.chatDisabledInPreferences) {
+      return;
+    }
+
     withPluginApi((api) => {
       api.setSidebarPanel(CHAT_PANEL);
 

--- a/plugins/chat/assets/javascripts/discourse/routes/chat/disabled.js
+++ b/plugins/chat/assets/javascripts/discourse/routes/chat/disabled.js
@@ -1,0 +1,18 @@
+import { service } from "@ember/service";
+import DiscourseRoute from "discourse/routes/discourse";
+import { i18n } from "discourse-i18n";
+
+export default class ChatDisabledRoute extends DiscourseRoute {
+  @service chat;
+  @service router;
+
+  titleToken() {
+    return i18n("chat.disabled.title");
+  }
+
+  beforeModel() {
+    if (!this.chat.chatDisabledInPreferences) {
+      return this.router.transitionTo("chat");
+    }
+  }
+}

--- a/plugins/chat/assets/javascripts/discourse/services/chat.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat.js
@@ -72,6 +72,11 @@ export default class Chat extends Service {
     );
   }
 
+  @computed("currentUser.can_chat", "currentUser.has_chat_enabled")
+  get chatDisabledInPreferences() {
+    return this.currentUser?.can_chat && !this.currentUser?.has_chat_enabled;
+  }
+
   get anonymousUserCanViewPublicChat() {
     return (
       !this.currentUser &&

--- a/plugins/chat/assets/javascripts/discourse/templates/chat/disabled.gjs
+++ b/plugins/chat/assets/javascripts/discourse/templates/chat/disabled.gjs
@@ -1,0 +1,3 @@
+import ChatDisabled from "discourse/plugins/chat/discourse/components/chat/disabled";
+
+export default <template><ChatDisabled /></template>

--- a/plugins/chat/assets/stylesheets/common/chat-disabled.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-disabled.scss
@@ -1,0 +1,8 @@
+.chat-disabled {
+  display: flex;
+  min-height: calc(100vh - var(--main-outlet-offset, 4em));
+
+  .empty-state__container {
+    margin: auto;
+  }
+}

--- a/plugins/chat/assets/stylesheets/common/index.scss
+++ b/plugins/chat/assets/stylesheets/common/index.scss
@@ -3,6 +3,7 @@
 @import "base-common";
 @import "chat-drawer-routes";
 @import "chat-browse";
+@import "chat-disabled";
 @import "chat-sidebar";
 @import "chat-channel";
 @import "chat-channel-card";

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -349,6 +349,10 @@ en:
         ethereal: "Ethereal glass"
       title: "chat"
       title_capitalized: "Chat"
+      disabled:
+        title: "You have disabled chat"
+        body: "Turn it back on to view channels and messages."
+        cta: "My chat preferences"
       upload: "Attach a file"
       upload_to_channel: "Upload to %{title}"
       upload_to_thread: "Upload to thread"

--- a/plugins/chat/config/routes.rb
+++ b/plugins/chat/config/routes.rb
@@ -94,6 +94,7 @@ Chat::Engine.routes.draw do
 
   # chat_controller routes
   get "/" => "chat#respond"
+  get "/disabled" => "chat#respond"
   get "/search" => "chat#respond"
   get "/new-message" => "chat#respond"
   get "/direct-messages" => "chat#respond"

--- a/plugins/chat/spec/system/browse_page_spec.rb
+++ b/plugins/chat/spec/system/browse_page_spec.rb
@@ -11,15 +11,6 @@ RSpec.describe "Browse page" do
     chat_system_bootstrap
   end
 
-  context "when user has chat disabled" do
-    before { current_user.user_option.update!(chat_enabled: false) }
-
-    it "redirects to homepage" do
-      visit("/chat/browse") # no page object here as we actually don't load it
-      expect(page).to have_current_path("/latest")
-    end
-  end
-
   context "when public channels are disabled" do
     before { SiteSetting.enable_public_channels = false }
 

--- a/plugins/chat/spec/system/chat_disabled_spec.rb
+++ b/plugins/chat/spec/system/chat_disabled_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chat | disabled in preferences" do
+  include ThemeScreenshotMarker
+
+  fab!(:current_user, :user)
+  fab!(:inviter, :user)
+  fab!(:channel_1, :category_channel)
+  fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1, user: inviter) }
+
+  let(:user_menu) { PageObjects::Components::UserMenu.new }
+
+  before do
+    chat_system_bootstrap(current_user, [channel_1])
+    current_user.user_option.update!(chat_enabled: false)
+
+    current_user.notifications.create!(
+      notification_type: Notification.types[:chat_invitation],
+      high_priority: true,
+      read: false,
+      data: {
+        chat_channel_id: channel_1.id,
+        chat_channel_title: channel_1.title(current_user),
+        chat_channel_slug: channel_1.slug,
+        invited_by_username: inviter.username,
+        chat_message_id: message_1.id,
+      }.to_json,
+    )
+
+    current_user.notifications.create!(
+      notification_type: Notification.types[:chat_mention],
+      high_priority: true,
+      read: false,
+      data: {
+        chat_message_id: message_1.id,
+        chat_channel_id: channel_1.id,
+        mentioned_by_username: inviter.username,
+        is_direct_message_channel: false,
+        chat_channel_title: channel_1.title(current_user),
+        chat_channel_slug: channel_1.slug,
+      }.to_json,
+    )
+
+    sign_in(current_user)
+  end
+
+  it "still renders chat notifications in the user menu" do
+    visit "/"
+    user_menu.open
+
+    expect(page).to have_css(
+      ".user-menu .notification.chat-invitation .item-label",
+      text: inviter.username,
+    )
+    screenshot_marker(label: "chatdisabled-notifications", only: :desktop)
+  end
+
+  it "shows the disabled page instead of redirecting home" do
+    visit "/chat/disabled"
+
+    expect(page).to have_css(".chat-disabled .empty-state__title")
+    screenshot_marker(label: "chatdisabled-page", only: :desktop)
+  end
+end

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -42,16 +42,6 @@ RSpec.describe "Visit channel" do
     context "when regular user" do
       before { sign_in(current_user) }
 
-      context "when chat is disabled" do
-        before { current_user.user_option.update!(chat_enabled: false) }
-
-        it "redirects to homepage" do
-          visit("/chat/c/-/#{category_channel_1.id}")
-
-          expect(page).to have_current_path("/latest")
-        end
-      end
-
       context "when current user is not allowed to chat" do
         before { SiteSetting.chat_allowed_groups = Group::AUTO_GROUPS[:staff] }
 

--- a/plugins/chat/test/javascripts/acceptance/chat-disabled-test.js
+++ b/plugins/chat/test/javascripts/acceptance/chat-disabled-test.js
@@ -1,0 +1,80 @@
+import {
+  click,
+  currentRouteName,
+  currentURL,
+  visit,
+} from "@ember/test-helpers";
+import { test } from "qunit";
+import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
+
+acceptance("Chat | Disabled in preferences", function (needs) {
+  needs.user();
+  needs.settings({ chat_enabled: true });
+
+  needs.pretender((server, helper) => {
+    server.get("/notifications", () =>
+      helper.response({
+        notifications: [
+          {
+            id: 1,
+            user_id: 1,
+            notification_type: NOTIFICATION_TYPES.chat_invitation,
+            read: false,
+            high_priority: true,
+            created_at: "2026-01-01T00:00:00.000Z",
+            data: {
+              chat_channel_id: 9,
+              chat_channel_title: "Design",
+              chat_channel_slug: "design",
+              invited_by_username: "alice",
+              chat_message_id: 5,
+            },
+          },
+        ],
+        total_rows_notifications: 1,
+        seen_notification_id: 0,
+      })
+    );
+  });
+
+  test("shows an empty state instead of redirecting to the homepage", async function (assert) {
+    updateCurrentUser({ can_chat: true, has_chat_enabled: false });
+
+    await visit("/chat/c/design/9/5");
+
+    assert.strictEqual(
+      currentRouteName(),
+      "chat.disabled",
+      "lands on the chat disabled route rather than bouncing home"
+    );
+    assert
+      .dom(".chat-disabled .empty-state__title")
+      .hasText(i18n("chat.disabled.title"));
+    assert
+      .dom(".chat-disabled .empty-state__cta a")
+      .hasAttribute(
+        "href",
+        /\/my\/preferences\/chat$/,
+        "the call to action links to chat preferences"
+      );
+  });
+
+  test("clicking a chat notification lands on the disabled page", async function (assert) {
+    updateCurrentUser({ can_chat: true, has_chat_enabled: false });
+
+    await visit("/");
+    await click("#toggle-current-user");
+    await click(".user-menu .notification.chat-invitation a");
+
+    assert.strictEqual(
+      currentURL(),
+      "/chat/disabled",
+      "clicking the chat notification lands on the disabled page"
+    );
+  });
+});

--- a/plugins/chat/test/javascripts/integration/components/user-menu/chat-notifications-when-disabled-test.gjs
+++ b/plugins/chat/test/javascripts/integration/components/user-menu/chat-notifications-when-disabled-test.gjs
@@ -1,0 +1,68 @@
+import { getOwner } from "@ember/owner";
+import Service from "@ember/service";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import MenuItem from "discourse/components/user-menu/menu-item";
+import UserMenuNotificationItem from "discourse/lib/user-menu/notification-item";
+import Notification from "discourse/models/notification";
+import { NOTIFICATION_TYPES } from "discourse/tests/fixtures/concerns/notification-types";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import chatUserMenu from "discourse/plugins/chat/discourse/initializers/chat-user-menu";
+
+class ChatDisabledStub extends Service {
+  userCanChat = false;
+}
+
+module(
+  "Integration | Component | Chat | user-menu notifications when the user has chat disabled",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      const owner = getOwner(this);
+      owner.unregister("service:chat");
+      owner.register("service:chat", ChatDisabledStub);
+      chatUserMenu.initialize(owner);
+    });
+
+    test("chat notifications are rendered instead of appearing blank", async function (assert) {
+      const notification = Notification.create({
+        id: 1,
+        user_id: 1,
+        notification_type: NOTIFICATION_TYPES.chat_invitation,
+        read: false,
+        high_priority: true,
+        data: {
+          chat_channel_id: 9,
+          chat_channel_title: "Design",
+          chat_channel_slug: "design",
+          invited_by_username: "alice",
+          chat_message_id: 5,
+        },
+      });
+
+      const item = new UserMenuNotificationItem({
+        notification,
+        currentUser: this.currentUser,
+        siteSettings: this.siteSettings,
+        site: this.site,
+      });
+
+      await render(<template><MenuItem @item={{item}} /></template>);
+
+      assert
+        .dom("li.chat-invitation .item-label")
+        .hasText("alice", "renders the inviter's username as the label");
+      assert
+        .dom("li.chat-invitation svg.d-icon-link")
+        .exists("renders the chat invitation icon rather than a blank row");
+      assert
+        .dom("li.chat-invitation a")
+        .hasAttribute(
+          "href",
+          /\/chat\/c\/design\/9\/5$/,
+          "links to the channel"
+        );
+    });
+  }
+);


### PR DESCRIPTION
Previously, a member who turned chat off in their preferences saw their existing chat notifications render as blank rows, and any chat link silently bounced them to the homepage.

This change registers the chat notification renderers whenever chat is enabled site-wide so those notifications still render correctly, and sends chat links to a new "chat is disabled" page that explains how to turn it back on.

**BEFORE**

(the notification are "blank")

<img width="1400" height="1200" alt="before-notifications" src="https://github.com/user-attachments/assets/d8dcef2e-98eb-4b30-bf33-4a1f8c2c4626" />

**AFTER**

(the notification are there)

<img width="1400" height="1200" alt="after-notifications" src="https://github.com/user-attachments/assets/72b17123-8f82-4c5e-a74d-7d5347de623a" />

(the "blank slate" page that is displayed when you click a #chat notification after you've disabled #chat in your preferences)

<img width="1400" height="1200" alt="after-disabled-page" src="https://github.com/user-attachments/assets/1905ecb5-7b8c-4682-87a9-1559ca4ec569" />
