### PR TITLE
UX: remove absolute positioning for tip in EmptyState

### DIFF
--- a/app/assets/stylesheets/common/components/empty-states.scss
+++ b/app/assets/stylesheets/common/components/empty-states.scss
@@ -63,13 +63,5 @@
     .d-icon {
       font-size: var(--font-down-1);
     }
-
-    @include viewport.until(sm) {
-      position: absolute;
-      bottom: 3rem;
-      margin-inline: auto;
-      margin-top: 0;
-      left: 0;
-    }
   }
 }


### PR DESCRIPTION
No need for it. Shouldn't cause a big visual difference, if any.