### PR TITLE
SECURITY: Anonymous users can inherit legacy `everyone` permissions for deleted-post visibility

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -102,10 +102,6 @@ class Guardian
     end
 
     def in_any_groups?(group_ids)
-      if !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
-        return group_ids.include?(Group::AUTO_GROUPS[:everyone])
-      end
-
       group_ids.include?(Group::AUTO_GROUPS[:anonymous_users])
     end
 
@@ -666,7 +662,8 @@ class Guardian
   end
 
   def can_lazy_load_categories?
-    in_any_groups?(SiteSetting.lazy_load_categories_groups_map)
+    SiteSetting.lazy_load_categories_groups_map.include?(Group::AUTO_GROUPS[:everyone]) ||
+      in_any_groups?(SiteSetting.lazy_load_categories_groups_map)
   end
 
   def is_me?(other)

--- a/spec/requests/anonymous_legacy_everyone_permissions_spec.rb
+++ b/spec/requests/anonymous_legacy_everyone_permissions_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe "anonymous legacy everyone permissions" do
+  fab!(:admin)
+  fab!(:shared_drafts_category, :category)
+
+  before { SiteSetting.granular_anonymous_and_logged_in_groups_permissions = false }
+
+  it "does not inherit everyone permissions for sensitive visibility checks" do
+    SiteSetting.delete_all_posts_and_topics_allowed_groups = Group::AUTO_GROUPS[:everyone].to_s
+    first_post = Fabricate(:post)
+    topic = first_post.topic
+    deleted_post = Fabricate(:post, topic:, raw: "deleted post should stay private")
+    PostDestroyer.new(admin, deleted_post).destroy
+    deleted_post.reload
+
+    get "/t/#{topic.slug}/#{topic.id}.json", params: { show_deleted: true }
+
+    expect(response.status).to eq(200)
+    post_ids = response.parsed_body.dig("post_stream", "posts").map { |post| post["id"] }
+    expect(post_ids).not_to include(deleted_post.id)
+    expect(response.body).not_to include(deleted_post.raw)
+
+    SiteSetting.shared_drafts_category = shared_drafts_category.id
+    SiteSetting.shared_drafts_allowed_groups = Group::AUTO_GROUPS[:everyone].to_s
+    shared_draft_topic = Fabricate(:topic, category: shared_drafts_category)
+    shared_draft_post =
+      Fabricate(:post, topic: shared_draft_topic, raw: "shared draft should stay private")
+    Fabricate(:shared_draft, topic: shared_draft_topic, category: Fabricate(:category))
+
+    get "/t/#{shared_draft_topic.slug}/#{shared_draft_topic.id}.json"
+
+    expect(response).to be_not_found
+    expect(response.body).not_to include(shared_draft_post.raw)
+
+    SiteSetting.lazy_load_categories_groups = Group::AUTO_GROUPS[:everyone].to_s
+
+    get "/site.json"
+
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["lazy_load_categories"]).to eq(true)
+  end
+end


### PR DESCRIPTION
## Summary

Prevent anonymous users from inheriting legacy "everyone" group permissions for sensitive visibility checks, such as viewing deleted posts or shared drafts. The patch removes a global fallback in the permission system that incorrectly treated unauthenticated users as members of the "everyone" group, while preserving backward compatibility for safe, non-sensitive features like category lazy loading.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1411

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>