### PR TITLE
FIX: Allow manual Community sidebar links to be localized

### DIFF
--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -51,20 +51,25 @@ class SidebarSectionsController < ApplicationController
   end
 
   def update
-    sidebar_section = SidebarSection.find(section_params["id"])
+    sidebar_section = SidebarSection.find(params[:id])
     @guardian.ensure_can_edit!(sidebar_section)
-    @guardian.ensure_can_localize_sidebar_section!(sidebar_section) if localization_params_present?
+    ensure_localization_params_allowed(sidebar_section) if localization_params_present?
+    permitted_section_params = section_params(sidebar_section)
+    permitted_links_params = links_params(sidebar_section)
 
     ActiveRecord::Base.transaction do
-      sidebar_section.update!(section_params.merge(sidebar_urls_attributes: links_params))
+      sidebar_section.update!(
+        permitted_section_params.merge(sidebar_urls_attributes: permitted_links_params),
+      )
       sidebar_section.sidebar_section_links.update_all(user_id: sidebar_section.user_id)
 
       order =
         sidebar_section
           .sidebar_urls
           .sort_by do |url|
-            links_params.index { |link| link["name"] == url.name && link["value"] == url.value } ||
-              -1
+            permitted_links_params.index do |link|
+              link["name"] == url.name && link["value"] == url.value
+            end || -1
           end
           .each_with_index
           .map { |url, index| [url.id, index] }
@@ -116,13 +121,14 @@ class SidebarSectionsController < ApplicationController
     render json: failed_json, status: :forbidden
   end
 
-  def section_params
+  def section_params(sidebar_section = nil)
     section_params = params.permit(:id, :title).to_h.with_indifferent_access
 
     if current_user.admin?
       section_params.merge!(params.permit(:public).to_h.with_indifferent_access)
 
-      if SiteSetting.content_localization_enabled
+      if SiteSetting.content_localization_enabled &&
+           (sidebar_section.blank? || guardian.can_localize_sidebar_section_title?(sidebar_section))
         section_params.merge!(
           params
             .permit(:locale, localizations: %i[id locale title _destroy])
@@ -142,7 +148,7 @@ class SidebarSectionsController < ApplicationController
     section_params
   end
 
-  def links_params
+  def links_params(sidebar_section = nil)
     permitted_link_params = %i[icon name value id _destroy segment]
     if current_user.admin? && SiteSetting.content_localization_enabled
       permitted_link_params << { localizations: %i[id locale name _destroy] }
@@ -152,6 +158,11 @@ class SidebarSectionsController < ApplicationController
 
     links&.each do |link|
       next if link[:localizations].blank?
+      if sidebar_section.present? &&
+           !guardian.can_localize_sidebar_section_link?(sidebar_section, link[:value])
+        link.delete(:localizations)
+        next
+      end
 
       link[:localizations_attributes] = prepare_localization_attributes(link.delete(:localizations))
     end
@@ -189,6 +200,20 @@ class SidebarSectionsController < ApplicationController
 
   def localization_params_present?
     params[:localizations].present? || params[:links]&.any? { |link| link[:localizations].present? }
+  end
+
+  def ensure_localization_params_allowed(sidebar_section)
+    if params[:localizations].present? &&
+         !guardian.can_localize_sidebar_section_title?(sidebar_section)
+      raise Discourse::InvalidAccess
+    end
+
+    params[:links]&.each do |link|
+      next if link[:localizations].blank?
+      next if guardian.can_localize_sidebar_section_link?(sidebar_section, link[:value])
+
+      raise Discourse::InvalidAccess
+    end
   end
 
   def prepare_localization_attributes(localizations)

--- a/app/controllers/sidebar_sections_controller.rb
+++ b/app/controllers/sidebar_sections_controller.rb
@@ -57,32 +57,12 @@ class SidebarSectionsController < ApplicationController
     permitted_section_params = section_params(sidebar_section)
     permitted_links_params = links_params(sidebar_section)
 
-    ActiveRecord::Base.transaction do
-      sidebar_section.update!(
-        permitted_section_params.merge(sidebar_urls_attributes: permitted_links_params),
-      )
-      sidebar_section.sidebar_section_links.update_all(user_id: sidebar_section.user_id)
-
-      order =
-        sidebar_section
-          .sidebar_urls
-          .sort_by do |url|
-            permitted_links_params.index do |link|
-              link["name"] == url.name && link["value"] == url.value
-            end || -1
-          end
-          .each_with_index
-          .map { |url, index| [url.id, index] }
-          .to_h
-
-      set_order(sidebar_section, order)
-    end
-
-    if sidebar_section.public?
-      StaffActionLogger.new(current_user).log_update_public_sidebar_section(sidebar_section)
-      MessageBus.publish("/refresh-sidebar-sections", nil)
-      Site.clear_anon_cache!
-    end
+    SidebarSectionUpdater.update!(
+      sidebar_section:,
+      user: current_user,
+      section_params: permitted_section_params,
+      links_params: permitted_links_params,
+    )
 
     render_serialized(sidebar_section.reload, SidebarSectionSerializer)
   rescue ActiveRecord::RecordInvalid => e
@@ -175,21 +155,6 @@ class SidebarSectionsController < ApplicationController
   end
 
   private
-
-  def set_order(sidebar_section, order)
-    position_generator =
-      (0..sidebar_section.sidebar_section_links.count * 2).excluding(
-        sidebar_section.sidebar_section_links.map(&:position),
-      ).each
-
-    links =
-      sidebar_section
-        .sidebar_section_links
-        .sort_by { |link| order[link.linkable_id] }
-        .map { |link| link.attributes.merge(position: position_generator.next) }
-
-    sidebar_section.sidebar_section_links.upsert_all(links, update_only: [:position])
-  end
 
   def check_access_if_public
     public_section = ActiveModel::Type::Boolean.new.cast(params[:public])

--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -39,6 +39,10 @@ class SidebarSection < ActiveRecord::Base
     section_type.blank?
   end
 
+  def community_section?
+    section_type == "community"
+  end
+
   def reset_community!
     ActiveRecord::Base.transaction do
       update!(title: "Community")

--- a/app/models/sidebar_url.rb
+++ b/app/models/sidebar_url.rb
@@ -57,6 +57,7 @@ class SidebarUrl < ActiveRecord::Base
     },
     { name: "Filter", path: "/filter", icon: "filter", segment: SidebarUrl.segments["secondary"] },
   ]
