### PR TITLE
FIX: Refresh GitHub PR onebox status for URL variants

### DIFF
--- a/plugins/discourse-github/app/jobs/regular/rebake_github_pr_posts.rb
+++ b/plugins/discourse-github/app/jobs/regular/rebake_github_pr_posts.rb
@@ -4,12 +4,11 @@ module Jobs
   class RebakeGithubPrPosts < ::Jobs::Base
     sidekiq_options queue: "low"
 
+    PR_PATH = %r{\A/[^/]+/[^/]+/pull/\d+\z}
+
     def execute(args)
       url = args[:pr_url]
-      return if url.blank?
-
-      Oneboxer.preview(url, invalidate_oneboxes: true)
-      InlineOneboxer.invalidate(url)
+      return unless pr_path(url)
 
       rebake_posts(url)
       rebake_chat_messages(url) if SiteSetting.chat_enabled
@@ -17,30 +16,63 @@ module Jobs
 
     private
 
+    def pr_path(url)
+      path = URI(url.to_s).path
+      path if path&.match?(PR_PATH)
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    # tolerates scheme/host variants (http, www) the onebox engine accepts
+    def pr_url_pattern(url)
+      "https?://(www\\.)?github\\.com#{Regexp.escape(pr_path(url))}"
+    end
+
+    # anchored so /pull/12 does not match /pull/123
+    def pr_links(relation, url)
+      relation.where("url ~* ?", "^#{pr_url_pattern(url)}([/?#].*)?$")
+    end
+
+    # oneboxes are cached per exact URL - raw for inline, normalized for full
+    def invalidate_onebox_caches(urls)
+      urls
+        .flat_map { |url| [url, normalized(url)] }
+        .compact
+        .uniq
+        .each do |url|
+          Oneboxer.invalidate(url)
+          InlineOneboxer.invalidate(url)
+        end
+    end
+
+    def normalized(url)
+      UrlHelper.normalized_encode(url).to_s
+    rescue StandardError
+      nil
+    end
+
     def rebake_posts(url)
-      post_ids = TopicLink.where(url:).or(TopicLink.where("url LIKE ?", "#{url}%")).select(:post_id)
+      rows = pr_links(TopicLink, url).distinct.pluck(:url, :post_id)
+      invalidate_onebox_caches(rows.map(&:first).uniq)
 
       Post
-        .where(id: post_ids)
+        .where(id: rows.map(&:last).uniq)
         .where(
-          "cooked LIKE :pattern AND (cooked LIKE '%githubpullrequest%' OR cooked LIKE '%inline-onebox%')",
-          pattern: "%#{url}%",
+          "cooked ~* :pattern AND (cooked LIKE '%githubpullrequest%' OR cooked LIKE '%inline-onebox%')",
+          pattern: pr_url_pattern(url),
         )
         .find_each { |post| post.rebake!(priority: :low, skip_publish_rebaked_changes: true) }
     end
 
     def rebake_chat_messages(url)
-      message_ids =
-        ::Chat::MessageLink
-          .where(url:)
-          .or(::Chat::MessageLink.where("url LIKE ?", "#{url}%"))
-          .select(:chat_message_id)
+      rows = pr_links(::Chat::MessageLink, url).distinct.pluck(:url, :chat_message_id)
+      invalidate_onebox_caches(rows.map(&:first).uniq)
 
       ::Chat::Message
-        .where(id: message_ids)
+        .where(id: rows.map(&:last).uniq)
         .where(
-          "cooked LIKE :pattern AND (cooked LIKE '%githubpullrequest%' OR cooked LIKE '%inline-onebox%')",
-          pattern: "%#{url}%",
+          "cooked ~* :pattern AND (cooked LIKE '%githubpullrequest%' OR cooked LIKE '%inline-onebox%')",
+          pattern: pr_url_pattern(url),
         )
         .find_each { |message| message.rebake!(priority: :low, skip_notifications: true) }
     end

--- a/plugins/discourse-github/spec/jobs/rebake_github_pr_posts_spec.rb
+++ b/plugins/discourse-github/spec/jobs/rebake_github_pr_posts_spec.rb
@@ -15,24 +15,98 @@ RSpec.describe Jobs::RebakeGithubPrPosts do
   end
 
   describe "#execute" do
-    before { allow(Oneboxer).to receive(:preview) }
-
-    it "does nothing with blank or missing pr_url" do
-      expect { described_class.new.execute(pr_url: nil) }.not_to raise_error
-      expect { described_class.new.execute(pr_url: "") }.not_to raise_error
+    def seed_onebox_caches(url)
+      Discourse.cache.write(
+        Oneboxer.send(:onebox_cache_key, url),
+        { onebox: "stale", preview: "stale" },
+      )
+      Discourse.cache.write(InlineOneboxer.send(:cache_key, url), { url:, title: "stale" })
     end
 
-    it "invalidates the onebox cache for the PR URL" do
-      described_class.new.execute(pr_url:)
+    it "does nothing for a blank, malformed, or non-PR pr_url" do
+      create_post_with_link(<<~HTML)
+        <aside class="onebox githubpullrequest"><a href="#{pr_url}">PR</a></aside>
+      HTML
+      seed_onebox_caches(pr_url)
 
