### PR TITLE
DEV: Sandbox all image processing via Landlock [backport 2026.6]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,7 @@ GEM
       simpleidn (~> 0.2)
     jwt (2.10.1)
       base64
-    landlock (0.2)
+    landlock (0.3)
     language_server-protocol (3.17.0.5)
     libv8-node (24.12.0.1-aarch64-linux)
     libv8-node (24.12.0.1-aarch64-linux-musl)
@@ -1096,7 +1096,7 @@ CHECKSUMS
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
-  landlock (0.2) sha256=9bb86d7d12b16485b278ba575d49f55b730089c7a3d0f45a769fe4d7384d5e55
+  landlock (0.3) sha256=841ae1ef1318082a485ae919b6a481ceb9c2d3ac9294ada27e2a3c529446b23c
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   libv8-node (24.12.0.1-aarch64-linux) sha256=22bd0246cde85d70c88cf772727ac3677a20ac1d169105f82efe5f1f7c39f755
   libv8-node (24.12.0.1-aarch64-linux-musl) sha256=791b5960f79525e87d1bd1e5f2bf3715ef2a38bac6c97f297853e98a8411ba89

--- a/app/models/optimized_image.rb
+++ b/app/models/optimized_image.rb
@@ -229,7 +229,7 @@ class OptimizedImage < ActiveRecord::Base
     from = prepend_decoder!(from, to, opts)
     to = prepend_decoder!(to, to, opts)
 
-    instructions = ["convert", "#{from}[0]"]
+    instructions = ["#{from}[0]"]
 
     instructions << "-colors" << opts[:colors].to_s if opts[:colors]
 
