### PR TITLE
FIX: Keep TCPServer.open(port) working with the Happy Eyeballs patch

### DIFF
--- a/lib/freedom_patches/final_destination_connect.rb
+++ b/lib/freedom_patches/final_destination_connect.rb
@@ -21,8 +21,15 @@ end
 # getaddrinfo patch. Instead, open the socket with `Socket.tcp`, then set up a `TCPSocket`
 # instance with the result.
 module FinalDestinationTCPSocketPatch
-  def open(host, port, local_host = nil, local_port = nil, **kwargs)
+  # Takes *args because TCPServer inherits this singleton method and
+  # `TCPServer.open(port)` has fewer arguments — a fixed host/port signature
+  # fails the arity check before `super` can run. A bare `super` forwards the
+  # original arguments untouched.
+  def open(*args, **kwargs)
+    host = args[0]
     return super unless FinalDestination::Connector.token?(host)
+
+    _, port, local_host, local_port = args
 
     socket =
       Socket.tcp(

--- a/spec/lib/final_destination/http_spec.rb
+++ b/spec/lib/final_destination/http_spec.rb
@@ -216,6 +216,15 @@ describe FinalDestination::HTTP do
         socket.close
       end
     end
+
+    it "does not break TCPServer.open with only a port argument" do
+      # TCPServer inherits TCPSocket's singleton methods, and TCPServer.open
+      # takes just a port; the patch must keep that shorter form working.
+      server = TCPServer.open(0)
+      expect(server).to be_a(TCPServer)
+    ensure
+      server&.close
+    end
   end
 
   describe "via a proxy" do


### PR DESCRIPTION
#41680 prepended a patch onto `TCPSocket.singleton_class` so FinalDestination connections go through `Socket.tcp`. `TCPServer` inherits singleton methods from `TCPSocket`, so the one-arg form `TCPServer.open(port)` now fails the patched method's arity check with `wrong number of arguments (given 1, expected 2..4)` — it never reaches `super`.

I ran into this via the migrations tooling: `TemporaryDb#port_available?` uses `TCPServer.open(port)`, so `disco check` died while refreshing the plugin schema manifest.

The patch now takes `*args` and only unpacks them when the host is a connector token; for everything else a bare `super` forwards the original arguments untouched. Added a regression spec next to the existing socket-patch examples.