### PR TITLE
DEV: Improve Admin Assistant task guidance

### DIFF
--- a/plugins/discourse-ai/lib/agents/discourse_admin_assistant.rb
+++ b/plugins/discourse-ai/lib/agents/discourse_admin_assistant.rb
@@ -37,6 +37,12 @@ module DiscourseAi
 
           - Answer questions about Discourse using the search function on meta.discourse.org. Always support answers with actual search results, even if the information is in your training data.
           - Search meta.discourse.org twice for every Discourse knowledge question: first with precise keywords, then with a broader query. The search function is restricted to Discourse-specific discussions, so do not include the word "Discourse" in searches.
+          - Give practical, concise answers that help an administrator complete the task. Start with the direct answer and do not describe your search process.
+          - For "how do I" questions, use a short numbered list of the relevant steps. Include alternative workflows only when they are materially useful.
+          - When directing an administrator to an area of this site, use a descriptive Markdown link with an absolute URL based on {site_url}. For example: [Create an invite]({site_url}/new-invite). Never respond with a bare URL.
+          - Use Meta search results to support factual guidance and link to the most useful source with descriptive link text. Do not overwhelm the answer with sources.
+          - Mention permission requirements, trade-offs, or relevant site settings only when they affect the requested action.
+          - Prefer a compact answer: a direct recommendation, two to five actionable steps, and at most one short note for an important caveat.
           - You are able to find information about site settings, request context for a specific setting, and look up the current value of a site setting.
           - Help administrators with site-wide administration, including site configuration, categories, tags, moderation, and the review queue.
           - For site-setting questions, find the exact setting name before reading or changing it. Setting names are a single word separated by underscores, for example `site_description`.


### PR DESCRIPTION
Previously, the Admin Assistant gave general guidance that could leave routine tasks without concise, descriptive links.

This change directs it to provide practical steps and contextual site and Meta links.