### PR TITLE
FIX: Restore the resized composer height when unminimizing

### DIFF
--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -174,14 +174,14 @@ export default class ComposerContainer extends Component {
   @bind
   onResizeDrag(size) {
     this.appEvents.trigger("composer:div-resizing");
-    this.composer.set("composerHeight", `${size}px`);
-    this.keyValueStore.set({
-      key: "composerHeight",
-      value: this.composer.composerHeight,
-    });
+
+    const height = `${size}px`;
+    // resuming from minimized restores the height from the model
+    this.composer.model?.set("composerHeight", height);
+    this.keyValueStore.set({ key: "composerHeight", value: height });
     document.documentElement.style.setProperty(
       "--composer-height",
-      size ? `${size}px` : ""
+      size ? height : ""
     );
 
     this._triggerComposerResized();

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -137,8 +137,6 @@ export default class ComposerService extends Service {
   topic = null;
   linkLookup = null;
 
-  composerHeight = null;
-
   @tracked _showPreview;
 
   @tracked _isStaffUserOverride;

--- a/frontend/discourse/tests/acceptance/composer-test.js
+++ b/frontend/discourse/tests/acceptance/composer-test.js
@@ -150,6 +150,35 @@ acceptance(`Composer`, function (needs) {
     );
   });
 
+  test("restores the resized height when resuming a minimized draft", async function (assert) {
+    await visit("/");
+    await click("#create-topic");
+    await fillIn(".d-editor-input", "this draft has been resized");
+
+    // drag past the minimum so the height clamps to a known value
+    await triggerEvent(".grippie", "mousedown", { clientY: 500 });
+    await triggerEvent(".grippie", "mousemove", { clientY: 3000 });
+    await triggerEvent(".grippie", "mouseup");
+
+    const resizedHeight =
+      document.documentElement.style.getPropertyValue("--composer-height");
+    assert.strictEqual(resizedHeight, "255px", "applies the dragged height");
+
+    await click(".toggle-minimize");
+    assert.strictEqual(
+      document.documentElement.style.getPropertyValue("--composer-height"),
+      "40px",
+      "minimizes to the draft bar"
+    );
+
+    await click(".toggle-fullscreen");
+    assert.strictEqual(
+      document.documentElement.style.getPropertyValue("--composer-height"),
+      resizedHeight,
+      "restores the resized height instead of the default when resumed"
+    );
+  });
+
   test("fires resize event after width transition", async function (assert) {
     await visit("/");
     await click("#create-topic");


### PR DESCRIPTION
Dragging the grippie only updated the composer service property, the key-value store, and the live CSS variable — never `model.composerHeight`, which is what every resume path (`unshrink`, `openIfDraft`, and the same-draft branch of `open`) reads when restoring from the minimized draft bar. Resizing, minimizing, and resuming within the same session snapped the composer back to the height it was opened at.

Write the height to the model directly on drag, and drop the service `composerHeight` property, which had no other readers and lagged the real value.