### PR TITLE
FIX: Correct topic OG image timeout

### DIFF
--- a/lib/topic_og_image_generator.rb
+++ b/lib/topic_og_image_generator.rb
@@ -342,7 +342,7 @@ class TopicOgImageGenerator
         read: [svg_path],
         write: [dir],
         nice: 10,
-        timeout: 20_000,
+        timeout: 20,
       )
 
       return nil unless File.exist?(png_path)


### PR DESCRIPTION
Topic OG image rasterization passed 20,000 to a seconds-based timeout, allowing a stalled command to occupy a worker for roughly 5.5 hours.