### PR TITLE
DEV: Centralize server-side image processing in `DiscourseImage`

### DIFF
--- a/.skills/discourse-upcoming-changes/scripts/optimize_upcoming_change_image.rb
+++ b/.skills/discourse-upcoming-changes/scripts/optimize_upcoming_change_image.rb
@@ -3,7 +3,6 @@
 # Usage: bin/rails runner ~/path/to/discourse-upcoming-changes/scripts/optimize_upcoming_change_image.rb <path>
 #
 # Converts (if needed), resizes, and optimizes an image for use as an upcoming change preview.
-# Uses Discourse's ImageMagick integration for format conversion and OptimizedImage for optimization.
 
 path = ARGV[0]
 
@@ -19,15 +18,12 @@ unless File.exist?(path)
   exit 1
 end
 
-# Detect actual image format using FastImage (not file extension)
-image_info = FastImage.new(path)
-
-if image_info.nil?
+begin
+  actual_type = DiscourseImage.type(path).to_s
+rescue DiscourseImage::Error
   puts "Error: Could not determine image format for: #{path}"
   exit 1
 end
-
-actual_type = image_info.type.to_s
 puts "Optimizing #{File.basename(path)} (detected format: #{actual_type})..."
 
 # Ensure output path ends with .png
@@ -37,28 +33,16 @@ output_path = path.sub(/\.[^.]+$/, ".png")
 if actual_type != "png"
   puts "Converting from #{actual_type} to PNG..."
 
-  # Use ImageMagick to convert to PNG (same approach as Discourse's UploadCreator)
-  Discourse::Utils.execute_command(
-    "magick",
-    path,
-    "-auto-orient",
-    "-background",
-    "white",
-    output_path,
-    failure_message: "Failed to convert image to PNG",
-    timeout: 30,
-  )
+  DiscourseImage.convert(input: path, output: output_path, timeout: 30)
 
   # Remove original if different from output
   File.delete(path) if path != output_path && File.exist?(path)
   path = output_path
 end
 
-# Use OptimizedImage.downsize to resize (max 1200px width, maintain aspect ratio)
-OptimizedImage.downsize(path, path, "1200x>")
+DiscourseImage.resize(input: path, output: path, width: 1200, allow_upscale: false)
 
-# Force pngquant optimization for better compression (OptimizedImage skips it for files > 500KB)
-FileHelper.optimize_image!(path, allow_pngquant: true)
+DiscourseImage.optimize!(path, allow_lossy: true)
 
 size = File.size(path)
 puts "Done! Final size: #{(size / 1024.0).round(1)}KB"

--- a/app/jobs/onceoff/fix_invalid_gravatar_uploads.rb
+++ b/app/jobs/onceoff/fix_invalid_gravatar_uploads.rb
@@ -10,8 +10,8 @@ module Jobs
           # we may need to re-evaluate this
           extension =
             begin
-              FastImage.type(Discourse.store.path_for(upload))
-            rescue StandardError
+              DiscourseImage.type(Discourse.store.path_for(upload))
+            rescue DiscourseImage::Error
               nil
             end
           current_extension = upload.extension

--- a/app/jobs/scheduled/update_animated_uploads.rb
+++ b/app/jobs/scheduled/update_animated_uploads.rb
@@ -13,7 +13,12 @@ module Jobs
         .limit(MAX_PROCESSED_GIF_IMAGES)
         .each do |upload|
           uri = Discourse.store.path_for(upload) || upload.url
-          upload.animated = FastImage.animated?(uri)
+          upload.animated =
+            begin
+              DiscourseImage.animated?(uri)
+            rescue DiscourseImage::Error
+              nil
+            end
           upload.save(validate: false)
           upload.optimized_images.destroy_all if upload.animated
         end

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -5,7 +5,7 @@ class OptimizedImage < ActiveRecord::Base
   belongs_to :upload
 
   # BUMP UP if optimized image algorithm changes
-  VERSION = 3
+  VERSION = 2
   URL_REGEX = %r{(/optimized/\dX[/\.\w]*/([a-zA-Z0-9]+)[\.\w]*)}
 
   def self.lock(upload_id, width, height)

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -5,7 +5,7 @@ class OptimizedImage < ActiveRecord::Base
   belongs_to :upload
 
   # BUMP UP if optimized image algorithm changes
-  VERSION = 2
+  VERSION = 3
   URL_REGEX = %r{(/optimized/\dX[/\.\w]*/([a-zA-Z0-9]+)[\.\w]*)}
 
   def self.lock(upload_id, width, height)
@@ -39,7 +39,7 @@ class OptimizedImage < ActiveRecord::Base
     # no extension so try to guess it
     upload.fix_image_extension if !upload.extension
 
-    if !upload.extension.match?(IM_DECODERS)
+    if !%w[jpg jpeg png ico gif webp avif svg].include?(upload.extension.downcase)
       if opts[:raise_on_error]
         raise InvalidAccess
       else
@@ -96,12 +96,7 @@ class OptimizedImage < ActiveRecord::Base
         temp_file = Tempfile.new(["discourse-thumbnail", extension])
         temp_path = temp_file.path
 
-        target_quality =
-          upload.target_image_quality(
-            original_path,
-            SiteSetting.ImageQuality.image_preview_jpg_quality,
-          )
-        opts = opts.merge(quality: target_quality) if target_quality
+        opts = opts.merge(quality: SiteSetting.ImageQuality.image_preview_jpg_quality)
         opts = opts.merge(upload_id: upload.id)
 
         # special case, when "resizing" vectors we simply copy
@@ -195,182 +190,93 @@ class OptimizedImage < ActiveRecord::Base
     paths.each { |path| raise Discourse::InvalidAccess unless safe_path?(path) }
   end
 
-  IM_DECODERS = /\A(jpe?g|png|ico|gif|webp|avif|svg)\z/i
-
-  def self.prepend_decoder!(path, ext_path = nil, opts = nil)
-    opts ||= {}
-
-    # This logic is a little messy but the result of using mocks for most
-    # of the image tests. The idea here is you shouldn't trust the "original"
-    # path of a file to figure out its extension. However, in certain cases
-    # such as generating the loading upload thumbnail, we force the format,
-    # and this allows us to use the forced format in that case.
-    extension = nil
-    if opts[:format] && path != ext_path
-      extension = File.extname(path)[1..-1]
-    else
-      extension = File.extname(opts[:filename] || ext_path || path)[1..-1]
-    end
-
-    if !extension || !extension.match?(IM_DECODERS)
-      raise Discourse::InvalidAccess.new("Unsupported extension: #{extension}")
-    end
-    "#{extension}:#{path}"
-  end
-
-  def self.thumbnail_or_resize
-    SiteSetting.strip_image_metadata ? "thumbnail" : "resize"
-  end
-
-  def self.resize_instructions(from, to, dimensions, opts = {})
-    ensure_safe_paths!(from, to)
-
-    # note FROM my not be named correctly
-    from = prepend_decoder!(from, to, opts)
-    to = prepend_decoder!(to, to, opts)
-
-    instructions = ["convert", "#{from}[0]"]
-
-    instructions << "-colors" << opts[:colors].to_s if opts[:colors]
-
-    instructions << "-quality" << opts[:quality].to_s if opts[:quality]
-
-    # NOTE: ORDER is important!
-    instructions.concat(
-      %W[
-        -auto-orient
-        -gravity
-        center
-        -background
-        transparent
-        -#{thumbnail_or_resize}
-        #{dimensions}^
-        -extent
-        #{dimensions}
-        -interpolate
-        catrom
-        -unsharp
-        2x0.5+0.7+0
-        -interlace
-        none
-        -profile
-        #{Rails.root.join("vendor/data/RT_sRGB.icm")}
-        #{to}
-      ],
-    )
-  end
-
-  def self.crop_instructions(from, to, dimensions, opts = {})
-    ensure_safe_paths!(from, to)
-
-    from = prepend_decoder!(from, to, opts)
-    to = prepend_decoder!(to, to, opts)
-
-    instructions = %W{
-      convert
-      #{from}[0]
-      -auto-orient
-      -gravity
-      north
-      -background
-      transparent
-      -#{thumbnail_or_resize}
-      #{dimensions}^
-      -crop
-      #{dimensions}+0+0
-      -unsharp
-      2x0.5+0.7+0
-      -interlace
-      none
-      -profile
-      #{Rails.root.join("vendor/data/RT_sRGB.icm")}
-    }
-
-    instructions << "-quality" << opts[:quality].to_s if opts[:quality]
-
-    instructions << to
-  end
-
-  def self.downsize_instructions(from, to, dimensions, opts = {})
-    ensure_safe_paths!(from, to)
-
-    from = prepend_decoder!(from, to, opts)
-    to = prepend_decoder!(to, to, opts)
-
-    %W{
-      convert
-      #{from}[0]
-      -auto-orient
-      -gravity
-      center
-      -background
-      transparent
-      -interlace
-      none
-      -resize
-      #{dimensions}
-      -profile
-      #{Rails.root.join("vendor/data/RT_sRGB.icm")}
-      #{to}
-    }
-  end
-
   def self.resize(from, to, width, height, opts = {})
-    optimize("resize", from, to, "#{width}x#{height}", opts)
+    process(from: from, to: to, opts: opts) do |output_path|
+      DiscourseImage.crop(
+        input: from,
+        output: output_path,
+        width: width,
+        height: height,
+        position: :center,
+        maximum_quality: opts[:quality],
+      )
+    end
   end
 
   def self.crop(from, to, width, height, opts = {})
-    optimize("crop", from, to, "#{width}x#{height}", opts)
+    process(from: from, to: to, opts: opts) do |output_path|
+      DiscourseImage.crop(
+        input: from,
+        output: output_path,
+        width: width,
+        height: height,
+        position: :top,
+        maximum_quality: opts[:quality],
+      )
+    end
   end
 
   def self.downsize(from, to, dimensions, opts = {})
