### PR TITLE
FIX: Disable the ai query generation toggle on the frontend when AI disabled

### DIFF
--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-mode-switch.gjs
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/components/query-mode-switch.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import DSegmentedControl from "discourse/components/d-segmented-control";
 import { i18n } from "discourse-i18n";
+import { dataExplorerAiQueriesEnabled } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-query-availability";
 
 export default class QueryModeSwitch extends Component {
   @service siteSettings;
@@ -18,7 +19,7 @@ export default class QueryModeSwitch extends Component {
         icon: "discourse-sparkles",
         label: i18n("explorer.mode.ai"),
         disabled:
-          !this.siteSettings.data_explorer_ai_queries_enabled ||
+          !dataExplorerAiQueriesEnabled(this.siteSettings) ||
           this.args.editDisabled,
       },
     ];

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/edit.js
@@ -11,6 +11,7 @@ import { i18n } from "discourse-i18n";
 import QueryHelp from "discourse/plugins/discourse-data-explorer/discourse/components/modal/query-help";
 import { ParamValidationError } from "discourse/plugins/discourse-data-explorer/discourse/components/param-input-form";
 import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
+import { dataExplorerAiQueriesEnabled } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-query-availability";
 import { defaultView } from "discourse/plugins/discourse-data-explorer/discourse/lib/chart-helpers";
 import {
   dataExplorerStore,
@@ -145,7 +146,7 @@ export default class PluginsExplorerController extends Controller {
   }
 
   get aiQueriesEnabled() {
-    return this.siteSettings.data_explorer_ai_queries_enabled;
+    return dataExplorerAiQueriesEnabled(this.siteSettings);
   }
 
   get regenerateDisabled() {

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/controllers/admin-plugins/show/explorer/new.js
@@ -6,6 +6,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import I18n, { i18n } from "discourse-i18n";
 import { subscribeToAiGeneration } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-generation";
+import { dataExplorerAiQueriesEnabled } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-query-availability";
 import { defaultView } from "discourse/plugins/discourse-data-explorer/discourse/lib/chart-helpers";
 import {
   dataExplorerStore,
@@ -85,7 +86,7 @@ export default class AdminPluginsExplorerNew extends Controller {
   }
 
   get aiQueriesEnabled() {
-    return this.siteSettings.data_explorer_ai_queries_enabled;
+    return dataExplorerAiQueriesEnabled(this.siteSettings);
   }
 
   @action

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/ai-query-availability.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/lib/ai-query-availability.js
@@ -1,0 +1,6 @@
+export function dataExplorerAiQueriesEnabled(siteSettings) {
+  return !!(
+    siteSettings.data_explorer_ai_queries_enabled &&
+    siteSettings.discourse_ai_enabled
+  );
+}

--- a/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
+++ b/plugins/discourse-data-explorer/assets/javascripts/discourse/routes/admin-plugins/show/explorer/edit.js
@@ -1,6 +1,7 @@
 import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DiscourseRoute from "discourse/routes/discourse";
+import { dataExplorerAiQueriesEnabled } from "discourse/plugins/discourse-data-explorer/discourse/lib/ai-query-availability";
 import { rememberedMode } from "discourse/plugins/discourse-data-explorer/discourse/lib/data-explorer-store";
 
 export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
@@ -64,7 +65,7 @@ export default class AdminPluginsExplorerQueriesDetails extends DiscourseRoute {
     const shouldAutoRun = !!transition.to.queryParams.run;
     const showCachedResult = !!cachedResult && !shouldAutoRun;
     const aiAvailable =
-      this.siteSettings.data_explorer_ai_queries_enabled &&
+      dataExplorerAiQueriesEnabled(this.siteSettings) &&
       !model.model.is_default;
     const defaultMode = aiAvailable ? (rememberedMode() ?? "ai") : "manual";
 

--- a/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/ai_query_generation_spec.rb
@@ -21,8 +21,27 @@ RSpec.describe "Data Explorer AI query generation" do
     end
   end
 
+  context "when Discourse AI is disabled" do
+    before do
+      SiteSetting.discourse_ai_enabled = false
+      SiteSetting.data_explorer_ai_queries_enabled = true
+    end
+
+    it "shows only the manual form with no mode switch" do
+      visit("/admin/plugins/discourse-data-explorer/queries/new")
+
+      expect(page).to have_css(".query-new")
+      expect(page).to have_no_css(".query-mode-switch")
+      expect(page).to have_css(".query-new [data-name='name']")
+      expect(page).to have_no_css(".query-new__ai-section")
+    end
+  end
+
   context "when ai queries setting is enabled" do
-    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+    before do
+      SiteSetting.discourse_ai_enabled = true
+      SiteSetting.data_explorer_ai_queries_enabled = true
+    end
 
     it "shows the AI form with generate button by default" do
       visit("/admin/plugins/discourse-data-explorer/queries/new")
@@ -49,7 +68,10 @@ RSpec.describe "Data Explorer AI query generation" do
   context "when on the edit page" do
     fab!(:query) { Fabricate(:query, name: "Existing query", sql: "SELECT 1", user: admin) }
 
-    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+    before do
+      SiteSetting.discourse_ai_enabled = true
+      SiteSetting.data_explorer_ai_queries_enabled = true
+    end
 
     it "shows the AI prompt and view segmented control (with SQL option) by default in AI mode" do
       visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")
@@ -104,7 +126,10 @@ RSpec.describe "Data Explorer AI query generation" do
   end
 
   context "when on the edit page for a default query" do
-    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+    before do
+      SiteSetting.discourse_ai_enabled = true
+      SiteSetting.data_explorer_ai_queries_enabled = true
+    end
 
     it "disables the AI option in the mode switch" do
       visit("/admin/plugins/discourse-data-explorer/queries/-1")
@@ -119,7 +144,10 @@ RSpec.describe "Data Explorer AI query generation" do
     fab!(:query) { Fabricate(:query, name: "First query", sql: "SELECT 1", user: admin) }
     fab!(:other_query) { Fabricate(:query, name: "Second query", sql: "SELECT 2", user: admin) }
 
-    before { SiteSetting.data_explorer_ai_queries_enabled = true }
+    before do
+      SiteSetting.discourse_ai_enabled = true
+      SiteSetting.data_explorer_ai_queries_enabled = true
+    end
 
     it "opens subsequent queries and the new query page in the last used mode" do
       visit("/admin/plugins/discourse-data-explorer/queries/new")

--- a/plugins/discourse-data-explorer/spec/system/query_runner_spec.rb
+++ b/plugins/discourse-data-explorer/spec/system/query_runner_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "Data explorer query runner" do
   context "with the mode switch in the header" do
     fab!(:query) { Fabricate(:query, name: "Query", sql: "SELECT 1", user: admin) }
 
+    before { SiteSetting.discourse_ai_enabled = true }
+
     it "hides the switch when AI queries are disabled" do
       SiteSetting.data_explorer_ai_queries_enabled = false
       visit("/admin/plugins/discourse-data-explorer/queries/#{query.id}")

--- a/plugins/discourse-data-explorer/test/javascripts/acceptance/new-query-test.js
+++ b/plugins/discourse-data-explorer/test/javascripts/acceptance/new-query-test.js
@@ -156,6 +156,7 @@ acceptance("New Query - AI", function (needs) {
   needs.settings({
     data_explorer_enabled: true,
     data_explorer_ai_queries_enabled: true,
+    discourse_ai_enabled: true,
   });
 
   const GENERATION_ID = "test-generation";
@@ -268,6 +269,22 @@ acceptance("New Query - AI", function (needs) {
     );
     await settled();
   }
+
+  test("renders the manual form when Discourse AI is disabled", async function (assert) {
+    this.siteSettings.discourse_ai_enabled = false;
+
+    await visit("/admin/plugins/discourse-data-explorer/queries/new");
+
+    assert
+      .dom(".query-mode-switch")
+      .doesNotExist("the AI/manual mode switch is hidden");
+    assert
+      .dom(".query-new__manual-form")
+      .exists("the manual query form renders");
+    assert
+      .dom(".query-new__ai-section")
+      .doesNotExist("the AI generation form is hidden");
+  });
 
   test("save query is the primary action and the result is shown first", async function (assert) {
     await generate("show me a value");


### PR DESCRIPTION
<img width="351" height="57" alt="Screenshot 2026-07-22 at 3 09 27 PM" src="https://github.com/user-attachments/assets/b6059716-d160-406d-9f5c-a502ef1c3905" />

Generate with AI was still showing up when the plugin is disabled. This is only on the frontend.