### PR TITLE
DEV: Sandbox all image processing via Landlock

### DIFF
--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -229,7 +229,7 @@ class OptimizedImage < ActiveRecord::Base
     from = prepend_decoder!(from, to, opts)
     to = prepend_decoder!(to, to, opts)
 
-    instructions = ["convert", "#{from}[0]"]
+    instructions = ["#{from}[0]"]
 
     instructions << "-colors" << opts[:colors].to_s if opts[:colors]
 
@@ -267,7 +267,6 @@ class OptimizedImage < ActiveRecord::Base
     to = prepend_decoder!(to, to, opts)
 
     instructions = %W{
-      convert
       #{from}[0]
       -auto-orient
       -gravity
@@ -298,7 +297,6 @@ class OptimizedImage < ActiveRecord::Base
     to = prepend_decoder!(to, to, opts)
 
     %W{
-      convert
       #{from}[0]
       -auto-orient
       -gravity
@@ -331,18 +329,18 @@ class OptimizedImage < ActiveRecord::Base
     method_name = "#{operation}_instructions"
 
     instructions = public_send(method_name.to_sym, from, to, dimensions, opts)
-    convert_with(instructions, to, opts)
+    convert_with(instructions, from, to, opts)
   end
 
   MAX_PNGQUANT_SIZE = 500_000
   MAX_CONVERT_SECONDS = 20
 
-  def self.convert_with(instructions, to, opts = {})
-    Discourse::Utils.execute_command(
-      "nice",
-      "-n",
-      "10",
+  def self.convert_with(instructions, from, to, opts = {})
+    ImageMagick.magick(
       *instructions,
+      read: [from],
+      write: [File.dirname(to)],
+      nice: 10,
       timeout: MAX_CONVERT_SECONDS,
     )
 
@@ -355,7 +353,7 @@ class OptimizedImage < ActiveRecord::Base
     else
       error = +"Failed to optimize image:"
 
-      if e.message =~ /\Aconvert:([^`]+)/
+      if e.message =~ /\A(?:convert|magick):([^`]+)/
         error << $1
       else
         error << " unknown reason"

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -306,12 +306,12 @@ class Upload < ActiveRecord::Base
       if extension == "svg"
         w, h =
           begin
-            Discourse::Utils.execute_command(
-              "identify",
+            ImageMagick.identify(
               "-ping",
               "-format",
               "%w %h",
               "MSVG:#{path}",
+              read: [path],
               timeout: MAX_IDENTIFY_SECONDS,
             ).split(" ")
           rescue StandardError
@@ -395,11 +395,7 @@ class Upload < ActiveRecord::Base
       color ||=
         begin
           data =
-            Discourse::Utils.execute_command(
-              "nice",
-              "-n",
-              "10",
-              "convert",
+            ImageMagick.magick(
               local_path,
               "-depth",
               "8",
@@ -410,6 +406,8 @@ class Upload < ActiveRecord::Base
               "-format",
               "%c",
               "histogram:info:",
+              read: [local_path],
+              nice: 10,
               timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS,
             )
 
@@ -439,12 +437,12 @@ class Upload < ActiveRecord::Base
   def target_image_quality(local_path, test_quality)
     @file_quality ||=
       begin
-        Discourse::Utils.execute_command(
-          "identify",
+        ImageMagick.identify(
           "-ping",
           "-format",
           "%Q",
           local_path,
+          read: [local_path],
           timeout: MAX_IDENTIFY_SECONDS,
         ).to_i
       rescue StandardError

--- a/lib/freedom_patches/image_optim_sandbox.rb
+++ b/lib/freedom_patches/image_optim_sandbox.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "image_optim/cmd"
+
+# Route image_optim's optimizer binaries through the Landlock sandbox, confining
+# them to the file being optimized with no network. Cmd.capture (version/CPU
+# probes, no untrusted input) is intentionally not patched.
+class ImageOptim
+  module Cmd
+    class << self
+      def run(*args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        env = args.first.is_a?(Hash) ? args.shift : {}
+
+        files = args.select { |arg| arg.is_a?(String) && File.file?(arg) }
+        dirs = files.map { |file| File.dirname(file) }.uniq
+
+        Discourse::SafeExec.capture(
+          *args,
+          env: {
+            **env,
+            "MALLOC_ARENA_MAX" => "2",
+          },
+          unsetenv_others: true,
+          read: [*Discourse::SafeExec.default_read_paths, *files],
+          write: [*files, *dirs],
+          execute: Discourse::SafeExec.default_execute_paths,
+          timeout: options[:timeout]&.to_f || ImageMagick::DEFAULT_TIMEOUT,
+          rlimits: ImageMagick::RLIMITS,
+          seccomp_deny_network: true,
+        )
+        true
+      rescue Discourse::Utils::CommandError
+        # non-zero exit means "kept the original", like system(*args) => false
+        false
+      end
+    end
+  end
+end

--- a/lib/image_magick.rb
+++ b/lib/image_magick.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+# Runs ImageMagick under the Landlock sandbox (via Discourse::SafeExec) so a
+# decoder bug parsing an untrusted upload is confined to an explicit filesystem
+# allowlist with no network, not the full rights of the calling process.
+module ImageMagick
+  # memory_bytes sits above the policy.xml ceiling (memory 1GiB + map 2GiB) so a
+  # legitimate ≤128MP decode is not killed; MALLOC_ARENA_MAX bounds per-thread
+  # arenas that would otherwise inflate address space against it. cpu_seconds is
+  # a runaway backstop above the wall-clock timeout.
+  RLIMITS = {
+    cpu_seconds: 300,
+    memory_bytes: 4 * 1024 * 1024 * 1024,
+    file_size_bytes: 10 * 1024 * 1024 * 1024,
+    open_files: 1024,
+  }.freeze
+
+  DEFAULT_TIMEOUT = 30
+
+  def self.asset_read_paths
+    @asset_read_paths ||= [Rails.root.join("vendor").to_s, ENV["MAGICK_CONFIGURE_PATH"]].compact
+  end
+
+  def self.magick(*args, read: [], write: [], timeout: nil, nice: nil, failure_message: "")
+    command = ["magick", *args]
+    command = ["nice", "-n", nice.to_s, *command] if nice
+    run(*command, read:, write:, timeout:, failure_message:)
+  end
+
+  def self.identify(*args, read: [], write: [], timeout: nil, failure_message: "")
+    run("identify", *args, read:, write:, timeout:, failure_message:)
+  end
+
+  def self.run(*command, read:, write:, timeout:, failure_message:)
+    # A private scratch dir keeps ImageMagick's disk-backed pixel cache inside
+    # the write allowlist, so large images that spill to disk still succeed.
+    Dir.mktmpdir("discourse-imagemagick-") do |scratch|
+      Discourse::SafeExec.capture(
+        *command,
+        env: {
+          **ENV.slice("PATH", "MAGICK_CONFIGURE_PATH", "LANG", "LC_ALL"),
+          "MAGICK_TEMPORARY_PATH" => scratch,
+          "TMPDIR" => scratch,
+          "HOME" => scratch,
+          "XDG_CACHE_HOME" => scratch,
+          "MALLOC_ARENA_MAX" => "2",
+        },
+        unsetenv_others: true,
+        read: [*Discourse::SafeExec.default_read_paths, *asset_read_paths, *read],
+        write: [scratch, *write],
+        execute: Discourse::SafeExec.default_execute_paths,
+        timeout: timeout || DEFAULT_TIMEOUT,
+        rlimits: RLIMITS,
+        failure_message:,
+        seccomp_deny_network: true,
+      )
+    end
+  end
+  private_class_method :run
+end

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -96,7 +96,7 @@ class LetterAvatar
         #{filename}
       ]
 
-      Discourse::Utils.execute_command("magick", *instructions)
+      ImageMagick.magick(*instructions, write: [File.dirname(filename)])
 
       ## do not optimize image, it will end up larger than original
       filename
@@ -114,7 +114,9 @@ class LetterAvatar
             sleep 2
             cleanup_old
           end
-          Digest::MD5.hexdigest(`magick --version` << `magick -list font`)
+          Digest::MD5.hexdigest(
+            ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
+          )
         end
     end
 

--- a/lib/topic_og_image_generator.rb
+++ b/lib/topic_og_image_generator.rb
@@ -328,11 +328,7 @@ class TopicOgImageGenerator
 
       File.write(svg_path, svg)
 
-      Discourse::Utils.execute_command(
-        "nice",
-        "-n",
-        "10",
-        "convert",
+      ImageMagick.magick(
         "-background",
         "none",
         "-size",
@@ -343,6 +339,9 @@ class TopicOgImageGenerator
         "-define",
         "png:compression-level=9",
         png_path,
+        read: [svg_path],
+        write: [dir],
+        nice: 10,
         timeout: 20_000,
       )
 

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -201,13 +201,13 @@ class UploadCreator
           # consistently whether it's running from our docker container or not
           begin
             w, h =
-              Discourse::Utils
-                .execute_command(
-                  "identify",
+              ImageMagick
+                .identify(
                   "-ping",
                   "-format",
                   "%w %h",
                   "MSVG:#{@file.path}",
+                  read: [@file.path],
                   timeout: Upload::MAX_IDENTIFY_SECONDS,
                 )
                 .split(" ")
@@ -355,11 +355,14 @@ class UploadCreator
 
     opts = { flatten: false } # Preserve transparency
 
+    read = [@file.path]
+    write = [File.dirname(png_tempfile.path)]
+
     begin
-      execute_convert(from, to, opts)
+      execute_convert(from, to, opts, read:, write:)
     rescue StandardError
       # retry with debugging enabled
-      execute_convert(from, to, opts.merge(debug: true))
+      execute_convert(from, to, opts.merge(debug: true), read:, write:)
     end
 
     @file.respond_to?(:close!) ? @file.close! : @file.close
@@ -389,14 +392,17 @@ class UploadCreator
       SiteSetting.ImageQuality.recompress_original_jpg_quality,
     ].compact.min
 
-    target_quality = @upload.target_image_quality(from, desired_quality)
+    target_quality = @upload.target_image_quality(@file.path, desired_quality)
     opts = { quality: target_quality } if target_quality
 
+    read = [@file.path]
+    write = [File.dirname(jpeg_tempfile.path)]
+
     begin
-      execute_convert(from, to, opts)
+      execute_convert(from, to, opts, read:, write:)
     rescue StandardError
       # retry with debugging enabled
-      execute_convert(from, to, opts.merge(debug: true))
+      execute_convert(from, to, opts.merge(debug: true), read:, write:)
     end
 
     new_size = File.size(jpeg_tempfile.path)
@@ -423,11 +429,14 @@ class UploadCreator
     to = jpeg_tempfile.path
     OptimizedImage.ensure_safe_paths!(from, to)
 
+    read = [@file.path]
+    write = [File.dirname(jpeg_tempfile.path)]
+
     begin
-      execute_convert(from, to)
+      execute_convert(from, to, {}, read:, write:)
     rescue StandardError
       # retry with debugging enabled
-      execute_convert(from, to, { debug: true })
+      execute_convert(from, to, { debug: true }, read:, write:)
     end
 
     @file.respond_to?(:close!) ? @file.close! : @file.close
@@ -436,15 +445,17 @@ class UploadCreator
   end
 
   MAX_CONVERT_FORMAT_SECONDS = 20
-  def execute_convert(from, to, opts = {})
-    command = ["magick", from, "-auto-orient", "-background", "white", "-interlace", "none"]
+  def execute_convert(from, to, opts = {}, read: [], write: [])
+    command = [from, "-auto-orient", "-background", "white", "-interlace", "none"]
     command << "-flatten" unless opts[:flatten] == false
     command << "-debug" << "all" if opts[:debug]
     command << "-quality" << opts[:quality].to_s if opts[:quality]
     command << to
 
-    Discourse::Utils.execute_command(
+    ImageMagick.magick(
       *command,
+      read:,
+      write:,
       failure_message: I18n.t("upload.png_to_jpg_conversion_failure_message"),
       timeout: MAX_CONVERT_FORMAT_SECONDS,
     )
@@ -550,11 +561,12 @@ class UploadCreator
     OptimizedImage.ensure_safe_paths!(path)
     path = OptimizedImage.prepend_decoder!(path, nil, filename: "image.#{@image_info.type}")
 
-    Discourse::Utils.execute_command(
-      "magick",
+    ImageMagick.magick(
       path,
       "-auto-orient",
       path,
+      read: [@file.path],
+      write: [@file.path, File.dirname(@file.path)],
       timeout: MAX_FIX_ORIENTATION_TIME,
     )
 
@@ -689,10 +701,16 @@ class UploadCreator
           # Only GIFs, WEBPs and a few other unsupported image types can be animated
           OptimizedImage.ensure_safe_paths!(@file.path)
 
-          command = ["identify", "-ping", "-format", "%n\\n", @file.path]
           frames =
             begin
-              Discourse::Utils.execute_command(*command, timeout: Upload::MAX_IDENTIFY_SECONDS).to_i
+              ImageMagick.identify(
+                "-ping",
+                "-format",
+                "%n\\n",
+                @file.path,
+                read: [@file.path],
+                timeout: Upload::MAX_IDENTIFY_SECONDS,
+              ).to_i
             rescue StandardError
               1
             end

--- a/spec/lib/freedom_patches/image_optim_sandbox_spec.rb
+++ b/spec/lib/freedom_patches/image_optim_sandbox_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "image_optim Landlock sandbox freedom patch" do
+  def landlock?
+    Discourse::SafeExec.landlock_supported?
+  end
+
+  it "routes worker commands through Discourse::SafeExec with the network denied" do
+    Discourse::SafeExec
+      .expects(:capture)
+      .with { |*_command, **opts| opts[:seccomp_deny_network] == true }
+      .returns("")
+
+    expect(ImageOptim::Cmd.run({ "PATH" => ENV["PATH"] }, "true")).to eq(true)
+  end
+
+  it "returns false (keep original) when the sandboxed command fails" do
+    Discourse::SafeExec.expects(:capture).raises(
+      Discourse::Utils::CommandError.new("boom", stdout: "", stderr: "", status: nil),
+    )
+
+    expect(ImageOptim::Cmd.run({}, "false")).to eq(false)
+  end
+
+  it "allows reading a file passed in argv" do
+    skip("Landlock unsupported on this host") unless landlock?
+
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, "data")
+      File.write(file, "hello")
+      expect(ImageOptim::Cmd.run({ "PATH" => ENV["PATH"] }, "cat", file)).to eq(true)
+    end
+  end
+
+  it "denies reading a file outside the allowlist" do
+    skip("Landlock unsupported on this host") unless landlock?
+
+    Dir.mktmpdir do |dir|
+      secret = File.join(dir, "secret")
+      File.write(secret, "top secret")
+      # secret is referenced only inside a shell string, so its directory is
+      # never granted and the sandbox must block the read.
+      expect(ImageOptim::Cmd.run({ "PATH" => ENV["PATH"] }, "sh", "-c", "cat #{secret}")).to eq(
+        false,
+      )
+    end
+  end
+
+  it "still optimizes a real image through the sandbox" do
+    skip("Landlock unsupported on this host") unless landlock?
+
+    Dir.mktmpdir do |dir|
+      png = File.join(dir, "logo.png")
+      FileUtils.cp(Rails.root.join("spec/fixtures/images/logo.png"), png)
+      before = File.size(png)
+
+      FileHelper.optimize_image!(png)
+
+      expect(File.size(png)).to be <= before
+      expect(FastImage.type(png)).to eq(:png)
+    end
+  end
+end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1008,7 +1008,7 @@ RSpec.describe Upload do
     end
 
     it "correctly handles unparsable ImageMagick output" do
-      Discourse::Utils.stubs(:execute_command).returns("someinvalidoutput")
+      ImageMagick.stubs(:magick).returns("someinvalidoutput")
 
       expect(invalid_image.dominant_color).to eq(nil)
 


### PR DESCRIPTION
- Update all imagemagick calls to go through a new `::Imagemagick` wrapper, which wraps the command in `Discourse::SafeExec`
- Patch image_optim to force its calls through `SafeExec`

This provides robust defense-in-depth against vulnerabilities in image processing binaries. Landlock is supported on Linux Kernel 5.13 and above.