### PR TITLE
SECURITY: Access control bypass in PM email recipients defeats message opt-out

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -322,6 +322,8 @@ class TopicCreator
         display_name = email.split("@").first
 
         if user = find_or_create_user(email, display_name)
+          check_can_send_permission!(topic, user)
+
           if !@added_users.include?(user)
             @added_users << user
             topic.topic_allowed_users.build(user_id: user.id)
@@ -330,7 +332,7 @@ class TopicCreator
         end
       end
     ensure
-      rollback_with!(topic, :target_user_not_found) unless len == emails.length
+      rollback_with!(topic, :target_user_not_found) if topic.errors.blank? && len != emails.length
     end
   end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1356,6 +1356,34 @@ RSpec.describe PostsController do
         expect(new_topic.external_id).to eq("external_id")
       end
 
+      it "blocks email private message recipients that disabled private messages" do
+        SiteSetting.enable_staged_users = true
+        SiteSetting.personal_message_enabled_groups = Group::AUTO_GROUPS[:trust_level_4]
+        SiteSetting.send_email_messages_allowed_groups = Group::AUTO_GROUPS[:trust_level_4]
+        sender = Fabricate(:trust_level_4, refresh_auto_groups: true)
+        recipient = Fabricate(:user)
+        recipient.user_option.update!(allow_private_messages: false)
+        api_key = ApiKey.create!(user: sender).key
+
+        post "/posts.json",
+             params: {
+               raw: "this is the test content",
+               title: "this is some post",
+               archetype: Archetype.private_message,
+               target_recipients: recipient.email,
+             },
+             headers: {
+               HTTP_API_USERNAME: sender.username,
+               HTTP_API_KEY: api_key,
+             }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to include(
+          I18n.t("activerecord.errors.models.topic.attributes.base.cant_send_pm"),
+        )
+        expect(TopicAllowedUser.exists?(user: recipient)).to eq(false)
+      end
+
       it "prevents whispers for regular users" do
         post_1 = Fabricate(:post)
         user_key = ApiKey.create!(user: user).key


### PR DESCRIPTION
## Summary

Prevent a private message opt-out bypass by enforcing authorization checks when targeting recipients by email address. TopicCreator now validates that the sender has permission to message an existing user identified via email, ensuring the recipient's private message preferences are correctly respected.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1371

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>