### PR TITLE
PERF: Reduce large-category site serialization allocations

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -145,7 +145,8 @@ class Site
   end
 
   def categories
-    if @guardian.can_lazy_load_categories?
+    can_lazy_load_categories = @guardian.can_lazy_load_categories?
+    if can_lazy_load_categories
       preloaded_category_ids = []
       if @guardian.authenticated?
         sidebar_category_ids = @guardian.user.secured_sidebar_category_ids(@guardian)
@@ -161,10 +162,7 @@ class Site
         categories = []
 
         self.class.all_categories_cache.each do |category|
-          if (
-               !@guardian.can_lazy_load_categories? ||
-                 preloaded_category_ids.include?(category[:id])
-             ) &&
+          if (!can_lazy_load_categories || preloaded_category_ids.include?(category[:id])) &&
                @guardian.can_see_serialized_category?(
                  category_id: category[:id],
                  read_restricted: category[:read_restricted],

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -139,10 +139,16 @@ class Tag < ActiveRecord::Base
     # we add 1 to max_tags_in_filter_list to efficiently know we have more tags
     # than the limit. Frontend is responsible to enforce limit.
     limit = limit_arg || (SiteSetting.max_tags_in_filter_list + 1)
-    scope_category_ids = guardian.allowed_category_ids
-    scope_category_ids &= ([category.id] + category.subcategories.pluck(:id)) if category
+    scope_category_ids = guardian.allowed_category_ids if !guardian.is_staff?
+    if category
+      category_ids = [category.id] + category.subcategories.pluck(:id)
+      scope_category_ids = scope_category_ids ? scope_category_ids & category_ids : category_ids
+    end
 
-    return [] if scope_category_ids.empty?
+    return [] if scope_category_ids&.empty?
+
+    category_filter_sql =
+      "WHERE stats.category_id in (#{scope_category_ids.join(",")})" if scope_category_ids
 
     filter_sql =
       (
@@ -157,7 +163,7 @@ class Tag < ActiveRecord::Base
       SELECT tags.id as tag_id, tags.name as tag_name, tags.slug as tag_slug, SUM(stats.topic_count) AS sum_topic_count
         FROM category_tag_stats stats
         JOIN tags ON stats.tag_id = tags.id AND stats.topic_count > 0
-       WHERE stats.category_id in (#{scope_category_ids.join(",")})
+       #{category_filter_sql}
        #{filter_sql}
       GROUP BY tags.id
       ORDER BY sum_topic_count DESC, tag_name ASC


### PR DESCRIPTION
## What changed

- Evaluate `Guardian#can_lazy_load_categories?` once before iterating the site category collection rather than once per category.
- Skip constructing an explicit category-ID SQL filter for an unrestricted staff `Tag.top_tags` query. Category-scoped requests and non-staff guardians keep their existing category visibility filters.

## Why

On sites with thousands of categories, both request-wide operations created short-lived objects proportional to the category count:

- Rechecking category preload eligibility repeatedly parsed group-list site settings and consulted upcoming-change metadata for every category.
- Staff top-tag queries converted every allowed category ID to a string even though staff without a category scope can query all category tag statistics directly.

This does not make category loading conditional on the lazy-category site setting; it only reuses the request-wide eligibility result while processing one collection.

## Profiling

Development, authenticated homepage with 11,004 preloaded categories, using the same warmed process and route:

| `pp=profile-memory` | Before | After | Change |
|---|---:|---:|---:|
| Allocated objects | 476,013 | 408,366 | -67,647 (-14.2%) |
| Allocated bytes | 259,778,556 | 257,247,107 | -2,531,449 |

Across five wall-flamegraph captures:

| Median StackProf time | Before | After |
|---|---:|---:|
| Profiled request | 448.5 ms | 378.5 ms |
| GC marking + sweeping | 215 ms | 155 ms |

## Validation

- `bin/lint --fix app/models/site.rb app/models/tag.rb`
- `bin/rspec spec/models/site_spec.rb spec/models/tag_spec.rb spec/serializers/site_serializer_spec.rb` (144 examples, 0 failures)
