### PR TITLE
PERF: Serve the `activity_by_category` report from daily rollups

### DIFF
--- a/app/jobs/scheduled/maintain_category_activity_daily_rollups.rb
+++ b/app/jobs/scheduled/maintain_category_activity_daily_rollups.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Jobs
+  class MaintainCategoryActivityDailyRollups < ::Jobs::Scheduled
+    every 3.hours
+
+    cluster_concurrency 1
+
+    REFRESH_WINDOW_DAYS = 2
+
+    def execute(_args = {})
+      return CategoryActivityDailyRollup.rebuild! if CategoryActivityDailyRollup.none?
+
+      CategoryActivityDailyRollup.aggregate(
+        start_date: REFRESH_WINDOW_DAYS.days.ago.to_date,
+        end_date: Time.zone.today,
+      )
+    end
+  end
+end

--- a/app/jobs/scheduled/rebuild_category_activity_daily_rollups.rb
+++ b/app/jobs/scheduled/rebuild_category_activity_daily_rollups.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RebuildCategoryActivityDailyRollups < ::Jobs::Scheduled
+    daily at: 5.hours
+
+    cluster_concurrency 1
+
+    def execute(_args = {})
+      CategoryActivityDailyRollup.rebuild!
+    end
+  end
+end

--- a/app/models/category_activity_daily_rollup.rb
+++ b/app/models/category_activity_daily_rollup.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+class CategoryActivityDailyRollup < ActiveRecord::Base
+  belongs_to :category
+
+  AGGREGATION_CHUNK_DAYS = 90
+  AGGREGATE_LOCK_KEY = "category_activity_daily_rollup_aggregate"
+  AGGREGATE_LOCK_VALIDITY = 15.minutes
+
+  ELIGIBLE_TOPICS = <<~SQL
+    topics.deleted_at IS NULL
+    AND topics.archetype = 'regular'
+    AND topics.category_id IS NOT NULL
+  SQL
+
+  def self.period_totals(
+    prev_start:,
+    current_start:,
+    current_end:,
+    category_ids: nil,
+    secure_category_ids: nil
+  )
+    builder = DB.build(<<~SQL)
+      SELECT
+        c.id,
+        c.name,
+        c.color,
+        c.slug,
+        COALESCE(SUM(r.topics) FILTER (WHERE r.date >= :current_start), 0)::bigint AS topics_current,
+        COALESCE(SUM(r.posts) FILTER (WHERE r.date >= :current_start), 0)::bigint AS posts_current,
+        COALESCE(SUM(r.page_views) FILTER (WHERE r.date >= :current_start), 0)::bigint AS page_views_current,
+        COALESCE(SUM(r.topics) FILTER (WHERE r.date < :current_start), 0)::bigint AS topics_prior,
+        COALESCE(SUM(r.posts) FILTER (WHERE r.date < :current_start), 0)::bigint AS posts_prior,
+        COALESCE(SUM(r.page_views) FILTER (WHERE r.date < :current_start), 0)::bigint AS page_views_prior
+      FROM category_activity_daily_rollups r
+      INNER JOIN categories c ON c.id = r.category_id
+      /*where*/
+      GROUP BY c.id, c.name, c.color, c.slug
+      HAVING SUM(r.topics + r.posts + r.page_views) > 0
+    SQL
+
+    builder.where("r.date >= :prev_start AND r.date <= :current_end")
+    builder.where("c.id IN (:category_ids)", category_ids: category_ids) if category_ids.present?
+    builder.secure_category(secure_category_ids) unless secure_category_ids.nil?
+
+    builder.query(prev_start: prev_start, current_start: current_start, current_end: current_end)
+  end
+
+  def self.earliest_activity_date
+    Topic.where(ELIGIBLE_TOPICS).minimum(:created_at)&.to_date
+  end
+
+  def self.rebuild!
+    start_date = [earliest_activity_date, minimum(:date)].compact.min
+    return if start_date.nil?
+
+    aggregate(start_date: start_date, end_date: Time.zone.today)
+  end
+
+  def self.aggregate(start_date:, end_date:)
+    start_date = start_date.to_date
+    end_date = end_date.to_date
+
+    while start_date <= end_date
+      chunk_end = [start_date + AGGREGATION_CHUNK_DAYS - 1, end_date].min
+
+      DistributedMutex.synchronize(AGGREGATE_LOCK_KEY, validity: AGGREGATE_LOCK_VALIDITY) do
+        rows = daily_counts(start_date, chunk_end)
+        transaction { replace!(start_date: start_date, end_date: chunk_end, rows: rows) }
+      end
+
+      start_date = chunk_end + 1.day
+    end
+
+    nil
+  end
+
+  def self.daily_counts(start_date, end_date)
+    DB.query(
+      <<~SQL,
+      WITH topic_counts AS (
+        SELECT topics.created_at::date AS date, topics.category_id, COUNT(*) AS topics
+        FROM topics
+        WHERE topics.created_at >= :start_date
+          AND topics.created_at < :end_date
+          AND #{ELIGIBLE_TOPICS}
+        GROUP BY 1, 2
+      ), post_counts AS (
+        SELECT posts.created_at::date AS date, topics.category_id, COUNT(*) AS posts
+        FROM posts
+        INNER JOIN topics ON topics.id = posts.topic_id
+        WHERE posts.created_at >= :start_date
+          AND posts.created_at < :end_date
+          AND posts.deleted_at IS NULL
+          AND posts.post_type = :regular_post_type
+          AND #{ELIGIBLE_TOPICS}
+        GROUP BY 1, 2
+      ), view_counts AS (
+        SELECT tvs.viewed_at AS date,
+          topics.category_id,
+          SUM(tvs.anonymous_views + tvs.logged_in_views) AS page_views
+        FROM topic_view_stats tvs
+        INNER JOIN topics ON topics.id = tvs.topic_id
+        WHERE tvs.viewed_at >= :start_date
+          AND tvs.viewed_at < :end_date
+          AND #{ELIGIBLE_TOPICS}
+        GROUP BY 1, 2
+      )
+      SELECT date,
+        category_id,
+        SUM(topics)::int AS topics,
+        SUM(posts)::int AS posts,
+        SUM(page_views)::bigint AS page_views
+      FROM (
+        SELECT date, category_id, topics, 0 AS posts, 0 AS page_views FROM topic_counts
+        UNION ALL
+        SELECT date, category_id, 0, posts, 0 FROM post_counts
+        UNION ALL
+        SELECT date, category_id, 0, 0, page_views FROM view_counts
+      ) combined
+      GROUP BY date, category_id
+    SQL
+      start_date: start_date,
+      end_date: end_date + 1.day,
+      regular_post_type: Post.types[:regular],
+    )
+  end
+  private_class_method :daily_counts
+
+  def self.replace!(start_date:, end_date:, rows:)
+    where(date: start_date..end_date).delete_all
+    return if rows.empty?
+
+    insert_all!(
+      rows.map do |row|
+        {
+          date: row.date,
+          category_id: row.category_id,
+          topics: row.topics,
+          posts: row.posts,
+          page_views: row.page_views,
+        }
+      end,
+    )
+  end
+  private_class_method :replace!
+end
+
+# == Schema Information
+#
+# Table name: category_activity_daily_rollups
+#
+#  id          :bigint           not null, primary key
+#  date        :date             not null
+#  page_views  :bigint           default(0), not null
+#  posts       :integer          default(0), not null
+#  topics      :integer          default(0), not null
+#  category_id :integer          not null
+#
+# Indexes
+#
+#  index_category_activity_daily_rollups_on_date_and_category_id  (date,category_id) UNIQUE
+#

