### PR TITLE
FEATURE: Show progress of other translation targets in the AI translation admin page

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-detail-card.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-detail-card.gjs
@@ -1,0 +1,210 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import { trustHTML } from "@ember/template";
+import DTooltip from "discourse/float-kit/components/d-tooltip";
+import { i18n } from "discourse-i18n";
+
+export default class AiTranslationModelProgressDetailCard extends Component {
+  @service languageNameLookup;
+
+  get targetType() {
+    return this.args.data.target_type;
+  }
+
+  get isTag() {
+    return this.targetType === "tag";
+  }
+
+  get rows() {
+    return (this.args.data.locales || []).map((locale) => {
+      const denominator = Number(
+        this.isTag ? locale.total_count : locale.eligible_count
+      );
+      const translated = Number(locale.translated_count) || 0;
+      const percentage =
+        denominator > 0
+          ? Math.min(Math.round((translated / denominator) * 100), 100)
+          : 0;
+
+      return {
+        ...locale,
+        denominator,
+        languageName: this.languageNameLookup.getLanguageName(locale.locale),
+        percentage,
+        progressStyle: trustHTML(`width: ${percentage}%`),
+      };
+    });
+  }
+
+  get showPending() {
+    return (
+      this.rows.length > 0 &&
+      this.rows.every(({ pending_count }) => pending_count !== null)
+    );
+  }
+
+  get denominatorLabel() {
+    return i18n(
+      `discourse_ai.translations.model_progress.detail.columns.${
+        this.isTag ? "total" : "eligible"
+      }`
+    );
+  }
+
+  get eligibleHelp() {
+    return i18n(
+      `discourse_ai.translations.model_progress.detail.eligible_help.${this.targetType}`
+    );
+  }
+
+  get pendingHelp() {
+    return i18n(
+      `discourse_ai.translations.model_progress.detail.pending_help.${this.targetType}`
+    );
+  }
+
+  progressLabel(row) {
+    return i18n(
+      "discourse_ai.translations.model_progress.detail.progress_label",
+      {
+        translated: row.translated_count,
+        total: row.denominator,
+        language: row.languageName,
+      }
+    );
+  }
+
+  <template>
+    <div class="ai-translation-model-progress-detail">
+      {{#if this.rows.length}}
+        <table class="d-table ai-translation-locale-progress">
+          <thead class="d-table__header">
+            <tr>
+              <th class="ai-translation-locale-progress__locale-header">
+                {{i18n
+                  "discourse_ai.translations.model_progress.detail.columns.locale"
+                }}
+              </th>
+              <th class="ai-translation-locale-progress__translated-header">
+                {{i18n
+                  "discourse_ai.translations.model_progress.detail.columns.translated"
+                }}
+              </th>
+              {{#if this.showPending}}
+                <th class="ai-translation-locale-progress__pending-header">
+                  <DTooltip
+                    @icon="circle-question"
+                    @content={{this.pendingHelp}}
+                    class="ai-translation-locale-progress__help"
+                  />
+                  <span>
+                    {{i18n
+                      "discourse_ai.translations.model_progress.detail.columns.pending"
+                    }}
+                  </span>
+                </th>
+              {{/if}}
+              <th class="ai-translation-locale-progress__denominator-header">
+                {{#unless this.isTag}}
+                  <DTooltip
+                    @icon="circle-question"
+                    @content={{this.eligibleHelp}}
+                    class="ai-translation-locale-progress__help"
+                  />
+                {{/unless}}
+                <span>{{this.denominatorLabel}}</span>
+              </th>
+              <th class="ai-translation-locale-progress__progress-header">
+                {{i18n
+                  "discourse_ai.translations.model_progress.detail.columns.progress"
+                }}
+              </th>
+            </tr>
+          </thead>
+          <tbody class="d-table__body">
+            {{#each this.rows as |row|}}
+              <tr class="d-table__row ai-translation-locale-progress__row">
+                <td
+                  class="d-table__cell --overview ai-translation-locale-progress__locale"
+                >
+                  <span class="ai-translation-locale-progress__locale-name">
+                    {{row.languageName}}
+                  </span>
+                  <span class="ai-translation-locale-progress__locale-code">
+                    {{row.locale}}
+                  </span>
+                </td>
+                <td
+                  class="d-table__cell --detail ai-translation-locale-progress__translated"
+                >
+                  <span class="d-table__mobile-label">
+                    {{i18n
+                      "discourse_ai.translations.model_progress.detail.columns.translated"
+                    }}
+                  </span>
+                  <span
+                    class="ai-translation-locale-progress__translated-value"
+                  >
+                    {{row.translated_count}}
+                  </span>
+                </td>
+                {{#if this.showPending}}
+                  <td
+                    class="d-table__cell --detail ai-translation-locale-progress__pending"
+                  >
+                    <span class="d-table__mobile-label">
+                      {{i18n
+                        "discourse_ai.translations.model_progress.detail.columns.pending"
+                      }}
+                    </span>
+                    <span class="ai-translation-locale-progress__pending-value">
+                      {{row.pending_count}}
+                    </span>
+                  </td>
+                {{/if}}
+                <td
+                  class="d-table__cell --detail ai-translation-locale-progress__denominator"
+                >
+                  <span class="d-table__mobile-label">
+                    {{this.denominatorLabel}}
+                  </span>
+                  <span
+                    class="ai-translation-locale-progress__denominator-value"
+                  >
+                    {{row.denominator}}
+                  </span>
+                </td>
+                <td
+                  class="d-table__cell --detail ai-translation-locale-progress__progress"
+                >
+                  <span class="d-table__mobile-label">
+                    {{i18n
+                      "discourse_ai.translations.model_progress.detail.columns.progress"
+                    }}
+                  </span>
+                  <div
+                    class="ai-translation-progress-bar"
+                    role="progressbar"
+                    aria-label={{this.progressLabel row}}
+                    aria-valuenow={{row.percentage}}
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                  >
+                    <span
+                      class="ai-translation-progress-bar__fill"
+                      style={{row.progressStyle}}
+                    ></span>
+                  </div>
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      {{else}}
+        <p class="ai-translation-model-progress-detail__empty">
+          {{i18n "discourse_ai.translations.model_progress.detail.empty"}}
+        </p>
+      {{/if}}
+    </div>
+  </template>
+}

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-detail-card.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-detail-card.gjs
@@ -53,14 +53,12 @@ export default class AiTranslationModelProgressDetailCard extends Component {
 
   get eligibleHelp() {
     return i18n(
-      `discourse_ai.translations.model_progress.detail.eligible_help.${this.targetType}`
+      "discourse_ai.translations.model_progress.detail.eligible_help"
     );
   }
 
   get pendingHelp() {
-    return i18n(
-      `discourse_ai.translations.model_progress.detail.pending_help.${this.targetType}`
-    );
+    return i18n("discourse_ai.translations.model_progress.detail.pending_help");
   }
 
   progressLabel(row) {

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-overview-card.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-overview-card.gjs
@@ -1,0 +1,148 @@
+import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { trustHTML } from "@ember/template";
+import { i18n } from "discourse-i18n";
+
+export default class AiTranslationModelProgressOverviewCard extends Component {
+  get totalCount() {
+    return Math.max(Number(this.args.target.total_count) || 0, 0);
+  }
+
+  get translatedCount() {
+    return Math.min(
+      Math.max(Number(this.args.target.translated_count) || 0, 0),
+      this.totalCount
+    );
+  }
+
+  get needsLanguageDetectionCount() {
+    return Math.min(
+      Math.max(Number(this.args.target.needs_language_detection_count) || 0, 0),
+      this.totalCount - this.translatedCount
+    );
+  }
+
+  get percentage() {
+    if (this.totalCount === 0) {
+      return 0;
+    }
+
+    return Math.round((this.translatedCount / this.totalCount) * 100);
+  }
+
+  get translatedSegmentStyle() {
+    return trustHTML(
+      `width: ${(this.translatedCount / Math.max(this.totalCount, 1)) * 100}%`
+    );
+  }
+
+  get needsLanguageDetectionSegmentStyle() {
+    return trustHTML(
+      `width: ${
+        (this.needsLanguageDetectionCount / Math.max(this.totalCount, 1)) * 100
+      }%`
+    );
+  }
+
+  get title() {
+    return i18n(
+      `discourse_ai.translations.model_progress.targets.${this.args.target.target_type}.title`
+    );
+  }
+
+  get isFullyTranslated() {
+    return this.totalCount > 0 && this.translatedCount === this.totalCount;
+  }
+
+  get headline() {
+    const key = this.isFullyTranslated
+      ? "all_translated"
+      : this.args.target.target_type === "tag"
+        ? "total"
+        : "eligible_total";
+
+    return i18n(
+      `discourse_ai.translations.model_progress.targets.${this.args.target.target_type}.${key}`,
+      { count: this.totalCount }
+    );
+  }
+
+  get translatedText() {
+    return i18n(
+      `discourse_ai.translations.model_progress.targets.${this.args.target.target_type}.translated`,
+      { count: this.translatedCount }
+    );
+  }
+
+  get needsLanguageDetectionText() {
+    return i18n(
+      `discourse_ai.translations.model_progress.targets.${this.args.target.target_type}.needs_language_detection`,
+      { count: this.needsLanguageDetectionCount }
+    );
+  }
+
+  @action
+  toggle() {
+    this.args.onToggle?.(this.args.target.target_type);
+  }
+
+  <template>
+    <button
+      type="button"
+      class="ai-translation-model-progress-overview-card"
+      data-target-type={{@target.target_type}}
+      aria-expanded={{if @expanded "true" "false"}}
+      {{on "click" this.toggle}}
+    >
+      <span class="ai-translation-model-progress-overview-card__header">
+        <span class="ai-translation-model-progress-overview-card__title">
+          {{this.title}}
+        </span>
+        <span class="ai-translation-model-progress-overview-card__percentage">
+          {{this.percentage}}%
+        </span>
+      </span>
+
+      <span class="ai-translation-model-progress-overview-card__headline">
+        {{this.headline}}
+      </span>
+
+      {{#if this.isFullyTranslated}}
+        <span
+          class="ai-translation-model-progress-overview-card__subheader"
+          aria-hidden="true"
+        ></span>
+        <span
+          class="ai-translation-model-progress-overview-card__subheader"
+          aria-hidden="true"
+        ></span>
+      {{else}}
+        <span
+          class="ai-translation-model-progress-overview-card__subheader ai-translation-model-progress-overview-card__translated"
+        >
+          {{this.translatedText}}
+        </span>
+        <span
+          class="ai-translation-model-progress-overview-card__subheader ai-translation-model-progress-overview-card__needs-detection"
+        >
+          {{this.needsLanguageDetectionText}}
+        </span>
+      {{/if}}
+
+      <span
+        class="ai-translation-model-progress-overview-card__meter"
+        aria-hidden="true"
+      >
+        <span
+          class="ai-translation-model-progress-overview-card__meter-translated"
+          style={{this.translatedSegmentStyle}}
+        ></span>
+        <span
+          class="ai-translation-model-progress-overview-card__meter-needs-detection"
+          style={{this.needsLanguageDetectionSegmentStyle}}
+        ></span>
+      </span>
+    </button>
+  </template>
+}

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-overview-skeleton.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translation-model-progress-overview-skeleton.gjs
@@ -1,0 +1,36 @@
+import { i18n } from "discourse-i18n";
+
+const PLACEHOLDERS = [0, 1, 2, 3];
+
+export default <template>
+  <div
+    class="ai-translation-model-progress-overview-skeleton --animation"
+    role="status"
+    aria-label={{i18n "discourse_ai.translations.model_progress.loading"}}
+  >
+    {{#each PLACEHOLDERS}}
+      <div class="ai-translation-model-progress-overview-skeleton__card">
+        <div class="ai-translation-model-progress-overview-skeleton__header">
+          <span
+            class="ai-translation-model-progress-overview-skeleton__title"
+          ></span>
+          <span
+            class="ai-translation-model-progress-overview-skeleton__percentage"
+          ></span>
+        </div>
+        <span
+          class="ai-translation-model-progress-overview-skeleton__headline"
+        ></span>
+        <span
+          class="ai-translation-model-progress-overview-skeleton__subheader"
+        ></span>
+        <span
+          class="ai-translation-model-progress-overview-skeleton__subheader"
+        ></span>
+        <span
+          class="ai-translation-model-progress-overview-skeleton__meter"
+        ></span>
+      </div>
+    {{/each}}
+  </div>
+</template>

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -6,33 +6,30 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import moment from "moment";
-import AdminConfigAreaCard from "discourse/admin/components/admin-config-area-card";
-import Chart from "discourse/admin/components/chart";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Category from "discourse/models/category";
 import CategorySelector from "discourse/select-kit/components/category-selector";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import MultiSelect from "discourse/select-kit/components/multi-select";
+import { eq } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
-import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import AiTranslationModelProgressOverviewCard from "./ai-translation-model-progress-overview-card";
+import AiTranslationModelProgressOverviewSkeleton from "./ai-translation-model-progress-overview-skeleton";
 
 export default class AiTranslations extends Component {
   @service aiCredits;
   @service router;
-  @service languageNameLookup;
-  @service site;
   @service siteSettings;
 
-  @tracked data = null;
-  @tracked done = null;
-  @tracked total = null;
+  @tracked targets = null;
   @tracked loadingProgress = false;
   @tracked progressCachedAt = null;
+  @tracked expandedTargetType = null;
   @tracked
   translationEnabled =
     this.args.model?.translation_enabled &&
@@ -79,9 +76,7 @@ export default class AiTranslations extends Component {
       const response = await ajax(
         "/admin/plugins/discourse-ai/ai-translations/progress.json"
       );
-      this.data = response.translation_progress;
-      this.total = response.total;
-      this.done = response.posts_with_detected_locale;
+      this.targets = response.targets;
       this.progressCachedAt = response.cached_at;
     } catch (e) {
       popupAjaxError(e);
@@ -318,25 +313,14 @@ export default class AiTranslations extends Component {
         this._loadProgress();
       } else {
         this.enabled = false;
+        this.targets = null;
+        this.progressCachedAt = null;
+        this.expandedTargetType = null;
       }
     } catch (e) {
       popupAjaxError(e);
     } finally {
       this.isTogglingTranslation = false;
-    }
-  }
-
-  get chartRightPadding() {
-    const max = Math.max(...this.data.map(({ total }) => total));
-    switch (true) {
-      case max >= 100000:
-        return 90;
-      case max >= 10000:
-        return 80;
-      case max >= 20:
-        return 70;
-      default:
-        return 50;
     }
   }
 
@@ -346,10 +330,12 @@ export default class AiTranslations extends Component {
       this.args.model?.backfill_max_age_days &&
       this.hourlyRate > 0
     ) {
-      const totalRemaining = this.data?.reduce(
-        (sum, { total, done }) => sum + (total - done),
-        0
+      const posts = this.targets?.find(
+        ({ target_type }) => target_type === "post"
       );
+      const totalRemaining = posts
+        ? posts.total_count - posts.translated_count
+        : 0;
 
       if (totalRemaining && totalRemaining > 0) {
         const cutoffDate = new Date();
@@ -389,131 +375,10 @@ export default class AiTranslations extends Component {
     });
   }
 
-  get chartColors() {
-    const styles = getComputedStyle(document.querySelector(".ai-translations"));
-    return {
-      progress: styles.getPropertyValue("--chart-progress-color").trim(),
-      remaining: styles.getPropertyValue("--chart-remaining-color").trim(),
-      text: styles.getPropertyValue("--chart-text-color").trim(),
-      label: styles.getPropertyValue("--chart-label-color").trim(),
-    };
-  }
-
-  get chartConfig() {
-    if (!this.data?.length) {
-      return {};
-    }
-
-    const colors = this.chartColors;
-    const processedData = this.data.map(({ locale, total, done }) => {
-      const rawPercentage = total > 0 ? (done / total) * 100 : 0;
-      const donePercentage = Math.trunc(rawPercentage).toString();
-      const localeName = this.languageNameLookup.getLanguageName(locale);
-      const languageNameForTooltip = localeName.split(" (")[0];
-
-      return {
-        locale: localeName,
-        done,
-        total,
-        donePercentage,
-        tooltip: [
-          i18n("discourse_ai.translations.progress_chart.tooltip_translated", {
-            done,
-            total,
-            language: languageNameForTooltip,
-          }),
-        ],
-      };
-    });
-    const chartData = {
-      labels: processedData.map(({ locale }) => locale),
-      datasets: [
-        {
-          tooltip: processedData.map(({ tooltip }) => tooltip),
-          data: processedData.map(({ donePercentage }) => donePercentage),
-          totalItems: processedData.map(({ total }) => total),
-          backgroundColor: colors.progress,
-          barThickness: 30,
-          borderRadius: 4,
-        },
-      ],
-    };
-
-    return {
-      type: "bar",
-      data: chartData,
-      plugins: [
-        {
-          id: "barTotalText",
-          afterDraw: ({ ctx, data, scales }) => {
-            ctx.save();
-            ctx.textBaseline = "middle";
-            ctx.fillStyle = colors.text;
-            const items = data.datasets[0].totalItems;
-            items.forEach((count, i) => {
-              ctx.fillText(
-                i18n("discourse_ai.translations.progress_chart.bar_done", {
-                  count,
-                }),
-                scales.x.getPixelForValue(100) + 10,
-                scales.y.getPixelForValue(i)
-              );
-            });
-            ctx.canvas.parentElement.style.height = `${items.length * 50 + 40}px`;
-            ctx.restore();
-          },
-        },
-      ],
-      options: {
-        indexAxis: "y",
-        responsive: true,
-        maintainAspectRatio: false,
-        layout: { padding: { right: this.chartRightPadding } },
-        scales: {
-          x: {
-            beginAtZero: true,
-            max: 100,
-            grid: {
-              display: false,
-            },
-            ticks: {
-              color: colors.text,
-              callback: (percentage) =>
-                i18n("discourse_ai.translations.progress_chart.data_label", {
-                  percentage,
-                }),
-            },
-          },
-          y: {
-            grid: {
-              display: false,
-            },
-            ticks: {
-              color: colors.text,
-            },
-          },
-        },
-        plugins: {
-          legend: { display: false },
-          tooltip: {
-            displayColors: false,
-            callbacks: {
-              label: ({ dataset: { tooltip }, dataIndex }) =>
-                tooltip[dataIndex],
-            },
-          },
-          datalabels: {
-            formatter: (percentage) =>
-              this.site.mobileView && percentage < 20
-                ? ""
-                : i18n("discourse_ai.translations.progress_chart.data_label", {
-                    percentage,
-                  }),
-            color: colors.label,
-          },
-        },
-      },
-    };
+  @action
+  toggleTarget(targetType) {
+    this.expandedTargetType =
+      this.expandedTargetType === targetType ? null : targetType;
   }
 
   <template>
@@ -684,36 +549,42 @@ export default class AiTranslations extends Component {
       </div>
 
       {{#if this.enabled}}
-        <DConditionalLoadingSpinner @condition={{this.loadingProgress}}>
-          {{#if this.data}}
-            <AdminConfigAreaCard class="ai-translations__charts">
-              <:content>
-                <div class="ai-translations__progress-meta">
-                  {{#if this.backfillStatusMessage}}
-                    <div class="ai-translations__stat-item">
-                      <span class="ai-translations__stat-label">
-                        {{this.backfillStatusMessage}}
-                      </span>
-                    </div>
-                  {{/if}}
-                  {{#if this.cachedResultsNotice}}
-                    <div class="ai-translations__cached-results">
-                      {{dIcon "clock-rotate-left"}}
-                      <span>{{this.cachedResultsNotice}}</span>
-                    </div>
-                  {{/if}}
-                </div>
-                <div class="ai-translations__chart-container">
-                  <Chart
-                    @chartConfig={{this.chartConfig}}
-                    @loadChartDataLabelsPlugin={{true}}
-                    class="ai-translations__chart"
-                  />
-                </div>
-              </:content>
-            </AdminConfigAreaCard>
+        <div class="ai-translations__overview">
+          <div class="ai-translations__progress-meta">
+            {{#if this.backfillStatusMessage}}
+              <div class="ai-translations__stat-item">
+                <span class="ai-translations__stat-label">
+                  {{this.backfillStatusMessage}}
+                </span>
+              </div>
+            {{/if}}
+            {{#if this.cachedResultsNotice}}
+              <div class="ai-translations__cached-results">
+                {{dIcon "clock-rotate-left"}}
+                <span>{{this.cachedResultsNotice}}</span>
+              </div>
+            {{/if}}
+          </div>
+
+          {{#if this.loadingProgress}}
+            <AiTranslationModelProgressOverviewSkeleton />
+          {{else if this.targets}}
+            <div
+              class="ai-translations__overview-grid"
+              aria-label={{i18n
+                "discourse_ai.translations.model_progress.overview_label"
+              }}
+            >
+              {{#each this.targets as |target|}}
+                <AiTranslationModelProgressOverviewCard
+                  @target={{target}}
+                  @expanded={{eq this.expandedTargetType target.target_type}}
+                  @onToggle={{this.toggleTarget}}
+                />
+              {{/each}}
+            </div>
           {{/if}}
-        </DConditionalLoadingSpinner>
+        </div>
       {{/if}}
 
     </div>

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -18,6 +18,7 @@ import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
+import AiTranslationModelProgressDetailCard from "./ai-translation-model-progress-detail-card";
 import AiTranslationModelProgressOverviewCard from "./ai-translation-model-progress-overview-card";
 import AiTranslationModelProgressOverviewSkeleton from "./ai-translation-model-progress-overview-skeleton";
 
@@ -30,6 +31,10 @@ export default class AiTranslations extends Component {
   @tracked loadingProgress = false;
   @tracked progressCachedAt = null;
   @tracked expandedTargetType = null;
+  @tracked targetDetails = {};
+  @tracked loadingTargetDetails = {};
+  @tracked targetDetailErrors = {};
+  @tracked displayedTargetDetails = null;
   @tracked
   translationEnabled =
     this.args.model?.translation_enabled &&
@@ -53,6 +58,8 @@ export default class AiTranslations extends Component {
   @tracked categories = [];
   @tracked originalCategoryIds = this.args.model?.category_ids || [];
   hourlyRate = this.args.model?.hourly_rate || 0;
+  targetDetailRequests = new Map();
+  targetDetailGeneration = 0;
 
   constructor() {
     super(...arguments);
@@ -70,8 +77,11 @@ export default class AiTranslations extends Component {
     }
   }
 
-  async _loadProgress() {
-    this.loadingProgress = true;
+  async _loadProgress({ showLoading = true } = {}) {
+    if (showLoading) {
+      this.loadingProgress = true;
+    }
+
     try {
       const response = await ajax(
         "/admin/plugins/discourse-ai/ai-translations/progress.json"
@@ -81,7 +91,9 @@ export default class AiTranslations extends Component {
     } catch (e) {
       popupAjaxError(e);
     } finally {
-      this.loadingProgress = false;
+      if (showLoading) {
+        this.loadingProgress = false;
+      }
     }
   }
 
@@ -264,6 +276,17 @@ export default class AiTranslations extends Component {
       });
       this.originalCategoryScope = this.categoryScope;
       this.originalCategoryIds = ids;
+
+      const expandedTargetType = this.expandedTargetType;
+      this._invalidateTargetDetails({ keepDisplayed: true });
+
+      const refreshes = [this._loadProgress({ showLoading: false })];
+      if (expandedTargetType) {
+        refreshes.push(
+          this._loadTargetDetails(expandedTargetType, { retry: true })
+        );
+      }
+      await Promise.all(refreshes);
     } catch (e) {
       popupAjaxError(e);
     } finally {
@@ -316,6 +339,7 @@ export default class AiTranslations extends Component {
         this.targets = null;
         this.progressCachedAt = null;
         this.expandedTargetType = null;
+        this._invalidateTargetDetails();
       }
     } catch (e) {
       popupAjaxError(e);
@@ -377,8 +401,111 @@ export default class AiTranslations extends Component {
 
   @action
   toggleTarget(targetType) {
-    this.expandedTargetType =
-      this.expandedTargetType === targetType ? null : targetType;
+    if (this.expandedTargetType === targetType) {
+      this.expandedTargetType = null;
+      this.displayedTargetDetails = null;
+      return;
+    }
+
+    this.expandedTargetType = targetType;
+    this._loadTargetDetails(targetType);
+  }
+
+  async _loadTargetDetails(targetType, { retry = false } = {}) {
+    if (this.targetDetails[targetType] && !retry) {
+      this.displayedTargetDetails = this.targetDetails[targetType];
+      return;
+    }
+
+    const generation = this.targetDetailGeneration;
+    let request = this.targetDetailRequests.get(targetType);
+    if (!request || retry) {
+      request = ajax(
+        `/admin/plugins/discourse-ai/ai-translations/progress/${targetType}.json`
+      );
+      this.targetDetailRequests.set(targetType, request);
+    }
+
+    this.loadingTargetDetails = {
+      ...this.loadingTargetDetails,
+      [targetType]: true,
+    };
+    this.targetDetailErrors = {
+      ...this.targetDetailErrors,
+      [targetType]: false,
+    };
+
+    try {
+      const response = await request;
+      if (generation === this.targetDetailGeneration && this.enabled) {
+        this.targetDetails = {
+          ...this.targetDetails,
+          [targetType]: response,
+        };
+        if (this.expandedTargetType === targetType) {
+          this.displayedTargetDetails = response;
+        }
+      }
+    } catch {
+      if (generation === this.targetDetailGeneration && this.enabled) {
+        this.targetDetailErrors = {
+          ...this.targetDetailErrors,
+          [targetType]: true,
+        };
+      }
+    } finally {
+      if (generation === this.targetDetailGeneration) {
+        if (this.targetDetailRequests.get(targetType) === request) {
+          this.targetDetailRequests.delete(targetType);
+        }
+        this.loadingTargetDetails = {
+          ...this.loadingTargetDetails,
+          [targetType]: false,
+        };
+      }
+    }
+  }
+
+  _invalidateTargetDetails({ keepDisplayed = false } = {}) {
+    this.targetDetailGeneration += 1;
+    this.targetDetails = {};
+    this.loadingTargetDetails = {};
+    this.targetDetailErrors = {};
+    this.targetDetailRequests.clear();
+
+    if (!keepDisplayed) {
+      this.displayedTargetDetails = null;
+    }
+  }
+
+  get isLoadingExpandedTargetDetails() {
+    return this.loadingTargetDetails[this.expandedTargetType];
+  }
+
+  get hasExpandedTargetDetailError() {
+    return this.targetDetailErrors[this.expandedTargetType];
+  }
+
+  get isDetailStateOverlay() {
+    return Boolean(
+      this.displayedTargetDetails &&
+      (this.isLoadingExpandedTargetDetails || this.hasExpandedTargetDetailError)
+    );
+  }
+
+  get expandedTargetTitle() {
+    if (!this.expandedTargetType) {
+      return null;
+    }
+
+    return i18n(
+      `discourse_ai.translations.model_progress.targets.${this.expandedTargetType}.title`
+    );
+  }
+
+  @action
+  retryTargetDetails() {
+    this._loadTargetDetails(this.expandedTargetType, { retry: true });
   }
 
   <template>
@@ -583,6 +710,48 @@ export default class AiTranslations extends Component {
                 />
               {{/each}}
             </div>
+            {{#if this.expandedTargetType}}
+              <div class="ai-translation-model-progress-detail-region">
+                {{#if this.displayedTargetDetails}}
+                  <div aria-hidden={{this.isDetailStateOverlay}}>
+                    <AiTranslationModelProgressDetailCard
+                      @data={{this.displayedTargetDetails}}
+                    />
+                  </div>
+                {{/if}}
+                {{#if this.isLoadingExpandedTargetDetails}}
+                  <div
+                    class="ai-translation-model-progress-detail-state
+                      {{if this.isDetailStateOverlay '--overlay'}}"
+                    role="status"
+                  >
+                    {{i18n
+                      "discourse_ai.translations.model_progress.detail.loading"
+                      target=this.expandedTargetTitle
+                    }}
+                  </div>
+                {{else if this.hasExpandedTargetDetailError}}
+                  <div
+                    class="ai-translation-model-progress-detail-state --error
+                      {{if this.isDetailStateOverlay '--overlay'}}"
+                    role="alert"
+                  >
+                    <span>
+                      {{i18n
+                        "discourse_ai.translations.model_progress.detail.load_error"
+                        target=this.expandedTargetTitle
+                      }}
+                    </span>
+                    <DButton
+                      @action={{this.retryTargetDetails}}
+                      @icon="rotate"
+                      @label="discourse_ai.translations.model_progress.detail.retry"
+                      class="btn-default"
+                    />
+                  </div>
+                {{/if}}
+              </div>
+            {{/if}}
           {{/if}}
         </div>
       {{/if}}

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -8,11 +8,13 @@ import { trustHTML } from "@ember/template";
 import moment from "moment";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { bind } from "discourse/lib/decorators";
 import Category from "discourse/models/category";
 import CategorySelector from "discourse/select-kit/components/category-selector";
 import ComboBox from "discourse/select-kit/components/combo-box";
 import MultiSelect from "discourse/select-kit/components/multi-select";
 import { eq } from "discourse/truth-helpers";
+import DAsyncContent from "discourse/ui-kit/d-async-content";
 import DButton from "discourse/ui-kit/d-button";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
@@ -27,9 +29,7 @@ export default class AiTranslations extends Component {
   @service router;
   @service siteSettings;
 
-  @tracked targets = null;
-  @tracked loadingProgress = false;
-  @tracked progressCachedAt = null;
+  @tracked overviewGeneration = 0;
   @tracked expandedTargetType = null;
   @tracked targetDetails = {};
   @tracked loadingTargetDetails = {};
@@ -65,9 +65,6 @@ export default class AiTranslations extends Component {
     super(...arguments);
     this._checkCredits();
     this._loadCategories();
-    if (this.enabled) {
-      this._loadProgress();
-    }
   }
 
   async _loadCategories() {
@@ -77,24 +74,9 @@ export default class AiTranslations extends Component {
     }
   }
 
-  async _loadProgress({ showLoading = true } = {}) {
-    if (showLoading) {
-      this.loadingProgress = true;
-    }
-
-    try {
-      const response = await ajax(
-        "/admin/plugins/discourse-ai/ai-translations/progress.json"
-      );
-      this.targets = response.targets;
-      this.progressCachedAt = response.cached_at;
-    } catch (e) {
-      popupAjaxError(e);
-    } finally {
-      if (showLoading) {
-        this.loadingProgress = false;
-      }
-    }
+  @bind
+  loadProgress() {
+    return ajax("/admin/plugins/discourse-ai/ai-translations/progress.json");
   }
 
   async _checkCredits() {
@@ -279,14 +261,11 @@ export default class AiTranslations extends Component {
 
       const expandedTargetType = this.expandedTargetType;
       this._invalidateTargetDetails({ keepDisplayed: true });
+      this.overviewGeneration += 1;
 
-      const refreshes = [this._loadProgress({ showLoading: false })];
       if (expandedTargetType) {
-        refreshes.push(
-          this._loadTargetDetails(expandedTargetType, { retry: true })
-        );
+        await this._loadTargetDetails(expandedTargetType, { retry: true });
       }
-      await Promise.all(refreshes);
     } catch (e) {
       popupAjaxError(e);
     } finally {
@@ -333,11 +312,8 @@ export default class AiTranslations extends Component {
 
       if (this.translationEnabled && !this.args.model.no_locales_configured) {
         this.enabled = true;
-        this._loadProgress();
       } else {
         this.enabled = false;
-        this.targets = null;
-        this.progressCachedAt = null;
         this.expandedTargetType = null;
         this._invalidateTargetDetails();
       }
@@ -348,15 +324,14 @@ export default class AiTranslations extends Component {
     }
   }
 
-  get backfillStatusMessage() {
+  @bind
+  backfillStatusMessage(targets) {
     if (
       this.args.model?.backfill_enabled &&
       this.args.model?.backfill_max_age_days &&
       this.hourlyRate > 0
     ) {
-      const posts = this.targets?.find(
-        ({ target_type }) => target_type === "post"
-      );
+      const posts = targets?.find(({ target_type }) => target_type === "post");
       const totalRemaining = posts
         ? posts.total_count - posts.translated_count
         : 0;
@@ -389,13 +364,14 @@ export default class AiTranslations extends Component {
     return null;
   }
 
-  get cachedResultsNotice() {
-    if (!this.progressCachedAt) {
+  @bind
+  cachedResultsNotice(cachedAt) {
+    if (!cachedAt) {
       return null;
     }
 
     return i18n("discourse_ai.translations.cached_results_notice", {
-      relative_time: moment(this.progressCachedAt).fromNow(),
+      relative_time: moment(cachedAt).fromNow(),
     });
   }
 
@@ -677,82 +653,100 @@ export default class AiTranslations extends Component {
 
       {{#if this.enabled}}
         <div class="ai-translations__overview">
-          <div class="ai-translations__progress-meta">
-            {{#if this.backfillStatusMessage}}
-              <div class="ai-translations__stat-item">
-                <span class="ai-translations__stat-label">
-                  {{this.backfillStatusMessage}}
-                </span>
+          <DAsyncContent
+            @asyncData={{this.loadProgress}}
+            @context={{this.overviewGeneration}}
+            @retainWhileReloading={{true}}
+            @errorMode="popup"
+          >
+            <:loading>
+              <AiTranslationModelProgressOverviewSkeleton />
+            </:loading>
+            <:content as |progress|>
+              <div class="ai-translations__progress-meta">
+                {{#let
+                  (this.backfillStatusMessage progress.targets)
+                  as |backfillStatusMessage|
+                }}
+                  {{#if backfillStatusMessage}}
+                    <div class="ai-translations__stat-item">
+                      <span class="ai-translations__stat-label">
+                        {{backfillStatusMessage}}
+                      </span>
+                    </div>
+                  {{/if}}
+                {{/let}}
+                {{#let
+                  (this.cachedResultsNotice progress.cached_at)
+                  as |cachedResultsNotice|
+                }}
+                  {{#if cachedResultsNotice}}
+                    <div class="ai-translations__cached-results">
+                      {{dIcon "clock-rotate-left"}}
+                      <span>{{cachedResultsNotice}}</span>
+                    </div>
+                  {{/if}}
+                {{/let}}
               </div>
-            {{/if}}
-            {{#if this.cachedResultsNotice}}
-              <div class="ai-translations__cached-results">
-                {{dIcon "clock-rotate-left"}}
-                <span>{{this.cachedResultsNotice}}</span>
-              </div>
-            {{/if}}
-          </div>
 
-          {{#if this.loadingProgress}}
-            <AiTranslationModelProgressOverviewSkeleton />
-          {{else if this.targets}}
-            <div
-              class="ai-translations__overview-grid"
-              aria-label={{i18n
-                "discourse_ai.translations.model_progress.overview_label"
-              }}
-            >
-              {{#each this.targets as |target|}}
-                <AiTranslationModelProgressOverviewCard
-                  @target={{target}}
-                  @expanded={{eq this.expandedTargetType target.target_type}}
-                  @onToggle={{this.toggleTarget}}
-                />
-              {{/each}}
-            </div>
-            {{#if this.expandedTargetType}}
-              <div class="ai-translation-model-progress-detail-region">
-                {{#if this.displayedTargetDetails}}
-                  <div aria-hidden={{this.isDetailStateOverlay}}>
-                    <AiTranslationModelProgressDetailCard
-                      @data={{this.displayedTargetDetails}}
-                    />
-                  </div>
-                {{/if}}
-                {{#if this.isLoadingExpandedTargetDetails}}
-                  <div
-                    class="ai-translation-model-progress-detail-state
-                      {{if this.isDetailStateOverlay '--overlay'}}"
-                    role="status"
-                  >
-                    {{i18n
-                      "discourse_ai.translations.model_progress.detail.loading"
-                      target=this.expandedTargetTitle
-                    }}
-                  </div>
-                {{else if this.hasExpandedTargetDetailError}}
-                  <div
-                    class="ai-translation-model-progress-detail-state --error
-                      {{if this.isDetailStateOverlay '--overlay'}}"
-                    role="alert"
-                  >
-                    <span>
+              <div
+                class="ai-translations__overview-grid"
+                aria-label={{i18n
+                  "discourse_ai.translations.model_progress.overview_label"
+                }}
+              >
+                {{#each progress.targets as |target|}}
+                  <AiTranslationModelProgressOverviewCard
+                    @target={{target}}
+                    @expanded={{eq this.expandedTargetType target.target_type}}
+                    @onToggle={{this.toggleTarget}}
+                  />
+                {{/each}}
+              </div>
+              {{#if this.expandedTargetType}}
+                <div class="ai-translation-model-progress-detail-region">
+                  {{#if this.displayedTargetDetails}}
+                    <div aria-hidden={{this.isDetailStateOverlay}}>
+                      <AiTranslationModelProgressDetailCard
+                        @data={{this.displayedTargetDetails}}
+                      />
+                    </div>
+                  {{/if}}
+                  {{#if this.isLoadingExpandedTargetDetails}}
+                    <div
+                      class="ai-translation-model-progress-detail-state
+                        {{if this.isDetailStateOverlay '--overlay'}}"
+                      role="status"
+                    >
                       {{i18n
-                        "discourse_ai.translations.model_progress.detail.load_error"
+                        "discourse_ai.translations.model_progress.detail.loading"
                         target=this.expandedTargetTitle
                       }}
-                    </span>
-                    <DButton
-                      @action={{this.retryTargetDetails}}
-                      @icon="rotate"
-                      @label="discourse_ai.translations.model_progress.detail.retry"
-                      class="btn-default"
-                    />
-                  </div>
-                {{/if}}
-              </div>
-            {{/if}}
-          {{/if}}
+                    </div>
+                  {{else if this.hasExpandedTargetDetailError}}
+                    <div
+                      class="ai-translation-model-progress-detail-state --error
+                        {{if this.isDetailStateOverlay '--overlay'}}"
+                      role="alert"
+                    >
+                      <span>
+                        {{i18n
+                          "discourse_ai.translations.model_progress.detail.load_error"
+                          target=this.expandedTargetTitle
+                        }}
+                      </span>
+                      <DButton
+                        @action={{this.retryTargetDetails}}
+                        @icon="rotate"
+                        @label="discourse_ai.translations.model_progress.detail.retry"
+                        class="btn-default"
+                      />
+                    </div>
+                  {{/if}}
+                </div>
+              {{/if}}
+            </:content>
+          </DAsyncContent>
         </div>
       {{/if}}
 

--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -585,7 +585,7 @@ export default class AiTranslations extends Component {
                     @action={{this.resetLocales}}
                     @icon="arrow-rotate-left"
                     @label="admin.settings.reset"
-                    class="undo setting-controls__undo"
+                    class="btn-default undo setting-controls__undo"
                   />
                 {{/if}}
               </div>
@@ -628,7 +628,7 @@ export default class AiTranslations extends Component {
                         @action={{this.resetCategories}}
                         @icon="arrow-rotate-left"
                         @label="admin.settings.reset"
-                        class="undo setting-controls__undo"
+                        class="btn-default undo setting-controls__undo"
                       />
                     {{/if}}
                   {{/unless}}
@@ -661,7 +661,7 @@ export default class AiTranslations extends Component {
                         @action={{this.resetCategories}}
                         @icon="arrow-rotate-left"
                         @label="admin.settings.reset"
-                        class="undo setting-controls__undo"
+                        class="btn-default undo setting-controls__undo"
                       />
                     {{/if}}
                   </div>

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -16,14 +16,9 @@ module DiscourseAi
       end
 
       def progress
-        unless DiscourseAi::Translation.enabled? &&
-                 SiteSetting.ai_translation_backfill_max_age_days > 0
-          return(render json: { translation_progress: [], total: 0, posts_with_detected_locale: 0 })
-        end
+        return render json: { cached_at: nil, targets: [] } unless DiscourseAi::Translation.enabled?
 
-        data = DiscourseAi::Translation::PostCandidates.get_completion_all_locales
-
-        render json: data
+        render json: DiscourseAi::Translation::Progress.fetch
       end
 
       private
@@ -31,10 +26,7 @@ module DiscourseAi
       def base_result
         {
           translation_id: DiscourseAi::Configuration::Module::TRANSLATION_ID,
-          # the progress chart will be empty if max_age_days is 0
-          enabled:
-            DiscourseAi::Translation.enabled? &&
-              SiteSetting.ai_translation_backfill_max_age_days > 0,
+          enabled: DiscourseAi::Translation.enabled?,
           backfill_enabled: DiscourseAi::Translation.backfill_enabled?,
           translation_enabled: SiteSetting.ai_translation_enabled,
           hourly_rate: SiteSetting.ai_translation_backfill_hourly_rate,

--- a/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/admin/ai_translations_controller.rb
@@ -21,6 +21,19 @@ module DiscourseAi
         render json: DiscourseAi::Translation::Progress.fetch
       end
 
+      def progress_detail
+        target_type = params[:target_type]
+        unless DiscourseAi::Translation::Progress.supported_target?(target_type)
+          return head :not_found
+        end
+
+        unless DiscourseAi::Translation.enabled?
+          return render json: { target_type:, cached_at: nil, locales: [] }
+        end
+
+        render json: DiscourseAi::Translation::Progress.fetch_detail(target_type)
+      end
+
       private
 
       def base_result

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -1,13 +1,4 @@
 .ai-translations {
-  --chart-progress-color: var(--tertiary);
-  --chart-remaining-color: var(--tertiary-low);
-  --chart-text-color: var(--primary);
-  --chart-label-color: var(--secondary);
-
-  &__charts {
-    margin-top: 2em;
-  }
-
   &__settings-panel {
     background: var(--primary-very-low);
     margin-block: var(--space-4);
@@ -25,6 +16,16 @@
     flex-wrap: wrap;
     gap: var(--space-2);
     margin-block-end: var(--space-4);
+  }
+
+  &__overview {
+    margin-block-start: var(--space-4);
+  }
+
+  &__overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: var(--space-4);
   }
 
   &__cached-results {
@@ -110,6 +111,193 @@
       .select-kit {
         max-width: 100%;
       }
+    }
+  }
+}
+
+.ai-translation-model-progress-overview-card {
+  display: grid;
+  grid-template-rows:
+    auto
+    minmax(3.5rem, auto)
+    minmax(2.75rem, auto)
+    minmax(2.75rem, auto)
+    auto;
+  gap: var(--space-3);
+  align-content: start;
+  width: 100%;
+  min-width: 0;
+  min-height: 11.5rem;
+  padding: var(--space-4);
+  border: 1px solid var(--primary-low);
+  border-radius: var(--d-border-radius);
+  color: var(--primary);
+  background: var(--secondary);
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--tertiary);
+  }
+
+  &:focus-visible {
+    border-color: var(--tertiary);
+    outline: 2px solid var(--tertiary);
+    outline-offset: 2px;
+  }
+
+  &[aria-expanded="true"] {
+    border-color: var(--tertiary);
+    box-shadow: inset 0 3px 0 var(--tertiary);
+  }
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  &__title,
+  &__percentage {
+    font-size: var(--font-0);
+    font-weight: 700;
+  }
+
+  &__headline,
+  &__subheader {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__subheader {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
+
+    &[aria-hidden="true"] {
+      visibility: hidden;
+    }
+  }
+
+  &__meter {
+    display: flex;
+    overflow: hidden;
+    height: 0.5rem;
+    margin-block-start: var(--space-1);
+    border-radius: 1rem;
+    background: var(--primary-very-low);
+  }
+
+  &__meter-translated {
+    background: var(--tertiary);
+  }
+
+  &__meter-needs-detection {
+    background: var(--tertiary-low);
+  }
+}
+
+.ai-translation-model-progress-overview-skeleton {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: var(--space-4);
+
+  &__card {
+    display: grid;
+    grid-template-rows:
+      auto
+      minmax(3.5rem, auto)
+      minmax(2.75rem, auto)
+      minmax(2.75rem, auto)
+      auto;
+    gap: var(--space-3);
+    min-height: 11.5rem;
+    padding: var(--space-4);
+    border: 1px solid var(--primary-low);
+    border-radius: var(--d-border-radius);
+    background: var(--secondary);
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+
+  &__title,
+  &__percentage,
+  &__headline,
+  &__subheader,
+  &__meter {
+    display: block;
+    border-radius: var(--d-border-radius);
+    background: var(--primary-low);
+  }
+
+  &__title {
+    width: 5rem;
+    height: 1.25rem;
+  }
+
+  &__percentage {
+    width: 2.5rem;
+    height: 1.25rem;
+  }
+
+  &__headline {
+    width: 90%;
+    height: 2.5rem;
+  }
+
+  &__subheader {
+    width: 80%;
+    height: 1rem;
+  }
+
+  &__meter {
+    width: 100%;
+    height: 0.5rem;
+    margin-block-start: var(--space-1);
+    border-radius: 1rem;
+  }
+
+  &.--animation {
+    .ai-translation-model-progress-overview-skeleton__title,
+    .ai-translation-model-progress-overview-skeleton__percentage,
+    .ai-translation-model-progress-overview-skeleton__headline,
+    .ai-translation-model-progress-overview-skeleton__subheader,
+    .ai-translation-model-progress-overview-skeleton__meter {
+      background-image: linear-gradient(
+        90deg,
+        var(--primary-low) 25%,
+        var(--primary-very-low) 50%,
+        var(--primary-low) 75%
+      );
+      background-size: 200% 100%;
+      animation: ai-translation-progress-skeleton 1.4s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes ai-translation-progress-skeleton {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-translation-model-progress-overview-skeleton.--animation {
+    .ai-translation-model-progress-overview-skeleton__title,
+    .ai-translation-model-progress-overview-skeleton__percentage,
+    .ai-translation-model-progress-overview-skeleton__headline,
+    .ai-translation-model-progress-overview-skeleton__subheader,
+    .ai-translation-model-progress-overview-skeleton__meter {
+      animation: none;
     }
   }
 }

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -3,6 +3,7 @@
     background: var(--primary-very-low);
     margin-block: var(--space-4);
     padding: var(--space-2);
+    border-radius: var(--d-border-radius);
   }
 
   &__toggle-container {
@@ -150,7 +151,7 @@
 
   &[aria-expanded="true"] {
     border-color: var(--tertiary);
-    box-shadow: inset 0 3px 0 var(--tertiary);
+    box-shadow: inset 3px 0 0 var(--tertiary);
   }
 
   &__header {

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -20,6 +20,7 @@
 
   &__overview {
     margin-block-start: var(--space-4);
+    margin-block-end: calc(var(--space-10) * 2);
   }
 
   &__overview-grid {
@@ -280,6 +281,111 @@
   }
 }
 
+.ai-translation-model-progress-detail {
+  &__empty {
+    margin: 0;
+    padding-block: var(--space-4);
+    color: var(--primary-medium);
+  }
+}
+
+.ai-translation-model-progress-detail-region {
+  position: relative;
+  min-height: calc(var(--space-12) * 2);
+  margin-block-start: var(--space-4);
+}
+
+.ai-translation-locale-progress {
+  width: 100%;
+  table-layout: fixed;
+
+  th,
+  td {
+    vertical-align: middle;
+  }
+
+  &__locale-header,
+  &__locale {
+    width: 12rem;
+  }
+
+  &__translated-header,
+  &__translated,
+  &__pending-header,
+  &__pending,
+  &__denominator-header,
+  &__denominator {
+    width: 7rem;
+    text-align: end;
+  }
+
+  &__progress-header,
+  &__progress {
+    width: auto;
+  }
+
+  &__pending-header,
+  &__denominator-header {
+    > span {
+      vertical-align: middle;
+    }
+  }
+
+  &__help {
+    display: inline-flex;
+    align-items: center;
+    margin-inline-end: var(--space-1);
+    color: var(--primary-medium);
+    cursor: help;
+    vertical-align: middle;
+  }
+
+  &__locale-name {
+    display: block;
+    font-weight: 600;
+  }
+
+  &__locale-code {
+    color: var(--primary-medium);
+    font-size: var(--font-down-1);
+  }
+}
+
+.ai-translation-progress-bar {
+  overflow: hidden;
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 1rem;
+  background: var(--primary-very-low);
+
+  &__fill {
+    display: block;
+    height: 100%;
+    background: var(--tertiary);
+  }
+}
+
+.ai-translation-model-progress-detail-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: calc(var(--space-12) * 2);
+  color: var(--primary-medium);
+
+  &.--error {
+    color: var(--primary);
+  }
+
+  &.--overlay {
+    position: absolute;
+    z-index: 1;
+    inset: 0;
+    min-height: 0;
+    background: var(--secondary);
+  }
+}
+
 @keyframes ai-translation-progress-skeleton {
   from {
     background-position: 200% 0;
@@ -287,6 +393,52 @@
 
   to {
     background-position: -200% 0;
+  }
+}
+
+@media screen and (width <= 700px) {
+  .ai-translation-locale-progress {
+    display: block;
+
+    .d-table__header {
+      display: none;
+    }
+
+    .d-table__body,
+    .d-table__row,
+    .d-table__cell {
+      display: block;
+      box-sizing: border-box;
+      width: 100%;
+    }
+
+    .d-table__row {
+      padding-block: var(--space-3);
+    }
+
+    .d-table__cell {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--space-3);
+      padding-block: var(--space-1);
+      text-align: end;
+    }
+
+    &__locale {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0;
+      text-align: start;
+    }
+
+    &__progress {
+      align-items: center;
+    }
+
+    .ai-translation-progress-bar {
+      max-width: 65%;
+    }
   }
 }
 

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -453,15 +453,8 @@ en:
               eligible: "Eligible"
               total: "Total"
               progress: "Progress"
-            eligible_help:
-              post: "If a post is already in the language, it is excluded."
-              topic: "If a topic is already in the language, it is excluded."
-              category: "If a category is already in the language, it is excluded."
-            pending_help:
-              post: "Includes eligible posts that do not have language detected yet."
-              topic: "Includes eligible topics that do not have language detected yet."
-              category: "Includes eligible categories that do not have language detected yet."
-              tag: "Includes tags that do not have language detected yet."
+            eligible_help: "Content already in this language is excluded."
+            pending_help: "Includes content that still needs language detection."
           targets:
             post:
               title: "Posts"

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -437,6 +437,66 @@ en:
         category_scope: "Categories"
         category_scope_description: "Choose whether automatic translations apply to content in all categories, public categories, or selected categories."
         cached_results_notice: "Showing cached results from %{relative_time}."
+        model_progress:
+          loading: "Loading translation progress"
+          overview_label: "Translation progress by content type"
+          targets:
+            post:
+              title: "Posts"
+              eligible_total:
+                one: "There is %{count} eligible post for translation."
+                other: "There are %{count} eligible posts for translation."
+              translated:
+                one: "%{count} post has been fully translated."
+                other: "%{count} posts have been fully translated."
+              needs_language_detection:
+                one: "%{count} post still needs language detection."
+                other: "%{count} posts still need language detection."
+              all_translated:
+                one: "The eligible post is fully translated."
+                other: "All %{count} eligible posts are fully translated."
+            topic:
+              title: "Topics"
+              eligible_total:
+                one: "There is %{count} eligible topic for translation."
+                other: "There are %{count} eligible topics for translation."
+              translated:
+                one: "%{count} topic has been fully translated."
+                other: "%{count} topics have been fully translated."
+              needs_language_detection:
+                one: "%{count} topic still needs language detection."
+                other: "%{count} topics still need language detection."
+              all_translated:
+                one: "The eligible topic is fully translated."
+                other: "All %{count} eligible topics are fully translated."
+            category:
+              title: "Categories"
+              eligible_total:
+                one: "There is %{count} eligible category for translation."
+                other: "There are %{count} eligible categories for translation."
+              translated:
+                one: "%{count} category has been fully translated."
+                other: "%{count} categories have been fully translated."
+              needs_language_detection:
+                one: "%{count} category still needs language detection."
+                other: "%{count} categories still need language detection."
+              all_translated:
+                one: "The eligible category is fully translated."
+                other: "All %{count} eligible categories are fully translated."
+            tag:
+              title: "Tags"
+              total:
+                one: "There is %{count} tag for translation."
+                other: "There are %{count} tags for translation."
+              translated:
+                one: "%{count} tag has been fully translated."
+                other: "%{count} tags have been fully translated."
+              needs_language_detection:
+                one: "%{count} tag still needs language detection."
+                other: "%{count} tags still need language detection."
+              all_translated:
+                one: "The tag is fully translated."
+                other: "All %{count} tags are fully translated."
         admin_actions:
           translation_settings: "AI settings"
           localization_settings: "App language settings"

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -440,6 +440,28 @@ en:
         model_progress:
           loading: "Loading translation progress"
           overview_label: "Translation progress by content type"
+          detail:
+            loading: "Loading %{target} details..."
+            load_error: "%{target} details could not be loaded."
+            retry: "Retry"
+            empty: "No language progress is available."
+            progress_label: "%{translated} of %{total} translated into %{language}"
+            columns:
+              locale: "Locale"
+              translated: "Translated"
+              pending: "Pending"
+              eligible: "Eligible"
+              total: "Total"
+              progress: "Progress"
+            eligible_help:
+              post: "If a post is already in the language, it is excluded."
+              topic: "If a topic is already in the language, it is excluded."
+              category: "If a category is already in the language, it is excluded."
+            pending_help:
+              post: "Includes eligible posts that do not have language detected yet."
+              topic: "Includes eligible topics that do not have language detected yet."
+              category: "Includes eligible categories that do not have language detected yet."
+              tag: "Includes tags that do not have language detected yet."
           targets:
             post:
               title: "Posts"

--- a/plugins/discourse-ai/config/routes.rb
+++ b/plugins/discourse-ai/config/routes.rb
@@ -160,6 +160,8 @@ Discourse::Application.routes.draw do
 
     get "/ai-translations", to: "discourse_ai/admin/ai_translations#show"
     get "/ai-translations/progress", to: "discourse_ai/admin/ai_translations#progress"
+    get "/ai-translations/progress/:target_type",
+        to: "discourse_ai/admin/ai_translations#progress_detail"
     post "/ai-theme-translations", to: "discourse_ai/admin/ai_theme_translations#create"
 
     resources :ai_llms,

--- a/plugins/discourse-ai/lib/translation.rb
+++ b/plugins/discourse-ai/lib/translation.rb
@@ -11,6 +11,20 @@ module DiscourseAi
       SiteSetting.content_localization_locales
     end
 
+    def self.supported_locale_bases_cte
+      <<~SQL
+        supported AS MATERIALIZED (
+          SELECT COALESCE(
+            array_agg(
+              DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
+            ) FILTER (WHERE locale IS NOT NULL),
+            ARRAY[]::text[]
+          ) AS bases
+          FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
+        )
+      SQL
+    end
+
     def self.has_llm_model?
       agent_ids = [
         SiteSetting.ai_translation_locale_detector_agent,

--- a/plugins/discourse-ai/lib/translation/category_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/category_candidates.rb
@@ -3,6 +3,64 @@
 module DiscourseAi
   module Translation
     class CategoryCandidates < BaseCandidates
+      def self.progress_summary
+        supported_locales = SiteSetting.content_localization_supported_locales.split("|")
+        eligible_categories_sql = get.select(:id, :locale).to_sql
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT COALESCE(
+              array_agg(
+                DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
+              ) FILTER (WHERE locale IS NOT NULL),
+              ARRAY[]::text[]
+            ) AS bases
+            FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
+          ),
+          eligible_categories AS (
+            SELECT id,
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS source_base
+            FROM (#{eligible_categories_sql}) candidates
+          ),
+          localization_coverage AS (
+            SELECT cl.category_id,
+                   array_agg(
+                     split_part(
+                       lower(replace(cl.locale, '-', '_')), '_', 1
+                     )
+                   ) AS bases
+            FROM category_localizations cl
+            GROUP BY cl.category_id
+          )
+          SELECT
+            COUNT(*)::bigint AS total_count,
+            COUNT(*) FILTER (
+              WHERE ec.locale IS NOT NULL
+                AND supported.bases <@ (
+                  COALESCE(lc.bases, ARRAY[]::text[]) || ec.source_base
+                )
+            )::bigint AS translated_count,
+            COUNT(*) FILTER (
+              WHERE ec.locale IS NULL
+            )::bigint AS needs_language_detection_count
+          FROM eligible_categories ec
+          CROSS JOIN supported
+          LEFT JOIN localization_coverage lc ON lc.category_id = ec.id
+        SQL
+
+        result = DB.query(sql, supported_locales:).first
+
+        {
+          target_type: "category",
+          total_count: result.total_count,
+          translated_count: result.translated_count,
+          needs_language_detection_count: result.needs_language_detection_count,
+        }
+      end
+
       private
 
       # all categories that are eligible for translation based on site settings,

--- a/plugins/discourse-ai/lib/translation/category_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/category_candidates.rb
@@ -8,15 +8,7 @@ module DiscourseAi
         eligible_categories_sql = get.select(:id, :locale).to_sql
 
         sql = <<~SQL
-          WITH supported AS MATERIALIZED (
-            SELECT COALESCE(
-              array_agg(
-                DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
-              ) FILTER (WHERE locale IS NOT NULL),
-              ARRAY[]::text[]
-            ) AS bases
-            FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
-          ),
+          WITH #{DiscourseAi::Translation.supported_locale_bases_cte},
           eligible_categories AS (
             SELECT id,
                    locale,

--- a/plugins/discourse-ai/lib/translation/category_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/category_candidates.rb
@@ -61,6 +61,96 @@ module DiscourseAi
         }
       end
 
+      def self.progress_details
+        eligible_categories_sql = get.select("categories.id, categories.locale").to_sql
+        supported_locales =
+          ActiveRecord::Base.connection.quote(SiteSetting.content_localization_supported_locales)
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT DISTINCT ON (
+                     split_part(lower(replace(locale, '-', '_')), '_', 1)
+                   )
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM unnest(string_to_array(#{supported_locales}, '|'))
+              WITH ORDINALITY configured(locale, position)
+            ORDER BY split_part(
+                       lower(replace(locale, '-', '_')), '_', 1
+                     ),
+                     position
+          ),
+          eligible_categories AS MATERIALIZED (
+            SELECT categories.id,
+                   categories.locale,
+                   split_part(
+                     lower(replace(categories.locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM (#{eligible_categories_sql}) categories
+          ),
+          totals AS (
+            SELECT COUNT(*)::bigint AS total
+            FROM eligible_categories
+          ),
+          source_locale_counts AS (
+            SELECT base,
+                   COUNT(*)::bigint AS count
+            FROM eligible_categories
+            WHERE locale IS NOT NULL
+            GROUP BY base
+          ),
+          translated_counts AS (
+            SELECT supported.base,
+                   COUNT(DISTINCT categories.id)::bigint AS count
+            FROM eligible_categories categories
+            JOIN category_localizations localization
+              ON localization.category_id = categories.id
+            JOIN supported
+              ON supported.base = split_part(
+                lower(replace(localization.locale, '-', '_')), '_', 1
+              )
+            WHERE categories.locale IS NOT NULL
+              AND categories.base <> supported.base
+            GROUP BY supported.base
+          )
+          SELECT supported.locale,
+                 COALESCE(translated.count, 0)::bigint AS translated_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0) -
+                   COALESCE(translated.count, 0)
+                 )::bigint AS pending_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0)
+                 )::bigint AS eligible_count
+          FROM supported
+          CROSS JOIN totals
+          LEFT JOIN translated_counts translated
+            ON translated.base = supported.base
+          LEFT JOIN source_locale_counts source_locales
+            ON source_locales.base = supported.base
+          ORDER BY supported.locale
+        SQL
+
+        {
+          target_type: "category",
+          locales:
+            DB
+              .query(sql)
+              .map do |row|
+                {
+                  locale: row.locale,
+                  translated_count: row.translated_count,
+                  pending_count: row.pending_count,
+                  eligible_count: row.eligible_count,
+                }
+              end,
+        }
+      end
+
       private
 
       # all categories that are eligible for translation based on site settings,

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -61,6 +61,145 @@ module DiscourseAi
         }
       end
 
+      def self.progress_details
+        main_posts =
+          Post
+            .where(
+              "posts.created_at > ?",
+              SiteSetting.ai_translation_backfill_max_age_days.days.ago,
+            )
+            .where(deleted_at: nil)
+            .where.not(raw: [nil, ""])
+            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
+
+        main_posts =
+          main_posts.where(
+            "posts.user_id > 0",
+          ) unless SiteSetting.ai_translation_include_bot_content
+
+        main_posts = main_posts.joins(:topic)
+        category_condition, category_params =
+          DiscourseAi::Translation.category_scope_condition(category_column: "topics.category_id")
+        main_posts =
+          main_posts.where(
+            "topics.archetype = :pm OR (#{category_condition})",
+            category_params.merge(pm: Archetype.private_message),
+          )
+
+        case SiteSetting.ai_translation_personal_messages
+        when "group"
+          main_posts =
+            main_posts.where(
+              "topics.archetype != :pm OR topics.id IN (SELECT topic_id FROM topic_allowed_groups)",
+              pm: Archetype.private_message,
+            )
+        when "none", nil
+          main_posts = main_posts.where.not(topics: { archetype: Archetype.private_message })
+        end
+
+        banner_posts =
+          Post
+            .where(deleted_at: nil)
+            .where.not(raw: [nil, ""])
+            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
+            .joins(:topic)
+            .where(topics: { archetype: Archetype.banner, deleted_at: nil })
+        banner_posts =
+          banner_posts.where(
+            "posts.user_id > 0",
+          ) unless SiteSetting.ai_translation_include_bot_content
+
+        eligible_posts_sql =
+          "(#{main_posts.select("posts.id, posts.locale").to_sql}) UNION " \
+            "(#{banner_posts.select("posts.id, posts.locale").to_sql})"
+        supported_locales =
+          ActiveRecord::Base.connection.quote(SiteSetting.content_localization_supported_locales)
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT DISTINCT ON (
+                     split_part(lower(replace(locale, '-', '_')), '_', 1)
+                   )
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM unnest(string_to_array(#{supported_locales}, '|'))
+              WITH ORDINALITY configured(locale, position)
+            ORDER BY split_part(
+                       lower(replace(locale, '-', '_')), '_', 1
+                     ),
+                     position
+          ),
+          eligible_posts AS MATERIALIZED (
+            SELECT posts.id,
+                   posts.locale,
+                   split_part(
+                     lower(replace(posts.locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM (#{eligible_posts_sql}) posts
+          ),
+          totals AS (
+            SELECT COUNT(*)::bigint AS total
+            FROM eligible_posts
+          ),
+          source_locale_counts AS (
+            SELECT base,
+                   COUNT(*)::bigint AS count
+            FROM eligible_posts
+            WHERE locale IS NOT NULL
+            GROUP BY base
+          ),
+          translated_counts AS (
+            SELECT supported.base,
+                   COUNT(DISTINCT posts.id)::bigint AS count
+            FROM eligible_posts posts
+            JOIN post_localizations localization
+              ON localization.post_id = posts.id
+            JOIN supported
+              ON supported.base = split_part(
+                lower(replace(localization.locale, '-', '_')), '_', 1
+              )
+            WHERE posts.locale IS NOT NULL
+              AND posts.base <> supported.base
+            GROUP BY supported.base
+          )
+          SELECT supported.locale,
+                 COALESCE(translated.count, 0)::bigint AS translated_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0) -
+                   COALESCE(translated.count, 0)
+                 )::bigint AS pending_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0)
+                 )::bigint AS eligible_count
+          FROM supported
+          CROSS JOIN totals
+          LEFT JOIN translated_counts translated
+            ON translated.base = supported.base
+          LEFT JOIN source_locale_counts source_locales
+            ON source_locales.base = supported.base
+          ORDER BY supported.locale
+        SQL
+
+        {
+          target_type: "post",
+          locales:
+            DB
+              .query(sql)
+              .map do |row|
+                {
+                  locale: row.locale,
+                  translated_count: row.translated_count,
+                  pending_count: row.pending_count,
+                  eligible_count: row.eligible_count,
+                }
+              end,
+        }
+      end
+
       def self.needs_localization(limit:)
         locales = DiscourseAi::Translation.locales
         return [] if locales.blank?

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -3,16 +3,62 @@
 module DiscourseAi
   module Translation
     class PostCandidates
-      # Returns the number of posts that have been translated, and the total number of posts that need translation for a given locale.
-      # The total number of posts is based off candidates that already have a locale.
-      # Also returns aggregate counts for total eligible posts and posts with detected locale.
-      # @return [Hash] a hash with keys :translation_progress (array), :total (integer), :posts_with_detected_locale (integer), and :cached_at (string)
-      def self.get_completion_all_locales
-        Discourse
-          .cache
-          .fetch(progress_cache_key, expires_in: 30.minutes) do
-            completion_all_locales.merge(cached_at: Time.now.utc.iso8601)
-          end
+      def self.progress_summary
+        supported_locales = SiteSetting.content_localization_supported_locales.split("|")
+        eligible_posts_sql = get.select(:id, :locale).to_sql
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT COALESCE(
+              array_agg(
+                DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
+              ) FILTER (WHERE locale IS NOT NULL),
+              ARRAY[]::text[]
+            ) AS bases
+            FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
+          ),
+          eligible_posts AS (
+            SELECT id,
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS source_base
+            FROM (#{eligible_posts_sql}) candidates
+          ),
+          localization_coverage AS (
+            SELECT pl.post_id,
+                   array_agg(
+                     split_part(
+                       lower(replace(pl.locale, '-', '_')), '_', 1
+                     )
+                   ) AS bases
+            FROM post_localizations pl
+            GROUP BY pl.post_id
+          )
+          SELECT
+            COUNT(*)::bigint AS total_count,
+            COUNT(*) FILTER (
+              WHERE ep.locale IS NOT NULL
+                AND supported.bases <@ (
+                  COALESCE(lc.bases, ARRAY[]::text[]) || ep.source_base
+                )
+            )::bigint AS translated_count,
+            COUNT(*) FILTER (
+              WHERE ep.locale IS NULL
+            )::bigint AS needs_language_detection_count
+          FROM eligible_posts ep
+          CROSS JOIN supported
+          LEFT JOIN localization_coverage lc ON lc.post_id = ep.id
+        SQL
+
+        result = DB.query(sql, supported_locales:).first
+
+        {
+          target_type: "post",
+          total_count: result.total_count,
+          translated_count: result.translated_count,
+          needs_language_detection_count: result.needs_language_detection_count,
+        }
       end
 
       def self.needs_localization(limit:)
@@ -100,98 +146,6 @@ module DiscourseAi
         posts = posts.or(banner_posts)
 
         posts
-      end
-
-      def self.progress_cache_key
-        [
-          "ai-translations-progress",
-          SiteSetting.content_localization_supported_locales,
-          SiteSetting.ai_translation_backfill_max_age_days,
-          SiteSetting.ai_translation_include_bot_content,
-          SiteSetting.ai_translation_max_post_length,
-          SiteSetting.ai_translation_personal_messages,
-          DiscourseAi::Translation.category_scope_cache_key,
-        ].join(":")
-      end
-
-      def self.completion_all_locales
-        supported = SiteSetting.content_localization_supported_locales.split("|")
-        values_rows = supported.map { |loc| "('#{loc}')" }.join(", ")
-
-        sql = <<~SQL
-          WITH supported AS (
-            SELECT localestr,
-                   split_part(localestr, '_', 1) AS base
-            FROM (VALUES #{values_rows}) AS t(localestr)
-          ),
-          all_eligible_posts AS (
-            #{get.to_sql}
-          ),
-          total_eligible_count AS (
-            SELECT COUNT(*)::bigint AS count FROM all_eligible_posts
-          ),
-          eligible_posts AS (
-            SELECT * FROM all_eligible_posts WHERE locale IS NOT NULL
-          ),
-          all_posts_count AS (
-            SELECT COUNT(*)::bigint AS count FROM eligible_posts
-          ),
-          non_target_locale_counts AS (
-            SELECT s.base,
-                   COUNT(*)::bigint AS count
-            FROM eligible_posts p
-            CROSS JOIN supported s
-            WHERE split_part(p.locale, '_', 1) != s.base
-            GROUP BY s.base
-          ),
-          done_per_base AS (
-            SELECT s.base,
-                   COUNT(*)::bigint AS done
-            FROM eligible_posts p
-            JOIN supported s ON TRUE
-            WHERE split_part(p.locale, '_', 1) != s.base AND EXISTS (
-              SELECT 1
-              FROM post_localizations pl
-              WHERE pl.post_id = p.id
-                AND split_part(pl.locale, '_', 1) = s.base
-            )
-            GROUP BY s.base
-          )
-          SELECT s.localestr AS locale,
-                 COALESCE(d.done, 0) AS done,
-                 COALESCE(ntl.count, 0) AS total,
-                 (SELECT count FROM total_eligible_count) AS total_eligible,
-                 (SELECT count FROM all_posts_count) AS posts_with_locale
-          FROM supported s
-          LEFT JOIN done_per_base d ON d.base = s.base
-          LEFT JOIN non_target_locale_counts ntl ON ntl.base = s.base
-        SQL
-
-        results = DB.query(sql)
-
-        if results.empty?
-          return { translation_progress: [], total: 0, posts_with_detected_locale: 0 }
-        end
-
-        # Extract aggregate counts from first row (same for all rows)
-        total_eligible = results.first.total_eligible
-        posts_with_locale = results.first.posts_with_locale
-
-        # Build per-locale progress array
-        translation_progress =
-          results.map { |r| { locale: r.locale, done: r.done, total: r.total } }
-
-        translation_progress =
-          translation_progress.sort_by do |r|
-            percentage = r[:total] > 0 ? r[:done].to_f / r[:total] : 0
-            -percentage
-          end
-
-        {
-          translation_progress: translation_progress,
-          total: total_eligible,
-          posts_with_detected_locale: posts_with_locale,
-        }
       end
     end
   end

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -8,15 +8,7 @@ module DiscourseAi
         eligible_posts_sql = get.select(:id, :locale).to_sql
 
         sql = <<~SQL
-          WITH supported AS MATERIALIZED (
-            SELECT COALESCE(
-              array_agg(
-                DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
-              ) FILTER (WHERE locale IS NOT NULL),
-              ARRAY[]::text[]
-            ) AS bases
-            FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
-          ),
+          WITH #{DiscourseAi::Translation.supported_locale_bases_cte},
           eligible_posts AS (
             SELECT id,
                    locale,

--- a/plugins/discourse-ai/lib/translation/progress.rb
+++ b/plugins/discourse-ai/lib/translation/progress.rb
@@ -5,7 +5,15 @@ module DiscourseAi
     class Progress
       CACHE_VERSION = 1
       CACHE_TTL = 2.hours
-      TARGETS = [PostCandidates, TopicCandidates, CategoryCandidates, TagCandidates].freeze
+      DETAIL_CACHE_VERSION = 1
+      DETAIL_CACHE_TTL = 2.hours
+      TARGET_CLASSES = {
+        "post" => PostCandidates,
+        "topic" => TopicCandidates,
+        "category" => CategoryCandidates,
+        "tag" => TagCandidates,
+      }.freeze
+      TARGETS = TARGET_CLASSES.values.freeze
 
       def self.fetch
         Discourse
@@ -15,20 +23,64 @@ module DiscourseAi
           end
       end
 
+      def self.fetch_detail(target_type)
+        candidate_class = TARGET_CLASSES.fetch(target_type) { raise ArgumentError, target_type }
+        cache_key = detail_cache_key(target_type)
+
+        cached = Discourse.cache.read(cache_key)
+        return cached if cached
+
+        DistributedMutex.synchronize(detail_mutex_key(cache_key), validity: 5.minutes) do
+          Discourse
+            .cache
+            .fetch(cache_key, expires_in: DETAIL_CACHE_TTL) do
+              candidate_class.progress_details.merge(cached_at: Time.now.utc.iso8601)
+            end
+        end
+      end
+
+      def self.supported_target?(target_type)
+        TARGET_CLASSES.key?(target_type)
+      end
+
       def self.cache_key
         [
           "discourse-ai",
           "translation-progress-overview",
           "v#{CACHE_VERSION}",
+          *settings_cache_key_parts,
+        ].join(":")
+      end
+
+      def self.detail_cache_key(target_type)
+        [
+          "discourse-ai",
+          "translation-progress-detail",
+          "v#{DETAIL_CACHE_VERSION}",
+          target_type,
+          *settings_cache_key_parts,
+        ].join(":")
+      end
+
+      def self.settings_cache_key_parts
+        [
           SiteSetting.content_localization_supported_locales,
           SiteSetting.ai_translation_backfill_max_age_days,
           SiteSetting.ai_translation_include_bot_content,
           SiteSetting.ai_translation_max_post_length,
           SiteSetting.ai_translation_personal_messages,
           DiscourseAi::Translation.category_scope_cache_key,
-        ].join(":")
+        ]
       end
-      private_class_method :cache_key
+
+      def self.detail_mutex_key(cache_key)
+        "discourse_ai_translation_progress_detail_#{Digest::SHA1.hexdigest(cache_key)}"
+      end
+
+      private_class_method :cache_key,
+                           :detail_cache_key,
+                           :settings_cache_key_parts,
+                           :detail_mutex_key
     end
   end
 end

--- a/plugins/discourse-ai/lib/translation/progress.rb
+++ b/plugins/discourse-ai/lib/translation/progress.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DiscourseAi
+  module Translation
+    class Progress
+      CACHE_VERSION = 1
+      CACHE_TTL = 2.hours
+      TARGETS = [PostCandidates, TopicCandidates, CategoryCandidates, TagCandidates].freeze
+
+      def self.fetch
+        Discourse
+          .cache
+          .fetch(cache_key, expires_in: CACHE_TTL) do
+            { cached_at: Time.now.utc.iso8601, targets: TARGETS.map(&:progress_summary) }
+          end
+      end
+
+      def self.cache_key
+        [
+          "discourse-ai",
+          "translation-progress-overview",
+          "v#{CACHE_VERSION}",
+          SiteSetting.content_localization_supported_locales,
+          SiteSetting.ai_translation_backfill_max_age_days,
+          SiteSetting.ai_translation_include_bot_content,
+          SiteSetting.ai_translation_max_post_length,
+          SiteSetting.ai_translation_personal_messages,
+          DiscourseAi::Translation.category_scope_cache_key,
+        ].join(":")
+      end
+      private_class_method :cache_key
+    end
+  end
+end

--- a/plugins/discourse-ai/lib/translation/tag_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/tag_candidates.rb
@@ -3,6 +3,59 @@
 module DiscourseAi
   module Translation
     class TagCandidates < BaseCandidates
+      def self.progress_summary
+        connection = ActiveRecord::Base.connection
+        supported_bases =
+          SiteSetting
+            .content_localization_supported_locales
+            .split("|")
+            .map { |locale| locale.downcase.tr("-", "_").split("_").first }
+            .uniq
+        bases_sql =
+          "ARRAY[#{supported_bases.map { |base| connection.quote(base) }.join(",")}]::text[]"
+        tags_sql = get.select(:id, :locale).to_sql
+
+        sql = <<~SQL
+          WITH supported(base) AS MATERIALIZED (
+            SELECT unnest(#{bases_sql})
+          )
+          SELECT
+            COUNT(*)::bigint AS total_count,
+            COUNT(*) FILTER (
+              WHERE tag.locale IS NOT NULL
+                AND EXISTS (SELECT 1 FROM supported)
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM supported target
+                  WHERE target.base <> split_part(
+                    lower(replace(tag.locale, '-', '_')), '_', 1
+                  )
+                    AND NOT EXISTS (
+                      SELECT 1
+                      FROM tag_localizations localization
+                      WHERE localization.tag_id = tag.id
+                        AND split_part(
+                          lower(replace(localization.locale, '-', '_')), '_', 1
+                        ) = target.base
+                    )
+                )
+            )::bigint AS translated_count,
+            COUNT(*) FILTER (
+              WHERE tag.locale IS NULL
+            )::bigint AS needs_language_detection_count
+          FROM (#{tags_sql}) tag
+        SQL
+
+        result = DB.query(sql).first
+
+        {
+          target_type: "tag",
+          total_count: result.total_count,
+          translated_count: result.translated_count,
+          needs_language_detection_count: result.needs_language_detection_count,
+        }
+      end
+
       private
 
       # all tags that are eligible for translation based on site settings,

--- a/plugins/discourse-ai/lib/translation/tag_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/tag_candidates.rb
@@ -56,6 +56,95 @@ module DiscourseAi
         }
       end
 
+      def self.progress_details
+        supported_locales =
+          ActiveRecord::Base.connection.quote(SiteSetting.content_localization_supported_locales)
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT DISTINCT ON (
+                     split_part(lower(replace(locale, '-', '_')), '_', 1)
+                   )
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM unnest(string_to_array(#{supported_locales}, '|'))
+              WITH ORDINALITY configured(locale, position)
+            ORDER BY split_part(
+                       lower(replace(locale, '-', '_')), '_', 1
+                     ),
+                     position
+          ),
+          tags AS MATERIALIZED (
+            SELECT tags.id,
+                   tags.locale,
+                   split_part(
+                     lower(replace(tags.locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM tags
+          ),
+          totals AS (
+            SELECT COUNT(*)::bigint AS total
+            FROM tags
+          ),
+          source_locale_counts AS (
+            SELECT base,
+                   COUNT(*)::bigint AS count
+            FROM tags
+            WHERE locale IS NOT NULL
+            GROUP BY base
+          ),
+          translated_counts AS (
+            SELECT supported.base,
+                   COUNT(DISTINCT tags.id)::bigint AS count
+            FROM tags
+            JOIN tag_localizations localization
+              ON localization.tag_id = tags.id
+            JOIN supported
+              ON supported.base = split_part(
+                lower(replace(localization.locale, '-', '_')), '_', 1
+              )
+            WHERE tags.locale IS NOT NULL
+              AND tags.base <> supported.base
+            GROUP BY supported.base
+          )
+          SELECT supported.locale,
+                 COALESCE(translated.count, 0)::bigint AS translated_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0) -
+                   COALESCE(translated.count, 0)
+                 )::bigint AS pending_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0)
+                 )::bigint AS total_count
+          FROM supported
+          CROSS JOIN totals
+          LEFT JOIN translated_counts translated
+            ON translated.base = supported.base
+          LEFT JOIN source_locale_counts source_locales
+            ON source_locales.base = supported.base
+          ORDER BY supported.locale
+        SQL
+
+        {
+          target_type: "tag",
+          locales:
+            DB
+              .query(sql)
+              .map do |row|
+                {
+                  locale: row.locale,
+                  translated_count: row.translated_count,
+                  pending_count: row.pending_count,
+                  total_count: row.total_count,
+                }
+              end,
+        }
+      end
+
       private
 
       # all tags that are eligible for translation based on site settings,

--- a/plugins/discourse-ai/lib/translation/topic_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/topic_candidates.rb
@@ -8,15 +8,7 @@ module DiscourseAi
         eligible_topics_sql = get.select(:id, :locale).to_sql
 
         sql = <<~SQL
-          WITH supported AS MATERIALIZED (
-            SELECT COALESCE(
-              array_agg(
-                DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
-              ) FILTER (WHERE locale IS NOT NULL),
-              ARRAY[]::text[]
-            ) AS bases
-            FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
-          ),
+          WITH #{DiscourseAi::Translation.supported_locale_bases_cte},
           eligible_topics AS (
             SELECT id,
                    locale,

--- a/plugins/discourse-ai/lib/translation/topic_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/topic_candidates.rb
@@ -3,6 +3,64 @@
 module DiscourseAi
   module Translation
     class TopicCandidates < BaseCandidates
+      def self.progress_summary
+        supported_locales = SiteSetting.content_localization_supported_locales.split("|")
+        eligible_topics_sql = get.select(:id, :locale).to_sql
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT COALESCE(
+              array_agg(
+                DISTINCT split_part(lower(replace(locale, '-', '_')), '_', 1)
+              ) FILTER (WHERE locale IS NOT NULL),
+              ARRAY[]::text[]
+            ) AS bases
+            FROM unnest(ARRAY[:supported_locales]::text[]) configured(locale)
+          ),
+          eligible_topics AS (
+            SELECT id,
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS source_base
+            FROM (#{eligible_topics_sql}) candidates
+          ),
+          localization_coverage AS (
+            SELECT tl.topic_id,
+                   array_agg(
+                     split_part(
+                       lower(replace(tl.locale, '-', '_')), '_', 1
+                     )
+                   ) AS bases
+            FROM topic_localizations tl
+            GROUP BY tl.topic_id
+          )
+          SELECT
+            COUNT(*)::bigint AS total_count,
+            COUNT(*) FILTER (
+              WHERE et.locale IS NOT NULL
+                AND supported.bases <@ (
+                  COALESCE(lc.bases, ARRAY[]::text[]) || et.source_base
+                )
+            )::bigint AS translated_count,
+            COUNT(*) FILTER (
+              WHERE et.locale IS NULL
+            )::bigint AS needs_language_detection_count
+          FROM eligible_topics et
+          CROSS JOIN supported
+          LEFT JOIN localization_coverage lc ON lc.topic_id = et.id
+        SQL
+
+        result = DB.query(sql, supported_locales:).first
+
+        {
+          target_type: "topic",
+          total_count: result.total_count,
+          translated_count: result.translated_count,
+          needs_language_detection_count: result.needs_language_detection_count,
+        }
+      end
+
       def self.needs_localization(limit:)
         locales = DiscourseAi::Translation.locales
         return [] if locales.blank?

--- a/plugins/discourse-ai/lib/translation/topic_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/topic_candidates.rb
@@ -61,6 +61,128 @@ module DiscourseAi
         }
       end
 
+      def self.progress_details
+        main_topics =
+          Topic.where(
+            "topics.created_at > ?",
+            SiteSetting.ai_translation_backfill_max_age_days.days.ago,
+          ).where(deleted_at: nil)
+        main_topics =
+          main_topics.where(
+            "topics.user_id > 0",
+          ) unless SiteSetting.ai_translation_include_bot_content
+
+        category_condition, category_params =
+          DiscourseAi::Translation.category_scope_condition(category_column: "topics.category_id")
+        main_topics =
+          main_topics.where(
+            "topics.archetype = :pm OR (#{category_condition})",
+            category_params.merge(pm: Archetype.private_message),
+          )
+
+        case SiteSetting.ai_translation_personal_messages
+        when "group"
+          main_topics =
+            main_topics.where(
+              "topics.archetype != :pm OR topics.id IN (SELECT topic_id FROM topic_allowed_groups)",
+              pm: Archetype.private_message,
+            )
+        when "none", nil
+          main_topics = main_topics.where.not(archetype: Archetype.private_message)
+        end
+
+        banner_topics = Topic.where(archetype: Archetype.banner, deleted_at: nil)
+        eligible_topics_sql =
+          "(#{main_topics.select("topics.id, topics.locale").to_sql}) UNION " \
+            "(#{banner_topics.select("topics.id, topics.locale").to_sql})"
+        supported_locales =
+          ActiveRecord::Base.connection.quote(SiteSetting.content_localization_supported_locales)
+
+        sql = <<~SQL
+          WITH supported AS MATERIALIZED (
+            SELECT DISTINCT ON (
+                     split_part(lower(replace(locale, '-', '_')), '_', 1)
+                   )
+                   locale,
+                   split_part(
+                     lower(replace(locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM unnest(string_to_array(#{supported_locales}, '|'))
+              WITH ORDINALITY configured(locale, position)
+            ORDER BY split_part(
+                       lower(replace(locale, '-', '_')), '_', 1
+                     ),
+                     position
+          ),
+          eligible_topics AS MATERIALIZED (
+            SELECT topics.id,
+                   topics.locale,
+                   split_part(
+                     lower(replace(topics.locale, '-', '_')), '_', 1
+                   ) AS base
+            FROM (#{eligible_topics_sql}) topics
+          ),
+          totals AS (
+            SELECT COUNT(*)::bigint AS total
+            FROM eligible_topics
+          ),
+          source_locale_counts AS (
+            SELECT base,
+                   COUNT(*)::bigint AS count
+            FROM eligible_topics
+            WHERE locale IS NOT NULL
+            GROUP BY base
+          ),
+          translated_counts AS (
+            SELECT supported.base,
+                   COUNT(DISTINCT topics.id)::bigint AS count
+            FROM eligible_topics topics
+            JOIN topic_localizations localization
+              ON localization.topic_id = topics.id
+            JOIN supported
+              ON supported.base = split_part(
+                lower(replace(localization.locale, '-', '_')), '_', 1
+              )
+            WHERE topics.locale IS NOT NULL
+              AND topics.base <> supported.base
+            GROUP BY supported.base
+          )
+          SELECT supported.locale,
+                 COALESCE(translated.count, 0)::bigint AS translated_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0) -
+                   COALESCE(translated.count, 0)
+                 )::bigint AS pending_count,
+                 (
+                   totals.total -
+                   COALESCE(source_locales.count, 0)
+                 )::bigint AS eligible_count
+          FROM supported
+          CROSS JOIN totals
+          LEFT JOIN translated_counts translated
+            ON translated.base = supported.base
+          LEFT JOIN source_locale_counts source_locales
+            ON source_locales.base = supported.base
+          ORDER BY supported.locale
+        SQL
+
+        {
+          target_type: "topic",
+          locales:
+            DB
+              .query(sql)
+              .map do |row|
+                {
+                  locale: row.locale,
+                  translated_count: row.translated_count,
+                  pending_count: row.pending_count,
+                  eligible_count: row.eligible_count,
+                }
+              end,
+        }
+      end
+
       def self.needs_localization(limit:)
         locales = DiscourseAi::Translation.locales
         return [] if locales.blank?

--- a/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
@@ -155,4 +155,34 @@ describe DiscourseAi::Translation::CategoryCandidates do
       )
     end
   end
+
+  describe ".progress_details" do
+    before do
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+      SiteSetting.ai_translation_category_scope = "include_strict"
+    end
+
+    it "returns translated, pending, and eligible counts per configured locale" do
+      translated_category = Fabricate(:category, locale: "EN-US")
+      untranslated_category = Fabricate(:category, locale: "en-US")
+      undetected_category = Fabricate(:category, locale: nil)
+      SiteSetting.ai_translation_categories = [
+        translated_category.id,
+        untranslated_category.id,
+        undetected_category.id,
+      ].join("|")
+      localization = Fabricate(:category_localization, category: translated_category, locale: "fr")
+      localization.update_column(:locale, "FR-fr")
+
+      expect(described_class.progress_details).to eq(
+        {
+          target_type: "category",
+          locales: [
+            { locale: "en_GB", translated_count: 0, pending_count: 1, eligible_count: 1 },
+            { locale: "fr", translated_count: 1, pending_count: 2, eligible_count: 3 },
+          ],
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/category_candidates_spec.rb
@@ -127,4 +127,32 @@ describe DiscourseAi::Translation::CategoryCandidates do
       expect(completion).to eq({ done: 0, total: 0 })
     end
   end
+
+  describe ".progress_summary" do
+    before do
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+      SiteSetting.ai_translation_category_scope = "include_strict"
+    end
+
+    it "counts eligible, fully translated, and undetected categories" do
+      fully_translated_category = Fabricate(:category, locale: "en_US")
+      partially_translated_category = Fabricate(:category, locale: "en_US")
+      undetected_category = Fabricate(:category, locale: nil)
+      SiteSetting.ai_translation_categories = [
+        fully_translated_category.id,
+        partially_translated_category.id,
+        undetected_category.id,
+      ].join("|")
+      Fabricate(:category_localization, category: fully_translated_category, locale: "fr")
+
+      expect(described_class.progress_summary).to eq(
+        {
+          target_type: "category",
+          total_count: 3,
+          translated_count: 1,
+          needs_language_detection_count: 1,
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -244,4 +244,34 @@ describe DiscourseAi::Translation::PostCandidates do
       )
     end
   end
+
+  describe ".progress_details" do
+    fab!(:target_category, :category)
+
+    before do
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+      SiteSetting.ai_translation_backfill_max_age_days = 30
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      SiteSetting.ai_translation_categories = target_category.id.to_s
+      SiteSetting.ai_translation_personal_messages = "none"
+    end
+
+    it "returns translated, pending, and eligible counts per configured locale" do
+      translated_post =
+        Fabricate(:post, locale: "EN-US", topic: Fabricate(:topic, category: target_category))
+      Fabricate(:post_localization, post: translated_post, locale: "FR-fr")
+      Fabricate(:post, locale: "en-US", topic: Fabricate(:topic, category: target_category))
+      Fabricate(:post, locale: nil, topic: Fabricate(:topic, category: target_category))
+
+      expect(described_class.progress_details).to eq(
+        {
+          target_type: "post",
+          locales: [
+            { locale: "en_GB", translated_count: 0, pending_count: 1, eligible_count: 1 },
+            { locale: "fr", translated_count: 1, pending_count: 2, eligible_count: 3 },
+          ],
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -216,136 +216,32 @@ describe DiscourseAi::Translation::PostCandidates do
     end
   end
 
-  describe ".get_completion_all_locales" do
+  describe ".progress_summary" do
     fab!(:target_category, :category)
 
     before do
-      Discourse.cache.clear
-      SiteSetting.content_localization_supported_locales = "en_GB|pt|es"
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
       SiteSetting.ai_translation_backfill_max_age_days = 30
-      SiteSetting.ai_translation_category_scope = "all"
-      SiteSetting.ai_translation_categories = ""
-      SiteSetting.ai_translation_personal_messages = "group"
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      SiteSetting.ai_translation_categories = target_category.id.to_s
+      SiteSetting.ai_translation_personal_messages = "none"
     end
 
-    it "returns empty state when no posts exist" do
-      Post.delete_all
+    it "counts eligible, fully translated, and undetected posts" do
+      fully_translated_post =
+        Fabricate(:post, locale: "en_US", topic: Fabricate(:topic, category: target_category))
+      Fabricate(:post_localization, post: fully_translated_post, locale: "fr")
+      Fabricate(:post, locale: "en_US", topic: Fabricate(:topic, category: target_category))
+      Fabricate(:post, locale: nil, topic: Fabricate(:topic, category: target_category))
 
-      result = DiscourseAi::Translation::PostCandidates.get_completion_all_locales
-      expect(result).to be_a(Hash)
-      expect(result[:translation_progress].length).to eq(3)
-      expect(result[:translation_progress]).to all(include(done: 0, total: 0))
-      expect(result[:total]).to eq(0)
-      expect(result[:posts_with_detected_locale]).to eq(0)
-    end
-
-    it "returns the time when the progress result was cached" do
-      Post.delete_all
-      cached_at = Time.zone.parse("2026-07-23 09:00:00 UTC")
-
-      freeze_time(cached_at) { described_class.get_completion_all_locales }
-
-      freeze_time(cached_at + 5.minutes) do
-        expect(described_class.get_completion_all_locales[:cached_at]).to eq(cached_at.utc.iso8601)
-      end
-    end
-
-    it "uses category scope in the cache key" do
-      Post.delete_all
-      scoped_category = Fabricate(:category)
-      Fabricate(:post, locale: "en_GB", topic: Fabricate(:topic, category: target_category))
-      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: scoped_category))
-
-      SiteSetting.ai_translation_category_scope = "all"
-      SiteSetting.ai_translation_categories = ""
-      expect(described_class.get_completion_all_locales[:total]).to eq(2)
-
-      SiteSetting.ai_translation_category_scope = "include"
-      SiteSetting.ai_translation_categories = scoped_category.id.to_s
-      expect(described_class.get_completion_all_locales[:total]).to eq(1)
-    end
-
-    it "uses expanded subcategory ids in the cache key" do
-      Post.delete_all
-      parent_category = Fabricate(:category)
-      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: parent_category))
-      SiteSetting.ai_translation_category_scope = "include"
-      SiteSetting.ai_translation_categories = parent_category.id.to_s
-
-      expect(described_class.get_completion_all_locales[:total]).to eq(1)
-
-      subcategory = Fabricate(:category, parent_category:)
-      Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: subcategory))
-
-      expect(described_class.get_completion_all_locales[:total]).to eq(2)
-    end
-
-    it "returns progress grouped by base locale (of en_GB) and correct totals" do
-      post1 = Fabricate(:post, locale: "en_GB", topic: Fabricate(:topic, category: target_category))
-      post2 = Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: target_category))
-      post3 = Fabricate(:post, locale: "es", topic: Fabricate(:topic, category: target_category))
-      post_without_locale =
-        Fabricate(:post, locale: nil, topic: Fabricate(:topic, category: target_category))
-
-      # add an en_GB localization to a non-en base post
-      PostLocalization.create!(
-        post: post2,
-        locale: "en",
-        raw: "Translated to English",
-        cooked: "<p>Translated to English</p>",
-        post_version: post2.version,
-        localizer_user_id: Discourse.system_user.id,
+      expect(described_class.progress_summary).to eq(
+        {
+          target_type: "post",
+          total_count: 3,
+          translated_count: 1,
+          needs_language_detection_count: 1,
+        },
       )
-
-      result = DiscourseAi::Translation::PostCandidates.completion_all_locales
-      expect(result).to be_a(Hash)
-      expect(result[:translation_progress].length).to eq(3)
-      expect(result[:total]).to eq(4) # all eligible posts (including one without locale)
-      expect(result[:posts_with_detected_locale]).to eq(3) # only posts with locale
-
-      progress = result[:translation_progress]
-      expect(progress).to all(include(:locale, :done, :total))
-
-      expect(progress.first[:locale]).to eq("en_GB")
-
-      en_entry = progress.find { |r| r[:locale] == "en_GB" }
-      expect(en_entry).to be_present
-      # total is non-English posts (post2 + post3)
-      expect(en_entry[:done]).to eq(1)
-      expect(en_entry[:total]).to eq(2)
-
-      pt_entry = progress.find { |r| r[:locale] == "pt" }
-      expect(pt_entry).to be_present
-      expect(pt_entry[:done]).to eq(0)
-      expect(pt_entry[:total]).to eq(3)
-      es_entry = progress.find { |r| r[:locale] == "es" }
-      expect(es_entry).to be_present
-      expect(es_entry[:done]).to eq(0)
-      expect(es_entry[:total]).to eq(2)
-      fr_entry = progress.find { |r| r[:locale] == "fr" }
-      expect(fr_entry).to be_nil
-    end
-
-    it "excludes posts longer than ai_translation_max_post_length from totals" do
-      SiteSetting.ai_translation_max_post_length = 100
-      short_post =
-        Fabricate(
-          :post,
-          locale: "en_GB",
-          raw: "This is a short post that fits.",
-          topic: Fabricate(:topic, category: target_category),
-        )
-      long_post =
-        Fabricate(
-          :post,
-          locale: "fr",
-          raw: "a" * 50 + " This is a long post. " + "b" * 50,
-          topic: Fabricate(:topic, category: target_category),
-        )
-
-      result = DiscourseAi::Translation::PostCandidates.get_completion_all_locales
-      expect(result[:total]).to eq(1)
-      expect(result[:posts_with_detected_locale]).to eq(1)
     end
   end
 end

--- a/plugins/discourse-ai/spec/lib/translation/progress_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/progress_spec.rb
@@ -39,6 +39,24 @@ describe DiscourseAi::Translation::Progress do
         needs_language_detection_count: 1,
       },
     )
+
+    [
+      DiscourseAi::Translation::PostCandidates,
+      DiscourseAi::Translation::TopicCandidates,
+      DiscourseAi::Translation::CategoryCandidates,
+      DiscourseAi::Translation::TagCandidates,
+    ].each do |candidate_class|
+      target_type = candidate_class.name.demodulize.delete_suffix("Candidates").underscore
+      denominator_key = target_type == "tag" ? :total_count : :eligible_count
+      allow(candidate_class).to receive(:progress_details).and_return(
+        {
+          target_type:,
+          locales: [
+            { :locale => "en", :translated_count => 3, :pending_count => 2, denominator_key => 5 },
+          ],
+        },
+      )
+    end
   end
 
   it "caches all target summaries and their timestamp together for two hours" do
@@ -89,5 +107,68 @@ describe DiscourseAi::Translation::Progress do
     expect(DiscourseAi::Translation::TopicCandidates).to have_received(:progress_summary).twice
     expect(DiscourseAi::Translation::CategoryCandidates).to have_received(:progress_summary).twice
     expect(DiscourseAi::Translation::TagCandidates).to have_received(:progress_summary).twice
+  end
+
+  describe ".fetch_detail" do
+    it "caches each target independently for two hours" do
+      cached_at = Time.zone.parse("2026-07-23 09:00:00 UTC")
+      cache = Discourse.cache
+      allow(cache).to receive(:fetch).and_call_original
+      allow(cache).to receive(:read).and_call_original
+
+      first_post = freeze_time(cached_at) { described_class.fetch_detail("post") }
+      second_post = freeze_time(cached_at + 1.hour) { described_class.fetch_detail("post") }
+      topic = freeze_time(cached_at + 1.hour) { described_class.fetch_detail("topic") }
+
+      expect(second_post).to eq(first_post)
+      expect(first_post[:cached_at]).to eq(cached_at.utc.iso8601)
+      expect(topic[:cached_at]).to eq((cached_at + 1.hour).utc.iso8601)
+      expect(cache).to have_received(:fetch).with(
+        a_string_starting_with("discourse-ai:translation-progress-detail:v1:post:"),
+        expires_in: 2.hours,
+      ).once
+      expect(cache).to have_received(:fetch).with(
+        a_string_starting_with("discourse-ai:translation-progress-detail:v1:topic:"),
+        expires_in: 2.hours,
+      ).once
+      expect(cache).to have_received(:read).with(
+        a_string_starting_with("discourse-ai:translation-progress-detail:v1:post:"),
+      ).twice
+      expect(cache).to have_received(:read).with(
+        a_string_starting_with("discourse-ai:translation-progress-detail:v1:topic:"),
+      ).once
+      expect(DiscourseAi::Translation::PostCandidates).to have_received(:progress_details).once
+      expect(DiscourseAi::Translation::TopicCandidates).to have_received(:progress_details).once
+      expect(DiscourseAi::Translation::CategoryCandidates).not_to have_received(:progress_details)
+      expect(DiscourseAi::Translation::TagCandidates).not_to have_received(:progress_details)
+    end
+
+    it "runs one query when concurrent requests miss the same target cache" do
+      query_started = Queue.new
+      release_queries = Queue.new
+      call_count = 0
+
+      allow(DiscourseAi::Translation::PostCandidates).to receive(:progress_details) do
+        call_count += 1
+        query_started << true
+        release_queries.pop
+        { target_type: "post", locales: [] }
+      end
+
+      first_request = Thread.new { described_class.fetch_detail("post") }
+      query_started.pop
+      second_request = Thread.new { described_class.fetch_detail("post") }
+
+      sleep 0.05
+      2.times { release_queries << true }
+      results = [first_request.value, second_request.value]
+
+      expect(call_count).to eq(1)
+      expect(results.uniq.length).to eq(1)
+    end
+
+    it "rejects unsupported target types" do
+      expect { described_class.fetch_detail("user") }.to raise_error(ArgumentError)
+    end
   end
 end

--- a/plugins/discourse-ai/spec/lib/translation/progress_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/progress_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+describe DiscourseAi::Translation::Progress do
+  before do
+    Discourse.cache.clear
+    SiteSetting.content_localization_supported_locales = "en|fr"
+    SiteSetting.ai_translation_backfill_max_age_days = 30
+    SiteSetting.ai_translation_category_scope = "public"
+
+    allow(DiscourseAi::Translation::PostCandidates).to receive(:progress_summary).and_return(
+      {
+        target_type: "post",
+        total_count: 10,
+        translated_count: 4,
+        needs_language_detection_count: 2,
+      },
+    )
+    allow(DiscourseAi::Translation::TopicCandidates).to receive(:progress_summary).and_return(
+      {
+        target_type: "topic",
+        total_count: 8,
+        translated_count: 3,
+        needs_language_detection_count: 1,
+      },
+    )
+    allow(DiscourseAi::Translation::CategoryCandidates).to receive(:progress_summary).and_return(
+      {
+        target_type: "category",
+        total_count: 5,
+        translated_count: 5,
+        needs_language_detection_count: 0,
+      },
+    )
+    allow(DiscourseAi::Translation::TagCandidates).to receive(:progress_summary).and_return(
+      {
+        target_type: "tag",
+        total_count: 7,
+        translated_count: 2,
+        needs_language_detection_count: 1,
+      },
+    )
+  end
+
+  it "caches all target summaries and their timestamp together for two hours" do
+    cached_at = Time.zone.parse("2026-07-23 09:00:00 UTC")
+    cache = Discourse.cache
+    allow(cache).to receive(:fetch).and_call_original
+
+    first_result = freeze_time(cached_at) { described_class.fetch }
+    second_result = freeze_time(cached_at + 1.hour) { described_class.fetch }
+
+    expect(second_result).to eq(first_result)
+    expect(second_result[:cached_at]).to eq(cached_at.utc.iso8601)
+    expect(second_result[:targets].map { |target| target[:target_type] }).to eq(
+      %w[post topic category tag],
+    )
+    expect(cache).to have_received(:fetch).with(
+      a_string_starting_with("discourse-ai:translation-progress-overview:v1:"),
+      expires_in: 2.hours,
+    ).twice
+    expect(DiscourseAi::Translation::PostCandidates).to have_received(:progress_summary).once
+    expect(DiscourseAi::Translation::TopicCandidates).to have_received(:progress_summary).once
+    expect(DiscourseAi::Translation::CategoryCandidates).to have_received(:progress_summary).once
+    expect(DiscourseAi::Translation::TagCandidates).to have_received(:progress_summary).once
+    expect(described_class::CACHE_TTL).to eq(2.hours)
+  end
+
+  it "uses relevant site settings in the cache key" do
+    described_class.fetch
+
+    SiteSetting.content_localization_supported_locales = "en|de"
+    described_class.fetch
+
+    expect(DiscourseAi::Translation::PostCandidates).to have_received(:progress_summary).twice
+    expect(DiscourseAi::Translation::TopicCandidates).to have_received(:progress_summary).twice
+    expect(DiscourseAi::Translation::CategoryCandidates).to have_received(:progress_summary).twice
+    expect(DiscourseAi::Translation::TagCandidates).to have_received(:progress_summary).twice
+  end
+
+  it "uses the configured category scope in the cache key" do
+    category = Fabricate(:category)
+    described_class.fetch
+
+    SiteSetting.ai_translation_category_scope = "include_strict"
+    SiteSetting.ai_translation_categories = category.id.to_s
+    described_class.fetch
+
+    expect(DiscourseAi::Translation::PostCandidates).to have_received(:progress_summary).twice
+    expect(DiscourseAi::Translation::TopicCandidates).to have_received(:progress_summary).twice
+    expect(DiscourseAi::Translation::CategoryCandidates).to have_received(:progress_summary).twice
+    expect(DiscourseAi::Translation::TagCandidates).to have_received(:progress_summary).twice
+  end
+end

--- a/plugins/discourse-ai/spec/lib/translation/tag_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/tag_candidates_spec.rb
@@ -102,4 +102,27 @@ describe DiscourseAi::Translation::TagCandidates do
       expect(completion).to eq({ done: 0, total: 0 })
     end
   end
+
+  describe ".progress_summary" do
+    before do
+      Tag.destroy_all
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+    end
+
+    it "counts all, fully translated, and undetected tags" do
+      fully_translated_tag = Fabricate(:tag, locale: "en_US")
+      Fabricate(:tag_localization, tag: fully_translated_tag, locale: "fr")
+      Fabricate(:tag, locale: "en_US")
+      Fabricate(:tag, locale: nil)
+
+      expect(described_class.progress_summary).to eq(
+        {
+          target_type: "tag",
+          total_count: 3,
+          translated_count: 1,
+          needs_language_detection_count: 1,
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/tag_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/tag_candidates_spec.rb
@@ -125,4 +125,28 @@ describe DiscourseAi::Translation::TagCandidates do
       )
     end
   end
+
+  describe ".progress_details" do
+    before do
+      Tag.destroy_all
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+    end
+
+    it "returns translated, pending, and total counts per configured locale" do
+      translated_tag = Fabricate(:tag, locale: "EN-US")
+      Fabricate(:tag_localization, tag: translated_tag, locale: "FR-fr")
+      Fabricate(:tag, locale: "en-US")
+      Fabricate(:tag, locale: nil)
+
+      expect(described_class.progress_details).to eq(
+        {
+          target_type: "tag",
+          locales: [
+            { locale: "en_GB", translated_count: 0, pending_count: 1, total_count: 1 },
+            { locale: "fr", translated_count: 1, pending_count: 2, total_count: 3 },
+          ],
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
@@ -350,4 +350,33 @@ describe DiscourseAi::Translation::TopicCandidates do
       )
     end
   end
+
+  describe ".progress_details" do
+    fab!(:target_category, :category)
+
+    before do
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+      SiteSetting.ai_translation_backfill_max_age_days = 30
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      SiteSetting.ai_translation_categories = target_category.id.to_s
+      SiteSetting.ai_translation_personal_messages = "none"
+    end
+
+    it "returns translated, pending, and eligible counts per configured locale" do
+      translated_topic = Fabricate(:topic, category: target_category, locale: "EN-US")
+      Fabricate(:topic_localization, topic: translated_topic, locale: "FR-fr")
+      Fabricate(:topic, category: target_category, locale: "en-US")
+      Fabricate(:topic, category: target_category, locale: nil)
+
+      expect(described_class.progress_details).to eq(
+        {
+          target_type: "topic",
+          locales: [
+            { locale: "en_GB", translated_count: 0, pending_count: 1, eligible_count: 1 },
+            { locale: "fr", translated_count: 1, pending_count: 2, eligible_count: 3 },
+          ],
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/topic_candidates_spec.rb
@@ -322,4 +322,32 @@ describe DiscourseAi::Translation::TopicCandidates do
       expect(completion).to eq({ done: 0, total: 0 })
     end
   end
+
+  describe ".progress_summary" do
+    fab!(:target_category, :category)
+
+    before do
+      SiteSetting.content_localization_supported_locales = "en_GB|fr"
+      SiteSetting.ai_translation_backfill_max_age_days = 30
+      SiteSetting.ai_translation_category_scope = "include_strict"
+      SiteSetting.ai_translation_categories = target_category.id.to_s
+      SiteSetting.ai_translation_personal_messages = "none"
+    end
+
+    it "counts eligible, fully translated, and undetected topics" do
+      fully_translated_topic = Fabricate(:topic, category: target_category, locale: "en_US")
+      Fabricate(:topic_localization, topic: fully_translated_topic, locale: "fr")
+      Fabricate(:topic, category: target_category, locale: "en_US")
+      Fabricate(:topic, category: target_category, locale: nil)
+
+      expect(described_class.progress_summary).to eq(
+        {
+          target_type: "topic",
+          total_count: 3,
+          translated_count: 1,
+          needs_language_detection_count: 1,
+        },
+      )
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/lib/translation/translation_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/translation_spec.rb
@@ -18,6 +18,20 @@ describe DiscourseAi::Translation do
     end
   end
 
+  describe ".supported_locale_bases_cte" do
+    it "normalizes and deduplicates supported locale bases" do
+      sql = <<~SQL
+        WITH #{described_class.supported_locale_bases_cte}
+        SELECT bases
+        FROM supported
+      SQL
+
+      result = DB.query_single(sql, supported_locales: %w[en_GB EN-us pt-BR])
+
+      expect(result.first).to contain_exactly("en", "pt")
+    end
+  end
+
   describe ".category_scope_condition" do
     it "filters categories for all and public scopes", :aggregate_failures do
       public_category = Fabricate(:category)

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -135,7 +135,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
         get "/admin/plugins/discourse-ai/ai-translations.json"
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body["enabled"]).to eq(false)
+        expect(response.parsed_body["enabled"]).to eq(true)
       end
     end
 
@@ -182,171 +182,61 @@ describe DiscourseAi::Admin::AiTranslationsController do
 
   describe "#progress" do
     context "when logged in as admin" do
-      fab!(:target_category, :category)
+      let(:progress) do
+        {
+          cached_at: "2026-07-23T09:00:00Z",
+          targets: [
+            {
+              target_type: "post",
+              total_count: 474,
+              translated_count: 215,
+              needs_language_detection_count: 93,
+            },
+            {
+              target_type: "topic",
+              total_count: 86,
+              translated_count: 51,
+              needs_language_detection_count: 12,
+            },
+            {
+              target_type: "category",
+              total_count: 18,
+              translated_count: 18,
+              needs_language_detection_count: 0,
+            },
+            {
+              target_type: "tag",
+              total_count: 142,
+              translated_count: 64,
+              needs_language_detection_count: 7,
+            },
+          ],
+        }
+      end
 
       before do
-        Discourse.cache.clear
         sign_in(admin)
         SiteSetting.discourse_ai_enabled = true
         SiteSetting.ai_translation_enabled = true
         SiteSetting.content_localization_supported_locales = "en|fr|es"
-        SiteSetting.ai_translation_category_scope = "all"
-        SiteSetting.ai_translation_categories = ""
+        allow(DiscourseAi::Translation::Progress).to receive(:fetch).and_return(progress)
       end
 
-      it "returns translation progress data" do
-        cached_at = Time.zone.parse("2026-07-23 09:00:00 UTC")
-        SiteSetting.ai_translation_backfill_max_age_days = 30
-        SiteSetting.ai_translation_personal_messages = "group"
-        SiteSetting.ai_translation_backfill_hourly_rate = 100
-
-        english_posts =
-          Fabricate.times(
-            14,
-            :post,
-            locale: "en",
-            topic: Fabricate(:topic, category: target_category),
-          )
-        french_post =
-          Fabricate(:post, locale: "fr", topic: Fabricate(:topic, category: target_category))
-        Fabricate.times(4, :post, topic: Fabricate(:topic, category: target_category))
-
-        PostLocalization.create!(
-          post: french_post,
-          locale: "en",
-          raw: "Translated to English",
-          cooked: "<p>Translated to English</p>",
-          post_version: french_post.version,
-          localizer_user_id: admin.id,
-        )
-
-        freeze_time(cached_at) { get "/admin/plugins/discourse-ai/ai-translations/progress.json" }
+      it "returns all overview targets from the shared cache" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
 
         expect(response.status).to eq(200)
-        json = response.parsed_body
-
-        expect(json["translation_progress"]).to be_an(Array)
-        expect(json["translation_progress"].length).to eq(3)
-        expect(json["total"]).to eq(19)
-        expect(json["posts_with_detected_locale"]).to eq(15)
-        expect(json["cached_at"]).to eq(cached_at.utc.iso8601)
-
-        locale_data = json["translation_progress"].first
-        expect(locale_data["locale"]).to eq("en")
-        expect(locale_data["total"]).to eq(1)
-        expect(locale_data["done"]).to eq(1)
+        expect(response.parsed_body).to eq(progress.deep_stringify_keys)
+        expect(DiscourseAi::Translation::Progress).to have_received(:fetch)
       end
 
-      it "shows only posts requiring translation for all locales (consistent behavior)" do
-        SiteSetting.ai_translation_backfill_max_age_days = 30
-        SiteSetting.ai_translation_personal_messages = "group"
-        SiteSetting.default_locale = "en"
-
-        english_posts =
-          Fabricate.times(
-            100,
-            :post,
-            locale: "en",
-            topic: Fabricate(:topic, category: target_category),
-          )
-        french_posts =
-          Fabricate.times(
-            10,
-            :post,
-            locale: "fr",
-            topic: Fabricate(:topic, category: target_category),
-          )
-        spanish_posts =
-          Fabricate.times(
-            5,
-            :post,
-            locale: "es",
-            topic: Fabricate(:topic, category: target_category),
-          )
-
-        french_posts
-          .take(8)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "en",
-              raw: "Translated to English",
-              cooked: "<p>Translated to English</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-        spanish_posts
-          .take(3)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "en",
-              raw: "Translated to English",
-              cooked: "<p>Translated to English</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-
-        english_posts
-          .take(50)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "fr",
-              raw: "Translated to French",
-              cooked: "<p>Translated to French</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
-
-        english_posts
-          .drop(50)
-          .take(30)
-          .each do |post|
-            PostLocalization.create!(
-              post: post,
-              locale: "es",
-              raw: "Translated to Spanish",
-              cooked: "<p>Translated to Spanish</p>",
-              post_version: post.version,
-              localizer_user_id: admin.id,
-            )
-          end
+      it "returns progress when the post backfill age is zero" do
+        SiteSetting.ai_translation_backfill_max_age_days = 0
 
         get "/admin/plugins/discourse-ai/ai-translations/progress.json"
 
         expect(response.status).to eq(200)
-        json = response.parsed_body
-        progress = json["translation_progress"]
-
-        en_data = progress.find { |p| p["locale"] == "en" }
-        fr_data = progress.find { |p| p["locale"] == "fr" }
-        es_data = progress.find { |p| p["locale"] == "es" }
-
-        expect(en_data["total"]).to eq(15)
-        expect(en_data["done"]).to eq(11)
-
-        expect(fr_data["total"]).to eq(105)
-        expect(fr_data["done"]).to eq(50)
-
-        expect(es_data["total"]).to eq(110)
-        expect(es_data["done"]).to eq(30)
-      end
-
-      it "returns empty when no locales are supported" do
-        SiteSetting.content_localization_supported_locales = ""
-
-        get "/admin/plugins/discourse-ai/ai-translations/progress.json"
-
-        expect(response.status).to eq(200)
-        json = response.parsed_body
-
-        expect(json["translation_progress"]).to eq([])
-        expect(json["total"]).to eq(0)
-        expect(json["posts_with_detected_locale"]).to eq(0)
+        expect(response.parsed_body).to eq(progress.deep_stringify_keys)
       end
     end
 
@@ -387,11 +277,7 @@ describe DiscourseAi::Admin::AiTranslationsController do
         get "/admin/plugins/discourse-ai/ai-translations/progress.json"
 
         expect(response.status).to eq(200)
-        json = response.parsed_body
-
-        expect(json["translation_progress"]).to eq([])
-        expect(json["total"]).to eq(0)
-        expect(json["posts_with_detected_locale"]).to eq(0)
+        expect(response.parsed_body).to eq({ "cached_at" => nil, "targets" => [] })
       end
     end
   end

--- a/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/admin/ai_translations_controller_spec.rb
@@ -281,4 +281,70 @@ describe DiscourseAi::Admin::AiTranslationsController do
       end
     end
   end
+
+  describe "#progress_detail" do
+    let(:detail) do
+      {
+        target_type: "post",
+        cached_at: "2026-07-23T09:00:00Z",
+        locales: [{ locale: "en", translated_count: 215, pending_count: 93, eligible_count: 474 }],
+      }
+    end
+
+    context "when logged in as admin" do
+      before do
+        sign_in(admin)
+        SiteSetting.discourse_ai_enabled = true
+        SiteSetting.ai_translation_enabled = true
+        SiteSetting.content_localization_supported_locales = "en|fr"
+        allow(DiscourseAi::Translation::Progress).to receive(:fetch_detail).and_return(detail)
+      end
+
+      it "returns cached details for an allowed target" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress/post.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq(detail.deep_stringify_keys)
+        expect(DiscourseAi::Translation::Progress).to have_received(:fetch_detail).with("post")
+      end
+
+      it "returns 404 for an unsupported target" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress/user.json"
+
+        expect(response.status).to eq(404)
+        expect(DiscourseAi::Translation::Progress).not_to have_received(:fetch_detail)
+      end
+    end
+
+    context "when translation is not fully enabled" do
+      before do
+        sign_in(admin)
+        SiteSetting.discourse_ai_enabled = true
+        SiteSetting.ai_translation_enabled = false
+        SiteSetting.content_localization_supported_locales = "en|fr"
+      end
+
+      it "returns an empty detail response" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress/post.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body).to eq(
+          { "target_type" => "post", "cached_at" => nil, "locales" => [] },
+        )
+      end
+    end
+
+    context "when not logged in as admin" do
+      it "returns 404 for anonymous users" do
+        get "/admin/plugins/discourse-ai/ai-translations/progress/post.json"
+        expect(response.status).to eq(404)
+      end
+
+      it "returns 404 for regular users" do
+        sign_in(user)
+        get "/admin/plugins/discourse-ai/ai-translations/progress/post.json"
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -40,6 +40,16 @@ describe "Admin AI translations" do
         cached_at: Time.now.utc.iso8601,
       },
     )
+    allow(DiscourseAi::Translation::Progress).to receive(:fetch_detail) do |target_type|
+      denominator_key = target_type == "tag" ? :total_count : :eligible_count
+      {
+        target_type:,
+        cached_at: Time.now.utc.iso8601,
+        locales: [
+          { :locale => "en", :translated_count => 30, :pending_count => 20, denominator_key => 50 },
+        ],
+      }
+    end
 
     sign_in(admin)
   end
@@ -117,6 +127,37 @@ describe "Admin AI translations" do
 
       translations_page.toggle_target("post")
       expect(translations_page).to have_no_expanded_target
+    end
+
+    it "loads and reuses per-target locale details when a card is expanded" do
+      translations_page.toggle_target("post")
+
+      expect(translations_page).to have_detail_table
+      expect(translations_page).to have_detail_row(
+        locale: "en",
+        translated: 30,
+        pending: 20,
+        denominator: 50,
+      )
+
+      translations_page.toggle_target("post")
+      expect(translations_page).to have_no_detail_table
+
+      translations_page.toggle_target("post")
+      expect(translations_page).to have_detail_table
+      expect(DiscourseAi::Translation::Progress).to have_received(:fetch_detail).with("post").once
+    end
+
+    it "reloads expanded details after category settings change" do
+      translations_page.toggle_target("post")
+      expect(translations_page).to have_detail_table
+
+      find(".ai-translations__category-scope-row .combo-box").click
+      find(".select-kit-row[data-value='all']").click
+      within(".ai-translations__category-input-row") { find(".setting-controls__ok").click }
+
+      expect(translations_page).to have_detail_table
+      expect(DiscourseAi::Translation::Progress).to have_received(:fetch_detail).with("post").twice
     end
   end
 

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe "Admin AI translations" do
+describe "Admin AI translations" do
   fab!(:admin)
   let(:translations_page) { PageObjects::Pages::AdminAiTranslations.new }
 
@@ -9,17 +9,34 @@ RSpec.describe "Admin AI translations" do
     assign_fake_provider_to(:ai_default_llm_model)
 
     allow(DiscourseAi::Translation).to receive(:has_llm_model?).and_return(true)
-    allow(DiscourseAi::Translation::PostCandidates).to receive(
-      :get_completion_all_locales,
-    ).and_return(
+    allow(DiscourseAi::Translation::Progress).to receive(:fetch).and_return(
       {
-        translation_progress: [
-          { done: 50, locale: "en", total: 100 },
-          { done: 50, locale: "fr", total: 100 },
-          { done: 50, locale: "es", total: 100 },
+        targets: [
+          {
+            target_type: "post",
+            total_count: 474,
+            translated_count: 215,
+            needs_language_detection_count: 93,
+          },
+          {
+            target_type: "topic",
+            total_count: 86,
+            translated_count: 51,
+            needs_language_detection_count: 12,
+          },
+          {
+            target_type: "category",
+            total_count: 18,
+            translated_count: 18,
+            needs_language_detection_count: 0,
+          },
+          {
+            target_type: "tag",
+            total_count: 142,
+            translated_count: 64,
+            needs_language_detection_count: 7,
+          },
         ],
-        total: 300,
-        posts_with_detected_locale: 150,
         cached_at: Time.now.utc.iso8601,
       },
     )
@@ -38,7 +55,7 @@ RSpec.describe "Admin AI translations" do
       translations_page.visit
     end
 
-    it "displays the translations page with chart" do
+    it "displays the translations page with model progress cards" do
       expect(translations_page).to have_translations_page
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.title"))
       expect(page).to have_content(I18n.t("js.discourse_ai.translations.description"))
@@ -60,17 +77,21 @@ RSpec.describe "Admin AI translations" do
       )
       expect(page).to have_no_css(".ai-translations__settings-panel.alert-info")
 
-      expect(translations_page).to have_charts_section
-      expect(translations_page).to have_chart
-      expect(page).to have_no_css(
-        ".admin-config-area-card__title",
-        text: I18n.t("js.discourse_ai.translations.progress_chart.title"),
-      )
+      expect(translations_page).to have_overview_cards
+      expect(page).to have_no_css(".ai-translations__overview .admin-config-area-card")
       expect(page).to have_css(
         ".ai-translations__cached-results",
         text: "Showing cached results from",
       )
       expect(page).to have_no_content("estimated to take")
+      expect(page).to have_css(
+        ".ai-translation-model-progress-overview-card__headline",
+        text: "All 18 eligible categories are fully translated.",
+      )
+      expect(page).to have_css(
+        ".ai-translation-model-progress-overview-card__headline",
+        text: "There are 142 tags for translation.",
+      )
 
       screenshot_marker(label: "ai-admin-translations", only: "desktop")
     end
@@ -89,6 +110,14 @@ RSpec.describe "Admin AI translations" do
 
       expect(page).to have_current_path("/admin/config/localization")
     end
+
+    it "toggles the selected target for the upcoming details panel" do
+      translations_page.toggle_target("post")
+      expect(translations_page).to have_expanded_target("post")
+
+      translations_page.toggle_target("post")
+      expect(translations_page).to have_no_expanded_target
+    end
   end
 
   describe "when translations are disabled" do
@@ -105,10 +134,10 @@ RSpec.describe "Admin AI translations" do
       translations_page.visit
     end
 
-    it "shows the toggle in off state and no chart" do
+    it "shows the toggle in off state and no progress cards" do
       expect(translations_page).to have_toggle
 
-      expect(translations_page).to have_no_chart
+      expect(translations_page).to have_no_overview_cards
     end
 
     it "shows localization settings button" do
@@ -192,20 +221,6 @@ RSpec.describe "Admin AI translations" do
       SiteSetting.discourse_ai_enabled = true
       SiteSetting.content_localization_supported_locales = "en|fr"
       SiteSetting.ai_translation_backfill_max_age_days = 30
-
-      allow(DiscourseAi::Translation::PostCandidates).to receive(
-        :get_completion_all_locales,
-      ).and_return(
-        {
-          translation_progress: [
-            { done: 50, locale: "en", total: 100 },
-            { done: 50, locale: "fr", total: 100 },
-          ],
-          total: 200,
-          posts_with_detected_locale: 100,
-          cached_at: Time.now.utc.iso8601,
-        },
-      )
     end
 
     it "displays the translation toggle" do
@@ -216,23 +231,23 @@ RSpec.describe "Admin AI translations" do
       expect(translations_page).to have_toggle
     end
 
-    it "shows charts when translations are enabled" do
+    it "shows progress cards when translations are enabled" do
       SiteSetting.ai_translation_enabled = true
       SiteSetting.ai_translation_backfill_hourly_rate = 10
 
       translations_page.visit
 
       expect(translations_page).to have_toggle
-      expect(translations_page).to have_charts_section
+      expect(translations_page).to have_overview_cards
     end
 
-    it "hides charts when translations are disabled" do
+    it "hides progress cards when translations are disabled" do
       SiteSetting.ai_translation_enabled = false
 
       translations_page.visit
 
       expect(translations_page).to have_toggle
-      expect(translations_page).to have_no_chart
+      expect(translations_page).to have_no_overview_cards
     end
 
     it "keeps toggle disabled when no locales are configured" do

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
@@ -19,16 +19,29 @@ module PageObjects
         page.has_css?(".d-toggle-switch__checkbox[disabled]")
       end
 
-      def has_chart?
-        page.has_css?(".ai-translations__chart")
+      def has_overview_cards?
+        page.has_css?(".ai-translation-model-progress-overview-card", count: 4)
       end
 
-      def has_no_chart?
-        page.has_no_css?(".ai-translations__chart")
+      def has_no_overview_cards?
+        page.has_no_css?(".ai-translation-model-progress-overview-card")
       end
 
-      def has_charts_section?
-        page.has_css?(".ai-translations__charts")
+      def toggle_target(target_type)
+        page.find(
+          ".ai-translation-model-progress-overview-card[data-target-type='#{target_type}']",
+        ).click
+        self
+      end
+
+      def has_expanded_target?(target_type)
+        page.has_css?(
+          ".ai-translation-model-progress-overview-card[data-target-type='#{target_type}'][aria-expanded='true']",
+        )
+      end
+
+      def has_no_expanded_target?
+        page.has_no_css?(".ai-translation-model-progress-overview-card[aria-expanded='true']")
       end
 
       def has_locale_selector?

--- a/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
+++ b/plugins/discourse-ai/spec/system/page_objects/pages/admin_ai_translations.rb
@@ -44,6 +44,21 @@ module PageObjects
         page.has_no_css?(".ai-translation-model-progress-overview-card[aria-expanded='true']")
       end
 
+      def has_detail_table?
+        page.has_css?(".ai-translation-model-progress-detail .d-table")
+      end
+
+      def has_no_detail_table?
+        page.has_no_css?(".ai-translation-model-progress-detail .d-table")
+      end
+
+      def has_detail_row?(locale:, translated:, pending:, denominator:)
+        page.has_css?(
+          ".ai-translation-locale-progress__row",
+          text: /#{locale}.*#{translated}.*#{pending}.*#{denominator}/m,
+        )
+      end
+
       def has_locale_selector?
         page.has_css?(".ai-translations__settings-panel .multi-select")
       end

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-translation-model-progress-detail-card-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-translation-model-progress-detail-card-test.gjs
@@ -69,9 +69,19 @@ module(
       );
       assert
         .dom(".fk-d-tooltip__content")
-        .includesText(
-          "Includes eligible posts that do not have language detected yet."
-        );
+        .includesText("Includes content that still needs language detection.");
+
+      await triggerEvent(
+        ".ai-translation-locale-progress__pending-header .fk-d-tooltip__trigger",
+        "pointerleave"
+      );
+      await triggerEvent(
+        ".ai-translation-locale-progress__denominator-header .fk-d-tooltip__trigger",
+        "pointermove"
+      );
+      assert
+        .dom(".fk-d-tooltip__content")
+        .includesText("Content already in this language is excluded.");
     });
 
     test("uses total for tags without eligibility help", async function (assert) {

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-translation-model-progress-detail-card-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-translation-model-progress-detail-card-test.gjs
@@ -1,0 +1,191 @@
+import { render, settled, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import AiTranslationModelProgressDetailCard from "discourse/plugins/discourse-ai/discourse/components/ai-translation-model-progress-detail-card";
+
+module(
+  "Integration | Component | ai-translation-model-progress-detail-card",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.siteSettings.available_locales = [
+        { name: "English", value: "en" },
+        { name: "French", value: "fr" },
+      ];
+    });
+
+    test("renders locale progress with eligible and pending help", async function (assert) {
+      const data = {
+        target_type: "post",
+        locales: [
+          {
+            locale: "en",
+            translated_count: 215,
+            pending_count: 93,
+            eligible_count: 474,
+          },
+          {
+            locale: "fr",
+            translated_count: 30,
+            pending_count: 20,
+            eligible_count: 50,
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressDetailCard @data={{data}} />
+        </template>
+      );
+
+      assert.dom(".ai-translation-model-progress-detail").exists();
+      assert.dom(".ai-translation-locale-progress__row").exists({ count: 2 });
+      assert
+        .dom(".ai-translation-locale-progress__locale-code")
+        .exists({ count: 2 });
+      assert
+        .dom(".ai-translation-locale-progress__translated-value")
+        .hasText("215");
+      assert
+        .dom(".ai-translation-locale-progress__pending-value")
+        .hasText("93");
+      assert
+        .dom(".ai-translation-locale-progress__denominator-value")
+        .hasText("474");
+      assert
+        .dom(".ai-translation-progress-bar")
+        .hasAttribute("role", "progressbar")
+        .hasAria("label", "215 of 474 translated into English")
+        .hasAria("valuenow", "45")
+        .hasAria("valuemin", "0")
+        .hasAria("valuemax", "100");
+      assert.dom(".fk-d-tooltip__trigger").exists({ count: 2 });
+
+      await triggerEvent(
+        ".ai-translation-locale-progress__pending-header .fk-d-tooltip__trigger",
+        "pointermove"
+      );
+      assert
+        .dom(".fk-d-tooltip__content")
+        .includesText(
+          "Includes eligible posts that do not have language detected yet."
+        );
+    });
+
+    test("uses total for tags without eligibility help", async function (assert) {
+      const data = {
+        target_type: "tag",
+        locales: [
+          {
+            locale: "en",
+            translated_count: 10,
+            pending_count: 5,
+            total_count: 15,
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressDetailCard @data={{data}} />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-locale-progress__denominator-header")
+        .hasText("Total");
+      assert
+        .dom(
+          ".ai-translation-locale-progress__denominator-header .fk-d-tooltip__trigger"
+        )
+        .doesNotExist();
+      assert
+        .dom(".ai-translation-locale-progress__denominator-value")
+        .hasText("15");
+    });
+
+    test("excludes pending when its values are nil", async function (assert) {
+      const data = {
+        target_type: "category",
+        locales: [
+          {
+            locale: "en",
+            translated_count: 10,
+            pending_count: null,
+            eligible_count: 15,
+          },
+        ],
+      };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressDetailCard @data={{data}} />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-locale-progress__pending-header")
+        .doesNotExist();
+      assert.dom(".ai-translation-locale-progress__pending").doesNotExist();
+    });
+
+    test("renders an empty state when no locale details are available", async function (assert) {
+      const data = { target_type: "post", locales: [] };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressDetailCard @data={{data}} />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-model-progress-detail__empty")
+        .hasText("No language progress is available.");
+    });
+
+    test("updates tooltips and columns when the target changes", async function (assert) {
+      this.set("data", {
+        target_type: "post",
+        locales: [
+          {
+            locale: "en",
+            translated_count: 10,
+            pending_count: 5,
+            eligible_count: 15,
+          },
+        ],
+      });
+
+      await render(
+        <template>
+          <AiTranslationModelProgressDetailCard @data={{this.data}} />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-locale-progress__denominator-header")
+        .includesText("Eligible");
+      assert.dom(".fk-d-tooltip__trigger").exists({ count: 2 });
+
+      this.set("data", {
+        target_type: "tag",
+        locales: [
+          {
+            locale: "en",
+            translated_count: 10,
+            pending_count: 5,
+            total_count: 15,
+          },
+        ],
+      });
+      await settled();
+
+      assert
+        .dom(".ai-translation-locale-progress__denominator-header")
+        .hasText("Total");
+      assert.dom(".fk-d-tooltip__trigger").exists({ count: 1 });
+    });
+  }
+);

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-translation-model-progress-overview-card-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-translation-model-progress-overview-card-test.gjs
@@ -1,0 +1,133 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
+import AiTranslationModelProgressOverviewCard from "discourse/plugins/discourse-ai/discourse/components/ai-translation-model-progress-overview-card";
+import AiTranslationModelProgressOverviewSkeleton from "discourse/plugins/discourse-ai/discourse/components/ai-translation-model-progress-overview-skeleton";
+
+module(
+  "Integration | Component | ai-translation-model-progress-overview-card",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("renders eligible target counts and segmented progress", async function (assert) {
+      const target = {
+        target_type: "post",
+        total_count: 474,
+        translated_count: 215,
+        needs_language_detection_count: 93,
+      };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressOverviewCard
+            @target={{target}}
+            @expanded={{false}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-model-progress-overview-card__title")
+        .hasText("Posts");
+      assert
+        .dom(".ai-translation-model-progress-overview-card__percentage")
+        .hasText("45%");
+      assert
+        .dom(".ai-translation-model-progress-overview-card__headline")
+        .hasText("There are 474 eligible posts for translation.");
+      assert
+        .dom(".ai-translation-model-progress-overview-card__subheader")
+        .exists({ count: 2 });
+      assert
+        .dom(".ai-translation-model-progress-overview-card__translated")
+        .hasText("215 posts have been fully translated.");
+      assert
+        .dom(".ai-translation-model-progress-overview-card__needs-detection")
+        .hasText("93 posts still need language detection.");
+      assert
+        .dom(".ai-translation-model-progress-overview-card__meter")
+        .hasAttribute("aria-hidden", "true");
+      assert
+        .dom(".ai-translation-model-progress-overview-card")
+        .hasAttribute("aria-expanded", "false");
+    });
+
+    test("uses the complete state while preserving card geometry", async function (assert) {
+      const target = {
+        target_type: "category",
+        total_count: 18,
+        translated_count: 18,
+        needs_language_detection_count: 0,
+      };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressOverviewCard
+            @target={{target}}
+            @expanded={{false}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-model-progress-overview-card__headline")
+        .hasText("All 18 eligible categories are fully translated.");
+      assert
+        .dom(".ai-translation-model-progress-overview-card__subheader")
+        .exists({ count: 2 });
+      assert
+        .dom(".ai-translation-model-progress-overview-card__subheader")
+        .hasAttribute("aria-hidden", "true");
+    });
+
+    test("does not describe tags as eligible", async function (assert) {
+      const target = {
+        target_type: "tag",
+        total_count: 142,
+        translated_count: 64,
+        needs_language_detection_count: 7,
+      };
+
+      await render(
+        <template>
+          <AiTranslationModelProgressOverviewCard
+            @target={{target}}
+            @expanded={{false}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".ai-translation-model-progress-overview-card__headline")
+        .hasText("There are 142 tags for translation.");
+      assert
+        .dom(".ai-translation-model-progress-overview-card")
+        .doesNotIncludeText("eligible");
+    });
+  }
+);
+
+module(
+  "Integration | Component | ai-translation-model-progress-overview-skeleton",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("renders four accessible card placeholders", async function (assert) {
+      await render(
+        <template><AiTranslationModelProgressOverviewSkeleton /></template>
+      );
+
+      assert
+        .dom(".ai-translation-model-progress-overview-skeleton")
+        .hasAttribute("role", "status")
+        .hasAria(
+          "label",
+          i18n("discourse_ai.translations.model_progress.loading")
+        );
+      assert
+        .dom(".ai-translation-model-progress-overview-skeleton__card")
+        .exists({ count: 4 });
+    });
+  }
+);

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-translations-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-translations-test.gjs
@@ -1,0 +1,170 @@
+import Service from "@ember/service";
+import { click, find, render, settled, waitUntil } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+import AiTranslations from "discourse/plugins/discourse-ai/discourse/components/ai-translations";
+
+class AiCreditsStub extends Service {
+  async getFeatureCreditStatus() {
+    return null;
+  }
+}
+
+const overview = {
+  cached_at: "2026-07-23T09:00:00Z",
+  targets: ["post", "topic", "category", "tag"].map((target_type) => ({
+    target_type,
+    total_count: 10,
+    translated_count: 5,
+    needs_language_detection_count: 2,
+  })),
+};
+
+function detail(target_type, translated_count) {
+  return {
+    target_type,
+    cached_at: "2026-07-23T09:00:00Z",
+    locales: [
+      {
+        locale: "en",
+        translated_count,
+        pending_count: 10 - translated_count,
+        eligible_count: 10,
+      },
+      {
+        locale: "fr",
+        translated_count,
+        pending_count: 10 - translated_count,
+        eligible_count: 10,
+      },
+    ],
+  };
+}
+
+module("Integration | Component | AiTranslations", function (hooks) {
+  setupRenderingTest(hooks, { stubRouter: true });
+
+  hooks.beforeEach(function () {
+    this.owner.unregister("service:ai-credits");
+    this.owner.register("service:ai-credits", AiCreditsStub);
+
+    this.siteSettings.content_localization_supported_locales = "en|fr";
+    this.siteSettings.available_locales = [
+      { name: "English", value: "en" },
+      { name: "French", value: "fr" },
+    ];
+    this.model = {
+      enabled: true,
+      translation_enabled: true,
+      no_locales_configured: false,
+      backfill_enabled: false,
+      category_scope: "public",
+      category_ids: [],
+      hourly_rate: 0,
+      translation_id: 6,
+    };
+
+    pretender.get(
+      "/admin/plugins/discourse-ai/ai-translations/progress.json",
+      () => response(overview)
+    );
+  });
+
+  test("keeps the current detail table open while another target loads", async function (assert) {
+    let resolveTopic;
+
+    pretender.get(
+      "/admin/plugins/discourse-ai/ai-translations/progress/post.json",
+      () => response(detail("post", 4))
+    );
+    pretender.get(
+      "/admin/plugins/discourse-ai/ai-translations/progress/topic.json",
+      () =>
+        new Promise((resolve) => {
+          resolveTopic = () => resolve(response(detail("topic", 7)));
+        })
+    );
+
+    await render(<template><AiTranslations @model={{this.model}} /></template>);
+    await click(
+      ".ai-translation-model-progress-overview-card[data-target-type='post']"
+    );
+
+    find(
+      ".ai-translation-model-progress-overview-card[data-target-type='topic']"
+    ).click();
+    await waitUntil(() => find(".ai-translation-model-progress-detail-state"));
+
+    assert
+      .dom(".ai-translation-model-progress-detail")
+      .exists("the current detail table remains mounted");
+    assert
+      .dom(".ai-translation-model-progress-detail-state.--overlay")
+      .exists("the loading state overlays the current table");
+
+    resolveTopic();
+    await settled();
+
+    assert
+      .dom(".ai-translation-locale-progress__translated-value")
+      .hasText("7", "the newly loaded detail replaces the previous table");
+  });
+
+  test("does not reuse a detail response that finishes after disabling translations", async function (assert) {
+    let resolveFirstRequest;
+    let detailRequestCount = 0;
+
+    pretender.get(
+      "/admin/plugins/discourse-ai/ai-translations/progress/post.json",
+      () => {
+        detailRequestCount += 1;
+
+        if (detailRequestCount === 1) {
+          return new Promise((resolve) => {
+            resolveFirstRequest = () => resolve(response(detail("post", 4)));
+          });
+        }
+
+        return response(detail("post", 8));
+      }
+    );
+    pretender.put("/admin/site_settings/ai_translation_enabled", () =>
+      response({})
+    );
+    pretender.put("/admin/site_settings/content_localization_enabled", () =>
+      response({})
+    );
+
+    await render(<template><AiTranslations @model={{this.model}} /></template>);
+
+    find(
+      ".ai-translation-model-progress-overview-card[data-target-type='post']"
+    ).click();
+    await waitUntil(() => resolveFirstRequest);
+
+    find(
+      ".ai-translations__toggle-container .d-toggle-switch__checkbox"
+    ).click();
+    await waitUntil(() => !find(".ai-translations__overview"));
+
+    resolveFirstRequest();
+    await settled();
+
+    await click(
+      ".ai-translations__toggle-container .d-toggle-switch__checkbox"
+    );
+    await click(
+      ".ai-translation-model-progress-overview-card[data-target-type='post']"
+    );
+
+    assert.strictEqual(
+      detailRequestCount,
+      2,
+      "the stale response is not retained in the frontend cache"
+    );
+    assert
+      .dom(".ai-translation-locale-progress__translated-value")
+      .hasText("8", "the refreshed response is rendered");
+  });
+});


### PR DESCRIPTION
Related: https://meta.discourse.org/t/ai-translation-progress-graph/405915/3

A more thorough translation progress screen.

Progress now covers posts, topics, categories and tags. The overview cards show the total content in scope, how many are fully translated across all supported locales, and how many still need language detection.

Eligibility follows the existing translation settings, including max age, category scope, bot content and PM settings. Tags don't have eligibility settings, so they use the total instead.

Opening a card loads its per-locale breakdown separately, so the initial page load doesn't also run every detail query. For each locale, content already in that language is excluded from eligible. Pending includes eligible content that still needs language detection.

The posts query is quite heavy, so the overview is cached together for 2h and each detail target has its own 2h cache. Relevant translation settings are part of the cache key, and a distributed mutex prevents duplicate detail queries when two requests miss the same cache.

**Perf note**: Calculating translation progress can be expensive on large sites, particularly for posts. The production dataset used for testing contained approximately 2 million posts, 2.5 million post localizations, and 730,000 topic localizations. Post eligibility must also inspect `raw` for the empty and maximum-length rules, so the candidate scope cannot be answered entirely from the existing indexes. To limit the impact we do have cache, and details are fetched only when a card is opened, and the queries aggregate localization coverage in bulk instead of repeatedly probing the localization indexes for every eligible record and target locale.

### before

<img width="1168" height="941" alt="Screenshot 2026-07-23 at 11 10 11 PM" src="https://github.com/user-attachments/assets/4e97a052-bc0a-46e3-ae96-49aa378f92e6" />


### after

https://github.com/user-attachments/assets/7349f622-63b8-43af-af3d-3cf2f40ed6ef

