### PR TITLE
FEATURE: Allow editing translated image captions

### DIFF
--- a/frontend/discourse/app/components/d-editor-original-translation-preview.gjs
+++ b/frontend/discourse/app/components/d-editor-original-translation-preview.gjs
@@ -3,10 +3,62 @@ import { tracked } from "@glimmer/tracking";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+import { waitForPromise } from "@ember/test-waiters";
+import { resolveAllShortUrls } from "pretty-text/upload-short-url";
+import { ajax } from "discourse/lib/ajax";
+import { cook } from "discourse/lib/text";
 import DCookText from "discourse/ui-kit/d-cook-text";
+import DDecoratedHtml, {
+  applyHtmlDecorators,
+} from "discourse/ui-kit/d-decorated-html";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import { i18n } from "discourse-i18n";
+
+class DecoratedPreviewCookText extends Component {
+  @service siteSettings;
+
+  @tracked cooked = null;
+
+  constructor(owner, args) {
+    super(owner, args);
+    this.loadCookedText();
+  }
+
+  @action
+  async loadCookedText() {
+    const rawText = this.args.rawText;
+    const cooked = await waitForPromise(cook(rawText, { previewing: true }));
+
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+
+    if (this.args.rawText !== rawText) {
+      return;
+    }
+
+    this.cooked = trustHTML(cooked);
+  }
+
+  @action
+  decoratePreview(preview, helper) {
+    applyHtmlDecorators(preview, helper);
+    resolveAllShortUrls(ajax, this.siteSettings, preview);
+  }
+
+  <template>
+    <div {{didUpdate this.loadCookedText @rawText}}>
+      <DDecoratedHtml
+        @className="d-editor-preview"
+        @decorate={{this.decoratePreview}}
+        @html={{this.cooked}}
+      />
+    </div>
+  </template>
+}
 
 export default class DEditorOriginalTranslationPreview extends Component {
   @tracked showOriginal = true;
@@ -93,7 +145,7 @@ export default class DEditorOriginalTranslationPreview extends Component {
           {{/if}}
         {{else}}
           {{#if this.translationText}}
-            <DCookText @rawText={{this.translationText}} />
+            <DecoratedPreviewCookText @rawText={{this.translationText}} />
           {{else}}
             <div class="d-editor-translation-preview-empty">
               {{i18n "composer.translations.no_translation_yet"}}

--- a/plugins/discourse-ai/assets/javascripts/discourse/services/post-image-caption-editor.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/services/post-image-caption-editor.js
@@ -2,7 +2,7 @@ import { tracked } from "@glimmer/tracking";
 import Service, { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import { EDIT } from "discourse/models/composer";
+import { ADD_TRANSLATION, EDIT } from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
 
 export default class PostImageCaptionEditor extends Service {
@@ -16,10 +16,12 @@ export default class PostImageCaptionEditor extends Service {
   @tracked loadingKey = null;
 
   get canEditCurrentComposer() {
+    const action = this.composer.model?.action;
+
     return Boolean(
       this.siteSettings.ai_post_image_captions_enabled &&
-      this.composer.model?.action === EDIT &&
-      this.currentPostId
+      this.currentPostId &&
+      (action === EDIT || (action === ADD_TRANSLATION && this.currentLocale))
     );
   }
 
@@ -28,6 +30,10 @@ export default class PostImageCaptionEditor extends Service {
   }
 
   get currentLocale() {
+    if (this.composer.model?.action === ADD_TRANSLATION) {
+      return this.composer.selectedTranslationLocale;
+    }
+
     return this.composer.model?.locale;
   }
 

--- a/plugins/discourse-ai/spec/system/edit_post_image_captions_spec.rb
+++ b/plugins/discourse-ai/spec/system/edit_post_image_captions_spec.rb
@@ -59,6 +59,8 @@ describe "Edit AI post image captions" do
 
   let(:topic_page) { PageObjects::Pages::Topic.new }
   let(:composer) { PageObjects::Components::Composer.new }
+  let(:edit_localized_post_dialog) { PageObjects::Components::Dialog.new }
+  let(:translation_preview) { PageObjects::Components::DEditorOriginalTranslationPreview.new }
   let(:captions) { PageObjects::Components::AiPostImageCaptions.new }
 
   let(:first_cat_caption) { "An old caption for the first cat" }
@@ -140,6 +142,54 @@ describe "Edit AI post image captions" do
       image: 2,
       description: japanese_second_cat_caption,
     )
+
+    admin.user_option.update!(show_original_content: true)
+    topic_page.visit_topic(cat_topic)
+
+    expect(captions).to have_image_caption(second_post, image: 2, description: second_cat_caption)
+  end
+
+  it "lets the user edit a translated image caption", :aggregate_failures do
+    SiteSetting.allow_user_locale = true
+    SiteSetting.content_localization_enabled = true
+    SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:admins]
+    SiteSetting.content_localization_supported_locales = "en|ja"
+    admin.update!(locale: "ja")
+    admin.user_option.update!(show_original_content: false)
+    Fabricate(:topic_localization, topic: cat_topic, locale: "ja", fancy_title: "猫についての話題")
+    create_japanese_localization(second_post)
+    seed_english_descriptions
+    seed_image_caption(second_post, first_cat_upload, japanese_first_cat_caption, locale: "ja")
+    seed_image_caption(second_post, second_cat_upload, japanese_second_cat_caption, locale: "ja")
+    process_description_cooked(post_id: second_post.id, locale: "ja")
+
+    sign_in(admin)
+    topic_page.visit_topic(cat_topic)
+
+    expect(captions).to have_image_caption(
+      second_post,
+      image: 2,
+      description: japanese_second_cat_caption,
+    )
+
+    topic_page.expand_post_actions(second_post)
+    topic_page.click_post_action_button(second_post, :edit)
+    expect(edit_localized_post_dialog).to be_open
+    edit_localized_post_dialog.click_no
+    expect(composer).to be_opened
+
+    translation_preview.click_translation_tab
+    expect(translation_preview).to have_rendered_preview_image(alt: "二匹目の猫")
+    expect(captions).to have_editor_button_count(count: 2)
+
+    captions.edit_preview_image_caption(image: 2, description: "翻訳された二匹目の猫だけの新しい説明")
+    process_description_cooked(post_id: second_post.id, locale: "ja")
+    composer.close
+    expect(composer).to be_closed
+
+    topic_page.visit_topic(cat_topic)
+
+    expect(captions).to have_image_caption(second_post, image: 2, description: "翻訳された二匹目の猫だけの新しい説明")
 
     admin.user_option.update!(show_original_content: true)
     topic_page.visit_topic(cat_topic)

--- a/plugins/discourse-ai/test/javascripts/unit/services/post-image-caption-editor-test.js
+++ b/plugins/discourse-ai/test/javascripts/unit/services/post-image-caption-editor-test.js
@@ -1,7 +1,7 @@
 import { getOwner } from "@ember/owner";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
-import { EDIT } from "discourse/models/composer";
+import { ADD_TRANSLATION, EDIT } from "discourse/models/composer";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 
 module("Unit | Service | post-image-caption-editor", function (hooks) {
@@ -15,6 +15,7 @@ module("Unit | Service | post-image-caption-editor", function (hooks) {
       locale: "ja",
       post: { id: 42 },
     };
+    composer.selectedTranslationLocale = null;
 
     owner.lookup("service:site-settings").ai_post_image_captions_enabled = true;
 
@@ -41,6 +42,35 @@ module("Unit | Service | post-image-caption-editor", function (hooks) {
     await service.ensureLoaded();
 
     assert.strictEqual(service.captionFor("abc123"), "A stored description");
+  });
+
+  test("ensureLoaded fetches captions for the selected translation locale", async function (assert) {
+    const composer = getOwner(this).lookup("service:composer");
+    composer.model.action = ADD_TRANSLATION;
+    composer.selectedTranslationLocale = "fr";
+
+    pretender.get("/discourse-ai/post-image-captions/:post_id", (request) => {
+      assert.strictEqual(request.params.post_id, "42");
+      assert.strictEqual(request.queryParams.locale, "fr");
+
+      return response({
+        captions: [
+          {
+            base62_sha1: "abc123",
+            description: "Une description enregistrée",
+          },
+        ],
+      });
+    });
+
+    const service = getOwner(this).lookup("service:post-image-caption-editor");
+
+    await service.ensureLoaded();
+
+    assert.strictEqual(
+      service.captionFor("abc123"),
+      "Une description enregistrée"
+    );
   });
 
   test("ensureLoaded skips non-edit composers", async function (assert) {

--- a/spec/system/page_objects/components/d_editor_original_translation_preview.rb
+++ b/spec/system/page_objects/components/d_editor_original_translation_preview.rb
@@ -7,6 +7,10 @@ module PageObjects
       RAW_TOGGLE_SELECTOR = ".d-editor-translation-preview-header__raw-toggle"
       RAW_CONTENT_SELECTOR = "pre.d-editor-translation-preview-raw"
       RENDERED_CONTENT_SELECTOR = ".d-editor-translation-preview-content"
+      RENDERED_PREVIEW_IMAGE_SELECTOR = "#{RENDERED_CONTENT_SELECTOR} .d-editor-preview img"
+      ORIGINAL_TAB_SELECTOR = ".d-editor-translation-preview-header__controls button:nth-child(1)"
+      TRANSLATION_TAB_SELECTOR =
+        ".d-editor-translation-preview-header__controls button:nth-child(2)"
 
       def has_raw_toggle?
         page.has_css?(RAW_TOGGLE_SELECTOR)
@@ -23,21 +27,21 @@ module PageObjects
       end
 
       def click_original_tab
-        find("button", text: I18n.t("js.composer.translations.original")).click
+        find(ORIGINAL_TAB_SELECTOR).click
         self
       end
 
       def click_translation_tab
-        find("button", text: I18n.t("js.composer.translations.translation")).click
+        find(TRANSLATION_TAB_SELECTOR).click
         self
       end
 
       def original_tab_active?
-        page.has_css?("button.active", text: I18n.t("js.composer.translations.original"))
+        page.has_css?("#{ORIGINAL_TAB_SELECTOR}.active")
       end
 
       def translation_tab_active?
-        page.has_css?("button.active", text: I18n.t("js.composer.translations.translation"))
+        page.has_css?("#{TRANSLATION_TAB_SELECTOR}.active")
       end
 
       def has_raw_markdown_content?
@@ -54,6 +58,25 @@ module PageObjects
 
       def has_rendered_content?
         page.has_css?(RENDERED_CONTENT_SELECTOR) && page.has_no_css?(RAW_CONTENT_SELECTOR)
+      end
+
+      def has_rendered_preview_image?(alt:)
+        page.has_xpath?(
+          ".//*[contains(concat(' ', normalize-space(@class), ' '), ' d-editor-translation-preview-content ')]" \
+            "//*[contains(concat(' ', normalize-space(@class), ' '), ' d-editor-preview ')]" \
+            "//img[@alt=#{xpath_literal(alt)}][@src != '/images/transparent.png'][not(@data-orig-src)]",
+        )
+      end
+
+      private
+
+      def xpath_literal(value)
+        value = value.to_s
+
+        return "'#{value}'" if !value.include?("'")
+        return "\"#{value}\"" if !value.include?('"')
+
+        "concat(#{value.split("'").map { |part| "'#{part}'" }.join(%{, "\"'\"", })})"
       end
     end
   end


### PR DESCRIPTION
Following up from https://github.com/discourse/discourse/pull/41586

In https://github.com/discourse/discourse/pull/41586 we also generate captions in other languages, but did not provide a way to edit them. This PR adds the ability to do so in the translation composer.

| desc | 📸 |
|--|--|
|  composer | <img width="1512" height="939" alt="Screenshot 2026-07-22 at 8 28 40 PM" src="https://github.com/user-attachments/assets/d68a7d3d-aac4-4f38-a58c-2b6733df8203" /> |
| composer modal, similar to non-translated version | <img width="1512" height="939" alt="Screenshot 2026-07-22 at 8 29 01 PM" src="https://github.com/user-attachments/assets/1db34644-1f89-4d9c-8d9e-3e24efe2c8c8" /> |