### PR TITLE
DEV: Do not seed TOS and Privacy topics even if company_name is present

### DIFF
--- a/config/initializers/014-track-setting-changes.rb
+++ b/config/initializers/014-track-setting-changes.rb
@@ -56,20 +56,6 @@ DiscourseEvent.on(:site_setting_changed) do |name, old_value, new_value|
   if %i[title site_description].include?(name)
     topics = SeedData::Topics.with_default_locale
     topics.update(site_setting_names: ["welcome_topic_id"], skip_changed: true)
-  elsif %i[company_name contact_email governing_law city_for_disputes].include?(name)
-    topics = SeedData::Topics.with_default_locale
-    %w[tos_topic_id privacy_topic_id].each do |site_setting|
-      topic_id = SiteSetting.get(site_setting)
-      if topic_id > 0 && Topic.with_deleted.exists?(id: topic_id)
-        if SiteSetting.company_name.blank?
-          topics.delete(site_setting_names: [site_setting], skip_changed: true)
-        else
-          topics.update(site_setting_names: [site_setting], skip_changed: true)
-        end
-      elsif SiteSetting.company_name.present?
-        topics.create(site_setting_names: [site_setting])
-      end
-    end
   end
 
   Theme.expire_site_cache! if name == :default_theme_id

--- a/lib/seed_data/topics.rb
+++ b/lib/seed_data/topics.rb
@@ -10,12 +10,11 @@ module SeedData
       @locale = locale
     end
 
-    def create(site_setting_names: nil, include_welcome_topics: true, include_legal_topics: false)
+    def create(site_setting_names: nil, include_welcome_topics: true)
       I18n.with_locale(@locale) do
         topics(
           site_setting_names: site_setting_names,
           include_welcome_topics: include_welcome_topics,
-          include_legal_topics: include_legal_topics || SiteSetting.company_name.present?,
         ).each { |params| create_topic(**params) }
       end
     end
@@ -57,7 +56,6 @@ module SeedData
     def topics(
       site_setting_names: nil,
       include_welcome_topics: true,
-      include_legal_topics: true,
       require_existing_categories: true
     )
       general_category = Category.find_by(id: SiteSetting.general_category_id)
@@ -67,25 +65,6 @@ module SeedData
         feedback_category ? "##{feedback_category.slug}" : "#site-feedback"
 
       topics = []
-
-      # Terms of Service
-      if include_legal_topics
-        topics << {
-          site_setting_name: "tos_topic_id",
-          title: I18n.t("tos_topic.title"),
-          raw:
-            I18n.t(
-              "tos_topic.body",
-              company_name: setting_value("company_name"),
-              base_url: Discourse.base_url,
-              contact_email: setting_value("contact_email"),
-              governing_law: setting_value("governing_law"),
-              city_for_disputes: setting_value("city_for_disputes"),
-            ),
-          category: staff_category,
-          static_first_reply: true,
-        }
-      end
 
       # FAQ/Guidelines
       topics << {
@@ -110,17 +89,6 @@ module SeedData
         category: staff_category,
         static_first_reply: true,
       }
-
-      # Privacy Policy
-      if include_legal_topics
-        topics << {
-          site_setting_name: "privacy_topic_id",
-          title: I18n.t("privacy_topic.title"),
-          raw: I18n.t("privacy_topic.body"),
-          category: staff_category,
-          static_first_reply: true,
-        }
-      end
 
       if include_welcome_topics
         # Welcome Topic
@@ -254,10 +222,6 @@ module SeedData
     def unchanged?(post)
       post.last_editor_id == Discourse::SYSTEM_USER_ID &&
         (!post.deleted_by_id || post.deleted_by_id == Discourse::SYSTEM_USER_ID)
-    end
-
-    def setting_value(site_setting_key)
-      SiteSetting.get(site_setting_key).presence || "<ins>#{site_setting_key}</ins>"
     end
 
     def first_reply(post)

--- a/spec/initializers/track_setting_changes_spec.rb
+++ b/spec/initializers/track_setting_changes_spec.rb
@@ -87,29 +87,10 @@ RSpec.describe "Setting changes" do
   end
 
   describe "#company_name" do
