### PR TITLE
UX: fixes and improvements for the admin code editor nav

### DIFF
--- a/app/assets/stylesheets/admin/admin_base.scss
+++ b/app/assets/stylesheets/admin/admin_base.scss
@@ -698,6 +698,10 @@ $mobile-breakpoint: 700px;
 
   .admin-actions {
     margin-left: auto;
+
+    @include viewport.until(md) {
+      margin-left: 10px;
+    }
   }
 
   nav {
@@ -714,51 +718,6 @@ $mobile-breakpoint: 700px;
       padding-left: 10px;
       margin-left: -10px;
       margin-right: -10px;
-    }
-
-    &::before {
-      // Fade out sides of horizontal nav
-      content: "";
-      position: absolute;
-      width: 10px;
-      left: 0;
-      height: calc(100% - 5px);
-      background: linear-gradient(
-        to right,
-        rgb(var(--primary-low-rgb), 1),
-        rgb(var(--primary-low-rgb), 0)
-      );
-    }
-
-    &::after {
-      content: "";
-      position: absolute;
-      right: 0;
-      width: 15px;
-      height: calc(100% - 5px);
-      background: linear-gradient(
-        to right,
-        rgb(var(--primary-low-rgb), 0),
-        rgb(var(--primary-low-rgb), 1)
-      );
-    }
-  }
-
-  .nav-pills {
-    width: 100%;
-    display: inline-flex;
-    padding: 0.5em;
-    margin: 0;
-    white-space: nowrap;
-    overflow-x: auto;
-
-    @include viewport.until(md) {
-      margin-left: -10px;
-      overflow-x: scroll;
-    }
-
-    &::before {
-      display: none;
     }
   }
 
@@ -831,12 +790,6 @@ $mobile-breakpoint: 700px;
   label {
     display: inline-block;
     margin-right: 5px;
-  }
-
-  .horizontal-overflow-nav__scroll-right,
-  .horizontal-overflow-nav__scroll-left {
-    --fade-color: var(--primary-low-rgb);
-    background: var(--primary-low);
   }
 }
 

--- a/app/assets/stylesheets/admin/customize.scss
+++ b/app/assets/stylesheets/admin/customize.scss
@@ -113,10 +113,10 @@
 
   .field-error,
   .field-warning {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin-top: var(--space-2);
+    margin-bottom: 0;
     background-color: var(--danger-low-mid);
-    padding: 10px;
+    padding: var(--space-2);
     white-space: pre-wrap;
   }
 
@@ -127,9 +127,10 @@
   .field-info {
     background-color: var(--tertiary-low);
     padding: 10px;
-    margin: 10px 0;
+    margin: 10px 0 0;
     white-space: nowrap;
     overflow-x: auto;
+    border-radius: var(--d-border-radius) var(--d-border-radius) 0 0;
   }
 
   .admin-container {
@@ -361,18 +362,43 @@
     display: flex;
     align-items: center;
     font-size: var(--font-up-1);
-    margin-bottom: 0.5em;
+    flex-wrap: wrap;
+    border-bottom: 1px solid var(--content-border-color);
+    padding-bottom: var(--space-2);
+    gap: var(--space-2);
 
     .editor-back-button {
       margin-right: 0.25em;
+      font-size: var(--font-down-3);
     }
 
     .editor-theme-name-wrapper {
       margin-left: 0.25em;
+      margin-right: auto;
     }
 
     .editor-theme-name {
       font-weight: bold;
+    }
+
+    &__title {
+      margin-right: auto;
+      display: flex;
+      line-height: var(--line-height-medium);
+      align-items: baseline;
+    }
+
+    &__admin-actions {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      font-size: var(--font-down-1);
+      white-space: nowrap;
+
+      @include viewport.until(sm) {
+        width: 100%;
+        justify-content: space-between;
+      }
     }
   }
 
@@ -401,6 +427,7 @@
       position: relative;
       min-height: unset;
       flex: 1 1 0;
