### PR TITLE
FIX: correctly display http errors in http request

### DIFF
--- a/plugins/discourse-workflows/lib/discourse_workflows/executor/http_client.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/executor/http_client.rb
@@ -11,6 +11,7 @@ module DiscourseWorkflows
       TIMEOUT_SECONDS = 30
       DEFAULT_MAX_RETRIES = 0
       DEFAULT_RETRY_STATUSES = Set[429, 500, 502, 503, 504].freeze
+      ERROR_BODY_MAX_BYTES = 10.kilobytes
 
       def initialize(exec_ctx, item_index = 0)
         @exec_ctx = exec_ctx
@@ -31,6 +32,7 @@ module DiscourseWorkflows
           filtered_url = filtered_url_for_logging(config["url"], config["query_params"])
           raise_node_error!(
             "HTTP #{config["method"]} #{filtered_url} failed with status #{response.status}",
+            description: error_body_description(response),
           )
         end
 
@@ -49,6 +51,14 @@ module DiscourseWorkflows
       end
 
       private
+
+      def error_body_description(response)
+        body = response.body.to_s.scrub("").strip
+        return if body.empty?
+        return body if body.bytesize <= ERROR_BODY_MAX_BYTES
+
+        "#{body.byteslice(0, ERROR_BODY_MAX_BYTES).scrub("")}…"
+      end
 
       def build_config(method, url, headers, body, options)
         config =

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/executor/node_execution_context_spec.rb
@@ -933,7 +933,7 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
         ctx.http_request(method: "GET", url: "https://api.example.com/retry")
       }.to raise_error(
         DiscourseWorkflows::NodeError,
-        "HTTP GET https://api.example.com/retry failed with status 503",
+        "HTTP GET https://api.example.com/retry failed with status 503: unavailable",
       )
       expect(WebMock).to have_requested(:get, "https://api.example.com/retry").once
     end
@@ -950,7 +950,7 @@ RSpec.describe DiscourseWorkflows::Executor::NodeExecutionContext do
         ctx.http_request(method: "POST", url: "https://api.example.com/retry")
       }.to raise_error(
         DiscourseWorkflows::NodeError,
-        "HTTP POST https://api.example.com/retry failed with status 503",
+        "HTTP POST https://api.example.com/retry failed with status 503: unavailable",
       )
       expect(WebMock).to have_requested(:post, "https://api.example.com/retry").once
     end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/http_request_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/http_request_spec.rb
@@ -179,7 +179,53 @@ RSpec.describe DiscourseWorkflows::Nodes::HttpRequest::V1 do
 
       expect { execute_node(configuration: config, item: item) }.to raise_error(
         DiscourseWorkflows::NodeError,
-        "HTTP GET https://api.example.com/fail?token=[FILTERED] failed with status 404",
+        "HTTP GET https://api.example.com/fail?token=[FILTERED] failed with status 404: Not Found",
+      )
+    end
+
+    it "includes the response body in the error message" do
+      stub_request(:post, "https://api.example.com/categories").to_return(
+        status: 422,
+        body: { errors: ["Group PrivateGroup has no access to the parent category"] }.to_json,
+        headers: {
+          "content-type" => "application/json",
+        },
+      )
+
+      config = {
+        "method" => "POST",
+        "url" => "https://api.example.com/categories",
+        "body_json" => "{}",
+      }
+
+      expect { execute_node(configuration: config, item: item) }.to raise_error(
+        DiscourseWorkflows::NodeError,
+        /failed with status 422: \{"errors":\["Group PrivateGroup has no access/,
+      )
+    end
+
+    it "truncates long response bodies in the error message" do
+      body = "x" * (DiscourseWorkflows::Executor::HttpClient::ERROR_BODY_MAX_BYTES * 2)
+      stub_request(:get, "https://api.example.com/fail").to_return(status: 500, body:)
+
+      config = { "method" => "GET", "url" => "https://api.example.com/fail" }
+
+      expect { execute_node(configuration: config, item: item) }.to raise_error(
+        DiscourseWorkflows::NodeError,
+      ) do |error|
+        expect(error.message).to end_with("…")
+        expect(error.message.bytesize).to be < body.bytesize
+      end
+    end
+
+    it "omits the description when the failed response has no body" do
+      stub_request(:get, "https://api.example.com/empty").to_return(status: 503, body: "")
+
+      config = { "method" => "GET", "url" => "https://api.example.com/empty" }
+
+      expect { execute_node(configuration: config, item: item) }.to raise_error(
+        DiscourseWorkflows::NodeError,
+        "HTTP GET https://api.example.com/empty failed with status 503",
       )
     end
 


### PR DESCRIPTION
Prior to this fix we would show a generic error and would lose the original http error.