### PR TITLE
FIX: Preserve overridden translation keys in admin notices

### DIFF
--- a/app/models/admin_notice.rb
+++ b/app/models/admin_notice.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AdminNotice < ActiveRecord::Base
+  TRANSLATION_KEY_DETAIL = "_translation_key"
   MESSAGE_ALLOWED_TAGS = %w[a pre ul li].freeze
   MESSAGE_ALLOWED_ATTRIBUTES =
     (%w[href target rel] + SiteSettings::LabelFormatter::LINK_ATTRIBUTES).freeze
@@ -12,11 +13,11 @@ class AdminNotice < ActiveRecord::Base
   enum :subject, %i[problem].freeze
 
   def message
-    translated =
-      I18n.t(
-        "dashboard.#{subject}.#{identifier}",
-        **details.symbolize_keys.merge(base_path: Discourse.base_path),
-      )
+    translation_data = details.symbolize_keys
+    translation_key =
+      translation_data.delete(TRANSLATION_KEY_DETAIL.to_sym) || "dashboard.#{subject}.#{identifier}"
+
+    translated = I18n.t(translation_key, **translation_data.merge(base_path: Discourse.base_path))
 
     MESSAGE_SANITIZER.sanitize(
       SiteSettings::LabelFormatter.expand_setting_links(translated),

--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -218,13 +218,15 @@ class ProblemCheck
       override_data.merge(
         target.present? ? translation_data(target) : translation_data,
       ).symbolize_keys
+    notice_details = problem_details.merge(details)
+    notice_details[AdminNotice::TRANSLATION_KEY_DETAIL] = override_key if override_key
 
     Problem.new(
       I18n.t(override_key || translation_key, base_path: Discourse.base_path, **problem_details),
       priority: config.priority,
       identifier:,
       target: target_identifier,
-      details: problem_details.merge(details),
+      details: notice_details,
     )
   end
 

--- a/spec/system/admin_notices_spec.rb
+++ b/spec/system/admin_notices_spec.rb
@@ -23,6 +23,27 @@ describe "Admin Notices" do
 
       expect(admin_dashboard).to have_no_admin_notice(I18n.t("dashboard.problem.test_notice"))
     end
+
+    it "warns the admin when the Sidekiq queue is too large" do
+      Jobs.stubs(:last_job_performed_at).returns(1.second.ago)
+      Jobs.stubs(:queued).returns(100_000)
+
+      admin_dashboard.visit
+
+      expect(admin_dashboard).to have_admin_notice(
+        I18n.t("dashboard.problem.queue_size", queue_size: 100_000),
+      )
+    end
+
+    it "warns the admin when Sidekiq is not processing queued jobs" do
+      Jobs.stubs(:last_job_performed_at).returns(20.minutes.ago)
+      Jobs.stubs(:queued).returns(1)
+
+      admin_dashboard.visit
+
+      message = Nokogiri::HTML5.fragment(I18n.t("dashboard.problem.sidekiq_check")).text
+      expect(admin_dashboard).to have_admin_notice(message)
+    end
   end
 
   context "when signed in as moderator" do


### PR DESCRIPTION
Previously, persisted problem notices ignored custom translation keys and displayed incorrectly.

This change stores and reuses the override when rendering admin notices.