### PR TITLE
DEV: Resolve preload-store-test flake

### DIFF
--- a/frontend/discourse/tests/unit/lib/preload-store-test.js
+++ b/frontend/discourse/tests/unit/lib/preload-store-test.js
@@ -6,12 +6,20 @@ import PreloadStore, { readPreloadedData } from "discourse/lib/preload-store";
 module("Unit | Utility | preload-store", function (hooks) {
   setupTest(hooks);
 
+  let realPreloadElement;
+
   hooks.beforeEach(function () {
     PreloadStore.store("bane", "evil");
+
+    realPreloadElement = document.getElementById("data-preloaded");
+    realPreloadElement?.remove();
   });
 
   hooks.afterEach(function () {
     document.getElementById("data-preloaded")?.remove();
+    if (realPreloadElement) {
+      document.head.append(realPreloadElement);
+    }
   });
 
   test("readPreloadedData reads JSON script content", function (assert) {


### PR DESCRIPTION
There is already a `#data-preloaded` on the page, which was interacting badly with the test. Add before/after logic to temporarily remove the real preload element while these tests run, then restore it afterwards.