### PR TITLE
DEV: Drop empty core mobile/desktop stylesheets

### DIFF
--- a/app/assets/stylesheets/desktop.scss
+++ b/app/assets/stylesheets/desktop.scss
@@ -1,3 +1,0 @@
-// This file intentionally left blank — the stylesheet compiler generates `@import "desktop"`
-// Plugins and themes can still add desktop styles for import
-// Instead of authoring desktop-specific styles, use media queries in the common stylesheets

--- a/app/assets/stylesheets/desktop_rtl.scss
+++ b/app/assets/stylesheets/desktop_rtl.scss
@@ -1,2 +1,0 @@
-// stub file used to clean up asset precompilation process
-@import "desktop";

--- a/app/assets/stylesheets/mobile.scss
+++ b/app/assets/stylesheets/mobile.scss
@@ -1,3 +1,0 @@
-// This file intentionally left blank — the stylesheet compiler generates `@import "mobile"`
-// Plugins and themes can still add mobile styles for import
-// Instead of authoring mobile-specific styles, use media queries in the common stylesheets

--- a/app/assets/stylesheets/mobile_rtl.scss
+++ b/app/assets/stylesheets/mobile_rtl.scss
@@ -1,2 +1,0 @@
-// stub file used to clean up asset precompilation process
-@import "mobile";

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -542,7 +542,7 @@ class Theme < ActiveRecord::Base
     targets = %i[common_theme mobile_theme desktop_theme]
 
     if with_scheme
