### PR TITLE
FIX: Stop overflow control buttons from overscrolling on iOS

### DIFF
--- a/frontend/discourse/app/ui-kit/d-overflow-controls.gts
+++ b/frontend/discourse/app/ui-kit/d-overflow-controls.gts
@@ -146,11 +146,22 @@ export default class DOverflowControls extends Component<DOverflowControlsSignat
       return;
     }
 
-    element.scrollBy({
-      left: dx * element.offsetWidth,
-      top: dy * element.offsetHeight,
-      behavior: "smooth",
-    });
+    // iOS Safari doesn't clamp smooth programmatic scrolls, so an
+    // out-of-bounds target rubber-bands into blank overscroll space
+    const options: ScrollToOptions = { behavior: "smooth" };
+
+    if (dx) {
+      const max = element.scrollWidth - element.offsetWidth;
+      const target = element.scrollLeft + dx * element.offsetWidth;
+      const [lower, upper] = isDocumentRTL() ? [-max, 0] : [0, max];
+      options.left = Math.max(lower, Math.min(target, upper));
+    } else {
+      const max = element.scrollHeight - element.offsetHeight;
+      const target = element.scrollTop + dy * element.offsetHeight;
+      options.top = Math.max(0, Math.min(target, max));
+    }
+
+    element.scrollTo(options);
   }
 
   <template>

--- a/frontend/discourse/tests/integration/ui-kit/d-overflow-controls-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-overflow-controls-test.gjs
@@ -1,4 +1,4 @@
-import { render, triggerEvent } from "@ember/test-helpers";
+import { click, render, triggerEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DOverflowControls from "discourse/ui-kit/d-overflow-controls";
@@ -93,6 +93,72 @@ module("Integration | ui-kit | DOverflowControls", function (hooks) {
     assert
       .dom(".d-overflow-controls__btn.--down")
       .doesNotExist("hides the scroll-down button at the bottom");
+  });
+
+  test("clamps button scroll targets to the content edges", async function (assert) {
+    await render(
+      <template>
+        <DOverflowControls style="width: 100px; overflow-x: auto">
+          <div style="width: 500px; height: 20px"></div>
+        </DOverflowControls>
+      </template>
+    );
+
+    const content = document.querySelector(".d-overflow-controls__content");
+    let target;
+    content.scrollTo = (options) => (target = options);
+
+    await scrollTo(".d-overflow-controls__content", { scrollLeft: 350 });
+    await click(".d-overflow-controls__btn.--right");
+    assert.deepEqual(
+      target,
+      { left: 400, behavior: "smooth" },
+      "forward tap targets the right edge instead of overshooting"
+    );
+
+    await scrollTo(".d-overflow-controls__content", { scrollLeft: 50 });
+    await click(".d-overflow-controls__btn.--left");
+    assert.deepEqual(
+      target,
+      { left: 0, behavior: "smooth" },
+      "backward tap targets the start instead of overshooting"
+    );
+  });
+
+  test("targets only the tapped axis when both axes overflow", async function (assert) {
+    await render(
+      <template>
+        {{! scrollbar-width: none keeps offset sizes exact across platforms }}
+        <DOverflowControls
+          style="width: 100px; height: 100px; overflow: auto; scrollbar-width: none"
+        >
+          <div style="width: 500px; height: 500px"></div>
+        </DOverflowControls>
+      </template>
+    );
+
+    const content = document.querySelector(".d-overflow-controls__content");
+    let target;
+    content.scrollTo = (options) => (target = options);
+
+    await scrollTo(".d-overflow-controls__content", {
+      scrollLeft: 50,
+      scrollTop: 50,
+    });
+
+    await click(".d-overflow-controls__btn.--right");
+    assert.deepEqual(
+      target,
+      { left: 150, behavior: "smooth" },
+      "horizontal tap targets the horizontal axis only"
+    );
+
+    await click(".d-overflow-controls__btn.--down");
+    assert.deepEqual(
+      target,
+      { top: 150, behavior: "smooth" },
+      "vertical tap targets the vertical axis only"
+    );
   });
 
   test("applies consumer classes and attributes", async function (assert) {


### PR DESCRIPTION
The edge scroll buttons in `DOverflowControls` used a relative `scrollBy` with a full-viewport delta. iOS Safari doesn't clamp smooth programmatic scrolls, so tapping a button near an edge rubber-banded into blank overscroll space instead of stopping at the content edge.

Switch to an absolute, clamped `scrollTo` target, and only set the axis being scrolled so a tap never disturbs the other axis when the container overflows both horizontally and vertically.

Avoids this state (notice the blank space after the + while there are many hidden buttons at the left):
<img width="1290" height="414" alt="image" src="https://github.com/user-attachments/assets/50aeee35-f2aa-4fc8-b812-b37c01f31e5c" />