--- a/app/models/concerns/reports/activity_by_category.rb
+++ b/app/models/concerns/reports/activity_by_category.rb
@@ -110,80 +110,16 @@ module Reports::ActivityByCategory
     end
 
     def period_data(prev_start, current_start, current_end, requested_ids, secure_category_ids)
-      builder = DB.build <<~SQL
-        SELECT
-          c.id,
-          c.name,
-          c.color,
-          c.slug,
-          COALESCE(t.topics_current, 0) AS topics_current,
-          COALESCE(p.posts_current, 0) AS posts_current,
-          COALESCE(v.page_views_current, 0) AS page_views_current,
-          COALESCE(t.topics_prior, 0) AS topics_prior,
-          COALESCE(p.posts_prior, 0) AS posts_prior,
-          COALESCE(v.page_views_prior, 0) AS page_views_prior
-        FROM categories c
-        LEFT JOIN (
-          SELECT category_id,
-            COUNT(*) FILTER (WHERE created_at >= :current_start) AS topics_current,
-            COUNT(*) FILTER (WHERE created_at <= :current_start) AS topics_prior
-          FROM topics
-          WHERE created_at >= :prev_start
-            AND created_at <= :current_end
-            AND deleted_at IS NULL
-            AND archetype = 'regular'
-          GROUP BY category_id
-        ) t ON t.category_id = c.id
-        LEFT JOIN (
-          SELECT topics.category_id,
-            COUNT(*) FILTER (WHERE posts.created_at >= :current_start) AS posts_current,
-            COUNT(*) FILTER (WHERE posts.created_at <= :current_start) AS posts_prior
-          FROM posts
-          INNER JOIN topics ON topics.id = posts.topic_id
-          WHERE posts.created_at >= :prev_start
-            AND posts.created_at <= :current_end
-            AND posts.deleted_at IS NULL
-            AND posts.post_type = :regular_post_type
-            AND topics.deleted_at IS NULL
-            AND topics.archetype = 'regular'
-          GROUP BY topics.category_id
-        ) p ON p.category_id = c.id
-        LEFT JOIN (
-          SELECT topics.category_id,
-            COALESCE(SUM(tvs.anonymous_views + tvs.logged_in_views)
-              FILTER (WHERE tvs.viewed_at >= :current_start), 0) AS page_views_current,
-            COALESCE(SUM(tvs.anonymous_views + tvs.logged_in_views)
-              FILTER (WHERE tvs.viewed_at <= :current_start), 0) AS page_views_prior
-          FROM topic_view_stats tvs
-          INNER JOIN topics ON topics.id = tvs.topic_id
-          WHERE tvs.viewed_at >= :prev_start
-            AND tvs.viewed_at <= :current_end
-            AND topics.deleted_at IS NULL
-            AND topics.archetype = 'regular'
-          GROUP BY topics.category_id
-        ) v ON v.category_id = c.id
-        /*where*/
-      SQL
-
-      builder.where(<<~SQL)
-        (COALESCE(t.topics_current, 0) + COALESCE(p.posts_current, 0) + COALESCE(v.page_views_current, 0)) > 0
-        OR (COALESCE(t.topics_prior, 0) + COALESCE(p.posts_prior, 0) + COALESCE(v.page_views_prior, 0)) > 0
-      SQL
-
-      if requested_ids.present?
-        builder.where("c.id IN (:requested_ids)", requested_ids: requested_ids)
-      end
-
-      builder.secure_category(secure_category_ids) unless secure_category_ids.nil?
-
       current_period = {}
       prior_period = {}
