### PR TITLE
UX: Hide signup when the site is in read only or staff only mode

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1081,7 +1081,7 @@ module ApplicationHelper
   end
 
   def can_sign_up?
-    SiteSetting.allow_new_registrations && !SiteSetting.invite_only &&
+    !@readonly_mode && SiteSetting.allow_new_registrations && !SiteSetting.invite_only &&
       !SiteSetting.enable_discourse_connect
   end
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2810,10 +2810,15 @@ en:
     home: "Home"
     read_only_mode:
       enabled: "This site is in read only mode. Please continue to browse, but replying, likes, and other actions are disabled for now."
+      enabled_anonymous: "This site is in read only mode. Please continue to browse, but signing up and logging in are unavailable for now."
       login_disabled: "Login is disabled while the site is in read only mode."
       logout_disabled: "Logout is disabled while the site is in read only mode."
+      signup_disabled: "Signing up is disabled while the site is in read only mode."
     staff_writes_only_mode:
       enabled: "This site is in staff only mode. Please continue to browse, but replying, likes, and other actions are limited to staff members only."
+      enabled_anonymous: "This site is in staff only mode. Please continue to browse, but signing up is unavailable and only staff members can log in."
+      login_disabled: "Only staff members can log in while the site is in staff only mode."
+      signup_disabled: "Signing up is disabled while the site is in staff only mode."
 
     logs_error_rate_notice:
       # This string uses the ICU Message Format. See https://meta.discourse.org/t/7035 for translation guidelines.

--- a/frontend/discourse/app/components/code-login-form.gjs
+++ b/frontend/discourse/app/components/code-login-form.gjs
@@ -16,7 +16,7 @@ import WelcomeHeader from "discourse/components/welcome-header";
 import lazyHash from "discourse/helpers/lazy-hash";
 import valueEntered from "discourse/helpers/value-entered";
 import { ajax } from "discourse/lib/ajax";
-import { popupAjaxError } from "discourse/lib/ajax-error";
+import { isReadOnlyError, popupAjaxError } from "discourse/lib/ajax-error";
 import cookie, { removeCookie } from "discourse/lib/cookie";
 import discourseDebounce from "discourse/lib/debounce";
 import escape from "discourse/lib/escape";
