### PR TITLE
UX: all node defining a category now allow a list of categories

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -22828,6 +22828,8 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260722140539'),
+('20260722140536'),
 ('20260721080424'),
 ('20260721080420'),
 ('20260721043536'),

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/category-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/category-control.gjs
@@ -1,17 +1,101 @@
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
 import { action } from "@ember/object";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import Category from "discourse/models/category";
 import CategoryChooser from "discourse/select-kit/components/category-chooser";
+import CategorySelector from "discourse/select-kit/components/category-selector";
 import ExpressionWrapper from "./expression-wrapper";
 
+function categoryIdsFromValue(value) {
+  if (value == null || value === "") {
+    return [];
+  }
+
+  return (Array.isArray(value) ? value : [value])
+    .map((id) => parseInt(id, 10))
+    .filter((id) => !isNaN(id));
+}
+
 export default class CategoryControl extends Component {
+  @tracked selectedCategories = [];
+
+  constructor() {
+    super(...arguments);
+    this.pendingCategoriesRequest = Promise.resolve();
+
+    if (this.multiple) {
+      this.hydrateSelectedCategories();
+    }
+  }
+
+  get multiple() {
+    return Boolean(this.args.schema?.ui?.multiple);
+  }
+
   get clearable() {
     return !this.args.schema?.required;
+  }
+
+  get categoryIds() {
+    return categoryIdsFromValue(this.args.field.value);
+  }
+
+  async updateSelectedCategories(previousRequest) {
+    const requestedIds = this.categoryIds;
+
+    let categories;
+    try {
+      categories = await Category.asyncFindByIds(requestedIds);
+    } catch {
+      return;
+    }
+
+    await previousRequest;
+
+    if (
+      this.isDestroying ||
+      this.isDestroyed ||
+      !this.#sameIds(this.categoryIds, requestedIds)
+    ) {
+      return;
+    }
+
+    this.selectedCategories = categories.filter(Boolean);
+  }
+
+  @action
+  hydrateSelectedCategories() {
+    const ids = this.categoryIds;
+    if (
+      this.#sameIds(
+        ids,
+        this.selectedCategories.map((category) => category.id)
+      )
+    ) {
+      return;
+    }
+
+    const previousRequest = this.pendingCategoriesRequest;
+    this.pendingCategoriesRequest =
+      this.updateSelectedCategories(previousRequest);
+  }
+
+  #sameIds(a, b) {
+    return a.length === b.length && a.every((id, index) => id === b[index]);
   }
 
   @action
   handleChange(categoryId) {
     this.args.field.set(categoryId == null ? "" : String(categoryId));
+  }
+
+  @action
+  handleMultiChange(categories) {
+    categories = categories || [];
+    this.selectedCategories = categories;
+    this.args.field.set(categories.map((category) => category.id));
   }
 
   <template>
