### PR TITLE
DEV: Remove deprecated array `.clear()` call

### DIFF
--- a/frontend/discourse/admin/routes/admin/backups.js
+++ b/frontend/discourse/admin/routes/admin/backups.js
@@ -50,7 +50,7 @@ export default class AdminBackupsRoute extends DiscourseRoute {
     if (log.message === "[STARTED]") {
       this.currentUser.set("hideReadOnlyAlert", true);
       this.controllerFor("admin.backups").set("model.isOperationRunning", true);
-      this.controllerFor("admin.backups.logs").get("logs").clear();
+      this.controllerFor("admin.backups.logs").get("logs").length = 0;
     } else if (log.message === "[FAILED]") {
       this.controllerFor("admin.backups").set(
         "model.isOperationRunning",


### PR DESCRIPTION
This was triggered when restoring a backup at `/admin/backups/logs`