### PR TITLE
DEV: Use beacon counters for dashboard traffic

### DIFF
--- a/app/models/browser_pageview_event.rb
+++ b/app/models/browser_pageview_event.rb
@@ -77,6 +77,29 @@ class BrowserPageviewEvent < ActiveRecord::Base
       Discourse.redis.llen(REDIS_QUEUE_KEY).to_i
     end
 
+    def beacon_cutover_date
+      return if SiteSetting.use_legacy_pageviews
+      return if !UpcomingChanges.enabled?(:dashboard_improvements)
+      if !SiteSetting.trigger_browser_pageview_events &&
+           !SiteSetting.persist_browser_pageview_events
+        return
+      end
+
+      enabled_at = [
+        UpcomingChangeEvent.where(
+          upcoming_change_name: "dashboard_improvements",
+          event_type: %i[manual_opt_in automatically_promoted],
+        ).maximum(:created_at),
+        SiteSetting.where(name: "dashboard_improvements").maximum(:updated_at),
+      ].compact.max
+
+      return enabled_at.utc.to_date.tomorrow if enabled_at
+
+      ApplicationRequest.where(
+        req_type: %w[page_view_logged_in_browser_beacon page_view_anon_browser_beacon],
+      ).minimum(:date)
+    end
+
     def clear_queued!
       Discourse.redis.del(REDIS_QUEUE_KEY)
     end

--- a/app/services/admin_dashboard_site_traffic.rb
+++ b/app/services/admin_dashboard_site_traffic.rb
@@ -235,9 +235,16 @@ class AdminDashboardSiteTraffic
 
     req_type_sql =
       if login_required?
-        "req_type = :logged_in_req_type"
+        "req_type IN (:logged_in_req_type, :logged_in_beacon_req_type)"
       else
-        "req_type IN (:logged_in_req_type, :anonymous_req_type)"
+        <<~SQL.squish
+          req_type IN (
+            :logged_in_req_type,
+            :anonymous_req_type,
+            :logged_in_beacon_req_type,
+            :anonymous_beacon_req_type
+          )
+        SQL
       end
 
     @prior_period_tracking_started =
@@ -252,6 +259,8 @@ class AdminDashboardSiteTraffic
         prior_start_date: prior_start_date,
         logged_in_req_type: selected_request_types[:logged_in],
         anonymous_req_type: selected_request_types[:anonymous],
+        logged_in_beacon_req_type: beacon_request_types[:logged_in],
+        anonymous_beacon_req_type: beacon_request_types[:anonymous],
       ).present?
   end
 
@@ -277,7 +286,22 @@ class AdminDashboardSiteTraffic
       end.merge(crawlers: "page_view_crawler", embedded: "page_view_embed")
   end
 
+  def beacon_request_types
+    @beacon_request_types ||= {
+      logged_in: ApplicationRequest.req_types["page_view_logged_in_browser_beacon"],
+      anonymous: ApplicationRequest.req_types["page_view_anon_browser_beacon"],
+    }
+  end
+
+  def beacon_cutover_date
+    return @beacon_cutover_date if defined?(@beacon_cutover_date)
+
+    @beacon_cutover_date = BrowserPageviewEvent.beacon_cutover_date
+  end
+
   def traffic_rows(range_start_date, range_end_date)
+    cutover_date = beacon_cutover_date || (range_end_date + 1.day)
+
     DB.query(
       <<~SQL,
         WITH dates AS (
@@ -291,8 +315,26 @@ class AdminDashboardSiteTraffic
         )
         SELECT
           dates.date,
-          COALESCE(SUM(CASE WHEN ar.req_type = :logged_in_req_type THEN ar.count ELSE 0 END), 0)::bigint AS logged_in,
-          COALESCE(SUM(CASE WHEN ar.req_type = :anonymous_req_type THEN ar.count ELSE 0 END), 0)::bigint AS anonymous,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN dates.date < :beacon_cutover_date AND ar.req_type = :logged_in_req_type THEN ar.count
+                WHEN dates.date >= :beacon_cutover_date AND ar.req_type = :logged_in_beacon_req_type THEN ar.count
+                ELSE 0
+              END
+            ),
+            0
+          )::bigint AS logged_in,
+          COALESCE(
+            SUM(
+              CASE
+                WHEN dates.date < :beacon_cutover_date AND ar.req_type = :anonymous_req_type THEN ar.count
+                WHEN dates.date >= :beacon_cutover_date AND ar.req_type = :anonymous_beacon_req_type THEN ar.count
+                ELSE 0
+              END
+            ),
+            0
+          )::bigint AS anonymous,
           COALESCE(SUM(CASE WHEN ar.req_type = :crawler_req_type THEN ar.count ELSE 0 END), 0)::bigint AS crawlers,
           COALESCE(SUM(CASE WHEN ar.req_type = :embedded_req_type THEN ar.count ELSE 0 END), 0)::bigint AS embedded
         FROM dates
