### PR TITLE
SECURITY: Sitemap exposes shared-draft titles to anonymous users

### DIFF
--- a/app/models/sitemap.rb
+++ b/app/models/sitemap.rb
@@ -53,7 +53,13 @@ class Sitemap < ActiveRecord::Base
 
   def sitemap_topics
     indexable_topics =
-      Topic.where(visible: true).joins(:category).where(categories: { read_restricted: false })
+      Topic
+        .visible
+        .listable_topics
+        .where
+        .missing(:shared_draft)
+        .joins(:category)
+        .where(categories: { read_restricted: false })
 
     if name == RECENT_SITEMAP_NAME
       indexable_topics.where("bumped_at > ?", 3.days.ago).order(bumped_at: :desc)

--- a/spec/models/sitemap_spec.rb
+++ b/spec/models/sitemap_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe Sitemap do
 
         expect(topics_data).to be_empty
       end
+
+      it "doesn't include shared draft topics from unrestricted categories" do
+        shared_drafts_category = Fabricate(:category, read_restricted: false)
+        SiteSetting.shared_drafts_category = shared_drafts_category.id
+        shared_draft_topic = Fabricate(:topic, category: shared_drafts_category)
+        Fabricate(:shared_draft, topic: shared_draft_topic)
+
+        topics_data = sitemap.topics
+
+        expect(topics_data).to be_empty
+      end
     end
 
     context "when the sitemap corresponds to a page" do

--- a/spec/requests/sitemap_controller_spec.rb
+++ b/spec/requests/sitemap_controller_spec.rb
@@ -69,6 +69,21 @@ RSpec.describe SitemapController do
       expect(loc).to eq("#{Discourse.base_url}/t/#{topic.slug}/#{topic.id}")
       expect(last_mod).to eq(topic.bumped_at.xmlschema)
     end
+
+    it "does not expose shared draft topics to anonymous users" do
+      shared_drafts_category = Fabricate(:category, read_restricted: false)
+      SiteSetting.shared_drafts_category = shared_drafts_category.id
+      shared_draft_topic =
+        Fabricate(:topic, title: "Confidential shared draft", category: shared_drafts_category)
+      Fabricate(:shared_draft, topic: shared_draft_topic)
+      Sitemap.create!(name: "1", enabled: true, last_posted_at: 1.minute.ago)
+
+      get "/sitemap_1.xml"
+
+      expect(response.status).to eq(200)
+      expect(response.body).not_to include(shared_draft_topic.title)
+      expect(response.body).not_to include(shared_draft_topic.slug)
+    end
   end
 
   describe "#recent" do
@@ -91,6 +106,20 @@ RSpec.describe SitemapController do
 
       all_urls = urls.map { |u| u.at_css("loc").text }
       expect(all_urls).not_to include("#{Discourse.base_url}/t/#{old_topic.slug}/#{old_topic.id}")
+    end
+
+    it "does not expose shared draft topics to anonymous users" do
+      shared_drafts_category = Fabricate(:category, read_restricted: false)
+      SiteSetting.shared_drafts_category = shared_drafts_category.id
+      shared_draft_topic =
+        Fabricate(:topic, title: "Confidential shared draft", category: shared_drafts_category)
+      Fabricate(:shared_draft, topic: shared_draft_topic)
+
+      get "/sitemap_recent.xml"
+
+      expect(response.status).to eq(200)
+      expect(response.body).not_to include(shared_draft_topic.title)
+      expect(response.body).not_to include(shared_draft_topic.slug)
     end
 
     it "generates correct page numbers based on the topic post count" do
@@ -134,6 +163,20 @@ RSpec.describe SitemapController do
 
       all_urls = urls.map { |u| u.at_css("loc").text }
       expect(all_urls).not_to include("#{Discourse.base_url}/t/#{old_topic.slug}/#{old_topic.id}")
+    end
+
+    it "does not expose shared draft topics to anonymous users" do
+      shared_drafts_category = Fabricate(:category, read_restricted: false)
+      SiteSetting.shared_drafts_category = shared_drafts_category.id
+      shared_draft_topic =
+        Fabricate(:topic, title: "Confidential shared draft", category: shared_drafts_category)
+      Fabricate(:shared_draft, topic: shared_draft_topic)
+
+      get "/news.xml"
+
+      expect(response.status).to eq(200)
+      expect(response.body).not_to include(shared_draft_topic.title)
+      expect(response.body).not_to include(shared_draft_topic.slug)
     end
   end
 end


### PR DESCRIPTION
## Summary

Prevent the disclosure of shared-draft topic titles and slugs in public sitemap endpoints. Correctly filter topics in the sitemap model to exclude those with an associated shared draft, even when the draft's category is unrestricted.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1433

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>