### PR TITLE
FIX: Stop nested scroll restoration from overriding user scrolls

### DIFF
--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -62,21 +62,57 @@ export default class Nested extends Component {
   #retryTimer = null;
   #highlightTimer = null;
   #lastScrollKey = null;
+  #lastRestoredScrollY = null;
+  #activeScrollAnchorKey = null;
+  #cancelledScrollAnchorKey = null;
   #restoringStoredScroll = false;
+  #scrollRestoreCompletionTimer = null;
+  #scrollRestoreTimers = [];
   #onPopstate = () => {
     this.#restoringStoredScroll = true;
     next(this, this.syncFocusFromURL);
   };
-  #onScroll = () => this.persistScrollAnchor();
+  #onScroll = () => this.#handleScroll();
+  #onUserScrollIntent = () => this.#cancelUserScrollRestoration();
+  #onUserScrollKey = (event) => {
+    if (
+      [
+        "ArrowDown",
+        "ArrowUp",
+        "End",
+        "Home",
+        "PageDown",
+        "PageUp",
+        " ",
+      ].includes(event.key)
+    ) {
+      this.#cancelUserScrollRestoration();
+    }
+  };
   #onPageHide = () => this.persistScrollAnchor();
 
   constructor() {
     super(...arguments);
-    this.#restoringStoredScroll = Boolean(this.#loadStoredScrollAnchor());
+    this.#restoringStoredScroll = Boolean(
+      this.args.scrollAnchor || this.#loadStoredScrollAnchor()
+    );
     this.applyInitialFocusedPath();
     window.addEventListener("popstate", this.#onPopstate);
     window.addEventListener("scroll", this.#onScroll, { passive: true });
+    window.addEventListener("touchmove", this.#onUserScrollIntent, {
+      passive: true,
+    });
+    window.addEventListener("wheel", this.#onUserScrollIntent, {
+      passive: true,
+    });
+    window.addEventListener("keydown", this.#onUserScrollKey);
     document.addEventListener("scroll", this.#onScroll, { passive: true });
+    document.addEventListener("touchmove", this.#onUserScrollIntent, {
+      passive: true,
+    });
+    document.addEventListener("wheel", this.#onUserScrollIntent, {
+      passive: true,
+    });
     window.addEventListener("pagehide", this.#onPageHide);
     this.router.on("routeWillChange", this.persistScrollAnchor);
     this.appEvents.on("keyboard:move-selection", this, this.maybeLoadMoreRoots);
@@ -111,11 +147,17 @@ export default class Nested extends Component {
     );
     cancel(this.#nextTimer);
     cancel(this.#retryTimer);
+    this.#cancelScrollRestoration();
     clearTimeout(this.#highlightTimer);
     this.persistScrollAnchor();
     window.removeEventListener("popstate", this.#onPopstate);
     window.removeEventListener("scroll", this.#onScroll);
+    window.removeEventListener("touchmove", this.#onUserScrollIntent);
+    window.removeEventListener("wheel", this.#onUserScrollIntent);
+    window.removeEventListener("keydown", this.#onUserScrollKey);
     document.removeEventListener("scroll", this.#onScroll);
+    document.removeEventListener("touchmove", this.#onUserScrollIntent);
+    document.removeEventListener("wheel", this.#onUserScrollIntent);
     window.removeEventListener("pagehide", this.#onPageHide);
     this.router.off("routeWillChange", this.persistScrollAnchor);
     this.viewportTracker.destroy();
@@ -186,6 +228,18 @@ export default class Nested extends Component {
 
   get rootScrollAnchor() {
     return this.mobileReturnAnchor || this.args.scrollAnchor;
+  }
+
+  get rootPostScrollAnchor() {
+    return this.postLevelScrollAnchor(this.rootScrollAnchor);
+  }
+
+  get focusedPostScrollAnchor() {
+    return this.postLevelScrollAnchor(this.args.scrollAnchor);
+  }
+
+  postLevelScrollAnchor(anchor) {
+    return Number.isFinite(anchor?.scrollY) ? null : anchor;
   }
 
   get focusedNode() {
@@ -265,6 +319,58 @@ export default class Nested extends Component {
     return this.findScrollAnchor();
   }
 
+  #handleScroll() {
+    if (!this.#restoringStoredScroll) {
+      this.persistScrollAnchor();
+      return;
+    }
+
+    if (this.#isRestoredScrollEcho()) {
+      return;
+    }
+
+    this.#cancelledScrollAnchorKey =
+      this.#activeScrollAnchorKey ||
+      this.#scrollAnchorRestoreKey(this.args.scrollAnchor);
+    this.#cancelScrollRestoration({ clearAnchor: true });
+    this.persistScrollAnchor();
+  }
+
+  #isRestoredScrollEcho() {
+    return (
+      this.#lastRestoredScrollY != null &&
+      Math.abs(window.scrollY - this.#lastRestoredScrollY) <= 2
+    );
+  }
+
+  #cancelUserScrollRestoration() {
+    if (!this.#restoringStoredScroll && !this.args.scrollAnchor) {
+      return;
+    }
+
+    this.#cancelledScrollAnchorKey =
+      this.#activeScrollAnchorKey ||
+      this.#scrollAnchorRestoreKey(this.args.scrollAnchor);
+    this.#cancelScrollRestoration({ clearAnchor: true });
+    this.persistScrollAnchor();
+  }
+
+  #cancelScrollRestoration({ clearAnchor = false } = {}) {
+    for (const timer of this.#scrollRestoreTimers) {
+      clearTimeout(timer);
+    }
+    this.#scrollRestoreTimers = [];
+
+    clearTimeout(this.#scrollRestoreCompletionTimer);
+    this.#scrollRestoreCompletionTimer = null;
+    if (clearAnchor) {
+      this.args.clearScrollAnchor?.();
+    }
+    this.#activeScrollAnchorKey = null;
+    this.#lastRestoredScrollY = null;
+    this.#restoringStoredScroll = false;
+  }
+
   @action
   persistScrollAnchor() {
     if (this.isDestroying || this.isDestroyed || this.#restoringStoredScroll) {
@@ -288,23 +394,60 @@ export default class Nested extends Component {
       return;
     }
 
+    this.#cancelledScrollAnchorKey = null;
     this.#restoreScrollAnchorAfterRender(anchor);
   }
 
+  @action
+  restoreUpdatedScrollAnchor() {
+    if (!this.args.scrollAnchor) {
+      return;
+    }
+
+    const anchorKey = this.#scrollAnchorRestoreKey(this.args.scrollAnchor);
+    if (anchorKey && anchorKey === this.#cancelledScrollAnchorKey) {
+      return;
+    }
+
+    this.#restoreScrollAnchorAfterRender(this.args.scrollAnchor);
+  }
+
   #restoreScrollAnchorAfterRender(anchor) {
+    this.#cancelScrollRestoration();
+    this.#activeScrollAnchorKey = this.#scrollAnchorRestoreKey(anchor);
     this.#restoringStoredScroll = true;
+
+    const initialScrollY = window.scrollY;
+
     schedule("afterRender", () => {
+      if (!this.#restoringStoredScroll) {
+        return;
+      }
+
+      if (Math.abs(window.scrollY - initialScrollY) > 2) {
+        this.#cancelScrollRestoration({ clearAnchor: true });
+        return;
+      }
+
       this.#restoreScrollAnchor(anchor);
       for (const delay of [50, 150, 300, 600, 1000]) {
-        setTimeout(() => this.#restoreScrollAnchor(anchor), delay);
+        const timer = setTimeout(() => {
+          if (this.#restoringStoredScroll) {
+            this.#restoreScrollAnchor(anchor);
+          }
+        }, delay);
+        this.#scrollRestoreTimers.push(timer);
       }
-      setTimeout(() => (this.#restoringStoredScroll = false), 1250);
+      this.#scrollRestoreCompletionTimer = setTimeout(() => {
+        this.#cancelScrollRestoration({ clearAnchor: true });
+      }, 1250);
     });
   }
 
   #restoreScrollAnchor(anchor) {
     if (Number.isFinite(anchor.scrollY)) {
       window.scrollTo(0, anchor.scrollY);
+      this.#lastRestoredScrollY = window.scrollY;
       return;
     }
 
@@ -315,7 +458,20 @@ export default class Nested extends Component {
     if (element) {
       const rect = element.getBoundingClientRect();
       window.scrollTo(0, window.scrollY + rect.top - anchor.offsetFromTop);
+      this.#lastRestoredScrollY = window.scrollY;
     }
+  }
+
+  #scrollAnchorRestoreKey(anchor) {
+    if (!anchor) {
+      return null;
+    }
+
+    return [
+      anchor.postNumber,
+      anchor.scrollY ?? "",
+      anchor.offsetFromTop ?? "",
+    ].join(":");
   }
 
   #saveStoredScrollAnchor(anchor, postNumber = this.args.postNumber) {
@@ -667,7 +823,8 @@ export default class Nested extends Component {
       {{didInsert this.scheduleTargetScroll}}
       {{didInsert this.restoreStoredScrollAnchor}}
       {{didUpdate this.scheduleTargetScroll @targetPostNumber @rootNodes}}
-      {{didUpdate this.restoreStoredScrollAnchor @scrollAnchor}}
+      {{didUpdate this.restoreUpdatedScrollAnchor @scrollAnchor}}
+      {{didUpdate this.restoreUpdatedScrollAnchor @rootNodes}}
       {{didUpdate this.applyInitialFocusedPath @initialFocusedPath}}
       {{this.viewportTracker.setup
         eyeline=false
@@ -781,7 +938,7 @@ export default class Nested extends Component {
                 @unhidePost={{@unhidePost}}
                 @expansionState={{@expansionState}}
                 @fetchedChildrenCache={{@fetchedChildrenCache}}
-                @scrollAnchor={{@scrollAnchor}}
+                @scrollAnchor={{this.focusedPostScrollAnchor}}
                 @registerPost={{this.viewportTracker.registerPost}}
                 @getCloakingData={{this.viewportTracker.getCloakingData}}
                 @cloakAbove={{this.cloakAbove}}
@@ -919,7 +1076,7 @@ export default class Nested extends Component {
               @unhidePost={{@unhidePost}}
               @expansionState={{@expansionState}}
               @fetchedChildrenCache={{@fetchedChildrenCache}}
-              @scrollAnchor={{this.rootScrollAnchor}}
+              @scrollAnchor={{this.rootPostScrollAnchor}}
               @registerPost={{this.viewportTracker.registerPost}}
               @getCloakingData={{this.viewportTracker.getCloakingData}}
               @cloakAbove={{this.cloakAbove}}

--- a/spec/system/nested_scroll_restoration_spec.rb
+++ b/spec/system/nested_scroll_restoration_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe "Nested view scroll restoration" do
+  fab!(:user) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:topic) { Fabricate(:topic, user: user) }
+  fab!(:op) { Fabricate(:post, topic: topic, user: user, post_number: 1) }
+
+  fab!(:root_posts) do
+    60.times.map do |index|
+      Fabricate(
+        :post,
+        topic: topic,
+        user: Fabricate(:user),
+        raw: "Root post number #{index + 1}\n\n#{"filler text " * 300}",
+        reply_to_post_number: nil,
+      )
+    end
+  end
+
+  let(:nested_view) { PageObjects::Pages::NestedView.new }
+
+  before do
+    SiteSetting.nested_replies_enabled = true
+    Fabricate(:nested_topic, topic: topic)
+
+    sign_in(user)
+  end
+
+  it "lets the user keep scrolling after returning to a topic", :aggregate_failures do
+    nested_view.visit_nested(topic)
+    expect(nested_view).to have_nested_view
+
+    nested_view.scroll_to_position(5000)
+    nested_view.visit_nested(topic)
+    expect(nested_view).to have_nested_view
+
+    try_until_success(reason: "scroll anchor restores after render") do
+      expect(nested_view.current_scroll_position).to be_within(10).of(5000)
+    end
+
+    positions = nested_view.scroll_during_pending_restore(distance: 3000)
+
+    expect(positions["restored"]).to be_within(10).of(5000)
+    expect(positions["afterUserScroll"]).to be > positions["restored"] + 2500
+    expect(positions["afterRetries"]).to be_within(10).of(positions["afterUserScroll"])
+  end
+
+  it "restores after pagination when the user does not scroll", :aggregate_failures do
+    target_post = root_posts[24]
+
+    nested_view.visit_nested(topic).disable_cloaking
+    expect(nested_view).to have_root_post_count(20)
+
+    nested_view.scroll_to_bottom
+    expect(nested_view).to have_root_post_count(40)
+
+    nested_view.scroll_to_post(target_post)
+    saved_position = nested_view.current_scroll_position
+
+    nested_view.visit_nested(topic)
+    expect(nested_view).to have_root_post_count(20)
+
+    try_until_success(reason: "scroll anchor restores after paginated roots load") do
+      expect(nested_view).to have_root_post_count(40)
+      expect(nested_view.current_scroll_position).to be_within(10).of(saved_position)
+    end
+  end
+
+  it "lets the user keep scrolling when pagination loads the restored post", :aggregate_failures do
+    target_post = root_posts[24]
+
+    nested_view.visit_nested(topic).disable_cloaking
+    expect(nested_view).to have_root_post_count(20)
+
+    nested_view.scroll_to_bottom
+    expect(nested_view).to have_root_post_count(40)
+
+    nested_view.scroll_to_post(target_post)
+    saved_position = nested_view.current_scroll_position
+
+    nested_view.visit_nested(topic)
+    expect(nested_view).to have_root_post_count(20)
+
+    restored_position = nested_view.current_scroll_position
+    nested_view.wheel_down.scroll_to_bottom
+    after_bottom_position = nested_view.current_scroll_position
+
+    expect(restored_position).to be < saved_position
+    expect(after_bottom_position).to be >= restored_position
+    expect(nested_view).to have_root_post_count(40)
+    expect(nested_view.current_scroll_position).to be_within(10).of(after_bottom_position)
+  end
+end

--- a/spec/system/page_objects/pages/nested_view.rb
+++ b/spec/system/page_objects/pages/nested_view.rb
@@ -230,6 +230,41 @@ module PageObjects
         has_css?(".nested-sort-selector__trigger", text: I18n.t("js.nested_replies.sort.#{sort}"))
       end
 
+      def has_root_post_count?(count)
+        has_css?(".nested-view__roots > .nested-post", count: count)
+      end
+
+      def current_scroll_position
+        page.evaluate_script("window.scrollY")
+      end
+
+      def disable_cloaking
+        page.execute_script(
+          'require("discourse/modifiers/post-stream-viewport-tracker").disableCloaking()',
+        )
+        self
+      end
+
+      def scroll_to_bottom
+        page.execute_script("window.scrollTo(0, document.body.scrollHeight)")
+        self
+      end
+
+      def wheel_down
+        page.driver.with_playwright_page do |playwright_page|
+          playwright_page.mouse.move(200, 200)
+          playwright_page.mouse.wheel(0, 1000)
+        end
+        self
+      end
+
+      def scroll_to_post(post)
+        page.execute_script(<<~JS)
+          document.querySelector("[data-post-number='#{post.post_number}']").scrollIntoView();
+        JS
+        self
+      end
+
       def has_op_post?
         has_css?(".nested-view__op")
       end
@@ -491,6 +526,32 @@ module PageObjects
         find(".nested-sort-selector__trigger").click
         find(".dropdown-menu .btn", text: I18n.t("js.nested_replies.sort.#{sort}")).click
         self
+      end
+
+      def scroll_to_position(scroll_y)
+        page.evaluate_async_script(<<~JS)
+          const done = arguments[0];
+          window.scrollTo(0, #{scroll_y});
+          setTimeout(done, 50);
+        JS
+        self
+      end
+
+      def scroll_during_pending_restore(distance:)
+        page.evaluate_async_script(<<~JS)
+          const done = arguments[0];
+          const positions = { restored: window.scrollY };
+
+          setTimeout(() => {
+            window.scrollBy(0, #{distance});
+            positions.afterUserScroll = window.scrollY;
+          }, 20);
+
+          setTimeout(() => {
+            positions.afterRetries = window.scrollY;
+            done(positions);
+          }, 250);
+        JS
       end
 
       # ── Deletion/recovery assertions ─────────────────────────────


### PR DESCRIPTION
Previously, nested replies retried cached scroll restoration while users were already scrolling, which could snap them back after returning to a topic or when pagination later rendered the restored post.

This change keeps programmatic scroll echoes from cancelling restoration, cancels stale restoration when the user scrolls, avoids post-level restore for pixel-based anchors, and adds system specs for both cancellation and pagination restore paths.