### PR TITLE
FIX: Ensure deleted posts do not show up when viewing a different language

### DIFF
--- a/app/jobs/regular/deliver_push_notification.rb
+++ b/app/jobs/regular/deliver_push_notification.rb
@@ -36,12 +36,20 @@ module Jobs
       end
 
       if (post_id = payload[:post_id])
-        post_localization =
-          PostLocalization.find_by(post_id: post_id, locale: locale) ||
-            PostLocalization.matching_locale(locale).find_by(post_id: post_id)
-        if post_localization
+        post = Post.select(:id, :post_number, :user_deleted).find_by(id: post_id)
+        cooked =
+          if post&.user_deleted?
+            ContentLocalization.user_deleted_post_cooked(post, locale: locale)
+          else
+            (
+              PostLocalization.find_by(post_id: post_id, locale: locale) ||
+                PostLocalization.matching_locale(locale).find_by(post_id: post_id)
+            )&.cooked
+          end
+
+        if cooked.present?
           payload[:excerpt] = Post.excerpt(
-            post_localization.cooked,
+            cooked,
             400,
             text_entities: true,
             strip_links: true,

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -116,6 +116,14 @@ class PostSerializer < BasicPostSerializer
     object&.url
   end
 
+  def cooked
+    if SiteSetting.content_localization_enabled && object.user_deleted?
+      ContentLocalization.user_deleted_post_cooked(object)
+    else
+      super
+    end
+  end
+
   def topic_slug
     topic&.slug
   end

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -16,8 +16,16 @@ class ContentLocalization
   # @param post [Post] The post object
   # @return [Boolean]
   def self.show_translated_post?(post, scope)
-    SiteSetting.content_localization_enabled && post.raw.present? && post.locale.present? &&
-      !post.in_user_locale? && !show_original?(scope)
+    SiteSetting.content_localization_enabled && !post.user_deleted? && post.raw.present? &&
+      post.locale.present? && !post.in_user_locale? && !show_original?(scope)
+  end
+
+  def self.user_deleted_post_cooked(post, locale: I18n.locale)
+    locale = SiteSetting.default_locale if !I18n.locale_available?(locale)
+    key =
+      post.is_first_post? ? "js.topic.deleted_by_author_simple" : "js.post.deleted_by_author_simple"
+
+    "<p>#{ERB::Util.html_escape(I18n.t(key, locale: locale))}</p>"
   end
 
   # This method returns true when we should try to show the translated topic.

--- a/lib/localization_attributes_replacer.rb
+++ b/lib/localization_attributes_replacer.rb
@@ -38,6 +38,11 @@ module LocalizationAttributesReplacer
   end
 
   def self.replace_post_attributes(post, crawl_locale)
+    if post.user_deleted?
+      post.cooked = ContentLocalization.user_deleted_post_cooked(post, locale: crawl_locale)
+      return
+    end
+
     if loc = get_localization(post, crawl_locale)
       post.cooked = loc.cooked if loc.cooked.present?
     end

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -442,11 +442,17 @@ module Oneboxer
       title = topic_localization.title.presence || title
     end
 
-    if (post_localization = post.get_localization(locale, fallback: false)) &&
-         post_localization.cooked.present?
+    localized_cooked =
+      if post.user_deleted?
+        ContentLocalization.user_deleted_post_cooked(post, locale: locale)
+      else
+        post.get_localization(locale, fallback: false)&.cooked
+      end
+
+    if localized_cooked.present?
       excerpt =
         Post.excerpt(
-          post_localization.cooked,
+          localized_cooked,
           SiteSetting.post_onebox_maxlength,
           keep_svg: true,
           post: post,

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -50,7 +50,7 @@ module DiscourseAi
               "posts.created_at > ?",
               SiteSetting.ai_translation_backfill_max_age_days.days.ago,
             )
-            .where(deleted_at: nil)
+            .where(deleted_at: nil, user_deleted: false)
             .where.not(raw: [nil, ""])
             .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
 
@@ -84,7 +84,7 @@ module DiscourseAi
         # Always include posts from banner topics regardless of age or category filters
         banner_posts =
           Post
-            .where(deleted_at: nil)
+            .where(deleted_at: nil, user_deleted: false)
             .where.not(raw: [nil, ""])
             .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
             .joins(:topic)

--- a/plugins/discourse-ai/lib/translation/post_localizer.rb
+++ b/plugins/discourse-ai/lib/translation/post_localizer.rb
@@ -6,7 +6,7 @@ module DiscourseAi
       include LocalizableQuota
 
       def self.localize(post, target_locale = I18n.locale, llm_model: nil)
-        if post.blank? || target_locale.blank? ||
+        if post.blank? || post.user_deleted? || target_locale.blank? ||
              LocaleNormalizer.is_same?(post.locale, target_locale) || post.raw.blank?
           return
         end

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -41,6 +41,14 @@ describe DiscourseAi::Translation::PostCandidates do
       expect(DiscourseAi::Translation::PostCandidates.get).not_to include(post)
     end
 
+    it "does not return user-deleted posts" do
+      post = Fabricate(:post, user_deleted: true)
+      banner_post =
+        Fabricate(:post, topic: Fabricate(:topic, archetype: Archetype.banner), user_deleted: true)
+
+      expect(DiscourseAi::Translation::PostCandidates.get).not_to include(post, banner_post)
+    end
+
     it "does not return posts longer than ai_translation_max_post_length" do
       SiteSetting.ai_translation_max_post_length = 100
       short_post = Fabricate(:post, raw: "This is a short post that fits within the limit.")

--- a/plugins/discourse-ai/spec/lib/translation/post_localizer_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_localizer_spec.rb
@@ -30,6 +30,14 @@ describe DiscourseAi::Translation::PostLocalizer do
       expect(described_class.localize(post, "")).to eq(nil)
     end
 
+    it "does not localize a user-deleted post" do
+      post.user_deleted = true
+      allow(DiscourseAi::Translation::PostRawTranslator).to receive(:new)
+
+      expect(described_class.localize(post, "ja")).to eq(nil)
+      expect(DiscourseAi::Translation::PostRawTranslator).not_to have_received(:new)
+    end
+
     it "returns nil if target_locale is same as post locale" do
       post.locale = "en"
 

--- a/spec/jobs/deliver_push_notification_spec.rb
+++ b/spec/jobs/deliver_push_notification_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe Jobs::DeliverPushNotification do
       Jobs::DeliverPushNotification.new.execute(user_id: user.id, payload: localizable_payload)
     end
 
+    it "uses the localized deletion notice when the author deleted the post before delivery" do
+      Fabricate(:push_subscription, user: user)
+      Fabricate(:post_localization, post: localized_post, locale: "ja", cooked: "<p>削除された投稿の翻訳</p>")
+      PostDestroyer.new(localized_post.user, localized_post, delete_removed_posts_after: 1).destroy
+      type = localized_post.is_first_post? ? "topic" : "post"
+      key = "js.#{type}.deleted_by_author_simple"
+
+      PushNotificationPusher
+        .expects(:push)
+        .with do |_user, delivered_payload|
+          delivered_payload[:excerpt] == I18n.t(key, locale: user.effective_locale)
+        end
+
+      Jobs::DeliverPushNotification.new.execute(user_id: user.id, payload: localizable_payload)
+    end
+
     it "localizes payload before delivering to hub push" do
       SiteSetting.allowed_user_api_push_urls = "https://hub.example.com/push"
       client = Fabricate(:user_api_key_client)

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -91,6 +91,13 @@ describe ContentLocalization do
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
       end
 
+      it "returns false when the author deleted the post" do
+        post.update!(user_deleted: true)
+        scope = create_scope
+
+        expect(ContentLocalization.show_translated_post?(post, scope)).to be false
+      end
+
       it "returns false when post is in user locale" do
         post.update!(locale: I18n.locale)
         scope = create_scope
@@ -103,6 +110,34 @@ describe ContentLocalization do
 
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
       end
+    end
+  end
+
+  describe ".user_deleted_post_cooked" do
+    fab!(:post) { Fabricate(:post, post_number: 2) }
+
+    it "uses the requested locale" do
+      expect(ContentLocalization.user_deleted_post_cooked(post, locale: "ja")).to eq(
+        "<p>(作成者が削除した投稿)</p>",
+      )
+    end
+
+    it "falls back to the default locale when the requested locale is invalid" do
+      translated = I18n.t("js.post.deleted_by_author_simple", locale: SiteSetting.default_locale)
+
+      expect(ContentLocalization.user_deleted_post_cooked(post, locale: "invalid")).to eq(
+        "<p>#{ERB::Util.html_escape(translated)}</p>",
+      )
+    end
+
+    it "escapes the translated text" do
+      allow(I18n).to receive(:t).with("js.post.deleted_by_author_simple", locale: "ja").and_return(
+        "<deleted>",
+      )
+
+      expect(ContentLocalization.user_deleted_post_cooked(post, locale: "ja")).to eq(
+        "<p>&lt;deleted&gt;</p>",
+      )
     end
   end
 

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -322,6 +322,17 @@ RSpec.describe Oneboxer do
       expect(html).not_to include("戦わずして勝つ")
     end
 
+    it "shows the deletion notice instead of the linked post's translation when its author deleted it" do
+      localization =
+        Fabricate(:post_localization, post: first_post, locale: "ja", cooked: "削除された投稿の翻訳")
+      PostDestroyer.new(first_post.user, first_post, delete_removed_posts_after: 1).destroy
+
+      html = card(linked_topic.relative_url, locale: "ja")
+
+      expect(html).to include(I18n.t("js.topic.deleted_by_author_simple", locale: "ja"))
+      expect(html).not_to include(localization.cooked)
+    end
+
     it "keeps the preview original when only the title is translated" do
       Fabricate(:topic_localization, topic: linked_topic, locale: "ja", title: "孫子の兵法")
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7484,6 +7484,36 @@ RSpec.describe TopicsController do
             expect(response.body).to include(ja_subcategory.name)
           end
 
+          it "does not show a stale post translation after author deletion" do
+            deleted_post = page_1_posts.find { |post| !post.is_first_post? }
+            deleted_post.update!(locale: "en")
+            localization =
+              Fabricate(
+                :post_localization,
+                post: deleted_post,
+                locale: "ja",
+                cooked: "<p>削除された投稿の翻訳</p>",
+              )
+            PostDestroyer.new(
+              deleted_post.user,
+              deleted_post,
+              delete_removed_posts_after: 1,
+            ).destroy
+
+            get topic.relative_url,
+                env: {
+                  "HTTP_USER_AGENT" => bot_user_agent,
+                },
+                params: {
+                  tl: "ja",
+                }
+
+            expect(response.body).to include(
+              I18n.t("js.post.deleted_by_author_simple", locale: "ja"),
+            )
+            expect(response.body).not_to include(localization.cooked)
+          end
+
           it "does not persist localized fancy_title to the database when topic fancy_title is null" do
             topic.update_column(:fancy_title, nil)
 

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -76,6 +76,71 @@ describe "Content Localization" do
       expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
     end
 
+    it "shows an author's localized deletion notice and restores the translation on recovery" do
+      localized_text = "最大の勝利は戦いを必要としないものです"
+      authored_post =
+        Fabricate(
+          :post,
+          topic:,
+          user: japanese_user,
+          locale: "en",
+          raw: "The supreme art of war is to subdue the enemy without fighting",
+        )
+      Fabricate(:post_localization, post: authored_post, locale: "ja", cooked: localized_text)
+      deletion_notice = I18n.t("js.post.deleted_by_author_simple", locale: japanese_user.locale)
+      SiteSetting.post_menu_hidden_items = ""
+      sign_in(japanese_user)
+
+      topic_page.visit_topic(topic)
+      expect(topic_page).to have_exact_post_content(
+        post_number: authored_post.post_number,
+        content: localized_text,
+      )
+
+      using_session(:second_tab) do
+        sign_in(japanese_user)
+        topic_page.visit_topic(topic)
+        expect(topic_page).to have_exact_post_content(
+          post_number: authored_post.post_number,
+          content: localized_text,
+        )
+      end
+
+      topic_page.click_post_action_button(authored_post, :delete)
+
+      expect(topic_page).to have_exact_post_content(
+        post_number: authored_post.post_number,
+        content: deletion_notice,
+      )
+      expect(topic_page).to have_post_action_button(authored_post, :recover)
+
+      using_session(:second_tab) do
+        try_until_success(reason: "Relies on the deleted-post MessageBus update") do
+          expect(topic_page).to have_exact_post_content(
+            post_number: authored_post.post_number,
+            content: deletion_notice,
+          )
+        end
+      end
+
+      topic_page.click_post_action_button(authored_post, :recover)
+
+      expect(topic_page).to have_post_action_button(authored_post, :delete)
+      expect(topic_page).to have_exact_post_content(
+        post_number: authored_post.post_number,
+        content: localized_text,
+      )
+
+      using_session(:second_tab) do
+        try_until_success(reason: "Relies on the recovered-post MessageBus update") do
+          expect(topic_page).to have_exact_post_content(
+            post_number: authored_post.post_number,
+            content: localized_text,
+          )
+        end
+      end
+    end
+
     it "persists 'Show Original' preference from user preferences interface" do
       sign_in(japanese_user)
 

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -59,6 +59,10 @@ module PageObjects
         find(post_by_number_selector(post_number)).has_content?(content)
       end
 
+      def has_exact_post_content?(post_number:, content:)
+        has_css?("#{post_by_number_selector(post_number)} .cooked", exact_text: content)
+      end
+
       def has_deleted_post?(post)
         has_css?(".topic-post.deleted:has(#post_#{post.post_number})")
       end


### PR DESCRIPTION
Related: https://meta.discourse.org/t/deleted-posts-still-show-full-content-when-translation-is-enabled/407942

Translations could reveal a post’s content after its author deleted it. Translation backfills could also recreate localizations that had been removed.

This PR prevents author-deleted posts from using or generating localizations. The stored localizations are preserved so they become available again if the post is recovered, while deleted posts display the deletion notice in the viewer’s locale.

<img width="803" height="483" alt="Screenshot 2026-07-21 at 12 15 07 PM" src="https://github.com/user-attachments/assets/9ec52dfa-1b9d-4557-aece-1c58cf216c81" />
