### PR TITLE
PERF: Avoid unnecessary upcoming change lookups for group lists

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -564,8 +564,8 @@ class User < ActiveRecord::Base
     # including anon" and is gated behind the granular pseudogroups upcoming
     # change.
     everyone_shortcut =
-      !SiteSetting.granular_anonymous_and_logged_in_groups_permissions &&
-        group_ids.include?(Group::AUTO_GROUPS[:everyone])
+      group_ids.include?(Group::AUTO_GROUPS[:everyone]) &&
+        !SiteSetting.granular_anonymous_and_logged_in_groups_permissions
 
     logged_in_shortcut = group_ids.include?(Group::AUTO_GROUPS[:logged_in_users])
 

--- a/lib/site_setting_extension.rb
+++ b/lib/site_setting_extension.rb
@@ -1192,8 +1192,8 @@ module SiteSettingExtension
     elsif setting_type == :group_list
       define_singleton_method("#{clean_name}_map") do
         ids = public_send(clean_name).to_s.split("|").map(&:to_i)
-        if SiteSetting.granular_anonymous_and_logged_in_groups_permissions &&
-             ids.include?(Group::AUTO_GROUPS[:everyone])
+        if ids.include?(Group::AUTO_GROUPS[:everyone]) &&
+             SiteSetting.granular_anonymous_and_logged_in_groups_permissions
           ids =
             ids
               .map do |id|


### PR DESCRIPTION
Group-list permission checks resolved the granular pseudogroups upcoming change before determining whether the everyone group was present. This made unrelated checks pay the full upcoming-change default-resolution cost.

Check for the everyone group first so lists that cannot be affected retain the existing result without resolving the upcoming change.