### PR TITLE
DEV: Enable Playwright soft reset by default in system tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,6 @@ jobs:
       CAPYBARA_DEFAULT_MAX_WAIT_TIME: 20
       MINIO_RUNNER_LOG_LEVEL: WARN
       DISCOURSE_TURBO_RSPEC_RETRY_AND_LOG_FLAKY_TESTS: ${{ (matrix.build_type == 'system' || matrix.build_type == 'backend') && '1' }}
-      CAPYBARA_PLAYWRIGHT_SOFT_RESET: ${{ matrix.build_type == 'system' && '1' }}
       CHEAP_SOURCE_MAPS: "1"
       DBUS_SESSION_BUS_ADDRESS: "unix:path=/dev/null"
       MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner

--- a/spec/support/system/capybara_patches.rb
+++ b/spec/support/system/capybara_patches.rb
@@ -258,7 +258,7 @@ module PlaywrightSoftReset
     private
 
     def soft_reset_enabled?
-      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] != "1"
+      return false if ENV["CAPYBARA_PLAYWRIGHT_SOFT_RESET"] == "0"
       !(callback_on_save_screenrecord? || @callback_on_save_trace)
     end
   end


### PR DESCRIPTION
Playwright soft reset currently requires `CAPYBARA_PLAYWRIGHT_SOFT_RESET=1`, so system test runs outside CI still use the slower full context reset. CI has been running stable with soft reset enabled for 2 weeks so we are now ready to promote it as the default. 

This commit enables soft reset unless the `CAPYBARA_PLAYWRIGHT_SOFT_RESET ` env is explicitly set to `0`, preserving an opt-out for troubleshooting and removing the now-redundant CI assignment.