### PR TITLE
FIX: Refresh site settings after process forks

### DIFF
--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -594,7 +594,7 @@ module SiteSettingExtension
   # Merges the provider values of site settings (whether it be from the DB or wherever)
   # and theme site settings with the default values of those settings, also taking into
   # account shadowed site settings and upcoming change behaviour.
-  def refresh!(refresh_site_settings: true, refresh_theme_site_settings: true)
+  def refresh!(refresh_site_settings: true, refresh_theme_site_settings: true, clear_caches: true)
     mutex.synchronize do
       ensure_listen_for_changes
 
@@ -669,10 +669,12 @@ module SiteSettingExtension
 
       refresh_theme_site_settings! if refresh_theme_site_settings
 
-      clear_cache!(
-        expire_theme_site_setting_cache:
-          ThemeSiteSetting.can_access_db? && refresh_theme_site_settings,
-      )
+      if clear_caches
+        clear_cache!(
+          expire_theme_site_setting_cache:
+            ThemeSiteSetting.can_access_db? && refresh_theme_site_settings,
+        )
+      end
     end
   end
 
@@ -736,6 +738,7 @@ module SiteSettingExtension
   def after_fork
     @process_id = nil
     ensure_listen_for_changes
+    RailsMultisite::ConnectionManagement.safe_each_connection { refresh!(clear_caches: false) }
   end
 
   def raise_invalid_setting_access(setting_name)

--- a/spec/lib/site_setting_extension_multisite_spec.rb
+++ b/spec/lib/site_setting_extension_multisite_spec.rb
@@ -15,4 +15,36 @@ RSpec.describe SiteSettingExtension, type: :multisite do
 
     test_multisite_connection("second") { expect(settings.hello).to eq(1) }
   end
+
+  describe ".after_fork" do
+    it "loads the current settings for each configured site" do
+      settings.setting(:hello, 1)
+
+      settings.hello = 100
+      test_multisite_connection("second") { settings.hello = 200 }
+
+      settings.provider.save(:hello, 111, SiteSetting.types[:integer])
+      test_multisite_connection("second") do
+        settings.provider.save(:hello, 222, SiteSetting.types[:integer])
+      end
+
+      settings.after_fork
+
+      expect(settings.hello).to eq(111)
+      test_multisite_connection("second") { expect(settings.hello).to eq(222) }
+    end
+
+    it "does not publish cache invalidation messages while reloading settings" do
+      settings.setting(:hello, 1)
+      settings.hello = 100
+      settings.provider.save(:hello, 111, SiteSetting.types[:integer])
+      test_multisite_connection("second") do
+        settings.provider.save(:hello, 222, SiteSetting.types[:integer])
+      end
+
+      messages = MessageBus.track_publish { settings.after_fork }
+
+      expect(messages).to eq([])
+    end
+  end
 end

--- a/spec/lib/site_setting_extension_spec.rb
+++ b/spec/lib/site_setting_extension_spec.rb
@@ -184,6 +184,19 @@ RSpec.describe SiteSettingExtension do
     end
   end
 
+  describe ".after_fork" do
+    it "refreshes the site settings" do
+      settings.setting(:hello, 1)
+      settings.hello = 100
+
+      settings.provider.save(:hello, 200, SiteSetting.types[:integer])
+
+      settings.after_fork
+
+      expect(settings.hello).to eq(200)
+    end
+  end
+
   describe "DiscourseEvent" do
     before do
       settings.setting(:test_setting, 1)


### PR DESCRIPTION
Discourse keeps site settings in memory so it does not need to read them from the database for every request or job.

Pitchfork starts Sidekiq from a long-running parent process. That parent can still have the site settings that were loaded when Discourse first started. When an admin changes a setting, the running Sidekiq process gets the new value through MessageBus, but the parent can keep the old value.

If Sidekiq is later restarted, the new Sidekiq process copies the old settings from its parent. For example, after changing `site_contact_username`, a restarted Sidekiq process could send system messages from the previous account. The wrong value remained in use until another setting changed or Discourse was restarted.

This change reloads site settings from the database after Discourse starts a new process. It starts listening for new setting changes before the reload, so a change made during startup is not missed. On multisite installations, it reloads each site separately.

The reload only updates memory in the new process. It does not clear shared caches or send another MessageBus message, which avoids extra work when several processes restart at the same time.

Reported at https://meta.discourse.org/t/site-settings-are-stale-in-sidekiq-after-it-re-forks/408094