### PR TITLE
DEV: Better logging of unexpected UC notification error

### DIFF
--- a/app/jobs/scheduled/check_upcoming_changes.rb
+++ b/app/jobs/scheduled/check_upcoming_changes.rb
@@ -85,10 +85,12 @@ module Jobs
                 :error
               end
 
+            backtrace = (status[:backtrace] || status[:result_inspect_steps])&.join("\n") || "N/A"
+
             verbose_log(
               site,
               log_level,
-              "Failed to notify about promotion of '#{setting_name}': #{status[:error]} with backtrace: #{status[:backtrace]&.join("\n") || "N/A"}",
+              "Failed to notify about promotion of '#{setting_name}': #{status[:error]} with backtrace: #{backtrace}",
             )
           end
         end

--- a/app/services/upcoming_changes/notify_promotions.rb
+++ b/app/services/upcoming_changes/notify_promotions.rb
@@ -81,6 +81,14 @@ class UpcomingChanges::NotifyPromotions
         end
       end
 
+      if !status_hash[:success] && (!status_hash[:error_key] || !status_hash[:error])
+        status_hash[
+          :error
+        ] = "An unexpected error in UpcomingChanges::NotifyPromotion occurred while notifying about promotion of #{setting_name}"
+        status_hash[:error_key] = :unexpected_error
+        status_hash[:result_inspect_steps] = result.inspect_steps
+      end
+
       status_hash
     end
   end


### PR DESCRIPTION
This kind of error and backtrace that is unexpected and
has no error backtrace info is happening for some sites in
production, but I can't tell why:

> [CheckUpcomingChanges (SITE)] Failed to notify about promotion of 'enable_simplified_category_creation': with backtrace: N/A

Add more logging to try get a better reason
