### PR TITLE
FIX: Fix broken notifyModeratorsFlag

### DIFF
--- a/frontend/discourse/app/components/modal/flag.gjs
+++ b/frontend/discourse/app/components/modal/flag.gjs
@@ -17,8 +17,6 @@ import DButton from "discourse/ui-kit/d-button";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
 
-const NOTIFY_MODERATORS_KEY = "notify_moderators";
-
 export default class Flag extends Component {
   @service adminTools;
   @service currentUser;
@@ -127,10 +125,6 @@ export default class Flag extends Component {
     );
   }
 
-  get notifyModeratorsFlag() {
-    return this.flagsAvailable.find((f) => f.id === NOTIFY_MODERATORS_KEY);
-  }
-
   get canTakeAction() {
     return (
       !this.args.model.flagTarget.targetsTopic() &&
@@ -217,7 +211,6 @@ export default class Flag extends Component {
 
   @action
   flagForReview() {
-    this.selected ||= this.notifyModeratorsFlag;
     this.createFlag({ queue_for_review: true });
     this.args.model.setHidden();
   }
@@ -297,7 +290,7 @@ export default class Flag extends Component {
           <DButton
             class="btn-danger flag-modal__flag-for-review"
             @action={{this.flagForReview}}
-            @disabled={{not this.submitEnabled this.notifyModeratorsFlag}}
+            @disabled={{not this.submitEnabled}}
             @icon="triangle-exclamation"
             @label="flagging.flag_for_review"
           />

--- a/frontend/discourse/tests/acceptance/flag-post-test.js
+++ b/frontend/discourse/tests/acceptance/flag-post-test.js
@@ -155,6 +155,21 @@ acceptance(`flagging`, function (needs) {
       );
   });
 
+  test("Flag for Review requires a selected reason", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await openFlagModal();
+
+    assert
+      .dom(".flag-modal__flag-for-review")
+      .isDisabled("stays disabled until a reason is selected");
+
+    await click("#radio_inappropriate");
+
+    assert
+      .dom(".flag-modal__flag-for-review")
+      .isNotDisabled("enables once a non-require_message reason is selected");
+  });
+
   test("Can delete spammer from spam", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await openFlagModal();


### PR DESCRIPTION
The modal for post flagging had a notifyModeratorsFlag that was always evaluating to false as it was strict comparing a string with an integer. This fixes that broken flag (by removing it) because we actually want the behavior it was broken to.

For 3 years post flagging has required a reason to flag the post, this was happening by accident because of the broken flag. That is the behavior that is intended though, so fix the bug by removing the code for it, and add a test making sure the flag modal cannot be submitted without a reason.