### PR TITLE
FIX: Prevent stale nested replies from leaking between topics

### DIFF
--- a/frontend/discourse/app/components/nested/post-children.gjs
+++ b/frontend/discourse/app/components/nested/post-children.gjs
@@ -27,6 +27,7 @@ export default class NestedPostChildren extends Component {
   // Tracks whether we've fetched from the server yet (vs only having preloaded data)
   _fetchedFromServer = false;
   _identityKey = null;
+  _activeCacheKey = null;
 
   constructor() {
     super(...arguments);
@@ -62,8 +63,11 @@ export default class NestedPostChildren extends Component {
     this._hydrateFromArgs();
   }
 
-  _cacheKey(parentPostNumber = this.args.parentPostNumber) {
-    return `${this.args.topic?.id}:${parentPostNumber}`;
+  _cacheKeyFor(
+    parentPostNumber = this.args.parentPostNumber,
+    topicId = this.args.topic?.id
+  ) {
+    return `${topicId}:${parentPostNumber}`;
   }
 
   _hydrateFromArgs() {
@@ -72,6 +76,7 @@ export default class NestedPostChildren extends Component {
     }
 
     this._identityKey = this.identityKey;
+    this._activeCacheKey = this._cacheKeyFor();
     this.childNodes = [];
     this.loading = false;
     this.page = 0;
@@ -80,7 +85,7 @@ export default class NestedPostChildren extends Component {
     this.loaded = false;
     this._fetchedFromServer = false;
 
-    const cached = this.args.fetchedChildrenCache?.get(this._cacheKey());
+    const cached = this.args.fetchedChildrenCache?.get(this._activeCacheKey);
     if (cached) {
       this.childNodes = cached.childNodes;
       this.page = cached.page;
@@ -107,11 +112,11 @@ export default class NestedPostChildren extends Component {
     }
   }
 
-  _reportToCache(parentPostNumber = this.args.parentPostNumber) {
-    if (!this.loaded || !parentPostNumber || !this.args.fetchedChildrenCache) {
+  _reportToCache(cacheKey = this._activeCacheKey) {
+    if (!this.loaded || !cacheKey || !this.args.fetchedChildrenCache) {
       return;
     }
-    this.args.fetchedChildrenCache.set(this._cacheKey(parentPostNumber), {
+    this.args.fetchedChildrenCache.set(cacheKey, {
       childNodes: this.childNodes,
       page: this.page,
       hasMore: this.hasMore,
@@ -162,6 +167,9 @@ export default class NestedPostChildren extends Component {
   }
 
   async loadChildren() {
+    const identityKey = this.identityKey;
+    const topicId = this.args.topic?.id;
+
     this.loading = true;
     try {
       const query = new URLSearchParams({
@@ -171,11 +179,15 @@ export default class NestedPostChildren extends Component {
       const data = await ajax(
         `/n/${this.args.topic.slug}/${this.args.topic.id}/children/${this.args.parentPostNumber}.json?${query}`
       );
-      if (this.isDestroying || this.isDestroyed) {
+      if (
+        this.isDestroying ||
+        this.isDestroyed ||
+        this.identityKey !== identityKey
+      ) {
         return;
       }
-      this.childNodes = (data.children || []).map((child) =>
-        this._processNode(child)
+      this.childNodes = this._childrenForTopic(data.children, topicId).map(
+        (child) => this._processNode(child)
       );
       this.page = data.page;
       this.hasMore = data.has_more || false;
@@ -199,6 +211,9 @@ export default class NestedPostChildren extends Component {
       return;
     }
 
+    const identityKey = this.identityKey;
+    const topicId = this.args.topic?.id;
+
     this.loadingMore = true;
     try {
       // First server fetch after preloaded data: get page 0 and merge
@@ -213,11 +228,15 @@ export default class NestedPostChildren extends Component {
       const data = await ajax(
         `/n/${this.args.topic.slug}/${this.args.topic.id}/children/${this.args.parentPostNumber}.json?${query}`
       );
-      if (this.isDestroying || this.isDestroyed) {
+      if (
+        this.isDestroying ||
+        this.isDestroyed ||
+        this.identityKey !== identityKey
+      ) {
         return;
       }
-      const newNodes = (data.children || []).map((child) =>
-        this._processNode(child)
+      const newNodes = this._childrenForTopic(data.children, topicId).map(
+        (child) => this._processNode(child)
       );
 
       if (!this._fetchedFromServer) {
@@ -247,6 +266,13 @@ export default class NestedPostChildren extends Component {
         this.loadingMore = false;
       }
     }
+  }
+
+  _childrenForTopic(children, topicId) {
+    return (children || []).filter(
+      (child) =>
+        child.topic_id != null && String(child.topic_id) === String(topicId)
+    );
   }
 
   _processNode(nodeData) {

--- a/frontend/discourse/app/components/nested/post.gjs
+++ b/frontend/discourse/app/components/nested/post.gjs
@@ -385,10 +385,18 @@ export default class NestedPost extends Component {
     });
   }
 
+  get childCacheKey() {
+    return `${this.args.topic?.id}:${this.args.post.post_number}`;
+  }
+
   async childrenForMobileFocus() {
-    const cached = this.args.fetchedChildrenCache?.get(
-      this.args.post.post_number
-    );
+    const cacheKey = this.childCacheKey;
+    const identityKey = [
+      this.args.topic?.id,
+      this.args.post.post_number,
+      this.args.sort,
+    ].join(":");
+    const cached = this.args.fetchedChildrenCache?.get(cacheKey);
     if (cached) {
       return cached.childNodes;
     }
@@ -406,14 +414,25 @@ export default class NestedPost extends Component {
       const data = await ajax(
         `/n/${this.args.topic.slug}/${this.args.topic.id}/children/${this.args.post.post_number}.json?${query}`
       );
-      if (this.isDestroying || this.isDestroyed) {
+      if (
+        this.isDestroying ||
+        this.isDestroyed ||
+        this.childCacheKey !== cacheKey ||
+        [this.args.topic?.id, this.args.post.post_number, this.args.sort].join(
+          ":"
+        ) !== identityKey
+      ) {
         return null;
       }
 
-      const childNodes = (data.children || []).map((child) =>
-        processNode(this.store, this.args.topic, child)
-      );
-      this.args.fetchedChildrenCache?.set(this.args.post.post_number, {
+      const childNodes = (data.children || [])
+        .filter(
+          (child) =>
+            child.topic_id != null &&
+            String(child.topic_id) === String(this.args.topic?.id)
+        )
+        .map((child) => processNode(this.store, this.args.topic, child));
+      this.args.fetchedChildrenCache?.set(cacheKey, {
         childNodes,
         page: data.page,
         hasMore: data.has_more || false,

--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -787,7 +787,10 @@ export default class NestedController extends Controller {
     const topicId = this.topic?.id;
     try {
       const postData = await ajax(`/posts/${data.id}.json`);
-      if (this.topic?.id !== topicId) {
+      if (
+        this.topic?.id !== topicId ||
+        !this.#postBelongsToTopic(postData, topicId)
+      ) {
         return;
       }
 
@@ -861,6 +864,13 @@ export default class NestedController extends Controller {
     return ancestors.length > maxDepth ? ancestors[maxDepth - 1] : replyTo;
   }
 
+  #postBelongsToTopic(postData, topicId = this.topic?.id) {
+    return (
+      postData?.topic_id != null &&
+      String(postData.topic_id) === String(topicId)
+    );
+  }
+
   #isPostKnown(postId) {
     if (this.rootNodes.some((n) => n.post.id === postId)) {
       return true;
@@ -885,7 +895,10 @@ export default class NestedController extends Controller {
     const topicId = this.topic?.id;
     try {
       const postData = await ajax(`/posts/${data.id}.json`);
-      if (this.topic?.id !== topicId) {
+      if (
+        this.topic?.id !== topicId ||
+        !this.#postBelongsToTopic(postData, topicId)
+      ) {
         return;
       }
 
@@ -943,7 +956,10 @@ export default class NestedController extends Controller {
 
     const newNodes = [];
     for (const result of results) {
-      if (result.status === "fulfilled") {
+      if (
+        result.status === "fulfilled" &&
+        this.#postBelongsToTopic(result.value, topicId)
+      ) {
         newNodes.push(this.#processNode({ ...result.value, children: [] }));
       }
     }

--- a/frontend/discourse/tests/integration/components/nested/post-test.gjs
+++ b/frontend/discourse/tests/integration/components/nested/post-test.gjs
@@ -259,7 +259,7 @@ module("Integration | Component | Nested | Post", function (hooks) {
       "hydrates the focused path with the fetched child"
     );
     assert.strictEqual(
-      this.fetchedChildrenCache.get(2).childNodes,
+      this.fetchedChildrenCache.get("1:2").childNodes,
       focusedPath[0].children,
       "stores the fetched children in the shared cache"
     );

--- a/spec/system/nested_realtime_spec.rb
+++ b/spec/system/nested_realtime_spec.rb
@@ -62,6 +62,63 @@ RSpec.describe "Nested view real-time updates" do
     end
   end
 
+  describe "stale events from another topic" do
+    fab!(:other_topic) { Fabricate(:topic, user: other_user, title: "Topic with stale replies") }
+    fab!(:other_op) { Fabricate(:post, topic: other_topic, user: other_user, post_number: 1) }
+    fab!(:other_root) do
+      Fabricate(:post, topic: other_topic, user: other_user, raw: "Other topic root reply")
+    end
+    fab!(:other_sibling) do
+      Fabricate(:post, topic: other_topic, user: other_user, raw: "Other topic sibling reply")
+    end
+    fab!(:wrong_topic_reply) do
+      Fabricate(
+        :post,
+        topic: other_topic,
+        user: other_user,
+        raw: "Wrong topic leaked reply",
+        reply_to_post_number: other_root.post_number,
+      )
+    end
+    fab!(:existing_child) do
+      Fabricate(
+        :post,
+        topic: topic,
+        user: user,
+        raw: "Legitimate child reply",
+        reply_to_post_number: root_reply.post_number,
+      )
+    end
+
+    before { Fabricate(:nested_topic, topic: other_topic) }
+
+    it "ignores stale created events for posts from a different topic" do
+      nested_view.visit_nested(topic)
+      expect(nested_view).to have_nested_view
+      expect(page).to have_content("Legitimate child reply")
+
+      page.execute_script(<<~JS)
+        window.__stalePostLookupFinished = false;
+        jQuery(document).one("ajaxComplete", (_event, _xhr, settings) => {
+          if (settings.url.includes("/posts/#{wrong_topic_reply.id}.json")) {
+            window.__stalePostLookupFinished = true;
+          }
+        });
+        Discourse.lookup("controller:nested")._onMessage({
+          type: "created",
+          id: #{wrong_topic_reply.id},
+          user_id: #{other_user.id}
+        });
+      JS
+
+      try_until_success(reason: "stale post lookup finishes") do
+        expect(page.evaluate_script("window.__stalePostLookupFinished")).to eq(true)
+      end
+
+      expect(page).to have_no_content("Wrong topic leaked reply")
+    end
+  end
+
   describe "small_action posts" do
     it "does not insert close/open small_actions into the tree" do
       nested_view.visit_nested(topic)


### PR DESCRIPTION
Previously, stale realtime events and async child loads could insert nested replies fetched from a different topic into the current nested topic.

This change validates fetched post and child payloads against the active topic before hydrating them, preventing cross-topic replies from leaking into the nested tree.

Tests:
- `bin/rspec spec/system/nested_realtime_spec.rb`
- `bin/qunit frontend/discourse/tests/integration/components/nested/post-test.gjs`
- `bin/lint --fix frontend/discourse/app/controllers/nested.js frontend/discourse/app/components/nested/post-children.gjs frontend/discourse/app/components/nested/post.gjs frontend/discourse/tests/integration/components/nested/post-test.gjs spec/system/nested_realtime_spec.rb`