### PR TITLE
FIX: Preserve URI delimiters in ICS URL properties, removing TEXT escaping

### DIFF
--- a/app/views/users/bookmarks.ics.erb
+++ b/app/views/users/bookmarks.ics.erb
@@ -10,7 +10,7 @@ DTSTART:<%= bookmark.reminder_at_ics_start %>
 DTEND:<%= bookmark.reminder_at_ics_end %>
 SUMMARY:<%= IcalEncoder.encode(bookmark.name.presence || bookmark.title) %>
 DESCRIPTION:<%= IcalEncoder.encode(bookmark.bookmarkable_url) %>
-URL:<%= IcalEncoder.encode(bookmark.bookmarkable_url) %>
+URL:<%= IcalEncoder.encode_uri(bookmark.bookmarkable_url) %>
 END:VEVENT
 <% end %>
 END:VCALENDAR

--- a/lib/ical_encoder.rb
+++ b/lib/ical_encoder.rb
@@ -18,6 +18,12 @@ module IcalEncoder
       .html_safe
   end
 
+  # Encodes a URI for iCalendar URL properties (RFC 5545 §3.8.4.6).
+  # URL values are URIs per RFC 3986, so comma and semicolon (valid sub-delimiters)
+  # must not be TEXT-escaped. Entities are decoded first, then CR/LF stripped —
+  # order matters: stripping CR/LF after decoding neutralizes entity-encoded
+  # newlines (e.g. `&#13;&#10;`) that would otherwise inject additional ICS
+  # properties on the following line.
   def self.encode_uri(uri)
     return "" if uri.blank?
 

--- a/lib/ical_encoder.rb
+++ b/lib/ical_encoder.rb
@@ -17,4 +17,10 @@ module IcalEncoder
       .gsub("\n", "\\n")
       .html_safe
   end
+
+  def self.encode_uri(uri)
+    return "" if uri.blank?
+
+    CGI.unescapeHTML(uri.to_s).delete("\r\n").html_safe
+  end
 end

--- a/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
+++ b/plugins/discourse-calendar/app/views/discourse_post_event/events/index.ics.erb
@@ -22,7 +22,7 @@ SUMMARY:<%= IcalEncoder.encode(event.name.presence || event.post.topic.title) %>
 <%- if event.location.present? -%>LOCATION:<%= IcalEncoder.encode(event.location) %>
 <%- end -%>
 DESCRIPTION:<%= IcalEncoder.encode([(event.description.presence || event.post.excerpt), event.post.full_url].compact.join("\n")) %>
-URL:<%= IcalEncoder.encode(event.url.presence || event.post.topic.url(event.post.post_number)) %>
+URL:<%= IcalEncoder.encode_uri(event.url.presence || event.post.topic.url(event.post.post_number)) %>
 END:VEVENT
 <%- end -%>
 END:VCALENDAR

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -131,6 +131,26 @@ module DiscoursePostEvent
         expect(body).to include("URL:https://example.com/event-info")
       end
 
+      it "preserves URI delimiters in URL fields while escaping text fields" do
+        event =
+          Fabricate(
+            :event,
+            original_starts_at: 1.day.from_now,
+            name: "Conference, day; one",
+            location: "Room A, floor 2; west",
+            description: "Agenda, demos; questions",
+            url: "https://example.com/events?tags=one,two;sort=asc&name=tom",
+          )
+
+        get "/discourse-post-event/events.ics"
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("SUMMARY:Conference\\, day\\; one")
+        expect(response.body).to include("LOCATION:Room A\\, floor 2\\; west")
+        expect(response.body).to include("DESCRIPTION:Agenda\\, demos\\; questions")
+        expect(response.body).to include("URL:#{event.url}")
+      end
+
       it "should not HTML-encode ampersands in ics format" do
         Fabricate(
           :event,

--- a/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/events_controller_spec.rb
@@ -151,6 +151,20 @@ module DiscoursePostEvent
         expect(response.body).to include("URL:#{event.url}")
       end
 
+      it "strips CR/LF from URL fields so a stored URL cannot inject ICS properties" do
+        Fabricate(
+          :event,
+          original_starts_at: 1.day.from_now,
+          url: "https://example.com/\r\nX-INJECTED:evil\r\n",
+        )
+
+        get "/discourse-post-event/events.ics"
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("URL:https://example.com/X-INJECTED:evil")
+        expect(response.body).not_to match(/^X-INJECTED:evil$/)
+      end
+
       it "should not HTML-encode ampersands in ics format" do
         Fabricate(
           :event,

--- a/spec/lib/ical_encoder_spec.rb
+++ b/spec/lib/ical_encoder_spec.rb
@@ -61,4 +61,18 @@ RSpec.describe IcalEncoder do
       expect(result).to include("& special chars")
     end
   end
+
+  describe ".encode_uri" do
+    it "preserves URI delimiters and removes newlines" do
+      result =
+        described_class.encode_uri(
+          "https://example.com/events?tags=one,two;sort=asc&amp;name=Tom\r\nATTACH:https://bad.example",
+        )
+
+      expect(result).to eq(
+        "https://example.com/events?tags=one,two;sort=asc&name=TomATTACH:https://bad.example",
+      )
+      expect(result).to be_html_safe
+    end
+  end
 end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7755,6 +7755,20 @@ RSpec.describe UsersController do
       expect(body).to include("SUMMARY:Tom & Jerry")
     end
 
+    it "preserves URI delimiters in .ics feed URL fields" do
+      bookmark2.bookmarkable.update_column(:slug, "bookmark,url;with-delimiters")
+      bookmark2.update!(name: "Reminder, with; delimiters", reminder_at: 1.day.from_now)
+
+      sign_in(user1)
+      get "/u/#{user1.username}/bookmarks.ics"
+
+      expect(response.status).to eq(200)
+      bookmarkable_url = bookmark2.bookmarkable.url
+      expect(response.body).to include("SUMMARY:Reminder\\, with\\; delimiters")
+      expect(response.body).to include("DESCRIPTION:#{IcalEncoder.encode(bookmarkable_url)}")
+      expect(response.body).to include("URL:#{bookmarkable_url}")
+    end
+
     it "does not show another user's bookmarks" do
       sign_in(Fabricate(:user))
       get "/u/#{bookmark3.user.username}/bookmarks.json"


### PR DESCRIPTION
## Summary

Correctly emit `URL` properties in ICS export without RFC 5545 TEXT escaping by introducing `IcalEncoder.encode_uri`, which decodes HTML entities, strips CR/LF characters, and leaves valid URI delimiters such as commas and semicolons intact. This change is applied to both the Discourse Events calendar feed and the user bookmarks ICS feed; all textual properties (`SUMMARY`, `LOCATION`, `DESCRIPTION`) continue to use the existing TEXT encoder.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1547

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>