### PR TITLE
UX: Add site setting to toggle AI bot submit on Enter

### DIFF
--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -250,7 +250,7 @@ export default class AiBotConversations extends Component {
     const shiftHeld = this.shiftHeldOnEnter;
     this.shiftHeldOnEnter = false;
     // If the admin has disabled Enter-to-submit, do nothing and allow native line breaks
-    if (!this.siteSettings.ai_bot_chat_composer_submit_on_enter) {
+    if (!this.siteSettings.ai_bot_composer_submit_on_enter) {
       return;
     }
     // Existing forced-submit logic

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -249,6 +249,11 @@ export default class AiBotConversations extends Component {
     // browsers regardless of compositionend/keydown ordering quirks.
     const shiftHeld = this.shiftHeldOnEnter;
     this.shiftHeldOnEnter = false;
+    // If the admin has disabled Enter-to-submit, do nothing and allow native line breaks
+    if (!this.siteSettings.ai_bot_chat_composer_submit_on_enter) {
+      return;
+    }
+    // Existing forced-submit logic
     if (event.inputType !== "insertLineBreak" || shiftHeld) {
       return;
     }

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -391,10 +391,15 @@ export default class AiBotDockedComposer extends Component {
     this.editingPost = null;
     return { ok: true };
   }
-
+  #handleBeforeInput = (event) => {
+    if (!this.siteSettings.ai_bot_composer_submit_on_enter && event.inputType === "insertLineBreak") {
+      event.stopImmediatePropagation();
+    }
+  };
   @action
   setupScrollListener(element) {
     this.#composerEl = element;
+    element.addEventListener("beforeinput", this.#handleBeforeInput, { capture: true });
     window.addEventListener("scroll", this.#checkScroll, { passive: true });
     this.#resizeObserver = new ResizeObserver(this.#checkScroll);
     this.#resizeObserver.observe(document.body);
@@ -420,6 +425,7 @@ export default class AiBotDockedComposer extends Component {
 
   @action
   teardownScrollListener() {
+    this.#composerEl?.removeEventListener("beforeinput", this.#handleBeforeInput, { capture: true });
     this.#composerEl = null;
     window.removeEventListener("scroll", this.#checkScroll);
     this.#resizeObserver?.disconnect();

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs
@@ -391,15 +391,37 @@ export default class AiBotDockedComposer extends Component {
     this.editingPost = null;
     return { ok: true };
   }
-  #handleBeforeInput = (event) => {
-    if (!this.siteSettings.ai_bot_composer_submit_on_enter && event.inputType === "insertLineBreak") {
+
+#handleKeyDown = (event) => {
+    if (this.siteSettings.ai_bot_composer_submit_on_enter) {
+      return;
+    }
+    
+    if (event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey) {
+      const target = event.target;
+      if (!target || target.tagName !== "TEXTAREA") return;
+
+      event.preventDefault();
       event.stopImmediatePropagation();
+
+      const start = target.selectionStart;
+      const end = target.selectionEnd;
+      const val = target.value;
+
+      target.value = val.substring(0, start) + "\n" + val.substring(end);
+
+      target.selectionStart = target.selectionEnd = start + 1;
+
+      target.dispatchEvent(new Event("input", { bubbles: true, cancelable: true }));
     }
   };
+
   @action
   setupScrollListener(element) {
     this.#composerEl = element;
-    element.addEventListener("beforeinput", this.#handleBeforeInput, { capture: true });
+    
+    element.addEventListener("keydown", this.#handleKeyDown, { capture: true });
+    
     window.addEventListener("scroll", this.#checkScroll, { passive: true });
     this.#resizeObserver = new ResizeObserver(this.#checkScroll);
     this.#resizeObserver.observe(document.body);
@@ -425,7 +447,7 @@ export default class AiBotDockedComposer extends Component {
 
   @action
   teardownScrollListener() {
-    this.#composerEl?.removeEventListener("beforeinput", this.#handleBeforeInput, { capture: true });
+    this.#composerEl?.removeEventListener("keydown", this.#handleKeyDown, { capture: true });
     this.#composerEl = null;
     window.removeEventListener("scroll", this.#checkScroll);
     this.#resizeObserver?.disconnect();

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -152,8 +152,8 @@ en:
     ai_bot_add_to_community_section: "Display a link in the sidebar community section to start a PM with an AI Bot"
     ai_bot_github_access_token: "GitHub access token for use with GitHub AI tools (required for search support)"
     ai_bot_enable_docked_composer: "Enable the docked chat-style composer for AI bot conversations instead of the standard floating composer."
-    ai_bot_composer_submit_on_enter: "Submit AI Bot initial conversation on Enter key"
-    ai_bot_composer_submit_on_enter_description: "When enabled, pressing Enter in the AI Bot composer will submit the first message (Shift+Enter for a new line). When disabled, pressing Enter creates a new line, mimicking standard Discourse behavior."
+    ai_bot_composer_submit_on_enter: "Submit AI Bot conversation on Enter key"
+    ai_bot_composer_submit_on_enter_description: "When enabled, pressing Enter in the AI Bot composer will submit the message (Shift+Enter for a new line). When disabled, pressing Enter creates a new line, mimicking standard Discourse behavior."
 
     ai_discover_enabled: "Enable the discovery search feature"
     ai_discover_agent: "Agent to use for discovery search feature"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -152,8 +152,8 @@ en:
     ai_bot_add_to_community_section: "Display a link in the sidebar community section to start a PM with an AI Bot"
     ai_bot_github_access_token: "GitHub access token for use with GitHub AI tools (required for search support)"
     ai_bot_enable_docked_composer: "Enable the docked chat-style composer for AI bot conversations instead of the standard floating composer."
-    ai_bot_composer_submit_on_enter: "Submit AI Bot conversations on Enter key"
-    ai_bot_composer_submit_on_enter_description: "When enabled, pressing Enter in the AI Bot composer will submit the message (Shift+Enter for a new line). When disabled, pressing Enter creates a new line, mimicking standard Discourse behavior."
+    ai_bot_composer_submit_on_enter: "Submit AI Bot initial conversation on Enter key"
+    ai_bot_composer_submit_on_enter_description: "When enabled, pressing Enter in the AI Bot composer will submit the first message (Shift+Enter for a new line). When disabled, pressing Enter creates a new line, mimicking standard Discourse behavior."
 
     ai_discover_enabled: "Enable the discovery search feature"
     ai_discover_agent: "Agent to use for discovery search feature"

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -152,6 +152,8 @@ en:
     ai_bot_add_to_community_section: "Display a link in the sidebar community section to start a PM with an AI Bot"
     ai_bot_github_access_token: "GitHub access token for use with GitHub AI tools (required for search support)"
     ai_bot_enable_docked_composer: "Enable the docked chat-style composer for AI bot conversations instead of the standard floating composer."
+    ai_bot_composer_submit_on_enter: "Submit AI Bot conversations on Enter key"
+    ai_bot_composer_submit_on_enter_description: "When enabled, pressing Enter in the AI Bot composer will submit the message (Shift+Enter for a new line). When disabled, pressing Enter creates a new line, mimicking standard Discourse behavior."
 
     ai_discover_enabled: "Enable the discovery search feature"
     ai_discover_agent: "Agent to use for discovery search feature"

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -440,6 +440,11 @@ discourse_ai:
       status: "stable"
       impact: "feature,all_members"
       learn_more_url: "https://meta.discourse.org/t/-/403327"
+  ai_bot_composer_submit_on_enter:
+    default: true
+    client: true
+    type: bool
+    area: "ai-features/bot"
   ai_discover_enabled:
     default: false
     client: true

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
@@ -23,6 +23,7 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
     discourse_ai_enabled: true,
     ai_bot_enabled: true,
     min_personal_message_post_length: 10,
+    ai_bot_composer_submit_on_enter: true,
   });
 
   needs.pretender((server, helper) => {
@@ -78,6 +79,17 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
     await triggerEvent(INPUT, "beforeinput", {
       inputType: "insertCompositionText",
     });
+
+    assert.strictEqual(conversationRequests, 0, "did not submit");
+  });
+
+  test("Enter does not submit when ai_bot_composer_submit_on_enter is disabled", async function (assert) {
+    this.siteSettings.ai_bot_composer_submit_on_enter = false;
+
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "keydown", { key: "Enter" });
+    await triggerEvent(INPUT, "beforeinput", { inputType: "insertLineBreak" });
 
     assert.strictEqual(conversationRequests, 0, "did not submit");
   });


### PR DESCRIPTION
### What does this PR do?
Adds a new admin site setting (`ai_bot_composer_submit_on_enter`) to toggle the "Submit on Enter" keystroke behavior in the AI Bot full-page chat UI. 

*   **Default (`true`)**: Maintains the existing ChatGPT-style behavior where pressing `Enter` submits the post message and `Shift+Enter` creates a new line.
*   **Toggled (`false`)**: Allows the browser to handle the `insertLineBreak` event natively. Pressing `Enter` creates a new line in the Bot message, perfectly mimicking standard Discourse forum composer behavior. 


<img width="80%" height="80%" alt="image" src="https://github.com/user-attachments/assets/2a4e07bd-0091-4f24-8223-cf89be120a59" />



### Why is this needed?
The ChatGPT-style submit behaviour directly conflicts with standard Discourse composer muscle-memory. Many forum users rely on the `Enter` key for formatting and paragraph breaks, leading to inadvertent and premature message submissions when submitting their post to the AI Bot. 

While the ChatGPT UI paradigm makes sense for this plugin, this PR provides an escape hatch for communities that heavily prioritize standard forum composer consistency.

### Notes:
* Note that this change works whether the new docked composer is enabled or not
* Because the docked composer will eventually become permanent, the ideal long-term solution for this UX conflict might be a User Preference (similar to the Discourse Chat ‘Send shortcut’ setting) rather than a global site setting. I implemented this as a Site Setting to provide an immediate escape hatch for admins, but I am open to feedback if the team prefers this live as a user preference instead.

### Files Touched:
* `plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs`
* `plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-docked-composer.gjs`
* `plugins/discourse-ai/config/locales/server.en.yml`
* `plugins/discourse-ai/config/settings.yml`
* `plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js`