### PR TITLE
DEV: Use a forced output tool for AI agent structured responses

### DIFF
--- a/plugins/discourse-ai/lib/agents/bot.rb
+++ b/plugins/discourse-ai/lib/agents/bot.rb
@@ -4,6 +4,15 @@ module DiscourseAi
   module Agents
     class Bot
       BOT_NOT_FOUND = Class.new(StandardError)
+      OUTPUT_TOOL_NOT_CALLED = Class.new(StandardError)
+
+      OUTPUT_TOOL_NAME = "submit_response"
+      OUTPUT_TOOL_RETRY_INSTRUCTION =
+        "Submit the final response by calling #{OUTPUT_TOOL_NAME}. Do not reply with plain text."
+      OUTPUT_TOOL_INSTRUCTION = <<~TEXT.strip
+        Submit the final response by calling #{OUTPUT_TOOL_NAME}. Do not return the final response as JSON or plain text.
+        Any instructions or examples that describe JSON output refer to the arguments of #{OUTPUT_TOOL_NAME}.
+      TEXT
 
       DEFAULT_MAX_TURN_TOKENS = 32_000
       CONTEXT_TOKEN_BUDGET_RATIO = 0.5
@@ -89,9 +98,16 @@ module DiscourseAi
         current_llm = llm
         prompt = agent.craft_prompt(context, llm: current_llm)
 
+        response_format = agent.response_format if !context.bypass_response_format
+        response_properties = build_response_properties(response_format)
+        output_tool = add_output_tool(prompt, response_format) if response_format.present?
+        output_tool_only =
+          response_format.present? && prompt.tools.one? && !prompt.has_native_tools?
+
         total_completions = 0
         ongoing_chain = true
         raw_context = []
+        force_output_tool = false
 
         user = context.user
 
@@ -101,9 +117,7 @@ module DiscourseAi
         llm_kwargs[:top_p] = agent.top_p if agent.top_p
         llm_kwargs[:thinking_effort] = agent.thinking_effort if agent.thinking_effort.present?
 
-        if !context.bypass_response_format && agent.response_format.present?
-          llm_kwargs[:response_format] = build_json_schema(agent.response_format)
-        end
+        llm_kwargs.delete(:response_format) if response_format.present?
 
         needs_newlines = false
 
@@ -127,7 +141,7 @@ module DiscourseAi
 
         while ongoing_chain
           if final_answer_requested
-            break # already ran the final text-only generate
+            break # already ran the final constrained generate
           end
 
           should_stop = token_usage_tracker.total >= token_budget
@@ -135,7 +149,7 @@ module DiscourseAi
           if should_stop
             if prompt.messages.last&.dig(:type) == :tool
               self.class.inject_budget_exhausted_hint(prompt)
-              prompt.tool_choice = :none
+              prompt.tool_choice = response_format.present? ? OUTPUT_TOOL_NAME : :none
               final_answer_requested = true
             else
               break
@@ -154,13 +168,18 @@ module DiscourseAi
 
           tool_found = false
           force_tool_if_needed(prompt, context)
+          if response_format.present? && (output_tool_only || force_output_tool)
+            prompt.tool_choice = OUTPUT_TOOL_NAME
+          end
 
           tool_halted = false
 
-          allow_partial_tool_calls = agent.allow_partial_tool_calls?
+          allow_partial_tool_calls = response_format.present? || agent.allow_partial_tool_calls?
           existing_tools = Set.new
           current_thinking = []
           thinking_placeholder = nil
+          structured_output = nil
+          output_submitted = false
 
           result =
             current_llm.generate(
@@ -171,6 +190,37 @@ module DiscourseAi
               cancel_manager: context.cancel_manager,
               **llm_kwargs,
             ) do |partial|
