### PR TITLE
FEATURE: Add basic slash actions to chat

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -10,6 +10,20 @@ module Chat
 
     BAKED_VERSION = 2
     EXCERPT_LENGTH = 150
+    SLASH_COMMAND_PATTERNS = {
+      me: {
+        pattern: %r{\A/me[ \t]+([^\r\n]+)\z},
+        formatter: :action,
+      },
+      shrug: {
+        pattern: %r{\A/shrug(?:[ \t]+([^\r\n]+))?\z},
+        text: "¯\\_(ツ)_/¯",
+      },
+      tableflip: {
+        pattern: %r{\A/tableflip(?:[ \t]+([^\r\n]+))?\z},
+        text: "(╯°□°)╯︵ ┻━┻",
+      },
+    }.freeze
 
     attribute :has_oneboxes, default: false
 
@@ -191,7 +205,8 @@ module Chat
     def cook
       ensure_last_editor_id
 
-      self.cooked = self.class.cook(message, user_id: last_editor_id)
+      self.cooked =
+        self.class.cook(message, user_id: last_editor_id, author_username: user&.username)
       self.cooked_version = BAKED_VERSION
 
       invalidate_parsed_mentions
@@ -252,6 +267,8 @@ module Chat
 
     def self.cook(message, opts = {})
       bot = opts[:user_id] && opts[:user_id].negative?
+      slash_command = match_slash_command(message, opts[:author_username])
+      message_to_cook = slash_command ? slash_command[:content] : message
 
       features = MARKDOWN_FEATURES.dup
       features << "image-grid" if bot
@@ -268,13 +285,14 @@ module Chat
       # is referencing.
       cooked =
         PrettyText.cook(
-          message,
+          message_to_cook,
           features_override: features + DiscoursePluginRegistry.chat_markdown_features.to_a,
           markdown_it_rules: rules,
           force_quote_link: true,
           user_id: opts[:user_id],
           hashtag_context: "chat-composer",
         )
+      cooked = format_slash_command(cooked, slash_command, opts[:author_username]) if slash_command
 
       result =
         Oneboxer.apply(cooked) do |url|
@@ -289,6 +307,60 @@ module Chat
       cooked = result.to_html if result.changed?
       cooked
     end
+
+    def self.match_slash_command(message, author_username)
+      return if message.blank?
+
+      SLASH_COMMAND_PATTERNS.each do |name, command|
+        next if command[:formatter] == :action && author_username.blank?
+        next if !(match = message.match(command[:pattern]))
+
+        return { name:, content: match[1].to_s, **command }
+      end
+
+      nil
+    end
+    private_class_method :match_slash_command
+
+    def self.format_slash_command(cooked, command, author_username)
+      if command[:formatter] == :action
+        format_action(cooked, author_username)
+      else
+        append_command_text(cooked, command[:text])
+      end
+    end
+    private_class_method :format_slash_command
+
+    def self.format_action(cooked, author_username)
+      fragment = Loofah.html5_fragment(cooked)
+      elements = fragment.children.select(&:element?)
+      return cooked if elements.length != 1 || elements.first.name != "p"
+
+      paragraph = elements.first
+      emphasis = Nokogiri::XML::Node.new("em", fragment.document)
+      emphasis["class"] = "chat-message-action"
+      emphasis.add_child(Nokogiri::XML::Text.new("#{author_username} ", fragment.document))
+      paragraph.children.to_a.each { |child| emphasis.add_child(child) }
+      paragraph.add_child(emphasis)
+
+      fragment.to_html
+    end
+    private_class_method :format_action
+
+    def self.append_command_text(cooked, text)
+      fragment = Loofah.html5_fragment(cooked)
+      elements = fragment.children.select(&:element?)
+      return cooked if elements.length > 1
+      return cooked if elements.one? && elements.first.name != "p"
+
+      paragraph = elements.first || Nokogiri::XML::Node.new("p", fragment.document)
+      fragment.add_child(paragraph) if elements.empty?
+      separator = paragraph.children.empty? ? "" : " "
+      paragraph.add_child(Nokogiri::XML::Text.new("#{separator}#{text}", fragment.document))
+
+      fragment.to_html
+    end
+    private_class_method :append_command_text
 
     def full_url
       "#{Discourse.base_url_no_prefix}#{url}"

