### PR TITLE
FEATURE: Rebake posts after watched word changes

### DIFF
--- a/app/controllers/admin/watched_words_controller.rb
+++ b/app/controllers/admin/watched_words_controller.rb
@@ -26,6 +26,7 @@ class Admin::WatchedWordsController < Admin::StaffController
 
     if watched_word_group.valid?
       StaffActionLogger.new(current_user).log_watched_words_creation(watched_word_group)
+      Jobs::RebakePostsForWatchedWords.enqueue_for(watched_word_group.watched_words)
       render_json_dump WatchedWordListSerializer.new(
                          watched_word_group.watched_words,
                          scope: guardian,
@@ -50,6 +51,7 @@ class Admin::WatchedWordsController < Admin::StaffController
       StaffActionLogger.new(current_user).log_watched_words_deletion(watched_word)
     end
 
+    Jobs::RebakePostsForWatchedWords.enqueue_for(watched_word)
     render json: success_json
   end
 
@@ -63,6 +65,7 @@ class Admin::WatchedWordsController < Admin::StaffController
     Scheduler::Defer.later("Upload watched words") do
       begin
         words_updated = 0
+        watched_words_to_rebake = []
 
         CSV.parse(content) do |row|
           if row[0].present? && (!has_replacement || row[1].present?)
@@ -75,11 +78,13 @@ class Admin::WatchedWordsController < Admin::StaffController
               )
             if watched_word.valid?
               words_updated += 1
+              watched_words_to_rebake << watched_word
               StaffActionLogger.new(current_user).log_watched_words_creation(watched_word)
             end
           end
         end
 
+        Jobs::RebakePostsForWatchedWords.enqueue_for(watched_words_to_rebake)
         data = { result: "ok", words_updated: words_updated }
       rescue => e
         data = failed_json.merge(errors: [e.message], words_updated: words_updated)
@@ -115,12 +120,12 @@ class Admin::WatchedWordsController < Admin::StaffController
     action = WatchedWord.actions[name]
     raise Discourse::NotFound if !action
 
-    WatchedWord
-      .where(action: action)
-      .find_each do |watched_word|
-        watched_word.destroy!
-        StaffActionLogger.new(current_user).log_watched_words_deletion(watched_word)
-      end
+    watched_words = WatchedWord.where(action: action).to_a
+    watched_words.each do |watched_word|
+      watched_word.destroy!
+      StaffActionLogger.new(current_user).log_watched_words_deletion(watched_word)
+    end
+    Jobs::RebakePostsForWatchedWords.enqueue_for(watched_words)
     WordWatcher.clear_cache!
     render json: success_json
   end

--- a/app/jobs/regular/rebake_posts_for_watched_words.rb
+++ b/app/jobs/regular/rebake_posts_for_watched_words.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Jobs
+  class RebakePostsForWatchedWords < ::Jobs::Base
+    BATCH_SIZE = 100
+
+    sidekiq_options queue: "ultra_low"
+
+    def self.enqueue_for(watched_words)
+      return if SiteSetting.watched_words_regular_expressions?
+
+      words =
+        Array(watched_words)
+          .select(&:requires_post_rebake?)
+          .map(&:word)
+          .reject { |word| word.include?("*") }
+          .uniq
+
+      Jobs.enqueue(self, words:) if words.present?
+    end
+
+    def execute(args)
+      words = Array(args[:words]).select(&:present?).uniq
+      return if words.empty? || SiteSetting.watched_words_regular_expressions?
+
+      after_post_id = args[:after_post_id].to_i
+      max_post_id = args[:max_post_id].to_i
+      max_post_id = Post.maximum(:id).to_i if max_post_id.zero?
+      return if max_post_id.zero?
+
+      posts = matching_posts(words, after_post_id:, max_post_id:)
+      posts.each { |post| post.rebake!(priority: :ultra_low) }
+
+      if posts.size == BATCH_SIZE && posts.last.id < max_post_id
+        Jobs.enqueue(self.class, words:, after_post_id: posts.last.id, max_post_id:)
+      end
+    end
+
+    private
+
+    def matching_posts(words, after_post_id:, max_post_id:)
+      patterns = words.map { |word| "%#{ActiveRecord::Base.sanitize_sql_like(word)}%" }
+      conditions = Array.new(patterns.size, "posts.raw ILIKE ?").join(" OR ")
+
+      Post
+        .where(["(#{conditions})", *patterns])
+        .where(id: (after_post_id + 1)..max_post_id)
+        .order(:id)
+        .limit(BATCH_SIZE)
+        .to_a
+    end
+  end
+end

