### PR TITLE
UX: Reflow the composer in step with the keyboard

### DIFF
--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -125,10 +125,13 @@ export default class ComposerContainer extends Component {
       ".d-editor-textarea-wrapper.in-focus, .d-editor-textarea-wrapper:focus-within"
     );
 
-    // dragging a selection handle emits the same touch moves as a swipe
+    // dragging a selection handle emits the same touch moves as a swipe;
+    // selections elsewhere on the page have no handles near the composer
     const active = document.activeElement;
+    const selection = window.getSelection();
     const hasTextSelection =
-      !window.getSelection().isCollapsed ||
+      (!selection.isCollapsed &&
+        state.element.contains(selection.anchorNode)) ||
       (active?.selectionStart ?? 0) !== (active?.selectionEnd ?? 0);
 
     if (
@@ -195,32 +198,23 @@ export default class ComposerContainer extends Component {
     this.appEvents.trigger("keyboard:will-hide");
 
     const delta = draggedTop - editor.getBoundingClientRect().top;
-    const reduceMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
-    ).matches;
 
-    if (!delta || reduceMotion) {
+    if (
+      !delta ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
       editor.style.transition = "";
       return;
     }
 
     editor.style.transform = `translateY(${delta}px)`;
+    // flush so the transition below starts from the dragged offset
     editor.getBoundingClientRect();
     editor.style.transition =
       "transform 250ms var(--composer-slide-easing, ease)";
     editor.style.transform = "";
 
-    let settled = false;
-    const cleanup = (event) => {
-      if (settled || (event && event.target !== editor)) {
-        return;
-      }
-      settled = true;
-      editor.removeEventListener("transitionend", cleanup);
-      editor.style.transition = "";
-    };
-    editor.addEventListener("transitionend", cleanup);
-    discourseLater(cleanup, 300);
+    discourseLater(() => (editor.style.transition = ""), 300);
   }
 
   @action

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -181,9 +181,8 @@ export default class ComposerContainer extends Component {
     editor.style.marginTop = "";
   }
 
-  // the reflow on blur shifts the layout under the released editor, so the
-  // margin transition would settle it toward its pre-reflow spot; glide it
-  // into the new layout from where the drag left it instead
+  // glide the released editor into the post-reflow layout; the stylesheet
+  // margin transition would target its pre-reflow spot
   #settleDismissedEditor(editor) {
     const draggedTop = editor.getBoundingClientRect().top;
 

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -24,6 +24,7 @@ import htmlClass from "discourse/helpers/html-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
+import discourseLater from "discourse/lib/later";
 import {
   dampenedOverdrag,
   shouldDeferSwipeToContent,
@@ -124,9 +125,16 @@ export default class ComposerContainer extends Component {
       ".d-editor-textarea-wrapper.in-focus, .d-editor-textarea-wrapper:focus-within"
     );
 
+    // dragging a selection handle emits the same touch moves as a swipe
+    const active = document.activeElement;
+    const hasTextSelection =
+      !window.getSelection().isCollapsed ||
+      (active?.selectionStart ?? 0) !== (active?.selectionEnd ?? 0);
+
     if (
       !editor ||
       !state.goingDown() ||
+      hasTextSelection ||
       shouldDeferSwipeToContent(state, state.element)
     ) {
       event.preventDefault();
@@ -159,17 +167,60 @@ export default class ComposerContainer extends Component {
       return;
     }
     this.#swipeEditor = null;
-    editor.style.transition = "";
 
     const dismissed =
       state.deltaY > SWIPE_DISTANCE_THRESHOLD ||
       state.velocityY > SWIPE_VELOCITY_THRESHOLD;
 
     if (dismissed && editor.contains(document.activeElement)) {
-      document.activeElement.blur();
+      this.#settleDismissedEditor(editor);
+      return;
     }
 
+    editor.style.transition = "";
     editor.style.marginTop = "";
+  }
+
+  // the reflow on blur shifts the layout under the released editor, so the
+  // margin transition would settle it toward its pre-reflow spot; glide it
+  // into the new layout from where the drag left it instead
+  #settleDismissedEditor(editor) {
+    const draggedTop = editor.getBoundingClientRect().top;
+
+    editor.style.marginTop = "";
+    document.activeElement.blur();
+
+    // in-focus is template state that only leaves on the next render;
+    // pre-apply it so the measurement below sees the final layout
+    editor.classList.remove("in-focus");
+    this.appEvents.trigger("keyboard:will-hide");
+
+    const delta = draggedTop - editor.getBoundingClientRect().top;
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+
+    if (!delta || reduceMotion) {
+      editor.style.transition = "";
+      return;
+    }
+
+    editor.style.transform = `translateY(${delta}px)`;
+    editor.getBoundingClientRect();
+    editor.style.transition = "transform 250ms var(--composer-slide-easing)";
+    editor.style.transform = "";
+
+    let settled = false;
+    const cleanup = (event) => {
+      if (settled || (event && event.target !== editor)) {
+        return;
+      }
+      settled = true;
+      editor.removeEventListener("transitionend", cleanup);
+      editor.style.transition = "";
+    };
+    editor.addEventListener("transitionend", cleanup);
+    discourseLater(cleanup, 300);
   }
 
   @action

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -207,7 +207,8 @@ export default class ComposerContainer extends Component {
 
     editor.style.transform = `translateY(${delta}px)`;
     editor.getBoundingClientRect();
-    editor.style.transition = "transform 250ms var(--composer-slide-easing)";
+    editor.style.transition =
+      "transform 250ms var(--composer-slide-easing, ease)";
     editor.style.transform = "";
 
     let settled = false;

--- a/frontend/discourse/app/components/d-virtual-height.gjs
+++ b/frontend/discourse/app/components/d-virtual-height.gjs
@@ -3,14 +3,44 @@ import { cancel, scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
+import discourseLater from "discourse/lib/later";
 import isZoomed from "discourse/lib/zoom-check";
 
 const KEYBOARD_DETECT_THRESHOLD = 150;
+
+// long enough for an async refocus (e.g. a dropdown autofocusing its search
+// input) to land; well under the OS hide animation
+const FOCUS_SETTLE_MS = 100;
+
+// ties a focus loss to the touch that caused it
+const RECENT_TOUCH_MS = 500;
+
+// how long the dismissing tap's synthesized click can lag the reflow
+const GHOST_TAP_MS = 400;
+
+// a release this far from the start is a drag, which synthesizes no click
+const TAP_SLOP_PX = 8;
+
+// optimistic keyboard state is provisional this long, until the viewport
+// reports; covers the OS animation, its late report, and the resize debounce
+const VIEWPORT_CONFIRM_MS = 800;
+
+// a tap on these may hand focus back to an editable, so it can't be
+// trusted as a keyboard dismiss
+const FOCUS_CAPABLE_SELECTOR =
+  "a, button, input, textarea, select, summary, label, [contenteditable], [tabindex], [role='button']";
+
+// select is excluded: focusing one opens a picker, not a keyboard
+function isEditable(el) {
+  return el && (el.matches("input, textarea") || el.isContentEditable);
+}
 
 export default class DVirtualHeight extends Component {
   @service site;
   @service capabilities;
   @service appEvents;
+
+  #enabled = false;
 
   constructor() {
     super(...arguments);
@@ -23,23 +53,262 @@ export default class DVirtualHeight extends Component {
       return;
     }
 
+    this.#enabled = true;
+
     scheduleOnce("afterRender", this, this.debouncedOnViewportResize);
 
     window.visualViewport.addEventListener(
       "resize",
       this.debouncedOnViewportResize
     );
+
+    this.appEvents.on("keyboard:will-hide", this, this.onKeyboardWillHide);
+    document.addEventListener("focusout", this.onFocusOut);
+    document.addEventListener("focusin", this.onFocusIn);
+    document.addEventListener("touchstart", this.onTouchStart, {
+      passive: true,
+      capture: true,
+    });
+    document.addEventListener("touchend", this.onTouchEnd, {
+      passive: true,
+      capture: true,
+    });
+    document.addEventListener("touchcancel", this.onTouchCancel, {
+      passive: true,
+      capture: true,
+    });
+    // browser-chrome taps (e.g. the address bar) dismiss with no page event
+    window.addEventListener("blur", this.onWindowBlur);
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
 
+    if (!this.#enabled) {
+      return;
+    }
+
     cancel(this.debouncedHandler);
+    cancel(this.focusSettleHandler);
+    cancel(this.showConfirmHandler);
+    this.clearGhostTapSuppression?.();
 
     window.visualViewport.removeEventListener(
       "resize",
       this.debouncedOnViewportResize
     );
+
+    this.appEvents.off("keyboard:will-hide", this, this.onKeyboardWillHide);
+    document.removeEventListener("focusout", this.onFocusOut);
+    document.removeEventListener("focusin", this.onFocusIn);
+    document.removeEventListener("touchstart", this.onTouchStart, {
+      capture: true,
+    });
+    document.removeEventListener("touchend", this.onTouchEnd, {
+      capture: true,
+    });
+    document.removeEventListener("touchcancel", this.onTouchCancel, {
+      capture: true,
+    });
+    window.removeEventListener("blur", this.onWindowBlur);
+  }
+
+  @bind
+  onTouchStart(event) {
+    const touch = event.touches?.[0];
+    this.lastTouch = {
+      at: Date.now(),
+      x: touch?.clientX ?? 0,
+      y: touch?.clientY ?? 0,
+      moved: false,
+      inert:
+        event.target instanceof Element &&
+        !event.target.closest(FOCUS_CAPABLE_SELECTOR),
+    };
+  }
+
+  @bind
+  onTouchEnd(event) {
+    const touch = event.changedTouches?.[0];
+    if (!this.lastTouch || !touch) {
+      return;
+    }
+
+    this.lastTouch.at = Date.now();
+    this.lastTouch.moved ||=
+      Math.hypot(
+        touch.clientX - this.lastTouch.x,
+        touch.clientY - this.lastTouch.y
+      ) > TAP_SLOP_PX;
+  }
+
+  @bind
+  onTouchCancel() {
+    // a cancelled touch is not a tap and synthesizes no click
+    if (this.lastTouch) {
+      this.lastTouch.moved = true;
+    }
+  }
+
+  @bind
+  onWindowBlur() {
+    cancel(this.focusSettleHandler);
+    this.onKeyboardWillHide();
+  }
+
+  // once focus settles outside any editable, the keyboard can't stay up
+  @bind
+  onFocusOut() {
+    if (!document.documentElement.classList.contains("keyboard-visible")) {
+      return;
+    }
+
+    cancel(this.focusSettleHandler);
+
+    if (this.#focusLostToInertTouch()) {
+      this.onKeyboardWillHide();
+
+      // a tap's synthesized click would land on controls the reflow just
+      // moved under the finger; drags synthesize none
+      if (!this.lastTouch.moved) {
+        this.#suppressGhostTap();
+      }
+      return;
+    }
+
+    this.focusSettleHandler = discourseDebounce(
+      this,
+      this.onFocusSettled,
+      FOCUS_SETTLE_MS
+    );
+  }
+
+  #focusLostToInertTouch() {
+    const touch = this.lastTouch;
+    return touch?.inert && Date.now() - touch.at < RECENT_TOUCH_MS;
+  }
+
+  #suppressGhostTap() {
+    this.clearGhostTapSuppression?.();
+
+    const swallow = (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      this.clearGhostTapSuppression();
+    };
+
+    const timer = discourseLater(
+      () => this.clearGhostTapSuppression(),
+      GHOST_TAP_MS
+    );
+
+    this.clearGhostTapSuppression = () => {
+      cancel(timer);
+      document.removeEventListener("click", swallow, { capture: true });
+      this.clearGhostTapSuppression = null;
+    };
+
+    document.addEventListener("click", swallow, { capture: true });
+  }
+
+  onFocusSettled() {
+    if (!isEditable(document.activeElement)) {
+      this.onKeyboardWillHide();
+    }
+  }
+
+  // reflow immediately instead of waiting for the visualViewport resize,
+  // which only fires after the OS hide animation
+  onKeyboardWillHide() {
+    const docEl = document.documentElement;
+
+    if (!docEl.classList.contains("keyboard-visible") || isZoomed()) {
+      return;
+    }
+
+    cancel(this.debouncedHandler);
+    cancel(this.showConfirmHandler);
+
+    this.lastKeyboardHeight = this.previousHeight;
+    this.pendingHide = {
+      at: Date.now(),
+      composerVh: docEl.style.getPropertyValue("--composer-vh"),
+      height: this.previousHeight,
+      confirmed: this.keyboardConfirmed,
+    };
+
+    this.previousHeight = Math.round(window.innerHeight);
+    docEl.style.setProperty("--composer-vh", `${this.previousHeight / 100}px`);
+
+    this.appEvents.trigger("keyboard-visibility-change", false);
+    docEl.classList.remove("keyboard-visible");
+  }
+
+  @bind
+  onFocusIn(event) {
+    const docEl = document.documentElement;
+
+    if (
+      !isEditable(event.target) ||
+      docEl.classList.contains("keyboard-visible") ||
+      isZoomed()
+    ) {
+      return;
+    }
+
+    cancel(this.focusSettleHandler);
+
+    // a refocus mid-hide cancels the OS animation, and the unchanged
+    // viewport never reports back — restore the interrupted state
+    const pending = this.pendingHide;
+    if (pending && Date.now() - pending.at <= VIEWPORT_CONFIRM_MS) {
+      this.pendingHide = null;
+      this.keyboardConfirmed = pending.confirmed;
+      this.#showKeyboardState(pending.height, pending.composerVh);
+
+      // a snapshot of a keyboard the viewport never confirmed must stay
+      // provisional, or a predict -> dismiss -> refocus loop keeps a
+      // phantom keyboard state alive indefinitely
+      if (!pending.confirmed) {
+        this.#armShowConfirm();
+      }
+      return;
+    }
+
+    // the keyboard only reports after its show animation; apply the last
+    // known keyboard height now and revert if the viewport never confirms
+    if (this.lastKeyboardHeight) {
+      this.#showKeyboardState(this.lastKeyboardHeight);
+      this.#armShowConfirm();
+    }
+  }
+
+  #showKeyboardState(height, composerVh = `${height / 100}px`) {
+    this.previousHeight = height;
+    document.documentElement.style.setProperty("--composer-vh", composerVh);
+
+    this.appEvents.trigger("keyboard-visibility-change", true);
+    document.documentElement.classList.add("keyboard-visible");
+  }
+
+  #armShowConfirm() {
+    this.keyboardConfirmed = false;
+
+    cancel(this.showConfirmHandler);
+    this.showConfirmHandler = discourseLater(
+      this,
+      this.revertUnconfirmedShow,
+      VIEWPORT_CONFIRM_MS
+    );
+  }
+
+  revertUnconfirmedShow() {
+    this.onKeyboardWillHide();
+
+    // no keyboard came (e.g. a hardware keyboard); stop predicting until a
+    // real one is observed again
+    this.lastKeyboardHeight = null;
+    this.pendingHide = null;
   }
 
   setVH() {
@@ -68,6 +337,10 @@ export default class DVirtualHeight extends Component {
 
   @bind
   onViewportResize() {
+    // the viewport speaking is the source of truth again
+    this.pendingHide = null;
+    cancel(this.showConfirmHandler);
+
     const setVHresult = this.setVH();
 
     if (setVHresult === false) {
@@ -82,6 +355,8 @@ export default class DVirtualHeight extends Component {
 
     if (viewportWindowDiff > KEYBOARD_DETECT_THRESHOLD) {
       keyboardVisible = true;
+      this.lastKeyboardHeight = this.previousHeight;
+      this.keyboardConfirmed = true;
     }
 
     this.appEvents.trigger("keyboard-visibility-change", keyboardVisible);

--- a/frontend/discourse/app/components/d-virtual-height.gjs
+++ b/frontend/discourse/app/components/d-virtual-height.gjs
@@ -8,8 +8,7 @@ import isZoomed from "discourse/lib/zoom-check";
 
 const KEYBOARD_DETECT_THRESHOLD = 150;
 
-// long enough for an async refocus (e.g. a dropdown autofocusing its search
-// input) to land; well under the OS hide animation
+// long enough for an async refocus to land; well under the OS hide animation
 const FOCUS_SETTLE_MS = 100;
 
 // ties a focus loss to the touch that caused it
@@ -21,17 +20,14 @@ const GHOST_TAP_MS = 400;
 // a release this far from the start is a drag, which synthesizes no click
 const TAP_SLOP_PX = 8;
 
-// optimistic keyboard state is provisional this long, until the viewport
-// reports; covers the OS animation, its late report, and the resize debounce
+// covers the OS animation, its late report, and the resize debounce
 const VIEWPORT_CONFIRM_MS = 800;
 
-// a tap on these may hand focus back to an editable, so it can't be
-// trusted as a keyboard dismiss
+// a tap on these may hand focus back to an editable
 const FOCUS_CAPABLE_SELECTOR =
   "a, button, input, textarea, select, summary, label, [contenteditable], [tabindex], [role='button']";
 
-// only fields that summon a soft keyboard; the rest (select, checkbox,
-// date, ...) open pickers or nothing
+// input types that summon a soft keyboard, rather than a picker or nothing
 const KEYBOARD_INPUT_TYPES = [
   "text",
   "search",
@@ -131,6 +127,9 @@ export default class DVirtualHeight extends Component {
 
   @bind
   onTouchStart(event) {
+    // a click that follows a new touch is that tap's own, not a ghost
+    this.clearGhostTapSuppression?.();
+
     const touch = event.touches?.[0];
     this.lastTouch = {
       at: Date.now(),
@@ -183,8 +182,8 @@ export default class DVirtualHeight extends Component {
     if (this.#focusLostToInertTouch()) {
       this.onKeyboardWillHide();
 
-      // a tap's synthesized click would land on controls the reflow just
-      // moved under the finger; drags synthesize none
+      // the tap's synthesized click would land on controls the reflow just
+      // moved; drags synthesize none
       if (!this.lastTouch.moved) {
         this.#suppressGhostTap();
       }
@@ -249,7 +248,6 @@ export default class DVirtualHeight extends Component {
       at: Date.now(),
       composerVh: docEl.style.getPropertyValue("--composer-vh"),
       height: this.previousHeight,
-      confirmed: this.keyboardConfirmed,
     };
 
     this.previousHeight = Math.round(window.innerHeight);
@@ -278,15 +276,8 @@ export default class DVirtualHeight extends Component {
     const pending = this.pendingHide;
     if (pending && Date.now() - pending.at <= VIEWPORT_CONFIRM_MS) {
       this.pendingHide = null;
-      this.keyboardConfirmed = pending.confirmed;
       this.#showKeyboardState(pending.height, pending.composerVh);
-
-      // a snapshot of a keyboard the viewport never confirmed must stay
-      // provisional, or a predict -> dismiss -> refocus loop keeps a
-      // phantom keyboard state alive indefinitely
-      if (!pending.confirmed) {
-        this.#armShowConfirm();
-      }
+      this.#armShowConfirm();
       return;
     }
 
@@ -307,8 +298,6 @@ export default class DVirtualHeight extends Component {
   }
 
   #armShowConfirm() {
-    this.keyboardConfirmed = false;
-
     cancel(this.showConfirmHandler);
     this.showConfirmHandler = discourseLater(
       this,
@@ -318,6 +307,15 @@ export default class DVirtualHeight extends Component {
   }
 
   revertUnconfirmedShow() {
+    // a cancelled hide leaves the viewport unchanged with nothing to
+    // report; check the geometry directly
+    if (
+      window.innerHeight - window.visualViewport.height >
+      KEYBOARD_DETECT_THRESHOLD
+    ) {
+      return;
+    }
+
     this.onKeyboardWillHide();
 
     // no keyboard came (e.g. a hardware keyboard); stop predicting until a
@@ -370,7 +368,6 @@ export default class DVirtualHeight extends Component {
     if (viewportWindowDiff > KEYBOARD_DETECT_THRESHOLD) {
       keyboardVisible = true;
       this.lastKeyboardHeight = this.previousHeight;
-      this.keyboardConfirmed = true;
     }
 
     this.appEvents.trigger("keyboard-visibility-change", keyboardVisible);

--- a/frontend/discourse/app/components/d-virtual-height.gjs
+++ b/frontend/discourse/app/components/d-virtual-height.gjs
@@ -30,9 +30,25 @@ const VIEWPORT_CONFIRM_MS = 800;
 const FOCUS_CAPABLE_SELECTOR =
   "a, button, input, textarea, select, summary, label, [contenteditable], [tabindex], [role='button']";
 
-// select is excluded: focusing one opens a picker, not a keyboard
+// only fields that summon a soft keyboard; the rest (select, checkbox,
+// date, ...) open pickers or nothing
+const KEYBOARD_INPUT_TYPES = [
+  "text",
+  "search",
+  "email",
+  "url",
+  "tel",
+  "password",
+  "number",
+];
+
 function isEditable(el) {
-  return el && (el.matches("input, textarea") || el.isContentEditable);
+  return (
+    el &&
+    (el.isContentEditable ||
+      el.matches("textarea") ||
+      (el.matches("input") && KEYBOARD_INPUT_TYPES.includes(el.type)))
+  );
 }
 
 export default class DVirtualHeight extends Component {
@@ -156,7 +172,6 @@ export default class DVirtualHeight extends Component {
     this.onKeyboardWillHide();
   }
 
-  // once focus settles outside any editable, the keyboard can't stay up
   @bind
   onFocusOut() {
     if (!document.documentElement.classList.contains("keyboard-visible")) {
@@ -337,7 +352,6 @@ export default class DVirtualHeight extends Component {
 
   @bind
   onViewportResize() {
-    // the viewport speaking is the source of truth again
     this.pendingHide = null;
     cancel(this.showConfirmHandler);
 

--- a/frontend/discourse/app/components/d-virtual-height.gjs
+++ b/frontend/discourse/app/components/d-virtual-height.gjs
@@ -3,6 +3,7 @@ import { cancel, scheduleOnce } from "@ember/runloop";
 import { service } from "@ember/service";
 import discourseDebounce from "discourse/lib/debounce";
 import { bind } from "discourse/lib/decorators";
+import { summonsSoftKeyboard } from "discourse/lib/dom-utils";
 import discourseLater from "discourse/lib/later";
 import isZoomed from "discourse/lib/zoom-check";
 
@@ -27,32 +28,12 @@ const VIEWPORT_CONFIRM_MS = 800;
 const FOCUS_CAPABLE_SELECTOR =
   "a, button, input, textarea, select, summary, label, [contenteditable], [tabindex], [role='button']";
 
-// input types that summon a soft keyboard, rather than a picker or nothing
-const KEYBOARD_INPUT_TYPES = [
-  "text",
-  "search",
-  "email",
-  "url",
-  "tel",
-  "password",
-  "number",
-];
-
-function isEditable(el) {
-  return (
-    el &&
-    (el.isContentEditable ||
-      el.matches("textarea") ||
-      (el.matches("input") && KEYBOARD_INPUT_TYPES.includes(el.type)))
-  );
-}
-
 export default class DVirtualHeight extends Component {
   @service site;
   @service capabilities;
   @service appEvents;
 
-  #enabled = false;
+  #removeListeners = [];
 
   constructor() {
     super(...arguments);
@@ -65,64 +46,57 @@ export default class DVirtualHeight extends Component {
       return;
     }
 
-    this.#enabled = true;
-
     scheduleOnce("afterRender", this, this.debouncedOnViewportResize);
 
-    window.visualViewport.addEventListener(
+    this.appEvents.on("keyboard:will-hide", this, this.onKeyboardWillHide);
+
+    this.#listen(
+      window.visualViewport,
       "resize",
       this.debouncedOnViewportResize
     );
+    this.#listen(document, "focusout", this.onFocusOut);
+    this.#listen(document, "focusin", this.onFocusIn);
 
-    this.appEvents.on("keyboard:will-hide", this, this.onKeyboardWillHide);
-    document.addEventListener("focusout", this.onFocusOut);
-    document.addEventListener("focusin", this.onFocusIn);
-    document.addEventListener("touchstart", this.onTouchStart, {
-      passive: true,
-      capture: true,
-    });
-    document.addEventListener("touchend", this.onTouchEnd, {
-      passive: true,
-      capture: true,
-    });
-    document.addEventListener("touchcancel", this.onTouchCancel, {
-      passive: true,
-      capture: true,
-    });
+    const touchOptions = { passive: true, capture: true };
+    this.#listen(document, "touchstart", this.onTouchStart, touchOptions);
+    this.#listen(document, "touchend", this.onTouchEnd, touchOptions);
+    this.#listen(document, "touchcancel", this.onTouchCancel, touchOptions);
+
     // browser-chrome taps (e.g. the address bar) dismiss with no page event
-    window.addEventListener("blur", this.onWindowBlur);
+    this.#listen(window, "blur", this.onWindowBlur);
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
-
-    if (!this.#enabled) {
-      return;
-    }
 
     cancel(this.debouncedHandler);
     cancel(this.focusSettleHandler);
     cancel(this.showConfirmHandler);
     this.clearGhostTapSuppression?.();
 
-    window.visualViewport.removeEventListener(
-      "resize",
-      this.debouncedOnViewportResize
-    );
-
     this.appEvents.off("keyboard:will-hide", this, this.onKeyboardWillHide);
-    document.removeEventListener("focusout", this.onFocusOut);
-    document.removeEventListener("focusin", this.onFocusIn);
-    document.removeEventListener("touchstart", this.onTouchStart, {
-      capture: true,
-    });
-    document.removeEventListener("touchend", this.onTouchEnd, {
-      capture: true,
-    });
-    document.removeEventListener("touchcancel", this.onTouchCancel, {
-      capture: true,
-    });
-    window.removeEventListener("blur", this.onWindowBlur);
+    this.#removeListeners.forEach((remove) => remove());
+  }
+
+  #listen(target, type, handler, options) {
+    target.addEventListener(type, handler, options);
+    this.#removeListeners.push(() =>
+      target.removeEventListener(type, handler, options)
+    );
+  }
+
+  #applyHeight(height) {
+    this.previousHeight = height;
+    document.documentElement.style.setProperty(
+      "--composer-vh",
+      `${height / 100}px`
+    );
+  }
+
+  #announceKeyboard(visible) {
+    this.appEvents.trigger("keyboard-visibility-change", visible);
+    document.documentElement.classList.toggle("keyboard-visible", visible);
   }
 
   @bind
@@ -131,14 +105,14 @@ export default class DVirtualHeight extends Component {
     this.clearGhostTapSuppression?.();
 
     const touch = event.touches?.[0];
+    const target = event.target instanceof Element ? event.target : null;
     this.lastTouch = {
       at: Date.now(),
       x: touch?.clientX ?? 0,
       y: touch?.clientY ?? 0,
+      target,
       moved: false,
-      inert:
-        event.target instanceof Element &&
-        !event.target.closest(FOCUS_CAPABLE_SELECTOR),
+      inert: !!target && !target.closest(FOCUS_CAPABLE_SELECTOR),
     };
   }
 
@@ -168,7 +142,23 @@ export default class DVirtualHeight extends Component {
   @bind
   onWindowBlur() {
     cancel(this.focusSettleHandler);
+
+    const hadKeyboard =
+      document.documentElement.classList.contains("keyboard-visible");
     this.onKeyboardWillHide();
+
+    // an in-page chrome tap (e.g. the address bar) keeps DOM focus, so no
+    // focus event would correct the stranded editor; release it so a later
+    // tap refocuses. backgrounding stays visible=hidden and is left for the
+    // OS to restore
+    if (
+      hadKeyboard &&
+      document.visibilityState === "visible" &&
+      !this.#recentTouch() &&
+      summonsSoftKeyboard(document.activeElement)
+    ) {
+      document.activeElement.blur();
+    }
   }
 
   @bind
@@ -179,13 +169,13 @@ export default class DVirtualHeight extends Component {
 
     cancel(this.focusSettleHandler);
 
-    if (this.#focusLostToInertTouch()) {
+    if (this.#recentTouch() && this.lastTouch.inert) {
       this.onKeyboardWillHide();
 
       // the tap's synthesized click would land on controls the reflow just
       // moved; drags synthesize none
       if (!this.lastTouch.moved) {
-        this.#suppressGhostTap();
+        this.#suppressGhostTap(this.lastTouch.target);
       }
       return;
     }
@@ -197,17 +187,20 @@ export default class DVirtualHeight extends Component {
     );
   }
 
-  #focusLostToInertTouch() {
-    const touch = this.lastTouch;
-    return touch?.inert && Date.now() - touch.at < RECENT_TOUCH_MS;
+  #recentTouch() {
+    return !!this.lastTouch && Date.now() - this.lastTouch.at < RECENT_TOUCH_MS;
   }
 
-  #suppressGhostTap() {
+  #suppressGhostTap(touchedTarget) {
     this.clearGhostTapSuppression?.();
 
     const swallow = (event) => {
-      event.preventDefault();
-      event.stopPropagation();
+      // let the tap through if it still lands on what was touched; only the
+      // reflow displacing a control under the finger is a ghost
+      if (event.target !== touchedTarget) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       this.clearGhostTapSuppression();
     };
 
@@ -226,7 +219,7 @@ export default class DVirtualHeight extends Component {
   }
 
   onFocusSettled() {
-    if (!isEditable(document.activeElement)) {
+    if (!summonsSoftKeyboard(document.activeElement)) {
       this.onKeyboardWillHide();
     }
   }
@@ -234,36 +227,27 @@ export default class DVirtualHeight extends Component {
   // reflow immediately instead of waiting for the visualViewport resize,
   // which only fires after the OS hide animation
   onKeyboardWillHide() {
-    const docEl = document.documentElement;
-
-    if (!docEl.classList.contains("keyboard-visible") || isZoomed()) {
+    if (
+      !document.documentElement.classList.contains("keyboard-visible") ||
+      isZoomed()
+    ) {
       return;
     }
 
     cancel(this.debouncedHandler);
     cancel(this.showConfirmHandler);
+    this.showPredicted = false;
 
     this.lastKeyboardHeight = this.previousHeight;
-    this.pendingHide = {
-      at: Date.now(),
-      composerVh: docEl.style.getPropertyValue("--composer-vh"),
-      height: this.previousHeight,
-    };
-
-    this.previousHeight = Math.round(window.innerHeight);
-    docEl.style.setProperty("--composer-vh", `${this.previousHeight / 100}px`);
-
-    this.appEvents.trigger("keyboard-visibility-change", false);
-    docEl.classList.remove("keyboard-visible");
+    this.#applyHeight(Math.round(window.innerHeight));
+    this.#announceKeyboard(false);
   }
 
   @bind
   onFocusIn(event) {
-    const docEl = document.documentElement;
-
     if (
-      !isEditable(event.target) ||
-      docEl.classList.contains("keyboard-visible") ||
+      !summonsSoftKeyboard(event.target) ||
+      document.documentElement.classList.contains("keyboard-visible") ||
       isZoomed()
     ) {
       return;
@@ -271,30 +255,38 @@ export default class DVirtualHeight extends Component {
 
     cancel(this.focusSettleHandler);
 
-    // a refocus mid-hide cancels the OS animation, and the unchanged
-    // viewport never reports back — restore the interrupted state
-    const pending = this.pendingHide;
-    if (pending && Date.now() - pending.at <= VIEWPORT_CONFIRM_MS) {
-      this.pendingHide = null;
-      this.#showKeyboardState(pending.height, pending.composerVh);
-      this.#armShowConfirm();
-      return;
-    }
-
-    // the keyboard only reports after its show animation; apply the last
-    // known keyboard height now and revert if the viewport never confirms
-    if (this.lastKeyboardHeight) {
+    // apply the last known keyboard height ahead of its show animation, but
+    // only when the tap landed on the field being focused — a tap that
+    // programmatically focuses something else (a chooser's filter input)
+    // raises no keyboard. a wrong guess is corrected by the revert timer or
+    // the next real viewport report
+    if (this.lastKeyboardHeight && this.#tappedInto(event.target)) {
       this.#showKeyboardState(this.lastKeyboardHeight);
       this.#armShowConfirm();
     }
   }
 
-  #showKeyboardState(height, composerVh = `${height / 100}px`) {
-    this.previousHeight = height;
-    document.documentElement.style.setProperty("--composer-vh", composerVh);
+  #tappedInto(focused) {
+    const touch = this.lastTouch;
+    return (
+      this.#recentTouch() &&
+      !!touch.target &&
+      (focused === touch.target || focused.contains(touch.target))
+    );
+  }
 
-    this.appEvents.trigger("keyboard-visibility-change", true);
-    document.documentElement.classList.add("keyboard-visible");
+  #showKeyboardState(height) {
+    // a hide-report resize may still sit in the debounce; it would strip
+    // the state we are applying right here
+    cancel(this.debouncedHandler);
+
+    this.#applyHeight(height);
+    this.#announceKeyboard(true);
+
+    // this optimistic height animates the composer up in step with the
+    // keyboard; the real viewport report that follows only corrects it, and
+    // that correction must not re-animate (see onViewportResize)
+    this.showPredicted = true;
   }
 
   #armShowConfirm() {
@@ -321,7 +313,6 @@ export default class DVirtualHeight extends Component {
     // no keyboard came (e.g. a hardware keyboard); stop predicting until a
     // real one is observed again
     this.lastKeyboardHeight = null;
-    this.pendingHide = null;
   }
 
   setVH() {
@@ -335,12 +326,7 @@ export default class DVirtualHeight extends Component {
       return false;
     }
 
-    this.previousHeight = height;
-
-    document.documentElement.style.setProperty(
-      "--composer-vh",
-      `${height / 100}px`
-    );
+    this.#applyHeight(height);
   }
 
   @bind
@@ -350,30 +336,39 @@ export default class DVirtualHeight extends Component {
 
   @bind
   onViewportResize() {
-    this.pendingHide = null;
+    // the real viewport report supersedes any optimistic guess
     cancel(this.showConfirmHandler);
 
-    const setVHresult = this.setVH();
+    // when this report is correcting a predicted show, the composer has
+    // already glided to the predicted height; snap the (small) correction so
+    // it doesn't run a second, visible height animation
+    const composer =
+      this.showPredicted && document.getElementById("reply-control");
+    this.showPredicted = false;
 
-    if (setVHresult === false) {
+    if (composer) {
+      composer.style.transition = "none";
+    }
+
+    const changed = this.setVH() !== false;
+
+    if (composer) {
+      composer.offsetHeight; // flush the snapped height before restoring
+      composer.style.transition = "";
+    }
+
+    if (!changed) {
       return;
     }
 
-    const docEl = document.documentElement;
+    const keyboardVisible =
+      window.innerHeight - window.visualViewport.height >
+      KEYBOARD_DETECT_THRESHOLD;
 
-    let keyboardVisible = false;
-
-    let viewportWindowDiff = window.innerHeight - window.visualViewport.height;
-
-    if (viewportWindowDiff > KEYBOARD_DETECT_THRESHOLD) {
-      keyboardVisible = true;
+    if (keyboardVisible) {
       this.lastKeyboardHeight = this.previousHeight;
     }
 
-    this.appEvents.trigger("keyboard-visibility-change", keyboardVisible);
-
-    keyboardVisible
-      ? docEl.classList.add("keyboard-visible")
-      : docEl.classList.remove("keyboard-visible");
+    this.#announceKeyboard(keyboardVisible);
   }
 }

--- a/frontend/discourse/app/components/d-virtual-height.gjs
+++ b/frontend/discourse/app/components/d-virtual-height.gjs
@@ -238,6 +238,7 @@ export default class DVirtualHeight extends Component {
     cancel(this.showConfirmHandler);
     this.showPredicted = false;
 
+    this.inferredHideAt = Date.now();
     this.lastKeyboardHeight = this.previousHeight;
     this.#applyHeight(Math.round(window.innerHeight));
     this.#announceKeyboard(false);
@@ -255,12 +256,17 @@ export default class DVirtualHeight extends Component {
 
     cancel(this.focusSettleHandler);
 
-    // apply the last known keyboard height ahead of its show animation, but
-    // only when the tap landed on the field being focused — a tap that
-    // programmatically focuses something else (a chooser's filter input)
-    // raises no keyboard. a wrong guess is corrected by the revert timer or
-    // the next real viewport report
-    if (this.lastKeyboardHeight && this.#tappedInto(event.target)) {
+    // apply the last known keyboard height ahead of its show animation, when
+    // the tap landed on the field being focused — a tap that programmatically
+    // focuses something else (a chooser's filter input) may raise no
+    // keyboard — or right after an inferred hide: a refocus mid-hide (e.g. a
+    // modal autofocusing its input) cancels the OS animation and the
+    // unchanged viewport never reports back. a wrong guess is corrected by
+    // the revert timer or the next real viewport report
+    if (
+      this.lastKeyboardHeight &&
+      (this.#tappedInto(event.target) || this.#midInferredHide())
+    ) {
       this.#showKeyboardState(this.lastKeyboardHeight);
       this.#armShowConfirm();
     }
@@ -272,6 +278,13 @@ export default class DVirtualHeight extends Component {
       this.#recentTouch() &&
       !!touch.target &&
       (focused === touch.target || focused.contains(touch.target))
+    );
+  }
+
+  #midInferredHide() {
+    return (
+      !!this.inferredHideAt &&
+      Date.now() - this.inferredHideAt < VIEWPORT_CONFIRM_MS
     );
   }
 
@@ -338,6 +351,7 @@ export default class DVirtualHeight extends Component {
   onViewportResize() {
     // the real viewport report supersedes any optimistic guess
     cancel(this.showConfirmHandler);
+    this.inferredHideAt = null;
 
     // when this report is correcting a predicted show, the composer has
     // already glided to the predicted height; snap the (small) correction so

--- a/frontend/discourse/app/lib/dom-utils.js
+++ b/frontend/discourse/app/lib/dom-utils.js
@@ -79,6 +79,43 @@ function isElementNaturallyFocusable(element) {
   return false;
 }
 
+const SOFT_KEYBOARD_INPUT_TYPES = [
+  "text",
+  "search",
+  "email",
+  "url",
+  "tel",
+  "password",
+  "number",
+];
+
+/**
+ * Whether focusing an element summons a soft keyboard on touch devices:
+ * text-like inputs, textareas, and contenteditable regions. Other
+ * focusables (select, checkbox, date, ...) open pickers or nothing, and
+ * readonly/disabled fields or `inputmode="none"` suppress the keyboard.
+ *
+ * @param {Element|null} element
+ * @returns {boolean}
+ */
+export function summonsSoftKeyboard(element) {
+  if (
+    !element ||
+    element.readOnly ||
+    element.disabled ||
+    element.closest("[inputmode='none']")
+  ) {
+    return false;
+  }
+
+  return !!(
+    element.isContentEditable ||
+    element.matches("textarea") ||
+    (element.matches("input") &&
+      SOFT_KEYBOARD_INPUT_TYPES.includes(element.type))
+  );
+}
+
 function offset(element) {
   // note that getBoundingClientRect forces a reflow.
   // When used in critical performance conditions

--- a/frontend/discourse/app/lib/wait-for-keyboard.js
+++ b/frontend/discourse/app/lib/wait-for-keyboard.js
@@ -1,3 +1,5 @@
+const KEYBOARD_DETECT_THRESHOLD = 150;
+
 export async function waitForClosedKeyboard(siteService, capabilitiesService) {
   if (!window.visualViewport) {
     return;
@@ -11,60 +13,56 @@ export async function waitForClosedKeyboard(siteService, capabilitiesService) {
     return;
   }
 
-  let timeout;
+  // the keyboard height is now applied optimistically, ahead of the viewport
+  // settling, so the class alone no longer means the keyboard has gone —
+  // wait on the geometry the callers actually measure against
   const initialWindowHeight = window.innerHeight;
-  let observer;
 
-  await Promise.race([
-    new Promise((resolve) => {
-      timeout = setTimeout(() => {
-        // eslint-disable-next-line no-console
-        console.warn("Keyboard visibility didn't change after 1s.");
-
-        resolve();
-      }, 1000);
-    }),
-    new Promise((resolve) => {
-      observer = new MutationObserver(() => {
-        if (!document.documentElement.classList.contains("keyboard-visible")) {
-          resolve();
-        }
-      });
-
-      observer.observe(document.documentElement, {
-        attributes: true,
-        attributeFilter: ["class"],
-      });
-    }),
-  ]);
-
-  clearTimeout(timeout);
-  observer?.disconnect();
-
-  if ("virtualKeyboard" in navigator) {
-    if (navigator.virtualKeyboard.boundingRect.height > 0) {
-      // eslint-disable-next-line no-console
-      console.warn("Expected virtual keyboard to be closed but it wasn't.");
-      return;
+  const keyboardClosed = () => {
+    if ("virtualKeyboard" in navigator) {
+      return navigator.virtualKeyboard.boundingRect.height === 0;
     }
-  } else if (capabilitiesService.isFirefox && capabilitiesService.isAndroid) {
-    const KEYBOARD_DETECT_THRESHOLD = 150;
-    if (
-      Math.abs(
-        initialWindowHeight -
-          Math.min(window.innerHeight, window.visualViewport.height)
-      ) > KEYBOARD_DETECT_THRESHOLD
-    ) {
-      // eslint-disable-next-line no-console
-      console.warn("Expected virtual keyboard to be closed but it wasn't.");
-      return;
+
+    if (capabilitiesService.isFirefox && capabilitiesService.isAndroid) {
+      return (
+        Math.abs(
+          initialWindowHeight -
+            Math.min(window.innerHeight, window.visualViewport.height)
+        ) <= KEYBOARD_DETECT_THRESHOLD
+      );
     }
-  } else {
-    let viewportWindowDiff = initialWindowHeight - window.visualViewport.height;
-    if (viewportWindowDiff > 0) {
-      // eslint-disable-next-line no-console
-      console.warn("Expected virtual keyboard to be closed but it wasn't.");
-      return;
-    }
+
+    // same definition of "no keyboard" the detection logic uses; a persistent
+    // sub-threshold offset (e.g. a browser toolbar) is not the keyboard
+    return (
+      window.innerHeight - window.visualViewport.height <=
+      KEYBOARD_DETECT_THRESHOLD
+    );
+  };
+
+  if (keyboardClosed()) {
+    return;
   }
+
+  await new Promise((resolve) => {
+    const onResize = () => {
+      if (keyboardClosed()) {
+        settle();
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.warn("Keyboard visibility didn't change after 1s.");
+      settle();
+    }, 1000);
+
+    function settle() {
+      clearTimeout(timeout);
+      window.visualViewport.removeEventListener("resize", onResize);
+      resolve();
+    }
+
+    window.visualViewport.addEventListener("resize", onResize);
+  });
 }

--- a/frontend/discourse/tests/acceptance/composer-swipe-to-collapse-test.js
+++ b/frontend/discourse/tests/acceptance/composer-swipe-to-collapse-test.js
@@ -56,4 +56,45 @@ acceptance("Composer - swipe to collapse", function (needs) {
 
     assert.dom(".d-editor-input").isFocused();
   });
+
+  test("a swipe is deferred while text is selected", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".topic-post[data-post-number='1'] button.reply");
+    await focus(".d-editor-input");
+
+    window
+      .getSelection()
+      .selectAllChildren(
+        document.querySelector(".topic-post[data-post-number='1'] .cooked p")
+      );
+
+    try {
+      await swipeDown(".composer-footer");
+      assert.dom(".d-editor-input").isFocused();
+    } finally {
+      window.getSelection().removeAllRanges();
+    }
+  });
+
+  test("a dismissing swipe reflows the composer without waiting for the viewport", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".topic-post[data-post-number='1'] button.reply");
+    await focus(".d-editor-input");
+
+    const docEl = document.documentElement;
+    docEl.classList.add("keyboard-visible");
+
+    try {
+      await swipeDown(".composer-footer", { to: 20 });
+      assert
+        .dom(docEl)
+        .hasClass("keyboard-visible", "snap-back keeps the keyboard state");
+
+      await swipeDown(".composer-footer");
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    } finally {
+      docEl.classList.remove("keyboard-visible");
+      docEl.style.removeProperty("--composer-vh");
+    }
+  });
 });

--- a/frontend/discourse/tests/acceptance/composer-swipe-to-collapse-test.js
+++ b/frontend/discourse/tests/acceptance/composer-swipe-to-collapse-test.js
@@ -1,4 +1,11 @@
-import { click, focus, triggerEvent, visit } from "@ember/test-helpers";
+import {
+  click,
+  fillIn,
+  find,
+  focus,
+  triggerEvent,
+  visit,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
@@ -57,20 +64,28 @@ acceptance("Composer - swipe to collapse", function (needs) {
     assert.dom(".d-editor-input").isFocused();
   });
 
-  test("a swipe is deferred while text is selected", async function (assert) {
+  test("a swipe is deferred while text is selected in the editor", async function (assert) {
+    await visit("/t/internationalization-localization/280");
+    await click(".topic-post[data-post-number='1'] button.reply");
+    await fillIn(".d-editor-input", "some text");
+    find(".d-editor-input").setSelectionRange(0, 4);
+
+    await swipeDown(".composer-footer");
+    assert.dom(".d-editor-input").isFocused();
+  });
+
+  test("a selection outside the composer does not defer the swipe", async function (assert) {
     await visit("/t/internationalization-localization/280");
     await click(".topic-post[data-post-number='1'] button.reply");
     await focus(".d-editor-input");
 
     window
       .getSelection()
-      .selectAllChildren(
-        document.querySelector(".topic-post[data-post-number='1'] .cooked p")
-      );
+      .selectAllChildren(find(".topic-post[data-post-number='1'] .cooked p"));
 
     try {
       await swipeDown(".composer-footer");
-      assert.dom(".d-editor-input").isFocused();
+      assert.dom(".d-editor-input").isNotFocused();
     } finally {
       window.getSelection().removeAllRanges();
     }

--- a/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
@@ -1,0 +1,355 @@
+import { getOwner } from "@ember/owner";
+import { click, render, settled, triggerEvent } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import DVirtualHeight from "discourse/components/d-virtual-height";
+import { forceMobile } from "discourse/lib/mobile";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | DVirtualHeight", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    forceMobile();
+  });
+
+  hooks.afterEach(function () {
+    document.documentElement.classList.remove("keyboard-visible");
+    document.documentElement.style.removeProperty("--composer-vh");
+  });
+
+  test("keyboard:will-hide tears down the keyboard state immediately", async function (assert) {
+    await render(<template><DVirtualHeight /></template>);
+
+    const docEl = document.documentElement;
+    docEl.classList.add("keyboard-visible");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    const received = [];
+    const recorder = (visible) => received.push(visible);
+    appEvents.on("keyboard-visibility-change", recorder);
+
+    try {
+      appEvents.trigger("keyboard:will-hide");
+
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+      assert.deepEqual(received, [false]);
+      assert.strictEqual(
+        docEl.style.getPropertyValue("--composer-vh"),
+        `${Math.round(window.innerHeight) / 100}px`,
+        "composer height is grown to the keyboard-free viewport"
+      );
+    } finally {
+      appEvents.off("keyboard-visibility-change", recorder);
+    }
+  });
+
+  test("focus settling outside editable elements tears down the keyboard state", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <button type="button">other</button>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    editableEl.blur();
+    await settled();
+
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+  });
+
+  test("focus lost to a tap on inert content tears down without settling", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    editableEl.blur();
+
+    // asserted before any timers can run
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+  });
+
+  test("focus moving to another editable element keeps the keyboard state", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <input type="text" />
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+    const inputEl = document.querySelector("#ember-testing input");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    inputEl.focus();
+    await settled();
+
+    assert.dom(docEl).hasClass("keyboard-visible");
+  });
+
+  test("the dismissing tap's ghost click does not activate controls", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+        <button type="button" class="target">target</button>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+    const target = document.querySelector("#ember-testing .target");
+
+    let activations = 0;
+    target.addEventListener("click", () => activations++);
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    editableEl.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    await click("#ember-testing .target");
+    assert.strictEqual(activations, 0, "the tap's own click is swallowed");
+
+    await click("#ember-testing .target");
+    assert.strictEqual(activations, 1, "a deliberate follow-up tap works");
+  });
+
+  test("a dismissing drag does not swallow the next click", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+        <button type="button" class="target">target</button>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+    const target = document.querySelector("#ember-testing .target");
+
+    let activations = 0;
+    target.addEventListener("click", () => activations++);
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    await triggerEvent("#ember-testing .inert-content", "touchstart", {
+      touches: [{ clientX: 0, clientY: 0 }],
+    });
+    await triggerEvent("#ember-testing .inert-content", "touchend", {
+      changedTouches: [{ clientX: 0, clientY: 120 }],
+    });
+    editableEl.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    await click("#ember-testing .target");
+    assert.strictEqual(activations, 1, "drags synthesize no click to swallow");
+  });
+
+  test("refocusing an editable right after a dismiss restores the keyboard state", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+    docEl.style.setProperty("--composer-vh", "5px");
+
+    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    editableEl.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    const received = [];
+    const recorder = (visible) => received.push(visible);
+    appEvents.on("keyboard-visibility-change", recorder);
+
+    try {
+      editableEl.focus();
+
+      assert.dom(docEl).hasClass("keyboard-visible");
+      assert.strictEqual(
+        docEl.style.getPropertyValue("--composer-vh"),
+        "5px",
+        "the keyboard-sized composer height is restored"
+      );
+      assert.deepEqual(received, [true]);
+    } finally {
+      appEvents.off("keyboard-visibility-change", recorder);
+    }
+  });
+
+  test("focusing an editable applies the last known keyboard height until the viewport reports", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <input type="text" />
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+    const inputEl = document.querySelector("#ember-testing input");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    appEvents.trigger("keyboard:will-hide");
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    // the viewport reporting settles the provisional hide
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+
+    const received = [];
+    const recorder = (visible) => received.push(visible);
+    appEvents.on("keyboard-visibility-change", recorder);
+
+    try {
+      inputEl.focus();
+
+      assert.dom(docEl).hasClass("keyboard-visible");
+      assert.deepEqual(received, [true]);
+
+      // no real keyboard ever reported: the optimistic state reverts
+      await settled();
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+      assert.deepEqual(received, [true, false]);
+
+      // and prediction stays disabled until a real keyboard is seen
+      editableEl.focus();
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    } finally {
+      appEvents.off("keyboard-visibility-change", recorder);
+    }
+  });
+
+  test("an unconfirmed prediction stays provisional through a dismiss and refocus", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <input type="text" />
+        <div class="inert-content">plain text</div>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+    const inputEl = document.querySelector("#ember-testing input");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    appEvents.trigger("keyboard:will-hide");
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+
+    // predictive show (unconfirmed), dismissed by an inert tap; dispatched
+    // synchronously so no await runs the pending revert timer early
+    inputEl.focus();
+    assert.dom(docEl).hasClass("keyboard-visible", "predictive show applies");
+    document
+      .querySelector("#ember-testing .inert-content")
+      .dispatchEvent(new TouchEvent("touchstart", { bubbles: true }));
+    inputEl.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    // the restored snapshot descends from an unconfirmed prediction, so it
+    // must revert too instead of persisting as phantom state
+    editableEl.focus();
+    assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
+
+    await settled();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+  });
+
+  test("focusing a select does not predict a keyboard", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <select><option>a</option></select>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = document.querySelector("#ember-testing textarea");
+    const selectEl = document.querySelector("#ember-testing select");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    appEvents.trigger("keyboard:will-hide");
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+
+    selectEl.focus();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+  });
+
+  test("window blur tears down the keyboard state immediately", async function (assert) {
+    await render(<template><DVirtualHeight /></template>);
+
+    const docEl = document.documentElement;
+    docEl.classList.add("keyboard-visible");
+
+    window.dispatchEvent(new Event("blur"));
+
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+  });
+
+  test("keyboard:will-hide is a no-op while the keyboard is not visible", async function (assert) {
+    await render(<template><DVirtualHeight /></template>);
+
+    const appEvents = getOwner(this).lookup("service:app-events");
+    const received = [];
+    const recorder = (visible) => received.push(visible);
+    appEvents.on("keyboard-visibility-change", recorder);
+
+    try {
+      appEvents.trigger("keyboard:will-hide");
+
+      assert.deepEqual(received, []);
+    } finally {
+      appEvents.off("keyboard-visibility-change", recorder);
+    }
+  });
+});

--- a/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
@@ -1,9 +1,11 @@
 import { getOwner } from "@ember/owner";
-import { click, find, findAll, render, settled } from "@ember/test-helpers";
+import { click, find, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DVirtualHeight from "discourse/components/d-virtual-height";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+const docEl = document.documentElement;
 
 // touch dispatch is synchronous so wall-clock gaps between events can't
 // exceed the recent-touch window under a slow test runner
@@ -13,160 +15,169 @@ function touch(el, type, props = {}) {
   el.dispatchEvent(event);
 }
 
+// a keyboard of `px` height in the viewport geometry; 0 removes it
+function setViewportKeyboard(px) {
+  if (px) {
+    Object.defineProperty(window.visualViewport, "height", {
+      configurable: true,
+      value: window.innerHeight - px,
+    });
+  } else {
+    delete window.visualViewport.height;
+  }
+}
+
+async function reportViewport() {
+  window.visualViewport.dispatchEvent(new Event("resize"));
+  await settled();
+}
+
 module("Integration | Component | DVirtualHeight", function (hooks) {
   setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
+  let appEvents;
+  let editable;
+  let teardown;
+
+  hooks.beforeEach(async function () {
     forceMobile();
-  });
+    appEvents = getOwner(this).lookup("service:app-events");
+    teardown = [];
 
-  hooks.afterEach(function () {
-    document.documentElement.classList.remove("keyboard-visible");
-    document.documentElement.style.removeProperty("--composer-vh");
-  });
-
-  test("keyboard:will-hide tears down the keyboard state immediately", async function (assert) {
-    await render(<template><DVirtualHeight /></template>);
-
-    const docEl = document.documentElement;
-    docEl.classList.add("keyboard-visible");
-
-    const appEvents = getOwner(this).lookup("service:app-events");
-    const received = [];
-    const recorder = (visible) => received.push(visible);
-    appEvents.on("keyboard-visibility-change", recorder);
-
-    try {
-      appEvents.trigger("keyboard:will-hide");
-
-      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-      assert.deepEqual(received, [false]);
-      assert.strictEqual(
-        docEl.style.getPropertyValue("--composer-vh"),
-        `${Math.round(window.innerHeight) / 100}px`,
-        "composer height is grown to the keyboard-free viewport"
-      );
-    } finally {
-      appEvents.off("keyboard-visibility-change", recorder);
-    }
-  });
-
-  test("focus settling outside editable elements tears down the keyboard state", async function (assert) {
     await render(
       <template>
         <DVirtualHeight />
         <textarea></textarea>
-        <button type="button">other</button>
+        <input type="text" class="field" />
+        <textarea class="readonly" readonly></textarea>
+        <select><option>a</option></select>
+        <input type="checkbox" />
+        <div class="inert-content" role="none">plain text</div>
+        <button type="button" class="target">target</button>
       </template>
     );
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
+    editable = find("textarea");
+  });
 
-    editableEl.focus();
+  hooks.afterEach(function () {
+    teardown.forEach((cleanup) => cleanup());
+    docEl.classList.remove("keyboard-visible");
+    docEl.style.removeProperty("--composer-vh");
+    setViewportKeyboard(0);
+  });
+
+  function recordVisibility() {
+    const received = [];
+    const recorder = (visible) => received.push(visible);
+    appEvents.on("keyboard-visibility-change", recorder);
+    teardown.push(() => appEvents.off("keyboard-visibility-change", recorder));
+    return received;
+  }
+
+  function countClicks(selector) {
+    const counter = { count: 0 };
+    find(selector).addEventListener("click", () => counter.count++);
+    return counter;
+  }
+
+  function focusWithKeyboard() {
+    editable.focus();
     docEl.classList.add("keyboard-visible");
+  }
 
-    editableEl.blur();
+  function dismissByInertTap() {
+    touch(find(".inert-content"), "touchstart");
+    editable.blur();
+  }
+
+  // record a keyboard height, then settle its dismissal, leaving a snapshot
+  // for prediction to restore
+  async function learnKeyboardHeight() {
+    focusWithKeyboard();
+    appEvents.trigger("keyboard:will-hide");
+    await reportViewport();
+  }
+
+  test("keyboard:will-hide tears down the keyboard state immediately", function (assert) {
+    docEl.classList.add("keyboard-visible");
+    const received = recordVisibility();
+
+    appEvents.trigger("keyboard:will-hide");
+
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    assert.deepEqual(received, [false]);
+    assert.strictEqual(
+      docEl.style.getPropertyValue("--composer-vh"),
+      `${Math.round(window.innerHeight) / 100}px`,
+      "composer height is grown to the keyboard-free viewport"
+    );
+  });
+
+  test("keyboard:will-hide is a no-op while the keyboard is not visible", function (assert) {
+    const received = recordVisibility();
+
+    appEvents.trigger("keyboard:will-hide");
+
+    assert.deepEqual(received, []);
+  });
+
+  test("focus settling outside editable elements tears down the keyboard state", async function (assert) {
+    focusWithKeyboard();
+
+    editable.blur();
     await settled();
 
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
   });
 
-  test("focus lost to a tap on inert content tears down without settling", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-      </template>
-    );
+  test("focus moving to another editable element keeps the keyboard state", async function (assert) {
+    focusWithKeyboard();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
+    find(".field").focus();
+    await settled();
 
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
+    assert.dom(docEl).hasClass("keyboard-visible");
+  });
 
-    touch(find(".inert-content"), "touchstart");
-    editableEl.blur();
+  test("focus lost to a tap on inert content tears down without settling", function (assert) {
+    focusWithKeyboard();
+
+    dismissByInertTap();
 
     assert
       .dom(docEl)
       .doesNotHaveClass("keyboard-visible", "torn down before any timers run");
   });
 
-  test("focus moving to another editable element keeps the keyboard state", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <input type="text" />
-      </template>
-    );
+  test("the dismissing tap's ghost click does not activate controls", async function (assert) {
+    const clicks = countClicks(".target");
+    focusWithKeyboard();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const inputEl = find("input");
+    dismissByInertTap();
 
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
+    await click("#ember-testing .target");
+    assert.strictEqual(clicks.count, 0, "the tap's own click is swallowed");
 
-    inputEl.focus();
-    await settled();
-
-    assert.dom(docEl).hasClass("keyboard-visible");
+    await click("#ember-testing .target");
+    assert.strictEqual(clicks.count, 1, "a deliberate follow-up tap works");
   });
 
-  test("the dismissing tap's ghost click does not activate controls", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-        <button type="button" class="target">target</button>
-      </template>
-    );
+  test("the dismissing tap's click passes through when it lands on the touched element", async function (assert) {
+    const clicks = countClicks(".inert-content");
+    focusWithKeyboard();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const target = find(".target");
+    // the reflow did not move this element out from under the finger, so its
+    // own click must still activate it
+    dismissByInertTap();
 
-    let activations = 0;
-    target.addEventListener("click", () => activations++);
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-
-    touch(find(".inert-content"), "touchstart");
-    editableEl.blur();
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-
-    await click("#ember-testing .target");
-    assert.strictEqual(activations, 0, "the tap's own click is swallowed");
-
-    await click("#ember-testing .target");
-    assert.strictEqual(activations, 1, "a deliberate follow-up tap works");
+    await click("#ember-testing .inert-content");
+    assert.strictEqual(clicks.count, 1, "the touched element's click lands");
   });
 
   test("a dismissing drag does not swallow the next click", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-        <button type="button" class="target">target</button>
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const target = find(".target");
-
-    let activations = 0;
-    target.addEventListener("click", () => activations++);
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
+    const clicks = countClicks(".target");
+    focusWithKeyboard();
 
     touch(find(".inert-content"), "touchstart", {
       touches: [{ clientX: 0, clientY: 0 }],
@@ -174,316 +185,168 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     touch(find(".inert-content"), "touchend", {
       changedTouches: [{ clientX: 0, clientY: 120 }],
     });
-    editableEl.blur();
+    editable.blur();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
     await click("#ember-testing .target");
-    assert.strictEqual(activations, 1, "drags synthesize no click to swallow");
+    assert.strictEqual(clicks.count, 1, "drags synthesize no click to swallow");
+  });
+
+  test("a cancelled touch does not arm the ghost click suppression", async function (assert) {
+    const clicks = countClicks(".target");
+    focusWithKeyboard();
+
+    touch(find(".inert-content"), "touchstart");
+    touch(find(".inert-content"), "touchcancel");
+    editable.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    await click("#ember-testing .target");
+    assert.strictEqual(clicks.count, 1, "no ghost click is expected");
   });
 
   test("a new touch releases the ghost click suppression", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-        <button type="button" class="target">target</button>
-      </template>
-    );
+    const clicks = countClicks(".target");
+    focusWithKeyboard();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const target = find(".target");
-
-    let activations = 0;
-    target.addEventListener("click", () => activations++);
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-
-    touch(find(".inert-content"), "touchstart");
-    editableEl.blur();
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    dismissByInertTap();
 
     // a deliberate follow-up tap within the ghost window
     touch(find(".target"), "touchstart");
     await click("#ember-testing .target");
-    assert.strictEqual(activations, 1, "the new tap's click lands");
+    assert.strictEqual(clicks.count, 1, "the new tap's click lands");
   });
 
   test("tapping back into an editable right after a dismiss restores the keyboard state", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-
     // a real keyboard shrinks the viewport, setting the keyboard-sized height
-    editableEl.focus();
-    Object.defineProperty(window.visualViewport, "height", {
-      configurable: true,
-      value: window.innerHeight - 300,
-    });
-    window.visualViewport.dispatchEvent(new Event("resize"));
-    await settled();
+    editable.focus();
+    setViewportKeyboard(300);
+    await reportViewport();
     const keyboardVh = docEl.style.getPropertyValue("--composer-vh");
     assert.dom(docEl).hasClass("keyboard-visible");
 
-    touch(find(".inert-content"), "touchstart");
-    editableEl.blur();
+    dismissByInertTap();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
-    const appEvents = getOwner(this).lookup("service:app-events");
-    const received = [];
-    const recorder = (visible) => received.push(visible);
-    appEvents.on("keyboard-visibility-change", recorder);
+    const received = recordVisibility();
+    touch(editable, "touchstart");
+    editable.focus();
 
-    try {
-      touch(editableEl, "touchstart");
-      editableEl.focus();
-
-      assert.dom(docEl).hasClass("keyboard-visible");
-      assert.strictEqual(
-        docEl.style.getPropertyValue("--composer-vh"),
-        keyboardVh,
-        "the keyboard-sized composer height is restored"
-      );
-      assert.deepEqual(received, [true]);
-    } finally {
-      appEvents.off("keyboard-visibility-change", recorder);
-      delete window.visualViewport.height;
-    }
+    assert.dom(docEl).hasClass("keyboard-visible");
+    assert.strictEqual(
+      docEl.style.getPropertyValue("--composer-vh"),
+      keyboardVh,
+      "the keyboard-sized composer height is restored"
+    );
+    assert.deepEqual(received, [true]);
   });
 
   test("a restored keyboard state reverts when the keyboard stays hidden", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-      </template>
-    );
+    editable.focus();
+    setViewportKeyboard(300);
+    await reportViewport();
+    assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
+    // the keyboard leaves the geometry, dismissed by an inert tap
+    setViewportKeyboard(0);
+    dismissByInertTap();
 
-    editableEl.focus();
+    touch(editable, "touchstart");
+    editable.focus();
+    assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
 
-    try {
-      // a real keyboard: the viewport reports shorter than the window
-      Object.defineProperty(window.visualViewport, "height", {
-        value: window.innerHeight - 300,
-        configurable: true,
-      });
-      window.visualViewport.dispatchEvent(new Event("resize"));
-      await settled();
-      assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
-
-      // the keyboard leaves the geometry, dismissed by an inert tap
-      delete window.visualViewport.height;
-      touch(find(".inert-content"), "touchstart");
-      editableEl.blur();
-      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-
-      // the user taps back into the field
-      touch(editableEl, "touchstart");
-      editableEl.focus();
-      assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
-
-      await settled();
-      assert
-        .dom(docEl)
-        .doesNotHaveClass(
-          "keyboard-visible",
-          "a restore the viewport geometry contradicts reverts"
-        );
-    } finally {
-      delete window.visualViewport.height;
-    }
+    await settled();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass(
+        "keyboard-visible",
+        "a restore the viewport geometry contradicts reverts"
+      );
   });
 
   test("a restored keyboard state is kept while the viewport still reports one", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-      </template>
-    );
+    editable.focus();
+    setViewportKeyboard(300);
+    await reportViewport();
+    assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
+    // dismissed and refocused mid-hide: the keyboard never actually left
+    dismissByInertTap();
 
-    editableEl.focus();
+    touch(editable, "touchstart");
+    editable.focus();
+    assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
 
-    try {
-      Object.defineProperty(window.visualViewport, "height", {
-        value: window.innerHeight - 300,
-        configurable: true,
-      });
-      window.visualViewport.dispatchEvent(new Event("resize"));
-      await settled();
-      assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
-
-      // dismissed and refocused mid-hide: the keyboard never actually left
-      touch(find(".inert-content"), "touchstart");
-      editableEl.blur();
-      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-
-      // the user taps back into the field
-      touch(editableEl, "touchstart");
-      editableEl.focus();
-      assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
-
-      await settled();
-      assert
-        .dom(docEl)
-        .hasClass("keyboard-visible", "the geometry-backed restore holds");
-    } finally {
-      delete window.visualViewport.height;
-    }
+    await settled();
+    assert
+      .dom(docEl)
+      .hasClass("keyboard-visible", "the geometry-backed restore holds");
   });
 
   test("focusing an editable applies the last known keyboard height until the viewport reports", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <input type="text" />
-      </template>
-    );
+    await learnKeyboardHeight();
+    const received = recordVisibility();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const inputEl = find("input");
+    // a gesture-driven focus (a tap raises the keyboard)
+    touch(find(".field"), "touchstart");
+    find(".field").focus();
 
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
+    assert.dom(docEl).hasClass("keyboard-visible");
+    assert.deepEqual(received, [true]);
 
-    const appEvents = getOwner(this).lookup("service:app-events");
-    appEvents.trigger("keyboard:will-hide");
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-
-    // the viewport reporting settles the provisional hide
-    window.visualViewport.dispatchEvent(new Event("resize"));
     await settled();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass(
+        "keyboard-visible",
+        "no real keyboard ever reported: the optimistic state reverts"
+      );
+    assert.deepEqual(received, [true, false]);
 
-    const received = [];
-    const recorder = (visible) => received.push(visible);
-    appEvents.on("keyboard-visibility-change", recorder);
-
-    try {
-      // a gesture-driven focus (a tap raises the keyboard)
-      touch(inputEl, "touchstart");
-      inputEl.focus();
-
-      assert.dom(docEl).hasClass("keyboard-visible");
-      assert.deepEqual(received, [true]);
-
-      await settled();
-      assert
-        .dom(docEl)
-        .doesNotHaveClass(
-          "keyboard-visible",
-          "no real keyboard ever reported: the optimistic state reverts"
-        );
-      assert.deepEqual(received, [true, false]);
-
-      touch(editableEl, "touchstart");
-      editableEl.focus();
-      assert
-        .dom(docEl)
-        .doesNotHaveClass(
-          "keyboard-visible",
-          "prediction stays disabled until a real keyboard is seen"
-        );
-    } finally {
-      appEvents.off("keyboard-visibility-change", recorder);
-    }
+    touch(editable, "touchstart");
+    editable.focus();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass(
+        "keyboard-visible",
+        "prediction stays disabled until a real keyboard is seen"
+      );
   });
 
   test("tapping a control that focuses another field does not predict", async function (assert) {
-    // a chooser: tapping the trigger opens it and programmatically focuses a
-    // filter input, which raises no keyboard
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <button type="button" class="chooser-trigger">open</button>
-        <input type="text" class="chooser-filter" />
-      </template>
-    );
+    await learnKeyboardHeight();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
+    // e.g. a chooser: the tap lands on its trigger while focus lands
+    // programmatically on its filter input, which raises no keyboard
+    touch(find(".target"), "touchstart");
+    find(".field").focus();
 
-    // learn a keyboard height from a real gesture, then dismiss
-    touch(editableEl, "touchstart");
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
-    window.visualViewport.dispatchEvent(new Event("resize"));
-    await settled();
-
-    // the tap lands on the trigger; focus lands on the filter input
-    touch(find(".chooser-trigger"), "touchstart");
-    find(".chooser-filter").focus();
     assert
       .dom(docEl)
       .doesNotHaveClass("keyboard-visible", "no phantom keyboard layout");
   });
 
   test("tapping directly into a field does predict", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <input type="text" class="chooser-filter" />
-      </template>
-    );
+    await learnKeyboardHeight();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const filterEl = find(".chooser-filter");
+    touch(find(".field"), "touchstart");
+    find(".field").focus();
 
-    touch(editableEl, "touchstart");
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
-    window.visualViewport.dispatchEvent(new Event("resize"));
-    await settled();
-
-    // the tap lands on the filter input itself — a keyboard is expected
-    touch(filterEl, "touchstart");
-    filterEl.focus();
     assert.dom(docEl).hasClass("keyboard-visible");
   });
 
+  test("a programmatic focus with no preceding touch does not predict", async function (assert) {
+    await learnKeyboardHeight();
+
+    find(".field").focus();
+
+    assert
+      .dom(docEl)
+      .doesNotHaveClass("keyboard-visible", "no phantom keyboard layout");
+  });
+
   test("focusing a non-keyboard field does not predict a keyboard", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <select><option>a</option></select>
-        <input type="checkbox" />
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-
-    const appEvents = getOwner(this).lookup("service:app-events");
-    appEvents.trigger("keyboard:will-hide");
-    window.visualViewport.dispatchEvent(new Event("resize"));
-    await settled();
+    await learnKeyboardHeight();
 
     find("select").focus();
     assert
@@ -496,89 +359,18 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       .doesNotHaveClass("keyboard-visible", "a checkbox summons no keyboard");
   });
 
-  test("a programmatic focus with no preceding touch does not predict", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <input type="text" />
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const inputEl = find("input");
-
-    // a keyboard height is on record, then the keyboard is dismissed
-    docEl.classList.add("keyboard-visible");
-    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
-    window.visualViewport.dispatchEvent(new Event("resize"));
-    await settled();
-
-    // no touch precedes this focus — the browser raises no keyboard for it
-    inputEl.focus();
-    assert
-      .dom(docEl)
-      .doesNotHaveClass("keyboard-visible", "no phantom keyboard layout");
-  });
-
   test("a readonly editable does not predict a keyboard", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <textarea readonly></textarea>
-      </template>
-    );
+    await learnKeyboardHeight();
 
-    const docEl = document.documentElement;
-    const [editableEl, readonlyEl] = findAll("#ember-testing textarea");
+    touch(find(".readonly"), "touchstart");
+    find(".readonly").focus();
 
-    touch(editableEl, "touchstart");
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
-    window.visualViewport.dispatchEvent(new Event("resize"));
-    await settled();
-
-    touch(readonlyEl, "touchstart");
-    readonlyEl.focus();
     assert
       .dom(docEl)
       .doesNotHaveClass("keyboard-visible", "readonly summons no keyboard");
   });
 
-  test("the dismissing tap's click passes through when it lands on the touched element", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content" role="none">plain text</div>
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const inertEl = find(".inert-content");
-
-    let activations = 0;
-    inertEl.addEventListener("click", () => activations++);
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-
-    // the reflow did not move this element out from under the finger, so its
-    // own click must still activate it
-    touch(inertEl, "touchstart");
-    editableEl.blur();
-
-    await click("#ember-testing .inert-content");
-    assert.strictEqual(activations, 1, "the touched element's click lands");
-  });
-
-  test("window blur tears down the keyboard state immediately", async function (assert) {
-    await render(<template><DVirtualHeight /></template>);
-
-    const docEl = document.documentElement;
+  test("window blur tears down the keyboard state immediately", function (assert) {
     docEl.classList.add("keyboard-visible");
 
     window.dispatchEvent(new Event("blur"));
@@ -586,130 +378,41 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
   });
 
-  test("window blur from browser chrome blurs the editor too", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
+  test("window blur from browser chrome blurs the editor too", function (assert) {
+    focusWithKeyboard();
 
     window.dispatchEvent(new Event("blur"));
 
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
     assert
-      .dom(editableEl)
+      .dom(editable)
       .isNotFocused("focus is released so a later tap can refocus normally");
   });
 
-  test("window blur from backgrounding keeps the editor focused", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
+  test("window blur from backgrounding keeps the editor focused", function (assert) {
+    focusWithKeyboard();
 
     // an app switch / lock hides the page; the OS restores focus on return
-    const visibility = Object.getOwnPropertyDescriptor(
-      Document.prototype,
-      "visibilityState"
-    );
     Object.defineProperty(document, "visibilityState", {
       configurable: true,
       get: () => "hidden",
     });
+    teardown.push(() => delete document.visibilityState);
 
-    try {
-      window.dispatchEvent(new Event("blur"));
-      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-      assert.dom(editableEl).isFocused("focus is left for the OS to restore");
-    } finally {
-      if (visibility) {
-        Object.defineProperty(document, "visibilityState", visibility);
-      } else {
-        delete document.visibilityState;
-      }
-    }
-  });
-
-  test("window blur explained by a page touch keeps the editor focused", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-      </template>
-    );
-
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-
-    // e.g. a tap on an upload button opening a file picker
-    touch(editableEl, "touchstart");
     window.dispatchEvent(new Event("blur"));
 
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-    assert.dom(editableEl).isFocused();
+    assert.dom(editable).isFocused("focus is left for the OS to restore");
   });
 
-  test("a cancelled touch does not arm the ghost click suppression", async function (assert) {
-    await render(
-      <template>
-        <DVirtualHeight />
-        <textarea></textarea>
-        <div class="inert-content">plain text</div>
-        <button type="button" class="target">target</button>
-      </template>
-    );
+  test("window blur explained by a page touch keeps the editor focused", function (assert) {
+    focusWithKeyboard();
 
-    const docEl = document.documentElement;
-    const editableEl = find("textarea");
-    const target = find(".target");
+    // e.g. a tap on an upload button opening a file picker
+    touch(editable, "touchstart");
+    window.dispatchEvent(new Event("blur"));
 
-    let activations = 0;
-    target.addEventListener("click", () => activations++);
-
-    editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-
-    touch(find(".inert-content"), "touchstart");
-    touch(find(".inert-content"), "touchcancel");
-    editableEl.blur();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-
-    await click("#ember-testing .target");
-    assert.strictEqual(activations, 1, "no ghost click is expected");
-  });
-
-  test("keyboard:will-hide is a no-op while the keyboard is not visible", async function (assert) {
-    await render(<template><DVirtualHeight /></template>);
-
-    const appEvents = getOwner(this).lookup("service:app-events");
-    const received = [];
-    const recorder = (visible) => received.push(visible);
-    appEvents.on("keyboard-visibility-change", recorder);
-
-    try {
-      appEvents.trigger("keyboard:will-hide");
-
-      assert.deepEqual(received, []);
-    } finally {
-      appEvents.off("keyboard-visibility-change", recorder);
-    }
+    assert.dom(editable).isFocused();
   });
 });

--- a/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
@@ -1,5 +1,11 @@
 import { getOwner } from "@ember/owner";
-import { click, render, settled, triggerEvent } from "@ember/test-helpers";
+import {
+  click,
+  find,
+  render,
+  settled,
+  triggerEvent,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DVirtualHeight from "discourse/components/d-virtual-height";
 import { forceMobile } from "discourse/lib/mobile";
@@ -53,7 +59,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
+    const editableEl = find("textarea");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -74,7 +80,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
+    const editableEl = find("textarea");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -82,8 +88,9 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     await triggerEvent("#ember-testing .inert-content", "touchstart");
     editableEl.blur();
 
-    // asserted before any timers can run
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    assert
+      .dom(docEl)
+      .doesNotHaveClass("keyboard-visible", "torn down before any timers run");
   });
 
   test("focus moving to another editable element keeps the keyboard state", async function (assert) {
@@ -96,8 +103,8 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
-    const inputEl = document.querySelector("#ember-testing input");
+    const editableEl = find("textarea");
+    const inputEl = find("input");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -119,8 +126,8 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
-    const target = document.querySelector("#ember-testing .target");
+    const editableEl = find("textarea");
+    const target = find(".target");
 
     let activations = 0;
     target.addEventListener("click", () => activations++);
@@ -150,8 +157,8 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
-    const target = document.querySelector("#ember-testing .target");
+    const editableEl = find("textarea");
+    const target = find(".target");
 
     let activations = 0;
     target.addEventListener("click", () => activations++);
@@ -182,7 +189,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
+    const editableEl = find("textarea");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -222,8 +229,8 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
-    const inputEl = document.querySelector("#ember-testing input");
+    const editableEl = find("textarea");
+    const inputEl = find("input");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -246,14 +253,22 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       assert.dom(docEl).hasClass("keyboard-visible");
       assert.deepEqual(received, [true]);
 
-      // no real keyboard ever reported: the optimistic state reverts
       await settled();
-      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+      assert
+        .dom(docEl)
+        .doesNotHaveClass(
+          "keyboard-visible",
+          "no real keyboard ever reported: the optimistic state reverts"
+        );
       assert.deepEqual(received, [true, false]);
 
-      // and prediction stays disabled until a real keyboard is seen
       editableEl.focus();
-      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+      assert
+        .dom(docEl)
+        .doesNotHaveClass(
+          "keyboard-visible",
+          "prediction stays disabled until a real keyboard is seen"
+        );
     } finally {
       appEvents.off("keyboard-visibility-change", recorder);
     }
@@ -270,8 +285,8 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
-    const inputEl = document.querySelector("#ember-testing input");
+    const editableEl = find("textarea");
+    const inputEl = find("input");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -285,33 +300,36 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     // synchronously so no await runs the pending revert timer early
     inputEl.focus();
     assert.dom(docEl).hasClass("keyboard-visible", "predictive show applies");
-    document
-      .querySelector("#ember-testing .inert-content")
-      .dispatchEvent(new TouchEvent("touchstart", { bubbles: true }));
+    find(".inert-content").dispatchEvent(
+      new Event("touchstart", { bubbles: true })
+    );
     inputEl.blur();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
-    // the restored snapshot descends from an unconfirmed prediction, so it
-    // must revert too instead of persisting as phantom state
     editableEl.focus();
     assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
 
     await settled();
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    assert
+      .dom(docEl)
+      .doesNotHaveClass(
+        "keyboard-visible",
+        "a snapshot descending from an unconfirmed prediction reverts too"
+      );
   });
 
-  test("focusing a select does not predict a keyboard", async function (assert) {
+  test("focusing a non-keyboard field does not predict a keyboard", async function (assert) {
     await render(
       <template>
         <DVirtualHeight />
         <textarea></textarea>
         <select><option>a</option></select>
+        <input type="checkbox" />
       </template>
     );
 
     const docEl = document.documentElement;
-    const editableEl = document.querySelector("#ember-testing textarea");
-    const selectEl = document.querySelector("#ember-testing select");
+    const editableEl = find("textarea");
 
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
@@ -321,8 +339,15 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     window.visualViewport.dispatchEvent(new Event("resize"));
     await settled();
 
-    selectEl.focus();
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    find("select").focus();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass("keyboard-visible", "a select opens a picker");
+
+    find("[type=checkbox]").focus();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass("keyboard-visible", "a checkbox summons no keyboard");
   });
 
   test("window blur tears down the keyboard state immediately", async function (assert) {

--- a/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
@@ -1,15 +1,17 @@
 import { getOwner } from "@ember/owner";
-import {
-  click,
-  find,
-  render,
-  settled,
-  triggerEvent,
-} from "@ember/test-helpers";
+import { click, find, findAll, render, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DVirtualHeight from "discourse/components/d-virtual-height";
 import { forceMobile } from "discourse/lib/mobile";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+// touch dispatch is synchronous so wall-clock gaps between events can't
+// exceed the recent-touch window under a slow test runner
+function touch(el, type, props = {}) {
+  const event = new Event(type, { bubbles: true });
+  Object.assign(event, props);
+  el.dispatchEvent(event);
+}
 
 module("Integration | Component | DVirtualHeight", function (hooks) {
   setupRenderingTest(hooks);
@@ -85,7 +87,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
 
-    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    touch(find(".inert-content"), "touchstart");
     editableEl.blur();
 
     assert
@@ -135,7 +137,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
 
-    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    touch(find(".inert-content"), "touchstart");
     editableEl.blur();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
@@ -166,10 +168,10 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
 
-    await triggerEvent("#ember-testing .inert-content", "touchstart", {
+    touch(find(".inert-content"), "touchstart", {
       touches: [{ clientX: 0, clientY: 0 }],
     });
-    await triggerEvent("#ember-testing .inert-content", "touchend", {
+    touch(find(".inert-content"), "touchend", {
       changedTouches: [{ clientX: 0, clientY: 120 }],
     });
     editableEl.blur();
@@ -199,17 +201,17 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
 
-    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    touch(find(".inert-content"), "touchstart");
     editableEl.blur();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
     // a deliberate follow-up tap within the ghost window
-    await triggerEvent("#ember-testing .target", "touchstart");
+    touch(find(".target"), "touchstart");
     await click("#ember-testing .target");
     assert.strictEqual(activations, 1, "the new tap's click lands");
   });
 
-  test("refocusing an editable right after a dismiss restores the keyboard state", async function (assert) {
+  test("tapping back into an editable right after a dismiss restores the keyboard state", async function (assert) {
     await render(
       <template>
         <DVirtualHeight />
@@ -221,11 +223,18 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     const docEl = document.documentElement;
     const editableEl = find("textarea");
 
+    // a real keyboard shrinks the viewport, setting the keyboard-sized height
     editableEl.focus();
-    docEl.classList.add("keyboard-visible");
-    docEl.style.setProperty("--composer-vh", "5px");
+    Object.defineProperty(window.visualViewport, "height", {
+      configurable: true,
+      value: window.innerHeight - 300,
+    });
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+    const keyboardVh = docEl.style.getPropertyValue("--composer-vh");
+    assert.dom(docEl).hasClass("keyboard-visible");
 
-    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    touch(find(".inert-content"), "touchstart");
     editableEl.blur();
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
@@ -235,17 +244,19 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     appEvents.on("keyboard-visibility-change", recorder);
 
     try {
+      touch(editableEl, "touchstart");
       editableEl.focus();
 
       assert.dom(docEl).hasClass("keyboard-visible");
       assert.strictEqual(
         docEl.style.getPropertyValue("--composer-vh"),
-        "5px",
+        keyboardVh,
         "the keyboard-sized composer height is restored"
       );
       assert.deepEqual(received, [true]);
     } finally {
       appEvents.off("keyboard-visibility-change", recorder);
+      delete window.visualViewport.height;
     }
   });
 
@@ -275,10 +286,12 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
 
       // the keyboard leaves the geometry, dismissed by an inert tap
       delete window.visualViewport.height;
-      await triggerEvent("#ember-testing .inert-content", "touchstart");
+      touch(find(".inert-content"), "touchstart");
       editableEl.blur();
       assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
+      // the user taps back into the field
+      touch(editableEl, "touchstart");
       editableEl.focus();
       assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
 
@@ -318,10 +331,12 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
 
       // dismissed and refocused mid-hide: the keyboard never actually left
-      await triggerEvent("#ember-testing .inert-content", "touchstart");
+      touch(find(".inert-content"), "touchstart");
       editableEl.blur();
       assert.dom(docEl).doesNotHaveClass("keyboard-visible");
 
+      // the user taps back into the field
+      touch(editableEl, "touchstart");
       editableEl.focus();
       assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
 
@@ -363,6 +378,8 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     appEvents.on("keyboard-visibility-change", recorder);
 
     try {
+      // a gesture-driven focus (a tap raises the keyboard)
+      touch(inputEl, "touchstart");
       inputEl.focus();
 
       assert.dom(docEl).hasClass("keyboard-visible");
@@ -377,6 +394,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
         );
       assert.deepEqual(received, [true, false]);
 
+      touch(editableEl, "touchstart");
       editableEl.focus();
       assert
         .dom(docEl)
@@ -389,47 +407,61 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     }
   });
 
-  test("an unconfirmed prediction stays provisional through a dismiss and refocus", async function (assert) {
+  test("tapping a control that focuses another field does not predict", async function (assert) {
+    // a chooser: tapping the trigger opens it and programmatically focuses a
+    // filter input, which raises no keyboard
     await render(
       <template>
         <DVirtualHeight />
         <textarea></textarea>
-        <input type="text" />
-        <div class="inert-content">plain text</div>
+        <button type="button" class="chooser-trigger">open</button>
+        <input type="text" class="chooser-filter" />
       </template>
     );
 
     const docEl = document.documentElement;
     const editableEl = find("textarea");
-    const inputEl = find("input");
 
+    // learn a keyboard height from a real gesture, then dismiss
+    touch(editableEl, "touchstart");
     editableEl.focus();
     docEl.classList.add("keyboard-visible");
-
-    const appEvents = getOwner(this).lookup("service:app-events");
-    appEvents.trigger("keyboard:will-hide");
+    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
     window.visualViewport.dispatchEvent(new Event("resize"));
     await settled();
 
-    // dispatched synchronously so no await runs the pending revert timer early
-    inputEl.focus();
-    assert.dom(docEl).hasClass("keyboard-visible", "predictive show applies");
-    find(".inert-content").dispatchEvent(
-      new Event("touchstart", { bubbles: true })
-    );
-    inputEl.blur();
-    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
-
-    editableEl.focus();
-    assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
-
-    await settled();
+    // the tap lands on the trigger; focus lands on the filter input
+    touch(find(".chooser-trigger"), "touchstart");
+    find(".chooser-filter").focus();
     assert
       .dom(docEl)
-      .doesNotHaveClass(
-        "keyboard-visible",
-        "a restored snapshot the viewport never confirms reverts too"
-      );
+      .doesNotHaveClass("keyboard-visible", "no phantom keyboard layout");
+  });
+
+  test("tapping directly into a field does predict", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <input type="text" class="chooser-filter" />
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+    const filterEl = find(".chooser-filter");
+
+    touch(editableEl, "touchstart");
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+
+    // the tap lands on the filter input itself — a keyboard is expected
+    touch(filterEl, "touchstart");
+    filterEl.focus();
+    assert.dom(docEl).hasClass("keyboard-visible");
   });
 
   test("focusing a non-keyboard field does not predict a keyboard", async function (assert) {
@@ -464,6 +496,85 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       .doesNotHaveClass("keyboard-visible", "a checkbox summons no keyboard");
   });
 
+  test("a programmatic focus with no preceding touch does not predict", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <input type="text" />
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const inputEl = find("input");
+
+    // a keyboard height is on record, then the keyboard is dismissed
+    docEl.classList.add("keyboard-visible");
+    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+
+    // no touch precedes this focus — the browser raises no keyboard for it
+    inputEl.focus();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass("keyboard-visible", "no phantom keyboard layout");
+  });
+
+  test("a readonly editable does not predict a keyboard", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <textarea readonly></textarea>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const [editableEl, readonlyEl] = findAll("#ember-testing textarea");
+
+    touch(editableEl, "touchstart");
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+    getOwner(this).lookup("service:app-events").trigger("keyboard:will-hide");
+    window.visualViewport.dispatchEvent(new Event("resize"));
+    await settled();
+
+    touch(readonlyEl, "touchstart");
+    readonlyEl.focus();
+    assert
+      .dom(docEl)
+      .doesNotHaveClass("keyboard-visible", "readonly summons no keyboard");
+  });
+
+  test("the dismissing tap's click passes through when it lands on the touched element", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content" role="none">plain text</div>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+    const inertEl = find(".inert-content");
+
+    let activations = 0;
+    inertEl.addEventListener("click", () => activations++);
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    // the reflow did not move this element out from under the finger, so its
+    // own click must still activate it
+    touch(inertEl, "touchstart");
+    editableEl.blur();
+
+    await click("#ember-testing .inert-content");
+    assert.strictEqual(activations, 1, "the touched element's click lands");
+  });
+
   test("window blur tears down the keyboard state immediately", async function (assert) {
     await render(<template><DVirtualHeight /></template>);
 
@@ -473,6 +584,116 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     window.dispatchEvent(new Event("blur"));
 
     assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+  });
+
+  test("window blur from browser chrome blurs the editor too", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    window.dispatchEvent(new Event("blur"));
+
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    assert
+      .dom(editableEl)
+      .isNotFocused("focus is released so a later tap can refocus normally");
+  });
+
+  test("window blur from backgrounding keeps the editor focused", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    // an app switch / lock hides the page; the OS restores focus on return
+    const visibility = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      "visibilityState"
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+
+    try {
+      window.dispatchEvent(new Event("blur"));
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+      assert.dom(editableEl).isFocused("focus is left for the OS to restore");
+    } finally {
+      if (visibility) {
+        Object.defineProperty(document, "visibilityState", visibility);
+      } else {
+        delete document.visibilityState;
+      }
+    }
+  });
+
+  test("window blur explained by a page touch keeps the editor focused", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    // e.g. a tap on an upload button opening a file picker
+    touch(editableEl, "touchstart");
+    window.dispatchEvent(new Event("blur"));
+
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+    assert.dom(editableEl).isFocused();
+  });
+
+  test("a cancelled touch does not arm the ghost click suppression", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+        <button type="button" class="target">target</button>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+    const target = find(".target");
+
+    let activations = 0;
+    target.addEventListener("click", () => activations++);
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    touch(find(".inert-content"), "touchstart");
+    touch(find(".inert-content"), "touchcancel");
+    editableEl.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    await click("#ember-testing .target");
+    assert.strictEqual(activations, 1, "no ghost click is expected");
   });
 
   test("keyboard:will-hide is a no-op while the keyboard is not visible", async function (assert) {

--- a/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
@@ -345,6 +345,31 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       .doesNotHaveClass("keyboard-visible", "no phantom keyboard layout");
   });
 
+  test("a programmatic focus right after an inferred hide restores the keyboard state", async function (assert) {
+    editable.focus();
+    setViewportKeyboard(300);
+    await reportViewport();
+    assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
+
+    // e.g. a toolbar tap opening a modal: focus settles outside any editable
+    // before the modal autofocuses its input, and that refocus cancels the
+    // keyboard hide, so the unchanged viewport never reports back
+    touch(find(".target"), "touchstart");
+    editable.blur();
+    await settled();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible", "hide is inferred");
+
+    find(".field").focus();
+    assert
+      .dom(docEl)
+      .hasClass("keyboard-visible", "the interrupted state is restored");
+
+    await settled();
+    assert
+      .dom(docEl)
+      .hasClass("keyboard-visible", "the geometry-backed restore holds");
+  });
+
   test("focusing a non-keyboard field does not predict a keyboard", async function (assert) {
     await learnKeyboardHeight();
 

--- a/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
+++ b/frontend/discourse/tests/integration/components/d-virtual-height-test.gjs
@@ -179,6 +179,36 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     assert.strictEqual(activations, 1, "drags synthesize no click to swallow");
   });
 
+  test("a new touch releases the ghost click suppression", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+        <button type="button" class="target">target</button>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+    const target = find(".target");
+
+    let activations = 0;
+    target.addEventListener("click", () => activations++);
+
+    editableEl.focus();
+    docEl.classList.add("keyboard-visible");
+
+    await triggerEvent("#ember-testing .inert-content", "touchstart");
+    editableEl.blur();
+    assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+    // a deliberate follow-up tap within the ghost window
+    await triggerEvent("#ember-testing .target", "touchstart");
+    await click("#ember-testing .target");
+    assert.strictEqual(activations, 1, "the new tap's click lands");
+  });
+
   test("refocusing an editable right after a dismiss restores the keyboard state", async function (assert) {
     await render(
       <template>
@@ -216,6 +246,91 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       assert.deepEqual(received, [true]);
     } finally {
       appEvents.off("keyboard-visibility-change", recorder);
+    }
+  });
+
+  test("a restored keyboard state reverts when the keyboard stays hidden", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+
+    editableEl.focus();
+
+    try {
+      // a real keyboard: the viewport reports shorter than the window
+      Object.defineProperty(window.visualViewport, "height", {
+        value: window.innerHeight - 300,
+        configurable: true,
+      });
+      window.visualViewport.dispatchEvent(new Event("resize"));
+      await settled();
+      assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
+
+      // the keyboard leaves the geometry, dismissed by an inert tap
+      delete window.visualViewport.height;
+      await triggerEvent("#ember-testing .inert-content", "touchstart");
+      editableEl.blur();
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+      editableEl.focus();
+      assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
+
+      await settled();
+      assert
+        .dom(docEl)
+        .doesNotHaveClass(
+          "keyboard-visible",
+          "a restore the viewport geometry contradicts reverts"
+        );
+    } finally {
+      delete window.visualViewport.height;
+    }
+  });
+
+  test("a restored keyboard state is kept while the viewport still reports one", async function (assert) {
+    await render(
+      <template>
+        <DVirtualHeight />
+        <textarea></textarea>
+        <div class="inert-content">plain text</div>
+      </template>
+    );
+
+    const docEl = document.documentElement;
+    const editableEl = find("textarea");
+
+    editableEl.focus();
+
+    try {
+      Object.defineProperty(window.visualViewport, "height", {
+        value: window.innerHeight - 300,
+        configurable: true,
+      });
+      window.visualViewport.dispatchEvent(new Event("resize"));
+      await settled();
+      assert.dom(docEl).hasClass("keyboard-visible", "keyboard is confirmed");
+
+      // dismissed and refocused mid-hide: the keyboard never actually left
+      await triggerEvent("#ember-testing .inert-content", "touchstart");
+      editableEl.blur();
+      assert.dom(docEl).doesNotHaveClass("keyboard-visible");
+
+      editableEl.focus();
+      assert.dom(docEl).hasClass("keyboard-visible", "snapshot restores");
+
+      await settled();
+      assert
+        .dom(docEl)
+        .hasClass("keyboard-visible", "the geometry-backed restore holds");
+    } finally {
+      delete window.visualViewport.height;
     }
   });
 
@@ -296,8 +411,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
     window.visualViewport.dispatchEvent(new Event("resize"));
     await settled();
 
-    // predictive show (unconfirmed), dismissed by an inert tap; dispatched
-    // synchronously so no await runs the pending revert timer early
+    // dispatched synchronously so no await runs the pending revert timer early
     inputEl.focus();
     assert.dom(docEl).hasClass("keyboard-visible", "predictive show applies");
     find(".inert-content").dispatchEvent(
@@ -314,7 +428,7 @@ module("Integration | Component | DVirtualHeight", function (hooks) {
       .dom(docEl)
       .doesNotHaveClass(
         "keyboard-visible",
-        "a snapshot descending from an unconfirmed prediction reverts too"
+        "a restored snapshot the viewport never confirms reverts too"
       );
   });
 

--- a/frontend/discourse/tests/unit/lib/wait-for-keyboard-test.js
+++ b/frontend/discourse/tests/unit/lib/wait-for-keyboard-test.js
@@ -1,0 +1,71 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { waitForClosedKeyboard } from "discourse/lib/wait-for-keyboard";
+
+const SITE_MOBILE = { desktopView: false };
+const CAPS = { isIpadOS: false, isFirefox: false, isAndroid: false };
+
+module("Unit | Lib | wait-for-keyboard", function (hooks) {
+  setupTest(hooks);
+
+  // drive the closed/open signal through whichever primitive the running
+  // browser uses (Chrome exposes navigator.virtualKeyboard; others report
+  // via the visual viewport height), so the test is deterministic anywhere
+  const usesVirtualKeyboard = "virtualKeyboard" in navigator;
+
+  function setKeyboardHeight(px) {
+    if (usesVirtualKeyboard) {
+      Object.defineProperty(navigator.virtualKeyboard, "boundingRect", {
+        configurable: true,
+        get: () => new DOMRect(0, 0, 0, px),
+      });
+    } else {
+      Object.defineProperty(window.visualViewport, "height", {
+        configurable: true,
+        value: window.innerHeight - px,
+      });
+    }
+  }
+
+  hooks.afterEach(function () {
+    document.documentElement.classList.remove("keyboard-visible");
+    if (usesVirtualKeyboard) {
+      delete navigator.virtualKeyboard.boundingRect;
+    } else {
+      delete window.visualViewport.height;
+    }
+  });
+
+  test("resolves immediately when the keyboard class is absent", async function (assert) {
+    setKeyboardHeight(300);
+    await waitForClosedKeyboard(SITE_MOBILE, CAPS);
+    assert.true(true, "did not hang on the still-open keyboard");
+  });
+
+  test("resolves immediately when the keyboard already reads closed", async function (assert) {
+    document.documentElement.classList.add("keyboard-visible");
+    setKeyboardHeight(0);
+    await waitForClosedKeyboard(SITE_MOBILE, CAPS);
+    assert.true(true, "a zero-height keyboard counts as closed");
+  });
+
+  test("waits for the keyboard to actually close before resolving", async function (assert) {
+    document.documentElement.classList.add("keyboard-visible");
+    setKeyboardHeight(300);
+
+    let resolved = false;
+    const done = waitForClosedKeyboard(SITE_MOBILE, CAPS).then(
+      () => (resolved = true)
+    );
+
+    await Promise.resolve();
+    assert.false(resolved, "still pending while the keyboard occupies space");
+
+    // the OS hide animation completes and the viewport settles
+    setKeyboardHeight(0);
+    window.visualViewport.dispatchEvent(new Event("resize"));
+
+    await done;
+    assert.true(resolved, "resolves once the keyboard reports closed");
+  });
+});


### PR DESCRIPTION
The composer only reacted to the mobile keyboard after the fact: `visualViewport` reports once the OS animation ends, plus a 50ms debounce. On dismiss this showed a blank gap below the keyboard-sized composer while the bottom bar lagged into place; on focus, the bar hid behind the rising keyboard and popped up late.

`d-virtual-height` now reflows as soon as a keyboard transition is knowable. Safari exposes none of the keyboard viewport primitives and reports nothing until the animation ends, so the state is inferred from page signals: a `keyboard:will-hide` app event (fired by swipe-to-dismiss), focus settling outside any editable, focus lost to a tap on inert content (instant, with that tap's synthesized click swallowed once), and `window` blur. In the show direction, focusing an editable applies the last known keyboard height, and a refocus right after a dismiss restores the torn-down state.

Every inferred state is provisional: a real `visualViewport` report supersedes it, and an inferred show reverts after 800ms unless the viewport geometry backs it up. If no keyboard ever shows (e.g. a hardware keyboard), prediction disables until a soft keyboard is seen again.

On a dismissing swipe release, the editor glides into the reflowed layout with a transform, since the stylesheet margin transition would target the pre-reflow position.

The inference applies to all mobile/iPadOS sessions; only the swipe glide is gated behind `enable_composer_redesign`.
