### PR TITLE
FIX: Preserve "+" in server-side sync_sso payloads

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -496,25 +496,25 @@ class Admin::UsersController < Admin::StaffController
   def sync_sso
     return render body: nil, status: :not_found unless SiteSetting.enable_discourse_connect
 
-    begin
-      sso = DiscourseConnect.parse("sso=#{params[:sso]}&sig=#{params[:sig]}", server_session:)
-    rescue DiscourseConnect::ParseError
-      return(
-        render json: failed_json.merge(message: I18n.t("discourse_connect.login_error")),
-               status: :unprocessable_entity
+    sso =
+      DiscourseConnect.parse(
+        Rack::Utils.build_query(sso: params[:sso].to_s, sig: params[:sig].to_s),
+        server_session:,
       )
-    end
-
-    begin
-      user = sso.lookup_or_create_user
-      DiscourseEvent.trigger(:sync_sso, user)
-      render_serialized(user, AdminDetailedUserSerializer, root: false)
-    rescue ActiveRecord::RecordInvalid => ex
-      render json: failed_json.merge(message: ex.message), status: :forbidden
-    rescue DiscourseConnect::BlankExternalId => ex
-      render json: failed_json.merge(message: I18n.t("discourse_connect.blank_id_error")),
-             status: :unprocessable_entity
-    end
+    user = sso.lookup_or_create_user
+    DiscourseEvent.trigger(:sync_sso, user)
+    render_serialized(user, AdminDetailedUserSerializer, root: false)
+  rescue DiscourseConnect::ParseError
+    render json: failed_json.merge(message: I18n.t("discourse_connect.login_error")),
+           status: :unprocessable_entity
+  rescue DiscourseConnect::BlankExternalId
+    render json: failed_json.merge(message: I18n.t("discourse_connect.blank_id_error")),
+           status: :unprocessable_entity
+  rescue DiscourseConnect::BannedExternalId
+    render json: failed_json.merge(message: I18n.t("discourse_connect.banned_id_error")),
+           status: :unprocessable_entity
+  rescue ActiveRecord::RecordInvalid => e
+    render json: failed_json.merge(message: e.message), status: :forbidden
   end
 
   def delete_other_accounts_with_same_ip

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3231,6 +3231,7 @@ en:
     timeout_expired: "Account login timed out, please try logging in again."
     no_email: "No email address was provided. Please contact the site's administrator."
     blank_id_error: "The `external_id` is required but was blank"
+    banned_id_error: "The `external_id` value is not allowed"
     email_error: "An account could not be registered with the email address <b>%{email}</b>. Please contact the site's administrator."
     missing_secret: "Authentication failed due to missing secret. Contact the site administrators to fix this problem."
     invite_redeem_failed: "Invite redemption failed. Please contact the site's administrator."

--- a/lib/cooked_post_processor.rb
+++ b/lib/cooked_post_processor.rb
@@ -212,7 +212,7 @@ class CookedPostProcessor
         query = Rack::Utils.parse_nested_query(uri.query)
         next if !query.delete("u")
 
-        uri.query = query.map { |k, v| "#{k}=#{v}" }.join("&").presence
+        uri.query = Rack::Utils.build_nested_query(query).presence
         a["href"] = uri.to_s
       end
   end

--- a/spec/lib/cooked_post_processor_spec.rb
+++ b/spec/lib/cooked_post_processor_spec.rb
@@ -1953,6 +1953,15 @@ RSpec.describe CookedPostProcessor do
       expect(cpp.html).to have_tag("a", with: { href: "https://google.com/?u=bar" })
       expect(cpp.html).to have_tag("a", with: { href: "https://www.example.com/#123#4" })
     end
+
+    it "preserves encoded characters in the remaining query params" do
+      post = Fabricate(:post, user: user_with_auto_groups, raw: "link: #{topic.url}?ref=a%26b&u=99")
+      cpp = CookedPostProcessor.new(post, disable_dominant_color: true)
+
+      cpp.remove_user_ids
+
+      expect(cpp.html).to have_tag("a", with: { href: "#{topic.url}?ref=a%26b" })
+    end
   end
 
   describe "#is_a_hyperlink?" do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -2650,6 +2650,16 @@ RSpec.describe Admin::UsersController do
         expect(response.status).to eq(200)
       end
 
+      it "handles a payload whose base64 contains a '+'" do
+        encoded = Base64.strict_encode64("external_id=1&email=bob@bob.com&username=bob&name=Bob~~~")
+        expect(encoded).to include("+")
+        sig = OpenSSL::HMAC.hexdigest("sha256", sso_secret, encoded)
+
+        post "/admin/users/sync_sso.json", params: { sso: encoded, sig: sig }
+        expect(response.status).to eq(200)
+        expect(User.find_by(username: "bob").name).to eq("Bob~~~")
+      end
+
       it "should create new users" do
         sso.name = "Dr. Claw"
         sso.username = "dr_claw"
@@ -2715,6 +2725,18 @@ RSpec.describe Admin::UsersController do
         expect(response.status).to eq(422)
         expect(response.parsed_body["message"]).to include(
           I18n.t("discourse_connect.blank_id_error"),
+        )
+      end
+
+      it "returns the right message if the external id is banned" do
+        sso.name = "Dr. Claw"
+        sso.username = "dr_claw"
+        sso.email = "dr@claw.com"
+        sso.external_id = "none"
+        post "/admin/users/sync_sso.json", params: Rack::Utils.parse_query(sso.payload)
+        expect(response.status).to eq(422)
+        expect(response.parsed_body["message"]).to include(
+          I18n.t("discourse_connect.banned_id_error"),
         )
       end
     end


### PR DESCRIPTION
Previously, `sync_sso` rebuilt its query string from the already form-decoded `params[:sso]` and let `DiscourseConnect.parse` decode it a second time, so any literal `+` in the base64 payload became a space and a correctly-signed request was rejected with a generic 422 "Login Error".

This change rebuilds the query with `Rack::Utils.build_query` — the exact inverse of the `parse_query` the parser runs — so the payload is decoded exactly once. The second commit applies the same reasoning to `CookedPostProcessor#remove_user_ids`, which rebuilt link query strings by hand and corrupted encoded values (e.g. `%26`) when stripping the `u=` param.

Reported at https://meta.discourse.org/t/407426.
