### PR TITLE
FEATURE: Allow selection of multiple content languages when viewing topics and posts

### DIFF
--- a/.skills/discourse-content-localization/SKILL.md
+++ b/.skills/discourse-content-localization/SKILL.md
@@ -19,7 +19,7 @@ Use this before localizing dynamic Discourse content such as Sidebar sections, G
 - Add `include Localizable` to the source model and a nullable `locale` column with limit 20.
 - Add `<Model>Localization` with `include LocaleMatchable`, `belongs_to :model`, a `locale` string limit 20, translated fields with source-model length limits, and a unique `(model_id, locale)` index.
 - Use `get_localization` for exact, normalized, and optional default-locale fallback behavior. Do not reimplement locale fallback in serializers.
-- Add `ContentLocalization.show_translated_<model>?` using `SiteSetting.content_localization_enabled`, source `locale.present?`, and `!model.in_user_locale?`. Match Post/Topic only when show-original behavior is relevant.
+- Add `ContentLocalization.show_translated_<model>?` using `SiteSetting.content_localization_enabled`, source `locale.present?`, and `!model.in_user_locale?`. Preserve existing model-specific presentation gates; do not copy them to unrelated model types without explicit product intent.
 - Preload in every list, boot, site JSON, admin list, and controller path that serializes localized fields. Use `includes(:localizations)` or `includes(:localizations, children: :localizations)` as needed.
 - Serializer methods should return `localization.field.presence || original_field` and expose localization rows only to users who can edit them.
 
@@ -44,6 +44,7 @@ Use this before localizing dynamic Discourse content such as Sidebar sections, G
 
 - Model specs: validations, uniqueness, dependency cleanup, fallback via `get_localization`.
 - Serializer/request specs: localized value when enabled, original value when disabled/source locale missing/same locale, editor-only `localizations`, and no N+1 on hot routes.
+- When changing model-specific presentation gates, test authenticated and anonymous behavior and verify unrelated localizable model types remain unaffected.
 - UI/system or QUnit specs: authorized editor can view/add/remove localization rows on the chosen edit surface; unauthorized users cannot.
 - discourse-ai specs: detector text, localizer writes, scheduled job enqueue/credit gates, regular job limits/skips/errors, and candidate completion if the model appears in translation-progress UI.
 

--- a/app/assets/stylesheets/common/base/embed-mode.scss
+++ b/app/assets/stylesheets/common/base/embed-mode.scss
@@ -133,7 +133,8 @@ body.embed-mode {
   }
 
   // Hide admin menu in the progress bar for embed context
-  #topic-progress-wrapper .topic-admin-menu-trigger {
+  #topic-progress-wrapper .topic-admin-menu-trigger,
+  #topic-progress-wrapper .topic-content-language-preferences {
     display: none;
   }
 

--- a/app/assets/stylesheets/common/base/topic-footer.scss
+++ b/app/assets/stylesheets/common/base/topic-footer.scss
@@ -135,10 +135,15 @@
     width: auto;
     margin-top: var(--border-offset);
 
-    .topic-admin-menu-trigger {
+    .topic-admin-menu-trigger,
+    .topic-content-language-preferences {
       border-radius: 0;
       background: var(--secondary);
       border: 1px solid var(--primary-low);
+    }
+
+    .topic-admin-menu-trigger + .topic-content-language-preferences {
+      margin-inline-start: var(--border-offset);
     }
   }
 }

--- a/app/assets/stylesheets/common/base/user.scss
+++ b/app/assets/stylesheets/common/base/user.scss
@@ -1081,7 +1081,11 @@
     margin-top: 0.5em;
   }
 
-  .pref-show-original-content {
+  .pref-understood-languages {
+    margin-top: var(--space-2);
+  }
+
+  .pref-automatically-translate {
     margin-top: var(--space-4);
     margin-bottom: var(--space-4);
   }

--- a/app/assets/stylesheets/common/components/_index.scss
+++ b/app/assets/stylesheets/common/components/_index.scss
@@ -19,6 +19,7 @@
 @import "calendar-date-time-input";
 @import "composer-toggle-switch";
 @import "convert-to-public-topic-modal";
+@import "content-language-preferences-modal";
 @import "d-autocomplete";
 @import "d-filter-controls";
 @import "docked-composer";

--- a/app/assets/stylesheets/common/components/content-language-preferences-modal.scss
+++ b/app/assets/stylesheets/common/components/content-language-preferences-modal.scss
@@ -1,0 +1,13 @@
+.content-language-preferences-modal {
+  &__understood {
+    display: grid;
+    gap: var(--space-1);
+    width: 100%;
+
+    > span {
+      color: var(--primary);
+      font-size: var(--font-down-1-rem);
+      font-weight: 600;
+    }
+  }
+}

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -8,12 +8,7 @@ class AboutController < ApplicationController
   def index
     return redirect_to path("/login") if SiteSetting.login_required? && current_user.nil?
 
-    @about =
-      About.new(
-        current_user,
-        locale: I18n.locale,
-        show_original: ContentLocalization.show_original?(guardian),
-      )
+    @about = About.new(current_user, locale: I18n.locale)
     @title = "#{I18n.t("js.about.simple_title")} - #{@about.title}"
     @description_meta = @about.description
     respond_to do |format|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2208,7 +2208,9 @@ class UsersController < ApplicationController
 
     editable_custom_fields = User.editable_user_custom_fields(by_staff: current_user.try(:staff?))
     permitted << { custom_fields: editable_custom_fields } if editable_custom_fields.present?
-    permitted.concat UserUpdater::OPTION_ATTR
+    permitted.concat(UserUpdater::OPTION_ATTR - [:understood_languages])
+    permitted << UserUpdater::LEGACY_SHOW_ORIGINAL_CONTENT_ATTR
+    permitted << { understood_languages: [] }
     permitted.concat UserUpdater::CATEGORY_IDS.keys.map { |k| { k => [] } }
     permitted.concat UserUpdater::TAG_NAMES.keys
     permitted << UserUpdater::NOTIFICATION_SCHEDULE_ATTRS

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -22,16 +22,18 @@ module TopicsHelper
   end
 
   def localize_topic_view_content(topic_view)
-    return if cookies.key?(ContentLocalization::SHOW_ORIGINAL_COOKIE)
-    return if current_user&.user_option&.show_original_content
-
     # locale param is appropriately set in the application controller
     # depending on site settings and presence of user
     locale = I18n.locale
 
-    LocalizationAttributesReplacer.replace_topic_attributes(topic_view.topic, locale)
+    if ContentLocalization.show_translated_topic?(topic_view.topic, guardian)
+      LocalizationAttributesReplacer.replace_topic_attributes(topic_view.topic, locale)
+    end
+
     topic_view.posts.each do |post|
-      LocalizationAttributesReplacer.replace_post_attributes(post, locale)
+      if ContentLocalization.show_translated_post?(post, guardian)
+        LocalizationAttributesReplacer.replace_post_attributes(post, locale)
+      end
     end
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -176,13 +176,11 @@ class Tag < ActiveRecord::Base
     end
 
     tags_by_id = Tag.where(id: tag_data.map(&:tag_id)).includes(:localizations).index_by(&:id)
-    show_localized = !ContentLocalization.show_original?(guardian)
-
     tag_data.filter_map do |row|
       tag = tags_by_id[row.tag_id]
       next unless tag
 
-      name = show_localized ? (tag.get_localization&.name || tag.name) : tag.name
+      name = tag.get_localization&.name || tag.name
       slug = row.tag_slug.presence || "#{row.tag_id}-tag"
       { id: tag.id, name:, slug: }
     end

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -75,6 +75,7 @@ class UserOption < ActiveRecord::Base
   validates :email_level, inclusion: { in: UserOption.email_level_types.values }
   validates :email_messages_level, inclusion: { in: UserOption.email_level_types.values }
   validates :timezone, timezone: true
+  validate :understood_languages_are_supported, if: :will_save_change_to_understood_languages?
 
   def set_defaults
     self.mailing_list_mode = SiteSetting.default_email_mailing_list_mode
@@ -248,6 +249,14 @@ class UserOption < ActiveRecord::Base
 
   private
 
+  def understood_languages_are_supported
+    if understood_languages.all? { |locale| LocaleSiteSetting.supported_locales.include?(locale) }
+      return
+    end
+
+    errors.add(:understood_languages, :invalid)
+  end
+
   def update_hide_profile_and_presence
     if hide_profile_changed? || hide_presence_changed?
       self.hide_profile_and_presence = hide_profile || hide_presence
@@ -271,6 +280,7 @@ end
 #  allow_private_messages                         :boolean          default(TRUE), not null
 #  auto_image_caption                             :boolean          default(FALSE), not null
 #  auto_track_topics_after_msecs                  :integer
+#  automatically_translate                        :boolean          default(TRUE), not null
 #  automatically_unpin_topics                     :boolean          default(TRUE), not null
 #  bookmark_auto_delete_preference                :integer          default(3), not null
 #  chat_announce_new_messages                     :boolean          default(TRUE), not null
@@ -335,6 +345,7 @@ end
 #  timezone                                       :string
 #  title_count_mode_key                           :integer          default(0), not null
 #  topics_unread_when_closed                      :boolean          default(TRUE), not null
+#  understood_languages                           :string           default([]), not null, is an Array
 #  watched_precedence_over_muted                  :boolean          default(FALSE), not null
 #  color_scheme_id                                :integer
 #  dark_scheme_id                                 :integer

--- a/app/serializers/current_user_option_serializer.rb
+++ b/app/serializers/current_user_option_serializer.rb
@@ -28,10 +28,16 @@ class CurrentUserOptionSerializer < ApplicationSerializer
              :composition_mode,
              :interface_color_mode,
              :show_original_content,
-             :send_shortcut
+             :send_shortcut,
+             :automatically_translate,
+             :understood_languages
 
   def likes_notifications_disabled
     object.likes_notifications_disabled?
+  end
+
+  def show_original_content
+    !object.automatically_translate
   end
 
   def include_redirected_to_top?

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -284,7 +284,7 @@ class PostSerializer < BasicPostSerializer
 
   def include_localized_oneboxes?
     SiteSetting.content_localization_enabled && @topic_view.present? &&
-      !ContentLocalization.show_original?(scope) &&
+      ContentLocalization.automatically_translate?(scope) &&
       @topic_view.localized_oneboxes[object.id].present?
   end
 

--- a/app/serializers/topic_view_serializer.rb
+++ b/app/serializers/topic_view_serializer.rb
@@ -78,6 +78,7 @@ class TopicViewSerializer < ApplicationSerializer
     :user_last_posted_at,
     :is_shared_draft,
     :slow_mode_enabled_until,
+    :has_localized_content,
     :can_localize_topic,
     :is_nested_view,
   )
@@ -318,6 +319,14 @@ class TopicViewSerializer < ApplicationSerializer
 
   def include_visibility_reason_id?
     object.topic.visibility_reason_id.present?
+  end
+
+  def has_localized_content
+    object.has_localized_content?
+  end
+
+  def include_has_localized_content?
+    SiteSetting.content_localization_enabled
   end
 
   def can_localize_topic

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -51,7 +51,9 @@ class UserOptionSerializer < ApplicationSerializer
              :composition_mode,
              :interface_color_mode,
              :show_original_content,
