### PR TITLE
FIX: Render topic OG images under ImageMagick policy

### DIFF
--- a/config/imagemagick/policy.xml
+++ b/config/imagemagick/policy.xml
@@ -33,6 +33,7 @@
   <policy domain="coder" rights="read|write" pattern="{HEIC,HEIF}"/>
   <!-- MSVG: SVG dimension reads; the plain SVG coder stays denied -->
   <policy domain="coder" rights="read|write" pattern="MSVG"/>
+  <policy domain="coder" rights="read|write" pattern="MVG"/>
   <!-- XC: LetterAvatar canvas -->
   <policy domain="coder" rights="read|write" pattern="XC"/>
   <!-- ICC/ICM: RT_sRGB.icm "-profile" on resize/crop/downsize -->

--- a/lib/topic_og_image_generator.rb
+++ b/lib/topic_og_image_generator.rb
@@ -29,8 +29,7 @@ class TopicOgImageGenerator
 
   # Generates the OG image, persists as an Upload, and returns it (or nil on failure).
   def generate
-    svg = build_svg
-    png = render_png(svg)
+    png = render_png
     return nil if png.nil?
     create_upload(png)
   end
@@ -38,13 +37,12 @@ class TopicOgImageGenerator
   # Renders the OG image to PNG bytes without persisting an Upload. Used by the
   # admin preview endpoint to avoid producing orphaned uploads on every click.
   def generate_bytes
-    svg = build_svg
-    render_png(svg)
+    render_png
   end
 
   private
 
-  def build_svg
+  def build_svg(asset_directory: nil)
     title = truncated_title
     category_name = @topic.category&.name || ""
     category_color = @topic.category&.color || "888888"
@@ -54,6 +52,7 @@ class TopicOgImageGenerator
     colors = fetch_colors
     logo_upload = SiteSetting.logo.presence || SiteSetting.logo_small
     logo_data_uri = fetch_as_data_uri(logo_upload&.url)
+    logo_path = materialize_asset(logo_data_uri, directory: asset_directory, basename: "logo")
 
     title_lines = word_wrap(title, TITLE_LINE_CHARS)
     truncated = title_lines.length > MAX_TITLE_LINES
@@ -76,6 +75,7 @@ class TopicOgImageGenerator
     author = @topic.user
     avatar_data_uri =
       author ? fetch_as_data_uri(author.avatar_template_url.gsub("{size}", "120")) : nil
+    avatar_path = materialize_asset(avatar_data_uri, directory: asset_directory, basename: "avatar")
     username = author&.username
     created_at = @topic.created_at&.strftime("%b %-d, %Y")
 
@@ -103,10 +103,10 @@ class TopicOgImageGenerator
         #{title_svg(display_lines, colors[:primary], SIDE_MARGIN, title_start_y)}
 
         <!-- Author -->
-        #{author_svg(avatar_data_uri, username, created_at, colors, SIDE_MARGIN, author_y)}
+        #{author_svg(avatar_path, username, created_at, colors, SIDE_MARGIN, author_y)}
 
         <!-- Site logo -->
-        #{logo_svg(logo_data_uri, logo_upload, SIDE_MARGIN, logo_y)}
+        #{logo_svg(logo_path, logo_upload, SIDE_MARGIN, logo_y)}
 
         <!-- Stats -->
         #{stats_svg(like_count, posts_count, read_time, colors, OG_WIDTH - SIDE_MARGIN, stats_y)}
@@ -311,6 +311,50 @@ class TopicOgImageGenerator
     "#{Discourse.base_url_no_prefix}#{url}"
   end
 
