### PR TITLE
MT: Add the Discourse posts and custom_emojis conversion steps

### DIFF
--- a/migrations/converters/lib/migrations/converters/discourse/converter.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/converter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module Migrations
   module Converters
     module Discourse
@@ -7,7 +9,158 @@ module Migrations
         # Steps run concurrently and a Postgres connection can't be shared, so each
         # step gets its own adapter; the step's source closes it in its `cleanup`.
         def step_args(step_class)
-          { source_db: Adapter::Postgres.new(settings[:source_db]) }
+          source_db = Adapter::Postgres.new(settings[:source_db])
+
+          # Only the Posts step classifies `@group`/`@here` mentions and extracts
+          # custom emoji, so only it pays for these metadata queries. They reuse the
+          # step's own adapter and hand back plain values, so no connection is shared
+          # across the steps.
+          return { source_db: } unless step_class == Posts
+
+          # Loaded once and reused: `mention_names` folds the group names and the
+          # `here_mention` value into its gate, so re-querying them would be waste.
+          group_names = group_names(source_db)
+          here_mention = here_mention(source_db)
+
+          {
+            source_db:,
+            group_names:,
+            here_mention:,
+            mention_names: mention_names(source_db, group_names, here_mention),
+            hashtag_names: hashtag_names(source_db),
+            custom_emoji_names: custom_emoji_names(source_db),
+            internal_link_hosts:,
+            internal_link_base_prefix:,
+          }
+        end
+
+        private
+
+        # The source's own hosts mapped to their path prefixes, so the Posts step can
+        # tell an absolute internal link from an external one and, on a host shared
+        # with other apps, which paths belong to the forum. Built from `base_url` and
+        # any `former_domains` under the `source_site` setting (a site that moved
+        # carries links to both). Each host is downcased with the port dropped, so
+        # `http://`, `https://` and protocol-relative links all match; the prefix is
+        # the URL's path (`/forum` for a subfolder install, nil for a root install).
+        # Entries may carry different prefixes when a former root domain later moved
+        # into a subfolder. No setting means an empty hash, i.e. relative-only
+        # detection.
+        def internal_link_hosts
+          source_site_urls.to_h { |url| host_and_prefix(url) }
+        end
+
+        # The current site's own path prefix, taken from `base_url`, so the Posts step
+        # can strip it from a relative internal link (`/forum/t/5`) before parsing the
+        # route. Nil for a root install (or no `base_url`).
+        def internal_link_base_prefix
+          base_url = settings.dig(:source_site, :base_url)
+          base_url && host_and_prefix(base_url).last
+        end
+
+        def source_site_urls
+          site = settings[:source_site] || {}
+          [site[:base_url], *Array(site[:former_domains])].compact
+        end
+
+        # Splits a configured URL into its downcased host (port dropped) and path
+        # prefix, tolerating a bare host, a scheme-less `//host`, and a full URL with a
+        # path. The prefix is normalized to a leading slash and no trailing slash, or
+        # nil when the path is empty or the bare root `/`. A malformed URL or a URL
+        # with no host raises, so a settings typo surfaces here instead of silently
+        # disabling link detection.
+        def host_and_prefix(url)
+          normalized = url.to_s.strip
+          normalized = "//#{normalized}" if normalized.exclude?("//")
+          uri = URI.parse(normalized)
+          host = uri.host&.downcase
+
+          raise "Invalid source_site URL (no host): #{url.inspect}" if host.nil? || host.empty?
+
+          [host, normalize_prefix(uri.path)]
+        rescue URI::InvalidURIError => e
+          raise "Invalid source_site URL #{url.inspect}: #{e.message}"
+        end
+
+        def normalize_prefix(path)
+          prefix = path.to_s.chomp("/")
+          prefix.empty? ? nil : prefix
+        end
+
+        # Source group names, so the Posts step can classify `@group` mentions.
+        def group_names(source_db)
+          source_db.query("SELECT name FROM groups").map { |row| row[:name] }
+        end
+
+        # Every name that can legitimately follow `@`, so the Posts step defers only
+        # a mention that names something real and leaves the rest (`@3pm`) as plain
+        # text: every username, every group name, the source's `here_mention` value
+        # and the literal `all`. Without the last three, `@staff`, `@here` and `@all`
+        # would be dropped — the gate must never be usernames only. Normalized like
+        # the importer normalizes a mention when it resolves it, so the two sides
+        # agree on what matches.
+        #
+        # Usernames can run into the millions, so they're streamed straight into the
+        # gate; the query is drained fully (every row consumed) so the connection is
+        # clean for the queries that follow.
+        def mention_names(source_db, group_names, here_mention)
+          names = []
+
+          source_db
+            .query("SELECT username FROM users")
+            .each { |row| names << normalize(row[:username]) }
+
+          group_names.each { |name| names << normalize(name) }
+          # `here_mention` only falls back to "here" for a NULL setting, so a blank
+          # value would slip an empty name into the gate.
+          names << normalize(here_mention) if here_mention.present?
+          names << normalize("all")
+
+          Migrations::SortedStringSet.new(names)
+        end
+
+        # The names a hashtag can address on the source — every category slug, every
+        # `parent:child` category path, and every tag name (synonyms are tags too, so
+        # `SELECT name FROM tags` already covers them). Normalized like the importer
+        # normalizes them when it resolves a hashtag, so the Posts step defers only a
+        # `#name` that names something real and the two sides agree on what matches.
+        def hashtag_names(source_db)
+          names = []
+
+          source_db
+            .query(<<~SQL)
+              SELECT c.slug AS slug, parent.slug AS parent_slug
+              FROM categories c
+                   LEFT JOIN categories parent ON parent.id = c.parent_category_id
+            SQL
+            .each do |row|
+              names << normalize(row[:slug])
+              names << normalize("#{row[:parent_slug]}:#{row[:slug]}") if row[:parent_slug]
+            end
+
+          source_db.query("SELECT name FROM tags").each { |row| names << normalize(row[:name]) }
+
+          # Tags reach six figures on big sites, so the gate is a SortedStringSet for
+          # the same copy-on-write reason the mention gate is (and it dedupes here).
+          Migrations::SortedStringSet.new(names)
+        end
+
+        # Source custom emoji names, so the Posts step extracts only `:name:`
+        # shortcodes that name a real custom emoji (standard ones stay plain text).
+        def custom_emoji_names(source_db)
+          source_db.query("SELECT name FROM custom_emojis").map { |row| row[:name] }
+        end
+
+        # The source's `here_mention` setting value (the configurable name that
+        # triggers an `@here` mention); falls back to the Discourse default, which
+        # isn't stored in `site_settings`.
+        def here_mention(source_db)
+          source_db.query_value("SELECT value FROM site_settings WHERE name = 'here_mention'") ||
+            "here"
+        end
+
+        def normalize(name)
+          Migrations::NameNormalizer.normalize(name)
         end
       end
     end

