### PR TITLE
FIX: Stop double-counting embedded views with beacon

### DIFF
--- a/lib/middleware/request_tracker.rb
+++ b/lib/middleware/request_tracker.rb
@@ -120,10 +120,11 @@ class Middleware::RequestTracker
     end
 
     if tracks_browser_page_view?(data)
-      if data[:is_beacon]
-        if data[:is_embed]
-          ApplicationRequest.increment!(:page_view_embed)
-        elsif data[:has_auth_cookie]
+      if data[:is_embed]
+        count_embed = beacon_pageviews_enabled? ? data[:is_beacon] : !data[:is_beacon]
+        ApplicationRequest.increment!(:page_view_embed) if count_embed
+      elsif data[:is_beacon]
+        if data[:has_auth_cookie]
           ApplicationRequest.increment!(:page_view_logged_in_browser_beacon)
           if data[:is_mobile]
             ApplicationRequest.increment!(:page_view_logged_in_browser_mobile_beacon)
@@ -133,9 +134,7 @@ class Middleware::RequestTracker
           ApplicationRequest.increment!(:page_view_anon_browser_mobile_beacon) if data[:is_mobile]
         end
       else
-        if data[:is_embed]
-          ApplicationRequest.increment!(:page_view_embed)
-        elsif data[:has_auth_cookie]
+        if data[:has_auth_cookie]
           ApplicationRequest.increment!(:page_view_logged_in_browser)
           ApplicationRequest.increment!(:page_view_logged_in_browser_mobile) if data[:is_mobile]
         else
@@ -667,11 +666,13 @@ class Middleware::RequestTracker
     true
   end
 
-  def self.is_beacon_tracking_request?(request)
+  def self.beacon_pageviews_enabled?
     UpcomingChanges.enabled?(:dashboard_improvements) &&
-      (
-        SiteSetting.persist_browser_pageview_events || SiteSetting.trigger_browser_pageview_events
-      ) && request.post? && request.path == Discourse.beacon_pv_tracking_path
+      (SiteSetting.persist_browser_pageview_events || SiteSetting.trigger_browser_pageview_events)
+  end
+
+  def self.is_beacon_tracking_request?(request)
+    beacon_pageviews_enabled? && request.post? && request.path == Discourse.beacon_pv_tracking_path
   end
 
   def self.same_origin_request?(request)

--- a/spec/lib/middleware/request_tracker_spec.rb
+++ b/spec/lib/middleware/request_tracker_spec.rb
@@ -331,7 +331,7 @@ RSpec.describe Middleware::RequestTracker do
         Middleware::RequestTracker.log_request(data)
       end
 
-      it "counts beacon pageview with embed flag as page_view_embed" do
+      it "counts embed views from the beacon instead of the piggyback when beacons are enabled" do
         SiteSetting.dashboard_improvements = true
         SiteSetting.trigger_browser_pageview_events = true
         body = {
@@ -352,10 +352,19 @@ RSpec.describe Middleware::RequestTracker do
             0.1,
           )
         Middleware::RequestTracker.log_request(data)
+
+        piggyback_data =
+          Middleware::RequestTracker.get_data(
+            env("HTTP_DISCOURSE_TRACK_VIEW" => "1", "HTTP_DISCOURSE_TRACK_VIEW_EMBED" => "true"),
+            ["200", {}],
+            0.1,
+          )
+        Middleware::RequestTracker.log_request(piggyback_data)
         CachedCounting.flush
 
         expect(data[:is_embed]).to eq(true)
-        expect(ApplicationRequest.page_view_embed.first.count).to eq(1)
+        expect(piggyback_data[:is_embed]).to eq(true)
+        expect(ApplicationRequest.page_view_embed.sum(:count)).to eq(1)
         expect(ApplicationRequest.page_view_anon_browser_beacon.sum(:count)).to eq(0)
       end
 


### PR DESCRIPTION
Previously, an embedded pageview incremented the `page_view_embed` counter twice on sites with beacon tracking enabled. Once from the piggybacked track-view request and once from the beacon POST.

This change counts each embedded pageview exactly once into the same counter — from the beacon when beacon tracking is active, and from the piggybacked track-view otherwise.