### PR TITLE
SECURITY: Enforce recipient PM allowlists for existing direct chat channels

### DIFF
--- a/plugins/chat/lib/chat/guardian_extensions.rb
+++ b/plugins/chat/lib/chat/guardian_extensions.rb
@@ -63,7 +63,9 @@ module Chat
       return true if is_staff?
       return false if !target.user_option.allow_private_messages
 
-      !is_ignored_by_user?(target) && !is_muted_by_user?(target) && !target.suspended?
+      user_comm_screener = UserCommScreener.new(acting_user: @user, target_user_ids: target.id)
+
+      !user_comm_screener.disallowing_pms_from_actor?(target.id) && !target.suspended?
     end
 
     def hidden_tag_names

--- a/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
+++ b/plugins/chat/spec/lib/chat/guardian_extensions_spec.rb
@@ -999,6 +999,19 @@ RSpec.describe Chat::GuardianExtensions do
       end
     end
 
+    context "when target user only allows private messages from other users" do
+      fab!(:allowed_user, :user)
+
+      before do
+        other_user.user_option.update!(enable_allowed_pm_users: true)
+        AllowedPmUser.create!(user: other_user, allowed_pm_user: allowed_user)
+      end
+
+      it "returns false" do
+        expect(guardian).not_to be_able_to_receive_direct_message(other_user)
+      end
+    end
+
     context "when target user is suspended" do
       before do
         UserSuspender.new(

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -189,6 +189,43 @@ RSpec.describe Chat::Api::ChannelMessagesController do
 
     before { sign_in(current_user) }
 
+    context "when a recipient limits direct messages to specific users" do
+      fab!(:recipient, :user)
+      fab!(:allowed_user, :user)
+      fab!(:channel) { Fabricate(:direct_message_channel, users: [current_user, recipient]) }
+
+      before { SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone] }
+
+      it "does not let an excluded existing participant send another message" do
+        expect { post "/chat/#{channel.id}.json", params: params }.to change {
+          channel.chat_messages.count
+        }.by(1)
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["message_id"]).to eq(channel.chat_messages.last.id)
+
+        sign_in(recipient)
+        put "/u/#{recipient.username}.json",
+            params: {
+              enable_allowed_pm_users: true,
+              allowed_pm_usernames: allowed_user.username,
+            }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig("user", "id")).to eq(recipient.id)
+        expect(AllowedPmUser.exists?(user: recipient, allowed_pm_user: allowed_user)).to eq(true)
+
+        sign_in(current_user)
+        expect {
+          post "/chat/#{channel.id}.json", params: params.merge(message: "excluded message")
+        }.not_to change { channel.chat_messages.count }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          I18n.t("chat.errors.not_accepting_dms", username: recipient.username),
+        )
+      end
+    end
+
     context "when force_thread param is given" do
       let!(:message) { Fabricate(:chat_message, chat_channel: channel) }
 

--- a/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_threads_controller_spec.rb
@@ -378,6 +378,33 @@ RSpec.describe Chat::Api::ChannelThreadsController do
       end
     end
 
+    context "when a direct-message recipient excludes the current user from their PM allowlist" do
+      fab!(:recipient, :user)
+      fab!(:allowed_user, :user)
+      fab!(:channel_1) do
+        Fabricate(
+          :direct_message_channel,
+          users: [current_user, recipient],
+          threading_enabled: true,
+        )
+      end
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+
+      before do
+        recipient.user_option.update!(enable_allowed_pm_users: true)
+        AllowedPmUser.create!(user: recipient, allowed_pm_user: allowed_user)
+      end
+
+      it "does not create a thread" do
+        expect { post "/chat/api/channels/#{channel_id}/threads", params: params }.not_to change {
+          Chat::Thread.count
+        }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+      end
+    end
+
     context "when channel does not have threading enabled" do
       fab!(:channel_1) { Fabricate(:chat_channel, threading_enabled: false) }
 

--- a/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
+++ b/plugins/chat/spec/requests/core_ext/users_controller_spec.rb
@@ -64,6 +64,23 @@ describe UsersController do
       SiteSetting.direct_message_enabled_groups = Group::AUTO_GROUPS[:everyone]
     end
 
+    context "when the card owner excludes the current user from their PM allowlist" do
+      fab!(:allowed_user, :user)
+
+      before do
+        user.user_option.update!(enable_allowed_pm_users: true, chat_enabled: true)
+        AllowedPmUser.create!(user: user, allowed_pm_user: allowed_user)
+        sign_in(another_user)
+      end
+
+      it "returns that the current user cannot chat with the card owner" do
+        get "/u/#{user.username}/card.json"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig("user", "can_chat_user")).to eq(false)
+      end
+    end
+
     context "when the card belongs to the current user" do
       before { sign_in(user) }
 


### PR DESCRIPTION
## Summary

Correctly enforce the PM allowlist preference (`enable_allowed_pm_users`) when an excluded user attempts to send a message in an existing one-to-one direct message channel. Previously, the Guardian helper did not check the allowlist, allowing excluded users to continue sending messages after the recipient enabled the restriction. The fix integrates `UserCommScreener` into the recipient authorization check, also preventing thread creation and updating user card chat availability accordingly.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1454

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>