### PR TITLE
FEATURE: Upcoming change to lower the pending users reminder delay default

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2970,6 +2970,7 @@ en:
     granular_anonymous_and_logged_in_groups_permissions: "Makes group-based site setting permissions treat 'everyone' as 'all logged-in users', and enables the new 'anonymous_users' and 'logged_in_users' pseudogroups so admins can explicitly target anonymous visitors and authenticated users."
     dashboard_improvements: "Enables the redesigned admin dashboard that lets you pin custom reports and includes improved site traffic, engagement, and other analytics tied to community success and value."
     enable_invite_modal_with_roles: "Enables a redesigned invite flow that lets admins invite someone directly as an admin. The invitee becomes a moderator on signup and an admin once the inviter confirms via email."
+    update_pending_users_reminder_default: "We are updating the default for the {{setting:pending_users_reminder_delay_minutes}} setting to 30 minutes so that staff are promptly notified when a new member is waiting for approval. If you have previously changed this setting, this change will have no effect."
 
     errors:
       invalid_css_color: "Invalid color. Enter a color name or hex value."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -981,6 +981,9 @@ login:
     min: -1
     default: 480
     area: "login"
+    upcoming_change_default_override:
+      upcoming_change: "update_pending_users_reminder_default"
+      new_default: 30
   persistent_sessions:
     default: true
     area: "login"
@@ -4815,3 +4818,14 @@ experimental:
       status: "experimental"
       impact: "feature,admins"
       learn_more_url: "https://meta.discourse.org/t/-/407727"
+  update_pending_users_reminder_default:
+    default: false
+    hidden: true
+    client: true
+    upcoming_change:
+      status: "alpha"
+      impact: "site_setting_default,all_members"
+      learn_more_url: "https://meta.discourse.org/t/-/408429"
+      permanent_warning: false
+      allow_enabled_for:
+        - everyone

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -59,6 +59,13 @@ module UpcomingChanges
       SiteSetting.enable_local_logins && SiteSetting.enable_local_logins_via_email &&
         !SiteSetting.enable_discourse_connect
     end
+
+    # Pending-user reminders only fire when must_approve_users is on, so the
+    # change is irrelevant elsewhere, including when enabled: the overridden
+    # default has no effect on a site where nobody can be pending.
+    def self.should_display_update_pending_users_reminder_default?
+      SiteSetting.must_approve_users
+    end
   end
 
   def self.user_enabled_reasons

--- a/spec/lib/upcoming_changes_spec.rb
+++ b/spec/lib/upcoming_changes_spec.rb
@@ -1366,5 +1366,35 @@ RSpec.describe UpcomingChanges do
         ).to eq(true)
       end
     end
+
+    describe ".should_display_update_pending_users_reminder_default?" do
+      it "returns false when must_approve_users is disabled" do
+        expect(
+          UpcomingChanges::ConditionalDisplay.should_display?(
+            :update_pending_users_reminder_default,
+          ),
+        ).to eq(false)
+      end
+
+      it "returns true when must_approve_users is enabled" do
+        SiteSetting.must_approve_users = true
+
+        expect(
+          UpcomingChanges::ConditionalDisplay.should_display?(
+            :update_pending_users_reminder_default,
+          ),
+        ).to eq(true)
+      end
+
+      it "returns false even when the change is enabled, since it has no effect without must_approve_users" do
+        SiteSetting.update_pending_users_reminder_default = true
+
+        expect(
+          UpcomingChanges::ConditionalDisplay.should_display?(
+            :update_pending_users_reminder_default,
+          ),
+        ).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/site_setting_spec.rb
+++ b/spec/models/site_setting_spec.rb
@@ -49,6 +49,25 @@ RSpec.describe SiteSetting do
     end
   end
 
+  describe "pending_users_reminder_delay_minutes" do
+    it "defaults to 30 while the update_pending_users_reminder_default change is enabled" do
+      expect(SiteSetting.pending_users_reminder_delay_minutes).to eq(480)
+
+      SiteSetting.update_pending_users_reminder_default = true
+      expect(SiteSetting.pending_users_reminder_delay_minutes).to eq(30)
+
+      SiteSetting.update_pending_users_reminder_default = false
+      expect(SiteSetting.pending_users_reminder_delay_minutes).to eq(480)
+    end
+
+    it "keeps a value an admin has set when the change is enabled" do
+      SiteSetting.pending_users_reminder_delay_minutes = 60
+
+      SiteSetting.update_pending_users_reminder_default = true
+      expect(SiteSetting.pending_users_reminder_delay_minutes).to eq(60)
+    end
+  end
+
   describe "top_menu" do
     describe "validations" do
       it "always demands latest" do


### PR DESCRIPTION
Previously, on sites that require staff to approve new members, moderators were not reminded about people waiting for approval until 8 hours (480 minutes) after they registered, leaving new members waiting far longer than necessary.

This change adds an `update_pending_users_reminder_default` upcoming change that lowers the `pending_users_reminder_delay_minutes` default to 30 when enabled, so staff are notified promptly. It uses the virtual default-override mechanism rather than writing to the DB, so an admin who has customized the setting keeps their value and disabling the change restores the previous default. The change is only surfaced on sites with `must_approve_users` enabled, since the reminder never fires otherwise.