### PR TITLE
UX: composer redesign > action button experimental styling

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1449,7 +1449,6 @@ body.has-sidebar-page {
     display: flex;
     align-items: center;
     flex-wrap: nowrap;
-    gap: var(--space-2);
 
     @include viewport.from(sm) {
       padding: var(--space-2) var(--space-4);
@@ -1486,6 +1485,13 @@ body.has-sidebar-page {
           margin-left: auto;
           flex: unset !important;
           margin-right: 0 !important;
+
+          // temporary overrule, should be done in template eventually
+          .btn.btn-primary {
+            background: transparent;
+            color: var(--tertiary);
+            font-weight: bold;
+          }
         }
 
         #draft-status {
@@ -1529,7 +1535,7 @@ body.has-sidebar-page {
     }
 
     .reply-to {
-      padding: var(--space-3);
+      padding: var(--space-1) var(--space-3);
     }
   }
 }


### PR DESCRIPTION
Saving a few more pixels by slimming down the action buttons

<img width="428" height="431" alt="CleanShot 2026-07-20 at 14 23 31" src="https://github.com/user-attachments/assets/a9560909-33a7-49dc-a84f-3665cda171fc" />

<img width="428" height="431" alt="CleanShot 2026-07-20 at 14 23 01" src="https://github.com/user-attachments/assets/67073055-dfca-4b89-9a63-ebce7f0b0f0d" />