+  COMMUNITY_SECTION_LINK_PATHS = COMMUNITY_SECTION_LINKS.map { |link| link[:path] }.freeze
 
   validates :icon, presence: true, length: { maximum: MAX_ICON_LENGTH }
   validates :name, presence: true, length: { maximum: MAX_NAME_LENGTH }
@@ -89,6 +90,16 @@ class SidebarUrl < ActiveRecord::Base
 
   def set_default_locale
     self.locale ||= SiteSetting.default_locale.to_s
+  end
+
+  def self.built_in_community_section_link_value?(value)
+    normalized_value =
+      value.to_s.sub(%r{\Ahttps?://#{Regexp.escape(Discourse.current_hostname)}}, "")
+    COMMUNITY_SECTION_LINK_PATHS.include?(normalized_value)
+  end
+
+  def built_in_community_section_link?
+    self.class.built_in_community_section_link_value?(value)
   end
 end
 

--- a/app/serializers/sidebar_section_edit_serializer.rb
+++ b/app/serializers/sidebar_section_edit_serializer.rb
@@ -11,12 +11,19 @@ class SidebarSectionEditSerializer < SidebarSectionSerializer
         sidebar_url,
         root: false,
         scope: scope,
-        include_localizations: scope.can_localize_sidebar_section?(object),
+        include_localizations: can_localize_sidebar_url?(sidebar_url),
+        can_localize: can_localize_sidebar_url?(sidebar_url),
       ).as_json
     end
   end
 
   def include_localizations?
-    object.localizations.loaded? && scope.can_localize_sidebar_section?(object)
+    object.localizations.loaded? && scope.can_localize_sidebar_section_title?(object)
+  end
+
+  private
+
+  def can_localize_sidebar_url?(sidebar_url)
+    scope.can_localize_sidebar_section_link?(object, sidebar_url.value)
   end
 end

--- a/app/serializers/sidebar_section_serializer.rb
+++ b/app/serializers/sidebar_section_serializer.rb
@@ -11,7 +11,7 @@ class SidebarSectionSerializer < ApplicationSerializer
         sidebar_url,
         root: false,
         scope: scope,
-        show_translated_name: object.public? && object.custom_section?,
+        show_translated_name: show_translated_sidebar_url?(sidebar_url),
       ).as_json
     end
   end