--- a/plugins/chat/app/services/chat/create_message.rb
+++ b/plugins/chat/app/services/chat/create_message.rb
@@ -167,7 +167,12 @@ module Chat
         message: params.message,
         uploads: uploads,
         thread: thread,
-        cooked: ::Chat::Message.cook(params.message, user_id: guardian.user.id),
+        cooked:
+          ::Chat::Message.cook(
+            params.message,
+            user_id: guardian.user.id,
+            author_username: guardian.user.username,
+          ),
         cooked_version: ::Chat::Message::BAKED_VERSION,
         streaming: options.streaming,
         blocks: params.blocks,

--- a/plugins/chat/lib/chat/message_processor.rb
+++ b/plugins/chat/lib/chat/message_processor.rb
@@ -12,7 +12,10 @@ module Chat
       @size_cache = {}
       @opts = opts
 
-      cook_opts = { user_id: chat_message.last_editor_id }
+      cook_opts = {
+        user_id: chat_message.last_editor_id,
+        author_username: chat_message.user&.username,
+      }
       cook_opts[:invalidate_oneboxes] = true if opts[:invalidate_oneboxes] == true
       cooked = Chat::Message.cook(chat_message.message, **cook_opts)
       @doc = Loofah.html5_fragment(cooked)

--- a/plugins/chat/spec/lib/chat/message_processor_spec.rb
+++ b/plugins/chat/spec/lib/chat/message_processor_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe Chat::MessageProcessor do
   fab!(:message, :chat_message)
 
   it "cooks using the last_editor_id of the message" do
-    Chat::Message.expects(:cook).with(message.message, user_id: message.last_editor_id)
+    Chat::Message.expects(:cook).with(
+      message.message,
+      user_id: message.last_editor_id,
+      author_username: message.user.username,
+    )
     described_class.new(message)
   end
 
@@ -12,6 +16,7 @@ RSpec.describe Chat::MessageProcessor do
     Chat::Message.expects(:cook).with(
       message.message,
       user_id: message.last_editor_id,
+      author_username: message.user.username,
       invalidate_oneboxes: true,
     )
     described_class.new(message, invalidate_oneboxes: true)

--- a/plugins/chat/spec/models/chat/message_spec.rb
+++ b/plugins/chat/spec/models/chat/message_spec.rb
@@ -201,7 +201,85 @@ describe Chat::Message do
     end
   end
 
