### PR TITLE
FIX: Surface actionable errors when chat policy checks fail

### DIFF
--- a/plugins/chat/app/controllers/chat/api/channel_messages_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channel_messages_controller.rb
@@ -38,7 +38,7 @@ class Chat::Api::ChannelMessagesController < Chat::ApiController
       on_success { render(json: success_json) }
       on_failure { render(json: failed_json, status: :unprocessable_entity) }
       on_model_not_found(:messages) { raise Discourse::NotFound }
-      on_failed_policy(:invalid_access) { raise Discourse::InvalidAccess }
+      on_failed_policy(:can_delete_all_chat_messages) { raise Discourse::InvalidAccess }
       on_failed_contract do |contract|
         render(json: failed_json.merge(errors: contract.errors.full_messages), status: :bad_request)
       end
@@ -62,6 +62,11 @@ class Chat::Api::ChannelMessagesController < Chat::ApiController
       on_success { |message:| render json: success_json.merge(message_id: message.id) }
       on_failure { render(json: failed_json, status: :unprocessable_entity) }
       on_model_not_found(:message) { raise Discourse::NotFound }
+      on_model_not_found(:membership) { raise Discourse::NotFound }
+      on_failed_policy(:can_edit_message) { raise Discourse::InvalidAccess }
+      on_failed_policy(:channel_allows_message_modification) do |policy|
+        render_json_error(policy.reason)
+      end
       on_model_errors(:message) do |model|
         render_json_error(model.errors.map(&:full_message).join(", "))
       end
@@ -81,11 +86,10 @@ class Chat::Api::ChannelMessagesController < Chat::ApiController
       on_failure { render(json: failed_json, status: :unprocessable_entity) }
       on_failed_policy(:no_silenced_user) { raise Discourse::InvalidAccess }
       on_model_not_found(:channel) { raise Discourse::NotFound }
-      on_failed_policy(:allowed_to_join_channel) { raise Discourse::InvalidAccess }
       on_failed_policy(:accept_blocks) { raise Discourse::InvalidAccess }
       on_model_not_found(:membership) { raise Discourse::NotFound }
       on_failed_policy(:ensure_reply_consistency) { raise Discourse::NotFound }
-      on_failed_policy(:allowed_to_create_message_in_channel) do |policy|
+      on_failed_policy(:channel_allows_message_creation) do |policy|
         render_json_error(policy.reason)
       end
       on_failed_policy(:ensure_valid_thread_for_channel) do

--- a/plugins/chat/app/controllers/chat/api/channels_controller.rb
+++ b/plugins/chat/app/controllers/chat/api/channels_controller.rb
@@ -83,6 +83,9 @@ class Chat::Api::ChannelsController < Chat::ApiController
       end
       on_model_not_found(:category) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:can_create_channel) { raise Discourse::InvalidAccess }
+      on_failed_policy(:public_channels_enabled) do
+        render_json_error(I18n.t("chat.errors.public_channels_disabled"))
+      end
       on_failed_policy(:can_create_channel_in_category) { raise Discourse::InvalidAccess }
       on_failed_policy(:category_channel_does_not_exist) do
         raise Discourse::InvalidParameters.new(I18n.t("chat.errors.channel_exists_for_category"))
@@ -128,7 +131,6 @@ class Chat::Api::ChannelsController < Chat::ApiController
       end
       on_model_not_found(:channel) { raise ActiveRecord::RecordNotFound }
       on_failed_policy(:check_channel_permission) { raise Discourse::InvalidAccess }
-      on_failed_policy(:no_direct_message_channel) { raise Discourse::InvalidAccess }
     end
   end
 

--- a/plugins/chat/app/controllers/chat/incoming_webhooks_controller.rb
+++ b/plugins/chat/app/controllers/chat/incoming_webhooks_controller.rb
@@ -70,10 +70,9 @@ module Chat
         end
         on_failed_policy(:no_silenced_user) { raise Discourse::InvalidAccess }
         on_model_not_found(:channel) { raise Discourse::NotFound }
