### PR TITLE
Add container queries library

### DIFF
--- a/app/assets/stylesheets/lib/breakpoints.import.scss
+++ b/app/assets/stylesheets/lib/breakpoints.import.scss
@@ -1,0 +1,1 @@
+@error "lib/breakpoints should be accessed via @use not @import";

--- a/app/assets/stylesheets/lib/breakpoints.scss
+++ b/app/assets/stylesheets/lib/breakpoints.scss
@@ -1,0 +1,9 @@
+// Shared breakpoint scale used by both the viewport (media query) and
+// container (container query) libraries.
+$breakpoints: (
+  sm: 40rem,
+  md: 48rem,
+  lg: 64rem,
+  xl: 80rem,
+  2xl: 96rem,
+);

--- a/app/assets/stylesheets/lib/breakpoints.scss
+++ b/app/assets/stylesheets/lib/breakpoints.scss
@@ -1,5 +1,4 @@
-// Shared breakpoint scale used by both the viewport (media query) and
-// container (container query) libraries.
+// Shared breakpoint scale used by the viewport and container libraries
 $breakpoints: (
   sm: 40rem,
   md: 48rem,

--- a/app/assets/stylesheets/lib/breakpoints.scss
+++ b/app/assets/stylesheets/lib/breakpoints.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 // Shared breakpoint scale used by the viewport and container libraries
 $breakpoints: (
   xs: 20rem,
@@ -7,3 +9,11 @@ $breakpoints: (
   xl: 80rem,
   2xl: 96rem,
 );
+
+@function get($bp) {
+  @if not map.has-key($breakpoints, $bp) {
+    @error "Invalid breakpoint: #{$bp}";
+  }
+
+  @return map.get($breakpoints, $bp);
+}

--- a/app/assets/stylesheets/lib/breakpoints.scss
+++ b/app/assets/stylesheets/lib/breakpoints.scss
@@ -1,5 +1,6 @@
 // Shared breakpoint scale used by the viewport and container libraries
 $breakpoints: (
+  xs: 20rem,
   sm: 40rem,
   md: 48rem,
   lg: 64rem,

--- a/app/assets/stylesheets/lib/container.import.scss
+++ b/app/assets/stylesheets/lib/container.import.scss
@@ -1,0 +1,1 @@
+@error "lib/container should be accessed via @use not @import";

--- a/app/assets/stylesheets/lib/container.scss
+++ b/app/assets/stylesheets/lib/container.scss
@@ -1,8 +1,7 @@
 @use "sass:map";
 @use "breakpoints";
 
-// The shared scale plus an `xs` step, since containers (e.g. sidebars) can
-// be narrower than any viewport.
+// Containers add an `xs` breakpoint step, since containers can be narrower than any viewport
 $breakpoints: map.merge(
   (
     xs: 20rem,

--- a/app/assets/stylesheets/lib/container.scss
+++ b/app/assets/stylesheets/lib/container.scss
@@ -1,0 +1,45 @@
+@use "sass:map";
+@use "breakpoints";
+
+// The shared scale plus an `xs` step, since containers (e.g. sidebars) can
+// be narrower than any viewport.
+$breakpoints: map.merge(
+  (
+    xs: 20rem,
+  ),
+  breakpoints.$breakpoints
+);
+
+@function _get-breakpoint($bp) {
+  @if not map.has-key($breakpoints, $bp) {
+    @error "Invalid container breakpoint: #{$bp}";
+  }
+
+  @return map.get($breakpoints, $bp);
+}
+
+@function _container-name($name) {
+  @if $name {
+    @return "#{$name} ";
+  }
+
+  @return "";
+}
+
+@mixin from($bp, $name: null) {
+  @container #{_container-name($name)}(width >= #{_get-breakpoint($bp)}) {
+    @content;
+  }
+}
+
+@mixin until($bp, $name: null) {
+  @container #{_container-name($name)}(width < #{_get-breakpoint($bp)}) {
+    @content;
+  }
+}
+
+@mixin between($from, $until, $name: null) {
+  @container #{_container-name($name)}(#{_get-breakpoint($from)} <= width < #{_get-breakpoint($until)}) {
+    @content;
+  }
+}

--- a/app/assets/stylesheets/lib/container.scss
+++ b/app/assets/stylesheets/lib/container.scss
@@ -1,15 +1,6 @@
-@use "sass:map";
 @use "breakpoints";
 
 $breakpoints: breakpoints.$breakpoints;
-
-@function _get-breakpoint($bp) {
-  @if not map.has-key($breakpoints, $bp) {
-    @error "Invalid container breakpoint: #{$bp}";
-  }
-
-  @return map.get($breakpoints, $bp);
-}
 
 @function _container-name($name) {
   @if $name {
@@ -20,19 +11,19 @@ $breakpoints: breakpoints.$breakpoints;
 }
 
 @mixin from($bp, $name: null) {
-  @container #{_container-name($name)}(width >= #{_get-breakpoint($bp)}) {
+  @container #{_container-name($name)}(width >= #{breakpoints.get($bp)}) {
     @content;
   }
 }
 
 @mixin until($bp, $name: null) {
-  @container #{_container-name($name)}(width < #{_get-breakpoint($bp)}) {
+  @container #{_container-name($name)}(width < #{breakpoints.get($bp)}) {
     @content;
   }
 }
 
 @mixin between($from, $until, $name: null) {
-  @container #{_container-name($name)}(#{_get-breakpoint($from)} <= width < #{_get-breakpoint($until)}) {
+  @container #{_container-name($name)}(#{breakpoints.get($from)} <= width < #{breakpoints.get($until)}) {
     @content;
   }
 }