+      border-radius: 0 0 var(--d-border-radius) var(--d-border-radius);
     }
 
     &.maximized {
@@ -444,34 +471,12 @@
         margin-right: 0;
         display: flex;
 
-        &.spacer {
-          flex-grow: 1;
-        }
-
         &:last-of-type > a {
           margin-right: 0;
         }
 
-        a.no-text .d-icon {
-          margin-right: 0;
-        }
-
-        label {
-          padding: 6px 12px;
-          margin-bottom: 0;
-        }
-
         a.blank:not(.active) {
           color: var(--primary-medium);
-        }
-
-        input {
-          margin-bottom: 0;
-          margin-left: 6px;
-        }
-
-        button {
-          margin-right: 0;
         }
       }
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -8371,6 +8371,8 @@ en:
           default: "Default theme"
           settings_editor: "Settings Editor"
           show_advanced: "Show advanced"
+          maximize_editor: "Maximize editor"
+          minimize_editor: "Minimize editor"
           is_default: "Theme is enabled by default"
           user_selectable: "Theme can be selected by users"
           user_selectable_badge_label: "User selectable"

--- a/frontend/discourse/admin/components/admin-theme-editor.gjs
+++ b/frontend/discourse/admin/components/admin-theme-editor.gjs
@@ -1,6 +1,6 @@
 /* eslint-disable ember/no-classic-components */
 import { tracked } from "@glimmer/tracking";
-import Component, { Input } from "@ember/component";
+import Component from "@ember/component";
 import { array, concat, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action, computed } from "@ember/object";
@@ -11,7 +11,10 @@ import { trustHTML } from "@ember/template";
 import { tagName } from "@ember-decorators/component";
 import AceEditor from "discourse/components/ace-editor";
 import { isDocumentRTL } from "discourse/lib/text-direction";
-import { gt, lte } from "discourse/truth-helpers";
+import { gt } from "discourse/truth-helpers";
+import DButton from "discourse/ui-kit/d-button";
+import DHorizontalOverflowNav from "discourse/ui-kit/d-horizontal-overflow-nav";
+import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
@@ -57,6 +60,7 @@ export default class AdminThemeEditor extends Component {
     });
   }
 