@@ -30,5 +30,14 @@ class SidebarSectionSerializer < ApplicationSerializer
 
   def include_localizations?
     false
+  end
+
+  private
+
+  def show_translated_sidebar_url?(sidebar_url)
+    return false if !object.public?
+    return true if object.custom_section?
+
+    object.community_section? && !sidebar_url.built_in_community_section_link?
   end
 end

--- a/app/serializers/sidebar_url_serializer.rb
+++ b/app/serializers/sidebar_url_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SidebarUrlSerializer < ApplicationSerializer
-  attributes :id, :name, :value, :icon, :external, :segment, :locale
+  attributes :id, :name, :value, :icon, :external, :segment, :locale, :can_localize
 
   has_many :localizations, embed: :objects, serializer: SidebarUrlLocalizationSerializer
 
@@ -20,5 +20,13 @@ class SidebarUrlSerializer < ApplicationSerializer
 
   def include_localizations?
     @options[:include_localizations]
+  end
+
+  def can_localize
+    @options[:can_localize]
+  end
+
+  def include_can_localize?
+    @options.key?(:can_localize)
   end
 end

--- a/app/services/sidebar_section_updater.rb
+++ b/app/services/sidebar_section_updater.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class SidebarSectionUpdater
+  def self.update!(sidebar_section:, user:, section_params:, links_params:)
+    new(sidebar_section:, user:, section_params:, links_params:).update!
+  end
+
+  def initialize(sidebar_section:, user:, section_params:, links_params:)
+    @sidebar_section = sidebar_section
+    @user = user
+    @section_params = section_params
+    @links_params = (links_params || []).map { |link| link.to_h.with_indifferent_access }
+  end
+
+  def update!
+    ActiveRecord::Base.transaction do
+      @sidebar_section.update!(@section_params.merge(sidebar_urls_attributes: @links_params))
+      @sidebar_section.sidebar_section_links.update_all(user_id: @sidebar_section.user_id)
+      update_link_order
+    end
+
+    publish_public_update if @sidebar_section.public?
+
+    @sidebar_section
+  end
+
+  private
+
+  def update_link_order
+    order =
+      @sidebar_section
+        .sidebar_urls
+        .sort_by do |url|
+          @links_params.index { |link| link[:name] == url.name && link[:value] == url.value } || -1
+        end
+        .each_with_index
+        .map { |url, index| [url.id, index] }
+        .to_h
+
+    set_order(order)
+  end
+
+  def set_order(order)
+    position_generator =
+      (0..@sidebar_section.sidebar_section_links.count * 2).excluding(
+        @sidebar_section.sidebar_section_links.map(&:position),
+      ).each
+
+    links =
+      @sidebar_section
+        .sidebar_section_links
+        .sort_by { |link| order[link.linkable_id] }
+        .map { |link| link.attributes.merge(position: position_generator.next) }
+
+    @sidebar_section.sidebar_section_links.upsert_all(links, update_only: [:position])
+  end
+
+  def publish_public_update
+    StaffActionLogger.new(@user).log_update_public_sidebar_section(@sidebar_section)
+    MessageBus.publish("/refresh-sidebar-sections", nil)
+    Site.clear_anon_cache!
+  end
+end

--- a/frontend/discourse/app/components/modal/sidebar-section-form.gjs
+++ b/frontend/discourse/app/components/modal/sidebar-section-form.gjs
@@ -70,6 +70,10 @@ class Section {
     return !this.sectionType;
   }
 
+  get communitySection() {
+    return this.sectionType === "community";
+  }
+
   get validTitle() {
     return !this.#blankTitle && !this.#tooLongTitle;
   }
