### PR TITLE
FEATURE: Show cached time for translation progress

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -5,6 +5,7 @@ import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
+import moment from "moment";
 import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
 import Chart from "discourse/admin/components/chart";
 import { ajax } from "discourse/lib/ajax";
@@ -31,6 +32,7 @@ export default class AiTranslations extends Component {
   @tracked done = null;
   @tracked total = null;
   @tracked loadingProgress = false;
+  @tracked progressCachedAt = null;
   @tracked
   translationEnabled =
     this.args.model?.translation_enabled &&
@@ -80,6 +82,7 @@ export default class AiTranslations extends Component {
       this.data = response.translation_progress;
       this.total = response.total;
       this.done = response.posts_with_detected_locale;
+      this.progressCachedAt = response.cached_at;
     } catch (e) {
       popupAjaxError(e);
     } finally {
@@ -124,10 +127,6 @@ export default class AiTranslations extends Component {
     const current = [...this.selectedLocales].sort().join("|");
     const original = [...this.originalLocales].sort().join("|");
     return current !== original;
-  }
-
-  get showLocaleSelector() {
-    return !this.translationEnabled;
   }
 
   get categoriesChanged() {
@@ -353,8 +352,6 @@ export default class AiTranslations extends Component {
       );
 
       if (totalRemaining && totalRemaining > 0) {
-        const hoursRemaining = totalRemaining / this.hourlyRate;
-
         const cutoffDate = new Date();
         cutoffDate.setDate(
           cutoffDate.getDate() - this.args.model.backfill_max_age_days
@@ -366,28 +363,9 @@ export default class AiTranslations extends Component {
           day: "numeric",
         });
 
-        let timeKey;
-        if (hoursRemaining < 1) {
-          const minutes = Math.ceil(hoursRemaining * 60);
-          timeKey = i18n("discourse_ai.translations.stats.eta_minutes", {
-            count: minutes,
-          });
-        } else if (hoursRemaining < 24) {
-          const hours = Math.ceil(hoursRemaining);
-          timeKey = i18n("discourse_ai.translations.stats.eta_hours", {
-            count: hours,
-          });
-        } else {
-          const days = Math.ceil(hoursRemaining / 24);
-          timeKey = i18n("discourse_ai.translations.stats.eta_days", {
-            count: days,
-          });
-        }
-
         return trustHTML(
           i18n("discourse_ai.translations.stats.backfill_message", {
             date: formattedDate,
-            eta: timeKey,
             settingsUrl: this.settingsUrl,
           })
         );
@@ -399,6 +377,16 @@ export default class AiTranslations extends Component {
     }
 
     return null;
+  }
+
+  get cachedResultsNotice() {
+    if (!this.progressCachedAt) {
+      return null;
+    }
+
+    return i18n("discourse_ai.translations.cached_results_notice", {
+      relative_time: moment(this.progressCachedAt).fromNow(),
+    });
   }
 
   get chartColors() {
@@ -557,166 +545,161 @@ export default class AiTranslations extends Component {
         </div>
       {{/if}}
 
-      {{#if this.showLocaleSelector}}
-        <div class="alert alert-info">
-          <div class="settings">
-            <div class="setting">
-              <div class="setting-label">
-                <label>{{i18n
-                    "discourse_ai.translations.supported_locales"
-                  }}</label>
-              </div>
-              <div class="setting-value">
-                <div class="ai-translations__locale-input-row">
-                  <MultiSelect
-                    @value={{this.selectedLocales}}
-                    @content={{this.availableLocales}}
-                    @nameProperty="name"
-                    @valueProperty="value"
-                    @onChange={{this.updateSelectedLocales}}
-                    @options={{hash allowAny=false}}
-                  />
-                  {{#if this.localesChanged}}
-                    <div class="setting-controls">
-                      <DButton
-                        @action={{this.saveLocales}}
-                        @icon="check"
-                        @isLoading={{this.isSavingLocales}}
-                        @ariaLabel="save"
-                        class="ok setting-controls__ok"
-                      />
-                      <DButton
-                        @action={{this.cancelLocales}}
-                        @icon="xmark"
-                        @isLoading={{this.isSavingLocales}}
-                        @ariaLabel="cancel"
-                        class="cancel setting-controls__cancel"
-                      />
-                    </div>
-                  {{else if this.selectedLocales.length}}
-                    <DButton
-                      @action={{this.resetLocales}}
-                      @icon="arrow-rotate-left"
-                      @label="admin.settings.reset"
-                      class="undo setting-controls__undo"
-                    />
-                  {{/if}}
-                </div>
-                <div class="desc">{{i18n
-                    "discourse_ai.translations.supported_locales_description"
-                  }}</div>
-              </div>
+      <div class="ai-translations__settings-panel settings">
+        <div class="setting ai-translations__toggle-container">
+          <DToggleSwitch
+            @state={{this.translationEnabled}}
+            @label="discourse_ai.translations.admin_actions.enable_translations"
+            disabled={{this.isToggleDisabled}}
+            {{on "click" this.toggleTranslationEnabled}}
+          />
+        </div>
+        <div class="ai-translations__settings-fields">
+          <div class="setting">
+            <div class="setting-label">
+              <label>{{i18n
+                  "discourse_ai.translations.supported_locales"
+                }}</label>
             </div>
-            <div class="setting">
-              <div class="setting-label">
-                <label>{{i18n
-                    "discourse_ai.translations.category_scope"
-                  }}</label>
-              </div>
-              <div class="setting-value">
-                <div class="ai-translations__category-input-row">
-                  <div class="ai-translations__category-scope-row">
-                    <ComboBox
-                      @value={{this.categoryScope}}
-                      @content={{this.categoryScopeOptions}}
-                      @onChange={{this.updateCategoryScope}}
-                      @valueProperty="value"
-                      @nameProperty="name"
+            <div class="setting-value">
+              <div class="ai-translations__locale-input-row">
+                <MultiSelect
+                  @value={{this.selectedLocales}}
+                  @content={{this.availableLocales}}
+                  @nameProperty="name"
+                  @valueProperty="value"
+                  @onChange={{this.updateSelectedLocales}}
+                  @options={{hash allowAny=false}}
+                />
+                {{#if this.localesChanged}}
+                  <div class="setting-controls">
+                    <DButton
+                      @action={{this.saveLocales}}
+                      @icon="check"
+                      @isLoading={{this.isSavingLocales}}
+                      @ariaLabel="save"
+                      class="ok setting-controls__ok"
                     />
-                    {{#unless this.showCategorySelector}}
-                      {{#if this.categoriesChanged}}
-                        <div class="setting-controls">
-                          <DButton
-                            @action={{this.saveCategories}}
-                            @icon="check"
-                            @isLoading={{this.isSavingCategories}}
-                            @ariaLabel="save"
-                            class="ok setting-controls__ok"
-                          />
-                          <DButton
-                            @action={{this.cancelCategories}}
-                            @icon="xmark"
-                            @isLoading={{this.isSavingCategories}}
-                            @ariaLabel="cancel"
-                            class="cancel setting-controls__cancel"
-                          />
-                        </div>
-                      {{else if this.categories.length}}
-                        <DButton
-                          @action={{this.resetCategories}}
-                          @icon="arrow-rotate-left"
-                          @label="admin.settings.reset"
-                          class="undo setting-controls__undo"
-                        />
-                      {{/if}}
-                    {{/unless}}
+                    <DButton
+                      @action={{this.cancelLocales}}
+                      @icon="xmark"
+                      @isLoading={{this.isSavingLocales}}
+                      @ariaLabel="cancel"
+                      class="cancel setting-controls__cancel"
+                    />
                   </div>
-                  {{#if this.showCategorySelector}}
-                    <div class="ai-translations__category-selector-row">
-                      <CategorySelector
-                        @categories={{this.categories}}
-                        @onChange={{this.updateCategories}}
-                      />
-                      {{#if this.categoriesChanged}}
-                        <div class="setting-controls">
-                          <DButton
-                            @action={{this.saveCategories}}
-                            @icon="check"
-                            @isLoading={{this.isSavingCategories}}
-                            @ariaLabel="save"
-                            class="ok setting-controls__ok"
-                          />
-                          <DButton
-                            @action={{this.cancelCategories}}
-                            @icon="xmark"
-                            @isLoading={{this.isSavingCategories}}
-                            @ariaLabel="cancel"
-                            class="cancel setting-controls__cancel"
-                          />
-                        </div>
-                      {{else if this.categories.length}}
-                        <DButton
-                          @action={{this.resetCategories}}
-                          @icon="arrow-rotate-left"
-                          @label="admin.settings.reset"
-                          class="undo setting-controls__undo"
-                        />
-                      {{/if}}
-                    </div>
-                  {{/if}}
-                </div>
-                <div class="desc">{{i18n
-                    "discourse_ai.translations.category_scope_description"
-                  }}</div>
+                {{else if this.selectedLocales.length}}
+                  <DButton
+                    @action={{this.resetLocales}}
+                    @icon="arrow-rotate-left"
+                    @label="admin.settings.reset"
+                    class="undo setting-controls__undo"
+                  />
+                {{/if}}
               </div>
             </div>
           </div>
+          <div class="setting">
+            <div class="setting-label">
+              <label>{{i18n "discourse_ai.translations.category_scope"}}</label>
+            </div>
+            <div class="setting-value">
+              <div class="ai-translations__category-input-row">
+                <div class="ai-translations__category-scope-row">
+                  <ComboBox
+                    @value={{this.categoryScope}}
+                    @content={{this.categoryScopeOptions}}
+                    @onChange={{this.updateCategoryScope}}
+                    @valueProperty="value"
+                    @nameProperty="name"
+                  />
+                  {{#unless this.showCategorySelector}}
+                    {{#if this.categoriesChanged}}
+                      <div class="setting-controls">
+                        <DButton
+                          @action={{this.saveCategories}}
+                          @icon="check"
+                          @isLoading={{this.isSavingCategories}}
+                          @ariaLabel="save"
+                          class="ok setting-controls__ok"
+                        />
+                        <DButton
+                          @action={{this.cancelCategories}}
+                          @icon="xmark"
+                          @isLoading={{this.isSavingCategories}}
+                          @ariaLabel="cancel"
+                          class="cancel setting-controls__cancel"
+                        />
+                      </div>
+                    {{else if this.categories.length}}
+                      <DButton
+                        @action={{this.resetCategories}}
+                        @icon="arrow-rotate-left"
+                        @label="admin.settings.reset"
+                        class="undo setting-controls__undo"
+                      />
+                    {{/if}}
+                  {{/unless}}
+                </div>
+                {{#if this.showCategorySelector}}
+                  <div class="ai-translations__category-selector-row">
+                    <CategorySelector
+                      @categories={{this.categories}}
+                      @onChange={{this.updateCategories}}
+                    />
+                    {{#if this.categoriesChanged}}
+                      <div class="setting-controls">
+                        <DButton
+                          @action={{this.saveCategories}}
+                          @icon="check"
+                          @isLoading={{this.isSavingCategories}}
+                          @ariaLabel="save"
+                          class="ok setting-controls__ok"
+                        />
+                        <DButton
+                          @action={{this.cancelCategories}}
+                          @icon="xmark"
+                          @isLoading={{this.isSavingCategories}}
+                          @ariaLabel="cancel"
+                          class="cancel setting-controls__cancel"
+                        />
+                      </div>
+                    {{else if this.categories.length}}
+                      <DButton
+                        @action={{this.resetCategories}}
+                        @icon="arrow-rotate-left"
+                        @label="admin.settings.reset"
+                        class="undo setting-controls__undo"
+                      />
+                    {{/if}}
+                  </div>
+                {{/if}}
+              </div>
+              <div class="desc">{{i18n
+                  "discourse_ai.translations.category_scope_description"
+                }}</div>
+            </div>
+          </div>
         </div>
-      {{/if}}
-
-      <div class="ai-translations__toggle-container">
-        <DToggleSwitch
-          @state={{this.translationEnabled}}
-          @label="discourse_ai.translations.admin_actions.enable_translations"
-          disabled={{this.isToggleDisabled}}
-          {{on "click" this.toggleTranslationEnabled}}
-        />
       </div>
 
       {{#if this.enabled}}
         <DConditionalLoadingSpinner @condition={{this.loadingProgress}}>
           {{#if this.data}}
             <AdminConfigAreaCard class="ai-translations__charts">
-              <:header>
-                {{i18n "discourse_ai.translations.progress_chart.title"}}
-              </:header>
               <:content>
-                <div class="ai-translations__stats-container">
+                <div class="ai-translations__progress-meta">
                   {{#if this.backfillStatusMessage}}
                     <div class="ai-translations__stat-item">
                       <span class="ai-translations__stat-label">
                         {{this.backfillStatusMessage}}
                       </span>
+                    </div>
+                  {{/if}}
+                  {{#if this.cachedResultsNotice}}
+                    <div class="ai-translations__cached-results">
+                      {{dIcon "clock-rotate-left"}}
+                      <span>{{this.cachedResultsNotice}}</span>
                     </div>
                   {{/if}}
                 </div>

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -8,6 +8,35 @@
     margin-top: 2em;
   }
 
+  &__settings-panel {
+    background: var(--primary-very-low);
+    margin-block: var(--space-4);
+    padding: var(--space-2);
+  }
+
+  &__toggle-container {
+    margin-block-end: var(--space-3);
+  }
+
+  &__progress-meta {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-block-end: var(--space-4);
+  }
+
+  &__cached-results {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin-inline-start: auto;
+    text-align: end;
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
+  }
+
   &__locale-input-row,
   &__category-input-row {
     display: flex;

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -434,17 +434,17 @@ en:
         title: "Translations"
         description: "Automatically translate all content on your forum to the user's preferred language"
         supported_locales: "Supported languages"
-        supported_locales_description: "This site setting also allows visitors to contribute post translations."
         category_scope: "Categories"
-        category_scope_description: "Choose whether automatic translations use all categories, public categories, or selected categories."
+        category_scope_description: "Choose whether automatic translations apply to content in all categories, public categories, or selected categories."
+        cached_results_notice: "Showing cached results from %{relative_time}."
         admin_actions:
-          translation_settings: "Translation settings"
-          localization_settings: "Localization settings"
+          translation_settings: "AI settings"
+          localization_settings: "App language settings"
           enable_translations: "Enable automatic translations"
         stats:
           title: "Translation statistics"
           backfill_disabled: "Backfilling is disabled, only new posts will be translated."
-          backfill_message: "<a href='%{settingsUrl}'>Backfill settings</a> are configured to translate all posts after %{date} — this is estimated to take %{eta}."
+          backfill_message: "<a href='%{settingsUrl}'>Backfill settings</a> are configured to translate all posts after %{date}."
           eta_minutes:
             one: "%{count} minute"
             other: "%{count} minutes"

--- a/plugins/discourse-ai/lib/tasks/create_topics.rake
+++ b/plugins/discourse-ai/lib/tasks/create_topics.rake
@@ -20,7 +20,7 @@ namespace :ai do
       creator = TopicGenerator.new(title)
       first_post = creator.get_first_post
       replies_count = rand(4..10)
-      replies = creator.get_replies(replies_count)
+      replies = creator.get_replies(replies_count, first_post)
 
       post = create_topic(category, first_post, title, users)
       replies.each_with_index { |reply, i| create_post(users[i + 1], post.topic_id, reply) }
@@ -48,38 +48,88 @@ namespace :ai do
   end
 
   class TopicGenerator
+    FIRST_POST_RESPONSE_FORMAT = {
+      type: "json_schema",
+      json_schema: {
+        name: "topic_generator_first_post",
+        schema: {
+          type: "object",
+          properties: {
+            first_post: {
+              type: "string",
+            },
+          },
+          required: %w[first_post],
+          additionalProperties: false,
+        },
+        strict: true,
+      },
+    }.freeze
+
+    REPLIES_RESPONSE_FORMAT = {
+      type: "json_schema",
+      json_schema: {
+        name: "topic_generator_replies",
+        schema: {
+          type: "object",
+          properties: {
+            replies: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+          },
+          required: %w[replies],
+          additionalProperties: false,
+        },
+        strict: true,
+      },
+    }.freeze
+
     def initialize(title)
       @title = title
     end
 
     def get_first_post
-      TopicGenerator.generate(<<~PROMPT)
-        Write and opening topic about title: #{@title}.
+      prompt = <<~PROMPT
+        Write and opening topic about title: #{@title}. The title is likely regarding a fictional piece of work.
         - content must be in the same language as title
         - content in markdown
         - content should exclude the title
         - maximum of 200 words
       PROMPT
+
+      response = TopicGenerator.generate(prompt, response_format: FIRST_POST_RESPONSE_FORMAT)
+
+      TopicGenerator.structured_value(response, :first_post).to_s
     end
 
-    def get_replies(count)
-      JSON.parse(
-        TopicGenerator.generate(<<~PROMPT).gsub(/```json\n?|\```/, "").gsub(/,\n\n/, ",\n").strip,
-                Write #{count} replies to a topic with title #{@title}.
-                - respond in an array of strings within double quotes ["", "", ""]
-                - each with a maximum of 100 words
-                - keep to same language of title
-                - each reply may contain markdown to bold, italicize, link, or bullet point
-                - do not return anything else other than the array
-                - the last item in the array should not have a trailing comma
-                - Example return value ["I agree with you. So and so...", "It is fun ... etc"]
-              PROMPT
-      )
+    def get_replies(count, first_post)
+      prompt = <<~PROMPT
+        Write #{count} replies to a topic with title #{@title}. The title is likely regarding a fictional piece of work.
+
+        ________________
+
+        The topic's first post has this content:
+        #{first_post}
+
+        ________________
+
+        The replies
+        - must each have a maximum of 100 words
+        - keep to same language of title
+        - may contain markdown to bold, italicize, link, or bullet point
+      PROMPT
+
+      response = TopicGenerator.generate(prompt, response_format: REPLIES_RESPONSE_FORMAT)
+
+      TopicGenerator.structured_replies(response).filter_map { |reply| reply.to_s.presence }
     end
 
     private
 
-    def self.generate(prompt)
+    def self.generate(prompt, response_format:)
       return "" if prompt.blank?
 
       prompt =
@@ -92,10 +142,36 @@ namespace :ai do
         prompt,
         user: Discourse.system_user,
         feature_name: "topic-generator",
+        response_format: response_format,
       )
     rescue => e
       Rails.logger.error("AI TopicGenerator Error: #{e.message}")
       ""
+    end
+
+    def self.structured_value(response, key)
+      return response.read_buffered_property(key) if response.respond_to?(:read_buffered_property)
+
+      parsed_response =
+        response.is_a?(Hash) || response.is_a?(Array) ? response : JSON.parse(response)
+
+      if parsed_response.is_a?(Hash)
+        parsed_response[key.to_s] || parsed_response[key]
+      else
+        parsed_response
+      end
+    rescue JSON::ParserError
+      response
+    end
+
+    def self.structured_replies(response)
+      replies = structured_value(response, :replies)
+      return replies if replies.is_a?(Array)
+
+      parsed_replies = JSON.parse(replies) if replies.is_a?(String)
+      parsed_replies.is_a?(Array) ? parsed_replies : Array(replies)
+    rescue JSON::ParserError
+      Array(replies)
     end
   end
 end

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -6,9 +6,13 @@ module DiscourseAi
       # Returns the number of posts that have been translated, and the total number of posts that need translation for a given locale.
       # The total number of posts is based off candidates that already have a locale.
       # Also returns aggregate counts for total eligible posts and posts with detected locale.
-      # @return [Hash] a hash with keys :translation_progress (array), :total (integer), and :posts_with_detected_locale (integer)
+      # @return [Hash] a hash with keys :translation_progress (array), :total (integer), :posts_with_detected_locale (integer), and :cached_at (string)
       def self.get_completion_all_locales
-        Discourse.cache.fetch(progress_cache_key, expires_in: 30.minutes) { completion_all_locales }
+        Discourse
+          .cache
+          .fetch(progress_cache_key, expires_in: 30.minutes) do
+            completion_all_locales.merge(cached_at: Time.now.utc.iso8601)
+          end
       end
 
       def self.needs_localization(limit:)

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -239,6 +239,17 @@ describe DiscourseAi::Translation::PostCandidates do
       expect(result[:posts_with_detected_locale]).to eq(0)
     end
 
+    it "returns the time when the progress result was cached" do
+      Post.delete_all
+      cached_at = Time.zone.parse("2026-07-23 09:00:00 UTC")
+
+      freeze_time(cached_at) { described_class.get_completion_all_locales }
+
+      freeze_time(cached_at + 5.minutes) do
+        expect(described_class.get_completion_all_locales[:cached_at]).to eq(cached_at.utc.iso8601)
+      end
+    end
+
     it "uses category scope in the cache key" do
       Post.delete_all
       scoped_category = Fabricate(:category)

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -195,6 +195,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
       end
 
       it "returns translation progress data" do
+        cached_at = Time.zone.parse("2026-07-23 09:00:00 UTC")
         SiteSetting.ai_translation_backfill_max_age_days = 30
         SiteSetting.ai_translation_personal_messages = "group"
         SiteSetting.ai_translation_backfill_hourly_rate = 100
@@ -219,7 +220,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
           localizer_user_id: admin.id,
         )
 
-        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
+        freeze_time(cached_at) { get "/admin/plugins/discourse-ai/ai-translations/progress.json" }
 
         expect(response.status).to eq(200)
         json = response.parsed_body
@@ -228,6 +229,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
         expect(json["translation_progress"].length).to eq(3)
         expect(json["total"]).to eq(19)
         expect(json["posts_with_detected_locale"]).to eq(15)
+        expect(json["cached_at"]).to eq(cached_at.utc.iso8601)
 
         locale_data = json["translation_progress"].first
         expect(locale_data["locale"]).to eq("en")

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Admin AI translations" do
         ],
         total: 300,
         posts_with_detected_locale: 150,
+        cached_at: Time.now.utc.iso8601,
       },
     )
 
@@ -44,9 +45,32 @@ RSpec.describe "Admin AI translations" do
 
       expect(translations_page).to have_translation_settings_button
       expect(translations_page).to have_localization_settings_button
+      expect(page).to have_css(
+        ".ai-translation-settings-button",
+        text: I18n.t("js.discourse_ai.translations.admin_actions.translation_settings"),
+      )
+      expect(page).to have_css(
+        ".ai-localization-settings-button",
+        text: I18n.t("js.discourse_ai.translations.admin_actions.localization_settings"),
+      )
+      expect(page).to have_css(".ai-translations__locale-input-row .multi-select")
+      expect(page).to have_css(".ai-translations__category-input-row .combo-box")
+      expect(page).to have_css(
+        ".ai-translations__settings-panel > .setting:first-child .d-toggle-switch",
+      )
+      expect(page).to have_no_css(".ai-translations__settings-panel.alert-info")
 
       expect(translations_page).to have_charts_section
       expect(translations_page).to have_chart
+      expect(page).to have_no_css(
+        ".admin-config-area-card__title",
+        text: I18n.t("js.discourse_ai.translations.progress_chart.title"),
+      )
+      expect(page).to have_css(
+        ".ai-translations__cached-results",
+        text: "Showing cached results from",
+      )
+      expect(page).to have_no_content("estimated to take")
 
       screenshot_marker(label: "ai-admin-translations", only: "desktop")
     end
@@ -60,7 +84,7 @@ RSpec.describe "Admin AI translations" do
       )
     end
 
-    it "navigates to localization settings when clicking the localization button" do
+    it "navigates to app language settings when clicking the app language button" do
       find(".ai-localization-settings-button").click
 
       expect(page).to have_current_path("/admin/config/localization")
@@ -107,13 +131,13 @@ RSpec.describe "Admin AI translations" do
       translations_page.visit
     end
 
-    it "displays the alert with locale selector" do
+    it "displays the settings panel with locale selector" do
       expect(translations_page).to have_locale_selector
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.supported_locales"))
     end
 
     it "displays the category scope selector alongside the locale selector" do
-      expect(page).to have_css(".alert.alert-info")
+      expect(page).to have_css(".ai-translations__settings-panel")
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.category_scope"))
       expect(page).to have_css(".ai-translations__category-input-row .combo-box")
     end
@@ -145,8 +169,8 @@ RSpec.describe "Admin AI translations" do
       visit "/admin/plugins/discourse-ai/ai-translations"
     end
 
-    it "displays the setup alert with the category selector" do
-      expect(page).to have_css(".alert.alert-info")
+    it "displays the settings panel with the category selector" do
+      expect(page).to have_css(".ai-translations__settings-panel")
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.category_scope"))
       expect(page).to have_css(".category-selector")
     end
@@ -179,6 +203,7 @@ RSpec.describe "Admin AI translations" do
           ],
           total: 200,
           posts_with_detected_locale: 100,
+          cached_at: Time.now.utc.iso8601,
         },
       )
     end

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
@@ -32,7 +32,7 @@ module PageObjects
       end
 
       def has_locale_selector?
-        page.has_css?(".alert.alert-info .multi-select")
+        page.has_css?(".ai-translations__settings-panel .multi-select")
       end
 
       def has_translation_settings_button?


### PR DESCRIPTION
Small updates coming for the translation progress page on /admin/plugins/discourse-ai/ai-translations

Related: https://meta.discourse.org/t/ai-translation-progress-graph/405915

In this PR we keep settings available, and show the cached time of the progress.

| before | after |
|--|--|
| <img width="1512" height="939" alt="Screenshot 2026-07-23 at 6 22 53 PM" src="https://github.com/user-attachments/assets/d0c9e2d3-8bfb-4f74-bbdc-2232449b3422" /> | <img width="1139" height="924" alt="Screenshot 2026-07-23 at 5 59 16 PM copy" src="https://github.com/user-attachments/assets/ba3b8fc4-df95-4159-91d7-b05e002c2879" /> |

In a subsequent PR, we will be showing progress for other areas besides posts.