### PR TITLE
PERF: Speed up category visibility checks

### DIFF
--- a/lib/guardian/category_guardian.rb
+++ b/lib/guardian/category_guardian.rb
@@ -31,7 +31,7 @@ module CategoryGuardian
     read_restricted = true unless !!read_restricted == read_restricted
 
     return true if !read_restricted
-    secure_category_ids.include?(category_id)
+    secure_category_ids_set.include?(category_id)
   end
 
   def can_see_category?(category)
@@ -39,7 +39,7 @@ module CategoryGuardian
     return true if is_admin? && !SiteSetting.suppress_secured_categories_from_admin
     return true if !category.read_restricted
     return true if is_staged? && category.email_in.present? && category.email_in_allow_strangers
-    secure_category_ids.include?(category.id)
+    secure_category_ids_set.include?(category.id)
   end
 
   def can_post_in_category?(category)
@@ -80,6 +80,10 @@ module CategoryGuardian
   end
 
   private
+
+  def secure_category_ids_set
+    @secure_category_ids_set ||= secure_category_ids.to_set
+  end
 
   def posting_review_required?(category, post_type)
     return false if category.nil?


### PR DESCRIPTION
Category visibility checks previously searched `secure_category_ids` linearly for every secured category. On sites with many secured categories, serializing category data therefore repeatedly scanned the same large array.

This commit memoizes the IDs as a `Set` on each `Guardian`, making repeated membership checks constant-time.

On a site with 11K categories, a full page load spends about 240ms executing `Array#include?`

<img width="312" height="97" alt="Screenshot 2026-07-23 at 8 13 38 PM" src="https://github.com/user-attachments/assets/91678c9a-3a85-4c40-83c4-95d22ef992f9" />
