### PR TITLE
SECURITY: DoS vis uncapped Bulk Topic Actions

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -4,6 +4,8 @@ class TopicsController < ApplicationController
   include TagParamLimit
   include EmbedModeHandler
 
+  MAX_BULK_TOPIC_IDS = 1_000
+
   requires_login only: %i[
                    timings
                    destroy_timings
@@ -1156,7 +1158,12 @@ class TopicsController < ApplicationController
       unless Array === params[:topic_ids]
         raise Discourse::InvalidParameters.new("Expecting topic_ids to contain a list of topic ids")
       end
-      topic_ids = params[:topic_ids].map { |t| t.to_i }
+      topic_ids = params[:topic_ids].map { |topic_id| topic_id.to_i }.uniq
+      if topic_ids.size > MAX_BULK_TOPIC_IDS
+        raise Discourse::InvalidParameters.new(
+                I18n.t("topics_bulk_action.too_many_topic_ids", limit: MAX_BULK_TOPIC_IDS),
+              )
+      end
     elsif params[:filter] == "unread"
       topic_ids = bulk_unread_topic_ids
     else

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -67,6 +67,9 @@ en:
     added: "Added %{added}"
     removed: "Removed %{removed}"
 
+  topics_bulk_action:
+    too_many_topic_ids: "You can only perform a bulk action on up to %{limit} topics at once."
+
   inline_oneboxer:
     topic_page_title_post_number: "#%{post_number}"
     topic_page_title_post_number_by_user: "#%{post_number} by %{username}"

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -5379,6 +5379,41 @@ RSpec.describe TopicsController do
         expect(response.parsed_body["errors"]).to eq(nil)
       end
 
+      it "deduplicates explicit topic IDs before processing them" do
+        sign_in(trust_level_0)
+
+        put "/topics/bulk.json",
+            params: {
+              topic_ids: Array.new(1_000_000, 0),
+              operation: {
+                type: "dismiss_posts",
+              },
+            },
+            as: :json
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["topic_ids"].size).to eq(1)
+        expect(response.parsed_body["topic_ids"].first).to eq(0)
+      end
+
+      it "rejects more than 1,000 unique explicit topic IDs" do
+        sign_in(trust_level_0)
+
+        put "/topics/bulk.json",
+            params: {
+              topic_ids: (1..1_001).to_a,
+              operation: {
+                type: "dismiss_posts",
+              },
+            },
+            as: :json
+
+        expect(response.status).to eq(400)
+        expect(response.parsed_body["errors"].first).to include(
+          I18n.t("topics_bulk_action.too_many_topic_ids", limit: 1_000),
+        )
+      end
+
       it "can pin multiple topics with pinned_until" do
         sign_in(moderator)
         pinned_until = 3.days.from_now.beginning_of_minute.iso8601


### PR DESCRIPTION
## Summary

Limit and deduplicate topic_ids for bulk actions.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1477

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>