--- a/migrations/converters/lib/migrations/converters/discourse/settings.yml
+++ b/migrations/converters/lib/migrations/converters/discourse/settings.yml
@@ -18,3 +18,17 @@ source_db:
 
 categories:
   map_seeded_categories: true
+
+# The source site's own address, used to recognize absolute internal links
+# (`https://forum.example.com/t/slug/123`) so they can be rewritten at import.
+# Optional: without it, only relative links (`/t/slug/123`) are rewritten. List
+# `former_domains` when the site moved and old posts still link to the old host.
+# The scheme and port are ignored, but a path is not: for a subdirectory install
+# include the prefix (`https://www.example.com/forum`) so only links under it are
+# treated as the forum's. Each entry may carry its own prefix — a former domain
+# can sit at the root while the current one moved into a subfolder, or vice versa.
+#
+#   source_site:
+#     base_url: "https://forum.example.com/forum"
+#     former_domains:
+#       - "https://old.example.com"

--- a/migrations/converters/lib/migrations/converters/discourse/steps/custom_emojis.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/custom_emojis.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Discourse
+      class CustomEmojis < Conversion::Step
+        DANGLING_UPLOAD_LOG_MESSAGE = "Custom emoji skipped: its upload is missing"
+
+        source do
+          def max_progress
+            @source_db.count <<~SQL
+              SELECT COUNT(*) FROM custom_emojis
+            SQL
+          end
+
+          def items
+            # The join hands the upload's columns to the processor (prefixed, so
+            # they can't collide with the emoji's own — `user_id` in particular),
+            # which registers the upload and stores the returned reference — the
+            # emoji image must be fetched like any other upload before the
+            # importer can create the emoji from it.
+            # LEFT JOIN so every emoji row arrives even when its upload is missing;
+            # an INNER JOIN would drop those rows and leave the progress short of
+            # `max_progress` (which counts every `custom_emojis` row).
+            @source_db.query <<~SQL
+              SELECT custom_emojis.id,
+                     custom_emojis.name,
+                     custom_emojis."group",
+                     custom_emojis.created_at,
+                     uploads.url               AS upload_url,
+                     uploads.original_filename AS upload_filename,
+                     uploads.origin            AS upload_origin
+              FROM custom_emojis
+                   LEFT JOIN uploads ON uploads.id = custom_emojis.upload_id
+              ORDER BY custom_emojis.id
+            SQL
+          end
+        end
+
+        processor do
+          def setup
+            @upload_creator =
+              UploadCreator.new(column_prefix: "upload", upload_type: "custom_emoji")
+          end
+
+          def process(item)
+            # A dangling upload_id (the upload row was deleted) must be visible, not
+            # silently dropped: an emoji without its image can't be imported, so warn
+            # and skip rather than write a row that points at nothing.
+            if item[:upload_url].nil?
+              tracker.log_warning(
+                DANGLING_UPLOAD_LOG_MESSAGE,
+                details: {
+                  id: item[:id],
+                  name: item[:name],
+                },
+              )
+              return
+            end
+
+            IntermediateDB::CustomEmoji.create(
+              original_id: item[:id],
+              name: item[:name],
+              group: item[:group],
+              upload_id: @upload_creator.create_for(item),
+              created_at: item[:created_at],
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/lib/migrations/converters/discourse/steps/posts.rb
+++ b/migrations/converters/lib/migrations/converters/discourse/steps/posts.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+module Migrations
+  module Converters
+    module Discourse
+      class Posts < Conversion::Step
+        # One log entry for the whole run: each worker tallies foreign-host links
+        # per host, and the reducer (`combine_results`) merges the tallies into a
+        # single entry with the top hosts in `details`, sorted by link count.
+        # Posts link many other Discourse sites, so a long list of hosts with a few
+        # links each is normal and the entry stays INFO. It becomes a WARNING (and
+        # the step shows one warning) only when a single host holds a large share
+        # of the links — the typical sign of a former domain that is missing from
+        # the `source_site` settings.
+        FOREIGN_LINK_LOG_MESSAGE = "Internal-looking links on unconfigured hosts"
+
+        # A host counts as dominant when it holds this share of all foreign
+        # route-shaped links AND at least this many links, so a small forum with a
+        # handful of links never triggers the warning. On a large forum without
+        # former domains, the most-linked foreign host stayed around 15%.
+        DOMINANT_HOST_SHARE = 0.25
+        DOMINANT_HOST_MINIMUM = 100
+        private_constant :DOMINANT_HOST_SHARE, :DOMINANT_HOST_MINIMUM
+
+        # The most hosts we keep in `details`. The dominance signal and the
+        # former-domain forensics only need the top of the list, and an unbounded
+        # list bloats one log row on link-heavy forums.
+        DETAILS_HOST_LIMIT = 500
+        private_constant :DETAILS_HOST_LIMIT
+
+        # Merges every worker's per-host link tally and logs the one entry through
+        # `tracker`, which counts the warning automatically (see
+        # {StepCoordinator#reduce_results}). Runs in the parent under the run DB's
+        # single-writer discipline; `results` are the workers' `result` hashes,
+        # with string keys from crossing the process boundary as JSON.
+        def self.combine_results(results, tracker)
+          totals = Hash.new(0)
+          results.each { |tally| tally.each { |host, count| totals[host] += count } }
+          return if totals.empty?
+
+          total = totals.values.sum
+          sorted_hosts = totals.sort_by { |host, count| [-count, host] }
+          _top_host, top_count = sorted_hosts.first
+          dominant = top_count >= DOMINANT_HOST_MINIMUM && top_count >= total * DOMINANT_HOST_SHARE
+
+          kept = sorted_hosts.take(DETAILS_HOST_LIMIT)
+          details = { total:, hosts: kept.map { |host, count| { host:, count: } } }
+          omitted = sorted_hosts.size - kept.size
+          details[:omitted] = omitted if omitted > 0
+
+          if dominant
+            tracker.log_warning(FOREIGN_LINK_LOG_MESSAGE, details:)
+          else
+            tracker.log_info(FOREIGN_LINK_LOG_MESSAGE, details:)
+          end
+        end
+
+        source do
+          # Posts is the heaviest step, so split it across forks. Partition on the
+          # composite `(topic_id, post_number)`, not the obvious `id`: that pair is
+          # the target table's index (`idx_posts_topic_id_post_number`), so each fork
+          # converts a contiguous slice of it and the shards merge into the run DB as
+          # sequential index appends. Splitting on `id` would spread every fork's rows
+          # across that index, turning the merge into random inserts (~2x slower over
+          # the run). The pair is effectively unique, so the forks still get even row
+          # counts, and a huge topic is split across them instead of landing on one.
+          partition_by %i[topic_id post_number], from: "posts"
+
+          def max_progress
+            @source_db.count(<<~SQL)
+              SELECT COUNT(*) FROM posts #{partition_where}
+            SQL
+          end
+
+          def items
+            # `reply_to_post_id` resolves the source `reply_to_post_number` to the
+            # parent post's id (same topic) so the reference survives renumbering.
+            # The chunk filter goes on the scan subquery, where `topic_id` is
+            # unambiguous next to the `reply_to` self-join (which reads every post,
+            # so a parent in another chunk still resolves).
+            @source_db.query(<<~SQL)
+              SELECT posts.*,
+                     reply_to.id AS reply_to_post_id
+                FROM (SELECT * FROM posts #{partition_where}) posts
+                     LEFT JOIN posts reply_to
+                       ON reply_to.topic_id = posts.topic_id
+                      AND reply_to.post_number = posts.reply_to_post_number
+              ORDER BY posts.topic_id, posts.post_number
+            SQL
+          end
+
+          private
+
+          # The `WHERE` limiting the scan to this worker's chunk, or "" when the step
+          # runs whole (inline or a single fork), where `partition_slice` is nil.
+          def partition_where
+            slice = partition_slice
+            slice ? "WHERE #{slice}" : ""
+          end
+        end
+
+        processor do
+          attr_accessor :group_names,
+                        :here_mention,
+                        :mention_names,
+                        :hashtag_names,
+                        :custom_emoji_names,
+                        :internal_link_hosts,
+                        :internal_link_base_prefix
+
+          def setup
+            # Tally foreign-host links per host, with no logging or tracker calls —
+            # this runs while posts are scanned, and a real forum has tens of
+            # thousands of these links. `result` sends the tally to the parent,
+            # where `combine_results` merges all workers' tallies into one log
+            # entry.
+            @foreign_hosts = Hash.new(0)
+
+            # One buffer, reused (cleared) per post — a fresh one would allocate a
+            # new placeholder (a random nonce) for every post, most of which record
+            # nothing. The extractor binds it once at construction and records onto
+            # it on every `extract`.
+            @embeds = EmbedBuffer.new(owner_type: Enums::EmbedOwner::POST)
+
+            @extractor =
+              RawExtractor.new(
+                embeds: @embeds,
+                mention_classifier:
+                  MentionClassifier.new(here_mention:, group_names: group_names || []),
+                mention_names:,
+                hashtag_names:,
+                custom_emoji_names:,
+                internal_link_hosts: internal_link_hosts || {},
+                internal_link_base_prefix:,
+                on_foreign_host: ->(host) { @foreign_hosts[host] += 1 },
+              )
+          end
+
+          def process(item)
+            @embeds.clear
+            raw = @extractor.extract(item[:raw], topic_id: item[:topic_id])
+
+            IntermediateDB::Post.create(
+              original_id: item[:id],
+              action_code: item[:action_code],
+              created_at: item[:created_at],
+              deleted_at: item[:deleted_at],
+              deleted_by_id: item[:deleted_by_id],
+              hidden: item[:hidden],
+              hidden_at: item[:hidden_at],
+              hidden_reason_id: valid_enum(Enums::PostHiddenReason, item[:hidden_reason_id]),
+              last_editor_id: item[:last_editor_id],
+              like_count: item[:like_count],
+              locale: item[:locale],
+              locked_by_id: item[:locked_by_id],
+              original_raw: item[:raw],
+              post_number: item[:post_number],
+              post_type:
+                valid_enum(Enums::PostType, item[:post_type], fallback: Enums::PostType::REGULAR),
+              raw:,
+              reply_to_post_id: item[:reply_to_post_id],
+              reply_to_user_id: item[:reply_to_user_id],
+              sort_order: item[:sort_order],
+              topic_id: item[:topic_id],
+              user_deleted: item[:user_deleted],
+              user_id: item[:user_id],
+              wiki: item[:wiki],
+            )
+
+            # The linkage tables are written by the shared `EmbedBuffer#write_for`,
+            # not here, so the per-converter coverage check holds them out (see
+            # `ReferenceCheck::EMBED_BUFFER_TABLES`).
+            @embeds.write_for(item[:id])
+          end
+
+          # The worker's per-host link tally, sent to `combine_results` in the
+          # parent. Nil when this worker saw no foreign-host links, so it sends
+          # nothing.
+          def result
+            @foreign_hosts unless @foreign_hosts.empty?
+          end
+
+          private
+
+          # Keeps only values the enum recognizes, otherwise the fallback (the
+          # source may carry values from plugins or versions we don't model).
+          def valid_enum(enum_module, value, fallback: nil)
+            enum_module.valid?(value) ? value : fallback
+          end
+        end
+      end
+    end
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/discourse/converter_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/discourse/converter_spec.rb
@@ -20,5 +20,176 @@ RSpec.describe Migrations::Converters::Discourse::Converter do
         { host: "localhost" },
       ).twice
     end
+
+    context "for the Posts step" do
+      let(:source_db) { instance_double(Migrations::Converters::Adapter::Postgres) }
+
+      before do
+        allow(Migrations::Converters::Adapter::Postgres).to receive(:new).and_return(source_db)
+        allow(source_db).to receive(:query).with("SELECT username FROM users").and_return([])
+        allow(source_db).to receive(:query).with("SELECT name FROM groups").and_return([])
+        allow(source_db).to receive(:query).with("SELECT name FROM custom_emojis").and_return([])
+        allow(source_db).to receive(:query).with("SELECT name FROM tags").and_return([])
+        allow(source_db).to receive(:query).with(a_string_including("FROM categories")).and_return(
+          [],
+        )
+        allow(source_db).to receive(:query_value).and_return(nil)
+      end
+
+      it "loads the source group names and here_mention setting for mention classification" do
+        allow(source_db).to receive(:query).with("SELECT name FROM groups").and_return(
+          [{ name: "staff" }, { name: "moderators" }],
+        )
+        allow(source_db).to receive(:query_value).and_return("everyone")
+
+        args = described_class.new({}).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:source_db]).to be(source_db)
+        expect(args[:group_names]).to eq(%w[staff moderators])
+        expect(args[:here_mention]).to eq("everyone")
+      end
+
+      it "falls back to the default here_mention when the source has no such setting" do
+        args = described_class.new({}).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:group_names]).to eq([])
+        expect(args[:here_mention]).to eq("here")
+      end
+
+      it "builds the mention gate from usernames, group names, here_mention and all" do
+        allow(source_db).to receive(:query).with("SELECT username FROM users").and_return(
+          [{ username: "alice" }, { username: "Bob" }],
+        )
+        allow(source_db).to receive(:query).with("SELECT name FROM groups").and_return(
+          [{ name: "Staff" }],
+        )
+        allow(source_db).to receive(:query_value).and_return("everyone")
+
+        args = described_class.new({}).step_args(Migrations::Converters::Discourse::Posts)
+        gate = args[:mention_names]
+
+        expect(gate).to be_a(Migrations::SortedStringSet)
+        expect(gate.include?("alice")).to be true
+        expect(gate.include?("bob")).to be true
+        expect(gate.include?("staff")).to be true
+        expect(gate.include?("everyone")).to be true
+        expect(gate.include?("all")).to be true
+        expect(gate.include?("nobody")).to be false
+      end
+
+      it "loads normalized category slug paths and tag names for the hashtag gate" do
+        allow(source_db).to receive(:query).with(a_string_including("FROM categories")).and_return(
+          [{ slug: "Support", parent_slug: nil }, { slug: "Billing", parent_slug: "Support" }],
+        )
+        allow(source_db).to receive(:query).with("SELECT name FROM tags").and_return(
+          [{ name: "Release" }],
+        )
+
+        args = described_class.new({}).step_args(Migrations::Converters::Discourse::Posts)
+        gate = args[:hashtag_names]
+
+        expect(gate).to be_a(Migrations::SortedStringSet)
+        expect(gate.size).to eq(4)
+        expect(gate.include?("support")).to be true
+        expect(gate.include?("billing")).to be true
+        expect(gate.include?("support:billing")).to be true
+        expect(gate.include?("release")).to be true
+      end
+
+      it "loads the source custom emoji names for emoji extraction" do
+        allow(source_db).to receive(:query).with("SELECT name FROM custom_emojis").and_return(
+          [{ name: "parrot" }, { name: "+1" }],
+        )
+
+        args = described_class.new({}).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:custom_emoji_names]).to eq(%w[parrot +1])
+      end
+
+      it "maps each source host to its path prefix (base URL and former domains)" do
+        settings = {
+          source_site: {
+            base_url: "https://forum.example.com/forum",
+            former_domains: %w[http://old.example.com older.example.com],
+          },
+        }
+
+        args = described_class.new(settings).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:internal_link_hosts]).to eq(
+          "forum.example.com" => "/forum",
+          "old.example.com" => nil,
+          "older.example.com" => nil,
+        )
+        expect(args[:internal_link_base_prefix]).to eq("/forum")
+      end
+
+      it "keeps a distinct prefix per entry (root former domain, subfolder base)" do
+        settings = {
+          source_site: {
+            base_url: "https://www.example.com/community",
+            former_domains: %w[https://old.example.com https://legacy.example.com/board],
+          },
+        }
+
+        args = described_class.new(settings).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:internal_link_hosts]).to eq(
+          "www.example.com" => "/community",
+          "old.example.com" => nil,
+          "legacy.example.com" => "/board",
+        )
+        expect(args[:internal_link_base_prefix]).to eq("/community")
+      end
+
+      it "leaves the base prefix nil when the base URL sits at the root" do
+        settings = {
+          source_site: {
+            base_url: "https://forum.example.com",
+            former_domains: %w[https://old.example.com/forum],
+          },
+        }
+
+        args = described_class.new(settings).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:internal_link_hosts]).to eq(
+          "forum.example.com" => nil,
+          "old.example.com" => "/forum",
+        )
+        expect(args[:internal_link_base_prefix]).to be_nil
+      end
+
+      it "drops the port and normalizes a trailing slash in the prefix" do
+        settings = {
+          source_site: {
+            base_url: "https://forum.example.com:8080/forum/",
+            former_domains: %w[old.example.com],
+          },
+        }
+
+        args = described_class.new(settings).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:internal_link_hosts]).to eq(
+          "forum.example.com" => "/forum",
+          "old.example.com" => nil,
+        )
+        expect(args[:internal_link_base_prefix]).to eq("/forum")
+      end
+
+      it "leaves the host map empty and the base prefix nil with no source site" do
+        args = described_class.new({}).step_args(Migrations::Converters::Discourse::Posts)
+
+        expect(args[:internal_link_hosts]).to be_empty
+        expect(args[:internal_link_base_prefix]).to be_nil
+      end
+
+      it "raises a clear error for a malformed source_site URL" do
+        settings = { source_site: { base_url: "https://exa mple.com" } }
+
+        expect {
+          described_class.new(settings).step_args(Migrations::Converters::Discourse::Posts)
+        }.to raise_error(/Invalid source_site URL/)
+      end
+    end
   end
 end

