### PR TITLE
FIX: Race condition allows bypass of data export rate limit in Discourse

### DIFF
--- a/app/controllers/export_csv_controller.rb
+++ b/app/controllers/export_csv_controller.rb
@@ -17,21 +17,20 @@ class ExportCsvController < ApplicationController
     end
 
     if entity == "user_archive"
+      archive_user_id = entity_id || current_user.id
       requesting_user_id = current_user.id if entity_id
 
       # Rate limit user archive exports to 1 per day
-      unless current_user.admin ||
-               UserExport.where(
-                 user_id: entity_id || current_user.id,
-                 created_at: Time.zone.now.all_day,
-               ).count == 0
+      unless current_user.admin || reserve_user_archive_export!(archive_user_id)
         render_json_error I18n.t("csv_export.rate_limit_error")
         return
       end
 
+      reserve_user_archive_export!(archive_user_id) if current_user.admin
+
       Jobs.enqueue(
         :export_user_archive,
-        user_id: entity_id || current_user.id,
+        user_id: archive_user_id,
         requesting_user_id:,
         args: export_params[:args],
       )
@@ -63,6 +62,26 @@ class ExportCsvController < ApplicationController
   end
 
   private
+
+  def reserve_user_archive_export!(user_id)
+    return false if UserExport.exists?(user_id: user_id, created_at: Time.zone.now.all_day)
+
+    Discourse.redis.set(
+      user_archive_export_rate_limit_key(user_id),
+      "1",
+      nx: true,
+      ex: seconds_until_tomorrow,
+    )
+  end
+
+  def user_archive_export_rate_limit_key(user_id)
+    "user_archive_export_rate_limit:#{user_id}:#{Time.zone.today}"
+  end
+
+  def seconds_until_tomorrow
+    now = Time.zone.now
+    [(now.end_of_day - now).ceil, 1].max
+  end
 
   def export_params
     @_export_params ||=

--- a/app/controllers/export_csv_controller.rb
+++ b/app/controllers/export_csv_controller.rb
@@ -21,19 +21,24 @@ class ExportCsvController < ApplicationController
       requesting_user_id = current_user.id if entity_id
 
       # Rate limit user archive exports to 1 per day
-      unless current_user.admin || reserve_user_archive_export!(archive_user_id)
+      reservation_key = reserve_user_archive_export!(archive_user_id)
+
+      unless current_user.admin || reservation_key
         render_json_error I18n.t("csv_export.rate_limit_error")
         return
       end
 
-      reserve_user_archive_export!(archive_user_id) if current_user.admin
-
-      Jobs.enqueue(
-        :export_user_archive,
-        user_id: archive_user_id,
-        requesting_user_id:,
-        args: export_params[:args],
-      )
+      begin
+        Jobs.enqueue(
+          :export_user_archive,
+          user_id: archive_user_id,
+          requesting_user_id:,
+          args: export_params[:args],
+        )
+      rescue StandardError
+        Discourse.redis.del(reservation_key) if reservation_key
+        raise
+      end
     else
       Jobs.enqueue(
         :export_csv_file,
@@ -64,14 +69,12 @@ class ExportCsvController < ApplicationController
   private
 
   def reserve_user_archive_export!(user_id)
-    return false if UserExport.exists?(user_id: user_id, created_at: Time.zone.now.all_day)
+    return nil if UserExport.exists?(user_id: user_id, created_at: Time.zone.now.all_day)
 
-    Discourse.redis.set(
-      user_archive_export_rate_limit_key(user_id),
-      "1",
-      nx: true,
-      ex: seconds_until_tomorrow,
-    )
+    key = user_archive_export_rate_limit_key(user_id)
+    return nil unless Discourse.redis.set(key, "1", nx: true, ex: seconds_until_tomorrow)
+
+    key
   end
 
   def user_archive_export_rate_limit_key(user_id)

--- a/spec/requests/export_csv_controller_spec.rb
+++ b/spec/requests/export_csv_controller_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe ExportCsvController do
         expect(Jobs::ExportUserArchive.jobs.size).to eq(0)
       end
 
+      it "rate limits repeated archive requests while the export job is pending" do
+        post "/export_csv/export_entity.json", params: { entity: "user_archive" }
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+
+        post "/export_csv/export_entity.json", params: { entity: "user_archive" }
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["errors"]).to contain_exactly(
+          I18n.t("csv_export.rate_limit_error"),
+        )
+        expect(Jobs::ExportUserArchive.jobs.size).to eq(1)
+      end
+
       it "returns 404 when normal user tries to export admin entity" do
         post "/export_csv/export_entity.json", params: { entity: "staff_action" }
         expect(response.status).to eq(422)

--- a/spec/requests/export_csv_controller_spec.rb
+++ b/spec/requests/export_csv_controller_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe ExportCsvController do
         expect(Jobs::ExportUserArchive.jobs.size).to eq(1)
       end
 
+      it "releases the reservation if enqueuing the job raises" do
+        Jobs::ExportUserArchive.stubs(:client_push).raises("boom").once
+        post "/export_csv/export_entity.json", params: { entity: "user_archive" }
+        expect(response.status).to eq(500)
+        expect(Jobs::ExportUserArchive.jobs.size).to eq(0)
+
+        Jobs::ExportUserArchive.unstub(:client_push)
+        post "/export_csv/export_entity.json", params: { entity: "user_archive" }
+        expect(response.status).to eq(200)
+        expect(Jobs::ExportUserArchive.jobs.size).to eq(1)
+      end
+
       it "returns 404 when normal user tries to export admin entity" do
         post "/export_csv/export_entity.json", params: { entity: "staff_action" }
         expect(response.status).to eq(422)


### PR DESCRIPTION
## Summary

Prevent a race condition in the user archive export rate limit by implementing an atomic Redis-based reservation. This ensures that multiple export jobs cannot be enqueued for the same user on the same day before the background job creates a database record.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1380

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>