### PR TITLE
UX: Style tweaks for wizard & onboarding banner

### DIFF
--- a/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
+++ b/app/assets/stylesheets/common/components/admin-onboarding-banner.scss
@@ -186,10 +186,6 @@
 }
 
 .theme-picker-modal {
-  .d-modal__container {
-    background-color: var(--primary-very-low);
-  }
-
   &__loading {
     display: flex;
     justify-content: center;
@@ -212,7 +208,6 @@
       border: 2px solid var(--content-border-color);
       height: 250px;
       border-radius: var(--d-border-radius);
-      box-shadow: var(--shadow-card);
 
       @include viewport.from(md) {
         height: 24vw; // adjusts with window width (like the modal itself)
@@ -251,6 +246,8 @@
     background: var(--tertiary);
     padding: var(--space-1) var(--space-2);
     border-radius: var(--d-border-radius);
+    border-top-left-radius: 0;
+    border-bottom-right-radius: 0;
     z-index: 1;
   }
 

--- a/app/assets/stylesheets/wizard.scss
+++ b/app/assets/stylesheets/wizard.scss
@@ -116,9 +116,18 @@ body.wizard {
     #wizard-main {
       position: fixed;
       inset: 0;
-      justify-content: safe center;
+
+      // inset must size the box alone; height + padding on a content-box
+      // element pushes it past the viewport and skews centering
+      height: auto;
       padding: 1.5rem;
       overflow: auto;
+    }
+
+    // auto margins center the step when short, but unlike justify-content:
+    // center keep the top reachable when a tall step overflows
+    .wizard-container__step {
+      margin-block: auto;
     }
 
     #wizard-main::after {
@@ -147,7 +156,6 @@ body.wizard {
   background-color: var(--secondary);
   box-shadow: 0 10px 30px light-dark(rgb(123, 95, 226, 0.15), transparent);
   box-sizing: border-box;
-  margin: 1em auto;
   border-radius: 16px;
   padding: 3em;
 
@@ -156,7 +164,6 @@ body.wizard {
   }
 
   &__step {
-    margin-top: 1em;
     max-width: 700px;
     width: 100%;
 


### PR DESCRIPTION
This PR when merged will style some minor tweaks to both the wizard & onboarding banner theme modal

|before|after|
| -- | -- |
|<img width="2758" height="1858" alt="CleanShot 2026-07-22 at 16 59 00@2x" src="https://github.com/user-attachments/assets/341863c7-a266-4567-8081-aa0cff16845f" />|<img width="2758" height="1852" alt="CleanShot 2026-07-22 at 16 30 23@2x" src="https://github.com/user-attachments/assets/7f5625b7-0a16-4347-8b9e-d475321d147c" />|
|<img width="2748" height="1850" alt="CleanShot 2026-07-22 at 16 31 05@2x" src="https://github.com/user-attachments/assets/3e74e113-b2dd-43e9-a362-80b20af83d8f" />|<img width="2736" height="1854" alt="CleanShot 2026-07-22 at 16 30 40@2x" src="https://github.com/user-attachments/assets/74ddb6c3-c55c-45d9-9020-3ee331c6e7af" />|