### PR TITLE
FIX: Flag modal crash in nested view on 2nd flag

### DIFF
--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -893,7 +893,13 @@ export default class NestedController extends Controller {
         (p) => p.id === data.id
       );
       if (existing) {
-        existing.setProperties(postData);
+        // Route through the store so Post.munge runs — it rebuilds
+        // actions_summary as ActionSummary instances and repopulates
+        // actionByName. Without this, flagsAvailable (reads actionByName)
+        // and postActionFor (reads actions_summary) drift apart after an
+        // "acted" event, which crashes the flag modal on the next submit.
+        const updated = this.store.createRecord("post", postData);
+        existing.updateFromPost(updated);
         if (!postData.deleted_at) {
           existing.set("deleted_post_placeholder", false);
         }

--- a/frontend/discourse/app/lib/flag-targets/post-flag.js
+++ b/frontend/discourse/app/lib/flag-targets/post-flag.js
@@ -45,8 +45,8 @@ export default class PostFlag extends Flag {
   }
 
   postActionFor(flagModal) {
-    return flagModal.args.model.flagModel.actions_summary.find(
-      (item) => item.id === flagModal.selected.id
-    );
+    return flagModal.args.model.flagModel.actionByName?.[
+      flagModal.selected.name_key
+    ];
   }
 }

--- a/frontend/discourse/tests/unit/controllers/nested-test.js
+++ b/frontend/discourse/tests/unit/controllers/nested-test.js
@@ -353,6 +353,66 @@ module("Unit | Controller | nested", function (hooks) {
     }
   });
 
+  test("acted event refreshes actionByName so the flag modal stays in sync", async function (assert) {
+    const topic = buildTopic(this.store, 724);
+    const postId = 3001;
+
+    const post = this.store.createRecord("post", {
+      id: postId,
+      post_number: 2,
+      topic,
+      actions_summary: [
+        { id: 3, can_act: true }, // off_topic
+        { id: 4, can_act: true }, // inappropriate
+        { id: 6, can_act: true }, // notify_user
+        { id: 7, can_act: true }, // notify_moderators
+        { id: 8, can_act: true }, // spam
+      ],
+    });
+    post.topic = topic;
+
+    this.controller.topic = topic;
+    this.controller.subscribe();
+    this.controller.postRegistry.set(post.post_number, post);
+
+    pretender.get(`/posts/${postId}.json`, () =>
+      response({
+        id: postId,
+        post_number: 2,
+        topic_id: topic.id,
+        actions_summary: [{ id: 6, acted: true, count: 1 }],
+      })
+    );
+
+    this.controller._onMessage(
+      { type: "acted", id: postId, updated_at: "2026-01-02T00:00:00.000Z" },
+      null,
+      200
+    );
+    await settled();
+
+    assert.strictEqual(
+      typeof post.actions_summary[0].act,
+      "function",
+      "rebuilds actions_summary as ActionSummary instances so postActionFor().act() works"
+    );
+
+    assert.strictEqual(
+      post.actionByName.spam,
+      undefined,
+      "refreshes actionByName so flagsAvailable no longer offers types the server dropped"
+    );
+    assert.strictEqual(
+      post.actionByName.off_topic,
+      undefined,
+      "clears every trimmed flag type, not just notify_user"
+    );
+    assert.true(
+      post.actionByName.notify_user.acted,
+      "reflects the newly-recorded flag on actionByName"
+    );
+  });
+
   test("scroll position persistence avoids full cache snapshots", function (assert) {
     const topic = buildTopic(this.store, 725);
     const anchor = { postNumber: 2, offsetFromTop: 80, scrollY: 1600 };

--- a/frontend/discourse/tests/unit/lib/flag-targets/post-flag-test.js
+++ b/frontend/discourse/tests/unit/lib/flag-targets/post-flag-test.js
@@ -1,0 +1,74 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import PostFlag from "discourse/lib/flag-targets/post-flag";
+import { logIn } from "discourse/tests/helpers/qunit-helpers";
+
+module("Unit | Lib | flag-targets | post-flag", function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    logIn(this.owner);
+    this.store = this.owner.lookup("service:store");
+  });
+
+  function buildFlagModal(post, selected) {
+    return {
+      args: { model: { flagModel: post } },
+      selected,
+    };
+  }
+
+  test("postActionFor resolves via actionByName by name_key", function (assert) {
+    const post = this.store.createRecord("post", {
+      id: 4001,
+      post_number: 2,
+      actions_summary: [
+        { id: 8, can_act: true }, // spam
+        { id: 6, can_act: true }, // notify_user
+      ],
+    });
+
+    const postFlag = new PostFlag();
+    const spamFlag = { id: 8, name_key: "spam" };
+    const postAction = postFlag.postActionFor(buildFlagModal(post, spamFlag));
+
+    assert.strictEqual(
+      postAction,
+      post.actionByName.spam,
+      "returns the ActionSummary instance keyed by name_key"
+    );
+    assert.strictEqual(
+      typeof postAction.act,
+      "function",
+      "the returned entry is a real ActionSummary with .act()"
+    );
+  });
+
+  test("postActionFor still resolves when actions_summary has been trimmed", function (assert) {
+    const post = this.store.createRecord("post", {
+      id: 4002,
+      post_number: 2,
+      actions_summary: [
+        { id: 8, can_act: true }, // spam
+        { id: 7, can_act: true }, // notify_moderators
+      ],
+    });
+
+    const staleActionByName = post.actionByName;
+    post.actions_summary = [
+      { id: 6, acted: true, count: 1, name_key: "notify_user" },
+    ];
+
+    const postFlag = new PostFlag();
+    const notifyModeratorsFlag = { id: 7, name_key: "notify_moderators" };
+    const postAction = postFlag.postActionFor(
+      buildFlagModal(post, notifyModeratorsFlag)
+    );
+
+    assert.strictEqual(
+      postAction,
+      staleActionByName.notify_moderators,
+      "falls back to the actionByName entry even after actions_summary drops it"
+    );
+  });
+});


### PR DESCRIPTION
Reopening the flag modal in nested view after already flagging a post offered flag types the server had trimmed from `actions_summary`, and submitting a new one crashed with `TypeError: Cannot read properties of undefined (reading 'act')`.

Two complementary changes:

NestedController#handlePostChanged routes the message-bus "acted" refresh through the store so Post.munge runs, which rebuilds `actions_summary` as ActionSummary instances and repopulates `actionByName`. Without this the two properties drift apart after an "acted" event, which crashes the flag modal on the next submit.

PostFlag#postActionfor now reads `actionByName` instead of `actions_summary`, so it can find the action even if the server has trimmed `actions_summary` to only include the most recent action.

Meta topic: https://meta.discourse.org/t/typeerror-when-submitting-a-flag-with-custom-content-require-message-flags/403133