### PR TITLE
FIX: Make the tag show route work with `lazy_load_categories`

### DIFF
--- a/frontend/discourse/app/routes/tag/show.js
+++ b/frontend/discourse/app/routes/tag/show.js
@@ -23,6 +23,7 @@ const ALL = "all";
 export default class TagShowRoute extends DiscourseRoute {
   @service router;
   @service currentUser;
+  @service site;
   @service store;
   @service topicTrackingState;
   @service("search") searchService;
@@ -113,9 +114,14 @@ export default class TagShowRoute extends DiscourseRoute {
       tagNotification = await this.store.find("tagNotification", id);
     }
 
-    let category = params.category_slug_path_with_id
-      ? Category.findBySlugPathWithID(params.category_slug_path_with_id)
-      : null;
+    let category = null;
+    if (params.category_slug_path_with_id) {
+      category = this.site.lazy_load_categories
+        ? await Category.asyncFindBySlugPathWithID(
+            params.category_slug_path_with_id
+          )
+        : Category.findBySlugPathWithID(params.category_slug_path_with_id);
+    }
     const filteredQueryParams = filterQueryParams(
       transition.to.queryParams,
       {}
@@ -143,9 +149,13 @@ export default class TagShowRoute extends DiscourseRoute {
 
       if (transition.to.queryParams["category"]) {
         filteredQueryParams["category"] = transition.to.queryParams["category"];
-        category = Category.findBySlugPathWithID(
-          transition.to.queryParams["category"]
-        );
+        category = this.site.lazy_load_categories
+          ? await Category.asyncFindBySlugPathWithID(
+              transition.to.queryParams["category"]
+            )
+          : Category.findBySlugPathWithID(
+              transition.to.queryParams["category"]
+            );
       }
     } else if (slug === NONE) {
       filter = `tag/${NONE}/l/${topicFilter}`;

--- a/frontend/discourse/tests/acceptance/tags-test.js
+++ b/frontend/discourse/tests/acceptance/tags-test.js
@@ -1,6 +1,8 @@
 import { click, currentURL, findAll, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { withPluginApi } from "discourse/lib/plugin-api";
+import Category from "discourse/models/category";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import formKit from "discourse/tests/helpers/form-kit-helper";
 import {
   acceptance,
@@ -119,6 +121,19 @@ acceptance("Tags", function (needs) {
   test("hide tag notifications menu", async function (assert) {
     await visit("/tags/c/faq/4/test/42");
     assert.dom(".tag-notifications-tracking").doesNotExist();
+  });
+
+  test("resolves the full category when lazy loading categories", async function (assert) {
+    this.owner.lookup("service:site").set("lazy_load_categories", true);
+    pretender.get("/categories/find", () =>
+      response({
+        categories: [{ id: 4, slug: "faq", allowed_tag_groups: ["support"] }],
+      })
+    );
+
+    await visit("/tags/c/faq/4/test/42");
+
+    assert.deepEqual(Category.findById(4).allowed_tag_groups, ["support"]);
   });
 });
 


### PR DESCRIPTION
Previously, the tag show route always resolved its category synchronously from the client-side store, so on sites with category lazy loading it could hand discovery navigation an `undefined` category or a slim record hydrated from a topic-list payload, which lacks full-serializer fields such as `allowed_tag_groups`.

This change resolves the category via `Category.asyncFindBySlugPathWithID` when lazy loading is enabled, mirroring `build-category-route`, so tag routes always receive the fully serialized category record.