### PR TITLE
FEATURE: Support markdown in tag descriptions

### DIFF
--- a/app/jobs/scheduled/periodical_updates.rb
+++ b/app/jobs/scheduled/periodical_updates.rb
@@ -49,6 +49,19 @@ module Jobs
         )
       end
 
+      # rebake out of date tag descriptions
+      [Tag, TagLocalization].each do |klass|
+        klass
+          .rebake_old(250)
+          .each do |hash|
+            record = hash[:record]
+            Discourse.handle_job_exception(
+              hash[:ex],
+              error_context(args, "Rebaking #{klass.name} id #{record.id}", record_id: record.id),
+            )
+          end
+      end
+
       offset = SiteSetting.max_new_topics.to_i
       last_new_topic = Topic.order("created_at desc").offset(offset).select(:created_at).first
       SiteSetting.min_new_topics_time = last_new_topic.created_at.to_i if last_new_topic

--- a/app/models/concerns/has_cooked_tag_description.rb
+++ b/app/models/concerns/has_cooked_tag_description.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module HasCookedTagDescription
+  extend ActiveSupport::Concern
+
+  BAKED_VERSION = 1
+  COOK_OPTIONS = { features: { onebox: false } }.freeze
+
+  def cook_description
+    return unless description_changed?
+
+    self.description_cooked = cook_description_html
+    self.description_cooked_version = BAKED_VERSION
+  end
+
+  def rebake!
+    update_columns(
+      description_cooked: cook_description_html,
+      description_cooked_version: BAKED_VERSION,
+    )
+  end
+
+  private
+
+  def cook_description_html
+    description.present? ? PrettyText.cook(description, COOK_OPTIONS) : nil
+  end
+
+  class_methods do
+    def rebake_old(limit)
+      problems = []
+
+      where(
+        "description_cooked_version IS NULL OR description_cooked_version < ?",
+        HasCookedTagDescription::BAKED_VERSION,
+      )
+        .limit(limit)
+        .each do |record|
+          record.rebake!
+        rescue => e
+          problems << { record: record, ex: e }
+        end
+
+      problems
+    end
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,7 @@
 class Tag < ActiveRecord::Base
   include Searchable
   include HasDestroyedWebHook
