### PR TITLE
FIX: Run validation checks for heic, heif files before conversion

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -100,12 +100,6 @@ class UploadCreator
     sha1_before_changes = Upload.generate_digest(@file) if @file
 
     DistributedMutex.synchronize("upload_#{user_id}_#{@filename}") do
-      # We need to convert HEIFs early because FastImage does not consider them as images
-      if convert_heif_to_jpeg? && !external_upload_too_big
-        convert_heif!
-        is_image = FileHelper.is_supported_image?("test.#{@image_info.type}")
-      end
-
       if is_image && !external_upload_too_big
         extract_image_info!
         return @upload if @upload.errors.present?
@@ -115,6 +109,7 @@ class UploadCreator
         elsif @image_info.type == :ico
           convert_favicon_to_png!
         elsif !Rails.env.test? || @opts[:force_optimize]
+          convert_heif! if %i[heic heif].include?(@image_info.type)
           convert_to_jpeg! if convert_png_to_jpeg? || should_alter_quality?
           fix_orientation! if should_fix_orientation?
           crop! if should_crop?
@@ -417,10 +412,6 @@ class UploadCreator
     else
       jpeg_tempfile.close!
     end
-  end
-
-  def convert_heif_to_jpeg?
-    File.extname(@filename).downcase.match?(/\.hei(f|c)\z/)
   end
 
   def convert_heif!

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -319,9 +319,9 @@ RSpec.describe UploadCreator do
       let(:file) { file_from_fixtures(filename, "images") }
 
       it "should store the upload with the right extension" do
-        expect do UploadCreator.new(file, filename).create_for(user.id) end.to change {
-          Upload.count
-        }.by(1)
+        expect do
+          UploadCreator.new(file, filename, force_optimize: true).create_for(user.id)
+        end.to change { Upload.count }.by(1)
 
         upload = Upload.last
 

--- a/spec/services/external_upload_manager_spec.rb
+++ b/spec/services/external_upload_manager_spec.rb
@@ -104,6 +104,8 @@ RSpec.describe ExternalUploadManager do
       end
 
       context "when the upload does get changed by the UploadCreator" do
+        subject(:manager) { ExternalUploadManager.new(external_upload_stub, force_optimize: true) }
+
         let(:object_file) { file_from_fixtures("should_be_jpeg.heic", "images") }
         let(:object_size) { 1.megabyte }
         let(:external_upload_stub) do


### PR DESCRIPTION
FastImage detects heic and heif file formats now so the comment is stale and the extra conditional is no longer required. This change also means we now run `UploadCreator#extract_image_info!`validations checks where we check if the image is valid or have too many pixels before converting the image to jpeg.  