### PR TITLE
DEV: fix clear deprecation for search history

### DIFF
--- a/frontend/discourse/app/components/search-menu/results/recent-searches.gjs
+++ b/frontend/discourse/app/components/search-menu/results/recent-searches.gjs
@@ -26,7 +26,7 @@ export default class RecentSearches extends Component {
   async clearRecent() {
     const result = await User.resetRecentSearches();
     if (result.success) {
-      this.currentUser.recent_searches.clear();
+      this.currentUser.set("recent_searches", []);
     }
   }
 


### PR DESCRIPTION
Fixes this deprecation notice when clearing recent searches, reported here https://meta.discourse.org/t/deprecation-notice-recent-searches-clear/408083

> DEPRECATION NOTICE: The array.clear is a deprecated Ember native array extension. Use native array methods or a TrackedArray instead. [deprecated since Discourse 3.6.0.beta1-dev] [deprecation id: discourse.native-array-extensions.clear]