### PR TITLE
FEATURE: Make the message send shortcut a core user option

### DIFF
--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -20,6 +20,7 @@ class UserOption < ActiveRecord::Base
   self.ignored_columns = [
     "enable_experimental_sidebar", # TODO: Remove when 20250804021210_drop_enable_experimental_sidebar_user_option has been promoted to pre-deploy
     "only_chat_push_notifications", # TODO(2027-01): replaced by push_notification_level; drop the column in a follow-up PR once this has shipped
+    "chat_send_shortcut", # TODO(2027-01): replaced by send_shortcut; drop the column in a follow-up PR once this has shipped
   ]
 
   self.primary_key = :user_id
@@ -33,6 +34,7 @@ class UserOption < ActiveRecord::Base
 
   enum :default_calendar, { none_selected: 0, ics: 1, google: 2 }, scopes: false
   enum :push_notification_level, { none: 0, all: 1, chat_only: 2 }, prefix: true, scopes: false
+  enum :send_shortcut, { enter: 0, meta_enter: 1 }, prefix: true, scopes: false
 
   def self.ensure_consistency!
     sql = <<~SQL
@@ -278,7 +280,6 @@ end
 #  chat_new_message_sound                         :boolean          default(FALSE), not null
 #  chat_quick_reaction_type                       :integer          default("frequent"), not null
 #  chat_quick_reactions_custom                    :string
-#  chat_send_shortcut                             :integer          default("enter"), not null
 #  chat_separate_sidebar_mode                     :integer          default("default"), not null
 #  chat_sound                                     :string
 #  composition_mode                               :integer          default(1), not null
@@ -321,6 +322,7 @@ end
 #  policy_email_frequency                         :integer          default("never"), not null
 #  push_notification_level                        :integer          default("all"), not null
 #  seen_popups                                    :integer          is an Array
+#  send_shortcut                                  :integer          default("enter"), not null
 #  show_original_content                          :boolean          default(FALSE), not null
 #  show_thread_title_prompts                      :boolean          default(TRUE), not null
 #  sidebar_link_to_filtered_list                  :boolean          default(FALSE), not null

--- a/app/serializers/current_user_option_serializer.rb
+++ b/app/serializers/current_user_option_serializer.rb
@@ -27,7 +27,8 @@ class CurrentUserOptionSerializer < ApplicationSerializer
              :sidebar_show_count_of_new_items,
              :composition_mode,
              :interface_color_mode,
-             :show_original_content
+             :show_original_content,
+             :send_shortcut
 
   def likes_notifications_disabled
     object.likes_notifications_disabled?

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -50,7 +50,8 @@ class UserOptionSerializer < ApplicationSerializer
              :topics_unread_when_closed,
              :composition_mode,
              :interface_color_mode,
-             :show_original_content
+             :show_original_content,
+             :send_shortcut
 
   def auto_track_topics_after_msecs
     object.auto_track_topics_after_msecs || SiteSetting.default_other_auto_track_topics_after_msecs

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -62,6 +62,7 @@ class UserUpdater
     topics_unread_when_closed
     composition_mode
     show_original_content
+    send_shortcut
   ]
 
   NOTIFICATION_SCHEDULE_ATTRS = -> do

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2351,6 +2351,11 @@ en:
       bookmark_after_notification:
         title: "After a bookmark reminder notification is sent:"
 
+      send_shortcut:
+        title: "Send messages in chat-style composers with:"
+        enter: "Enter"
+        meta_enter: "%{meta_key} + Enter"
+
       like_notification_frequency:
         title: "Notify when liked"
         always: "Always"

--- a/db/migrate/20260728162516_add_send_shortcut_to_user_options.rb
+++ b/db/migrate/20260728162516_add_send_shortcut_to_user_options.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSendShortcutToUserOptions < ActiveRecord::Migration[8.0]
+  def change
+    # send_shortcut enum: enter: 0, meta_enter: 1. Default to `enter` to
+    # preserve the prior chat_send_shortcut default.
+    add_column :user_options, :send_shortcut, :integer, null: false, default: 0
+  end
+end

