### PR TITLE
DEV: Penalize pageviews with no engagement in `CrawlerScorer`

### DIFF
--- a/app/models/browser_pageview_session_engagement.rb
+++ b/app/models/browser_pageview_session_engagement.rb
@@ -2,7 +2,7 @@
 
 class BrowserPageviewSessionEngagement < ActiveRecord::Base
   MAX_SESSION_ID_LENGTH = 32
-  BEACON_SETTLE_PERIOD = 10.minutes
+  BEACON_SETTLE_PERIOD = 30.minutes
 
   INTERACTION_COLUMNS = %i[
     mouse_move_events

--- a/lib/crawler_scorer.rb
+++ b/lib/crawler_scorer.rb
@@ -34,7 +34,7 @@ class CrawlerScorer
   REFERRER_LOW_SCORE = 5
   REFERRER_HIGH_SCORE = 10
 
-  HUMAN_ACTIVITY_SCORE = -40
+  MISSING_ENGAGEMENT_SCORE = 40
 
   def self.score!(window_start:, window_end:)
     crawler_asns = SiteSetting.crawler_asns_map.map(&:to_i)
@@ -71,7 +71,7 @@ class CrawlerScorer
         referrer_high_ratio: REFERRER_HIGH_RATIO,
         referrer_low_score: REFERRER_LOW_SCORE,
         referrer_high_score: REFERRER_HIGH_SCORE,
-        human_activity_score: HUMAN_ACTIVITY_SCORE,
+        missing_engagement_score: MISSING_ENGAGEMENT_SCORE,
       )
     end
   end
@@ -186,7 +186,7 @@ class CrawlerScorer
           ELSE 0
         END AS referrer_score,
         CASE
-          WHEN se.session_id IS NOT NULL THEN :human_activity_score
+          WHEN se.session_id IS NULL THEN :missing_engagement_score
           ELSE 0
         END AS engagement_score
       FROM events e

--- a/plugins/discourse-data-explorer/lib/discourse_data_explorer/queries.rb
+++ b/plugins/discourse-data-explorer/lib/discourse_data_explorer/queries.rb
@@ -252,19 +252,19 @@ module DiscourseDataExplorer
           id: -42,
           name: "Crawler and Bot Traffic Overview",
           description:
-            "Buckets recent pageviews by bot-likelihood score from Discourse's built-in crawler detection, from 'definitely user' to 'definitely crawler'. WARNING: requires browser pageview event collection to be enabled (hidden site setting trigger_browser_pageview_events); without it no events are recorded and this report will be empty. Accepts an 'hours' parameter, defaults to the last 24 hours.",
+            "Buckets recent beacon pageviews by bot-likelihood score from Discourse's built-in crawler detection. Scoring lags live traffic, so the newest pageviews sit in the 'not scored' bucket alongside those that carried no bot signals at all, rather than counting as users. WARNING: requires browser pageview event collection (hidden site setting persist_browser_pageview_events) and scoring (hidden site setting experimental_detect_crawler_pageviews); without both, every pageview lands in 'not scored'. Accepts an 'hours' parameter, defaults to the last 24 hours.",
         },
         "crawler-traffic-detailed": {
           id: -43,
           name: "Crawler and Bot Traffic Detailed Report",
           description:
-            "Row-per-IP breakdown of likely bot pageview activity, with the individual signals that drove the score (automated user agent, known crawler network, velocity, session churn, rapid navigation, bad referrer). WARNING: requires browser pageview event collection to be enabled (hidden site setting trigger_browser_pageview_events); without it no events are recorded and this report will be empty. Accepts 'hours' and 'min_score' parameters.",
+            "Row-per-IP breakdown of likely bot pageview activity, with the individual signals that drove the score (automated user agent, known crawler network, velocity, session churn, rapid navigation, bad referrer, no measured interaction). WARNING: requires browser pageview event collection (hidden site setting persist_browser_pageview_events) and scoring (hidden site setting experimental_detect_crawler_pageviews); without both this report will be empty. Accepts 'hours' and 'min_score' parameters.",
         },
         "suspected-bot-networks": {
           id: -44,
           name: "Suspected Automated Traffic by IP and Network",
           description:
-            "Networks (ASNs) and IPs generating high pageview volume with bot-like session patterns (near 1.0 views per session, rotating user agents, systematic topic harvesting), sorted so a scrape spread across many IPs on one network floats to the top. WARNING: requires browser pageview event collection to be enabled (hidden site setting trigger_browser_pageview_events); without it no events are recorded and this report will be empty. Accepts a 'days_ago' parameter, defaults to the last 3 days.",
+            "Networks (ASNs) and IPs generating high pageview volume with bot-like session patterns (near 1.0 views per session, rotating user agents, systematic topic harvesting), sorted so a scrape spread across many IPs on one network floats to the top. WARNING: requires browser pageview event collection to be enabled (hidden site setting persist_browser_pageview_events); without it no events are recorded and this report will be empty. Accepts a 'days_ago' parameter, defaults to the last 3 days.",
         },
       }.with_indifferent_access
 
