### PR TITLE
PERF: limit categories rendered in dashboard category pickers

### DIFF
--- a/app/assets/stylesheets/admin/dashboard/engagement.scss
+++ b/app/assets/stylesheets/admin/dashboard/engagement.scss
@@ -111,7 +111,7 @@
     @container db-whos-posting (width < 22rem) {
       width: 100%;
 
-      .select-kit.multi-select.category-selector {
+      .select-kit.multi-select.multiple-categories-selector {
         max-width: none;
       }
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3223,6 +3223,10 @@ en:
         other: "Select at least %{count} items."
       components:
         filter_for_more: Filter for more…
+        multiple_categories_selector:
+          limited_results_notice:
+            one: "Showing %{shown} of %{count} category. Type to search for more."
+            other: "Showing %{shown} of %{count} categories. Type to search for more."
         categories_admin_dropdown:
           title: "Manage categories"
         tag_category_admin_dropdown:

--- a/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/activity-by-category.gjs
@@ -11,7 +11,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { number } from "discourse/lib/formatter";
 import Category from "discourse/models/category";
-import CategorySelector from "discourse/select-kit/components/category-selector";
+import MultipleCategoriesSelector from "discourse/select-kit/components/multiple-categories-selector";
 import { eq } from "discourse/truth-helpers";
 import dCategoryBadge from "discourse/ui-kit/helpers/d-category-badge";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -170,7 +170,7 @@ export default class ActivityByCategory extends Component {
           }}
         </LinkTo>
 
-        <CategorySelector
+        <MultipleCategoriesSelector
           @categories={{this.selectedCategories}}
           @onChange={{this.onCategoriesChange}}
           @options={{hash maximum=MAX_CATEGORIES}}

--- a/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
+++ b/frontend/discourse/admin/components/dashboard/engagement/whos-posting.gjs
@@ -9,7 +9,7 @@ import { trustHTML } from "@ember/template";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import Category from "discourse/models/category";
-import CategorySelector from "discourse/select-kit/components/category-selector";
+import MultipleCategoriesSelector from "discourse/select-kit/components/multiple-categories-selector";
 import { i18n } from "discourse-i18n";
 
 const ROW_ORDER = ["new_members", "returning", "staff"];
@@ -176,7 +176,7 @@ export default class WhosPosting extends Component {
           {{i18n "admin.dashboard.sections.engagement.whos_posting.title"}}
         </LinkTo>
         <div class="db-whos-posting__filter">
-          <CategorySelector
+          <MultipleCategoriesSelector
             @categories={{this.selectedCategories}}
             @onChange={{this.onCategoriesChange}}
             @onClose={{this.onClose}}

--- a/frontend/discourse/admin/components/report-filters/category-list.gjs
+++ b/frontend/discourse/admin/components/report-filters/category-list.gjs
@@ -3,7 +3,7 @@ import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import FilterComponent from "discourse/admin/components/report-filters/filter";
 import Category from "discourse/models/category";
-import CategorySelector from "discourse/select-kit/components/category-selector";
+import MultipleCategoriesSelector from "discourse/select-kit/components/multiple-categories-selector";
 
 export default class CategoryList extends FilterComponent {
   @tracked selectedCategories;
@@ -38,7 +38,7 @@ export default class CategoryList extends FilterComponent {
   }
 
   <template>
-    <CategorySelector
+    <MultipleCategoriesSelector
       @categories={{this.selectedCategories}}
       @onChange={{this.onChange}}
       @onClose={{this.onClose}}

--- a/frontend/discourse/select-kit/components/multiple-categories-selector.js
+++ b/frontend/discourse/select-kit/components/multiple-categories-selector.js
@@ -1,0 +1,128 @@
+import EmberObject, { action, computed } from "@ember/object";
+import { classNames } from "@ember-decorators/component";
+import { makeArray } from "discourse/lib/helpers";
+import Category from "discourse/models/category";
+import CategoryRow from "discourse/select-kit/components/category-row";
+import MultiSelectComponent from "discourse/select-kit/components/multi-select";
+import { i18n } from "discourse-i18n";
+import { pluginApiIdentifiers, selectKitOptions } from "./select-kit";
+import SelectedChoiceCategory from "./selected-choice-category";
+
+export const MAX_UNSELECTED_RESULTS = 30;
+export const LIMITED_RESULTS_NOTICE_VALUE =
+  "multiple-categories-selector-limited-results-notice";
+
+// Multi-select category picker. Unlike `category-selector`, it caps the
+// number of unselected categories rendered when there's no search text
+// (search still matches the full list), so opening the dropdown stays fast
+// on sites with thousands of categories. It also never uses
+// `lazy_load_categories`, since that feature may be removed.
+@classNames("multiple-categories-selector")
+@selectKitOptions({
+  filterable: true,
+  allowAny: false,
+  allowUncategorized: true,
+  displayCategoryDescription: false,
+  selectedChoiceComponent: SelectedChoiceCategory,
+})
+@pluginApiIdentifiers(["multiple-categories-selector"])
+export default class MultipleCategoriesSelector extends MultiSelectComponent {
+  categories = null;
+  blockedCategories = null;
+
+  init() {
+    super.init(...arguments);
+
+    if (!this.blockedCategories) {
+      this.set("blockedCategories", []);
+    }
+  }
+
+  @computed("categories.@each.id")
+  get value() {
+    return this.categories?.map?.((item) => item.id) ?? [];
+  }
+
+  @computed("categories.[]", "blockedCategories.[]")
+  get content() {
+    return Category.list().filter((category) => {
+      if (category.isUncategorizedCategory) {
+        if (this.options?.allowUncategorized !== undefined) {
+          return this.options.allowUncategorized;
+        }
+
+        return this.selectKit.options.allowUncategorized;
+      }
+
+      return (
+        this.categories.includes(category) ||
+        !this.blockedCategories.includes(category)
+      );
+    });
+  }
+
+  modifyComponentForRow() {
+    return CategoryRow;
+  }
+
+  search(filter) {
+    let categories = super.search(filter);
+
+    let uncappedTotal = null;
+    if (!filter && categories.length > MAX_UNSELECTED_RESULTS) {
+      uncappedTotal = categories.length;
+      categories = categories.slice(0, MAX_UNSELECTED_RESULTS);
+    }
+
+    if (
+      (categories.length === 1 ||
+        (categories.length > 0 &&
+          categories[0].name.localeCompare(filter || "") === 0)) &&
+      categories[0]?.subcategory_count > 0
+    ) {
+      categories.splice(
+        1,
+        0,
+        EmberObject.create({
+          id: `${categories[0].id}+subcategories`,
+          category: categories[0],
+        })
+      );
+    }
+
+    if (uncappedTotal) {
+      categories.push(
+        EmberObject.create({
+          id: LIMITED_RESULTS_NOTICE_VALUE,
+          label: i18n(
+            "select_kit.components.multiple_categories_selector.limited_results_notice",
+            { shown: MAX_UNSELECTED_RESULTS, count: uncappedTotal }
+          ),
+        })
+      );
+    }
+
+    return categories;
+  }
+
+  select(value, item) {
+    if (item?.category) {
+      this.selectKit.change(
+        makeArray(this.value).concat(
+          item.category.descendants.map((subcategory) => subcategory.id)
+        ),
+        makeArray(this.selectedContent).concat(item.category.descendants)
+      );
+    } else if (item?.id === LIMITED_RESULTS_NOTICE_VALUE) {
+      return;
+    } else {
+      super.select(value, item);
+    }
+  }
+
+  @action
+  _onChange(values) {
+    this.onChange(values.map((v) => Category.findById(v)).filter(Boolean));
+    return false;
+  }
+}

--- a/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/activity-by-category-test.gjs
@@ -137,7 +137,7 @@ module(
       assert.dom(".db-activity__empty").exists();
     });
 
-    test("includes a CategorySelector for filtering", async function (assert) {
+    test("includes a category selector for filtering", async function (assert) {
       await render(
         <template>
           <ActivityByCategory
@@ -148,7 +148,7 @@ module(
         </template>
       );
 
-      assert.dom(".category-selector").exists();
+      assert.dom(".multiple-categories-selector").exists();
     });
 
     test("prefills the selector with the categories shown by default", async function (assert) {
@@ -163,7 +163,7 @@ module(
       );
 
       assert.strictEqual(
-        selectKit(".category-selector").header().value(),
+        selectKit(".multiple-categories-selector").header().value(),
         "1,2,3"
       );
     });

--- a/frontend/discourse/tests/integration/components/dashboard/whos-posting-test.gjs
+++ b/frontend/discourse/tests/integration/components/dashboard/whos-posting-test.gjs
@@ -57,7 +57,7 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
       .dom("a.db-section__row-block-title.--label")
       .hasText("Who's posting?")
       .hasAttribute("href", /\/admin\/reports\/posters_by_member_type/);
-    assert.dom(".category-selector").exists();
+    assert.dom(".multiple-categories-selector").exists();
   });
 
   test("shows an 'All categories' placeholder when nothing is selected", async function (assert) {
@@ -72,7 +72,7 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
     );
 
     assert.strictEqual(
-      selectKit(".category-selector").header().label(),
+      selectKit(".multiple-categories-selector").header().label(),
       i18n("category.all")
     );
   });
@@ -90,7 +90,10 @@ module("Integration | Component | Dashboard | WhosPosting", function (hooks) {
       </template>
     );
 
-    assert.strictEqual(selectKit(".category-selector").header().value(), "1,2");
+    assert.strictEqual(
+      selectKit(".multiple-categories-selector").header().value(),
+      "1,2"
+    );
   });
 
   test("falls back to an empty-state message when there are no posts", async function (assert) {

--- a/frontend/discourse/tests/integration/components/select-kit/multiple-categories-selector-test.gjs
+++ b/frontend/discourse/tests/integration/components/select-kit/multiple-categories-selector-test.gjs
@@ -1,0 +1,146 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import Category from "discourse/models/category";
+import Site from "discourse/models/site";
+import MultipleCategoriesSelector, {
+  LIMITED_RESULTS_NOTICE_VALUE,
+  MAX_UNSELECTED_RESULTS,
+} from "discourse/select-kit/components/multiple-categories-selector";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import selectKit from "discourse/tests/helpers/select-kit-helper";
+
+module(
+  "Integration | Component | SelectKit | MultipleCategoriesSelector",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.set("subject", selectKit());
+      this.site = Site.current();
+      this.originalCategories = this.site.categories;
+    });
+
+    hooks.afterEach(function () {
+      this.site.categories = this.originalCategories;
+    });
+
+    test("with value", async function (assert) {
+      const category = Category.findById(1001);
+      const subcategory = Category.findById(1002);
+      const value = [category, subcategory];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+
+      assert.strictEqual(this.subject.header().value(), "1001,1002");
+      assert.strictEqual(
+        this.subject.header().label(),
+        "Parent Category, Sub Category"
+      );
+    });
+
+    test("has +subcategories row", async function (assert) {
+      const value = [];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+      await this.subject.expand();
+      await this.subject.fillInFilter("Parent Category");
+
+      assert.strictEqual(this.subject.rows().length, 2);
+      assert
+        .dom(this.subject.rowByIndex(0).el())
+        .hasText("Parent Category× 95");
+      assert
+        .dom(this.subject.rowByIndex(1).el())
+        .hasText("Parent Category× 95+2 subcategories");
+    });
+
+    test("caps unselected results and shows a notice when there are more than the limit", async function (assert) {
+      const extraCategories = Array.from(
+        { length: MAX_UNSELECTED_RESULTS + 20 },
+        (_, i) =>
+          Category.create({
+            id: 90000 + i,
+            name: `Extra Category ${i}`,
+            topic_count: 0,
+          })
+      );
+      this.site.categories = [...this.originalCategories, ...extraCategories];
+
+      const value = [];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+      await this.subject.expand();
+
+      assert.strictEqual(
+        this.subject.rows().length,
+        MAX_UNSELECTED_RESULTS + 1,
+        "shows the capped number of categories plus the notice row"
+      );
+      assert.true(
+        this.subject.rowByValue(LIMITED_RESULTS_NOTICE_VALUE).exists(),
+        "the notice row is rendered"
+      );
+    });
+
+    test("search reveals categories beyond the cap", async function (assert) {
+      const extraCategories = Array.from(
+        { length: MAX_UNSELECTED_RESULTS + 20 },
+        (_, i) =>
+          Category.create({
+            id: 90000 + i,
+            name: `Extra Category ${i}`,
+            topic_count: 0,
+          })
+      );
+      this.site.categories = [...this.originalCategories, ...extraCategories];
+
+      const value = [];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+      await this.subject.expand();
+      await this.subject.fillInFilter("Extra Category 39");
+
+      assert.strictEqual(
+        this.subject.rows().length,
+        1,
+        "the search matches exactly one category"
+      );
+      assert.true(
+        this.subject.rowByValue(90039).exists(),
+        "search finds a category beyond the cap"
+      );
+    });
+
+    test("no notice when the number of categories is within the limit", async function (assert) {
+      const value = [];
+
+      await render(
+        <template>
+          <MultipleCategoriesSelector @categories={{value}} />
+        </template>
+      );
+      await this.subject.expand();
+
+      assert.false(
+        this.subject.rowByValue(LIMITED_RESULTS_NOTICE_VALUE).exists(),
+        "no capped-results notice when nothing is capped"
+      );
+    });
+  }
+);

