### PR TITLE
FIX: Add small action controls to nested activity log

### DIFF
--- a/app/assets/stylesheets/common/nested-view.scss
+++ b/app/assets/stylesheets/common/nested-view.scss
@@ -1052,29 +1052,68 @@
 
 // ── Activity log modal ────────────────────────────────────────────
 .nested-activity-log-modal {
-  .d-modal__body {
-    display: flex;
-    flex-direction: column-reverse;
-  }
+  --activity-log-row-padding-block: var(--space-3);
+  --activity-log-row-gap: var(--space-2);
+  --activity-log-icon-color: var(--primary-medium);
+  --activity-log-description-color: var(--primary-700);
 
   &__list {
     @include unstyled-list;
   }
 
   &__item {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5em;
-    padding: 0.65em 0;
-
     &:not(:last-child) {
       border-bottom: 1px solid var(--primary-low);
+    }
+
+    &.--synthetic {
+      display: flex;
+      align-items: flex-start;
+      gap: var(--activity-log-row-gap);
+      padding-block: var(--activity-log-row-padding-block);
+      color: var(--activity-log-description-color);
+    }
+  }
+
+  &__post {
+    .small-action {
+      align-items: stretch;
+    }
+
+    .small-action .topic-avatar {
+      align-items: flex-start;
+      width: auto;
+      padding: var(--activity-log-row-padding-block) 0 0;
+      border-top: 0;
+
+      .d-icon {
+        font-size: var(--font-0);
+        color: var(--activity-log-icon-color);
+      }
+    }
+
+    .small-action .small-action-desc {
+      flex: 1;
+      width: auto;
+      padding: 0 0 var(--activity-log-row-padding-block)
+        var(--activity-log-row-gap);
+      border-top: 0;
+      color: var(--activity-log-description-color);
+    }
+
+    .small-action .small-action-contents,
+    .small-action .small-action-buttons {
+      padding-top: var(--activity-log-row-padding-block);
+    }
+
+    .small-action .small-action-custom-message {
+      font-size: var(--font-down-1);
     }
   }
 
   &__icon {
     flex-shrink: 0;
-    color: var(--primary-medium);
+    color: var(--activity-log-icon-color);
     margin-top: 0.15em;
   }
 
@@ -1100,6 +1139,12 @@
     color: var(--primary-medium);
     text-align: center;
     padding: 1em 0;
+  }
+
+  &__load-more {
+    display: flex;
+    justify-content: center;
+    padding-top: var(--space-3);
   }
 }
 

--- a/app/controllers/nested_topics_controller.rb
+++ b/app/controllers/nested_topics_controller.rb
@@ -3,6 +3,33 @@
 class NestedTopicsController < ApplicationController
   include EmbedModeHandler
 
+  ACTIVITY_PAGE_SIZE = 50
+  ACTIVITY_POST_ATTRIBUTES = %i[
+    id
+    name
+    username
+    avatar_template
+    created_at
+    cooked
+    cooked_hidden
+    post_number
+    post_type
+    topic_id
+    user_id
+    version
+    action_code
+    action_code_who
+    action_code_path
+    deleted_at
+    user_deleted
+    can_edit
+    can_delete
+    can_recover
+    moderator?
+    admin?
+    staff?
+  ].freeze
+
   skip_before_action :check_xhr, only: %i[show context]
 
   before_action :ensure_nested_replies_enabled
@@ -72,47 +99,30 @@ class NestedTopicsController < ApplicationController
 
   # GET /n/:slug/:topic_id/activity
   def activity
-    post_types = [Post.types[:small_action]]
-    post_types << Post.types[:whisper] if guardian.user&.whisperer?
-
-    posts =
-      @topic
-        .posts
-        .where(post_type: post_types)
-        .where.not(action_code: [nil, ""])
-        .includes(:user)
-        .order(:created_at)
+    page = params[:page].to_i.clamp(0, 1000)
+    posts = activity_posts.offset(page * ACTIVITY_PAGE_SIZE).limit(ACTIVITY_PAGE_SIZE + 1).to_a
+    has_more = posts.length > ACTIVITY_PAGE_SIZE
+    posts = posts.first(ACTIVITY_PAGE_SIZE)
+    posts.each { |post| post.topic = @topic }
 
     Post.preload_custom_fields(posts, %w[action_code_who action_code_path])
+    actions = serialize_data(posts, PostSerializer, only: ACTIVITY_POST_ATTRIBUTES)
 
-    creator = @topic.user
-    actions = [
-      {
-        action_code: "topic_created",
-        created_at: @topic.created_at,
-        username: creator&.username,
-        avatar_template: creator&.avatar_template,
-      },
-    ]
+    if page.zero?
+      creator = @topic.user
+      actions.unshift(
+        {
+          synthetic: true,
+          action_code: "topic_created",
+          created_at: @topic.created_at,
+          user_id: creator&.id,
+          username: creator&.username,
+          avatar_template: creator&.avatar_template,
+        },
+      )
+    end
 
