### PR TITLE
FIX: Don't elide numbered lists from Word emails

### DIFF
--- a/lib/email/receiver.rb
+++ b/lib/email/receiver.rb
@@ -545,10 +545,8 @@ module Email
     def extract_from_word(doc)
       # Word (?) keeps the content in the 'WordSection1' class and uses <p> tags
       # When there's something else (<table>, <div>, etc..) there's high chance it's a signature or forwarded email
-      elided =
-        doc.css(
-          ".WordSection1 > :not(p):not(ul):first-of-type, .WordSection1 > :not(p):not(ul):first-of-type ~ *",
-        ).remove
+      signature_start = ".WordSection1 > :not(p):not(ul):not(ol):first-of-type"
+      elided = doc.css("#{signature_start}, #{signature_start} ~ *").remove
       to_markdown(doc.at(".WordSection1").to_html, elided.to_html)
     end
 

--- a/spec/fixtures/emails/word_html_reply.eml
+++ b/spec/fixtures/emails/word_html_reply.eml
@@ -1,0 +1,25 @@
+Return-Path: <discourse@bar.com>
+From: Foo Bar <discourse@bar.com>
+To: reply+4f97315cc828096c9cb34c6f1a0d6fe8@bar.com
+Date: Fri, 15 Jan 2017 00:12:43 +0100
+Message-ID: <181@foo.bar.mail>
+Mime-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<div class="WordSection1">
+  <p class="MsoNormal">This is the <b>body</b> of the email.</p>
+  <ul>
+    <li>a bullet</li>
+    <li>another bullet</li>
+  </ul>
+  <p class="MsoNormal">And these are the steps to follow:</p>
+  <ol>
+    <li>a first step</li>
+    <li>a second step</li>
+  </ol>
+  <p class="MsoNormal">That's all folks!</p>
+  <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
+    <p class="MsoNormal">This is the <i>elided</i> part!</p>
+  </div>
+</div>

--- a/spec/lib/email/receiver_spec.rb
+++ b/spec/lib/email/receiver_spec.rb
@@ -2059,6 +2059,23 @@ RSpec.describe Email::Receiver do
       MD
       end
 
+      it "keeps the lists and only elides the signature from word emails" do
+        expect { process(:word_html_reply) }.to change { topic.posts.count }
+        expect(topic.posts.last.raw).to eq <<~MD.strip
+        This is the **body** of the email.
+
+        - a bullet
+        - another bullet
+
+        And these are the steps to follow:
+
+        1. a first step
+        1. a second step
+
+        That's all folks!
+      MD
+      end
+
       it "doesn't process email with same message-id more than once" do
         expect do
           process(:text_reply)


### PR DESCRIPTION
Previously, a reply sent from Outlook was truncated at its first numbered list — `extract_from_word` treats any child of `.WordSection1` that is neither a `<p>` nor a `<ul>` as the start of a signature or forwarded message, and Outlook renders numbered lists as `<ol>`, so the list and everything after it was elided and (outside of private messages, or with `always_show_trimmed_content` disabled) dropped from the post with no error.

This change excludes `<ol>` as well, so numbered lists are kept along with the content that follows them, while the `<div>`/`<table>` signature and forwarded-message blocks the method exists to strip are still elided.