-        on_failed_policy(:allowed_to_join_channel) { raise Discourse::InvalidAccess }
-        on_model_not_found(:channel_membership) { raise Discourse::InvalidAccess }
+        on_model_not_found(:membership) { raise Discourse::InvalidAccess }
         on_failed_policy(:ensure_reply_consistency) { raise Discourse::NotFound }
-        on_failed_policy(:allowed_to_create_message_in_channel) do |policy|
+        on_failed_policy(:channel_allows_message_creation) do |policy|
           render_json_error(policy.reason)
         end
         on_failed_policy(:ensure_valid_thread_for_channel) do

--- a/plugins/chat/app/services/chat/channel/policy/message_modification.rb
+++ b/plugins/chat/app/services/chat/channel/policy/message_modification.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Chat::Channel::Policy::MessageModification < Service::PolicyBase
+  delegate :message, to: :context
+
+  def call
+    guardian.can_modify_channel_message?(message.chat_channel)
+  end
+
+  def reason
+    I18n.t("chat.errors.channel_modify_message_disallowed.#{message.chat_channel.status}")
+  end
+end

--- a/plugins/chat/app/services/chat/create_category_channel.rb
+++ b/plugins/chat/app/services/chat/create_category_channel.rb
@@ -30,8 +30,8 @@ module Chat
     #   @option params [String] :emoji
     #   @return [Service::Base::Context]
 
-    policy :public_channels_enabled
     policy :can_create_channel
+    policy :public_channels_enabled
 
     params do
       attribute :name, :string
@@ -65,12 +65,12 @@ module Chat
 
     private
 
-    def public_channels_enabled
-      SiteSetting.enable_public_channels
-    end
-
     def can_create_channel(guardian:)
       guardian.can_create_chat_channel?
+    end
+
+    def public_channels_enabled
+      SiteSetting.enable_public_channels
     end
 
     def fetch_category(params:)

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -66,7 +66,7 @@ module Chat
     model :channel
     step :enforce_membership
     model :membership
-    policy :allowed_to_create_message_in_channel, class_name: Chat::Channel::Policy::MessageCreation
+    policy :channel_allows_message_creation, class_name: Chat::Channel::Policy::MessageCreation
     model :reply, optional: true
     policy :ensure_reply_consistency
     model :thread, optional: true

--- a/plugins/chat/app/services/chat/update_message.rb
+++ b/plugins/chat/app/services/chat/update_message.rb
@@ -52,8 +52,9 @@ module Chat
     model :uploads, optional: true
     step :enforce_membership
     model :membership
-    policy :can_modify_channel_message
-    policy :can_modify_message
+    policy :can_edit_message
+    policy :channel_allows_message_modification,
+           class_name: Chat::Channel::Policy::MessageModification
 
     transaction do
       step :modify_message
@@ -103,11 +104,7 @@ module Chat
         .where(user_uploads: { user: guardian.user })
     end
 
-    def can_modify_channel_message(guardian:, message:)
-      guardian.can_modify_channel_message?(message.chat_channel)
-    end
-
-    def can_modify_message(guardian:, message:)
+    def can_edit_message(guardian:, message:)
       guardian.can_edit_chat?(message)
     end
 

--- a/plugins/chat/config/locales/server.en.yml
+++ b/plugins/chat/config/locales/server.en.yml
@@ -63,6 +63,7 @@ en:
       users_cant_be_added_to_channel: "Users can't be added to this channel."
       user_cant_be_removed_from_channel: "User can't be removed from this channel"
       channel_exists_for_category: "A channel already exists for this category and name"
+      public_channels_disabled: "Unable to create the channel because public channels are disabled. An admin can enable the 'enable public channels' site setting."
       channel_new_message_disallowed:
         archived: "The channel is archived, no new messages can be sent"
         closed: "The channel is closed, no new messages can be sent"

--- a/plugins/chat/lib/chat_sdk/message.rb
+++ b/plugins/chat/lib/chat_sdk/message.rb
@@ -95,9 +95,6 @@ module ChatSDK
         on_model_not_found(:membership) do
           raise "Couldn't find membership for user with id: `#{guardian.user.id}`"
         end