-             :send_shortcut
+             :send_shortcut,
+             :automatically_translate,
+             :understood_languages
 
   def auto_track_topics_after_msecs
     object.auto_track_topics_after_msecs || SiteSetting.default_other_auto_track_topics_after_msecs
@@ -68,5 +70,9 @@ class UserOptionSerializer < ApplicationSerializer
 
   def theme_ids
     object.theme_ids.presence || [SiteSetting.default_theme_id]
+  end
+
+  def show_original_content
+    !object.automatically_translate
   end
 end

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserUpdater
+  LEGACY_SHOW_ORIGINAL_CONTENT_ATTR = :show_original_content
+
   CATEGORY_IDS = {
     watched_first_post_category_ids: :watching_first_post,
     watched_category_ids: :watching,
@@ -61,8 +63,9 @@ class UserUpdater
     watched_precedence_over_muted
     topics_unread_when_closed
     composition_mode
-    show_original_content
     send_shortcut
+    automatically_translate
+    understood_languages
   ]
 
   NOTIFICATION_SCHEDULE_ATTRS = -> do
@@ -82,6 +85,12 @@ class UserUpdater
   end
 
   def update(attributes = {})
+    if attributes.key?(LEGACY_SHOW_ORIGINAL_CONTENT_ATTR)
+      attributes[:automatically_translate] = attributes[LEGACY_SHOW_ORIGINAL_CONTENT_ATTR].to_s !=
+        "true" unless attributes.key?(:automatically_translate)
+      attributes.delete(LEGACY_SHOW_ORIGINAL_CONTENT_ATTR)
+    end
+
     user_profile = user.user_profile
     user_profile.dismissed_banner_key = attributes[:dismissed_banner_key] if attributes[
       :dismissed_banner_key
@@ -180,6 +189,13 @@ class UserUpdater
     if attributes.key?(:text_size)
       user.user_option.text_size_seq += 1 if user.user_option.text_size.to_s !=
         attributes[:text_size]
+    end
+
+    if attributes.key?(:locale) || attributes.key?(:understood_languages)
+      understood_languages =
+        attributes.fetch(:understood_languages) { user.user_option.understood_languages }
+      interface_locale = user.effective_locale
+      attributes[:understood_languages] = [interface_locale, *understood_languages].compact.uniq
     end
 
     OPTION_ATTR.each do |attribute|

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1818,7 +1818,11 @@ en:
       enable_smart_lists: "Enable smart lists when writing in the composer"
       enable_defer: "Enable mark topics as unread"
       enable_markdown_monospace_font: "Use monospace font in composer's Markdown mode"
-      show_original_content: "Show original content instead of translated content."
+      automatically_translate: "Automatically translate topics and posts in other languages"
+      content_languages:
+        title: "Content languages"
+        understood: "Languages I understand"
+        understood_description: "Topics and posts in these languages won’t be translated. Your interface language is always included."
       experimental_sidebar:
         enable: "Enable sidebar"
         options: "Options"
@@ -5203,6 +5207,12 @@ en:
       click_to_show_translation: "Click to show translation"
       tap_to_show_translation: "Tap here to show translation"
       ai_translation_disclaimer: "AI-generated translations may be inaccurate."
+
+    content_localization:
+      preferences:
+        title: "Content language preferences"
+        login_to_set_languages: "Log in to set more languages"
+        interface_language_mandatory: "Your interface language is always included."
 
     category:
       none: "(no category)"

--- a/db/migrate/20260728134532_add_content_language_preferences_to_user_options.rb
+++ b/db/migrate/20260728134532_add_content_language_preferences_to_user_options.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddContentLanguagePreferencesToUserOptions < ActiveRecord::Migration[8.0]
+  def up
+    add_column :user_options, :automatically_translate, :boolean, default: true, null: false
+    add_column :user_options, :understood_languages, :string, array: true, default: [], null: false
+
+    execute <<~SQL
+      UPDATE user_options
+      SET automatically_translate = FALSE
+      WHERE show_original_content = TRUE
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11763,6 +11763,8 @@ CREATE TABLE public.user_options (
     chat_announce_new_messages boolean DEFAULT true NOT NULL,
     chat_new_message_sound boolean DEFAULT false NOT NULL,
     push_notification_level integer DEFAULT 1 NOT NULL,
+    automatically_translate boolean DEFAULT true NOT NULL,
+    understood_languages character varying[] DEFAULT '{}'::character varying[] NOT NULL,
     send_shortcut integer DEFAULT 0 NOT NULL
 );
 
@@ -23054,6 +23056,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260728162521'),
 ('20260728162516'),
+('20260728134532'),
 ('20260728071552'),
 ('20260728045008'),
 ('20260727085824'),

--- a/frontend/discourse/app/components/language-switcher.gjs
+++ b/frontend/discourse/app/components/language-switcher.gjs
@@ -4,13 +4,11 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import DMenu from "discourse/float-kit/components/d-menu";
 import { ajax } from "discourse/lib/ajax";
-import cookie, { removeCookie } from "discourse/lib/cookie";
+import cookie from "discourse/lib/cookie";
 import DButton from "discourse/ui-kit/d-button";
 import DDropdownMenu from "discourse/ui-kit/d-dropdown-menu";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
 import I18n, { i18n } from "discourse-i18n";
-
-const SHOW_ORIGINAL_COOKIE = "content-localization-show-original";
 
 export default class LanguageSwitcher extends Component {
   @service siteSettings;
@@ -21,16 +19,13 @@ export default class LanguageSwitcher extends Component {
   async changeLocale(locale) {
     if (this.currentUser) {
       this.currentUser.set("locale", locale);
-      this.currentUser.set("user_option.show_original_content", false);
       await ajax(`/u/${this.currentUser.username}.json`, {
         type: "PUT",
-        data: { locale, show_original_content: false },
+        data: { locale },
       });
     } else {
       cookie("locale", locale, { path: "/" });
     }
-
-    removeCookie(SHOW_ORIGINAL_COOKIE, { path: "/" });
 
     this.dMenu.close();
     // content should switch immediately,

--- a/frontend/discourse/app/components/modal/content-language-preferences.gjs
+++ b/frontend/discourse/app/components/modal/content-language-preferences.gjs
@@ -1,0 +1,257 @@
+import Component from "@glimmer/component";
+import { cached, tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import Form from "discourse/components/form";
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import {
+  AUTOMATICALLY_TRANSLATE_COOKIE,
+  AUTOMATICALLY_TRANSLATE_COOKIE_EXPIRY,
+  automaticallyTranslate,
+  contentLanguageOptions,
+  normalizeUnderstoodLanguages,
+} from "discourse/lib/content-localization";
+import cookie from "discourse/lib/cookie";
+import getURL from "discourse/lib/get-url";
+import MultiSelect from "discourse/select-kit/components/multi-select";
+import DButton from "discourse/ui-kit/d-button";
+import DModal from "discourse/ui-kit/d-modal";
+import DModalCancel from "discourse/ui-kit/d-modal-cancel";
+import I18n, { i18n } from "discourse-i18n";
+
+export default class ContentLanguagePreferencesModal extends Component {
+  @service currentUser;
+  @service siteSettings;
+  @service languageNameLookup;
+
+  @tracked formApi;
+  @tracked saving = false;
+
+  @cached
+  get data() {
+    const interfaceLanguage = this.currentUser?.effective_locale ?? I18n.locale;
+
+    return {
+      interfaceLanguage,
+      understoodLanguages: normalizeUnderstoodLanguages(
+        this.currentUser?.user_option?.understood_languages,
+        interfaceLanguage
+      ),
+      automaticallyTranslate: automaticallyTranslate(this.currentUser),
+    };
+  }
+
+  get interfaceLanguageOptions() {
+    return this.siteSettings.available_locales.map(({ value }) => ({
+      name: this.languageNameLookup.getLanguageName(value),
+      value,
+      id: value,
+    }));
+  }
+
+  get understoodLanguageOptions() {
+    const interfaceLanguage =
+      this.formApi?.get("interfaceLanguage") ?? this.data.interfaceLanguage;
+    const understoodLanguages =
+      this.formApi?.get("understoodLanguages") ?? this.data.understoodLanguages;
+
+    return contentLanguageOptions(
+      this.interfaceLanguageOptions,
+      this.siteSettings.available_content_localization_locales,
+      [interfaceLanguage, ...understoodLanguages]
+    );
+  }
+
+  get canChangeInterfaceLanguage() {
+    return (
+      this.siteSettings.allow_user_locale &&
+      (this.currentUser || this.siteSettings.set_locale_from_cookie)
+    );
+  }
+
+  get interfaceLanguageReadOnly() {
+    return !this.canChangeInterfaceLanguage;
+  }
+
+  get loginPath() {
+    return getURL("/login");
+  }
+
+  @action
+  registerFormApi(formApi) {
+    this.formApi = formApi;
+  }
+
+  @action
+  submit() {
+    this.formApi.submit();
+  }
+
+  @action
+  async setInterfaceLanguage(value, { set }) {
+    await set("interfaceLanguage", value);
+    await set(
+      "understoodLanguages",
+      normalizeUnderstoodLanguages(
+        this.formApi.get("understoodLanguages"),
+        value
+      )
+    );
+  }
+
+  @action
+  setUnderstoodLanguages(value, { set }) {
+    return set(
+      "understoodLanguages",
+      normalizeUnderstoodLanguages(value, this.formApi.get("interfaceLanguage"))
+    );
+  }
+
+  @action
+  async save(data) {
+    this.saving = true;
+
+    try {
+      if (this.currentUser) {
+        const understoodLanguages = normalizeUnderstoodLanguages(
+          data.understoodLanguages,
+          data.interfaceLanguage
+        );
+
+        const preferences = {
+          automatically_translate: data.automaticallyTranslate,
+          understood_languages: understoodLanguages,
+        };
+        if (this.canChangeInterfaceLanguage) {
+          preferences.locale = data.interfaceLanguage;
+        }
+
+        await ajax(`/u/${this.currentUser.username}.json`, {
+          type: "PUT",
+          data: preferences,
+        });
+        if (this.canChangeInterfaceLanguage) {
+          this.currentUser.set("locale", data.interfaceLanguage);
+          this.currentUser.set("effective_locale", data.interfaceLanguage);
+        }
+        this.currentUser.set(
+          "user_option.automatically_translate",
+          data.automaticallyTranslate
+        );
+        this.currentUser.set(
+          "user_option.understood_languages",
+          understoodLanguages
+        );
+      } else {
+        if (this.canChangeInterfaceLanguage) {
+          cookie("locale", data.interfaceLanguage, { path: "/" });
+        }
+        cookie(AUTOMATICALLY_TRANSLATE_COOKIE, data.automaticallyTranslate, {
+          path: "/",
+          expires: AUTOMATICALLY_TRANSLATE_COOKIE_EXPIRY,
+        });
+      }
+
+      this.args.closeModal();
+      window.location.reload();
+    } catch (error) {
+      popupAjaxError(error);
+      this.saving = false;
+    }
+  }
+
+  <template>
+    <DModal
+      @title={{i18n "content_localization.preferences.title"}}
+      @closeModal={{@closeModal}}
+      class="content-language-preferences-modal"
+    >
+      <:body>
+        <Form
+          @data={{this.data}}
+          @onSubmit={{this.save}}
+          @onRegisterApi={{this.registerFormApi}}
+          as |form transientData|
+        >
+          <form.Field
+            @name="interfaceLanguage"
+            @type="select"
+            @title={{i18n "user.locale.title"}}
+            @validation="required"
+            @format="full"
+            @onSet={{this.setInterfaceLanguage}}
+            @disabled={{this.interfaceLanguageReadOnly}}
+            as |field|
+          >
+            <field.Control as |select|>
+              {{#each this.interfaceLanguageOptions as |language|}}
+                <select.Option @value={{language.value}}>
+                  {{language.name}}
+                </select.Option>
+              {{/each}}
+            </field.Control>
+          </form.Field>
+
+          {{#if this.currentUser}}
+            <form.Field
+              @name="understoodLanguages"
+              @type="custom"
+              @title={{i18n "user.content_languages.understood"}}
+              @description={{i18n
+                "user.content_languages.understood_description"
+              }}
+              @showOptional={{false}}
+              @format="full"
+              @onSet={{this.setUnderstoodLanguages}}
+              as |field|
+            >
+              <field.Control>
+                <MultiSelect
+                  @valueProperty="value"
+                  @langProperty="value"
+                  @content={{this.understoodLanguageOptions}}
+                  @value={{field.value}}
+                  @onChange={{field.set}}
+                  @mandatoryValues={{transientData.interfaceLanguage}}
+                  @mandatoryValueTitle={{i18n
+                    "content_localization.preferences.interface_language_mandatory"
+                  }}
+                  @options={{hash filterable=true}}
+                />
+              </field.Control>
+            </form.Field>
+          {{else}}
+            <div class="content-language-preferences-modal__understood">
+              <span>{{i18n "user.content_languages.understood"}}</span>
+              <a href={{this.loginPath}}>{{i18n
+                  "content_localization.preferences.login_to_set_languages"
+                }}</a>
+            </div>
+          {{/if}}
+
+          <form.Field
+            @name="automaticallyTranslate"
+            @type="checkbox"
+            @title={{i18n "user.automatically_translate"}}
+            @format="full"
+            as |field|
+          >
+            <field.Control data-test-automatically-translate />
+          </form.Field>
+        </Form>
+      </:body>
+
+      <:footer>
+        <DButton
+          @label="save"
+          @action={{this.submit}}
+          @disabled={{this.saving}}
+          class="btn-primary"
+        />
+        <DModalCancel @close={{@closeModal}} />
+      </:footer>
+    </DModal>
+  </template>
+}

--- a/frontend/discourse/app/components/topic-content-language-preferences.gjs
+++ b/frontend/discourse/app/components/topic-content-language-preferences.gjs
@@ -1,0 +1,25 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import ContentLanguagePreferencesModal from "discourse/components/modal/content-language-preferences";
+import DButton from "discourse/ui-kit/d-button";
+
+export default class TopicContentLanguagePreferences extends Component {
+  @service modal;
+
+  @action
+  openPreferences() {
+    this.modal.show(ContentLanguagePreferencesModal);
+  }
+
+  <template>
+    <DButton
+      @icon="language"
+      @title="content_localization.preferences.title"
+      @action={{this.openPreferences}}
+      class="btn-default topic-content-language-preferences no-text"
+      data-test-content-language-preferences
+      ...attributes
+    />
+  </template>
+}

--- a/frontend/discourse/app/components/topic-timeline/container.gjs
+++ b/frontend/discourse/app/components/topic-timeline/container.gjs
@@ -9,6 +9,7 @@ import { trustHTML } from "@ember/template";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import { actionDescriptionHtml } from "discourse/components/post-action-description";
 import TopicAdminMenu from "discourse/components/topic-admin-menu";
+import TopicContentLanguagePreferences from "discourse/components/topic-content-language-preferences";
 import UserTip from "discourse/components/user-tip";
 import lazyHash from "discourse/helpers/lazy-hash";
 import topicFeaturedLink from "discourse/helpers/topic-featured-link";
@@ -167,7 +168,10 @@ export default class TopicTimelineScrollArea extends Component {
   }
 
   get showTimelineControls() {
-    return !this.args.fullscreen && this.currentUser;
+    return (
+      !this.args.fullscreen &&
+      (this.currentUser || this.args.model.has_localized_content)
+    );
   }
 
   get topicTitle() {
@@ -566,6 +570,10 @@ export default class TopicTimelineScrollArea extends Component {
           @convertToPublicTopic={{@convertToPublicTopic}}
           @convertToPrivateMessage={{@convertToPrivateMessage}}
         />
+
+        {{#if @model.has_localized_content}}
+          <TopicContentLanguagePreferences />
+        {{/if}}
       </div>
     {{/if}}
 

--- a/frontend/discourse/app/controllers/preferences/interface.js
+++ b/frontend/discourse/app/controllers/preferences/interface.js
@@ -130,7 +130,7 @@ export default class InterfaceController extends Controller {
 
   @computed()
   get availableLocales() {
-    return this.siteSettings.available_locales.map((locale) => ({
+    return (this.siteSettings.available_locales ?? []).map((locale) => ({
       ...locale,
       id: locale.value,
     }));

--- a/frontend/discourse/app/controllers/preferences/interface.js
+++ b/frontend/discourse/app/controllers/preferences/interface.js
@@ -14,6 +14,10 @@ import {
   SEND_SHORTCUT_ENTER,
   SEND_SHORTCUT_META_ENTER,
 } from "discourse/lib/constants";
+import {
+  contentLanguageOptions,
+  normalizeUnderstoodLanguages,
+} from "discourse/lib/content-localization";
 import { deepEqual } from "discourse/lib/object";
 import {
   currentThemeId,
@@ -28,7 +32,7 @@ import {
 } from "discourse/lib/utilities";
 import { AUTO_DELETE_PREFERENCES } from "discourse/models/bookmark";
 import { PLATFORM_KEY_MODIFIER } from "discourse/services/keyboard-shortcuts";
-import { i18n } from "discourse-i18n";
+import I18n, { i18n } from "discourse-i18n";
 
 // same as UserOption::HOMEPAGES
 const USER_HOMES = {
@@ -70,7 +74,6 @@ export default class InterfaceController extends Controller {
   @computed("makeThemeDefault")
   get saveAttrNames() {
     let attrs = [
-      "locale",
       "external_links_in_new_tab",
       "dynamic_favicon",
       "enable_quoting",
@@ -90,9 +93,14 @@ export default class InterfaceController extends Controller {
       "bookmark_auto_delete_preference",
       "interface_color_mode",
       "enable_markdown_monospace_font",
-      "show_original_content",
       "send_shortcut",
+      "automatically_translate",
+      "understood_languages",
     ];
+
+    if (this.siteSettings.allow_user_locale) {
+      attrs.push("locale");
+    }
 
     if (this.makeThemeDefault) {
       attrs.push("theme_ids");
@@ -103,9 +111,56 @@ export default class InterfaceController extends Controller {
     });
   }
 
+  @computed("model.locale")
+  get interfaceLanguage() {
+    if (!this.siteSettings.allow_user_locale) {
+      return this.siteSettings.default_locale ?? I18n.locale;
+    }
+
+    return this.model.locale ?? this.siteSettings.default_locale ?? I18n.locale;
+  }
+
+  @computed("model.locale", "model.user_option.understood_languages.[]")
+  get understoodLanguages() {
+    return normalizeUnderstoodLanguages(
+      this.model.user_option.understood_languages,
+      this.interfaceLanguage
+    );
+  }
+
   @computed()
   get availableLocales() {
-    return this.siteSettings.available_locales;
+    return this.siteSettings.available_locales.map((locale) => ({
+      ...locale,
+      id: locale.value,
+    }));
+  }
+
+  @computed(
+    "model.locale",
+    "model.user_option.understood_languages.[]",
+    "siteSettings.available_content_localization_locales"
+  )
+  get understoodLanguageOptions() {
+    return contentLanguageOptions(
+      this.availableLocales,
+      this.siteSettings.available_content_localization_locales,
+      this.understoodLanguages
+    );
+  }
+
+  @action
+  setInterfaceLanguage(locale) {
+    this.model.set("locale", locale);
+    this.setUnderstoodLanguages(this.model.user_option.understood_languages);
+  }
+
+  @action
+  setUnderstoodLanguages(locales) {
+    this.model.set(
+      "user_option.understood_languages",
+      normalizeUnderstoodLanguages(locales, this.interfaceLanguage)
+    );
   }
 
   @computed("currentThemeId")

--- a/frontend/discourse/app/lib/content-localization.js
+++ b/frontend/discourse/app/lib/content-localization.js
@@ -1,0 +1,31 @@
+import cookie from "discourse/lib/cookie";
+
+export const AUTOMATICALLY_TRANSLATE_COOKIE = "automatically_translate";
+export const AUTOMATICALLY_TRANSLATE_COOKIE_EXPIRY = 30;
+
+export function normalizeUnderstoodLanguages(languages, interfaceLanguage) {
+  return [
+    ...new Set([interfaceLanguage, ...(languages ?? [])].filter(Boolean)),
+  ];
+}
+
+export function contentLanguageOptions(
+  availableLocales,
+  supportedLocales,
+  retainedLocales = []
+) {
+  const allowedLocales = new Set([
+    ...(supportedLocales ?? []).map((locale) => locale.value ?? locale),
+    ...retainedLocales,
+  ]);
+
+  return availableLocales.filter((locale) => allowedLocales.has(locale.value));
+}
+
+export function automaticallyTranslate(currentUser) {
+  if (currentUser) {
+    return currentUser.user_option?.automatically_translate ?? true;
+  }
+
+  return cookie(AUTOMATICALLY_TRANSLATE_COOKIE) !== "false";
+}

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -146,6 +146,7 @@ let userOptionFields = [
   "push_notification_level",
   "seen_popups",
   "send_shortcut",
+  "automatically_translate",
   "show_original_content",
   "sidebar_link_to_filtered_list",
   "sidebar_show_count_of_new_items",
@@ -155,6 +156,7 @@ let userOptionFields = [
   "timezone",
   "title_count_mode",
   "topics_unread_when_closed",
+  "understood_languages",
   "watched_precedence_over_muted",
 ];
 

--- a/frontend/discourse/app/templates/preferences/interface.gjs
+++ b/frontend/discourse/app/templates/preferences/interface.gjs
@@ -4,6 +4,7 @@ import PreferenceCheckbox from "discourse/components/preference-checkbox";
 import lazyHash from "discourse/helpers/lazy-hash";
 import ColorPalettePicker from "discourse/select-kit/components/color-palette-picker";
 import ComboBox from "discourse/select-kit/components/combo-box";
+import MultiSelect from "discourse/select-kit/components/multi-select";
 import DButton from "discourse/ui-kit/d-button";
 import DSaveControls from "discourse/ui-kit/d-save-controls";
 import { i18n } from "discourse-i18n";
@@ -143,14 +144,6 @@ export default <template>
       <label for="locale-selector" class="control-label">{{i18n
           "user.locale.title"
         }}</label>
-      {{#if @controller.siteSettings.content_localization_enabled}}
-        <PreferenceCheckbox
-          @labelKey="user.show_original_content"
-          @checked={{@controller.model.user_option.show_original_content}}
-          data-setting-name="user-show-original-content"
-          class="pref-show-original-content"
-        />
-      {{/if}}
       <div class="controls">
         <ComboBox
           @id="locale-selector"
@@ -158,7 +151,7 @@ export default <template>
           @langProperty="value"
           @content={{@controller.availableLocales}}
           @value={{@controller.model.locale}}
-          @onChange={{fn (mut @controller.model.locale)}}
+          @onChange={{@controller.setInterfaceLanguage}}
           @options={{hash filterable=true none="user.locale.default"}}
         />
       </div>
@@ -166,6 +159,44 @@ export default <template>
         {{i18n "user.locale.instructions"}}
       </div>
     </div>
+  {{/if}}
+
+  {{#if @controller.siteSettings.content_localization_enabled}}
+    <fieldset
+      class="control-group pref-content-languages"
+      data-setting-name="user-content-languages"
+    >
+      <legend class="control-label">{{i18n
+          "user.content_languages.title"
+        }}</legend>
+      <div class="controls controls-dropdown pref-understood-languages">
+        <label for="understood-languages-selector">{{i18n
+            "user.content_languages.understood"
+          }}</label>
+        <MultiSelect
+          @id="understood-languages-selector"
+          @valueProperty="value"
+          @langProperty="value"
+          @content={{@controller.understoodLanguageOptions}}
+          @value={{@controller.understoodLanguages}}
+          @onChange={{@controller.setUnderstoodLanguages}}
+          @mandatoryValues={{@controller.interfaceLanguage}}
+          @mandatoryValueTitle={{i18n
+            "content_localization.preferences.interface_language_mandatory"
+          }}
+          @options={{hash filterable=true}}
+        />
+        <div class="instructions">
+          {{i18n "user.content_languages.understood_description"}}
+        </div>
+      </div>
+      <PreferenceCheckbox
+        @labelKey="user.automatically_translate"
+        @checked={{@controller.model.user_option.automatically_translate}}
+        data-setting-name="user-automatically-translate"
+        class="pref-automatically-translate"
+      />
+    </fieldset>
   {{/if}}
 
   <div class="control-group home" data-setting-name="user-home">

--- a/frontend/discourse/app/templates/topic.gjs
+++ b/frontend/discourse/app/templates/topic.gjs
@@ -23,6 +23,7 @@ import SignupCta from "discourse/components/signup-cta";
 import SlowModeInfo from "discourse/components/slow-mode-info";
 import TopicAdminMenu from "discourse/components/topic-admin-menu";
 import TopicCategory from "discourse/components/topic-category";
+import TopicContentLanguagePreferences from "discourse/components/topic-content-language-preferences";
 import TopicFooterButtons from "discourse/components/topic-footer-buttons";
 import TopicMap from "discourse/components/topic-map/index";
 import TopicMetadata from "discourse/components/topic-metadata";
@@ -451,6 +452,9 @@ export default <template>
                     @convertToPublicTopic={{@controller.convertToPublicTopic}}
                     @convertToPrivateMessage={{@controller.convertToPrivateMessage}}
                   />
+                  {{#if @controller.model.has_localized_content}}
+                    <TopicContentLanguagePreferences />
+                  {{/if}}
                 </TopicProgress>
               {{/if}}
 

--- a/frontend/discourse/select-kit/components/multi-select.gjs
+++ b/frontend/discourse/select-kit/components/multi-select.gjs
@@ -250,6 +250,7 @@ export default class MultiSelect extends SelectKitComponent {
                     @item={{item}}
                     @selectKit={{this.selectKit}}
                     @mandatoryValues={{@mandatoryValues}}
+                    @mandatoryValueTitle={{@mandatoryValueTitle}}
                   />
                 {{/each}}
               {{/let}}

--- a/frontend/discourse/select-kit/components/selected-choice.gjs
+++ b/frontend/discourse/select-kit/components/selected-choice.gjs
@@ -46,11 +46,18 @@ export default class SelectedChoice extends Component {
     return this.mandatoryValuesArray.includes(this.item.id);
   }
 
+  @computed("mandatoryValueTitle")
+  get readOnlyTitle() {
+    return (
+      this.mandatoryValueTitle || i18n("admin.site_settings.mandatory_group")
+    );
+  }
+
   <template>
     {{#if this.readOnly}}
       <button
         class="btn btn-default disabled tag-choice"
-        title={{i18n "admin.site_settings.mandatory_group"}}
+        title={{this.readOnlyTitle}}
       >{{this.itemName}}</button>
     {{else}}
       <button

--- a/frontend/discourse/tests/unit/lib/content-localization-test.js
+++ b/frontend/discourse/tests/unit/lib/content-localization-test.js
@@ -1,0 +1,95 @@
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import {
+  AUTOMATICALLY_TRANSLATE_COOKIE,
+  automaticallyTranslate,
+  contentLanguageOptions,
+  normalizeUnderstoodLanguages,
+} from "discourse/lib/content-localization";
+import cookie, { removeCookie } from "discourse/lib/cookie";
+
+module("Unit | Lib | content-localization", function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    removeCookie(AUTOMATICALLY_TRANSLATE_COOKIE);
+  });
+
+  test("resolves the anonymous preference from the positive cookie", function (assert) {
+    assert.true(
+      automaticallyTranslate(),
+      "automatic translation is enabled when no cookie exists"
+    );
+
+    cookie(AUTOMATICALLY_TRANSLATE_COOKIE, true);
+    assert.true(
+      automaticallyTranslate(),
+      "the positive preference enables automatic translation"
+    );
+
+    cookie(AUTOMATICALLY_TRANSLATE_COOKIE, false);
+    assert.false(
+      automaticallyTranslate(),
+      "the new false preference disables automatic translation"
+    );
+  });
+
+  test("always resolves a logged-in user's preference without cookies", function (assert) {
+    cookie(AUTOMATICALLY_TRANSLATE_COOKIE, false);
+
+    assert.true(
+      automaticallyTranslate({
+        user_option: { automatically_translate: true },
+      }),
+      "the positive user preference wins over both cookies"
+    );
+    assert.false(
+      automaticallyTranslate({
+        user_option: { automatically_translate: false },
+      }),
+      "a disabled user preference wins over both cookies"
+    );
+  });
+
+  test("keeps the interface language first in understood languages", function (assert) {
+    assert.deepEqual(
+      normalizeUnderstoodLanguages(["en", "de", "de"], "en"),
+      ["en", "de"],
+      "it removes duplicate languages"
+    );
+    assert.deepEqual(
+      normalizeUnderstoodLanguages(["en"], "ja"),
+      ["ja", "en"],
+      "it inserts a missing interface language"
+    );
+  });
+
+  test("limits understood language choices without hiding retained values", function (assert) {
+    const availableLocales = [
+      { name: "English", value: "en", id: "en" },
+      { name: "Deutsch", value: "de", id: "de" },
+      { name: "Français", value: "fr", id: "fr" },
+      { name: "日本語", value: "ja", id: "ja" },
+    ];
+
+    assert.deepEqual(
+      contentLanguageOptions(
+        availableLocales,
+        [{ value: "en" }, { value: "ja" }],
+        ["de", "fr"]
+      ),
+      availableLocales,
+      "it includes the interface language and saved values outside the current site setting"
+    );
+
+    assert.deepEqual(
+      contentLanguageOptions(
+        availableLocales,
+        [{ value: "en" }, { value: "ja" }],
+        ["de"]
+      ).map(({ value }) => value),
+      ["en", "de", "ja"],
+      "a removed saved value is no longer offered"
+    );
+  });
+});

--- a/lib/content_localization.rb
+++ b/lib/content_localization.rb
@@ -1,14 +1,37 @@
 # frozen_string_literal: true
 
 class ContentLocalization
-  SHOW_ORIGINAL_COOKIE = "content-localization-show-original"
+  AUTOMATICALLY_TRANSLATE_COOKIE = "automatically_translate"
 
   # @param scope [Object] The serializer scope from which the method is called
-  # @return [Boolean] if the cookie is set, false otherwise
+  # @return [Boolean]
+  def self.automatically_translate?(scope)
+    return scope.user.user_option.automatically_translate if scope&.user
+
+    automatically_translate_anonymously?(scope&.request&.cookies)
+  end
+
   def self.show_original?(scope)
-    return true if scope&.user&.user_option&.show_original_content
-    return false if scope&.user
-    scope&.request&.cookies&.key?(SHOW_ORIGINAL_COOKIE)
+    !automatically_translate?(scope)
+  end
+
+  # @param cookies [ActionDispatch::Cookies::CookieJar, Hash]
+  # @return [Boolean]
+  def self.automatically_translate_anonymously?(cookies)
+    return true if cookies.blank?
+
+    cookies[AUTOMATICALLY_TRANSLATE_COOKIE].to_s != "false"
+  end
+
+  # @param locale [String] The source locale of a topic or post
+  # @param scope [Object] The serializer scope from which the method is called
+  # @return [Boolean]
+  def self.understands?(locale, scope)
+    return false if locale.blank? || !scope&.user
+
+    scope.user.user_option.understood_languages.any? do |understood_locale|
+      LocaleNormalizer.is_same?(locale, understood_locale)
+    end
   end
 
   # This method returns true when we should try to show the translated post.
@@ -17,7 +40,7 @@ class ContentLocalization
   # @return [Boolean]
   def self.show_translated_post?(post, scope)
     SiteSetting.content_localization_enabled && post.raw.present? && post.locale.present? &&
-      !post.in_user_locale? && !show_original?(scope)
+      !post.in_user_locale? && automatically_translate?(scope) && !understands?(post.locale, scope)
   end
 
   # This method returns true when we should try to show the translated topic.
@@ -26,7 +49,7 @@ class ContentLocalization
   # @return [Boolean]
   def self.show_translated_topic?(topic, scope)
     SiteSetting.content_localization_enabled && topic.locale.present? && !topic.in_user_locale? &&
-      !show_original?(scope)
+      automatically_translate?(scope) && !understands?(topic.locale, scope)
   end
 
   # This method returns true when we should try to show the translated category.

--- a/lib/content_localization/onebox_localizer.rb
+++ b/lib/content_localization/onebox_localizer.rb
@@ -13,11 +13,10 @@ class ContentLocalization
   # title and excerpt are each present only when that part has a translation, so
   # a translated title can sit above an untranslated preview.
   #
-  # NOTE: this deliberately does not honour the "show original" preference — the
-  # guardian passed in (from TopicView) has no request, so it cannot read the
-  # anonymous show-original cookie. PostSerializer#include_localized_oneboxes? is
-  # the authoritative gate for that (it has the request-aware scope). Any new
-  # caller must apply the same gate.
+  # NOTE: the guardian passed in (from TopicView) has no request, so it cannot
+  # read the anonymous automatic-translation cookie.
+  # PostSerializer#include_localized_oneboxes? is the request-aware gate. Any
+  # new caller must apply the same gate.
   class OneboxLocalizer
     def self.build(...)
       new(...).build

--- a/lib/middleware/anonymous_cache.rb
+++ b/lib/middleware/anonymous_cache.rb
@@ -20,7 +20,7 @@ module Middleware
         t: "key_cache_theme_ids",
         ca: "key_compress_anon",
         l: "key_locale",
-        lso: "key_show_original_content",
+        lat: "key_automatically_translate",
         cm: "key_forced_color_mode",
         cs: "key_color_scheme_id",
         ds: "key_dark_scheme_id",
@@ -194,8 +194,8 @@ module Middleware
         GlobalSetting.compress_anon_cache
       end
 
-      def key_show_original_content
-        @request.cookies.key?(ContentLocalization::SHOW_ORIGINAL_COOKIE)
+      def key_automatically_translate
+        ContentLocalization.automatically_translate_anonymously?(@request.cookies)
       end
 
       def theme_ids

--- a/lib/topic_list_responder.rb
+++ b/lib/topic_list_responder.rb
@@ -23,12 +23,12 @@ module TopicListResponder
 
   def localize_topic_list_content(list)
     return if list.topics.blank? || !SiteSetting.content_localization_enabled
-    return if cookies.key?(ContentLocalization::SHOW_ORIGINAL_COOKIE)
-    return if current_user&.user_option&.show_original_content
     crawl_locale = I18n.locale
 
     list.topics.each do |topic|
-      LocalizationAttributesReplacer.replace_topic_attributes(topic, crawl_locale)
+      if ContentLocalization.show_translated_topic?(topic, guardian)
+        LocalizationAttributesReplacer.replace_topic_attributes(topic, crawl_locale)
+      end
     end
   end
 end

--- a/lib/topic_view.rb
+++ b/lib/topic_view.rb
@@ -191,6 +191,42 @@ class TopicView
     @personal_message = @topic.private_message?
   end
 
+  def has_localized_content?
+    return @has_localized_content if defined?(@has_localized_content)
+
+    @has_localized_content =
+      if !SiteSetting.content_localization_enabled
+        false
+      elsif !topic.in_user_locale? && topic.has_localization?
+        true
+      elsif skip_post_loading
+        false
+      else
+        source_language = I18n.locale.to_s.tr("-", "_").split("_").first.downcase
+        localization_languages = [source_language]
+        if SiteSetting.content_localization_use_default_locale_when_unsupported
+          localization_languages << SiteSetting.default_locale.to_s
+        end
+        localization_locale = PostLocalization.arel_table[:locale]
+        localization_condition =
+          localization_languages
+            .map { |locale| locale.tr("-", "_").split("_").first.downcase }
+            .uniq
+            .map { |language| localization_locale.matches("#{language}%") }
+            .reduce(&:or)
+
+        filtered_posts
+          .joins(:localizations)
+          .where(localization_condition)
+          .where(
+            "posts.raw <> '' AND posts.locale IS NOT NULL AND posts.locale <> '' AND " \
+              "SPLIT_PART(REPLACE(LOWER(posts.locale), '-', '_'), '_', 1) <> ?",
+            source_language,
+          )
+          .exists?
+      end
+  end
+
   def user_badges(badge_names)
     return if !badge_names.present?
 
@@ -780,7 +816,7 @@ class TopicView
 
   # Per-post localized title/preview for internal topic oneboxes the reader sees
   # in their own language. See ContentLocalization::OneboxLocalizer for the full
-  # contract (including why "show original" is gated in the serializer, not here).
+  # contract (including the request-aware preference gate in the serializer).
   def localized_oneboxes
     return @localized_oneboxes if defined?(@localized_oneboxes)
 
@@ -1021,7 +1057,18 @@ class TopicView
   end
 
   def find_topic(topic_or_topic_id)
-    return topic_or_topic_id if topic_or_topic_id.is_a?(Topic)
+    if topic_or_topic_id.is_a?(Topic)
+      if SiteSetting.content_localization_enabled &&
+           !topic_or_topic_id.association(:localizations).loaded?
+        ActiveRecord::Associations::Preloader.new(
+          records: [topic_or_topic_id],
+          associations: :localizations,
+        ).call
+      end
+
+      return topic_or_topic_id
+    end
+
     # with_deleted covered in #check_and_raise_exceptions
     tags_include =
       if SiteSetting.tagging_enabled && SiteSetting.content_localization_enabled
@@ -1030,9 +1077,10 @@ class TopicView
         :tags
       end
     nested_topic_include = :nested_topic if SiteSetting.nested_replies_enabled
+    localizations_include = :localizations if SiteSetting.content_localization_enabled
     Topic
       .with_deleted
-      .includes(:category, nested_topic_include, tags_include)
+      .includes(:category, nested_topic_include, tags_include, localizations_include)
       .find_by(id: topic_or_topic_id)
   end
 

--- a/plugins/discourse-ai/assets/javascripts/discourse/initializers/translation.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/initializers/translation.js
@@ -1,5 +1,5 @@
 import { apiInitializer } from "discourse/lib/api";
-import cookie from "discourse/lib/cookie";
+import { automaticallyTranslate } from "discourse/lib/content-localization";
 
 export default apiInitializer((api) => {
   const settings = api.container.lookup("service:site-settings");
@@ -15,11 +15,8 @@ export default apiInitializer((api) => {
     "localized",
     (topicController, data) => {
       const currentUser = api.getCurrentUser();
-      const showOriginal = currentUser
-        ? currentUser.user_option?.show_original_content
-        : cookie("content-localization-show-original");
 
-      if (!showOriginal) {
+      if (automaticallyTranslate(currentUser)) {
         const postStream = topicController.get("model.postStream");
         postStream.triggerChangedPost(data.id, data.updated_at);
       }

--- a/plugins/discourse-ai/lib/summarization.rb
+++ b/plugins/discourse-ai/lib/summarization.rb
@@ -81,11 +81,9 @@ module DiscourseAi
 
       def display_locale(topic, scope:)
         source_locale = raw_source_locale(topic)
-        should_show_localized_content =
-          SiteSetting.content_localization_enabled && !ContentLocalization.show_original?(scope)
 
         locale =
-          if should_show_localized_content
+          if ContentLocalization.show_translated_topic?(topic, scope)
             SiteSetting.content_localization_locales.find do |supported_locale|
               LocaleNormalizer.is_same?(supported_locale, I18n.locale)
             end || source_locale

--- a/plugins/discourse-ai/spec/lib/modules/summarization/entry_point_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/summarization/entry_point_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe DiscourseAi::Summarization::EntryPoint do
             expect(serialized[:ai_topic_gist]).to be_present
           end
 
-          it "selects the localized gist and respects the show-original preference" do
+          it "selects the localized gist and respects the automatic-translation preference" do
             topic_ai_gist.target.update!(locale: "en")
             english_gist =
               topic_ai_gist.tap { |gist| gist.update!(summarized_text: "English gist") }
@@ -109,7 +109,7 @@ RSpec.describe DiscourseAi::Summarization::EntryPoint do
 
             expect(serialized[:ai_topic_gist]).to eq(japanese_gist.summarized_text)
 
-            user.user_option.update!(show_original_content: true)
+            user.user_option.update!(automatically_translate: false)
             original_serialized =
               TopicListItemSerializer.new(
                 gist_topic,

--- a/plugins/discourse-ai/spec/lib/modules/summarization/summarization_spec.rb
+++ b/plugins/discourse-ai/spec/lib/modules/summarization/summarization_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe DiscourseAi::Summarization do
       expect(described_class.gist_for(topic, scope: user.guardian)).to eq(german_gist)
     end
 
-    it "returns the source-locale gist when the user requests original content" do
+    it "returns the source-locale gist when the user disables automatic translation" do
       topic.update!(locale: "fr")
       source_gist =
         Fabricate(:topic_ai_gist, target: topic, locale: "fr", summarized_text: "Résumé français")
@@ -108,7 +108,7 @@ RSpec.describe DiscourseAi::Summarization do
       )
       SiteSetting.content_localization_enabled = true
       I18n.locale = :de
-      user.user_option.update!(show_original_content: true)
+      user.user_option.update!(automatically_translate: false)
 
       expect(described_class.gist_for(topic, scope: user.guardian)).to eq(source_gist)
     end

--- a/plugins/discourse-ai/spec/services/discourse_ai/topic_summarization_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/topic_summarization_spec.rb
@@ -30,7 +30,7 @@ describe DiscourseAi::TopicSummarization do
   let(:summary) { "This is the final summary" }
 
   describe ".for" do
-    it "selects the displayed locale and respects the show-original preference" do
+    it "selects the displayed locale and respects the automatic-translation preference" do
       SiteSetting.content_localization_enabled = true
       SiteSetting.content_localization_supported_locales = "he"
       topic.update!(locale: "en")
@@ -43,7 +43,7 @@ describe DiscourseAi::TopicSummarization do
         I18n.with_locale(:he) { described_class.for(topic, user, scope: user.guardian) }
       expect(localized_service.cached_summary).to eq(hebrew_summary)
 
-      user.user_option.update!(show_original_content: true)
+      user.user_option.update!(automatically_translate: false)
       original_service =
         I18n.with_locale(:he) { described_class.for(topic, user, scope: user.guardian) }
       expect(original_service.cached_summary).to eq(english_summary)

--- a/plugins/discourse-ai/spec/system/edit_post_image_captions_spec.rb
+++ b/plugins/discourse-ai/spec/system/edit_post_image_captions_spec.rb
@@ -126,7 +126,7 @@ describe "Edit AI post image captions" do
     SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:admins]
     SiteSetting.content_localization_supported_locales = "en|ja"
     admin.update!(locale: "ja")
-    admin.user_option.update!(show_original_content: false)
+    admin.user_option.update!(automatically_translate: true)
     Fabricate(:topic_localization, topic: cat_topic, locale: "ja", fancy_title: "猫についての話題")
     create_japanese_localization(second_post)
     seed_english_descriptions
@@ -143,7 +143,7 @@ describe "Edit AI post image captions" do
       description: japanese_second_cat_caption,
     )
 
-    admin.user_option.update!(show_original_content: true)
+    admin.user_option.update!(automatically_translate: false)
     topic_page.visit_topic(cat_topic)
 
     expect(captions).to have_image_caption(second_post, image: 2, description: second_cat_caption)
@@ -155,7 +155,7 @@ describe "Edit AI post image captions" do
     SiteSetting.content_localization_allowed_groups = Group::AUTO_GROUPS[:admins]
     SiteSetting.content_localization_supported_locales = "en|ja"
     admin.update!(locale: "ja")
-    admin.user_option.update!(show_original_content: false)
+    admin.user_option.update!(automatically_translate: true)
     Fabricate(:topic_localization, topic: cat_topic, locale: "ja", fancy_title: "猫についての話題")
     create_japanese_localization(second_post)
     seed_english_descriptions
@@ -191,7 +191,7 @@ describe "Edit AI post image captions" do
 
     expect(captions).to have_image_caption(second_post, image: 2, description: "翻訳された二匹目の猫だけの新しい説明")
 
-    admin.user_option.update!(show_original_content: true)
+    admin.user_option.update!(automatically_translate: false)
     topic_page.visit_topic(cat_topic)
 
     expect(captions).to have_image_caption(second_post, image: 2, description: second_cat_caption)

--- a/spec/lib/content_localization_spec.rb
+++ b/spec/lib/content_localization_spec.rb
@@ -9,45 +9,45 @@ describe ContentLocalization do
     end
   end
 
-  describe ".show_original?" do
-    it "returns true when cookie is present" do
-      scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
-
-      expect(ContentLocalization.show_original?(scope)).to be true
+  describe ".automatically_translate?" do
+    it "defaults to true for anonymous users and supports the positive cookie" do
+      expect(ContentLocalization.automatically_translate?(create_scope)).to be true
+      expect(
+        ContentLocalization.automatically_translate?(
+          create_scope(cookie: "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=true"),
+        ),
+      ).to be true
+      expect(
+        ContentLocalization.automatically_translate?(
+          create_scope(cookie: "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=false"),
+        ),
+      ).to be false
     end
 
-    it "returns false when cookie is absent" do
-      scope = create_scope
-
-      expect(ContentLocalization.show_original?(scope)).to be false
-    end
-
-    it "returns true when user preference is set" do
+    it "always uses the logged-in user's preference instead of cookies" do
       user = Fabricate(:user)
-      user.user_option.update!(show_original_content: true)
-      scope = create_scope(user: user)
+      user.user_option.update!(automatically_translate: false)
 
-      expect(ContentLocalization.show_original?(scope)).to be true
+      expect(ContentLocalization.automatically_translate?(create_scope(user: user))).to be false
+
+      user.user_option.update!(automatically_translate: true)
+      scope =
+        create_scope(user:, cookie: "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=false")
+
+      expect(ContentLocalization.automatically_translate?(scope)).to be true
     end
+  end
 
-    it "returns false when user preference is not set and no cookie" do
+  describe ".understands?" do
+    it "matches the logged-in user's languages using normalized locales" do
       user = Fabricate(:user)
-      scope = create_scope(user: user)
+      user.user_option.update!(understood_languages: %w[en_GB ja])
+      scope = create_scope(user:)
 
-      expect(ContentLocalization.show_original?(scope)).to be false
-    end
-
-    it "returns false when user preference is not set but cookie is present for a logged-in user" do
-      user = Fabricate(:user)
-      scope = create_scope(user: user, cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
-
-      expect(ContentLocalization.show_original?(scope)).to be false
-    end
-
-    it "returns true when cookie is present for an anonymous user" do
-      scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
-
-      expect(ContentLocalization.show_original?(scope)).to be true
+      expect(ContentLocalization.understands?("en", scope)).to be true
+      expect(ContentLocalization.understands?("ja-JP", scope)).to be true
+      expect(ContentLocalization.understands?("de", scope)).to be false
+      expect(ContentLocalization.understands?("en", create_scope)).to be false
     end
   end
 
@@ -98,8 +98,16 @@ describe ContentLocalization do
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
       end
 
-      it "returns false when show_original? is true" do
-        scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
+      it "returns false when automatic translation is disabled" do
+        scope = create_scope(cookie: "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=false")
+
+        expect(ContentLocalization.show_translated_post?(post, scope)).to be false
+      end
+
+      it "returns false when the user understands the post's language" do
+        user = Fabricate(:user)
+        user.user_option.update!(understood_languages: ["ja"])
+        scope = create_scope(user:)
 
         expect(ContentLocalization.show_translated_post?(post, scope)).to be false
       end
@@ -146,8 +154,16 @@ describe ContentLocalization do
         expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
       end
 
-      it "returns false when show_original? is true" do
-        scope = create_scope(cookie: ContentLocalization::SHOW_ORIGINAL_COOKIE)
+      it "returns false when automatic translation is disabled" do
+        scope = create_scope(cookie: "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=false")
+
+        expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
+      end
+
+      it "returns false when the user understands the topic's language" do
+        user = Fabricate(:user)
+        user.user_option.update!(understood_languages: ["ja"])
+        scope = create_scope(user:)
 
         expect(ContentLocalization.show_translated_topic?(topic, scope)).to be false
       end

--- a/spec/lib/middleware/anonymous_cache_spec.rb
+++ b/spec/lib/middleware/anonymous_cache_spec.rb
@@ -145,12 +145,19 @@ RSpec.describe Middleware::AnonymousCache do
       }.not_to raise_error
     end
 
-    it "handles showing original content" do
-      show_orig_key =
-        new_helper("HTTP_COOKIE" => ContentLocalization::SHOW_ORIGINAL_COOKIE).cache_key
+    it "keys only on the resolved automatic translation preference" do
       regular_key = new_helper.cache_key
+      enabled_key =
+        new_helper(
+          "HTTP_COOKIE" => "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=true",
+        ).cache_key
+      disabled_key =
+        new_helper(
+          "HTTP_COOKIE" => "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=false",
+        ).cache_key
 
-      expect(show_orig_key).not_to eq(regular_key)
+      expect(enabled_key).to eq(regular_key)
+      expect(disabled_key).not_to eq(regular_key)
     end
 
     context "when cached" do

--- a/spec/lib/topic_view_spec.rb
+++ b/spec/lib/topic_view_spec.rb
@@ -28,6 +28,30 @@ RSpec.describe TopicView do
     end
   end
 
+  describe "#has_localized_content?" do
+    before { SiteSetting.content_localization_enabled = true }
+
+    it "ignores localizations on posts that are not eligible for translation" do
+      localized_topic = Fabricate(:topic, locale: "en")
+      post = Fabricate(:post, topic: localized_topic, locale: nil)
+      Fabricate(:post_localization, post:, locale: "en")
+
+      expect(TopicView.new(localized_topic.id, user).has_localized_content?).to eq(false)
+    end
+
+    it "detects a site-default post localization when default fallback is enabled" do
+      SiteSetting.default_locale = "en"
+      SiteSetting.content_localization_use_default_locale_when_unsupported = true
+      localized_topic = Fabricate(:topic, locale: "de")
+      post = Fabricate(:post, topic: localized_topic, locale: "ja")
+      Fabricate(:post_localization, post:, locale: "en")
+
+      I18n.with_locale(:de) do
+        expect(TopicView.new(localized_topic.id, user).has_localized_content?).to eq(true)
+      end
+    end
+  end
+
   describe "#reset_post_collection" do
     fab!(:post1) { Fabricate(:post, topic: topic) }
     fab!(:post2) { Fabricate(:post, topic: topic) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -234,11 +234,13 @@ RSpec.describe Tag do
         )
       end
 
-      it "returns localized names when localization enabled and user not in tag locale" do
+      it "returns localized tag names independently of topic and post translation preferences" do
         SiteSetting.content_localization_enabled = true
         I18n.locale = "ja"
+        user = Fabricate(:user, locale: "ja")
+        user.user_option.update!(automatically_translate: false)
 
-        expect(Tag.top_tags).to include(
+        expect(Tag.top_tags(guardian: Guardian.new(user))).to include(
           { id: localized_tag.id, name: "猫", slug: localized_tag.slug },
         )
       end

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe UserOption do
       expect(user.user_option.hide_presence).to eq(false)
     end
 
+    it "enables automatic translation without assuming understood languages" do
+      expect(user.user_option.automatically_translate).to eq(true)
+      expect(user.user_option.understood_languages).to eq([])
+    end
+
     it "should correctly set digest frequency" do
       SiteSetting.default_email_digest_frequency = 1440
       user = Fabricate(:user)
@@ -74,6 +79,27 @@ RSpec.describe UserOption do
       SiteSetting.default_composition_mode = UserOption.composition_mode_types[:markdown]
       user = Fabricate(:user)
       expect(user.user_option.composition_mode).to eq(UserOption.composition_mode_types[:markdown])
+    end
+  end
+
+  describe "understood languages" do
+    fab!(:user)
+
+    it "accepts supported locales" do
+      expect(user.user_option.update(understood_languages: %w[en ja])).to eq(true)
+    end
+
+    it "rejects unsupported locales" do
+      expect(user.user_option.update(understood_languages: ["not-a-locale"])).to eq(false)
+      expect(user.user_option.errors[:understood_languages]).to be_present
+    end
+
+    it "allows unrelated preferences to be saved after a language provider is removed" do
+      user.user_option.update!(understood_languages: ["en"])
+      LocaleSiteSetting.stubs(:supported_locales).returns(["ja"])
+
+      expect(user.user_option.update(automatically_translate: false)).to eq(true)
+      expect(user.user_option.reload.automatically_translate).to eq(false)
     end
   end
 

--- a/spec/requests/about_controller_spec.rb
+++ b/spec/requests/about_controller_spec.rb
@@ -100,16 +100,16 @@ RSpec.describe AboutController do
         expect(response.body).to include(%(meta name="description" content="日本語の説明"))
       end
 
-      it "uses original values when the user prefers original content" do
+      it "localizes site settings independently of topic and post translation preferences" do
         user = Fabricate(:user, locale: "ja")
-        user.user_option.update!(show_original_content: true)
+        user.user_option.update!(automatically_translate: false)
         sign_in(user)
 
         get "/about.json", params: { Discourse::LOCALE_PARAM => "ja" }
 
         expect(response.status).to eq(200)
-        expect(response.parsed_body.dig("about", "title")).to eq("English title")
-        expect(response.parsed_body.dig("about", "description")).to eq("English description")
+        expect(response.parsed_body.dig("about", "title")).to eq("日本語タイトル")
+        expect(response.parsed_body.dig("about", "description")).to eq("日本語の説明")
       end
     end
 

--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -853,6 +853,15 @@
             "interface_color_mode": {
               "type": "integer"
             },
+            "automatically_translate": {
+              "type": "boolean"
+            },
+            "understood_languages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "show_original_content": {
               "type": "boolean"
             },
@@ -903,7 +912,9 @@
             "topics_unread_when_closed",
             "interface_color_mode",
             "show_original_content",
-            "send_shortcut"
+            "send_shortcut",
+            "automatically_translate",
+            "understood_languages"
           ]
         }
       },

--- a/spec/requests/search_controller_spec.rb
+++ b/spec/requests/search_controller_spec.rb
@@ -637,8 +637,8 @@ RSpec.describe SearchController do
         end
       end
 
-      context "when show_original cookie is set" do
-        before { cookies[ContentLocalization::SHOW_ORIGINAL_COOKIE] = "true" }
+      context "when automatic translation is disabled by cookie" do
+        before { cookies[ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE] = "false" }
 
         it "returns original blurb in search results" do
           with_search_indexer_enabled { SearchIndexer.index(localized_post.topic, force: true) }

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3529,8 +3529,8 @@ RSpec.describe TopicsController do
           expect(entry["excerpt"]).to include("戦わずして勝つ")
         end
 
-        it "omits localized onebox data when the reader chose to see original content" do
-          reader.user_option.update!(show_original_content: true)
+        it "omits localized onebox data when the reader disables automatic translation" do
+          reader.user_option.update!(automatically_translate: false)
           sign_in(reader)
 
           expect(host_post_json.key?("localized_oneboxes")).to eq(false)
@@ -4851,8 +4851,8 @@ RSpec.describe TopicsController do
         end
       end
 
-      context "when show_original cookie is set" do
-        before { cookies[ContentLocalization::SHOW_ORIGINAL_COOKIE] = "true" }
+      context "when automatic translation is disabled by cookie" do
+        before { cookies[ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE] = "false" }
 
         it "returns original posts" do
           get "/t/#{localized_topic.id}/posts.json"

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -2701,6 +2701,8 @@ RSpec.describe UsersController do
                 watched_tags: "#{tags[0].name},#{tag_synonym.name}",
                 card_background_upload_url: upload.url,
                 profile_background_upload_url: upload.url,
+                show_original_content: true,
+                understood_languages: ["ja"],
               }
 
           expect(response.status).to eq(200)
@@ -2717,6 +2719,8 @@ RSpec.describe UsersController do
               notification_level: TagUser.notification_levels[:watching],
             ).pluck(:tag_id),
           ).to contain_exactly(tags[0].id, tags[1].id)
+          expect(user.user_option.automatically_translate).to eq(false)
+          expect(user.user_option.understood_languages).to contain_exactly("en", "ja")
 
           theme = Fabricate(:theme, user_selectable: true)
 
@@ -2725,6 +2729,7 @@ RSpec.describe UsersController do
                 muted_usernames: "",
                 theme_ids: [theme.id],
                 email_level: UserOption.email_level_types[:always],
+                automatically_translate: true,
               }
 
           user.reload
@@ -2732,6 +2737,7 @@ RSpec.describe UsersController do
           expect(user.muted_users.pluck(:username).sort).to be_empty
           expect(user.user_option.theme_ids).to eq([theme.id])
           expect(user.user_option.email_level).to eq(UserOption.email_level_types[:always])
+          expect(user.user_option.automatically_translate).to eq(true)
           expect(user.profile_background_upload).to eq(upload)
           expect(user.card_background_upload).to eq(upload)
         end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -285,6 +285,18 @@ RSpec.describe CurrentUserSerializer do
     end
   end
 
+  describe "content localization preferences" do
+    it "computes the legacy JSON preference from automatically_translate" do
+      user.user_option.automatically_translate = false
+      user.user_option.show_original_content = false
+
+      expect(serializer.as_json[:user_option]).to include(
+        automatically_translate: false,
+        show_original_content: true,
+      )
+    end
+  end
+
   describe "#associated_account_ids" do
     before do
       UserAssociatedAccount.create(

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -1075,19 +1075,22 @@ RSpec.describe PostSerializer do
       expect(entry[:excerpt]).to include("戦わずして勝つ")
     end
 
-    it "is omitted when the reader chose to see original content" do
-      reader.user_option.update!(show_original_content: true)
+    it "is omitted when the reader disables automatic translation" do
+      reader.user_option.update!(automatically_translate: false)
       expect(json_for(reader).key?(:localized_oneboxes)).to eq(false)
     end
 
-    it "is omitted for an anonymous reader with the show-original cookie" do
-      env = create_request_env.merge("HTTP_COOKIE" => ContentLocalization::SHOW_ORIGINAL_COOKIE)
+    it "is omitted for an anonymous reader with automatic translation disabled by cookie" do
+      env =
+        create_request_env.merge(
+          "HTTP_COOKIE" => "#{ContentLocalization::AUTOMATICALLY_TRANSLATE_COOKIE}=false",
+        )
       anon_scope = Guardian.new(nil, ActionDispatch::Request.new(env))
 
       expect(json_for(nil, scope: anon_scope).key?(:localized_oneboxes)).to eq(false)
     end
 
-    it "is included for an anonymous reader without the show-original cookie" do
+    it "is included for an anonymous reader without an automatic translation cookie" do
       anon_scope = Guardian.new(nil, ActionDispatch::Request.new(create_request_env))
 
       expect(json_for(nil, scope: anon_scope)[:localized_oneboxes].first[:title]).to eq("孫子の兵法")

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -61,6 +61,18 @@ RSpec.describe UserSerializer do
       expect(json[:group_users]).to eq([])
       expect(json[:second_factor_enabled]).to eq(false)
     end
+
+    it "computes the legacy localization preference from automatically_translate" do
+      user.user_option.automatically_translate = false
+      user.user_option.show_original_content = false
+
+      json = UserSerializer.new(user, scope: Guardian.new(user), root: false).as_json
+
+      expect(json[:user_option]).to include(
+        automatically_translate: false,
+        show_original_content: true,
+      )
+    end
   end
 
   context "with a user" do

--- a/spec/services/user_updater_spec.rb
+++ b/spec/services/user_updater_spec.rb
@@ -46,6 +46,34 @@ RSpec.describe UserUpdater do
       expect(user.reload.name).to eq "Jim Tom"
     end
 
+    it "keeps the interface locale among the user's understood languages" do
+      user.update!(locale: "en")
+      user.user_option.update!(understood_languages: ["en"])
+
+      UserUpdater.new(user, user).update(locale: "ja", understood_languages: [])
+
+      expect(user.reload.locale).to eq("ja")
+      expect(user.user_option.understood_languages).to eq(["ja"])
+    end
+
+    it "uses the effective interface locale when user locales are disabled" do
+      SiteSetting.default_locale = "en"
+      SiteSetting.allow_user_locale = false
+      user.update!(locale: "fr")
+
+      UserUpdater.new(user, user).update(understood_languages: [])
+
+      expect(user.user_option.understood_languages).to eq(["en"])
+    end
+
+    it "adapts legacy show-original updates to the positive preference" do
+      UserUpdater.new(user, user).update(show_original_content: true)
+      expect(user.reload.user_option.automatically_translate).to eq(false)
+
+      UserUpdater.new(user, user).update(show_original_content: true, automatically_translate: true)
+      expect(user.reload.user_option.automatically_translate).to eq(true)
+    end
+
     describe "the within_user_updater_transaction event" do
       it "allows plugins to perform additional updates" do
         update_attributes = { name: "Jimmmy Johnny" }

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -42,6 +42,9 @@ describe "Content Localization" do
   let(:post_1_obj) { PageObjects::Components::Post.new(1) }
   let(:post_3_obj) { PageObjects::Components::Post.new(3) }
   let(:post_4_obj) { PageObjects::Components::Post.new(4) }
+  let(:preferences_interface_page) { PageObjects::Pages::UserPreferencesInterface.new }
+  let(:sidebar) { PageObjects::Components::NavigationMenu::Sidebar.new }
+  let(:language_switcher) { PageObjects::Components::LanguageSwitcher.new }
 
   def scroll_to_post(post_number)
     5.times do
@@ -66,7 +69,7 @@ describe "Content Localization" do
       SiteSetting.content_localization_allowed_groups =
         "#{Group::AUTO_GROUPS[:admins]}|#{jap_group.id}"
       SiteSetting.content_localization_supported_locales = "en|ja"
-      japanese_user.user_option.update!(show_original_content: false)
+      japanese_user.user_option.update!(automatically_translate: true)
     end
 
     it "shows the user's language based on their user locale" do
@@ -76,24 +79,70 @@ describe "Content Localization" do
       expect(topic_page.has_topic_title?("孫子兵法からの人生戦略")).to eq(true)
     end
 
-    it "persists 'Show Original' preference from user preferences interface" do
+    it "lets the user keep topic and post content original without changing localized navigation" do
+      tag = Fabricate(:tag, name: "strategy", locale: "en")
+      Fabricate(:tag_localization, tag:, locale: "ja", name: "戦略")
+      Fabricate(:topic_tag, topic:, tag:)
+      SiteSetting.tagging_enabled = true
+      SiteSetting.navigation_menu = "sidebar"
+      SiteSetting.default_navigation_menu_tags = tag.name
+      SiteSetting.set_locale_from_cookie = true
+      SiteSetting.content_localization_language_switcher = "all"
+
       sign_in(japanese_user)
 
-      visit("/u/#{japanese_user.username}/preferences/interface")
-      page.find(".pref-show-original-content input[type='checkbox']").click
-      page.find(".save-changes").click
+      preferences_interface_page.visit(japanese_user)
+      expect(preferences_interface_page).to have_interface_language_section
+      expect(preferences_interface_page).to have_content_languages_section
+      expect(preferences_interface_page).to have_locked_understood_language
+      expect(preferences_interface_page).to be_automatic_translation_enabled
 
-      I18n.with_locale(:ja) { expect(page).to have_content(I18n.t("js.saved")) }
+      preferences_interface_page.disable_automatic_translation.save_changes
+      page.refresh
+      expect(preferences_interface_page).to be_automatic_translation_disabled
 
-      expect(japanese_user.reload.user_option.show_original_content).to eq(true)
+      topic_page.visit_topic(topic)
+      expect(topic_page).to have_topic_title("Life strategies from The Art of War")
+      expect(post_1_obj).to have_cooked_content(post_1.raw)
+      expect(post_3_obj).to have_cooked_content(post_3.raw)
+      expect(topic_page).to have_topic_tag("戦略")
+      expect(sidebar).to have_section_link("戦略")
 
-      # preference persists after page reload
-      visit("/u/#{japanese_user.username}/preferences/interface")
-      expect(page).to have_css(".pref-show-original-content input[type='checkbox']:checked")
+      language_switcher.select_language("en")
+      preferences_interface_page.visit(japanese_user)
+      expect(preferences_interface_page).to be_automatic_translation_disabled
+      language_switcher.select_language("ja")
 
-      # and reflects on topic view
-      visit("/t/#{topic.id}")
-      expect(topic_page.has_topic_title?("Life strategies from The Art of War")).to eq(true)
+      preferences_interface_page.visit(japanese_user)
+      preferences_interface_page.enable_automatic_translation.save_changes
+      page.refresh
+      expect(preferences_interface_page).to be_automatic_translation_enabled
+      expect(preferences_interface_page).to have_understood_language("en")
+
+      topic_page.visit_topic(topic)
+      expect(topic_page).to have_topic_title("Life strategies from The Art of War")
+      expect(post_1_obj).to have_cooked_content(post_1.raw)
+      expect(post_3_obj).to have_cooked_content(post_3.raw)
+      expect(topic_page).to have_topic_tag("戦略")
+      expect(sidebar).to have_section_link("戦略")
+
+      modal = topic_page.open_content_language_preferences
+      expect(modal).to be_open
+      expect(modal).to have_logged_in_language_controls
+      expect(modal).to have_understood_languages_description
+      expect(modal).to have_locked_understood_language
+      expect(modal).to be_automatic_translation_enabled
+      modal.close
+
+      SiteSetting.allow_user_locale = false
+      topic_page.visit_topic(topic)
+      modal = topic_page.open_content_language_preferences
+      expect(modal).to have_read_only_interface_language("English")
+      modal.close
+
+      preferences_interface_page.visit(japanese_user)
+      expect(preferences_interface_page).to have_no_interface_language_section
+      expect(preferences_interface_page).to have_locked_understood_language("English")
     end
 
     it "allows users to set their post's locale when posting" do
@@ -158,6 +207,37 @@ describe "Content Localization" do
 
         visit("/t/#{topic2.id}")
         expect(topic_page.topic_title).to have_content("織田信長の生涯")
+      end
+
+      it "lets anonymous users control topic and post translation from the topic-side modal" do
+        tag = Fabricate(:tag, name: "strategy", locale: "en")
+        Fabricate(:tag_localization, tag:, locale: "ja", name: "戦略")
+        Fabricate(:topic_tag, topic:, tag:)
+        SiteSetting.tagging_enabled = true
+        SiteSetting.navigation_menu = "sidebar"
+        SiteSetting.default_navigation_menu_tags = tag.name
+
+        visit("/t/#{topic.id}?tl=ja")
+        expect(topic_page).to have_topic_title("孫子兵法からの人生戦略")
+        expect(post_1_obj).to have_cooked_content("傑作は単なる軍事戦略についてではありません")
+        expect(topic_page).to have_content_language_preferences_launcher
+        expect(topic_page).to have_no_topic_admin_menu
+
+        modal = topic_page.open_content_language_preferences
+        expect(modal).to be_open
+        expect(modal).to have_understood_languages_login_prompt
+        expect(modal).to be_automatic_translation_enabled
+        modal.disable_automatic_translation.save
+
+        expect(topic_page).to have_topic_title("Life strategies from The Art of War")
+        expect(post_1_obj).to have_cooked_content(post_1.raw)
+        expect(topic_page).to have_topic_tag("戦略")
+        expect(sidebar).to have_section_link("戦略")
+
+        SiteSetting.set_locale_from_cookie = false
+        page.refresh
+        modal = topic_page.open_content_language_preferences
+        expect(modal).to have_read_only_interface_language("English")
       end
 
       fab!(:ja_topic) do
@@ -414,7 +494,39 @@ describe "Content Localization" do
         # the per-post toggle shows the original content for the loaded post
         post_21_obj.toggle_localized_content
         expect(post_21_obj.post).to have_content("日本語コンテンツ 21")
+        expect(site_local_user.reload.user_option.automatically_translate).to eq(true)
+
+        page.refresh
+        scroll_to_post(21)
+        expect(topic_page).to have_post_content(post_number: 21, content: "English translation 21")
       end
+    end
+
+    it "shows the topic-side launcher when only a later visible post has a localization" do
+      late_localization_topic =
+        Fabricate(:topic, title: "A long multilingual topic", locale: "en", user: admin)
+      20.times do |index|
+        Fabricate(
+          :post,
+          topic: late_localization_topic,
+          locale: "en",
+          raw: "English post #{index + 1}",
+        )
+      end
+      late_post =
+        Fabricate(:post, topic: late_localization_topic, locale: "ja", raw: "最初のページより後の投稿")
+      Fabricate(
+        :post_localization,
+        post: late_post,
+        locale: "en",
+        cooked: "<p>A post after the first page</p>",
+      )
+
+      sign_in(site_local_user)
+      topic_page.visit_topic(late_localization_topic)
+
+      expect(page).to have_no_css("#post_21", wait: 0)
+      expect(topic_page).to have_content_language_preferences_launcher
     end
 
     context "for html title" do

--- a/spec/system/localized_internal_oneboxes_spec.rb
+++ b/spec/system/localized_internal_oneboxes_spec.rb
@@ -65,8 +65,8 @@ describe "Localized internal oneboxes" do
     expect(host_post_obj).to have_cooked_content("戦わずして勝つ")
   end
 
-  it "leaves the onebox in its original language when 'Show Original' is on" do
-    japanese_user.user_option.update!(show_original_content: true)
+  it "leaves the onebox in its original language when automatic translation is off" do
+    japanese_user.user_option.update!(automatically_translate: false)
     sign_in(japanese_user)
     visit("/t/#{host_topic.id}")
 

--- a/spec/system/page_objects/modals/content_language_preferences.rb
+++ b/spec/system/page_objects/modals/content_language_preferences.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Modals
+    class ContentLanguagePreferences < PageObjects::Modals::Base
+      MODAL_SELECTOR = ".content-language-preferences-modal"
+
+      def initialize
+        super(body_selector: "", modal_selector: MODAL_SELECTOR)
+      end
+
+      def has_understood_languages_login_prompt?
+        body.has_css?(
+          ".content-language-preferences-modal__understood",
+          text: "Languages I understand Log in to set more languages",
+        ) && body.has_no_css?(".form-kit__field[data-name='understoodLanguages']", wait: 0)
+      end
+
+      def has_logged_in_language_controls?
+        body.has_css?(".form-kit__field[data-name='interfaceLanguage'] select") &&
+          body.has_css?(".form-kit__field[data-name='understoodLanguages'] .multi-select") &&
+          body.has_no_css?(".content-language-preferences-modal__understood")
+      end
+
+      def has_read_only_interface_language?(language)
+        body.has_css?(".form-kit__field[data-name='interfaceLanguage'] select:disabled") &&
+          body.has_css?(
+            ".form-kit__field[data-name='interfaceLanguage'] option:checked",
+            text: language,
+          )
+      end
+
+      def has_understood_languages_description?
+        body.has_css?(
+          ".form-kit__field[data-name='understoodLanguages'] " \
+            ".form-kit__container-description",
+          text:
+            "Topics and posts in these languages won’t be translated. " \
+              "Your interface language is always included.",
+        )
+      end
+
+      def has_locked_understood_language?
+        understood_languages_dropdown.expand
+        result =
+          body.has_css?(
+            ".form-kit__field[data-name='understoodLanguages'] " \
+              ".selected-content .tag-choice.disabled",
+            count: 1,
+          )
+        understood_languages_dropdown.collapse
+        result
+      end
+
+      def automatic_translation_enabled?
+        body.has_css?("[data-test-automatically-translate]:checked", visible: :all)
+      end
+
+      def disable_automatic_translation
+        body.find(".form-kit__field-checkbox label").click
+        self
+      end
+
+      def save
+        click_primary_button
+        self
+      end
+
+      private
+
+      def understood_languages_dropdown
+        PageObjects::Components::SelectKit.new(
+          ".form-kit__field[data-name='understoodLanguages'] .multi-select",
+        )
+      end
+    end
+  end
+end

--- a/spec/system/page_objects/modals/content_language_preferences.rb
+++ b/spec/system/page_objects/modals/content_language_preferences.rb
@@ -10,10 +10,10 @@ module PageObjects
       end
 
       def has_understood_languages_login_prompt?
-        body.has_css?(
-          ".content-language-preferences-modal__understood",
-          text: "Languages I understand Log in to set more languages",
-        ) && body.has_no_css?(".form-kit__field[data-name='understoodLanguages']", wait: 0)
+        has_css?(
+          "#{full_modal_selector} " \
+            ".content-language-preferences-modal__understood a[href='/login']",
+        )
       end
 
       def has_logged_in_language_controls?

--- a/spec/system/page_objects/pages/topic.rb
+++ b/spec/system/page_objects/pages/topic.rb
@@ -449,6 +449,23 @@ module PageObjects
         all(tags_selector).map(&:text)
       end
 
+      def has_topic_tag?(name)
+        has_css?(".title-wrapper .discourse-tag", text: name)
+      end
+
+      def has_content_language_preferences_launcher?
+        has_css?(".topic-content-language-preferences")
+      end
+
+      def has_no_topic_admin_menu?
+        has_no_css?(".topic-admin-menu-trigger")
+      end
+
+      def open_content_language_preferences
+        find(".topic-content-language-preferences").click
+        PageObjects::Modals::ContentLanguagePreferences.new
+      end
+
       private
 
       def within_topic_footer_buttons

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -3,6 +3,10 @@
 module PageObjects
   module Pages
     class UserPreferencesInterface < PageObjects::Pages::Base
+      AUTOMATIC_TRANSLATION_SELECTOR =
+        "[data-setting-name='user-content-languages'] " \
+          "[data-setting-name='user-automatically-translate'] input"
+
       def visit(user)
         page.visit("/u/#{user.username}/preferences/interface")
         self
@@ -26,6 +30,56 @@ module PageObjects
 
       def text_size_dropdown
         PageObjects::Components::SelectKit.new("[data-setting-name='user-text-size'] .combo-box")
+      end
+
+      def has_interface_language_section?
+        page.has_css?("[data-setting-name='user-locale'] .control-label")
+      end
+
+      def has_no_interface_language_section?
+        page.has_no_css?("[data-setting-name='user-locale'] .control-label")
+      end
+
+      def has_content_languages_section?
+        page.has_css?("[data-setting-name='user-content-languages'] .control-label")
+      end
+
+      def automatic_translation_enabled?
+        page.has_css?("#{AUTOMATIC_TRANSLATION_SELECTOR}:checked")
+      end
+
+      def automatic_translation_disabled?
+        page.has_no_css?("#{AUTOMATIC_TRANSLATION_SELECTOR}:checked")
+      end
+
+      def disable_automatic_translation
+        page.find("#{AUTOMATIC_TRANSLATION_SELECTOR}:checked").click
+        self
+      end
+
+      def enable_automatic_translation
+        page.find("#{AUTOMATIC_TRANSLATION_SELECTOR}:not(:checked)").click
+        self
+      end
+
+      def has_understood_language?(locale)
+        understood_languages_dropdown.expand
+        result =
+          page.has_css?("#understood-languages-selector .selected-choice[data-value='#{locale}']")
+        understood_languages_dropdown.collapse
+        result
+      end
+
+      def has_locked_understood_language?(language = nil)
+        understood_languages_dropdown.expand
+        result =
+          page.has_css?(
+            "#understood-languages-selector .selected-content .tag-choice.disabled",
+            count: 1,
+            text: language,
+          )
+        understood_languages_dropdown.collapse
+        result
       end
 
       def light_scheme_dropdown
@@ -63,9 +117,15 @@ module PageObjects
       end
 
       def save_changes
-        click_button "Save Changes"
-        expect(page).to have_content(I18n.t("js.saved"))
+        find(".save-changes").click
+        expect(page).to have_css(".saved")
         self
+      end
+
+      private
+
+      def understood_languages_dropdown
+        PageObjects::Components::SelectKit.new("#understood-languages-selector")
       end
     end
   end


### PR DESCRIPTION
Related: https://meta.discourse.org/t/multi-language-preferences-for-displaying-localized-content/381116

Allow anon and logged in users to set more than one language that they understand, when content localization is enabled.


### User preferences

In user preferences, we now include a Content Languages section when the site has Content Localization enabled.

<img width="1103" height="614" alt="Screenshot 2026-07-29 at 6 40 10 PM" src="https://github.com/user-attachments/assets/851a8338-6f86-48fb-afb9-3da84b8c58e9" />

### Topic menu

In topics where there are any languages that's not the user's language, the option will appear to set their preferred content languages. This appears for anon and logged in users, but anon users will be asked to logged in to set the languages.

(logged in user)
<img width="1085" height="925" alt="Screenshot 2026-07-29 at 7 04 32 PM copy" src="https://github.com/user-attachments/assets/902b0562-4a56-43da-a2fa-a8c5e91b5380" />

(anon)
<img width="634" height="360" alt="Screenshot 2026-07-29 at 7 06 00 PM" src="https://github.com/user-attachments/assets/d33ff7dd-b651-4ac4-918e-c7c8332e4351" />

__________

These preferences apply only to topic titles and posts. They do not affect navigational features like categories, tags, or sidebar content. The per-post option to show the original remains independent of the user's preferences.

This PR temporarily retains `show_original_content` as a compatibility field computed from `automatically_translate`, keeping cached clients and rolling deployments safe. A follow-up PR will remove the legacy API and frontend compatibility code, then retire the old database column through the staged column-removal process.