### PR TITLE
FIX: Create tags in composer creates instead of fallback to ID

### DIFF
--- a/frontend/discourse/app/lib/serialize-tags.js
+++ b/frontend/discourse/app/lib/serialize-tags.js
@@ -3,6 +3,9 @@ export function serializeTags(tags) {
     if (typeof t === "string") {
       return { name: t };
     }
+    if (t.isNew) {
+      return { name: t.name };
+    }
     const numId = Number(t.id);
     if (Number.isInteger(numId) && numId > 0) {
       return { id: numId, name: t.name };

--- a/frontend/discourse/select-kit/components/mini-tag-chooser.js
+++ b/frontend/discourse/select-kit/components/mini-tag-chooser.js
@@ -115,7 +115,11 @@ export default class MiniTagChooser extends MultiSelectComponent {
     }
     return tags.map((t) => {
       if (typeof t === "object" && t !== null) {
-        return this.defaultItem(t.id, t.name);
+        const item = this.defaultItem(t.id, t.name);
+        if (t.isNew) {
+          item.isNew = true;
+        }
+        return item;
       }
       return this.defaultItem(t, t);
     });

--- a/frontend/discourse/select-kit/components/select-kit.js
+++ b/frontend/discourse/select-kit/components/select-kit.js
@@ -774,7 +774,11 @@ export default class SelectKit extends Component {
         ) {
           filter = this.createContentFromInput(filter);
           if (this.validateCreate(filter, content)) {
-            this.selectKit.set("newItem", this.defaultItem(filter, filter));
+            const newItem = this.defaultItem(filter, filter);
+            if (typeof newItem === "object" && newItem !== null) {
+              newItem.isNew = true;
+            }
+            this.selectKit.set("newItem", newItem);
             content.unshift(this.selectKit.newItem);
           }
         }

--- a/frontend/discourse/select-kit/components/tag-chooser.js
+++ b/frontend/discourse/select-kit/components/tag-chooser.js
@@ -93,7 +93,11 @@ export default class TagChooser extends MultiSelectComponent {
           // numeric ID - use as both id and name until we can look up the actual name
           return this.defaultItem(t, t);
         }
-        return this.defaultItem(t.id, t.name);
+        const item = this.defaultItem(t.id, t.name);
+        if (t.isNew) {
+          item.isNew = true;
+        }
+        return item;
       })
     );
   }

--- a/frontend/discourse/tests/unit/lib/serialize-tags-test.js
+++ b/frontend/discourse/tests/unit/lib/serialize-tags-test.js
@@ -1,0 +1,40 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { serializeTags } from "discourse/lib/serialize-tags";
+
+module("Unit | Utility | serialize-tags", function (hooks) {
+  setupTest(hooks);
+
+  test("plain string tag names are serialized as name-only", function (assert) {
+    assert.deepEqual(serializeTags(["10"]), [{ name: "10" }]);
+    assert.deepEqual(serializeTags(["foo"]), [{ name: "foo" }]);
+  });
+
+  test("existing tags with numeric id are serialized with id and name", function (assert) {
+    assert.deepEqual(serializeTags([{ id: 10, name: "bulk-test-tag-10" }]), [
+      { id: 10, name: "bulk-test-tag-10" },
+    ]);
+  });
+
+  test("isNew items are serialized as name-only, even when id looks numeric", function (assert) {
+    assert.deepEqual(serializeTags([{ id: "10", name: "10", isNew: true }]), [
+      { name: "10" },
+    ]);
+  });
+
+  test("mixed input: existing tag alongside a freshly created numeric-name tag", function (assert) {
+    assert.deepEqual(
+      serializeTags([
+        { id: 42, name: "bulk-test-tag-10" },
+        { id: "10", name: "10", isNew: true },
+      ]),
+      [{ id: 42, name: "bulk-test-tag-10" }, { name: "10" }]
+    );
+  });
+
+  test("non-numeric id falls back to name-only", function (assert) {
+    assert.deepEqual(serializeTags([{ id: "hello", name: "hello" }]), [
+      { name: "hello" },
+    ]);
+  });
+});

--- a/spec/system/composer_spec.rb
+++ b/spec/system/composer_spec.rb
@@ -121,6 +121,35 @@ describe "Composer" do
       expect(topic_page).to have_topic_title("Test topic with tags")
       expect(topic_page.topic_tags).to include(tag.name)
     end
+
+    it "creates a new numeric-name tag rather than reusing an existing tag with that id" do
+      SiteSetting.create_tag_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
+
+      # A pre-existing tag whose id (as a string) will collide with what the
+      # user types. If serialization ever treats the typed name as an id, the
+      # backend would attach this tag instead of creating a new one.
+      existing_tag = Fabricate(:tag, name: "existing-tag-name")
+      numeric_name = existing_tag.id.to_s
+
+      page.visit "/new-topic"
+      expect(composer).to be_opened
+
+      composer.fill_title("Test topic with numeric-name tag")
+      composer.fill_content("This is a test topic with a numeric-name tag")
+      composer.switch_category(category.name)
+
+      mini_tag_chooser.expand
+      mini_tag_chooser.search(numeric_name)
+      mini_tag_chooser.select_row_by_name(numeric_name)
+      mini_tag_chooser.collapse
+
+      composer.create
+
+      expect(topic_page).to have_topic_title("Test topic with numeric-name tag")
+      expect(topic_page.topic_tags).to eq([numeric_name])
+      expect(topic_page.topic_tags).not_to include(existing_tag.name)
+      expect(Tag.exists?(name: numeric_name)).to eq(true)
+    end
   end
 
   context "with fixed category positions" do


### PR DESCRIPTION
There's a small bug with creating tags inside of the composer and choosing "Create: '20'" or some numeric name for the tagname. If there is already a tag with that ID, it will use the existing tag instead of creating the new one.

This changes to ensure that when the "Create" option is selected, it does not populate the ID and will instead create the tag with name "20".