### PR TITLE
FEATURE: Allow custom Telegram API base URL

### DIFF
--- a/plugins/discourse-chat-integration/config/locales/client.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/client.en.yml
@@ -138,6 +138,8 @@ en:
             webhook_setup_failed: "Could not register the webhook with Telegram. Check the token and try again."
             channel_not_found: "The specified channel does not exist on Telegram"
             forbidden: "The bot does not have permission to post to this channel"
+            invalid_api_base_url: "The Telegram API base URL site setting is not a valid HTTPS URL."
+            api_base_url_blocked: "Requests to the Telegram API base URL were blocked. Hosts on private networks must be added to the allowed internal hosts site setting."
 
         #######################################
         ########### DISCORD STRINGS ###########

--- a/plugins/discourse-chat-integration/config/locales/server.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/server.en.yml
@@ -18,12 +18,14 @@ en:
 
     errors:
       chat_integration_slack_api_configs_are_empty: "You must enter either an outbound webhook URL, or an access token"
+      chat_integration_telegram_api_base_url_invalid: "The Telegram API base URL must be a valid HTTPS URL without credentials, a query string, or a fragment"
 
     #######################################
     ######### TELEGRAM SETTINGS ###########
     #######################################
     chat_integration_telegram_enabled: "Enable the Telegram chat-integration provider"
     chat_integration_telegram_access_token: "Your bot's access token from the Telegram botfather"
+    chat_integration_telegram_api_base_url: "Base URL used for Telegram Bot API requests. Change this only when routing requests through a trusted proxy."
     chat_integration_telegram_excerpt_length: "Telegram post excerpt length"
     chat_integration_telegram_enable_slash_commands: "Allow telegram subscriptions to be managed using 'slash commands'"
 

--- a/plugins/discourse-chat-integration/config/locales/server.en.yml
+++ b/plugins/discourse-chat-integration/config/locales/server.en.yml
@@ -25,7 +25,7 @@ en:
     #######################################
     chat_integration_telegram_enabled: "Enable the Telegram chat-integration provider"
     chat_integration_telegram_access_token: "Your bot's access token from the Telegram botfather"
-    chat_integration_telegram_api_base_url: "Base URL used for Telegram Bot API requests. Change this only when routing requests through a trusted proxy."
+    chat_integration_telegram_api_base_url: "Base URL used for Telegram Bot API requests. Change this only when routing requests through a trusted HTTPS proxy. Hosts on private networks must also be added to the allowed internal hosts site setting."
     chat_integration_telegram_excerpt_length: "Telegram post excerpt length"
     chat_integration_telegram_enable_slash_commands: "Allow telegram subscriptions to be managed using 'slash commands'"
 

--- a/plugins/discourse-chat-integration/config/settings.yml
+++ b/plugins/discourse-chat-integration/config/settings.yml
@@ -40,6 +40,9 @@ chat_integration:
   chat_integration_telegram_access_token:
     default: ''
     secret: true
+  chat_integration_telegram_api_base_url:
+    default: 'https://api.telegram.org'
+    validator: "ChatIntegrationTelegramApiBaseUrlSettingValidator"
   chat_integration_telegram_excerpt_length:
     default: 400
   chat_integration_telegram_enable_slash_commands:

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator.rb
@@ -1,23 +1,12 @@
 # frozen_string_literal: true
 
-require "uri"
-
 class ChatIntegrationTelegramApiBaseUrlSettingValidator
   def initialize(opts = {})
     @opts = opts
   end
 
-  def self.valid_value?(value)
-    uri = URI(value)
-
-    uri.is_a?(URI::HTTPS) && uri.host.present? && uri.userinfo.blank? && uri.query.blank? &&
-      uri.fragment.blank?
-  rescue URI::Error, TypeError
-    false
-  end
-
   def valid_value?(value)
-    self.class.valid_value?(value)
+    DiscourseChatIntegration::Provider::TelegramProvider.parse_base_url(value).present?
   end
 
   def error_message

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "uri"
+
+class ChatIntegrationTelegramApiBaseUrlSettingValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def self.valid_value?(value)
+    uri = URI(value)
+
+    uri.is_a?(URI::HTTPS) && uri.host.present? && uri.userinfo.blank? && uri.query.blank? &&
+      uri.fragment.blank?
+  rescue URI::Error, TypeError
+    false
+  end
+
+  def valid_value?(value)
+    self.class.valid_value?(value)
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.chat_integration_telegram_api_base_url_invalid")
+  end
+end

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_command_controller.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_command_controller.rb
@@ -13,6 +13,16 @@ module DiscourseChatIntegration::Provider::TelegramProvider
                        only: :command
 
     def command