-    actions.concat(
-      posts
-        .select { |post| guardian.can_see_post?(post) }
-        .map do |post|
-          {
-            id: post.id,
-            action_code: post.action_code,
-            action_code_who: post.custom_fields["action_code_who"],
-            action_code_path: post.custom_fields["action_code_path"],
-            created_at: post.created_at,
-            username: post.user&.username,
-            avatar_template: post.user&.avatar_template,
-            cooked: post.cooked,
-          }
-        end,
-    )
-
-    render json: { small_actions: actions }
+    render json: { small_actions: actions, has_more: has_more }
   end
 
   # PUT /n/:slug/:topic_id/toggle
@@ -129,6 +139,23 @@ class NestedTopicsController < ApplicationController
   private
 
   TOPIC_ROUTE_QUERY_PARAMS = %w[sort collapse_replies context embed_mode class_name].freeze
+
+  def activity_posts
+    post_types = [Post.types[:small_action]]
+    post_types << Post.types[:whisper] if guardian.user&.whisperer?
+
+    posts = @topic.posts
+    posts = posts.with_deleted if guardian.can_see_deleted_posts?(@topic.category)
+
+    posts =
+      posts
+        .where(post_type: post_types)
+        .where.not(action_code: [nil, ""])
+        .includes(:user)
+        .order(:created_at, :id)
+
+    guardian.filter_hidden_posts(posts, category: @topic.category)
+  end
 
   def list_roots_response(page:)
     result = nil

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4307,6 +4307,8 @@ en:
         link: "Activity log"
         title: "Topic activity log"
         empty: "No topic activity to show."
+        load_more: "Load more activity"
+        updated: "Topic activity updated."
       context:
         banner: "You are viewing a single thread from this topic."
         view_full_topic: "View full topic"

--- a/frontend/discourse/app/components/modal/nested-activity-log.gjs
+++ b/frontend/discourse/app/components/modal/nested-activity-log.gjs
@@ -1,39 +1,167 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
 import NestedActivityLogItem from "discourse/components/modal/nested-activity-log/item";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import DButton from "discourse/ui-kit/d-button";
 import DConditionalLoadingSpinner from "discourse/ui-kit/d-conditional-loading-spinner";
 import DModal from "discourse/ui-kit/d-modal";
 import { i18n } from "discourse-i18n";
 
 export default class NestedActivityLog extends Component {
+  @service a11y;
+  @service appEvents;
+  @service currentUser;
+  @service dialog;
+  @service store;
+
   @tracked loading = true;
+  @tracked loadingMore = false;
   @tracked smallActions = [];
+  @tracked page = 0;
+  @tracked hasMore = false;
 
   constructor() {
     super(...arguments);
     this.fetchActivity();
+    this.appEvents.on(
+      "nested-replies:activity-changed",
+      this,
+      this.handleActivityChanged
+    );
+  }
+
+  willDestroy() {
+    this.appEvents.off(
+      "nested-replies:activity-changed",
+      this,
+      this.handleActivityChanged
+    );
+    super.willDestroy(...arguments);
+  }
+
+  handleActivityChanged({ topicId }) {
+    if (String(topicId) !== String(this.args.model.topic.id)) {
+      return;
+    }
+
+    this.fetchActivity({ announce: true });
   }
 
   @action
-  async fetchActivity() {
+  async fetchActivity({ announce = false } = {}) {
+    const isInitialLoad = this.smallActions.length === 0;
+    if (isInitialLoad) {
+      this.loading = true;
+    }
+
     try {
-      const topic = this.args.model.topic;
-      const data = await ajax(`/n/${topic.slug}/${topic.id}/activity.json`);
-      this.smallActions = data.small_actions || [];
+      const data = await this.#fetchPage(0);
+      this.page = 0;
+      this.hasMore = data.has_more;
+      this.smallActions = this.#hydrateActions(data.small_actions);
+
+      if (announce) {
+        this.a11y.announce(
+          i18n("nested_replies.activity_log.updated"),
+          "polite"
+        );
+      }
     } catch (e) {
       popupAjaxError(e);
     } finally {
-      this.loading = false;
+      if (isInitialLoad) {
+        this.loading = false;
+      }
     }
+  }
+
+  @action
+  async loadMore() {
+    if (this.loadingMore || !this.hasMore) {
+      return;
+    }
+
+    this.loadingMore = true;
+    try {
+      const nextPage = this.page + 1;
+      const data = await this.#fetchPage(nextPage);
+      this.page = nextPage;
+      this.hasMore = data.has_more;
+      this.smallActions = [
+        ...this.smallActions,
+        ...this.#hydrateActions(data.small_actions),
+      ];
+    } catch (e) {
+      popupAjaxError(e);
+    } finally {
+      this.loadingMore = false;
+    }
+  }
+
+  @action
+  editPost(post) {
+    this.args.closeModal();
+    this.args.model.editPost(post);
+  }
+
+  @action
+  deletePost(post) {
+    if (!post.canDelete) {
+      return;
+    }
+
+    this.dialog.yesNoConfirm({
+      message: i18n("post.confirm_delete"),
+      didConfirm: async () => {
+        try {
+          await post.destroy(this.currentUser);
+          await this.fetchActivity();
+        } catch (error) {
+          post.undoDeleteState();
+          popupAjaxError(error);
+        }
+      },
+    });
+  }
+
+  @action
+  async recoverPost(post) {
+    await post.recover();
+    await this.fetchActivity();
+  }
+
+  async #fetchPage(page) {
+    const topic = this.args.model.topic;
+    return await ajax(`/n/${topic.slug}/${topic.id}/activity.json`, {
+      data: { page },
+    });
+  }
+
+  #hydrateActions(actions = []) {
+    return actions.map((activity) => {
+      if (activity.synthetic) {
+        return activity;
+      }
+
+      const topic = this.args.model.topic;
+      const post = this.store.createRecord("post", {
+        ...activity,
+        topic,
+        action_code_path: activity.action_code_path || `/t/${topic.id}`,
+      });
+      post.topic = topic;
+      return post;
+    });
   }
 
   <template>
     <DModal
       @title={{i18n "nested_replies.activity_log.title"}}
       @closeModal={{@closeModal}}