--- a/migrations/converters/spec/lib/migrations/converters/discourse/steps/custom_emojis_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/discourse/steps/custom_emojis_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe Migrations::Converters::Discourse::CustomEmojis do
+  subject(:processor) { described_class.processor_class.new({}) }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      db_path = File.join(dir, "intermediate.db")
+      Migrations::Database.migrate(
+        db_path,
+        migrations_path: Migrations::Database::INTERMEDIATE_DB_SCHEMA_PATH,
+      )
+      @db = Migrations::Database.connect(db_path)
+      Migrations::Database::IntermediateDB.setup(@db)
+      example.run
+    ensure
+      Migrations::Database::IntermediateDB.setup(nil)
+    end
+  end
+
+  def rows(table)
+    [].tap { |out| @db.query("SELECT * FROM #{table}") { |row| out << row } }
+  end
+
+  before { processor.setup }
+
+  it "registers the emoji's upload and stores the returned reference" do
+    path = "/uploads/default/original/1X/parrot.png"
+    processor.process(
+      {
+        id: 5,
+        name: "parrot",
+        group: "animals",
+        upload_url: path,
+        upload_filename: "parrot.png",
+        upload_origin: nil,
+        created_at: Time.utc(2020, 1, 2, 3, 4, 5),
+      },
+    )
+
+    upload_id = Migrations::ID.hash(path)
+    expect(rows("uploads")).to contain_exactly(
+      hash_including(id: upload_id, path:, filename: "parrot.png", type: "custom_emoji"),
+    )
+    expect(rows("custom_emojis")).to contain_exactly(
+      hash_including(original_id: 5, name: "parrot", group: "animals", upload_id:),
+    )
+  end
+
+  it "warns and skips an emoji whose upload is missing, but converts the rest" do
+    processor.process(
+      {
+        id: 7,
+        name: "orphan",
+        group: nil,
+        upload_url: nil,
+        upload_filename: nil,
+        upload_origin: nil,
+        created_at: Time.utc(2020, 1, 2, 3, 4, 5),
+      },
+    )
+    processor.process(
+      {
+        id: 8,
+        name: "smile",
+        group: nil,
+        upload_url: "/uploads/s.png",
+        upload_filename: "s.png",
+        upload_origin: nil,
+        created_at: Time.utc(2020, 1, 2, 3, 4, 5),
+      },
+    )
+
+    expect(processor.tracker.stats.warning_count).to eq(1)
+    expect(rows("custom_emojis")).to contain_exactly(hash_including(original_id: 8, name: "smile"))
+  end
+
+  it "keeps a nil group for an ungrouped emoji" do
+    processor.process(
+      {
+        id: 6,
+        name: "smile",
+        group: nil,
+        upload_url: "/uploads/s.png",
+        upload_filename: "s.png",
+        upload_origin: nil,
+      },
+    )
+
+    expect(rows("custom_emojis")).to contain_exactly(hash_including(original_id: 6, group: nil))
+  end
+end