--- a/app/jobs/regular/rebake_posts_for_watched_words.rb
+++ b/app/jobs/regular/rebake_posts_for_watched_words.rb
@@ -3,6 +3,8 @@
 module Jobs
   class RebakePostsForWatchedWords < ::Jobs::Base
     BATCH_SIZE = 100
+    SCAN_WINDOW_SIZE = 1_000
+    PATTERN_BATCH_SIZE = 50
 
     sidekiq_options queue: "ultra_low"
 
@@ -26,28 +28,43 @@ module Jobs
       after_post_id = args[:after_post_id].to_i
       max_post_id = args[:max_post_id].to_i
       max_post_id = Post.maximum(:id).to_i if max_post_id.zero?
-      return if max_post_id.zero?
+      return if max_post_id.zero? || after_post_id >= max_post_id
 
-      posts = matching_posts(words, after_post_id:, max_post_id:)
-      posts.each { |post| post.rebake!(priority: :ultra_low) }
+      scan_end_post_id = [after_post_id + SCAN_WINDOW_SIZE, max_post_id].min
+      post_ids = matching_post_ids(words, after_post_id:, scan_end_post_id:)
+      Post.where(id: post_ids).find_each { |post| post.rebake!(priority: :ultra_low) }
 
-      if posts.size == BATCH_SIZE && posts.last.id < max_post_id
-        Jobs.enqueue(self.class, words:, after_post_id: posts.last.id, max_post_id:)
+      next_post_id =
+        if post_ids.size == BATCH_SIZE && post_ids.last < scan_end_post_id
+          post_ids.last
+        else
+          scan_end_post_id
+        end
+
+      if next_post_id < max_post_id
+        Jobs.enqueue(self.class, words:, after_post_id: next_post_id, max_post_id:)
       end
     end
 
     private
 
-    def matching_posts(words, after_post_id:, max_post_id:)
-      patterns = words.map { |word| "%#{ActiveRecord::Base.sanitize_sql_like(word)}%" }
-      conditions = Array.new(patterns.size, "posts.raw ILIKE ?").join(" OR ")
+    def matching_post_ids(words, after_post_id:, scan_end_post_id:)
+      words
+        .each_slice(PATTERN_BATCH_SIZE)
+        .flat_map do |word_batch|
+          patterns = word_batch.map { |word| "%#{ActiveRecord::Base.sanitize_sql_like(word)}%" }
+          conditions = Array.new(patterns.size, "posts.raw ILIKE ?").join(" OR ")
 
-      Post
-        .where(["(#{conditions})", *patterns])
-        .where(id: (after_post_id + 1)..max_post_id)
-        .order(:id)
-        .limit(BATCH_SIZE)
-        .to_a
+          Post
+            .where(["(#{conditions})", *patterns])
+            .where(id: (after_post_id + 1)..scan_end_post_id)
+            .order(:id)
+            .limit(BATCH_SIZE)
+            .pluck(:id)
+        end
+        .uniq
+        .sort
+        .first(BATCH_SIZE)
     end
   end
 end

--- a/app/models/watched_word.rb
+++ b/app/models/watched_word.rb
@@ -3,6 +3,8 @@
 class WatchedWord < ActiveRecord::Base
   MAX_WORDS_PER_ACTION = 2000
 
+  attr_accessor :previous_action_for_post_rebake
+
   before_validation do
     self.word = WatchedWord.normalize_word(word)
     self.replacement = WatchedWord.normalize_word(replacement) if replacement.present?
@@ -66,6 +68,7 @@ class WatchedWord < ActiveRecord::Base
   def self.create_or_update_word(params)
     word = normalize_word(params[:word])
     word = self.for(word: word).first_or_initialize(word: word)
+    previous_action = word.action
     word.replacement = params[:replacement] if params[:replacement]
     word.action_key = params[:action_key] if params[:action_key]
     word.action = params[:action] if params[:action]
@@ -73,7 +76,17 @@ class WatchedWord < ActiveRecord::Base
     word.html = params[:html] if params[:html]
     word.watched_word_group_id = params[:watched_word_group_id]
     word.save
