### PR TITLE
FIX: Upcoming change problem check not respecting should_display?

### DIFF
--- a/app/services/problem_check/upcoming_change_stable_opted_out.rb
+++ b/app/services/problem_check/upcoming_change_stable_opted_out.rb
@@ -5,9 +5,11 @@ class ProblemCheck::UpcomingChangeStableOptedOut < ProblemCheck
   self.targets = -> { SiteSetting.upcoming_change_site_settings }
 
   def call
+    return no_problem if !UpcomingChanges::ConditionalDisplay.should_display?(target)
+
     # If the site setting is enabled, then the change is opted in, either
     # manually or automatically, so we skip it.
-    return no_problem if SiteSetting.send(target)
+    return no_problem if UpcomingChanges.enabled?(target)
 
     # Don't care about any changes that are not yet stable, admins can opt
     # in and out of these without worry.

--- a/spec/services/problem_check/upcoming_change_stable_opted_out_spec.rb
+++ b/spec/services/problem_check/upcoming_change_stable_opted_out_spec.rb
@@ -49,5 +49,27 @@ RSpec.describe ProblemCheck::UpcomingChangeStableOptedOut do
 
       it { expect(check).to be_chill_about_it }
     end
+
+    context "when upcoming change is not enabled and should not be displayed for the site" do
+      before do
+        mock_upcoming_change_metadata(
+          {
+            enable_upload_debug_mode: {
+              impact: "other,developers",
+              status: :stable,
+              impact_type: "feature",
+              impact_role: "admins",
+            },
+          },
+        )
+        UpcomingChanges::ConditionalDisplay
+          .expects(:should_display_enable_upload_debug_mode?)
+          .at_least_once
+          .returns(false)
+        SiteSetting.enable_upload_debug_mode = false
+      end
+
+      it { expect(check).to be_chill_about_it }
+    end
   end
 end

--- a/spec/support/matchers/problem_check_matcher.rb
+++ b/spec/support/matchers/problem_check_matcher.rb
@@ -2,6 +2,10 @@
 
 RSpec::Matchers.define :be_chill_about_it do
   match { |service| expect(service.call).to be_blank }
+
+  failure_message do |service|
+    "Expected check to be chill about it, but it had a problem: #{service.call.inspect}"
+  end
 end
 
 RSpec::Matchers.define :have_a_problem do


### PR DESCRIPTION
Our UpcomingChangeStableOptedOut problem check was showing
problems on brand new sites, when it should only show a
problem after admin has opted out of a stable upcoming change.

This was happening because on some sites a plugin might be disabled
or not configurable, so it would return false when calling
`SiteSetting.send(change_name)`, but crucially we weren't filtering
out upcoming changes that shouldn't display on the site.

This commit fixes the issue by returning no problem if the upcoming
change is not configured to display on the site.