--- a/migrations/converters/spec/lib/migrations/converters/discourse/steps/posts_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/discourse/steps/posts_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+RSpec.describe Migrations::Converters::Discourse::Posts do
+  subject(:processor) { described_class.processor_class.new({}) }
+
+  def enums
+    Migrations::Database::IntermediateDB::Enums
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      db_path = File.join(dir, "intermediate.db")
+      Migrations::Database.migrate(
+        db_path,
+        migrations_path: Migrations::Database::INTERMEDIATE_DB_SCHEMA_PATH,
+      )
+      @db = Migrations::Database.connect(db_path)
+      Migrations::Database::IntermediateDB.setup(@db)
+      example.run
+    ensure
+      Migrations::Database::IntermediateDB.setup(nil)
+    end
+  end
+
+  def rows(table)
+    [].tap { |out| @db.query("SELECT * FROM #{table}") { |row| out << row } }
+  end
+
+  def post_item(raw, id: 1)
+    { id:, topic_id: 10, post_number: id, raw:, created_at: Time.utc(2020, 1, 2, 3, 4, 5) }
+  end
+
+  describe "the foreign-host internal-link signal" do
+    before do
+      processor.internal_link_hosts = { "forum.example.com" => nil }
+      processor.setup
+    end
+
+    it "tallies foreign-host links per host instead of logging on the scan path" do
+      processor.process(post_item("see https://old-forum.example.com/t/slug/99 here", id: 1))
+      processor.process(post_item("also https://old-forum.example.com/t/other/7 there", id: 2))
+
+      # Nothing is written or counted during the scan; the tally rides back via
+      # `result` for the parent's reducer.
+      expect(rows("log_entries")).to be_empty
+      expect(processor.tracker.stats.warning_count).to eq(0)
+      expect(processor.tracker.stats.error_count).to eq(0)
+      expect(processor.result).to eq({ "old-forum.example.com" => 2 })
+    end
+
+    it "hands back nil when no foreign-host link was seen" do
+      processor.process(post_item("read https://forum.example.com/t/slug/99 now"))
+
+      expect(rows("log_entries")).to be_empty
+      expect(processor.result).to be_nil
+    end
+  end
+
+  describe "converting a post" do
+    before do
+      processor.internal_link_hosts = { "forum.example.com" => nil }
+      processor.setup
+    end
+
+    it "writes the post row and the deferred embed linkage" do
+      raw = "Welcome @alice, glad you joined!"
+      processor.process(
+        post_item(raw, id: 42).merge(locale: "de", post_type: enums::PostType::REGULAR),
+      )
+
+      post = rows("posts").first
+      expect(post).to include(
+        original_id: 42,
+        topic_id: 10,
+        post_number: 42,
+        locale: "de",
+        original_raw: raw,
+      )
+      # The mention is deferred, so the stored raw carries a placeholder token
+      # in place of the input body's mention.
+      expect(Migrations::Placeholder).to be_include(post[:raw])
+
+      mention = rows("embed_mentions").first
+      expect(mention).to include(owner_id: 42, name: "alice")
+    end
+
+    it "falls back on unknown enum values and passes known ones through" do
+      processor.process(post_item("first", id: 1).merge(post_type: 999, hidden_reason_id: 999))
+      processor.process(post_item("second", id: 2).merge(post_type: enums::PostType::WHISPER))
+
+      by_id = rows("posts").index_by { |row| row[:original_id] }
+      expect(by_id[1][:post_type]).to eq(enums::PostType::REGULAR)
+      expect(by_id[1][:hidden_reason_id]).to be_nil
+      expect(by_id[2][:post_type]).to eq(enums::PostType::WHISPER)
+    end
+  end
+
+  describe "a subfolder install (host prefix and base prefix)" do
+    before do
+      processor.internal_link_hosts = { "forum.example.com" => "/forum" }
+      processor.internal_link_base_prefix = "/forum"
+      processor.setup
+    end
+
+    it "defers a relative link written with the site's own prefix" do
+      processor.process(post_item("see [here](/forum/t/slug/99) please"))
+
+      link = rows("embed_links").first
+      expect(link).to include(owner_id: 1, url: "/forum/t/slug/99")
+    end
+
+    it "defers an absolute link inside the host's prefix" do
+      processor.process(post_item("see https://forum.example.com/forum/t/slug/99 please"))
+
+      link = rows("embed_links").first
+      expect(link).to include(url: "https://forum.example.com/forum/t/slug/99")
+    end
+
+    it "leaves an absolute link outside the host's prefix alone" do
+      raw = "see https://forum.example.com/other/t/slug/99 please"
+      processor.process(post_item(raw))
+
+      expect(rows("embed_links")).to be_empty
+      expect(rows("posts").first[:raw]).to eq(raw)
+    end
+  end
+
+  describe ".combine_results" do
+    let(:tracker) { Migrations::Conversion::StepTracker.new }
+
+    def entry
+      entries = rows("log_entries")
+      expect(entries.size).to eq(1)
+      entries.first
+    end
+
+    def hosts_in(details)
+      JSON.parse(details)["hosts"].map { |row| [row["host"], row["count"]] }
+    end
+
+    it "merges the workers' tallies into one INFO entry, hosts sorted by count" do
+      described_class.combine_results(
+        [
+          { "old-forum.example.com" => 3, "legacy.example.com" => 1 },
+          { "old-forum.example.com" => 2, "another.example.com" => 4 },
+        ],
+        tracker,
+      )
+
+      expect(tracker.stats.warning_count).to eq(0) # no dominant host, nothing to warn about
+      expect(entry).to include(
+        type: Migrations::Database::IntermediateDB::LogEntry::INFO,
+        message: described_class::FOREIGN_LINK_LOG_MESSAGE,
+      )
+      expect(JSON.parse(entry[:details])["total"]).to eq(10)
+      expect(hosts_in(entry[:details])).to eq(
+        [["old-forum.example.com", 5], ["another.example.com", 4], ["legacy.example.com", 1]],
+      )
+      expect(JSON.parse(entry[:details])).not_to have_key("omitted")
+    end
+
+    it "caps the host list and records how many hosts it dropped" do
+      # One more host than the cap, each with a distinct count so the order is
+      # deterministic and the smallest one is the host that gets dropped.
+      tally = {}
+      501.times { |i| tally["host#{i}.example"] = i + 1 }
+
+      described_class.combine_results([tally], tracker)
+
+      details = JSON.parse(entry[:details])
+      expect(details["hosts"].size).to eq(500)
+      expect(details["omitted"]).to eq(1)
+      # `total` still sums every host, dropped ones included.
+      expect(details["total"]).to eq((1..501).sum)
+      # The busiest host stays at the head of the kept list.
+      expect(hosts_in(entry[:details]).first).to eq(["host500.example", 501])
+    end
+
+    it "logs a WARNING through the tracker when a host dominates the list" do
+      described_class.combine_results(
+        [{ "old-forum.example.com" => 300 }, { "other.example.com" => 50, "misc.example" => 40 }],
+        tracker,
+      )
+
+      expect(tracker.stats.warning_count).to eq(1)
+      expect(entry).to include(type: Migrations::Database::IntermediateDB::LogEntry::WARNING)
+      expect(hosts_in(entry[:details]).first).to eq(["old-forum.example.com", 300])
+    end
+
+    it "does not let a small forum's handful of links dominate" do
+      # 3 of 4 links is 75%, but far below the absolute minimum a former domain
+      # would accumulate.
+      described_class.combine_results([{ "old.example" => 3, "other.example" => 1 }], tracker)
+
+      expect(tracker.stats.warning_count).to eq(0)
+      expect(entry).to include(type: Migrations::Database::IntermediateDB::LogEntry::INFO)
+    end
+
+    it "writes nothing for no results" do
+      described_class.combine_results([], tracker)
+
+      expect(tracker.stats.warning_count).to eq(0)
+      expect(rows("log_entries")).to be_empty
+    end
+  end
+end