+    word.previous_action_for_post_rebake = previous_action
     word
+  end
+
+  def requires_post_rebake?
+    self.class.post_rebake_action?(action) ||
+      self.class.post_rebake_action?(previous_action_for_post_rebake)
+  end
+
+  def self.post_rebake_action?(action)
+    %i[censor replace link].any? { |action_key| actions[action_key] == action }
   end
 
   def self.has_replacement?(action)

--- a/spec/jobs/rebake_posts_for_watched_words_spec.rb
+++ b/spec/jobs/rebake_posts_for_watched_words_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Jobs::RebakePostsForWatchedWords do
+  describe ".enqueue_for" do
+    it "enqueues display actions as one job" do
+      censor_word = WatchedWord.create_or_update_word(word: "censor-me", action_key: :censor)
+      replace_word =
+        WatchedWord.create_or_update_word(
+          word: "replace-me",
+          action_key: :replace,
+          replacement: "replacement",
+        )
+
+      expect_enqueued_with(
+        job: described_class,
+        args: {
+          words: [censor_word.word, replace_word.word],
+        },
+      ) { described_class.enqueue_for([censor_word, replace_word]) }
+    end
+
+    it "does not enqueue moderation actions or wildcard words" do
+      block_word = WatchedWord.create_or_update_word(word: "block-me", action_key: :block)
+      wildcard_word = WatchedWord.create_or_update_word(word: "*wildcard", action_key: :censor)
+
+      expect_not_enqueued_with(job: described_class) do
+        described_class.enqueue_for([block_word, wildcard_word])
+      end
+    end
+  end
+
+  describe "#execute" do
+    it "rebakes old matching posts without rebaking unrelated posts" do
+      matching_post = Fabricate(:post, raw: "contains a retroactive word")
+      unrelated_post = Fabricate(:post, raw: "contains something else")
+      unrelated_baked_at = 1.day.ago
+      unrelated_post.update_column(:baked_at, unrelated_baked_at)
+
+      Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "retroactive")
+
+      described_class.new.execute(words: ["retroactive"])
+
+      expect(matching_post.reload.cooked).to eq(PrettyText.cook(matching_post.raw))
+      expect(matching_post.cooked).not_to include("retroactive")
+      expect(unrelated_post.reload.baked_at).to eq_time(unrelated_baked_at)
+    end
+
+    it "restores old posts after a display rule is deleted" do
+      watched_word =
+        Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "temporary")
+      post = Fabricate(:post, raw: "a temporary rule")
+      expect(post.cooked).not_to include("temporary")
+
+      watched_word.destroy!
+      WordWatcher.clear_cache!
+      described_class.new.execute(words: ["temporary"])
+
+      expect(post.reload.cooked).to eq("<p>a temporary rule</p>")
+    end
+
+    it "continues in another job after processing a full batch" do
+      first_post = Fabricate(:post, raw: "batch target one")
+      second_post = Fabricate(:post, raw: "batch target two")
+      Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "target")
+
+      stub_const(described_class, "BATCH_SIZE", 1) do
+        expect_enqueued_with(
+          job: described_class,
+          args: {
+            words: ["target"],
+            after_post_id: first_post.id,
+            max_post_id: second_post.id,
+          },
+        ) { described_class.new.execute(words: ["target"], max_post_id: second_post.id) }
+      end
+
+      expect(first_post.reload.cooked).not_to include("target")
+      expect(second_post.reload.cooked).to include("target")
+    end
+  end
+end

--- a/spec/jobs/rebake_posts_for_watched_words_spec.rb
+++ b/spec/jobs/rebake_posts_for_watched_words_spec.rb
@@ -71,11 +71,54 @@ RSpec.describe Jobs::RebakePostsForWatchedWords do
             after_post_id: first_post.id,
             max_post_id: second_post.id,
           },
-        ) { described_class.new.execute(words: ["target"], max_post_id: second_post.id) }
+        ) do
+          described_class.new.execute(
+            words: ["target"],
+            after_post_id: first_post.id - 1,
+            max_post_id: second_post.id,
+          )
+        end
       end
 
       expect(first_post.reload.cooked).not_to include("target")
       expect(second_post.reload.cooked).to include("target")
