### PR TITLE
FIX: Support uppercase in User Profile Website URL 

### DIFF
--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -260,10 +260,8 @@ class UserUpdater
           attributes.fetch(:name) { "" },
         )
       end
+
       DiscourseEvent.trigger(:within_user_updater_transaction, user, attributes)
-    rescue Addressable::URI::InvalidURIError
-      # Prevent 500 for crazy url input
-      return saved
     end
 
     if saved
@@ -375,6 +373,10 @@ class UserUpdater
 
   def format_url(website)
     return nil if website.blank?
-    website =~ /\Ahttp/ ? website : "http://#{website}"
+
+    uri = URI.parse(website)
+    "#{"http://" if uri.scheme.blank?}#{website}"
+  rescue URI::Error
+    website
   end
 end

--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -9,11 +9,13 @@ class UrlValidator < ActiveModel::EachValidator
           uri.is_a?(URI::HTTP) && !uri.host.nil? && uri.host.include?(".")
         rescue URI::Error => e
           if (e.message =~ /URI must be ascii only/)
-            value = UrlHelper.encode(value)
-            retry
+            begin
+              value = UrlHelper.encode(value)
+              retry
+            rescue Addressable::URI::InvalidURIError
+              false
+            end
           end
-
-          nil
         end
 
       unless valid

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -559,12 +559,35 @@ RSpec.describe UserUpdater do
     end
 
     context "when website does not include http" do
-      it "adds http before updating" do
+      it "adds http before updating if no scheme" do
         updater = UserUpdater.new(acting_user, user)
 
         updater.update(website: "example.com")
 
         expect(user.reload.user_profile.website).to eq "http://example.com"
+      end
+
+      it "returns an error for non-http scheme" do
+        updater = UserUpdater.new(acting_user, user)
+
+        expect(updater.update(website: "ftp://example.com")).to eq false
+        expect(updater.update(website: "file://example.com")).to eq false
+        expect(updater.update(website: "mailto://example.com")).to eq false
+        expect(updater.update(website: "something://example.com")).to eq false
+      end
+    end
+
+    context "when website includes http but with uppercase" do
+      it "does not add an additional http:// before" do
+        updater = UserUpdater.new(acting_user, user)
+        updater.update(website: "Http://example.com")
+        expect(user.reload.user_profile.website).to eq "Http://example.com"
+        updater.update(website: "hTtp://example.com")
+        expect(user.reload.user_profile.website).to eq "hTtp://example.com"
+        updater.update(website: "HTTP://example.com")
+        expect(user.reload.user_profile.website).to eq "HTTP://example.com"
+        updater.update(website: "HttpS://example.com")
+        expect(user.reload.user_profile.website).to eq "HttpS://example.com"
       end
     end
 
@@ -572,7 +595,8 @@ RSpec.describe UserUpdater do
       it "returns an error" do
         updater = UserUpdater.new(acting_user, user)
 
-        expect(updater.update(website: "ʔ<")).to eq nil
+        expect(updater.update(website: "ʔ<")).to eq false
+        expect(updater.update(website: "http://bad-domain-no-period")).to eq false
       end
     end
 


### PR DESCRIPTION
Don't prepend http:// to the beginning of user profile website if it has a scheme but the scheme contains uppercase letters.

A user reported an error when saving their profile which turned out to be due to the website in their profile being set to a URL starting with "Https://".

Previously, there was a case-sensitive regex checking if the URL started with "http" and otherwise prepending "http://", so a URL starting with "Https://..." would become "http://Https://" and eventually fail the URL validator. This PR changes that logic to instead parse the URL, check if it has a scheme, and only prepend "http://" in the case where there's no scheme.

It also fixes a small bug in the URL validator handling cases where `URI.parse()` and the fallback to `UrlHelper.encode()` both fail. I moved the exception handler into that method, where previously we were rescuing it at the end of `UserUpdater.update()` and failing to produce a proper error message.

Meta ref: /t/408630