### PR TITLE
SECURITY: Stale featured rows expose unlisted topic content

### DIFF
--- a/app/models/category_list.rb
+++ b/app/models/category_list.rb
@@ -81,6 +81,7 @@ class CategoryList
           include_uncategorized: false,
         ) # perf optimization since category featured topics can't have `category_id` set to null
         .listable_topics
+        .visible
         .joins(
           "INNER JOIN category_featured_topics ON topics.id = category_featured_topics.topic_id",
         )

--- a/app/services/user_silencer.rb
+++ b/app/services/user_silencer.rb
@@ -90,7 +90,10 @@ class UserSilencer
         .where(user_id: @user.id, post_number: 1)
         .where("created_at > ?", 24.hours.ago)
         .pluck(:topic_id)
-    Topic.where(id: topic_ids).update_all(visible: false) unless topic_ids.empty?
+    unless topic_ids.empty?
+      Topic.where(id: topic_ids).update_all(visible: false)
+      CategoryFeaturedTopic.where(topic_id: topic_ids).delete_all
+    end
   end
 
   def unsilence

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -66,6 +66,21 @@ RSpec.describe CategoriesController do
       )
     end
 
+    it "omits invisible topics with stale featured rows", :aggregate_failures do
+      topic = Fabricate(:topic, category: category)
+      CategoryFeaturedTopic.create!(category: category, topic: topic)
+      topic.update_column(:visible, false)
+
+      get "/categories.json?include_topics=true"
+
+      expect(response).to have_http_status(:ok)
+      category_response =
+        response.parsed_body["category_list"]["categories"].find do |category_json|
+          category_json["id"] == category.id
+        end
+      expect(category_response).not_to have_key("topics")
+    end
+
     it "does not returns subcategories without permission" do
       subcategory = Fabricate(:category, user: admin, parent_category: category)
       subcategory.set_permissions(admins: :full)

--- a/spec/services/user_silencer_spec.rb
+++ b/spec/services/user_silencer_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe UserSilencer do
       expect(count).to eq(1)
     end
 
+    it "removes featured rows for hidden topics" do
+      CategoryFeaturedTopic.create!(category: post.topic.category, topic: post.topic)
+
+      expect { UserSilencer.silence(user, admin) }.to change {
+        CategoryFeaturedTopic.exists?(topic_id: post.topic_id)
+      }.from(true).to(false)
+    end
+
     it "skips sending the email for the silence PM via post alert" do
       NotificationEmailer.enable
       Jobs.run_immediately!


### PR DESCRIPTION
## Summary

Prevent the exposure of unlisted topic metadata in the categories response by enforcing live visibility checks on featured topics. Additionally, the UserSilencer service now correctly removes featured topic records when bulk-hiding topics from new users, ensuring stale records do not bypass visibility constraints.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1427

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>