-        on_failed_policy(:can_join_channel) do
-          raise "User with id: `#{guardian.user.id}` can't join this channel"
-        end
         on_failed_policy(:can_stop_streaming) do
           raise "User with id: `#{guardian.user.id}` can't stop streaming this message"
         end
@@ -148,9 +145,6 @@ module ChatSDK
             raise "Couldn't find thread with id: `#{thread_id}`"
           end
           on_failed_policy(:accept_blocks) { raise "Only bots can create messages with blocks" }
-          on_failed_policy(:allowed_to_join_channel) do
-            raise "User with id: `#{guardian.user.id}` can't join this channel"
-          end
           on_failed_contract { |contract| raise contract.errors.full_messages.join(", ") }
           on_success { |message_instance:| message_instance }
           on_failure { raise "Unexpected error" }

--- a/plugins/chat/lib/chat_sdk/thread.rb
+++ b/plugins/chat/lib/chat_sdk/thread.rb
@@ -97,9 +97,6 @@ module ChatSDK
 
     def update(guardian:, **params)
       Chat::UpdateThread.call(guardian:, params:) do
-        on_model_not_found(:channel) do
-          raise "Couldn’t find channel with id: `#{params[:channel_id]}`"
-        end
         on_model_not_found(:thread) do
           raise "Couldn’t find thread with id: `#{params[:thread_id]}`"
         end

--- a/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channel_messages_controller_spec.rb
@@ -238,6 +238,39 @@ RSpec.describe Chat::Api::ChannelMessagesController do
     end
   end
 
+  describe "#bulk_destroy" do
+    fab!(:other_user, :user)
+    fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel, user: other_user) }
+    fab!(:message_2) { Fabricate(:chat_message, chat_channel: channel, user: other_user) }
+
+    context "when user is staff" do
+      fab!(:current_user, :admin)
+
+      it "deletes the messages" do
+        delete "/chat/api/channels/#{channel.id}/messages",
+               params: {
+                 message_ids: [message_1.id, message_2.id],
+               }
+
+        expect(response.status).to eq(200)
+        expect(Chat::Message.where(id: [message_1.id, message_2.id])).to be_empty
+      end
+    end
+
+    context "when user can't delete the messages" do
+      it "returns a generic permission error" do
+        delete "/chat/api/channels/#{channel.id}/messages",
+               params: {
+                 message_ids: [message_1.id, message_2.id],
+               }
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        expect(Chat::Message.where(id: [message_1.id, message_2.id]).count).to eq(2)
+      end
+    end
+  end
+
   describe "#update" do
     context "when message is updated" do
       fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel, user: current_user) }
@@ -282,35 +315,70 @@ RSpec.describe Chat::Api::ChannelMessagesController do
         before { channel.membership_for(current_user).destroy! }
 
         it "returns a 404" do
-          put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}"
+          put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}",
+              params: {
+                message: "abcdefg",
+              }
 
-          expect(response.status).to eq(400)
+          expect(response.status).to eq(404)
         end
       end
 
       context "when user is not the author" do
         fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel) }
 
-        it "returns a 422" do
+        it "returns a 403" do
           put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}",
               params: {
                 message: "abcdefg",
               }
 
-          expect(response.status).to eq(422)
+          expect(response.status).to eq(403)
+          expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
         end
       end
 
       context "when current user is silenced" do
         before { UserSilencer.new(current_user).silence }
 
-        it "returns a 422" do
+        it "returns a 403" do
+          put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}",
+              params: {
+                message: "abcdefg",
+              }
+
+          expect(response.status).to eq(403)
+        end
+      end
+
+      context "when the channel is closed" do
+        before { channel.closed!(Discourse.system_user) }
+
+        it "returns an actionable error message" do
           put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}",
               params: {
                 message: "abcdefg",
               }
 
           expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"]).to contain_exactly(
