### PR TITLE
FIX: Steer translation agents away from ASCII quotes in structured output

### DIFF
--- a/plugins/discourse-ai/lib/agents/post_raw_translator.rb
+++ b/plugins/discourse-ai/lib/agents/post_raw_translator.rb
@@ -20,7 +20,7 @@ module DiscourseAi
           5. For ambiguous terms or phrases, do not translate word-for-word in isolation. Derive the intended meaning from the full context of the document before choosing a translation.
           6. Ensure the translation only contains the original language and the target language.
           7. Match the tone and register of the source text. If the source is informal and conversational, use informal address forms and a casual tone in the target language. Do not default to formal address (e.g. German Sie, French vous) unless the source text is itself formal.
-          8. For any quoted text, use the target language's native quotation marks — for example German „…", French «…», Japanese 「…」 — rather than ASCII quotes.
+          8. For any quoted text, use the target language's native quotation marks — for example German „…“, French «…», Japanese 「…」 — rather than ASCII quotes.
 
           Follow these instructions on what NOT to do:
           9. Do not translate code snippets or programming language names, but ensure that any comments within the code are translated. Code can be represented in ``` or in single ` backticks or in <code> HTML tags.

--- a/plugins/discourse-ai/lib/agents/short_text_translator.rb
+++ b/plugins/discourse-ai/lib/agents/short_text_translator.rb
@@ -16,6 +16,7 @@ module DiscourseAi
           2. Keep the translated content close to the original length
           3. Translation maintains the original meaning
           4. Preserve any Markdown, HTML elements, links, parenthesis, or newlines
+          5. Never use ASCII double quotes (") inside the translation. For quoted text, use the target language's native quotation marks — for example German „…“, French «…», Japanese 「…」
 
           The text to translate will be provided in JSON format with the following structure:
           {"content": "Text to translate", "target_locale": "Target language code"}
@@ -43,6 +44,10 @@ module DiscourseAi
             { output: "Perguntas e Respostas" }.to_json,
           ],
           [{ content: "Minecraft", target_locale: "fr" }.to_json, { output: "Minecraft" }.to_json],
+          [
+            { content: %(Click "Reply"), target_locale: "fr" }.to_json,
+            { output: "Cliquez sur « Répondre »" }.to_json,
+          ],
         ]
       end
     end

--- a/plugins/discourse-ai/lib/agents/topic_title_translator.rb
+++ b/plugins/discourse-ai/lib/agents/topic_title_translator.rb
@@ -16,6 +16,7 @@ module DiscourseAi
           3. Attempt to keep the translated title length close to the original when possible.
           4. Match the tone and register of the source text. Do not default to formal address unless the source is itself formal.
           5. For ambiguous terms or phrases, do not translate word-for-word in isolation. Derive the intended meaning from the full context of the title before choosing a translation.
+          6. Never use ASCII double quotes (") inside the translation. For quoted text or UI labels, use the target language's native quotation marks — for example German „…“, French «…», Japanese 「…」.
 
           The text to translate will be provided in JSON format with the following structure:
           {"content": "Title to translate", "target_locale": "Target language code"}
@@ -60,6 +61,13 @@ module DiscourseAi
               output:
                 "Heathrow closed: flight disruption expected to continue in coming days, says London airport management",
             }.to_json,
+          ],
+          [
+            {
+              content: "Permanently Delete does not show (even after 5 minutes)",
+              target_locale: "de",
+            }.to_json,
+            { output: "„Endgültig löschen“ wird nicht angezeigt (auch nach 5 Minuten)" }.to_json,
           ],
         ]
       end


### PR DESCRIPTION
## Problem

A topic title translation was saved truncated: `Permanently Delete does not show (even after 5 minutes)` → `"Endgültig löschen`.

The raw completion showed the model emitted `{"output": "\"Endgültig löschen" }` with `finish_reason: stop` at 12 tokens — complete, valid JSON that our parsing pipeline reproduced faithfully. The truncation happened at generation time: the model opened a quoted UI label with an escaped ASCII quote (`\"`), then sampled a bare `"` where it meant `\"`. Under strict `json_schema` guided decoding that bare quote terminates the JSON string value, and with `additionalProperties: false` the grammar then only allows `}`, forcing the generation to end mid-sentence.

Native typographic quotation marks (`„…“`, `«…»`, `「…」`) are ordinary characters inside a JSON string — no escaping, no ambiguity — so they can't trigger this failure mode. A parallel successful run that happened to use `„…“` completed fine.

## Fix

`PostRawTranslator` already has a rule instructing native quotation marks. This adds the same rule to `TopicTitleTranslator` and `ShortTextTranslator`:

- **TopicTitleTranslator**: new guideline 6, plus a few-shot example using the exact title from the incident, showing German `„…“` around the UI label.
- **ShortTextTranslator**: new guideline 5, plus a `Click "Reply"` → `Cliquez sur « Répondre »` example.
- **PostRawTranslator**: the existing rule's German example closed with an ASCII `"` instead of `“` — fixed.

Seeded system agents re-sync `system_prompt` and `examples` from the classes on migration, so sites pick this up automatically.
