### PR TITLE
SECURITY: An unauthorized user can delete emails of other users including Admins [backport 2026.1]

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -386,7 +386,7 @@ class UsersController < ApplicationController
     params.require(:email)
 
     user = fetch_user_from_params
-    guardian.ensure_can_edit!(user)
+    guardian.ensure_can_edit_email!(user)
 
     ActiveRecord::Base.transaction do
       if change_requests = user.email_change_requests.where(new_email: params[:email]).presence

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -4465,6 +4465,22 @@ RSpec.describe UsersController do
       sign_in(user1)
     end
 
+    it "prevents a moderator from destroying another user's secondary email" do
+      SiteSetting.email_editable = true
+      admin_secondary_email = Fabricate(:secondary_email, user: admin)
+      sign_in(moderator)
+
+      expect {
+        delete "/u/#{admin.username}/preferences/email.json",
+               params: {
+                 email: admin_secondary_email.email,
+               }
+      }.not_to change { UserEmail.exists?(admin_secondary_email.id) }
+
+      expect(response).to be_forbidden
+      expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+    end
+
     it "can destroy secondary emails" do
       delete "/u/#{user1.username}/preferences/email.json", params: { email: user_email.email }
       expect(response.status).to eq(428)


### PR DESCRIPTION
Backport of #41927 to release/2026.1.

---

## Summary

`UsersController#destroy_email` used the generic `ensure_can_edit!` authorization check, allowing moderators to delete other users’ secondary emails, including administrators’ emails, through the email preferences DELETE endpoint. The fix applies the email-specific `ensure_can_edit_email!` policy and adds a request-level regression test confirming the deletion is forbidden and the administrator’s email remains intact.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1452

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
