### PR TITLE
FIX: Reliably highlight fenced code blocks with no language

### DIFF
--- a/frontend/discourse/app/lib/highlight-syntax.js
+++ b/frontend/discourse/app/lib/highlight-syntax.js
@@ -8,6 +8,9 @@ let _moreLanguages = [];
 let _plugins = [];
 let hljsLoadPromise;
 
+// bounds language detection cost, which scales with content length
+const AUTO_DETECT_SAMPLE_LENGTH = 2000;
+
 export default async function highlightSyntax(elem, siteSettings, session) {
   if (!elem) {
     return;
@@ -28,11 +31,6 @@ export default async function highlightSyntax(elem, siteSettings, session) {
   const hljs = await ensureHighlightJs(path);
 
   codeblocks.forEach((e) => {
-    // Large code blocks can cause crashes or slowdowns
-    if (e.innerHTML.length > 30000) {
-      return;
-    }
-
     let lang;
     for (const className of e.classList) {
       const m = className.match(/^lang(?:uage)?-(.+)$/);
@@ -42,14 +40,33 @@ export default async function highlightSyntax(elem, siteSettings, session) {
       }
     }
 
-    if (lang === "auto" && e.innerHTML.length > 1000) {
+    const autodetect = lang === "auto";
+    if (autodetect) {
+      // not a real hljs language — remove even from blocks skipped below
+      e.classList.remove("lang-auto");
+    }
+
+    // Large code blocks can cause crashes or slowdowns
+    if (e.innerHTML.length > 30000) {
       return;
     }
 
-    const canHighlight = lang && (lang === "auto" || hljs.getLanguage(lang));
+    if (autodetect) {
+      const text = e.textContent;
+      const { language } = hljs.highlightAuto(
+        text.trimStart().slice(0, AUTO_DETECT_SAMPLE_LENGTH)
+      );
 
-    if (canHighlight) {
-      e.classList.remove("lang-auto"); // This isn't a real hljs language. HLJS will warn if it's present, so we remove it.
+      if (language) {
+        // highlightElement will use this grammar instead of re-detecting
+        e.classList.add(`language-${language}`);
+      } else if (text.length > AUTO_DETECT_SAMPLE_LENGTH) {
+        // too large for a full re-scan; smaller blocks fall through
+        return;
+      }
+
+      hljs.highlightElement(e);
+    } else if (lang && hljs.getLanguage(lang)) {
       hljs.highlightElement(e);
     } else {
       // To make debugging easier, add a data attribute to indicate we skipped it

--- a/frontend/discourse/tests/unit/lib/highlight-syntax-test.js
+++ b/frontend/discourse/tests/unit/lib/highlight-syntax-test.js
@@ -44,4 +44,46 @@ module("Unit | Utility | highlight-syntax", function (hooks) {
     // Checks if HTML structure was preserved
     assert.dom("code.lang-ruby.hljs ol li", fixture()).exists({ count: 3 });
   });
+
+  test("auto language is detected and the placeholder class removed", async function (assert) {
+    fixture().innerHTML = `<pre><code class="lang-auto">def code
+  puts 1 + 2
+end</code></pre>`;
+
+    await highlightSyntax(fixture(), siteSettings, {});
+
+    assert.dom("pre code", fixture()).hasClass("hljs");
+    assert
+      .dom("pre code.lang-auto", fixture())
+      .doesNotExist("removes the invalid lang-auto class");
+  });
+
+  test("large auto blocks are still detected via a sampled prefix", async function (assert) {
+    // Comfortably larger than the detection sample so the sampling path is used.
+    const bigContent = "def code\n  puts 1 + 2\nend\n".repeat(150);
+    fixture().innerHTML = `<pre><code class="lang-auto">${bigContent}</code></pre>`;
+
+    await highlightSyntax(fixture(), siteSettings, {});
+
+    assert.dom("pre code", fixture()).hasClass("hljs");
+    assert.dom("pre code .hljs-keyword", fixture()).exists();
+    assert
+      .dom("pre code.lang-auto", fixture())
+      .doesNotExist("still removes the invalid lang-auto class");
+  });
+
+  test("large auto blocks with no detectable language are left as plain text", async function (assert) {
+    fixture().innerHTML = `<pre><code class="lang-auto">${"\n".repeat(
+      3000
+    )}</code></pre>`;
+
+    await highlightSyntax(fixture(), siteSettings, {});
+
+    assert
+      .dom("pre code", fixture())
+      .doesNotHaveClass("hljs", "nothing detected, so it is not highlighted");
+    assert
+      .dom("pre code.lang-auto", fixture())
+      .doesNotExist("still removes the invalid lang-auto class");
+  });
 });


### PR DESCRIPTION
Fenced code blocks with no language are cooked as `<code class="lang-auto">` and highlighted via auto-detection at runtime. Blocks over 1000 characters of markup were skipped entirely, and that early-out left the invalid `lang-auto` class on the element, so they rendered unhighlighted and unstyled. The threshold was arbitrary and small enough to catch ordinary snippets.

Auto-detection weighs the content against every enabled language, so its cost grows with both block size and language count. Rather than cap by size, detect the language from a bounded prefix and then highlight the full block with just that language, keeping detection cost constant regardless of block size.

The `lang-auto` marker is now always removed, so a block that still cannot be highlighted degrades to plain text instead of carrying an invalid class.