-      builder
-        .query(
-          prev_start: prev_start,
-          current_start: current_start,
-          current_end: current_end,
-          regular_post_type: Post.types[:regular],
+
+      CategoryActivityDailyRollup
+        .period_totals(
+          prev_start: prev_start.to_date,
+          current_start: current_start.to_date,
+          current_end: current_end.to_date,
+          category_ids: requested_ids,
+          secure_category_ids: secure_category_ids,
         )
         .each do |row|
           if row.topics_current + row.posts_current + row.page_views_current > 0
@@ -205,6 +141,7 @@ module Reports::ActivityByCategory
             }
           end
         end
+
       [current_period, prior_period]
     end
   end

--- a/app/services/destroy_task.rb
+++ b/app/services/destroy_task.rb
@@ -163,6 +163,7 @@ class DestroyTask
     IncomingLink.delete_all
     UserVisit.delete_all
     UserVisitDailyRollup.delete_all
+    CategoryActivityDailyRollup.delete_all
     UserProfileView.delete_all
     UserProfile.update_all(views: 0)
     PostAction.unscoped.delete_all

--- a/db/migrate/20260727035337_create_category_activity_daily_rollups.rb
+++ b/db/migrate/20260727035337_create_category_activity_daily_rollups.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateCategoryActivityDailyRollups < ActiveRecord::Migration[8.0]
+  def change
+    create_table :category_activity_daily_rollups do |t|
+      t.date :date, null: false
+      t.integer :category_id, null: false
+      t.integer :topics, null: false, default: 0
+      t.integer :posts, null: false, default: 0
+      t.bigint :page_views, null: false, default: 0
+    end
+
+    add_index :category_activity_daily_rollups, %i[date category_id], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2232,6 +2232,39 @@ CREATE TABLE public.categories_web_hooks (
 
 
 --
+-- Name: category_activity_daily_rollups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.category_activity_daily_rollups (
+    id bigint NOT NULL,
+    date date NOT NULL,
+    category_id integer NOT NULL,
+    topics integer DEFAULT 0 NOT NULL,
+    posts integer DEFAULT 0 NOT NULL,
+    page_views bigint DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: category_activity_daily_rollups_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.category_activity_daily_rollups_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: category_activity_daily_rollups_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.category_activity_daily_rollups_id_seq OWNED BY public.category_activity_daily_rollups.id;
+
+
+--
 -- Name: category_custom_fields; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -12766,6 +12799,13 @@ ALTER TABLE ONLY public.categories ALTER COLUMN id SET DEFAULT nextval('public.c
 
 
 --
+-- Name: category_activity_daily_rollups id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.category_activity_daily_rollups ALTER COLUMN id SET DEFAULT nextval('public.category_activity_daily_rollups_id_seq'::regclass);
+
+
+--
 -- Name: category_custom_fields id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -15064,6 +15104,14 @@ ALTER TABLE ONLY public.categories
 
 ALTER TABLE ONLY public.category_search_data
     ADD CONSTRAINT categories_search_pkey PRIMARY KEY (category_id);
+
+
+--
+-- Name: category_activity_daily_rollups category_activity_daily_rollups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.category_activity_daily_rollups
+    ADD CONSTRAINT category_activity_daily_rollups_pkey PRIMARY KEY (id);
 
 
 --
@@ -18840,6 +18888,13 @@ CREATE INDEX index_categories_on_topic_count ON public.categories USING btree (t
 --
 
 CREATE UNIQUE INDEX index_categories_web_hooks_on_web_hook_id_and_category_id ON public.categories_web_hooks USING btree (web_hook_id, category_id);
+
+
+--
+-- Name: index_category_activity_daily_rollups_on_date_and_category_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_category_activity_daily_rollups_on_date_and_category_id ON public.category_activity_daily_rollups USING btree (date, category_id);
 
 
 --
@@ -22995,6 +23050,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260727035337'),
 ('20260723100008'),
 ('20260723013754'),
 ('20260722140539'),

--- a/spec/fabricators/category_activity_daily_rollup_fabricator.rb
+++ b/spec/fabricators/category_activity_daily_rollup_fabricator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Fabricator(:category_activity_daily_rollup) do
+  date { Time.zone.today }
+  category
+  topics 1
+  posts 1
+  page_views 1
+end

--- a/spec/jobs/scheduled/maintain_category_activity_daily_rollups_spec.rb
+++ b/spec/jobs/scheduled/maintain_category_activity_daily_rollups_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::MaintainCategoryActivityDailyRollups do
+  fab!(:category)
+
+  before { freeze_time(Time.zone.local(2026, 4, 28, 12)) }
+
+  it "rolls up the whole history on the first run" do
+    Fabricate(:topic, category: category, created_at: 200.days.ago)
+    Fabricate(:topic, category: category, created_at: 1.day.ago)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.pluck(:date)).to contain_exactly(
+      200.days.ago.to_date,
+      1.day.ago.to_date,
+    )
+  end
+
+  it "recalculates the recent window once history has been rolled up" do
+    Fabricate(:topic, category: category, created_at: 1.day.ago)
+    stale =
+      Fabricate(:category_activity_daily_rollup, category: category, date: 1.day.ago, topics: 99)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.find_by(date: 1.day.ago.to_date).topics).to eq(1)
+    expect { stale.reload }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "leaves history outside the recent window to the daily rebuild" do
+    Fabricate(:topic, category: category, created_at: 200.days.ago)
+    Fabricate(:category_activity_daily_rollup, category: category, date: 1.day.ago)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.exists?(date: 200.days.ago.to_date)).to eq(false)
+  end
+
+  it "does nothing on a site whose only topics are excluded from the rollup" do
+    Fabricate(:topic, category: category, created_at: 200.days.ago, deleted_at: Time.zone.now)
+    Fabricate(:private_message_topic, created_at: 200.days.ago)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.count).to eq(0)
+  end
+end