-  include HasSanitizableFields
+  include HasCookedTagDescription
   include Localizable
 
   RESERVED_TAGS = [
@@ -60,7 +60,7 @@ class Tag < ActiveRecord::Base
   has_many :embeddable_host_tags
   has_many :embeddable_hosts, through: :embeddable_host_tags
 
-  before_save :sanitize_description
+  before_save :cook_description
 
   after_save :index_search
   after_save :update_synonym_associations
@@ -337,10 +337,6 @@ class Tag < ActiveRecord::Base
     scope.exists?
   end
 
-  def sanitize_description
-    self.description = sanitize_field(description) if description_changed?
-  end
-
   def name_validator
     errors.add(:name, :invalid) if name.present? && RESERVED_TAGS.include?(name.strip.downcase)
   end
@@ -350,22 +346,25 @@ end
 #
 # Table name: tags
 #
-#  id                 :integer          not null, primary key
-#  description        :string(1000)
-#  locale             :string(20)
-#  name               :string           not null
-#  pm_topic_count     :integer          default(0), not null
-#  public_topic_count :integer          default(0), not null
-#  slug               :string           default(""), not null
-#  staff_topic_count  :integer          default(0), not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  target_tag_id      :integer
+#  id                         :integer          not null, primary key
+#  description                :string(1000)
+#  description_cooked         :string(2000)
+#  description_cooked_version :integer
+#  locale                     :string(20)
+#  name                       :string           not null
+#  pm_topic_count             :integer          default(0), not null
+#  public_topic_count         :integer          default(0), not null
+#  slug                       :string           default(""), not null
+#  staff_topic_count          :integer          default(0), not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  target_tag_id              :integer
 #
 # Indexes
 #
-#  index_tags_on_lower_name     (lower((name)::text)) UNIQUE
-#  index_tags_on_name           (name) UNIQUE
-#  index_tags_on_slug           (slug) WHERE ((slug)::text <> ''::text)
-#  index_tags_on_target_tag_id  (target_tag_id) WHERE (target_tag_id IS NOT NULL)
+#  index_tags_on_description_cooked_version  (description_cooked_version)
+#  index_tags_on_lower_name                  (lower((name)::text)) UNIQUE
+#  index_tags_on_name                        (name) UNIQUE
+#  index_tags_on_slug                        (slug) WHERE ((slug)::text <> ''::text)
+#  index_tags_on_target_tag_id               (target_tag_id) WHERE (target_tag_id IS NOT NULL)
 #

--- a/app/models/tag_localization.rb
+++ b/app/models/tag_localization.rb
@@ -2,12 +2,12 @@
 
 class TagLocalization < ActiveRecord::Base
   include LocaleMatchable
-  include HasSanitizableFields
+  include HasCookedTagDescription
 
   belongs_to :tag
 
   before_validation :clean_name
-  before_save :sanitize_description
+  before_save :cook_description
 
   validates :locale, presence: true, length: { maximum: 20 }
   validates :name, presence: true
@@ -19,26 +19,25 @@ class TagLocalization < ActiveRecord::Base
   def clean_name
     self.name = DiscourseTagging.clean_tag(name) if name.present?
   end
-
-  def sanitize_description
-    self.description = sanitize_field(description) if description_changed?
-  end
 end
 
 # == Schema Information
 #
 # Table name: tag_localizations
 #
-#  id          :bigint           not null, primary key
-#  description :string(1000)
-#  locale      :string(20)       not null
-#  name        :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  tag_id      :bigint           not null
+#  id                         :bigint           not null, primary key
+#  description                :string(1000)
+#  description_cooked         :string(2000)
+#  description_cooked_version :integer
+#  locale                     :string(20)       not null
+#  name                       :string           not null
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  tag_id                     :bigint           not null
 #
 # Indexes
 #
-#  index_tag_localizations_on_tag_id             (tag_id)
-#  index_tag_localizations_on_tag_id_and_locale  (tag_id,locale) UNIQUE
+#  index_tag_localizations_on_description_cooked_version  (description_cooked_version)
+#  index_tag_localizations_on_tag_id                      (tag_id)
+#  index_tag_localizations_on_tag_id_and_locale           (tag_id,locale) UNIQUE
 #

--- a/app/serializers/tag_localization_serializer.rb
+++ b/app/serializers/tag_localization_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TagLocalizationSerializer < ApplicationSerializer
-  attributes :id, :tag_id, :locale, :name, :description
+  attributes :id, :tag_id, :locale, :name, :description, :description_cooked
 end

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TagSerializer < ApplicationSerializer
-  attributes :id, :name, :slug, :topic_count, :staff, :description
+  attributes :id, :name, :slug, :topic_count, :staff, :description, :description_cooked
 
   has_many :localizations, serializer: TagLocalizationSerializer, embed: :objects
 
@@ -21,6 +21,14 @@ class TagSerializer < ApplicationSerializer
         object.get_localization&.description
       end
     translated || object.description
+  end
+
+  def description_cooked
+    translated =
+      if ContentLocalization.show_translated_tag?(object, scope)
+        object.get_localization&.description_cooked
+      end
+    translated || object.description_cooked
   end
 
   def topic_count

--- a/app/serializers/tag_settings_serializer.rb
+++ b/app/serializers/tag_settings_serializer.rb
@@ -5,6 +5,7 @@ class TagSettingsSerializer < ApplicationSerializer
              :name,
              :slug,
              :description,
+             :description_cooked,
              :synonyms,
              :tag_group_names,
              :tag_groups,
@@ -25,6 +26,10 @@ class TagSettingsSerializer < ApplicationSerializer
 
   def description
     object.description
+  end
+
+  def description_cooked
+    object.description_cooked
   end
 
   def synonyms

--- a/db/migrate/20260723183001_add_description_cooked_to_tags.rb
+++ b/db/migrate/20260723183001_add_description_cooked_to_tags.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddDescriptionCookedToTags < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tags, :description_cooked, :string, limit: 2000
+    add_column :tags, :description_cooked_version, :integer
+    add_column :tag_localizations, :description_cooked, :string, limit: 2000
+    add_column :tag_localizations, :description_cooked_version, :integer
+    add_index :tags, :description_cooked_version
+    add_index :tag_localizations, :description_cooked_version
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9481,7 +9481,9 @@ CREATE TABLE public.tag_localizations (
     name character varying NOT NULL,
     description character varying(1000),
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    description_cooked character varying(2000),
+    description_cooked_version integer
 );
 
 
@@ -9586,7 +9588,9 @@ CREATE TABLE public.tags (
     public_topic_count integer DEFAULT 0 NOT NULL,
     staff_topic_count integer DEFAULT 0 NOT NULL,
     locale character varying(20),
-    slug character varying DEFAULT ''::character varying NOT NULL
+    slug character varying DEFAULT ''::character varying NOT NULL,
+    description_cooked character varying(2000),
+    description_cooked_version integer
 );
 
 
@@ -21371,6 +21375,13 @@ CREATE UNIQUE INDEX index_tag_groups_on_lower_name ON public.tag_groups USING bt
 
 
 --
+-- Name: index_tag_localizations_on_description_cooked_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_tag_localizations_on_description_cooked_version ON public.tag_localizations USING btree (description_cooked_version);
+
+
+--
 -- Name: index_tag_localizations_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -21403,6 +21414,13 @@ CREATE UNIQUE INDEX index_tag_users_on_user_id_and_tag_id ON public.tag_users US
 --
 
 CREATE INDEX index_tag_users_on_user_id_and_tag_id_and_notification_level ON public.tag_users USING btree (user_id, tag_id, notification_level);
+
+
+--
+-- Name: index_tags_on_description_cooked_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_tags_on_description_cooked_version ON public.tags USING btree (description_cooked_version);
 
 
 --
@@ -23058,6 +23076,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260728045008'),
 ('20260727085824'),
 ('20260727035337'),
+('20260723183001'),
 ('20260723100008'),
 ('20260723094850'),
 ('20260723013754'),

--- a/frontend/discourse/app/components/tag-info.gjs
+++ b/frontend/discourse/app/components/tag-info.gjs
@@ -48,9 +48,9 @@ const TagInfo = <template>
         <div class="tag-name-wrapper">
           {{dDiscourseTag @tagInfo}}
         </div>
-        {{#if @tagInfo.description}}
+        {{#if @tagInfo.description_cooked}}
           <div class="tag-description-wrapper">
-            <span>{{trustHTML @tagInfo.description}}</span>
+            <div class="cooked">{{trustHTML @tagInfo.description_cooked}}</div>
           </div>
         {{/if}}
       </div>

--- a/frontend/discourse/app/components/tag-settings.gjs
+++ b/frontend/discourse/app/components/tag-settings.gjs
@@ -346,13 +346,13 @@ export default class TagSettings extends Component {
 
           <form.Field
             @name="description"
-            @type="textarea"
+            @type="composer"
             @title={{i18n "tagging.description"}}
             @format="large"
             @validation="length:0,1000"
             as |field|
           >
-            <field.Control @height={{80}} />
+            <field.Control @height={{200}} />
           </form.Field>
 
           <form.Field

--- a/frontend/discourse/app/components/tag-settings/localizations.gjs
+++ b/frontend/discourse/app/components/tag-settings/localizations.gjs
@@ -80,12 +80,12 @@ export default class TagSettingsLocalizations extends Component {
           <row.Col @size={{6}}>
             <collection.Field
               @name="description"
-              @type="textarea"
+              @type="composer"
               @title={{i18n "tagging.localization.description"}}
               @validation="length:0,1000"
               as |field|
             >
-              <field.Control @height={{80}} />
+              <field.Control @height={{120}} />
             </collection.Field>
           </row.Col>
 

--- a/spec/lib/tag_localization_creator_spec.rb
+++ b/spec/lib/tag_localization_creator_spec.rb
@@ -26,16 +26,17 @@ describe TagLocalizationCreator do
     )
   end
 
-  it "sanitizes unsafe description HTML", :aggregate_failures do
+  it "cooks the description into a safe description_cooked", :aggregate_failures do
     unsafe_description =
       '<script>alert("xss")</script><a href="https://example.com" onclick="alert(1)">link</a>'
-    sanitized_description = Fabricate(:tag, description: unsafe_description).description
+    cooked_description = Fabricate(:tag, description: unsafe_description).description_cooked
 
     localization =
       described_class.create(tag:, locale:, name:, description: unsafe_description, user:)
 
-    expect(localization.description).to eq(sanitized_description)
-    expect(localization.description).not_to match(/<script|onclick/i)
+    expect(localization.description).to eq(unsafe_description)
+    expect(localization.description_cooked).to eq(cooked_description)
+    expect(localization.description_cooked).not_to match(/<script|onclick/i)
   end
 
   it "creates localization without description" do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -638,13 +638,56 @@ RSpec.describe Tag do
   end
 
   describe "description" do
-    it "uses the HTMLSanitizer to remove unsafe tags and attributes" do
+    it "preserves the raw markdown source and cooks it into a safe description_cooked" do
+      tag.description = "Topics about **markdown** and a < b"
+      tag.save!
+
+      expect(tag.description).to eq("Topics about **markdown** and a < b")
+      expect(tag.description_cooked).to include("<strong>markdown</strong>")
+      expect(tag.description_cooked).to include("a &lt; b")
+    end
+
+    it "sanitizes unsafe markup when cooking, without mutating the raw source" do
       tag.description =
         "<div>hi</div><script>a=0;</script> <a onclick='const a=0;' href=\"https://www.discourse.org\">discourse</a>"
       tag.save!
-      expect(tag.description.strip).to eq(
-        "<div>hi</div>a=0; <a href=\"https://www.discourse.org\">discourse</a>",
-      )
+
+      expect(tag.description).to include("<script>")
+      expect(tag.description_cooked).not_to include("<script>")
+      expect(tag.description_cooked).not_to include("onclick")
+      expect(tag.description_cooked).to include('href="https://www.discourse.org"')
+    end
+
+    it "clears description_cooked when the description is blank" do
+      tag.update!(description: "something")
+      expect(tag.description_cooked).to be_present
+
+      tag.update!(description: "")
+      expect(tag.description_cooked).to be_nil
+    end
+
+    it "stamps the baked version on save" do
+      tag.update!(description: "**hi**")
+      expect(tag.description_cooked_version).to eq(HasCookedTagDescription::BAKED_VERSION)
+    end
+
+    describe ".rebake_old" do
+      it "reconciles rows with missing or stale cooked HTML and leaves current ones alone" do
+        tag.update!(description: "**current**")
+        stale = Fabricate(:tag, description: "**stale**")
+        stale.update_columns(description_cooked: nil, description_cooked_version: nil)
+
+        expect(Tag.rebake_old(100)).to eq([])
+
+        expect(stale.reload.description_cooked).to include("<strong>stale</strong>")
+        expect(stale.description_cooked_version).to eq(HasCookedTagDescription::BAKED_VERSION)
+        expect(
+          Tag.where(
+            "description_cooked_version IS NULL OR description_cooked_version < ?",
+            HasCookedTagDescription::BAKED_VERSION,
+          ),
+        ).to be_empty
+      end
     end
   end
 

--- a/spec/system/page_objects/pages/tag_settings.rb
+++ b/spec/system/page_objects/pages/tag_settings.rb
@@ -60,7 +60,7 @@ module PageObjects
       end
 
       def description_textarea
-        find("textarea[name='description']")
+        find(".form-kit__field[data-name='description'] textarea.d-editor-input")
       end
 
       def fill_name(value)

--- a/spec/system/tag_settings_spec.rb
+++ b/spec/system/tag_settings_spec.rb
@@ -17,6 +17,9 @@ describe "Tag Settings" do
   before do
     SiteSetting.tagging_enabled = true
     SiteSetting.edit_tags_allowed_groups = "1|2|14"
+    [admin, trust_level_4, user].each do |u|
+      u.user_option.update!(composition_mode: UserOption.composition_mode_types[:markdown])
+    end
   end
 
   context "when using the tag settings page" do


### PR DESCRIPTION
We previously supported a subset of HTML in tag descriptions, but the escaping/unescaping of characters wasn't perfectly consistent, so results could be surprising.

This commit runs tag descriptions through our standard markdown pipeline, which supports the same subset of HTML, plus real markdown. It also adds the standard DEditor in tag editing forms. This has parity with group/user bios, and with category descriptions.

Now the character support is clearly defined, and perfectly matches other parts of Discourse.

---

<img width="527" height="545" alt="SCR-20260723-rdpm" src="https://github.com/user-attachments/assets/812a9a3a-ece7-4594-8d9b-65e7e30649c8" />

---

<img width="564" height="213" alt="SCR-20260723-rduy" src="https://github.com/user-attachments/assets/4ea4a6ff-81d3-4489-95b3-bf5f9b1e5fa0" />
---