### PR TITLE
FIX: Display poll voters in the order they voted

### DIFF
--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -265,16 +265,14 @@ class DiscoursePoll::Poll
                , po.digest
                , pv.rank AS int_rank
                , pv.user_id
-               , u.username
-               , ROW_NUMBER() OVER (PARTITION BY pv.poll_option_id ORDER BY pv.created_at) AS row
+               , ROW_NUMBER() OVER (PARTITION BY pv.poll_option_id ORDER BY pv.created_at, pv.user_id) AS row
           FROM poll_votes pv
           JOIN poll_options po ON pv.poll_id = po.poll_id AND pv.poll_option_id = po.id
-          JOIN users u ON pv.user_id = u.id
           WHERE pv.poll_id IN (:poll_ids)
                 /* where */
         ) v
         WHERE row BETWEEN :offset AND :offset_plus_limit
-        ORDER BY digest, int_rank, username
+        ORDER BY digest, int_rank, row
       SQL
 
     votes = DB.query(query, params.merge(poll_ids: uncached_poll_ids))

--- a/plugins/poll/spec/lib/poll_spec.rb
+++ b/plugins/poll/spec/lib/poll_spec.rb
@@ -456,9 +456,9 @@ RSpec.describe DiscoursePoll::Poll do
       let(:poll_options) { poll.poll_options }
       let(:votes) do
         {
+          user_3 => [poll_options.first.digest],
           user => [poll_options.first.digest],
           user_2 => [poll_options.second.digest],
-          user_3 => [poll_options.first.digest],
         }
       end
 
@@ -466,14 +466,13 @@ RSpec.describe DiscoursePoll::Poll do
         votes.each_pair { |user, options| DiscoursePoll::Poll.vote(user, post.id, "poll", options) }
       end
 
-      it "returns all serialized voters" do
+      it "returns all serialized voters in the order they voted" do
         voters = DiscoursePoll::Poll.serialized_voters(poll)