-      targets.prepend(:common, :desktop, :mobile, :admin)
+      targets.prepend(:common, :admin)
       targets.append(
         *Discourse.find_plugin_css_assets(
           mobile_view: true,

--- a/app/views/common/_discourse_preload_stylesheet.html.erb
+++ b/app/views/common/_discourse_preload_stylesheet.html.erb
@@ -2,10 +2,8 @@
 
 <%- if rtl? %>
   <%= discourse_stylesheet_preload_tag(:common_rtl) %>
-  <%= discourse_stylesheet_preload_tag(mobile_device? ? :mobile_rtl : :desktop_rtl) %>
 <%- else %>
   <%= discourse_stylesheet_preload_tag(:common) %>
-  <%= discourse_stylesheet_preload_tag(mobile_device? ? :mobile : :desktop) %>
 <%- end %>
 
 <%- if staff? %>

--- a/app/views/common/_discourse_stylesheet.html.erb
+++ b/app/views/common/_discourse_stylesheet.html.erb
@@ -2,9 +2,6 @@
 
 <%= discourse_stylesheet_link_tag(:common, supports_rtl: true) %>
 
-<%= discourse_stylesheet_link_tag(:mobile, supports_rtl: true, media: "(width < 40rem)") %>
-<%= discourse_stylesheet_link_tag(:desktop, supports_rtl: true, media: "(width >= 40rem)") %>
-
 <%- if staff? %>
   <%= discourse_stylesheet_link_tag(:admin, supports_rtl: true) %>
 <%- end %>

--- a/app/views/qunit/qunit.html.erb
+++ b/app/views/qunit/qunit.html.erb
@@ -70,7 +70,6 @@
       </style>
 
       <%= discourse_stylesheet_link_tag(:common, theme_id: nil) %>
-      <%= discourse_stylesheet_link_tag(:desktop, theme_id: nil) %>
       <%= discourse_stylesheet_link_tag(:admin) %>
       <%= discourse_stylesheet_link_tag(:wizard) %>
 

--- a/lib/stylesheet/manager.rb
+++ b/lib/stylesheet/manager.rb
@@ -49,7 +49,7 @@ class Stylesheet::Manager
   end
 
   def self.precompile_css
-    targets = %i[common desktop mobile admin wizard]
+    targets = %i[common admin wizard]
     targets += targets.map { |t| :"#{t}_rtl" }
 
     targets +=
@@ -267,11 +267,11 @@ class Stylesheet::Manager
     themes
   end
 
-  def stylesheet_data(target = :desktop)
+  def stylesheet_data(target)
     stylesheet_details(target, "all")
   end
 
-  def stylesheet_preload_tag(target = :desktop, media = "all")
+  def stylesheet_preload_tag(target, media = "all")
     stylesheets = stylesheet_details(target, media)
     stylesheets
       .map do |stylesheet|
@@ -282,7 +282,7 @@ class Stylesheet::Manager
       .html_safe
   end
 
-  def stylesheet_link_tag(target = :desktop, media = "all", preload_callback = nil)
+  def stylesheet_link_tag(target, media = "all", preload_callback = nil)
     stylesheets = stylesheet_details(target, media)
     stylesheets
       .map do |stylesheet|
@@ -298,7 +298,7 @@ class Stylesheet::Manager
       .html_safe
   end
 
-  def stylesheet_details(target = :desktop, media = "all")
+  def stylesheet_details(target, media = "all")
     target = target.to_sym
     current_hostname = Discourse.current_hostname
     relative_url_root = GlobalSetting.relative_url_root

--- a/lib/stylesheet/manager/builder.rb
+++ b/lib/stylesheet/manager/builder.rb
@@ -3,7 +3,7 @@
 class Stylesheet::Manager::Builder
   attr_reader :theme
 
-  def initialize(target: :desktop, theme: nil, color_scheme: nil, manager:)
+  def initialize(target:, theme: nil, color_scheme: nil, manager:)
     @target = target
     @theme = theme
     @color_scheme = color_scheme

--- a/lib/stylesheet/watcher.rb
+++ b/lib/stylesheet/watcher.rb
@@ -4,7 +4,7 @@ require "listen"
 
 module Stylesheet
   class Watcher
-    CORE_TARGETS = %w[admin desktop mobile publish wizard wcag]
+    CORE_TARGETS = %w[admin publish wizard wcag]
     SPECIAL_CORE_TARGETS = %w[color_definitions]
 
     def self.watch(paths = nil)
@@ -115,7 +115,7 @@ module Stylesheet
         return
       end
 
-      targets = target ? [target] : %w[admin common desktop mobile]
+      targets = target ? [target] : %w[admin common]
       Stylesheet::Manager.clear_core_cache!(targets)
       message =
         targets.map! { |name| Stylesheet::Manager.new.stylesheet_data(name.to_sym) }.flatten!

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -224,13 +224,13 @@ RSpec.describe ApplicationHelper do
     end
 
     it "adds resources to the preload list when discourse_stylesheet_link_tag is called" do
-      helper.discourse_stylesheet_link_tag(:desktop)
+      helper.discourse_stylesheet_link_tag(:common)
 
       expect(controller.instance_variable_get(:@asset_preload_links).size).to eq(1)
     end
 
     it "adds resources as the correct type" do
-      helper.discourse_stylesheet_link_tag(:desktop)
+      helper.discourse_stylesheet_link_tag(:common)
       helper.preload_script("discourse")
 
       expect(controller.instance_variable_get(:@asset_preload_links)[0]).to match(/as="style"/)

--- a/spec/lib/stylesheet/manager_spec.rb
+++ b/spec/lib/stylesheet/manager_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Stylesheet::Manager do
   end
 
   it "still returns something for no themes" do
-    link = manager.stylesheet_link_tag(:desktop, "all")
+    link = manager.stylesheet_link_tag(:common, "all")
     expect(link).not_to eq("")
   end
 
@@ -58,7 +58,7 @@ RSpec.describe Stylesheet::Manager do
     it "generates the right links for non-theme targets" do
       manager = manager(nil)
 
-      hrefs = manager.stylesheet_details(:desktop, "all")
+      hrefs = manager.stylesheet_details(:common, "all")
 
       expect(hrefs.length).to eq(1)
     end
@@ -254,9 +254,9 @@ RSpec.describe Stylesheet::Manager do
     it "outputs tags for non-theme targets for theme component" do
       child_theme = Fabricate(:theme, component: true)
 
-      hrefs = manager(child_theme.id).stylesheet_details(:desktop, "all")
+      hrefs = manager(child_theme.id).stylesheet_details(:common, "all")
 
-      expect(hrefs.count).to eq(1) # desktop
+      expect(hrefs.count).to eq(1) # common
     end
 
     it "does not output tags for component targets with no styles" do
@@ -298,7 +298,7 @@ RSpec.describe Stylesheet::Manager do
       hrefs = manager.stylesheet_details(:admin, "all")
       expect(hrefs.count).to eq(1)
 
-      hrefs = manager.stylesheet_details(:mobile, "all")
+      hrefs = manager.stylesheet_details(:common, "all")
       expect(hrefs.count).to eq(1)
     end
   end
@@ -307,11 +307,11 @@ RSpec.describe Stylesheet::Manager do
     after { DiscoursePluginRegistry.reset! }
 
     it "can correctly account for plugins in default digest" do
-      builder = Stylesheet::Manager::Builder.new(target: :desktop, manager: manager)
+      builder = Stylesheet::Manager::Builder.new(target: :common, manager: manager)
       digest1 = builder.digest
 
       DiscoursePluginRegistry.stylesheets["fake"] = Set.new(["fake_file"])
-      builder = Stylesheet::Manager::Builder.new(target: :desktop, manager: manager)
+      builder = Stylesheet::Manager::Builder.new(target: :common, manager: manager)
       digest2 = builder.digest
 
       expect(digest1).not_to eq(digest2)
@@ -449,9 +449,6 @@ RSpec.describe Stylesheet::Manager do
 
       builder = Stylesheet::Manager::Builder.new(target: :admin, manager: manager)
       expect(builder.digest).to eq(builder.default_digest)
-
-      builder = Stylesheet::Manager::Builder.new(target: :desktop, manager: manager)
-      expect(builder.digest).to eq(builder.default_digest)
     end
 
     it "returns different digest based on hostname" do
@@ -467,7 +464,7 @@ RSpec.describe Stylesheet::Manager do
       initial_color_scheme_digest =
         Stylesheet::Manager::Builder.new(target: :color_definitions, manager: manager).digest
       initial_default_digest =
-        Stylesheet::Manager::Builder.new(target: :desktop, manager: manager).digest
+        Stylesheet::Manager::Builder.new(target: :common, manager: manager).digest
 
       SiteSetting.force_hostname = "host2.example.com"
       new_theme_digest =
@@ -479,7 +476,7 @@ RSpec.describe Stylesheet::Manager do
       new_color_scheme_digest =
         Stylesheet::Manager::Builder.new(target: :color_definitions, manager: manager).digest
       new_default_digest =
-        Stylesheet::Manager::Builder.new(target: :desktop, manager: manager).digest
+        Stylesheet::Manager::Builder.new(target: :common, manager: manager).digest
 
       expect(initial_theme_digest).not_to eq(new_theme_digest)
       expect(initial_color_scheme_digest).not_to eq(new_color_scheme_digest)
@@ -870,9 +867,7 @@ RSpec.describe Stylesheet::Manager do
   end
 
   describe ".precompile_css" do
-    let(:core_targets) do
-      %w[common desktop mobile admin wizard common_rtl desktop_rtl mobile_rtl admin_rtl wizard_rtl]
-    end
+    let(:core_targets) { %w[common admin wizard common_rtl admin_rtl wizard_rtl] }
 
     let(:theme_targets) do
       %i[
@@ -962,7 +957,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(16) # 10 core targets + 2 theme (ltr/rtl) + 4 color schemes
+      expect(results.size).to eq(12) # 6 core targets + 2 theme (ltr/rtl) + 4 color schemes
 
       expect(results.count { |target| target =~ /^common_theme_/ }).to eq(2) # ltr/rtl
     end
@@ -974,7 +969,7 @@ RSpec.describe Stylesheet::Manager do
       Stylesheet::Manager.precompile_theme_css
 
       results = StylesheetCache.pluck(:target)
-      expect(results.size).to eq(18) # 10 core targets + 2 theme rtl/ltr + 6 color schemes
+      expect(results.size).to eq(14) # 6 core targets + 2 theme rtl/ltr + 6 color schemes
 
       expect(results).to include("color_definitions_#{scheme1.name}_#{scheme1.id}_#{user_theme.id}")
       expect(results).to include(

--- a/spec/lib/stylesheet/watcher_spec.rb
+++ b/spec/lib/stylesheet/watcher_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe Stylesheet::Watcher do
     end
 
     it "infers core targets from top-level stylesheet filenames" do
-      path = Rails.root.join("app/assets/stylesheets/mobile.scss")
+      path = Rails.root.join("app/assets/stylesheets/wizard.scss")
 
-      expect(watcher.path_data(path.to_s, [])).to include(target: "mobile", plugin_name: nil)
+      expect(watcher.path_data(path.to_s, [])).to include(target: "wizard", plugin_name: nil)
     end
 
     it "infers special core targets from top-level filenames" do

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -520,8 +520,6 @@ RSpec.describe Theme do
     expect(messages.first.data.map { |d| d[:target] }).to contain_exactly(
       :common,
       :admin,
-      :desktop,
-      :mobile,
       :common_theme,
     )
   end

--- a/spec/requests/stylesheets_controller_spec.rb
+++ b/spec/requests/stylesheets_controller_spec.rb
@@ -4,23 +4,23 @@ RSpec.describe StylesheetsController do
   it "can survive cache miss" do
     StylesheetCache.destroy_all
     manager = Stylesheet::Manager.new(theme_id: nil)
-    builder = Stylesheet::Manager::Builder.new(target: "desktop_rtl", manager: manager, theme: nil)
+    builder = Stylesheet::Manager::Builder.new(target: "common_rtl", manager: manager, theme: nil)
     builder.compile
 
     digest = StylesheetCache.first.digest
     StylesheetCache.destroy_all
 
-    get "/stylesheets/desktop_rtl_#{digest}.css"
+    get "/stylesheets/common_rtl_#{digest}.css"
     expect(response.status).to eq(200)
 
     cached = StylesheetCache.first
-    expect(cached.target).to eq "desktop_rtl"
+    expect(cached.target).to eq "common_rtl"
     expect(cached.digest).to eq digest
 
     # tmp folder destruction and cached
     Stylesheet::Manager.rm_cache_folder
 
-    get "/stylesheets/desktop_rtl_#{digest}.css"
+    get "/stylesheets/common_rtl_#{digest}.css"
     expect(response.status).to eq(200)
 
     # there is an edge case which is ... disk and db cache is nuked, very unlikely to happen
@@ -32,7 +32,7 @@ RSpec.describe StylesheetsController do
 
     manager = Stylesheet::Manager.new(theme_id: theme.id)
 
-    builder = Stylesheet::Manager::Builder.new(target: :desktop, theme: theme, manager: manager)
+    builder = Stylesheet::Manager::Builder.new(target: :common, theme: theme, manager: manager)
     builder.compile
 
     Stylesheet::Manager.rm_cache_folder
@@ -174,22 +174,22 @@ RSpec.describe StylesheetsController do
   it "ignores Accept header and does not include Vary header" do
     StylesheetCache.destroy_all
     manager = Stylesheet::Manager.new(theme_id: nil)
-    builder = Stylesheet::Manager::Builder.new(target: "desktop", manager: manager, theme: nil)
+    builder = Stylesheet::Manager::Builder.new(target: "common", manager: manager, theme: nil)
     builder.compile
 
     digest = StylesheetCache.first.digest
 
-    get "/stylesheets/desktop_#{digest}.css"
+    get "/stylesheets/common_#{digest}.css"
     expect(response.status).to eq(200)
     expect(response.headers["Content-Type"]).to eq("text/css")
     expect(response.headers["Vary"]).to eq(nil)
 
-    get "/stylesheets/desktop_#{digest}.css", headers: { "Accept" => "text/html" }
+    get "/stylesheets/common_#{digest}.css", headers: { "Accept" => "text/html" }
     expect(response.status).to eq(200)
     expect(response.headers["Content-Type"]).to eq("text/css")
     expect(response.headers["Vary"]).to eq(nil)
 
-    get "/stylesheets/desktop_#{digest}.css", headers: { "Accept" => "invalidcontenttype" }
+    get "/stylesheets/common_#{digest}.css", headers: { "Accept" => "invalidcontenttype" }
     expect(response.status).to eq(200)
     expect(response.headers["Content-Type"]).to eq("text/css")
     expect(response.headers["Vary"]).to eq(nil)

--- a/spec/system/mobile_mode_spec.rb
+++ b/spec/system/mobile_mode_spec.rb
@@ -1,14 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe "Viewport-based mobile mode" do
-  it "has both stylesheets, and updates classes at runtime" do
+  it "updates classes at runtime" do
     visit "/"
-
-    mobile_stylesheet = find("link[rel=stylesheet][href*='stylesheets/mobile']", visible: false)
-    desktop_stylesheet = find("link[rel=stylesheet][href*='stylesheets/desktop']", visible: false)
-
-    expect(mobile_stylesheet["media"]).to include("width < 40rem")
-    expect(desktop_stylesheet["media"]).to include("width >= 40rem")
 
     expect(page).to have_css("html.desktop-view")
     expect(page).not_to have_css("html.mobile-view")


### PR DESCRIPTION
b1399d6a6f4 removed the last mobile/desktop-specific CSS from Discourse. Everything is now handled by media queries in common scss.

This commit drops the mobile/desktop stylesheet infrastructure for core. It remains in place for themes & plugins.

Much of the diff is updating specs to avoid mobile/desktop as fixtures, and to remove argument defaults which no longer make sense.