### PR TITLE
FIX: Prevent cached asset responses leaking usernames

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -380,10 +380,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_current_user_for_logs
-    if current_user
-      Logster.add_to_env(request.env, "username", current_user.username)
-      response.headers["X-Discourse-Username"] = current_user.username
-    end
+    Logster.add_to_env(request.env, "username", current_user.username) if current_user
     response.headers["X-Discourse-Route"] = "#{controller_path}/#{action_name}"
   end
 
@@ -1126,6 +1123,24 @@ class ApplicationController < ActionController::Base
     yield
   ensure
     dont_cache_page
+    set_current_user_header_for_logs
+  end
+
+  def set_current_user_header_for_logs
+    return if !current_user
+
+    cache_control = response.cache_control
+    extras = cache_control[:extras]
+    # `dont_cache_page` sets both of these through `extras` rather than as
+    # their own keys, and Rails only populates `cache_control[:private]` when
+    # the directive was set that way, so both spellings have to be checked.
+    no_store = cache_control[:no_store] || extras&.include?("no-store")
+    private_response =
+      cache_control[:private] || extras&.include?("private") ||
+        (cache_control[:max_age] && !cache_control[:public])
+    return if !private_response && !no_store
+
+    response.headers["X-Discourse-Username"] = current_user.username
   end
 
   def persist_locale_param_to_cookie

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -379,10 +379,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_current_user_for_logs
-    if current_user
-      Logster.add_to_env(request.env, "username", current_user.username)
-      response.headers["X-Discourse-Username"] = current_user.username
-    end
+    Logster.add_to_env(request.env, "username", current_user.username) if current_user
     response.headers["X-Discourse-Route"] = "#{controller_path}/#{action_name}"
   end
 
@@ -1125,6 +1122,19 @@ class ApplicationController < ActionController::Base
     yield
   ensure
     dont_cache_page
+    set_current_user_header_for_logs
+  end
+
+  def set_current_user_header_for_logs
+    return if !current_user
+
+    cache_control = response.cache_control
+    no_store = cache_control[:no_store] || cache_control[:extras]&.include?("no-store")
+    private_response =
+      cache_control[:private] || (cache_control[:max_age] && !cache_control[:public])
+    return if !private_response && !no_store
+
+    response.headers["X-Discourse-Username"] = current_user.username
   end
 
   def persist_locale_param_to_cookie

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1987,6 +1987,37 @@ RSpec.describe ApplicationController do
   describe "#set_current_user_for_logs" do
     fab!(:admin)
 
+    it "sets the X-Discourse-Username header for responses that cannot be stored" do
+      sign_in(admin)
+
+      get "/u/#{admin.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Cache-Control"]).to include("no-store")
+      expect(response.headers["X-Discourse-Username"]).to eq(admin.username)
+    end
+
+    it "does not set the X-Discourse-Username header for responses that can be stored" do
+      SiteSetting.cache_control_bfcache_compatibility = true
+      sign_in(admin)
+
+      get "/u/#{admin.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Cache-Control"]).to eq("no-cache")
+      expect(response.headers["X-Discourse-Username"]).to be_nil
+    end
+
+    it "sets the X-Discourse-Username header for private cached responses" do
+      sign_in(admin)
+
+      get "/manifest.webmanifest"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Cache-Control"]).to eq("max-age=60, private")
+      expect(response.headers["X-Discourse-Username"]).to eq(admin.username)
+    end
+
     it "sets the X-Discourse-Route header to the controller name and action including namespace" do
       sign_in(admin)
 

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -2135,6 +2135,39 @@ RSpec.describe ApplicationController do
   describe "#set_current_user_for_logs" do
     fab!(:admin)
 
+    it "sets the X-Discourse-Username header for responses that cannot be stored" do
+      sign_in(admin)
+
+      get "/u/#{admin.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Cache-Control"]).to include("no-store")
+      expect(response.headers["X-Discourse-Username"]).to eq(admin.username)
+    end
+
+    it "sets the X-Discourse-Username header in bfcache compatibility mode" do
+      # bfcache mode swaps `no-store` for `private`, which still keeps the
+      # response out of any shared cache, so attribution is safe to keep.
+      SiteSetting.cache_control_bfcache_compatibility = true
+      sign_in(admin)
+
+      get "/u/#{admin.username}.json"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Cache-Control"]).to eq("no-cache, private")
+      expect(response.headers["X-Discourse-Username"]).to eq(admin.username)
+    end
+
+    it "sets the X-Discourse-Username header for private cached responses" do
+      sign_in(admin)
+
+      get "/manifest.webmanifest"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["Cache-Control"]).to eq("max-age=60, private")
+      expect(response.headers["X-Discourse-Username"]).to eq(admin.username)
+    end
+
     it "sets the X-Discourse-Route header to the controller name and action including namespace" do
       sign_in(admin)
 

--- a/spec/requests/highlightjs_controller_spec.rb
+++ b/spec/requests/highlightjs_controller_spec.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe HighlightJsController do
+  fab!(:user)
+
   it "works via the site URL" do
     get HighlightJs.path
     expect(response.status).to eq(200)
     expect(response.body).to include("export default function")
     expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+  end
+
+  it "does not include a username in the cacheable response" do
+    sign_in(user)
+
+    get HighlightJs.path
+
+    expect(response.status).to eq(200)
+    expect(response.headers["X-Discourse-Username"]).to be_nil
   end
 
   it "works via a CDN" do

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe StaticController do
   fab!(:upload)
 
   describe "#favicon" do
