### PR TITLE
FIX: Skip dominant color calculation when the upload file is missing

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -387,8 +387,9 @@ class Upload < ActiveRecord::Base
           Discourse.store.download(self)
         end
 
-      if local_path.nil?
-        # Download failed. Could be too large to download, or file could be missing in s3
+      if local_path.nil? || !File.exist?(local_path)
+        # Download failed, or the file is gone from the store. Could be too large
+        # to download, or file could be missing in s3
         color = ""
       end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1001,6 +1001,14 @@ RSpec.describe Upload do
       expect(not_an_image.dominant_color).to eq("")
     end
 
+    it "stores an empty string when the file is missing from the store" do
+      File.delete(Discourse.store.path_for(white_image))
+
+      expect(white_image.dominant_color).to eq(nil)
+      expect(white_image.dominant_color(calculate_if_missing: true)).to eq("")
+      expect(white_image.dominant_color).to eq("")
+    end
+
     it "correctly handles invalid image files" do
       expect(invalid_image.dominant_color).to eq(nil)
       expect(invalid_image.dominant_color(calculate_if_missing: true)).to eq("")


### PR DESCRIPTION
Previously, `Upload#calculate_dominant_color!` passed the local path straight to ImageMagick. When the file was missing from the store the command simply failed, and the rescue for `Discourse::Utils::CommandError` stored an empty string so the upload was not re-evaluated. Since image processing was sandboxed, the sandbox validates read paths up front and raises `ArgumentError` before the command runs, and nothing rescues that. `Jobs::BackfillDominantColors` aborts the whole batch when a single upload's file is gone.

This commit checks that the file exists before shelling out and stores an empty string when it does not, matching what already happens when a download fails.