+      send_reply
+
+      # Always give telegram a success message, otherwise we'll stop receiving webhooks
+      data = { success: true }
+      render json: data
+    end
+
+    private
+
+    def send_reply
       # If it's a new message (telegram also sends hooks for other reasons that we don't care about)
       if params.key?("message")
         chat_id = params["message"]["chat"]["id"]
@@ -48,13 +58,9 @@ module DiscourseChatIntegration::Provider::TelegramProvider
 
         DiscourseChatIntegration::Provider::TelegramProvider.sendMessage(message)
       end
-
-      # Always give telegram a success message, otherwise we'll stop receiving webhooks
-      data = { success: true }
-      render json: data
+    rescue DiscourseChatIntegration::ProviderError => e
+      Rails.logger.warn("Failed to send telegram command reply: #{e.info.to_json}")
     end
-
-    private
 
     def process_command(message)
       return unless message["text"] # No command to be processed

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -82,12 +82,18 @@ module DiscourseChatIntegration
       end
 
       def self.do_api_request(method_name, message, access_token: nil)
-        http = FinalDestination::HTTP.new("api.telegram.org", 443)
-        http.use_ssl = true
-
         token = access_token.presence || SiteSetting.chat_integration_telegram_access_token
+        api_base_url = SiteSetting.chat_integration_telegram_api_base_url
 
-        uri = URI("https://api.telegram.org/bot#{token}/#{method_name}")
+        if !ChatIntegrationTelegramApiBaseUrlSettingValidator.valid_value?(api_base_url)
+          raise URI::InvalidURIError, "Invalid Telegram API base URL"
+        end
+
+        uri = URI(api_base_url)
+        uri.path = "#{uri.path.sub(%r{/+\z}, "")}/bot#{token}/#{method_name}"
+
+        http = FinalDestination::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == "https")
 
         req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
         req.body = message.to_json

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/telegram/telegram_provider.rb
@@ -81,23 +81,47 @@ module DiscourseChatIntegration
         do_api_request("sendMessage", message)
       end
 
+      def self.parse_base_url(value)
+        uri = URI(value)
+
+        if uri.is_a?(URI::HTTPS) && uri.host.present? && uri.userinfo.blank? && uri.query.blank? &&
+             uri.fragment.blank?
+          uri
+        end
+      rescue URI::Error, TypeError
+        nil
+      end
+
       def self.do_api_request(method_name, message, access_token: nil)
         token = access_token.presence || SiteSetting.chat_integration_telegram_access_token
-        api_base_url = SiteSetting.chat_integration_telegram_api_base_url
 
-        if !ChatIntegrationTelegramApiBaseUrlSettingValidator.valid_value?(api_base_url)
-          raise URI::InvalidURIError, "Invalid Telegram API base URL"
+        uri = parse_base_url(SiteSetting.chat_integration_telegram_api_base_url)
+
+        if uri.nil?
+          raise DiscourseChatIntegration::ProviderError.new(
+                  info: {
+                    error_key: "chat_integration.provider.telegram.errors.invalid_api_base_url",
+                  },
+                )
         end
 
-        uri = URI(api_base_url)
-        uri.path = "#{uri.path.sub(%r{/+\z}, "")}/bot#{token}/#{method_name}"
+        uri.path = File.join(uri.path, "bot#{token}", method_name)
 
         http = FinalDestination::HTTP.new(uri.host, uri.port)
-        http.use_ssl = (uri.scheme == "https")
+        http.use_ssl = true
 
         req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
         req.body = message.to_json
-        response = http.request(req)
+
+        begin
+          response = http.request(req)
+        rescue FinalDestination::SSRFDetector::DisallowedIpError
+          raise DiscourseChatIntegration::ProviderError.new(
+                  info: {
+                    error_key: "chat_integration.provider.telegram.errors.api_base_url_blocked",
+                  },
+                )
+        end
 
         JSON.parse(response.body)
       end

--- a/plugins/discourse-chat-integration/plugin.rb
+++ b/plugins/discourse-chat-integration/plugin.rb
@@ -20,6 +20,7 @@ end
 
 # Site setting validators must be loaded before initialize
 require_relative "lib/discourse_chat_integration/provider/slack/slack_enabled_setting_validator"