+    fab!(:user)
+
     let(:filename) { "smallest.png" }
     let(:file) { file_from_fixtures(filename) }
 
@@ -18,6 +20,15 @@ RSpec.describe StaticController do
         expect(response.status).to eq(200)
         expect(response.media_type).to eq("image/png")
         expect(response.body.bytesize).to eq(SiteIconManager.favicon.filesize)
+      end
+
+      it "does not include a username in the cacheable response" do
+        sign_in(user)
+
+        get "/favicon/proxied"
+
+        expect(response.status).to eq(200)
+        expect(response.headers["X-Discourse-Username"]).to be_nil
       end
 
       it "returns the configured favicon" do
@@ -615,11 +626,22 @@ RSpec.describe StaticController do
   end
 
   describe "#service_worker_asset" do
+    fab!(:user)
+
     it "works" do
       get "/service-worker.js"
       expect(response.status).to eq(200)
       expect(response.content_type).to start_with("text/javascript")
       expect(response.body).to include("addEventListener")
+    end
+
+    it "does not include a username in the cacheable response" do
+      sign_in(user)
+
+      get "/service-worker.js"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Username"]).to be_nil
     end
   end
 

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe StaticController do
   fab!(:upload)
 
   describe "#favicon" do
+    fab!(:user)
+
     let(:filename) { "smallest.png" }
     let(:file) { file_from_fixtures(filename) }
 
@@ -18,6 +20,15 @@ RSpec.describe StaticController do
         expect(response.status).to eq(200)
         expect(response.media_type).to eq("image/png")
         expect(response.body.bytesize).to eq(SiteIconManager.favicon.filesize)
+      end
+
+      it "does not include a username in the cacheable response" do
+        sign_in(user)
+
+        get "/favicon/proxied"
+
+        expect(response.status).to eq(200)
+        expect(response.headers["X-Discourse-Username"]).to be_nil
       end
 
       it "returns the configured favicon" do
@@ -617,11 +628,22 @@ RSpec.describe StaticController do
   end
 
   describe "#service_worker_asset" do
+    fab!(:user)
+
     it "renders the requested static page" do
       get "/service-worker.js"
       expect(response.status).to eq(200)
       expect(response.content_type).to start_with("text/javascript")
       expect(response.body).to include("addEventListener")
+    end
+
+    it "does not include a username in the cacheable response" do
+      sign_in(user)
+
+      get "/service-worker.js"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Username"]).to be_nil
     end
   end
 

--- a/spec/requests/stylesheets_controller_spec.rb
+++ b/spec/requests/stylesheets_controller_spec.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe StylesheetsController do
+  fab!(:user)
+
+  describe "#show_source_map" do
+    it "does not include a username in the cacheable response" do
+      sign_in(user)
+
+      manager = Stylesheet::Manager.new(theme_id: nil)
+      builder = Stylesheet::Manager::Builder.new(target: "common", manager: manager, theme: nil)
+      builder.compile
+
+      get "/stylesheets/#{builder.stylesheet_filename}.map"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Username"]).to be_nil
+    end
+  end
+
   it "can survive cache miss" do
     StylesheetCache.destroy_all
     manager = Stylesheet::Manager.new(theme_id: nil)

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe SvgSpriteController do
       expect(response.status).to eq(200)
     end
 
+    it "does not include a username in the cacheable response" do
+      sign_in(user)
+
+      get "/svg-sprite/#{Discourse.current_hostname}/svg--#{SvgSprite.version}.js"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Username"]).to be_nil
+    end
+
     it "should redirect to current version" do
       random_hash = Digest::SHA1.hexdigest("somerandomstring")
       get "/svg-sprite/#{Discourse.current_hostname}/svg--#{random_hash}.js"

--- a/spec/requests/svg_sprite_controller_spec.rb
+++ b/spec/requests/svg_sprite_controller_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe SvgSpriteController do
       expect(response.status).to eq(200)
     end
 
+    it "does not include a username in the cacheable response" do
+      sign_in(user)
+
+      get "/svg-sprite/#{Discourse.current_hostname}/svg--#{SvgSprite.version}.js"
+
+      expect(response.status).to eq(200)
+      expect(response.headers["X-Discourse-Username"]).to be_nil
+    end
+
     it "redirects to the current version" do
       random_hash = Digest::SHA1.hexdigest("somerandomstring")
       get "/svg-sprite/#{Discourse.current_hostname}/svg--#{random_hash}.js"


### PR DESCRIPTION
## What does this change?

Prevents `X-Discourse-Username` from being retained on responses that may be stored by NGINX or another intermediate cache.

The username header was previously added in an early controller callback, before the response cache policy was known. A shared cache could therefore retain that response metadata and later attribute requests to the user who populated the cache.

This change keeps username attribution in the request logging environment, but delays adding `X-Discourse-Username` to the response until after `Cache-Control` has been finalized. The header is only added when shared caching is prohibited by `private` or `no-store`.

This applies the rule based on response cacheability rather than maintaining a list of asset paths.

## Tests

Added regression coverage for:

- responses using `no-store`
- storable `no-cache` responses
- private cached responses
- favicon responses
- service worker responses
- Highlight.js assets
- SVG sprites
- stylesheet source maps

Validated through `dv`:

- 251 RSpec examples, 0 failures
- RuboCop and Syntax Tree hooks pass

Ref: /t/115535