### PR TITLE
FIX: Skip composer media optimization on EOL iOS versions

### DIFF
--- a/frontend/discourse/app/instance-initializers/register-media-optimization-upload-processor.js
+++ b/frontend/discourse/app/instance-initializers/register-media-optimization-upload-processor.js
@@ -2,6 +2,12 @@ import { Promise } from "rsvp";
 import { addComposerUploadPreProcessor } from "discourse/components/composer-editor";
 import UppyMediaOptimization from "discourse/lib/uppy-media-optimization-plugin";
 
+// Devices stuck on EOL iOS versions are older hardware where WebKit's memory
+// watchdog kills (and reloads) the page during WASM image processing instead
+// of raising a catchable error, so skip optimization there entirely.
+// https://endoflife.date/iphone
+export const MAX_EOL_IOS_MAJOR_VERSION = 18;
+
 export default {
   initialize(owner) {
     const siteSettings = owner.lookup("service:site-settings");
@@ -10,7 +16,9 @@ export default {
     if (siteSettings.composer_media_optimization_image_enabled) {
       if (
         capabilities.isIOS &&
-        !siteSettings.composer_ios_media_optimisation_image_enabled
+        (!siteSettings.composer_ios_media_optimisation_image_enabled ||
+          (capabilities.iosMajorVersion &&
+            capabilities.iosMajorVersion <= MAX_EOL_IOS_MAJOR_VERSION))
       ) {
         return;
       }

--- a/frontend/discourse/app/services/capabilities.js
+++ b/frontend/discourse/app/services/capabilities.js
@@ -21,6 +21,15 @@ class _Capabilities {
   isWinphone = ua.includes("Windows Phone");
   isIpadOS = ua.includes("Mac OS") && !/iPhone|iPod/.test(ua) && this.touch;
   isIOS = (/iPhone|iPod/.test(ua) || this.isIpadOS) && !window.MSStream;
+  // iPadOS Safari masquerades as desktop macOS (frozen "Mac OS X 10_15_7"
+  // token); Safari's Version/ token tracks the iOS version there instead.
+  iosMajorVersion = this.isIOS
+    ? parseInt(
+        ua.match(/(?:iPhone|iPad|iPod).*? OS (\d+)_/)?.[1] ??
+          ua.match(/Version\/(\d+)/)?.[1],
+        10
+      ) || null
+    : null;
   isApple =
     APPLE_NAVIGATOR_PLATFORMS.test(navigator.platform) ||
     (navigator.userAgentData &&


### PR DESCRIPTION
Previously, the WASM-based composer image optimization crashed the page on devices stuck on EOL iOS versions (e.g. iPhone 8 / iPad 5 on iOS 16.7), where WebKit's memory watchdog reloads the page instead of raising a catchable error.

This change detects the iOS major version from the user agent (falling back to Safari's `Version/` token on iPadOS, whose desktop UA masquerades as macOS) and skips client-side optimization entirely on iOS 18 and older, matching the EOL list at https://endoflife.date/iphone. Affected devices upload their original files instead.