@@ -185,6 +189,7 @@ class SectionLink {
     objectId,
     segment,
     localizations,
+    canLocalize = true,
   }) {
     this.router = router;
     this.icon = iconName || "link";
@@ -196,6 +201,7 @@ class SectionLink {
     this.objectId = objectId;
     this.segment = segment;
     this.localizations = localizations || [];
+    this.canLocalize = canLocalize;
   }
 
   get path() {
@@ -388,6 +394,7 @@ export default class SidebarSectionForm extends Component {
         link.localizations,
         LinkLocalization
       ),
+      canLocalize: link.can_localize ?? link.canLocalize,
     });
   }
 
@@ -538,6 +545,16 @@ export default class SidebarSectionForm extends Component {
       this.siteSettings.content_localization_enabled &&
       this.transformedModel.public &&
       this.transformedModel.customSection
+    );
+  }
+
+  get showLinkLocalizations() {
+    return (
+      this.currentUser?.admin &&
+      this.siteSettings.content_localization_enabled &&
+      this.transformedModel.public &&
+      (this.transformedModel.customSection ||
+        this.transformedModel.communitySection)
     );
   }
 
@@ -729,7 +746,7 @@ export default class SidebarSectionForm extends Component {
   }
 
   serializeLinkLocalizations(link) {
-    if (!this.showLocalizations) {
+    if (!this.showLinkLocalizations || !link.canLocalize) {
       return [];
     }
 
@@ -749,6 +766,7 @@ export default class SidebarSectionForm extends Component {
         router: this.router,
         objectId: this.nextObjectId,
         segment: "primary",
+        canLocalize: true,
       })
     );
 
@@ -763,6 +781,7 @@ export default class SidebarSectionForm extends Component {
         router: this.router,
         objectId: this.nextObjectId,
         segment: "secondary",
+        canLocalize: true,
       })
     );
 