@@ -1513,17 +1513,16 @@ module DiscourseDataExplorer
       -- int :hours = 24
 
       WITH events AS (
-          SELECT COALESCE(score, 0) AS score
+          SELECT score
           FROM browser_pageview_events
           WHERE created_at >= NOW() - (:hours * INTERVAL '1 hour')
+            AND source = #{BrowserPageviewEvent::SOURCE_BEACON}
       )
-      SELECT 'Definitely user (0)' AS bucket, COUNT(*) FILTER (WHERE score = 0) AS pageviews FROM events
+      SELECT 'Not scored (pending or no signals)' AS bucket, COUNT(*) FILTER (WHERE score IS NULL) AS pageviews FROM events
       UNION ALL
-      SELECT 'Very likely user (1-40)', COUNT(*) FILTER (WHERE score BETWEEN 1 AND 40) FROM events
+      SELECT 'Very likely user (under 60)', COUNT(*) FILTER (WHERE score < 60) FROM events
       UNION ALL
-      SELECT 'Maybe crawler (41-99)', COUNT(*) FILTER (WHERE score BETWEEN 41 AND 99) FROM events
-      UNION ALL
-      SELECT 'Definitely crawler (100+)', COUNT(*) FILTER (WHERE score >= 100) FROM events
+      SELECT 'Likely crawler (60+)', COUNT(*) FILTER (WHERE score >= 60) FROM events
       SQL
 
       queries["crawler-traffic-detailed"]["sql"] = <<~SQL
@@ -1547,6 +1546,7 @@ module DiscourseDataExplorer
           MAX(s.rapid_nav_score) AS rapid_nav,
           MAX(s.ip_rotation_score) AS ip_rotation,
           MAX(s.referrer_score) AS referrer,
+          MAX(s.engagement_score) AS no_engagement,
           NULLIF(
               CONCAT_WS(', ',
                   CASE WHEN MAX(s.automation_ua_score) > 0 THEN 'automation UA' END,
@@ -1555,13 +1555,15 @@ module DiscourseDataExplorer
                   CASE WHEN MAX(s.churn_score) > 0 THEN 'session churn (+' || MAX(s.churn_score) || ')' END,
                   CASE WHEN MAX(s.rapid_nav_score) > 0 THEN 'rapid navigation' END,
                   CASE WHEN MAX(s.ip_rotation_score) > 0 THEN 'ip rotation (+' || MAX(s.ip_rotation_score) || ')' END,
-                  CASE WHEN MAX(s.referrer_score) > 0 THEN 'bad referrer (+' || MAX(s.referrer_score) || ')' END
+                  CASE WHEN MAX(s.referrer_score) > 0 THEN 'bad referrer (+' || MAX(s.referrer_score) || ')' END,
+                  CASE WHEN MAX(s.engagement_score) > 0 THEN 'no measured interaction (+' || MAX(s.engagement_score) || ')' END
               ),
               ''
           ) AS reasons
       FROM browser_pageview_events e
       JOIN browser_pageview_event_scores s ON s.event_id = e.id
       WHERE e.created_at >= NOW() - (:hours * INTERVAL '1 hour')
+          AND e.source = #{BrowserPageviewEvent::SOURCE_BEACON}
           AND e.score > :min_score
       GROUP BY e.ip_address, e.user_agent, e.asn, e.country_code, e.user_id, e.session_id
       ORDER BY max_score DESC, pageviews DESC
@@ -1588,6 +1590,7 @@ module DiscourseDataExplorer
           (array_agg(user_agent ORDER BY created_at DESC))[1] AS sample_user_agent
       FROM browser_pageview_events
       WHERE created_at >= CURRENT_DATE - :days_ago
+          AND source = #{BrowserPageviewEvent::SOURCE_BEACON}
       GROUP BY ip_address, asn, country_code
       ORDER BY asn_total_pageviews DESC, pageviews DESC
       LIMIT 100