+              next if output_submitted
+
+              if output_tool_call?(partial)
+                output_arguments = output_tool.coerce_parameters(partial.parameters)
+                if !partial.partial? &&
+                     !valid_output_tool_arguments?(
+                       output_tool,
+                       partial.parameters,
+                       output_arguments,
+                     )
+                  raise OUTPUT_TOOL_NOT_CALLED, "#{OUTPUT_TOOL_NAME} returned invalid arguments"
+                end
+
+                structured_output ||=
+                  DiscourseAi::Completions::StructuredOutput.new(response_properties)
+                structured_output.update_from_tool_arguments(
+                  output_arguments,
+                  finished: !partial.partial?,
+                )
+                update_blk.call(structured_output, nil, :structured_output)
+
+                if !partial.partial?
+                  tool_found = true
+                  tool_halted = true
+                  output_submitted = true
+                  ongoing_chain = false
+                  raw_context << [structured_output.to_s, bot_user&.username]
+                end
+                next
+              end
+
               tool =
                 agent.find_tool(
                   partial,
@@ -234,6 +284,8 @@ module DiscourseAi
                   else
                     if partial.is_a?(DiscourseAi::Completions::StructuredOutput)
                       update_blk.call(partial, nil, :structured_output)
+                    elsif response_format.present?
+                      next
                     else
                       update_blk.call(partial)
                     end
@@ -243,7 +295,6 @@ module DiscourseAi
             end
 
           if !tool_found
-            ongoing_chain = false
             text = result
 
             # we must strip out thinking and other types of blocks
@@ -251,14 +302,30 @@ module DiscourseAi
               text = +""
               result.each { |item| text << item if item.is_a?(String) }
             end
-            raw_context << [text, bot_user&.username]
+
+            if response_format.present?
+              if force_output_tool || final_answer_requested
+                raise OUTPUT_TOOL_NOT_CALLED, "LLM did not call #{OUTPUT_TOOL_NAME}"
+              end
+
+              prompt.push_model_response(result)
+              prompt.push(type: :user, content: OUTPUT_TOOL_RETRY_INSTRUCTION)
+              force_output_tool = true
+              ongoing_chain = true
+            else
+              ongoing_chain = false
+              raw_context << [text, bot_user&.username]
+            end
           end
 
           total_completions += 1
 
           if !final_answer_requested
             total_used = token_usage_tracker.total
-            prompt.tool_choice = :none if total_used >= (token_budget * 0.85)
+            if total_used >= (token_budget * 0.85)
+              prompt.tool_choice = response_format.present? ? OUTPUT_TOOL_NAME : :none
+              force_output_tool = true if response_format.present?
+            end
 
             # Safety valve against pathological tool loops.
             break if total_completions >= 100
@@ -701,34 +768,59 @@ module DiscourseAi
         placeholder
       end
 
-      def build_json_schema(response_format)
-        properties =
-          response_format
-            .to_a
-            .reduce({}) do |memo, format|
-              type_desc = { type: format["type"] }
+      def add_output_tool(prompt, response_format)
+        if prompt.tools.any? { |tool| tool.name == OUTPUT_TOOL_NAME }
+          raise ArgumentError, "#{OUTPUT_TOOL_NAME} is reserved for structured responses"
+        end
 
-              if format["type"] == "array"
-                type_desc[:items] = { type: format["array_type"] || "string" }
-              end
+        parameters =
+          response_format.to_a.map do |format|
+            parameter = {
+              name: format["key"],
+              description: "The #{format["key"]} value for the response.",
+              type: format["type"],
+              required: true,
+            }
+            parameter[:item_type] = format["array_type"] || "string" if format["type"] == "array"
+            parameter
+          end
 
-              memo[format["key"].to_sym] = type_desc
-              memo
-            end
+        prompt.append_system_message(OUTPUT_TOOL_INSTRUCTION)
 
-        {
-          type: "json_schema",
-          json_schema: {
-            name: "reply",
-            schema: {
-              type: "object",
-              properties: properties,
-              required: properties.keys.map(&:to_s),
-              additionalProperties: false,
-            },
-            strict: true,
-          },
-        }
+        prompt.tools =
+          prompt.tools +
+            [
+              {
+                name: OUTPUT_TOOL_NAME,
+                description:
+                  "Submit the final response. Call this tool instead of returning a plain-text final answer.",
+                parameters: parameters,
+              },
+            ]
+
+        prompt.tools.find { |tool| tool.name == OUTPUT_TOOL_NAME }
+      end
+
+      def build_response_properties(response_format)
+        response_format
+          .to_a
+          .each_with_object({}) do |format, properties|
+            property = { type: format["type"] }
+            property[:items] = { type: format["array_type"] || "string" } if format["type"] ==
+              "array"
+            properties[format["key"].to_sym] = property
+          end
+      end
+
+      def output_tool_call?(partial)
+        partial.is_a?(DiscourseAi::Completions::ToolCall) && partial.name == OUTPUT_TOOL_NAME
+      end
+
+      def valid_output_tool_arguments?(tool, raw_arguments, coerced_arguments)
+        tool.parameters.all? do |parameter|
+          key = parameter.name.to_sym
+          raw_arguments.key?(key) && !coerced_arguments[key].nil?
+        end
       end
     end
   end

--- a/plugins/discourse-ai/lib/completions/endpoints/canned_response.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/canned_response.rb
@@ -46,6 +46,7 @@ module DiscourseAi
 
           @completions += 1
           response_enum = response.is_a?(Array) ? response : [response]
+          response_enum = output_tool_calls(response_enum) if output_tool
           if block_given?
             cancelled = false
             cancel_fn = lambda { cancelled = true }
@@ -118,6 +119,68 @@ module DiscourseAi
 
         def is_tool?(response)
           response.is_a?(DiscourseAi::Completions::ToolCall)
+        end
+
+        def output_tool
+          dialect&.prompt&.tools&.find { |tool| tool.name == "submit_response" }
+        end
+
+        def output_tool_calls(response_enum)
+          return response_enum if response_enum.all? { |response| is_tool?(response) }
+
+          raw_responses =
+            response_enum.reject { |response| is_thinking?(response) || is_tool?(response) }
+          if output_tool.parameters.one? && output_tool.parameters.first.type == :array &&
+               raw_responses.many?
+            return [build_output_tool_call({ output_tool.parameters.first.name => raw_responses })]
+          end
+
+          accumulated_strings = {}
+          raw_index = 0
+          response_enum.map do |response|
+            next response if is_thinking?(response) || is_tool?(response)
+
+            raw_index += 1
+            parameters = output_tool_parameters(response)
+            output_tool.parameters.each do |parameter|
+              next if parameter.type != :string || !parameters[parameter.name].is_a?(String)
+
+              accumulated_strings[parameter.name] ||= +""
+              accumulated_strings[parameter.name] << parameters[parameter.name]
+              parameters[parameter.name] = accumulated_strings[parameter.name].dup
+            end
+
+            build_output_tool_call(parameters, partial: raw_index < raw_responses.length)
+          end
+        end
+
+        def output_tool_parameters(response)
+          parsed = parse_structured_response(response)
+          parsed = response if parsed.nil? && !response.nil?
+          if parsed.is_a?(Hash)
+            parsed = parsed.stringify_keys
+            return(
+              output_tool
+                .parameters
+                .each_with_object({}) do |parameter, result|
+                  result[parameter.name] = parsed[parameter.name] if parsed.key?(parameter.name)
+                end
+            )
+          end
+
+          return {} if output_tool.parameters.empty?
+          { output_tool.parameters.first.name => parsed }
+        end
+
+        def build_output_tool_call(parameters, partial: false)
+          call =
+            DiscourseAi::Completions::ToolCall.new(
+              id: "canned_output",
+              name: output_tool.name,
+              parameters: parameters,
+            )
+          call.partial = partial
+          call
         end
 
         def as_structured_output(response)

--- a/plugins/discourse-ai/lib/completions/endpoints/fake.rb
+++ b/plugins/discourse-ai/lib/completions/endpoints/fake.rb
@@ -135,6 +135,8 @@ module DiscourseAi
           content = self.class.fake_content
 
           content = content.shift if content.is_a?(Array)
+          content = output_tool_call(dialect, content) if output_tool(dialect) &&
+            !content.is_a?(DiscourseAi::Completions::ToolCall)
 
           if block_given?
             if content.is_a?(DiscourseAi::Completions::ToolCall)
@@ -177,6 +179,42 @@ module DiscourseAi
           end
 
           content
+        end
+
+        private
+
+        def output_tool(dialect)
+          dialect.prompt.tools.find { |tool| tool.name == "submit_response" }
+        end
+
+        def output_tool_call(dialect, content)
+          tool = output_tool(dialect)
+          parsed = JSON.parse(content)
+          parsed = parsed.stringify_keys if parsed.is_a?(Hash)
+          parameters =
+            tool
+              .parameters
+              .each_with_object({}) do |parameter, result|
+                result[parameter.name] = parsed[parameter.name] if parsed.is_a?(Hash) &&
+                  parsed.key?(parameter.name)
+              end
+          if parameters.empty? && tool.parameters.first
+            parameters[tool.parameters.first.name] = parsed
+          end
+
+          DiscourseAi::Completions::ToolCall.new(
+            id: "fake_output",
+            name: tool.name,
+            parameters: parameters,
+          )
+        rescue JSON::ParserError
+          DiscourseAi::Completions::ToolCall.new(
+            id: "fake_output",
+            name: tool.name,
+            parameters: {
+              tool.parameters.first.name => content,
+            },
+          )
         end
       end
     end

--- a/plugins/discourse-ai/lib/completions/prompt.rb
+++ b/plugins/discourse-ai/lib/completions/prompt.rb
@@ -68,6 +68,15 @@ module DiscourseAi
           end
       end
 
+      def append_system_message(content)
+        if system_message = messages.find { |message| message[:type] == :system }
+          system_message[:content] = "#{system_message[:content]}\n\n#{content}"
+        else
+          messages.unshift(type: :system, content: content)
+        end
+        @system_message_text = messages.first[:content]
+      end
+
       # this new api tries to create symmetry between responses and prompts
       # this means anything we get back from the model via endpoint can be easily appended
       def push_model_response(response)

--- a/plugins/discourse-ai/lib/completions/structured_output.rb
+++ b/plugins/discourse-ai/lib/completions/structured_output.rb
@@ -46,6 +46,13 @@ module DiscourseAi
         @done = true
       end
 
+      def update_from_tool_arguments(arguments, finished: false)
+        @raw_response.replace(arguments.to_json)
+        arguments.each { |name, value| notify_progress(name, value) }
+        finish if finished
+        self
+      end
+
       def finished?
         @done
       end

--- a/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
+++ b/plugins/discourse-ai/spec/lib/agents/bot_spec.rb
@@ -108,6 +108,219 @@ RSpec.describe DiscourseAi::Agents::Bot do
       expect(captured_kwargs.first[:extra_model_params]).to be_nil
     end
 
+    context "with a response format" do
+      fab!(:response_agent_record) do
+        Fabricate(
+          :ai_agent,
+          name: "Response agent",
+          response_format: [{ "key" => "output", "type" => "string" }],
+        )
+      end
+
+      it "forces a terminal tool call and yields it as structured output" do
+        tool_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "output_1",
+            name: "submit_response",
+            parameters: {
+              output: "Hello world",
+            },
+          )
+        captured_prompt = nil
+        captured_model_params = nil
+        result = nil
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([tool_call]) do
+          response_bot =
+            described_class.as(bot_user, agent: response_agent_record.class_instance.new)
+          context =
+            DiscourseAi::Agents::BotContext.new(messages: [{ type: :user, content: "Say hello" }])
+
+          allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+            :generate,
+          ).and_wrap_original do |original, *args, **kwargs, &block|
+            captured_prompt = args.first
+            captured_model_params = kwargs
+            original.call(*args, **kwargs, &block)
+          end
+
+          response_bot.reply(context) do |partial, _, type|
+            result = partial if type == :structured_output
+          end
+        end
+
+        output_tool = captured_prompt.tools.find { |tool| tool.name == "submit_response" }
+
+        expect(captured_prompt.tool_choice).to eq("submit_response")
+        expect(captured_prompt.system_message_text).to include(
+          "Any instructions or examples that describe JSON output refer to the arguments of submit_response.",
+        )
+        expect(output_tool.parameters_json_schema).to eq(
+          {
+            type: "object",
+            properties: {
+              "output" => {
+                type: :string,
+                description: "The output value for the response.",
+              },
+            },
+            required: ["output"],
+          },
+        )
+        expect(captured_model_params).not_to have_key(:response_format)
+        expect(result).to be_a(DiscourseAi::Completions::StructuredOutput)
+        expect(result).to be_finished
+        expect(result.to_s).to eq({ output: "Hello world" }.to_json)
+        expect(result.read_buffered_property(:output)).to eq("Hello world")
+      end
+
+      it "allows operational tools before the terminal response tool" do
+        response_agent_record.update!(tools: [["ListCategories", nil, false]])
+        category_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "categories_1",
+            name: "categories",
+            parameters: {
+            },
+          )
+        output_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "output_1",
+            name: "submit_response",
+            parameters: {
+              output: "There are several categories",
+            },
+          )
+        tool_choices = []
+        result = nil
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([category_call, output_call]) do
+          response_bot =
+            described_class.as(bot_user, agent: response_agent_record.class_instance.new)
+          context =
+            DiscourseAi::Agents::BotContext.new(
+              messages: [{ type: :user, content: "List the categories" }],
+            )
+
+          allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+            :generate,
+          ).and_wrap_original do |original, *args, **kwargs, &block|
+            tool_choices << args.first.tool_choice
+            original.call(*args, **kwargs, &block)
+          end
+
+          response_bot.reply(context) do |partial, _, type|
+            result = partial if type == :structured_output
+          end
+        end
+
+        expect(tool_choices).to eq([nil, nil])
+        expect(result.read_buffered_property(:output)).to eq("There are several categories")
+      end
+
+      it "streams changing terminal tool arguments through the structured output buffer" do
+        partial_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "output_1",
+            name: "submit_response",
+            parameters: {
+              output: "Hello",
+            },
+          )
+        partial_call.partial = true
+        final_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "output_1",
+            name: "submit_response",
+            parameters: {
+              output: "Hello world",
+            },
+          )
+        chunks = []
+        completion_states = []
+
+        DiscourseAi::Completions::Llm.with_prepared_responses([[partial_call, final_call]]) do
+          response_bot =
+            described_class.as(bot_user, agent: response_agent_record.class_instance.new)
+          context =
+            DiscourseAi::Agents::BotContext.new(messages: [{ type: :user, content: "Say hello" }])
+
+          response_bot.reply(context) do |partial, _, type|
+            next if type != :structured_output
+
+            chunks << partial.read_buffered_property(:output)
+            completion_states << partial.finished?
+          end
+        end
+
+        expect(chunks).to eq(["Hello", " world"])
+        expect(completion_states).to eq([false, true])
+      end
+
+      it "retries once with a forced tool when the model returns plain text" do
+        output_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "output_1",
+            name: "submit_response",
+            parameters: {
+              output: "Corrected response",
+            },
+          )
+        generated_responses = ["Plain response", output_call]
+        tool_choices = []
+        yielded_plain_text = false
+        result = nil
+        response_bot = described_class.as(bot_user, agent: response_agent_record.class_instance.new)
+        context =
+          DiscourseAi::Agents::BotContext.new(messages: [{ type: :user, content: "Respond" }])
+
+        allow_any_instance_of(DiscourseAi::Completions::Llm).to receive(
+          :generate,
+        ) do |_, prompt, **_kwargs, &callback|
+          tool_choices << prompt.tool_choice
+          response = generated_responses.shift
+          if response.is_a?(DiscourseAi::Completions::ToolCall)
+            callback.call(response)
+          else
+            response.each_char { |character| callback.call(character) }
+          end
+          response
+        end
+
+        response_bot.reply(context) do |partial, _, type|
+          yielded_plain_text = true if type.nil? && partial.present?
+          result = partial if type == :structured_output
+        end
+
+        expect(tool_choices).to eq(%w[submit_response submit_response])
+        expect(yielded_plain_text).to eq(false)
+        expect(result.read_buffered_property(:output)).to eq("Corrected response")
+      end
+
+      it "rejects a terminal tool call with missing required arguments" do
+        output_call =
+          DiscourseAi::Completions::ToolCall.new(
+            id: "output_1",
+            name: "submit_response",
+            parameters: {
+            },
+          )
+
+        expect do
+          DiscourseAi::Completions::Llm.with_prepared_responses([output_call]) do
+            response_bot =
+              described_class.as(bot_user, agent: response_agent_record.class_instance.new)
+            context =
+              DiscourseAi::Agents::BotContext.new(messages: [{ type: :user, content: "Respond" }])
+            response_bot.reply(context)
+          end
+        end.to raise_error(
+          DiscourseAi::Agents::Bot::OUTPUT_TOOL_NOT_CALLED,
+          "submit_response returned invalid arguments",
+        )
+      end
+    end
+
     context "when using function chaining" do
       it "yields a loading placeholder while proceeds to invoke the command" do
         tool = DiscourseAi::Agents::Tools::ListCategories.new({}, bot_user: nil, llm: nil)