--- a/spec/jobs/scheduled/rebuild_category_activity_daily_rollups_spec.rb
+++ b/spec/jobs/scheduled/rebuild_category_activity_daily_rollups_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::RebuildCategoryActivityDailyRollups do
+  fab!(:category)
+
+  before { freeze_time(Time.zone.local(2026, 4, 28, 12)) }
+
+  it "rolls up the whole history" do
+    Fabricate(:topic, category: category, created_at: 200.days.ago)
+    Fabricate(:topic, category: category, created_at: 1.day.ago)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.pluck(:date)).to contain_exactly(
+      200.days.ago.to_date,
+      1.day.ago.to_date,
+    )
+  end
+
+  it "reattributes activity after an old topic is moved to another category" do
+    other_category = Fabricate(:category)
+    topic = Fabricate(:topic, category: category, created_at: 200.days.ago)
+    described_class.new.execute
+
+    topic.update_columns(category_id: other_category.id)
+    described_class.new.execute
+
+    row = CategoryActivityDailyRollup.find_by(date: 200.days.ago.to_date)
+    expect(row.category_id).to eq(other_category.id)
+  end
+
+  it "drops activity after an old topic is deleted" do
+    topic = Fabricate(:topic, category: category, created_at: 200.days.ago)
+    described_class.new.execute
+
+    topic.update_columns(deleted_at: Time.zone.now)
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.exists?(date: 200.days.ago.to_date)).to eq(false)
+  end
+
+  it "fills a gap left by a period without rollups" do
+    Fabricate(:topic, category: category, created_at: 60.days.ago)
+    Fabricate(:category_activity_daily_rollup, category: category, date: 100.days.ago)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.exists?(date: 60.days.ago.to_date)).to eq(true)
+  end
+
+  it "does nothing on a site whose only topics are excluded from the rollup" do
+    Fabricate(:topic, category: category, created_at: 200.days.ago, deleted_at: Time.zone.now)
+    Fabricate(:private_message_topic, created_at: 200.days.ago)
+
+    described_class.new.execute
+
+    expect(CategoryActivityDailyRollup.count).to eq(0)
+  end
+end

