### PR TITLE
FIX: Hidden setting error when enabling plugin linked to UC

### DIFF
--- a/app/services/site_setting/policy/settings_are_visible.rb
+++ b/app/services/site_setting/policy/settings_are_visible.rb
@@ -19,6 +19,7 @@ class SiteSetting::Policy::SettingsAreVisible < Service::PolicyBase
 
   def validate_setting(setting_name)
     return false if options.allow_changing_hidden.include?(setting_name)
+    return false if SiteSetting.upcoming_change_site_settings.include?(setting_name)
     SiteSetting.hidden_settings.include?(setting_name)
   end
 end

--- a/spec/services/site_setting/update_spec.rb
+++ b/spec/services/site_setting/update_spec.rb
@@ -97,6 +97,26 @@ RSpec.describe SiteSetting::Update do
           expect { result }.to change { SiteSetting.max_category_nesting }.to(3)
         end
       end
+
+      context "when the hidden setting is an upcoming change" do
+        let(:setting_name) { :enable_upload_debug_mode }
+        let(:new_value) { true }
+
+        before do
+          mock_upcoming_change_metadata(
+            {
+              enable_upload_debug_mode: {
+                impact: "other,developers",
+                status: :stable,
+                impact_type: "other",
+                impact_role: "developers",
+              },
+            },
+          )
+        end
+
+        it { is_expected.to run_successfully }
+      end
     end
 
     context "when a user changes a setting shadowed by a global variable" do


### PR DESCRIPTION
The `enable_discourse_workflows` site setting is both the plugin enabled
setting AND an upcoming change, which are always hidden settings.

Admins, when enabling the plugin, would see an error like this
since the setting was hidden:

> You are not allowed to change hidden settings: enable_discourse_workflows

This commit fixes this by allowing hidden settings to be changed if the
setting is an upcoming change