--- a/db/post_migrate/20260728162521_backfill_send_shortcut.rb
+++ b/db/post_migrate/20260728162521_backfill_send_shortcut.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class BackfillSendShortcut < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 30_000
+
+  def up
+    # `chat_send_shortcut` is a chat-plugin column; skip when it isn't present
+    # (e.g. the chat plugin is absent, or the migrations-tooling core-only
+    # schema) so this core migration never references a missing column.
+    return unless column_exists?(:user_options, :chat_send_shortcut)
+
+    loop do
+      count = DB.exec(<<~SQL, batch_size: BATCH_SIZE)
+        WITH cte AS (
+          SELECT user_id
+          FROM user_options
+          WHERE chat_send_shortcut <> 0 AND send_shortcut <> chat_send_shortcut
+          LIMIT :batch_size
+        )
+        UPDATE user_options
+        SET send_shortcut = user_options.chat_send_shortcut
+        FROM cte
+        WHERE user_options.user_id = cte.user_id
+      SQL
+
+      break if count == 0
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11762,7 +11762,8 @@ CREATE TABLE public.user_options (
     enable_upcoming_change_available_notifications boolean DEFAULT true NOT NULL,
     chat_announce_new_messages boolean DEFAULT true NOT NULL,
     chat_new_message_sound boolean DEFAULT false NOT NULL,
-    push_notification_level integer DEFAULT 1 NOT NULL
+    push_notification_level integer DEFAULT 1 NOT NULL,
+    send_shortcut integer DEFAULT 0 NOT NULL
 );
 
 
@@ -23051,6 +23052,8 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260728162521'),
+('20260728162516'),
 ('20260728071552'),
 ('20260728045008'),
 ('20260727085824'),

--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -13,6 +13,7 @@ import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import bodyClass from "discourse/helpers/body-class";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { SEND_SHORTCUT_META_ENTER } from "discourse/lib/constants";
 import UppyUpload from "discourse/lib/uppy/uppy-upload";
 import UppyMediaOptimization from "discourse/lib/uppy-media-optimization-plugin";
 import { clipboardHelpers } from "discourse/lib/utilities";