--- a/plugins/discourse-ai/spec/lib/completions/structured_output_spec.rb
+++ b/plugins/discourse-ai/spec/lib/completions/structured_output_spec.rb
@@ -151,6 +151,25 @@ RSpec.describe DiscourseAi::Completions::StructuredOutput do
     end
   end
 
+  describe "streaming tool arguments" do
+    it "buffers appended string content and serializes the latest arguments" do
+      structured_output.update_from_tool_arguments({ message: "Hello", bool: true })
+
+      expect(structured_output.read_buffered_property(:message)).to eq("Hello")
+      expect(structured_output.read_buffered_property(:bool)).to eq(true)
+      expect(structured_output).not_to be_finished
+
+      structured_output.update_from_tool_arguments(
+        { message: "Hello world", bool: true },
+        finished: true,
+      )
+
+      expect(structured_output.read_buffered_property(:message)).to eq(" world")
+      expect(structured_output).to be_finished
+      expect(structured_output.to_s).to eq({ message: "Hello world", bool: true }.to_json)
+    end
+  end
+
   describe "recovering from streams with unescaped control characters" do
     # regression specs for https://meta.discourse.org/t/407251
     it "streams the full content instead of truncating at escaped quotes" do


### PR DESCRIPTION
We have quite a few AI features relying on model-generated JSON. In an investigation, forced tool calls produced valid arguments in 40/40 cases across 10 models and four source languages, compared with 36/40 for raw JSON.

This improves the structural contract only. It does not guarantee that the model follows semantic instructions such as the requested language or summary quality.

This PR changes response formats used through DiscourseAi::Agents::Bot. AI agents with a response_format now receive a dynamically generated terminal tool called submit_response. The tool arguments use the fields and types from the agent’s existing response format. Bot captures those arguments and returns them through the existing StructuredOutput interface, so feature consumers do not need to change.