### PR TITLE
DEV: Move composer actions upcoming change to stable

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4476,7 +4476,7 @@ experimental:
     hidden: true
     area: "experimental"
     upcoming_change:
-      status: "beta"
+      status: "stable"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/403635"
   rename_faq_to_guidelines:


### PR DESCRIPTION
Moves the `enable_new_composer_actions` upcoming change from `beta` to `stable`.

Follow-up to #40895 (alpha → beta).

Learn more: https://meta.discourse.org/t/-/403635