-    it "creates the TOS and Privacy topics" do
-      expect { SiteSetting.company_name = "Company Name" }.to change { Topic.count }.by(
-        2,
-      ).and change { SiteSetting.tos_topic_id }.and change { SiteSetting.privacy_topic_id }
-    end
-
-    it "creates, updates and deletes the topic" do
-      # Topic is created
-      expect { SiteSetting.company_name = "Company Name" }.to change { Topic.count }.by(2)
-      topic = Topic.find(SiteSetting.tos_topic_id)
-      first_post = topic.first_post
-      expect(first_post.raw).to include("Company Name")
-
-      # Topic is edited
-      expect { SiteSetting.company_name = "Other Name" }.not_to change { Topic.count }
-      expect(first_post.reload.raw).to include("Other Name")
-
-      # Topic can be deleted
-      expect { SiteSetting.company_name = "" }.to change { Topic.count }.by(-2)
-
-      # Topic can be recovered and edited
-      SiteSetting.company_name = "New Name"
-      expect(first_post.reload.raw).to include("New Name")
+    it "does not seed legal topics" do
+      expect { SiteSetting.company_name = "Company Name" }.to not_change {
+        Topic.count
+      }.and not_change { SiteSetting.tos_topic_id }.and not_change { SiteSetting.privacy_topic_id }
     end
   end
 end

--- a/spec/lib/seed_data/topics_spec.rb
+++ b/spec/lib/seed_data/topics_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SeedData::Topics do
   end
 
   def create_topic(name = "welcome_topic_id")
-    seeder.create(site_setting_names: [name], include_legal_topics: true)
+    seeder.create(site_setting_names: [name])
   end
 
   describe "#create" do
@@ -47,7 +47,7 @@ RSpec.describe SeedData::Topics do
       staff_category = Fabricate(:category, name: "Staff")
       SiteSetting.staff_category_id = staff_category.id
 
-      expect { create_topic("privacy_topic_id") }.to change { Topic.count }.by(1).and change {
+      expect { create_topic("guidelines_topic_id") }.to change { Topic.count }.by(1).and change {
               Post.count
             }.by(2)
 
@@ -77,7 +77,9 @@ RSpec.describe SeedData::Topics do
       expect { create_topic }.to_not change { Topic.count }
     end
 
-    it "does not create a legal topic if company_name is not set" do
+    it "does not create a legal topic when company_name is set" do
+      SiteSetting.company_name = "Company Name"
+
       seeder.create(site_setting_names: ["tos_topic_id"])
 
       expect(SiteSetting.tos_topic_id).to eq(-1)
@@ -110,13 +112,6 @@ RSpec.describe SeedData::Topics do
       post = Post.find_by(topic_id: SiteSetting.welcome_topic_id, post_number: 1)
       expect(post.raw).to include("> ## My Awesome Community")
       expect(post.raw).to include("> The best community")
-    end
-
-    it "creates a legal topic if company_name is set" do
-      SiteSetting.company_name = "Company Name"
-      seeder.create(site_setting_names: ["tos_topic_id"])
-
-      expect(SiteSetting.tos_topic_id).to_not eq(-1)
     end
 
     it "creates FAQ topic" do
@@ -163,17 +158,15 @@ RSpec.describe SeedData::Topics do
     end
 
     it "updates an existing first reply when `static_first_reply` is true" do
-      create_topic("privacy_topic_id")
+      create_topic("guidelines_topic_id")
 
       post = Post.last
       post.revise(Discourse.system_user, raw: "New text of first reply.")
 
-      update_topic("privacy_topic_id")
+      update_topic("guidelines_topic_id")
       post.reload
 
-      expect(post.raw).to eq(
-        I18n.t("static_topic_first_reply", page_name: I18n.t("privacy_topic.title")).rstrip,
-      )
+      expect(post.raw).to eq(I18n.t("static_topic_first_reply", page_name: post.topic.title).rstrip)
     end
 
     it "does not update a change topic and `skip_changed` is true" do


### PR DESCRIPTION
- Removed TOS and Privacy Policy from seeded topics, regardless of company_name.
- Removed the company_name/legal-details setting callback that created and maintained those topics.
- Updated focused regression specs.