### PR TITLE
UX: add dismiss keyboard action for Hub

### DIFF
--- a/app/assets/stylesheets/common/base/compose.scss
+++ b/app/assets/stylesheets/common/base/compose.scss
@@ -1564,3 +1564,13 @@ body.has-sidebar-page {
     }
   }
 }
+
+// to be merged with new composer-footer styles once the redesign is fully rolled out
+.composer-footer__dismiss-keyboard {
+  display: none;
+  margin-right: var(--space-2);
+
+  .keyboard-visible & {
+    display: block;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3562,6 +3562,7 @@ en:
       exit_fullscreen_prompt: "Press <kbd>ESC</kbd> to exit full screen"
       show_toolbar: "Show composer toolbar"
       hide_toolbar: "Hide composer toolbar"
+      dismiss_keyboard: "Dismiss keyboard"
       peek_mode_toggle: "Toggle peek mode"
       modal_ok: "OK"
       cant_send_pm: "Sorry, you can't send a message to %{username}."

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -94,6 +94,7 @@ export default class ComposerContainer extends Component {
   @service siteSettings;
   @service appEvents;
   @service keyValueStore;
+  @service capabilities;
 
   @tracked toolbarPortalTarget;
 
@@ -104,6 +105,13 @@ export default class ComposerContainer extends Component {
 
   get composerRedesign() {
     return this.siteSettings.enable_composer_redesign;
+  }
+
+  get showDismissKeyboardButton() {
+    const { capabilities } = this;
+    return (
+      capabilities.isAppWebview && capabilities.isIOS && !capabilities.isIpadOS
+    );
   }
 
   @action
@@ -707,6 +715,15 @@ export default class ComposerContainer extends Component {
                       @outletArgs={{lazyHash model=this.composer.model}}
                     />
                   </span>
+
+                  {{#if this.showDismissKeyboardButton}}
+                    <DButton
+                      @action={{this.composer.dismissKeyboard}}
+                      @title="composer.dismiss_keyboard"
+                      @icon="keyboard"
+                      class="btn-default btn-small composer-footer__dismiss-keyboard"
+                    />
+                  {{/if}}
 
                   {{#if this.composer.allowUpload}}
                     <a

--- a/frontend/discourse/app/services/composer.js
+++ b/frontend/discourse/app/services/composer.js
@@ -2089,6 +2089,10 @@ export default class ComposerService extends Service {
     this.composerActionState.clear();
   }
 
+  dismissKeyboard() {
+    document.activeElement?.blur();
+  }
+
   @computed("model.action")
   get canEdit() {
     return this.model?.action === "edit" && this.currentUser.can_edit;


### PR DESCRIPTION
Possible follow-up for

https://github.com/discourse/DiscourseMobile/pull/294
