### PR TITLE
DEV: Add literal and regex filter modes to bin/qunit

### DIFF
--- a/.skills/discourse-writing-js-tests/SKILL.md
+++ b/.skills/discourse-writing-js-tests/SKILL.md
@@ -213,9 +213,13 @@ Beyond [qunit-dom](https://github.com/mainmatter/qunit-dom/blob/master/API.md)'s
 bin/qunit --help                       # full options
 bin/qunit path/to/some-test.gjs        # one file
 bin/qunit path/to/integration/components  # a directory
-bin/qunit -f "BookmarkIcon"            # filter by module/test name
+bin/qunit --filter "BookmarkIcon"      # literal, case-insensitive substring of "module: test name"
+bin/qunit --filter-regex "Foo|Bar"     # JavaScript regex over "module: test name" (use for alternation)
 bin/qunit --target chat                # a specific plugin
 ```
+
+`--filter` matches a literal substring, so `|` and other regex characters are treated
+literally; use `--filter-regex` when you need alternation or other patterns.
 
 Requires a running Rails server (or pass `--standalone` to spin up an isolated one).
 

--- a/AI-AGENTS.md
+++ b/AI-AGENTS.md
@@ -38,6 +38,8 @@ Discourse is large with long history. Understand context before changes.
 bin/qunit --help # detailed help
 bin/qunit path/to/test-file.js  # Run all tests in file
 bin/qunit path/to/tests/directory # Run all tests in directory
+bin/qunit --filter "Some text" # Literal, case-insensitive match on "module: test name" (pipes are literal)
+bin/qunit --filter-regex "Foo|Bar" # JavaScript regex over "module: test name" (use for alternation)
 
 # Linting
 bin/lint --fix path/to/file path/to/another/file

--- a/bin/qunit
+++ b/bin/qunit
@@ -56,9 +56,16 @@ class QunitRunner
         opts.separator ""
         opts.separator "Options:"
 
-        opts.on("-f", "--filter FILTER", "Run tests matching this filter") do |filter|
-          @filter = filter
-        end
+        opts.on(
+          "-f",
+          "--filter FILTER",
+          "Run tests whose \"module: test name\" contains this literal, case-insensitive substring",
+        ) { |filter| @filter = filter }
+
+        opts.on(
+          "--filter-regex PATTERN",
+          "Run tests matching this case-insensitive JavaScript regular expression",
+        ) { |pattern| @filter_regex = pattern }
 
         opts.on("--dry-run", "Show what would run without executing") { @dry_run = true }
 
@@ -126,7 +133,8 @@ class QunitRunner
             bin/qunit --standalone --target plugins  # Run all plugin tests
             bin/qunit --standalone --target chat     # Run single plugin tests
             bin/qunit --standalone plugins/chat/test/javascripts/unit/lib/chat-audio-test.js
-            bin/qunit --standalone --filter "Acceptance: Emoji"
+            bin/qunit --standalone --filter 'Integration | ui-kit | DButton'
+            bin/qunit --standalone --filter-regex 'DButton|DIconGridPicker'
         NOTES
       end
 
@@ -138,6 +146,8 @@ class QunitRunner
       puts parser
       exit 1
     end
+
+    abort "Error: Use either --filter or --filter-regex, not both" if @filter && @filter_regex
 
     ensure_supported_target!
 
@@ -211,10 +221,10 @@ class QunitRunner
 
     file_path_filter = build_file_path_filter(@file_paths)
 
-    run_ember_exam(file_path_filter: file_path_filter, filter: @filter)
+    run_ember_exam(file_path_filter: file_path_filter)
   end
 
-  def run_ember_exam(filter: nil, file_path_filter: nil)
+  def run_ember_exam(file_path_filter: nil)
     check_dev_environment!
 
     puts "\nRunning tests against Rails on localhost:#{@rails_port}"
@@ -225,7 +235,8 @@ class QunitRunner
     elsif file_path_filter
       puts "  Filtered by file path" if file_path_filter
     end
-    puts "  Filter: #{filter}" if filter
+    puts "  Filter: #{@filter}" if @filter
+    puts "  Filter regex: #{@filter_regex}" if @filter_regex
     puts "  Load plugins: #{should_load_plugins?}"
     puts ""
 
@@ -259,7 +270,6 @@ class QunitRunner
     else
       args = %w[pnpm ember exam]
       args += ["--query", query] if query && !query.empty?
-      args += ["--filter", filter] if filter
       args += ["--file-path", file_path_filter] if file_path_filter
       args += ["--load-balance", "--parallel", parallel.to_s] if parallel
       args += ["--random", resolved_seed]
@@ -525,6 +535,10 @@ class QunitRunner
       params["seed"] = resolved_seed
     end
     params["module"] = @module if @module
+    if @filter || @filter_regex
+      params["filter"] = @filter || @filter_regex
+      params["discourseTestFilterMode"] = @filter ? "literal" : "regex"
+    end
     params["theme_name"] = @theme_name if @theme_name
     params["theme_url"] = @theme_url if @theme_url
     params["theme_id"] = @theme_id if @theme_id

--- a/docs/developer-guides/docs/03-code-internals/04-run-test-suites.md
+++ b/docs/developer-guides/docs/03-code-internals/04-run-test-suites.md
@@ -20,22 +20,29 @@ In general, when working on core tests you should enable "Skip Plugins", and whe
 
 ### Core
 
-Navigate to the root of the Ember application (`app/assets/javascripts/discourse`) in the Discourse repository and make sure you have run `pnpm install` since you last pulled in upstream changes.
-
-From there, you can use standard Ember-CLI tooling to run the tests - check out the ["How to Run Tests" section of the Ember Guides](https://guides.emberjs.com/release/testing/#toc_how-to-run-tests). We also have [Ember Exam](https://ember-cli.github.io/ember-exam/) installed which provides some very useful randomization and parallelisation flags.
+From the root directory of Discourse, use `bin/qunit` (make sure you have run `pnpm install` since you last pulled in upstream changes). It wraps [Ember Exam](https://ember-cli.github.io/ember-exam/) for randomization and parallelisation, and by default runs against the running Rails server and existing JS assets. Run `bin/qunit --help` for the full list of options.
 
 Here are some useful examples:
 
 ```sh
-# Run entire core test suite across 5 'headless' instances of Chrome in parallel:
-pnpm ember exam --parallel 5 --load-balance
+# Run a single test file, or every test in a directory:
+bin/qunit frontend/discourse/tests/integration/components/bookmark-test.gjs
+bin/qunit frontend/discourse/tests/integration/components
 
-# Run all tests which contain a certain string in their module/test name:
-pnpm ember exam --filter "Integration | Component | bookmark"
+# Run the entire core suite across 5 headless Chrome instances in parallel:
+bin/qunit --parallel 5
 
-# Run in "server" mode, which gives you a URL to load in a browser for easier debugging:
-pnpm ember exam --filter "somefilter" --server
+# Run all tests whose "module: test name" contains a literal substring (case-insensitive):
+bin/qunit --filter "Integration | Component | bookmark"
+
+# Use a JavaScript regular expression instead, e.g. for alternation:
+bin/qunit --filter-regex "bookmark|reaction"
+
+# Spin up an isolated server and run in a visible browser for easier debugging:
+bin/qunit --standalone --no-headless
 ```
+
+> :information_source: `--filter` matches a literal substring, so `|` and other regex metacharacters are treated literally. Use `--filter-regex` when you need alternation or other patterns.
 
 ### Plugins
 

--- a/frontend/discourse/tests/helpers/configure-test-filter.js
+++ b/frontend/discourse/tests/helpers/configure-test-filter.js
@@ -1,0 +1,33 @@
+export default function configureTestFilter(config, queryParams) {
+  const mode = queryParams.get("discourseTestFilterMode");
+  if (!["literal", "regex"].includes(mode)) {
+    return;
+  }
+
+  const filter = queryParams.get("filter");
+  if (filter === null) {
+    return;
+  }
+
+  config.filter = undefined;
+
+  if (mode === "literal") {
+    const normalizedLiteral = filter.toLowerCase();
+    config.testFilter = ({ module, testName }) =>
+      `${module}: ${testName}`.toLowerCase().includes(normalizedLiteral);
+  } else if (mode === "regex") {
+    let regex;
+    try {
+      regex = new RegExp(filter, "i");
+    } catch (e) {
+      throw new Error(
+        `Invalid --filter-regex pattern: ${filter} (${e.message})`,
+        {
+          cause: e,
+        }
+      );
+    }
+    config.testFilter = ({ module, testName }) =>
+      regex.test(`${module}: ${testName}`);
+  }
+}

--- a/frontend/discourse/tests/setup-tests.js
+++ b/frontend/discourse/tests/setup-tests.js
@@ -44,6 +44,7 @@ import {
   testsInitialized,
   testsTornDown,
 } from "discourse/tests/helpers/qunit-helpers";
+import configureTestFilter from "discourse/tests/helpers/configure-test-filter";
 import { configureRaiseOnDeprecation } from "discourse/tests/helpers/raise-on-deprecation";
 import { resetSettings } from "discourse/tests/helpers/site-settings";
 import {
@@ -222,6 +223,11 @@ export default async function setupTests(config) {
       "0"
     );
   };
+
+  configureTestFilter(
+    QUnit.config,
+    new URLSearchParams(window.location.search)
+  );
 
   // Stop the message bus so we don't get ajax calls
   window.MessageBus.stop();

--- a/frontend/discourse/tests/unit/lib/configure-test-filter-test.js
+++ b/frontend/discourse/tests/unit/lib/configure-test-filter-test.js
@@ -1,0 +1,86 @@
+import { module, test } from "qunit";
+import configureTestFilter from "discourse/tests/helpers/configure-test-filter";
+
+module("Unit | Helper | configure-test-filter", function () {
+  test("preserves native QUnit filtering without a mode marker", function (assert) {
+    const config = { filter: "DButton" };
+
+    configureTestFilter(config, new URLSearchParams("filter=DButton"));
+
+    assert.strictEqual(
+      config.filter,
+      "DButton",
+      "the native filter remains configured"
+    );
+    assert.strictEqual(
+      config.testFilter,
+      undefined,
+      "a custom filter is not installed"
+    );
+  });
+
+  test("treats a marked literal filter as literal text", function (assert) {
+    const config = { filter: "Integration | ui-kit | DButton" };
+    const queryParams = new URLSearchParams(
+      "filter=Integration+%7C+ui-kit+%7C+DButton&discourseTestFilterMode=literal"
+    );
+
+    configureTestFilter(config, queryParams);
+
+    assert.strictEqual(
+      config.filter,
+      undefined,
+      "the native filter is disabled"
+    );
+    assert.true(
+      config.testFilter({
+        module: "Integration | ui-kit | DButton",
+        testName: "aria-label",
+      }),
+      "the complete literal text matches"
+    );
+    assert.false(
+      config.testFilter({ module: "Integration", testName: "DButton" }),
+      "the pipe is not treated as alternation"
+    );
+  });
+
+  test("treats a marked regex filter as a regular expression", function (assert) {
+    const config = { filter: "DButton|DIconGridPicker" };
+    const queryParams = new URLSearchParams(
+      "filter=DButton%7CDIconGridPicker&discourseTestFilterMode=regex"
+    );
+
+    configureTestFilter(config, queryParams);
+
+    assert.strictEqual(
+      config.filter,
+      undefined,
+      "the native filter is disabled"
+    );
+    assert.true(
+      config.testFilter({ module: "Integration", testName: "DButton" }),
+      "the first alternative matches"
+    );
+    assert.true(
+      config.testFilter({
+        module: "Integration",
+        testName: "DIconGridPicker",
+      }),
+      "the second alternative matches"
+    );
+  });
+
+  test("throws a clear error for an invalid regex filter", function (assert) {
+    const config = { filter: "(" };
+    const queryParams = new URLSearchParams(
+      "filter=%28&discourseTestFilterMode=regex"
+    );
+
+    assert.throws(
+      () => configureTestFilter(config, queryParams),
+      /Invalid --filter-regex pattern: \(/,
+      "the malformed pattern is named in the error"
+    );
+  });
+});

--- a/spec/tasks/qunit_cli_spec.rb
+++ b/spec/tasks/qunit_cli_spec.rb
@@ -9,12 +9,18 @@ describe "bin/qunit" do
         [JSON.parse(parsed_result[:args]), JSON.parse(parsed_result[:env])]
       end
 
+    query =
+      if parsed_args && (query_index = parsed_args.index("--query"))
+        URI.decode_www_form(parsed_args.fetch(query_index + 1)).to_h
+      end
+
     OpenStruct.new(
       out: out,
       err: err,
       status: status.exitstatus,
       args: parsed_args,
       env: parsed_env,
+      query: query,
       launched_server: out.include?("[dry-run] skipping server startup"),
     )
   end
@@ -171,5 +177,32 @@ describe "bin/qunit" do
     result = run("--standalone")
     expect(result.status).to eq(0)
     expect(result.launched_server).to eq(true)
+  end
+
+  it "treats pipes in --filter as literal characters" do
+    result = run("--filter", "Integration | ui-kit | DButton")
+
+    expect(result.status).to eq(0)
+    expect(result.args).not_to include("--filter")
+    expect(result.query["filter"]).to eq("Integration | ui-kit | DButton")
+    expect(result.query["discourseTestFilterMode"]).to eq("literal")
+    expect(result.query).not_to have_key("discourseTestFilter")
+  end
+
+  it "treats pipes in --filter-regex as alternation" do
+    result = run("--filter-regex", "DButton|DIconGridPicker")
+
+    expect(result.status).to eq(0)
+    expect(result.args).not_to include("--filter")
+    expect(result.query["filter"]).to eq("DButton|DIconGridPicker")
+    expect(result.query["discourseTestFilterMode"]).to eq("regex")
+    expect(result.query).not_to have_key("discourseTestFilter")
+  end
+
+  it "rejects combining literal and regex filters" do
+    result = run("--filter", "DButton", "--filter-regex", "DIconGridPicker")
+
+    expect(result.status).to eq(1)
+    expect(result.err).to include("Use either --filter or --filter-regex, not both")
   end
 end


### PR DESCRIPTION
`bin/qunit --filter` previously forwarded its value to Ember Exam's `--filter`, where quoted pipes were ambiguous between literal text and regex alternation.

`--filter` now performs a strictly literal, case-insensitive match against `"module: test name"`, so pipes and other regex metacharacters are treated literally. A new `--filter-regex` accepts an explicit case-insensitive JavaScript regular expression. Both modes travel in the conventional QUnit `filter` query parameter alongside a `discourseTestFilterMode` marker, so existing QUnit URL behavior is preserved while a test-setup helper (`configure-test-filter`) applies the requested matching mode. Passing both flags, or an invalid regular expression, fails with a clear error instead of an opaque test-bootstrap crash.

The `--filter` / `--filter-regex` distinction is documented in the writing-js-tests skill, the AI agent guide, and `bin/qunit --help`, and the "Run test suites" developer guide now runs `bin/qunit` from the repository root.

Coverage spans the literal and regex query wiring (RSpec) and the filter-mode helper (QUnit).