@@ -301,6 +343,8 @@ class AdminDashboardSiteTraffic
           AND ar.req_type IN (
             :logged_in_req_type,
             :anonymous_req_type,
+            :logged_in_beacon_req_type,
+            :anonymous_beacon_req_type,
             :crawler_req_type,
             :embedded_req_type
           )
@@ -309,8 +353,11 @@ class AdminDashboardSiteTraffic
       SQL
       start_date: range_start_date,
       end_date: range_end_date,
+      beacon_cutover_date: cutover_date,
       logged_in_req_type: selected_request_types[:logged_in],
       anonymous_req_type: selected_request_types[:anonymous],
+      logged_in_beacon_req_type: beacon_request_types[:logged_in],
+      anonymous_beacon_req_type: beacon_request_types[:anonymous],
       crawler_req_type: selected_request_types[:crawlers],
       embedded_req_type: selected_request_types[:embedded],
     )

--- a/spec/models/browser_pageview_event_spec.rb
+++ b/spec/models/browser_pageview_event_spec.rb
@@ -11,6 +11,88 @@ RSpec.describe BrowserPageviewEvent do
     Discourse.clear_readonly!
   end
 
+  describe ".beacon_cutover_date" do
+    it "returns the day after dashboard improvements was manually opted into" do
+      SiteSetting.dashboard_improvements = true
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: :manual_opt_in,
+        created_at: Time.zone.local(2026, 5, 1, 10),
+      )
+
+      expect(described_class.beacon_cutover_date).to eq(Date.new(2026, 5, 2))
+    end
+
+    it "returns the day after dashboard improvements was automatically promoted" do
+      SiteSetting.dashboard_improvements = true
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: :automatically_promoted,
+        created_at: Time.zone.local(2026, 5, 1, 10),
+      )
+
+      expect(described_class.beacon_cutover_date).to eq(Date.new(2026, 5, 2))
+    end
+
+    it "falls back to the site setting row when no enablement event exists" do
+      SiteSetting.dashboard_improvements = true
+      SiteSetting
+        .stubs(:where)
+        .with(name: "dashboard_improvements")
+        .returns(stub(maximum: Time.zone.local(2026, 5, 1, 10)))
+
+      expect(described_class.beacon_cutover_date).to eq(Date.new(2026, 5, 2))
+    end
+
+    it "uses the most recent enablement time across events and the setting row" do
+      SiteSetting.dashboard_improvements = true
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: :automatically_promoted,
+        created_at: Time.zone.local(2026, 5, 1, 10),
+      )
+      SiteSetting
+        .stubs(:where)
+        .with(name: "dashboard_improvements")
+        .returns(stub(maximum: Time.zone.local(2026, 5, 5, 10)))
+
+      expect(described_class.beacon_cutover_date).to eq(Date.new(2026, 5, 6))
+    end
+
+    it "returns nil when dashboard improvements are disabled" do
+      SiteSetting.dashboard_improvements = false
+
+      expect(described_class.beacon_cutover_date).to be_nil
+    end
+
+    it "falls back to the first beacon counter date when no enablement record exists" do
+      SiteSetting.dashboard_improvements = true
+      Fabricate(:anonymous_browser_beacon_application_request, date: "2026-05-04", count: 2)
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-05-05", count: 1)
+
+      expect(described_class.beacon_cutover_date).to eq(Date.new(2026, 5, 4))
+    end
+
+    it "returns nil when no beacons are collected" do
+      SiteSetting.dashboard_improvements = true
+      SiteSetting.trigger_browser_pageview_events = false
+      SiteSetting.persist_browser_pageview_events = false
+      UpcomingChangeEvent.create!(
+        upcoming_change_name: "dashboard_improvements",
+        event_type: :manual_opt_in,
+      )
+
+      expect(described_class.beacon_cutover_date).to be_nil
+    end
+
+    it "returns nil when legacy pageviews are enabled" do
+      SiteSetting.use_legacy_pageviews = true
+      SiteSetting.dashboard_improvements = true
+
+      expect(described_class.beacon_cutover_date).to be_nil
+    end
+  end
+
   it "truncates string fields before saving" do
     event =
       described_class.create!(

--- a/spec/services/admin_dashboard_site_traffic_spec.rb
+++ b/spec/services/admin_dashboard_site_traffic_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe AdminDashboardSiteTraffic do
     response[:pageview_series].find { |traffic_series| traffic_series[:req] == req }[:data]
   end
 
+  def use_beacon_cutover_date(date)
+    BrowserPageviewEvent.stubs(:beacon_cutover_date).returns(date)
+  end
+
   describe ".build" do
     it "returns public-community KPIs and pageview series for selected dates" do
       SiteSetting.embed_topics_list = true
@@ -290,6 +294,92 @@ RSpec.describe AdminDashboardSiteTraffic do
           traffic_series(:anonymous, [traffic_point("2026-05-01", 20)]),
           traffic_series(:crawlers, [traffic_point("2026-05-01", 0)]),
         ],