--- a/app/assets/stylesheets/lib/container.scss
+++ b/app/assets/stylesheets/lib/container.scss
@@ -1,13 +1,7 @@
 @use "sass:map";
 @use "breakpoints";
 
-// Containers add an `xs` breakpoint step, since containers can be narrower than any viewport
-$breakpoints: map.merge(
-  (
-    xs: 20rem,
-  ),
-  breakpoints.$breakpoints
-);
+$breakpoints: breakpoints.$breakpoints;
 
 @function _get-breakpoint($bp) {
   @if not map.has-key($breakpoints, $bp) {

--- a/app/assets/stylesheets/lib/viewport.scss
+++ b/app/assets/stylesheets/lib/viewport.scss
@@ -1,12 +1,7 @@
 @use "sass:map";
+@use "breakpoints";
 
-$breakpoints: (
-  sm: 40rem,
-  md: 48rem,
-  lg: 64rem,
-  xl: 80rem,
-  2xl: 96rem,
-);
+$breakpoints: breakpoints.$breakpoints;
 
 @function _get-breakpoint($bp) {
   @if not map.has-key($breakpoints, $bp) {

--- a/app/assets/stylesheets/lib/viewport.scss
+++ b/app/assets/stylesheets/lib/viewport.scss
@@ -1,30 +1,21 @@
-@use "sass:map";
 @use "breakpoints";
 
 $breakpoints: breakpoints.$breakpoints;
 
-@function _get-breakpoint($bp) {
-  @if not map.has-key($breakpoints, $bp) {
-    @error "Invalid breakpoint: #{$bp}";
-  }
-
-  @return map.get($breakpoints, $bp);
-}
-
 @mixin from($bp) {
-  @media (width >= #{_get-breakpoint($bp)}) {
+  @media (width >= #{breakpoints.get($bp)}) {
     @content;
   }
 }
 
 @mixin until($bp) {
-  @media (width < #{_get-breakpoint($bp)}) {
+  @media (width < #{breakpoints.get($bp)}) {
     @content;
   }
 }
 
 @mixin between($from, $until) {
-  @media (#{_get-breakpoint($from)} <= width < #{_get-breakpoint($until)}) {
+  @media (#{breakpoints.get($from)} <= width < #{breakpoints.get($until)}) {
     @content;
   }
 }


### PR DESCRIPTION
Adds lib/container alongside the existing lib/viewport library and moves the shared breakpoint scale into a dedicated lib/breakpoints file used by both libraries. 

Also includes the .import.scss shims.