### PR TITLE
FIX: Don't show quote/edit toolbar until the selection drag ends (pointerup/pointercancel)

### DIFF
--- a/frontend/discourse/app/components/post-text-selection.gjs
+++ b/frontend/discourse/app/components/post-text-selection.gjs
@@ -55,14 +55,64 @@ export default class PostTextSelection extends Component {
   @service menu;
   @service modal;
 
+  // Track whether the primary pointer button is currently held so the quote
+  // toolbar can be gated on gesture end instead of appearing mid-drag.
+  // Rendering the toolbar above an in-progress selection perturbs the native
+  // selection endpoint and causes the selection to flicker to end-of-page.
+  // The show is flushed on `pointerup` OR `pointercancel` (the latter is how
+  // mobile long-press selection gestures usually end).
+  pointerDown = false;
+
   setup = modifier(() => {
     document.addEventListener("selectionchange", this.selectionChange);
+
+    this.onPointerDown = (event) => {
+      if (event.button === 0) {
+        this.pointerDown = true;
+      }
+    };
+    this.flushShow = () => {
+      cancel(this.debouncedSelectionChangeHandler);
+      // selection is final on gesture end; flush the (debounced) show now
+      this.debouncedSelectionChangeHandler = discourseDebounce(
+        this.selectionChangeHandler,
+        INPUT_DELAY
+      );
+    };
+    this.onPointerUp = (event) => {
+      if (event.button !== 0 || !this.pointerDown) {
+        return;
+      }
+      this.pointerDown = false;
+      this.flushShow();
+    };
+    this.onPointerCancel = () => {
+      if (!this.pointerDown) {
+        return;
+      }
+      this.pointerDown = false;
+      this.flushShow();
+    };
+    this.onBlur = () => {
+      this.pointerDown = false;
+    };
+
+    document.addEventListener("pointerdown", this.onPointerDown, true);
+    // pointerup/cancel on window so a release outside the viewport still clears
+    window.addEventListener("pointerup", this.onPointerUp);
+    window.addEventListener("pointercancel", this.onPointerCancel);
+    window.addEventListener("blur", this.onBlur);
+
     this.appEvents.on("quote-button:quote", this, "insertQuote");
     this.appEvents.on("quote-button:edit", this, "toggleHeadlessFastEdit");
 
     return () => {
       cancel(this.debouncedSelectionChangeHandler);
       document.removeEventListener("selectionchange", this.selectionChange);
+      document.removeEventListener("pointerdown", this.onPointerDown, true);
+      window.removeEventListener("pointerup", this.onPointerUp);
+      window.removeEventListener("pointercancel", this.onPointerCancel);
+      window.removeEventListener("blur", this.onBlur);
       this.appEvents.off("quote-button:quote", this, "insertQuote");
       this.appEvents.off("quote-button:edit", this, "toggleHeadlessFastEdit");
       this.menuInstance?.close();
@@ -221,6 +271,13 @@ export default class PostTextSelection extends Component {
   @bind
   async selectionChange() {
     await this.hideToolbar();
+    if (this.pointerDown) {
+      // Mid-drag: don't show the toolbar (it would sit on the active drag
+      // endpoint and perturb the native selection). Flush on gesture end
+      // (`pointerup`/`pointercancel`).
+      cancel(this.debouncedSelectionChangeHandler);
+      return;
+    }
     this.debouncedSelectionChangeHandler = discourseDebounce(
       this.selectionChangeHandler,
       INPUT_DELAY

--- a/spec/system/post_text_selection_drag_spec.rb
+++ b/spec/system/post_text_selection_drag_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+describe "Post text selection | drag gate" do
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  fab!(:topic)
+  fab!(:post) { Fabricate(:post, topic: topic, raw: "Hello world this is time for quoting") }
+  fab!(:current_user, :admin)
+
+  before { sign_in(current_user) }
+
+  it "does not show the quote toolbar while the primary button is held, only on pointerup" do
+    topic_page.visit_topic(topic)
+
+    # Simulate an active drag: dispatch `pointerdown` (button 0) on the post, then
+    # extend the selection WITHOUT releasing the button. The toolbar must not
+    # appear while the button is held — previously it rendered mid-drag, sat on
+    # top of the active selection endpoint, and perturbed the native selection,
+    # causing the selection to flicker to the end of the page.
+    page.execute_script(<<~JS)
+      const cooked = document.querySelector("#{topic_page.post_by_number_selector(1)} .cooked p");
+      const node = cooked.childNodes[0];
+      cooked.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerType: "mouse" }));
+      const sel = window.getSelection();
+      const range = document.createRange();
+      range.setStart(node, 0);
+      range.setEnd(node, 10);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    JS
+
+    # Past INPUT_DELAY (250ms) — the toolbar must NOT be present while held.
+    sleep 0.4
+    expect(page).not_to have_css(topic_page.copy_quote_button_selector)
+
+    # Releasing the button finishes the drag — the toolbar should appear now.
+    page.execute_script(<<~JS)
+      window.dispatchEvent(new PointerEvent("pointerup", { button: 0, pointerType: "mouse" }));
+    JS
+
+    expect(page).to have_css(topic_page.copy_quote_button_selector)
+  end
+
+  it "shows the toolbar when a touch selection gesture ends in pointercancel" do
+    topic_page.visit_topic(topic)
+
+    # Touch long-press selections frequently end in `pointercancel` (the browser
+    # takes over the gesture for its native selection handles) rather than
+    # `pointerup`. The toolbar must still appear once the gesture ends.
+    page.execute_script(<<~JS)
+      const cooked = document.querySelector("#{topic_page.post_by_number_selector(1)} .cooked p");
+      const node = cooked.childNodes[0];
+      cooked.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0, pointerType: "touch" }));
+      const sel = window.getSelection();
+      const range = document.createRange();
+      range.setStart(node, 0);
+      range.setEnd(node, 10);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    JS
+
+    # While the gesture is active the toolbar must NOT be present.
+    sleep 0.4
+    expect(page).not_to have_css(topic_page.copy_quote_button_selector)
+
+    # The browser cancels the pointer to take over selection handles.
+    page.execute_script(<<~JS)
+      window.dispatchEvent(new PointerEvent("pointercancel", { bubbles: true, button: 0, pointerType: "touch" }));
+    JS
+
+    expect(page).to have_css(topic_page.copy_quote_button_selector)
+  end
+end


### PR DESCRIPTION
## What this does

Gates the Quote/Edit/Copy-Quote toolbar on the end of the selection gesture so it no longer renders while the user is still drag-selecting text. In `post-text-selection.gjs`, track whether the primary pointer button is held (`pointerDown`) via a capture-phase `pointerdown` listener on `document` and `pointerup`/`pointercancel`/`blur` on `window`; `selectionChange()` now hides the toolbar and, while the button is held, cancels the debounced re-show. The toolbar is shown once, on gesture end.

## Why

When the toolbar rendered mid-drag, the floating-ui `.fk-d-menu` overlay (position: fixed, `top-start` on desktop, anchored to the selection's bounding rect) sat directly on top of the active drag endpoint. The native selection couldn't extend cleanly through it; the browser clamped/jumped the focus point around the overlay, so the selection snapped to "from the cursor to the end of the page." That fired another `selectionchange`, which hid the toolbar; the selection snapped back to the real dragged range; the 250ms debounce then re-showed the toolbar; repeat — a self-sustaining flicker loop as long as the button was held near the toolbar's edge. Reproduces on meta.discourse.org.

## Changes

- `frontend/discourse/app/components/post-text-selection.gjs`
  - Add a `pointerDown` flag.
  - In `setup`, register `pointerdown` (capture, `document`, `button === 0`) and `pointerup`/`pointercancel`/`window` `blur` on `window`. `pointerup` and `pointercancel` clear the flag and flush the debounced show; `blur` only clears the flag.
  - `selectionChange()`: while `pointerDown`, hide and cancel the debounced show.
  - Teardown removes the new listeners.

`pointercancel` is treated the same as `pointerup` because mobile long-press selection gestures frequently end in `pointercancel` (the browser cancels the pointer to take over native selection handles) rather than `pointerup` — flushing only on `pointerup` would prevent the toolbar from ever appearing on mobile. Keyboard selections (Shift+arrows) never set `pointerDown`, so the toolbar still appears via the unchanged `selectionchange` path — no a11y regression. Right-click (`button === 2`) is ignored, so context menus on an existing selection are unaffected.

## Test plan

- [x] New system spec `post_text_selection_drag_spec.rb`, case 1 (mouse): dispatch a `pointerdown` + extend the selection while held → assert the toolbar is absent past `INPUT_DELAY` (250ms) → dispatch `pointerup` → assert the toolbar appears.
- [x] New system spec, case 2 (touch): dispatch a `pointerdown` (`pointerType: "touch"`) + selection while held → toolbar absent → dispatch `pointercancel` → toolbar appears.
- [ ] Existing `post_selection_copy_quote_spec.rb`, `post_selection_fast_edit_spec.rb`, and `nested_quoting_spec.rb` use programmatic `Selection.addRange` (no pointer events), so `pointerDown` stays false and the show path is unchanged — they remain green.
- [x] Manual (desktop): drag-select text and park the cursor at the top edge of where the toolbar would appear; the end-of-page flicker no longer occurs, and the toolbar appears on release.
- [x] Manual (mobile/touch): long-press to select; the toolbar does not appear mid-gesture, and appears once the gesture ends.
