### PR TITLE
DEV: Use precise dates in versions.json

### DIFF
--- a/lib/release_utils.rb
+++ b/lib/release_utils.rb
@@ -50,19 +50,29 @@ module ReleaseUtils
     git "commit", "-m", message
   end
 
+  def self.last_tuesday_of_month(year, month)
+    date = Date.new(year, month, -1)
+    date -= 1 while date.wday != 2
+    date
+  end
+
   def self.update_versions_json(new_version)
     today_date = DateTime.now.utc.strftime("%Y-%m-%d")
 
     version_year, version_month = new_version.split(".").map(&:to_i)
     esr = [1, 7].include?(version_month)
 
+    release_date = last_tuesday_of_month(version_year, version_month).strftime("%Y-%m-%d")
+
     support_period = esr ? 8.months : 2.months
-    support_end_date = (Date.new(version_year, version_month, 1) + support_period).strftime("%Y-%m")
+    support_end_month = Date.new(version_year, version_month, 1) + support_period
+    support_end_date =
+      last_tuesday_of_month(support_end_month.year, support_end_month.month).strftime("%Y-%m-%d")
 
     new_version_info = {
       new_version => {
         developmentStartDate: today_date,
-        releaseDate: "#{version_year}-#{version_month.to_s.rjust(2, "0")}",
+        releaseDate: release_date,
         supportEndDate: support_end_date,
         released: false,
         esr: esr,
@@ -78,7 +88,7 @@ module ReleaseUtils
       end
 
       if v["supported"] &&
-           Date.parse(v["supportEndDate"] + "-01") < Date.new(version_year, version_month, 1)
+           Date.parse(v["supportEndDate"]) < Date.new(version_year, version_month, 1)
         v["supported"] = false
         v["supportEndDate"] = today_date
       end

--- a/lib/release_utils.rb
+++ b/lib/release_utils.rb
@@ -50,32 +50,24 @@ module ReleaseUtils
     git "commit", "-m", message
   end
 
-  def self.last_tuesday_of_month(year, month)
-    date = Date.new(year, month, -1)
-    date -= 1 while date.wday != 2
-    date
+  def self.last_tuesday_of_month(date)
+    date.beginning_of_month.next_month.prev_occurring(:tuesday)
   end
 
   def self.update_versions_json(new_version)
-    today_date = DateTime.now.utc.strftime("%Y-%m-%d")
+    today = Date.current.to_s
 
     version_year, version_month = new_version.split(".").map(&:to_i)
-    esr = [1, 7].include?(version_month)
-
-    release_date = last_tuesday_of_month(version_year, version_month).strftime("%Y-%m-%d")
-
-    support_period = esr ? 8.months : 2.months
-    support_end_month = Date.new(version_year, version_month, 1) + support_period
-    support_end_date =
-      last_tuesday_of_month(support_end_month.year, support_end_month.month).strftime("%Y-%m-%d")
+    version_start = Date.new(version_year, version_month)
+    esr = version_month.in?([1, 7])
 
     new_version_info = {
       new_version => {
-        developmentStartDate: today_date,
-        releaseDate: release_date,
-        supportEndDate: support_end_date,
+        developmentStartDate: today,
+        releaseDate: last_tuesday_of_month(version_start).to_s,
+        supportEndDate: last_tuesday_of_month(version_start + (esr ? 8.months : 2.months)).to_s,
         released: false,
-        esr: esr,
+        esr:,
         supported: true,
       },
     }
@@ -84,13 +76,12 @@ module ReleaseUtils
     data.transform_values! do |v|
       if !v["released"]
         v["released"] = true
-        v["releaseDate"] = today_date
+        v["releaseDate"] = today
       end
 
-      if v["supported"] &&
-           Date.parse(v["supportEndDate"]) < Date.new(version_year, version_month, 1)
+      if v["supported"] && Date.parse(v["supportEndDate"]) < version_start
         v["supported"] = false
-        v["supportEndDate"] = today_date
+        v["supportEndDate"] = today
       end
 
       v

--- a/spec/lib/release_utils_spec.rb
+++ b/spec/lib/release_utils_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "release_utils"
+
+RSpec.describe ReleaseUtils do
+  describe ".last_tuesday_of_month" do
+    subject(:last_tuesday) { described_class.last_tuesday_of_month(date) }
+
+    context "with a month ending mid-week" do
+      let(:date) { Date.new(2026, 7) }
+
+      it { is_expected.to eq(Date.new(2026, 7, 28)) }
+    end
+
+    context "when the month ends on a Tuesday" do
+      let(:date) { Date.new(2026, 6) }
+
+      it { is_expected.to eq(Date.new(2026, 6, 30)) }
+    end
+
+    context "when the following month starts on a Tuesday" do
+      let(:date) { Date.new(2026, 8) }
+
+      it { is_expected.to eq(Date.new(2026, 8, 25)) }
+    end
+
+    context "with a leap February ending on a Tuesday" do
+      let(:date) { Date.new(2028, 2) }
+
+      it { is_expected.to eq(Date.new(2028, 2, 29)) }
+    end
+
+    context "with December (year rollover)" do
+      let(:date) { Date.new(2026, 12) }
+
+      it { is_expected.to eq(Date.new(2026, 12, 29)) }
+    end
+
+    context "with a date mid-month" do
+      let(:date) { Date.new(2026, 7, 15) }
+
+      it { is_expected.to eq(Date.new(2026, 7, 28)) }
+    end
+  end
+end

--- a/spec/tasks/release_spec.rb
+++ b/spec/tasks/release_spec.rb
@@ -444,8 +444,8 @@ RSpec.describe "tasks/release" do
         expect(versions_json["2026.1"]).to eq(
           {
             "developmentStartDate" => "2025-12-28",
-            "releaseDate" => "2026-01",
-            "supportEndDate" => "2026-09",
+            "releaseDate" => "2026-01-27",
+            "supportEndDate" => "2026-09-29",
             "released" => false,
             "esr" => true,
             "supported" => true,

--- a/versions.json
+++ b/versions.json
@@ -1,8 +1,8 @@
 {
   "2026.8": {
     "developmentStartDate": "2026-07-28",
-    "releaseDate": "2026-08",
-    "supportEndDate": "2026-10",
+    "releaseDate": "2026-08-25",
+    "supportEndDate": "2026-10-27",
     "released": false,
     "esr": false,
     "supported": true
@@ -10,7 +10,7 @@
   "2026.7": {
     "developmentStartDate": "2026-06-30",
     "releaseDate": "2026-07-28",
-    "supportEndDate": "2027-03",
+    "supportEndDate": "2027-03-30",
     "released": true,
     "esr": true,
     "supported": true
@@ -18,7 +18,7 @@
   "2026.6": {
     "developmentStartDate": "2026-05-28",
     "releaseDate": "2026-06-30",
-    "supportEndDate": "2026-08",
+    "supportEndDate": "2026-08-25",
     "released": true,
     "esr": false,
     "supported": true
@@ -58,7 +58,7 @@
   "2026.1": {
     "developmentStartDate": "2025-12-30",
     "releaseDate": "2026-01-28",
-    "supportEndDate": "2026-09",
+    "supportEndDate": "2026-09-29",
     "released": true,
     "esr": true,
     "supported": true


### PR DESCRIPTION
Compute releaseDate and supportEndDate as the last Tuesday of the relevant month (a fully-specified YYYY-MM-DD) instead of an approximate YYYY-MM month, and convert the remaining vague values in versions.json to their precise last-Tuesday equivalents.