@@ -32,6 +33,7 @@ import { i18n } from "discourse-i18n";
 // the live API surface.
 export default class DockedComposer extends Component {
   @service capabilities;
+  @service currentUser;
   @service keyValueStore;
   @service mediaOptimizationWorker;
   @service siteSettings;
@@ -69,7 +71,9 @@ export default class DockedComposer extends Component {
       return;
     }
 
-    const submitOnEnter = this.args.submitOnEnter ?? true;
+    const submitOnEnter =
+      this.args.submitOnEnter ??
+      this.currentUser?.user_option?.send_shortcut !== SEND_SHORTCUT_META_ENTER;
 
     if (submitOnEnter) {
       if (

--- a/frontend/discourse/app/controllers/preferences/interface.js
+++ b/frontend/discourse/app/controllers/preferences/interface.js
@@ -9,7 +9,11 @@ import {
   loadColorSchemeStylesheet,
   updateColorSchemeCookie,
 } from "discourse/lib/color-scheme-picker";
-import { INTERFACE_COLOR_MODES } from "discourse/lib/constants";
+import {
+  INTERFACE_COLOR_MODES,
+  SEND_SHORTCUT_ENTER,
+  SEND_SHORTCUT_META_ENTER,
+} from "discourse/lib/constants";
 import { deepEqual } from "discourse/lib/object";
 import {
   currentThemeId,
@@ -20,8 +24,10 @@ import { applyValueTransformer } from "discourse/lib/transformer";
 import {
   setDefaultHomepage,
   siteDefaultHomepage,
+  translateModKey,
 } from "discourse/lib/utilities";
 import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
+import { PLATFORM_KEY_MODIFIER } from "discourse/services/keyboard-shortcuts";
 import { i18n } from "discourse-i18n";
 
 // same as UserOption::HOMEPAGES
@@ -85,6 +91,7 @@ export default class InterfaceController extends Controller {
       "interface_color_mode",
       "enable_markdown_monospace_font",
       "show_original_content",
+      "send_shortcut",
     ];
 
     if (this.makeThemeDefault) {
@@ -129,6 +136,22 @@ export default class InterfaceController extends Controller {
     return TITLE_COUNT_MODES.map((value) => {
       return { name: i18n(`user.title_count_mode.${value}`), value };
     });
+  }
+
+  @computed
+  get sendShortcutOptions() {
+    return [
+      {
+        name: i18n("user.send_shortcut.enter"),
+        value: SEND_SHORTCUT_ENTER,
+      },
+      {
+        name: i18n("user.send_shortcut.meta_enter", {
+          meta_key: translateModKey(PLATFORM_KEY_MODIFIER),
+        }),
+        value: SEND_SHORTCUT_META_ENTER,
+      },
+    ];
   }
 
   @computed

--- a/frontend/discourse/app/lib/constants.js
+++ b/frontend/discourse/app/lib/constants.js
@@ -91,6 +91,9 @@ export const POSTING_REVIEW_GROUP_BASED_MODES = [
 
 export const USER_OPTION_COMPOSITION_MODES = { markdown: 0, rich: 1 };
 
+export const SEND_SHORTCUT_ENTER = "enter";
+export const SEND_SHORTCUT_META_ENTER = "meta_enter";
+
 export const UPCOMING_CHANGES_USER_ENABLED_REASONS = {
   enabled_for_everyone: "enabled_for_everyone",
   enabled_for_no_one: "enabled_for_no_one",

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -145,6 +145,7 @@ let userOptionFields = [
   "notify_on_linked_posts",
   "push_notification_level",
   "seen_popups",
+  "send_shortcut",
   "show_original_content",
   "sidebar_link_to_filtered_list",
   "sidebar_show_count_of_new_items",

--- a/frontend/discourse/app/templates/preferences/interface.gjs
+++ b/frontend/discourse/app/templates/preferences/interface.gjs
@@ -246,6 +246,21 @@ export default <template>
       />
     </div>
     <div
+      class="controls controls-dropdown pref-send-shortcut"
+      data-setting-name="user-send-shortcut"
+    >
+      <label for="user-send-shortcut">{{i18n
+          "user.send_shortcut.title"
+        }}</label>
+      <ComboBox
+        @valueProperty="value"
+        @content={{@controller.sendShortcutOptions}}
+        @value={{@controller.model.user_option.send_shortcut}}
+        @id="user-send-shortcut"
+        @onChange={{fn (mut @controller.model.user_option.send_shortcut)}}
+      />
+    </div>
+    <div
       class="controls controls-dropdown pref-bookmark-after-notification"
       data-setting-name="user-bookmark-after-notification"
     >

--- a/frontend/discourse/tests/fixtures/session-fixtures.js
+++ b/frontend/discourse/tests/fixtures/session-fixtures.js
@@ -51,6 +51,7 @@ const sessionFixtures = {
         skip_new_user_tips: false,
         should_be_redirected_to_top: false,
         composition_mode: 0,
+        send_shortcut: "enter",
       },
       sidebar_sections: [
         {

--- a/frontend/discourse/tests/integration/components/docked-composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/docked-composer-test.gjs
@@ -1,3 +1,4 @@
+import { getOwner } from "@ember/owner";
 import { fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import DockedComposer from "discourse/components/docked-composer";
@@ -32,6 +33,97 @@ module("Integration | Component | DockedComposer", function (hooks) {
     await triggerKeyEvent(".d-editor-input", "keydown", "Enter");
 
     assert.true(submitted, "bare Enter submits when submitOnEnter is default");
+  });
+
+  test("honors the meta_enter send_shortcut user option", async function (assert) {
+    const currentUser = getOwner(this).lookup("service:current-user");
+    currentUser.set("user_option.send_shortcut", "meta_enter");
+
+    let submitted = false;
+    const handleSubmit = async () => {
+      submitted = true;
+      return { ok: true };
+    };
+
+    await render(
+      <template>
+        <DockedComposer
+          @onSubmit={{handleSubmit}}
+          @composerEvents={{false}}
+          @draftKey="test-send-shortcut-option"
+        />
+      </template>
+    );
+
+    await fillIn(".d-editor-input", "hello");
+    await triggerKeyEvent(".d-editor-input", "keydown", "Enter");
+    assert.false(
+      submitted,
+      "bare Enter does not submit for meta_enter send_shortcut"
+    );
+
+    await triggerKeyEvent(".d-editor-input", "keydown", "Enter", {
+      metaKey: true,
+    });
+    assert.true(submitted, "Meta+Enter submits for meta_enter send_shortcut");
+  });
+
+  test("submits on Ctrl+Enter for the meta_enter send_shortcut user option", async function (assert) {
+    const currentUser = getOwner(this).lookup("service:current-user");
+    currentUser.set("user_option.send_shortcut", "meta_enter");
+
+    let submitted = false;
+    const handleSubmit = async () => {
+      submitted = true;
+      return { ok: true };
+    };
+
+    await render(
+      <template>
+        <DockedComposer
+          @onSubmit={{handleSubmit}}
+          @composerEvents={{false}}
+          @draftKey="test-send-shortcut-ctrl"
+        />
+      </template>
+    );
+
+    await fillIn(".d-editor-input", "hello");
+    await triggerKeyEvent(".d-editor-input", "keydown", "Enter", {
+      ctrlKey: true,
+    });
+
+    assert.true(submitted, "Ctrl+Enter submits for meta_enter send_shortcut");
+  });
+
+  test("explicit @submitOnEnter overrides the send_shortcut user option", async function (assert) {
+    const currentUser = getOwner(this).lookup("service:current-user");
+    currentUser.set("user_option.send_shortcut", "meta_enter");
+
+    let submitted = false;
+    const handleSubmit = async () => {
+      submitted = true;
+      return { ok: true };
+    };
+
+    await render(
+      <template>
+        <DockedComposer
+          @onSubmit={{handleSubmit}}
+          @submitOnEnter={{true}}
+          @composerEvents={{false}}
+          @draftKey="test-send-shortcut-override"
+        />
+      </template>
+    );
+
+    await fillIn(".d-editor-input", "hello");
+    await triggerKeyEvent(".d-editor-input", "keydown", "Enter");
+
+    assert.true(
+      submitted,
+      "bare Enter submits when @submitOnEnter is explicitly true"
+    );
   });
 
   test("does not submit on bare Enter when @submitOnEnter is false", async function (assert) {

--- a/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-composer.gjs
@@ -23,6 +23,7 @@ import UpsertHyperlink from "discourse/components/modal/upsert-hyperlink";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import UserAutocompleteResults from "discourse/components/user-autocomplete-results";
 import lazyHash from "discourse/helpers/lazy-hash";
+import { SEND_SHORTCUT_META_ENTER } from "discourse/lib/constants";
 import { hashtagAutocompleteOptions } from "discourse/lib/hashtag-autocomplete";
 import loadEmojiSearchAliases from "discourse/lib/load-emoji-search-aliases";
 import { cloneJSON } from "discourse/lib/object";
@@ -414,10 +415,9 @@ export default class ChatComposer extends Component {
     }
 
     if (event.key === "Enter") {
-      const shortcutPreference =
-        this.currentUser.user_option.chat_send_shortcut;
+      const shortcutPreference = this.currentUser.user_option.send_shortcut;
       const send =
-        (shortcutPreference === "enter" && !event.shiftKey) ||
+        (shortcutPreference !== SEND_SHORTCUT_META_ENTER && !event.shiftKey) ||
         event.ctrlKey ||
         event.metaKey;
 

--- a/plugins/chat/assets/javascripts/discourse/initializers/chat-user-options.js
+++ b/plugins/chat/assets/javascripts/discourse/initializers/chat-user-options.js
@@ -14,7 +14,6 @@ export default {
         api.addSaveableUserOption("chat_enabled");
         api.addSaveableUserOption("chat_quick_reaction_type");
         api.addSaveableUserOption("chat_quick_reactions_custom");
-        api.addSaveableUserOption("chat_send_shortcut");
         api.addSaveableUserOption("chat_separate_sidebar_mode");
         api.addSaveableUserOption("show_thread_title_prompts");
         // Notification settings (rendered on the notifications preferences tab)

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-constants.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-constants.js
@@ -23,7 +23,6 @@ export const CHAT_ATTRS = [
   "show_thread_title_prompts",
   "chat_email_frequency",
   "chat_separate_sidebar_mode",
-  "chat_send_shortcut",
   "chat_quick_reaction_type",
   "chat_quick_reactions_custom",
 ];
@@ -34,8 +33,6 @@ export const HEADER_INDICATOR_PREFERENCE_NEVER = "never";
 export const HEADER_INDICATOR_PREFERENCE_DM_AND_MENTIONS = "dm_and_mentions";
 export const HEADER_INDICATOR_PREFERENCE_ALL_NEW = "all_new";
 export const HEADER_INDICATOR_PREFERENCE_ONLY_MENTIONS = "only_mentions";
-export const CHAT_SEND_SHORTCUT_ENTER = "enter";
-export const CHAT_SEND_SHORTCUT_META_ENTER = "meta_enter";
 export const CHAT_QUICK_REACTION_TYPE_FREQUENT = "frequent";
 export const CHAT_QUICK_REACTION_TYPE_CUSTOM = "custom";
 export const CHAT_SEPARATE_SIDEBAR_MODE_ALWAYS = "always";

--- a/plugins/chat/assets/javascripts/discourse/templates/preferences/chat.gjs
+++ b/plugins/chat/assets/javascripts/discourse/templates/preferences/chat.gjs
@@ -6,8 +6,6 @@ import EmojiPicker from "discourse/components/emoji-picker";
 import Form from "discourse/components/form";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { isTesting } from "discourse/lib/environment";
-import { translateModKey } from "discourse/lib/utilities";
-import { PLATFORM_KEY_MODIFIER } from "discourse/services/keyboard-shortcuts";
 import { eq } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 import {
@@ -15,8 +13,6 @@ import {
   CHAT_QUICK_REACTION_TYPE_CUSTOM,
   CHAT_QUICK_REACTION_TYPE_FREQUENT,
   CHAT_QUICK_REACTIONS_CUSTOM_DEFAULT,
-  CHAT_SEND_SHORTCUT_ENTER,
-  CHAT_SEND_SHORTCUT_META_ENTER,
   CHAT_SEPARATE_SIDEBAR_MODE_ALWAYS,
   CHAT_SEPARATE_SIDEBAR_MODE_FULLSCREEN,
   CHAT_SEPARATE_SIDEBAR_MODE_NEVER,
@@ -34,21 +30,6 @@ export default class Chat extends Component {
       {
         label: i18n("chat.quick_reaction_type.options.custom"),
         value: CHAT_QUICK_REACTION_TYPE_CUSTOM,
-      },
-    ];
-  }
-
-  get chatSendShortcutOptions() {
-    return [
-      {
-        label: i18n("chat.send_shortcut.enter.label"),
-        value: CHAT_SEND_SHORTCUT_ENTER,
-      },
-      {
-        label: i18n("chat.send_shortcut.meta_enter.label", {
-          meta_key: translateModKey(PLATFORM_KEY_MODIFIER),
-        }),
-        value: CHAT_SEND_SHORTCUT_META_ENTER,
       },
     ];
   }
@@ -84,7 +65,6 @@ export default class Chat extends Component {
       chat_announce_new_messages: userOption.chat_announce_new_messages,
       chat_new_message_sound: userOption.chat_new_message_sound,
       chat_separate_sidebar_mode: userOption.chat_separate_sidebar_mode,
-      chat_send_shortcut: userOption.chat_send_shortcut,
     };
   }
 
@@ -175,21 +155,6 @@ export default class Chat extends Component {
             </field.Control>
           </form.Field>
         {{/if}}
-        <form.Field
-          @title={{i18n "chat.send_shortcut.title"}}
-          @name="chat_send_shortcut"
-          @format="large"
-          @type="radio-group"
-          as |field|
-        >
-          <field.Control as |radioGroup|>
-            {{#each this.chatSendShortcutOptions as |option|}}
-              <radioGroup.Radio @value={{option.value}}>
-                {{option.label}}
-              </radioGroup.Radio>
-            {{/each}}
-          </field.Control>
-        </form.Field>
         <form.Field
           @title={{i18n "chat.separate_sidebar_mode.title"}}
           @name="chat_separate_sidebar_mode"

--- a/plugins/chat/config/locales/client.en.yml
+++ b/plugins/chat/config/locales/client.en.yml
@@ -164,12 +164,6 @@ en:
         never: "Never"
       separate_sidebar_mode:
         title: "Show separate sidebar modes for forum and chat"
-      send_shortcut:
-        title: "Send shortcut"
-        enter:
-          label: "Send by Enter"
-        meta_enter:
-          label: "Send by %{meta_key} + Enter"
       enable: "Enable chat"
       flag: "Flag"
       emoji: "Insert emoji"

--- a/plugins/chat/lib/chat/user_option_extension.rb
+++ b/plugins/chat/lib/chat/user_option_extension.rb
@@ -32,19 +32,11 @@ module Chat
         @chat_separate_sidebar_mode ||= { default: 0, never: 1, always: 2, fullscreen: 3 }
       end
 
-      def base.chat_send_shortcut
-        @chat_send_shortcut ||= { enter: 0, meta_enter: 1 }
-      end
-
       # Avoid attempting to override when autoloading
       if !base.method_defined?(:chat_separate_sidebar_mode_default?)
         base.enum :chat_separate_sidebar_mode,
                   base.chat_separate_sidebar_mode,
                   prefix: "chat_separate_sidebar_mode"
-      end
-
-      if !base.method_defined?(:chat_send_shortcut_enter?)
-        base.enum :chat_send_shortcut, base.chat_send_shortcut, prefix: "chat_send_shortcut"
       end
 
       if !base.method_defined?(:show_thread_title_prompts?)

--- a/plugins/chat/lib/chat/user_option_extension.rb
+++ b/plugins/chat/lib/chat/user_option_extension.rb
@@ -54,6 +54,11 @@ module Chat
       if !base.method_defined?(:chat_quick_reaction_type_frequent?)
         base.enum :chat_quick_reaction_type, { frequent: 0, custom: 1 }, prefix: true
       end
+
+      if !base.method_defined?(:chat_send_shortcut)
+        base.define_method(:chat_send_shortcut) { send_shortcut }
+        base.define_method(:chat_send_shortcut=) { |value| self.send_shortcut = value }
+      end
     end
   end
 end

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -94,6 +94,7 @@ after_initialize do
   UserUpdater::OPTION_ATTR.push(:chat_email_frequency)
   UserUpdater::OPTION_ATTR.push(:chat_header_indicator_preference)
   UserUpdater::OPTION_ATTR.push(:chat_separate_sidebar_mode)
+  UserUpdater::OPTION_ATTR.push(:chat_send_shortcut)
 
   # When a user opts into chat-only push notifications, suppress every push that
   # isn't a chat message/mention. Registered here (rather than in core) so it's

--- a/plugins/chat/plugin.rb
+++ b/plugins/chat/plugin.rb
@@ -94,7 +94,6 @@ after_initialize do
   UserUpdater::OPTION_ATTR.push(:chat_email_frequency)
   UserUpdater::OPTION_ATTR.push(:chat_header_indicator_preference)
   UserUpdater::OPTION_ATTR.push(:chat_separate_sidebar_mode)
-  UserUpdater::OPTION_ATTR.push(:chat_send_shortcut)
 
   # When a user opts into chat-only push notifications, suppress every push that
   # isn't a chat message/mention. Registered here (rather than in core) so it's
@@ -338,9 +337,11 @@ after_initialize do
     object.chat_separate_sidebar_mode
   end
 
-  add_to_serializer(:user_option, :chat_send_shortcut) { object.chat_send_shortcut }
+  # TODO(2027-01): compatibility alias for cached JS bundles that still read
+  # chat_send_shortcut; remove alongside the chat_send_shortcut column drop.
+  add_to_serializer(:user_option, :chat_send_shortcut) { object.send_shortcut }
 
-  add_to_serializer(:current_user_option, :chat_send_shortcut) { object.chat_send_shortcut }
+  add_to_serializer(:current_user_option, :chat_send_shortcut) { object.send_shortcut }
 
   add_to_serializer(:user_option, :chat_quick_reaction_type) { object.chat_quick_reaction_type }
   add_to_serializer(:current_user_option, :chat_quick_reaction_type) do

--- a/plugins/chat/spec/models/user_option_spec.rb
+++ b/plugins/chat/spec/models/user_option_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe UserOption do
       expect(described_class.new.chat_quick_reaction_type).to eq("frequent")
     end
   end
+
+  describe "#chat_send_shortcut" do
+    fab!(:user)
+
+    it "persists legacy updater assignments to send_shortcut" do
+      expect(UserUpdater.new(user, user).update(chat_send_shortcut: "meta_enter")).to eq(true)
+
+      expect(user.user_option.reload.send_shortcut).to eq("meta_enter")
+    end
+  end
 end

--- a/plugins/chat/spec/system/chat_composer_spec.rb
+++ b/plugins/chat/spec/system/chat_composer_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "Chat composer" do
     end
 
     context "when user preference is set to send on enter" do
-      before { current_user.user_option.update!(chat_send_shortcut: 0) }
+      before { current_user.user_option.update!(send_shortcut: "enter") }
 
       context "when pressing enter" do
         it "sends the message" do
@@ -163,7 +163,7 @@ RSpec.describe "Chat composer" do
     end
 
     context "when user preference is set to send on meta + enter" do
-      before { current_user.user_option.update!(chat_send_shortcut: 1) }
+      before { current_user.user_option.update!(send_shortcut: "meta_enter") }
 
       context "when pressing enter" do
         it "adds a linebreak" do

--- a/plugins/chat/spec/system/user_chat_preferences_spec.rb
+++ b/plugins/chat/spec/system/user_chat_preferences_spec.rb
@@ -88,17 +88,6 @@ RSpec.describe "User chat preferences" do
     end
   end
 
-  it "can select send shorcut sidebar mode" do
-    user_preferences_chat_page.visit
-    form.field("chat_send_shortcut").select("meta_enter")
-    form.submit
-    user_preferences_chat_page.visit
-
-    expect(
-      form.field("chat_send_shortcut").component.find("input[type='radio'][value='meta_enter']"),
-    ).to be_checked
-  end
-
   it "can select and save separate sidebar mode" do
     user_preferences_chat_page.visit
     form.field("chat_separate_sidebar_mode").select("fullscreen")

--- a/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
+++ b/plugins/discourse-ai/assets/javascripts/discourse/components/ai-bot-conversations.gjs
@@ -17,6 +17,7 @@ import UserAutocompleteResults from "discourse/components/user-autocomplete-resu
 import bodyClass from "discourse/helpers/body-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import { SEND_SHORTCUT_META_ENTER } from "discourse/lib/constants";
 import { hashtagAutocompleteOptions } from "discourse/lib/hashtag-autocomplete";
 import { TextareaAutocompleteHandler } from "discourse/lib/textarea-text-manipulation";
 import UppyUpload from "discourse/lib/uppy/uppy-upload";
@@ -40,6 +41,7 @@ export default class AiBotConversations extends Component {
   @service aiCredits;
   @service aiBotConversationsHiddenSubmit;
   @service capabilities;
+  @service currentUser;
   @service mediaOptimizationWorker;
   @service site;
   @service siteSettings;
@@ -232,12 +234,30 @@ export default class AiBotConversations extends Component {
       value.target?.value || value;
   }
 
+  get sendOnMetaEnter() {
+    return (
+      this.currentUser?.user_option?.send_shortcut === SEND_SHORTCUT_META_ENTER
+    );
+  }
+
   @action
   handleKeyDown(event) {
     if (event.target.tagName !== "TEXTAREA") {
       return;
     }
     if (event.key === "Enter") {
+      // Meta/ctrl+Enter never produces an insertLineBreak beforeinput, so it
+      // must be handled here rather than in handleBeforeInput.
+      if (
+        this.sendOnMetaEnter &&
+        !event.isComposing &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.prepareAndSubmitToBot();
+        return;
+      }
       this.shiftHeldOnEnter = event.shiftKey;
     }
   }
@@ -249,7 +269,11 @@ export default class AiBotConversations extends Component {
     // browsers regardless of compositionend/keydown ordering quirks.
     const shiftHeld = this.shiftHeldOnEnter;
     this.shiftHeldOnEnter = false;
-    if (event.inputType !== "insertLineBreak" || shiftHeld) {
+    if (
+      event.inputType !== "insertLineBreak" ||
+      shiftHeld ||
+      this.sendOnMetaEnter
+    ) {
       return;
     }
     event.preventDefault();

--- a/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
+++ b/plugins/discourse-ai/test/javascripts/acceptance/ai-bot-conversations-test.js
@@ -1,6 +1,10 @@
 import { fillIn, triggerEvent, visit } from "@ember/test-helpers";
 import { test } from "qunit";
-import { acceptance } from "discourse/tests/helpers/qunit-helpers";
+import User from "discourse/models/user";
+import {
+  acceptance,
+  updateCurrentUser,
+} from "discourse/tests/helpers/qunit-helpers";
 
 const INPUT = "#ai-bot-conversations-input";
 
@@ -80,5 +84,34 @@ acceptance("AI Bot - Conversations IME handling", function (needs) {
     });
 
     assert.strictEqual(conversationRequests, 0, "did not submit");
+  });
+
+  test("Enter does not submit with the meta_enter send shortcut", async function (assert) {
+    updateCurrentUser({
+      user_option: {
+        ...User.current().user_option,
+        send_shortcut: "meta_enter",
+      },
+    });
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "keydown", { key: "Enter" });
+    await triggerEvent(INPUT, "beforeinput", { inputType: "insertLineBreak" });
+
+    assert.strictEqual(conversationRequests, 0, "did not submit");
+  });
+
+  test("Meta+Enter submits with the meta_enter send shortcut", async function (assert) {
+    updateCurrentUser({
+      user_option: {
+        ...User.current().user_option,
+        send_shortcut: "meta_enter",
+      },
+    });
+    await prepareDraft();
+
+    await triggerEvent(INPUT, "keydown", { key: "Enter", metaKey: true });
+
+    assert.strictEqual(conversationRequests, 1, "submitted once");
   });
 });

--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -855,6 +855,9 @@
             },
             "show_original_content": {
               "type": "boolean"
+            },
+            "send_shortcut": {
+              "type": "string"
             }
           },
           "required": [
@@ -899,7 +902,8 @@
             "skip_new_user_tips",
             "topics_unread_when_closed",
             "interface_color_mode",
-            "show_original_content"
+            "show_original_content",
+            "send_shortcut"
           ]
         }
       },

--- a/spec/system/user_page/user_preferences_interface_spec.rb
+++ b/spec/system/user_page/user_preferences_interface_spec.rb
@@ -29,6 +29,22 @@ describe "User preferences | Interface" do
     end
   end
 
+  describe "Send shortcut" do
+    it "changes the send shortcut preference" do
+      user_preferences_page.visit(user)
+      click_link(I18n.t("js.user.preferences_nav.interface"))
+
+      dropdown = PageObjects::Components::SelectKit.new("#user-send-shortcut")
+
+      expect(dropdown).to have_selected_value("enter")
+
+      dropdown.select_row_by_value("meta_enter")
+      click_button(I18n.t("js.save"))
+
+      expect(UserOption.exists?(user_id: user.id, send_shortcut: "meta_enter")).to be_truthy
+    end
+  end
+
   describe "Default Home Page" do
     context "when a user has picked a home page that is no longer available in top_menu" do
       it "shows the selected homepage" do


### PR DESCRIPTION
**Previously**, the enter/meta+enter send shortcut was a chat-only preference (`chat_send_shortcut`), so chat-style composers in other plugins — like AI bot conversations — always sent on Enter with no way to insert a newline.

**In this update**, promoted it to a core `send_shortcut` user option on the Interface preferences page, honored by the chat composer, the core docked composer, and AI bot conversations.

The `chat_send_shortcut` column is backfilled into `send_shortcut` post-deploy and kept (ignored) for now, mirroring the `push_notification_level` promotion; the column drop, the serializer compatibility alias removal, and the `plugin_manifest.yml` cleanup land in a follow-up PR.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-jmgi09.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-crkznx.png) |