### PR TITLE
FIX: Allow selecting tags that are only used in personal messages

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -48,12 +48,11 @@ class TagsController < ::ApplicationController
     @description_meta = I18n.t("tags.title")
     @title = @description_meta
 
-    show_all_tags = guardian.can_admin_tags? && guardian.is_admin?
     preload_localizations = SiteSetting.content_localization_enabled
 
     if SiteSetting.tags_listed_by_group
       ungrouped_tags = Tag.where("tags.id NOT IN (SELECT tag_id FROM tag_group_memberships)")
-      ungrouped_tags = ungrouped_tags.used_tags_in_regular_topics(guardian) unless show_all_tags
+      ungrouped_tags = ungrouped_tags.used_tags_in_regular_topics(guardian) unless show_all_tags?
       ungrouped_tags = ungrouped_tags.order(:id)
       ungrouped_tags = ungrouped_tags.includes(:localizations) if preload_localizations
 
@@ -69,14 +68,15 @@ class TagsController < ::ApplicationController
             {
               id: tag_group.id,
               name: tag_group.name,
-              tags: self.class.tag_counts_json(tag_group.none_synonym_tags, guardian),
+              tags:
+                self.class.tag_counts_json(browsable_tags(tag_group.none_synonym_tags), guardian),
             }
           end
 
       @tags = self.class.tag_counts_json(ungrouped_tags, guardian)
       @extras = { tag_groups: grouped_tag_counts }
     else
-      tags = show_all_tags ? Tag.all : Tag.used_tags_in_regular_topics(guardian)
+      tags = show_all_tags? ? Tag.all : Tag.used_tags_in_regular_topics(guardian)
       tags = tags.order(:id)
       unrestricted_tags = DiscourseTagging.filter_visible(tags.where(target_tag_id: nil), guardian)
       unrestricted_tags = unrestricted_tags.includes(:localizations) if preload_localizations
@@ -96,11 +96,9 @@ class TagsController < ::ApplicationController
       category_tag_counts =
         categories
           .map do |c|
-            category_tags =
-              self.class.tag_counts_json(
-                DiscourseTagging.filter_visible(c.none_synonym_tags, guardian),
-                guardian,
-              )
+            visible_category_tags =
+              browsable_tags(DiscourseTagging.filter_visible(c.none_synonym_tags, guardian))
+            category_tags = self.class.tag_counts_json(visible_category_tags, guardian)
 
             next if category_tags.empty?
 
@@ -495,6 +493,15 @@ class TagsController < ::ApplicationController
 
   private
 
+  def show_all_tags?
+    guardian.can_admin_tags? && guardian.is_admin?
+  end
+
+  def browsable_tags(tags)
+    return tags if show_all_tags?
+    DiscourseTagging.without_pm_only_tags(tags, guardian)
+  end
+
   def fetch_tag(raise_not_found: true)
     if params[:tag_id].present?
       # Try finding by ID first
@@ -575,43 +582,39 @@ class TagsController < ::ApplicationController
         .where(id: tags.filter_map(&:target_tag_id).uniq)
         .select(:id, :name, :slug)
 
-    tags
-      .map do |t|
-        topic_count = t.public_send(Tag.topic_count_column(guardian))
+    tags.map do |t|
+      topic_count = t.public_send(Tag.topic_count_column(guardian))
 
-        next if topic_count == 0 && t.pm_topic_count > 0 && !show_pm_tags
+      tag_name = t.name
+      tag_description = t.description
 
-        tag_name = t.name
-        tag_description = t.description
-
-        if ContentLocalization.show_translated_tag?(t, guardian)
-          localization = t.get_localization
-          tag_name = localization&.name || tag_name
-          tag_description = localization&.description || tag_description
-        end
-
-        attrs = {
-          id: t.id,
-          text: tag_name,
-          name: tag_name,
-          slug: t.slug.presence || "#{t.id}-tag",
-          description: tag_description,
-          count: topic_count,
-          pm_only: topic_count == 0 && t.pm_topic_count > 0,
-          target_tag:
-            if t.target_tag_id
-              target = target_tags.find { |x| x.id == t.target_tag_id }
-              target ? { id: target.id, name: target.name, slug: target.slug } : nil
-            end,
-        }
-
-        if show_pm_tags && SiteSetting.display_personal_messages_tag_counts
-          attrs[:pm_count] = t.pm_topic_count
-        end
-
-        attrs
+      if ContentLocalization.show_translated_tag?(t, guardian)
+        localization = t.get_localization
+        tag_name = localization&.name || tag_name
+        tag_description = localization&.description || tag_description
       end
