### PR TITLE
FIX: Moderator Can Modify Trust Level of Admin and Staff Accounts

### DIFF
--- a/lib/guardian.rb
+++ b/lib/guardian.rb
@@ -432,7 +432,8 @@ class Guardian
   end
 
   def can_change_trust_level?(user)
-    user && (is_admin? || (is_moderator? && SiteSetting.moderators_change_trust_levels))
+    user &&
+      (is_admin? || (is_moderator? && SiteSetting.moderators_change_trust_levels && !user.staff?))
   end
 
   # Support sites that have to approve users

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1270,6 +1270,33 @@ RSpec.describe Admin::UsersController do
         before { SiteSetting.moderators_change_trust_levels = true }
 
         include_examples "trust level updates possible"
+
+        it "prevents changing or locking a staff user's trust level" do
+          another_admin.update!(trust_level: TrustLevel[4], manual_locked_trust_level: nil)
+
+          put "/admin/users/#{another_admin.id}/trust_level.json", params: { level: TrustLevel[0] }
+
+          trust_level_status = response.status
+          trust_level_errors = response.parsed_body["errors"]
+          trust_level = another_admin.reload.trust_level
+
+          another_admin.update!(trust_level: TrustLevel[4], manual_locked_trust_level: nil)
+
+          put "/admin/users/#{another_admin.id}/trust_level_lock.json", params: { locked: "true" }
+
+          trust_level_lock_status = response.status
+          trust_level_lock_errors = response.parsed_body["errors"] if response.body.present?
+          manual_locked_trust_level = another_admin.reload.manual_locked_trust_level
+
+          aggregate_failures do
+            expect(trust_level_status).to eq(422)
+            expect(trust_level_errors).to be_present
+            expect(trust_level).to eq(TrustLevel[4])
+            expect(trust_level_lock_status).to eq(403)
+            expect(trust_level_lock_errors).to be_present
+            expect(manual_locked_trust_level).to eq(nil)
+          end
+        end
       end
 
       context "when moderators_change_trust_levels setting is disabled" do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1270,6 +1270,24 @@ RSpec.describe Admin::UsersController do
         before { SiteSetting.moderators_change_trust_levels = true }
 
         include_examples "trust level updates possible"
+      end
+
+      context "when moderators_change_trust_levels setting is disabled" do
+        before { SiteSetting.moderators_change_trust_levels = false }
+
+        include_examples "trust level updates possible"
+      end
+    end
+
+    context "when logged in as a moderator" do
+      let(:acting_user) { moderator }
+
+      before { sign_in(moderator) }
+
+      context "when moderators_change_trust_levels setting is enabled" do
+        before { SiteSetting.moderators_change_trust_levels = true }
+
+        include_examples "trust level updates possible"
 
         it "prevents changing or locking a staff user's trust level" do
           another_admin.update!(trust_level: TrustLevel[4], manual_locked_trust_level: nil)
@@ -1297,24 +1315,6 @@ RSpec.describe Admin::UsersController do
             expect(manual_locked_trust_level).to eq(nil)
           end
         end
-      end
-
-      context "when moderators_change_trust_levels setting is disabled" do
-        before { SiteSetting.moderators_change_trust_levels = false }
-
-        include_examples "trust level updates possible"
-      end
-    end
-
-    context "when logged in as a moderator" do
-      let(:acting_user) { moderator }
-
-      before { sign_in(moderator) }
-
-      context "when moderators_change_trust_levels setting is enabled" do
-        before { SiteSetting.moderators_change_trust_levels = true }
-
-        include_examples "trust level updates possible"
       end
 
       context "when moderators_change_trust_levels setting is disabled" do


### PR DESCRIPTION
## Summary

Prevent moderators from modifying the trust levels of admin and staff accounts by enforcing a non-staff target check in the authorization logic. This ensures that the permission for moderators to manage trust levels is correctly restricted to non-staff users, protecting staff accounts from unauthorized demotion or modification.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1168

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>