+  @computed("currentTargetName", "showAdvanced", "theme.fields")
   get visibleFields() {
     let fields = this.theme.fields[this.currentTargetName];
     if (!this.showAdvanced) {
@@ -67,6 +71,7 @@ export default class AdminThemeEditor extends Component {
     return fields;
   }
 
+  @computed("currentTargetName", "fieldName", "theme.fields")
   get currentField() {
     return this.theme.fields[this.currentTargetName].find(
       (field) => field.name === this.fieldName
@@ -123,14 +128,20 @@ export default class AdminThemeEditor extends Component {
     return this.maximized ? "discourse-compress" : "discourse-expand";
   }
 
+  @computed("maximized")
+  get maximizeTitle() {
+    return this.maximized
+      ? "admin.customize.theme.minimize_editor"
+      : "admin.customize.theme.maximize_editor";
+  }
+
   @computed("currentTargetName", "fieldName", "theme.theme_fields.@each.error")
   get error() {
     return this.theme.getError(this.currentTargetName, this.fieldName);
   }
 
   @action
-  toggleMaximize(event) {
-    event?.preventDefault();
+  toggleMaximize() {
     this.toggleProperty("maximized");
     next(() => this.appEvents.trigger("ace:resize"));
   }
@@ -158,82 +169,88 @@ export default class AdminThemeEditor extends Component {
 
   <template>
     <div ...attributes>
+      <div class="editor-information">
+        <div class="editor-information__title">
+          <DButton
+            @title="go_back"
+            @action={{this.goBack}}
+            @icon="chevron-left"
+            class="btn-default btn-small editor-back-button"
+          />
+
+          <span class="editor-theme-name-wrapper">
+            {{i18n "admin.customize.theme.edit_css_html"}}
+            <LinkTo
+              @route={{this.showRouteName}}
+              @model={{this.theme.id}}
+              @replace={{true}}
+              class="editor-theme-name"
+            >
+              {{this.theme.name}}
+            </LinkTo>
+          </span>
+        </div>
+
+        <div class="editor-information__admin-actions">
+          <DToggleSwitch
+            @state={{this.showAdvanced}}
+            @label="admin.customize.theme.show_advanced"
+            {{on "click" this.toggleShowAdvanced}}
+          />
+
+          <DButton
+            @action={{this.toggleMaximize}}
+            @icon={{this.maximizeIcon}}
+            @title={{this.maximizeTitle}}
+            class="btn-transparent theme-editor-maximize"
+          />
+        </div>
+      </div>
+
       {{#if (gt this.visibleTargets.length 1)}}
         <div class="edit-main-nav admin-controls">
-          <nav>
-            <ul class="nav nav-pills target">
-              {{#each this.visibleTargets as |target|}}
-                <li>
-                  <LinkTo
-                    @route={{this.editRouteName}}
-                    @models={{array this.theme.id target.name this.fieldName}}
-                    @replace={{true}}
-                    title={{this.field.title}}
-                    class={{if target.edited "edited" "blank"}}
-                  >
-                    {{#if target.error}}{{dIcon "triangle-exclamation"}}{{/if}}
-                    {{#if target.icon}}{{dIcon target.icon}}{{/if}}
-                    {{i18n (concat "admin.customize.theme." target.name)}}
-                  </LinkTo>
-                </li>
-              {{/each}}
-              <li class="spacer"></li>
+          <DHorizontalOverflowNav @className="target">
+            {{#each this.visibleTargets as |target|}}
               <li>
-                <label>
-                  <Input
-                    @type="checkbox"
-                    @checked={{this.showAdvanced}}
-                    {{on "click" this.toggleShowAdvanced}}
-                  />
-                  {{i18n "admin.customize.theme.show_advanced"}}
-                </label>
+                <LinkTo
+                  @route={{this.editRouteName}}
+                  @models={{array this.theme.id target.name this.fieldName}}
+                  @replace={{true}}
+                  title={{this.field.title}}
+                  class={{if target.edited "edited" "blank"}}
+                >
+                  {{#if target.error}}{{dIcon "triangle-exclamation"}}{{/if}}
+                  {{#if target.icon}}{{dIcon target.icon}}{{/if}}
+                  {{i18n (concat "admin.customize.theme." target.name)}}
+                </LinkTo>
               </li>
-            </ul>
-          </nav>
+            {{/each}}
+          </DHorizontalOverflowNav>
         </div>
       {{/if}}
 
       <div class="admin-controls">
-        <nav>
-          <ul class="nav nav-pills fields">
-            {{#each this.visibleFields as |field|}}
-              <li>
-                <LinkTo
-                  @route={{this.editRouteName}}
-                  @models={{array
-                    this.theme.id
-                    this.currentTargetName
-                    field.name
-                  }}
-                  @replace={{true}}
-                  title={{field.title}}
-                  class={{if field.edited "edited" "blank"}}
-                >
-                  {{#if field.error}}{{dIcon "triangle-exclamation"}}{{/if}}
-                  {{#if field.icon}}{{dIcon field.icon}}{{/if}}
-                  {{field.translatedName}}
-                </LinkTo>
-              </li>
-            {{/each}}
-
-            <li class="spacer"></li>
+        <DHorizontalOverflowNav @className="fields">
+          {{#each this.visibleFields as |field|}}
             <li>
-              {{#if (lte this.visibleTargets.length 1)}}
-                <label>
-                  <Input
-                    @type="checkbox"
-                    @checked={{this.showAdvanced}}
-                    {{on "click" this.toggleShowAdvanced}}
-                  />
-                  {{i18n "admin.customize.theme.show_advanced"}}
-                </label>
-              {{/if}}
-              <a href {{on "click" this.toggleMaximize}} class="no-text">
-                {{dIcon this.maximizeIcon}}
-              </a>
+              <LinkTo
+                @route={{this.editRouteName}}
+                @models={{array
+                  this.theme.id
+                  this.currentTargetName
+                  field.name
+                }}
+                @replace={{true}}
+                title={{field.title}}
+                class={{if field.edited "edited" "blank"}}
+              >
+                {{#if field.error}}{{dIcon "triangle-exclamation"}}{{/if}}
+                {{#if field.icon}}{{dIcon field.icon}}{{/if}}
+                {{field.translatedName}}
+              </LinkTo>
             </li>
-          </ul>
-        </nav>
+          {{/each}}
+        </DHorizontalOverflowNav>
       </div>
 
       {{#if this.error}}

--- a/frontend/discourse/admin/templates/admin-customize-themes/edit.gjs
+++ b/frontend/discourse/admin/templates/admin-customize-themes/edit.gjs
@@ -1,4 +1,3 @@
-import { LinkTo } from "@ember/routing";
 import AdminThemeEditor from "discourse/admin/components/admin-theme-editor";
 import DButton from "discourse/ui-kit/d-button";
 import { i18n } from "discourse-i18n";
@@ -6,34 +5,15 @@ import { i18n } from "discourse-i18n";
 export default <template>
   <div class="current-style {{if @controller.maximized 'maximized'}}">
     <div class="wrapper">
-      <div class="editor-information">
-        <DButton
-          @title="go_back"
-          @action={{@controller.goBack}}
-          @icon="chevron-left"
-          class="btn-default btn-small editor-back-button"
-        />
-
-        <span class="editor-theme-name-wrapper">
-          {{i18n "admin.customize.theme.edit_css_html"}}
-          <LinkTo
-            @route={{@controller.showRouteName}}
-            @model={{@controller.model.id}}
-            @replace={{true}}
-            class="editor-theme-name"
-          >
-            {{@controller.model.name}}
-          </LinkTo>
-        </span>
-      </div>
-
       <AdminThemeEditor
         @theme={{@controller.model}}
         @editRouteName={{@controller.editRouteName}}
+        @showRouteName={{@controller.showRouteName}}
         @currentTargetName={{@controller.currentTargetName}}
         @fieldName={{@controller.fieldName}}
         @fieldAdded={{@controller.fieldAdded}}
         @maximized={{@controller.maximized}}
+        @goBack={{@controller.goBack}}
         @save={{@controller.save}}
         class="editor-container"
       />

--- a/spec/system/admin_customize_themes_spec.rb
+++ b/spec/system/admin_customize_themes_spec.rb
@@ -106,6 +106,16 @@ describe "Admin Customize Themes" do
 
       expect(find(".ace_content")).to have_content("console.log('second test')")
     end
+
+    it "shows the description of the field the admin switches to" do
+      theme_page.visit_editor(theme)
+
+      expect(theme_page).to have_editor_field_description("scss")
+
+      theme_page.click_editor_field("head_tag")
+
+      expect(theme_page).to have_editor_field_description("head_tag")
+    end
   end
 
   it "cannot edit js, upload files or delete system themes" do

--- a/spec/system/page_objects/pages/admin_customize_themes.rb
+++ b/spec/system/page_objects/pages/admin_customize_themes.rb
@@ -10,6 +10,19 @@ module PageObjects
         self
       end
 
+      def visit_editor(theme, target: "common", field: "scss")
+        page.visit("/admin/customize/themes/#{theme.id}/#{target}/#{field}/edit")
+        self
+      end
+
+      def click_editor_field(field)
+        find(".nav-pills.fields a[href$='/#{field}/edit']").click
+      end
+
+      def has_editor_field_description?(field)
+        has_css?(".field-info", text: I18n.t("admin_js.admin.customize.theme.#{field}.title"))
+      end
+
       def has_colors_tab?
         header.has_tab?("colors")
       end


### PR DESCRIPTION
This cleans up the layout of the admin code editor nav and fixes an issue where the tab descriptions weren't changing without a full page refresh. Also added a spec to catch further regression

Before:

<img width="2232" height="468" alt="image" src="https://github.com/user-attachments/assets/1661ca63-5c5e-41a7-a920-60b43e27b6ec" />


<img width="2220" height="598" alt="image" src="https://github.com/user-attachments/assets/a66378d8-73c1-45b3-9c2e-99526195efcc" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/17164c1e-7978-441b-adfa-ee669bdf2f3e" />


After:

<img width="2136" height="576" alt="image" src="https://github.com/user-attachments/assets/d19fcfc0-b5f8-4f49-bafd-0b05ff328585" />


<img width="2136" height="552" alt="image" src="https://github.com/user-attachments/assets/56af1cc9-95cc-48db-9e01-6fb4164ad19d" />


<img width="350" alt="image" src="https://github.com/user-attachments/assets/a2eb2048-1d73-4cb7-bad2-042097e1b8da" />