-      .compact
+
+      attrs = {
+        id: t.id,
+        text: tag_name,
+        name: tag_name,
+        slug: t.slug.presence || "#{t.id}-tag",
+        description: tag_description,
+        count: topic_count,
+        pm_only: topic_count == 0 && t.pm_topic_count > 0,
+        target_tag:
+          if t.target_tag_id
+            target = target_tags.find { |x| x.id == t.target_tag_id }
+            target ? { id: target.id, name: target.name, slug: target.slug } : nil
+          end,
+      }
+
+      if show_pm_tags && SiteSetting.display_personal_messages_tag_counts
+        attrs[:pm_count] = t.pm_topic_count
+      end
+
+      attrs
+    end
   end
 
   def set_category

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1585,7 +1585,7 @@ class TopicsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        @tags = SiteSetting.tagging_enabled ? @topic_view.topic.tags.visible(guardian) : []
+        @tags = @topic_view.visible_tags
 
         if SiteSetting.content_localization_enabled && use_crawler_layout?
           helpers.localize_topic_view_content(@topic_view)

--- a/app/models/topic_converter.rb
+++ b/app/models/topic_converter.rb
@@ -21,18 +21,20 @@ class TopicConverter
           .where.not(id: SiteSetting.uncategorized_category_id)
           .first
 
-      PostRevisor.new(@topic.first_post, @topic).revise!(
-        @user,
-        { category_id: @category.id, archetype: Archetype.default },
-        revise_opts,
-      )
+      revised =
+        PostRevisor.new(@topic.first_post, @topic).revise!(
+          @user,
+          { category_id: @category.id, archetype: Archetype.default },
+          revise_opts,
+        )
 
-      raise ActiveRecord::Rollback if !@topic.valid?
+      raise ActiveRecord::Rollback if !revised || !@topic.valid?
 
       update_user_stats
       update_post_uploads_secure_status
       add_small_action("public_topic") unless @silent
-      Tag.update_counters(@topic.tags, { public_topic_count: 1 }) if !@category.read_restricted
+
+      update_tag_counters(1, include_public: !@category.read_restricted)
 
       Jobs.enqueue(:topic_action_converter, topic_id: @topic.id)
       Jobs.enqueue(:delete_inaccessible_notifications, topic_id: @topic.id)
@@ -59,18 +61,20 @@ class TopicConverter
       was_public = !@topic.category.read_restricted
       @topic.update_category_topic_count_by(-1) if @topic.visible
 
-      PostRevisor.new(@topic.first_post, @topic).revise!(
-        @user,
-        { category_id: nil, archetype: Archetype.private_message },
-        revise_opts,
-      )
+      revised =
+        PostRevisor.new(@topic.first_post, @topic).revise!(
+          @user,
+          { category_id: nil, archetype: Archetype.private_message },
+          revise_opts,
+        )
 
-      raise ActiveRecord::Rollback if !@topic.valid?
+      raise ActiveRecord::Rollback if !revised || !@topic.valid?
 
       add_allowed_users
       update_post_uploads_secure_status
       add_small_action("private_topic") unless @silent
-      Tag.update_counters(@topic.tags, { public_topic_count: -1 }) if was_public
+
+      update_tag_counters(-1, include_public: was_public)
       UserProfile.remove_featured_topic_from_all_profiles(@topic)
 
       Jobs.enqueue(:topic_action_converter, topic_id: @topic.id)
@@ -83,6 +87,12 @@ class TopicConverter
   end
 
   private
+
+  def update_tag_counters(topic_count_delta, include_public:)
+    counters = { staff_topic_count: topic_count_delta, pm_topic_count: -topic_count_delta }
+    counters[:public_topic_count] = topic_count_delta if include_public
+    Tag.update_counters(@topic.tags, counters)
+  end
 
   def revise_opts
     { bypass_bump: @silent, silent: @silent, hidden: true }