+            I18n.t("chat.errors.channel_modify_message_disallowed.closed"),
+          )
+          expect(message_1.reload.message).not_to eq("abcdefg")
+        end
+
+        context "when the user is not the author" do
+          fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel) }
+
+          it "returns a 403" do
+            put "/chat/api/channels/#{channel.id}/messages/#{message_1.id}",
+                params: {
+                  message: "abcdefg",
+                }
+
+            expect(response.status).to eq(403)
+            expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+          end
         end
       end
 
@@ -339,8 +407,8 @@ RSpec.describe Chat::Api::ChannelMessagesController do
                 message: "edited message",
               }
 
-          expect(response).to have_http_status(:unprocessable_entity)
-          expect(response.parsed_body["failed"]).to eq("FAILED")
+          expect(response).to have_http_status(:forbidden)
+          expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
           expect(message.reload.message).to eq("original message")
         end
       end

--- a/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
+++ b/plugins/chat/spec/requests/chat/api/channels_controller_spec.rb
@@ -391,6 +391,32 @@ RSpec.describe Chat::Api::ChannelsController do
       end
     end
 
+    context "when public channels are disabled" do
+      before { SiteSetting.enable_public_channels = false }
+
+      it "returns an actionable error message" do
+        expect { post "/chat/api/channels", params: }.to not_change { Chat::Channel.count }
+
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          I18n.t("chat.errors.public_channels_disabled"),
+        )
+      end
+
+      context "when the user is not staff" do
+        fab!(:user)
+
+        before { sign_in(user) }
+
+        it "returns a generic permission error" do
+          post "/chat/api/channels", params: params
+
+          expect(response.status).to eq(403)
+          expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+        end
+      end
+    end
+
     it "creates a channel using the user-provided slug" do
       new_params = params.dup
       new_params[:channel][:slug] = "wow-so-cool"

--- a/plugins/chat/spec/services/chat/channel/policy/message_modification_spec.rb
+++ b/plugins/chat/spec/services/chat/channel/policy/message_modification_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe Chat::Channel::Policy::MessageModification do
+  subject(:policy) { described_class.new(context) }
+
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:chat_channel)
+  fab!(:message) { Fabricate(:chat_message, chat_channel:, user:) }
+
+  let(:guardian) { user.guardian }
+  let(:context) { Service::Base::Context.build(message:, guardian:) }
+
+  describe "#call" do
+    subject(:result) { policy.call }
+
+    context "when the channel is open" do
+      it "returns true" do
+        expect(result).to be_truthy
+      end
+    end
+
+    context "when the channel is closed" do
+      before { chat_channel.update!(status: :closed) }
+
+      it "returns false" do
+        expect(result).to be_falsey
+      end
+    end
+  end
+
+  describe "#reason" do
+    subject(:reason) { policy.reason }
+
+    %w[closed read_only archived].each do |status|
+      context "when the channel is #{status}" do
+        before { chat_channel.update!(status:) }
+
+        it "returns the #{status} message" do
+          expect(reason).to eq(I18n.t("chat.errors.channel_modify_message_disallowed.#{status}"))
+        end
+      end
+    end
+  end
+end

--- a/plugins/chat/spec/services/chat/create_category_channel_spec.rb
+++ b/plugins/chat/spec/services/chat/create_category_channel_spec.rb
@@ -18,18 +18,22 @@ RSpec.describe Chat::CreateCategoryChannel do
     let(:params) { { category_id:, name: name } }
     let(:dependencies) { { guardian: } }
 
-    context "when public channels are disabled" do
-      fab!(:current_user, :user)
-
-      before { SiteSetting.enable_public_channels = false }
-
-      it { is_expected.to fail_a_policy(:public_channels_enabled) }
-    end
-
     context "when the current user cannot make a channel" do
       fab!(:current_user, :user)
 
       it { is_expected.to fail_a_policy(:can_create_channel) }
