### PR TITLE
DEV: remove simple email subject upcoming change metadata

### DIFF
--- a/app/services/site_setting/action/simple_email_subject_toggled.rb
+++ b/app/services/site_setting/action/simple_email_subject_toggled.rb
@@ -1,24 +1,23 @@
 # frozen_string_literal: true
 
-class SiteSetting::Action::SimpleEmailSubjectToggled
-  include Service::Base
+# Reacts to the `simple_email_subject` site setting being enabled or disabled.
+# See config/initializers/014-track-setting-changes.rb for the dispatch.
 
+class SiteSetting::Action::SimpleEmailSubjectToggled < Service::ActionBase
   SIMPLE_EMAIL_SUBJECT = "%{site_name}: %{topic_title}"
 
-  params { attribute :setting_enabled, :boolean }
+  option :enabled
 
-  step :update_email_subject
-  only_if(:has_setting_enabled) { step :copy_translation_overrides }
-  step :request_refresh
-
-  def has_setting_enabled(params:)
-    params.setting_enabled
+  def call
+    update_email_subject
+    copy_translation_overrides if enabled
+    Discourse.request_refresh!
   end
 
   private
 
-  def update_email_subject(params:)
-    if params.setting_enabled
+  def update_email_subject
+    if enabled
       return if SiteSetting.email_subject != SiteSetting.defaults.get(:email_subject)
       SiteSetting.set_and_log(:email_subject, SIMPLE_EMAIL_SUBJECT)
     else
@@ -48,9 +47,5 @@ class SiteSetting::Action::SimpleEmailSubjectToggled
 
     pluralized = "#{match[1]}_improved.#{match[2]}"
     I18n.exists?(pluralized) ? pluralized : nil
-  end
-
-  def request_refresh
-    Discourse.request_refresh!
   end
 end

--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -88,6 +88,10 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
     end
   end
 
+  if name == :simple_email_subject
+    SiteSetting::Action::SimpleEmailSubjectToggled.call(enabled: new_value)
+  end
+
   if name == :content_localization_enabled && new_value == true
     %i[post_menu post_menu_hidden_items].each do |setting_name|
       current_items = SiteSetting.get(setting_name).split("|")

--- a/config/initializers/015-track-upcoming-change-toggle.rb
+++ b/config/initializers/015-track-upcoming-change-toggle.rb
@@ -18,9 +18,7 @@ Rails.application.config.after_initialize { UpcomingChanges.clear_caches! }
 
 DiscourseEvent.on(:upcoming_change_enabled) do |setting_name|
   # Respond to event here, e.g. if setting_name == :enable_form_templates do X.
-  if setting_name == :simple_email_subject
-    SiteSetting::Action::SimpleEmailSubjectToggled.call(params: { setting_enabled: true })
-  elsif setting_name == :enable_horizon_high_context_topic_cards
+  if setting_name == :enable_horizon_high_context_topic_cards
     Themes::Action::HorizonHighContextTopicCardsToggled.call(enabled: true)
   elsif setting_name == :remove_and_replace_uncategorized
     SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.call(enabled: true)
@@ -29,9 +27,7 @@ end
 
 DiscourseEvent.on(:upcoming_change_disabled) do |setting_name|
   # Respond to event here, e.g. if setting_name == :enable_form_templates do X.
-  if setting_name == :simple_email_subject
-    SiteSetting::Action::SimpleEmailSubjectToggled.call(params: { setting_enabled: false })
-  elsif setting_name == :enable_horizon_high_context_topic_cards
+  if setting_name == :enable_horizon_high_context_topic_cards
     Themes::Action::HorizonHighContextTopicCardsToggled.call(enabled: false)
   elsif setting_name == :remove_and_replace_uncategorized
     SiteSetting::Action::RemoveAndReplaceUncategorizedToggled.call(enabled: false)

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -2089,14 +2089,6 @@ email:
   simple_email_subject:
     default: false
     client: true
-    hidden: true
-    upcoming_change:
-      status: "stable"
-      impact: "feature,all_members"
-      allow_enabled_for:
-        - everyone
-      learn_more_url: "https://meta.discourse.org/t/-/395927"
-      permanent_warning: false
   reply_by_email_enabled:
     default: false
     validator: "ReplyByEmailEnabledValidator"

--- a/spec/mailers/user_notifications_spec.rb
+++ b/spec/mailers/user_notifications_spec.rb
@@ -1000,6 +1000,10 @@ RSpec.describe UserNotifications do
       before do
         SiteSetting.group_in_subject = true
         SiteSetting.simple_email_subject = true
+
+        # Enabling simple_email_subject rewrites email_subject to a template
+        # without %{optional_pm}, which is where the group name is rendered.
+        SiteSetting.email_subject = "[%{site_name}] %{optional_pm}%{optional_cat}%{topic_title}"
       end
 
       let(:group) { Fabricate(:group, name: "my_group") }

--- a/spec/services/site_setting/action/simple_email_subject_toggled_spec.rb
+++ b/spec/services/site_setting/action/simple_email_subject_toggled_spec.rb
@@ -2,15 +2,13 @@
 
 RSpec.describe SiteSetting::Action::SimpleEmailSubjectToggled do
   describe ".call" do
-    subject(:result) { described_class.call(params:) }
+    subject(:result) { described_class.call(enabled:) }
 
     let(:default_email_subject) { SiteSetting.defaults.get(:email_subject) }
     let(:simple_email_subject) { described_class::SIMPLE_EMAIL_SUBJECT }
 
     context "when enabling" do
-      let(:params) { { setting_enabled: true } }
-
-      it { is_expected.to run_successfully }
+      let(:enabled) { true }
 
       it "updates email_subject to the simple format" do
         result
@@ -112,11 +110,9 @@ RSpec.describe SiteSetting::Action::SimpleEmailSubjectToggled do
     end
 
     context "when disabling" do
-      let(:params) { { setting_enabled: false } }
+      let(:enabled) { false }
 
       before { SiteSetting.email_subject = simple_email_subject }
-
-      it { is_expected.to run_successfully }
 
       it "resets email_subject to the default" do
         result


### PR DESCRIPTION
We want to allow users to choose between email subject formats, so we will retire this setting at `stable` and remove the associated upcoming change metadata. The site setting action was also updated to follow the convention adopted in other site setting actions by inheriting from `Service::ActionBase` and passing an `enabled` value as true/false.

I have moved the call site for this site setting toggle from track upcoming change toggle over to the track site setting initializer.