--- a/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support.gjs
+++ b/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support.gjs
@@ -11,7 +11,7 @@ import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { durationTiny } from "discourse/lib/formatter";
 import Category from "discourse/models/category";
-import CategorySelector from "discourse/select-kit/components/category-selector";
+import MultipleCategoriesSelector from "discourse/select-kit/components/multiple-categories-selector";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import SupportResponseTime from "./support/response-time";
@@ -340,7 +340,7 @@ export default class SupportSection extends Component {
 
         {{#if this.showFilter}}
           <div class="db-support__filter">
-            <CategorySelector
+            <MultipleCategoriesSelector
               @categories={{this.selectedCategories}}
               @blockedCategories={{this.blockedCategories}}
               @onChange={{this.onCategoriesChange}}

--- a/plugins/discourse-solved/assets/stylesheets/admin/dashboard-support.scss
+++ b/plugins/discourse-solved/assets/stylesheets/admin/dashboard-support.scss
@@ -5,7 +5,7 @@
 $db-bar-height: var(--space-2);
 
 .db-support__filter {
-  .select-kit.multi-select.category-selector {
+  .select-kit.multi-select.multiple-categories-selector {
     max-width: 220px;
   }
 }

--- a/plugins/discourse-solved/spec/system/page_objects/components/admin_dashboard_support.rb
+++ b/plugins/discourse-solved/spec/system/page_objects/components/admin_dashboard_support.rb
@@ -43,7 +43,7 @@ module PageObjects
         has_no_css?("#{SELECTOR} .db-support__filter")
       end
 
-      CATEGORY_FILTER = "#{SELECTOR} .db-support__filter .category-selector"
+      CATEGORY_FILTER = "#{SELECTOR} .db-support__filter .multiple-categories-selector"
 
       def category_filter
         PageObjects::Components::SelectKit.new(CATEGORY_FILTER)

--- a/plugins/discourse-solved/test/javascripts/integration/support-test.gjs
+++ b/plugins/discourse-solved/test/javascripts/integration/support-test.gjs
@@ -246,7 +246,7 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
     );
 
     assert.dom(".db-support__filter").exists("shown with multiple categories");
-    assert.dom(".category-selector").exists();
+    assert.dom(".multiple-categories-selector").exists();
   });
 
   test("prefills the selector with the persisted category selection", async function (assert) {
@@ -268,6 +268,9 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
       </template>
     );
 
-    assert.strictEqual(selectKit(".category-selector").header().value(), "1,2");
+    assert.strictEqual(
+      selectKit(".multiple-categories-selector").header().value(),
+      "1,2"
+    );
   });
 });

