### PR TITLE
PERF: Avoid HTML escaping preloaded JSON

### DIFF
--- a/app/helpers/qunit_helper.rb
+++ b/app/helpers/qunit_helper.rb
@@ -20,7 +20,11 @@ module QunitHelper
     preloaded.merge!(site_settings_preload_data)
     return "" if preloaded.empty?
 
-    tag.div("", id: "data-preloaded", data: { preloaded: preloaded.to_json })
+    tag.script(
+      raw(ERB::Util.json_escape(preloaded.to_json)),
+      type: "application/json",
+      id: "data-preloaded",
+    )
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,7 +98,7 @@
         <%= render partial: "common/discourse_stylesheet" %>
       </discourse-assets-stylesheets>
       <discourse-assets-json>
-        <div class="hidden" id="data-preloaded" data-preloaded="<%= preloaded_json %>"></div>
+        <script type="application/json" id="data-preloaded"><%= raw(preloaded_json) %></script>
       </discourse-assets-json>
       <discourse-assets-icons></discourse-assets-icons>
     </discourse-assets>

--- a/frontend/discourse/app/app.js
+++ b/frontend/discourse/app/app.js
@@ -22,7 +22,10 @@ import { importSync } from "@embroider/macros";
 import { normalizeEmberEventHandling } from "discourse/lib/ember-events";
 import { isRailsTesting, isTesting } from "discourse/lib/environment";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { populatePreloadStore } from "discourse/lib/preload-store";
+import {
+  populatePreloadStore,
+  readPreloadedData,
+} from "discourse/lib/preload-store";
 import { buildResolver } from "discourse/resolver";
 
 populatePreloadStore();