@@ -993,7 +1012,10 @@ export default class SidebarSectionForm extends Component {
                 @deleteLink={{this.deleteLink}}
                 @reorderCallback={{this.reorder}}
                 @setDraggedLinkCallback={{this.setDraggedLink}}
-                @showLocalizations={{this.showLocalizations}}
+                @showLocalizations={{and
+                  this.showLinkLocalizations
+                  link.canLocalize
+                }}
                 @localeOptions={{this.localeOptions}}
                 @deleteLocalization={{this.deleteLinkLocalization}}
                 @addLocalization={{this.addLinkLocalization}}
@@ -1021,7 +1043,10 @@ export default class SidebarSectionForm extends Component {
                 @deleteLink={{this.deleteLink}}
                 @reorderCallback={{this.reorder}}
                 @setDraggedLinkCallback={{this.setDraggedLink}}
-                @showLocalizations={{this.showLocalizations}}
+                @showLocalizations={{and
+                  this.showLinkLocalizations
+                  link.canLocalize
+                }}
                 @localeOptions={{this.localeOptions}}
                 @deleteLocalization={{this.deleteLinkLocalization}}
                 @addLocalization={{this.addLinkLocalization}}

--- a/frontend/discourse/app/lib/sidebar/user/community-section/admin-section.js
+++ b/frontend/discourse/app/lib/sidebar/user/community-section/admin-section.js
@@ -1,6 +1,7 @@
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import SidebarSectionForm from "discourse/components/modal/sidebar-section-form";
+import { ajax } from "discourse/lib/ajax";
 import CommonCommunitySection from "discourse/lib/sidebar/common/community-section/section";
 import { i18n } from "discourse-i18n";
 
@@ -9,8 +10,15 @@ export default class extends CommonCommunitySection {
   @service navigationMenu;
 
   @action
-  moreSectionButtonAction() {
-    return this.modal.show(SidebarSectionForm, { model: this });
+  async moreSectionButtonAction() {
+    const json = await ajax(`/sidebar_sections/${this.section.id}.json`);
+
+    return this.modal.show(SidebarSectionForm, {
+      model: {
+        hideSectionHeader: this.hideSectionHeader,
+        section: json.sidebar_section,
+      },
+    });
   }
 
   get moreSectionButtonText() {

--- a/lib/guardian/localization_guardian.rb
+++ b/lib/guardian/localization_guardian.rb
@@ -50,10 +50,35 @@ module LocalizationGuardian
   end
 
   def can_localize_sidebar_section?(section_or_section_id)
+    section = find_sidebar_section(section_or_section_id)
+
+    can_localize_sidebar_section_title?(section)
+  end
+
+  def can_localize_sidebar_section_title?(section_or_section_id)
     return false if !SiteSetting.content_localization_enabled
     return false if anonymous?
     return false if !@user.admin?
 
+    section = find_sidebar_section(section_or_section_id)
+    section.present? && section.public? && section.custom_section?
+  end
+
+  def can_localize_sidebar_section_link?(section_or_section_id, link_value)
+    return false if !SiteSetting.content_localization_enabled
+    return false if anonymous?
+    return false if !@user.admin?
+
+    section = find_sidebar_section(section_or_section_id)
+    return false if !section&.public?
+    return true if section.custom_section?
+
+    section.community_section? && !SidebarUrl.built_in_community_section_link_value?(link_value)
+  end
+
+  private
+
+  def find_sidebar_section(section_or_section_id)
     section =
       (
         if section_or_section_id.is_a?(SidebarSection)
@@ -62,6 +87,5 @@ module LocalizationGuardian
           SidebarSection.find_by(id: section_or_section_id)
         end
       )
-    section.present? && section.public? && section.custom_section?
   end
 end

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -66,25 +66,29 @@ RSpec.describe SidebarSectionsController do
       ).to eq("タグ")
     end
 
-    it "does not return localization rows for admins editing a built-in section" do
+    it "returns localization rows only for manually created built-in section links" do
       SiteSetting.content_localization_enabled = true
       sign_in(admin)
       community_section =
         SidebarSection.find_by(section_type: SidebarSection.section_types[:community])
       topics_link = community_section.sidebar_urls.find_by(name: "Topics")
+      manual_link = Fabricate(:sidebar_url, name: "Solutions", value: "/solutions", locale: "en")
+      Fabricate(:sidebar_section_link, sidebar_section: community_section, linkable: manual_link)
       Fabricate(:sidebar_section_localization, sidebar_section: community_section, locale: "ja")
       Fabricate(:sidebar_url_localization, sidebar_url: topics_link, locale: "ja")
+      Fabricate(:sidebar_url_localization, sidebar_url: manual_link, locale: "ja", name: "解決策")
 
       get "/sidebar_sections/#{community_section.id}.json"
 
       expect(response.status).to eq(200)
       expect(response.parsed_body.dig("sidebar_section", "localizations")).to eq(nil)
+      links = response.parsed_body.dig("sidebar_section", "links")
+      expect(links.find { |link| link["id"] == topics_link.id }["localizations"]).to eq(nil)
+      expect(links.find { |link| link["id"] == topics_link.id }["can_localize"]).to eq(false)
       expect(
-        response
-          .parsed_body
-          .dig("sidebar_section", "links")
-          .filter_map { |link| link["localizations"] },
-      ).to be_empty
+        links.find { |link| link["id"] == manual_link.id }["localizations"].first["name"],
+      ).to eq("解決策")
+      expect(links.find { |link| link["id"] == manual_link.id }["can_localize"]).to eq(true)
     end
 
     it "does not allow regular users to load a public section for editing" do
@@ -519,6 +523,32 @@ RSpec.describe SidebarSectionsController do
       expect(response.status).to eq(403)
       expect(community_section.reload.localizations).to be_blank
       expect(topics_link.reload.localizations).to be_blank
+    end
+
+    it "allows admin to update manually created Community section link localizations" do
+      SiteSetting.content_localization_enabled = true
+      sign_in(admin)
+      manual_link = Fabricate(:sidebar_url, name: "Solutions", value: "/solutions", locale: "en")
+      Fabricate(:sidebar_section_link, sidebar_section: community_section, linkable: manual_link)
+
+      put "/sidebar_sections/#{community_section.id}.json",
+          params: {
+            title: "community section edited",
+            links: [
+              {
+                icon: "link",
+                id: manual_link.id,
+                name: "Solutions",
+                value: "/solutions",
+                localizations: [{ locale: "ja", name: "解決策" }],
+              },
+            ],
+          }
+
+      expect(response.status).to eq(200)
+      expect(manual_link.reload.localizations.order(:locale).pluck(:locale, :name)).to eq(
+        [%w[ja 解決策]],
+      )
     end
 
     it "allows admin to remove public section localizations" do

--- a/spec/serializers/sidebar_section_serializer_spec.rb
+++ b/spec/serializers/sidebar_section_serializer_spec.rb
@@ -96,15 +96,18 @@ describe SidebarSectionSerializer do
     end
   end
 
-  it "returns original labels for built-in sections with localizations" do
+  it "returns localized labels only for manually created built-in section links" do
     SiteSetting.content_localization_enabled = true
     community_section =
       SidebarSection.find_by(section_type: SidebarSection.section_types[:community])
     community_section.update!(locale: "en")
     topics_link = community_section.sidebar_urls.find_by(name: "Topics")
     topics_link.update!(locale: "en")
+    manual_link = Fabricate(:sidebar_url, name: "Solutions", value: "/solutions", locale: "en")
+    Fabricate(:sidebar_section_link, sidebar_section: community_section, linkable: manual_link)
     Fabricate(:sidebar_section_localization, sidebar_section: community_section, locale: "ja")
     Fabricate(:sidebar_url_localization, sidebar_url: topics_link, locale: "ja")
+    Fabricate(:sidebar_url_localization, sidebar_url: manual_link, locale: "ja", name: "解決策")
 
     I18n.with_locale("ja") do
       reloaded =
@@ -115,8 +118,10 @@ describe SidebarSectionSerializer do
 
       expect(json[:title]).to eq("Community")
       expect(json[:links].find { |link| link[:id] == topics_link.id }[:name]).to eq("Topics")
+      expect(json[:links].find { |link| link[:id] == manual_link.id }[:name]).to eq("解決策")
       expect(json[:localizations]).to eq(nil)
       expect(json[:links].find { |link| link[:id] == topics_link.id }[:localizations]).to eq(nil)
+      expect(json[:links].find { |link| link[:id] == manual_link.id }[:localizations]).to eq(nil)
     end
   end
 end

--- a/spec/services/sidebar_section_updater_spec.rb
+++ b/spec/services/sidebar_section_updater_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe SidebarSectionUpdater do
+  fab!(:admin)
+  fab!(:sidebar_section) { Fabricate(:sidebar_section, public: true) }
+  fab!(:first_url) { Fabricate(:sidebar_url, name: "First", value: "/first") }
+  fab!(:second_url) { Fabricate(:sidebar_url, name: "Second", value: "/second") }
+
+  before do
+    Fabricate(:sidebar_section_link, sidebar_section:, linkable: first_url, position: 0)
+    Fabricate(:sidebar_section_link, sidebar_section:, linkable: second_url, position: 1)
+  end
+
+  it "updates the section, persists submitted link order, and publishes public updates" do
+    Site.expects(:clear_anon_cache!)
+
+    messages =
+      MessageBus.track_publish("/refresh-sidebar-sections") do
+        described_class.update!(
+          sidebar_section:,
+          user: admin,
+          section_params: {
+            title: "Updated section",
+            public: true,
+          },
+          links_params: [
+            { id: second_url.id, icon: "link", name: "Second edited", value: "/second" },
+            { id: first_url.id, icon: "link", name: "First edited", value: "/first" },
+            { icon: "link", name: "Third", value: "/third" },
+          ],
+        )
+      end
+
+    expect(messages.size).to eq(1)
+    expect(sidebar_section.reload.title).to eq("Updated section")
+    expect(
+      sidebar_section.reload.sidebar_section_links.reload.map { |link| link.linkable.name },
+    ).to eq(["Second edited", "First edited", "Third"])
+    expect(UserHistory.last.action).to eq(UserHistory.actions[:update_public_sidebar_section])
+    expect(UserHistory.last.acting_user_id).to eq(admin.id)
+  end
+end

--- a/spec/system/editing_sidebar_community_section_spec.rb
+++ b/spec/system/editing_sidebar_community_section_spec.rb
@@ -56,6 +56,32 @@ RSpec.describe "Editing Sidebar Community Section" do
     )
   end
 
+  it "lets an admin localize manually created Community section links" do
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_supported_locales = "ja"
+    user.update!(locale: "ja")
+
+    sign_in(admin)
+
+    visit("/latest")
+
+    modal = sidebar.click_community_section_more_button.click_customize_community_section_button
+    modal.add_link
+    modal.fill_last_link("Solutions Leaderboard", "/solutions-leaderboard")
+    modal.add_last_link_localization("ソリューションリーダーボード")
+    modal.add_link
+    modal.fill_last_link("Untranslated Link", "/untranslated-link")
+    modal.save
+    modal.confirm_update
+
+    sign_in(user)
+
+    visit("/latest")
+
+    expect(sidebar).to have_community_section_link("ソリューションリーダーボード", href: "/solutions-leaderboard")
+    expect(sidebar).to have_community_section_link("Untranslated Link", href: "/untranslated-link")
+  end
+
   it "allows admin to edit community section when no secondary section links" do
     SidebarSection
       .where(title: "Community")

--- a/spec/system/page_objects/components/navigation_menu/base.rb
+++ b/spec/system/page_objects/components/navigation_menu/base.rb
@@ -36,6 +36,13 @@ module PageObjects
           ).click
         end
 
+        def has_community_section_link?(text, href: nil)
+          selector = ".#{SIDEBAR_SECTION_LINK_SELECTOR}"
+          selector += "[href='#{href}']" if href.present?
+
+          community_section.has_css?(selector, text:)
+        end
+
         def has_one_active_section_link?
           has_css?(".#{SIDEBAR_SECTION_LINK_SELECTOR}--active", count: 1)
         end

--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -16,10 +16,30 @@ module PageObjects
         icon_picker.select_icon(icon)
       end
 
+      def fill_last_link(name, url, icon = "link")
+        primary_links_wrapper
+          .all(".sidebar-section-form-link")
+          .last
+          .then do |link_row|
+            link_row.fill_in("link-name", with: name)
+            link_row.fill_in("link-url", with: url)
+
+            icon_picker = PageObjects::Components::DIconGridPicker.new(link_row)
+            icon_picker.expand
+            icon_picker.filter(icon)
+            icon_picker.select_icon(icon)
+          end
+      end
+
       def first_link_icon_picker
         PageObjects::Components::DIconGridPicker.new(
           find(".sidebar-section-form-link", match: :first),
         )
+      end
+
+      def add_link
+        all(".sidebar-section-form-modal .add-link").first.click
+        self
       end
 
       def mark_as_public
@@ -47,6 +67,21 @@ module PageObjects
 
       def add_first_link_localization(name)
         find(".add-link-localization", match: :first).click
+        all("select[aria-label='#{I18n.t("js.sidebar.sections.custom.localizations.locale")}']")
+          .last
+          .find("option[value='ja']")
+          .select_option
+        all(
+          "input[aria-label='#{I18n.t("js.sidebar.sections.custom.localizations.link_label")}']",
+        ).last.fill_in(with: name)
+      end
+
+      def add_last_link_localization(name)
+        primary_links_wrapper
+          .all(".sidebar-section-form-link-wrapper")
+          .last
+          .find(".add-link-localization")
+          .click
         all("select[aria-label='#{I18n.t("js.sidebar.sections.custom.localizations.locale")}']")
           .last
           .find("option[value='ja']")
@@ -161,6 +196,10 @@ module PageObjects
 
       def section_title_translation_locale_selector
         ".sidebar-section-form > .sidebar-section-form__localizations select[aria-label='#{I18n.t("js.sidebar.sections.custom.localizations.locale")}']"
+      end
+
+      def primary_links_wrapper
+        find(".sidebar-section-form__links-wrapper")
       end
     end
   end


### PR DESCRIPTION
Follow up to https://github.com/discourse/discourse/pull/41795

This adds content-localization support for manually created links in the built-in Community sidebar section.

Built-in Community links like Topics, My posts, Review, Admin, etc. still use their existing frontend i18n labels and do not expose localization controls. Only admin-created links in the Community section can be localized (since only the admin can edit it).

The earlier PR had skipped adding these entirely for the Community section

<img width="1576" height="997" alt="Screenshot 2026-07-22 at 2 30 46 PM" src="https://github.com/user-attachments/assets/695b29c7-cc6a-4bd2-b738-00902d0b0eec" />