--- a/spec/jobs/detect_crawler_pageviews_spec.rb
+++ b/spec/jobs/detect_crawler_pageviews_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Jobs::DetectCrawlerPageviews do
     described_class.new.execute({})
   end
 
-  it "scores a one hour window delayed to let engagement beacons arrive" do
+  it "scores a one hour wide window, held back by the beacon settle period" do
     SiteSetting.experimental_detect_crawler_pageviews = true
     freeze_time
 
-    CrawlerScorer.expects(:score!).with(window_start: 70.minutes.ago, window_end: 10.minutes.ago)
+    CrawlerScorer.expects(:score!).with(window_start: 90.minutes.ago, window_end: 30.minutes.ago)
 
     described_class.new.execute({})
   end

--- a/spec/lib/crawler_scorer_spec.rb
+++ b/spec/lib/crawler_scorer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CrawlerScorer do
   it "scores automation user agents at +100" do
     event = make_event(user_agent: "Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/120.0.0.0")
     score!
-    expect(event.reload.score).to eq(100)
+    expect(event.reload.score).to eq(140)
   end
 
   it "writes the score breakdown per heuristic to the side table" do
@@ -35,7 +35,7 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(115)
+    expect(event.reload.score).to eq(155)
     breakdown = event.browser_pageview_event_score
     expect(breakdown.automation_ua_score).to eq(100)
     expect(breakdown.known_asn_score).to eq(15)
@@ -44,9 +44,10 @@ RSpec.describe CrawlerScorer do
     expect(breakdown.rapid_nav_score).to eq(0)
     expect(breakdown.ip_rotation_score).to eq(0)
     expect(breakdown.referrer_score).to eq(0)
+    expect(breakdown.engagement_score).to eq(40)
   end
 
-  it "does not write a breakdown row for events that score 0" do
+  it "does not score an event whose only signal is missing engagement" do
     event = make_event
     score!
     expect(event.reload.score).to be_nil
@@ -57,7 +58,7 @@ RSpec.describe CrawlerScorer do
     SiteSetting.crawler_asns = "12345"
     event = make_event(asn: 12_345)
     score!
-    expect(event.reload.score).to eq(15)
+    expect(event.reload.score).to eq(55)
   end
 
   it "scores pageview velocity at or above VELOCITY_LOW threshold at +15" do
@@ -70,7 +71,7 @@ RSpec.describe CrawlerScorer do
 
       expect(
         BrowserPageviewEvent.where(session_id: session_id).pluck(:score).uniq,
-      ).to contain_exactly(15)
+      ).to contain_exactly(55)
     end
   end
 
@@ -84,7 +85,7 @@ RSpec.describe CrawlerScorer do
 
       expect(
         BrowserPageviewEvent.where(ip_address: "9.9.9.9").pluck(:score).uniq,
-      ).to contain_exactly(20)
+      ).to contain_exactly(60)
     end
   end
 
@@ -98,7 +99,7 @@ RSpec.describe CrawlerScorer do
 
       expect(
         BrowserPageviewEvent.where(session_id: session_id).pluck(:score).uniq,
-      ).to contain_exactly(15)
+      ).to contain_exactly(55)
     end
   end
 
@@ -112,7 +113,7 @@ RSpec.describe CrawlerScorer do
 
     expect(
       BrowserPageviewEvent.where(session_id: "rotating-session").pluck(:score).uniq,
-    ).to contain_exactly(30)
+    ).to contain_exactly(70)
   end
 
   it "scores ip rotation the same whether or not the addresses cross ASNs" do
@@ -134,7 +135,7 @@ RSpec.describe CrawlerScorer do
 
     expect(
       BrowserPageviewEvent.where(session_id: "cross-asn-session").pluck(:score).uniq,
-    ).to contain_exactly(30)
+    ).to contain_exactly(70)
   end
 
   it "does not score a session that only ever uses two addresses" do
@@ -177,7 +178,7 @@ RSpec.describe CrawlerScorer do
 
       expect(
         BrowserPageviewEvent.where(ip_address: "5.5.5.5").pluck(:score).uniq,
-      ).to contain_exactly(10)
+      ).to contain_exactly(50)
     end
   end
 
@@ -187,7 +188,7 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(100)
+    expect(event.reload.score).to eq(140)
   end
 
   it "ignores events outside the window" do
@@ -198,16 +199,7 @@ RSpec.describe CrawlerScorer do
     expect(event.reload.score).to be_nil
   end
 