@@ -106,8 +109,7 @@ async function loadPluginFromModulePreload(link) {
 
 function registerPreloadedThemeSettings() {
   try {
-    const element = document.getElementById("data-preloaded");
-    const preloaded = JSON.parse(element.dataset.preloaded);
+    const preloaded = readPreloadedData();
     const activatedThemes = JSON.parse(preloaded.activatedThemes);
     for (const [themeId, info] of Object.entries(activatedThemes)) {
       registerSettings(parseInt(themeId, 10), info.settings);

--- a/frontend/discourse/app/lib/preload-store.js
+++ b/frontend/discourse/app/lib/preload-store.js
@@ -58,6 +58,15 @@ const PreloadStore = {
   },
 };
 
+export function readPreloadedData() {
+  const element = document.getElementById("data-preloaded");
+  if (!element) {
+    return;
+  }
+
+  return JSON.parse(element.textContent);
+}
+
 export function populatePreloadStore() {
   let setupData;
   const setupDataElement = document.getElementById("data-discourse-setup");
@@ -65,12 +74,7 @@ export function populatePreloadStore() {
     setupData = setupDataElement.dataset;
   }
 
-  let preloaded;
-  const preloadedDataElement = document.getElementById("data-preloaded");
-  if (preloadedDataElement) {
-    preloaded = JSON.parse(preloadedDataElement.dataset.preloaded);
-  }
-
+  const preloaded = readPreloadedData();
   const keys = preloaded ? Object.keys(preloaded) : [];
   if (keys.length === 0 && !isTesting()) {
     throw "No preload data found in #data-preloaded. Unable to boot Discourse.";

--- a/frontend/discourse/tests/unit/lib/preload-store-test.js
+++ b/frontend/discourse/tests/unit/lib/preload-store-test.js
@@ -1,13 +1,31 @@
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 import { Promise } from "rsvp";
-import PreloadStore from "discourse/lib/preload-store";
+import PreloadStore, { readPreloadedData } from "discourse/lib/preload-store";
 
 module("Unit | Utility | preload-store", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
     PreloadStore.store("bane", "evil");
+  });
+
+  hooks.afterEach(function () {
+    document.getElementById("data-preloaded")?.remove();
+  });
+
+  test("readPreloadedData reads JSON script content", function (assert) {
+    const element = document.createElement("script");
+    element.id = "data-preloaded";
+    element.type = "application/json";
+    element.textContent = JSON.stringify({ site: "{}" });
+    document.body.append(element);
+
+    assert.deepEqual(
+      readPreloadedData(),
+      { site: "{}" },
+      "reads the preloaded data"
+    );
   });
 
   test("get", function (assert) {

--- a/plugins/chat/spec/requests/application_controller_spec.rb
+++ b/plugins/chat/spec/requests/application_controller_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe ApplicationController do
   fab!(:admin)
 
   def preloaded_json
-    JSON.parse(
-      Nokogiri::HTML5.fragment(response.body).css("div#data-preloaded").first["data-preloaded"],
-    )
+    JSON.parse(Nokogiri::HTML5.fragment(response.body).css("script#data-preloaded").first.text)
   end
 
   before do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -569,8 +569,11 @@ RSpec.describe ApplicationHelper do
           login_method: nil,
         )
 
-      @application_layout_preloader.store_preloaded("test", %{["< \x80"]})
-      expect(helper.preloaded_json).to include(%{"test":"[\\"\\u003c \uFFFD\\"]"})
+      @application_layout_preloader.store_preloaded("test", %{["</script><script> \x80"]})
+      expect(helper.preloaded_json).to include(
+        %{"test":"[\\"\\u003c\\\\/script\\u003e\\u003cscript\\u003e \uFFFD\\"]"},
+      )
+      expect(helper.preloaded_json).not_to include("</script>")
     end
   end
 

--- a/spec/requests/admin/backups_controller_spec.rb
+++ b/spec/requests/admin/backups_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Admin::BackupsController do
 
   def map_preloaded
     JSON
-      .parse(Nokogiri.HTML5(response.body).at_css("[data-preloaded]")["data-preloaded"])
+      .parse(Nokogiri.HTML5(response.body).at_css("#data-preloaded").text)
       .map { |key, value| [key, JSON.parse(value)] }
       .to_h
   end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1752,8 +1752,8 @@ RSpec.describe ApplicationController do
       it "does not include banner info for anonymous users" do
         get "/login"
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           expect(json["banner"]).to eq("{}")
         end
       end
@@ -1762,8 +1762,8 @@ RSpec.describe ApplicationController do
         sign_in(user)
         get "/"
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           expect(JSON.parse(json["banner"])["html"]).to eq("<p>A banner topic</p>")
         end
       end
@@ -1774,8 +1774,8 @@ RSpec.describe ApplicationController do
       it "does include banner info for anonymous users" do
         get "/login"
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           expect(JSON.parse(json["banner"])["html"]).to eq("<p>A banner topic</p>")
         end
       end
@@ -1784,7 +1784,7 @@ RSpec.describe ApplicationController do
     context "with content localization enabled" do
       def banner_html
         preloaded = Nokogiri::HTML5.fragment(response.body).css("#data-preloaded").first
-        JSON.parse(JSON.parse(preloaded["data-preloaded"])["banner"])["html"]
+        JSON.parse(JSON.parse(preloaded.text)["banner"])["html"]
       end
 
       before do
@@ -1862,9 +1862,7 @@ RSpec.describe ApplicationController do
 
   describe "preloading data" do
     def preloaded_json
-      JSON.parse(
-        Nokogiri::HTML5.fragment(response.body).css("div#data-preloaded").first["data-preloaded"],
-      )
+      JSON.parse(Nokogiri::HTML5.fragment(response.body).css("script#data-preloaded").first.text)
     end
 
     context "when user is anon" do

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe CategoriesController do
       SiteSetting.categories_topics.times { Fabricate(:topic) }
       get "/categories"
 
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         expect(json["topic_list"]).to include(%{"more_topics_url":"/latest"})
       end
     end

--- a/spec/requests/invites_controller_spec.rb
+++ b/spec/requests/invites_controller_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe InvitesController do
         ),
       )
 
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["username"]).to eq("")
         expect(invite_info["email"]).to eq("i*****g@a***********e.ooo")
@@ -38,8 +38,8 @@ RSpec.describe InvitesController do
       expect(response.status).to eq(200)
       expect(response.body).to include(invite.email)
 
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["username"]).to eq("") # Default is that we don't use emails to suggest usernames
         expect(invite_info["email"]).to eq(invite.email)
@@ -65,8 +65,8 @@ RSpec.describe InvitesController do
       staged_user.save_custom_fields
 
       get "/invites/#{invite.invite_key}"
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["username"]).not_to eq(staged_user.username)
         expect(invite_info["user_fields"]).to be_nil
@@ -82,8 +82,8 @@ RSpec.describe InvitesController do
       server_session[:authentication] = { email: invite.email, email_valid: false }
 
       get "/invites/#{invite.invite_key}"
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["email"]).to eq(invite.email)
         expect(invite_info["user_fields"]).to be_nil
@@ -99,8 +99,8 @@ RSpec.describe InvitesController do
       server_session[:authentication] = { email: invite.email, email_valid: true }
 
       get "/invites/#{invite.invite_key}"
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["username"]).to eq(staged_user.username)
         expect(invite_info["user_fields"][user_field.id.to_s]).to eq("some value")
@@ -114,8 +114,8 @@ RSpec.describe InvitesController do
       staged_user.save_custom_fields
 
       get "/invites/#{invite.invite_key}?t=#{invite.email_token}"
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["username"]).to eq(staged_user.username)
         expect(invite_info["user_fields"][user_field.id.to_s]).to eq("some value")
@@ -124,15 +124,15 @@ RSpec.describe InvitesController do
 
     it "includes token validity boolean" do
       get "/invites/#{invite.invite_key}"
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["email_verified_by_link"]).to eq(false)
       end
 
       get "/invites/#{invite.invite_key}?t=#{invite.email_token}"
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        json = JSON.parse(element.current_scope.text)
         invite_info = JSON.parse(json["invite_info"])
         expect(invite_info["email_verified_by_link"]).to eq(true)
       end
