### PR TITLE
UX: Move preview toggle into composer controls

### DIFF
--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -856,18 +856,6 @@ export default class ComposerContainer extends Component {
                     </span>
                   </div>
                 {{/if}}
-
-                {{#if (and this.composer.allowPreview this.site.desktopView)}}
-                  <DButton
-                    @action={{this.composer.togglePreview}}
-                    @translatedTitle={{this.composer.toggleText}}
-                    @icon="angles-left"
-                    class={{dConcatClass
-                      "btn-transparent btn-small toggle-preview"
-                      (unless this.composer.isPreviewVisible "active")
-                    }}
-                  />
-                {{/if}}
               </div>
             {{/if}}
           </div>

--- a/frontend/discourse/app/components/composer-container.gjs
+++ b/frontend/discourse/app/components/composer-container.gjs
@@ -35,7 +35,7 @@ import grippieDragResize from "discourse/modifiers/grippie-drag-resize";
 import CategoryChooser from "discourse/select-kit/components/category-chooser";
 import DropdownSelectBox from "discourse/select-kit/components/dropdown-select-box";
 import MiniTagChooser from "discourse/select-kit/components/mini-tag-chooser";
-import { and, or } from "discourse/truth-helpers";
+import { or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DPopupInputTip from "discourse/ui-kit/d-popup-input-tip";
 import DTextField from "discourse/ui-kit/d-text-field";
@@ -703,40 +703,6 @@ export default class ComposerContainer extends Component {
                         @outletArgs={{lazyHash model=this.composer.model}}
                       />
                     </span>
-
-                    {{#if this.composer.allowPreview}}
-                      <a
-                        href
-                        class="btn btn-default no-text mobile-preview"
-                        title={{i18n "composer.show_preview"}}
-                        {{on "click" this.composer.togglePreview}}
-                        aria-label={{i18n "composer.show_preview"}}
-                      >
-                        {{dIcon "desktop"}}
-                      </a>
-                    {{/if}}
-
-                    {{#if this.composer.isPreviewVisible}}
-                      <DButton
-                        @action={{this.composer.togglePreview}}
-                        @title="composer.hide_preview"
-                        @ariaLabel="composer.hide_preview"
-                        @icon="pencil"
-                        class="hide-preview"
-                      />
-                    {{/if}}
-                  {{/if}}
-
-                  {{#if (and this.composer.allowPreview this.site.desktopView)}}
-                    <DButton
-                      @action={{this.composer.togglePreview}}
-                      @translatedTitle={{this.composer.toggleText}}
-                      @icon="angles-left"
-                      class={{dConcatClass
-                        "btn-transparent btn-mini-toggle toggle-preview"
-                        (unless this.composer.isPreviewVisible "active")
-                      }}
-                    />
                   {{/if}}
                 </div>
               </div>

--- a/frontend/discourse/app/components/composer-toggles.gjs
+++ b/frontend/discourse/app/components/composer-toggles.gjs
@@ -2,10 +2,12 @@ import Component from "@glimmer/component";
 import { service } from "@ember/service";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { applyValueTransformer } from "discourse/lib/transformer";
+import { and } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 
 export default class ComposerToggles extends Component {
+  @service composer;
   @service site;
 
   get additionalClasses() {
@@ -18,6 +20,10 @@ export default class ComposerToggles extends Component {
     );
   }
 
+  get showPreviewToggle() {
+    return this.args.composeState !== "draft";
+  }
+
   get toggleToolbarTitle() {
     return this.args.showToolbar
       ? "composer.hide_toolbar"
@@ -25,23 +31,19 @@ export default class ComposerToggles extends Component {
   }
 
   get fullscreenTitle() {
-    return this.args.composeState === "draft"
-      ? "composer.open"
-      : this.args.composeState === "fullscreen"
-        ? "composer.exit_fullscreen"
-        : "composer.enter_fullscreen";
+    return this.args.composeState === "fullscreen"
+      ? "composer.exit_fullscreen"
+      : "composer.enter_fullscreen";
   }
 
   get fullscreenIcon() {
-    return this.args.composeState === "draft"
-      ? "angles-up"
-      : this.args.composeState === "fullscreen"
-        ? "discourse-compress"
-        : "discourse-expand";
+    return this.args.composeState === "fullscreen"
+      ? "discourse-compress"
+      : "discourse-expand";
   }
 
   get showFullScreenButton() {
-    if (this.site.mobileView) {
+    if (this.site.mobileView || this.args.composeState === "draft") {
       return false;
     }
     return !this.args.disableTextarea;
@@ -64,6 +66,23 @@ export default class ComposerToggles extends Component {
           class="btn-transparent toggle-toolbar btn-small"
         />
       {{/if}}
+      {{#if
+        (and
+          this.composer.allowPreview
+          this.site.desktopView
+          this.showPreviewToggle
+        )
+      }}
+        <DButton
+          @action={{this.composer.togglePreview}}
+          @translatedTitle={{this.composer.toggleText}}
+          @icon="angles-left"
+          class={{dConcatClass
+            "btn-transparent btn-mini-toggle toggle-preview"
+            (unless this.composer.isPreviewVisible "active")
+          }}
+        />
+      {{/if}}
 
       {{#if this.showFullScreenButton}}
         <DButton
@@ -76,7 +95,7 @@ export default class ComposerToggles extends Component {
 
       {{#if this.showCollapseButton}}
         <DButton
-          @icon="angles-down"
+          @icon="minus"
           @action={{@toggleComposer}}
           @title="composer.collapse"
           class="btn-transparent toggler toggle-minimize btn-small"

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -142,7 +142,7 @@ acceptance("Composer Form Template", function (needs) {
       .dom("#reply-control")
       .hasClass("draft", "reply control is minimized into draft mode");
 
-    await click(".toggle-fullscreen");
+    await click("#reply-control");
 
     assert
       .dom("#reply-control")

--- a/frontend/discourse/tests/acceptance/composer-test.js
+++ b/frontend/discourse/tests/acceptance/composer-test.js
@@ -100,7 +100,7 @@ acceptance(`Composer`, function (needs) {
       "sets --composer-height to 40px when composer is minimized without content"
     );
 
-    await click(".toggle-fullscreen");
+    await click("#reply-control");
     await fillIn(
       ".d-editor-input",
       "this is the *content* of a new topic post"
@@ -112,7 +112,7 @@ acceptance(`Composer`, function (needs) {
       "sets --composer-height to 40px when composer is minimized to draft mode"
     );
 
-    await click(".toggle-fullscreen");
+    await click("#reply-control");
     assert.strictEqual(
       document.documentElement.style.getPropertyValue("--composer-height"),
       "var(--new-topic-composer-height, 400px)",
@@ -171,7 +171,7 @@ acceptance(`Composer`, function (needs) {
       "minimizes to the draft bar"
     );
 
-    await click(".toggle-fullscreen");
+    await click("#reply-control");
     assert.strictEqual(
       document.documentElement.style.getPropertyValue("--composer-height"),
       resizedHeight,
@@ -822,7 +822,7 @@ acceptance(`Composer`, function (needs) {
       .dom("#reply-control.draft")
       .isVisible("collapses composer to draft bar");
 
-    await click(".toggle-fullscreen");
+    await click("#reply-control");
 
     assert
       .dom("#reply-control.open")


### PR DESCRIPTION
1. Move the preview toggle to the top, with the other window-controlling actions
3. Change the minimise icon to the industry default minimise icon
4. Don’t show any icon when minimised, the whole bar is clickable as stated by its copy

<img width="655" height="500" alt="image" src="https://github.com/user-attachments/assets/f5b6b7a9-5545-40f6-9bdc-87747eb083f8" />
<img width="1598" height="166" alt="image" src="https://github.com/user-attachments/assets/abcf6a0c-9e72-4293-b628-b4c22288c55b" />


`t/188570`