@@ -36,6 +36,7 @@ import { i18n } from "discourse-i18n";
 const RESEND_COOLDOWN_SECONDS = 30;
 
 export default class CodeLoginForm extends Component {
+  @service login;
   @service site;
   @service modal;
 
@@ -321,7 +322,11 @@ export default class CodeLoginForm extends Component {
 
       this.redirectAfterLogin(result?.redirect_url);
     } catch (e) {
-      popupAjaxError(e);
+      if (isReadOnlyError(e)) {
+        this.codeError = this.login.readOnlyLoginMessage;
+      } else {
+        popupAjaxError(e);
+      }
     } finally {
       this.verifying = false;
     }

--- a/frontend/discourse/app/components/global-notice.gjs
+++ b/frontend/discourse/app/components/global-notice.gjs
@@ -122,14 +122,18 @@ export default class GlobalNotice extends Component {
     if (this.site.get("isStaffWritesOnly")) {
       notices.push(
         Notice.create({
-          text: i18n("staff_writes_only_mode.enabled"),
+          text: this.currentUser
+            ? i18n("staff_writes_only_mode.enabled")
+            : i18n("staff_writes_only_mode.enabled_anonymous"),
           id: "alert-staff-writes-only",
         })
       );
     } else if (this.site.get("isReadOnly")) {
       notices.push(
         Notice.create({
-          text: i18n("read_only_mode.enabled"),
+          text: this.currentUser
+            ? i18n("read_only_mode.enabled")
+            : i18n("read_only_mode.enabled_anonymous"),
           id: "alert-read-only",
         })
       );

--- a/frontend/discourse/app/components/local-login-form.gjs
+++ b/frontend/discourse/app/components/local-login-form.gjs
@@ -13,7 +13,7 @@ import SecondFactorForm from "discourse/components/second-factor-form";
 import SecurityKeyForm from "discourse/components/security-key-form";
 import valueEntered from "discourse/helpers/value-entered";
 import { ajax } from "discourse/lib/ajax";
-import { popupAjaxError } from "discourse/lib/ajax-error";
+import { isReadOnlyError, popupAjaxError } from "discourse/lib/ajax-error";
 import { escapeExpression } from "discourse/lib/utilities";
 import { getWebauthnCredential } from "discourse/lib/webauthn";
 import DPasswordField from "discourse/ui-kit/d-password-field";
@@ -23,6 +23,7 @@ import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 
 export default class LocalLoginForm extends Component {
+  @service login;
   @service modal;
   @service siteSettings;
 
@@ -112,7 +113,12 @@ export default class LocalLoginForm extends Component {
         this.args.flashTypeChanged("success");
       }
     } catch (e) {
-      popupAjaxError(e);
+      if (isReadOnlyError(e)) {
+        this.args.flashChanged(this.login.readOnlyLoginMessage);
+        this.args.flashTypeChanged("error");
+      } else {
+        popupAjaxError(e);
+      }
     } finally {
       this.processingEmailLink = false;
     }

--- a/frontend/discourse/app/controllers/application.js
+++ b/frontend/discourse/app/controllers/application.js
@@ -95,9 +95,9 @@ export default class ApplicationController extends Controller {
     return this.showFooter && this.siteSettings.enable_powered_by_discourse;
   }
 
-  @computed
   get canSignUp() {
     return (
+      !this.site.isReadOnly &&
       !this.siteSettings.invite_only &&
       this.siteSettings.allow_new_registrations &&
       !this.siteSettings.enable_discourse_connect

--- a/frontend/discourse/app/controllers/login.js
+++ b/frontend/discourse/app/controllers/login.js
@@ -6,7 +6,7 @@ import { trustHTML } from "@ember/template";
 import { isEmpty } from "@ember/utils";
 import NotActivatedModal from "discourse/components/modal/not-activated";
 import { ajax } from "discourse/lib/ajax";
-import { popupAjaxError } from "discourse/lib/ajax-error";
+import { isReadOnlyError, popupAjaxError } from "discourse/lib/ajax-error";
 import cookie, { removeCookie } from "discourse/lib/cookie";
 import escape from "discourse/lib/escape";
 import getURL from "discourse/lib/get-url";
@@ -318,11 +318,8 @@ export default class LoginPageController extends Controller {
       this.flashType = "error";
       if (e.jqXHR?.status === 429) {
         this.flash = i18n("login.rate_limit");
-      } else if (
-        e.jqXHR?.status === 503 &&
-        e.jqXHR?.responseJSON?.error_type === "read_only"
-      ) {
-        this.flash = i18n("read_only_mode.login_disabled");
+      } else if (isReadOnlyError(e)) {
+        this.flash = this.login.readOnlyLoginMessage;
       } else if (!areCookiesEnabled()) {
         this.flash = i18n("login.cookies_error");
       } else {

--- a/frontend/discourse/app/instance-initializers/signup-cta.js
+++ b/frontend/discourse/app/instance-initializers/signup-cta.js
@@ -9,7 +9,7 @@ const PROMPT_HIDE_DURATION = ONE_DAY;
 export default {
   initialize(owner) {
     const appEvents = owner.lookup("service:app-events");
-    const { canSignUp } = owner.lookup("controller:application");
+    const applicationController = owner.lookup("controller:application");
     const currentUser = owner.lookup("service:current-user");
     const keyValueStore = owner.lookup("service:key-value-store");
     const screenTrack = owner.lookup("service:screen-track");
@@ -24,9 +24,6 @@ export default {
     if (!enable_signup_cta) {
       return;
     }
-    if (!canSignUp) {
-      return;
-    }
     if (login_required) {
       return;
     }
@@ -35,6 +32,10 @@ export default {
     }
 
     function checkSignupCtaRequirements() {
+      if (!applicationController.canSignUp) {
+        return; // signup is unavailable
+      }
+
       if (session.get("showSignupCta")) {
         return; // already shown
       }

--- a/frontend/discourse/app/lib/ajax-error.js
+++ b/frontend/discourse/app/lib/ajax-error.js
@@ -87,6 +87,11 @@ export function extractError(error, defaultMessage) {
   return extractErrorInfo(error, defaultMessage).message;
 }
 
+export function isReadOnlyError(error) {
+  const xhr = error.jqXHR ?? error;
+  return xhr.status === 503 && xhr.responseJSON?.error_type === "read_only";
+}
+
 export function throwAjaxError(undoCallback, defaultMessage) {
   return function (error) {
     // If we provided an `undo` callback

--- a/frontend/discourse/app/routes/login.js
+++ b/frontend/discourse/app/routes/login.js
@@ -3,11 +3,11 @@ import cookie from "discourse/lib/cookie";
 import getURL from "discourse/lib/get-url";
 import DiscourseURL from "discourse/lib/url";
 import {
+  defaultHomepage,
   isValidDestinationUrl,
   postRNWebviewMessage,
 } from "discourse/lib/utilities";
 import DiscourseRoute from "discourse/routes/discourse";
-import { i18n } from "discourse-i18n";
 
 export default class extends DiscourseRoute {
   @service capabilities;
@@ -29,11 +29,17 @@ export default class extends DiscourseRoute {
     const { referrer } = document;
     const { isOnlyOneExternalLoginMethod, singleExternalLogin } = this.login;
     const redirect = auth_immediately || login_required || !from || wantsTo;
+    const homepage = `discovery.${login_required ? "login-required" : defaultHomepage()}`;
 
     // Regular users can't log in but staff can when the site is read-only
     if (isReadOnly && !isStaffWritesOnly) {
-      transition.abort();
-      dialog.alert(i18n("read_only_mode.login_disabled"));
+      if (from) {
+        transition.abort();
+      } else {
+        router.replaceWith(homepage).followRedirects();
+      }
+
+      dialog.alert(this.login.readOnlyLoginMessage);
       return;
     }
 

--- a/frontend/discourse/app/routes/signup.js
+++ b/frontend/discourse/app/routes/signup.js
@@ -8,7 +8,6 @@ import {
   postRNWebviewMessage,
 } from "discourse/lib/utilities";
 import DiscourseRoute from "discourse/routes/discourse";
-import { i18n } from "discourse-i18n";
 
 export default class extends DiscourseRoute {
   @service capabilities;
@@ -35,18 +34,23 @@ export default class extends DiscourseRoute {
     const { canSignUp } = this.controllerFor("application");
     const { isOnlyOneExternalLoginMethod, singleExternalLogin } = this.login;
     const redirect = auth_immediately || login_required || !from || wantsTo;
+    const homepage = `discovery.${login_required ? "login-required" : defaultHomepage()}`;
 
     // Can't sign up when the site is read-only
     if (isReadOnly) {
-      transition.abort();
-      dialog.alert(i18n("read_only_mode.login_disabled"));
+      if (from) {
+        transition.abort();
+      } else {
+        router.replaceWith(homepage).followRedirects();
+      }
+
+      dialog.alert(this.login.readOnlySignupMessage);
       return;
     }
 
     // In some cases, the user is only allowed to log in, not sign up
     if (!canSignUp && (invite_only || !auth_immediately)) {
-      const route = `discovery.${login_required ? "login-required" : defaultHomepage()}`;
-      router.replaceWith(route).followRedirects();
+      router.replaceWith(homepage).followRedirects();
       return;
     }
 

--- a/frontend/discourse/app/services/login.js
+++ b/frontend/discourse/app/services/login.js
@@ -2,9 +2,11 @@ import { action } from "@ember/object";
 import Service, { service } from "@ember/service";
 import { disableImplicitInjections } from "discourse/lib/implicit-injections";
 import { findAll } from "discourse/models/login-method";
+import { i18n } from "discourse-i18n";
 
 @disableImplicitInjections
 export default class LoginService extends Service {
+  @service site;
   @service siteSettings;
 
   @action
@@ -34,5 +36,21 @@ export default class LoginService extends Service {
 
   get externalLoginMethods() {
     return findAll();
+  }
+
+  get readOnlyLoginMessage() {
+    return i18n(
+      this.site.isStaffWritesOnly
+        ? "staff_writes_only_mode.login_disabled"
+        : "read_only_mode.login_disabled"
+    );
+  }
+
+  get readOnlySignupMessage() {
+    return i18n(
+      this.site.isStaffWritesOnly
+        ? "staff_writes_only_mode.signup_disabled"
+        : "read_only_mode.signup_disabled"
+    );
   }
 }

--- a/frontend/discourse/tests/acceptance/read-only-mode-test.js
+++ b/frontend/discourse/tests/acceptance/read-only-mode-test.js
@@ -1,0 +1,140 @@
+import { getOwner } from "@ember/owner";
+import { click, currentRouteName, fillIn, visit } from "@ember/test-helpers";
+import { test } from "qunit";
+import {
+  acceptance,
+  publishToMessageBus,
+} from "discourse/tests/helpers/qunit-helpers";
+import { i18n } from "discourse-i18n";
+
+acceptance("Read only mode - anonymous", function () {
+  test("hides the sign up button for as long as read only mode lasts", async function (assert) {
+    await visit("/");
+
+    assert.dom("header .sign-up-button").exists("shows the sign up button");
+
+    await publishToMessageBus("/site/read-only", true);
+
+    assert
+      .dom("header .sign-up-button")
+      .doesNotExist("hides the sign up button");
+    assert.dom("header .login-button").exists("keeps the log in button");
+    assert
+      .dom("#global-notice-alert-read-only .text")
+      .hasText(
+        i18n("read_only_mode.enabled_anonymous"),
+        "tells anonymous visitors that signing up and logging in are unavailable"
+      );
+
+    await publishToMessageBus("/site/read-only", false);
+
+    assert
+      .dom("header .sign-up-button")
+      .exists("shows the sign up button once read only mode ends");
+  });
+
+  test("keeps you where you are when you try to log in", async function (assert) {
+    await visit("/");
+    await publishToMessageBus("/site/read-only", true);
+
+    await click("header .login-button");
+
+    assert.strictEqual(
+      currentRouteName(),
+      "discovery.latest",
+      "stays on the page you were on"
+    );
+    assert
+      .dom(".dialog-body")
+      .hasText(
+        i18n("read_only_mode.login_disabled"),
+        "explains why logging in is unavailable"
+      );
+  });
+
+  test("redirects home when /login is opened directly", async function (assert) {
+    getOwner(this).lookup("service:site").set("isReadOnly", true);
+
+    await visit("/login");
+
+    assert.strictEqual(
+      currentRouteName(),
+      "discovery.latest",
+      "redirects to the homepage instead of rendering nothing"
+    );
+    assert
+      .dom(".dialog-body")
+      .hasText(
+        i18n("read_only_mode.login_disabled"),
+        "explains why logging in is unavailable"
+      );
+  });
+
+  test("redirects home when /signup is opened directly", async function (assert) {
+    getOwner(this).lookup("service:site").set("isReadOnly", true);
+
+    await visit("/signup");
+
+    assert.strictEqual(
+      currentRouteName(),
+      "discovery.latest",
+      "redirects to the homepage instead of rendering nothing"
+    );
+    assert
+      .dom(".dialog-body")
+      .hasText(
+        i18n("read_only_mode.signup_disabled"),
+        "explains why signing up is unavailable"
+      );
+  });
+});
+
+acceptance("Staff writes only mode - anonymous", function (needs) {
+  needs.pretender((server, helper) => {
+    const readOnly = () =>
+      helper.response(503, {
+        errors: ["The site is in read only mode. Interactions are disabled."],
+        error_type: "read_only",
+      });
+
+    server.post("/session", readOnly);
+    server.post("/u/email-login", readOnly);
+  });
+
+  test("explains that only staff can sign up or log in", async function (assert) {
+    getOwner(this).lookup("service:site").set("isStaffWritesOnly", true);
+
+    await visit("/login");
+    await publishToMessageBus("/site/read-only", true);
+
+    assert
+      .dom("#global-notice-alert-staff-writes-only .text")
+      .hasText(
+        i18n("staff_writes_only_mode.enabled_anonymous"),
+        "tells anonymous visitors that only staff can log in"
+      );
+    assert
+      .dom("#new-account-link")
+      .doesNotExist("hides the create account link");
+
+    await fillIn("#login-account-name", "eviltrout");
+    await fillIn("#login-account-password", "correct");
+    await click(".login-fullpage .btn-primary");
+
+    assert
+      .dom(".login-fullpage .alert-error")
+      .hasText(
+        i18n("staff_writes_only_mode.login_disabled"),
+        "explains why a password login failed"
+      );
+
+    await click("#email-login-link");
+
+    assert
+      .dom(".login-fullpage .alert-error")
+      .hasText(
+        i18n("staff_writes_only_mode.login_disabled"),
+        "explains why an email login link was refused"
+      );
+  });
+});

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1407,4 +1407,14 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "#can_sign_up?" do
+    it "returns false when the site is in read only mode" do
+      expect(helper.can_sign_up?).to eq(true)
+
+      helper.instance_variable_set(:@readonly_mode, true)
+
+      expect(helper.can_sign_up?).to eq(false)
+    end
+  end
 end

--- a/spec/system/staff_writes_only_mode_spec.rb
+++ b/spec/system/staff_writes_only_mode_spec.rb
@@ -20,6 +20,7 @@ describe "Staff writes only mode" do
       login_form.open.fill(username: moderator.username, password:).click_login
 
       expect(page).to have_css(".header-dropdown-toggle.current-user")
+      expect(page).to have_content(I18n.t("js.staff_writes_only_mode.enabled"))
 
       page.visit "/new-topic"
 
@@ -53,7 +54,9 @@ describe "Staff writes only mode" do
 
       expect(page).to have_content(topic.title)
       expect(page).to have_content(post.raw)
-      expect(page).to have_content(I18n.t("js.staff_writes_only_mode.enabled"))
+      expect(page).to have_content(I18n.t("js.staff_writes_only_mode.enabled_anonymous"))
+      expect(page).to have_css(".login-button")
+      expect(page).to have_no_css(".sign-up-button")
     end
   end
 end


### PR DESCRIPTION
Previously, a site in read only or staff only mode still offered
anonymous visitors every way in: the header "Sign Up" button, the signup
call to action at the end of a topic, the create account link on the
login page, and the server-rendered header — including the one on the
read only error page itself. Account creation is blocked in both modes,
so all of them were dead ends. The banner made it worse by describing
what members lose (replying, likes) rather than what an anonymous
visitor is actually unable to do.

This change gates the JS `canSignUp` getter and its Ruby twin
`can_sign_up?` on read only state, which covers every signup entry point
at once. `canSignUp` had to drop its `@computed` decorator to do so:
with no dependent keys it cached permanently, so the new term would have
been evaluated once at boot and then frozen — leaving the button visible
if read only mode started later, and hidden long after it ended.

The "Log In" button deliberately stays, because staff can still log in
during staff only mode. Anonymous visitors now get banner copy naming
signup and login instead, a refused login says only staff can log in
rather than claiming login is disabled outright, and the email and code
login forms show that inline instead of a generic "an error occurred"
dialog.

It also fixes a pre-existing blank page. Both `/login` and `/signup`
aborted the transition when read only, which on a direct URL load left
the application template unrendered — and with it the dialog holder, so
the explanation never appeared either. They now redirect home when there
is no route to stay on, and keep aborting when there is.

Meta ref: /t/408703