+
+      context "when public channels are also disabled" do
+        before { SiteSetting.enable_public_channels = false }
+
+        it { is_expected.to fail_a_policy(:can_create_channel) }
+      end
+    end
+
+    context "when public channels are disabled" do
+      before { SiteSetting.enable_public_channels = false }
+
+      it { is_expected.to fail_a_policy(:public_channels_enabled) }
     end
 
     context "when the current user can make a channel" do

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Chat::CreateMessage do
             context "when user can't create a message in the channel" do
               before { channel.closed!(Discourse.system_user) }
 
-              it { is_expected.to fail_a_policy(:allowed_to_create_message_in_channel) }
+              it { is_expected.to fail_a_policy(:channel_allows_message_creation) }
             end
 
             context "when user can create a message in the channel" do

--- a/plugins/chat/spec/services/chat/update_message_spec.rb
+++ b/plugins/chat/spec/services/chat/update_message_spec.rb
@@ -1050,12 +1050,6 @@ RSpec.describe Chat::UpdateMessage do
       it { is_expected.to fail_a_contract }
     end
 
-    context "when user can't modify a channel message" do
-      before { channel_1.update!(status: :read_only) }
-
-      it { is_expected.to fail_a_policy(:can_modify_channel_message) }
-    end
-
     context "when user is not member of the channel" do
       fab!(:channel_2, :chat_channel)
       fab!(:other_message) { Fabricate(:chat_message, chat_channel: channel_2) }
@@ -1070,6 +1064,24 @@ RSpec.describe Chat::UpdateMessage do
       end
 
       it { is_expected.to fail_to_find_a_model(:membership) }
+    end
+
+    context "when user can't edit the message" do
+      fab!(:message_1) { Fabricate(:chat_message, chat_channel: channel_1) }
+
+      it { is_expected.to fail_a_policy(:can_edit_message) }
+
+      context "when the channel is also closed" do
+        before { channel_1.update!(status: :closed) }
+
+        it { is_expected.to fail_a_policy(:can_edit_message) }
+      end
+    end
+
+    context "when the channel doesn't allow modifying messages" do
+      before { channel_1.update!(status: :read_only) }
+
+      it { is_expected.to fail_a_policy(:channel_allows_message_modification) }
     end
 
     context "when edit grace period" do


### PR DESCRIPTION
Previously, several chat endpoints answered policy failures with a generic 422 `{"failed":"FAILED"}`, rendered literally as "FAILED" in the UI: an admin creating a channel while `enable_public_channels` was disabled had no way to know why creation failed, and a user saving a message edit after staff closed the channel hit the same dead end. The root cause is structural — a service policy failing without a matching `on_failed_policy` handler silently falls through to the catch-all `on_failure`, and near-identical actor-shaped policy names made the handler lists look exhaustive when they weren't.

This change makes policy failures on the channel-creation and message-edit endpoints answer with either a 403 (authorization) or a 422 carrying an actionable reason (feature or channel state), and makes that split visible in the code:

- Creating a channel while public channels are disabled now explains the `enable public channels` site setting instead of failing blankly.
- Editing a message in a closed/read-only channel now explains the channel status via a new `Chat::Channel::Policy::MessageModification` reason, mirroring the existing `MessageCreation` pattern.
- Authorization policies run before feature/state policies on both endpoints (spec-pinned), so unauthorized users keep getting a plain 403 and are never shown state guidance they cannot act on. This flips a few edit-endpoint failures (non-author, silenced, lost channel access) from the opaque 422 to a proper 403.
- State policies are renamed with the channel as the grammatical subject — `channel_allows_message_creation`, `channel_allows_message_modification` — to distinguish them from actor checks like `can_edit_message`; the old actor-shaped names are how the gaps went unnoticed.
- An audit of every handler block in the chat plugin found nine handlers naming policies or models that no longer exist. Eight were dead code (removed or repaired to the current names); one was a live bug: `bulk_destroy` listened for `:invalid_access` while `Chat::TrashMessages` declares `:can_delete_all_chat_messages`, so unauthorized bulk deletions returned the generic 422 instead of 403. That endpoint also gains its first request specs.

Ref - t/188375