### PR TITLE
DEV: Make nested scroll restoration spec deterministic

### DIFF
--- a/frontend/discourse/app/components/nested.gjs
+++ b/frontend/discourse/app/components/nested.gjs
@@ -39,6 +39,9 @@ const postExcerpt = helper(([post]) => {
 const MOBILE_ROOT_VIEW_COLLAPSE_DEPTH = 3;
 const STORED_SCROLL_ANCHORS = Object.create(null);
 
+// Exported so system specs can wait out the full restoration window.
+export const SCROLL_RESTORE_WINDOW_MS = 1250;
+
 export default class Nested extends Component {
   @service appEvents;
   @service currentUser;
@@ -440,7 +443,7 @@ export default class Nested extends Component {
       }
       this.#scrollRestoreCompletionTimer = setTimeout(() => {
         this.#cancelScrollRestoration({ clearAnchor: true });
-      }, 1250);
+      }, SCROLL_RESTORE_WINDOW_MS);
     });
   }
 

--- a/spec/system/nested_scroll_restoration_spec.rb
+++ b/spec/system/nested_scroll_restoration_spec.rb
@@ -78,16 +78,21 @@ RSpec.describe "Nested view scroll restoration" do
     nested_view.scroll_to_post(target_post)
     saved_position = nested_view.current_scroll_position
 
-    nested_view.visit_nested(topic)
-    expect(nested_view).to have_root_post_count(20)
+    nested_view.with_root_pagination_paused(topic) do |pagination|
+      nested_view.visit_nested(topic)
+      expect(nested_view).to have_root_post_count(20)
+      pagination.wait
 
-    restored_position = nested_view.current_scroll_position
-    nested_view.wheel_down.scroll_to_bottom
-    after_bottom_position = nested_view.current_scroll_position
+      restored_position = nested_view.current_scroll_position
+      after_user_scroll_position = nested_view.user_scroll_by(distance: -1000)
+      centered_post_number = nested_view.centered_root_post_number
+      pagination.resume
 
-    expect(restored_position).to be < saved_position
-    expect(after_bottom_position).to be >= restored_position
-    expect(nested_view).to have_root_post_count(40)
-    expect(nested_view.current_scroll_position).to be_within(10).of(after_bottom_position)
+      expect(restored_position).to be < saved_position
+      expect(after_user_scroll_position).to be < restored_position - 500
+      expect(nested_view).to have_root_post_count(40)
+      expect(nested_view.scroll_position_after_restore_window).to be < saved_position
+      expect(nested_view.centered_root_post_number).to eq(centered_post_number)
+    end
   end
 end

--- a/spec/system/page_objects/cdp.rb
+++ b/spec/system/page_objects/cdp.rb
@@ -2,6 +2,34 @@
 
 module PageObjects
   class CDP
+    class PausedRequest
+      def initialize
+        @request_started = Queue.new
+        @resume_request = Queue.new
+        @resumed = false
+      end
+
+      def intercept(route, _request)
+        @request_started << true
+        @resume_request.pop
+        route.continue
+      end
+
+      def wait
+        return if @request_started.pop(timeout: Capybara.default_max_wait_time)
+
+        raise Capybara::ExpectationNotMet, "Timed out waiting for the paused request"
+      end
+
+      def resume
+        return if @resumed
+
+        @resumed = true
+        @resume_request << true
+      end
+    end
+    private_constant :PausedRequest
+
     include Capybara::DSL
     include SystemHelpers
     include RSpec::Matchers
@@ -160,6 +188,19 @@ module PageObjects
         yield
       ensure
         pw_page.unroute(pattern)
+      end
+    end
+
+    def with_paused_request(pattern)
+      paused_request = PausedRequest.new
+      handler = paused_request.method(:intercept)
+
+      page.driver.with_playwright_page do |pw_page|
+        pw_page.route(pattern, handler, times: 1)
+        yield(paused_request)
+      ensure
+        paused_request.resume
+        pw_page.unroute(pattern, handler:)
       end
     end
   end

--- a/spec/system/page_objects/pages/nested_view.rb
+++ b/spec/system/page_objects/pages/nested_view.rb
@@ -3,6 +3,8 @@
 module PageObjects
   module Pages
     class NestedView < PageObjects::Pages::Base
+      SCROLL_RESTORE_WINDOW_MS = 1300
+
       def visit_nested(topic, query: nil)
         url = "/t/#{topic.slug}/#{topic.id}"
         url += "?#{query}" if query
@@ -247,6 +249,11 @@ module PageObjects
         page.evaluate_script("window.scrollY")
       end
 
