### PR TITLE
UX: composer redesign > keep editor expanded on inner focus

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1418,6 +1418,7 @@ body.has-sidebar-page {
 
   #reply-control.has-composer-fields .d-editor-textarea-wrapper {
     &:focus,
+    &:focus-within,
     &.in-focus {
       @include viewport.until(sm) {
         margin-top: calc(


### PR DESCRIPTION
On mobile, the redesigned composer slides the editor up over the composer fields while the editor is focused. The state was driven off the editor's own focusin/focusout, so focus moving to an interactive control rendered inside the editor content collapsed the slide-up.

This regresses NodeView-based content: focusing the event card's native inputs, or opening a footnote's nested editor, moves DOM focus off the outer contenteditable and drops the focus state, sliding the composer fields back over the control being edited.

These controls live inside the editor wrapper (not a portal), so match `:focus-within` alongside the existing focus states to keep the editor expanded for the whole time focus stays within it.