### PR TITLE
FIX: makes time range required in time window node

### DIFF
--- a/plugins/discourse-workflows/config/locales/client.en.yml
+++ b/plugins/discourse-workflows/config/locales/client.en.yml
@@ -819,7 +819,7 @@ en:
         use_time_range: "Limit to a time range"
         start_time: "Start time"
         end_time: "End time"
-        end_time_description: "The window ends just before this time. Choose an end earlier than the start to span midnight (e.g. 22:00 to 06:00)."
+        end_time_description: "The window ends just before this time. Choose an end earlier than the start to span midnight (e.g. 22:00 to 06:00), or 00:00 to run until the end of the day."
         timezone: "Timezone"
         timezone_description: "Defaults to the workflow timezone."
         timezone_none: "Workflow default"

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/time_window/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/time_window/v1.rb
@@ -52,6 +52,7 @@ module DiscourseWorkflows
             start_time: {
               type: :string,
               default: "09:00",
+              required: true,
               display_options: {
                 show: {
                   use_time_range: [true],
@@ -64,6 +65,7 @@ module DiscourseWorkflows
             end_time: {
               type: :string,
               default: "17:00",
+              required: true,
               display_options: {
                 show: {
                   use_time_range: [true],

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/time_window_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/time_window_spec.rb
@@ -398,4 +398,33 @@ RSpec.describe DiscourseWorkflows::Nodes::TimeWindow::V1 do
       expect(errors).to be_empty
     end
   end
+
+  describe "required time fields" do
+    def issues_for(configuration)
+      node =
+        DiscourseWorkflows::WorkflowSnapshot::SnapshotNode.new(
+          id: "n1",
+          type: "condition:time_window",
+          type_version: "1.0",
+          name: "Time window",
+          parameters: configuration,
+        )
+      DiscourseWorkflows::NodeIssues.for_node(node, described_class)
+    end
+
+    it "flags blank times when the time range is enabled" do
+      issues = issues_for("use_time_range" => true, "start_time" => "", "end_time" => "")
+
+      expect(issues).to contain_exactly(
+        { path: "start_time", name: "start_time", message: "required" },
+        { path: "end_time", name: "end_time", message: "required" },
+      )
+    end
+
+    it "ignores blank times when the time range is disabled" do
+      expect(
+        issues_for("use_time_range" => false, "start_time" => "", "end_time" => ""),
+      ).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
It was already required server side, but not in the frontend. Also clarify how to make ranges from start of the day or to the end of the day.