+      def with_root_pagination_paused(topic, &block)
+        pattern = %r{/n/#{Regexp.escape(topic.slug)}/#{topic.id}\.json\?.*\bpage=1(?:&|$)}
+        PageObjects::CDP.new.with_paused_request(pattern, &block)
+      end
+
       def disable_cloaking
         page.execute_script(
           'require("discourse/modifiers/post-stream-viewport-tracker").disableCloaking()',
@@ -259,12 +266,52 @@ module PageObjects
         self
       end
 
-      def wheel_down
+      def user_scroll_by(distance:)
         page.driver.with_playwright_page do |playwright_page|
-          playwright_page.mouse.move(200, 200)
-          playwright_page.mouse.wheel(0, 1000)
+          viewport = playwright_page.viewport_size
+          playwright_page.mouse.move(viewport[:width] * 0.65, viewport[:height] * 0.5)
+          playwright_page.mouse.wheel(0, distance)
         end
-        self
+
+        page.evaluate_async_script(<<~JS)
+          const done = arguments[0];
+          let previousPosition;
+          let stableFrames = 0;
+
+          const finishWhenStable = () => {
+            const currentPosition = window.scrollY;
+            stableFrames =
+              currentPosition === previousPosition ? stableFrames + 1 : 0;
+            previousPosition = currentPosition;
+
+            if (stableFrames === 2) {
+              done(currentPosition);
+            } else {
+              requestAnimationFrame(finishWhenStable);
+            }
+          };
+
+          requestAnimationFrame(finishWhenStable);
+        JS
+      end
+
+      def centered_root_post_number
+        page.evaluate_script(<<~JS)
+          (() => {
+            const roots = document.querySelector(".nested-view__roots");
+            const rootsRect = roots.getBoundingClientRect();
+            const element = document.elementFromPoint(
+              rootsRect.left + rootsRect.width / 2,
+              window.innerHeight / 2
+            );
+            const root = element?.closest(".nested-post");
+            const article = root?.querySelector(
+              ":scope > .nested-post__main > [data-post-number]"
+            );
+
+            return Number(article?.dataset.postNumber);
+          })()
+        JS
       end
 
       def scroll_to_post(post)
@@ -570,6 +617,13 @@ module PageObjects
             positions.afterRetries = window.scrollY;
             done(positions);
           }, 250);
+        JS
+      end
+
+      def scroll_position_after_restore_window
+        page.evaluate_async_script(<<~JS)
+          const done = arguments[0];
+          setTimeout(() => done(window.scrollY), #{SCROLL_RESTORE_WINDOW_MS});
         JS
       end
 

--- a/spec/system/page_objects/pages/nested_view.rb
+++ b/spec/system/page_objects/pages/nested_view.rb
@@ -3,8 +3,6 @@
 module PageObjects
   module Pages
     class NestedView < PageObjects::Pages::Base
-      SCROLL_RESTORE_WINDOW_MS = 1300
-
       def visit_nested(topic, query: nil)
         url = "/t/#{topic.slug}/#{topic.id}"
         url += "?#{query}" if query
@@ -267,21 +265,26 @@ module PageObjects
       end
 
       def user_scroll_by(distance:)
+        start_position = current_scroll_position
+
         page.driver.with_playwright_page do |playwright_page|
           viewport = playwright_page.viewport_size
           playwright_page.mouse.move(viewport[:width] * 0.65, viewport[:height] * 0.5)
           playwright_page.mouse.wheel(0, distance)
         end
 
-        page.evaluate_async_script(<<~JS)
-          const done = arguments[0];
+        page.evaluate_async_script(<<~JS, start_position)
+          const [startPosition, done] = arguments;
           let previousPosition;
           let stableFrames = 0;
 
           const finishWhenStable = () => {
             const currentPosition = window.scrollY;
+            const hasMoved = currentPosition !== startPosition;
             stableFrames =
-              currentPosition === previousPosition ? stableFrames + 1 : 0;
+              hasMoved && currentPosition === previousPosition
+                ? stableFrames + 1
+                : 0;
             previousPosition = currentPosition;
 
             if (stableFrames === 2) {
@@ -623,7 +626,8 @@ module PageObjects
       def scroll_position_after_restore_window
         page.evaluate_async_script(<<~JS)
           const done = arguments[0];
-          setTimeout(() => done(window.scrollY), #{SCROLL_RESTORE_WINDOW_MS});
+          const { SCROLL_RESTORE_WINDOW_MS } = require("discourse/components/nested");
+          setTimeout(() => done(window.scrollY), SCROLL_RESTORE_WINDOW_MS + 50);
         JS
       end
 


### PR DESCRIPTION
Previously, the nested scroll restoration system spec raced pagination and sampled transient scroll positions, which caused intermittent failures.

This change pauses pagination until the user scroll is complete and verifies the visible post remains stable through the restoration retry window.