### PR TITLE
FIX: Load PostgreSQL structures in a single transaction

### DIFF
--- a/config/initializers/000-active_record.rb
+++ b/config/initializers/000-active_record.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = { postgresql: "--single-transaction" }
+if !Discourse.is_parallel_test?
+  ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = { postgresql: "--single-transaction" }
+end
 
 # No ActiveRecord for these models. Avoids the "unknown OID" warnings.
 # We need it in core, because plugins are not loaded in core tests,

--- a/config/initializers/000-active_record.rb
+++ b/config/initializers/000-active_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Concurrent structure loads exhaust PostgreSQL's shared lock table when each holds all locks until commit.
+# Concurrent transactional structure loads exhaust PostgreSQL's shared lock-tracking memory.
 if !Discourse.is_parallel_test?
   ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = { postgresql: "--single-transaction" }
 end

--- a/config/initializers/000-active_record.rb
+++ b/config/initializers/000-active_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = { postgresql: "--single-transaction" }
+
 # No ActiveRecord for these models. Avoids the "unknown OID" warnings.
 # We need it in core, because plugins are not loaded in core tests,
 # but the tables are likely still present in the test database.

--- a/config/initializers/000-active_record.rb
+++ b/config/initializers/000-active_record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Concurrent structure loads exhaust PostgreSQL's shared lock table when each holds all locks until commit.
 if !Discourse.is_parallel_test?
   ActiveRecord::Tasks::DatabaseTasks.structure_load_flags = { postgresql: "--single-transaction" }
 end


### PR DESCRIPTION
When Active Record migrates a brand-new Discourse database, [Discourse invokes `DatabaseTasks.migrate`](https://github.com/discourse/discourse/blob/62e56a45c407/lib/tasks/db.rake#L131-L136), which can initialize the database from [`db/structure.sql`](https://github.com/discourse/discourse/blob/62e56a45c407/db/structure.sql#L1-L10). That file [clears the session `search_path`](https://github.com/discourse/discourse/blob/62e56a45c407/db/structure.sql#L6) and [restores it near the end](https://github.com/discourse/discourse/blob/62e56a45c407/db/structure.sql#L22878-L22884). With [PgBouncer transaction pooling](https://github.com/pgbouncer/pgbouncer/blob/master/doc/config.md#pool_mode), `psql`'s autocommit statements can run on different PostgreSQL backends, leaving one pooled backend with an empty search path and causing later migrations or seeds to fail intermittently with “no schema has been selected” or missing-relation errors.

This commit [configures PostgreSQL structure loads with `--single-transaction`](https://github.com/discourse/discourse/blob/62e56a45c407/config/initializers/000-active_record.rb#L3-L6), using [Active Record's existing structure-loader flags](https://github.com/rails/rails/blob/v8.0.5/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb#L80-L85) to keep the restore on one PgBouncer backend and roll it back atomically on error. 