+  describe "#cook" do
+    fab!(:editor, :user)
+
+    it "uses the message author for a /me command after another user edits it" do
+      message.message = "/me waves"
+      message.last_editor = editor
+      message.cook
+
+      expect(message.cooked).to match_html(
+        %(<p><em class="chat-message-action">#{message.user.username} waves</em></p>),
+      )
+    end
+  end
+
   describe ".cook" do
+    context "with a /me command" do
+      it "renders the action with the author's username" do
+        cooked = described_class.cook("/me waves", author_username: "ducks")
+
+        expect(cooked).to match_html('<p><em class="chat-message-action">ducks waves</em></p>')
+      end
+
+      it "supports inline Markdown in the action" do
+        cooked = described_class.cook("/me waves **enthusiastically**", author_username: "ducks")
+
+        expect(cooked).to match_html(
+          '<p><em class="chat-message-action">ducks waves <strong>enthusiastically</strong></em></p>',
+        )
+      end
+
+      it "keeps links inline with the action" do
+        cooked = described_class.cook("/me visits https://example.com", author_username: "ducks")
+
+        expect(cooked).to match_html(
+          '<p><em class="chat-message-action">ducks visits <a href="https://example.com" rel="noopener nofollow ugc">https://example.com</a></em></p>',
+        )
+      end
+
+      it "does not match other commands or multiline messages" do
+        expect(described_class.cook("/message waves", author_username: "ducks")).to match_html(
+          "<p>/message waves</p>",
+        )
+        expect(described_class.cook("hello /me waves", author_username: "ducks")).to match_html(
+          "<p>hello /me waves</p>",
+        )
+        expect(described_class.cook("/me waves\nhello", author_username: "ducks")).to match_html(
+          "<p>/me waves<br>\nhello</p>",
+        )
+      end
+    end
+
+    context "with text expansion slash commands" do
+      it "expands /shrug with or without preceding text" do
+        expect(described_class.cook("/shrug")).to match_html("<p>¯\\_(ツ)_/¯</p>")
+        expect(described_class.cook("/shrug not sure")).to match_html("<p>not sure ¯\\_(ツ)_/¯</p>")
+      end
+
+      it "expands /tableflip with or without preceding text" do
+        expect(described_class.cook("/tableflip")).to match_html("<p>(╯°□°)╯︵ ┻━┻</p>")
+        expect(described_class.cook("/tableflip enough")).to match_html(
+          "<p>enough (╯°□°)╯︵ ┻━┻</p>",
+        )
+      end
+
+      it "supports inline Markdown in preceding text" do
+        expect(described_class.cook("/shrug **maybe**")).to match_html(
+          "<p><strong>maybe</strong> ¯\\_(ツ)_/¯</p>",
+        )
+      end
+
+      it "only matches commands at the start of single-line messages" do
+        expect(described_class.cook("hello /shrug")).to match_html("<p>hello /shrug</p>")
+        expect(described_class.cook("/shrugging")).to match_html("<p>/shrugging</p>")
+        expect(described_class.cook("/tableflip\nhello")).to match_html(
+          "<p>/tableflip<br>\nhello</p>",
+        )
+      end
+    end
+
     context "with enable_emoji_shortcuts site setting" do
       context "when enabled" do
         before { SiteSetting.enable_emoji_shortcuts = true }

--- a/plugins/chat/spec/services/chat/create_message_spec.rb
+++ b/plugins/chat/spec/services/chat/create_message_spec.rb
@@ -65,6 +65,35 @@ RSpec.describe Chat::CreateMessage do
 
     before { channel.add(guardian.user) }
 
+    context "with a /me command" do
+      let(:content) { "/me waves" }
+
+      it "preserves the raw message and cooks it as an action by the author" do
+        expect(message.message).to eq("/me waves")
+        expect(message.cooked).to match_html(
+          %(<p><em class="chat-message-action">#{user.username} waves</em></p>),
+        )
+      end
+    end
+
+    context "with a /shrug command" do
+      let(:content) { "/shrug not sure" }
+
+      it "preserves the raw message and expands the command" do
+        expect(message.message).to eq("/shrug not sure")
+        expect(message.cooked).to match_html("<p>not sure ¯\\_(ツ)_/¯</p>")
+      end
+    end
+
+    context "with a /tableflip command" do
+      let(:content) { "/tableflip" }
+
+      it "preserves the raw message and expands the command" do
+        expect(message.message).to eq("/tableflip")
+        expect(message.cooked).to match_html("<p>(╯°□°)╯︵ ┻━┻</p>")
+      end
+    end
+
     shared_examples "creating a new message" do
       it "saves the message" do
         expect { result }.to change { Chat::Message.count }.by(1)


### PR DESCRIPTION
Adds support for IRC-style /me action commands in Discourse Chat.

For example:

`/me waves`

is rendered as:

_ducks waves_

The original message remains stored as /me waves, so it can still be edited normally.

## Details
- Only recognizes /me  at the beginning of a single-line message.
- Supports inline Markdown, emoji, mentions, and links.
- Keeps links inline rather than converting them into oneboxes.
- Uses the original author’s username, even if another user edits the message.
- Adds a chat-message-action class to the rendered `<em>` element.
- Rebakes existing chat messages so previously posted /me messages are rendered as actions.
- Does not affect similar or embedded text such as /message or hello /me waves.

## Tests
- Basic /me rendering.
- Preserving the raw message.
- Inline Markdown and links.
- Original-author attribution after edits.
- Message processing and creation.
- False positives and multiline messages.