### PR TITLE
DEV: Fix flaky JsSandbox memory limit spec

### DIFF
--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/js_sandbox_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/js_sandbox_spec.rb
@@ -26,10 +26,14 @@ RSpec.describe DiscourseWorkflows::JsSandbox do
 
   describe "memory limit" do
     it "raises when JS allocates too much memory" do
-      expect { sandbox.eval(<<~JS) }.to raise_error(DiscourseWorkflows::JsSandbox::SandboxError)
+      # a generous timeout keeps the memory cap as the only limit that can
+      # fire, even on a slow CI box
+      stub_const(DiscourseWorkflows::JsSandbox, :EVAL_TIMEOUT_MS, 5_000) do
+        expect { sandbox.eval(<<~JS) }.to raise_error(DiscourseWorkflows::JsSandbox::SandboxError)
           var a = [];
-          while(true) { a.push(new Array(10000).fill('x')); }
+          while(true) { a.push(new Array(100000).fill(1.5)); }
         JS
+      end
     end
   end
 


### PR DESCRIPTION
The memory limit spec raced the 100ms eval watchdog against the 50MB memory cap: on a slow CI box the timeout fired first, raising `BudgetExceededError` instead of the expected `SandboxError`.

Stub the eval timeout to a generous value so the memory cap is the only limit that can fire, and make the workload allocate packed-double arrays, which reach the cap ~3x faster.