### PR TITLE
DEV: Add permanent_warning: false to more upcoming changes

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -718,6 +718,7 @@ login:
       status: "alpha"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/407068"
+      permanent_warning: false
       allow_enabled_for:
         - everyone
   enable_passkeys:

--- a/plugins/discourse-solved/config/settings.yml
+++ b/plugins/discourse-solved/config/settings.yml
@@ -4,7 +4,7 @@ discourse_solved:
     client: true
   solved_allow_multiple_solutions:
     default: false
-    client: true 
+    client: true
     hidden: true
   show_who_marked_solved:
     default: false
@@ -81,6 +81,7 @@ discourse_solved:
       status: "stable"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/402498"
+      permanent_warning: false
   enable_solved_badges:
     default: false
     hidden: true
@@ -89,6 +90,7 @@ discourse_solved:
       status: "alpha"
       impact: "site_setting_default,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/406386"
+      permanent_warning: false
   discourse_solved_admin_dashboard_seeded:
     default: false
     hidden: true

--- a/plugins/discourse-topic-voting/config/settings.yml
+++ b/plugins/discourse-topic-voting/config/settings.yml
@@ -64,3 +64,4 @@ discourse_topic_voting:
       status: "alpha"
       impact: "site_setting_default,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/401731"
+      permanent_warning: false

--- a/plugins/discourse-workflows/config/settings.yml
+++ b/plugins/discourse-workflows/config/settings.yml
@@ -10,6 +10,7 @@ plugins:
       allow_enabled_for:
         - everyone
       requires_plugin_enabled: false
+      permanent_warning: false
   discourse_workflows_ai_authoring_enabled:
     default: false
     client: true


### PR DESCRIPTION
These changes don't need to show the scary warning to
admins when they become stable, as they are still optional
features even when the upcoming change is gone
