### PR TITLE
DEV: Render bool and integer site settings with FormKit

### DIFF
--- a/frontend/discourse/admin/components/site-setting.gjs
+++ b/frontend/discourse/admin/components/site-setting.gjs
@@ -1,27 +1,33 @@
 /* eslint-disable ember/no-side-effects */
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
+import { cached, tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { dependentKeyCompat } from "@ember/object/compat";
 import { getOwner } from "@ember/owner";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { LinkTo } from "@ember/routing";
+import { scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
-import { isNone } from "@ember/utils";
+import { isEmpty, isNone } from "@ember/utils";
 import SettingValidationMessage from "discourse/admin/components/setting-validation-message";
 import Description from "discourse/admin/components/site-settings/description";
 import JobStatus from "discourse/admin/components/site-settings/job-status";
 import SiteSetting, {
   isSettingValueTrue,
 } from "discourse/admin/models/site-setting";
+import linkifySettingLinks from "discourse/admin/modifiers/linkify-setting-links";
+import Form from "discourse/components/form";
 import JsonSchemaEditorModal from "discourse/components/modal/json-schema-editor";
 import PluginOutlet from "discourse/components/plugin-outlet";
+import SettingDefinitionField from "discourse/components/setting-definition-field";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { uniqueItemsFromArray } from "discourse/lib/array-tools";
 import { bind } from "discourse/lib/decorators";
 import { deepEqual } from "discourse/lib/object";
+import { resolveSettingFieldType } from "discourse/lib/setting-field-registry";
 import { sanitize } from "discourse/lib/text";
 import { splitString } from "discourse/lib/utilities";
 import { and, not } from "discourse/truth-helpers";
@@ -76,6 +82,9 @@ export default class SiteSettingComponent extends Component {
   @tracked progress = null;
   updateExistingUsers = null;
   trackChanges = true;
+  formApi = null;
+
+  #formKitData;
 
   constructor() {
     super(...arguments);
@@ -97,6 +106,19 @@ export default class SiteSettingComponent extends Component {
         `/site_setting/${this.setting.setting}/process`,
         this.onMessage
       );
+    }
+  }
+
+  @action
+  syncFormValue(_element, [wireValue]) {
+    scheduleOnce("afterRender", this, this.applyFormValue, wireValue);
+  }
+
+  applyFormValue(wireValue) {
+    const name = this.setting.setting;
+
+    if (this.toWire(this.formApi.get(name)) !== wireValue) {
+      this.formApi.set(name, this.fromWire(wireValue));
     }
   }
 
@@ -168,6 +190,10 @@ export default class SiteSettingComponent extends Component {
 
   get displayDescription() {
     return this.componentType !== "bool";
+  }
+
+  get formInlineDescription() {
+    return this.displayDescription ? null : this.setting.description;
   }
 
   get showThemeSiteSettingWarning() {
@@ -343,6 +369,23 @@ export default class SiteSettingComponent extends Component {
     return setting.type;
   }
 
+  @cached
+  get definition() {
+    return this.setting.definition;
+  }
+
+  get useFormKit() {
+    return (
+      this.trackChanges && resolveSettingFieldType(this.setting).adminReady
+    );
+  }
+
+  get formKitData() {
+    return (this.#formKitData ??= {
+      [this.setting.setting]: this.fromWire(this.setting.buffered.get("value")),
+    });
+  }
+
   get allowAny() {
     const anyValue = this.setting?.anyValue;
     return anyValue !== false;
@@ -447,8 +490,21 @@ export default class SiteSettingComponent extends Component {
   }
 
   @action
+  async submit() {
+    if (this.formApi) {
+      await this.formApi.submit();
+    } else {
+      await this.update();
+    }
+  }
+
+  @action
   async update() {
     const dirtySettings = this.dirtySettings;
+
+    if (dirtySettings.length === 0) {
+      return;
+    }
 
     for (const setting of dirtySettings) {
       if (!setting.requiresConfirmation) {
@@ -522,6 +578,46 @@ export default class SiteSettingComponent extends Component {
     if (isSettingValueTrue(value)) {
       this.adminSiteSettingStore.reveal(this.setting.setting);
     }
+  }
+
+  @action
+  registerFormApi(api) {
+    this.formApi = api;
+  }
+
+  @action
+  onFormSet(name, value) {
+    const wireValue = this.toWire(value);
+
+    if (this.setting.type === "integer" && wireValue === "") {
+      return;
+    }
+
+    this.changeValueCallback(wireValue);
+  }
+
+  toWire(value) {
+    if (this.setting.type === "bool") {
+      return isSettingValueTrue(value) ? "true" : "false";
+    }
+
+    if (this.setting.type === "integer") {
+      return isEmpty(value) ? "" : String(Math.trunc(value));
+    }
+
+    return isEmpty(value) ? "" : String(value);
+  }
+
+  fromWire(value) {
+    if (this.setting.type === "bool") {
+      return isSettingValueTrue(value);
+    }
+
+    if (this.setting.type === "integer") {
+      return isEmpty(value) ? null : parseInt(value, 10);
+    }
+
+    return value;
   }
 
   @action
@@ -650,17 +746,38 @@ export default class SiteSettingComponent extends Component {
           <Description @description={{this.setting.description}} />
           <JobStatus @status={{this.status}} @progress={{this.progress}} />
         {{else}}
-          <this.resolvedComponent
-            {{on "keydown" this._handleKeydown}}
-            @disabled={{this.isDisabled}}
-            @setting={{this.setting}}
-            @value={{this.buffered.value}}
-            @preview={{this.preview}}
-            @isSecret={{this.isSecret}}
-            @allowAny={{this.allowAny}}
-            @changeValueCallback={{this.changeValueCallback}}
-            @setValidationMessage={{this.setValidationMessage}}
-          />
+          {{#if this.useFormKit}}
+            <Form
+              @data={{this.formKitData}}
+              @onSet={{this.onFormSet}}
+              @onSubmit={{this.update}}
+              @onRegisterApi={{this.registerFormApi}}
+              {{didUpdate this.syncFormValue this.buffered.value}}
+              {{linkifySettingLinks this.formInlineDescription}}
+              as |form|
+            >
+              <SettingDefinitionField
+                @definition={{this.definition}}
+                @form={{form}}
+                @showTitle={{false}}
+                @showControlTitle={{false}}
+                @showDescription={{false}}
+                @disabled={{this.isDisabled}}
+              />
+            </Form>
+          {{else}}
+            <this.resolvedComponent
+              {{on "keydown" this._handleKeydown}}
+              @disabled={{this.isDisabled}}
+              @setting={{this.setting}}
+              @value={{this.buffered.value}}
+              @preview={{this.preview}}
+              @isSecret={{this.isSecret}}
+              @allowAny={{this.allowAny}}
+              @changeValueCallback={{this.changeValueCallback}}
+              @setValidationMessage={{this.setValidationMessage}}
+            />
+          {{/if}}
           <SettingValidationMessage
             @message={{this.setting.validationMessage}}
           />
@@ -714,7 +831,7 @@ export default class SiteSettingComponent extends Component {
       {{#if (and this.groupedDirty this.canUpdate (not @inline))}}
         <div class="setting-controls">
           <DButton
-            @action={{this.update}}
+            @action={{this.submit}}
             @icon="check"
             @isLoading={{this.disableControls}}
             @ariaLabel="admin.settings.save"

--- a/frontend/discourse/admin/components/site-settings/integer.gjs
+++ b/frontend/discourse/admin/components/site-settings/integer.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { preventDecimal } from "discourse/components/setting-field/integer";
 
 export default class SiteSettingsInteger extends Component {
   @action
@@ -17,16 +18,9 @@ export default class SiteSettingsInteger extends Component {
     this.args.changeValueCallback(num.toString());
   }
 
-  @action
-  preventDecimal(event) {
-    if (event.key === "." || event.key === ",") {
-      event.preventDefault();
-    }
-  }
-
   <template>
     <input
-      {{on "keydown" this.preventDecimal}}
+      {{on "keydown" preventDecimal}}
       {{on "input" this.updateValue}}
       type="number"
       value={{@value}}

--- a/frontend/discourse/admin/models/site-setting.js
+++ b/frontend/discourse/admin/models/site-setting.js
@@ -162,7 +162,7 @@ export default class SiteSetting extends EmberObject {
   get definition() {
     return {
       key: this.setting,
-      label: this.humanized_name,
+      label: this.humanized_name || this.setting,
       description: trustHTML(this.description),
       type: this.type,
       list_type: this.list_type,

--- a/frontend/discourse/app/components/setting-definition-field.gjs
+++ b/frontend/discourse/app/components/setting-definition-field.gjs
@@ -16,9 +16,14 @@ export default class SettingDefinitionField extends Component {
   }
 
   get description() {
-    return this.entry.includeDescription === false
-      ? undefined
-      : this.args.definition.description;
+    if (
+      this.args.showDescription === false ||
+      this.entry.includeDescription === false
+    ) {
+      return undefined;
+    }
+
+    return this.args.definition.description;
   }
 
   get format() {
@@ -33,9 +38,12 @@ export default class SettingDefinitionField extends Component {
     <@form.Field
       @name={{@definition.key}}
       @title={{@definition.label}}
+      @showTitle={{@showTitle}}
+      @showControlTitle={{@showControlTitle}}
       @description={{this.description}}
       @placeholder={{@definition.placeholder}}
       @validation={{this.validation}}
+      @disabled={{@disabled}}
       @type={{this.entry.type}}
       @format={{this.format}}
       @labelFormat={{this.entry.labelFormat}}

--- a/frontend/discourse/app/components/setting-field/integer.gjs
+++ b/frontend/discourse/app/components/setting-field/integer.gjs
@@ -1,3 +1,15 @@
+import { on } from "@ember/modifier";
+
+export function preventDecimal(event) {
+  if (event.key === "." || event.key === ",") {
+    event.preventDefault();
+  }
+}
+
 export default <template>
-  <@field.Control min={{@definition.min}} max={{@definition.max}} />
+  <@field.Control
+    min={{@definition.min}}
+    max={{@definition.max}}
+    {{on "keydown" preventDecimal}}
+  />
 </template>

--- a/frontend/discourse/app/form-kit/components/fk/control/checkbox.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/checkbox.gjs
@@ -37,14 +37,16 @@ export default class FKControlCheckbox extends FKBaseControl {
           }}</span>
       {{/if}}
       <span class="form-kit__control-checkbox-content">
-        <span class="form-kit__control-checkbox-title">
-          <span>{{or @title @field.title}}</span>
+        {{#if @field.showControlTitle}}
+          <span class="form-kit__control-checkbox-title">
+            <span>{{or @title @field.title}}</span>
 
-          {{#if @field.required}}
-            <FKRequired @field={{@field}} />
-          {{/if}}
-          <FKTooltip @field={{@field}} />
-        </span>
+            {{#if @field.required}}
+              <FKRequired @field={{@field}} />
+            {{/if}}
+            <FKTooltip @field={{@field}} />
+          </span>
+        {{/if}}
         <span class="form-kit__control-checkbox-description">{{yield}}</span>
       </span>
     </FKLabel>

--- a/frontend/discourse/app/form-kit/components/fk/control/input.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/control/input.gjs
@@ -53,11 +53,17 @@ export default class FKControlInput extends FKBaseControl {
   }
 
   get displayValue() {
-    if (this.type === "number" && this.inputValue !== undefined) {
+    const fieldValue = this.args.field.value;
+
+    if (
+      this.type === "number" &&
+      this.inputValue !== undefined &&
+      Object.is(parseFloat(this.inputValue), parseFloat(fieldValue))
+    ) {
       return this.inputValue;
     }
 
-    return this.args.field.value ?? "";
+    return fieldValue ?? "";
   }
 
   @action

--- a/frontend/discourse/app/form-kit/components/fk/field-data.gjs
+++ b/frontend/discourse/app/form-kit/components/fk/field-data.gjs
@@ -207,12 +207,22 @@ export default class FKFieldData extends Component {
   }
 
   /**
-   * Indicates whether to show the field's title.
-   * Defaults to `true`.
+   * Indicates whether to show the title rendered by the field container.
+   * Has no effect on controls that render the title themselves; see
+   * `showControlTitle`. Defaults to `true`.
    * @type {boolean}
    */
   get showTitle() {
     return this.args.showTitle ?? true;
+  }
+
+  /**
+   * Indicates whether a control that renders the field's title itself, inline
+   * in its own markup, should render it. Defaults to `true`.
+   * @type {boolean}
+   */
+  get showControlTitle() {
+    return this.args.showControlTitle ?? true;
   }
 
   /**

--- a/frontend/discourse/app/lib/setting-field-registry.js
+++ b/frontend/discourse/app/lib/setting-field-registry.js
@@ -85,11 +85,13 @@ registerSettingFieldType("bool", {
   ...INLINE,
   type: "checkbox",
   includeDescription: false,
+  adminReady: true,
   renderer: BoolControl,
 });
 registerSettingFieldType("integer", {
   ...INLINE,
   type: "input-number",
+  adminReady: true,
   renderer: IntegerControl,
 });
 registerSettingFieldType("duration", {

--- a/frontend/discourse/tests/integration/components/site-setting-test.gjs
+++ b/frontend/discourse/tests/integration/components/site-setting-test.gjs
@@ -1,3 +1,4 @@
+import { getOwner } from "@ember/owner";
 import {
   click,
   fillIn,
@@ -13,50 +14,50 @@ import SiteSetting from "discourse/admin/models/site-setting";
 import ThemeSettings from "discourse/admin/models/theme-settings";
 import ThemeSiteSettings from "discourse/admin/models/theme-site-settings";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import pretender, { response } from "discourse/tests/helpers/create-pretender";
-import { publishToMessageBus } from "discourse/tests/helpers/qunit-helpers";
+import pretender, {
+  parsePostData,
+  response,
+} from "discourse/tests/helpers/create-pretender";
+import {
+  logIn,
+  publishToMessageBus,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 import { i18n } from "discourse-i18n";
+
+function renderSetting(props) {
+  const setting = SiteSetting.create(props);
+  return render(
+    <template><SiteSettingComponent @setting={{setting}} /></template>
+  );
+}
 
 module("Integration | Component | SiteSetting", function (hooks) {
   setupRenderingTest(hooks);
 
   test("displays host-list setting value", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "blocked_onebox_domains",
-        value: "a.com|b.com",
-        type: "host_list",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "blocked_onebox_domains",
+      value: "a.com|b.com",
+      type: "host_list",
+    });
 
     assert.dom(".formatted-selection").hasText("a.com, b.com");
   });
 
   test("error response with html_message is rendered as HTML", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "test_setting",
-        value: "",
-        type: "input-setting-string",
-      })
-    );
-
     const message = "<h1>Unable to update site settings</h1>";
 
     pretender.put("/admin/site_settings/test_setting", () => {
       return response(422, { html_message: true, errors: [message] });
     });
 
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "test_setting",
+      value: "",
+      type: "input-setting-string",
+    });
     await fillIn(".setting input", "value");
     await click(".setting .d-icon-check");
 
@@ -64,24 +65,17 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("error response without html_message is not rendered as HTML", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "test_setting",
-        value: "",
-        type: "input-setting-string",
-      })
-    );
-
     const message = "<h1>Unable to update site settings</h1>";
 
     pretender.put("/admin/site_settings/test_setting", () => {
       return response(422, { errors: [message] });
     });
 
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "test_setting",
+      value: "",
+      type: "input-setting-string",
+    });
     await fillIn(".setting input", "value");
     await click(".setting .d-icon-check");
 
@@ -89,15 +83,6 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("error response with html_message discards changes", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "test_setting",
-        value: "original",
-        type: "input-setting-string",
-      })
-    );
-
     pretender.put("/admin/site_settings/test_setting", () => {
       return response(422, {
         html_message: true,
@@ -105,9 +90,11 @@ module("Integration | Component | SiteSetting", function (hooks) {
       });
     });
 
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "test_setting",
+      value: "original",
+      type: "input-setting-string",
+    });
     await fillIn(".setting input", "new value");
     await click(".setting .d-icon-check");
 
@@ -115,18 +102,11 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("displays file types list setting", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "theme_authorized_extensions",
-        value: "jpg|jpeg|png",
-        type: "file_types_list",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "theme_authorized_extensions",
+      value: "jpg|jpeg|png",
+      type: "file_types_list",
+    });
 
     assert.dom(".formatted-selection").hasText("jpg, jpeg, png");
 
@@ -144,17 +124,13 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("prevents decimal in integer setting input", async function (assert) {
-    const setting = SiteSetting.create({
+    await renderSetting({
       setting: "suggested_topics_unread_max_days_old",
       value: "",
       type: "integer",
     });
 
-    await render(
-      <template><SiteSettingComponent @setting={{setting}} /></template>
-    );
-
-    const input = document.querySelector(".input-setting-integer");
+    const input = document.querySelector("input[type='number']");
     const isPrevented = (key) => {
       const event = new KeyboardEvent("keydown", {
         key,
@@ -171,38 +147,149 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("does not consider an integer setting overridden if the value is the same as the default", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "suggested_topics_unread_max_days_old",
-        value: "99",
-        default: "99",
-        type: "integer",
-      })
-    );
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
-    await fillIn(".input-setting-integer", "90");
-    assert.dom(".input-setting-integer").hasValue("90");
-    await fillIn(".input-setting-integer", "99");
+    await renderSetting({
+      setting: "suggested_topics_unread_max_days_old",
+      value: "99",
+      default: "99",
+      type: "integer",
+    });
+    await fillIn("input[type='number']", "90");
+    assert.dom("input[type='number']").hasValue("90");
+    await fillIn("input[type='number']", "99");
     assert
       .dom("[data-setting='suggested_topics_unread_max_days_old']")
       .hasNoClass("overridden");
   });
 
+  test("integer setting renders its description below the control", async function (assert) {
+    await renderSetting({
+      setting: "test_int",
+      value: "5",
+      type: "integer",
+      description: "Some helpful text",
+    });
+    assert.dom(".setting-value .desc").hasText("Some helpful text");
+    assert
+      .dom(".form-kit__container-description")
+      .doesNotExist("the FormKit field does not render its own description");
+  });
+
+  test("submitting an unchanged setting does not trigger a save request", async function (assert) {
+    let requested = false;
+    pretender.put("/admin/site_settings/test_int", () => {
+      requested = true;
+      return response(200, {});
+    });
+    pretender.put("/admin/site_settings/bulk_update.json", () => {
+      requested = true;
+      return response(200, {});
+    });
+
+    await renderSetting({
+      setting: "test_int",
+      value: "5",
+      default: "5",
+      type: "integer",
+    });
+    await triggerEvent("form", "submit");
+
+    assert.false(requested);
+  });
+
+  test("typing in an integer setting does not remount the input", async function (assert) {
+    await renderSetting({
+      setting: "test_int",
+      value: "5",
+      default: "5",
+      type: "integer",
+    });
+
+    const input = document.querySelector("input[type='number']");
+    await fillIn(input, "42");
+
+    assert.strictEqual(document.querySelector("input[type='number']"), input);
+    assert.dom(".setting-controls__ok").exists();
+  });
+
+  test("clearing an integer setting does not mark it dirty", async function (assert) {
+    await renderSetting({
+      setting: "test_int",
+      value: "5",
+      default: "5",
+      type: "integer",
+    });
+    await fillIn("input[type='number']", "");
+
+    assert.dom(".setting-controls__ok").doesNotExist();
+  });
+
+  test("cancelling a changed integer setting reverts the input", async function (assert) {
+    await renderSetting({
+      setting: "test_int",
+      value: "90",
+      default: "90",
+      type: "integer",
+    });
+    await fillIn("input[type='number']", "50");
+    assert.dom("input[type='number']").hasValue("50");
+    await click(".setting-controls__cancel");
+    assert.dom("input[type='number']").hasValue("90");
+  });
+
+  test("resetting an overridden integer setting reverts the input", async function (assert) {
+    await renderSetting({
+      setting: "test_int",
+      value: "50",
+      default: "90",
+      type: "integer",
+    });
+    assert.dom("input[type='number']").hasValue("50");
+    await click(".setting-controls__undo");
+    assert.dom("input[type='number']").hasValue("90");
+  });
+
+  test("toggling a bool setting on and saving persists the wire value", async function (assert) {
+    let body;
+    pretender.put("/admin/site_settings/test_bool", (request) => {
+      body = parsePostData(request.requestBody);
+      return response(200, {});
+    });
+
+    await renderSetting({
+      setting: "test_bool",
+      value: "false",
+      default: "false",
+      type: "bool",
+    });
+    await click("input[type='checkbox']");
+    await click(".setting-controls__ok");
+
+    assert.strictEqual(body.test_bool, "true");
+  });
+
+  test("rewrites setting links in a bool setting description", async function (assert) {
+    logIn(getOwner(this));
+    updateCurrentUser({ admin: true });
+
+    await renderSetting({
+      setting: "test_bool",
+      value: "false",
+      type: "bool",
+      description:
+        '<a class="site-setting-link" href="/admin/site_settings/category/all_results?filter=title" data-setting-name="title" data-setting-area="about">Title</a>',
+    });
+
+    assert
+      .dom("a.site-setting-link")
+      .hasAttribute("href", "/admin/config/about?filter=title");
+  });
+
   test("Input for secret site setting is hidden by default", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "test_setting",
-        secret: true,
-        value: "foo",
-      })
-    );
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "test_setting",
+      secret: true,
+      value: "foo",
+    });
     assert.dom(".input-setting-string").hasAttribute("type", "password");
     assert.dom(".setting-toggle-secret svg").hasClass("d-icon-far-eye");
     await click(".setting-toggle-secret");
@@ -214,19 +301,12 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("shows link to the staff action logs for the setting on hover", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "enable_badges",
-        value: "false",
-        default: "true",
-        type: "bool",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "enable_badges",
+      value: "false",
+      default: "true",
+      type: "bool",
+    });
 
     await triggerEvent("[data-setting='enable_badges']", "mouseenter");
 
@@ -240,18 +320,11 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("Shows update status for default_categories_* site settings", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "default_categories_test",
-        value: "",
-        type: "category_list",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "default_categories_test",
+      value: "",
+      type: "category_list",
+    });
 
     await publishToMessageBus("/site_setting/default_categories_test/process", {
       status: "enqueued",
@@ -274,18 +347,11 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("Shows update status for default_tags_* site settings", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "default_tags_test",
-        value: "",
-        type: "tag_list",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "default_tags_test",
+      value: "",
+      type: "tag_list",
+    });
 
     await publishToMessageBus("/site_setting/default_tags_test/process", {
       status: "enqueued",
@@ -307,18 +373,11 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("Doesn't shows update status for other site settings besides default_tags_test or default_categories_test", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "default_test",
-        value: "",
-        type: "tag_list",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "default_test",
+      value: "",
+      type: "tag_list",
+    });
 
     await publishToMessageBus("/site_setting/default_tags_test/process", {
       status: "enqueued",
@@ -332,18 +391,11 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("doesn't listen for job progress on unrelated settings", async function (assert) {
-    this.set(
-      "setting",
-      SiteSetting.create({
-        setting: "title",
-        value: "",
-        type: "string",
-      })
-    );
-
-    await render(
-      <template><SiteSettingComponent @setting={{this.setting}} /></template>
-    );
+    await renderSetting({
+      setting: "title",
+      value: "",
+      type: "string",
+    });
 
     await publishToMessageBus("/site_setting/title/process", {
       status: "enqueued",
@@ -413,7 +465,7 @@ module("Integration | Component | SiteSetting", function (hooks) {
   });
 
   test("doesn't display the save/cancel buttons when the selected value is returned to the current value", async function (assert) {
-    const setting = SiteSetting.create({
+    await renderSetting({
       setting: "some_enum",
       value: "2",
       default: "1",
@@ -423,10 +475,6 @@ module("Integration | Component | SiteSetting", function (hooks) {
         { name: "Option 2", value: 2 },
       ],
     });
-
-    await render(
-      <template><SiteSettingComponent @setting={{setting}} /></template>
-    );
 
     const selector = selectKit(".select-kit");
 
@@ -467,19 +515,12 @@ module(
         { theme_id: 5, default: true, name: "Default Theme" },
       ]);
 
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "test_themeable_setting",
-          value: "test value",
-          type: "string",
-          themeable: true,
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        setting: "test_themeable_setting",
+        value: "test value",
+        type: "string",
+        themeable: true,
+      });
 
       assert.dom(".input-setting-string").hasAttribute("disabled", "");
       assert
@@ -493,19 +534,12 @@ module(
         { theme_id: 5, default: true, name: "Default Theme" },
       ]);
 
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "test_themeable_setting",
-          value: "test value",
-          type: "string",
-          themeable: true,
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        setting: "test_themeable_setting",
+        value: "test value",
+        type: "string",
+        themeable: true,
+      });
 
       assert
         .dom(".setting-theme-warning")
@@ -528,20 +562,13 @@ module(
     });
 
     test("shows notice for settings that depend on another setting", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "dependent_setting",
-          value: "1",
-          type: "integer",
-          depends_on: ["parent_setting"],
-          depends_on_humanized_names: ["Parent setting"],
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        setting: "dependent_setting",
+        value: "1",
+        type: "integer",
+        depends_on: ["parent_setting"],
+        depends_on_humanized_names: ["Parent setting"],
+      });
 
       assert
         .dom(".setting-depends-on-notice")
@@ -561,18 +588,11 @@ module(
     });
 
     test("does not show the depends_on notice when setting has no dependencies", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "plain_setting",
-          value: "1",
-          type: "integer",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        setting: "plain_setting",
+        value: "1",
+        type: "integer",
+      });
 
       assert.dom(".setting-depends-on-notice").doesNotExist();
     });
@@ -584,62 +604,31 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
 
-    test("shows the reset button when the value has been changed from the default", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "2048",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
+    function renderMaxImageSizeSetting(value) {
+      return renderSetting({
+        setting: "max_image_size_kb",
+        value,
+        default: "1024",
+        min: 512,
+        max: 4096,
+        type: "file_size_restriction",
+      });
+    }
 
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+    test("shows the reset button when the value has been changed from the default", async function (assert) {
+      await renderMaxImageSizeSetting("2048");
       assert.dom(".setting-controls__undo").exists("reset button is shown");
     });
 
     test("doesn't show the reset button when the value is the same as the default", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "1024",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderMaxImageSizeSetting("1024");
       assert
         .dom(".setting-controls__undo")
         .doesNotExist("reset button is not shown");
     });
 
     test("shows validation error when the value exceeds the max limit", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "1024",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderMaxImageSizeSetting("1024");
       await fillIn(".file-size-input", "5000");
 
       assert.dom(".validation-error").hasText(
@@ -653,21 +642,7 @@ module(
     });
 
     test("shows validation error when the value is below the min limit", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "1000",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderMaxImageSizeSetting("1000");
       await fillIn(".file-size-input", "100");
 
       assert.dom(".validation-error").hasText(
@@ -681,21 +656,7 @@ module(
     });
 
     test("cancelling pending changes resets the value and removes validation error", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "1000",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderMaxImageSizeSetting("1000");
 
       await fillIn(".file-size-input", "100");
       assert.dom(".validation-error").hasNoClass("hidden");
@@ -708,21 +669,7 @@ module(
     });
 
     test("resetting to the default value changes the content of input field", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "1000",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderMaxImageSizeSetting("1000");
       assert
         .dom(".file-size-input")
         .hasValue("1000", "the input field contains the custom value");
@@ -742,19 +689,12 @@ module(
     });
 
     test("resetting to the default value changes the content of checkbox field", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "test_setting",
-          value: "true",
-          default: "false",
-          type: "bool",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        setting: "test_setting",
+        value: "true",
+        default: "false",
+        type: "bool",
+      });
       assert
         .dom("input[type=checkbox]")
         .isChecked("the checkbox contains the custom value");
@@ -774,21 +714,7 @@ module(
     });
 
     test("clearing the input field keeps the cancel button and the validation error shown", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          setting: "max_image_size_kb",
-          value: "1000",
-          default: "1024",
-          min: 512,
-          max: 4096,
-          type: "file_size_restriction",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderMaxImageSizeSetting("1000");
 
       await fillIn(".file-size-input", "100");
       assert.dom(".validation-error").hasNoClass("hidden");
@@ -825,25 +751,18 @@ module(
     ];
 
     test("base_font sets body-font-X classNames on each field choice", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          category: "",
-          choices: fonts,
-          default: "",
-          description: "Base font",
-          placeholder: null,
-          preview: null,
-          secret: false,
-          setting: "base_font",
-          type: "font_list",
-          value: "arial",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        category: "",
+        choices: fonts,
+        default: "",
+        description: "Base font",
+        placeholder: null,
+        preview: null,
+        secret: false,
+        setting: "base_font",
+        type: "font_list",
+        value: "arial",
+      });
       const fontSelector = selectKit(".font-selector");
       await fontSelector.expand();
 
@@ -857,25 +776,18 @@ module(
     });
 
     test("heading_font sets heading-font-X classNames on each field choice", async function (assert) {
-      this.set(
-        "setting",
-        SiteSetting.create({
-          category: "",
-          choices: fonts,
-          default: "",
-          description: "Heading font",
-          placeholder: null,
-          preview: null,
-          secret: false,
-          setting: "heading_font",
-          type: "font_list",
-          value: "arial",
-        })
-      );
-
-      await render(
-        <template><SiteSettingComponent @setting={{this.setting}} /></template>
-      );
+      await renderSetting({
+        category: "",
+        choices: fonts,
+        default: "",
+        description: "Heading font",
+        placeholder: null,
+        preview: null,
+        secret: false,
+        setting: "heading_font",
+        type: "font_list",
+        value: "arial",
+      });
       const fontSelector = selectKit(".font-selector");
       await fontSelector.expand();
 
@@ -923,7 +835,7 @@ module(
       assert
         .dom("[data-setting='child_value']")
         .hasClass("disabled-by-dependency");
-      assert.dom(".input-setting-integer").hasAttribute("disabled");
+      assert.dom("input[type='number']").hasAttribute("disabled");
     });
 
     test("child renders enabled when parent is truthy", async function (assert) {
@@ -937,7 +849,7 @@ module(
       assert
         .dom("[data-setting='child_value']")
         .hasNoClass("disabled-by-dependency");
-      assert.dom(".input-setting-integer").doesNotHaveAttribute("disabled");
+      assert.dom("input[type='number']").doesNotHaveAttribute("disabled");
     });
 
     test("toggling parent reactively flips child disabled and latches revealed", async function (assert) {

--- a/spec/system/admin_site_setting_requires_confirmation_spec.rb
+++ b/spec/system/admin_site_setting_requires_confirmation_spec.rb
@@ -29,6 +29,12 @@ describe "Admin Site Setting Requires Confirmation" do
     expect(settings_page).to have_overridden_setting("min_password_length", value: 12)
   end
 
+  it "shows the confirmation when submitting the change with the Enter key" do
+    settings_page.visit("min_password_length")
+    settings_page.submit_setting_with_keyboard("min_password_length", 12)
+    expect(dialog).to be_open
+  end
+
   it "does not save the new setting value if the admin cancels confirmation" do
     settings_page.visit("min_password_length")
     settings_page.change_number_setting("min_password_length", 12)

--- a/spec/system/admin_upcoming_changes_spec.rb
+++ b/spec/system/admin_upcoming_changes_spec.rb
@@ -572,13 +572,9 @@ describe "Admin upcoming changes" do
         old_default: false,
         new_default: true,
       )
-      expect(
-        settings_page.find_setting(:limit_suggested_to_category).find(
-          ".setting-value input[type=checkbox]",
-        ),
-      ).to be_checked
+      expect(settings_page.bool_setting_checkbox(:limit_suggested_to_category)).to be_checked
 
-      settings_page.toggle_setting(:limit_suggested_to_category)
+      settings_page.toggle_bool_setting(:limit_suggested_to_category)
 
       # Wait for the save to land in the DB before forcing the in-process
       # SiteSetting refresh below — the .overridden class only appears once
@@ -601,11 +597,7 @@ describe "Admin upcoming changes" do
         old_default: false,
         new_default: true,
       )
-      expect(
-        settings_page.find_setting(:limit_suggested_to_category).find(
-          ".setting-value input[type=checkbox]",
-        ),
-      ).not_to be_checked
+      expect(settings_page.bool_setting_checkbox(:limit_suggested_to_category)).not_to be_checked
     end
   end
 end

--- a/spec/system/page_objects/pages/admin_site_settings.rb
+++ b/spec/system/page_objects/pages/admin_site_settings.rb
@@ -74,8 +74,18 @@ module PageObjects
 
       def toggle_bool_setting(setting_name)
         setting = find_setting(setting_name)
-        setting.find(".setting-value input[type='checkbox']").click
+        PageObjects::Components::FormKitField.new(setting.find(".form-kit__field")).toggle
         save_setting(setting)
+      end
+
+      def bool_setting_checkbox(setting_name)
+        find_setting(setting_name).find(".setting-value input[type=checkbox]", visible: :all)
+      end
+
+      def submit_setting_with_keyboard(setting_name, value)
+        input = find_setting(setting_name).find(".form-kit__field input")
+        input.fill_in(with: value)
+        input.send_keys(:enter)
       end
 
       def change_number_setting(setting_name, value, save_changes = true)
@@ -171,7 +181,7 @@ module PageObjects
       end
 
       def has_disabled_input?(setting_name)
-        find_setting(setting_name).has_css?("input[disabled]")
+        find_setting(setting_name).has_css?("input[disabled]", visible: :all)
       end
 
       def has_visible_reorder_buttons?(setting_name)


### PR DESCRIPTION
Previously, the admin site settings page rendered every setting with bespoke per-type controls layered on a buffered proxy, separate from the shared FormKit field infrastructure (`SettingDefinitionField` and the setting-field registry) that category-type and plugin settings already use.

This change renders `bool` and `integer` settings through that shared infrastructure — gated per-type by an `adminReady` registry flag so the remaining types keep their current controls until they are converted in turn — by wrapping each row's control in a single-field `<Form>` whose `@onSet` writes back into the existing buffered proxy, so dirty tracking, the changes banner, and the route guard keep working unchanged. It also fixes two latent issues it surfaced: pressing Enter now submits through the row's full save path (including the confirmation dialog) instead of bypassing it, and `FKControlInput` no longer keeps a stale raw-text buffer that stopped Cancel and Reset from reverting a number field.
