### PR TITLE
SECURITY: Draft topic lookup exposes shared-draft titles to unauthorized users

### DIFF
--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -203,9 +203,13 @@ class Draft < ActiveRecord::Base
   end
 
   def self.allowed_draft_topics_for_user(user)
-    topics = Topic.listable_topics.secured(Guardian.new(user))
+    guardian = Guardian.new(user)
+    topics = Topic.listable_topics.secured(guardian)
     pms = Topic.private_messages_for_user(user)
-    topics.or(pms)
+    allowed_topics = topics.or(pms)
+    allowed_topics =
+      allowed_topics.where.not(id: SharedDraft.select(:topic_id)) if !guardian.can_see_shared_draft?
+    allowed_topics
   end
 
   def self.allowed_draft_posts_for_user(user)

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -50,6 +50,30 @@ RSpec.describe DraftsController do
       expect(response.parsed_body["drafts"].first["title"]).to eq(nil)
     end
 
+    it "does not include shared draft topic details when user cannot see shared drafts" do
+      shared_drafts_category = Fabricate(:category)
+      destination_category = Fabricate(:category)
+      shared_draft_topic = Fabricate(:topic, category: shared_drafts_category)
+      Fabricate(:shared_draft, topic: shared_draft_topic, category: destination_category)
+      SiteSetting.shared_drafts_category = shared_drafts_category.id
+      SiteSetting.shared_drafts_allowed_groups = Group::AUTO_GROUPS[:staff]
+      sign_in(user)
+
+      post "/drafts.json",
+           params: {
+             draft_key: "topic_#{shared_draft_topic.id}",
+             data: { reply: "draft reply" }.to_json,
+             sequence: 0,
+           }
+      expect(response.status).to eq(200)
+
+      get "/drafts.json"
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["drafts"].first["title"]).to be_nil
+      expect(response.body).not_to include(shared_draft_topic.title)
+    end
+
     it "returns categories when lazy load categories is enabled" do
       SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
       category = Fabricate(:category)


### PR DESCRIPTION
## Summary

Correctly enforce shared-draft visibility during draft lookup to prevent unauthorized users from obtaining the titles of unpublished shared-draft topics. The patch ensures that topics used as keys for user drafts are excluded from the results if they are marked as shared drafts and the user lacks permission to view them.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1435

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>