### PR TITLE
FIX: Don't reset customized site settings when new category

### DIFF
--- a/app/services/categories/types/base.rb
+++ b/app/services/categories/types/base.rb
@@ -418,6 +418,10 @@ module Categories
 
         private
 
+        def site_setting_overridden?(setting_name)
+          SiteSetting.provider.find(setting_name.to_sym).present?
+        end
+
         def resolved_configuration_schema
           schema = configuration_schema
           return {} if schema.blank?
@@ -460,6 +464,7 @@ module Categories
               key: setting_name.to_s,
               default:,
               current: SiteSetting.public_send(setting_name),
+              overridden: site_setting_overridden?(setting_name),
               type: custom_type || meta[:type],
               label: custom_label || meta[:humanized_name],
               choices: custom_choices || meta[:choices],

--- a/frontend/discourse/admin/controllers/edit-category/tabs.js
+++ b/frontend/discourse/admin/controllers/edit-category/tabs.js
@@ -155,7 +155,7 @@ export default class EditCategoryTabsController extends Controller {
       });
 
       categoryType.configuration_schema.site_settings?.forEach((setting) => {
-        data.category_type_site_settings[setting.key] = this.model.id
+        data.category_type_site_settings[setting.key] = setting.overridden
           ? setting.current
           : setting.default;
       });

--- a/plugins/discourse-topic-voting/spec/system/ideas_category_type_setup_spec.rb
+++ b/plugins/discourse-topic-voting/spec/system/ideas_category_type_setup_spec.rb
@@ -57,6 +57,31 @@ RSpec.describe "Ideas Category Type Setup" do
     expect(Category.can_vote?(category.id)).to eq(false)
   end
 
+  context "when a related site setting has been customized" do
+    before { SiteSetting.topic_voting_tl0_vote_limit = 10 }
+
+    it "prefills the customized value and keeps it when creating an ideas category" do
+      visit("/new-category/setup")
+      category_type_card.find_type_card("ideas").click
+      find(".edit-category-ideas").click
+
+      expect(form.field("category_type_site_settings.topic_voting_tl0_vote_limit").value).to eq(
+        "10",
+      )
+
+      banner.click_save
+      expect(page).to have_content(I18n.t("js.category.edit_dialog_title", categoryName: "Ideas"))
+
+      expect(SiteSetting.topic_voting_tl0_vote_limit).to eq(10)
+      expect(
+        UserHistory.where(
+          action: UserHistory.actions[:change_site_setting],
+          subject: "topic_voting_tl0_vote_limit",
+        ),
+      ).to be_empty
+    end
+  end
+
   context "when the ideas category type setup is disabled" do
     before { SiteSetting.enable_ideas_category_type_setup = false }
 

--- a/spec/services/categories/types/base_spec.rb
+++ b/spec/services/categories/types/base_spec.rb
@@ -348,6 +348,26 @@ RSpec.describe Categories::Types::Base do
       expect(entry[:label]).to be_present
     end
 
+    it "reflects whether the site setting has been overridden" do
+      test_type =
+        build_test_type(
+          :test_overridden,
+          configuration_schema: {
+            site_settings: {
+              title: "My Forum",
+            },
+          },
+        )
+
+      entry = test_type.send(:resolved_configuration_schema)[:site_settings].first
+      expect(entry[:overridden]).to eq(false)
+
+      SiteSetting.title = "Customized"
+
+      entry = test_type.send(:resolved_configuration_schema)[:site_settings].first
+      expect(entry[:overridden]).to eq(true)
+    end
+
     it "passes through category settings" do
       test_type =
         build_test_type(


### PR DESCRIPTION
Previously, the category creation form prefilled category type site settings with the type's recommended defaults, so creating another category of the same type (e.g. Ideas) silently reset any values the admin had customized — and logged the reset in the staff action log under their name.

This change serializes an `overridden` flag with each setting in the configuration schema and makes the form prefill the current value for overridden settings, only suggesting the recommended default for settings the admin has never customized.

Before it worked correctly when category was edited. 