### PR TITLE
UX: fix post ownership change modal on Android

### DIFF
--- a/app/assets/stylesheets/common/modal/modal-overrides.scss
+++ b/app/assets/stylesheets/common/modal/modal-overrides.scss
@@ -601,6 +601,18 @@
   }
 }
 
+.change-ownership-modal {
+  .d-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+
+    .select-kit-header--filter {
+      width: 100%;
+    }
+  }
+}
+
 .d-modal.admin-user-upcoming-changes-modal {
   .d-modal {
     &__container {

--- a/frontend/discourse/app/components/modal/change-owner.gjs
+++ b/frontend/discourse/app/components/modal/change-owner.gjs
@@ -94,6 +94,8 @@ export default class ChangeOwnerModal extends Component {
           @options={{hash
             maximum=1
             filterPlaceholder="topic.change_owner.placeholder"
+            filterIcon="magnifying-glass"
+            useHeaderFilter=true
           }}
         />
       </:body>


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/cannot-change-post-ownership-android-chrome/408402

On Android focusing the input in the ownership modal closes the keyboard, so you can't type to find a user... switching to `useHeaderFilter` avoids this and gets it working again. I've also added some minor style improvements. 

Before (can't keep the keyboard open):
<img width="350" alt="image" src="https://github.com/user-attachments/assets/2c890c66-d419-48a6-aeb1-39176199bbd7" />


After:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/816a2add-2d8f-4a97-b660-8ac28682ac74" />