+      @inline={{@inline}}
       class="nested-activity-log-modal"
     >
       <:body>
@@ -44,6 +172,9 @@ export default class NestedActivityLog extends Component {
                 <NestedActivityLogItem
                   @action={{sa}}
                   @topicId={{@model.topic.id}}
+                  @editPost={{this.editPost}}
+                  @deletePost={{this.deletePost}}
+                  @recoverPost={{this.recoverPost}}
                 />
               {{/each}}
             </ul>
@@ -51,6 +182,17 @@ export default class NestedActivityLog extends Component {
             <p class="nested-activity-log-modal__empty">
               {{i18n "nested_replies.activity_log.empty"}}
             </p>
+          {{/if}}
+          {{#if this.hasMore}}
+            <div class="nested-activity-log-modal__load-more">
+              <DButton
+                class="btn-default"
+                @action={{this.loadMore}}
+                @disabled={{this.loadingMore}}
+                @isLoading={{this.loadingMore}}
+                @label="nested_replies.activity_log.load_more"
+              />
+            </div>
           {{/if}}
         </DConditionalLoadingSpinner>
       </:body>

--- a/frontend/discourse/app/components/modal/nested-activity-log/item.gjs
+++ b/frontend/discourse/app/components/modal/nested-activity-log/item.gjs
@@ -1,21 +1,19 @@
 import Component from "@glimmer/component";
+import { fn } from "@ember/helper";
 import { trustHTML } from "@ember/template";
 import {
   customGroupActionCodes,
+  default as PostSmallAction,
   GROUP_ACTION_CODES,
-  ICONS,
 } from "discourse/components/post/small-action";
 import { autoUpdatingRelativeAge } from "discourse/lib/formatter";
 import getURL from "discourse/lib/get-url";
 import { userPath } from "discourse/lib/url";
 import { escapeExpression } from "discourse/lib/utilities";
 import DUserAvatar from "discourse/ui-kit/d-user-avatar";
+import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import { i18n } from "discourse-i18n";
-
-const ACTIVITY_LOG_ICONS = {
-  topic_created: "plus",
-};
 
 // `action_codes.*` translations interpolate %{who}/%{when}/%{path} at arbitrary
 // positions inside a translated sentence, so the substitutions have to be HTML
@@ -47,9 +45,8 @@ function mentionLinkFor(code, who) {
 }
 
 export default class NestedActivityLogItem extends Component {
-  get iconName() {
-    const code = this.args.action.action_code;
-    return ACTIVITY_LOG_ICONS[code] || ICONS[code] || "exclamation";
+  get isSynthetic() {
+    return this.args.action.synthetic;
   }
 
   get description() {
@@ -61,33 +58,45 @@ export default class NestedActivityLogItem extends Component {
       return null;
     }
     return {
+      id: this.args.action.user_id,
       username: this.args.action.username,
       avatar_template: this.args.action.avatar_template,
     };
   }
 
   <template>
-    <li class="nested-activity-log-modal__item">
-      <span class="nested-activity-log-modal__icon" aria-hidden="true">
-        {{dIcon this.iconName}}
-      </span>
-      <div class="nested-activity-log-modal__content">
-        <div class="nested-activity-log-modal__desc">
-          {{#if this.user}}
-            <DUserAvatar
-              @ariaHidden={{true}}
-              @size="small"
-              @user={{this.user}}
-            />
-          {{/if}}
-          <span>{{this.description}}</span>
-        </div>
-        {{#if @action.cooked}}
-          <div class="nested-activity-log-modal__message">
-            {{trustHTML @action.cooked}}
+    <li
+      class={{dConcatClass
+        "nested-activity-log-modal__item"
+        (if this.isSynthetic "--synthetic")
+      }}
+    >
+      {{#if this.isSynthetic}}
+        <span class="nested-activity-log-modal__icon" aria-hidden="true">
+          {{dIcon "plus"}}
+        </span>
+        <div class="nested-activity-log-modal__content">
+          <div class="nested-activity-log-modal__desc">
+            {{#if this.user}}
+              <DUserAvatar
+                @ariaHidden={{false}}
+                @size="small"
+                @user={{this.user}}
+              />
+            {{/if}}
+            <span>{{this.description}}</span>
           </div>
-        {{/if}}
-      </div>
+        </div>
+      {{else}}
+        <PostSmallAction
+          class="nested-activity-log-modal__post"
+          @elementId="nested-activity-log-post-{{@action.id}}"
+          @post={{@action}}
+          @editPost={{fn @editPost @action}}
+          @deletePost={{fn @deletePost @action}}
+          @recoverPost={{fn @recoverPost @action}}
+        />
+      {{/if}}
     </li>
   </template>
 }

--- a/frontend/discourse/app/controllers/nested.js
+++ b/frontend/discourse/app/controllers/nested.js
@@ -630,7 +630,7 @@ export default class NestedController extends Controller {
   @action
   showActivityLog() {
     this.modal.show(NestedActivityLog, {
-      model: { topic: this.topic },
+      model: { topic: this.topic, editPost: this.editPost },
     });
   }
 
@@ -794,6 +794,11 @@ export default class NestedController extends Controller {
         return;
       }
 
+      if (this.#isActivityLogPost(postData)) {
+        this.#notifyActivityChanged(data);
+        return;
+      }
+
       if (!this.#isVisibleInTree(postData)) {
         return;
       }
@@ -832,14 +837,33 @@ export default class NestedController extends Controller {
   // small_action posts (close/open/etc.) belong in the activity log, not the tree;
   // whispers with an action_code (e.g. assigns) are likewise activity-log-only.
   #isVisibleInTree(postData) {
+    return !this.#isActivityLogPost(postData);
+  }
+
+  #isActivityLogPost(postData) {
     const postTypes = this.site.post_types;
     if (postData.post_type === postTypes.small_action) {
-      return false;
+      return true;
     }
     if (postData.post_type === postTypes.whisper && postData.action_code) {
-      return false;
+      return true;
     }
-    return true;
+    return false;
+  }
+
+  #notifyActivityChanged(data) {
+    const topicId = this.topic?.id;
+    if (topicId) {
+      this.topic = this.store.createRecord("topic", {
+        id: topicId,
+        has_activity_log: true,
+      });
+    }
+    this.appEvents.trigger("nested-replies:activity-changed", {
+      topicId,
+      postId: data.id,
+      type: data.type,
+    });
   }
 
   #visibleParentPostNumber(postData) {
@@ -888,6 +912,9 @@ export default class NestedController extends Controller {
 
   async #handlePostChanged(data) {
     if (data.type === "deleted") {
+      if (this.topic?.has_activity_log) {
+        this.#notifyActivityChanged(data);
+      }
       this.#markPostDeletedLocally(data.id);
       return;
     }
@@ -899,6 +926,11 @@ export default class NestedController extends Controller {
         this.topic?.id !== topicId ||
         !this.#postBelongsToTopic(postData, topicId)
       ) {
+        return;
+      }
+
+      if (this.#isActivityLogPost(postData)) {
+        this.#notifyActivityChanged(data);
         return;
       }
 

--- a/frontend/discourse/tests/integration/components/post/small-action-test.gjs
+++ b/frontend/discourse/tests/integration/components/post/small-action-test.gjs
@@ -1,10 +1,19 @@
 import { getOwner } from "@ember/owner";
-import { render } from "@ember/test-helpers";
+import {
+  click,
+  render,
+  settled,
+  waitFor,
+  waitUntil,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
+import NestedActivityLog from "discourse/components/modal/nested-activity-log";
+import NestedActivityLogItem from "discourse/components/modal/nested-activity-log/item";
 import PostSmallAction from "discourse/components/post/small-action";
 import { shortDate } from "discourse/lib/formatter";
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import I18n from "discourse-i18n";
 
 function renderComponent(post) {
@@ -299,5 +308,161 @@ module("Integration | Component | Post | PostSmallAction", function (hooks) {
 
     assert.dom("#post-heading-1").exists("first post heading has correct id");
     assert.dom("#post-heading-2").exists("second post heading has correct id");
+  });
+});
+
+module(
+  "Integration | Component | Modal | NestedActivityLogItem",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      const store = getOwner(this).lookup("service:store");
+      const topic = store.createRecord("topic", { id: 1 });
+      this.post = store.createRecord("post", {
+        id: 123,
+        post_number: 2,
+        post_type: 3,
+        topic,
+        topic_id: topic.id,
+        user_id: 42,
+        username: "activity-author",
+        avatar_template: "/letter_avatar_proxy/v4/letter/a/13edae/{size}.png",
+        action_code: "closed.enabled",
+        created_at: "2025-09-23T16:10:28.695Z",
+        cooked: "<p>Activity details</p>",
+        can_edit: true,
+        can_delete: true,
+        can_recover: false,
+      });
+      this.currentUser.staff = true;
+    });
+
+    test("uses the canonical small-action renderer and forwards controls", async function (assert) {
+      withPluginApi((api) => {
+        api.registerValueTransformer("post-small-action-icon", () => "heart");
+        api.registerValueTransformer("post-small-action-class", ({ value }) => [
+          ...value,
+          "plugin-activity-class",
+        ]);
+      });
+
+      const editPost = (post) => {
+        assert.strictEqual(post, this.post, "forwards the post to edit");
+      };
+      const deletePost = (post) => {
+        assert.strictEqual(post, this.post, "forwards the post to delete");
+      };
+      const recoverPost = () => {};
+
+      await render(
+        <template>
+          <ul>
+            <NestedActivityLogItem
+              @action={{this.post}}
+              @topicId={{1}}
+              @editPost={{editPost}}
+              @deletePost={{deletePost}}
+              @recoverPost={{recoverPost}}
+            />
+          </ul>
+        </template>
+      );
+
+      assert
+        .dom(".nested-activity-log-modal__post .small-action")
+        .hasClass("plugin-activity-class");
+      assert.dom(".nested-activity-log-modal__post .d-icon-heart").exists();
+      assert
+        .dom(".nested-activity-log-modal__post .small-action-custom-message")
+        .hasText("Activity details");
+
+      await click(".nested-activity-log-modal__post .small-action-edit");
+      await click(".nested-activity-log-modal__post .small-action-delete");
+    });
+
+    test("keeps the synthetic topic-created row read-only", async function (assert) {
+      const syntheticAction = {
+        synthetic: true,
+        action_code: "topic_created",
+        created_at: "2025-09-23T16:10:28.695Z",
+        user_id: 42,
+        username: "activity-author",
+        avatar_template: "/letter_avatar_proxy/v4/letter/a/13edae/{size}.png",
+      };
+
+      await render(
+        <template>
+          <ul>
+            <NestedActivityLogItem @action={{syntheticAction}} @topicId={{1}} />
+          </ul>
+        </template>
+      );
+
+      assert.dom(".nested-activity-log-modal__icon .d-icon-plus").exists();
+      assert.dom(".nested-activity-log-modal__post").doesNotExist();
+      assert.dom(".small-action-buttons").doesNotExist();
+    });
+  }
+);
+
+module("Integration | Component | Modal | NestedActivityLog", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("keeps existing rows mounted while refreshing", async function (assert) {
+    const store = getOwner(this).lookup("service:store");
+    const appEvents = getOwner(this).lookup("service:app-events");
+    const topic = store.createRecord("topic", { id: 1, slug: "topic-1" });
+    const model = { topic, editPost() {} };
+    const closeModal = () => {};
+    const activity = {
+      synthetic: true,
+      action_code: "topic_created",
+      created_at: "2025-09-23T16:10:28.695Z",
+      user_id: 42,
+      username: "activity-author",
+      avatar_template: "/letter_avatar_proxy/v4/letter/a/13edae/{size}.png",
+    };
+    let holdRefresh = false;
+    let refreshRequested = false;
+    let releaseRefresh;
+
+    pretender.get("/n/topic-1/1/activity.json", async () => {
+      if (holdRefresh) {
+        refreshRequested = true;
+        await new Promise((resolve) => (releaseRefresh = resolve));
+      }
+
+      return response({ small_actions: [activity], has_more: false });
+    });
+
+    await render(
+      <template>
+        <NestedActivityLog
+          @model={{model}}
+          @closeModal={{closeModal}}
+          @inline={{true}}
+        />
+      </template>
+    );
+    await waitFor(".nested-activity-log-modal__item");
+
+    assert
+      .dom(".nested-activity-log-modal__item")
+      .exists("renders the initial activity");
+
+    holdRefresh = true;
+    appEvents.trigger("nested-replies:activity-changed", { topicId: topic.id });
+    await waitUntil(() => refreshRequested);
+
+    assert
+      .dom(".nested-activity-log-modal__item")
+      .exists("retains the activity while the refresh is in flight");
+    assert
+      .dom(".nested-activity-log-modal .spinner")
+      .doesNotExist("does not replace existing rows with the blocking spinner");
+
+    releaseRefresh();
+    await settled();
   });
 });

--- a/frontend/discourse/tests/unit/controllers/nested-test.js
+++ b/frontend/discourse/tests/unit/controllers/nested-test.js
@@ -205,6 +205,25 @@ module("Unit | Controller | nested", function (hooks) {
     );
   });
 
+  test("deleting a regular post does not expose the activity log", function (assert) {
+    const topic = buildTopic(this.store, 724);
+    const post = buildPost(this.store, topic, 2001, 2);
+
+    this.controller.topic = topic;
+    this.controller.postRegistry.set(post.post_number, post);
+
+    this.controller._onMessage(
+      { type: "deleted", id: post.id, user_id: this.currentUser.id },
+      null,
+      123
+    );
+
+    assert.false(
+      Boolean(this.controller.topic.has_activity_log),
+      "keeps the activity link hidden"
+    );
+  });
+
   test("context view ignores queued new root replies", async function (assert) {
     const topic = buildTopic(this.store, 724);
     const contextRoot = buildPost(this.store, topic, 1001, 2);

--- a/lib/nested_replies/post_tree_serializer.rb
+++ b/lib/nested_replies/post_tree_serializer.rb
@@ -109,7 +109,9 @@ module NestedReplies
       post_types = [Post.types[:small_action]]
       post_types << Post.types[:whisper] if @guardian.user&.whisperer?
 
-      scope = @topic.posts.where(post_type: post_types).where.not(action_code: [nil, ""])
+      scope = @topic.posts
+      scope = scope.with_deleted if @guardian.can_see_deleted_posts?(@topic.category)
+      scope = scope.where(post_type: post_types).where.not(action_code: [nil, ""])
       @guardian.filter_hidden_posts(scope, category: @topic.category).exists?
     end
   end

--- a/spec/requests/nested_topics_controller_spec.rb
+++ b/spec/requests/nested_topics_controller_spec.rb
@@ -546,6 +546,16 @@ RSpec.describe NestedTopicsController, type: :request do
 
         expect(response.parsed_body["topic"]["has_activity_log"]).to eq(true)
       end
+
+      it "stays true for staff when the only small_action is deleted and recoverable" do
+        action = Fabricate(:small_action, topic: topic, user: admin, action_code: "closed.enabled")
+        action.trash!(admin)
+
+        sign_in(admin)
+        get show_url(topic, page: 0)
+
+        expect(response.parsed_body["topic"]["has_activity_log"]).to eq(true)
+      end
     end
 
     it "paginates with has_more_roots" do
@@ -1675,7 +1685,7 @@ RSpec.describe NestedTopicsController, type: :request do
     end
   end
 
-  describe "GET activity" do
+  describe "#activity" do
     def activity_url(topic)
       "/n/#{topic.slug}/#{topic.id}/activity.json"
     end
@@ -1694,8 +1704,10 @@ RSpec.describe NestedTopicsController, type: :request do
 
       actions = response.parsed_body["small_actions"]
       expect(actions.length).to eq(1)
+      expect(actions[0]["synthetic"]).to eq(true)
       expect(actions[0]["action_code"]).to eq("topic_created")
       expect(actions[0]["username"]).to eq(user.username)
+      expect(response.parsed_body["has_more"]).to eq(false)
     end
 
     it "returns small action posts in chronological order after topic_created" do
@@ -1716,6 +1728,107 @@ RSpec.describe NestedTopicsController, type: :request do
       expect(actions[3]["action_code"]).to eq("invited_user")
       expect(actions[3]["action_code_who"]).to eq("testuser")
       expect(actions[1]["username"]).to eq(admin.username)
+    end
+
+    it "returns post permissions needed by the activity controls" do
+      action =
+        Fabricate(
+          :small_action,
+          topic: topic,
+          user: admin,
+          action_code: "closed.enabled",
+          raw: "Staff-editable activity body",
+        )
+
+      sign_in(user)
+      get activity_url(topic)
+
+      serialized_action =
+        response.parsed_body["small_actions"].find { |item| item["id"] == action.id }
+      expect(serialized_action).to include(
+        "can_edit" => false,
+        "can_delete" => false,
+        "can_recover" => false,
+      )
+
+      sign_in(admin)
+      get activity_url(topic)
+
+      serialized_action =
+        response.parsed_body["small_actions"].find { |item| item["id"] == action.id }
+      expect(serialized_action).to include(
+        "can_edit" => true,
+        "can_delete" => true,
+        "can_recover" => false,
+      )
+      expect(serialized_action).to include(
+        "post_number" => action.post_number,
+        "post_type" => Post.types[:small_action],
+        "topic_id" => topic.id,
+        "user_id" => admin.id,
+      )
+    end
+
+    it "keeps deleted activity available to staff for recovery" do
+      deleted_action =
+        Fabricate(
+          :small_action,
+          topic: topic,
+          user: admin,
+          action_code: "closed.enabled",
+          raw: "Recoverable activity body",
+        )
+      deleted_action.trash!(admin)
+
+      sign_in(user)
+      get activity_url(topic)
+      expect(response.parsed_body["small_actions"].map { |item| item["id"] }).not_to include(
+        deleted_action.id,
+      )
+
+      sign_in(admin)
+      get activity_url(topic)
+
+      serialized_action =
+        response.parsed_body["small_actions"].find { |item| item["id"] == deleted_action.id }
+      expect(serialized_action).to include(
+        "can_edit" => true,
+        "can_delete" => true,
+        "can_recover" => true,
+      )
+      expect(serialized_action["deleted_at"]).to be_present
+    end
+
+    it "paginates activity without repeating the synthetic entry" do
+      stub_const(described_class, :ACTIVITY_PAGE_SIZE, 2) do
+        actions =
+          3.times.map do |index|
+            Fabricate(
+              :small_action,
+              topic: topic,
+              user: admin,
+              action_code: "closed.enabled",
+              raw: "Activity body #{index}",
+            )
+          end
+
+        sign_in(user)
+        get activity_url(topic), params: { page: 0 }
+
+        first_page = response.parsed_body
+        expect(first_page["small_actions"].map { |item| item["id"] }).to eq(
+          [nil, actions[0].id, actions[1].id],
+        )
+        expect(first_page["small_actions"].first["synthetic"]).to eq(true)
+        expect(first_page["has_more"]).to eq(true)
+
+        get activity_url(topic), params: { page: 1 }
+
+        second_page = response.parsed_body
+        expect(second_page["small_actions"].map { |item| item["id"] }).to eq([actions[2].id])
+        expect(second_page["small_actions"]).to all(exclude("synthetic"))
+        expect(second_page["has_more"]).to eq(false)
+      end
     end
 
     it "does not expose hidden small-action posts to users who cannot see them" do

--- a/spec/system/nested_activity_log_spec.rb
+++ b/spec/system/nested_activity_log_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe "Nested activity log" do
   fab!(:topic) { Fabricate(:topic, user: admin) }
   fab!(:op) { Fabricate(:post, topic: topic, user: admin, post_number: 1) }
 
+  let(:activity_log) { PageObjects::Components::NestedActivityLog.new }
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:dialog) { PageObjects::Components::Dialog.new }
+  let(:nested_view) { PageObjects::Pages::NestedView.new }
+
   before do
     SiteSetting.nested_replies_enabled = true
     Fabricate(:nested_topic, topic: topic)
@@ -14,17 +19,53 @@ RSpec.describe "Nested activity log" do
   it "opens the activity log modal and lists small actions" do
     topic.add_small_action(admin, "closed.enabled")
 
-    page.visit("/t/#{topic.slug}/#{topic.id}")
-    find(".nested-view__activity-link").click
+    nested_view.visit_nested(topic).open_activity_log
 
-    expect(page).to have_css(".nested-activity-log-modal")
-    expect(page).to have_css(".nested-activity-log-modal__item", count: 2)
+    expect(activity_log).to be_open
+    expect(activity_log).to have_item_count(2)
   end
 
   it "hides the activity log link on a topic with no small actions" do
-    page.visit("/t/#{topic.slug}/#{topic.id}")
+    nested_view.visit_nested(topic)
 
     expect(page).to have_css(".nested-view__controls")
-    expect(page).to have_no_css(".nested-view__activity-link")
+    expect(nested_view).to have_no_activity_log_link
+  end
+
+  it "edits, deletes, and recovers a small action" do
+    action =
+      Fabricate(
+        :small_action,
+        topic: topic,
+        user: admin,
+        action_code: "closed.enabled",
+        raw: "Original activity details",
+      )
+
+    nested_view.visit_nested(topic).open_activity_log
+    expect(activity_log).to have_item_text(action, "Original activity details")
+    expect(activity_log).to have_edit_button(action)
+    expect(activity_log).to have_delete_button(action)
+
+    activity_log.click_edit(action)
+    expect(activity_log).to be_closed
+    expect(composer).to be_opened
+
+    composer.fill_content("Updated activity details")
+    composer.submit
+    expect(composer).to be_closed
+
+    nested_view.open_activity_log
+    expect(activity_log).to have_item_text(action, "Updated activity details")
+
+    activity_log.click_delete(action)
+    dialog.click_yes
+    expect(activity_log).to have_recover_button(action)
+    expect(activity_log).to have_no_edit_button(action)
+
+    activity_log.click_recover(action)
+    expect(activity_log).to have_item_text(action, "Updated activity details")
+    expect(activity_log).to have_edit_button(action)
+    expect(activity_log).to have_delete_button(action)
   end
 end

--- a/spec/system/nested_realtime_spec.rb
+++ b/spec/system/nested_realtime_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Nested view real-time updates" do
   end
 
   let(:nested_view) { PageObjects::Pages::NestedView.new }
+  let(:activity_log) { PageObjects::Components::NestedActivityLog.new }
 
   before do
     SiteSetting.nested_replies_enabled = true
@@ -120,23 +121,23 @@ RSpec.describe "Nested view real-time updates" do
   end
 
   describe "small_action posts" do
-    it "does not insert close/open small_actions into the tree" do
+    it "adds the activity link and updates the modal without inserting the action into the tree" do
       nested_view.visit_nested(topic)
       expect(nested_view).to have_root_post(root_reply)
+      expect(nested_view).to have_no_activity_log_link
 
       small_action = topic.add_small_action(admin, "closed.enabled")
 
-      # A real reply published right after — once it surfaces, the small_action's
-      # message bus event has already been delivered (same channel, in order),
-      # so we can safely assert it never landed in the tree.
-      new_reply =
-        PostCreator.create!(other_user, topic_id: topic.id, raw: "Real reply that must show")
-
-      expect(page).to have_css(".nested-view__new-replies-btn", wait: 10)
-      find(".nested-view__new-replies-btn").click
-
-      expect(nested_view).to have_root_post(new_reply)
+      expect(nested_view).to have_activity_log_link
       expect(page).to have_no_css("[data-post-number='#{small_action.post_number}']")
+
+      nested_view.open_activity_log
+      expect(activity_log).to have_item(small_action)
+
+      revised = PostRevisor.new(small_action)
+      revised.revise!(admin, raw: "Updated through the message bus")
+
+      expect(activity_log).to have_item_text(small_action, "Updated through the message bus")
     end
   end
 end

--- a/spec/system/page_objects/components/nested_activity_log.rb
+++ b/spec/system/page_objects/components/nested_activity_log.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class NestedActivityLog < PageObjects::Components::Base
+      MODAL_SELECTOR = ".nested-activity-log-modal"
+
+      def open?
+        has_css?(MODAL_SELECTOR)
+      end
+
+      def closed?
+        has_no_css?(MODAL_SELECTOR)
+      end
+
+      def has_item?(post)
+        has_css?(item_selector(post))
+      end
+
+      def has_item_text?(post, text)
+        has_css?(item_selector(post), text: text)
+      end
+
+      def has_item_count?(count)
+        has_css?("#{MODAL_SELECTOR} .nested-activity-log-modal__item", count: count)
+      end
+
+      def has_edit_button?(post)
+        has_css?("#{item_selector(post)} .small-action-edit")
+      end
+
+      def has_no_edit_button?(post)
+        has_no_css?("#{item_selector(post)} .small-action-edit")
+      end
+
+      def has_delete_button?(post)
+        has_css?("#{item_selector(post)} .small-action-delete")
+      end
+
+      def has_recover_button?(post)
+        has_css?("#{item_selector(post)} .small-action-recover")
+      end
+
+      def click_edit(post)
+        find("#{item_selector(post)} .small-action-edit").click
+        self
+      end
+
+      def click_delete(post)
+        find("#{item_selector(post)} .small-action-delete").click
+        self
+      end
+
+      def click_recover(post)
+        find("#{item_selector(post)} .small-action-recover").click
+        self
+      end
+
+      def click_load_more
+        find("#{MODAL_SELECTOR} .nested-activity-log-modal__load-more button").click
+        self
+      end
+
+      private
+
+      def item_selector(post)
+        "#{MODAL_SELECTOR} [data-post-id='#{post.id}']"
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/pages/nested_view.rb
+++ b/spec/system/page_objects/pages/nested_view.rb
@@ -366,6 +366,14 @@ module PageObjects
         has_css?(".nested-view__topic-actions + .nested-view__controls")
       end
 
+      def has_activity_log_link?
+        has_css?(".nested-view__activity-link", wait: 10)
+      end
+
+      def has_no_activity_log_link?
+        has_no_css?(".nested-view__activity-link")
+      end
+
       def has_share_topic_action?
         has_css?(".nested-view__topic-actions #topic-footer-button-share-and-invite")
       end
@@ -418,6 +426,11 @@ module PageObjects
 
       def click_edit_topic
         find(".nested-view__title .fancy-title").click
+        self
+      end
+
+      def open_activity_log
+        find(".nested-view__activity-link").click
         self
       end
 


### PR DESCRIPTION
Previously, small actions in nested replies' Activity Log modal could not be edited, deleted, or recovered, and refreshes collapsed the modal.

This change renders the activity log as proper small action posts with all the actions you expect from flat view.