### PR TITLE
UX: composer redesign > smooth editor slide-up on focus

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1394,9 +1394,15 @@ body.has-sidebar-page {
   }
 
   .d-editor-textarea-wrapper {
+    --composer-slide-easing: cubic-bezier(0.2, 0, 0, 1);
     border: 0;
+
+    // padding and border-radius must animate in lockstep with margin,
+    // otherwise the text counter-jumps when the focus state toggles
     transition:
-      margin 250ms cubic-bezier(0.05, 0.7, 0.1, 1),
+      margin 250ms var(--composer-slide-easing),
+      padding 250ms var(--composer-slide-easing),
+      border-radius 250ms var(--composer-slide-easing),
       box-shadow 250ms ease;
 
     @media (prefers-reduced-motion: reduce) {
@@ -1407,7 +1413,12 @@ body.has-sidebar-page {
     &.in-focus {
       outline: none;
       border: 0;
+    }
+  }
 
+  #reply-control.has-composer-fields .d-editor-textarea-wrapper {
+    &:focus,
+    &.in-focus {
       @include viewport.until(sm) {
         margin-top: calc(
           (

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -50,10 +50,9 @@ const trackFieldsHeight = modifier((element, [enabled]) => {
   }
 
   const update = (height) => {
-    target.style.setProperty(
-      "--composer-fields-height",
-      `${Math.round(height)}px`
-    );
+    const rounded = Math.round(height);
+    target.style.setProperty("--composer-fields-height", `${rounded}px`);
+    target.classList.toggle("has-composer-fields", rounded > 0);
   };
 
   update(element.offsetHeight);
@@ -66,6 +65,7 @@ const trackFieldsHeight = modifier((element, [enabled]) => {
   return () => {
     observer.disconnect();
     target.style.removeProperty("--composer-fields-height");
+    target.classList.remove("has-composer-fields");
   };
 });
 


### PR DESCRIPTION
The mobile focus animation slides the editor over the composer fields by transitioning margin-top, but it read as chunky:

- padding-top and border-radius changed instantly when the focus state toggled, counter-jumping the text 16px against the travel direction
- cubic-bezier(0.05, 0.7, 0.1, 1) covers ~65% of the distance within the first two frames, teleporting first and crawling sub-pixel after

Both properties now transition in lockstep with margin, using an easing curve that starts at zero velocity.

The slide is also skipped entirely when there are no composer fields to expand into (e.g. replies), instead of animating a pointless ~17px offset. A has-composer-fields state class is toggled from the same ResizeObserver that measures --composer-fields-height.