### PR TITLE
FIX: Don't double subfolder when clicking chat icon after opening chat in drawer

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-state-manager.js
@@ -195,8 +195,10 @@ export default class ChatStateManager extends Service {
   }
 
   get lastKnownChatURL() {
-    if (this._chatURL) {
-      return this._chatURL;
+    const url = this._chatURL;
+
+    if (url) {
+      return withoutPrefix(url);
     }
 
     // On mobile or drawer mode, default to starred channels if user has any

--- a/plugins/chat/spec/system/drawer_spec.rb
+++ b/plugins/chat/spec/system/drawer_spec.rb
@@ -228,6 +228,25 @@ RSpec.describe "Drawer" do
       expect(page).to have_current_path("/discuss/categories")
       expect(page).to have_no_css("body.has-full-page-chat")
     end
+
+    it "does not double the subfolder when returning to a chat channel via the header icon after a programmatic navigation" do
+      visit("/discuss/chat")
+      expect(page).to have_css("html.has-chat")
+
+      find(".title a").click
+      expect(page).to have_current_path("/discuss/")
+
+      find(".sidebar-section-link.channel-#{channel.id}").click
+      expect(page).to have_css("body.has-drawer-chat")
+
+      drawer_page.close
+
+      find(".chat-header-icon").click
+
+      expect(page).to have_current_path("/discuss/")
+      expect(page).to have_css("body.has-drawer-chat")
+      expect(page).to have_css(".chat-channel.--loaded[data-id='#{channel.id}']")
+    end
   end
 
   context "when sending a message from a thread while viewing a topic" do


### PR DESCRIPTION
Fixes a corner case where the chat URL was stored including prefix when opening a chat channel in drawer mode, and then the prefix was doubled when clicking the chat icon in the header.

The URL with the subfolder is stored by storeChatURL() when opening a chat channel in drawer mode. Then after navigating away, if the user clicked the chat icon in the header, it would prepend the subfolder again. 

Now we strip the subfolder away in lastKnownChatURL(), mirroring the fix in lastKnownAppURL().

Adds a system spec reproducing the issue which fails before the fix.

Reported in Meta /t/401446