### PR TITLE
UX: improve admin filters, add to users and permalinks

### DIFF
--- a/app/assets/stylesheets/admin/site-settings.scss
+++ b/app/assets/stylesheets/admin/site-settings.scss
@@ -66,7 +66,7 @@ body.has-admin-changes-banner #main-outlet {
     }
 
     .setting-description {
-      color: var(--primary-medium);
+      color: var(--primary-high);
       font-size: var(--font-down-1);
     }
   }

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -200,25 +200,6 @@
   .avatar {
     margin-right: 0.25em;
   }
-
-  &__controls {
-    display: flex;
-    gap: 1em;
-  }
-
-  &__search {
-    flex: 1 1 auto;
-  }
-
-  &__activation-filter.d-select {
-    flex: 0 1 auto;
-    max-width: 14em;
-    height: auto;
-
-    @media screen and (width <= 500px) {
-      max-width: none;
-    }
-  }
 }
 
 // mobile styles

--- a/app/assets/stylesheets/common/components/d-filter-controls.scss
+++ b/app/assets/stylesheets/common/components/d-filter-controls.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .d-filter-controls {
   display: flex;
   gap: var(--space-2);
@@ -18,9 +20,18 @@
     flex: 1 1 auto;
   }
 
+  &__dropdowns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10em, 1fr));
+    gap: var(--space-2);
+  }
+
   &__dropdown {
-    max-width: min(14em, 35vw);
     flex: 1 1 auto;
+
+    &.--active {
+      border-color: var(--tertiary);
+    }
   }
 
   &__no-results {

--- a/app/assets/stylesheets/common/components/d-select.scss
+++ b/app/assets/stylesheets/common/components/d-select.scss
@@ -16,6 +16,8 @@
   background-size: 16px 12px;
   cursor: pointer;
 
+  @include ellipsis;
+
   &:focus,
   &:focus-visible,
   &:focus:focus-visible,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3269,7 +3269,7 @@ en:
       clear: "Clear filter"
 
     filter_controls:
-      reset: "Reset filter"
+      reset: "Reset"
       toggle: "Toggle dropdown filters"
 
     d_icon_grid_picker:

--- a/frontend/discourse/admin/controllers/admin-permalinks/index.js
+++ b/frontend/discourse/admin/controllers/admin-permalinks/index.js
@@ -1,9 +1,7 @@
-/* eslint-disable ember/no-observers */
 import { tracked } from "@glimmer/tracking";
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
-import { observes } from "@ember-decorators/object";
 import Permalink from "discourse/admin/models/permalink";
 import { removeValueFromArray } from "discourse/lib/array-tools";
 import discourseDebounce from "discourse/lib/debounce";
@@ -20,13 +18,20 @@ export default class AdminPermalinksIndexController extends Controller {
   @tracked filter = null;
   @autoTrackedArray model;
 
-  get showSearch() {
-    return !!(this.model.length || this.filter);
+  get showEmptyList() {
+    return !this.loading && !this.filter && this.model.length === 0;
   }
 
-  @observes("filter")
-  show() {
-    discourseDebounce(this, this.#debouncedShow, INPUT_DELAY);
+  @action
+  onFilterChange(event) {
+    this.filter = event.target.value;
+    discourseDebounce(this, this.#loadPermalinks, INPUT_DELAY);
+  }
+
+  @action
+  onResetFilters() {
+    this.filter = null;
+    this.#loadPermalinks();
   }
 
   @action
@@ -56,7 +61,7 @@ export default class AdminPermalinksIndexController extends Controller {
     });
   }
 
-  async #debouncedShow() {
+  async #loadPermalinks() {
     this.loading = true;
 
     try {

--- a/frontend/discourse/admin/controllers/admin-users-list/show.js
+++ b/frontend/discourse/admin/controllers/admin-users-list/show.js
@@ -24,13 +24,15 @@ export default class AdminUsersListShowController extends Controller {
   @tracked displayBulkActions = false;
   @tracked bulkSelectedUsersMap = {};
 
+  @tracked activation = null;
+  @tracked refreshing = false;
+  @tracked listFilter = null;
+  @tracked initialFilter = null;
+
   query = null;
   order = null;
   asc = null;
-  activation = null;
   showEmails = false;
-  refreshing = false;
-  listFilter = null;
   lastSelected = null;
 
   _page = 1;
@@ -146,24 +148,30 @@ export default class AdminUsersListShowController extends Controller {
       });
   }
 
-  @action
-  onListFilterChange(event) {
-    this.set("listFilter", event.target.value);
-    discourseDebounce(this, this._listFilterChanged, INPUT_DELAY);
+  get showEmptyState() {
+    return (
+      !this.refreshing &&
+      this.users.length === 0 &&
+      !this.listFilter &&
+      !this.activation
+    );
   }
 
-  _listFilterChanged() {
-    // `filter` is deliberately not a registered query param (its name would
-    // clash with the :filter segment), so sync the URL without a transition
+  @action
+  onListFilterChange(event) {
+    this.listFilter = event.target.value;
+    discourseDebounce(this, this.resetFilters, INPUT_DELAY);
+  }
+
+  @action
+  onResetFilters() {
+    this.listFilter = null;
+    this.activation = null;
+    // `filter` is owned by the filter controls; drop the remaining params here
     const url = new URL(window.location.href);
     url.searchParams.delete("username");
-    if (this.listFilter) {
-      url.searchParams.set("filter", this.listFilter);
-    } else {
-      url.searchParams.delete("filter");
-    }
+    url.searchParams.delete("activation");
     DiscourseURL.replaceState(url.pathname + url.search);
-
     this.resetFilters();
   }
 
@@ -191,8 +199,16 @@ export default class AdminUsersListShowController extends Controller {
   }
 
   @action
-  updateActivation(value) {
-    this.set("activation", value);
+  onActivationChange(value) {
+    this.activation = value === "all" ? null : value;
+    const url = new URL(window.location.href);
+    if (this.activation) {
+      url.searchParams.set("activation", this.activation);
+    } else {
+      url.searchParams.delete("activation");
+    }
+    DiscourseURL.replaceState(url.pathname + url.search);
+    this.resetFilters();
   }
 
   @action

--- a/frontend/discourse/admin/routes/admin-users-list/show.js
+++ b/frontend/discourse/admin/routes/admin-users-list/show.js
@@ -5,7 +5,6 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
     order: { refreshModel: true },
     asc: { refreshModel: true },
     username: { refreshModel: true },
-    activation: { refreshModel: true },
   };
 
   // TODO: this has been introduced to fix a bug in admin-users-list-show
@@ -24,8 +23,12 @@ export default class AdminUsersListShowRoute extends DiscourseRoute {
           asc: transition.to.queryParams.asc,
           // `filter` is deliberately not a registered query param (its name
           // would clash with the :filter segment); `username` is kept as a
-          // legacy fallback for old links
+          // legacy fallback for old links. `initialFilter` seeds the filter
+          // controls input; `listFilter` is the live value sent to the server.
           listFilter:
+            transition.to.queryParams.filter ??
+            transition.to.queryParams.username,
+          initialFilter:
             transition.to.queryParams.filter ??
             transition.to.queryParams.username,
           query: params.filter,

--- a/frontend/discourse/admin/templates/admin-permalinks/index.gjs
+++ b/frontend/discourse/admin/templates/admin-permalinks/index.gjs
@@ -4,135 +4,138 @@ import DMenu from "discourse/float-kit/components/d-menu";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
-import DTextField from "discourse/ui-kit/d-text-field";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import dCategoryLink from "discourse/ui-kit/helpers/d-category-link";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
+const PermalinkEmptyList = <template>
+  <AdminConfigAreaEmptyList
+    @ctaLabel="admin.permalink.add"
+    @ctaRoute="adminPermalinks.new"
+    @ctaClass="admin-permalinks__add-permalink"
+    @emptyLabel="admin.permalink.no_permalinks"
+  />
+</template>;
+
 export default <template>
   {{#if @controller.hasPermalinks}}
-    <div class="d-admin-filter">
-      <div class="admin-filter__input-container permalink-search">
-        <DTextField
-          @value={{@controller.filter}}
-          @placeholderKey="admin.permalink.form.filter"
-          @autocorrect="off"
-          @autocapitalize="off"
-          class="admin-filter__input"
-        />
-      </div>
-    </div>
-  {{/if}}
+    <DFilterControls
+      @array={{@controller.model}}
+      @inputPlaceholder={{i18n "admin.permalink.form.filter"}}
+      @noResultsMessage={{i18n "search.no_results"}}
+      @onTextFilterChange={{@controller.onFilterChange}}
+      @onResetFilters={{@controller.onResetFilters}}
+      @loading={{@controller.loading}}
+    >
+      <:aboveContent>
+        <DConditionalLoadingSpinner @condition={{@controller.loading}} />
 
-  <DConditionalLoadingSpinner @condition={{@controller.loading}}>
-    <div class="permalink-results">
-      {{#if @controller.model.length}}
-        <table class="d-table permalinks">
-          <thead class="d-table__header">
-            <tr class="d-table__row">
-              <th class="d-table__header-cell">{{i18n
-                  "admin.permalink.url"
-                }}</th>
-              <th class="d-table__header-cell">{{i18n
-                  "admin.permalink.destination"
-                }}</th>
-            </tr>
-          </thead>
-          <tbody class="d-table__body">
-            {{#each @controller.model as |pl|}}
-              <tr
-                class={{dConcatClass
-                  "d-table__row admin-permalink-item"
-                  pl.key
-                }}
-              >
-                <td class="d-table__cell --overview">
-                  <DButton
-                    @title="admin.permalink.copy_to_clipboard"
-                    @icon="far-clipboard"
-                    @action={{fn @controller.copyUrl pl}}
-                    class="btn-flat"
-                  />
-                  <span
-                    id="admin-permalink-{{pl.id}}"
-                    class="admin-permalink-item__url"
-                    title={{pl.url}}
-                  >{{pl.url}}</span>
-                </td>
-                <td class="d-table__cell --detail destination">
-                  {{#if pl.topic_id}}
-                    <a href={{pl.topic_url}}>{{pl.topic_title}}</a>
-                  {{/if}}
-                  {{#if pl.post_id}}
-                    <a href={{pl.post_url}}>{{pl.post_topic_title}}
-                      #{{pl.post_number}}</a>
-                  {{/if}}
-                  {{#if pl.category_id}}
-                    {{dCategoryLink pl.category}}
-                  {{/if}}
-                  {{#if pl.tag_id}}
-                    <a href={{pl.tag_url}}>{{pl.tag_name}}</a>
-                  {{/if}}
-                  {{#if pl.external_url}}
-                    {{#if pl.linkIsExternal}}
-                      {{dIcon "up-right-from-square"}}
-                    {{/if}}
-                    <a href={{pl.external_url}}>{{pl.external_url}}</a>
-                  {{/if}}
-                  {{#if pl.user_id}}
-                    <a href={{pl.user_url}}>{{pl.username}}</a>
-                  {{/if}}
-                </td>
-                <td class="d-table__cell --controls">
-                  <div class="d-table__cell-actions">
-                    <DButton
-                      class="btn-default btn-small admin-permalink-item__edit"
-                      @route="adminPermalinks.edit"
-                      @routeModels={{pl}}
-                      @label="admin.config_areas.permalinks.edit"
-                    />
-
-                    <DMenu
-                      @identifier="permalink-menu"
-                      @title={{i18n "admin.permalink.more_options"}}
-                      @icon="ellipsis-vertical"
-                      @onRegisterApi={{@controller.onRegisterApi}}
-                      @triggerClass="btn-default"
-                    >
-                      <:content>
-                        <DDropdownMenu as |dropdown|>
-                          <dropdown.item>
-                            <DButton
-                              @action={{fn @controller.destroyRecord pl}}
-                              @icon="trash-can"
-                              class="btn-transparent --danger admin-permalink-item__delete"
-                              @label="admin.config_areas.permalinks.delete"
-                            />
-                          </dropdown.item>
-                        </DDropdownMenu>
-                      </:content>
-                    </DMenu>
-                  </div>
-                </td>
-              </tr>
-            {{/each}}
-          </tbody>
-        </table>
-      {{else}}
-        {{#if @controller.filter}}
-          <p class="permalink-results__no-result">{{i18n
-              "search.no_results"
-            }}</p>
-        {{else}}
-          <AdminConfigAreaEmptyList
-            @ctaLabel="admin.permalink.add"
-            @ctaRoute="adminPermalinks.new"
-            @ctaClass="admin-permalinks__add-permalink"
-            @emptyLabel="admin.permalink.no_permalinks"
-          />
+        {{#if @controller.showEmptyList}}
+          <PermalinkEmptyList />
         {{/if}}
-      {{/if}}
-    </div>
-  </DConditionalLoadingSpinner>
+      </:aboveContent>
+
+      <:content as |permalinks|>
+        {{#if permalinks.length}}
+          <div class="permalink-results">
+            <table class="d-table permalinks">
+              <thead class="d-table__header">
+                <tr class="d-table__row">
+                  <th class="d-table__header-cell">{{i18n
+                      "admin.permalink.url"
+                    }}</th>
+                  <th class="d-table__header-cell">{{i18n
+                      "admin.permalink.destination"
+                    }}</th>
+                </tr>
+              </thead>
+              <tbody class="d-table__body">
+                {{#each permalinks as |pl|}}
+                  <tr
+                    class={{dConcatClass
+                      "d-table__row admin-permalink-item"
+                      pl.key
+                    }}
+                  >
+                    <td class="d-table__cell --overview">
+                      <DButton
+                        @title="admin.permalink.copy_to_clipboard"
+                        @icon="far-clipboard"
+                        @action={{fn @controller.copyUrl pl}}
+                        class="btn-flat"
+                      />
+                      <span
+                        id="admin-permalink-{{pl.id}}"
+                        class="admin-permalink-item__url"
+                        title={{pl.url}}
+                      >{{pl.url}}</span>
+                    </td>
+                    <td class="d-table__cell --detail destination">
+                      {{#if pl.topic_id}}
+                        <a href={{pl.topic_url}}>{{pl.topic_title}}</a>
+                      {{/if}}
+                      {{#if pl.post_id}}
+                        <a href={{pl.post_url}}>{{pl.post_topic_title}}
+                          #{{pl.post_number}}</a>
+                      {{/if}}
+                      {{#if pl.category_id}}
+                        {{dCategoryLink pl.category}}
+                      {{/if}}
+                      {{#if pl.tag_id}}
+                        <a href={{pl.tag_url}}>{{pl.tag_name}}</a>
+                      {{/if}}
+                      {{#if pl.external_url}}
+                        {{#if pl.linkIsExternal}}
+                          {{dIcon "up-right-from-square"}}
+                        {{/if}}
+                        <a href={{pl.external_url}}>{{pl.external_url}}</a>
+                      {{/if}}
+                      {{#if pl.user_id}}
+                        <a href={{pl.user_url}}>{{pl.username}}</a>
+                      {{/if}}
+                    </td>
+                    <td class="d-table__cell --controls">
+                      <div class="d-table__cell-actions">
+                        <DButton
+                          class="btn-default btn-small admin-permalink-item__edit"
+                          @route="adminPermalinks.edit"
+                          @routeModels={{pl}}
+                          @label="admin.config_areas.permalinks.edit"
+                        />
+
+                        <DMenu
+                          @identifier="permalink-menu"
+                          @title={{i18n "admin.permalink.more_options"}}
+                          @icon="ellipsis-vertical"
+                          @onRegisterApi={{@controller.onRegisterApi}}
+                          @triggerClass="btn-default"
+                        >
+                          <:content>
+                            <DDropdownMenu as |dropdown|>
+                              <dropdown.item>
+                                <DButton
+                                  @action={{fn @controller.destroyRecord pl}}
+                                  @icon="trash-can"
+                                  class="btn-transparent --danger admin-permalink-item__delete"
+                                  @label="admin.config_areas.permalinks.delete"
+                                />
+                              </dropdown.item>
+                            </DDropdownMenu>
+                          </:content>
+                        </DMenu>
+                      </div>
+                    </td>
+                  </tr>
+                {{/each}}
+              </tbody>
+            </table>
+          </div>
+        {{/if}}
+      </:content>
+    </DFilterControls>
+  {{else}}
+    <PermalinkEmptyList />
+  {{/if}}
 </template>

--- a/frontend/discourse/admin/templates/admin-users-list/show.gjs
+++ b/frontend/discourse/admin/templates/admin-users-list/show.gjs
@@ -12,10 +12,10 @@ import { not, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import DLoadMore from "discourse/ui-kit/d-load-more";
 import DPageSubheader from "discourse/ui-kit/d-page-subheader";
 import DResponsiveTable from "discourse/ui-kit/d-responsive-table";
-import DSelect from "discourse/ui-kit/d-select";
 import DTableHeaderToggle from "discourse/ui-kit/d-table-header-toggle";
 import dAvatar from "discourse/ui-kit/helpers/d-avatar";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
@@ -23,6 +23,18 @@ import dFormatDuration from "discourse/ui-kit/helpers/d-format-duration";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import dNumber from "discourse/ui-kit/helpers/d-number";
 import { i18n } from "discourse-i18n";
+
+const ACTIVATION_FILTER_OPTIONS = [
+  { value: "all", label: i18n("admin.users.activation_filter.all") },
+  {
+    value: "activated",
+    label: i18n("admin.users.activation_filter.activated"),
+  },
+  {
+    value: "not_activated",
+    label: i18n("admin.users.activation_filter.not_activated"),
+  },
+];
 
 export default <template>
   <DPageSubheader @titleLabel={{@controller.title}}>
@@ -47,443 +59,452 @@ export default <template>
 
   <PluginOutlet @name="admin-users-list-show-before" />
 
-  <div class="d-admin-filter admin-users-list__controls">
-    <div class="admin-filter__input-container admin-users-list__search">
-      <input
-        class="admin-filter__input"
-        type="text"
-        dir="auto"
-        value={{@controller.listFilter}}
-        placeholder={{@controller.searchHint}}
-        title={{@controller.searchHint}}
-        {{on "input" @controller.onListFilterChange}}
-      />
-    </div>
-    {{#if @controller.showActivationFilter}}
-      <DSelect
-        @value={{@controller.activation}}
-        @onChange={{@controller.updateActivation}}
-        @nonePlaceholder={{i18n "admin.users.activation_filter.all"}}
-        class="admin-users-list__activation-filter"
-        aria-label={{i18n "admin.users.activation_filter.label"}}
-        as |select|
-      >
-        <select.Option @value="activated">
-          {{i18n "admin.users.activation_filter.activated"}}
-        </select.Option>
-        <select.Option @value="not_activated">
-          {{i18n "admin.users.activation_filter.not_activated"}}
-        </select.Option>
-      </DSelect>
-    {{/if}}
-    {{#if @controller.displayBulkActions}}
-      <div class="bulk-actions-dropdown">
-        <DMenu
-          @autofocus={{true}}
-          @identifier="bulk-select-admin-users-dropdown"
-          @triggerClass="btn-default"
-        >
-          <:trigger>
-            <span class="d-button-label">
-              {{i18n "admin.users.bulk_actions.title"}}
-            </span>
-            {{dIcon "angle-down"}}
-          </:trigger>
+  <DFilterControls
+    @array={{@controller.users}}
+    @inputPlaceholder={{@controller.searchHint}}
+    @initialTextFilter={{@controller.initialFilter}}
+    @textFilterQueryParam="filter"
+    @noResultsMessage={{i18n "search.no_results"}}
+    @onTextFilterChange={{@controller.onListFilterChange}}
+    @onResetFilters={{@controller.onResetFilters}}
+    @loading={{@controller.refreshing}}
+    @dropdownOptions={{if
+      @controller.showActivationFilter
+      ACTIVATION_FILTER_OPTIONS
+    }}
+    @dropdownValue={{or @controller.activation "all"}}
+    @onDropdownFilterChange={{@controller.onActivationChange}}
+  >
+    <:actions>
+      {{#if @controller.displayBulkActions}}
+        <div class="bulk-actions-dropdown">
+          <DMenu
+            @autofocus={{true}}
+            @identifier="bulk-select-admin-users-dropdown"
+            @triggerClass="btn-default"
+          >
+            <:trigger>
+              <span class="d-button-label">
+                {{i18n "admin.users.bulk_actions.title"}}
+              </span>
+              {{dIcon "angle-down"}}
+            </:trigger>
 
-          <:content>
-            <DDropdownMenu as |dropdown|>
-              <dropdown.item>
-                <DButton
-                  @translatedLabel={{i18n
-                    "admin.users.bulk_actions.suspend.label"
-                  }}
-                  @icon="ban"
-                  @action={{@controller.openBulkSuspendConfirmation}}
-                  class="bulk-suspend btn-danger"
-                />
-              </dropdown.item>
-              <dropdown.item>
-                <DButton
-                  @translatedLabel={{i18n
-                    "admin.users.bulk_actions.delete.label"
-                  }}
-                  @icon="trash-can"
-                  @action={{@controller.openBulkDeleteConfirmation}}
-                  class="bulk-delete btn-danger"
-                />
-              </dropdown.item>
-            </DDropdownMenu>
-          </:content>
-        </DMenu>
-      </div>
-    {{/if}}
-  </div>
-  <DLoadMore @action={{@controller.loadMore}} class="users-list-container">
-    {{#if @controller.users}}
-      <DResponsiveTable
-        @className={{dConcatClass "users-list" @controller.query}}
-        @ariaLabel={{@controller.title}}
-        @style={{trustHTML
-          (concat
-            "grid-template-columns: minmax(min-content, 2fr) repeat("
-            (trustHTML @controller.columnCount)
-            ", minmax(min-content, 1fr))"
-          )
-        }}
-      >
-        <:header>
-          <div class="directory-table__column-header-wrapper">
-            <DButton
-              class="btn-flat bulk-select"
-              @icon="list-check"
-              @action={{@controller.toggleBulkSelect}}
-            />
-            {{#if @controller.bulkSelect}}
+            <:content>
+              <DDropdownMenu as |dropdown|>
+                <dropdown.item>
+                  <DButton
+                    @translatedLabel={{i18n
+                      "admin.users.bulk_actions.suspend.label"
+                    }}
+                    @icon="ban"
+                    @action={{@controller.openBulkSuspendConfirmation}}
+                    class="bulk-suspend btn-danger"
+                  />
+                </dropdown.item>
+                <dropdown.item>
+                  <DButton
+                    @translatedLabel={{i18n
+                      "admin.users.bulk_actions.delete.label"
+                    }}
+                    @icon="trash-can"
+                    @action={{@controller.openBulkDeleteConfirmation}}
+                    class="bulk-delete btn-danger"
+                  />
+                </dropdown.item>
+              </DDropdownMenu>
+            </:content>
+          </DMenu>
+        </div>
+      {{/if}}
+    </:actions>
+
+    <:aboveContent>
+      {{! only spin above the table when there are no rows yet; otherwise the
+      pagination spinner lives below the table (see :content) so loading more
+      doesn't shove the table down }}
+      {{#unless @controller.users.length}}
+        <DConditionalLoadingSpinner @condition={{@controller.refreshing}} />
+      {{/unless}}
+
+      {{#if @controller.showEmptyState}}
+        <p class="admin-users-list__no-results">{{i18n "search.no_results"}}</p>
+      {{/if}}
+    </:aboveContent>
+
+    <:content as |users|>
+      <DLoadMore @action={{@controller.loadMore}} class="users-list-container">
+        <DResponsiveTable
+          @className={{dConcatClass "users-list" @controller.query}}
+          @ariaLabel={{@controller.title}}
+          @style={{trustHTML
+            (concat
+              "grid-template-columns: minmax(min-content, 2fr) repeat("
+              (trustHTML @controller.columnCount)
+              ", minmax(min-content, 1fr))"
+            )
+          }}
+        >
+          <:header>
+            <div class="directory-table__column-header-wrapper">
               <DButton
-                class="btn-flat bulk-select-all"
-                @label="admin.users.bulk_actions.select_all"
-                @action={{@controller.bulkSelectAll}}
+                class="btn-flat bulk-select"
+                @icon="list-check"
+                @action={{@controller.toggleBulkSelect}}
               />
-              <DButton
-                class="btn-flat bulk-clear-all"
-                @label="admin.users.bulk_actions.clear_all"
-                @action={{@controller.bulkClearAll}}
+              {{#if @controller.bulkSelect}}
+                <DButton
+                  class="btn-flat bulk-select-all"
+                  @label="admin.users.bulk_actions.select_all"
+                  @action={{@controller.bulkSelectAll}}
+                />
+                <DButton
+                  class="btn-flat bulk-clear-all"
+                  @label="admin.users.bulk_actions.clear_all"
+                  @action={{@controller.bulkClearAll}}
+                />
+              {{/if}}
+              <DTableHeaderToggle
+                @onToggle={{@controller.updateOrder}}
+                @field="username"
+                @labelKey="username"
+                @order={{@controller.order}}
+                @asc={{@controller.asc}}
+                @automatic={{true}}
+                class="directory-table__column-header--username"
+              />
+            </div>
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="email"
+              @labelKey="email"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+              class={{if
+                @controller.showEmails
+                "directory-table__column-header--email"
+                "hidden"
+              }}
+            />
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="last_emailed"
+              @labelKey="admin.users.last_emailed"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+            />
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="seen"
+              @labelKey="last_seen"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+            />
+            {{#unless
+              (or @controller.showSilenceReason @controller.showSuspendReason)
+            }}
+              <DTableHeaderToggle
+                @onToggle={{@controller.updateOrder}}
+                @field="topics_viewed"
+                @labelKey="admin.user.topics_entered"
+                @order={{@controller.order}}
+                @asc={{@controller.asc}}
+                @automatic={{true}}
+              />
+            {{/unless}}
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="posts_read"
+              @labelKey="admin.user.posts_read_count"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+            />
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="read_time"
+              @labelKey="admin.user.time_read"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+            />
+            <DTableHeaderToggle
+              @onToggle={{@controller.updateOrder}}
+              @field="created"
+              @labelKey="created"
+              @order={{@controller.order}}
+              @asc={{@controller.asc}}
+              @automatic={{true}}
+            />
+            {{#if @controller.showSilenceReason}}
+              <DTableHeaderToggle
+                @onToggle={{@controller.updateOrder}}
+                @field="silence_reason"
+                @labelKey="admin.users.silence_reason"
+                @order={{@controller.order}}
+                @asc={{@controller.asc}}
+                @automatic={{true}}
+                class="directory-table__column-header--silence-reason"
               />
             {{/if}}
-            <DTableHeaderToggle
-              @onToggle={{@controller.updateOrder}}
-              @field="username"
-              @labelKey="username"
-              @order={{@controller.order}}
-              @asc={{@controller.asc}}
-              @automatic={{true}}
-              class="directory-table__column-header--username"
-            />
-          </div>
-          <DTableHeaderToggle
-            @onToggle={{@controller.updateOrder}}
-            @field="email"
-            @labelKey="email"
-            @order={{@controller.order}}
-            @asc={{@controller.asc}}
-            @automatic={{true}}
-            class={{if
-              @controller.showEmails
-              "directory-table__column-header--email"
-              "hidden"
-            }}
-          />
-          <DTableHeaderToggle
-            @onToggle={{@controller.updateOrder}}
-            @field="last_emailed"
-            @labelKey="admin.users.last_emailed"
-            @order={{@controller.order}}
-            @asc={{@controller.asc}}
-            @automatic={{true}}
-          />
-          <DTableHeaderToggle
-            @onToggle={{@controller.updateOrder}}
-            @field="seen"
-            @labelKey="last_seen"
-            @order={{@controller.order}}
-            @asc={{@controller.asc}}
-            @automatic={{true}}
-          />
-          {{#unless
-            (or @controller.showSilenceReason @controller.showSuspendReason)
-          }}
-            <DTableHeaderToggle
-              @onToggle={{@controller.updateOrder}}
-              @field="topics_viewed"
-              @labelKey="admin.user.topics_entered"
-              @order={{@controller.order}}
-              @asc={{@controller.asc}}
-              @automatic={{true}}
-            />
-          {{/unless}}
-          <DTableHeaderToggle
-            @onToggle={{@controller.updateOrder}}
-            @field="posts_read"
-            @labelKey="admin.user.posts_read_count"
-            @order={{@controller.order}}
-            @asc={{@controller.asc}}
-            @automatic={{true}}
-          />
-          <DTableHeaderToggle
-            @onToggle={{@controller.updateOrder}}
-            @field="read_time"
-            @labelKey="admin.user.time_read"
-            @order={{@controller.order}}
-            @asc={{@controller.asc}}
-            @automatic={{true}}
-          />
-          <DTableHeaderToggle
-            @onToggle={{@controller.updateOrder}}
-            @field="created"
-            @labelKey="created"
-            @order={{@controller.order}}
-            @asc={{@controller.asc}}
-            @automatic={{true}}
-          />
-          {{#if @controller.showSilenceReason}}
-            <DTableHeaderToggle
-              @onToggle={{@controller.updateOrder}}
-              @field="silence_reason"
-              @labelKey="admin.users.silence_reason"
-              @order={{@controller.order}}
-              @asc={{@controller.asc}}
-              @automatic={{true}}
-              class="directory-table__column-header--silence-reason"
-            />
-          {{/if}}
-          {{#if @controller.showSuspendReason}}
-            <DTableHeaderToggle
-              @onToggle={{@controller.updateOrder}}
-              @field="suspend_reason"
-              @labelKey="admin.users.suspend_reason"
-              @order={{@controller.order}}
-              @asc={{@controller.asc}}
-              @automatic={{true}}
-              class="directory-table__column-header--suspend-reason"
-            />
-          {{/if}}
-          <PluginOutlet
-            @name="admin-users-list-thead-after"
-            @outletArgs={{lazyHash order=@controller.order asc=@controller.asc}}
-          />
-
-          {{#if @controller.siteSettings.must_approve_users}}
-            <div class="directory-table__column-header">{{i18n
-                "admin.users.approved"
-              }}</div>
-          {{/if}}
-          <div class="directory-table__column-header">&nbsp;</div>
-
-        </:header>
-
-        <:body>
-          {{#each @controller.users as |user|}}
-            <div
-              class="user
-                {{user.selected}}
-                {{unless user.active 'not-activated'}}
-                directory-table__row"
-              data-user-id={{user.id}}
-            >
-              <div class="directory-table__cell username">
-                {{#if @controller.bulkSelect}}
-                  {{#if (or user.can_be_deleted user.can_be_suspended)}}
-                    <input
-                      type="checkbox"
-                      class="directory-table__cell-bulk-select"
-                      checked={{get @controller.bulkSelectedUsersMap user.id}}
-                      data-user-id={{user.id}}
-                      {{on
-                        "click"
-                        (fn @controller.bulkSelectItemToggle user.id)
-                      }}
-                    />
-                  {{else}}
-                    <DTooltip
-                      @identifier="bulk-action-unavailable-reason"
-                      @placement="bottom-start"
-                    >
-                      <:trigger>
-                        <input
-                          type="checkbox"
-                          class="directory-table__cell-bulk-select"
-                          disabled={{true}}
-                        />
-                      </:trigger>
-                      <:content>
-                        {{i18n
-                          "admin.users.bulk_actions.staff_cant_be_actioned"
-                        }}
-                      </:content>
-                    </DTooltip>
-                  {{/if}}
-                {{/if}}
-                <a
-                  class="avatar"
-                  href={{user.path}}
-                  data-user-card={{user.username}}
-                >
-                  {{dAvatar user imageSize="small"}}
-                </a>
-                <LinkTo @route="adminUser" @model={{user}}>
-                  {{user.username}}
-                </LinkTo>
-                {{#if user.staged}}
-                  {{dIcon "far-envelope" title="user.staged"}}
-                {{/if}}
-              </div>
-              <div
-                class="directory-table__cell email
-                  {{if @controller.showEmails '' 'hidden'}}"
-              >
-                <span class="directory-table__value">
-                  {{~user.email~}}
-                </span>
-              </div>
-
-              {{#if user.last_emailed_at}}
-                <div
-                  class="directory-table__cell last-emailed"
-                  title={{rawDate user.last_emailed_at}}
-                >
-                  <span class="directory-table__label">
-                    <span>{{i18n "admin.users.last_emailed"}}</span>
-                  </span>
-                  <span class="directory-table__value">
-                    {{dFormatDuration user.last_emailed_age}}
-                  </span>
-                </div>
-              {{else}}
-                <div class="directory-table__cell last-emailed">
-                  <span class="directory-table__label">
-                    <span>{{i18n "admin.users.last_emailed"}}</span>
-                  </span>
-                  <span class="directory-table__value">
-                    {{dFormatDuration user.last_emailed_age}}
-                  </span>
-                </div>
-              {{/if}}
-
-              <div
-                class="directory-table__cell last-seen"
-                title={{rawDate user.last_seen_at}}
-              >
-                <span class="directory-table__label">
-                  <span>{{i18n "last_seen"}}</span>
-                </span>
-                <span class="directory-table__value">
-                  {{dFormatDuration user.last_seen_age}}
-                </span>
-              </div>
-
-              {{#unless
-                (or @controller.showSilenceReason @controller.showSuspendReason)
-              }}
-                <div class="directory-table__cell topics-entered">
-                  <span class="directory-table__label">
-                    <span>{{i18n "admin.user.topics_entered"}}</span>
-                  </span>
-                  <span class="directory-table__value">
-                    {{dNumber user.topics_entered}}
-                  </span>
-                </div>
-              {{/unless}}
-              <div class="directory-table__cell posts-read">
-                <span class="directory-table__label">
-                  <span>{{i18n "admin.user.posts_read_count"}}</span>
-                </span>
-                <span class="directory-table__value">
-                  {{dNumber user.posts_read_count}}
-                </span>
-              </div>
-              <div class="directory-table__cell time-read">
-                <span class="directory-table__label">
-                  <span>{{i18n "admin.user.time_read"}}</span>
-                </span>
-                <span class="directory-table__value">
-                  {{dFormatDuration user.time_read}}
-                </span>
-              </div>
-              <div
-                class="directory-table__cell created"
-                title={{rawDate user.created_at}}
-              >
-                <span class="directory-table__label">
-                  <span>{{i18n "created"}}</span>
-                </span>
-                <span class="directory-table__value">
-                  {{dFormatDuration user.created_at_age}}
-                </span>
-              </div>
-
-              {{#if @controller.showSilenceReason}}
-                <div
-                  class="directory-table__cell silence_reason"
-                  title={{@controller.stripHtml user.silence_reason}}
-                >
-                  <span class="directory-table__label">
-                    <span>{{i18n "admin.users.silence_reason"}}</span>
-                  </span>
-                  <span class="directory-table__value">
-                    {{trustHTML user.silence_reason}}
-                  </span>
-                </div>
-              {{/if}}
-
-              {{#if @controller.showSuspendReason}}
-                <div
-                  class="directory-table__cell suspend_reason"
-                  title={{@controller.stripHtml user.suspend_reason}}
-                >
-                  <span class="directory-table__label">
-                    <span>{{i18n "admin.users.suspend_reason"}}</span>
-                  </span>
-                  <span class="directory-table__value">
-                    {{trustHTML user.suspend_reason}}
-                  </span>
-                </div>
-              {{/if}}
-
-              <PluginOutlet
-                @name="admin-users-list-td-after"
-                @outletArgs={{lazyHash user=user query=@controller.query}}
+            {{#if @controller.showSuspendReason}}
+              <DTableHeaderToggle
+                @onToggle={{@controller.updateOrder}}
+                @field="suspend_reason"
+                @labelKey="admin.users.suspend_reason"
+                @order={{@controller.order}}
+                @asc={{@controller.asc}}
+                @automatic={{true}}
+                class="directory-table__column-header--suspend-reason"
               />
+            {{/if}}
+            <PluginOutlet
+              @name="admin-users-list-thead-after"
+              @outletArgs={{lazyHash
+                order=@controller.order
+                asc=@controller.asc
+              }}
+            />
 
-              {{#if @controller.siteSettings.must_approve_users}}
-                <div class="directory-table__cell">
-                  <span class="directory-table__label">
-                    <span>{{i18n "admin.users.approved"}}</span>
-                  </span>
+            {{#if @controller.siteSettings.must_approve_users}}
+              <div class="directory-table__column-header">{{i18n
+                  "admin.users.approved"
+                }}</div>
+            {{/if}}
+            <div class="directory-table__column-header">&nbsp;</div>
+
+          </:header>
+
+          <:body>
+            {{#each users as |user|}}
+              <div
+                class="user
+                  {{user.selected}}
+                  {{unless user.active 'not-activated'}}
+                  directory-table__row"
+                data-user-id={{user.id}}
+              >
+                <div class="directory-table__cell username">
+                  {{#if @controller.bulkSelect}}
+                    {{#if (or user.can_be_deleted user.can_be_suspended)}}
+                      <input
+                        type="checkbox"
+                        class="directory-table__cell-bulk-select"
+                        checked={{get @controller.bulkSelectedUsersMap user.id}}
+                        data-user-id={{user.id}}
+                        {{on
+                          "click"
+                          (fn @controller.bulkSelectItemToggle user.id)
+                        }}
+                      />
+                    {{else}}
+                      <DTooltip
+                        @identifier="bulk-action-unavailable-reason"
+                        @placement="bottom-start"
+                      >
+                        <:trigger>
+                          <input
+                            type="checkbox"
+                            class="directory-table__cell-bulk-select"
+                            disabled={{true}}
+                          />
+                        </:trigger>
+                        <:content>
+                          {{i18n
+                            "admin.users.bulk_actions.staff_cant_be_actioned"
+                          }}
+                        </:content>
+                      </DTooltip>
+                    {{/if}}
+                  {{/if}}
+                  <a
+                    class="avatar"
+                    href={{user.path}}
+                    data-user-card={{user.username}}
+                  >
+                    {{dAvatar user imageSize="small"}}
+                  </a>
+                  <LinkTo @route="adminUser" @model={{user}}>
+                    {{user.username}}
+                  </LinkTo>
+                  {{#if user.staged}}
+                    {{dIcon "far-envelope" title="user.staged"}}
+                  {{/if}}
+                </div>
+                <div
+                  class="directory-table__cell email
+                    {{if @controller.showEmails '' 'hidden'}}"
+                >
                   <span class="directory-table__value">
-                    {{i18nYesNo user.approved}}
+                    {{~user.email~}}
                   </span>
                 </div>
-              {{/if}}
 
-              <div
-                class={{dConcatClass
-                  "directory-table__cell"
-                  "user-role"
-                  (if
-                    (not
-                      (or user.admin user.moderator user.second_factor_enabled)
-                    )
-                    "--empty"
+                {{#if user.last_emailed_at}}
+                  <div
+                    class="directory-table__cell last-emailed"
+                    title={{rawDate user.last_emailed_at}}
+                  >
+                    <span class="directory-table__label">
+                      <span>{{i18n "admin.users.last_emailed"}}</span>
+                    </span>
+                    <span class="directory-table__value">
+                      {{dFormatDuration user.last_emailed_age}}
+                    </span>
+                  </div>
+                {{else}}
+                  <div class="directory-table__cell last-emailed">
+                    <span class="directory-table__label">
+                      <span>{{i18n "admin.users.last_emailed"}}</span>
+                    </span>
+                    <span class="directory-table__value">
+                      {{dFormatDuration user.last_emailed_age}}
+                    </span>
+                  </div>
+                {{/if}}
+
+                <div
+                  class="directory-table__cell last-seen"
+                  title={{rawDate user.last_seen_at}}
+                >
+                  <span class="directory-table__label">
+                    <span>{{i18n "last_seen"}}</span>
+                  </span>
+                  <span class="directory-table__value">
+                    {{dFormatDuration user.last_seen_age}}
+                  </span>
+                </div>
+
+                {{#unless
+                  (or
+                    @controller.showSilenceReason @controller.showSuspendReason
                   )
                 }}
-              >
-                <span class="directory-table__label">
-                  <span>{{i18n "admin.users.status"}}</span>
-                </span>
-                <span class="directory-table__value">
-                  {{#if user.admin}}
-                    {{dIcon "shield-halved" title="admin.title"}}
-                  {{/if}}
-                  {{#if user.moderator}}
-                    {{dIcon "shield-halved" title="admin.moderator"}}
-                  {{/if}}
-                  {{#if user.second_factor_enabled}}
-                    {{dIcon "lock" title="admin.user.second_factor_enabled"}}
-                  {{/if}}
-                </span>
+                  <div class="directory-table__cell topics-entered">
+                    <span class="directory-table__label">
+                      <span>{{i18n "admin.user.topics_entered"}}</span>
+                    </span>
+                    <span class="directory-table__value">
+                      {{dNumber user.topics_entered}}
+                    </span>
+                  </div>
+                {{/unless}}
+                <div class="directory-table__cell posts-read">
+                  <span class="directory-table__label">
+                    <span>{{i18n "admin.user.posts_read_count"}}</span>
+                  </span>
+                  <span class="directory-table__value">
+                    {{dNumber user.posts_read_count}}
+                  </span>
+                </div>
+                <div class="directory-table__cell time-read">
+                  <span class="directory-table__label">
+                    <span>{{i18n "admin.user.time_read"}}</span>
+                  </span>
+                  <span class="directory-table__value">
+                    {{dFormatDuration user.time_read}}
+                  </span>
+                </div>
+                <div
+                  class="directory-table__cell created"
+                  title={{rawDate user.created_at}}
+                >
+                  <span class="directory-table__label">
+                    <span>{{i18n "created"}}</span>
+                  </span>
+                  <span class="directory-table__value">
+                    {{dFormatDuration user.created_at_age}}
+                  </span>
+                </div>
+
+                {{#if @controller.showSilenceReason}}
+                  <div
+                    class="directory-table__cell silence_reason"
+                    title={{@controller.stripHtml user.silence_reason}}
+                  >
+                    <span class="directory-table__label">
+                      <span>{{i18n "admin.users.silence_reason"}}</span>
+                    </span>
+                    <span class="directory-table__value">
+                      {{trustHTML user.silence_reason}}
+                    </span>
+                  </div>
+                {{/if}}
+
+                {{#if @controller.showSuspendReason}}
+                  <div
+                    class="directory-table__cell suspend_reason"
+                    title={{@controller.stripHtml user.suspend_reason}}
+                  >
+                    <span class="directory-table__label">
+                      <span>{{i18n "admin.users.suspend_reason"}}</span>
+                    </span>
+                    <span class="directory-table__value">
+                      {{trustHTML user.suspend_reason}}
+                    </span>
+                  </div>
+                {{/if}}
+
                 <PluginOutlet
-                  @name="admin-users-list-icon"
-                  @connectorTagName="div"
+                  @name="admin-users-list-td-after"
                   @outletArgs={{lazyHash user=user query=@controller.query}}
                 />
+
+                {{#if @controller.siteSettings.must_approve_users}}
+                  <div class="directory-table__cell">
+                    <span class="directory-table__label">
+                      <span>{{i18n "admin.users.approved"}}</span>
+                    </span>
+                    <span class="directory-table__value">
+                      {{i18nYesNo user.approved}}
+                    </span>
+                  </div>
+                {{/if}}
+
+                <div
+                  class={{dConcatClass
+                    "directory-table__cell"
+                    "user-role"
+                    (if
+                      (not
+                        (or
+                          user.admin user.moderator user.second_factor_enabled
+                        )
+                      )
+                      "--empty"
+                    )
+                  }}
+                >
+                  <span class="directory-table__label">
+                    <span>{{i18n "admin.users.status"}}</span>
+                  </span>
+                  <span class="directory-table__value">
+                    {{#if user.admin}}
+                      {{dIcon "shield-halved" title="admin.title"}}
+                    {{/if}}
+                    {{#if user.moderator}}
+                      {{dIcon "shield-halved" title="admin.moderator"}}
+                    {{/if}}
+                    {{#if user.second_factor_enabled}}
+                      {{dIcon "lock" title="admin.user.second_factor_enabled"}}
+                    {{/if}}
+                  </span>
+                  <PluginOutlet
+                    @name="admin-users-list-icon"
+                    @connectorTagName="div"
+                    @outletArgs={{lazyHash user=user query=@controller.query}}
+                  />
+                </div>
               </div>
-            </div>
-          {{/each}}
-        </:body>
-      </DResponsiveTable>
-    {{else if (not @controller.refreshing)}}
-      <p>{{i18n "search.no_results"}}</p>
-    {{/if}}
-    <DConditionalLoadingSpinner @condition={{@controller.refreshing}} />
-  </DLoadMore>
+            {{/each}}
+          </:body>
+        </DResponsiveTable>
+
+        <DConditionalLoadingSpinner @condition={{@controller.refreshing}} />
+      </DLoadMore>
+    </:content>
+  </DFilterControls>
 </template>

--- a/frontend/discourse/app/ui-kit/d-filter-controls.gjs
+++ b/frontend/discourse/app/ui-kit/d-filter-controls.gjs
@@ -1,6 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { fn, get, hash } from "@ember/helper";
+import { concat, fn, get, hash } from "@ember/helper";
 import { action } from "@ember/object";
 import { trackedObject } from "@ember/reactive/collections";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
@@ -14,11 +14,20 @@ import DiscourseURL, {
   applyQueryParams,
   searchParamsFromPath,
 } from "discourse/lib/url";
-import { and, not } from "discourse/truth-helpers";
+import { and, eq, not } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
 import DSelect from "discourse/ui-kit/d-select";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+
+const ResetButton = <template>
+  <DButton
+    @icon="arrow-rotate-left"
+    @label="filter_controls.reset"
+    @action={{@action}}
+    class="btn-default d-filter-controls__reset"
+  />
+</template>;
 
 /**
  * filter controls component that support both client-side and server-side filtering
@@ -234,6 +243,8 @@ export default class DFilterControls extends Component {
     return path.split(".").reduce((current, key) => current?.[key], obj);
   }
 
+  // @action so it stays bound to `this` when invoked from the template
+  @action
   defaultValue(key) {
     const defaults =
       typeof this.defaultDropdownValue === "object"
@@ -419,11 +430,18 @@ export default class DFilterControls extends Component {
 
           {{#if this.hasMultipleDropdowns}}
             <DButton
-              class="btn-transparent d-filter-controls__toggle-filters"
-              @icon="filter"
+              class="btn-default d-filter-controls__toggle-filters"
+              @icon={{if
+                this.showDropdownFilter
+                "filter-circle-xmark"
+                "filter"
+              }}
               @title="filter_controls.toggle"
               @action={{this.toggleFilters}}
             />
+            {{#if this.hasActiveFilters}}
+              <ResetButton @action={{this.resetFilters}} />
+            {{/if}}
           {{/if}}
         </div>
 
@@ -435,7 +453,16 @@ export default class DFilterControls extends Component {
                   @value={{get this.dropdownFilters key}}
                   @includeNone={{false}}
                   @onChange={{fn this.onDropdownFilterChange key}}
-                  class="d-filter-controls__dropdown d-filter-controls__dropdown--{{key}}"
+                  class={{dConcatClass
+                    "d-filter-controls__dropdown"
+                    (concat "d-filter-controls__dropdown--" key)
+                    (unless
+                      (eq
+                        (get this.dropdownFilters key) (this.defaultValue key)
+                      )
+                      "--active"
+                    )
+                  }}
                   data-dropdown-key={{key}}
                   as |select|
                 >
@@ -451,7 +478,13 @@ export default class DFilterControls extends Component {
                 @value={{this.dropdownFilter}}
                 @includeNone={{false}}
                 @onChange={{this.onDropdownFilterChange}}
-                class="d-filter-controls__dropdown"
+                class={{dConcatClass
+                  "d-filter-controls__dropdown"
+                  (unless
+                    (eq this.dropdownFilter this.defaultDropdownValue)
+                    "--active"
+                  )
+                }}
                 as |select|
               >
                 {{#each this.dropdownOptions as |option|}}
@@ -464,13 +497,8 @@ export default class DFilterControls extends Component {
           </div>
         {{/if}}
 
-        {{#if (and this.hasActiveFilters (not @loading))}}
-          <DButton
-            @icon="arrow-rotate-left"
-            @label="filter_controls.reset"
-            @action={{this.resetFilters}}
-            class="btn-default d-filter-controls__reset"
-          />
+        {{#if (and (not this.hasMultipleDropdowns) this.hasActiveFilters)}}
+          <ResetButton @action={{this.resetFilters}} />
         {{/if}}
 
         {{yield to="actions"}}
@@ -487,12 +515,7 @@ export default class DFilterControls extends Component {
           {{#if @noResultsMessage}}
             <p>{{@noResultsMessage}}</p>
           {{/if}}
-          <DButton
-            @icon="arrow-rotate-left"
-            @label="filter_controls.reset"
-            @action={{this.resetFilters}}
-            class="btn-default d-filter-controls__reset"
-          />
+          <ResetButton @action={{this.resetFilters}} />
         </div>
       {{/if}}
     {{else}}

--- a/frontend/discourse/tests/acceptance/admin-permalink-test.js
+++ b/frontend/discourse/tests/acceptance/admin-permalink-test.js
@@ -36,7 +36,7 @@ acceptance("Admin - Permalinks", function (needs) {
 
   test("search permalinks with result", async function (assert) {
     await visit("/admin/config/permalinks");
-    await fillIn(".permalink-search input", "feature");
+    await fillIn(".d-filter-controls__input", "feature");
 
     assert
       .dom(".permalink-results span[title='c/feature/announcements']")
@@ -45,12 +45,14 @@ acceptance("Admin - Permalinks", function (needs) {
 
   test("search permalinks without results", async function (assert) {
     await visit("/admin/config/permalinks");
-    await fillIn(".permalink-search input", "garboogle");
+    await fillIn(".d-filter-controls__input", "garboogle");
 
     assert
-      .dom(".permalink-results__no-result")
+      .dom(".d-filter-controls__no-results")
       .exists("no results message shown");
 
-    assert.dom(".permalink-search").exists("search input still visible");
+    assert
+      .dom(".d-filter-controls__input")
+      .exists("search input still visible");
   });
 });

--- a/frontend/discourse/tests/acceptance/admin-users-list-test.js
+++ b/frontend/discourse/tests/acceptance/admin-users-list-test.js
@@ -61,9 +61,11 @@ acceptance("Admin - Users List", function (needs) {
   test("searching users with no matches", async function (assert) {
     await visit("/admin/users/list/active");
 
-    await fillIn(".admin-users-list__search input", "doesntexist");
+    await fillIn(".d-filter-controls__input", "doesntexist");
 
-    assert.dom(".users-list-container").hasText(i18n("search.no_results"));
+    assert
+      .dom(".d-filter-controls__no-results p")
+      .hasText(i18n("search.no_results"));
   });
 
   test("sorts users", async function (assert) {
@@ -158,10 +160,10 @@ acceptance("Admin - Users List", function (needs) {
 
   test("activation filter is only shown on the new tab", async function (assert) {
     await visit("/admin/users/list/active");
-    assert.dom(".admin-users-list__activation-filter").doesNotExist();
+    assert.dom(".d-filter-controls__dropdown").doesNotExist();
 
     await visit("/admin/users/list/new");
-    assert.dom(".admin-users-list__activation-filter").exists();
+    assert.dom(".d-filter-controls__dropdown").exists();
   });
 
   test("filters the new tab by activation status", async function (assert) {
@@ -169,7 +171,7 @@ acceptance("Admin - Users List", function (needs) {
 
     assert.dom(".users-list .user").exists({ count: 2 });
 
-    await fillIn(".admin-users-list__activation-filter", "not_activated");
+    await fillIn(".d-filter-controls__dropdown", "not_activated");
 
     assert.strictEqual(
       lastActivationFilter,
@@ -216,7 +218,7 @@ acceptance("Admin - Users List - bulk search", function (needs) {
   test("searches multiple users at once and reflects the search in the URL", async function (assert) {
     await visit("/admin/users/list/active");
 
-    await fillIn(".admin-users-list__search input", "sam,bob");
+    await fillIn(".d-filter-controls__input", "sam,bob");
 
     assert.strictEqual(
       lastFilter,
@@ -229,10 +231,10 @@ acceptance("Admin - Users List - bulk search", function (needs) {
       "reflects the search in the URL"
     );
     assert
-      .dom(".admin-users-list__search input")
+      .dom(".d-filter-controls__input")
       .isFocused("keeps focus while the URL updates");
 
-    await fillIn(".admin-users-list__search input", "");
+    await fillIn(".d-filter-controls__input", "");
 
     assert.false(
       currentURL().includes("filter="),
@@ -243,7 +245,7 @@ acceptance("Admin - Users List - bulk search", function (needs) {
   test("prefills and applies the search from the URL", async function (assert) {
     await visit("/admin/users/list/active?filter=sam");
 
-    assert.dom(".admin-users-list__search input").hasValue("sam");
+    assert.dom(".d-filter-controls__input").hasValue("sam");
     assert.strictEqual(lastFilter, "sam", "sends the filter from the URL");
     assert.dom(".users-list .user").exists({ count: 1 });
   });
@@ -251,19 +253,19 @@ acceptance("Admin - Users List - bulk search", function (needs) {
   test("prefills the search from the legacy username query param", async function (assert) {
     await visit("/admin/users/list/active?username=sam");
 
-    assert.dom(".admin-users-list__search input").hasValue("sam");
+    assert.dom(".d-filter-controls__input").hasValue("sam");
     assert.strictEqual(lastFilter, "sam", "sends the filter from the URL");
   });
 
   test("clears the search when switching tabs", async function (assert) {
     await visit("/admin/users/list/active");
 
-    await fillIn(".admin-users-list__search input", "sam");
+    await fillIn(".d-filter-controls__input", "sam");
     assert.dom(".users-list .user").exists({ count: 1 });
 
     await click('a[href="/admin/users/list/new"]');
 
-    assert.dom(".admin-users-list__search input").hasValue("");
+    assert.dom(".d-filter-controls__input").hasValue("");
     assert.strictEqual(
       lastFilter,
       undefined,
@@ -273,7 +275,7 @@ acceptance("Admin - Users List - bulk search", function (needs) {
     await click('a[href="/admin/users/list/active"]');
 
     assert
-      .dom(".admin-users-list__search input")
+      .dom(".d-filter-controls__input")
       .hasValue("", "does not restore the search when returning to the tab");
     assert.false(
       currentURL().includes("filter="),

--- a/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
@@ -172,6 +172,38 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
     assert.dom(".item[data-id='3']").exists("shows second feature item");
   });
 
+  test("marks the dropdown active when its value differs from the default", async function (assert) {
+    this.set("data", SAMPLE_DATA);
+    this.set("dropdownOptions", SAMPLE_DROPDOWN_OPTIONS);
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{this.data}}
+          @dropdownOptions={{this.dropdownOptions}}
+        >
+          <:content as |filteredData|>
+            <div class="results">
+              {{#each filteredData as |item|}}
+                <div class="item" data-id={{item.id}}>{{item.name}}</div>
+              {{/each}}
+            </div>
+          </:content>
+        </DFilterControls>
+      </template>
+    );
+
+    assert
+      .dom(".d-filter-controls__dropdown.--active")
+      .doesNotExist("not active while on the default option");
+
+    await select(".d-filter-controls__dropdown", "feature");
+
+    assert
+      .dom(".d-filter-controls__dropdown.--active")
+      .exists("active once a non-default option is chosen");
+  });
+
   test("combines text and dropdown filters (client-side)", async function (assert) {
     this.set("data", SAMPLE_DATA);
     this.set("searchableProps", ["name", "description"]);
@@ -282,7 +314,7 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
     assert.dom(".filter-input").hasValue("", "clears text input");
   });
 
-  test("shows reset button next to filter input when there are active filters that find results", async function (assert) {
+  test("shows the reset button next to the input when a text filter finds results", async function (assert) {
     this.set("data", SAMPLE_DATA);
     this.set("searchableProps", ["name"]);
 
@@ -306,7 +338,35 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
     await fillIn(".filter-input", "first");
     assert
       .dom(".d-filter-controls > .d-filter-controls__reset")
-      .exists("shows reset button after filter controls");
+      .exists("shows the reset button beside the input");
+  });
+
+  test("keeps the reset button visible while loading", async function (assert) {
+    this.set("data", SAMPLE_DATA);
+    this.set("onTextFilterChange", () => {});
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{this.data}}
+          @onTextFilterChange={{this.onTextFilterChange}}
+          @loading={{true}}
+        >
+          <:content as |filteredData|>
+            <div class="results">
+              {{#each filteredData as |item|}}
+                <div class="item" data-id={{item.id}}>{{item.name}}</div>
+              {{/each}}
+            </div>
+          </:content>
+        </DFilterControls>
+      </template>
+    );
+
+    await fillIn(".filter-input", "first");
+    assert
+      .dom(".d-filter-controls > .d-filter-controls__reset")
+      .exists("reset button stays put during a reload");
   });
 
   test("respects minItemsForFilter parameter", async function (assert) {

--- a/lib/svg_sprite.rb
+++ b/lib/svg_sprite.rb
@@ -174,6 +174,7 @@ module SvgSprite
         file
         file-lines
         filter
+        filter-circle-xmark
         flag
         flask
         folder

--- a/spec/system/page_objects/components/d_filter_controls.rb
+++ b/spec/system/page_objects/components/d_filter_controls.rb
@@ -41,11 +41,11 @@ module PageObjects
       end
 
       def has_reset_button?
-        component.has_css?("> .d-filter-controls__reset")
+        component.has_css?(".d-filter-controls__reset")
       end
 
       def click_reset_button
-        component.find("> .d-filter-controls__reset").click
+        component.find(".d-filter-controls__reset").click
       end
 
       def click_no_results_reset_button
@@ -57,7 +57,7 @@ module PageObjects
       end
 
       def has_no_reset_button?
-        component.has_no_css?("> .d-filter-controls__reset")
+        component.has_no_css?(".d-filter-controls__reset")
       end
 
       def has_no_results_message?

--- a/spec/system/page_objects/pages/admin_permalinks.rb
+++ b/spec/system/page_objects/pages/admin_permalinks.rb
@@ -42,19 +42,19 @@ module PageObjects
       end
 
       def has_no_filter?
-        has_no_css?(".permalink-search")
+        has_no_css?(".d-filter-controls__input")
       end
 
       def has_filter?
-        has_css?(".permalink-search")
+        has_css?(".d-filter-controls__input")
       end
 
       def filter(text)
-        find(".permalink-search").fill_in with: text
+        find(".d-filter-controls__input").fill_in with: text
       end
 
       def has_no_results?
-        has_css?(".permalink-results__no-result")
+        has_css?(".d-filter-controls__no-results")
       end
 
       def open_permalink_menu(url)

--- a/spec/system/page_objects/pages/admin_users.rb
+++ b/spec/system/page_objects/pages/admin_users.rb
@@ -44,7 +44,7 @@ module PageObjects
       end
 
       def search_input
-        find(".admin-users-list__search input")
+        find(".d-filter-controls__input")
       end
 
       def user_row(id)


### PR DESCRIPTION
This makes some consistency improvements to our `DFilterControls` component and applies it to the admin/users and admin/config/permalinks pages 


Before:
<img width="2250" height="592" alt="image" src="https://github.com/user-attachments/assets/23eafb7a-948c-4414-93f0-a906ffedb714" />


After: 
<img width="2190" height="648" alt="image" src="https://github.com/user-attachments/assets/e9cb4545-5b3a-4bd1-87ac-140113cee033" />


Before:
<img width="2234" height="886" alt="image" src="https://github.com/user-attachments/assets/efc51dac-4f95-4731-8c83-5285ba5e2528" />


After:
<img width="2298" height="872" alt="image" src="https://github.com/user-attachments/assets/d6434f44-311a-48cb-aeb6-b34fba7b9f05" />


Before:
<img width="2258" height="894" alt="image" src="https://github.com/user-attachments/assets/95972f51-b306-4c27-93ad-2a7c6c66080a" />


After:
<img width="2236" height="932" alt="image" src="https://github.com/user-attachments/assets/9cbfd319-e0ce-4bb5-97ea-c9e09c91dcf9" />