+  def materialize_asset(data_uri, directory:, basename:)
+    return data_uri if directory.nil? || data_uri.blank?
+
+    match = data_uri.match(%r{\Adata:(image/[a-z0-9.+-]+);base64,(.+)\z}m)
+    return nil if match.nil?
+
+    content_type = match[1]
+    bytes = Base64.strict_decode64(match[2])
+
+    if content_type == "image/svg+xml"
+      svg_path = File.join(directory, "#{basename}.svg")
+      png_path = File.join(directory, "#{basename}.png")
+      File.binwrite(svg_path, bytes)
+      ImageMagick.magick(
+        "MSVG:#{svg_path}",
+        png_path,
+        read: [svg_path],
+        write: [directory],
+        timeout: 10,
+      )
+      return png_path if File.exist?(png_path)
+
+      return nil
+    end
+
+    extension =
+      { "image/gif" => "gif", "image/jpeg" => "jpg", "image/png" => "png", "image/webp" => "webp" }[
+        content_type
+      ]
+    return nil if extension.nil?
+
+    path = File.join(directory, "#{basename}.#{extension}")
+    File.binwrite(path, bytes)
+    path
+  rescue ArgumentError, Discourse::Utils::CommandError => error
+    Discourse.warn(
+      "Failed to materialize topic OG image asset",
+      topic_id: @topic.id,
+      asset: basename,
+      error: error.message,
+    )
+    nil
+  end
+
   def escape_xml(text)
     text
       .to_s
@@ -321,25 +365,25 @@ class TopicOgImageGenerator
       .gsub('"', "&quot;")
   end
 
-  def render_png(svg)
+  def render_png
     Dir.mktmpdir("topic_og") do |dir|
       svg_path = File.join(dir, "og.svg")
       png_path = File.join(dir, "og.png")
 