+require_relative "lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator"
 require_relative "lib/discourse_chat_integration/chat_integration_reference_post"
 
 after_initialize do

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator_spec.rb
@@ -3,26 +3,29 @@
 RSpec.describe ChatIntegrationTelegramApiBaseUrlSettingValidator do
   subject(:validator) { described_class.new }
 
-  it "accepts HTTPS base URLs" do
-    valid_urls = %w[
-      https://api.telegram.org
-      https://telegram.example.com/
-      https://telegram.example.com/api
-    ]
+  describe "#valid_value?" do
+    it "accepts HTTPS base URLs" do
+      valid_urls = %w[
+        https://api.telegram.org
+        https://telegram.example.com/
+        https://telegram.example.com/api
+      ]
 
-    expect(valid_urls.map { |url| validator.valid_value?(url) }).to all(be(true))
-  end
+      expect(valid_urls.select { |url| validator.valid_value?(url) }).to eq(valid_urls)
+    end
 
-  it "rejects unsafe or malformed base URLs" do
-    invalid_urls = [
-      "http://telegram.example.com",
-      "https:///telegram",
-      "https://user:password@telegram.example.com",
-      "https://telegram.example.com/?route=telegram",
-      "https://telegram.example.com/#telegram",
-      "not a URL",
-    ]
+    it "rejects unsafe or malformed base URLs" do
+      invalid_urls = [
+        "http://telegram.example.com",
+        "https:///telegram",
+        "https://user:password@telegram.example.com",
+        "https://telegram.example.com/?route=telegram",
+        "https://telegram.example.com/#telegram",
+        "not a URL",
+        "",
+      ]
 
-    expect(invalid_urls.map { |url| validator.valid_value?(url) }).to all(be(false))
+      expect(invalid_urls.reject { |url| validator.valid_value?(url) }).to eq(invalid_urls)
+    end
   end
 end

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_api_base_url_setting_validator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe ChatIntegrationTelegramApiBaseUrlSettingValidator do
+  subject(:validator) { described_class.new }
+
+  it "accepts HTTPS base URLs" do
+    valid_urls = %w[
+      https://api.telegram.org
+      https://telegram.example.com/
+      https://telegram.example.com/api
+    ]
+
+    expect(valid_urls.map { |url| validator.valid_value?(url) }).to all(be(true))
+  end
+
+  it "rejects unsafe or malformed base URLs" do
+    invalid_urls = [
+      "http://telegram.example.com",
+      "https:///telegram",
+      "https://user:password@telegram.example.com",
+      "https://telegram.example.com/?route=telegram",
+      "https://telegram.example.com/#telegram",
+      "not a URL",
+    ]
+
+    expect(invalid_urls.map { |url| validator.valid_value?(url) }).to all(be(false))
+  end
+end

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_command_controller_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_command_controller_spec.rb
@@ -195,6 +195,25 @@ describe "Telegram Command Controller", type: :request do
         expect(stub).to have_been_requested.times(1)
       end
 
+      it "still returns success when the reply cannot be sent" do
+        SiteSetting.stubs(:chat_integration_telegram_api_base_url).returns(
+          "http://telegram.example.com",
+        )
+
+        post "/chat-integration/telegram/command/shhh.json",
+             params: {
+               message: {
+                 chat: {
+                   id: 123,
+                 },
+                 text: "/help",
+               },
+             }
+
+        expect(response.status).to eq(200)
+        expect(stub).to have_been_requested.times(0)
+      end
+
       context "when 'text' is missing" do
         it "does not break" do
           post "/chat-integration/telegram/command/shhh.json",

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_provider_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_provider_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
       expect(stub1).to have_been_requested.once
     end
 
