### PR TITLE
MT: Forbid send-style dispatch via Style/Send

### DIFF
--- a/migrations/.rubocop.yml
+++ b/migrations/.rubocop.yml
@@ -8,3 +8,6 @@ Style/ModuleFunction:
 
 Style/EndlessMethod:
   EnforcedStyle: disallow
+
+Style/Send:
+  Enabled: true

--- a/migrations/core/spec/lib/cli/command_spec.rb
+++ b/migrations/core/spec/lib/cli/command_spec.rb
@@ -2,14 +2,16 @@
 
 RSpec.describe Migrations::CLI::Command do
   describe "#require_positional!" do
-    subject(:command) { described_class.new }
+    # `require_positional!` is private; expose it through a subclass so these
+    # specs can drive it directly.
+    subject(:command) { Class.new(described_class) { public :require_positional! }.new }
 
     it "returns the value when it is present" do
-      expect(command.send(:require_positional!, "discourse", "converter_type")).to eq("discourse")
+      expect(command.require_positional!("discourse", "converter_type")).to eq("discourse")
     end
 
     it "raises a presentable error when the value is missing" do
-      expect { command.send(:require_positional!, nil, "table_name") }.to raise_error(
+      expect { command.require_positional!(nil, "table_name") }.to raise_error(
         described_class::MissingPositionalError,
         "Missing required argument: <table_name>",
       )
@@ -17,12 +19,7 @@ RSpec.describe Migrations::CLI::Command do
 
     it "appends the hint to the error message" do
       expect {
-        command.send(
-          :require_positional!,
-          nil,
-          "converter_type",
-          hint: "Valid names are: discourse",
-        )
+        command.require_positional!(nil, "converter_type", hint: "Valid names are: discourse")
       }.to raise_error(
         described_class::MissingPositionalError,
         "Missing required argument: <converter_type>\nValid names are: discourse",

--- a/migrations/core/spec/lib/common/reporting/tui_spec.rb
+++ b/migrations/core/spec/lib/common/reporting/tui_spec.rb
@@ -707,7 +707,10 @@ RSpec.describe Migrations::Reporting::Tui do
     end
 
     it "drops a coalesced progress report that lands after its step finished" do
-      reporter = described_class.new(fps: 60, output: io)
+      # `apply_coalesced_progress` is private and normally only runs on the render
+      # thread; expose it through a subclass to drive a frame by hand.
+      reporter =
+        Class.new(described_class) { public :apply_coalesced_progress }.new(fps: 60, output: io)
       reporter.start_step("Users").finish
       reporter.close # drains the finish and joins the render thread
 
@@ -717,7 +720,7 @@ RSpec.describe Migrations::Reporting::Tui do
 
       # The next frame swaps the map out, so the stale entry can't linger and be
       # re-applied as a no-op on every frame for the rest of the run.
-      reporter.send(:apply_coalesced_progress)
+      reporter.apply_coalesced_progress
       expect(reporter.instance_variable_get(:@progress)).to be_empty
     end
   end

--- a/migrations/core/spec/lib/common/step_dependencies_spec.rb
+++ b/migrations/core/spec/lib/common/step_dependencies_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Migrations::StepDependencies do
     DependenciesTestModule.const_set("NotAStep", Class.new)
   end
 
-  after { Object.send(:remove_const, "DependenciesTestModule") }
+  after { remove_test_const("DependenciesTestModule") }
 
   describe ".depends_on" do
     it "resolves symbol names to sibling step classes" do
@@ -57,7 +57,7 @@ RSpec.describe Migrations::StepDependencies do
 
     context "with a top-level constant matching the step name" do
       before { Object.const_set("GlobalStep", Class.new(DependenciesTestModule::BaseStep)) }
-      after { Object.send(:remove_const, "GlobalStep") }
+      after { remove_test_const("GlobalStep") }
 
       it "doesn't resolve it" do
         # Constant lookup on a module falls back to top-level constants by

--- a/migrations/core/spec/lib/conversion/base_spec.rb
+++ b/migrations/core/spec/lib/conversion/base_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Migrations::Conversion::Base do
 
     after do
       Migrations::Database::IntermediateDB.setup(nil)
-      Object.send(:remove_const, "TemporaryConverterModule")
+      remove_test_const("TemporaryConverterModule")
     end
 
     it "builds one reporter, then runs the scheduler over the filtered steps" do
@@ -59,6 +59,10 @@ RSpec.describe Migrations::Conversion::Base do
   describe "#steps" do
     subject(:converter) { TemporaryConverterModule::Converter.new(nil) }
 
+    # `filter_steps` is private; expose it through a subclass to assert the
+    # exact order `--only`/`--skip` produce.
+    let(:base) { Class.new(described_class) { public :filter_steps }.new(nil) }
+
     before do
       Object.const_set(
         "TemporaryConverterModule",
@@ -72,7 +76,7 @@ RSpec.describe Migrations::Conversion::Base do
       )
     end
 
-    after { Object.send(:remove_const, "TemporaryConverterModule") }
+    after { remove_test_const("TemporaryConverterModule") }
 
     it "discovers `Step` subclasses" do
       expect(converter.steps).to contain_exactly(
@@ -122,7 +126,7 @@ RSpec.describe Migrations::Conversion::Base do
 
       # `--only categories` pulls in the `users` dependency; it has to run
       # before `categories` because the filtered list is executed as-is.
-      filtered = converter.send(:filter_steps, converter.steps, ["categories"], [])
+      filtered = base.filter_steps(converter.steps, ["categories"], [])
 
       expect(filtered).to eq(
         [TemporaryConverterModule::Users, TemporaryConverterModule::Categories],
@@ -135,7 +139,7 @@ RSpec.describe Migrations::Conversion::Base do
       # `run` sorts the full step set first and filters afterwards, so
       # re-running a single step keeps working even when its dependency
       # isn't part of the filtered set.
-      filtered = converter.send(:filter_steps, converter.steps, ["categories"], ["users"])
+      filtered = base.filter_steps(converter.steps, ["categories"], ["users"])
 
       expect(filtered).to eq([TemporaryConverterModule::Categories])
     end

--- a/migrations/core/spec/lib/conversion/scheduler_integration_spec.rb
+++ b/migrations/core/spec/lib/conversion/scheduler_integration_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     expect(rows("topics")).to eq((0..49).to_a)
     expect(rows("users")).to eq((0..4).to_a)
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   it "splits a partitioned step across forks and merges every slice" do
@@ -194,7 +194,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     expect(Migrations::Conversion::ChunkQueue).to have_received(:filled).with(chunks)
     expect(rows("topics")).to eq((0..59).to_a)
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   # The coordinator caps the fork count at the number of chunks, so a source with
@@ -263,7 +263,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
 
     expect(rows("topics")).to eq([0, 1, 2]) # every row merged exactly once
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   it "runs a single empty worker for a partitioned step over an empty source" do
@@ -320,7 +320,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
 
     expect(rows("topics")).to eq([])
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   it "runs the step inline, without forking, when no_fork is set" do
@@ -390,7 +390,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     expect(Migrations::ForkManager).not_to have_received(:fork)
     expect(rows("topics")).to eq((0..19).to_a)
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   it "logs and skips a bad row instead of failing the step" do
@@ -465,7 +465,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     expect(rows("users")).to eq((0..4).to_a)
     expect(log_entry_count).to eq(1)
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   it "fails the step and finishes the run when a worker dies mid-stream" do
@@ -542,7 +542,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     # the crashed worker's half-written shard is discarded, not merged
     expect(rows("topics")).to eq([])
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   # Runs `TempIntegrationSteps::Keyed`, whose processor writes each item into the
@@ -604,7 +604,7 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
     # the existing row is kept and the new, non-colliding rows are appended
     expect(keyed).to eq([[1, "existing"], [2, "added"], [3, "more"]])
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 
   it "fails the run, naming the table, when a shard row collides with an existing one" do
@@ -641,6 +641,6 @@ RSpec.describe Migrations::Conversion::StepScheduler, :integration do
 
     expect { run_keyed_step }.to raise_error(Migrations::Conversion::ConvertError, /keyed/)
   ensure
-    Object.send(:remove_const, "TempIntegrationSteps")
+    remove_test_const("TempIntegrationSteps")
   end
 end

--- a/migrations/core/spec/lib/conversion/step_spec.rb
+++ b/migrations/core/spec/lib/conversion/step_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Migrations::Conversion::Step do
         end
       RUBY
 
-    after { Object.send(:remove_const, :StepConstantsFixture) }
+    after { remove_test_const(:StepConstantsFixture) }
 
     it "resolves `IntermediateDB` and `Enums` inside role blocks via the step's ancestry" do
       expected = [Migrations::Database::IntermediateDB, Migrations::Database::IntermediateDB::Enums]
@@ -486,7 +486,7 @@ RSpec.describe Migrations::Conversion::Step do
       )
     end
 
-    after { Object.send(:remove_const, "TemporaryStepsModule") }
+    after { remove_test_const("TemporaryStepsModule") }
 
     it "exposes the StepDependencies macros at class level" do
       expect(described_class).to be_a(Migrations::StepDependencies)

--- a/migrations/core/spec/support/helpers.rb
+++ b/migrations/core/spec/support/helpers.rb
@@ -9,3 +9,10 @@ end
 def fixture_root
   @fixture_root ||= File.join(Migrations.root_path, "spec", "support", "fixtures")
 end
+
+# Tears down a constant a test defined on `Object`. `Module#remove_const` is
+# private by design, so this helper is the one sanctioned spot that reaches for
+# it via `send`.
+def remove_test_const(name)
+  Object.send(:remove_const, name) # rubocop:disable Style/Send
+end

--- a/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/plugin_introspector_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/plugin_introspector_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Migrations::Tooling::Schema::DSL::PluginIntrospector do
 
   after { FileUtils.rm_rf(plugins_path) }
 
+  # `introspect_plugin`/`introspect_plugins` are private; a subclass exposes
+  # them so these specs can drive them directly.
+  let(:introspector_class) do
+    Class.new(described_class) { public :introspect_plugin, :introspect_plugins }
+  end
+
   def create_plugin(name, migrations: {})
     plugin_dir = File.join(plugins_path, name)
     migrate_dir = File.join(plugin_dir, "db", "migrate")
@@ -74,14 +80,14 @@ RSpec.describe Migrations::Tooling::Schema::DSL::PluginIntrospector do
 
   describe "#introspect_plugin" do
     it "drops partial schema data when a plugin migration fails" do
-      introspector = described_class.allocate
+      introspector = introspector_class.allocate
       stderr = StringIO.new
 
       allow(introspector).to receive(:snapshot_schema).and_return({ tables: Set[], columns: {} })
       allow(introspector).to receive(:run_plugin_migrations).and_raise(StandardError, "boom")
       allow(introspector).to receive(:diff_schema)
 
-      result, failed = introspector.send(:introspect_plugin, "chat", ["unused"], stderr)
+      result, failed = introspector.introspect_plugin("chat", ["unused"], stderr)
 
       expect(result).to be_nil
       expect(failed).to be true
@@ -92,7 +98,7 @@ RSpec.describe Migrations::Tooling::Schema::DSL::PluginIntrospector do
 
   describe "#introspect_plugins" do
     it "stops after the first failed plugin to avoid partial manifest data" do
-      introspector = described_class.allocate
+      introspector = introspector_class.allocate
       stderr = StringIO.new
       plugins = {
         "alpha" => ["001_alpha.rb"],
@@ -111,7 +117,7 @@ RSpec.describe Migrations::Tooling::Schema::DSL::PluginIntrospector do
         stderr,
       ).and_return([nil, true])
 
-      plugin_data, failed_plugins = introspector.send(:introspect_plugins, plugins, stderr)
+      plugin_data, failed_plugins = introspector.introspect_plugins(plugins, stderr)
 
       expect(plugin_data).to eq("alpha" => { "tables" => ["alpha_table"], "columns" => {} })
       expect(failed_plugins).to eq(["broken"])

--- a/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/table_builder_spec.rb
+++ b/migrations/tooling/spec/lib/migrations/tooling/schema/dsl/table_builder_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Migrations::Tooling::Schema::DSL::TableBuilder do
         expect do
           Migrations::Tooling::Schema.table :"log_#{method}" do
             synthetic!
-            send(method, *(:id if method == :include))
+            public_send(method, *(:id if method == :include))
           end
         end.to raise_error(
           Migrations::Tooling::Schema::ConfigError,


### PR DESCRIPTION
Direct method calls over dynamic dispatch: `send`-probing of privates in specs keeps showing up in review, so this enables RuboCop's `Style/Send` for the migrations tree and cleans up every offense.

- The ~20 `Object.send(:remove_const, …)` teardown sites now go through one sanctioned `remove_test_const` spec helper — the single place allowed to use `send`, since `remove_const` is private on `Module` by design.
- The specs that probed private methods via `send` now use an explicit anonymous-subclass seam (`Class.new(described_class) { public :the_method }`) instead, with unchanged assertions.

Note: `Style/Send` only flags bare `send`/`__send__`; `public_send` is the cop's recommended alternative and stays allowed.