-      File.write(svg_path, svg)
+      File.write(svg_path, build_svg(asset_directory: dir))
 
       ImageMagick.magick(
         "-background",
         "none",
         "-size",
         "#{OG_WIDTH}x#{OG_HEIGHT}",
-        svg_path,
+        "MSVG:#{svg_path}",
         "-depth",
         "8",
         "-define",
         "png:compression-level=9",
         png_path,
-        read: [svg_path],
+        read: [dir],
         write: [dir],
         nice: 10,
         timeout: 20,

--- a/spec/lib/topic_og_image_generator_spec.rb
+++ b/spec/lib/topic_og_image_generator_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "chunky_png"
+
 RSpec.describe TopicOgImageGenerator do
   fab!(:category) { Fabricate(:category, name: "Feature", color: "0088cc") }
   fab!(:topic) do
@@ -33,6 +35,101 @@ RSpec.describe TopicOgImageGenerator do
       expect(upload.errors).to be_empty
       expect(upload.extension).to eq("png")
       expect(upload.original_filename).to eq("topic-og-#{topic.id}.png")
+    end
+  end
+
+  describe "#generate_bytes" do
+    it "renders the topic OG image as a 1200x630 PNG" do
+      png_bytes = described_class.new(topic).generate_bytes
+
+      expect(png_bytes).to be_present
+      Tempfile.create(%w[topic-og .png], binmode: true) do |file|
+        file.write(png_bytes)
+        file.flush
+
+        expect(FastImage.type(file.path)).to eq(:png)
+        expect(FastImage.size(file.path)).to eq([1200, 630])
+      end
+    end
+
+    it "renders raster and SVG assets in their expected regions" do
+      logo_upload = Struct.new(:url, :width, :height).new("/marked-logo.svg", 200, 100)
+      logo_svg = <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+          <rect width="200" height="100" fill="#00ff00"/>
+        </svg>
+      SVG
+      avatar_png = ChunkyPNG::Image.new(16, 16, ChunkyPNG::Color.rgb(255, 0, 0)).to_blob
+      logo_data_uri = "data:image/svg+xml;base64,#{Base64.strict_encode64(logo_svg)}"
+      avatar_data_uri = "data:image/png;base64,#{Base64.strict_encode64(avatar_png)}"
+      avatar_url = topic.user.avatar_template_url.gsub("{size}", "120")
+      SiteSetting.stubs(:logo).returns(logo_upload)
+      described_class
+        .any_instance
+        .stubs(:fetch_as_data_uri)
+        .with("/marked-logo.svg")
+        .returns(logo_data_uri)
+      described_class
+        .any_instance
+        .stubs(:fetch_as_data_uri)
+        .with(avatar_url)
+        .returns(avatar_data_uri)
+
+      png = ChunkyPNG::Image.from_blob(described_class.new(topic).generate_bytes)
+
+      avatar_pixel = png[116, 339]
+      logo_pixel = png[180, 520]
+      expect(
+        [
+          [ChunkyPNG::Color.r(avatar_pixel), ChunkyPNG::Color.g(avatar_pixel)],
+          [ChunkyPNG::Color.g(logo_pixel), ChunkyPNG::Color.r(logo_pixel)],
+        ],
+      ).to eq([[255, 0], [255, 0]])
+    end
+
+    it "omits an unrenderable SVG asset and still renders the canvas" do
+      logo_upload = Struct.new(:url, :width, :height).new("/invalid-logo.svg", 200, 100)
+      invalid_svg_data_uri = "data:image/svg+xml;base64,#{Base64.strict_encode64("<svg><invalid")}"
+      avatar_url = topic.user.avatar_template_url.gsub("{size}", "120")
+      SiteSetting.stubs(:logo).returns(logo_upload)
+      described_class
+        .any_instance
+        .stubs(:fetch_as_data_uri)
+        .with("/invalid-logo.svg")
+        .returns(invalid_svg_data_uri)
+      described_class.any_instance.stubs(:fetch_as_data_uri).with(avatar_url).returns(nil)
+      Discourse.expects(:warn).with(
+        "Failed to materialize topic OG image asset",
+        has_entries(topic_id: topic.id, asset: "logo"),
+      )
+
+      png = ChunkyPNG::Image.from_blob(described_class.new(topic).generate_bytes)
+
+      expect([png.width, png.height]).to eq([1200, 630])
+      expect(png[180, 520]).to eq(png[500, 520])
+    end
+
+    it "allows explicit MSVG while denying ordinary SVG and DATA coders" do
+      Dir.mktmpdir("topic-og-policy") do |directory|
+        svg_path = File.join(directory, "source.svg")
+        msvg_png_path = File.join(directory, "msvg.png")
+        svg_png_path = File.join(directory, "svg.png")
+        data_png_path = File.join(directory, "data.png")
+        File.write(
+          svg_path,
+          '<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"><rect width="2" height="2" fill="red"/></svg>',
+        )
+
+        ImageMagick.magick("MSVG:#{svg_path}", msvg_png_path, read: [svg_path], write: [directory])
+
+        expect(File).to exist(msvg_png_path)
+        expect do
+          ImageMagick.magick(svg_path, svg_png_path, read: [svg_path], write: [directory])
+        end.to raise_error(Discourse::Utils::CommandError, /security policy `SVG'/)
+        expect do
+          ImageMagick.magick(TINY_PNG_DATA_URI, data_png_path, write: [directory])
+        end.to raise_error(Discourse::Utils::CommandError, /security policy `DATA'/)
+      end
     end
   end
 

--- a/spec/lib/topic_og_image_generator_spec.rb
+++ b/spec/lib/topic_og_image_generator_spec.rb
@@ -108,29 +108,6 @@ RSpec.describe TopicOgImageGenerator do
       expect([png.width, png.height]).to eq([1200, 630])
       expect(png[180, 520]).to eq(png[500, 520])
     end
-
-    it "allows explicit MSVG while denying ordinary SVG and DATA coders" do
-      Dir.mktmpdir("topic-og-policy") do |directory|
-        svg_path = File.join(directory, "source.svg")
-        msvg_png_path = File.join(directory, "msvg.png")
-        svg_png_path = File.join(directory, "svg.png")
-        data_png_path = File.join(directory, "data.png")
-        File.write(
-          svg_path,
-          '<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"><rect width="2" height="2" fill="red"/></svg>',
-        )
-
-        ImageMagick.magick("MSVG:#{svg_path}", msvg_png_path, read: [svg_path], write: [directory])
-
-        expect(File).to exist(msvg_png_path)
-        expect do
-          ImageMagick.magick(svg_path, svg_png_path, read: [svg_path], write: [directory])
-        end.to raise_error(Discourse::Utils::CommandError, /security policy `SVG'/)
-        expect do
-          ImageMagick.magick(TINY_PNG_DATA_URI, data_png_path, write: [directory])
-        end.to raise_error(Discourse::Utils::CommandError, /security policy `DATA'/)
-      end
-    end
   end
 
   describe ".eligible?" do


### PR DESCRIPTION
Previously, topic OG image generation passed an SVG containing data URI assets to ImageMagick, so the hardened policy denied the ordinary SVG and DATA coders and returned no preview.

This change materializes assets in an isolated per-render directory, pre-rasterizes SVG assets, and renders the canvas explicitly through MSVG with the required MVG coder, restoring previews while keeping ordinary SVG, DATA, delegates, filters, and restricted paths denied and omitting invalid assets without failing the full render.