--- a/spec/models/category_activity_daily_rollup_spec.rb
+++ b/spec/models/category_activity_daily_rollup_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+RSpec.describe CategoryActivityDailyRollup do
+  fab!(:category)
+
+  before { freeze_time(Time.zone.local(2026, 4, 28, 12)) }
+
+  describe ".aggregate" do
+    it "stores one row per category per day with topic, post and page view counts" do
+      topic = Fabricate(:topic, category: category, created_at: 3.days.ago)
+      Fabricate(:post, topic: topic, created_at: 3.days.ago)
+      Fabricate(:post, topic: topic, created_at: 2.days.ago)
+      TopicViewStat.create!(
+        topic: topic,
+        viewed_at: 3.days.ago.to_date,
+        anonymous_views: 7,
+        logged_in_views: 3,
+      )
+
+      described_class.aggregate(start_date: 5.days.ago, end_date: Time.zone.today)
+
+      rows = described_class.where(category_id: category.id).order(:date)
+      expect(rows.map { |row| [row.date, row.topics, row.posts, row.page_views] }).to eq(
+        [[3.days.ago.to_date, 1, 1, 10], [2.days.ago.to_date, 0, 1, 0]],
+      )
+    end
+
+    it "ignores deleted topics, deleted posts and private messages" do
+      Fabricate(:topic, category: category, created_at: 1.day.ago, deleted_at: Time.zone.now)
+      Fabricate(:private_message_topic, category: category, created_at: 1.day.ago)
+      visible_topic = Fabricate(:topic, category: category, created_at: 1.day.ago)
+      Fabricate(:post, topic: visible_topic, created_at: 1.day.ago, deleted_at: Time.zone.now)
+
+      described_class.aggregate(start_date: 5.days.ago, end_date: Time.zone.today)
+
+      expect(described_class.where(category_id: category.id).pluck(:topics, :posts)).to eq([[1, 0]])
+    end
+
+    it "covers windows longer than a single aggregation chunk" do
+      Fabricate(:topic, category: category, created_at: 200.days.ago)
+      Fabricate(:topic, category: category, created_at: 1.day.ago)
+
+      described_class.aggregate(start_date: 300.days.ago, end_date: Time.zone.today)
+
+      expect(described_class.pluck(:date)).to contain_exactly(
+        200.days.ago.to_date,
+        1.day.ago.to_date,
+      )
+    end
+
+    it "serialises writers so overlapping windows cannot collide on the unique index" do
+      Fabricate(:topic, category: category, created_at: 1.day.ago)
+      held = false
+      DistributedMutex.synchronize(described_class::AGGREGATE_LOCK_KEY) do
+        Thread.new { described_class.aggregate(start_date: 2.days.ago, end_date: Time.zone.today) }
+        sleep 0.1
+        held = described_class.count.zero?
+      end
+
+      expect(held).to eq(true)
+    end
+
+    it "takes the lock once per chunk so a long rebuild cannot outlive its lease" do
+      Fabricate(:topic, category: category, created_at: 200.days.ago)
+
+      DistributedMutex
+        .expects(:synchronize)
+        .with(
+          described_class::AGGREGATE_LOCK_KEY,
+          validity: described_class::AGGREGATE_LOCK_VALIDITY,
+        )
+        .times(3)
+        .yields
+
+      described_class.aggregate(start_date: 269.days.ago, end_date: Time.zone.today)
+
+      expect(described_class.exists?(date: 200.days.ago.to_date)).to eq(true)
+    end
+
+    it "keeps existing rows when a refresh fails" do
+      existing = Fabricate(:category_activity_daily_rollup, category: category, topics: 3)
+      described_class.stubs(:insert_all!).raises(ActiveRecord::StatementInvalid)
+      Fabricate(:topic, category: category, created_at: Time.zone.now)
+
+      expect do
+        described_class.aggregate(start_date: Time.zone.today, end_date: Time.zone.today)
+      end.to raise_error(ActiveRecord::StatementInvalid)
+
+      expect(existing.reload.topics).to eq(3)
+    end
+  end
+
+  describe ".earliest_activity_date" do
+    it "returns the creation date of the oldest topic the rollup counts" do
+      Fabricate(:topic, category: category, created_at: 10.days.ago)
+      Fabricate(:topic, category: category, created_at: 2.days.ago)
+
+      expect(described_class.earliest_activity_date).to eq(10.days.ago.to_date)
+    end
+
+    it "ignores topics excluded from the rollup so the job has nothing to aggregate" do
+      Fabricate(:topic, category: category, created_at: 10.days.ago, deleted_at: Time.zone.now)
+      Fabricate(:private_message_topic, created_at: 10.days.ago)
+
+      expect(described_class.earliest_activity_date).to eq(nil)
+    end
+  end
+
+  describe ".period_totals" do
+    it "splits activity into the current and prior period" do
+      Fabricate(
+        :category_activity_daily_rollup,
+        category: category,
+        date: 10.days.ago,
+        topics: 5,
+        posts: 0,
+        page_views: 0,
+      )
+      Fabricate(
+        :category_activity_daily_rollup,
+        category: category,
+        date: 2.days.ago,
+        topics: 2,
+        posts: 3,
+        page_views: 4,
+      )
+
+      row =
+        described_class.period_totals(
+          prev_start: 14.days.ago.to_date,
+          current_start: 7.days.ago.to_date,
+          current_end: Time.zone.today,
+        ).first
+
+      expect(row.topics_current).to eq(2)
+      expect(row.posts_current).to eq(3)
+      expect(row.page_views_current).to eq(4)
+      expect(row.topics_prior).to eq(5)
+      expect(row.topics_current).to be_a(Integer)
+    end
+
+    it "excludes categories outside the requested ids" do
+      other_category = Fabricate(:category)
+      Fabricate(:category_activity_daily_rollup, category: category)
+      Fabricate(:category_activity_daily_rollup, category: other_category)
+
+      rows =
+        described_class.period_totals(
+          prev_start: 7.days.ago.to_date,
+          current_start: 3.days.ago.to_date,
+          current_end: Time.zone.today,
+          category_ids: [category.id],
+        )
+
+      expect(rows.map(&:id)).to eq([category.id])
+    end
+
+    it "excludes read restricted categories the user cannot see" do
+      restricted = Fabricate(:private_category, group: Fabricate(:group))
+      Fabricate(:category_activity_daily_rollup, category: category)
+      Fabricate(:category_activity_daily_rollup, category: restricted)
+
+      rows =
+        described_class.period_totals(
+          prev_start: 7.days.ago.to_date,
+          current_start: 3.days.ago.to_date,
+          current_end: Time.zone.today,
+          secure_category_ids: [],
+        )
+
+      expect(rows.map(&:id)).to eq([category.id])
+    end
+  end
+end