+      )
+    end
+
+    it "uses beacon browser pageviews starting the day after dashboard improvements was enabled" do
+      use_beacon_cutover_date(Date.new(2026, 5, 3))
+
+      Fabricate(:logged_in_browser_application_request, date: "2026-05-01", count: 10)
+      Fabricate(:anonymous_browser_application_request, date: "2026-05-01", count: 20)
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-05-01", count: 100)
+      Fabricate(:anonymous_browser_beacon_application_request, date: "2026-05-01", count: 200)
+
+      Fabricate(:logged_in_browser_application_request, date: "2026-05-02", count: 11)
+      Fabricate(:anonymous_browser_application_request, date: "2026-05-02", count: 21)
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-05-02", count: 110)
+      Fabricate(:anonymous_browser_beacon_application_request, date: "2026-05-02", count: 210)
+
+      Fabricate(:logged_in_browser_application_request, date: "2026-05-03", count: 12)
+      Fabricate(:anonymous_browser_application_request, date: "2026-05-03", count: 22)
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-05-03", count: 120)
+      Fabricate(:anonymous_browser_beacon_application_request, date: "2026-05-03", count: 220)
+
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")).to eq(
+        kpis: {
+          browser_pageviews: {
+            value: 402,
+          },
+          logged_in_share: {
+            value: 35,
+          },
+        },
+        pageview_series: [
+          traffic_series(
+            :logged_in,
+            [
+              traffic_point("2026-05-01", 10),
+              traffic_point("2026-05-02", 11),
+              traffic_point("2026-05-03", 120),
+            ],
+          ),
+          traffic_series(
+            :anonymous,
+            [
+              traffic_point("2026-05-01", 20),
+              traffic_point("2026-05-02", 21),
+              traffic_point("2026-05-03", 220),
+            ],
+          ),
+          traffic_series(
+            :crawlers,
+            [
+              traffic_point("2026-05-01", 0),
+              traffic_point("2026-05-02", 0),
+              traffic_point("2026-05-03", 0),
+            ],
+          ),
+        ],
+      )
+    end
+
+    it "compares beacon pageviews against piggyback pageviews when the prior period predates the cutover" do
+      use_beacon_cutover_date(Date.new(2026, 5, 1))
+
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-04-28", count: 5)
+
+      Fabricate(:logged_in_browser_application_request, date: "2026-04-29", count: 30)
+      Fabricate(:anonymous_browser_application_request, date: "2026-04-29", count: 70)
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-04-29", count: 1)
+      Fabricate(:anonymous_browser_beacon_application_request, date: "2026-04-29", count: 2)
+
+      Fabricate(:logged_in_browser_beacon_application_request, date: "2026-05-02", count: 60)
+      Fabricate(:anonymous_browser_beacon_application_request, date: "2026-05-02", count: 140)
+      Fabricate(:logged_in_browser_application_request, date: "2026-05-02", count: 3)
+      Fabricate(:anonymous_browser_application_request, date: "2026-05-02", count: 4)
+
+      expect(build_traffic(start_date: "2026-05-01", end_date: "2026-05-03")[:kpis]).to eq(
+        browser_pageviews: {
+          value: 200,
+          percent_change: 100,
+          comparison_period: {
+            start_date: "2026-04-28",
+            end_date: "2026-04-30",
+          },
+        },
+        logged_in_share: {
+          value: 30,
+        },
       )
     end
 


### PR DESCRIPTION
The redesigned admin dashboard traffic graph was always reading the piggyback browser pageview counters, even after beacon pageview tracking was enabled.

Use BrowserPageviewEvent.beacon_cutover_date to switch dashboard traffic rows from piggyback counters to beacon counters. The cutover uses the day after dashboard_improvements was enabled, based on the site_settings.updated_at timestamp, so the first beacon day is a full day of data.

The dashboard keeps the public series names unchanged while internally selecting between page_view_logged_in_browser and page_view_logged_in_browser_beacon, and between page_view_anon_browser and page_view_anon_browser_beacon.