### PR TITLE
UX: remove MD preview toggle

### DIFF
--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -718,28 +718,6 @@ export default class ComposerContainer extends Component {
                       {{dIcon this.composer.uploadIcon}}
                     </a>
                   {{/if}}
-
-                  {{#if this.composer.allowPreview}}
-                    <a
-                      href
-                      class="btn btn-default no-text mobile-preview"
-                      title={{i18n "composer.show_preview"}}
-                      {{on "click" this.composer.togglePreview}}
-                      aria-label={{i18n "composer.show_preview"}}
-                    >
-                      {{dIcon "desktop"}}
-                    </a>
-                  {{/if}}
-
-                  {{#if this.composer.isPreviewVisible}}
-                    <DButton
-                      @action={{this.composer.togglePreview}}
-                      @title="composer.hide_preview"
-                      @ariaLabel="composer.hide_preview"
-                      @icon="pencil"
-                      class="hide-preview"
-                    />
-                  {{/if}}
                 {{/if}}
 
                 {{#if


### PR DESCRIPTION
This commit removes the old Markdown preview toggle, as the MD/RTE mode toggle can be used for the same purpose, with the added benefit of still being able to edit the content.

<img width="414" height="889" alt="CleanShot 2026-07-22 at 13 05 39" src="https://github.com/user-attachments/assets/983412b3-8408-4564-83f9-80b138b02235" />

