### PR TITLE
FIX: Chat browse page on mobile

### DIFF
--- a/app/assets/stylesheets/common/components/d-filter-controls.scss
+++ b/app/assets/stylesheets/common/components/d-filter-controls.scss
@@ -1,5 +1,9 @@
 @use "lib/viewport";
 
+.filter-input.d-filter-controls__input {
+  padding-left: 0;
+}
+
 .d-filter-controls {
   display: flex;
   gap: var(--space-2);
@@ -9,7 +13,7 @@
     flex: 1 1 auto;
   }
 
-  &.--multiple-dropdowns {
+  &.--dropdowns-in-filter-drawer {
     display: flex;
     flex-direction: column;
   }

--- a/frontend/discourse/app/ui-kit/d-filter-controls.gjs
+++ b/frontend/discourse/app/ui-kit/d-filter-controls.gjs
@@ -14,7 +14,7 @@ import DiscourseURL, {
   applyQueryParams,
   searchParamsFromPath,
 } from "discourse/lib/url";
-import { and, eq, not } from "discourse/truth-helpers";
+import { and, eq, not, or } from "discourse/truth-helpers";
 import DButton from "discourse/ui-kit/d-button";
 import DFilterInput from "discourse/ui-kit/d-filter-input";
 import DSelect from "discourse/ui-kit/d-select";
@@ -45,7 +45,9 @@ const ResetButton = <template>
  * @param {String|Object} [defaultDropdownValue="all"] - Default dropdown value(s). For single dropdown: "all",
  *                                                       for multiple: { dropdown1: "all", dropdown2: "all" }
  * @param {String|Object} [dropdownValue] - Current dropdown value(s), defaults to defaultDropdownValue
+ * @param {Boolean} [forceShowDropdownFilterToggle=false] - Whether to place a single dropdown behind the filter toggle
  * @param {String} [noResultsMessage] - Message shown when no results found
+ * @param {Boolean} [showNoResults=true] - Whether to show the built-in no-results state
  * @param {Boolean} [loading] - Whether data is loading (hides reset button during loading)
  * @param {Number} [minItemsForFilter] - Minimum items before showing filters (default: always show)
  * @param {Function} [onTextFilterChange] - Callback for text changes (enables server-side mode)
@@ -148,10 +150,24 @@ export default class DFilterControls extends Component {
     return this.args.dropdownOptions || [];
   }
 
+  get showDropdownFilterToggle() {
+    return this.hasMultipleDropdowns || this.args.forceShowDropdownFilterToggle;
+  }
+
   get showDropdownFilter() {
     return (
-      this.dropdownOptions.length > 1 ||
-      (this.hasMultipleDropdowns && this.showFilterDropdowns)
+      (this.dropdownOptions.length > 1 &&
+        !this.args.forceShowDropdownFilterToggle) ||
+      (this.hasMultipleDropdowns && this.showFilterDropdowns) ||
+      (this.args.forceShowDropdownFilterToggle && this.showFilterDropdowns)
+    );
+  }
+
+  get showFilterResetButton() {
+    return (
+      !this.hasMultipleDropdowns &&
+      !this.args.forceShowDropdownFilterToggle &&
+      this.hasActiveFilters
     );
   }
 
@@ -167,6 +183,10 @@ export default class DFilterControls extends Component {
     return this.args.minItemsForFilter
       ? this.array.length >= this.args.minItemsForFilter
       : true;
+  }
+
+  get showNoResults() {
+    return this.args.showNoResults ?? true;
   }
 
   get hasActiveFilters() {
@@ -410,7 +430,10 @@ export default class DFilterControls extends Component {
       <div
         class={{dConcatClass
           "d-filter-controls"
-          (if this.hasMultipleDropdowns "--multiple-dropdowns")
+          (if
+            (or this.hasMultipleDropdowns @forceShowDropdownFilterToggle)
+            "--dropdowns-in-filter-drawer"
+          )
         }}
         {{didInsert this.applyDropdownsFromUrl}}
         {{didUpdate
@@ -428,7 +451,7 @@ export default class DFilterControls extends Component {
             @icons={{hash left="magnifying-glass"}}
           />
 
-          {{#if this.hasMultipleDropdowns}}
+          {{#if this.showDropdownFilterToggle}}
             <DButton
               class="btn-default d-filter-controls__toggle-filters"
               @icon={{if
@@ -497,7 +520,7 @@ export default class DFilterControls extends Component {
           </div>
         {{/if}}
 
-        {{#if (and (not this.hasMultipleDropdowns) this.hasActiveFilters)}}
+        {{#if this.showFilterResetButton}}
           <ResetButton @action={{this.resetFilters}} />
         {{/if}}
 
@@ -510,7 +533,7 @@ export default class DFilterControls extends Component {
     {{#if this.filteredData.length}}
       {{yield this.filteredData to="content"}}
     {{else if this.showFilters}}
-      {{#if (and this.hasActiveFilters (not @loading))}}
+      {{#if (and this.showNoResults this.hasActiveFilters (not @loading))}}
         <div class="d-filter-controls__no-results">
           {{#if @noResultsMessage}}
             <p>{{@noResultsMessage}}</p>

--- a/frontend/discourse/app/ui-kit/d-filter-controls.gjs
+++ b/frontend/discourse/app/ui-kit/d-filter-controls.gjs
@@ -48,6 +48,7 @@ const ResetButton = <template>
  * @param {Boolean} [forceShowDropdownFilterToggle=false] - Whether to place a single dropdown behind the filter toggle
  * @param {String} [noResultsMessage] - Message shown when no results found
  * @param {Boolean} [showNoResults=true] - Whether to show the built-in no-results state
+ * @param {Boolean} [showResetButton=true] - Whether to show the reset filters button
  * @param {Boolean} [loading] - Whether data is loading (hides reset button during loading)
  * @param {Number} [minItemsForFilter] - Minimum items before showing filters (default: always show)
  * @param {Function} [onTextFilterChange] - Callback for text changes (enables server-side mode)
@@ -165,10 +166,15 @@ export default class DFilterControls extends Component {
 
   get showFilterResetButton() {
     return (
+      this.showResetButton &&
       !this.hasMultipleDropdowns &&
       !this.args.forceShowDropdownFilterToggle &&
       this.hasActiveFilters
     );
+  }
+
+  get showResetButton() {
+    return this.args.showResetButton ?? true;
   }
 
   get defaultDropdownValue() {
@@ -462,7 +468,7 @@ export default class DFilterControls extends Component {
               @title="filter_controls.toggle"
               @action={{this.toggleFilters}}
             />
-            {{#if this.hasActiveFilters}}
+            {{#if (and this.showResetButton this.hasActiveFilters)}}
               <ResetButton @action={{this.resetFilters}} />
             {{/if}}
           {{/if}}
@@ -538,7 +544,9 @@ export default class DFilterControls extends Component {
           {{#if @noResultsMessage}}
             <p>{{@noResultsMessage}}</p>
           {{/if}}
-          <ResetButton @action={{this.resetFilters}} />
+          {{#if this.showResetButton}}
+            <ResetButton @action={{this.resetFilters}} />
+          {{/if}}
         </div>
       {{/if}}
     {{else}}

--- a/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
@@ -137,6 +137,67 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
       .exists("renders dropdown filter");
   });
 
+  test("can collapse a single dropdown behind the filter toggle", async function (assert) {
+    this.set("data", SAMPLE_DATA);
+    this.set("dropdownOptions", SAMPLE_DROPDOWN_OPTIONS);
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{this.data}}
+          @dropdownOptions={{this.dropdownOptions}}
+          @filterDropdownsExpanded={{false}}
+          @forceShowDropdownFilterToggle={{true}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".d-filter-controls")
+      .hasClass(
+        "--dropdowns-in-filter-drawer",
+        "uses the filter drawer layout"
+      );
+    assert
+      .dom(".d-filter-controls__toggle-filters")
+      .exists("shows the filter toggle");
+    assert
+      .dom(".d-filter-controls__dropdown")
+      .doesNotExist("starts with the dropdown collapsed");
+
+    await click(".d-filter-controls__toggle-filters");
+
+    assert
+      .dom(".d-filter-controls__dropdown")
+      .exists("reveals the dropdown after toggling filters");
+  });
+
+  test("shows one reset button with a forced single-dropdown toggle", async function (assert) {
+    this.set("data", SAMPLE_DATA);
+    this.set("searchableProps", ["name"]);
+    this.set("dropdownOptions", SAMPLE_DROPDOWN_OPTIONS);
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{this.data}}
+          @searchableProps={{this.searchableProps}}
+          @dropdownOptions={{this.dropdownOptions}}
+          @forceShowDropdownFilterToggle={{true}}
+        />
+      </template>
+    );
+
+    await fillIn(".filter-input", "first");
+
+    assert
+      .dom(".d-filter-controls__reset")
+      .exists({ count: 1 }, "shows a single reset button");
+    assert
+      .dom(".d-filter-controls > .d-filter-controls__reset")
+      .doesNotExist("does not show a second reset button after the dropdowns");
+  });
+
   test("filters data by single dropdown (client-side)", async function (assert) {
     this.set("data", SAMPLE_DATA);
     this.set("dropdownOptions", SAMPLE_DROPDOWN_OPTIONS);
@@ -276,6 +337,30 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
     assert
       .dom(".d-filter-controls__reset")
       .exists("shows reset button after filtering");
+  });
+
+  test("can hide the built-in no-results state", async function (assert) {
+    this.set("data", SAMPLE_DATA);
+    this.set("searchableProps", ["name"]);
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{this.data}}
+          @searchableProps={{this.searchableProps}}
+          @showNoResults={{false}}
+        />
+      </template>
+    );
+
+    await fillIn(".filter-input", "nonexistent");
+
+    assert
+      .dom(".d-filter-controls > .d-filter-controls__reset")
+      .exists({ count: 1 }, "shows one reset button beside the filters");
+    assert
+      .dom(".d-filter-controls__no-results")
+      .doesNotExist("does not render the built-in no-results state");
   });
 
   test("reset button clears filters", async function (assert) {
@@ -660,6 +745,12 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
       </template>
     );
 
+    assert
+      .dom(".d-filter-controls")
+      .hasClass(
+        "--dropdowns-in-filter-drawer",
+        "uses the filter drawer layout"
+      );
     assert
       .dom(".d-filter-controls__dropdown")
       .exists({ count: 2 }, "renders two dropdowns");

--- a/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-filter-controls-test.gjs
@@ -363,6 +363,27 @@ module("Integration | ui-kit | DFilterControls", function (hooks) {
       .doesNotExist("does not render the built-in no-results state");
   });
 
+  test("can hide the reset button", async function (assert) {
+    this.set("data", SAMPLE_DATA);
+    this.set("searchableProps", ["name"]);
+
+    await render(
+      <template>
+        <DFilterControls
+          @array={{this.data}}
+          @searchableProps={{this.searchableProps}}
+          @showResetButton={{false}}
+        />
+      </template>
+    );
+
+    await fillIn(".filter-input", "nonexistent");
+
+    assert
+      .dom(".d-filter-controls__reset")
+      .doesNotExist("does not render the reset button");
+  });
+
   test("reset button clears filters", async function (assert) {
     this.set("data", SAMPLE_DATA);
     this.set("searchableProps", ["name"]);

--- a/plugins/chat/assets/javascripts/discourse/components/browse-channels.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/browse-channels.gjs
@@ -1,17 +1,14 @@
 import Component from "@glimmer/component";
 import { cached, tracked } from "@glimmer/tracking";
-import { concat, hash } from "@ember/helper";
+import { concat } from "@ember/helper";
 import { action } from "@ember/object";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { LinkTo } from "@ember/routing";
-import { schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import discourseDebounce from "discourse/lib/debounce";
 import { INPUT_DELAY } from "discourse/lib/environment";
 import { eq } from "discourse/truth-helpers";
 import DEmptyState from "discourse/ui-kit/d-empty-state";
-import DFilterInput from "discourse/ui-kit/d-filter-input";
-import DSelect from "discourse/ui-kit/d-select";
+import DFilterControls from "discourse/ui-kit/d-filter-controls";
 import { i18n } from "discourse-i18n";
 import List from "discourse/plugins/chat/discourse/components/chat/list";
 import ChatModalNewMessage from "discourse/plugins/chat/discourse/components/chat/modal/new-message";
@@ -27,6 +24,7 @@ export default class BrowseChannels extends Component {
   @service chatApi;
   @service modal;
   @service siteSettings;
+  @service capabilities;
 
   @tracked filter = "";
   @tracked selectedJoinedFilter = "all";
@@ -85,18 +83,23 @@ export default class BrowseChannels extends Component {
 
   @action
   setFilter(event) {
-    this.filter = event.target.value;
-    discourseDebounce(this.debouncedLoad, INPUT_DELAY);
+    discourseDebounce(
+      this,
+      this.debouncedSetFilter,
+      event.target.value,
+      INPUT_DELAY
+    );
   }
 
   @action
-  debouncedLoad() {
-    this.channelsCollection.load({ limit: 10 });
+  debouncedSetFilter(value) {
+    this.filter = value;
   }
 
   @action
-  focusFilterInput(input) {
-    schedule("afterRender", () => input?.focus());
+  resetFilters() {
+    this.filter = "";
+    this.selectedJoinedFilter = "all";
   }
 
   <template>
@@ -118,27 +121,18 @@ export default class BrowseChannels extends Component {
           </ul>
         </nav>
 
-        <div class="chat-browse-view__filter-controls">
-          <DSelect
-            @value={{this.selectedJoinedFilter}}
-            @onChange={{this.setJoinedFilter}}
-            @includeNone={{false}}
-            class="chat-browse-view__filter-select"
-            as |select|
-          >
-            {{#each this.joinedFilters as |filter|}}
-              <select.Option @value={{filter.value}}>
-                {{filter.label}}
-              </select.Option>
-            {{/each}}
-          </DSelect>
-          <DFilterInput
-            {{didInsert this.focusFilterInput}}
-            @filterAction={{this.setFilter}}
-            @icons={{hash right="magnifying-glass"}}
-            placeholder={{i18n "chat.browse.filter_input_placeholder"}}
-          />
-        </div>
+        <DFilterControls
+          @array={{this.channelsCollection.items}}
+          @dropdownOptions={{this.joinedFilters}}
+          @dropdownValue={{this.selectedJoinedFilter}}
+          @inputPlaceholder={{i18n "chat.browse.filter_input_placeholder"}}
+          @loading={{this.channelsCollection.loading}}
+          @onDropdownFilterChange={{this.setJoinedFilter}}
+          @forceShowDropdownFilterToggle={{this.capabilities.isMobileDevice}}
+          @onResetFilters={{this.resetFilters}}
+          @onTextFilterChange={{this.setFilter}}
+          @showNoResults={{false}}
+        />
       </div>
 
       <div class="chat-browse-view__content_wrapper">

--- a/plugins/chat/assets/javascripts/discourse/components/browse-channels.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/browse-channels.gjs
@@ -24,7 +24,6 @@ export default class BrowseChannels extends Component {
   @service chatApi;
   @service modal;
   @service siteSettings;
-  @service capabilities;
 
   @tracked filter = "";
   @tracked selectedJoinedFilter = "all";
@@ -122,7 +121,6 @@ export default class BrowseChannels extends Component {
           @inputPlaceholder={{i18n "chat.browse.filter_input_placeholder"}}
           @loading={{this.channelsCollection.loading}}
           @onDropdownFilterChange={{this.setJoinedFilter}}
-          @forceShowDropdownFilterToggle={{this.capabilities.isMobileDevice}}
           @onTextFilterChange={{this.setFilter}}
           @showNoResults={{false}}
           @showResetButton={{false}}

--- a/plugins/chat/assets/javascripts/discourse/components/browse-channels.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/browse-channels.gjs
@@ -96,12 +96,6 @@ export default class BrowseChannels extends Component {
     this.filter = value;
   }
 
-  @action
-  resetFilters() {
-    this.filter = "";
-    this.selectedJoinedFilter = "all";
-  }
-
   <template>
     <div class="chat-browse-view">
       <div class="chat-browse-view__actions">
@@ -129,9 +123,9 @@ export default class BrowseChannels extends Component {
           @loading={{this.channelsCollection.loading}}
           @onDropdownFilterChange={{this.setJoinedFilter}}
           @forceShowDropdownFilterToggle={{this.capabilities.isMobileDevice}}
-          @onResetFilters={{this.resetFilters}}
           @onTextFilterChange={{this.setFilter}}
           @showNoResults={{false}}
+          @showResetButton={{false}}
         />
       </div>
 

--- a/plugins/chat/assets/stylesheets/common/chat-browse.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-browse.scss
@@ -37,60 +37,27 @@
     align-items: center;
     gap: 1rem;
 
+    .d-filter-controls {
+      margin-inline-start: auto;
+    }
+
     .c-drawer-routes.--browse & {
       flex-direction: column;
-      gap: 1rem;
-      align-items: flex-start;
+      align-items: stretch;
 
-      .chat-browse-view__filter-controls,
-      .filter-input-container {
-        width: 100%;
+      .d-filter-controls {
+        margin-inline-start: 0;
       }
     }
 
     @include viewport.until(md) {
       flex-direction: column;
+      align-items: stretch;
 
-      .chat-browse-view__filter-controls {
-        margin-top: 1rem;
-      }
-
-      .chat-browse-view__filter-controls,
-      .filter-input-container,
-      nav {
-        width: 100%;
+      .d-filter-controls {
+        margin-inline-start: 0;
       }
     }
-
-    .chat-browse-view__filter-controls {
-      .filter-input,
-      .filter-input:focus {
-        width: 100%;
-      }
-    }
-  }
-
-  &__filter-controls {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex: 0 1 32rem;
-    margin-inline-start: auto;
-    min-width: 0;
-
-    .filter-input-container {
-      width: 100%;
-      min-width: 0;
-    }
-
-    @include viewport.until(sm) {
-      flex-direction: column;
-    }
-  }
-
-  &__filter-select,
-  &__filter-controls .filter-input-container {
-    flex: 1 1 0;
   }
 
   &__filters {


### PR DESCRIPTION
Followup 4c7a4f637f6c6eecdd3fcf6a46a198dbd1ba994a

Fixes the broken chat browse page on mobile, and moves
the filters to this page to use DFilterControls component.

Removed a lot of custom CSS and HTML.

Also added arguments to DFilterControls to:

* Hide the no results message
* Force the toggle filter button, even if there aren't
  more than 1 dropdown filters, which can be useful on mobile

**Before**

<img width="1195" height="674" alt="image" src="https://github.com/user-attachments/assets/417fad66-c045-43c7-b469-9f226678bdb2" />

<img width="383" height="675" alt="image" src="https://github.com/user-attachments/assets/3d2d458b-b335-4702-88d7-733f9152940d" />


**After**

<img width="1208" height="589" alt="image" src="https://github.com/user-attachments/assets/0353b6f5-c7af-4c67-82a8-87226dc9496a" />
<img width="424" height="707" alt="image" src="https://github.com/user-attachments/assets/702c8b35-fc43-45b6-a8ca-2d0a8066458c" />
