### PR TITLE
UX: fix /categories page tag alignment

### DIFF
--- a/app/assets/stylesheets/common/base/categories-topic-list.scss
+++ b/app/assets/stylesheets/common/base/categories-topic-list.scss
@@ -67,6 +67,7 @@
     .bottom-row {
       display: flex;
       flex-wrap: wrap;
+      align-items: baseline;
       gap: 0 0.5em;
     }
   }


### PR DESCRIPTION
Fixes a minor misalignment on the "categories with latest/top topics" layouts

before
<img width="600" alt="image" src="https://github.com/user-attachments/assets/52ae69c5-8d66-43c1-918f-3cadb2600e8a" />


after
<img width="600" alt="image" src="https://github.com/user-attachments/assets/5af552cf-f57e-4ea9-94ba-ab990ed4b95d" />