--- a/migrations/core/db/intermediate_db_schema/100-base-schema.sql
+++ b/migrations/core/db/intermediate_db_schema/100-base-schema.sql
@@ -117,6 +117,16 @@ CREATE TABLE category_users
 );
 
 
+CREATE TABLE custom_emojis
+(
+    original_id NUMERIC  NOT NULL PRIMARY KEY,
+    created_at  DATETIME,
+    "group"     TEXT,
+    name        TEXT     NOT NULL,
+    upload_id   TEXT     NOT NULL
+);
+
+
 CREATE TABLE embed_emojis
 (
     name        TEXT         NOT NULL,
@@ -280,6 +290,35 @@ CREATE TABLE permalink_normalizations
     normalization TEXT NOT NULL PRIMARY KEY
 );
 
+
+CREATE TABLE posts
+(
+    original_id      NUMERIC      NOT NULL PRIMARY KEY,
+    action_code      TEXT,
+    created_at       DATETIME,
+    deleted_at       DATETIME,
+    deleted_by_id    NUMERIC,
+    hidden           BOOLEAN,
+    hidden_at        DATETIME,
+    hidden_reason_id ENUM_INTEGER,
+    last_editor_id   NUMERIC,
+    like_count       INTEGER,
+    locale           TEXT,
+    locked_by_id     NUMERIC,
+    original_raw     TEXT,
+    post_number      INTEGER,
+    post_type        ENUM_INTEGER,
+    raw              TEXT         NOT NULL,
+    reply_to_post_id INTEGER,
+    reply_to_user_id NUMERIC,
+    sort_order       INTEGER,
+    topic_id         NUMERIC      NOT NULL,
+    user_deleted     BOOLEAN,
+    user_id          NUMERIC,
+    wiki             BOOLEAN
+);
+
+CREATE INDEX idx_posts_topic_id_post_number ON posts (topic_id, post_number);
 
 CREATE TABLE site_settings
 (

--- a/migrations/core/lib/migrations/database/intermediate_db/custom_emoji.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/custom_emoji.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module CustomEmoji
+        SQL = <<~SQL
+          INSERT INTO custom_emojis (
+            original_id,
+            created_at,
+            "group",
+            name,
+            upload_id
+          )
+          VALUES (
+            ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `custom_emojis` record in the IntermediateDB.
+        #
+        # @param original_id   [Integer, String]
+        # @param created_at    [Time, nil]
+        # @param group         [String, nil]
+        # @param name          [String]
+        # @param upload_id     [String]
+        #
+        # @return [void]
+        def self.create(original_id:, created_at: nil, group: nil, name:, upload_id:)
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            original_id,
+            Migrations::Database.format_datetime(created_at),
+            group,
+            name,
+            upload_id,
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/enums/post_hidden_reason.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/enums/post_hidden_reason.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module Enums
+        module PostHiddenReason
+          extend Migrations::Enum
+
+          FLAG_THRESHOLD_REACHED = 1
+          FLAG_THRESHOLD_REACHED_AGAIN = 2
+          NEW_USER_SPAM_THRESHOLD_REACHED = 3
+          FLAGGED_BY_TL3_USER = 4
+          EMAIL_SPAM_HEADER_FOUND = 5
+          FLAGGED_BY_TL4_USER = 6
+          EMAIL_AUTHENTICATION_RESULT_HEADER = 7
+          IMPORTED_AS_UNLISTED = 8
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/enums/post_type.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/enums/post_type.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module Enums
+        module PostType
+          extend Migrations::Enum
+
+          REGULAR = 1
+          MODERATOR_ACTION = 2
+          SMALL_ACTION = 3
+          WHISPER = 4
+        end
+      end
+    end
+  end
+end

--- a/migrations/core/lib/migrations/database/intermediate_db/post.rb
+++ b/migrations/core/lib/migrations/database/intermediate_db/post.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the IntermediateDB schema. To make changes,
+# update the configuration files in "migrations/tooling/config/schema/" and then run
+# `migrations/bin/disco schema generate` to regenerate this file.
+
+module Migrations
+  module Database
+    module IntermediateDB
+      module Post
+        SQL = <<~SQL
+          INSERT INTO posts (
+            original_id,
+            action_code,
+            created_at,
+            deleted_at,
+            deleted_by_id,
+            hidden,
+            hidden_at,
+            hidden_reason_id,
+            last_editor_id,
+            like_count,
+            locale,
+            locked_by_id,
+            original_raw,
+            post_number,
+            post_type,
+            raw,
+            reply_to_post_id,
+            reply_to_user_id,
+            sort_order,
+            topic_id,
+            user_deleted,
+            user_id,
+            wiki
+          )
+          VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          )
+        SQL
+        private_constant :SQL
+
+        # Creates a new `posts` record in the IntermediateDB.
+        #
+        # @param original_id        [Integer, String]
+        # @param action_code        [String, nil]
+        # @param created_at         [Time, nil]
+        # @param deleted_at         [Time, nil]
+        # @param deleted_by_id      [Integer, String, nil]
+        # @param hidden             [Boolean, nil]
+        # @param hidden_at          [Time, nil]
+        # @param hidden_reason_id   [Integer, nil]
+        #   Any constant from PostHiddenReason (e.g. PostHiddenReason::FLAG_THRESHOLD_REACHED)
+        # @param last_editor_id     [Integer, String, nil]
+        # @param like_count         [Integer, nil]
+        # @param locale             [String, nil]
+        # @param locked_by_id       [Integer, String, nil]
+        # @param original_raw       [String, nil]
+        # @param post_number        [Integer, nil]
+        # @param post_type          [Integer, nil]
+        #   Any constant from PostType (e.g. PostType::REGULAR)
+        # @param raw                [String]
+        # @param reply_to_post_id   [Integer, nil]
+        # @param reply_to_user_id   [Integer, String, nil]
+        # @param sort_order         [Integer, nil]
+        # @param topic_id           [Integer, String]
+        # @param user_deleted       [Boolean, nil]
+        # @param user_id            [Integer, String, nil]
+        # @param wiki               [Boolean, nil]
+        #
+        # @return [void]
+        #
+        # @see Migrations::Database::IntermediateDB::Enums::PostHiddenReason
+        # @see Migrations::Database::IntermediateDB::Enums::PostType
+        def self.create(
+          original_id:,
+          action_code: nil,
+          created_at: nil,
+          deleted_at: nil,
+          deleted_by_id: nil,
+          hidden: nil,
+          hidden_at: nil,
+          hidden_reason_id: nil,
+          last_editor_id: nil,
+          like_count: nil,
+          locale: nil,
+          locked_by_id: nil,
+          original_raw: nil,
+          post_number: nil,
+          post_type: nil,
+          raw:,
+          reply_to_post_id: nil,
+          reply_to_user_id: nil,
+          sort_order: nil,
+          topic_id:,
+          user_deleted: nil,
+          user_id: nil,
+          wiki: nil
+        )
+          Migrations::Database::IntermediateDB.insert(
+            SQL,
+            original_id,
+            action_code,
+            Migrations::Database.format_datetime(created_at),
+            Migrations::Database.format_datetime(deleted_at),
+            deleted_by_id,
+            Migrations::Database.format_boolean(hidden),
+            Migrations::Database.format_datetime(hidden_at),
+            hidden_reason_id,
+            last_editor_id,
+            like_count,
+            locale,
+            locked_by_id,
+            original_raw,
+            post_number,
+            post_type,
+            raw,
+            reply_to_post_id,
+            reply_to_user_id,
+            sort_order,
+            topic_id,
+            Migrations::Database.format_boolean(user_deleted),
+            user_id,
+            Migrations::Database.format_boolean(wiki),
+          )
+        end
+      end
+    end
+  end
+end

--- a/migrations/importer/spec/lib/migrations/importer/placeholder_resolver/id_resolution_spec.rb
+++ b/migrations/importer/spec/lib/migrations/importer/placeholder_resolver/id_resolution_spec.rb
@@ -28,6 +28,46 @@ RSpec.describe Migrations::Importer::PlaceholderResolver do
       expect(resolved[1]).to eq('x [quote="robert"] y')
     end
 
+    it "fills quoted_post_id from (topic_id, post_number) and feeds the maps flow" do
+      Migrations::Database::IntermediateDB::Post.create(
+        original_id: 200,
+        topic_id: 5,
+        post_number: 12,
+        raw: "quoted body",
+      )
+      quote = placeholder.mint(:quote)
+      Migrations::Database::IntermediateDB::EmbedQuote.create(
+        owner_type: embed_owner::POST,
+        owner_id: 1,
+        placeholder: quote,
+        quoted_topic_id: 5,
+        quoted_post_number: 12,
+        quoted_username: "bob",
+      )
+      maps = FakePlaceholderMaps.new(post: { 200 => { topic_id: 42, post_number: 3 } })
+      resolver = described_class.new(intermediate_db, maps, owner_type: embed_owner::POST)
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{quote} y" }])
+
+      expect(resolved[1]).to eq('x [quote="bob, post:3, topic:42"] y')
+    end
+
+    it "falls back to the username when the coordinates match no post" do
+      quote = placeholder.mint(:quote)
+      Migrations::Database::IntermediateDB::EmbedQuote.create(
+        owner_type: embed_owner::POST,
+        owner_id: 1,
+        placeholder: quote,
+        quoted_topic_id: 5,
+        quoted_post_number: 99,
+        quoted_username: "bob",
+      )
+
+      resolved = resolver.resolve_all([{ id: 1, raw: "x #{quote} y" }])
+
+      expect(resolved[1]).to eq('x [quote="bob"] y')
+    end
+
     it "maps a user mention name to the user's original_id, honoring an import-time rename" do
       Migrations::Database::IntermediateDB::User.create(
         original_id: 7,

--- a/migrations/importer/spec/lib/migrations/importer/placeholder_resolver/links_spec.rb
+++ b/migrations/importer/spec/lib/migrations/importer/placeholder_resolver/links_spec.rb
@@ -281,6 +281,29 @@ RSpec.describe Migrations::Importer::PlaceholderResolver do
       expect(resolved).to eq("x https://dest.example.com/tag/shipped y")
     end
 
+    it "resolves a post target addressed by source coordinates" do
+      Migrations::Database::IntermediateDB::Post.create(
+        original_id: 500,
+        topic_id: 12,
+        post_number: 3,
+        raw: "body",
+      )
+      maps = FakePlaceholderMaps.new(post: { 500 => { topic_id: 42, post_number: 7 } })
+
+      resolved =
+        render(
+          {
+            url: "/t/slug/12/3",
+            target_type: link_target::POST,
+            target_topic_id: 12,
+            target_post_number: 3,
+          },
+          maps:,
+        )
+
+      expect(resolved).to eq("x https://dest.example.com/t/42/7 y")
+    end
+
     # Reporting: an internal link that can't be resolved falls back to the source URL
     # but is still recorded, since a stale internal link points at the wrong record.
 

--- a/migrations/tooling/config/schema/intermediate_db/enums/post_hidden_reason.rb
+++ b/migrations/tooling/config/schema/intermediate_db/enums/post_hidden_reason.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Migrations::Tooling::Schema.enum :post_hidden_reason do
+  source { ::Post.hidden_reasons }
+end

--- a/migrations/tooling/config/schema/intermediate_db/enums/post_type.rb
+++ b/migrations/tooling/config/schema/intermediate_db/enums/post_type.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Migrations::Tooling::Schema.enum :post_type do
+  source { ::Post.types }
+end

--- a/migrations/tooling/config/schema/intermediate_db/ignored.rb
+++ b/migrations/tooling/config/schema/intermediate_db/ignored.rb
@@ -74,7 +74,6 @@ Migrations::Tooling::Schema.ignored do
          :post_search_data,
          :post_stats,
          :post_timings,
-         :posts,
          :quoted_posts,
          :shared_drafts
 
@@ -170,7 +169,6 @@ Migrations::Tooling::Schema.ignored do
          :browser_pageview_events,
          :browser_pageview_session_engagement_daily_rollups,
          :browser_pageview_session_engagements,
-         :custom_emojis,
          :developers,
          :directory_columns,
          :directory_items,

--- a/migrations/tooling/config/schema/intermediate_db/tables/custom_emojis.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/custom_emojis.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Custom emoji defined on the source site. `name` is the shortcode (without the
+# surrounding colons); a post's `:name:` renders this emoji when `name` matches.
+#
+# `upload_id` is the emoji image. The source stores it as a numeric FK into
+# `uploads`, but IntermediateDB references an upload by its content hash, so the
+# step resolves the FK to the upload's `sha1` in its `items` query. The global
+# `.*upload.*_id$ => :text` convention already types this column as text to match.
+Migrations::Tooling::Schema.table :custom_emojis do
+  ignore :user_id, reason: "The uploader isn't needed to recreate the emoji"
+end

--- a/migrations/tooling/config/schema/intermediate_db/tables/posts.rb
+++ b/migrations/tooling/config/schema/intermediate_db/tables/posts.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+Migrations::Tooling::Schema.table :posts do
+  index :topic_id, :post_number
+
+  # The finalized `raw` is rebuilt at import time; `original_raw` keeps the
+  # untouched source body alongside the placeholder-substituted `raw`.
+  add_column :original_raw, :text
+
+  # `reply_to_post_number` is resolved to the parent post's `original_id` in the
+  # converter, so it's stored as a post reference rather than a number.
+  column :reply_to_post_number, rename_to: :reply_to_post_id
+
+  column :post_type, :post_type
+  column :hidden_reason_id, :post_hidden_reason
+
+  # Post numbers are recomputed at import time, so the source value is optional.
+  column :post_number, required: false
+
+  # Every converted post is Markdown; the importer leaves `cook_method` at
+  # `regular`. A `raw_html`/`email` post bypasses markdown-it at cook time, so
+  # none of the markdown the placeholder resolver splices in — upload
+  # references, quote tags, hashtags, rebuilt links — would render inside one.
+  # Making this converter-settable means pairing it with an HTML rendering mode
+  # in the resolver (or a no-embeds rule for such posts); unlock it with that,
+  # not before.
+  ignore :cook_method, reason: "Fixed at regular until non-Markdown posts are a designed feature"
+
+  ignore :baked_at,
+         :baked_version,
+         :bookmark_count,
+         :cooked,
+         :edit_reason,
+         :illegal_count,
+         :image_upload_id,
+         :inappropriate_count,
+         :incoming_link_count,
+         :last_version_at,
+         :like_score,
+         :notify_moderators_count,
+         :notify_user_count,
+         :off_topic_count,
+         :outbound_message_id,
+         :percent_rank,
+         :public_version,
+         :qa_vote_count,
+         :quote_count,
+         :raw_email,
+         :reads,
+         :reply_count,
+         :reply_quoted,
+         :score,
+         :self_edits,
+         :spam_count,
+         :version,
+         :via_email,
+         :word_count,
+         reason: "Calculated or unused columns"
+end


### PR DESCRIPTION
The last PR from the split of #41473, on top of the scanner from #41911 — this one wires everything into an actual conversion.

- The **posts step** runs the RawExtractor over every post: one embed buffer per worker, cleared per post, and the extracted embeds land in the embed_* tables keyed by the post. The step's `step_args` carry the name gates (mentions, hashtags, custom emoji — the big ones as `SortedStringSet`s so they stay copy-on-write-shared across forks) and the `source_site` hosts for internal-link detection. Foreign-looking internal links tally per worker and reduce to a single log entry through `combine_results`, with a warning only when one host dominates.
- The **custom_emojis step** converts the source's custom emoji (joining each to its upload's sha1, warning and skipping on a dangling upload reference) and feeds the emoji name gate.
- `settings.yml` gains the `source_site` key (base_url + former_domains).
- The **posts and custom_emojis tables** leave the ignored list; models and schema.sql are regenerated from the schema config. Schema coverage is green again (336 columns across 33 tables).
- Three resolver examples that fabricate posts (quote and link resolution by source coordinates) return to the importer specs — they were parked in #41890 because the posts table didn't exist yet.

With this the convert side of the posts saga is complete. Part two — the importer step for posts and embeds, where the PlaceholderResolver and the cooking work happen — comes as its own series.