### PR TITLE
FIX: Sanitize namespaced SVG `<use>` references

### DIFF
--- a/lib/upload_creator.rb
+++ b/lib/upload_creator.rb
@@ -529,10 +529,11 @@ class UploadCreator
     doc
       .css("use")
       .each do |use_el|
-        if use_el.attr("href")
-          use_el.remove_attribute("href") unless use_el.attr("href").starts_with?("#")
+        use_el.attribute_nodes.each do |attribute|
+          next if attribute.name != "href" && attribute.name != "xlink:href"
+
+          attribute.remove unless attribute.value.starts_with?("#")
         end
-        use_el.remove_attribute("xlink:href")
       end
 
     File.write(@file.path, doc.to_s)

--- a/spec/lib/upload_creator_spec.rb
+++ b/spec/lib/upload_creator_spec.rb
@@ -7,6 +7,38 @@ RSpec.describe UploadCreator do
   fab!(:admin)
 
   describe "#create_for" do
+    describe "when the image is an SVG" do
+      it "removes external use references while preserving local fragments" do
+        xlink_namespace = "http://www.w3.org/1999/xlink"
+        svg = <<~XML
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="#{xlink_namespace}" width="10" height="10">
+        <defs><path id="mark" d="M0 0h10v10H0z" /></defs>
+        <use id="local-href" href="#mark" />
+        <use id="external-href" href="https://example.com/evil.svg#mark" />
+        <use id="data-href" href="data:image/svg+xml,evil" />
+        <use id="local-xlink-href" xlink:href="#mark" />
+        <use id="external-xlink-href" xlink:href="https://example.com/evil.svg#mark" />
+      </svg>
+    XML
+
+        upload =
+          UploadCreator.new(file_from_contents(svg, "image.svg"), "image.svg").create_for(user.id)
+
+        document = Nokogiri.XML(File.read(Discourse.store.path_for(upload)))
+
+        expect(upload).to be_persisted
+        expect(document.at_css("#local-href")["href"]).to eq("#mark")
+        expect(document.at_css("#external-href")["href"]).to eq(nil)
+        expect(document.at_css("#data-href")["href"]).to eq(nil)
+        expect(
+          document.at_css("#local-xlink-href").attribute_with_ns("href", xlink_namespace)&.value,
+        ).to eq("#mark")
+        expect(
+          document.at_css("#external-xlink-href").attribute_with_ns("href", xlink_namespace)&.value,
+        ).to eq(nil)
+      end
+    end
+
     describe "when upload is not an image" do
       before { SiteSetting.authorized_extensions = "txt|long-FileExtension" }
 


### PR DESCRIPTION
Previously, SVG sanitization could retain a properly namespaced external `<use xlink:href="https://example.com/icons.svg#mark">` reference because Nokogiri exposed the attribute using its local `href` name.

This change examines attribute nodes and preserves only same-document fragment references across `href` and `xlink:href`; it is defense in depth and does not address a demonstrated security issue.