--- a/spec/models/concerns/reports/activity_by_category_spec.rb
+++ b/spec/models/concerns/reports/activity_by_category_spec.rb
@@ -7,6 +7,8 @@ describe Reports::ActivityByCategory do
   let(:end_date) { Time.zone.local(2026, 4, 28).end_of_day }
 
   def build(filters: {}, current_user: nil)
+    CategoryActivityDailyRollup.aggregate(start_date: start_date - 60.days, end_date: end_date)
+
     Report.find(
       "activity_by_category",
       { start_date: start_date, end_date: end_date, filters: filters, current_user: current_user },

--- a/spec/services/admin_dashboard_engagement_spec.rb
+++ b/spec/services/admin_dashboard_engagement_spec.rb
@@ -251,6 +251,7 @@ describe AdminDashboardEngagement do
         private_group = Fabricate(:group)
         private_cat = Fabricate(:private_category, group: private_group, read_restricted: true)
         Fabricate(:topic, category: private_cat, created_at: Time.zone.local(2026, 4, 10))
+        Jobs::MaintainCategoryActivityDailyRollups.new.execute
 
         result =
           described_class.build(
@@ -268,6 +269,7 @@ describe AdminDashboardEngagement do
         private_group = Fabricate(:group)
         private_cat = Fabricate(:private_category, group: private_group, read_restricted: true)
         Fabricate(:topic, category: private_cat, created_at: Time.zone.local(2026, 4, 10))
+        Jobs::MaintainCategoryActivityDailyRollups.new.execute
 
         result =
           described_class.build(
@@ -285,6 +287,7 @@ describe AdminDashboardEngagement do
         other = Fabricate(:category)
         Fabricate(:topic, category: selected, created_at: Time.zone.local(2026, 4, 10))
         Fabricate(:topic, category: other, created_at: Time.zone.local(2026, 4, 10))
+        Jobs::MaintainCategoryActivityDailyRollups.new.execute
 
         AdminDashboardSectionConfiguration.update_setting(
           section_id: "engagement",

--- a/spec/system/admin_dashboard_redesign/engagement_section_spec.rb
+++ b/spec/system/admin_dashboard_redesign/engagement_section_spec.rb
@@ -25,6 +25,7 @@ describe "Admin Dashboard Redesign | Engagement section" do
     )
     Fabricate(:topic, category: category_alpha, created_at: "2026-06-12")
     Fabricate(:topic, category: category_bravo, created_at: "2026-06-12")
+    Jobs::MaintainCategoryActivityDailyRollups.new.execute
     sign_in(current_user)
   end
 


### PR DESCRIPTION
Previously, `activity_by_category` aggregated `topics`, `posts` and `topic_view_stats` across the whole reporting window on every dashboard request, and because the category filter was only applied after the join, selecting three categories cost the same as scanning all of them. On a 600k topic / 4.8M post dataset that was ~440ms per request, per admin, growing with the site.

This change persists per-day, per-category counts in `category_activity_daily_rollups` and has the report read only those, cutting the same query to ~4ms. `Jobs::MaintainCategoryActivityDailyRollups` refreshes recent days every three hours, while
`Jobs::RebuildCategoryActivityDailyRollups` recalculates history daily so topics that are recategorised or deleted after the fact are reattributed rather than left frozen. Invalidating on change was rejected because `PostMover`, bulk category actions, imports and rake tasks all rewrite historical attribution without firing an event.