### PR TITLE
DEV: Promote dashboard_improvements upcoming change to beta

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4806,7 +4806,7 @@ experimental:
     hidden: true
     client: true
     upcoming_change:
-      status: "alpha"
+      status: "beta"
       impact: "feature,admins"
       learn_more_url: "https://meta.discourse.org/t/-/404528"
   admin_dashboard_reports_seeded:

--- a/plugins/discourse-ai/spec/system/admin_dashboard_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_dashboard_spec.rb
@@ -3,7 +3,10 @@
 RSpec.describe "Admin dashboard" do
   fab!(:admin)
 
-  before { enable_current_plugin }
+  before do
+    enable_current_plugin
+    SiteSetting.dashboard_improvements = false
+  end
 
   it "displays the sentiment dashboard" do
     SiteSetting.ai_sentiment_enabled = true

--- a/spec/requests/admin/dashboard_controller_spec.rb
+++ b/spec/requests/admin/dashboard_controller_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Admin::DashboardController do
 
   describe "#index" do
     shared_examples "version info present" do
+      before { SiteSetting.dashboard_improvements = false }
+
       it "returns discourse version info" do
         get "/admin/dashboard.json"
 
@@ -50,7 +52,10 @@ RSpec.describe Admin::DashboardController do
     end
 
     shared_examples "version info absent" do
-      before { SiteSetting.version_checks = false }
+      before do
+        SiteSetting.dashboard_improvements = false
+        SiteSetting.version_checks = false
+      end
 
       it "does not return discourse version info" do
         get "/admin/dashboard.json"
@@ -256,6 +261,7 @@ RSpec.describe Admin::DashboardController do
         end
 
         it "does not expose admin-only browser pageview cards to moderators" do
+          SiteSetting.use_legacy_pageviews = false
           SiteSetting.persist_browser_pageview_events = true
           configure_dashboard_sections(%w[traffic])
 

--- a/spec/system/admin_dashboard_community_health_spec.rb
+++ b/spec/system/admin_dashboard_community_health_spec.rb
@@ -3,7 +3,10 @@
 describe "Admin Dashboard Community Health" do
   fab!(:current_user, :admin)
 
-  before { sign_in(current_user) }
+  before do
+    SiteSetting.dashboard_improvements = false
+    sign_in(current_user)
+  end
 
   describe "Pageview Report" do
     context "when use_legacy_pageviews is true" do

--- a/spec/system/admin_dashboard_general_spec.rb
+++ b/spec/system/admin_dashboard_general_spec.rb
@@ -7,7 +7,10 @@ describe "Admin Dashboard General Tab" do
   fab!(:user_visit_2) { Fabricate(:user_visit, user: user, mobile: true) }
   fab!(:user_visit_3) { Fabricate(:user_visit, user: user, visited_at: 1.day.ago) }
 
-  before { sign_in(admin) }
+  before do
+    SiteSetting.dashboard_improvements = false
+    sign_in(admin)
+  end
 
   it "displays correct visit counters combining desktop and mobile visits" do
     visit("/admin")

--- a/spec/system/admin_notices_spec.rb
+++ b/spec/system/admin_notices_spec.rb
@@ -4,6 +4,7 @@ describe "Admin Notices" do
   let(:admin_dashboard) { PageObjects::Pages::AdminDashboard.new }
 
   before do
+    SiteSetting.dashboard_improvements = false
     Fabricate(:admin_notice)
 
     I18n.backend.store_translations(:en, dashboard: { problem: { test_notice: "Houston" } })


### PR DESCRIPTION
`promote_upcoming_changes_on_status` defaults to `beta`, so promoting the change makes the redesigned dashboard the default everywhere, including in the test environment.

Specs covering the legacy dashboard now opt out explicitly with `SiteSetting.dashboard_improvements = false`.