### PR TITLE
DEV: Fix UC status report when reverted files encountered

### DIFF
--- a/lib/upcoming_changes/status_report.rb
+++ b/lib/upcoming_changes/status_report.rb
@@ -44,10 +44,18 @@ module UpcomingChanges
       end
 
       def show_file(commit_sha, path)
+        return if !file_exists_at?(commit_sha, path)
+
         capture("show", "#{commit_sha}:#{path}")
       end
 
       private
+
+      def file_exists_at?(commit_sha, path)
+        _stdout, _stderr, status =
+          Open3.capture3("git", "-C", @repo_path, "cat-file", "-e", "#{commit_sha}:#{path}")
+        status.success?
+      end
 
       def capture(*args)
         stdout, stderr, status = Open3.capture3("git", "-C", @repo_path, *args)

--- a/script/generate_upcoming_change_status_report
+++ b/script/generate_upcoming_change_status_report
@@ -13,18 +13,23 @@ cat /tmp/upcoming_changes_status_report.json
 eligible_count="$(
   ruby -rjson -e 'records = JSON.parse(File.read(ARGV.fetch(0))); puts records.count { |record| record["eligible"] }' /tmp/upcoming_changes_status_report.json
 )"
-echo "eligible_count=${eligible_count}" >> "${GITHUB_OUTPUT}"
 
-{
-  echo "### Upcoming change status report"
-  echo
-  echo "- Dry run: \`${dry_run}\`"
-  echo "- Stale after days: \`${stale_after_days}\`"
-  echo "- Eligible changes: \`${eligible_count}\`"
-  echo
-  ruby -rjson -e '
-    JSON.parse(File.read(ARGV.fetch(0))).select { |record| record["eligible"] }.each do |record|
-      puts "- `#{record["name"]}`: `#{record["current_status"]}` -> `#{record["next_status"]}` in `#{record["settings_path"]}`; last changed #{record["days_since_status_change"]} days ago"
-    end
-  ' /tmp/upcoming_changes_status_report.json
-} >> "${GITHUB_STEP_SUMMARY}"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "eligible_count=${eligible_count}" >> "${GITHUB_OUTPUT}"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Upcoming change status report"
+    echo
+    echo "- Dry run: \`${dry_run}\`"
+    echo "- Stale after days: \`${stale_after_days}\`"
+    echo "- Eligible changes: \`${eligible_count}\`"
+    echo
+    ruby -rjson -e '
+      JSON.parse(File.read(ARGV.fetch(0))).select { |record| record["eligible"] }.each do |record|
+        puts "- `#{record["name"]}`: `#{record["current_status"]}` -> `#{record["next_status"]}` in `#{record["settings_path"]}`; last changed #{record["days_since_status_change"]} days ago"
+      end
+    ' /tmp/upcoming_changes_status_report.json
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi

--- a/spec/script/upcoming_changes_status_report_spec.rb
+++ b/spec/script/upcoming_changes_status_report_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe UpcomingChanges::StatusReport do
       author_email: "alice@example.com",
     )
 
+    remove_plugin_settings
+    commit_shas[:plugin_removed] = commit(
+      "DEV: Remove plugin settings",
+      date: "2026-04-15T12:00:00Z",
+      author_name: "Alice Example",
+      author_email: "alice@example.com",
+    )
+
+    write_plugin_settings("plugin_alpha_change" => "alpha")
+    commit_shas[:plugin_restored] = commit(
+      "DEV: Restore plugin settings",
+      date: "2026-04-20T12:00:00Z",
+      author_name: "Alice Example",
+      author_email: "alice@example.com",
+    )
+
     write_settings(
       "experimental_change" => "experimental",
       "alpha_change" => "alpha",
@@ -129,6 +145,7 @@ RSpec.describe UpcomingChanges::StatusReport do
         next_status: "beta",
         eligible: true,
         original_commit: commit_shas[:original],
+        last_status_change_commit: commit_shas[:original],
       )
     end
   end
@@ -229,5 +246,9 @@ RSpec.describe UpcomingChanges::StatusReport do
         file.write("      learn_more_url: \"https://meta.discourse.org/t/-/123\"\n")
       end
     end
+  end
+
+  def remove_plugin_settings
+    FileUtils.rm_rf(File.join(repo_path, "plugins/chat"))
   end
 end


### PR DESCRIPTION
Fixes the following error when generating the upcoming changes status report
on a weekly basis in GitHub actions:

```
/__w/discourse/discourse/lib/upcoming_changes/status_report.rb:56:in 'UpcomingChanges::StatusReport::Git#capture': git show 45535887f1231b40f8a21b8c154e58cef8670063:plugins/discourse-workflows/config/settings.yml failed: fatal: path 'plugins/discourse-workflows/config/settings.yml' exists on disk, but not in '45535887f1231b40f8a21b8c154e58cef8670063' (RuntimeError)
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:47:in 'UpcomingChanges::StatusReport::Git#show_file'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:227:in 'UpcomingChanges::StatusReport::GitHistory#statuses_at'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:215:in 'block in UpcomingChanges::StatusReport::GitHistory#add_history_for_settings_file'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:214:in 'Array#reverse_each'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:214:in 'UpcomingChanges::StatusReport::GitHistory#add_history_for_settings_file'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:205:in 'block in UpcomingChanges::StatusReport::GitHistory#by_change'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:202:in 'Hash#each'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:202:in 'Enumerable#each_with_object'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:202:in 'UpcomingChanges::StatusReport::GitHistory#by_change'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:422:in 'UpcomingChanges::StatusReport#history_by_change'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:363:in 'block in UpcomingChanges::StatusReport#report'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:362:in 'Hash#each'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:362:in 'Enumerable#map'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:362:in 'UpcomingChanges::StatusReport#report'
	from /__w/discourse/discourse/lib/upcoming_changes/status_report.rb:499:in 'UpcomingChanges::StatusReport::CLI.run'
	from /__w/discourse/discourse/script/upcoming_changes_status_report:9:in '<main>'
```

This happened because we were trying to run `git sho` on a file that was
reverted in a commit. Now, we check whether the file exists for the
specific commit hash before running git show, and continue with the
next valid commit for the file.
