### PR TITLE
UX: disable chat key/focus capture on liestream topics

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -110,7 +110,7 @@ export default class ChatChannel extends Component {
 
   @action
   teardown() {
-    document.removeEventListener("keydown", this._autoFocus);
+    document.removeEventListener("keydown", this._captureKeystroke);
     this.#cancelHandlers();
     this.paneState.teardown();
     this.subscriptionManager.teardown();
@@ -138,7 +138,10 @@ export default class ChatChannel extends Component {
   @action
   setup(element) {
     this.uploadDropZone = element;
-    document.addEventListener("keydown", this._autoFocus);
+
+    if (!this.args.disableKeystrokeCapture) {
+      document.addEventListener("keydown", this._captureKeystroke);
+    }
 
     this.messagesManager.clear();
 
@@ -155,7 +158,10 @@ export default class ChatChannel extends Component {
         user: this.currentUser,
       });
 
-    this.composer.focus();
+    if (!this.args.disableAutoFocus) {
+      this.composer.focus();
+    }
+
     this.loadMessages();
 
     // We update this value server-side when we load the Channel
@@ -700,11 +706,7 @@ export default class ChatChannel extends Component {
   }
 
   @bind
-  _autoFocus(event) {
-    if (this.chatStateManager.isDrawerActive) {
-      return;
-    }
-
+  _captureKeystroke(event) {
     const { key, metaKey, ctrlKey, code, target } = event;
 
     if (

--- a/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/drawer-routes/channel.gjs
@@ -69,6 +69,7 @@ export default class ChatDrawerRoutesChannel extends Component {
                 @channel={{channel}}
                 @isFiltering={{this.isFiltering}}
                 @onToggleFilter={{this.toggleIsFiltering}}
+                @disableKeystrokeCapture={{true}}
               />
             {{/each}}
           </div>

--- a/plugins/chat/test/javascripts/components/chat-channel-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-channel-test.gjs
@@ -224,3 +224,70 @@ module("Component | ChatChannel | status on mentions", function (hooks) {
     return `.mention[href='/u/${username}'] .user-status-message img`;
   }
 });
+
+module("Component | ChatChannel | autofocus", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    pretender.get(`/chat/api/channels/1/messages`, () =>
+      response({ messages: [], meta: { can_delete_self: true } })
+    );
+    pretender.get(`/chat/api/me/channels`, () =>
+      response({ direct_message_channels: [], public_channels: [] })
+    );
+
+    this.channel = new ChatFabricators(getOwner(this)).channel({
+      id: 1,
+      meta: { can_join_chat_channel: false },
+    });
+    this.channel.currentUserMembership = { following: true };
+  });
+
+  test("captures bare keystrokes and focuses the composer by default", async function (assert) {
+    await render(
+      <template><ChatChannel @channel={{this.channel}} /></template>
+    );
+
+    assert.dom(".chat-composer__input").isFocused("composer is focused");
+    assert.true(pressKey("j").defaultPrevented, "keystroke is captured");
+  });
+
+  test("leaves keystrokes alone when capture is disabled", async function (assert) {
+    await render(
+      <template>
+        <ChatChannel
+          @channel={{this.channel}}
+          @disableKeystrokeCapture={{true}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".chat-composer__input")
+      .isFocused("composer is still focused on insert");
+    assert.false(
+      pressKey("j").defaultPrevented,
+      "keystroke is left for the host page"
+    );
+  });
+
+  test("skips focusing the composer when autofocus is disabled", async function (assert) {
+    await render(
+      <template>
+        <ChatChannel @channel={{this.channel}} @disableAutoFocus={{true}} />
+      </template>
+    );
+
+    assert.dom(".chat-composer__input").isNotFocused("composer is not focused");
+  });
+
+  function pressKey(key) {
+    const event = new KeyboardEvent("keydown", {
+      key,
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(event);
+    return event;
+  }
+});

--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/livestream/embeddable-chat-channel.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/livestream/embeddable-chat-channel.gjs
@@ -106,6 +106,8 @@ export default class EmbedableChatChannel extends Component {
               @channel={{channel}}
               @context={{LIVESTREAM_CHAT_CONTEXT}}
               @hiddenMessageIds={{this.hiddenMessageIds}}
+              @disableKeystrokeCapture={{true}}
+              @disableAutoFocus={{true}}
             />
           {{/each}}
         {{/if}}


### PR DESCRIPTION
The embedded chat channel on a livestream topic captures focus and keyboard commands, which breaks topic keyboard shortcuts. This change adds the ability to opt out of focus and keyboard capturing individually and also refactors drawer chat to use the same mechanism. 