+    it "uses the configured API base URL" do
+      SiteSetting.chat_integration_telegram_api_base_url = "https://telegram.example.com/api/"
+      request_stub =
+        stub_request(:post, "https://telegram.example.com/api/botTOKEN/sendMessage").to_return(
+          body: "{\"ok\":true}",
+        )
+
+      described_class.trigger_notification(post, chan1, nil)
+
+      expect(request_stub).to have_been_requested.once
+    end
+
     it "handles errors correctly" do
       stub1 =
         stub_request(:post, "https://api.telegram.org/botTOKEN/sendMessage").to_return(
@@ -81,8 +93,10 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
     end
 
     it "persists settings when setWebhook succeeds" do
+      SiteSetting.chat_integration_telegram_api_base_url = "https://telegram.example.com/"
+
       stub =
-        stub_request(:post, %r{https://api\.telegram\.org/botnewtok/setWebhook}).to_return(
+        stub_request(:post, %r{https://telegram\.example\.com/botnewtok/setWebhook}).to_return(
           body: { ok: true }.to_json,
           headers: {
             "Content-Type" => "application/json",

--- a/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_provider_spec.rb
+++ b/plugins/discourse-chat-integration/spec/lib/discourse_chat_integration/provider/telegram/telegram_provider_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
       expect(request_stub).to have_been_requested.once
     end
 
+    it "raises a provider error when the effective base URL is invalid" do
+      SiteSetting.stubs(:chat_integration_telegram_api_base_url).returns(
+        "http://telegram.example.com",
+      )
+
+      expect { described_class.trigger_notification(post, chan1, nil) }.to raise_error(
+        DiscourseChatIntegration::ProviderError,
+      ) do |e|
+        expect(e.info[:error_key]).to eq(
+          "chat_integration.provider.telegram.errors.invalid_api_base_url",
+        )
+      end
+    end
+
     it "handles errors correctly" do
       stub1 =
         stub_request(:post, "https://api.telegram.org/botTOKEN/sendMessage").to_return(
@@ -56,6 +70,13 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
         DiscourseChatIntegration::ProviderError,
       )
       expect(stub1).to have_been_requested.once
+    end
+  end
+
+  describe ".parse_base_url" do
+    it "returns the parsed URI for valid values and nil otherwise" do
+      expect(described_class.parse_base_url("https://telegram.example.com/api")).to be_a(URI::HTTPS)
+      expect(described_class.parse_base_url("http://telegram.example.com")).to be_nil
     end
   end
 
@@ -93,10 +114,8 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
     end
 
     it "persists settings when setWebhook succeeds" do
-      SiteSetting.chat_integration_telegram_api_base_url = "https://telegram.example.com/"
-
       stub =
-        stub_request(:post, %r{https://telegram\.example\.com/botnewtok/setWebhook}).to_return(
+        stub_request(:post, %r{https://api\.telegram\.org/botnewtok/setWebhook}).to_return(
           body: { ok: true }.to_json,
           headers: {
             "Content-Type" => "application/json",
@@ -109,6 +128,19 @@ RSpec.describe DiscourseChatIntegration::Provider::TelegramProvider do
       expect(SiteSetting.chat_integration_telegram_access_token).to eq("newtok")
       expect(SiteSetting.chat_integration_telegram_secret).to be_present
       expect(SiteSetting.chat_integration_telegram_enabled).to eq(true)
+    end
+
+    it "registers the webhook through a custom API base URL" do
+      SiteSetting.chat_integration_telegram_api_base_url = "https://telegram.example.com/"
+
+      stub =
+        stub_request(:post, %r{https://telegram\.example\.com/botnewtok/setWebhook}).to_return(
+          body: "{\"ok\":true}",
+        )
+
+      described_class.setup(admin, { chat_integration_telegram_access_token: "newtok" })
+
+      expect(stub).to have_been_requested.once
     end
 
     it "raises and does not change stored token when setWebhook fails" do


### PR DESCRIPTION
## What changed

Adds `chat_integration_telegram_api_base_url` setting for the Telegram chat integration (discourse-chat-integration plugin)

The setting defaults to `https://api.telegram.org`, so existing installations keep their current behavior.

## Why

Some Discourse installations cannot reach `api.telegram.org` directly because Telegram is blocked or restricted by local network providers.

This setting allows administrators to route Telegram Bot API requests through a trusted reverse proxy, such as a Cloudflare Worker, without patching the plugin.

## Cloudflare Worker example

The following Worker can be deployed as a small Telegram Bot API proxy:

```js
export default {
  async fetch(request) {
    const url = new URL(request.url);

    if (
      !url.pathname.startsWith("/bot") &&
      !url.pathname.startsWith("/file/bot")
    ) {
      return new Response("Not found", { status: 404 });
    }

    url.hostname = "api.telegram.org";
    url.protocol = "https:";
    url.port = "";

    return fetch(new Request(url, request));
  },
};
```

The proxy must be trusted because Telegram bot tokens are included in Bot API request paths.