@@ -213,8 +213,8 @@ RSpec.describe InvitesController do
           ),
         )
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           invite_info = JSON.parse(json["invite_info"])
           expect(invite_info["username"]).to eq(user.username)
           expect(invite_info["email"]).to eq(user.email)
@@ -238,8 +238,8 @@ RSpec.describe InvitesController do
           ),
         )
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           invite_info = JSON.parse(json["invite_info"])
           expect(invite_info["username"]).to eq(user.username)
           expect(invite_info["email"]).to eq(user.email)
@@ -255,8 +255,8 @@ RSpec.describe InvitesController do
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           invite_info = JSON.parse(json["invite_info"])
           expect(invite_info["existing_user_can_redeem"]).to eq(false)
           expect(invite_info["existing_user_can_redeem_error"]).to eq(
@@ -271,8 +271,8 @@ RSpec.describe InvitesController do
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           invite_info = JSON.parse(json["invite_info"])
           expect(invite_info["existing_user_can_redeem"]).to eq(false)
         end
@@ -285,8 +285,8 @@ RSpec.describe InvitesController do
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           invite_info = JSON.parse(json["invite_info"])
           expect(invite_info["existing_user_id"]).to eq(user.id)
           expect(invite_info["existing_user_can_redeem"]).to eq(false)
@@ -302,8 +302,8 @@ RSpec.describe InvitesController do
         get "/invites/#{invite.invite_key}"
         expect(response.status).to eq(200)
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           invite_info = JSON.parse(json["invite_info"])
           expect(invite_info["existing_user_id"]).to eq(user.id)
           expect(invite_info["existing_user_can_redeem"]).to eq(true)

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe ListController do
 
       expect(response.status).to eq(200)
       expect(response.body).not_to include(SiteSetting.klipy_api_key)
-      expect(response.body).to have_tag("div#data-preloaded") do |element|
-        data_preloaded = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+      expect(response.body).to have_tag("script#data-preloaded") do |element|
+        data_preloaded = JSON.parse(element.current_scope.text)
         site_settings = JSON.parse(data_preloaded["siteSettings"])
 
         expect(site_settings).not_to have_key("klipy_api_key")

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -375,8 +375,8 @@ RSpec.describe UsersController do
         )
 
         expect(response.status).to eq(200)
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           expect(json["password_reset"]).to include(
             '{"is_developer":false,"admin":false,"second_factor_required":false,"security_key_required":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
           )
@@ -532,8 +532,8 @@ RSpec.describe UsersController do
 
           get "/u/password-reset/#{email_token.token}"
 
-          expect(response.body).to have_tag("div#data-preloaded") do |element|
-            json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+          expect(response.body).to have_tag("script#data-preloaded") do |element|
+            json = JSON.parse(element.current_scope.text)
             expect(json["password_reset"]).to include(
               '{"is_developer":false,"admin":false,"second_factor_required":true,"security_key_required":false,"backup_enabled":false,"multiple_second_factor_methods":false}',
             )
@@ -589,8 +589,8 @@ RSpec.describe UsersController do
         end
 
         it "preloads with a security key challenge and allowed credential ids" do
-          expect(response.body).to have_tag("div#data-preloaded") do |element|
-            json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+          expect(response.body).to have_tag("script#data-preloaded") do |element|
+            json = JSON.parse(element.current_scope.text)
             password_reset = JSON.parse(json["password_reset"])
             expect(password_reset["challenge"]).not_to eq(nil)
             expect(password_reset["allowed_credential_ids"]).to eq(
@@ -5560,8 +5560,8 @@ RSpec.describe UsersController do
 
         expect(response.status).to eq(200)
 
-        expect(response.body).to have_tag("div#data-preloaded") do |element|
-          json = JSON.parse(element.current_scope.attribute("data-preloaded").value)
+        expect(response.body).to have_tag("script#data-preloaded") do |element|
+          json = JSON.parse(element.current_scope.text)
           expect(json["accountCreated"]).to include(
             "{\"message\":\"#{I18n.t("login.activate_email", email: user1.email).gsub!("</", "<\\/")}\",\"show_controls\":true,\"username\":\"#{user1.username}\",\"email\":\"#{user1.email}\"}",
           )


### PR DESCRIPTION
Large preloaded JSON was stored inside an HTML attribute. Because JSON contains quotation marks that could end the attribute early, Rails had to convert those characters into HTML-safe text. Processing every character made the response larger and slower to generate.

This change places the preloaded JSON in a non-executable `application/json` script element and reads it from the element's text content. 

On a site with 11K categories, the escaping was showing up as a hotspot.

<img width="1403" height="114" alt="Screenshot 2026-07-24 at 7 58 55 AM" src="https://github.com/user-attachments/assets/861e0598-a83f-480f-b8c1-3a38c55574d9" />

### Reviewer notes

This change has also been reviewed by two independent models fable 5 and gpt 5.6 sol both on high thinking.