### PR TITLE
SECURITY: anonymous users can read hidden real names via reaction-user endpoints [backport 2026.5]

### DIFF
--- a/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/plugins/discourse-reactions/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -179,13 +179,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
     users =
       rows.map do |row|
-        {
+        format_user(
+          row,
           id: row.id,
-          username: row.username,
-          name: row.name,
           avatar_template: User.avatar_template(row.username, row.uploaded_avatar_id),
           reaction: row.reaction,
-        }
+        )
       end
 
     render_json_dump(users: users, total_rows: total)
@@ -287,6 +286,13 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
 
   private
 
+  def format_user(user, avatar_template:, **extra_attributes)
+    attributes = { username: user.username }
+    attributes[:name] = user.name if SiteSetting.enable_names?
+    attributes[:avatar_template] = avatar_template
+    attributes.merge!(extra_attributes)
+  end
+
   def get_users(reaction)
     DiscourseReactions::PostReactionsQuery
       .apply_ignored_users_filter(
@@ -298,13 +304,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
       .order("discourse_reactions_reaction_users.created_at desc")
       .limit(MAX_USERS_COUNT + 1)
       .map do |reaction_user|
-        {
-          username: reaction_user.user.username,
-          name: reaction_user.user.name,
+        format_user(
+          reaction_user.user,
           avatar_template: reaction_user.user.avatar_template,
           can_undo: reaction_user.can_undo?,
           created_at: reaction_user.created_at.to_s,
-        }
+        )
       end
   end
 
@@ -335,13 +340,12 @@ class DiscourseReactions::CustomReactionsController < ApplicationController
   end
 
   def format_like_user(like)
-    {
-      username: like.user.username,
-      name: like.user.name,
+    format_user(
+      like.user,
       avatar_template: like.user.avatar_template,
       can_undo: guardian.can_delete_post_action?(like),
       created_at: like.created_at.to_s,
-    }
+    )
   end
 
   def format_likes_users(likes)

--- a/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
+++ b/plugins/discourse-reactions/spec/requests/custom_reactions_controller_spec.rb
@@ -490,8 +490,27 @@ describe DiscourseReactions::CustomReactionsController do
       get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
 
       expect(response.status).to eq(200)
-      usernames = response.parsed_body["users"].map { |u| u["username"] }
-      expect(usernames).to include(user_1.username, user_3.username, user_5.username)
+      users = response.parsed_body["users"]
+      expect(users.map { |user| user["username"] }).to include(
+        user_1.username,
+        user_3.username,
+        user_5.username,
+      )
+      expect(users.find { |user| user["username"] == user_1.username }["name"]).to eq(user_1.name)
+    end
+
+    it "does not expose reactor names to anonymous users when names are disabled" do
+      SiteSetting.enable_names = false
+      user_2.update!(name: "Hidden Reactor Name")
+      user_5.update!(name: "Hidden Liker Name")
+
+      get "/discourse-reactions/posts/#{post_2.id}/reactions-users-list.json"
+
+      expect(response.status).to eq(200)
+      users = response.parsed_body["users"]
+      expect(users.map { |user| user["username"] }).to include(user_2.username, user_5.username)
+      expect(users).to all(exclude("name"))
+      expect(response.body).not_to include(user_2.name, user_5.name)
     end
 
     it "filters by reaction_value" do
@@ -568,6 +587,20 @@ describe DiscourseReactions::CustomReactionsController do
       expect(parsed["reaction_users"][0]["users"][0]["avatar_template"]).to eq(
         user_5.avatar_template,
       )
+    end
+
+    it "does not expose reactor names to anonymous users when names are disabled" do
+      SiteSetting.enable_names = false
+      user_2.update!(name: "Hidden Reactor Name")
+      user_5.update!(name: "Hidden Liker Name")
+
+      get "/discourse-reactions/posts/#{post_2.id}/reactions-users.json"
+
+      expect(response.status).to eq(200)
+      users = response.parsed_body["reaction_users"].flat_map { |reaction| reaction["users"] }
+      expect(users.map { |user| user["username"] }).to include(user_2.username, user_5.username)
+      expect(users).to all(exclude("name"))
+      expect(response.body).not_to include(user_2.name, user_5.name)
     end
 
     it "return reaction_users of reaction when there are parameters" do


### PR DESCRIPTION
Backport of #41931 to release/2026.5.

---

## Summary

Fix anonymous disclosure of hidden full names of reactors and likers via reaction-user APIs when `enable_names` setting is disabled. The `CustomReactionsController` now conditionally includes the `name` field only when `enable_names` is enabled, ensuring the invariant that hidden full names are not exposed to unauthenticated users.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1451

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>