@@ -23,11 +107,20 @@ export default class CategoryControl extends Component {
       @dynamicValueHint={{@dynamicValueHint}}
       @session={{@session}}
     >
-      <CategoryChooser
-        @value={{if @field.value @field.value null}}
-        @onChange={{this.handleChange}}
-        @options={{hash clearable=this.clearable}}
-      />
+      {{#if this.multiple}}
+        <CategorySelector
+          {{didUpdate this.hydrateSelectedCategories @field.value}}
+          @categories={{this.selectedCategories}}
+          @onChange={{this.handleMultiChange}}
+          @options={{hash translatedNone=@placeholder}}
+        />
+      {{else}}
+        <CategoryChooser
+          @value={{if @field.value @field.value null}}
+          @onChange={{this.handleChange}}
+          @options={{hash clearable=this.clearable}}
+        />
+      {{/if}}
     </ExpressionWrapper>
   </template>
 }

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
@@ -112,8 +112,9 @@ export function propertyDescription(nodeDefinitionOrType, fieldName) {
   const labelKey = localeKeyPart(fieldName);
 
   return (
-    translatedOrNull(`${i18nBase(nodeDefinitionOrType)}.${labelKey}_description`) ||
-    translatedOrNull(`${SHARED_FIELDS_BASE}.${labelKey}_description`)
+    translatedOrNull(
+      `${i18nBase(nodeDefinitionOrType)}.${labelKey}_description`
+    ) || translatedOrNull(`${SHARED_FIELDS_BASE}.${labelKey}_description`)
   );
 }
 

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/lib/workflows/property-engine.js
@@ -94,6 +94,8 @@ function i18nBase(nodeDefinitionOrType) {
   return `${i18nPrefix(nodeDefinitionOrType)}.${i18nScope(nodeDefinitionOrType)}`;
 }
 
+const SHARED_FIELDS_BASE = "discourse_workflows.property_engine.fields";
+
 export function propertyLabel(nodeDefinitionOrType, fieldName) {
   const base = i18nBase(nodeDefinitionOrType);
   const labelKey = localeKeyPart(fieldName);
@@ -101,25 +103,36 @@ export function propertyLabel(nodeDefinitionOrType, fieldName) {
   return (
     translatedOrNull(`${base}.${labelKey}`) ||
     translatedOrNull(`${base}.${labelKey}.title`) ||
+    translatedOrNull(`${SHARED_FIELDS_BASE}.${labelKey}`) ||
     humanize(fieldName)
   );
 }
 
 export function propertyDescription(nodeDefinitionOrType, fieldName) {
-  return translatedOrNull(
-    `${i18nBase(nodeDefinitionOrType)}.${localeKeyPart(fieldName)}_description`
+  const labelKey = localeKeyPart(fieldName);
+
+  return (
+    translatedOrNull(`${i18nBase(nodeDefinitionOrType)}.${labelKey}_description`) ||
+    translatedOrNull(`${SHARED_FIELDS_BASE}.${labelKey}_description`)
   );
 }
 
 export function propertyTooltip(nodeDefinitionOrType, fieldName) {
-  return translatedOrNull(
-    `${i18nBase(nodeDefinitionOrType)}.${localeKeyPart(fieldName)}_tooltip`
+  const labelKey = localeKeyPart(fieldName);
+
+  return (
+    translatedOrNull(`${i18nBase(nodeDefinitionOrType)}.${labelKey}_tooltip`) ||
+    translatedOrNull(`${SHARED_FIELDS_BASE}.${labelKey}_tooltip`)
   );
 }
 
 export function propertyPlaceholder(nodeDefinitionOrType, fieldName) {
-  return translatedOrNull(
-    `${i18nBase(nodeDefinitionOrType)}.${localeKeyPart(fieldName)}_placeholder`
+  const labelKey = localeKeyPart(fieldName);
+
+  return (
+    translatedOrNull(
+      `${i18nBase(nodeDefinitionOrType)}.${labelKey}_placeholder`
+    ) || translatedOrNull(`${SHARED_FIELDS_BASE}.${labelKey}_placeholder`)
   );
 }
 

--- a/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator.scss
@@ -117,7 +117,8 @@
     > .icon-picker,
     > .select-kit.combo-box.category-chooser,
     > .user-chooser,
-    > .mini-tag-chooser {
+    > .mini-tag-chooser,
+    > .select-kit.category-selector {
       width: 100%;
       min-width: 0;
     }

--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -604,6 +604,11 @@ en:
           boolean: "Boolean"
           array: "Array"
           object: "Object"
+        fields:
+          category_ids: "Categories"
+          category_ids_description: "Only trigger for topics in these categories. Leave empty to match all categories."
+          category_ids_placeholder: "All categories"
+          include_subcategories: "Include subcategories"
         dynamic_values:
           badge_id: "a badge ID"
           boolean: "true or false"
@@ -661,14 +666,10 @@ en:
       stale_topic:
         hours: "Hours with no reply"
         description: "Fires when a topic has had no replies for the specified number of hours"
-        category_id: "Category"
-        category_id_description: "Only consider topics in this category"
-        include_subcategories: "Include subcategories"
+        category_ids_description: "Only consider topics in these categories. Leave empty to match all categories."
         tag_names: "Tags"
         tag_names_description: "Only consider topics that have at least one of these tags"
       topic_closed:
-        category_id: "Category"
-        category_id_description: "Only trigger for topics in this category"
         tag_names: "Tags"
         tag_names_description: "Only trigger for topics that have at least one of these tags"
       post_created:
@@ -680,14 +681,11 @@ en:
         group_inbox_id: "Group inbox"
         group_inbox_id_description: "Only trigger for personal messages in this group inbox"
         group_inbox_id_placeholder: "All group inboxes"
-        category_id: "Category"
-        category_id_description: "Only trigger for posts in this category"
-        include_subcategories: "Include subcategories"
+        category_ids_description: "Only trigger for posts in these categories. Leave empty to match all categories."
         tag_names: "Tags"
         tag_names_description: "Only trigger for posts in topics that have at least one of these tags"
       post_edited:
-        category_id: "Category"
-        category_id_description: "Only trigger for posts in this category"
+        category_ids_description: "Only trigger for posts in these categories. Leave empty to match all categories."
         tag_names: "Tags"
         tag_names_description: "Only trigger for posts in topics that have at least one of these tags"
         post_scope: "Post scope"
@@ -698,8 +696,8 @@ en:
         trust_levels: "Trust levels"
         trust_levels_description: "Only trigger for posts created by users with these trust levels"
       post_moved:
-        category_id: "Destination category"
-        category_id_description: "Only trigger for posts moved into this category"
+        category_ids: "Destination categories"
+        category_ids_description: "Only trigger for posts moved into these categories. Leave empty to match all categories."
         tag_names: "Destination tags"
         tag_names_description: "Only trigger for posts moved into topics that have at least one of these tags"
       topic_created:
@@ -711,14 +709,8 @@ en:
         group_inbox_id: "Group inbox"
         group_inbox_id_description: "Only trigger for personal messages in this group inbox"
         group_inbox_id_placeholder: "All group inboxes"
-        category_id: "Category"
-        category_id_description: "Only trigger for topics in this category"
-        include_subcategories: "Include subcategories"
         tag_names: "Tags"
         tag_names_description: "Only trigger for topics that have at least one of these tags"
-      topic_tag_changed:
-        category_id: "Category"
-        category_id_description: "Only trigger for topics in this category"
       user_added_to_group:
         group_id: "Group"
         group_id_description: "Only trigger when a user is added to this group"

--- a/plugins/discourse-workflows/db/migrate/20260722140536_copy_workflow_trigger_category_id_to_category_ids.rb
+++ b/plugins/discourse-workflows/db/migrate/20260722140536_copy_workflow_trigger_category_id_to_category_ids.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+class CopyWorkflowTriggerCategoryIdToCategoryIds < ActiveRecord::Migration[8.0]
+  TRIGGER_TYPES = <<~SQL.squish
+    ('trigger:topic_created', 'trigger:post_created', 'trigger:post_edited',
+     'trigger:post_moved', 'trigger:topic_closed', 'trigger:topic_tag_changed',
+     'trigger:stale_topic')
+  SQL
+
+  def up
+    migrate_node_arrays("discourse_workflows_workflows", "nodes")
+    migrate_node_arrays("discourse_workflows_workflow_versions", "nodes")
+    migrate_snapshot_nodes("discourse_workflows_execution_data", "workflow_data")
+    migrate_snapshot_nodes("discourse_workflows_webhooks", "workflow_snapshot")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def migrate_node_arrays(table_name, column_name)
+    execute <<~SQL
+      UPDATE #{table_name}
+      SET #{column_name} = (
+        SELECT COALESCE(
+          jsonb_agg(#{transformed_node_sql} ORDER BY nodes.ordinality),
+          '[]'::jsonb
+        )
+        FROM jsonb_array_elements(#{table_name}.#{column_name}) WITH ORDINALITY AS nodes(node, ordinality)
+      )
+      WHERE jsonb_typeof(#{column_name}) = 'array'
+        AND #{nodes_need_migration_sql(column_name)}
+    SQL
+  end
+
+  def migrate_snapshot_nodes(table_name, column_name)
+    execute <<~SQL
+      UPDATE #{table_name}
+      SET #{column_name} = jsonb_set(
+        #{column_name},
+        '{nodes}',
+        (
+          SELECT COALESCE(
+            jsonb_agg(#{transformed_node_sql} ORDER BY nodes.ordinality),
+            '[]'::jsonb
+          )
+          FROM jsonb_array_elements(#{table_name}.#{column_name}->'nodes') WITH ORDINALITY AS nodes(node, ordinality)
+        ),
+        false
+      )
+      WHERE jsonb_typeof(#{column_name}->'nodes') = 'array'
+        AND #{nodes_need_migration_sql("#{column_name}->'nodes'")}
+    SQL
+  end
+
+  def transformed_node_sql
+    <<~SQL.squish
+      CASE
+      WHEN #{node_needs_migration_sql("nodes.node", node_parameters_sql)} THEN
+        nodes.node || jsonb_build_object(
+          'parameters',
+          #{node_parameters_sql}
+            || jsonb_build_object(
+              'category_ids',
+              jsonb_build_array(#{node_parameters_sql}->'category_id')
+            )
+        )
+      ELSE nodes.node
+      END
+    SQL
+  end
+
+  def node_needs_migration_sql(node_expression, parameters_expression)
+    <<~SQL.squish
+      #{node_expression}->>'type' IN #{TRIGGER_TYPES}
+        AND (#{parameters_expression} ? 'category_id')
+        AND COALESCE(jsonb_typeof(#{parameters_expression}->'category_ids'), '') <> 'array'
+        AND COALESCE(#{parameters_expression}->>'category_id', '') <> ''
+    SQL
+  end
+
+  def node_parameters_sql
+    <<~SQL.squish
+      CASE
+      WHEN jsonb_typeof(nodes.node->'parameters') = 'object' THEN nodes.node->'parameters'
+      ELSE '{}'::jsonb
+      END
+    SQL
+  end
+
+  def existing_node_parameters_sql
+    <<~SQL.squish
+      CASE
+      WHEN jsonb_typeof(existing_nodes.node->'parameters') = 'object' THEN existing_nodes.node->'parameters'
+      ELSE '{}'::jsonb
+      END
+    SQL
+  end
+
+  def nodes_need_migration_sql(nodes_expression)
+    <<~SQL.squish
+      EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(#{nodes_expression}) AS existing_nodes(node)
+        WHERE #{node_needs_migration_sql("existing_nodes.node", existing_node_parameters_sql)}
+      )
+    SQL
+  end
+end

--- a/plugins/discourse-workflows/db/post_migrate/20260722140539_remove_workflow_trigger_category_id_from_trigger_nodes.rb
+++ b/plugins/discourse-workflows/db/post_migrate/20260722140539_remove_workflow_trigger_category_id_from_trigger_nodes.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+class RemoveWorkflowTriggerCategoryIdFromTriggerNodes < ActiveRecord::Migration[8.0]
+  TRIGGER_TYPES = <<~SQL.squish
+    ('trigger:topic_created', 'trigger:post_created', 'trigger:post_edited',
+     'trigger:post_moved', 'trigger:topic_closed', 'trigger:topic_tag_changed',
+     'trigger:stale_topic')
+  SQL
+
+  def up
+    migrate_node_arrays("discourse_workflows_workflows", "nodes")
+    migrate_node_arrays("discourse_workflows_workflow_versions", "nodes")
+    migrate_snapshot_nodes("discourse_workflows_execution_data", "workflow_data")
+    migrate_snapshot_nodes("discourse_workflows_webhooks", "workflow_snapshot")
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def migrate_node_arrays(table_name, column_name)
+    execute <<~SQL
+      UPDATE #{table_name}
+      SET #{column_name} = (
+        SELECT COALESCE(
+          jsonb_agg(#{transformed_node_sql} ORDER BY nodes.ordinality),
+          '[]'::jsonb
+        )
+        FROM jsonb_array_elements(#{table_name}.#{column_name}) WITH ORDINALITY AS nodes(node, ordinality)
+      )
+      WHERE jsonb_typeof(#{column_name}) = 'array'
+        AND #{nodes_need_migration_sql(column_name)}
+    SQL
+  end
+
+  def migrate_snapshot_nodes(table_name, column_name)
+    execute <<~SQL
+      UPDATE #{table_name}
+      SET #{column_name} = jsonb_set(
+        #{column_name},
+        '{nodes}',
+        (
+          SELECT COALESCE(
+            jsonb_agg(#{transformed_node_sql} ORDER BY nodes.ordinality),
+            '[]'::jsonb
+          )
+          FROM jsonb_array_elements(#{table_name}.#{column_name}->'nodes') WITH ORDINALITY AS nodes(node, ordinality)
+        ),
+        false
+      )
+      WHERE jsonb_typeof(#{column_name}->'nodes') = 'array'
+        AND #{nodes_need_migration_sql("#{column_name}->'nodes'")}
+    SQL
+  end
+
+  def transformed_node_sql
+    <<~SQL.squish
+      CASE
+      WHEN #{node_needs_migration_sql("nodes.node", node_parameters_sql)} THEN
+        nodes.node || jsonb_build_object(
+          'parameters',
+          (#{node_parameters_sql} - 'category_id')
+            || #{copied_category_ids_sql(node_parameters_sql)}
+        )
+      ELSE nodes.node
+      END
+    SQL
+  end
+
+  def copied_category_ids_sql(parameters_expression)
+    <<~SQL.squish
+      CASE
+      WHEN COALESCE(jsonb_typeof(#{parameters_expression}->'category_ids'), '') <> 'array'
+        AND COALESCE(#{parameters_expression}->>'category_id', '') <> '' THEN
+        jsonb_build_object(
+          'category_ids',
+          jsonb_build_array(#{parameters_expression}->'category_id')
+        )
+      ELSE '{}'::jsonb
+      END
+    SQL
+  end
+
+  def node_needs_migration_sql(node_expression, parameters_expression)
+    <<~SQL.squish
+      #{node_expression}->>'type' IN #{TRIGGER_TYPES}
+        AND (#{parameters_expression} ? 'category_id')
+    SQL
+  end
+
+  def node_parameters_sql
+    <<~SQL.squish
+      CASE
+      WHEN jsonb_typeof(nodes.node->'parameters') = 'object' THEN nodes.node->'parameters'
+      ELSE '{}'::jsonb
+      END
+    SQL
+  end
+
+  def existing_node_parameters_sql
+    <<~SQL.squish
+      CASE
+      WHEN jsonb_typeof(existing_nodes.node->'parameters') = 'object' THEN existing_nodes.node->'parameters'
+      ELSE '{}'::jsonb
+      END
+    SQL
+  end
+
+  def nodes_need_migration_sql(nodes_expression)
+    <<~SQL.squish
+      EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(#{nodes_expression}) AS existing_nodes(node)
+        WHERE #{node_needs_migration_sql("existing_nodes.node", existing_node_parameters_sql)}
+      )
+    SQL
+  end
+end

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -221,6 +221,29 @@ module DiscourseWorkflows
         .filter_map { |name| name.strip.presence }
     end
 
+    def self.normalize_category_ids(value)
+      Array.wrap(value).filter_map { |entry| entry.to_s.strip.presence&.to_i }.uniq
+    end
+
+    # TODO JOFFREY (01-2027): drop the category_id fallback once the post_migrate
+    # stripping the legacy key has been promoted.
+    def self.category_ids_parameter(trigger_ctx)
+      value = trigger_ctx.get_node_parameter("category_ids")
+      value = trigger_ctx.get_node_parameter("category_id") if value.nil?
+      normalize_category_ids(value)
+    end
+
+    def self.expand_subcategory_ids(category_ids)
+      category_ids.flat_map { |id| ::Category.subcategory_ids(id) }.uniq
+    end
+
+    def self.matches_category_ids?(topic_category_id, category_ids, include_subcategories: true)
+      return true if category_ids.empty?
+
+      category_ids = expand_subcategory_ids(category_ids) if include_subcategories != false
+      category_ids.include?(topic_category_id)
+    end
+
     def self.trust_level_options
       TrustLevel.levels.map do |name, level|
         { value: level.to_s, label_key: "trust_levels.names.#{name}" }
@@ -258,6 +281,18 @@ module DiscourseWorkflows
 
     def normalize_tag_names(value)
       self.class.normalize_tag_names(value)
+    end
+
+    def category_ids_parameter(trigger_ctx)
+      self.class.category_ids_parameter(trigger_ctx)
+    end
+
+    def matches_category_ids?(topic_category_id, category_ids, include_subcategories: true)
+      self.class.matches_category_ids?(
+        topic_category_id,
+        category_ids,
+        include_subcategories: include_subcategories,
+      )
     end
 
     def wrap(data, paired_item: nil)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
@@ -53,11 +53,12 @@ module DiscourseWorkflows
                 none: "discourse_workflows.post_created.group_inbox_id_placeholder",
               },
             },
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
               },
             },
             include_subcategories: {
@@ -69,7 +70,7 @@ module DiscourseWorkflows
               },
               display_options: {
                 show: {
-                  category_id: [{ condition: { exists: true } }],
+                  category_ids: [{ condition: { exists: true } }],
                 },
               },
             },
@@ -114,10 +115,10 @@ module DiscourseWorkflows
 
           matches_topic_type?(topic, trigger_ctx.get_node_parameter("topic_type", "topics")) &&
             matches_group_inbox?(topic, trigger_ctx.get_node_parameter("group_inbox_id")) &&
-            matches_category?(
-              topic,
-              trigger_ctx.get_node_parameter("category_id"),
-              trigger_ctx.get_node_parameter("include_subcategories", true),
+            matches_category_ids?(
+              topic.category_id,
+              category_ids_parameter(trigger_ctx),
+              include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
             ) &&
             matches_tags?(topic, normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
         end
@@ -154,15 +155,6 @@ module DiscourseWorkflows
           return false if !topic.private_message?
 
           topic.allowed_groups.exists?(id: group_id.to_i)
-        end
-
-        def matches_category?(topic, category_id, include_subcategories)
-          return true if category_id.blank?
-
-          category_id = category_id.to_i
-          return topic.category_id == category_id if include_subcategories == false
-
-          ::Category.subcategory_ids(category_id).include?(topic.category_id)
         end
 
         def matches_tags?(topic, tag_names)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
@@ -32,11 +32,25 @@ module DiscourseWorkflows
               default: "first_post",
               options: POST_SCOPE_OPTIONS,
             },
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
+              },
+            },
+            include_subcategories: {
+              type: :boolean,
+              required: false,
+              default: true,
+              ui: {
+                control: :checkbox,
+              },
+              display_options: {
+                show: {
+                  category_ids: [{ condition: { exists: true } }],
+                },
               },
             },
             tag_names: {
@@ -76,7 +90,11 @@ module DiscourseWorkflows
 
         def matches?(trigger_ctx)
           matches_post_scope?(trigger_ctx.get_node_parameter("post_scope", "first_post")) &&
-            matches_category?(trigger_ctx.get_node_parameter("category_id")) &&
+            matches_category_ids?(
+              @post.topic.category_id,
+              category_ids_parameter(trigger_ctx),
+              include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
+            ) &&
             matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names"))) &&
             matches_trust_level?(trigger_ctx.get_node_parameter("trust_levels"))
         end
@@ -100,14 +118,6 @@ module DiscourseWorkflows
           else
             @post.post_number == 1
           end
-        end
-
-        def matches_category?(category_id)
-          category_id.blank? || topic_category_ids.include?(category_id.to_i)
-        end
-
-        def topic_category_ids
-          [@post.topic.category_id, @post.topic.category&.parent_category_id].compact
         end
 
         def matches_tags?(tag_names)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
@@ -94,8 +94,7 @@ module DiscourseWorkflows
               @post.topic.category_id,
               category_ids_parameter(trigger_ctx),
               include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
-            ) &&
-            matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names"))) &&
+            ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names"))) &&
             matches_trust_level?(trigger_ctx.get_node_parameter("trust_levels"))
         end
 

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
@@ -29,11 +29,25 @@ module DiscourseWorkflows
           events: [:post_moved],
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
           properties: {
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
+              },
+            },
+            include_subcategories: {
+              type: :boolean,
+              required: false,
+              default: true,
+              ui: {
+                control: :checkbox,
+              },
+              display_options: {
+                show: {
+                  category_ids: [{ condition: { exists: true } }],
+                },
               },
             },
             tag_names: {
@@ -66,8 +80,11 @@ module DiscourseWorkflows
         end
 
         def matches?(trigger_ctx)
-          matches_category?(trigger_ctx.get_node_parameter("category_id")) &&
-            matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
+          matches_category_ids?(
+            destination_topic.category_id,
+            category_ids_parameter(trigger_ctx),
+            include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
+          ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
         end
 
         private
@@ -86,10 +103,6 @@ module DiscourseWorkflows
 
         def original_topic
           @original_topic ||= ::Topic.find_by(id: @original_topic_id)
-        end
-
-        def matches_category?(category_id)
-          category_id.blank? || destination_topic.category_id == category_id.to_i
         end
 
         def matches_tags?(tag_names)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
@@ -20,11 +20,12 @@ module DiscourseWorkflows
               default: 24,
               min: 1,
             },
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
               },
             },
             include_subcategories: {
@@ -36,7 +37,7 @@ module DiscourseWorkflows
               },
               display_options: {
                 show: {
-                  category_id: [{ condition: { exists: true } }],
+                  category_ids: [{ condition: { exists: true } }],
                 },
               },
             },
@@ -57,13 +58,13 @@ module DiscourseWorkflows
 
         def self.trigger_data_for(trigger_ctx)
           hours = trigger_ctx.get_node_parameter("hours", 24)
-          category_id = trigger_ctx.get_node_parameter("category_id").presence&.to_i
+          category_ids = category_ids_parameter(trigger_ctx)
           include_subcategories = trigger_ctx.get_node_parameter("include_subcategories", true)
           tag_names = normalize_tag_names(trigger_ctx.get_node_parameter("tag_names"))
 
           stale_topics(
             hours: hours,
-            category_id: category_id,
+            category_ids: category_ids,
             include_subcategories: include_subcategories,
             tag_names: tag_names,
             limit: MAX_TOPICS_PER_RUN,
@@ -72,7 +73,7 @@ module DiscourseWorkflows
 
         def self.stale_topics(
           hours:,
-          category_id: nil,
+          category_ids: [],
           include_subcategories: true,
           tag_names: [],
           limit:
@@ -86,10 +87,14 @@ module DiscourseWorkflows
               .where("topics.archetype = ?", Archetype.default)
               .includes(first_post: :user)
 
-          if category_id
-            category_ids =
-              include_subcategories == false ? category_id : ::Category.subcategory_ids(category_id)
-            scope = scope.where(category_id: category_ids)
+          if category_ids.present?
+            scoped_category_ids =
+              if include_subcategories == false
+                category_ids
+              else
+                expand_subcategory_ids(category_ids)
+              end
+            scope = scope.where(category_id: scoped_category_ids)
           end
 
           scope = scope.joins(:tags).where(tags: { name: tag_names }).distinct if tag_names.any?

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
@@ -15,11 +15,25 @@ module DiscourseWorkflows
           events: [:topic_status_updated],
           output_contracts: [{ schema: Schema::TOPIC_LIST_ITEM_SCHEMA }],
           properties: {
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
+              },
+            },
+            include_subcategories: {
+              type: :boolean,
+              required: false,
+              default: true,
+              ui: {
+                control: :checkbox,
+              },
+              display_options: {
+                show: {
+                  category_ids: [{ condition: { exists: true } }],
+                },
               },
             },
             tag_names: {
@@ -48,18 +62,17 @@ module DiscourseWorkflows
         end
 
         def matches?(trigger_ctx)
-          matches_category?(trigger_ctx.get_node_parameter("category_id")) &&
-            matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
+          matches_category_ids?(
+            @topic.category_id,
+            category_ids_parameter(trigger_ctx),
+            include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
+          ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
         end
 
         private
 
         def topic_data(topic)
           serialize_record(topic, TopicListItemSerializer)
-        end
-
-        def matches_category?(category_id)
-          category_id.blank? || @topic.category_id == category_id.to_i
         end
 
         def matches_tags?(tag_names)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
@@ -46,11 +46,12 @@ module DiscourseWorkflows
                 none: "discourse_workflows.topic_created.group_inbox_id_placeholder",
               },
             },
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
               },
             },
             include_subcategories: {
@@ -62,7 +63,7 @@ module DiscourseWorkflows
               },
               display_options: {
                 show: {
-                  category_id: [{ condition: { exists: true } }],
+                  category_ids: [{ condition: { exists: true } }],
                 },
               },
             },
@@ -104,9 +105,10 @@ module DiscourseWorkflows
         def matches?(trigger_ctx)
           matches_topic_type?(trigger_ctx.get_node_parameter("topic_type", "topics")) &&
             matches_group_inbox?(trigger_ctx.get_node_parameter("group_inbox_id")) &&
-            matches_category?(
-              trigger_ctx.get_node_parameter("category_id"),
-              trigger_ctx.get_node_parameter("include_subcategories", true),
+            matches_category_ids?(
+              @topic.category_id,
+              category_ids_parameter(trigger_ctx),
+              include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
             ) && matches_tags?(normalize_tag_names(trigger_ctx.get_node_parameter("tag_names")))
         end
 
@@ -138,15 +140,6 @@ module DiscourseWorkflows
           return false if !@topic.private_message?
 
           @topic.allowed_groups.exists?(id: group_id.to_i)
-        end
-
-        def matches_category?(category_id, include_subcategories)
-          return true if category_id.blank?
-
-          category_id = category_id.to_i
-          return @topic.category_id == category_id if include_subcategories == false
-
-          ::Category.subcategory_ids(category_id).include?(@topic.category_id)
         end
 
         def matches_tags?(tag_names)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
@@ -27,11 +27,25 @@ module DiscourseWorkflows
           events: [:topic_tags_changed],
           output_contracts: [{ schema: OUTPUT_SCHEMA }],
           properties: {
-            category_id: {
-              type: :integer,
+            category_ids: {
+              type: :array,
               required: false,
               ui: {
                 control: :category,
+                multiple: true,
+              },
+            },
+            include_subcategories: {
+              type: :boolean,
+              required: false,
+              default: true,
+              ui: {
+                control: :checkbox,
+              },
+              display_options: {
+                show: {
+                  category_ids: [{ condition: { exists: true } }],
+                },
               },
             },
           },
@@ -60,7 +74,11 @@ module DiscourseWorkflows
         end
 
         def matches?(trigger_ctx)
-          matches_category?(trigger_ctx.get_node_parameter("category_id"))
+          matches_category_ids?(
+            @topic.category_id,
+            category_ids_parameter(trigger_ctx),
+            include_subcategories: trigger_ctx.get_node_parameter("include_subcategories", true),
+          )
         end
 
         private
@@ -75,10 +93,6 @@ module DiscourseWorkflows
 
         def topic_data(topic)
           serialize_record(topic, TopicListItemSerializer)
-        end
-
-        def matches_category?(category_id)
-          category_id.blank? || @topic.category_id == category_id.to_i
         end
       end
     end

--- a/plugins/discourse-workflows/spec/db/migrate/copy_workflow_trigger_category_id_to_category_ids_spec.rb
+++ b/plugins/discourse-workflows/spec/db/migrate/copy_workflow_trigger_category_id_to_category_ids_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "plugins/discourse-workflows/db/migrate/20260722140536_copy_workflow_trigger_category_id_to_category_ids",
+        )
+
+RSpec.describe CopyWorkflowTriggerCategoryIdToCategoryIds do
+  subject(:migration) { described_class.new }
+
+  fab!(:workflow, :discourse_workflows_workflow)
+
+  around { |example| ActiveRecord::Migration.suppress_messages { example.run } }
+
+  def build_node(type:, parameters:, id: "node-1")
+    { "id" => id, "type" => type, "parameters" => parameters }
+  end
+
+  def set_workflow_nodes(nodes)
+    workflow.update_columns(nodes: nodes)
+  end
+
+  def workflow_nodes
+    workflow.reload.nodes
+  end
+
+  it "copies a scalar category_id into a category_ids array and keeps the legacy key" do
+    set_workflow_nodes(
+      [build_node(type: "trigger:topic_created", parameters: { "category_id" => "12" })],
+    )
+
+    migration.up
+
+    parameters = workflow_nodes.first["parameters"]
+    expect(parameters["category_ids"]).to eq(["12"])
+    expect(parameters["category_id"]).to eq("12")
+    expect(parameters).not_to have_key("include_subcategories")
+  end
+
+  it "preserves numeric and expression category_id values verbatim" do
+    set_workflow_nodes(
+      [
+        build_node(type: "trigger:topic_created", parameters: { "category_id" => 12 }, id: "a"),
+        build_node(
+          type: "trigger:post_created",
+          parameters: {
+            "category_id" => "=$json.category_id",
+          },
+          id: "b",
+        ),
+      ],
+    )
+
+    migration.up
+
+    expect(workflow_nodes.map { |node| node["parameters"]["category_ids"] }).to eq(
+      [[12], ["=$json.category_id"]],
+    )
+  end
+
+  it "overwrites an explicit null category_ids with the copied value" do
+    set_workflow_nodes(
+      [
+        build_node(
+          type: "trigger:topic_created",
+          parameters: {
+            "category_id" => "12",
+            "category_ids" => nil,
+          },
+        ),
+      ],
+    )
+
+    migration.up
+
+    expect(workflow_nodes.first["parameters"]["category_ids"]).to eq(["12"])
+  end
+
+  it "does not add category_ids for a blank category_id" do
+    set_workflow_nodes(
+      [build_node(type: "trigger:topic_created", parameters: { "category_id" => "" })],
+    )
+
+    migration.up
+
+    parameters = workflow_nodes.first["parameters"]
+    expect(parameters).not_to have_key("category_ids")
+    expect(parameters["category_id"]).to eq("")
+  end
+
+  it "does not touch include_subcategories" do
+    set_workflow_nodes(
+      [
+        build_node(type: "trigger:topic_closed", parameters: { "category_id" => "3" }, id: "a"),
+        build_node(
+          type: "trigger:topic_created",
+          parameters: {
+            "category_id" => "3",
+            "include_subcategories" => false,
+          },
+          id: "b",
+        ),
+      ],
+    )
+
+    migration.up
+
+    nodes_by_id = workflow_nodes.index_by { |node| node["id"] }
+    expect(nodes_by_id["a"]["parameters"]).not_to have_key("include_subcategories")
+    expect(nodes_by_id["b"]["parameters"]["include_subcategories"]).to eq(false)
+  end
+
+  it "leaves non-trigger nodes and already-migrated nodes untouched" do
+    nodes = [
+      build_node(type: "action:topic", parameters: { "category_id" => "5" }, id: "a"),
+      build_node(
+        type: "trigger:topic_created",
+        parameters: {
+          "category_id" => "5",
+          "category_ids" => ["7"],
+        },
+        id: "b",
+      ),
+    ]
+    set_workflow_nodes(nodes)
+
+    migration.up
+
+    expect(workflow_nodes).to eq(nodes)
+  end
+
+  it "is idempotent and preserves node ordering" do
+    set_workflow_nodes(
+      [
+        build_node(type: "trigger:topic_created", parameters: { "category_id" => "12" }, id: "a"),
+        build_node(type: "action:post", parameters: { "operation" => "create" }, id: "b"),
+      ],
+    )
+
+    migration.up
+    first_pass = workflow_nodes
+    migration.up
+
+    expect(workflow_nodes).to eq(first_pass)
+    expect(workflow_nodes.map { |node| node["id"] }).to eq(%w[a b])
+  end
+
+  it "migrates workflow version snapshots" do
+    node = build_node(type: "trigger:topic_created", parameters: { "category_id" => "12" })
+    DiscourseWorkflows::WorkflowVersion.where(workflow_id: workflow.id).update_all(nodes: [node])
+
+    migration.up
+
+    version_nodes = DiscourseWorkflows::WorkflowVersion.find_by(workflow_id: workflow.id).nodes
+    expect(version_nodes.first["parameters"]["category_ids"]).to eq(["12"])
+  end
+
+  it "migrates execution data snapshots" do
+    node = build_node(type: "trigger:topic_created", parameters: { "category_id" => "12" })
+    execution_data = Fabricate(:discourse_workflows_execution_data)
+    execution_data.update_columns(workflow_data: { "nodes" => [node] })
+
+    migration.up
+
+    reloaded_nodes = execution_data.reload.workflow_data["nodes"]
+    expect(reloaded_nodes.first["parameters"]["category_ids"]).to eq(["12"])
+  end
+
+  it "migrates webhook workflow snapshots" do
+    node = build_node(type: "trigger:topic_created", parameters: { "category_id" => "12" })
+    DB.exec(<<~SQL, workflow_id: workflow.id, snapshot: { "nodes" => [node] }.to_json)
+      INSERT INTO discourse_workflows_webhooks
+        (workflow_id, node_name, webhook_path, http_method, workflow_snapshot)
+      VALUES (:workflow_id, 'Webhook', '/spec-webhook', 'POST', :snapshot::jsonb)
+    SQL
+
+    migration.up
+
+    snapshot =
+      DB.query_single(
+        "SELECT workflow_snapshot FROM discourse_workflows_webhooks WHERE workflow_id = :workflow_id",
+        workflow_id: workflow.id,
+      ).first
+    expect(snapshot["nodes"].first["parameters"]["category_ids"]).to eq(["12"])
+  end
+end

--- a/plugins/discourse-workflows/spec/db/post_migrate/remove_workflow_trigger_category_id_from_trigger_nodes_spec.rb
+++ b/plugins/discourse-workflows/spec/db/post_migrate/remove_workflow_trigger_category_id_from_trigger_nodes_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require Rails.root.join(
+          "plugins/discourse-workflows/db/post_migrate/20260722140539_remove_workflow_trigger_category_id_from_trigger_nodes",
+        )
+
+RSpec.describe RemoveWorkflowTriggerCategoryIdFromTriggerNodes do
+  subject(:migration) { described_class.new }
+
+  fab!(:workflow, :discourse_workflows_workflow)
+
+  around { |example| ActiveRecord::Migration.suppress_messages { example.run } }
+
+  def build_node(type:, parameters:, id: "node-1")
+    { "id" => id, "type" => type, "parameters" => parameters }
+  end
+
+  def set_workflow_nodes(nodes)
+    workflow.update_columns(nodes: nodes)
+  end
+
+  def workflow_nodes
+    workflow.reload.nodes
+  end
+
+  it "strips category_id from already-copied trigger nodes" do
+    set_workflow_nodes(
+      [
+        build_node(
+          type: "trigger:topic_created",
+          parameters: {
+            "category_id" => "12",
+            "category_ids" => ["12"],
+          },
+        ),
+      ],
+    )
+
+    migration.up
+
+    parameters = workflow_nodes.first["parameters"]
+    expect(parameters).not_to have_key("category_id")
+    expect(parameters["category_ids"]).to eq(["12"])
+  end
+
+  it "copies then strips rows written by pre-rename code" do
+    set_workflow_nodes(
+      [build_node(type: "trigger:topic_closed", parameters: { "category_id" => "12" })],
+    )
+
+    migration.up
+
+    parameters = workflow_nodes.first["parameters"]
+    expect(parameters).not_to have_key("category_id")
+    expect(parameters["category_ids"]).to eq(["12"])
+    expect(parameters).not_to have_key("include_subcategories")
+  end
+
+  it "copies over an explicit null category_ids before stripping" do
+    set_workflow_nodes(
+      [
+        build_node(
+          type: "trigger:topic_created",
+          parameters: {
+            "category_id" => "12",
+            "category_ids" => nil,
+          },
+        ),
+      ],
+    )
+
+    migration.up
+
+    parameters = workflow_nodes.first["parameters"]
+    expect(parameters).not_to have_key("category_id")
+    expect(parameters["category_ids"]).to eq(["12"])
+  end
+
+  it "drops a blank category_id without adding category_ids" do
+    set_workflow_nodes(
+      [build_node(type: "trigger:topic_created", parameters: { "category_id" => "" })],
+    )
+
+    migration.up
+
+    parameters = workflow_nodes.first["parameters"]
+    expect(parameters).not_to have_key("category_id")
+    expect(parameters).not_to have_key("category_ids")
+  end
+
+  it "leaves non-trigger nodes untouched" do
+    nodes = [build_node(type: "action:topic", parameters: { "category_id" => "5" })]
+    set_workflow_nodes(nodes)
+
+    migration.up
+
+    expect(workflow_nodes).to eq(nodes)
+  end
+
+  it "strips the legacy key from version, execution, and webhook snapshots" do
+    node =
+      build_node(
+        type: "trigger:topic_created",
+        parameters: {
+          "category_id" => "12",
+          "category_ids" => ["12"],
+        },
+      )
+    DiscourseWorkflows::WorkflowVersion.where(workflow_id: workflow.id).update_all(nodes: [node])
+    execution_data = Fabricate(:discourse_workflows_execution_data)
+    execution_data.update_columns(workflow_data: { "nodes" => [node] })
+    DB.exec(<<~SQL, workflow_id: workflow.id, snapshot: { "nodes" => [node] }.to_json)
+      INSERT INTO discourse_workflows_webhooks
+        (workflow_id, node_name, webhook_path, http_method, workflow_snapshot)
+      VALUES (:workflow_id, 'Webhook', '/spec-webhook', 'POST', :snapshot::jsonb)
+    SQL
+
+    migration.up
+
+    version_parameters =
+      DiscourseWorkflows::WorkflowVersion.find_by(workflow_id: workflow.id).nodes.first[
+        "parameters"
+      ]
+    expect(version_parameters).not_to have_key("category_id")
+
+    execution_parameters = execution_data.reload.workflow_data["nodes"].first["parameters"]
+    expect(execution_parameters).not_to have_key("category_id")
+
+    webhook_snapshot =
+      DB.query_single(
+        "SELECT workflow_snapshot FROM discourse_workflows_webhooks WHERE workflow_id = :workflow_id",
+        workflow_id: workflow.id,
+      ).first
+    expect(webhook_snapshot["nodes"].first["parameters"]).not_to have_key("category_id")
+  end
+end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/event_listener_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/event_listener_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "matching-trigger",
       "trigger:topic_closed",
       configuration: {
-        "category_id" => category.id.to_s,
+        "category_ids" => [category.id.to_s],
         "tag_names" => [tag.name],
       },
     )
@@ -60,7 +60,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "category-mismatch",
       "trigger:topic_closed",
       configuration: {
-        "category_id" => other_category.id.to_s,
+        "category_ids" => [other_category.id.to_s],
       },
     )
     create_published_workflow(
@@ -84,7 +84,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "matching-trigger",
       "trigger:topic_created",
       configuration: {
-        "category_id" => category.id.to_s,
+        "category_ids" => [category.id.to_s],
         "tag_names" => [tag.name],
       },
     )
@@ -92,7 +92,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "category-mismatch",
       "trigger:topic_created",
       configuration: {
-        "category_id" => other_category.id.to_s,
+        "category_ids" => [other_category.id.to_s],
       },
     )
     create_published_workflow(
@@ -115,7 +115,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "matching-trigger",
       "trigger:post_created",
       configuration: {
-        "category_id" => category.id.to_s,
+        "category_ids" => [category.id.to_s],
         "tag_names" => [tag.name],
       },
     )
@@ -123,7 +123,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "category-mismatch",
       "trigger:post_created",
       configuration: {
-        "category_id" => other_category.id.to_s,
+        "category_ids" => [other_category.id.to_s],
       },
     )
     create_published_workflow(
@@ -147,7 +147,7 @@ RSpec.describe DiscourseWorkflows::EventListener do
       "matching-trigger",
       "trigger:post_edited",
       configuration: {
-        "category_id" => category.id.to_s,
+        "category_ids" => [category.id.to_s],
         "tag_names" => [tag.name],
         "trust_levels" => ["1"],
       },

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
@@ -284,6 +284,120 @@ RSpec.describe DiscourseWorkflows::NodeType do
     end
   end
 
+  describe ".normalize_category_ids" do
+    it "coerces scalars, arrays, and mixed values to unique integer ids" do
+      expect(described_class.normalize_category_ids(nil)).to eq([])
+      expect(described_class.normalize_category_ids("")).to eq([])
+      expect(described_class.normalize_category_ids([])).to eq([])
+      expect(described_class.normalize_category_ids("12")).to eq([12])
+      expect(described_class.normalize_category_ids(12)).to eq([12])
+      expect(described_class.normalize_category_ids(["12", 3, " 12 "])).to eq([12, 3])
+      expect(described_class.normalize_category_ids([nil, ""])).to eq([])
+    end
+
+    it "coerces unresolved expression strings to a non-matching id" do
+      expect(described_class.normalize_category_ids(["=$json.category_id"])).to eq([0])
+    end
+  end
+
+  describe ".category_ids_parameter" do
+    def trigger_context(parameters)
+      DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+    end
+
+    it "reads category_ids when present" do
+      expect(
+        described_class.category_ids_parameter(trigger_context("category_ids" => %w[1 2])),
+      ).to eq([1, 2])
+    end
+
+    it "falls back to the legacy category_id parameter" do
+      expect(
+        described_class.category_ids_parameter(trigger_context("category_id" => "3")),
+      ).to eq([3])
+    end
+
+    it "prefers category_ids over a stale category_id" do
+      expect(
+        described_class.category_ids_parameter(
+          trigger_context("category_ids" => ["1"], "category_id" => "3"),
+        ),
+      ).to eq([1])
+    end
+
+    it "returns an empty list when neither parameter is set" do
+      expect(described_class.category_ids_parameter(trigger_context({}))).to eq([])
+    end
+  end
+
+  describe ".matches_category_ids?" do
+    fab!(:parent_category, :category)
+    fab!(:subcategory) { Fabricate(:category, parent_category: parent_category) }
+    fab!(:other_category, :category)
+
+    it "matches everything when no categories are configured" do
+      expect(described_class.matches_category_ids?(subcategory.id, [])).to eq(true)
+      expect(described_class.matches_category_ids?(nil, [])).to eq(true)
+    end
+
+    it "expands subcategories by default" do
+      expect(
+        described_class.matches_category_ids?(subcategory.id, [parent_category.id]),
+      ).to eq(true)
+      expect(
+        described_class.matches_category_ids?(subcategory.id, [other_category.id]),
+      ).to eq(false)
+    end
+
+    it "matches exactly when include_subcategories is false" do
+      expect(
+        described_class.matches_category_ids?(
+          subcategory.id,
+          [parent_category.id],
+          include_subcategories: false,
+        ),
+      ).to eq(false)
+      expect(
+        described_class.matches_category_ids?(
+          parent_category.id,
+          [parent_category.id],
+          include_subcategories: false,
+        ),
+      ).to eq(true)
+    end
+
+    it "expands subcategories when include_subcategories is nil" do
+      expect(
+        described_class.matches_category_ids?(
+          subcategory.id,
+          [parent_category.id],
+          include_subcategories: nil,
+        ),
+      ).to eq(true)
+    end
+
+    it "matches against the union of all configured categories" do
+      expect(
+        described_class.matches_category_ids?(
+          subcategory.id,
+          [other_category.id, parent_category.id],
+        ),
+      ).to eq(true)
+    end
+  end
+
+  describe ".expand_subcategory_ids" do
+    fab!(:parent_category, :category)
+    fab!(:subcategory) { Fabricate(:category, parent_category: parent_category) }
+    fab!(:other_category, :category)
+
+    it "returns the union of each category's subtree" do
+      expect(
+        described_class.expand_subcategory_ids([parent_category.id, other_category.id]),
+      ).to contain_exactly(parent_category.id, subcategory.id, other_category.id)
+    end
+  end
+
   describe "#with_paired_item" do
     it "adds normalized paired item metadata to an item" do
       node = described_class.new

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/node_type_spec.rb
@@ -312,9 +312,9 @@ RSpec.describe DiscourseWorkflows::NodeType do
     end
 
     it "falls back to the legacy category_id parameter" do
-      expect(
-        described_class.category_ids_parameter(trigger_context("category_id" => "3")),
-      ).to eq([3])
+      expect(described_class.category_ids_parameter(trigger_context("category_id" => "3"))).to eq(
+        [3],
+      )
     end
 
     it "prefers category_ids over a stale category_id" do
@@ -341,12 +341,12 @@ RSpec.describe DiscourseWorkflows::NodeType do
     end
 
     it "expands subcategories by default" do
-      expect(
-        described_class.matches_category_ids?(subcategory.id, [parent_category.id]),
-      ).to eq(true)
-      expect(
-        described_class.matches_category_ids?(subcategory.id, [other_category.id]),
-      ).to eq(false)
+      expect(described_class.matches_category_ids?(subcategory.id, [parent_category.id])).to eq(
+        true,
+      )
+      expect(described_class.matches_category_ids?(subcategory.id, [other_category.id])).to eq(
+        false,
+      )
     end
 
     it "matches exactly when include_subcategories is false" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_created_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_created_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
     it "matches posts in subcategories by default" do
       expect(
         described_class.new(subcategory_post).matches?(
-          trigger_context("category_id" => topic.category_id.to_s),
+          trigger_context("category_ids" => [topic.category_id.to_s]),
         ),
       ).to eq(true)
     end
@@ -109,7 +109,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
       expect(
         described_class.new(subcategory_post).matches?(
           trigger_context(
-            "category_id" => topic.category_id.to_s,
+            "category_ids" => [topic.category_id.to_s],
             "include_subcategories" => false,
           ),
         ),
@@ -120,9 +120,27 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
       expect(
         described_class.new(reply).matches?(
           trigger_context(
-            "category_id" => topic.category_id.to_s,
+            "category_ids" => [topic.category_id.to_s],
             "include_subcategories" => false,
           ),
+        ),
+      ).to eq(true)
+    end
+
+    it "matches posts in any of the configured categories" do
+      expect(
+        described_class.new(reply).matches?(
+          trigger_context(
+            "category_ids" => [Fabricate(:category).id.to_s, topic.category_id.to_s],
+          ),
+        ),
+      ).to eq(true)
+    end
+
+    it "supports the legacy scalar category_id parameter" do
+      expect(
+        described_class.new(reply).matches?(
+          trigger_context("category_id" => topic.category_id.to_s),
         ),
       ).to eq(true)
     end
@@ -150,7 +168,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
 
       expect(
         trigger.matches?(
-          trigger_context("category_id" => topic.category_id.to_s, "tag_names" => [tag.name]),
+          trigger_context("category_ids" => [topic.category_id.to_s], "tag_names" => [tag.name]),
         ),
       ).to eq(true)
     end
@@ -159,7 +177,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
       other_category = Fabricate(:category)
       trigger = described_class.new(reply)
 
-      expect(trigger.matches?(trigger_context("category_id" => other_category.id.to_s))).to eq(
+      expect(trigger.matches?(trigger_context("category_ids" => [other_category.id.to_s]))).to eq(
         false,
       )
       expect(trigger.matches?(trigger_context("tag_names" => ["missing"]))).to eq(false)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_created_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_created_spec.rb
@@ -130,9 +130,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
     it "matches posts in any of the configured categories" do
       expect(
         described_class.new(reply).matches?(
-          trigger_context(
-            "category_ids" => [Fabricate(:category).id.to_s, topic.category_id.to_s],
-          ),
+          trigger_context("category_ids" => [Fabricate(:category).id.to_s, topic.category_id.to_s]),
         ),
       ).to eq(true)
     end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_edited/v1_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_edited/v1_spec.rb
@@ -89,12 +89,46 @@ RSpec.describe DiscourseWorkflows::Nodes::PostEdited::V1 do
       expect(reply_trigger.matches?(trigger_context("post_scope" => "replies"))).to eq(true)
     end
 
-    it "matches the configured category including parent categories" do
+    it "matches the configured category including subcategories by default" do
       trigger = described_class.new(first_post, "<p>Cooked</p>")
 
-      expect(trigger.matches?(trigger_context("category_id" => parent_category.id.to_s))).to eq(
+      expect(trigger.matches?(trigger_context("category_ids" => [parent_category.id.to_s]))).to eq(
         true,
       )
+      expect(trigger.matches?(trigger_context("category_ids" => [category.id.to_s]))).to eq(true)
+    end
+
+    it "does not match parent-category selections when subcategories are excluded" do
+      trigger = described_class.new(first_post, "<p>Cooked</p>")
+
+      expect(
+        trigger.matches?(
+          trigger_context(
+            "category_ids" => [parent_category.id.to_s],
+            "include_subcategories" => false,
+          ),
+        ),
+      ).to eq(false)
+      expect(
+        trigger.matches?(
+          trigger_context("category_ids" => [category.id.to_s], "include_subcategories" => false),
+        ),
+      ).to eq(true)
+    end
+
+    it "matches any of the configured categories" do
+      trigger = described_class.new(first_post, "<p>Cooked</p>")
+
+      expect(
+        trigger.matches?(
+          trigger_context("category_ids" => [Fabricate(:category).id.to_s, category.id.to_s]),
+        ),
+      ).to eq(true)
+    end
+
+    it "supports the legacy scalar category_id parameter" do
+      trigger = described_class.new(first_post, "<p>Cooked</p>")
+
       expect(trigger.matches?(trigger_context("category_id" => category.id.to_s))).to eq(true)
     end
 
@@ -110,7 +144,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostEdited::V1 do
       other_category = Fabricate(:category)
       trigger = described_class.new(first_post, "<p>Cooked</p>")
 
-      expect(trigger.matches?(trigger_context("category_id" => other_category.id.to_s))).to eq(
+      expect(trigger.matches?(trigger_context("category_ids" => [other_category.id.to_s]))).to eq(
         false,
       )
       expect(trigger.matches?(trigger_context("tag_names" => ["missing"]))).to eq(false)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_moved_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_moved_spec.rb
@@ -75,16 +75,67 @@ RSpec.describe DiscourseWorkflows::Nodes::PostMoved::V1 do
 
       expect(
         trigger.matches?(
-          trigger_context("category_id" => destination_category.id.to_s, "tag_names" => [tag.name]),
+          trigger_context(
+            "category_ids" => [destination_category.id.to_s],
+            "tag_names" => [tag.name],
+          ),
         ),
       ).to eq(true)
+    end
+
+    it "matches any of the configured destination categories" do
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(
+        trigger.matches?(
+          trigger_context(
+            "category_ids" => [Fabricate(:category).id.to_s, destination_category.id.to_s],
+          ),
+        ),
+      ).to eq(true)
+    end
+
+    it "matches destination subcategories by default but not when excluded" do
+      parent_category = Fabricate(:category)
+      destination_category.update!(parent_category: parent_category)
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(trigger.matches?(trigger_context("category_ids" => [parent_category.id.to_s]))).to eq(
+        true,
+      )
+      expect(
+        trigger.matches?(
+          trigger_context(
+            "category_ids" => [parent_category.id.to_s],
+            "include_subcategories" => false,
+          ),
+        ),
+      ).to eq(false)
+    end
+
+    it "supports the legacy scalar category_id parameter" do
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(
+        trigger.matches?(trigger_context("category_id" => destination_category.id.to_s)),
+      ).to eq(true)
+    end
+
+    it "matches subcategories by default for legacy category_id-only nodes" do
+      parent_category = Fabricate(:category)
+      destination_category.update!(parent_category: parent_category)
+      trigger = described_class.new(moved_post, source_topic.id)
+
+      expect(trigger.matches?(trigger_context("category_id" => parent_category.id.to_s))).to eq(
+        true,
+      )
     end
 
     it "returns false when the destination topic does not match category or tags" do
       other_category = Fabricate(:category)
       trigger = described_class.new(moved_post, source_topic.id)
 
-      expect(trigger.matches?(trigger_context("category_id" => other_category.id.to_s))).to eq(
+      expect(trigger.matches?(trigger_context("category_ids" => [other_category.id.to_s]))).to eq(
         false,
       )
       expect(trigger.matches?(trigger_context("tag_names" => ["missing"]))).to eq(false)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/stale_topic_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/stale_topic_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DiscourseWorkflows::Nodes::StaleTopic::V1 do
           "type" => "trigger:stale_topic",
           "parameters" => {
             "hours" => 24,
-            "category_id" => category.id.to_s,
+            "category_ids" => [category.id.to_s],
           },
         }
       end
@@ -84,6 +84,32 @@ RSpec.describe DiscourseWorkflows::Nodes::StaleTopic::V1 do
 
         topic_ids = items.map { |item| item[:topic][:id] }
         expect(topic_ids).to contain_exactly(stale_topic_in_category.id)
+      end
+
+      it "returns topics across all configured categories and their subcategories" do
+        trigger_node["parameters"]["category_ids"] = [category.id.to_s, other_category.id.to_s]
+
+        items = described_class.trigger_data_for(trigger_context)
+
+        topic_ids = items.map { |item| item[:topic][:id] }
+        expect(topic_ids).to contain_exactly(
+          stale_topic_in_category.id,
+          stale_topic_in_subcategory.id,
+          stale_topic_in_other_category.id,
+        )
+      end
+
+      it "supports the legacy scalar category_id parameter" do
+        trigger_node["parameters"].delete("category_ids")
+        trigger_node["parameters"]["category_id"] = category.id.to_s
+
+        items = described_class.trigger_data_for(trigger_context)
+
+        topic_ids = items.map { |item| item[:topic][:id] }
+        expect(topic_ids).to contain_exactly(
+          stale_topic_in_category.id,
+          stale_topic_in_subcategory.id,
+        )
       end
     end
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_closed_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_closed_spec.rb
@@ -35,4 +35,66 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicClosed::V1 do
       expect(output[:topic][:tags].map { |topic_tag| topic_tag[:name] }).to eq(["test-tag"])
     end
   end
+
+  describe "#matches?" do
+    it "returns true when no category is configured" do
+      trigger = described_class.new(topic, "closed", true)
+
+      expect(trigger.matches?(trigger_context({}))).to eq(true)
+      expect(trigger.matches?(trigger_context("category_ids" => []))).to eq(true)
+    end
+
+    it "matches topics in any of the configured categories" do
+      trigger = described_class.new(topic, "closed", true)
+
+      expect(
+        trigger.matches?(
+          trigger_context("category_ids" => [Fabricate(:category).id.to_s, topic.category_id.to_s]),
+        ),
+      ).to eq(true)
+      expect(
+        trigger.matches?(trigger_context("category_ids" => [Fabricate(:category).id.to_s])),
+      ).to eq(false)
+    end
+
+    it "matches subcategories by default but not when excluded" do
+      subcategory = Fabricate(:category, parent_category: topic.category)
+      subcategory_topic = Fabricate(:topic, category: subcategory)
+      trigger = described_class.new(subcategory_topic, "closed", true)
+
+      expect(trigger.matches?(trigger_context("category_ids" => [topic.category_id.to_s]))).to eq(
+        true,
+      )
+      expect(
+        trigger.matches?(
+          trigger_context(
+            "category_ids" => [topic.category_id.to_s],
+            "include_subcategories" => false,
+          ),
+        ),
+      ).to eq(false)
+    end
+
+    it "supports the legacy scalar category_id parameter" do
+      trigger = described_class.new(topic, "closed", true)
+
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
+        true,
+      )
+    end
+
+    it "matches subcategories by default for legacy category_id-only nodes" do
+      subcategory = Fabricate(:category, parent_category: topic.category)
+      subcategory_topic = Fabricate(:topic, category: subcategory)
+      trigger = described_class.new(subcategory_topic, "closed", true)
+
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
+        true,
+      )
+    end
+  end
+
+  def trigger_context(parameters)
+    DiscourseWorkflows::TriggerNodeContext.new({ "parameters" => parameters })
+  end
 end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_closed_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_closed_spec.rb
@@ -78,9 +78,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicClosed::V1 do
     it "supports the legacy scalar category_id parameter" do
       trigger = described_class.new(topic, "closed", true)
 
-      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
-        true,
-      )
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(true)
     end
 
     it "matches subcategories by default for legacy category_id-only nodes" do
@@ -88,9 +86,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicClosed::V1 do
       subcategory_topic = Fabricate(:topic, category: subcategory)
       trigger = described_class.new(subcategory_topic, "closed", true)
 
-      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
-        true,
-      )
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(true)
     end
   end
 

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_created_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_created_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicCreated::V1 do
     it "matches topics in subcategories by default" do
       expect(
         described_class.new(subcategory_topic).matches?(
-          trigger_context("category_id" => topic.category_id.to_s),
+          trigger_context("category_ids" => [topic.category_id.to_s]),
         ),
       ).to eq(true)
     end
@@ -77,7 +77,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicCreated::V1 do
       expect(
         described_class.new(subcategory_topic).matches?(
           trigger_context(
-            "category_id" => topic.category_id.to_s,
+            "category_ids" => [topic.category_id.to_s],
             "include_subcategories" => false,
           ),
         ),
@@ -88,11 +88,77 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicCreated::V1 do
       expect(
         described_class.new(topic).matches?(
           trigger_context(
-            "category_id" => topic.category_id.to_s,
+            "category_ids" => [topic.category_id.to_s],
             "include_subcategories" => false,
           ),
         ),
       ).to eq(true)
+    end
+
+    it "matches topics in any of the configured categories" do
+      other_category = Fabricate(:category)
+
+      expect(
+        described_class.new(topic).matches?(
+          trigger_context("category_ids" => [other_category.id.to_s, topic.category_id.to_s]),
+        ),
+      ).to eq(true)
+    end
+
+    it "does not match topics outside the configured categories" do
+      expect(
+        described_class.new(topic).matches?(
+          trigger_context("category_ids" => [Fabricate(:category).id.to_s]),
+        ),
+      ).to eq(false)
+    end
+
+    it "matches all categories when the configured list is empty" do
+      expect(described_class.new(topic).matches?(trigger_context("category_ids" => []))).to eq(
+        true,
+      )
+    end
+
+    it "expands subcategories for every configured category" do
+      other_parent = Fabricate(:category)
+      other_subcategory = Fabricate(:category, parent_category: other_parent)
+      other_subcategory_topic = Fabricate(:topic, category: other_subcategory, user: user)
+
+      parameters =
+        trigger_context("category_ids" => [topic.category_id.to_s, other_parent.id.to_s])
+
+      expect(described_class.new(subcategory_topic).matches?(parameters)).to eq(true)
+      expect(described_class.new(other_subcategory_topic).matches?(parameters)).to eq(true)
+    end
+
+    it "supports the legacy scalar category_id parameter" do
+      expect(
+        described_class.new(topic).matches?(
+          trigger_context("category_id" => topic.category_id.to_s),
+        ),
+      ).to eq(true)
+      expect(
+        described_class.new(topic).matches?(
+          trigger_context("category_id" => Fabricate(:category).id.to_s),
+        ),
+      ).to eq(false)
+    end
+
+    it "prefers category_ids over a stale category_id parameter" do
+      expect(
+        described_class.new(topic).matches?(
+          trigger_context(
+            "category_ids" => [Fabricate(:category).id.to_s],
+            "category_id" => topic.category_id.to_s,
+          ),
+        ),
+      ).to eq(false)
+    end
+
+    it "does not match when the configured value is an unresolved expression" do
+      expect(
+        described_class.new(topic).matches?(trigger_context("category_ids" => ["=$json.x"])),
+      ).to eq(false)
     end
 
     it "matches only topics when topic type is blank" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_created_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_created_spec.rb
@@ -114,9 +114,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicCreated::V1 do
     end
 
     it "matches all categories when the configured list is empty" do
-      expect(described_class.new(topic).matches?(trigger_context("category_ids" => []))).to eq(
-        true,
-      )
+      expect(described_class.new(topic).matches?(trigger_context("category_ids" => []))).to eq(true)
     end
 
     it "expands subcategories for every configured category" do
@@ -124,8 +122,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicCreated::V1 do
       other_subcategory = Fabricate(:category, parent_category: other_parent)
       other_subcategory_topic = Fabricate(:topic, category: other_subcategory, user: user)
 
-      parameters =
-        trigger_context("category_ids" => [topic.category_id.to_s, other_parent.id.to_s])
+      parameters = trigger_context("category_ids" => [topic.category_id.to_s, other_parent.id.to_s])
 
       expect(described_class.new(subcategory_topic).matches?(parameters)).to eq(true)
       expect(described_class.new(other_subcategory_topic).matches?(parameters)).to eq(true)

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_tag_changed_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_tag_changed_spec.rb
@@ -111,9 +111,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicTagChanged::V1 do
     it "supports the legacy scalar category_id parameter" do
       trigger = described_class.new(topic, old_tag_names: ["bug"], new_tag_names: %w[bug urgent])
 
-      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
-        true,
-      )
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(true)
     end
 
     it "matches subcategories by default for legacy category_id-only nodes" do
@@ -122,9 +120,7 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicTagChanged::V1 do
       trigger =
         described_class.new(subcategory_topic, old_tag_names: ["bug"], new_tag_names: %w[urgent])
 
-      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
-        true,
-      )
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(true)
     end
 
     it "returns false when the category parameter does not match the topic category" do

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_tag_changed_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/topic_tag_changed_spec.rb
@@ -74,14 +74,64 @@ RSpec.describe DiscourseWorkflows::Nodes::TopicTagChanged::V1 do
     it "returns true when the category parameter matches the topic category" do
       trigger = described_class.new(topic, old_tag_names: ["bug"], new_tag_names: %w[bug urgent])
 
-      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(true)
+      expect(trigger.matches?(trigger_context("category_ids" => [topic.category_id.to_s]))).to eq(
+        true,
+      )
+    end
+
+    it "matches topics in any of the configured categories" do
+      trigger = described_class.new(topic, old_tag_names: ["bug"], new_tag_names: %w[bug urgent])
+
+      expect(
+        trigger.matches?(
+          trigger_context("category_ids" => [Fabricate(:category).id.to_s, topic.category_id.to_s]),
+        ),
+      ).to eq(true)
+    end
+
+    it "matches subcategories by default but not when excluded" do
+      subcategory = Fabricate(:category, parent_category: topic.category)
+      subcategory_topic = Fabricate(:topic, category: subcategory)
+      trigger =
+        described_class.new(subcategory_topic, old_tag_names: ["bug"], new_tag_names: %w[urgent])
+
+      expect(trigger.matches?(trigger_context("category_ids" => [topic.category_id.to_s]))).to eq(
+        true,
+      )
+      expect(
+        trigger.matches?(
+          trigger_context(
+            "category_ids" => [topic.category_id.to_s],
+            "include_subcategories" => false,
+          ),
+        ),
+      ).to eq(false)
+    end
+
+    it "supports the legacy scalar category_id parameter" do
+      trigger = described_class.new(topic, old_tag_names: ["bug"], new_tag_names: %w[bug urgent])
+
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
+        true,
+      )
+    end
+
+    it "matches subcategories by default for legacy category_id-only nodes" do
+      subcategory = Fabricate(:category, parent_category: topic.category)
+      subcategory_topic = Fabricate(:topic, category: subcategory)
+      trigger =
+        described_class.new(subcategory_topic, old_tag_names: ["bug"], new_tag_names: %w[urgent])
+
+      expect(trigger.matches?(trigger_context("category_id" => topic.category_id.to_s))).to eq(
+        true,
+      )
     end
 
     it "returns false when the category parameter does not match the topic category" do
       other_category = Fabricate(:category)
       trigger = described_class.new(topic, old_tag_names: ["bug"], new_tag_names: %w[bug urgent])
 
-      expect(trigger.matches?(trigger_context("category_id" => other_category.id.to_s))).to eq(
+      expect(trigger.matches?(trigger_context("category_ids" => [other_category.id.to_s]))).to eq(
         false,
       )
     end

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/category-control-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/category-control-test.gjs
@@ -1,0 +1,129 @@
+import { tracked } from "@glimmer/tracking";
+import { render, waitFor } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import Category from "discourse/models/category";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+import CategoryControl from "discourse/plugins/discourse-workflows/admin/components/workflows/configurators/category-control";
+
+class TestField {
+  @tracked value;
+
+  constructor(value) {
+    this.value = value;
+  }
+
+  set(newValue) {
+    this.value = newValue;
+  }
+}
+
+function regularCategories() {
+  return Category.list().filter(
+    (category) => !category.isUncategorizedCategory
+  );
+}
+
+module(
+  "Integration | Component | Workflows | CategoryControl",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("stores one category id string by default", async function (assert) {
+      this.field = new TestField("");
+
+      await render(
+        <template>
+          <CategoryControl
+            @field={{this.field}}
+            @supportsExpression={{false}}
+          />
+        </template>
+      );
+
+      const category = regularCategories()[0];
+      const chooser = selectKit(".category-chooser");
+      await chooser.expand();
+      await chooser.selectRowByValue(category.id);
+
+      assert.strictEqual(this.field.value, String(category.id));
+    });
+
+    test("stores an array of category ids when configured as multiple", async function (assert) {
+      this.field = new TestField([]);
+      this.schema = { type: "array", ui: { multiple: true } };
+
+      await render(
+        <template>
+          <CategoryControl
+            @field={{this.field}}
+            @schema={{this.schema}}
+            @supportsExpression={{false}}
+          />
+        </template>
+      );
+
+      const [first, second] = regularCategories();
+      const selector = selectKit(".category-selector");
+
+      await selector.expand();
+      await selector.selectRowByValue(first.id);
+
+      assert.deepEqual(this.field.value, [first.id]);
+
+      await selector.selectRowByValue(second.id);
+
+      assert.deepEqual(this.field.value, [first.id, second.id]);
+    });
+
+    test("hydrates selected categories from stored ids", async function (assert) {
+      const category = regularCategories()[0];
+      this.field = new TestField([category.id]);
+      this.schema = { type: "array", ui: { multiple: true } };
+
+      await render(
+        <template>
+          <CategoryControl
+            @field={{this.field}}
+            @schema={{this.schema}}
+            @supportsExpression={{false}}
+          />
+        </template>
+      );
+
+      await waitFor(
+        `.category-selector .select-kit-header[data-value='${category.id}']`
+      );
+
+      assert.strictEqual(
+        selectKit(".category-selector").header().value(),
+        String(category.id)
+      );
+    });
+
+    test("ignores non-numeric stored entries when hydrating", async function (assert) {
+      const category = regularCategories()[0];
+      this.field = new TestField(["=$json.category_ids", category.id]);
+      this.schema = { type: "array", ui: { multiple: true } };
+
+      await render(
+        <template>
+          <CategoryControl
+            @field={{this.field}}
+            @schema={{this.schema}}
+            @supportsExpression={{false}}
+          />
+        </template>
+      );
+
+      await waitFor(
+        `.category-selector .select-kit-header[data-value='${category.id}']`
+      );
+
+      assert.strictEqual(
+        selectKit(".category-selector").header().value(),
+        String(category.id)
+      );
+    });
+  }
+);

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/property-engine-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/property-engine-test.gjs
@@ -161,14 +161,18 @@ module("Integration | Component | workflows property engine", function (hooks) {
   test("renders checkbox controls from metadata", async function (assert) {
     this.setProperties({
       configuration: {
-        category_id: 1,
+        category_ids: [1],
         include_subcategories: true,
       },
       formApi: null,
       nodeType: "trigger:topic_created",
       schema: {
-        category_id: {
-          type: "integer",
+        category_ids: {
+          type: "array",
+          ui: {
+            control: "category",
+            multiple: true,
+          },
         },
         include_subcategories: {
           type: "boolean",
@@ -177,7 +181,7 @@ module("Integration | Component | workflows property engine", function (hooks) {
           },
           display_options: {
             show: {
-              category_id: [{ condition: { exists: true } }],
+              category_ids: [{ condition: { exists: true } }],
             },
           },
         },
@@ -211,6 +215,53 @@ module("Integration | Component | workflows property engine", function (hooks) {
     await click("input[type='checkbox']");
 
     assert.false(this.formApi.get("include_subcategories"));
+  });
+
+  test("hides fields conditioned on a category list when it is empty", async function (assert) {
+    this.setProperties({
+      configuration: {
+        category_ids: [],
+        include_subcategories: true,
+      },
+      nodeType: "trigger:topic_created",
+      schema: {
+        category_ids: {
+          type: "array",
+          ui: {
+            control: "category",
+            multiple: true,
+          },
+        },
+        include_subcategories: {
+          type: "boolean",
+          ui: {
+            control: "checkbox",
+          },
+          display_options: {
+            show: {
+              category_ids: [{ condition: { exists: true } }],
+            },
+          },
+        },
+      },
+    });
+
+    await render(
+      <template>
+        <Form @data={{this.configuration}} as |form transientData|>
+          <PropertyEngineConfigurator
+            @form={{form}}
+            @configuration={{transientData}}
+            @nodeType={{this.nodeType}}
+            @schema={{this.schema}}
+            @session={{this.session}}
+          />
+        </Form>
+      </template>
+    );
+
+    assert.dom(".category-selector").exists();
+    assert.dom("input[type='checkbox']").doesNotExist();
   });
 
   test("renders user seen trigger options as a compact condition group", async function (assert) {

--- a/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
+++ b/plugins/discourse-workflows/test/javascripts/unit/lib/workflows-property-engine-test.js
@@ -67,6 +67,35 @@ module("Unit | Utility | workflows property engine", function () {
     );
   });
 
+  test("falls back to the shared property_engine.fields scope", function (assert) {
+    assert.strictEqual(
+      propertyLabel("trigger:topic_created", "category_ids"),
+      "Categories"
+    );
+    assert.strictEqual(
+      propertyDescription("trigger:topic_created", "category_ids"),
+      "Only trigger for topics in these categories. Leave empty to match all categories."
+    );
+    assert.strictEqual(
+      propertyPlaceholder("trigger:topic_closed", "category_ids"),
+      "All categories"
+    );
+    assert.strictEqual(
+      propertyLabel("trigger:topic_tag_changed", "include_subcategories"),
+      "Include subcategories"
+    );
+
+    // node-scoped keys win over the shared scope
+    assert.strictEqual(
+      propertyLabel("trigger:post_moved", "category_ids"),
+      "Destination categories"
+    );
+    assert.strictEqual(
+      propertyDescription("trigger:stale_topic", "category_ids"),
+      "Only consider topics in these categories. Leave empty to match all categories."
+    );
+  });
+
   test("resolves dynamic value hints for expression fields", function (assert) {
     assert.strictEqual(
       propertyDynamicValueHint("action:topic", "category_id", {


### PR DESCRIPTION
This should avoid having to define too many triggers or build complex workflows for simple cases. 

This commit also adds a way to define a top level key so we don't have to repeat the same translations for identical fields in different nodes.

Finally include subcategories has been applied to all the category fields and defaults to true.