### PR TITLE
PERF: Avoid copying safe preloaded JSON

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -241,14 +241,12 @@ module ApplicationHelper
   end
 
   def escape_unicode(javascript)
-    if javascript
-      javascript = javascript.scrub
-      javascript.gsub!(/\342\200\250/u, "&#x2028;")
-      javascript.gsub!(%r{(</)}u, '\u003C/')
-      javascript
-    else
-      ""
-    end
+    return "" if !javascript
+
+    javascript = javascript.scrub if !javascript.valid_encoding?
+    return javascript if !javascript.include?("\u2028") && !javascript.include?("</")
+
+    javascript.gsub(/\342\200\250/u, "&#x2028;").gsub(%r{(</)}u, '\u003C/')
   end
 
   def format_topic_title(title)


### PR DESCRIPTION
## What changed

`ApplicationHelper#escape_unicode` now returns valid JSON strings directly when they contain neither U+2028 nor an HTML closing-tag sequence. Invalid UTF-8 and strings requiring script-safe escaping continue through the existing repair and replacement paths.

## Why

The helper previously called `String#scrub` and two mutating substitutions for every preloaded value, even when there was nothing to repair or escape. On a development homepage containing 11,004 preloaded categories, `pp=profile-memory` attributed approximately 37.5 MB of transient string allocation to this helper.

The fast path removes that full-payload copy while retaining the same output for values requiring escaping. Existing helper coverage verifies invalid UTF-8 handling and that `</script>` cannot terminate the preloaded JSON script element.

## Validation

- `bin/lint --fix app/helpers/application_helper.rb`
- `bin/rspec spec/helpers/application_helper_spec.rb` (139 examples, 0 failures)
