### PR TITLE
Revert "FIX: Only allow OTPs to be generated from a browser session (#40964)" (#41875)

### DIFF
--- a/app/controllers/user_api_keys_controller.rb
+++ b/app/controllers/user_api_keys_controller.rb
@@ -691,9 +691,11 @@ class UserApiKeysController < ApplicationController
     current_user.staff? || current_user.in_any_groups?(SiteSetting.user_api_key_allowed_groups_map)
   end
 
+  # `create` and `create_otp` are the only callers, and both respond in JSON
+  # as well as HTML, so this is relied on by non-browser (API key/User API
+  # key) consumers, not just browser sessions. Don't restrict this to
+  # session auth without accounting for those consumers first.
   def one_time_password(public_key, username)
-    raise Discourse::InvalidAccess if is_api? || is_user_api?
-
     unless UserApiKey.allowed_scopes.superset?(Set.new(["one_time_password"]))
       raise Discourse::InvalidAccess
     end

--- a/spec/requests/user_api_keys_controller_spec.rb
+++ b/spec/requests/user_api_keys_controller_spec.rb
@@ -239,26 +239,6 @@ RSpec.describe UserApiKeysController do
       )
     end
 
-    it "does not generate an OTP when a User API key requests the one_time_password scope" do
-      SiteSetting.allowed_user_api_auth_redirects = args[:auth_redirect]
-      user = Fabricate(:user, refresh_auto_groups: true)
-      key =
-        Fabricate(
-          :user_api_key,
-          user: user,
-          scopes: [Fabricate.build(:user_api_key_scope, name: "write")],
-        )
-
-      post "/user-api-key.json",
-           params: args.merge(scopes: "one_time_password"),
-           headers: {
-             HTTP_USER_API_KEY: key.key,
-           }
-
-      expect(response.status).to eq(403)
-      expect(Discourse.redis.keys("otp_*")).to be_empty
-    end
-
     it "returns payload without redirect when auth_redirect not provided" do
       SiteSetting.user_api_key_allowed_groups = Group::AUTO_GROUPS[:trust_level_0]
       user = Fabricate(:user, trust_level: TrustLevel[0])
@@ -1140,38 +1120,6 @@ RSpec.describe UserApiKeysController do
 
       post "/user-api-key/otp", params: otp_args.merge(padding: "invalid")
       expect(response.status).to eq(400)
-    end
-
-    it "does not allow a User API key to generate an OTP" do
-      SiteSetting.allowed_user_api_auth_redirects = otp_args[:auth_redirect]
-      user = Fabricate(:user, refresh_auto_groups: true)
-      key =
-        Fabricate(
-          :user_api_key,
-          user: user,
-          scopes: [Fabricate.build(:user_api_key_scope, name: "write")],
-        )
-
-      post "/user-api-key/otp", params: otp_args, headers: { HTTP_USER_API_KEY: key.key }
-
-      expect(response.status).to eq(403)
-      expect(Discourse.redis.keys("otp_*")).to be_empty
-    end
-
-    it "does not allow an admin API key to generate an OTP" do
-      SiteSetting.allowed_user_api_auth_redirects = otp_args[:auth_redirect]
-      user = Fabricate(:user, refresh_auto_groups: true)
-      api_key = Fabricate(:api_key, user: Fabricate(:admin))
-
-      post "/user-api-key/otp",
-           params: otp_args,
-           headers: {
-             HTTP_API_KEY: api_key.key,
-             HTTP_API_USERNAME: user.username,
-           }
-
-      expect(response.status).to eq(403)
-      expect(Discourse.redis.keys("otp_*")).to be_empty
     end
   end
 end


### PR DESCRIPTION
This reverts commit fc704a8d11da17eea0db0b4e228345a0449ce515.

`create` and `create_otp` are the only callers of `one_time_password`, and both respond in JSON as well as HTML, so this is relied on by non-browser (API key/User API key) consumers, not just browser sessions. The original fix broke those consumers. A comment was added to document this so the check is not reintroduced again.

This is a backport for https://github.com/discourse/discourse/commit/524cba70d92be8c3eaec26351f9e1a315adbd31c.