--- a/lib/discourse_tagging.rb
+++ b/lib/discourse_tagging.rb
@@ -772,6 +772,13 @@ module DiscourseTagging
     SQL
   end
 
+  def self.without_pm_only_tags(tags, guardian)
+    return tags if guardian.can_tag_pms?
+
+    topic_count_column = Tag.topic_count_column(guardian)
+    tags.reject { |tag| tag.pm_topic_count > 0 && tag.public_send(topic_count_column) == 0 }
+  end
+
   def self.hidden_tags(guardian = nil)
     if guardian&.is_admin?
       Tag.none

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -355,7 +355,7 @@ class TopicView
       if @topic.category_id != SiteSetting.uncategorized_category_id && @topic.category_id &&
            @topic.category
         title += " - #{@topic.category.name}"
-      elsif SiteSetting.tagging_enabled && visible_tags.exists?
+      elsif visible_tags.exists?
         title +=
           " - #{visible_tags.order("tags.#{Tag.topic_count_column(@guardian)} DESC").first.name}"
       end
@@ -927,6 +927,10 @@ class TopicView
       .compact
   end
 
+  def visible_tags
+    @visible_tags ||= guardian.can_see_tags?(topic) ? topic.tags.visible(guardian) : Tag.none
+  end
+
   protected
 
   def read_posts_set
@@ -1205,9 +1209,5 @@ class TopicView
         StaffActionLogger.new(@user).log_check_personal_message(@topic)
       end
     end
-  end
-
-  def visible_tags
-    @visible_tags ||= topic.tags.visible(guardian)
   end
 end

--- a/spec/lib/discourse_tagging_spec.rb
+++ b/spec/lib/discourse_tagging_spec.rb
@@ -1140,6 +1140,31 @@ RSpec.describe DiscourseTagging do
     end
   end
 
+  describe "without_pm_only_tags" do
+    fab!(:pm_only_tag) { Fabricate(:tag, pm_topic_count: 1) }
+    fab!(:used_tag) { Fabricate(:tag, public_topic_count: 1, staff_topic_count: 1) }
+    fab!(:unused_tag, :tag)
+    fab!(:staff_seen_tag) { Fabricate(:tag, staff_topic_count: 1, pm_topic_count: 1) }
+
+    let(:all_tags) { Tag.where(id: [pm_only_tag, used_tag, unused_tag, staff_seen_tag]) }
+
+    it "rejects tags only used in personal messages for users who cannot tag PMs" do
+      tags = DiscourseTagging.without_pm_only_tags(all_tags, Guardian.new(user))
+      expect(tags).to contain_exactly(used_tag, unused_tag)
+    end
+
+    it "uses the staff topic count for staff users" do
+      tags = DiscourseTagging.without_pm_only_tags(all_tags, Guardian.new(admin))
+      expect(tags).to contain_exactly(used_tag, unused_tag, staff_seen_tag)
+    end
+
+    it "keeps all tags for users who can tag PMs" do
+      SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:trust_level_0]
+      tags = DiscourseTagging.without_pm_only_tags(all_tags, Guardian.new(user))
+      expect(tags).to contain_exactly(pm_only_tag, used_tag, unused_tag, staff_seen_tag)
+    end
+  end
+
   describe "tag_topic_by_names" do
     context "with a tag restricted to other categories" do
       fab!(:allowed_category, :category)

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -972,6 +972,27 @@ RSpec.describe TopicView do
       end
     end
 
+    context "with a tagged personal message" do
+      fab!(:pm) { Fabricate(:private_message_topic, user: user) }
+      fab!(:pm_post) { Fabricate(:post, topic: pm) }
+
+      before do
+        SiteSetting.tagging_enabled = true
+        SiteSetting.topic_page_title_includes_category = true
+        pm.tags << tag2
+      end
+
+      it "does not include the tag for participants who cannot tag personal messages" do
+        expect(TopicView.new(pm.id, user).page_title).not_to include(tag2.name)
+      end
+
+      it "includes the tag for participants who can tag personal messages" do
+        SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:trust_level_0]
+
+        expect(TopicView.new(pm.id, user).page_title).to end_with(tag2.name)
+      end
+    end
+
     context "with categorized topic" do
       let(:category) { Fabricate(:category) }
 