--- a/spec/system/page_objects/components/admin_dashboard_engagement.rb
+++ b/spec/system/page_objects/components/admin_dashboard_engagement.rb
@@ -4,8 +4,8 @@ module PageObjects
   module Components
     class AdminDashboardEngagement < PageObjects::Components::Base
       SECTION = "[data-section-id='engagement']"
-      ACTIVITY_CATEGORY_FILTER = "#{SECTION} .db-activity .category-selector"
-      WHOS_POSTING_CATEGORY_FILTER = "#{SECTION} .db-whos-posting .category-selector"
+      ACTIVITY_CATEGORY_FILTER = "#{SECTION} .db-activity .multiple-categories-selector"
+      WHOS_POSTING_CATEGORY_FILTER = "#{SECTION} .db-whos-posting .multiple-categories-selector"
       ACTIVITY_CATEGORY_CELL = "#{SECTION} .db-activity-table__cell-category"
 
       def activity_category_filter

--- a/spec/system/page_objects/pages/admin_report.rb
+++ b/spec/system/page_objects/pages/admin_report.rb
@@ -40,7 +40,7 @@ module PageObjects
         PageObjects::Components::DFilterControls.new(".d-filter-controls")
       end
 
-      CATEGORY_FILTER = ".admin-report .chart__additional-filters .category-selector"
+      CATEGORY_FILTER = ".admin-report .chart__additional-filters .multiple-categories-selector"
 
       def visit_report(type)
         page.visit("/admin/reports/#{type}")


### PR DESCRIPTION
On sites with many categories, opening a category filter on the new admin dashboard or the classic report page could take several seconds because every category was rendered at once. These pickers now show a capped list by default, with search still able to find any category.