-  it "only updates the score when the new value is higher" do
-    event = make_event(user_agent: "Mozilla/5.0 HeadlessChrome/120")
-    event.update!(score: 120)
-
-    score!
-
-    expect(event.reload.score).to eq(120)
-  end
-
-  it "discounts events whose session shows human interaction" do
+  it "does not penalise events whose session shows human interaction" do
     event = make_event(user_agent: "Mozilla/5.0 HeadlessChrome/120.0.0.0")
     Fabricate(
       :browser_pageview_session_engagement,
@@ -218,24 +210,24 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(60)
-    expect(event.browser_pageview_event_score.engagement_score).to eq(-40)
+    expect(event.reload.score).to eq(100)
+    expect(event.browser_pageview_event_score.engagement_score).to eq(0)
   end
 
-  it "writes a zero score when the discount cancels all bot signals" do
+  it "never scores an event below its bot signals" do
     SiteSetting.crawler_asns = "12345"
     event = make_event(asn: 12_345)
     Fabricate(:browser_pageview_session_engagement, session_id: event.session_id, scroll_events: 3)
 
     score!
 
-    expect(event.reload.score).to eq(0)
+    expect(event.reload.score).to eq(15)
     breakdown = event.browser_pageview_event_score
     expect(breakdown.known_asn_score).to eq(15)
-    expect(breakdown.engagement_score).to eq(-40)
+    expect(breakdown.engagement_score).to eq(0)
   end
 
-  it "does not discount engagement rows crafted without interaction counts" do
+  it "penalises engagement rows crafted without interaction counts" do
     event = make_event(user_agent: "Mozilla/5.0 HeadlessChrome/120.0.0.0")
     Fabricate(
       :browser_pageview_session_engagement,
@@ -245,20 +237,21 @@ RSpec.describe CrawlerScorer do
 
     score!
 
-    expect(event.reload.score).to eq(100)
+    expect(event.reload.score).to eq(140)
+    expect(event.browser_pageview_event_score.engagement_score).to eq(40)
   end
 
-  it "does not lower a previously assigned score when engagement arrives later" do
+  it "keeps the higher score when a later run would lower it" do
     SiteSetting.crawler_asns = "12345"
     event = make_event(asn: 12_345)
 
     score!
-    expect(event.reload.score).to eq(15)
+    expect(event.reload.score).to eq(55)
 
     Fabricate(:browser_pageview_session_engagement, session_id: event.session_id, key_events: 4)
     score!
 
-    expect(event.reload.score).to eq(15)
+    expect(event.reload.score).to eq(55)
   end
 
   it "scores each source but partitions velocity so transports do not inflate each other" do
@@ -286,13 +279,13 @@ RSpec.describe CrawlerScorer do
             .where(source: BrowserPageviewEvent::SOURCE_PIGGYBACK)
             .pluck(:score)
             .uniq,
-        ).to contain_exactly(15)
+        ).to contain_exactly(55)
         expect(
           BrowserPageviewEvent
             .where(source: BrowserPageviewEvent::SOURCE_BEACON)
             .pluck(:score)
             .uniq,
-        ).to contain_exactly(15)
+        ).to contain_exactly(55)
       end
     end
   end

--- a/spec/models/browser_pageview_session_engagement_daily_rollup_spec.rb
+++ b/spec/models/browser_pageview_session_engagement_daily_rollup_spec.rb
@@ -236,17 +236,17 @@ RSpec.describe BrowserPageviewSessionEngagementDailyRollup do
       expect(described_class.count).to eq(0)
     end
 
-    it "excludes sessions that started within the last 10 minutes" do
+    it "excludes sessions that started within the beacon settle period" do
       Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 11, 55))
-      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 11, 45))
+      Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 10, 45))
 
       described_class.aggregate(start_date:, end_date:)
 
       expect(described_class.all).to contain_exactly(have_attributes(sessions: 1))
     end
 
-    it "does not bounce a session whose second pageview arrived within the last 10 minutes" do
-      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 11, 30))
+    it "does not bounce a session whose second pageview arrived within the beacon settle period" do
+      event = Fabricate(:browser_pageview_event, created_at: Time.utc(2026, 6, 20, 10, 30))
       Fabricate(
         :browser_pageview_event,
         session_id: event.session_id,


### PR DESCRIPTION
Previously, `CrawlerScorer` discounted a pageview by 40 points when its session reported human interaction, so a pageview scored before its engagement beacon settled could never have that credit applied.

This change inverts the signal to penalize sessions with no measured interaction, raises `BEACON_SETTLE_PERIOD` to 30 minutes so engagement lands before scoring, and updates the built-in crawler data explorer reports to bucket on the 60-point threshold and to count only beacon pageviews.