### PR TITLE
UX: Unhide group name in ACL grantee chooser when different from full name

### DIFF
--- a/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
+++ b/app/assets/stylesheets/common/select-kit/email-group-user-chooser.scss
@@ -22,8 +22,10 @@
       @include ellipsis;
     }
 
-    .email-group-user-chooser--user {
-      &.--username-first {
+    .email-group-user-chooser--user,
+    .email-group-user-chooser--group {
+      &.--username-first,
+      &.--group-name-first {
         .identifier {
           color: var(--primary);
           white-space: nowrap;
@@ -39,11 +41,13 @@
         }
       }
 
-      &.--name-first {
+      &.--name-first,
+      &.--group-full-name-first {
         .name {
           color: var(--primary);
           white-space: nowrap;
           line-height: var(--line-height-medium);
+          font-size: var(--font-0);
           margin-right: 0.5em;
         }
 

--- a/frontend/discourse/app/ui-kit/d-access-control-grantee-chooser.gjs
+++ b/frontend/discourse/app/ui-kit/d-access-control-grantee-chooser.gjs
@@ -43,16 +43,17 @@ function userGranteeResult(user) {
  * excludedGrantees: an array of grantee values (in format type:id) that should be excluded from the search results,
  * since they have already been selected. These are passed from DAccessControl.
  *
- * onlyShowGroupFullName: for DAccessControl, it's ugly/unnecessary to show the group short_name_with_underscores, we only
- * want to show the group full name.
- *
  * prioritizeUserNameOrdering: for DAccessControl, we want to respect the prioritize_username_in_ux site setting and
  * show the name before the username in the search results depending on the setting.
+ *
+ * prioritizeGroupFullNameOrdering: for DAccessControl, we want to show the full
+ * name before the group name in the search results.
  */
 @selectKitOptions({
   excludedGrantees: undefined,
-  onlyShowGroupFullName: true,
   prioritizeUserNameOrdering: true,
+  prioritizeGroupFullNameOrdering: true,
+  excludeGroupNameWhenMatchingFullName: true,
 })
 export default class DAccessControlGranteeChooser extends EmailGroupUserChooser {
   valueProperty = "value";
@@ -71,8 +72,9 @@ export default class DAccessControlGranteeChooser extends EmailGroupUserChooser 
           acl_target: this.selectKit.options.aclTarget,
         },
       });
-      const results_2 = this.normalizeGranteeResults(results);
-      return this.excludeSelectedGrantees(results_2);
+      return this.excludeSelectedGrantees(
+        this.normalizeGranteeResults(results)
+      );
     } catch {
       return [];
     }

--- a/frontend/discourse/select-kit/components/email-group-user-chooser-row.gjs
+++ b/frontend/discourse/select-kit/components/email-group-user-chooser-row.gjs
@@ -21,6 +21,22 @@ export default class EmailGroupUserChooserRow extends SelectKitRowComponent {
     return "nameFirst";
   }
 
+  get groupNameOrdering() {
+    if (!this.selectKit.options.prioritizeGroupFullNameOrdering) {
+      return "groupNameFirst";
+    }
+
+    return "groupFullNameFirst";
+  }
+
+  get shouldExcludeGroupName() {
+    return (
+      this.selectKit.options.excludeGroupNameWhenMatchingFullName &&
+      this.item.full_name.toLowerCase() ===
+        this.item.id.toLowerCase().replaceAll("_", " ").replaceAll("-", " ")
+    );
+  }
+
   <template>
     {{#if this.item.isUser}}
       {{dAvatar this.item imageSize="tiny"}}
@@ -36,9 +52,13 @@ export default class EmailGroupUserChooserRow extends SelectKitRowComponent {
       >
         {{#if (eq this.userNameOrdering "usernameFirst")}}
           <span class="identifier">{{formatUsername this.item.id}}</span>
-          <span class="name">{{this.item.name}}</span>
+          {{#if this.item.name}}
+            <span class="name">{{this.item.name}}</span>
+          {{/if}}
         {{else}}
-          <span class="name">{{this.item.name}}</span>
+          {{#if this.item.name}}
+            <span class="name">{{this.item.name}}</span>
+          {{/if}}
           <span class="identifier">{{formatUsername this.item.id}}</span>
         {{/if}}
       </div>
@@ -54,23 +74,24 @@ export default class EmailGroupUserChooserRow extends SelectKitRowComponent {
       <div
         class={{dConcatClass
           "email-group-user-chooser--group"
-          (if this.selectKit.options.onlyShowGroupFullName "--full-name-only")
+          (if
+            (eq this.groupNameOrdering "groupNameFirst")
+            "--group-name-first"
+            "--group-full-name-first"
+          )
         }}
       >
-        {{#unless this.selectKit.options.onlyShowGroupFullName}}
-          <span class="identifier">{{this.item.id}}</span>
-        {{/unless}}
-        <span class="name">
-          {{#if this.selectKit.options.onlyShowGroupFullName}}
-            {{#if this.item.full_name}}
-              {{this.item.full_name}}
-            {{else}}
-              {{this.item.name}}
-            {{/if}}
-          {{else}}
-            {{this.item.name}}
-          {{/if}}
-        </span>
+        {{#if (eq this.groupNameOrdering "groupNameFirst")}}
+          {{#unless this.shouldExcludeGroupName}}
+            <span class="identifier">{{this.item.id}}</span>
+          {{/unless}}
+          <span class="name">{{this.item.full_name}}</span>
+        {{else}}
+          <span class="name">{{this.item.full_name}}</span>
+          {{#unless this.shouldExcludeGroupName}}
+            <span class="identifier">{{this.item.id}}</span>
+          {{/unless}}
+        {{/if}}
       </div>
     {{else}}
       {{dIcon "envelope"}}

--- a/frontend/discourse/select-kit/components/email-group-user-chooser.js
+++ b/frontend/discourse/select-kit/components/email-group-user-chooser.js
@@ -13,8 +13,9 @@ import EmailGroupUserChooserRow from "./email-group-user-chooser-row";
   filterComponent: EmailGroupUserChooserFilter,
   fullWidthWrap: false,
   autoWrap: false,
-  onlyShowGroupFullName: false,
   prioritizeUserNameOrdering: false,
+  prioritizeGroupFullNameOrdering: false,
+  excludeGroupNameWhenMatchingFullName: false,
 })
 @pluginApiIdentifiers(["email-group-user-chooser"])
 export default class EmailGroupUserChooser extends UserChooserComponent {

--- a/frontend/discourse/tests/integration/components/select-kit/email-group-user-chooser-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/email-group-user-chooser-test.gjs
@@ -1,5 +1,5 @@
 import { hash } from "@ember/helper";
-import { fillIn, find, findAll, render } from "@ember/test-helpers";
+import { fillIn, find, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import EmailGroupUserChooser from "discourse/select-kit/components/email-group-user-chooser";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -41,7 +41,7 @@ module(
 
       assert
         .dom(".email-group-user-chooser--group")
-        .doesNotHaveClass("--name-only", "renders the default group row style");
+        .hasClass("--group-name-first", "applies the group-name-first style");
       assert
         .dom(".email-group-user-chooser--group .identifier")
         .hasText("team_a", "renders the group name as the identifier");
@@ -50,15 +50,11 @@ module(
         .hasText("Team A", "renders the full group name as the label");
     });
 
-    test("onlyShowGroupFullName renders only the group display name", async function (assert) {
+    test("prioritizeGroupFullNameOrdering renders the full name before the group name", async function (assert) {
       this.set("defaultSearchResults", [
         {
           name: "team_a",
           full_name: "Team A Full Name",
-          isGroup: true,
-        },
-        {
-          name: "team_b",
           isGroup: true,
         },
       ]);
@@ -67,7 +63,48 @@ module(
         <template>
           <EmailGroupUserChooser
             @options={{hash
-              onlyShowGroupFullName=true
+              prioritizeGroupFullNameOrdering=true
+              customSearchOptions=(hash
+                defaultSearchResults=this.defaultSearchResults
+              )
+            }}
+          />
+        </template>
+      );
+
+      await this.subject.expand();
+
+      const groupRow = find(".email-group-user-chooser--group");
+
+      assert
+        .dom(groupRow)
+        .hasClass(
+          "--group-full-name-first",
+          "applies the full-name-first style"
+        );
+      assert.deepEqual(
+        [...groupRow.querySelectorAll("span")].map((row) =>
+          row.textContent.trim()
+        ),
+        ["Team A Full Name", "team_a"],
+        "renders the full name before the group name"
+      );
+    });
+
+    test("excludeGroupNameWhenMatchingFullName hides a redundant group name", async function (assert) {
+      this.set("defaultSearchResults", [
+        {
+          name: "team_a",
+          full_name: "Team A",
+          isGroup: true,
+        },
+      ]);
+
+      await render(
+        <template>
+          <EmailGroupUserChooser
+            @options={{hash
+              excludeGroupNameWhenMatchingFullName=true
               customSearchOptions=(hash
                 defaultSearchResults=this.defaultSearchResults
               )
@@ -79,21 +116,11 @@ module(
       await this.subject.expand();
 
       assert
-        .dom(".email-group-user-chooser--group")
-        .hasClass(
-          "--full-name-only",
-          "applies the full-name-only group row style"
-        );
-      assert
         .dom(".email-group-user-chooser--group .identifier")
-        .doesNotExist("hides the group identifier");
-      assert.deepEqual(
-        findAll(".email-group-user-chooser--group .name").map((row) =>
-          row.textContent.trim()
-        ),
-        ["Team A Full Name", "team_b"],
-        "uses the full name when present and falls back to the group name"
-      );
+        .doesNotExist("hides the equivalent group name");
+      assert
+        .dom(".email-group-user-chooser--group .name")
+        .hasText("Team A", "keeps the full group name visible");
     });
 
     test("prioritizeUserNameOrdering can render the name before username", async function (assert) {


### PR DESCRIPTION
Partial followup of 7ff30d81a32690543cc204db50d6d9066d4c65f6

The previous commit totally hid the group name
in the DAccessCopntrol grantee chooser (derived from
EmailGroupUserChooser) in favour of full name.

However in some cases it is useful to see the group name
as it may be different from the full name. This commit brings
back the group name after the full name, and adds an option
to not show the name if it's the same as the full name.

<img width="680" height="760" alt="image" src="https://github.com/user-attachments/assets/127187fe-4e23-4689-a97d-f7e65870a353" />