--- a/spec/models/topic_converter_spec.rb
+++ b/spec/models/topic_converter_spec.rb
@@ -44,6 +44,52 @@ RSpec.describe TopicConverter do
         expect(topic.category_id).to eq(SiteSetting.uncategorized_category_id)
       end
 
+      it "moves the tags' personal message counts to their topic counts" do
+        SiteSetting.allow_uncategorized_topics = true
+        tag = Fabricate(:tag)
+        first_post.topic.tags << tag
+        expect(tag.reload.pm_topic_count).to eq(1)
+
+        TopicConverter.new(first_post.topic, admin).convert_to_public_topic
+
+        tag.reload
+        expect(tag.pm_topic_count).to eq(0)
+        expect(tag.staff_topic_count).to eq(1)
+        expect(tag.public_topic_count).to eq(1)
+      end
+
+      it "does not change the tags' public topic counts when converting into a read-restricted category" do
+        private_category = Fabricate(:private_category, group: Group[:staff])
+        tag = Fabricate(:tag)
+        first_post.topic.tags << tag
+        expect(tag.reload.pm_topic_count).to eq(1)
+
+        TopicConverter.new(first_post.topic, admin).convert_to_public_topic(private_category.id)
+
+        tag.reload
+        expect(tag.pm_topic_count).to eq(0)
+        expect(tag.staff_topic_count).to eq(1)
+        expect(tag.public_topic_count).to eq(0)
+      end
+
+      it "does not update tag counters when the post revision fails" do
+        tag = Fabricate(:tag)
+        first_post.topic.tags << tag
+        expect(tag.reload.pm_topic_count).to eq(1)
+
+        required_tag_group = Fabricate(:tag_group, tags: [Fabricate(:tag)])
+        category.category_required_tag_groups.create!(tag_group: required_tag_group, min_count: 1)
+        moderator = Fabricate(:moderator)
+
+        TopicConverter.new(first_post.topic, moderator).convert_to_public_topic(category.id)
+
+        expect(first_post.topic.reload.archetype).to eq(Archetype.private_message)
+        tag.reload
+        expect(tag.pm_topic_count).to eq(1)
+        expect(tag.staff_topic_count).to eq(0)
+        expect(tag.public_topic_count).to eq(0)
+      end
+
       context "when uncategorized category is not allowed" do
         before do
           SiteSetting.allow_uncategorized_topics = false
@@ -176,6 +222,36 @@ RSpec.describe TopicConverter do
         expect(topic.archetype).to eq("private_message")
         expect(topic.category_id).to eq(nil)
         expect(category.reload.topic_count).to eq(0)
+      end
+
+      it "moves the tags' topic counts to their personal message counts" do
+        tag = Fabricate(:tag)
+        topic.tags << tag
+        expect(tag.reload.staff_topic_count).to eq(1)
+
+        topic.convert_to_private_message(admin)
+
+        tag.reload
+        expect(tag.public_topic_count).to eq(0)
+        expect(tag.staff_topic_count).to eq(0)
+        expect(tag.pm_topic_count).to eq(1)
+      end
+
+      it "does not change the tags' public topic counts when converting from a read-restricted category" do
+        private_category = Fabricate(:private_category, group: Group[:staff])
+        restricted_topic = Fabricate(:topic, user: author, category: private_category)
+        Fabricate(:post, topic: restricted_topic, user: author)
+        tag = Fabricate(:tag)
+        restricted_topic.tags << tag
+        expect(tag.reload.staff_topic_count).to eq(1)
+        expect(tag.public_topic_count).to eq(0)
+
+        restricted_topic.convert_to_private_message(admin)
+
+        tag.reload
+        expect(tag.public_topic_count).to eq(0)
+        expect(tag.staff_topic_count).to eq(0)
+        expect(tag.pm_topic_count).to eq(1)
       end
 
       it "converts unlisted topic to private message" do

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe TagsController do
         expect(serialized_tag["count"]).to eq(1)
         expect(serialized_tag["pm_count"]).to eq(nil)
         expect(serialized_tag["pm_only"]).to eq(false)
