### PR TITLE
DEV: Fix `ai_image_caption_agent` site setting leaking between specs

### DIFF
--- a/plugins/discourse-ai/spec/configuration/image_caption_enabled_validator_spec.rb
+++ b/plugins/discourse-ai/spec/configuration/image_caption_enabled_validator_spec.rb
@@ -20,7 +20,7 @@ describe DiscourseAi::Configuration::ImageCaptionEnabledValidator do
   end
 
   def set_caption_agent(agent)
-    SiteSetting.provider.save("ai_image_caption_agent", agent.id, SiteSetting.types[:enum])
+    SiteSetting.provider.save(:ai_image_caption_agent, agent.id, SiteSetting.types[:enum])
     SiteSetting.refresh!
   end
 


### PR DESCRIPTION
Previously, `image_caption_enabled_validator_spec` saved the `ai_image_caption_agent` override with a string key via `SiteSetting.provider.save`, so the symbol-keyed `remove_override!` cleanup never cleared it and a rolled-back agent id leaked into later specs in the same worker, making `generate_post_image_captions_spec` fail with `agent_missing` whenever the two ran together.

This change saves the override with a symbol key so it round-trips with the standard cleanup, keeping the setting isolated per example.