-    optimize("downsize", from, to, dimensions, opts)
-  end
-
-  def self.optimize(operation, from, to, dimensions, opts = {})
-    method_name = "#{operation}_instructions"
-
-    instructions = public_send(method_name.to_sym, from, to, dimensions, opts)
-    convert_with(instructions, to, opts)
-  end
-
-  MAX_PNGQUANT_SIZE = 500_000
-  MAX_CONVERT_SECONDS = 20
-
-  def self.convert_with(instructions, to, opts = {})
-    Discourse::Utils.execute_command(
-      "nice",
-      "-n",
-      "10",
-      *instructions,
-      timeout: MAX_CONVERT_SECONDS,
-    )
-
-    allow_pngquant = to.downcase.ends_with?(".png") && File.size(to) < MAX_PNGQUANT_SIZE
-    FileHelper.optimize_image!(to, allow_pngquant: allow_pngquant)
-    true
-  rescue => e
-    if opts[:raise_on_error]
-      raise e
-    else
-      error = +"Failed to optimize image:"
-
-      if e.message =~ /\Aconvert:([^`]+)/
-        error << $1
-      else
-        error << " unknown reason"
-      end
-
-      Discourse.warn(
-        error,
-        upload_id: opts[:upload_id],
-        location: to,
-        error_message: e.message,
-        instructions: instructions,
-      )
-      false
+    process(from: from, to: to, opts: opts) do |output_path|
+      resize_options = parse_resize_options(from: from, dimensions: dimensions)
+      DiscourseImage.resize(input: from, output: output_path, **resize_options)
     end
   end
+
+  def self.process(from:, to:, opts:)
+    extension = output_extension(from: from, to: to, opts: opts)
+    return yield(to) if File.extname(to).delete_prefix(".").casecmp?(extension)
+
+    Tempfile.create(["optimized-image", ".#{extension}"], File.dirname(to), binmode: true) do |file|
+      temporary_path = file.path
+      file.close
+      FileUtils.rm_f(temporary_path)
+      result = yield(temporary_path)
+      FileUtils.mv(temporary_path, to) if result
+      result
+    ensure
+      FileUtils.rm_f(temporary_path) if temporary_path
+    end
+  rescue => error
+    raise if opts[:raise_on_error]
+
+    Discourse.warn(
+      "Failed to optimize image: #{error.message}",
+      upload_id: opts[:upload_id],
+      location: to,
+      error_message: error.message,
+    )
+    false
+  end
+  private_class_method :process
+
+  def self.output_extension(from:, to:, opts:)
+    extension = File.extname(to).delete_prefix(".")
+    return extension if FileHelper.supported_images.include?(extension.downcase)
+
+    hint = opts[:format] || File.extname(opts[:filename].to_s).delete_prefix(".")
+    (hint.presence || DiscourseImage.type(from)).to_s.sub(/\Ajpeg\z/, "jpg")
+  end
+  private_class_method :output_extension
+
+  def self.parse_resize_options(from:, dimensions:)
+    case dimensions
+    when /\A(\d+(?:\.\d+)?)%\z/
+      { scale: $1.to_f / 100, allow_upscale: true }
+    when /\A(\d+)@\z/
+      width, height = DiscourseImage.size(from)
+      { scale: Math.sqrt($1.to_f / (width * height)), allow_upscale: true }
+    when /\A(\d*)x(\d*)>\z/
+      width = $1.presence&.to_i
+      height = $2.presence&.to_i
+      raise ArgumentError, "invalid resize dimensions" if width.nil? && height.nil?
+
+      { width: width, height: height, allow_upscale: false }
+    else
+      raise ArgumentError, "invalid resize dimensions"
+    end
+  end
+  private_class_method :parse_resize_options
 end
 
 # == Schema Information

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -189,15 +189,12 @@ class Upload < ActiveRecord::Base
       original_path = Discourse.store.path_for(self)
       original_path = Discourse.store.download(self) if original_path.blank?
 
-      image_info =
+      new_extension =
         begin
-          image = FastImage.new(original_path)
-          image.type # eager load to rescue errors early
-          image
-        rescue StandardError
-          nil
+          DiscourseImage.type(original_path).to_s
+        rescue DiscourseImage::Error
+          "unknown"
         end
-      new_extension = image_info&.type&.to_s || "unknown"
 
       if new_extension != extension
         update_columns(extension: new_extension)
@@ -306,19 +303,12 @@ class Upload < ActiveRecord::Base
       if extension == "svg"
         w, h =
           begin
-            Discourse::Utils.execute_command(
-              "identify",
-              "-ping",
-              "-format",
-              "%w %h",
-              "MSVG:#{path}",
-              timeout: MAX_IDENTIFY_SECONDS,
-            ).split(" ")
-          rescue StandardError
+            DiscourseImage.size(path, timeout: MAX_IDENTIFY_SECONDS)
+          rescue DiscourseImage::Error
             [0, 0]
           end
       else
-        w, h = FastImage.new(path, raise_on_failure: true).size
+        w, h = DiscourseImage.size(path)
       end
 
       self.width = w || 0
@@ -394,37 +384,11 @@ class Upload < ActiveRecord::Base
 
       color ||=
         begin
-          data =
-            Discourse::Utils.execute_command(
-              "nice",
-              "-n",
-              "10",
-              "convert",
-              local_path,
-              "-depth",
-              "8",
-              "-resize",
-              "1x1",
-              "-define",
-              "histogram:unique-colors=true",
-              "-format",
-              "%c",
-              "histogram:info:",
-              timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS,
-            )
-
-          # Output format:
-          # 1: (110.873,116.226,93.8821) #6F745E srgb(43.4798%,45.5789%,36.8165%)
-
-          color = data[/#([0-9A-F]{6})/, 1]
-
-          raise "Calculated dominant color but unable to parse output:\n#{data}" if color.nil?
-
-          color
-        rescue Discourse::Utils::CommandError
-          # Timeout or unable to parse image
-          # This can happen due to bad user input - ignore and save
-          # an empty string to prevent re-evaluation
+          DiscourseImage.calculate_dominant_color(
+            local_path,
+            timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS,
+          )
+        rescue DiscourseImage::Error
           ""
         end
     end
@@ -434,24 +398,6 @@ class Upload < ActiveRecord::Base
     else
       self.dominant_color = color
     end
-  end
-
-  def target_image_quality(local_path, test_quality)
-    @file_quality ||=
-      begin
-        Discourse::Utils.execute_command(
-          "identify",
-          "-ping",
-          "-format",
-          "%Q",
-          local_path,
-          timeout: MAX_IDENTIFY_SECONDS,
-        ).to_i
-      rescue StandardError
-        0
-      end
-
-    test_quality if @file_quality == 0 || @file_quality > test_quality
   end
 
   def self.sha1_from_short_path(path)

--- a/app/models/user_avatar.rb
+++ b/app/models/user_avatar.rb
@@ -121,8 +121,7 @@ class UserAvatar < ActiveRecord::Base
 
     return unless tempfile
 
-    ext = FastImage.type(tempfile).to_s
-    tempfile.rewind
+    ext = DiscourseImage.type(tempfile).to_s
 
     upload =
       UploadCreator.new(
@@ -143,7 +142,7 @@ class UserAvatar < ActiveRecord::Base
         user.update!(uploaded_avatar_id: upload.id)
       end
     end
-  rescue Net::ReadTimeout, OpenURI::HTTPError, FinalDestination::SSRFError
+  rescue DiscourseImage::Error, Net::ReadTimeout, OpenURI::HTTPError, FinalDestination::SSRFError
     # Skip saving. We are not connected to the net, or SSRF checks failed.
   ensure
     tempfile.close! if tempfile && tempfile.respond_to?(:close!)

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -117,8 +117,7 @@ class UserProfile < ActiveRecord::Base
 
     return unless tempfile
 
-    ext = FastImage.type(tempfile).to_s
-    tempfile.rewind
+    ext = DiscourseImage.type(tempfile).to_s
 
     is_card_background = !options || options[:is_card_background]
     type = is_card_background ? "card_background" : "profile_background"
@@ -136,7 +135,7 @@ class UserProfile < ActiveRecord::Base
     else
       user.user_profile.upload_profile_background(upload)
     end
-  rescue Net::ReadTimeout, OpenURI::HTTPError
+  rescue DiscourseImage::Error, Net::ReadTimeout, OpenURI::HTTPError
     # skip saving, we are not connected to the net
   ensure
     tempfile.close! if tempfile && tempfile.respond_to?(:close!)

--- a/config/imagemagick/policy.xml
+++ b/config/imagemagick/policy.xml
@@ -31,9 +31,7 @@
   <policy domain="coder" rights="read|write" pattern="{GIF,JPEG,JPG,PNG,WEBP,AVIF,ICO}"/>
   <!-- HEIC/HEIF: UploadCreator#convert_heif! transcodes to JPEG -->
   <policy domain="coder" rights="read|write" pattern="{HEIC,HEIF}"/>
-  <!-- MSVG: SVG dimension reads; the plain SVG coder stays denied -->
-  <policy domain="coder" rights="read|write" pattern="MSVG"/>
-  <!-- XC: LetterAvatar canvas -->
+  <policy domain="coder" rights="read" pattern="{DATA,MSVG,RSVG}"/>
   <policy domain="coder" rights="read|write" pattern="XC"/>
   <!-- ICC/ICM: RT_sRGB.icm "-profile" on resize/crop/downsize -->
   <policy domain="coder" rights="read|write" pattern="{ICC,ICM}"/>

--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -200,11 +200,8 @@ module CookedProcessorMixin
 
     return unless absolute_url
 
-    # FastImage fails when there's no scheme
     absolute_url = SiteSetting.scheme + ":" + absolute_url if absolute_url.start_with?("//")
 
-    # we can't direct FastImage to our secure-uploads url because it bounces
-    # anonymous requests with a 404 error
     if url && Upload.secure_uploads_url?(url)
       absolute_url =
         Upload.signed_url_from_secure_uploads_url(absolute_url, include_content_disposition: false)
@@ -216,10 +213,9 @@ module CookedProcessorMixin
     if upload && upload.width && upload.width > 0
       @size_cache[url] = [upload.width, upload.height]
     else
-      @size_cache[url] = FastImage.size(absolute_url)
+      @size_cache[url] = DiscourseImage.size(absolute_url)
     end
-  rescue Zlib::BufError, URI::Error, OpenSSL::SSL::SSLError
-    # FastImage.size raises BufError for some gifs, leave it.
+  rescue DiscourseImage::Error, Zlib::BufError, URI::Error, OpenSSL::SSL::SSLError
   end
 
   def get_filename(upload, src)

--- a/lib/discourse_image.rb
+++ b/lib/discourse_image.rb
@@ -1,0 +1,857 @@
+# frozen_string_literal: true
+
+require "fastimage"
+require "fileutils"
+require "image_optim"
+require "net/http"
+require "pathname"
+require "tempfile"
+require "timeout"
+require "uri"
+
+class DiscourseImage
+  class Error < StandardError
+  end
+  class InvalidImageError < Error
+  end
+  class UnsupportedFormatError < Error
+  end
+  class MetadataUnavailableError < Error
+  end
+  class ProcessingFailedError < Error
+  end
+  class TimeoutError < Error
+  end
+
+  IMAGE_TYPES = %i[avif bmp cur gif heic heif ico jpeg jxl png psd svg tiff webp].to_set.freeze
+  TRANSFORM_TYPES = %i[avif gif ico jpeg png svg webp].to_set.freeze
+  CONVERT_TYPES = (TRANSFORM_TYPES + %i[heic heif]).freeze
+  OPTIMIZABLE_TYPES = %i[jpeg png].to_set.freeze
+  LOSSY_TYPES = %i[avif jpeg webp].to_set.freeze
+  ANIMATED_TYPES = %i[avif gif png webp].to_set.freeze
+  ORIENTATIONS = {
+    1 => :normal,
+    2 => :flip_horizontal,
+    3 => :rotate_180,
+    4 => :flip_vertical,
+    5 => :transpose,
+    6 => :rotate_90,
+    7 => :transverse,
+    8 => :rotate_270,
+  }.freeze
+  SAFE_PATH_PATTERN = %r{\A[\w\-\./]+\z}m
+  MAX_PNGQUANT_SIZE_BYTES = 500_000
+  TRANSFORM_TIMEOUT_SECONDS = 20
+  OPTIMIZE_TIMEOUT_SECONDS = 15
+
+  private_constant :IMAGE_TYPES,
+                   :TRANSFORM_TYPES,
+                   :CONVERT_TYPES,
+                   :OPTIMIZABLE_TYPES,
+                   :LOSSY_TYPES,
+                   :ANIMATED_TYPES,
+                   :ORIENTATIONS,
+                   :SAFE_PATH_PATTERN,
+                   :MAX_PNGQUANT_SIZE_BYTES,
+                   :TRANSFORM_TIMEOUT_SECONDS,
+                   :OPTIMIZE_TIMEOUT_SECONDS
+
+  # Determines the encoded image type from the source content.
+  #
+  # This inspects the image signature and does not trust a filename
+  # extension. It does not fully validate or decode the image.
+  #
+  # @param source [String, Pathname, IO] a local path, HTTP/HTTPS URL,
+  #   data URI, or readable binary IO
+  # @param timeout [Numeric] maximum number of seconds spent reading the
+  #   source; defaults to 2 seconds
+  #
+  # @return [Symbol] one of `:avif`, `:bmp`, `:cur`, `:gif`, `:heic`,
+  #   `:heif`, `:ico`, `:jpeg`, `:jxl`, `:png`, `:psd`, `:svg`, `:tiff`,
+  #   or `:webp`
+  #
+  # @raise [ArgumentError] if timeout is not positive
+  # @raise [UnsupportedFormatError] if the image signature is not recognized
+  # @raise [MetadataUnavailableError] if the source cannot be read or fetched
+  # @raise [TimeoutError] if the deadline is exceeded
+  #
+  # @note Readable IO is rewound to position zero after inspection.
+  def self.type(source, timeout: 2)
+    with_metadata_errors(source, timeout: timeout) do |normalized_source|
+      image_type = FastImage.type(normalized_source, timeout: timeout, raise_on_failure: true)
+      raise UnsupportedFormatError if !IMAGE_TYPES.include?(image_type)
+
+      image_type
+    end
+  end
+
+  # Returns the intrinsic dimensions of an image.
+  #
+  # For raster images, these are the encoded pixel dimensions. For SVG
+  # images, these are the width and height of the SVG viewport.
+  #
+  # @param source [String, Pathname, IO] a local path, HTTP/HTTPS URL,
+  #   data URI, or readable binary IO
+  # @param timeout [Numeric] maximum number of seconds spent reading the
+  #   source; defaults to 2 seconds
+  #
+  # @return [Array<Integer>] a two-element `[width, height]` array containing
+  #   positive pixel dimensions
+  #
+  # @raise [ArgumentError] if timeout is not positive
+  # @raise [UnsupportedFormatError] if the image signature is not recognized
+  # @raise [InvalidImageError] if positive dimensions cannot be determined
+  # @raise [MetadataUnavailableError] if the source cannot be read or fetched
+  # @raise [TimeoutError] if the deadline is exceeded
+  #
+  # @note Readable IO is rewound to position zero after inspection.
+  def self.size(source, timeout: 2)
+    with_metadata_errors(source, timeout: timeout) do |normalized_source|
+      image_type = FastImage.type(normalized_source, timeout: timeout, raise_on_failure: true)
+      raise UnsupportedFormatError if !IMAGE_TYPES.include?(image_type)
+
+      local_path = local_source_path(source)
+      dimensions =
+        if image_type == :svg && local_path
+          svg_dimensions(normalized_source, local_path, timeout: timeout)
+        else
+          FastImage.size(normalized_source, timeout: timeout, raise_on_failure: true)
+        end
+      if dimensions.blank? || dimensions.length != 2 ||
+           dimensions.any? { |dimension| dimension.to_i <= 0 }
+        raise InvalidImageError
+      end
+
+      dimensions.map(&:to_i)
+    end
+  end
+
+  # Returns the transformation needed to display an image upright.
+  #
+  # Images without orientation metadata return `:normal`.
+  #
+  # @param source [String, Pathname, IO] a local path, HTTP/HTTPS URL,
+  #   data URI, or readable binary IO
+  # @param timeout [Numeric] maximum number of seconds spent reading the
+  #   source; defaults to 2 seconds
+  #
+  # @return [Symbol] one of `:normal`, `:flip_horizontal`, `:rotate_180`,
+  #   `:flip_vertical`, `:transpose`, `:rotate_90`, `:transverse`, or
+  #   `:rotate_270`; rotations are clockwise
+  #
+  # @raise [ArgumentError] if timeout is not positive
+  # @raise [UnsupportedFormatError] if the image signature is not recognized
+  # @raise [InvalidImageError] if orientation metadata is malformed
+  # @raise [MetadataUnavailableError] if the source cannot be read or fetched
+  # @raise [TimeoutError] if the deadline is exceeded
+  #
+  # @note Readable IO is rewound to position zero after inspection.
+  def self.orientation(source, timeout: 2)
+    with_metadata_errors(source, timeout: timeout) do |normalized_source|
+      image = FastImage.new(normalized_source, timeout: timeout, raise_on_failure: true)
+      raise UnsupportedFormatError if !IMAGE_TYPES.include?(image.type)
+
+      orientation = image.orientation
+      ORIENTATIONS.fetch(orientation || 1) { raise InvalidImageError }
+    end
+  end
+
+  # Determines whether an image contains animation.
+  #
+  # Animated GIF, PNG, WebP, and AVIF images return `true`. Recognized static
+  # images return `false`.
+  #
+  # @param source [String, Pathname, IO] a local path, HTTP/HTTPS URL,
+  #   data URI, or readable binary IO
+  # @param timeout [Numeric] maximum number of seconds spent reading the
+  #   source; defaults to 2 seconds
+  #
+  # @return [Boolean] whether the image is animated
+  #
+  # @raise [ArgumentError] if timeout is not positive
+  # @raise [UnsupportedFormatError] if the image signature is not recognized
+  # @raise [InvalidImageError] if animation status cannot be determined from
+  #   a recognized animation-capable image
+  # @raise [MetadataUnavailableError] if the source cannot be read or fetched
+  # @raise [TimeoutError] if the deadline is exceeded
+  #
+  # @note Readable IO is rewound to position zero after inspection.
+  def self.animated?(source, timeout: 2)
+    with_metadata_errors(source, timeout: timeout) do |normalized_source|
+      image = FastImage.new(normalized_source, timeout: timeout, raise_on_failure: true)
+      image_type = image.type
+      raise UnsupportedFormatError if !IMAGE_TYPES.include?(image_type)
+      return false if !ANIMATED_TYPES.include?(image_type)
+
+      animated = image.animated
+      return animated if !animated.nil?
+
+      local_path = local_source_path(source)
+      raise InvalidImageError if local_path.nil?
+
+      frame_count(local_path, image_type: image_type, timeout: timeout) > 1
+    end
+  end
+
+  # Calculates the dominant color of an image.
+  #
+  # For an animated image, the first frame is used. Supported encodings are
+  # AVIF, GIF, ICO, JPEG, PNG, and WebP.
+  #
+  # @param path [String, Pathname] an absolute local path to a raster image
+  # @param timeout [Numeric] maximum processing time; defaults to 5 seconds
+  #
+  # @return [String] the 8-bit sRGB color as six uppercase hexadecimal
+  #   characters without a leading `#`, such as `"6F745E"`
+  #
+  # @raise [ArgumentError] if timeout or the path type is invalid
+  # @raise [Discourse::InvalidAccess] if the path is not absolute or safe
+  # @raise [UnsupportedFormatError] if the file is not a supported raster image
+  # @raise [InvalidImageError] if the image cannot be decoded
+  # @raise [MetadataUnavailableError] if the file cannot be read
+  # @raise [TimeoutError] if the deadline is exceeded
+  def self.calculate_dominant_color(path, timeout: 5)
+    input_path = validated_input_path(path)
+    image_type = type(input_path)
+    raise UnsupportedFormatError if !TRANSFORM_TYPES.include?(image_type) || image_type == :svg
+
+    output =
+      execute_command(
+        "nice",
+        "-n",
+        "10",
+        "convert",
+        decoder_path(input_path, image_type, frame: :first),
+        "-depth",
+        "8",
+        "-resize",
+        "1x1",
+        "-define",
+        "histogram:unique-colors=true",
+        "-format",
+        "%c",
+        "histogram:info:",
+        timeout: timeout,
+      )
+    color = output[/#([0-9A-F]{6})/i, 1]
+    raise InvalidImageError if color.nil?
+
+    color.upcase
+  rescue UnsupportedFormatError, InvalidImageError, MetadataUnavailableError, TimeoutError
+    raise
+  rescue ProcessingFailedError => error
+    raise InvalidImageError, error.message
+  end
+
+  # Resizes an image while preserving its complete contents and aspect ratio.
+  #
+  # Exactly one sizing mode is required: `scale`, `maximum_pixels`, or one or
+  # both dimension bounds. Animated images use their first frame. The stored
+  # display orientation is applied before resizing. Supported inputs are AVIF,
+  # GIF, ICO, JPEG, PNG, SVG, and WebP. Supported outputs are the same raster
+  # formats, excluding SVG.
+  #
+  # @param input [String, Pathname] an absolute local input path
+  # @param output [String, Pathname] an absolute local output path; its
+  #   extension determines the output format
+  # @param width [Integer, nil] a positive output-width bound
+  # @param height [Integer, nil] a positive output-height bound
+  # @param scale [Numeric, nil] a positive multiplier applied to both source
+  #   dimensions; cannot be combined with another sizing mode
+  # @param maximum_pixels [Integer, nil] a positive output pixel-count ceiling;
+  #   cannot be combined with another sizing mode and never enlarges the image
+  # @param allow_upscale [Boolean] whether dimension or scale modes may exceed
+  #   the source dimensions; defaults to `true`
+  # @param maximum_quality [Integer, nil] the maximum output quality from
+  #   1 through 100 for lossy output, or `nil` for no explicit ceiling
+  #
+  # @return [Boolean] `true` when the output is written successfully
+  #
+  # @raise [ArgumentError] if sizing arguments, quality, or path types are invalid
+  # @raise [Discourse::InvalidAccess] if a path is not absolute or safe
+  # @raise [UnsupportedFormatError] if an input or output format is unsupported
+  # @raise [InvalidImageError] if the input cannot be decoded
+  # @raise [MetadataUnavailableError] if the input cannot be read
+  # @raise [ProcessingFailedError] if the output cannot be produced
+  # @raise [TimeoutError] if the internal deadline is exceeded
+  #
+  # @note The output is created or replaced atomically. The input is unchanged
+  #   unless input and output identify the same path.
+  def self.resize(
+    input:,
+    output:,
+    width: nil,
+    height: nil,
+    scale: nil,
+    maximum_pixels: nil,
+    allow_upscale: true,
+    maximum_quality: nil
+  )
+    validate_resize_options(
+      width: width,
+      height: height,
+      scale: scale,
+      maximum_pixels: maximum_pixels,
+      allow_upscale: allow_upscale,
+      maximum_quality: maximum_quality,
+    )
+    transform(
+      input: input,
+      output: output,
+      timeout: TRANSFORM_TIMEOUT_SECONDS,
+      maximum_quality: maximum_quality,
+    ) do |input_path, output_path, input_type, output_type|
+      dimensions =
+        resize_dimensions(
+          input_path,
+          width: width,
+          height: height,
+          scale: scale,
+          maximum_pixels: maximum_pixels,
+          allow_upscale: allow_upscale,
+        )
+      command = transform_command(input_path, input_type)
+      command.push("-resize", dimensions) if dimensions
+      command.concat(profile_arguments)
+      command << encoder_path(output_path, output_type)
+      command
+    end
+  end
+
+  # Crops an image to exact dimensions.
+  #
+  # The image is scaled proportionally to cover the requested dimensions and
+  # overflow is removed according to `position`. Animated images use their
+  # first frame. The stored display orientation is applied before cropping.
+  # Supported inputs are AVIF, GIF, ICO, JPEG, PNG, SVG, and WebP. Supported
+  # outputs are the same raster formats, excluding SVG.
+  #
+  # @param input [String, Pathname] an absolute local input path
+  # @param output [String, Pathname] an absolute local output path; its
+  #   extension determines the output format
+  # @param width [Integer] the required positive output width in pixels
+  # @param height [Integer] the required positive output height in pixels
+  # @param position [Symbol] where retained image content is positioned; one
+  #   of `:center` or `:top`; defaults to `:center`
+  # @param maximum_quality [Integer, nil] the maximum output quality from
+  #   1 through 100 for lossy output, or `nil` for no explicit ceiling
+  #
+  # @return [Boolean] `true` when the output is written successfully
+  #
+  # @raise [ArgumentError] if dimensions, position, quality, or path types are invalid
+  # @raise [Discourse::InvalidAccess] if a path is not absolute or safe
+  # @raise [UnsupportedFormatError] if an input or output format is unsupported
+  # @raise [InvalidImageError] if the input cannot be decoded
+  # @raise [MetadataUnavailableError] if the input cannot be read
+  # @raise [ProcessingFailedError] if the output cannot be produced
+  # @raise [TimeoutError] if the internal deadline is exceeded
+  #
+  # @note The output is created or replaced atomically. The input is unchanged
+  #   unless input and output identify the same path.
+  def self.crop(input:, output:, width:, height:, position: :center, maximum_quality: nil)
+    validate_positive_integer(width, name: :width)
+    validate_positive_integer(height, name: :height)
+    raise ArgumentError, "position must be :center or :top" if !%i[center top].include?(position)
+    validate_quality(maximum_quality)
+
+    transform(
+      input: input,
+      output: output,
+      timeout: TRANSFORM_TIMEOUT_SECONDS,
+      maximum_quality: maximum_quality,
+    ) do |input_path, output_path, input_type, output_type|
+      geometry = "#{width}x#{height}"
+      command = transform_command(input_path, input_type)
+      command.concat(["-gravity", position == :top ? "north" : "center"])
+      command.concat([metadata_resize_option, "#{geometry}^"])
+      command.concat(["-extent", geometry, "-interpolate", "catrom", "-unsharp", "2x0.5+0.7+0"])
+      command.concat(profile_arguments)
+      command << encoder_path(output_path, output_type)
+      command
+    end
+  end
+
+  # Converts an image to another encoded format.
+  #
+  # The output format is determined from the output filename extension.
+  # Dimensions, aspect ratio, and displayed orientation are preserved. ICO
+  # inputs use their final embedded image. Supported inputs are AVIF, GIF, HEIC,
+  # HEIF, ICO, JPEG, PNG, SVG, and WebP.
+  # Supported outputs are AVIF, GIF, ICO, JPEG, PNG, and WebP.
+  #
+  # @param input [String, Pathname] an absolute local input path
+  # @param output [String, Pathname] an absolute local output path; its
+  #   extension determines the required output format
+  # @param maximum_quality [Integer, nil] the maximum output quality from
+  #   1 through 100 for lossy output, or `nil` for no explicit ceiling
+  # @param timeout [Numeric] maximum processing time; defaults to 20 seconds
+  #
+  # @return [Boolean] `true` when the output is written successfully
+  #
+  # @raise [ArgumentError] if quality, timeout, or path types are invalid
+  # @raise [Discourse::InvalidAccess] if a path is not absolute or safe
+  # @raise [UnsupportedFormatError] if an input or output format is unsupported
+  # @raise [InvalidImageError] if the input cannot be decoded
+  # @raise [MetadataUnavailableError] if the input cannot be read
+  # @raise [ProcessingFailedError] if the output cannot be produced
+  # @raise [TimeoutError] if the deadline is exceeded
+  #
+  # @note The output is created or replaced atomically. The input is unchanged
+  #   unless input and output identify the same path.
+  def self.convert(input:, output:, maximum_quality: nil, timeout: 20)
+    validate_quality(maximum_quality)
+    validate_timeout(timeout)
+
+    transform(
+      input: input,
+      output: output,
+      timeout: timeout,
+      maximum_quality: maximum_quality,
+      supported_input_types: CONVERT_TYPES,
+      optimize_output: false,
+    ) do |input_path, output_path, input_type, output_type|
+      command = ["magick"]
+      command << decoder_path(input_path, input_type, frame: input_type == :ico ? :last : nil)
+      command << "-auto-orient"
+      if output_type == :jpeg
+        command.concat(%w[-background white -flatten -interlace none])
+      elsif input_type == :svg && output_type == :png
+        command.concat(%w[-background none -depth 8 -define png:compression-level=9])
+      end
+      command << encoder_path(output_path, output_type)
+      command
+    end
+  end
+
+  # Re-encodes an image in place when its encoding quality exceeds a maximum.
+  #
+  # The encoded format, dimensions, aspect ratio, framing, and displayed
+  # orientation are preserved. When source quality cannot be determined, the image is re-encoded
+  # conservatively.
+  #
+  # @param path [String, Pathname] an absolute local path to the image that
+  #   will be modified
+  # @param maximum_quality [Integer] the maximum encoding quality from
+  #   1 through 100
+  # @param timeout [Numeric] maximum processing time; defaults to 20 seconds
+  #
+  # @return [Boolean] `true` when the image is re-encoded, or `false` when it
+  #   is already at or below the maximum
+  #
+  # @raise [ArgumentError] if quality, timeout, or the path type is invalid
+  # @raise [Discourse::InvalidAccess] if the path is not absolute or safe
+  # @raise [UnsupportedFormatError] if the format cannot be recompressed
+  # @raise [InvalidImageError] if the image cannot be decoded
+  # @raise [MetadataUnavailableError] if the image cannot be read
+  # @raise [ProcessingFailedError] if the image cannot be replaced
+  # @raise [TimeoutError] if the deadline is exceeded
+  def self.recompress!(path, maximum_quality:, timeout: 20)
+    validate_quality(maximum_quality, allow_nil: false)
+    validate_timeout(timeout)
+    return false if maximum_quality == 100
+
+    input_path = validated_input_path(path)
+    image_type = type(input_path)
+    raise UnsupportedFormatError if image_type != :jpeg
+
+    quality = estimated_quality(input_path, image_type: image_type)
+    return false if quality && quality <= maximum_quality
+
+    with_atomic_output(input_path) do |output_path|
+      execute_command(
+        "magick",
+        decoder_path(input_path, image_type),
+        "-quality",
+        maximum_quality.to_s,
+        encoder_path(output_path, image_type),
+        timeout: timeout,
+      )
+    end
+    true
+  end
+
+  # Optimizes an image file in place.
+  #
+  # The encoded format, dimensions, aspect ratio, framing, and displayed
+  # orientation are preserved. If orientation metadata is stripped, its
+  # transformation is first applied to the pixels. JPEG and PNG are supported.
+  #
+  # @param path [String, Pathname] an absolute local path to the image that
+  #   will be modified
+  # @param allow_lossy [Boolean] whether optimization may discard image data;
+  #   defaults to `false`
+  #
+  # @return [Boolean] `true` when orientation is applied or the file is
+  #   replaced by a smaller optimized result; otherwise `false`
+  #
+  # @raise [ArgumentError] if `allow_lossy` or the path type is invalid
+  # @raise [Discourse::InvalidAccess] if the path is not absolute or safe
+  # @raise [UnsupportedFormatError] if the format cannot be optimized
+  # @raise [InvalidImageError] if the image cannot be decoded
+  # @raise [MetadataUnavailableError] if the image cannot be read
+  # @raise [ProcessingFailedError] if optimization fails
+  # @raise [TimeoutError] if the internal processing deadline is exceeded
+  def self.optimize!(path, allow_lossy: false)
+    raise ArgumentError, "allow_lossy must be true or false" if ![true, false].include?(allow_lossy)
+
+    input_path = validated_input_path(path)
+    image_type = type(input_path)
+    raise UnsupportedFormatError if !OPTIMIZABLE_TYPES.include?(image_type)
+
+    orientation_changed =
+      SiteSetting.strip_image_metadata && apply_orientation_before_metadata_strip(input_path)
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    optimized = image_optimizer(allow_lossy: allow_lossy).optimize_image!(input_path)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    raise TimeoutError if !optimized && elapsed >= OPTIMIZE_TIMEOUT_SECONDS
+
+    orientation_changed || !!optimized
+  rescue Error, ArgumentError
+    raise
+  rescue ImageOptim::Error, ImageOptim::ConfigurationError => error
+    raise ProcessingFailedError, error.message
+  rescue IOError, SystemCallError => error
+    raise ProcessingFailedError, error.message
+  end
+
+  def self.with_metadata_errors(source, timeout:)
+    validate_timeout(timeout)
+    normalized_source = source.is_a?(Pathname) ? source.to_s : source
+    yield normalized_source
+  rescue UnsupportedFormatError, InvalidImageError, MetadataUnavailableError, TimeoutError
+    raise
+  rescue FastImage::UnknownImageType
+    raise UnsupportedFormatError
+  rescue FastImage::SizeNotFound, FastImage::CannotParseImage, ProcessingFailedError
+    raise InvalidImageError
+  rescue FastImage::BadImageURI,
+         FastImage::ImageFetchFailure,
+         IOError,
+         SystemCallError,
+         URI::Error => error
+    raise MetadataUnavailableError, error.message
+  rescue Timeout::Error, Net::OpenTimeout, Net::ReadTimeout => error
+    raise TimeoutError, error.message
+  ensure
+    if source.respond_to?(:rewind) && (!source.respond_to?(:closed?) || !source.closed?)
+      source.rewind
+    end
+  end
+  private_class_method :with_metadata_errors
+
+  def self.svg_dimensions(source, path, timeout:)
+    dimensions = FastImage.size(source, timeout: timeout, raise_on_failure: true)
+    return dimensions if dimensions&.length == 2 && dimensions.all? { |value| value.to_i.positive? }
+
+    svg_size(path, timeout: timeout)
+  rescue FastImage::SizeNotFound, FastImage::CannotParseImage
+    svg_size(path, timeout: timeout)
+  end
+  private_class_method :svg_dimensions
+
+  def self.svg_size(path, timeout:)
+    execute_command(
+      "identify",
+      "-ping",
+      "-format",
+      "%w %h",
+      "MSVG:#{path}",
+      timeout: timeout,
+    ).split.map(&:to_i)
+  end
+  private_class_method :svg_size
+
+  def self.local_source_path(source)
+    value = source.is_a?(Pathname) ? source.to_s : source
+    return value if value.is_a?(String) && !value.match?(/\A(?:https?|data):/i)
+
+    value.path.to_s if value.respond_to?(:path) && value.path
+  end
+  private_class_method :local_source_path
+
+  def self.frame_count(path, image_type:, timeout:)
+    input_path = decoder_path(path, image_type)
+    execute_command("identify", "-ping", "-format", "%n\n", input_path, timeout: timeout).to_i
+  end
+  private_class_method :frame_count
+
+  def self.transform(
+    input:,
+    output:,
+    timeout:,
+    maximum_quality:,
+    supported_input_types: TRANSFORM_TYPES,
+    optimize_output: true
+  )
+    input_path = validated_input_path(input)
+    output_path = validated_output_path(output)
+    input_type = type(input_path)
+    output_type = output_type(output_path)
+    raise UnsupportedFormatError if !supported_input_types.include?(input_type)
+
+    size(input_path)
+    with_atomic_output(output_path) do |command_output_path|
+      command = yield(input_path, command_output_path, input_type, output_type)
+      append_quality(command, input_path, input_type, output_type, maximum_quality)
+      execute_command(*command, timeout: timeout)
+      optimize_transformed_output(command_output_path, output_type) if optimize_output
+    end
+    true
+  end
+  private_class_method :transform
+
+  def self.transform_command(input_path, input_type)
+    [
+      "nice",
+      "-n",
+      "10",
+      "convert",
+      decoder_path(input_path, input_type, frame: :first),
+      "-auto-orient",
+      "-gravity",
+      "center",
+      "-background",
+      "transparent",
+      "-interlace",
+      "none",
+    ]
+  end
+  private_class_method :transform_command
+
+  def self.resize_dimensions(input_path, width:, height:, scale:, maximum_pixels:, allow_upscale:)
+    return resize_scale(scale, allow_upscale: allow_upscale) if scale
+    if maximum_pixels
+      source_width, source_height = size(input_path)
+      return if source_width * source_height <= maximum_pixels
+
+      return "#{maximum_pixels}@"
+    end
+
+    suffix = allow_upscale ? "" : ">"
+    "#{width}x#{height}#{suffix}"
+  end
+  private_class_method :resize_dimensions
+
+  def self.resize_scale(scale, allow_upscale:)
+    effective_scale = allow_upscale ? scale : [scale, 1].min
+    "#{effective_scale * 100}%"
+  end
+  private_class_method :resize_scale
+
+  def self.validate_resize_options(
+    width:,
+    height:,
+    scale:,
+    maximum_pixels:,
+    allow_upscale:,
+    maximum_quality:
+  )
+    dimension_mode = width || height
+    modes = [!!dimension_mode, !scale.nil?, !maximum_pixels.nil?]
+    raise ArgumentError, "exactly one sizing mode is required" if modes.count(true) != 1
+
+    validate_positive_integer(width, name: :width) if width
+    validate_positive_integer(height, name: :height) if height
+    raise ArgumentError, "scale must be positive" if scale && (!scale.is_a?(Numeric) || scale <= 0)
+    validate_positive_integer(maximum_pixels, name: :maximum_pixels) if maximum_pixels
+    if ![true, false].include?(allow_upscale)
+      raise ArgumentError, "allow_upscale must be true or false"
+    end
+    validate_quality(maximum_quality)
+  end
+  private_class_method :validate_resize_options
+
+  def self.validate_positive_integer(value, name:)
+    raise ArgumentError, "#{name} must be a positive Integer" if !value.is_a?(Integer) || value <= 0
+  end
+  private_class_method :validate_positive_integer
+
+  def self.validate_quality(value, allow_nil: true)
+    return if value.nil? && allow_nil
+    if !value.is_a?(Integer) || !value.between?(1, 100)
+      raise ArgumentError, "maximum_quality must be between 1 and 100"
+    end
+  end
+  private_class_method :validate_quality
+
+  def self.validate_timeout(value)
+    raise ArgumentError, "timeout must be positive" if !value.is_a?(Numeric) || value <= 0
+  end
+  private_class_method :validate_timeout
+
+  def self.validated_input_path(value)
+    path = validated_path(value)
+    if !File.file?(path) || !File.readable?(path)
+      raise MetadataUnavailableError, "image does not exist"
+    end
+
+    path
+  end
+  private_class_method :validated_input_path
+
+  def self.validated_output_path(value)
+    path = validated_path(value)
+    parent = File.dirname(path)
+    raise MetadataUnavailableError, "output directory does not exist" if !Dir.exist?(parent)
+
+    path
+  end
+  private_class_method :validated_output_path
+
+  def self.validated_path(value)
+    path = value.is_a?(Pathname) ? value.to_s : value
+    raise ArgumentError, "path must be a String or Pathname" if !path.is_a?(String)
+    if path != File.expand_path(path) || !SAFE_PATH_PATTERN.match?(path)
+      raise Discourse::InvalidAccess
+    end
+
+    path
+  end
+  private_class_method :validated_path
+
+  def self.output_type(path)
+    extension = File.extname(path).delete_prefix(".").downcase
+    extension = "jpeg" if extension == "jpg"
+    image_type = extension.to_sym
+    raise UnsupportedFormatError if !TRANSFORM_TYPES.include?(image_type) || image_type == :svg
+
+    image_type
+  end
+  private_class_method :output_type
+
+  def self.decoder_path(path, image_type, frame: nil)
+    value =
+      if %i[heic heif].include?(image_type)
+        path
+      elsif image_type == :svg
+        "RSVG:#{path}"
+      else
+        "#{image_type}:#{path}"
+      end
+    return value if frame.nil?
+
+    frame_index = frame == :last ? -1 : 0
+    "#{value}[#{frame_index}]"
+  end
+  private_class_method :decoder_path
+
+  def self.encoder_path(path, image_type)
+    "#{image_type}:#{path}"
+  end
+  private_class_method :encoder_path
+
+  def self.metadata_resize_option
+    SiteSetting.strip_image_metadata ? "-thumbnail" : "-resize"
+  end
+  private_class_method :metadata_resize_option
+
+  def self.profile_arguments
+    ["-profile", Rails.root.join("vendor/data/RT_sRGB.icm").to_s]
+  end
+  private_class_method :profile_arguments
+
+  def self.append_quality(command, input_path, input_type, output_type, maximum_quality)
+    return if maximum_quality.nil? || !LOSSY_TYPES.include?(output_type)
+
+    source_quality =
+      if input_type == output_type && LOSSY_TYPES.include?(input_type)
+        estimated_quality(input_path, image_type: input_type)
+      end
+    if source_quality.nil? || source_quality > maximum_quality
+      command.insert(command.length - 1, "-quality", maximum_quality.to_s)
+    end
+  end
+  private_class_method :append_quality
+
+  def self.estimated_quality(path, image_type:)
+    input_path = decoder_path(path, image_type)
+    quality = execute_command("identify", "-ping", "-format", "%Q", input_path, timeout: 5).to_i
+    quality if quality.positive?
+  rescue Error
+    nil
+  end
+  private_class_method :estimated_quality
+
+  def self.optimize_transformed_output(path, output_type)
+    return if !OPTIMIZABLE_TYPES.include?(output_type)
+
+    allow_lossy = output_type == :png && File.size(path) < MAX_PNGQUANT_SIZE_BYTES
+    optimize!(path, allow_lossy: allow_lossy)
+  end
+  private_class_method :optimize_transformed_output
+
+  def self.apply_orientation_before_metadata_strip(path)
+    return false if orientation(path) == :normal
+
+    image_type = type(path)
+    with_atomic_output(path) do |output_path|
+      execute_command(
+        "magick",
+        decoder_path(path, image_type),
+        "-auto-orient",
+        encoder_path(output_path, image_type),
+        timeout: 5,
+      )
+    end
+    true
+  end
+  private_class_method :apply_orientation_before_metadata_strip
+
+  def self.image_optimizer(allow_lossy:)
+    @image_optimizers ||= {}
+    @image_optimizers[[allow_lossy, SiteSetting.strip_image_metadata]] ||= ImageOptim.new(
+      timeout: OPTIMIZE_TIMEOUT_SECONDS,
+      skip_missing_workers: true,
+      oxipng: {
+        level: 3,
+        strip: SiteSetting.strip_image_metadata,
+      },
+      optipng: false,
+      advpng: false,
+      pngcrush: false,
+      pngout: false,
+      pngquant: allow_lossy ? { allow_lossy: true } : false,
+      jpegoptim: {
+        strip: SiteSetting.strip_image_metadata ? "all" : "none",
+      },
+      jpegtran: false,
+      jpegrecompress: false,
+      gifsicle: false,
+      svgo: false,
+    )
+  end
+  private_class_method :image_optimizer
+
+  def self.with_atomic_output(output_path)
+    extension = File.extname(output_path)
+    Tempfile.create(
+      ["discourse-image", extension],
+      File.dirname(output_path),
+      binmode: true,
+    ) do |temporary_file|
+      temporary_path = temporary_file.path
+      temporary_file.close
+      FileUtils.rm_f(temporary_path)
+      yield temporary_path
+      FileUtils.mv(temporary_path, output_path)
+    ensure
+      FileUtils.rm_f(temporary_path) if temporary_path
+    end
+  rescue IOError, SystemCallError => error
+    raise ProcessingFailedError, error.message
+  end
+  private_class_method :with_atomic_output
+
+  def self.execute_command(*command, timeout:)
+    Discourse::Utils.execute_command(*command, timeout: timeout)
+  rescue Discourse::Utils::CommandError => error
+    if error.status&.exitstatus == 124
+      raise TimeoutError, error.message
+    else
+      raise ProcessingFailedError, error.message
+    end
+  rescue SystemCallError => error
+    raise ProcessingFailedError, error.message
+  end
+  private_class_method :execute_command
+end

--- a/lib/file_helper.rb
+++ b/lib/file_helper.rb
@@ -131,48 +131,7 @@ class FileHelper
   end
 
   def self.optimize_image!(filename, allow_pngquant: false)
-    image_optim(
-      allow_pngquant: allow_pngquant,
-      strip_image_metadata: SiteSetting.strip_image_metadata,
-    ).optimize_image!(filename)
-  end
-
-  def self.image_optim(allow_pngquant: false, strip_image_metadata: true)
-    # memoization is critical, initializing an ImageOptim object is very expensive
-    # sometimes up to 200ms searching for binaries and looking at versions
-    memoize("image_optim", allow_pngquant, strip_image_metadata) do
-      pngquant_options = false
-      pngquant_options = { allow_lossy: true } if allow_pngquant
-
-      ImageOptim.new(
-        # GLOBAL
-        timeout: 15,
-        skip_missing_workers: true,
-        # PNG
-        oxipng: {
-          level: 3,
-          strip: strip_image_metadata,
-        },
-        optipng: false,
-        advpng: false,
-        pngcrush: false,
-        pngout: false,
-        pngquant: pngquant_options,
-        # JPG
-        jpegoptim: {
-          strip: strip_image_metadata ? "all" : "none",
-        },
-        jpegtran: false,
-        jpegrecompress: false,
-        # Skip looking for gifsicle, svgo binaries
-        gifsicle: false,
-        svgo: false,
-      )
-    end
-  end
-
-  def self.memoize(*args)
-    (@memoized ||= {})[args] ||= yield
+    DiscourseImage.optimize!(filename, allow_lossy: allow_pngquant)
   end
 
   def self.supported_gravatar_extensions

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -16,7 +16,7 @@ class LetterAvatar
   end
 
   # BUMP UP if avatar algorithm changes
-  VERSION = 5
+  VERSION = 6
 
   # CHANGE these values to support more pixel ratios
   FULLSIZE = 120 * 3
@@ -24,7 +24,14 @@ class LetterAvatar
 
   class << self
     def version
-      "#{VERSION}_#{image_magick_version}"
+      @version ||=
+        begin
+          Thread.new do
+            sleep 2
+            cleanup_old
+          end
+          VERSION.to_s
+        end
     end
 
     def cache_path
@@ -66,56 +73,29 @@ class LetterAvatar
     end
 
     def generate_fullsize(identity)
-      color = identity.color
-      letter = identity.letter
-
       filename = fullsize_path(identity)
-
-      # Use NimbusSans-Regular, except for macOS where it is unavailable, use Helvetica there
       font = RbConfig::CONFIG["host_os"].match?(/darwin/i) ? "Helvetica" : "NimbusSans-Regular"
-      # and adjust vertical offset accordingly
       vertical_offset = font == "Helvetica" ? 26 : 34
+      letter = ERB::Util.html_escape(identity.letter)
+      svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="#{FULLSIZE}" height="#{FULLSIZE}" viewBox="0 0 #{FULLSIZE} #{FULLSIZE}">
+          <rect width="#{FULLSIZE}" height="#{FULLSIZE}" fill="#{to_rgb(identity.color)}"/>
+          <text x="#{FULLSIZE / 2}" y="#{FULLSIZE / 2 + vertical_offset}" text-anchor="middle" dominant-baseline="middle" font-family="#{font}" font-size="#{POINTSIZE}" fill="#FFFFFF" fill-opacity="0.8">#{letter}</text>
+        </svg>
+      SVG
 
-      instructions = %W[
-        -size
-        #{FULLSIZE}x#{FULLSIZE}
-        xc:#{to_rgb(color)}
-        -pointsize
-        #{POINTSIZE}
-        -fill
-        #FFFFFFCC
-        -font
-        #{font}
-        -gravity
-        Center
-        -annotate
-        -0+#{vertical_offset}
-        #{letter}
-        -depth
-        8
-        #{filename}
-      ]
+      Tempfile.create(%w[letter-avatar .svg]) do |svg_file|
+        svg_file.write(svg)
+        svg_file.flush
+        DiscourseImage.convert(input: svg_file.path, output: filename)
+      end
 
-      Discourse::Utils.execute_command("magick", *instructions)
-
-      ## do not optimize image, it will end up larger than original
       filename
     end
 
     def to_rgb(color)
       r, g, b = color
       "rgb(#{r},#{g},#{b})"
-    end
-
-    def image_magick_version
-      @image_magick_version ||=
-        begin
-          Thread.new do
-            sleep 2
-            cleanup_old
-          end
-          Digest::MD5.hexdigest(`magick --version` << `magick -list font`)
-        end
     end
 
     def cleanup_old

--- a/lib/shrink_uploaded_image.rb
+++ b/lib/shrink_uploaded_image.rb
@@ -41,8 +41,8 @@ class ShrinkUploadedImage
     end
 
     begin
-      w, h = FastImage.size(path, timeout: 15, raise_on_failure: true)
-    rescue FastImage::SizeNotFound
+      w, h = DiscourseImage.size(path, timeout: 15)
+    rescue DiscourseImage::Error
       return false
     end
 

--- a/lib/theme_screenshots_handler.rb
+++ b/lib/theme_screenshots_handler.rb
@@ -45,7 +45,12 @@ class ThemeScreenshotsHandler
               )
       end
 
-      screenshot_width, screenshot_height = FastImage.size(path)
+      screenshot_width, screenshot_height =
+        begin
+          DiscourseImage.size(path)
+        rescue DiscourseImage::Error
+          [nil, nil]
+        end
       if (screenshot_width.nil? || screenshot_height.nil?) ||
            screenshot_width > MAX_THEME_SCREENSHOT_DIMENSIONS[0] ||
            screenshot_height > MAX_THEME_SCREENSHOT_DIMENSIONS[1]

--- a/lib/topic_og_image_generator.rb
+++ b/lib/topic_og_image_generator.rb
@@ -328,29 +328,13 @@ class TopicOgImageGenerator
 
       File.write(svg_path, svg)
 
-      Discourse::Utils.execute_command(
-        "nice",
-        "-n",
-        "10",
-        "convert",
-        "-background",
-        "none",
-        "-size",
-        "#{OG_WIDTH}x#{OG_HEIGHT}",
-        svg_path,
-        "-depth",
-        "8",
-        "-define",
-        "png:compression-level=9",
-        png_path,
-        timeout: 20_000,
-      )
+      DiscourseImage.convert(input: svg_path, output: png_path, timeout: 20_000)
 
       return nil unless File.exist?(png_path)
-      FileHelper.optimize_image!(png_path)
+      DiscourseImage.optimize!(png_path)
       File.binread(png_path)
     end
-  rescue Discourse::Utils::CommandError => e
+  rescue DiscourseImage::Error => e
     Discourse.warn("Failed to render topic OG image", topic_id: @topic.id, error: e.message)
     nil
   end

--- a/lib/upcoming_changes.rb
+++ b/lib/upcoming_changes.rb
@@ -128,10 +128,7 @@ module UpcomingChanges
 
     full_file_path = File.join(Rails.public_path, image_path(change_setting_name))
 
-    File.open(full_file_path, "rb") do |file|
-      image_info = FastImage.new(file)
-      width, height = image_info.size
-    end
+    File.open(full_file_path, "rb") { |file| width, height = DiscourseImage.size(file) }
 
     data = { url: "#{Discourse.base_url}/#{image_path(change_setting_name)}", width:, height: }
 

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "fastimage"
-
 class UploadCreator
   TYPES_TO_CROP = %w[avatar card_background custom_emoji profile_background].each(&:freeze)
 
@@ -73,16 +71,14 @@ class UploadCreator
       return @upload
     end
 
-    @image_info =
+    @image_type =
       begin
-        image = FastImage.new(@file)
-        image.type # eager load to rescue errors early
-        image
-      rescue StandardError
+        DiscourseImage.type(@file)
+      rescue DiscourseImage::Error
         nil
       end
     is_image = FileHelper.is_supported_image?(@filename)
-    is_image ||= @image_info && FileHelper.is_supported_image?("test.#{@image_info.type}")
+    is_image ||= @image_type && FileHelper.is_supported_image?("test.#{@image_type}")
     is_image = false if @opts[:for_theme]
     is_thumbnail = SiteSetting.video_thumbnails_enabled && @opts[:type] == "thumbnail"
 
@@ -100,23 +96,23 @@ class UploadCreator
     sha1_before_changes = Upload.generate_digest(@file) if @file
 
     DistributedMutex.synchronize("upload_#{user_id}_#{@filename}") do
-      # We need to convert HEIFs early because FastImage does not consider them as images
       if convert_heif_to_jpeg? && !external_upload_too_big
         convert_heif!
-        is_image = FileHelper.is_supported_image?("test.#{@image_info.type}")
+        is_image = FileHelper.is_supported_image?("test.#{@image_type}")
       end
 
       if is_image && !external_upload_too_big
         extract_image_info!
         return @upload if @upload.errors.present?
 
-        if @image_info.type == :svg
+        if @image_type == :svg
           clean_svg!
-        elsif @image_info.type == :ico
+        elsif @image_type == :ico
           convert_favicon_to_png!
         elsif !Rails.env.test? || @opts[:force_optimize]
-          convert_to_jpeg! if convert_png_to_jpeg? || should_alter_quality?
-          fix_orientation! if should_fix_orientation?
+          recompress_jpeg! if should_recompress_jpeg?
+          convert_to_jpeg! if convert_png_to_jpeg?
+          normalize_orientation! if should_normalize_orientation?
           crop! if should_crop?
           optimize! if should_optimize?
           downsize! if should_downsize?
@@ -124,7 +120,7 @@ class UploadCreator
         end
 
         # conversion may have switched the type
-        image_type = @image_info.type.to_s
+        image_type = @image_type.to_s
       end
 
       # compute the sha of the file and generate a unique hash
@@ -192,32 +188,7 @@ class UploadCreator
       @upload.extension = image_type || File.extname(@filename)[1..10]
 
       if is_image && !external_upload_too_big
-        if @image_info.type.to_s == "svg"
-          w, h = [0, 0]
-
-          # identify can behave differently depending on how it's compiled and
-          # what programs (e.g. inkscape) are installed on your system.
-          # 'MSVG:' forces ImageMagick to use internal routines and behave
-          # consistently whether it's running from our docker container or not
-          begin
-            w, h =
-              Discourse::Utils
-                .execute_command(
-                  "identify",
-                  "-ping",
-                  "-format",
-                  "%w %h",
-                  "MSVG:#{@file.path}",
-                  timeout: Upload::MAX_IDENTIFY_SECONDS,
-                )
-                .split(" ")
-                .map(&:to_i)
-          rescue StandardError
-            # use default 0, 0
-          end
-        else
-          w, h = @image_info.size
-        end
+        w, h = @image_size
 
         @upload.thumbnail_width, @upload.thumbnail_height = ImageSizer.resize(w, h)
         @upload.width, @upload.height = w, h
@@ -300,23 +271,30 @@ class UploadCreator
   end
 
   def extract_image_info!
-    @image_info =
-      begin
-        image = FastImage.new(@file)
-        image.type # eager load to rescue errors early
-        image
-      rescue StandardError
-        nil
-      end
-    @file.rewind
+    begin
+      @image_type = DiscourseImage.type(@file)
+      @image_size =
+        begin
+          DiscourseImage.size(
+            @file,
+            timeout: @image_type == :svg ? Upload::MAX_IDENTIFY_SECONDS : 2,
+          )
+        rescue DiscourseImage::InvalidImageError
+          raise if @image_type != :svg
 
-    if @image_info.nil?
+          [0, 0]
+        end
+    rescue DiscourseImage::Error
+      @image_type = @image_size = nil
+    end
+
+    if @image_type.nil?
       @upload.errors.add(:base, I18n.t("upload.images.not_supported_or_corrupted"))
     elsif filesize <= 0
       @upload.errors.add(:base, I18n.t("upload.empty"))
-    elsif pixels == 0 && @image_info.type.to_s != "svg"
+    elsif pixels == 0 && @image_type != :svg
       @upload.errors.add(:base, I18n.t("upload.images.size_not_found"))
-    elsif max_image_pixels > 0 && pixels >= max_image_pixels
+    elsif @image_type != :svg && max_image_pixels > 0 && pixels >= max_image_pixels
       @upload.errors.add(
         :base,
         I18n.t(
@@ -328,13 +306,8 @@ class UploadCreator
     end
   end
 
-  MIN_PIXELS_TO_CONVERT_TO_JPEG = 1280 * 720
-
   def convert_png_to_jpeg?
-    return false unless @image_info.type == :png
-    return false if SiteSetting.ImageQuality.png_to_jpg_quality == 100
-    return true if @opts[:pasted]
-    pixels > MIN_PIXELS_TO_CONVERT_TO_JPEG
+    @image_type == :png && !animated? && SiteSetting.ImageQuality.png_to_jpg_quality < 100
   end
 
   MIN_CONVERT_TO_JPEG_BYTES_SAVED = 75_000
@@ -342,127 +315,88 @@ class UploadCreator
 
   def convert_favicon_to_png!
     png_tempfile = Tempfile.new(%w[image .png])
-
-    from = @file.path
-    to = png_tempfile.path
-
-    OptimizedImage.ensure_safe_paths!(from, to)
-
-    from = OptimizedImage.prepend_decoder!(from, nil, filename: "image.#{@image_info.type}")
-    to = OptimizedImage.prepend_decoder!(to)
-
-    from = "#{from}[-1]" # We only want the last(largest) image of the .ico file
-
-    opts = { flatten: false } # Preserve transparency
-
-    begin
-      execute_convert(from, to, opts)
-    rescue StandardError
-      # retry with debugging enabled
-      execute_convert(from, to, opts.merge(debug: true))
-    end
-
-    @file.respond_to?(:close!) ? @file.close! : @file.close
-    @file = png_tempfile
-    extract_image_info!
+    convert_image(input: @file.path, output: png_tempfile.path)
+    replace_file(png_tempfile)
   end
 
   def convert_to_jpeg!
-    return if @opts[:type] == "topic_og_image"
-    return if @opts[:for_site_setting] || ADMIN_ASSET_TYPES.include?(@opts[:type])
-    return if filesize < MIN_CONVERT_TO_JPEG_BYTES_SAVED
+    return if !eligible_for_jpeg_reencoding?
 
     jpeg_tempfile = Tempfile.new(%w[image .jpg])
-
-    from = @file.path
-    to = jpeg_tempfile.path
-
-    OptimizedImage.ensure_safe_paths!(from, to)
-
-    from = OptimizedImage.prepend_decoder!(from, nil, filename: "image.#{@image_info.type}")
-    to = OptimizedImage.prepend_decoder!(to)
-
-    opts = {}
-
-    desired_quality = [
+    maximum_quality = [
       SiteSetting.ImageQuality.png_to_jpg_quality,
       SiteSetting.ImageQuality.recompress_original_jpg_quality,
     ].compact.min
+    convert_image(input: @file.path, output: jpeg_tempfile.path, maximum_quality: maximum_quality)
+    keep_jpeg_candidate(jpeg_tempfile)
+  end
 
-    target_quality = @upload.target_image_quality(from, desired_quality)
-    opts = { quality: target_quality } if target_quality
+  def should_recompress_jpeg?
+    @image_type == :jpeg && !animated? &&
+      SiteSetting.ImageQuality.recompress_original_jpg_quality < 100
+  end
 
-    begin
-      execute_convert(from, to, opts)
-    rescue StandardError
-      # retry with debugging enabled
-      execute_convert(from, to, opts.merge(debug: true))
-    end
+  def recompress_jpeg!
+    return if !eligible_for_jpeg_reencoding?
 
+    jpeg_tempfile = Tempfile.new(%w[image .jpg])
+    FileUtils.cp(@file.path, jpeg_tempfile.path)
+    changed =
+      DiscourseImage.recompress!(
+        jpeg_tempfile.path,
+        maximum_quality: SiteSetting.ImageQuality.recompress_original_jpg_quality,
+      )
+    changed ? keep_jpeg_candidate(jpeg_tempfile) : jpeg_tempfile.close!
+  end
+
+  def eligible_for_jpeg_reencoding?
+    @opts[:type] != "topic_og_image" && !@opts[:for_site_setting] &&
+      !ADMIN_ASSET_TYPES.include?(@opts[:type]) && filesize >= MIN_CONVERT_TO_JPEG_BYTES_SAVED
+  end
+
+  def keep_jpeg_candidate(jpeg_tempfile)
     new_size = File.size(jpeg_tempfile.path)
-
     keep_jpeg = new_size < filesize * MIN_CONVERT_TO_JPEG_SAVING_RATIO
     keep_jpeg &&= (filesize - new_size) > MIN_CONVERT_TO_JPEG_BYTES_SAVED
 
-    if keep_jpeg
-      @file.respond_to?(:close!) ? @file.close! : @file.close
-      @file = jpeg_tempfile
-      extract_image_info!
-    else
-      jpeg_tempfile.close!
-    end
+    keep_jpeg ? replace_file(jpeg_tempfile) : jpeg_tempfile.close!
   end
 
   def convert_heif_to_jpeg?
-    File.extname(@filename).downcase.match?(/\.hei(f|c)\z/)
+    %i[heic heif].include?(@image_type)
   end
 
   def convert_heif!
     jpeg_tempfile = Tempfile.new(%w[image .jpg])
-    from = @file.path
-    to = jpeg_tempfile.path
-    OptimizedImage.ensure_safe_paths!(from, to)
+    convert_image(input: @file.path, output: jpeg_tempfile.path)
+    replace_file(jpeg_tempfile)
+  end
 
-    begin
-      execute_convert(from, to)
-    rescue StandardError
-      # retry with debugging enabled
-      execute_convert(from, to, { debug: true })
-    end
+  def convert_image(input:, output:, maximum_quality: nil)
+    DiscourseImage.convert(input: input, output: output, maximum_quality: maximum_quality)
+  rescue DiscourseImage::Error => error
+    raise error.class, I18n.t("upload.png_to_jpg_conversion_failure_message")
+  end
 
+  def replace_file(file)
+    file.close
+    file.open
+    file.binmode
     @file.respond_to?(:close!) ? @file.close! : @file.close
-    @file = jpeg_tempfile
+    @file = file
     extract_image_info!
   end
 
-  MAX_CONVERT_FORMAT_SECONDS = 20
-  def execute_convert(from, to, opts = {})
-    command = ["magick", from, "-auto-orient", "-background", "white", "-interlace", "none"]
-    command << "-flatten" unless opts[:flatten] == false
-    command << "-debug" << "all" if opts[:debug]
-    command << "-quality" << opts[:quality].to_s if opts[:quality]
-    command << to
-
-    Discourse::Utils.execute_command(
-      *command,
-      failure_message: I18n.t("upload.png_to_jpg_conversion_failure_message"),
-      timeout: MAX_CONVERT_FORMAT_SECONDS,
-    )
+  def should_normalize_orientation?
+    DiscourseImage.orientation(@file) != :normal
+  rescue DiscourseImage::Error
+    false
   end
 
-  def should_alter_quality?
-    return false if animated?
-
-    desired_quality =
-      (
-        if @image_info.type == :png
-          SiteSetting.ImageQuality.png_to_jpg_quality
-        else
-          SiteSetting.ImageQuality.recompress_original_jpg_quality
-        end
-      )
-
-    @upload.target_image_quality(@file.path, desired_quality).present?
+  def normalize_orientation!
+    transformed_file = Tempfile.new(["oriented", ".#{@image_type}"])
+    convert_image(input: @file.path, output: transformed_file.path)
+    replace_file(transformed_file)
   end
 
   def should_downsize?
@@ -472,19 +406,16 @@ class UploadCreator
   def downsize!
     3.times do
       original_size = filesize
-      down_tempfile = Tempfile.new(["down", ".#{@image_info.type}"])
+      down_tempfile = Tempfile.new(["down", ".#{@image_type}"])
 
-      from = @file.path
-      to = down_tempfile.path
+      DiscourseImage.resize(
+        input: @file.path,
+        output: down_tempfile.path,
+        scale: 0.5,
+        allow_upscale: false,
+      )
 
-      OptimizedImage.ensure_safe_paths!(from, to)
-
-      OptimizedImage.downsize(from, to, "50%", scale_image: true, raise_on_error: true)
-
-      @file.respond_to?(:close!) ? @file.close! : @file.close
-      @file = down_tempfile
-
-      extract_image_info!
+      replace_file(down_tempfile)
 
       return if filesize >= original_size || pixels == 0 || !should_downsize?
     end
@@ -537,30 +468,6 @@ class UploadCreator
     @file.rewind
   end
 
-  def should_fix_orientation?
-    # orientation is between 1 and 8, 1 being the default
-    # cf. http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/
-    @image_info.orientation.to_i > 1
-  end
-
-  MAX_FIX_ORIENTATION_TIME = 5
-  def fix_orientation!
-    path = @file.path
-
-    OptimizedImage.ensure_safe_paths!(path)
-    path = OptimizedImage.prepend_decoder!(path, nil, filename: "image.#{@image_info.type}")
-
-    Discourse::Utils.execute_command(
-      "magick",
-      path,
-      "-auto-orient",
-      path,
-      timeout: MAX_FIX_ORIENTATION_TIME,
-    )
-
-    extract_image_info!
-  end
-
   def should_crop?
     if %w[profile_background card_background custom_emoji].include?(@opts[:type]) && animated?
       return false
@@ -571,73 +478,55 @@ class UploadCreator
 
   def crop!
     max_pixel_ratio = Discourse::PIXEL_RATIOS.max
-    filename_with_correct_ext = "image.#{@image_info.type}"
+    transformed_file = Tempfile.new(["transformed", ".#{@image_type}"])
 
     case @opts[:type]
     when "avatar"
-      width = height = Discourse.avatar_sizes.max
-      OptimizedImage.resize(
-        @file.path,
-        @file.path,
-        width,
-        height,
-        filename: filename_with_correct_ext,
+      size = Discourse.avatar_sizes.max
+      DiscourseImage.crop(
+        input: @file.path,
+        output: transformed_file.path,
+        width: size,
+        height: size,
       )
     when "profile_background"
-      max_width = 850 * max_pixel_ratio
-      width, height =
-        ImageSizer.resize(
-          @image_info.size[0],
-          @image_info.size[1],
-          max_width: max_width,
-          max_height: max_width,
-        )
-      OptimizedImage.downsize(
-        @file.path,
-        @file.path,
-        "#{width}x#{height}\>",
-        filename: filename_with_correct_ext,
-      )
+      resize_background(output: transformed_file.path, max_width: 850 * max_pixel_ratio)
     when "card_background"
-      max_width = 590 * max_pixel_ratio
-      width, height =
-        ImageSizer.resize(
-          @image_info.size[0],
-          @image_info.size[1],
-          max_width: max_width,
-          max_height: max_width,
-        )
-      OptimizedImage.downsize(
-        @file.path,
-        @file.path,
-        "#{width}x#{height}\>",
-        filename: filename_with_correct_ext,
-      )
+      resize_background(output: transformed_file.path, max_width: 590 * max_pixel_ratio)
     when "custom_emoji"
-      OptimizedImage.downsize(
-        @file.path,
-        @file.path,
-        "100x100\>",
-        filename: filename_with_correct_ext,
+      DiscourseImage.resize(
+        input: @file.path,
+        output: transformed_file.path,
+        width: 100,
+        height: 100,
+        allow_upscale: false,
       )
     end
 
-    extract_image_info!
+    replace_file(transformed_file)
+  end
+
+  def resize_background(output:, max_width:)
+    width, height =
+      ImageSizer.resize(@image_size[0], @image_size[1], max_width: max_width, max_height: max_width)
+    DiscourseImage.resize(
+      input: @file.path,
+      output: output,
+      width: width,
+      height: height,
+      allow_upscale: false,
+    )
   end
 
   def should_optimize?
-    # GIF is too slow (plus, we'll soon be converting them to MP4)
-    # Optimizing SVG is useless
-    return false if @file.path =~ /\.(gif|svg)\z/i
-    # Safeguard for large PNGs
-    return pixels < 2_000_000 if @file.path =~ /\.png/i
-    # Everything else is fine!
+    return false if !%i[jpeg png].include?(@image_type)
+    return pixels < 2_000_000 if @image_type == :png
+
     true
   end
 
   def optimize!
-    OptimizedImage.ensure_safe_paths!(@file.path)
-    FileHelper.optimize_image!(@file.path)
+    DiscourseImage.optimize!(@file.path)
     extract_image_info!
   end
 
@@ -654,7 +543,7 @@ class UploadCreator
   end
 
   def pixels
-    @image_info.size&.reduce(:*).to_i
+    @image_size&.reduce(:*).to_i
   end
 
   def svg_allowlist_xpath
@@ -679,28 +568,9 @@ class UploadCreator
 
     @animated ||=
       begin
-        is_animated = FastImage.animated?(@file)
-        type = @image_info.type.to_s
-
-        if is_animated != nil
-          # FastImage will return nil if it cannot determine if animated
-          is_animated
-        elsif %w[gif webp avif].include?(type)
-          # Only GIFs, WEBPs and a few other unsupported image types can be animated
-          OptimizedImage.ensure_safe_paths!(@file.path)
-
-          command = ["identify", "-ping", "-format", "%n\\n", @file.path]
-          frames =
-            begin
-              Discourse::Utils.execute_command(*command, timeout: Upload::MAX_IDENTIFY_SECONDS).to_i
-            rescue StandardError
-              1
-            end
-
-          frames > 1
-        else
-          false
-        end
+        DiscourseImage.animated?(@file, timeout: Upload::MAX_IDENTIFY_SECONDS)
+      rescue DiscourseImage::Error
+        false
       end
   end
 

--- a/spec/jobs/update_animated_uploads_spec.rb
+++ b/spec/jobs/update_animated_uploads_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Jobs::UpdateAnimatedUploads do
 
   before do
     url = Discourse.store.path_for(gif_upload) || gif_upload.url
-    FastImage.expects(:animated?).with(url).returns(true).once
+    DiscourseImage.expects(:animated?).with(url).returns(true).once
   end
 
   it "affects only GIF uploads" do

--- a/spec/lib/discourse_image_spec.rb
+++ b/spec/lib/discourse_image_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+RSpec.describe DiscourseImage do
+  let(:fixtures_path) { Rails.root.join("spec/fixtures/images") }
+
+  around do |example|
+    Dir.mktmpdir("discourse-image-spec") do |directory|
+      @temporary_directory = directory
+      example.run
+    end
+  end
+
+  describe "public API" do
+    it "exposes only the approved image operations" do
+      methods = described_class.singleton_methods(false)
+
+      expect(methods).to contain_exactly(
+        :animated?,
+        :calculate_dominant_color,
+        :convert,
+        :crop,
+        :optimize!,
+        :orientation,
+        :recompress!,
+        :resize,
+        :size,
+        :type,
+      )
+    end
+  end
+
+  describe ".type" do
+    it "detects the encoded type from content and rewinds IO" do
+      path = fixtures_path.join("png_as.bin")
+      file = File.open(path, "rb")
+
+      image_type = described_class.type(file)
+
+      expect(image_type).to eq(:png)
+      expect(file.pos).to eq(0)
+    ensure
+      file&.close
+    end
+
+    it "raises a stable error for an unsupported file" do
+      path = fixtures_path.join("not_an_image")
+
+      expect { described_class.type(path) }.to raise_error(DiscourseImage::UnsupportedFormatError)
+    end
+  end
+
+  describe ".size" do
+    it "returns raster and SVG dimensions" do
+      raster_path = fixtures_path.join("logo.png")
+      svg_path = fixtures_path.join("image.svg")
+
+      raster_size = described_class.size(raster_path)
+      svg_size = described_class.size(svg_path)
+
+      expect(raster_size).to eq([244, 66])
+      expect(svg_size).to eq([100, 50])
+    end
+  end
+
+  describe ".orientation" do
+    it "returns normal for an image without a transformed orientation" do
+      path = fixtures_path.join("logo.jpg")
+
+      orientation = described_class.orientation(path)
+
+      expect(orientation).to eq(:normal)
+    end
+  end
+
+  describe ".animated?" do
+    it "distinguishes animated and static images" do
+      animated_path = fixtures_path.join("animated.gif")
+      static_path = fixtures_path.join("logo.jpg")
+
+      animated = described_class.animated?(animated_path, timeout: 5)
+      static = described_class.animated?(static_path)
+
+      expect(animated).to eq(true)
+      expect(static).to eq(false)
+    end
+  end
+
+  describe ".calculate_dominant_color" do
+    it "returns an uppercase hexadecimal color" do
+      path = fixtures_path.join("logo.jpg")
+
+      color = described_class.calculate_dominant_color(path)
+
+      expect(color).to match(/\A[0-9A-F]{6}\z/)
+    end
+  end
+
+  describe ".resize" do
+    it "preserves aspect ratio for dimension, scale, and pixel limit modes" do
+      input = fixtures_path.join("logo.png")
+      bounded_output = File.join(@temporary_directory, "bounded.jpg")
+      scaled_output = File.join(@temporary_directory, "scaled.jpg")
+      limited_output = File.join(@temporary_directory, "limited.jpg")
+
+      described_class.resize(
+        input: input,
+        output: bounded_output,
+        width: 100,
+        height: 50,
+        allow_upscale: false,
+      )
+      described_class.resize(input: input, output: scaled_output, scale: 0.5)
+      described_class.resize(input: input, output: limited_output, maximum_pixels: 10_000)
+
+      expect(described_class.size(bounded_output)).to eq([100, 27])
+      expect(described_class.size(scaled_output)).to eq([122, 33])
+      expect(described_class.size(limited_output)).to eq([192, 52])
+    end
+
+    it "rejects conflicting sizing modes" do
+      input = fixtures_path.join("logo.jpg")
+      output = File.join(@temporary_directory, "resized.jpg")
+
+      expect do
+        described_class.resize(input: input, output: output, width: 100, scale: 0.5)
+      end.to raise_error(ArgumentError, /exactly one sizing mode/)
+    end
+  end
+
+  describe ".crop" do
+    it "writes exact dimensions for center and top positions" do
+      input = fixtures_path.join("logo.png")
+      center_output = File.join(@temporary_directory, "center.png")
+      top_output = File.join(@temporary_directory, "top.png")
+
+      described_class.crop(input: input, output: center_output, width: 100, height: 100)
+      described_class.crop(
+        input: input,
+        output: top_output,
+        width: 100,
+        height: 100,
+        position: :top,
+      )
+
+      expect(described_class.size(center_output)).to eq([100, 100])
+      expect(described_class.size(top_output)).to eq([100, 100])
+    end
+  end
+
+  describe ".convert" do
+    it "infers the output type from the extension" do
+      input = fixtures_path.join("logo.jpg")
+      output = File.join(@temporary_directory, "converted.png")
+
+      result = described_class.convert(input: input, output: output)
+
+      expect(result).to eq(true)
+      expect(described_class.type(output)).to eq(:png)
+      expect(described_class.size(output)).to eq([512, 512])
+    end
+
+    it "rasterizes SVG input using its viewport dimensions" do
+      input = fixtures_path.join("image.svg")
+      output = File.join(@temporary_directory, "converted-svg.png")
+
+      result = described_class.convert(input: input, output: output)
+
+      expect(result).to eq(true)
+      expect(described_class.type(output)).to eq(:png)
+      expect(described_class.size(output)).to eq([100, 50])
+    end
+
+    it "maps command timeouts and preserves an existing output" do
+      input = fixtures_path.join("logo.jpg")
+      output = File.join(@temporary_directory, "converted.png")
+      File.binwrite(output, "existing output")
+      status = stub(exitstatus: 124)
+      error = Discourse::Utils::CommandError.new("timeout", status: status)
+      Discourse::Utils.stubs(:execute_command).raises(error)
+
+      expect do described_class.convert(input: input, output: output) end.to raise_error(
+        DiscourseImage::TimeoutError,
+      )
+      expect(File.binread(output)).to eq("existing output")
+    end
+  end
+
+  describe ".recompress!" do
+    it "recompresses above the ceiling and then returns false above the resulting quality" do
+      source = fixtures_path.join("logo.jpg")
+      path = File.join(@temporary_directory, "recompressed.jpg")
+      Discourse::Utils.execute_command("magick", source.to_s, "-quality", "95", path)
+
+      changed = described_class.recompress!(path, maximum_quality: 80)
+      unchanged = described_class.recompress!(path, maximum_quality: 90)
+
+      expect(changed).to eq(true)
+      expect(unchanged).to eq(false)
+      expect(described_class.size(path)).to eq([512, 512])
+    end
+  end
+
+  describe ".optimize!" do
+    it "replaces an image with a smaller optimized result" do
+      source = fixtures_path.join("large_and_unoptimized.png")
+      path = File.join(@temporary_directory, "optimized.png")
+      FileUtils.cp(source, path)
+      original_file_size = File.size(path)
+      original_dimensions = described_class.size(path)
+
+      changed = described_class.optimize!(path)
+
+      expect(changed).to eq(true)
+      expect(File.size(path)).to be < original_file_size
+      expect(described_class.size(path)).to eq(original_dimensions)
+    end
+  end
+end

--- a/spec/lib/topic_og_image_generator_spec.rb
+++ b/spec/lib/topic_og_image_generator_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe TopicOgImageGenerator do
     end
   end
 
+  describe "#render_png" do
+    it "rasterizes the generated SVG" do
+      generator = described_class.new(topic)
+      svg = generator.send(:build_svg)
+      bytes = generator.send(:render_png, svg)
+      image = StringIO.new(bytes)
+
+      expect(DiscourseImage.type(image)).to eq(:png)
+      expect(DiscourseImage.size(image)).to eq(
+        [TopicOgImageGenerator::OG_WIDTH, TopicOgImageGenerator::OG_HEIGHT],
+      )
+    end
+  end
+
   describe ".eligible?" do
     it "returns true for a public topic in a public category" do
       expect(described_class.eligible?(topic)).to eq(true)

--- a/spec/models/optimized_image_spec.rb
+++ b/spec/models/optimized_image_spec.rb
@@ -74,20 +74,6 @@ RSpec.describe OptimizedImage do
       end
     end
 
-    describe ".resize_instructions" do
-      let(:image) { "#{Rails.root.join("spec/fixtures/images/logo.png")}" }
-
-      it "doesn't return any color options by default" do
-        instructions = described_class.resize_instructions(image, image, "50x50")
-        expect(instructions).to_not include("-colors")
-      end
-
-      it "supports an optional color option" do
-        instructions = described_class.resize_instructions(image, image, "50x50", colors: 12)
-        expect(instructions).to include("-colors")
-      end
-    end
-
     describe ".resize" do
       it "should work correctly when extension is bad" do
         original_path = Dir::Tmpname.create(%w[origin .bin]) { nil }
@@ -154,7 +140,7 @@ RSpec.describe OptimizedImage do
                 5,
                 raise_on_error: true,
               )
-            end.to raise_error(RuntimeError, /improper image header/)
+            end.to raise_error(DiscourseImage::ProcessingFailedError)
           ensure
             File.delete(tmp_path) if File.exist?(tmp_path)
           end
@@ -338,7 +324,9 @@ RSpec.describe OptimizedImage do
       context "when the thumbnail is properly generated" do
         context "with secure uploads disabled" do
           let(:s3_upload) { Fabricate(:upload_s3) }
-          let(:optimized_path) { %r{/optimized/\d+X.*/#{s3_upload.sha1}_2_100x200\.png} }
+          let(:optimized_path) do
+            %r{/optimized/\d+X.*/#{s3_upload.sha1}_#{OptimizedImage::VERSION}_100x200\.png}
+          end
 
           before do
             stub_request(:head, "http://#{s3_upload.url}").to_return(status: 200)

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1007,16 +1007,13 @@ RSpec.describe Upload do
       expect(invalid_image.dominant_color).to eq("")
     end
 
-    it "correctly handles unparsable ImageMagick output" do
-      Discourse::Utils.stubs(:execute_command).returns("someinvalidoutput")
+    it "stores an empty string when dominant color cannot be calculated" do
+      DiscourseImage.stubs(:calculate_dominant_color).raises(DiscourseImage::InvalidImageError)
 
       expect(invalid_image.dominant_color).to eq(nil)
 
-      expect { invalid_image.dominant_color(calculate_if_missing: true) }.to raise_error(
-        /Calculated dominant color but unable to parse output/,
-      )
-
-      expect(invalid_image.dominant_color).to eq(nil)
+      expect(invalid_image.dominant_color(calculate_if_missing: true)).to eq("")
+      expect(invalid_image.dominant_color).to eq("")
     end
 
     it "correctly handles error when file is too large to download" do


### PR DESCRIPTION
Image handling was spread across Discourse and tied directly to FastImage, ImageMagick, and ImageOptim, making it hard to change.

This commit adds `DiscourseImage` as the single entry point for server-side image work. Existing behavior and compatibility methods stay the same. The current tools remain in use internally and can be replaced later without changing callers.