### PR TITLE
FIX: Hand off search cleanly between welcome banner and header search

### DIFF
--- a/frontend/discourse/app/components/search-menu.gjs
+++ b/frontend/discourse/app/components/search-menu.gjs
@@ -6,6 +6,7 @@ import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { cancel } from "@ember/runloop";
 import { service } from "@ember/service";
+import { modifier } from "ember-modifier";
 import { Promise } from "rsvp";
 import MenuPanel from "discourse/components/menu-panel";
 import PluginOutlet from "discourse/components/plugin-outlet";
@@ -55,6 +56,7 @@ export default class SearchMenu extends Component {
   searchInputId = this.args.searchInputId ?? "search-term";
   searchInputPlaceholder = this.args.searchInputPlaceholder || "search.title";
 
+  closeWhenHidden = modifier((_element, [hidden]) => hidden && this.close());
   _debouncer = null;
   _activeSearch = null;
 
@@ -153,6 +155,10 @@ export default class SearchMenu extends Component {
 
   @action
   open() {
+    if (this.args.hideResults) {
+      return;
+    }
+
     if (!this.menuPanelOpen) {
       this.appEvents.trigger("search-menu:search_menu_opened");
     }
@@ -194,7 +200,7 @@ export default class SearchMenu extends Component {
   }
 
   get displayMenuPanelResults() {
-    if (this.args.inlineResults) {
+    if (this.args.inlineResults || this.args.hideResults) {
       return false;
     }
 
@@ -407,6 +413,7 @@ export default class SearchMenu extends Component {
     <div
       class={{this.classNames}}
       {{didInsert this.setupEventListeners}}
+      {{this.closeWhenHidden @hideResults}}
       {{on "keydown" this.onKeydown}}
     >
       <div class="search-input-wrapper">

--- a/frontend/discourse/app/components/welcome-banner.gjs
+++ b/frontend/discourse/app/components/welcome-banner.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { next } from "@ember/runloop";
 import { service } from "@ember/service";
 import { dasherize } from "@ember/string";
 import { trustHTML } from "@ember/template";
@@ -6,10 +7,12 @@ import { modifier } from "ember-modifier";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import SearchMenu from "discourse/components/search-menu";
 import bodyClass from "discourse/helpers/body-class";
+import { headerOffset } from "discourse/lib/offset-calculator";
 import { prioritizeNameFallback } from "discourse/lib/settings";
 import { sanitize } from "discourse/lib/text";
 import { applyValueTransformer } from "discourse/lib/transformer";
 import { defaultHomepage, escapeExpression } from "discourse/lib/utilities";
+import { not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import I18n, { i18n } from "discourse-i18n";
@@ -34,18 +37,43 @@ export default class WelcomeBanner extends Component {
   @service search;
 
   checkViewport = modifier((element) => {
+    const searchMenu =
+      element.querySelector(".welcome-banner__search-menu") ?? element;
+
     const checkVisibility = () => {
       // Use getBoundingClientRect for reliable visibility detection.
       // IntersectionObserver's isIntersecting can return stale values during
       // SPA navigation, but getBoundingClientRect is always accurate.
-      const { top, bottom } = element.getBoundingClientRect();
-      const isFullyVisible = top >= 0 && bottom <= window.innerHeight;
-      this.search.welcomeBannerSearchInViewport = isFullyVisible;
+      // The banner search stays the only visible search bar while any part of
+      // it peeks below the header; the header search replaces it exactly when
+      // it is fully tucked away, so the two are never both usable.
+      const isUsable =
+        searchMenu.getBoundingClientRect().bottom > headerOffset();
+
+      const previousInputId = this.search.currentSearchInputId;
+      this.search.welcomeBannerSearchInViewport = isUsable;
+
+      if (
+        this.search.currentSearchInputId !== previousInputId &&
+        document.activeElement?.id === previousInputId
+      ) {
+        next(() => {
+          if (this.isDestroying) {
+            return;
+          }
+          this.search.focusSearchInput();
+          if (document.activeElement?.tagName !== "INPUT") {
+            document.getElementById(previousInputId)?.focus();
+          }
+        });
+      }
     };
 
     // Use IntersectionObserver only as a trigger for when to check visibility,
-    // not to determine actual visibility state.
-    const threshold = 1.0;
+    // not to determine actual visibility state. The handoff happens partway
+    // through the banner's crossing, so trigger throughout the crossing rather
+    // than only at full visibility.
+    const threshold = Array.from({ length: 101 }, (_, i) => i / 100);
     const observer = new IntersectionObserver(checkVisibility, { threshold });
     observer.observe(element);
 
@@ -57,6 +85,24 @@ export default class WelcomeBanner extends Component {
       observer.disconnect();
       this.search.welcomeBannerSearchInViewport = false;
     };
+  });
+
+  handoffFocus = modifier((element) => {
+    const onFocusin = (event) => {
+      if (event.target.id !== "welcome-banner-search-input") {
+        return;
+      }
+
+      const activeInput = document.getElementById(
+        this.search.currentSearchInputId
+      );
+      if (activeInput && activeInput !== event.target) {
+        activeInput.focus();
+      }
+    };
+
+    element.addEventListener("focusin", onFocusin);
+    return () => element.removeEventListener("focusin", onFocusin);
   });
 
   handleKeyboardShortcut = modifier(() => {
@@ -207,6 +253,7 @@ export default class WelcomeBanner extends Component {
           this.bgImgClass
         }}
         {{this.checkViewport}}
+        {{this.handoffFocus}}
         {{this.handleKeyboardShortcut}}
       >
         <div
@@ -236,6 +283,7 @@ export default class WelcomeBanner extends Component {
               @location="welcome-banner"
               @searchInputId="welcome-banner-search-input"
               @searchInputPlaceholder="welcome_banner.search_placeholder"
+              @hideResults={{not this.search.welcomeBannerSearchInViewport}}
             />
           </div>
           <PluginOutlet @name="welcome-banner-below-input" />

--- a/frontend/discourse/tests/integration/components/search-menu-test.gjs
+++ b/frontend/discourse/tests/integration/components/search-menu-test.gjs
@@ -1,6 +1,8 @@
+import { tracked } from "@glimmer/tracking";
 import {
   click,
   fillIn,
+  find,
   render,
   settled,
   triggerKeyEvent,
@@ -117,6 +119,46 @@ module("Integration | Component | SearchMenu", function (hooks) {
     assert
       .dom(".menu-panel .search-menu-initial-options")
       .doesNotExist("Menu panel is hidden");
+  });
+
+  test("@hideResults closes the menu and keeps it closed", async function (assert) {
+    const state = new (class {
+      @tracked hidden = false;
+    })();
+
+    await render(
+      <template>
+        <SearchMenu
+          @location="test"
+          @searchInputId="icon-search-input"
+          @hideResults={{state.hidden}}
+        />
+      </template>
+    );
+
+    await click("#icon-search-input");
+    assert.dom(".menu-panel").exists("menu opens from the input");
+
+    state.hidden = true;
+    await settled();
+    assert
+      .dom(".menu-panel")
+      .doesNotExist("menu closes when results are hidden");
+
+    await click("#icon-search-input");
+    assert
+      .dom(".menu-panel")
+      .doesNotExist("menu cannot open while results are hidden");
+
+    state.hidden = false;
+    await settled();
+    assert
+      .dom(".menu-panel")
+      .doesNotExist("menu stays closed when results can show again");
+
+    find("#icon-search-input").blur();
+    await click("#icon-search-input");
+    assert.dom(".menu-panel").exists("menu can reopen from the input");
   });
 
   test("rendering without a searchInputId provided", async function (assert) {

--- a/spec/system/page_objects/components/welcome_banner.rb
+++ b/spec/system/page_objects/components/welcome_banner.rb
@@ -15,6 +15,19 @@ module PageObjects
         has_css?(".welcome-banner", visible: false)
       end
 
+      def open_search_menu
+        find(".welcome-banner #welcome-banner-search-input").click
+        self
+      end
+
+      def has_search_menu?
+        has_css?(".welcome-banner .search-menu-panel", visible: false)
+      end
+
+      def has_no_search_menu?
+        has_no_css?(".welcome-banner .search-menu-panel", visible: false)
+      end
+
       def has_anonymous_title?
         has_css?(
           ".welcome-banner .welcome-banner__title",

--- a/spec/system/page_objects/pages/search.rb
+++ b/spec/system/page_objects/pages/search.rb
@@ -95,6 +95,10 @@ module PageObjects
         page.has_selector?(SEARCH_FIELD_SELECTOR, visible: true)
       end
 
+      def has_header_search_menu?
+        page.has_css?("#{SEARCH_FIELD_SELECTOR} .search-menu-panel", visible: false)
+      end
+
       def has_no_search_field?
         page.has_no_selector?(SEARCH_FIELD_SELECTOR)
       end

--- a/spec/system/search_shortcut_variation_spec.rb
+++ b/spec/system/search_shortcut_variation_spec.rb
@@ -8,6 +8,14 @@ describe "Search | Shortcuts for variations of search input" do
 
   before { sign_in(current_user) }
 
+  def expect_search_shortcut_to_toggle(input_id)
+    send_keys("/")
+    expect(search_page).to have_search_menu
+    expect(page).to have_css("##{input_id}:focus")
+    send_keys(:escape)
+    expect(search_page).to have_no_search_menu_visible
+  end
+
   context "when search_experience is search_field" do
     before do
       Fabricate(:theme_site_setting_with_service, name: "search_experience", value: "search_field")
@@ -21,11 +29,7 @@ describe "Search | Shortcuts for variations of search input" do
       it "displays and focuses welcome banner search when / is pressed and hides it when Escape is pressed" do
         visit("/")
         expect(welcome_banner).to be_visible
-        send_keys("/")
-        expect(search_page).to have_search_menu
-        expect(page).to have_css("#welcome-banner-search-input:focus")
-        send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
+        expect_search_shortcut_to_toggle("welcome-banner-search-input")
       end
 
       context "when welcome banner is not in the viewport" do
@@ -35,11 +39,31 @@ describe "Search | Shortcuts for variations of search input" do
           fake_scroll_down_long
           expect(search_page).to have_search_field
           expect(welcome_banner).to be_invisible
-          send_keys("/")
-          expect(search_page).to have_search_menu
+          expect_search_shortcut_to_toggle("header-search-input")
+        end
+
+        it "moves the search menu and focus between the welcome banner and the header search as the user scrolls" do
+          visit("/")
+          expect(welcome_banner).to be_visible
+          welcome_banner.open_search_menu
+          expect(welcome_banner).to have_search_menu
+
+          fake_scroll_down_long
+          expect(search_page).to have_search_field
           expect(page).to have_css("#header-search-input:focus")
-          send_keys(:escape)
-          expect(search_page).to have_no_search_menu_visible
+          expect(search_page).to have_header_search_menu
+          expect(welcome_banner).to have_no_search_menu
+
+          page.execute_script(
+            "document.getElementById('welcome-banner-search-input').focus({ preventScroll: true })",
+          )
+          expect(page).to have_css("#header-search-input:focus")
+          expect(welcome_banner).to have_no_search_menu
+
+          page.scroll_to(0, 0)
+          expect(search_page).to have_no_search_field
+          expect(page).to have_css("#welcome-banner-search-input:focus")
+          expect(welcome_banner).to have_search_menu
         end
       end
     end
@@ -52,11 +76,7 @@ describe "Search | Shortcuts for variations of search input" do
       it "displays and focuses header search when / is pressed and hides it when Escape is pressed" do
         visit("/")
         expect(welcome_banner).to be_hidden
-        send_keys("/")
-        expect(search_page).to have_search_menu
-        expect(page).to have_css("#header-search-input:focus")
-        send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
+        expect_search_shortcut_to_toggle("header-search-input")
       end
     end
   end
@@ -74,11 +94,7 @@ describe "Search | Shortcuts for variations of search input" do
       it "displays and focuses welcome banner search when / is pressed and hides it when Escape is pressed" do
         visit("/")
         expect(welcome_banner).to be_visible
-        send_keys("/")
-        expect(search_page).to have_search_menu
-        expect(page).to have_css("#welcome-banner-search-input:focus")
-        send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
+        expect_search_shortcut_to_toggle("welcome-banner-search-input")
       end
 
       context "when welcome banner is not in the viewport" do
@@ -88,11 +104,7 @@ describe "Search | Shortcuts for variations of search input" do
           fake_scroll_down_long
           expect(search_page).to have_search_icon
           expect(welcome_banner).to be_invisible
-          send_keys("/")
-          expect(search_page).to have_search_menu
-          expect(page).to have_css("#icon-search-input:focus")
-          send_keys(:escape)
-          expect(search_page).to have_no_search_menu_visible
+          expect_search_shortcut_to_toggle("icon-search-input")
         end
       end
     end
@@ -105,11 +117,7 @@ describe "Search | Shortcuts for variations of search input" do
       it "displays and focuses search icon search when / is pressed and hides it when Escape is pressed" do
         visit("/")
         expect(welcome_banner).to be_hidden
-        send_keys("/")
-        expect(search_page).to have_search_menu
-        expect(page).to have_css("#icon-search-input:focus")
-        send_keys(:escape)
-        expect(search_page).to have_no_search_menu_visible
+        expect_search_shortcut_to_toggle("icon-search-input")
       end
 
       # This search menu only shows within a topic, not in other pages on the site,
@@ -120,11 +128,7 @@ describe "Search | Shortcuts for variations of search input" do
 
         it "opens search on first press of /, and closes when Escape is pressed" do
           visit "/t/#{topic.slug}/#{topic.id}"
-          send_keys("/")
-          expect(search_page).to have_search_menu
-          expect(page).to have_css("#icon-search-input:focus")
-          send_keys(:escape)
-          expect(search_page).to have_no_search_menu_visible
+          expect_search_shortcut_to_toggle("icon-search-input")
         end
       end
     end


### PR DESCRIPTION
Previously, the header search field appeared as soon as the welcome banner was no longer fully visible, leaving both search bars on screen and interactive at once; since they share one search service, a single search could show its results in both panels, the banner's open results panel could overlay and swallow clicks aimed at the header field, and typing into the superseded banner input ran searches with no visible results.

This change bases the switch on the banner's search bar itself: the banner remains the only search UI while any part of its input is below the header, and the header search replaces it exactly when the input is fully tucked away — with focus and the open results panel following the handoff in both directions, stray focus on the superseded input redirected to the active one, and hidden menus closed so a dismissed panel stays dismissed.

Note the intentional behavior change: the header search field now appears slightly later when scrolling (once the banner search bar is fully under the header, rather than on the first pixel of scroll).

Internal topic: t/188511