### PR TITLE
UX: hide double empty state on chat thread

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-channel-preview-card.scss
@@ -1,3 +1,14 @@
+@use "lib/viewport";
+
+.chat-thread:has(.chat-channel-preview-card) {
+  .--channel-thread & {
+    @include viewport.from(sm) {
+      padding-bottom: var(--space-8);
+      box-sizing: border-box;
+    }
+  }
+}
+
 .chat-channel-preview-card {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -17,6 +28,12 @@
   width: max-content;
   min-width: 60%;
   box-sizing: border-box;
+
+  .--channel-thread & {
+    @include viewport.from(sm) {
+      display: none;
+    }
+  }
 
   &.--no-access {
     grid-template-columns: auto 1fr;

--- a/plugins/chat/spec/system/visit_channel_spec.rb
+++ b/plugins/chat/spec/system/visit_channel_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Visit channel" do
             it "allows to join it" do
               chat.visit_thread(thread)
 
-              expect(page).to have_css(".toggle-channel-membership-button.-join", count: 2)
+              expect(page).to have_css(".toggle-channel-membership-button.-join", count: 1)
             end
           end
         end


### PR DESCRIPTION
Hides the `preview-card` empty state on threads on desktop, to avoid doubling up.
Still shows on mobile.