### PR TITLE
DEV: Increase core backend test job timeout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,10 @@ jobs:
     container: discourse/discourse_test:release
     timeout-minutes: >-
       ${{
-        matrix.build_type == 'system' && (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'core')
-        && 30
+        (
+          matrix.build_type == 'backend' && matrix.target == 'core'
+          || matrix.build_type == 'system' && (matrix.target == 'core-plugins' || matrix.target == 'official-plugins' || matrix.target == 'core')
+        ) && 30
         || 20
       }}
 


### PR DESCRIPTION
Core backend test jobs can exceed the existing 20-minute job limit, causing GitHub Actions to cancel RSpec before the suite completes.

This commit gives the core backend job the same 30-minute timeout already used by core system jobs while leaving the other matrix jobs at 20 minutes.