-      expect(Oneboxer).to have_received(:preview).with(pr_url, invalidate_oneboxes: true)
+      expect_any_instance_of(Post).not_to receive(:rebake!)
+      bad_urls = [
+        "",
+        nil,
+        "https:// bad",
+        "https://github.com",
+        "#{pr_url}/../../456",
+        "mailto:x@y.com",
+      ]
+      bad_urls.each { |bad| expect { described_class.new.execute(pr_url: bad) }.not_to raise_error }
+
+      expect(Oneboxer.cached_onebox(pr_url)).to eq("stale")
     end
 
-    it "invalidates the inline onebox cache for the PR URL" do
-      allow(InlineOneboxer).to receive(:invalidate)
+    it "clears the onebox caches for the exact PR URL variant a post used (e.g. /changes)" do
+      variant = "#{pr_url}/changes"
+      post = Fabricate(:post, topic:, user:, cooked: <<~HTML)
+        <aside class="onebox githubpullrequest"><a href="#{variant}">PR</a></aside>
+      HTML
+      TopicLink.create!(topic:, post:, user:, url: variant, domain:)
+      seed_onebox_caches(variant)
+      allow_any_instance_of(Post).to receive(:rebake!)
+
       described_class.new.execute(pr_url:)
 
-      expect(InlineOneboxer).to have_received(:invalidate).with(pr_url)
+      expect(Oneboxer.cached_onebox(variant)).to be_blank
+      expect(InlineOneboxer.cache_lookup(variant)).to be_blank
+    end
+
+    it "refreshes links using scheme and host variants (http, www)" do
+      www_url = pr_url.sub("https://", "https://www.")
+      http_url = pr_url.sub("https://", "http://")
+      post = Fabricate(:post, topic:, user:, cooked: <<~HTML)
+        <aside class="onebox githubpullrequest"><a href="#{www_url}">PR</a></aside>
+      HTML
+      TopicLink.create!(topic:, post:, user:, url: www_url, domain: "www.github.com")
+      TopicLink.create!(topic:, post:, user:, url: http_url, domain:)
+      seed_onebox_caches(www_url)
+      seed_onebox_caches(http_url)
+
+      expect_any_instance_of(Post).to receive(:rebake!)
+      described_class.new.execute(pr_url:)
+
+      expect(Oneboxer.cached_onebox(www_url)).to be_blank
+      expect(Oneboxer.cached_onebox(http_url)).to be_blank
+    end
+
+    it "clears the normalized-encoding cache key used by full oneboxes" do
+      raw = "#{pr_url}#r\u00e9view"
+      normalized = UrlHelper.normalized_encode(raw).to_s
+      post = Fabricate(:post, topic:, user:, cooked: <<~HTML)
+        <aside class="onebox githubpullrequest"><a href="#{raw}">PR</a></aside>
+      HTML
+      TopicLink.create!(topic:, post:, user:, url: raw, domain:)
+      Discourse.cache.write(
+        Oneboxer.send(:onebox_cache_key, normalized),
+        { onebox: "stale", preview: "stale" },
+      )
+      allow_any_instance_of(Post).to receive(:rebake!)
+
+      described_class.new.execute(pr_url:)
+
+      expect(normalized).not_to eq(raw)
+      expect(Oneboxer.cached_onebox(normalized)).to be_blank
+    end
+
+    it "leaves a different PR that only shares a number prefix untouched" do
+      other_pr = "#{pr_url}4" # ...pull/123 must not match ...pull/1234
+      post = Fabricate(:post, topic:, user:, cooked: <<~HTML)
+        <aside class="onebox githubpullrequest"><a href="#{other_pr}">PR</a></aside>
+      HTML
+      TopicLink.create!(topic:, post:, user:, url: other_pr, domain:)
+      seed_onebox_caches(other_pr)
+
+      expect_any_instance_of(Post).not_to receive(:rebake!)
+      described_class.new.execute(pr_url:)
+
+      expect(Oneboxer.cached_onebox(other_pr)).to eq("stale")
     end
 
     it "rebakes posts with full GitHub PR oneboxes" do
@@ -130,6 +204,21 @@ RSpec.describe Jobs::RebakeGithubPrPosts do
         )
 
         described_class.new.execute(pr_url:)
+      end
+
+      it "clears the onebox caches for the exact PR URL variant a chat message used" do
+        variant = "#{pr_url}/files"
+        message = Fabricate(:chat_message, chat_channel:, user:, cooked: <<~HTML)
+          <aside class="onebox githubpullrequest"><a href="#{variant}">PR</a></aside>
+        HTML
+        Chat::MessageLink.create!(chat_message: message, url: variant)
+        seed_onebox_caches(variant)
+        allow_any_instance_of(Chat::Message).to receive(:rebake!)
+
+        described_class.new.execute(pr_url:)
+
+        expect(Oneboxer.cached_onebox(variant)).to be_blank
+        expect(InlineOneboxer.cache_lookup(variant)).to be_blank
       end
     end
   end


### PR DESCRIPTION
The PR status webhook only knows the canonical PR URL, but posts can link the PR in forms the onebox engine also accepts: with a path suffix (/changes, /files), query, fragment, http scheme, or www host. Oneboxes are cached per exact URL (and full oneboxes under the normalized encoding), so invalidating only the canonical URL left every other variant stale. The rebake then re-cooked the old status straight from cache and the icon never updated.

Match links with an anchored, scheme/host-tolerant pattern and invalidate the exact URLs stored in TopicLink/Chat::MessageLink (plus their normalized encodings), so whichever variant a post used gets a fresh fetch on rebake. The anchoring also stops a webhook for `/pull/12` from rebaking posts for `/pull/123`, which the old prefix match did.