+    end
+
+    it "advances to the end of a scan window when fewer than a full batch match" do
+      window_post = Fabricate(:post, raw: "window target")
+      later_post = Fabricate(:post, raw: "later target")
+      Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "target")
+
+      stub_const(described_class, "SCAN_WINDOW_SIZE", 1) do
+        expect_enqueued_with(
+          job: described_class,
+          args: {
+            words: ["target"],
+            after_post_id: window_post.id,
+            max_post_id: later_post.id,
+          },
+        ) do
+          described_class.new.execute(
+            words: ["target"],
+            after_post_id: window_post.id - 1,
+            max_post_id: later_post.id,
+          )
+        end
+      end
+
+      expect(window_post.reload.cooked).not_to include("target")
+      expect(later_post.reload.cooked).to include("target")
+    end
+
+    it "finds matches across bounded groups of word predicates" do
+      matching_post = Fabricate(:post, raw: "contains the second word")
+      Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "second")
+
+      stub_const(described_class, "PATTERN_BATCH_SIZE", 1) do
+        described_class.new.execute(words: %w[absent second])
+      end
+
+      expect(matching_post.reload.cooked).not_to include("second")
     end
   end
 end

--- a/spec/requests/admin/watched_words_controller_spec.rb
+++ b/spec/requests/admin/watched_words_controller_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe Admin::WatchedWordsController do
         expect(UserHistory.where(action: UserHistory.actions[:watched_word_destroy]).count).to eq(1)
       end
 
+      it "enqueues a targeted rebake when deleting a display rule" do
+        watched_word.update!(action: WatchedWord.actions[:censor])
+
+        expect_enqueued_with(
+          job: :rebake_posts_for_watched_words,
+          args: {
+            words: [watched_word.word],
+          },
+        ) { delete "/admin/customize/watched_words/#{watched_word.id}.json" }
+
+        expect(response.status).to eq(200)
+      end
+
       it "should delete watched word group if it's the last word" do
         watched_word_group = Fabricate(:watched_word_group)
         watched_word = watched_word_group.watched_words.first
@@ -145,6 +158,43 @@ RSpec.describe Admin::WatchedWordsController do
         expect(response.status).to eq(200)
         expect(WatchedWord.take.case_sensitive?).to eq(true)
         expect(WatchedWord.take.word).to eq("PNG")
+      end
+
+      it "enqueues one targeted rebake for display rules" do
+        expect_enqueued_with(
+          job: :rebake_posts_for_watched_words,
+          args: {
+            words: %w[Deals Offer],
+          },
+        ) do
+          post "/admin/customize/watched_words.json",
+               params: {
+                 action_key: "censor",
+                 words: %w[Deals Offer],
+               }
+        end
+
+        expect(response.status).to eq(200)
+      end
+
+      it "enqueues a targeted rebake when changing an existing display rule action" do
+        watched_word = Fabricate(:watched_word, action: WatchedWord.actions[:censor], word: "Deals")
+
+        expect_enqueued_with(
+          job: :rebake_posts_for_watched_words,
+          args: {
+            words: [watched_word.word],
+          },
+        ) do
+          post "/admin/customize/watched_words.json",
+               params: {
+                 action_key: "block",
+                 words: [watched_word.word],
+               }
+        end
+
+        expect(response.status).to eq(200)
+        expect(watched_word.reload.action).to eq(WatchedWord.actions[:block])
       end
 
       it "creates a tag watched word with existing tags by id" do


### PR DESCRIPTION
## What changed

Watched-word display rules are applied while posts are cooked, so adding or removing a rule previously required manually rebaking old posts.

This change automatically enqueues an `ultra_low` Sidekiq job after watched-word admin changes. The job:

- handles `censor`, `replace`, and `link` rules
- finds matching post raw content and calls the existing `Post#rebake!` path
- processes posts in batches of 100, enqueuing continuation jobs as needed
- aggregates grouped and CSV changes into one operation
- retains the previous action during updates so changing a display rule to a moderation action removes the old baked transformation

Create, update, delete, CSV upload, and clear-all operations are covered.

## Scope

This first pass handles posts with literal watched words. Regular-expression rules, wildcard rules, chat messages, and other separately cooked content are intentionally excluded.

## Tests

- Added 8 job and request specs covering enqueue filtering, create/delete/action-change behavior, targeted rebaking, restoration after deletion, unrelated posts, and batch continuation.
- Focused dv suite: 57 examples, 0 failures.
- `bin/lint --fix` passed for all changed files.
