### PR TITLE
FIX: Hide Horizon's new topic button when another panel owns the sidebar

### DIFF
--- a/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/themes/horizon/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -19,15 +19,19 @@ export default class SidebarNewTopicButton extends Component {
   @service router;
   @service header;
   @service appEvents;
+  @service sidebarState;
   @controller application;
 
   @tracked category;
   @tracked tag;
 
+  // Keyed on the panel that owns the sidebar rather than on the path: every takeover displaces
+  // the forum navigation this button is part of, and most have no distinguishing URL prefix.
+  // `isForcingSidebar` is not equivalent, since a panel can take over without setting it.
   get shouldRender() {
     return (
       this.currentUser &&
-      !this.router.currentURL.startsWith("/admin") &&
+      this.sidebarState.showMainPanel &&
       this.application.sidebarEnabled
     );
   }

--- a/themes/horizon/spec/system/sidebar_topic_button_spec.rb
+++ b/themes/horizon/spec/system/sidebar_topic_button_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe "Sidebar New Topic Button" do
     end
   end
 
+  context "when another panel has taken over the sidebar" do
+    fab!(:admin)
+
+    before { sign_in(admin) }
+
+    it "hides the button in the admin sidebar and brings it back on the way out" do
+      visit("/admin")
+      expect(page).to have_no_css(".sidebar-new-topic-button__wrapper")
+
+      visit("/latest")
+      expect(page).to have_css(".sidebar-new-topic-button__wrapper")
+    end
+  end
+
   context "for anon" do
     it "does not render the sidebar button for anons" do
       visit("/latest")

--- a/themes/horizon/test/acceptance/sidebar-new-topic-button-test.gjs
+++ b/themes/horizon/test/acceptance/sidebar-new-topic-button-test.gjs
@@ -1,0 +1,46 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { ADMIN_PANEL, MAIN_PANEL } from "discourse/lib/sidebar/panels";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import SidebarNewTopicButton from "../../discourse/components/sidebar-new-topic-button";
+
+module(
+  "Horizon | Integration | Component | SidebarNewTopicButton",
+  function (hooks) {
+    // stubRouter supplies the currentRoute the button reads to pre-fill a category or tag.
+    setupRenderingTest(hooks, { stubRouter: true });
+
+    hooks.beforeEach(function () {
+      // Both of these gate rendering on their own, so without them the negative assertion below
+      // would pass no matter what the panel is. `sidebarEnabled` is a getter and has to be
+      // stubbed rather than set.
+      sinon
+        .stub(this.owner.lookup("controller:application"), "sidebarEnabled")
+        .get(() => true);
+      this.currentUser.set("can_create_topic", true);
+
+      // A plain forum path. The panel, not the path, is what should decide this, so the
+      // assertions below have to hold on a URL that looks like ordinary browsing.
+      this.owner.lookup("service:router").currentURL = "/latest";
+    });
+
+    test("renders while the forum panel owns the sidebar", async function (assert) {
+      this.owner.lookup("service:sidebar-state").setPanel(MAIN_PANEL);
+
+      await render(<template><SidebarNewTopicButton /></template>);
+
+      assert.dom(".sidebar-new-topic-button__wrapper").exists();
+    });
+
+    // Rendering happens without a URL, so nothing here can be hidden by matching a path. Admin
+    // stands in for every takeover, which all claim the sidebar the same way.
+    test("is hidden while another panel owns the sidebar", async function (assert) {
+      this.owner.lookup("service:sidebar-state").setPanel(ADMIN_PANEL);
+
+      await render(<template><SidebarNewTopicButton /></template>);
+
+      assert.dom(".sidebar-new-topic-button__wrapper").doesNotExist();
+    });
+  }
+);


### PR DESCRIPTION
Horizon renders its new topic button into the `before-sidebar-sections` outlet, which
is rendered for whatever panel is current. The button is panel-agnostic by
construction, and the only thing keeping it off the admin sidebar was a string
comparison against the current URL.

Any other panel that claims the sidebar slips past that check, and none of them have a
URL prefix worth matching. `isForcingSidebar` looks like the shared signal but is not
one: a panel can swap the current panel without setting it. `showMainPanel` is what
every takeover has in common.

This is latent on main today rather than a visible regression, because the other
in-repo takeovers claim the panel while the sidebar is disabled anyway. It stops being
latent with #42058, which moves the styleguide navigation into a sidebar panel: the
sidebar stays enabled there, the path is not `/admin`, and the forum's new topic
button renders on top of the styleguide's own navigation.

Admin behavior is unchanged. `AdminRoute#activate` calls `maybeForceAdminSidebar` with
`onlyIfAlreadyActive: false`, so the panel is forced unconditionally on every admin
route despite the method name.

### Tests

A rendering test asserts both directions on an ordinary forum URL: rendered while the
forum panel owns the sidebar, hidden while another panel does. Reverting the component
leaves it rendered in the second case.