-        voters.transform_values! { |users| users.sort_by { |u| u[:id] } }
         expect(voters).to eq(
           {
             poll_options.first.digest => [
-              UserNameSerializer.new(user).serializable_hash,
               UserNameSerializer.new(user_3).serializable_hash,
+              UserNameSerializer.new(user).serializable_hash,
             ],
             poll_options.second.digest => [UserNameSerializer.new(user_2).serializable_hash],
           },
@@ -481,20 +480,22 @@ RSpec.describe DiscoursePoll::Poll do
       end
 
       it "correctly paginates voters" do
-        opts = { page: 1, limit: 2 }.with_indifferent_access
+        opts = { page: 1, limit: 1 }.with_indifferent_access
         voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
-        voters.transform_values! { |users| users.sort_by { |u| u[:id] } }
         expect(voters).to eq(
           {
-            poll_options.first.digest => [
-              UserNameSerializer.new(user).serializable_hash,
-              UserNameSerializer.new(user_3).serializable_hash,
-            ],
+            poll_options.first.digest => [UserNameSerializer.new(user_3).serializable_hash],
             poll_options.second.digest => [UserNameSerializer.new(user_2).serializable_hash],
           },
         )
 
-        opts = { page: 2, limit: 2 }.with_indifferent_access
+        opts = { page: 2, limit: 1 }.with_indifferent_access
+        voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
+        expect(voters).to eq(
+          { poll_options.first.digest => [UserNameSerializer.new(user).serializable_hash] },
+        )
+
+        opts = { page: 3, limit: 1 }.with_indifferent_access
         voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
         expect(voters).to be_nil
       end
@@ -506,13 +507,13 @@ RSpec.describe DiscoursePoll::Poll do
       let(:poll_options) { poll.poll_options }
       let(:votes) do
         {
-          user => [poll_options.first.digest, poll_options.second.digest],
           user_2 => [poll_options.second.digest, poll_options.third.digest],
           user_3 => [
             poll_options.second.digest,
             poll_options.third.digest,
             poll_options.fourth.digest,
           ],
+          user => [poll_options.first.digest, poll_options.second.digest],
         }
       end
 
@@ -520,16 +521,15 @@ RSpec.describe DiscoursePoll::Poll do
         votes.each_pair { |user, options| DiscoursePoll::Poll.vote(user, post.id, "poll", options) }
       end
 
-      it "returns all serialized voters" do
+      it "returns all serialized voters in the order they voted" do
         voters = DiscoursePoll::Poll.serialized_voters(poll)
-        voters.transform_values! { |users| users.sort_by { |u| u[:id] } }
         expect(voters).to eq(
           {
             poll_options.first.digest => [UserNameSerializer.new(user).serializable_hash],
             poll_options.second.digest => [
-              UserNameSerializer.new(user).serializable_hash,
               UserNameSerializer.new(user_2).serializable_hash,
               UserNameSerializer.new(user_3).serializable_hash,
+              UserNameSerializer.new(user).serializable_hash,
             ],
             poll_options.third.digest => [
               UserNameSerializer.new(user_2).serializable_hash,
@@ -543,13 +543,12 @@ RSpec.describe DiscoursePoll::Poll do
       it "correctly paginates voters" do
         opts = { page: 1, limit: 2 }.with_indifferent_access
         voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
-        voters.transform_values! { |users| users.sort_by { |u| u[:id] } }
         expect(voters).to eq(
           {
             poll_options.first.digest => [UserNameSerializer.new(user).serializable_hash],
             poll_options.second.digest => [
-              UserNameSerializer.new(user).serializable_hash,
               UserNameSerializer.new(user_2).serializable_hash,
+              UserNameSerializer.new(user_3).serializable_hash,
             ],
             poll_options.third.digest => [
               UserNameSerializer.new(user_2).serializable_hash,
@@ -561,9 +560,8 @@ RSpec.describe DiscoursePoll::Poll do
 
         opts = { page: 2, limit: 2 }.with_indifferent_access
         voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
-        voters.transform_values! { |users| users.sort_by { |u| u[:id] } }
         expect(voters).to eq(
-          { poll_options.second.digest => [UserNameSerializer.new(user_3).serializable_hash] },
+          { poll_options.second.digest => [UserNameSerializer.new(user).serializable_hash] },
         )
 
         opts = { page: 3, limit: 2 }.with_indifferent_access
@@ -627,25 +625,24 @@ RSpec.describe DiscoursePoll::Poll do
         votes.each_pair { |user, options| DiscoursePoll::Poll.vote(user, post.id, "poll", options) }
       end
 
-      it "returns all serialized voters" do
+      it "returns all serialized voters ordered by rank then vote time" do
         voters = DiscoursePoll::Poll.serialized_voters(poll)
-        voters.transform_values! { |users| users.sort_by { |ranked_u| ranked_u[:user][:id] } }
         expect(voters).to eq(
           {
             poll_options.first.digest => [
               { user: UserNameSerializer.new(user).serializable_hash, rank: "Abstain" },
-              { user: UserNameSerializer.new(user_2).serializable_hash, rank: "2" },
               { user: UserNameSerializer.new(user_3).serializable_hash, rank: "1" },
+              { user: UserNameSerializer.new(user_2).serializable_hash, rank: "2" },
             ],
             poll_options.second.digest => [
-              { user: UserNameSerializer.new(user).serializable_hash, rank: "1" },
               { user: UserNameSerializer.new(user_2).serializable_hash, rank: "Abstain" },
+              { user: UserNameSerializer.new(user).serializable_hash, rank: "1" },
               { user: UserNameSerializer.new(user_3).serializable_hash, rank: "2" },
             ],
             poll_options.third.digest => [
-              { user: UserNameSerializer.new(user).serializable_hash, rank: "2" },
-              { user: UserNameSerializer.new(user_2).serializable_hash, rank: "1" },
               { user: UserNameSerializer.new(user_3).serializable_hash, rank: "Abstain" },
+              { user: UserNameSerializer.new(user_2).serializable_hash, rank: "1" },
+              { user: UserNameSerializer.new(user).serializable_hash, rank: "2" },
             ],
           },
         )
@@ -654,7 +651,6 @@ RSpec.describe DiscoursePoll::Poll do
       it "correctly paginates voters" do
         opts = { page: 1, limit: 2 }.with_indifferent_access
         voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
-        voters.transform_values! { |users| users.sort_by { |ranked_u| ranked_u[:user][:id] } }
         expect(voters).to eq(
           {
             poll_options.first.digest => [
@@ -662,19 +658,18 @@ RSpec.describe DiscoursePoll::Poll do
               { user: UserNameSerializer.new(user_2).serializable_hash, rank: "2" },
             ],
             poll_options.second.digest => [
-              { user: UserNameSerializer.new(user).serializable_hash, rank: "1" },
               { user: UserNameSerializer.new(user_2).serializable_hash, rank: "Abstain" },
+              { user: UserNameSerializer.new(user).serializable_hash, rank: "1" },
             ],
             poll_options.third.digest => [
-              { user: UserNameSerializer.new(user).serializable_hash, rank: "2" },
               { user: UserNameSerializer.new(user_2).serializable_hash, rank: "1" },
+              { user: UserNameSerializer.new(user).serializable_hash, rank: "2" },
             ],
           },
         )
 
         opts = { page: 2, limit: 2 }.with_indifferent_access
         voters = DiscoursePoll::Poll.serialized_voters(poll, opts)
-        voters.transform_values! { |users| users.sort_by { |ranked_u| ranked_u[:user][:id] } }
         expect(voters).to eq(
           {
             poll_options.first.digest => [


### PR DESCRIPTION
Previously, public poll voters were displayed alphabetically by username while pagination selected them chronologically — a regression from the ranked choice feature (bae492efeeb) — so each "show more" appended an alphabetically-sorted chunk of 25 and the overall list read as random.

This change orders voters by the same `ROW_NUMBER()` over `created_at` that already drives pagination, restoring the pre-2024 chronological display and aligning display order with page selection. A `user_id` tiebreaker makes the order deterministic when votes share a timestamp (e.g. bulk imports), and the now unused `username` column is dropped from the query. The specs previously sorted voters by id before asserting — which is how the regression went unnoticed — and now assert the actual order, with vote order deliberately different from id order so any alphabetical or id-based ordering fails.