+
+        serialized_tag = tags.find { |t| t["name"] == pm_only_tag.name }
+
+        expect(serialized_tag["count"]).to eq(0)
+        expect(serialized_tag["pm_count"]).to eq(nil)
+        expect(serialized_tag["pm_only"]).to eq(true)
       end
 
       it "does not include pm_count attribute when user cannot tag PM topics even if display_personal_messages_tag_counts site setting has been enabled" do
@@ -157,12 +163,25 @@ RSpec.describe TagsController do
       end
 
       context "when disabled" do
-        before do
-          SiteSetting.pm_tags_allowed_for_groups = ""
+        before { SiteSetting.pm_tags_allowed_for_groups = "" }
+
+        it "shows tags only used in personal messages to admins" do
           sign_in(admin)
+
+          get "/tags.json"
+
+          expect(response.parsed_body["tags"]).to match(
+            [
+              include(name: test_tag.name, id: test_tag.id, pm_only: true),
+              include(name: topic_tag.name, id: topic_tag.id),
+              include(name: pm_only_tag.name, id: pm_only_tag.id, pm_only: true),
+            ],
+          )
         end
 
-        it "hides pm tags" do
+        it "hides tags only used in personal messages from regular users" do
+          sign_in(user)
+
           get "/tags.json"
 
           expect(response.parsed_body["tags"]).to match(
@@ -175,6 +194,31 @@ RSpec.describe TagsController do
     context "with tags_listed_by_group enabled" do
       before { SiteSetting.tags_listed_by_group = true }
       include_examples "retrieves the right tags"
+
+      it "hides tags only used in personal messages from grouped lists for regular users" do
+        Fabricate(:tag_group, tags: [topic_tag, pm_only_tag])
+
+        sign_in(user)
+
+        get "/tags.json"
+
+        group = response.parsed_body.dig("extras", "tag_groups").first
+        expect(group["tags"].map { |tag| tag["name"] }).to contain_exactly(topic_tag.name)
+      end
+
+      it "shows tags only used in personal messages in grouped lists to admins" do
+        Fabricate(:tag_group, tags: [topic_tag, pm_only_tag])
+
+        sign_in(admin)
+
+        get "/tags.json"
+
+        group = response.parsed_body.dig("extras", "tag_groups").first
+        expect(group["tags"].map { |tag| tag["name"] }).to contain_exactly(
+          topic_tag.name,
+          pm_only_tag.name,
+        )
+      end
 
       it "works for tags in groups" do
         _tag_group = Fabricate(:tag_group, tags: [test_tag, topic_tag, synonym])
@@ -240,6 +284,31 @@ RSpec.describe TagsController do
       before { SiteSetting.tags_listed_by_group = false }
       include_examples "retrieves the right tags"
 
+      it "hides tags only used in personal messages from category tag lists for regular users" do
+        category.update!(tags: [topic_tag, pm_only_tag])
+
+        sign_in(user)
+
+        get "/tags.json"
+
+        category_tags = response.parsed_body.dig("extras", "categories").first
+        expect(category_tags["tags"].map { |tag| tag["name"] }).to contain_exactly(topic_tag.name)
+      end
+
+      it "shows tags only used in personal messages in category tag lists to admins" do
+        category.update!(tags: [topic_tag, pm_only_tag])
+
+        sign_in(admin)
+
+        get "/tags.json"
+
+        category_tags = response.parsed_body.dig("extras", "categories").first
+        expect(category_tags["tags"].map { |tag| tag["name"] }).to contain_exactly(
+          topic_tag.name,
+          pm_only_tag.name,
+        )
+      end
+
       it "returns the right tags and categories tags for admin user" do
         category.update!(tags: [test_tag])
 
@@ -251,7 +320,7 @@ RSpec.describe TagsController do
 
         tags = response.parsed_body["tags"]
 
-        expect(tags.length).to eq(2)
+        expect(tags.length).to eq(3)
 
         expect(tags[0]["name"]).to eq(test_tag.name)
         expect(tags[0]["text"]).to eq(test_tag.name)
@@ -261,6 +330,9 @@ RSpec.describe TagsController do
         expect(tags[0]["target_tag"]).to eq(nil)
 
         expect(tags[1]["name"]).to eq(topic_tag.name)
+
+        expect(tags[2]["name"]).to eq(pm_only_tag.name)
+        expect(tags[2]["pm_only"]).to eq(true)
 
         categories = response.parsed_body["extras"]["categories"]
 
@@ -285,8 +357,10 @@ RSpec.describe TagsController do
 
         tags = response.parsed_body["tags"]
 
-        expect(tags.length).to eq(2)
-        expect(tags.map { |tag| tag["name"] }).to eq([test_tag.name, topic_tag.name])
+        expect(tags.length).to eq(3)
+        expect(tags.map { |tag| tag["name"] }).to eq(
+          [test_tag.name, topic_tag.name, pm_only_tag.name],
+        )
 
         initial_sql_queries_count =
           track_sql_queries do
@@ -296,8 +370,10 @@ RSpec.describe TagsController do
 
             tags = response.parsed_body["tags"]
 
-            expect(tags.length).to eq(2)
-            expect(tags.map { |tag| tag["name"] }).to eq([test_tag.name, topic_tag.name])
+            expect(tags.length).to eq(3)
+            expect(tags.map { |tag| tag["name"] }).to eq(
+              [test_tag.name, topic_tag.name, pm_only_tag.name],
+            )
 
             categories = response.parsed_body["extras"]["categories"]
 
@@ -316,8 +392,10 @@ RSpec.describe TagsController do
 
             tags = response.parsed_body["tags"]
 
-            expect(tags.length).to eq(2)
-            expect(tags.map { |tag| tag["name"] }).to eq([test_tag.name, topic_tag.name])
+            expect(tags.length).to eq(3)
+            expect(tags.map { |tag| tag["name"] }).to eq(
+              [test_tag.name, topic_tag.name, pm_only_tag.name],
+            )
 
             categories = response.parsed_body["extras"]["categories"]
 
@@ -705,6 +783,15 @@ RSpec.describe TagsController do
 
     it "can return a tag's synonyms" do
       synonym
+      get "/tag/#{tag.name}/info.json"
+      expect(response.status).to eq(200)
+      expect(response.parsed_body.dig("tag_info", "synonyms").map { |t| t["text"] }).to eq(
+        [synonym.name],
+      )
+    end
+
+    it "returns synonyms only used in personal messages to users who cannot tag PMs" do
+      synonym.update!(pm_topic_count: 1)
       get "/tag/#{tag.name}/info.json"
       expect(response.status).to eq(200)
       expect(response.parsed_body.dig("tag_info", "synonyms").map { |t| t["text"] }).to eq(

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -7231,6 +7231,37 @@ RSpec.describe TopicsController do
       end
     end
 
+    context "with a tagged personal message rendered in the crawler layout" do
+      fab!(:participant) { Fabricate(:user, refresh_auto_groups: true) }
+      fab!(:pm_tag, :tag)
+      fab!(:pm) { Fabricate(:private_message_topic, user: user, recipient: participant) }
+      fab!(:pm_post) { Fabricate(:post, topic: pm, user: user) }
+
+      before do
+        SiteSetting.tagging_enabled = true
+        pm.tags << pm_tag
+      end
+
+      it "does not include the tags in the print view for participants who cannot tag PMs" do
+        sign_in(participant)
+
+        get "#{pm.relative_url}/print"
+
+        expect(response.status).to eq(200)
+        expect(response.body).not_to include(pm_tag.name)
+      end
+
+      it "includes the tags in the print view for participants who can tag PMs" do
+        SiteSetting.pm_tags_allowed_for_groups = Group::AUTO_GROUPS[:trust_level_0]
+        sign_in(participant)
+
+        get "#{pm.relative_url}/print"
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include(pm_tag.name)
+      end
+    end
+
     context "when a crawler" do
       fab!(:page1_time) { 3.months.ago }
       fab!(:page2_time) { 2.months.ago }

--- a/spec/services/tag_hashtag_data_source_spec.rb
+++ b/spec/services/tag_hashtag_data_source_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe TagHashtagDataSource do
       expect(described_class.search(guardian, "fact", 5).map(&:slug)).not_to include("fact")
     end
 
+    it "includes tags only used in personal messages for users who cannot tag PMs" do
+      tag1.update!(pm_topic_count: 1)
+      expect(described_class.search(guardian, "fact", 5).map(&:slug)).to include("fact")
+    end
+
     it "returns an array of HashtagAutocompleteService::HashtagItem" do
       expect(described_class.search(guardian, "fact", 1).first).to be_a(
         HashtagAutocompleteService::HashtagItem,
@@ -73,6 +78,11 @@ RSpec.describe TagHashtagDataSource do
     it "does not return tags the user has muted" do
       TagUser.create(user: user, tag: tag2, notification_level: TagUser.notification_levels[:muted])
       expect(described_class.search_without_term(guardian, 5).map(&:slug)).not_to include("factor")
+    end
+
+    it "includes tags only used in personal messages for users who cannot tag PMs" do
+      tag1.update!(pm_topic_count: 1)
+      expect(described_class.search_without_term(guardian, 5).map(&:slug)).to include("fact")
     end
   end
 

--- a/spec/services/tags/search_spec.rb
+++ b/spec/services/tags/search_spec.rb
@@ -544,6 +544,27 @@ RSpec.describe(Tags::Search) do
       end
     end
 
+    context "with a tag only used in personal messages" do
+      fab!(:category)
+      fab!(:pm_only_tag) { Fabricate(:tag, name: "pmonly", pm_topic_count: 1) }
+
+      let(:params) { { q: "pmonly", categoryId: category.id, filterForInput: true, limit: 5 } }
+
+      it "returns the tag as selectable instead of mislabeling it as unusable" do
+        row = result[:tags].find { |tag| tag[:name] == "pmonly" }
+        expect(row).to be_present
+        expect(row[:disabled]).to be_blank
+        expect(result[:forbidden]).to be_nil
+        expect(result[:forbidden_message]).to be_nil
+      end
+
+      it "does not expose the PM tag count to users who cannot tag PMs" do
+        SiteSetting.display_personal_messages_tag_counts = true
+        row = result[:tags].find { |tag| tag[:name] == "pmonly" }
+        expect(row).not_to have_key(:pm_count)
+      end
+    end
+
     context "when a hidden tag does not leak via forbidden" do
       fab!(:hidden_tag) { Fabricate(:tag, name: "secrethidden") }
 


### PR DESCRIPTION
Previously, a tag whose only usage was in personal messages was silently dropped by `TagsController.tag_counts_json` — a display rule from 2020 meant to keep such tags off the `/tags` browse page for users who cannot tag messages (and `pm_tags_allowed_for_groups` has no staff bypass, so by default that includes admins). Every surface reusing that method as a plain serializer inherited the rule by accident:

- the composer tag search treated the missing row as unauthorized and showed the tag disabled with a bogus **"Can't be used in this category"** reason (the reported bug),
- every "show all tags" chooser (tag groups, synonyms, watched tags, category allowed tags, webhooks, automations, …) silently refused to offer such tags at all,
- the `#` autocomplete would not suggest a tag that nonetheless cooked into a working hashtag link when typed in full.

This change makes `tag_counts_json` a pure serializer and moves the rule into an explicit, named helper (`DiscourseTagging.without_pm_only_tags`) applied only where it belongs — the `/tags` browse lists — with an exemption for the admin "show all tags" view so the admin inventory is complete. Selection and search surfaces now offer every tag the user is allowed to use, and tag-group visibility rules still apply everywhere.

It also fixes two adjacent inconsistencies uncovered along the way:

- **Topic→message conversion counter drift.** Converting only adjusted `public_topic_count`, so a converted topic's tags kept working until the periodic consistency job recounted them into the broken state — the "worked at first, broke a day later" in the report. The converter now moves all three counters immediately, and rolls back cleanly when the underlying post revision fails (its return value was previously ignored, and `Topic#valid?` clears the errors it adds, so a failed conversion still applied its side effects).
- **Crawler/print tag leak.** The crawler layout leaked a message's tag names in the page title and `og:article:tag` metadata to participants the serializer already hides tags from; both now flow through `TopicView#visible_tags`, gated on `guardian.can_see_tags?`.

Reported in https://meta.discourse.org/t/407050