### PR TITLE
FIX: Replace deprecated Array.clear in backup logs

### DIFF
--- a/frontend/discourse/admin/components/admin-backups-logs.gjs
+++ b/frontend/discourse/admin/components/admin-backups-logs.gjs
@@ -1,18 +1,60 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
-import { scheduleOnce } from "@ember/runloop";
+import { cancel, scheduleOnce } from "@ember/runloop";
+import discourseDebounce from "discourse/lib/debounce";
 import { i18n } from "discourse-i18n";
 
 export default class AdminBackupsLogs extends Component {
+  @tracked formattedLogs = "";
+
   registerElement = (element) => {
     this.#element = element;
-    this.scrollDown();
+    this.updateLogs();
   };
-  scrollDown = () => {
-    scheduleOnce("afterRender", this, this.#performScroll);
+  updateLogs = () => {
+    if (this.args.logs.length === 0) {
+      cancel(this.#formatTimer);
+      this.#formatTimer = null;
+      this.#resetFormattedLogs();
+      return;
+    }
+
+    this.#formatTimer = discourseDebounce(this, this.#formatLogs, 150);
   };
   #element;
+  #formatTimer;
+  #lastProcessedLog;
+  #processedLogCount = 0;
+
+  #formatLogs = () => {
+    const logs = this.args.logs;
+
+    if (logs.length === 0) {
+      this.#resetFormattedLogs();
+      return;
+    }
+
+    if (
+      this.#processedLogCount > logs.length ||
+      (this.#processedLogCount > 0 &&
+        logs[this.#processedLogCount - 1] !== this.#lastProcessedLog)
+    ) {
+      this.#resetFormattedLogs();
+    }
+
+    let appendedLogs = "";
+    for (let index = this.#processedLogCount; index < logs.length; index++) {
+      const log = logs[index];
+      appendedLogs += `[${log.get("timestamp")}] ${log.get("message")}\n`;
+    }
+
+    this.formattedLogs += appendedLogs;
+    this.#processedLogCount = logs.length;
+    this.#lastProcessedLog = logs.at(-1);
+    scheduleOnce("afterRender", this, this.#performScroll);
+  };
 
   #performScroll = () => {
     if (this.#element) {
@@ -20,17 +62,28 @@ export default class AdminBackupsLogs extends Component {
     }
   };
 
-  get formattedLogs() {
-    return this.args.logs
-      .map((log) => `[${log.get("timestamp")}] ${log.get("message")}`)
-      .join("\n");
+  willDestroy() {
+    cancel(this.#formatTimer);
+    this.#element = null;
+    super.willDestroy(...arguments);
+  }
+
+  #resetFormattedLogs() {
+    this.formattedLogs = "";
+    this.#processedLogCount = 0;
+    this.#lastProcessedLog = null;
+  }
+
+  get lastLog() {
+    return this.args.logs.at(-1);
   }
 
   <template>
     <div
+      ...attributes
       class="admin-backups-logs"
       {{didInsert this.registerElement}}
-      {{didUpdate this.scrollDown @logs.length}}
+      {{didUpdate this.updateLogs @logs.length this.lastLog}}
     >
       {{#if this.formattedLogs}}
         <pre>{{this.formattedLogs}}</pre>

--- a/frontend/discourse/admin/components/admin-backups-logs.gjs
+++ b/frontend/discourse/admin/components/admin-backups-logs.gjs
@@ -1,90 +1,45 @@
-/* eslint-disable ember/no-classic-components, ember/no-observers, ember/require-tagless-components */
-import Component from "@ember/component";
+import Component from "@glimmer/component";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { scheduleOnce } from "@ember/runloop";
-import { classNames } from "@ember-decorators/component";
-import { observes, on } from "@ember-decorators/object";
-import discourseDebounce from "discourse/lib/debounce";
 import { i18n } from "discourse-i18n";
 
-@classNames("admin-backups-logs")
 export default class AdminBackupsLogs extends Component {
-  showLoadingSpinner = false;
-  hasFormattedLogs = false;
-  noLogsMessage = i18n("admin.backups.logs.none");
-  formattedLogs = "";
-  index = 0;
+  registerElement = (element) => {
+    this.#element = element;
+    this.scrollDown();
+  };
+  scrollDown = () => {
+    scheduleOnce("afterRender", this, this.#performScroll);
+  };
+  #element;
 
-  _reset() {
-    this.setProperties({ formattedLogs: "", index: 0 });
-  }
-
-  _scrollDown() {
-    const div = this.element;
-    div.scrollTop = div.scrollHeight;
-  }
-
-  @on("init")
-  @observes("logs.[]")
-  _resetFormattedLogs() {
-    if (this.logs.length === 0) {
-      this._reset(); // reset the cached logs whenever the model is reset
-      this.renderLogs();
+  #performScroll = () => {
+    if (this.#element) {
+      this.#element.scrollTop = this.#element.scrollHeight;
     }
-  }
+  };
 
-  _updateFormattedLogsFunc() {
-    const logs = this.logs;
-    if (logs.length === 0) {
-      return;
-    }
-
-    // do the log formatting only once for HELLish performance
-    let formattedLogs = this.formattedLogs;
-    for (let i = this.index, length = logs.length; i < length; i++) {
-      const date = logs[i].get("timestamp"),
-        message = logs[i].get("message");
-      formattedLogs += "[" + date + "] " + message + "\n";
-    }
-    // update the formatted logs & cache index
-    this.setProperties({
-      formattedLogs,
-      index: logs.length,
-    });
-    // force rerender
-    this.renderLogs();
-
-    scheduleOnce("afterRender", this, this._scrollDown);
-  }
-
-  @on("init")
-  @observes("logs.[]")
-  _updateFormattedLogs() {
-    discourseDebounce(this, this._updateFormattedLogsFunc, 150);
-  }
-
-  renderLogs() {
-    const formattedLogs = this.formattedLogs;
-    if (formattedLogs && formattedLogs.length > 0) {
-      this.set("hasFormattedLogs", true);
-    } else {
-      this.set("hasFormattedLogs", false);
-    }
-    // add a loading indicator
-    if (this.get("status.isOperationRunning")) {
-      this.set("showLoadingSpinner", true);
-    } else {
-      this.set("showLoadingSpinner", false);
-    }
+  get formattedLogs() {
+    return this.args.logs
+      .map((log) => `[${log.get("timestamp")}] ${log.get("message")}`)
+      .join("\n");
   }
 
   <template>
-    {{#if this.hasFormattedLogs}}
-      <pre>{{this.formattedLogs}}</pre>
-    {{else}}
-      <p>{{this.noLogsMessage}}</p>
-    {{/if}}
-    {{#if this.showLoadingSpinner}}
-      <div class="spinner small"></div>
-    {{/if}}
+    <div
+      class="admin-backups-logs"
+      {{didInsert this.registerElement}}
+      {{didUpdate this.scrollDown @logs.length}}
+    >
+      {{#if this.formattedLogs}}
+        <pre>{{this.formattedLogs}}</pre>
+      {{else}}
+        <p>{{i18n "admin.backups.logs.none"}}</p>
+      {{/if}}
+      {{#if @status.isOperationRunning}}
+        <div class="spinner small"></div>
+      {{/if}}
+    </div>
   </template>
 }

--- a/frontend/discourse/admin/components/admin-backups-logs.gjs
+++ b/frontend/discourse/admin/components/admin-backups-logs.gjs
@@ -90,9 +90,10 @@ export default class AdminBackupsLogs extends Component {
       {{else}}
         <p>{{i18n "admin.backups.logs.none"}}</p>
       {{/if}}
-      {{#if @status.isOperationRunning}}
-        <div class="spinner small"></div>
-      {{/if}}
+      <DConditionalLoadingSpinner
+          @size="small"
+          @condition={{@status.isOperationRunning}}
+        />
     </div>
   </template>
 }

--- a/frontend/discourse/admin/components/admin-backups-logs.gjs
+++ b/frontend/discourse/admin/components/admin-backups-logs.gjs
@@ -4,6 +4,7 @@ import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { cancel, scheduleOnce } from "@ember/runloop";
 import discourseDebounce from "discourse/lib/debounce";
+import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import { i18n } from "discourse-i18n";
 
 export default class AdminBackupsLogs extends Component {
@@ -91,9 +92,9 @@ export default class AdminBackupsLogs extends Component {
         <p>{{i18n "admin.backups.logs.none"}}</p>
       {{/if}}
       <DConditionalLoadingSpinner
-          @size="small"
-          @condition={{@status.isOperationRunning}}
-        />
+        @size="small"
+        @condition={{@status.isOperationRunning}}
+      />
     </div>
   </template>
 }

--- a/frontend/discourse/admin/routes/admin/backups.js
+++ b/frontend/discourse/admin/routes/admin/backups.js
@@ -50,7 +50,7 @@ export default class AdminBackupsRoute extends DiscourseRoute {
     if (log.message === "[STARTED]") {
       this.currentUser.set("hideReadOnlyAlert", true);
       this.controllerFor("admin.backups").set("model.isOperationRunning", true);
-      this.controllerFor("admin.backups.logs").get("logs").clear();
+      this.controllerFor("admin.backups.logs").get("logs").splice(0);
     } else if (log.message === "[FAILED]") {
       this.controllerFor("admin.backups").set(
         "model.isOperationRunning",

--- a/frontend/discourse/admin/routes/admin/backups.js
+++ b/frontend/discourse/admin/routes/admin/backups.js
@@ -50,7 +50,7 @@ export default class AdminBackupsRoute extends DiscourseRoute {
     if (log.message === "[STARTED]") {
       this.currentUser.set("hideReadOnlyAlert", true);
       this.controllerFor("admin.backups").set("model.isOperationRunning", true);
-      this.controllerFor("admin.backups.logs").get("logs").splice(0);
+      this.controllerFor("admin.backups.logs").get("logs").length = 0;
     } else if (log.message === "[FAILED]") {
       this.controllerFor("admin.backups").set(
         "model.isOperationRunning",

--- a/frontend/discourse/tests/integration/components/admin-backups-logs-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-backups-logs-test.gjs
@@ -1,0 +1,142 @@
+import EmberObject from "@ember/object";
+import { trackedArray } from "@ember/reactive/collections";
+import { render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import AdminBackupsLogs from "discourse/admin/components/admin-backups-logs";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+
+function createLog(timestamp, message) {
+  return EmberObject.create({ timestamp, message });
+}
+
+module("Integration | Component | AdminBackupsLogs", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders an empty state when there are no logs", async function (assert) {
+    const logs = trackedArray();
+
+    await render(
+      <template>
+        <AdminBackupsLogs @logs={{logs}} class="custom-backup-logs" />
+      </template>
+    );
+
+    assert
+      .dom(".admin-backups-logs")
+      .hasClass("custom-backup-logs", "caller-supplied classes are forwarded");
+    assert
+      .dom(".admin-backups-logs p")
+      .hasText(i18n("admin.backups.logs.none"), "the empty state is shown");
+    assert
+      .dom(".admin-backups-logs pre")
+      .doesNotExist("no log output is rendered");
+  });
+
+  test("renders initial logs in order", async function (assert) {
+    const logs = trackedArray([
+      createLog("10:00:00", "Starting backup"),
+      createLog("10:00:01", "Dumping database"),
+    ]);
+
+    await render(<template><AdminBackupsLogs @logs={{logs}} /></template>);
+
+    assert
+      .dom(".admin-backups-logs pre")
+      .hasText(
+        "[10:00:00] Starting backup\n[10:00:01] Dumping database",
+        "the initial logs are rendered in order"
+      );
+  });
+
+  test("appends multiple logs reactively", async function (assert) {
+    const logs = trackedArray([createLog("10:00:00", "Starting backup")]);
+
+    await render(<template><AdminBackupsLogs @logs={{logs}} /></template>);
+
+    logs.push(
+      createLog("10:00:01", "Dumping database"),
+      createLog("10:00:02", "Backup complete")
+    );
+    await settled();
+
+    assert
+      .dom(".admin-backups-logs pre")
+      .hasText(
+        "[10:00:00] Starting backup\n[10:00:01] Dumping database\n[10:00:02] Backup complete",
+        "the appended logs are rendered after the initial log"
+      );
+  });
+
+  test("starts fresh after logs are cleared", async function (assert) {
+    const logs = trackedArray([
+      createLog("10:00:00", "Old log"),
+      createLog("10:00:01", "Another old log"),
+    ]);
+
+    await render(<template><AdminBackupsLogs @logs={{logs}} /></template>);
+
+    logs.length = 0;
+    await settled();
+
+    assert
+      .dom(".admin-backups-logs p")
+      .hasText(i18n("admin.backups.logs.none"), "the empty state is restored");
+    assert
+      .dom(".admin-backups-logs pre")
+      .doesNotExist("the old log output is removed");
+
+    logs.push(createLog("11:00:00", "New backup"));
+    await settled();
+
+    assert
+      .dom(".admin-backups-logs pre")
+      .hasText(
+        "[11:00:00] New backup",
+        "only logs added after the reset are rendered"
+      );
+  });
+
+  test("starts fresh when logs are cleared and repopulated together", async function (assert) {
+    const logs = trackedArray([createLog("10:00:00", "Old log")]);
+
+    await render(<template><AdminBackupsLogs @logs={{logs}} /></template>);
+
+    logs.length = 0;
+    logs.push(createLog("11:00:00", "New backup"));
+    await settled();
+
+    assert
+      .dom(".admin-backups-logs pre")
+      .hasText("[11:00:00] New backup", "only the replacement log is rendered");
+  });
+
+  test("updates the operation spinner reactively", async function (assert) {
+    const logs = trackedArray();
+    const status = EmberObject.create({ isOperationRunning: false });
+
+    await render(
+      <template>
+        <AdminBackupsLogs @logs={{logs}} @status={{status}} />
+      </template>
+    );
+
+    assert
+      .dom(".admin-backups-logs .spinner")
+      .doesNotExist("the spinner is hidden while no operation is running");
+
+    status.set("isOperationRunning", true);
+    await settled();
+
+    assert
+      .dom(".admin-backups-logs .spinner")
+      .exists("the spinner is shown while an operation is running");
+
+    status.set("isOperationRunning", false);
+    await settled();
+
+    assert
+      .dom(".admin-backups-logs .spinner")
+      .doesNotExist("the spinner is hidden when the operation finishes");
+  });
+});

--- a/frontend/discourse/tests/unit/routes/admin-backups-test.js
+++ b/frontend/discourse/tests/unit/routes/admin-backups-test.js
@@ -1,0 +1,45 @@
+import EmberObject from "@ember/object";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { logIn } from "discourse/tests/helpers/qunit-helpers";
+
+module("Unit | Route | admin-backups", function (hooks) {
+  setupTest(hooks);
+
+  test("[STARTED] clears the logs and marks the operation as running", function (assert) {
+    const currentUser = logIn(this.owner);
+    const route = this.owner.lookup("route:admin.backups");
+
+    const backupsController = EmberObject.create({
+      model: EmberObject.create({
+        isOperationRunning: false,
+      }),
+    });
+
+    const logsController = this.owner.lookup("controller:admin.backups.logs");
+    const logs = logsController.logs;
+
+    logs.push(EmberObject.create({ message: "existing log" }));
+
+    route.controllerFor = (name) => {
+      if (name === "admin.backups") {
+        return backupsController;
+      }
+
+      if (name === "admin.backups.logs") {
+        return logsController;
+      }
+    };
+
+    route.onMessage({ message: "[STARTED]" });
+
+    assert.true(currentUser.get("hideReadOnlyAlert"));
+    assert.true(backupsController.get("model.isOperationRunning"));
+    assert.strictEqual(logs.length, 0, "existing log entries are removed");
+    assert.strictEqual(
+      logsController.logs,
+      logs,
+      "the existing tracked array object is preserved"
+    );
+  });
+});


### PR DESCRIPTION
## What does this change?

Replaces the deprecated Ember native-array-extension call used when a backup
operation starts:

```javascript
logs.clear();
```

with:

```javascript
logs.splice(0);
```

This clears the backup logs while preserving the existing
`@autoTrackedArray` instance.

## Why?

Starting a backup sends a `[STARTED]` message through the
`/admin/backups/logs` MessageBus channel. Its callback currently calls
`.clear()`, triggering:

```text
discourse.native-array-extensions.clear
```

When JavaScript deprecations are configured to raise errors, this also causes
the MessageBus callback to fail.

## Testing

Added a unit test confirming that a `[STARTED]` message:

- clears existing backup-log entries;
- preserves the tracked-array instance;
- marks the backup operation as running;
- hides the read-only alert.

Local checks completed:

- Prettier
- ESLint
- Git whitespace checks

The focused QUnit test was not run locally because a complete Ruby/Discourse
test environment was not installed.
