### PR TITLE
FIX: Staged-user email disclosure to moderators via UserCardSerializer

### DIFF
--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -95,7 +95,8 @@ class UserCardSerializer < BasicUserSerializer
   end
 
   def include_email?
-    (object.id && object.id == scope.user.try(:id)) || (scope.is_staff? && object.staged?)
+    (object.id && object.id == scope.user.try(:id)) ||
+      (object.staged? && scope.can_check_emails?(object))
   end
 
   alias_method :include_secondary_emails?, :include_email?

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -5463,6 +5463,54 @@ RSpec.describe UsersController do
     end
   end
 
+  describe "staged user email visibility" do
+    fab!(:staged_user) { Fabricate(:staged, email: "staged-primary@example.com") }
+    fab!(:secondary_email) do
+      Fabricate(:secondary_email, user: staged_user, email: "staged-secondary@example.com")
+    end
+    fab!(:email_change_request) do
+      Fabricate(
+        :email_change_request,
+        user: staged_user,
+        new_email: "staged-unconfirmed@example.com",
+      )
+    end
+
+    before do
+      SiteSetting.moderators_view_emails = false
+      sign_in(moderator)
+    end
+
+    it "respects email visibility for staged users" do
+      paths = ["/u/#{staged_user.username}.json", "/u/#{staged_user.username}/card.json"]
+
+      paths.each do |path|
+        get path
+
+        expect(response).to have_http_status(:ok)
+        user_json = response.parsed_body["user"]
+        expect(user_json["email"]).to eq(nil)
+        expect(user_json["secondary_emails"]).to eq(nil)
+        expect(user_json["unconfirmed_emails"]).to eq(nil)
+        expect(response.body).not_to include(staged_user.email)
+        expect(response.body).not_to include(secondary_email.email)
+        expect(response.body).not_to include(email_change_request.new_email)
+      end
+
+      SiteSetting.moderators_view_emails = true
+
+      paths.each do |path|
+        get path
+
+        expect(response).to have_http_status(:ok)
+        user_json = response.parsed_body["user"]
+        expect(user_json["email"]).to eq(staged_user.email)
+        expect(user_json["secondary_emails"]).to contain_exactly(secondary_email.email)
+        expect(user_json["unconfirmed_emails"]).to contain_exactly(email_change_request.new_email)
+      end
+    end
+  end
+
   describe "#cards" do
     fab!(:user) { Discourse.system_user }
     fab!(:user2, :user)


### PR DESCRIPTION
## Summary

Prevent the disclosure of staged-user email addresses to moderators when the 'moderators_view_emails' site setting is disabled. The 'UserCardSerializer' now uses a permission-aware check for staged users rather than a broad staff check, ensuring privacy settings are respected across user and card JSON endpoints.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1319

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>