### PR TITLE
UX: Match font size of one-time code login link

### DIFF
--- a/app/assets/stylesheets/common/base/login-signup-page.scss
+++ b/app/assets/stylesheets/common/base/login-signup-page.scss
@@ -318,6 +318,7 @@ body.signup-page {
     }
 
     #email-login-link,
+    #one-time-code-link,
     .login__password-links {
       font-size: var(--font-down-1);
       display: flex;


### PR DESCRIPTION
**Previously**, when local logins via code were enabled, the "Email me a one-time login code" link rendered slightly larger than the other login links like "I forgot my password".

**In this update**, added `#one-time-code-link` to the selector that applies `--font-down-1`, so all login links share the same font size.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after.png) |