### PR TITLE
FIX: Validate `resumableFilename` in `check_backup_chunk` to prevent path traversa...

### DIFF
--- a/app/controllers/admin/backups_controller.rb
+++ b/app/controllers/admin/backups_controller.rb
@@ -178,6 +178,7 @@ class Admin::BackupsController < Admin::AdminController
     current_chunk_size = params.fetch(:resumableCurrentChunkSize).to_i
 
     raise Discourse::InvalidParameters.new(:resumableIdentifier) unless valid_filename?(identifier)
+    raise Discourse::InvalidParameters.new(:resumableFilename) unless valid_filename?(filename)
 
     # path to chunk file
     chunk = BackupRestore::LocalBackupStore.chunk_path(identifier, filename, chunk_number)

--- a/spec/requests/admin/backups_controller_spec.rb
+++ b/spec/requests/admin/backups_controller_spec.rb
@@ -765,6 +765,44 @@ RSpec.describe Admin::BackupsController do
           expect(response.status).to eq(400)
         end
       end
+
+      describe "when resumableFilename contains path traversal characters" do
+        it "does not reveal the status of a chunk outside its upload directory" do
+          traversed_chunk = backup_path("traversed-backup.tar.gz.part1")
+          File.write(traversed_chunk, "secret")
+          @paths = [traversed_chunk]
+          chunk_directory = backup_path(File.join("tmp", "upload"))
+          FileUtils.mkdir_p(chunk_directory)
+
+          begin
+            get "/admin/backups/upload.json",
+                params: {
+                  resumableIdentifier: "upload",
+                  resumableFilename: "../../traversed-backup.tar.gz",
+                  resumableChunkNumber: "1",
+                  resumableCurrentChunkSize: File.size(traversed_chunk).to_s,
+                }
+
+            expect(response.status).to eq(400)
+            expect(response.parsed_body["errors"]).to contain_exactly(
+              I18n.t("invalid_params", message: "resumableFilename"),
+            )
+
+            get "/admin/backups/upload.json",
+                params: {
+                  resumableIdentifier: "upload",
+                  resumableFilename: "missing-backup.tar.gz",
+                  resumableChunkNumber: "1",
+                  resumableCurrentChunkSize: "6",
+                }
+
+            expect(response.status).to eq(404)
+            expect(response.body).to eq("")
+          ensure
+            FileUtils.rm_rf(chunk_directory)
+          end
+        end
+      end
     end
 
     shared_examples "checking backup chunk not allowed" do


### PR DESCRIPTION
## Summary

Correctly validate the `resumableFilename` parameter in the `check_backup_chunk` endpoint before constructing any filesystem path. Previously, only the identifier was validated, allowing path traversal sequences to expose an existence-and-size oracle for `.part` chunk files outside the intended upload directory. The fix applies the existing `valid_filename?` check to the filename parameter, matching the protection already present on the upload endpoint.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1558

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>