@@ -267,7 +267,6 @@ class OptimizedImage < ActiveRecord::Base
     to = prepend_decoder!(to, to, opts)
 
     instructions = %W{
-      convert
       #{from}[0]
       -auto-orient
       -gravity
@@ -298,7 +297,6 @@ class OptimizedImage < ActiveRecord::Base
     to = prepend_decoder!(to, to, opts)
 
     %W{
-      convert
       #{from}[0]
       -auto-orient
       -gravity
@@ -331,18 +329,18 @@ class OptimizedImage < ActiveRecord::Base
     method_name = "#{operation}_instructions"
 
     instructions = public_send(method_name.to_sym, from, to, dimensions, opts)
-    convert_with(instructions, to, opts)
+    convert_with(instructions, from, to, opts)
   end
 
   MAX_PNGQUANT_SIZE = 500_000
   MAX_CONVERT_SECONDS = 20
 
-  def self.convert_with(instructions, to, opts = {})
-    Discourse::Utils.execute_command(
-      "nice",
-      "-n",
-      "10",
+  def self.convert_with(instructions, from, to, opts = {})
+    ImageMagick.magick(
       *instructions,
+      read: [from],
+      write: [File.dirname(to)],
+      nice: 10,
       timeout: MAX_CONVERT_SECONDS,
     )
 
@@ -355,7 +353,7 @@ class OptimizedImage < ActiveRecord::Base
     else
       error = +"Failed to optimize image:"
 
-      if e.message =~ /\Aconvert:([^`]+)/
+      if e.message =~ /\A(?:convert|magick):([^`]+)/
         error << $1
       else
         error << " unknown reason"

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -306,12 +306,12 @@ class Upload < ActiveRecord::Base
       if extension == "svg"
         w, h =
           begin
-            Discourse::Utils.execute_command(
-              "identify",
+            ImageMagick.identify(
               "-ping",
               "-format",
               "%w %h",
               "MSVG:#{path}",
+              read: [path],
               timeout: MAX_IDENTIFY_SECONDS,
             ).split(" ")
           rescue StandardError
@@ -395,11 +395,7 @@ class Upload < ActiveRecord::Base
       color ||=
         begin
           data =
-            Discourse::Utils.execute_command(
-              "nice",
-              "-n",
-              "10",
-              "convert",
+            ImageMagick.magick(
               local_path,
               "-depth",
               "8",
@@ -410,6 +406,8 @@ class Upload < ActiveRecord::Base
               "-format",
               "%c",
               "histogram:info:",
+              read: [local_path],
+              nice: 10,
               timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS,
             )
 
@@ -439,12 +437,12 @@ class Upload < ActiveRecord::Base
   def target_image_quality(local_path, test_quality)
     @file_quality ||=
       begin
-        Discourse::Utils.execute_command(
-          "identify",
+        ImageMagick.identify(
           "-ping",
           "-format",
           "%Q",
           local_path,
+          read: [local_path],
           timeout: MAX_IDENTIFY_SECONDS,
         ).to_i
       rescue StandardError

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -154,6 +154,7 @@ module Discourse
         failure_message: "",
         success_status_codes: [0],
         chdir: ".",
+        unsetenv_others: false,
         unsafe_shell: false
       )
         env = nil
@@ -173,7 +174,10 @@ module Discourse
 
         args = command
         args = [env] + command if env
-        stdout, stderr, status = Open3.capture3(*args, chdir: chdir)
+
+        spawn_options = { chdir: chdir }
+        spawn_options[:unsetenv_others] = true if unsetenv_others
+        stdout, stderr, status = Open3.capture3(*args, **spawn_options)
 
         if !status.exited? || !success_status_codes.include?(status.exitstatus)
           message = [command.join(" "), failure_message, stderr].filter(&:present?).join("\n")

--- a/lib/discourse/safe_exec.rb
+++ b/lib/discourse/safe_exec.rb
@@ -1,20 +1,11 @@
 # frozen_string_literal: true
 
-begin
-  require "landlock"
-rescue LoadError
-end
+require "landlock"
 
 module Discourse
   class SafeExec
     DEFAULT_READ_PATHS = %w[/bin /etc /lib /lib64 /usr].freeze
     DEFAULT_EXECUTE_PATHS = %w[/bin /lib /lib64 /usr].freeze
-    LANDLOCK_COMMAND_ERROR =
-      if defined?(::Landlock::SafeExec::CommandError)
-        ::Landlock::SafeExec::CommandError
-      else
-        Class.new(StandardError)
-      end
 
     def self.capture(
       *command,
@@ -34,20 +25,20 @@ module Discourse
       max_output_bytes: nil,
       truncate_output: false
     )
-      if defined?(::Landlock::SafeExec)
+      if ::Landlock.supported?
         result =
-          ::Landlock::SafeExec.capture(
-            *command,
+          ::Landlock.capture(
+            command,
             read: read,
             write: write,
             execute: execute,
             timeout: timeout,
             failure_message: failure_message,
             success_status_codes: success_status_codes,
-            env: env || {},
-            inherit_env: !unsetenv_others,
+            env: env,
+            unsetenv_others: unsetenv_others,
             chdir: chdir,
-            connect_tcp: connect_tcp,
+            connect_tcp: Array(connect_tcp),
             bind_tcp: bind_tcp,
             rlimits: rlimits,
             seccomp_deny_network: seccomp_deny_network,
@@ -70,9 +61,10 @@ module Discourse
           failure_message: failure_message,
           success_status_codes: success_status_codes,
           chdir: chdir || ".",
+          unsetenv_others: unsetenv_others,
         )
       end
-    rescue LANDLOCK_COMMAND_ERROR => e
+    rescue ::Landlock::CommandError => e
       raise Discourse::Utils::CommandError.new(
               e.message,
               stdout: e.stdout,
@@ -82,23 +74,15 @@ module Discourse
     end
 
     def self.landlock_supported?
-      defined?(::Landlock::SafeExec) && ::Landlock::SafeExec.supported?
+      ::Landlock.supported?
     end
 
     def self.default_read_paths
-      if defined?(::Landlock::SafeExec)
-        ::Landlock::SafeExec.default_read_paths
-      else
-        existing_paths(DEFAULT_READ_PATHS)
-      end
+      existing_paths(DEFAULT_READ_PATHS)
     end
 
     def self.default_execute_paths
-      if defined?(::Landlock::SafeExec)
-        ::Landlock::SafeExec.default_execute_paths
-      else
-        existing_paths(DEFAULT_EXECUTE_PATHS)
-      end
+      existing_paths(DEFAULT_EXECUTE_PATHS)
     end
 
     def self.existing_paths(paths)

--- a/lib/freedom_patches/image_optim_sandbox.rb
+++ b/lib/freedom_patches/image_optim_sandbox.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "image_optim/cmd"
+
+# Route image_optim's optimizer binaries through the Landlock sandbox, confining
+# them to the file being optimized with no network. Cmd.capture (version/CPU
+# probes, no untrusted input) is intentionally not patched.
+class ImageOptim
+  module Cmd
+    class << self
+      def run(*args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        env = args.first.is_a?(Hash) ? args.shift : {}
+
+        files = args.select { |arg| arg.is_a?(String) && File.file?(arg) }
+        dirs = files.map { |file| File.dirname(file) }.uniq
+
+        Discourse::SafeExec.capture(
+          *args,
+          env: {
+            **env,
+            "MALLOC_ARENA_MAX" => "2",
+          },
+          unsetenv_others: true,
+          read: [*Discourse::SafeExec.default_read_paths, *files],
+          write: [*files, *dirs],
+          execute: Discourse::SafeExec.default_execute_paths,
+          timeout: options[:timeout]&.to_f || ImageMagick::DEFAULT_TIMEOUT,
+          rlimits: ImageMagick::RLIMITS,
+          seccomp_deny_network: true,
+        )
+        true
+      rescue Discourse::Utils::CommandError
+        # non-zero exit means "kept the original", like system(*args) => false
+        false
+      end
+    end
+  end
+end

--- a/lib/image_magick.rb
+++ b/lib/image_magick.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+# Runs ImageMagick under the Landlock sandbox (via Discourse::SafeExec) so a
+# decoder bug parsing an untrusted upload is confined to an explicit filesystem
+# allowlist with no network, not the full rights of the calling process.
+module ImageMagick
+  # memory_bytes sits above the policy.xml ceiling (memory 1GiB + map 2GiB) so a
+  # legitimate ≤128MP decode is not killed; MALLOC_ARENA_MAX bounds per-thread
+  # arenas that would otherwise inflate address space against it. cpu_seconds is
+  # a runaway backstop above the wall-clock timeout.
+  RLIMITS = {
+    cpu_seconds: 300,
+    memory_bytes: 4 * 1024 * 1024 * 1024,
+    file_size_bytes: 10 * 1024 * 1024 * 1024,
+    open_files: 1024,
+  }.freeze
+
+  DEFAULT_TIMEOUT = 30
+
+  def self.asset_read_paths
+    @asset_read_paths ||= [Rails.root.join("vendor").to_s, ENV["MAGICK_CONFIGURE_PATH"]].compact
+  end
+
+  def self.magick(*args, read: [], write: [], timeout: nil, nice: nil, failure_message: "")
+    command = ["magick", *args]
+    command = ["nice", "-n", nice.to_s, *command] if nice
+    run(*command, read:, write:, timeout:, failure_message:)
+  end
+
+  def self.identify(*args, read: [], write: [], timeout: nil, failure_message: "")
+    run("identify", *args, read:, write:, timeout:, failure_message:)
+  end
+
+  def self.run(*command, read:, write:, timeout:, failure_message:)
+    # A private scratch dir keeps ImageMagick's disk-backed pixel cache inside
+    # the write allowlist, so large images that spill to disk still succeed.
+    Dir.mktmpdir("discourse-imagemagick-") do |scratch|
+      Discourse::SafeExec.capture(
+        *command,
+        env: {
+          **ENV.slice("PATH", "MAGICK_CONFIGURE_PATH", "LANG", "LC_ALL"),
+          "MAGICK_TEMPORARY_PATH" => scratch,
+          "TMPDIR" => scratch,
+          "HOME" => scratch,
+          "XDG_CACHE_HOME" => scratch,
+          "MALLOC_ARENA_MAX" => "2",
+        },
+        unsetenv_others: true,
+        read: [*Discourse::SafeExec.default_read_paths, *asset_read_paths, *read],
+        write: [scratch, *write],
+        execute: Discourse::SafeExec.default_execute_paths,
+        timeout: timeout || DEFAULT_TIMEOUT,
+        rlimits: RLIMITS,
+        failure_message:,
+        seccomp_deny_network: true,
+      )
+    end
+  end
+  private_class_method :run
+end

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -96,7 +96,7 @@ class LetterAvatar
         #{filename}
       ]
 
-      Discourse::Utils.execute_command("magick", *instructions)
+      ImageMagick.magick(*instructions, write: [File.dirname(filename)])
 
       ## do not optimize image, it will end up larger than original
       filename
@@ -114,7 +114,9 @@ class LetterAvatar
             sleep 2
             cleanup_old
           end
-          Digest::MD5.hexdigest(`magick --version` << `magick -list font`)
+          Digest::MD5.hexdigest(
+            ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
+          )
         end
     end
 

--- a/lib/topic_og_image_generator.rb
+++ b/lib/topic_og_image_generator.rb
@@ -328,11 +328,7 @@ class TopicOgImageGenerator
 
       File.write(svg_path, svg)
 
-      Discourse::Utils.execute_command(
-        "nice",
-        "-n",
-        "10",
-        "convert",
+      ImageMagick.magick(
         "-background",
         "none",
         "-size",
@@ -343,6 +339,9 @@ class TopicOgImageGenerator
         "-define",
         "png:compression-level=9",
         png_path,
+        read: [svg_path],
+        write: [dir],
+        nice: 10,
         timeout: 20_000,
       )
 

--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -201,13 +201,13 @@ class UploadCreator
           # consistently whether it's running from our docker container or not
           begin
             w, h =
-              Discourse::Utils
-                .execute_command(
-                  "identify",
+              ImageMagick
+                .identify(
                   "-ping",
                   "-format",
                   "%w %h",
                   "MSVG:#{@file.path}",
+                  read: [@file.path],
                   timeout: Upload::MAX_IDENTIFY_SECONDS,
                 )
                 .split(" ")
@@ -355,11 +355,14 @@ class UploadCreator
 
     opts = { flatten: false } # Preserve transparency
 
+    read = [@file.path]
+    write = [File.dirname(png_tempfile.path)]
+
     begin
-      execute_convert(from, to, opts)
+      execute_convert(from, to, opts, read:, write:)
     rescue StandardError
       # retry with debugging enabled
-      execute_convert(from, to, opts.merge(debug: true))
+      execute_convert(from, to, opts.merge(debug: true), read:, write:)
     end
 
     @file.respond_to?(:close!) ? @file.close! : @file.close
@@ -389,14 +392,17 @@ class UploadCreator
       SiteSetting.ImageQuality.recompress_original_jpg_quality,
     ].compact.min
 
-    target_quality = @upload.target_image_quality(from, desired_quality)
+    target_quality = @upload.target_image_quality(@file.path, desired_quality)
     opts = { quality: target_quality } if target_quality
 
+    read = [@file.path]
+    write = [File.dirname(jpeg_tempfile.path)]
+
     begin
-      execute_convert(from, to, opts)
+      execute_convert(from, to, opts, read:, write:)
     rescue StandardError
       # retry with debugging enabled
-      execute_convert(from, to, opts.merge(debug: true))
+      execute_convert(from, to, opts.merge(debug: true), read:, write:)
     end
 
     new_size = File.size(jpeg_tempfile.path)
@@ -423,11 +429,14 @@ class UploadCreator
     to = jpeg_tempfile.path
     OptimizedImage.ensure_safe_paths!(from, to)
 
+    read = [@file.path]
+    write = [File.dirname(jpeg_tempfile.path)]
+
     begin
-      execute_convert(from, to)
+      execute_convert(from, to, {}, read:, write:)
     rescue StandardError
       # retry with debugging enabled
-      execute_convert(from, to, { debug: true })
+      execute_convert(from, to, { debug: true }, read:, write:)
     end
 
     @file.respond_to?(:close!) ? @file.close! : @file.close
@@ -436,15 +445,17 @@ class UploadCreator
   end
 
   MAX_CONVERT_FORMAT_SECONDS = 20
-  def execute_convert(from, to, opts = {})
-    command = ["magick", from, "-auto-orient", "-background", "white", "-interlace", "none"]
+  def execute_convert(from, to, opts = {}, read: [], write: [])
+    command = [from, "-auto-orient", "-background", "white", "-interlace", "none"]
     command << "-flatten" unless opts[:flatten] == false
     command << "-debug" << "all" if opts[:debug]
     command << "-quality" << opts[:quality].to_s if opts[:quality]
     command << to
 
-    Discourse::Utils.execute_command(
+    ImageMagick.magick(
       *command,
+      read:,
+      write:,
       failure_message: I18n.t("upload.png_to_jpg_conversion_failure_message"),
       timeout: MAX_CONVERT_FORMAT_SECONDS,
     )
@@ -550,11 +561,12 @@ class UploadCreator
     OptimizedImage.ensure_safe_paths!(path)
     path = OptimizedImage.prepend_decoder!(path, nil, filename: "image.#{@image_info.type}")
 
-    Discourse::Utils.execute_command(
-      "magick",
+    ImageMagick.magick(
       path,
       "-auto-orient",
       path,
+      read: [@file.path],
+      write: [@file.path, File.dirname(@file.path)],
       timeout: MAX_FIX_ORIENTATION_TIME,
     )
 
@@ -689,10 +701,16 @@ class UploadCreator
           # Only GIFs, WEBPs and a few other unsupported image types can be animated
           OptimizedImage.ensure_safe_paths!(@file.path)
 
-          command = ["identify", "-ping", "-format", "%n\\n", @file.path]
           frames =
             begin
-              Discourse::Utils.execute_command(*command, timeout: Upload::MAX_IDENTIFY_SECONDS).to_i
+              ImageMagick.identify(
+                "-ping",
+                "-format",
+                "%n\\n",
+                @file.path,
+                read: [@file.path],
+                timeout: Upload::MAX_IDENTIFY_SECONDS,
+              ).to_i
             rescue StandardError
               1
             end

--- a/spec/lib/discourse/safe_exec_spec.rb
+++ b/spec/lib/discourse/safe_exec_spec.rb
@@ -4,18 +4,19 @@ require "discourse/safe_exec"
 
 RSpec.describe Discourse::SafeExec do
   describe ".capture" do
-    it "delegates sandboxed execution to Landlock::SafeExec" do
+    it "delegates sandboxed execution to Landlock" do
       status = instance_double(Process::Status, exited?: true, exitstatus: 0)
       result =
         instance_double(
-          Landlock::SafeExec::Result,
+          Landlock::CaptureResult,
           stdout: "hello\n",
           stderr: "",
           status: status,
           output_truncated?: false,
         )
 
-      allow(Landlock::SafeExec).to receive(:capture).and_return(result)
+      allow(Landlock).to receive(:supported?).and_return(true)
+      allow(Landlock).to receive(:capture).and_return(result)
 
       expect(
         described_class.capture(
@@ -37,9 +38,8 @@ RSpec.describe Discourse::SafeExec do
         ),
       ).to eq("hello\n")
 
-      expect(Landlock::SafeExec).to have_received(:capture).with(
-        "echo",
-        "hello",
+      expect(Landlock).to have_received(:capture).with(
+        %w[echo hello],
         read: ["/tmp/input"],
         write: [],
         execute: described_class.default_execute_paths,
@@ -49,9 +49,9 @@ RSpec.describe Discourse::SafeExec do
         env: {
           "PATH" => ENV["PATH"].to_s,
         },
-        inherit_env: false,
+        unsetenv_others: true,
         chdir: nil,
-        connect_tcp: nil,
+        connect_tcp: [],
         bind_tcp: [],
         rlimits: {
           cpu_seconds: 1,
@@ -66,14 +66,15 @@ RSpec.describe Discourse::SafeExec do
       status = instance_double(Process::Status, exited?: true, exitstatus: 1)
       result =
         instance_double(
-          Landlock::SafeExec::Result,
+          Landlock::CaptureResult,
           stdout: "",
           stderr: "nope",
           status: status,
           output_truncated?: false,
         )
 
-      allow(Landlock::SafeExec).to receive(:capture).and_return(result)
+      allow(Landlock).to receive(:supported?).and_return(true)
+      allow(Landlock).to receive(:capture).and_return(result)
 
       expect { described_class.capture("false", failure_message: "failed") }.to raise_error(
         Discourse::Utils::CommandError,
@@ -81,24 +82,81 @@ RSpec.describe Discourse::SafeExec do
       )
     end
 
+    it "converts Landlock::CommandError into a Discourse command error" do
+      status = instance_double(Process::Status)
+
+      allow(Landlock).to receive(:supported?).and_return(true)
+      allow(Landlock).to receive(:capture).and_raise(
+        Landlock::CommandError.new("boom", stdout: "out", stderr: "err", status: status),
+      )
+
+      expect { described_class.capture("tool") }.to raise_error(
+        Discourse::Utils::CommandError,
+        /boom/,
+      )
+    end
+
     it "returns truncated stdout without checking the terminated status" do
       status = instance_double(Process::Status, exited?: false, exitstatus: nil)
       result =
         instance_double(
-          Landlock::SafeExec::Result,
+          Landlock::CaptureResult,
           stdout: "x" * 1024,
           stderr: "",
           status: status,
           output_truncated?: true,
         )
 
-      allow(Landlock::SafeExec).to receive(:capture).and_return(result)
+      allow(Landlock).to receive(:supported?).and_return(true)
+      allow(Landlock).to receive(:capture).and_return(result)
 
       expect(described_class.capture("tool", truncate_output: true)).to eq("x" * 1024)
     end
 
+    it "runs unsandboxed when Landlock is unavailable on the system" do
+      allow(Landlock).to receive(:supported?).and_return(false)
+      allow(Discourse::Utils).to receive(:execute_command).and_return("hello\n")
+
+      expect(described_class.capture("echo", "hello", chdir: "/tmp")).to eq("hello\n")
+
+      expect(Discourse::Utils).to have_received(:execute_command).with(
+        "echo",
+        "hello",
+        timeout: nil,
+        failure_message: "",
+        success_status_codes: [0],
+        chdir: "/tmp",
+        unsetenv_others: false,
+      )
+    end
+
+    it "still strips the child environment in the unsandboxed fallback" do
+      allow(Landlock).to receive(:supported?).and_return(false)
+
+      previous_secret = ENV["SAFE_EXEC_SECRET"]
+      ENV["SAFE_EXEC_SECRET"] = "hidden"
+      output =
+        described_class.capture(
+          "sh",
+          "-c",
+          "printf '%s' \"${SAFE_EXEC_SECRET-unset}\"",
+          env: {
+            "PATH" => ENV["PATH"].to_s,
+          },
+          unsetenv_others: true,
+        )
+
+      expect(output).to eq("unset")
+    ensure
+      if previous_secret.nil?
+        ENV.delete("SAFE_EXEC_SECRET")
+      else
+        ENV["SAFE_EXEC_SECRET"] = previous_secret
+      end
+    end
+
     it "captures stdout from a landlocked subprocess" do
-      skip "Landlock SafeExec is not supported" if !described_class.landlock_supported?
+      skip "Landlock is not supported" if !described_class.landlock_supported?
 
       output =
         described_class.capture(
@@ -112,7 +170,7 @@ RSpec.describe Discourse::SafeExec do
     end
 
     it "denies access to paths outside of the Landlock policy" do
-      skip "Landlock SafeExec is not supported" if !described_class.landlock_supported?
+      skip "Landlock is not supported" if !described_class.landlock_supported?
 
       Tempfile.create("safe-exec") do |tempfile|
         tempfile.write("secret")
@@ -130,6 +188,8 @@ RSpec.describe Discourse::SafeExec do
     end
 
     it "can clear the child environment" do
+      skip "Landlock is not supported" if !described_class.landlock_supported?
+
       previous_secret = ENV["SAFE_EXEC_SECRET"]
       ENV["SAFE_EXEC_SECRET"] = "hidden"
       output =
@@ -155,7 +215,7 @@ RSpec.describe Discourse::SafeExec do
     end
 
     it "denies network syscalls when requested" do
-      skip "Landlock SafeExec is not supported" if !described_class.landlock_supported?
+      skip "Landlock is not supported" if !described_class.landlock_supported?
 
       expect {
         described_class.capture(
@@ -175,22 +235,38 @@ RSpec.describe Discourse::SafeExec do
     end
 
     it "terminates commands that exceed the output limit" do
+      skip "Landlock is not supported" if !described_class.landlock_supported?
+
       expect {
         described_class.capture(
           RbConfig.ruby,
           "-e",
           "STDOUT.write('x' * 2048)",
+          read: described_class.default_read_paths,
+          execute: described_class.default_execute_paths,
+          env: {
+            "PATH" => ENV["PATH"].to_s,
+          },
+          unsetenv_others: true,
           max_output_bytes: 1024,
         )
       }.to raise_error(Discourse::Utils::CommandError, /output exceeded 1024 bytes/)
     end
 
     it "truncates commands that exceed the output limit when requested" do
+      skip "Landlock is not supported" if !described_class.landlock_supported?
+
       output =
         described_class.capture(
           RbConfig.ruby,
           "-e",
           "STDOUT.write('x' * 2048)",
+          read: described_class.default_read_paths,
+          execute: described_class.default_execute_paths,
+          env: {
+            "PATH" => ENV["PATH"].to_s,
+          },
+          unsetenv_others: true,
           max_output_bytes: 1024,
           truncate_output: true,
         )

--- a/spec/lib/freedom_patches/image_optim_sandbox_spec.rb
+++ b/spec/lib/freedom_patches/image_optim_sandbox_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "image_optim Landlock sandbox freedom patch" do
+  def landlock?
+    Discourse::SafeExec.landlock_supported?
+  end
+
+  it "routes worker commands through Discourse::SafeExec with the network denied" do
+    Discourse::SafeExec
+      .expects(:capture)
+      .with { |*_command, **opts| opts[:seccomp_deny_network] == true }
+      .returns("")
+
+    expect(ImageOptim::Cmd.run({ "PATH" => ENV["PATH"] }, "true")).to eq(true)
+  end
+
+  it "returns false (keep original) when the sandboxed command fails" do
+    Discourse::SafeExec.expects(:capture).raises(
+      Discourse::Utils::CommandError.new("boom", stdout: "", stderr: "", status: nil),
+    )
+
+    expect(ImageOptim::Cmd.run({}, "false")).to eq(false)
+  end
+
+  it "allows reading a file passed in argv" do
+    skip("Landlock unsupported on this host") unless landlock?
+
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, "data")
+      File.write(file, "hello")
+      expect(ImageOptim::Cmd.run({ "PATH" => ENV["PATH"] }, "cat", file)).to eq(true)
+    end
+  end
+
+  it "denies reading a file outside the allowlist" do
+    skip("Landlock unsupported on this host") unless landlock?
+
+    Dir.mktmpdir do |dir|
+      secret = File.join(dir, "secret")
+      File.write(secret, "top secret")
+      # secret is referenced only inside a shell string, so its directory is
+      # never granted and the sandbox must block the read.
+      expect(ImageOptim::Cmd.run({ "PATH" => ENV["PATH"] }, "sh", "-c", "cat #{secret}")).to eq(
+        false,
+      )
+    end
+  end
+
+  it "still optimizes a real image through the sandbox" do
+    skip("Landlock unsupported on this host") unless landlock?
+
+    Dir.mktmpdir do |dir|
+      png = File.join(dir, "logo.png")
+      FileUtils.cp(Rails.root.join("spec/fixtures/images/logo.png"), png)
+      before = File.size(png)
+
+      FileHelper.optimize_image!(png)
+
+      expect(File.size(png)).to be <= before
+      expect(FastImage.type(png)).to eq(:png)
+    end
+  end
+end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1008,7 +1008,7 @@ RSpec.describe Upload do
     end
 
     it "correctly handles unparsable ImageMagick output" do
-      Discourse::Utils.stubs(:execute_command).returns("someinvalidoutput")
+      ImageMagick.stubs(:magick).returns("someinvalidoutput")
 
       expect(invalid_image.dominant_color).to eq(nil)
 


### PR DESCRIPTION
Backport of #42048 to release/2026.6.

---

- Update all imagemagick calls to go through a new `::Imagemagick` wrapper, which wraps the command in `Discourse::SafeExec`
- Patch image_optim to force its calls through `SafeExec`

This provides robust defense-in-depth against vulnerabilities in image processing binaries

Also bumps landlock to 0.3 and brings in the latest `Discourse::SafeExec` (from #42049), which this change depends on. Landlock is supported on Linux kernel 5.13 and above.
