### PR TITLE
FEATURE: link Topic outcomes to the filtered topic list

### DIFF
--- a/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support.gjs
+++ b/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support.gjs
@@ -34,6 +34,7 @@ const DeltaPill = <template>
 
 export default class SupportSection extends Component {
   @service currentUser;
+  @service siteSettings;
   @service toasts;
 
   @tracked selectedCategories = [];
@@ -169,6 +170,69 @@ export default class SupportSection extends Component {
           : `${slower ? "+" : "-"}${durationTiny(Math.abs(diff))}`,
       deltaClass: diff === 0 ? "--neutral" : slower ? "--neg" : "--pos",
     };
+  }
+
+  get appliedCategories() {
+    return (this.data?.category_ids ?? [])
+      .map((id) => Category.findById(id))
+      .filter(Boolean);
+  }
+
+  get categoryFilterTerm() {
+    if (this.appliedCategories.length > 0) {
+      return this.#categoryTerm(this.appliedCategories);
+    }
+
+    if (this.siteSettings.allow_solved_on_all_topics) {
+      return null;
+    }
+
+    const allSupport = (this.args.data?.category_options ?? [])
+      .map((option) => Category.findById(option.id))
+      .filter(Boolean);
+
+    return allSupport.length > 0 ? this.#categoryTerm(allSupport) : null;
+  }
+
+  #categoryTerm(categories) {
+    const slugs = categories.map((category) => Category.slugFor(category, ":"));
+    return `category:${slugs.join(",")}`;
+  }
+
+  get dateRangeTerms() {
+    const terms = [];
+    if (this.args.startDate) {
+      terms.push(
+        `created-after:${moment(this.args.startDate).format("YYYY-MM-DD")}`
+      );
+    }
+    if (this.args.endDate) {
+      terms.push(
+        `created-before:${moment(this.args.endDate).format("YYYY-MM-DD")}`
+      );
+    }
+    return terms;
+  }
+
+  get outcomeQueries() {
+    const statusTermsByRow = {
+      resolved: ["status:solved"],
+      in_progress: ["status:unsolved", "posts-min:2"],
+      unanswered: ["status:unsolved", "status:noreplies"],
+    };
+
+    return Object.fromEntries(
+      Object.entries(statusTermsByRow).map(([key, statusTerms]) => {
+        const q = [
+          ...statusTerms,
+          ...this.dateRangeTerms,
+          this.categoryFilterTerm,
+        ]
+          .filter(Boolean)
+          .join(" ");
+        return [key, { q }];
+      })
+    );
   }
 
   @action
@@ -353,7 +417,10 @@ export default class SupportSection extends Component {
         <div class="db-section__row-group">
           <div class="db-section__row">
             <div class="db-section__row-block db-support-outcomes">
-              <SupportTopicOutcomes @outcomes={{this.data.topic_outcomes}} />
+              <SupportTopicOutcomes
+                @outcomes={{this.data.topic_outcomes}}
+                @queries={{this.outcomeQueries}}
+              />
 
             </div>
             <div class="db-section__row-block db-support-response">

--- a/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support/topic-outcomes.gjs
+++ b/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support/topic-outcomes.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { concat } from "@ember/helper";
+import { LinkTo } from "@ember/routing";
 import { trustHTML } from "@ember/template";
 import { i18n } from "discourse-i18n";
 
@@ -19,14 +20,11 @@ export default class SupportTopicOutcomes extends Component {
         tooltip: i18n(
           `admin.dashboard.sections.support.outcomes.${key}.tooltip`
         ),
+        query: this.args.queries?.[key] ?? {},
         fillStyle: trustHTML(`width: ${(count / max) * 100}%`),
         fillClass: `--${key.replace("_", "-")}`,
       };
     });
-  }
-
-  get ariaLabel() {
-    return this.rows.map((row) => `${row.label} ${row.count}`).join(", ");
   }
 
   <template>
@@ -36,17 +34,18 @@ export default class SupportTopicOutcomes extends Component {
       </h3>
     </div>
 
-    <div
-      class="db-support-outcomes__bars"
-      role="img"
-      aria-label={{this.ariaLabel}}
-    >
+    <div class="db-support-outcomes__bars">
       {{#each this.rows as |row|}}
         <div class="db-support-outcomes__row">
-          <span class="db-support-outcomes__label" title={{row.tooltip}}>
+          <LinkTo
+            @route="discovery.filter"
+            @query={{row.query}}
+            class="db-support-outcomes__label"
+            title={{row.tooltip}}
+          >
             {{row.label}}
-          </span>
-          <span class="db-support-outcomes__track">
+          </LinkTo>
+          <span class="db-support-outcomes__track" aria-hidden="true">
             <span
               class={{concat "db-support-outcomes__fill " row.fillClass}}
               style={{row.fillStyle}}

--- a/plugins/discourse-solved/assets/stylesheets/admin/dashboard-support.scss
+++ b/plugins/discourse-solved/assets/stylesheets/admin/dashboard-support.scss
@@ -45,8 +45,17 @@ $db-bar-height: var(--space-2);
     align-items: center;
     gap: var(--space-1);
     min-width: 0;
-    color: var(--primary);
-    cursor: help;
+    color: var(--primary-medium);
+
+    &:visited {
+      color: var(--primary-medium);
+    }
+
+    &:hover,
+    &:focus,
+    &:active {
+      color: var(--primary);
+    }
 
     @container db-support-outcomes (width < 22rem) {
       grid-column: 1 / -1;

--- a/plugins/discourse-solved/test/javascripts/integration/support-test.gjs
+++ b/plugins/discourse-solved/test/javascripts/integration/support-test.gjs
@@ -273,4 +273,155 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
       "1,2"
     );
   });
+
+  test("links Topic outcomes rows to the filtered topic list, scoped to the date range and without a category restriction when solved is allowed on all topics", async function (assert) {
+    this.siteSettings.allow_solved_on_all_topics = true;
+
+    const data = buildData({ category_options: [], category_ids: [] });
+
+    await render(
+      <template>
+        <SupportSection
+          @data={{data}}
+          @startDate={{startDate}}
+          @endDate={{endDate}}
+        />
+      </template>
+    );
+
+    const dateRange = `created-after:${moment(startDate).format(
+      "YYYY-MM-DD"
+    )} created-before:${moment(endDate).format("YYYY-MM-DD")}`;
+
+    assert
+      .dom(".db-support-outcomes__row:nth-child(1) a")
+      .hasAttribute(
+        "href",
+        `/filter?q=${encodeURIComponent(`status:solved ${dateRange}`)}`,
+        "resolved links to status:solved with the current date range"
+      );
+    assert
+      .dom(".db-support-outcomes__row:nth-child(2) a")
+      .hasAttribute(
+        "href",
+        `/filter?q=${encodeURIComponent(
+          `status:unsolved posts-min:2 ${dateRange}`
+        )}`,
+        "in progress links to status:unsolved posts-min:2 with the current date range"
+      );
+    assert
+      .dom(".db-support-outcomes__row:nth-child(3) a")
+      .hasAttribute(
+        "href",
+        `/filter?q=${encodeURIComponent(
+          `status:unsolved status:noreplies ${dateRange}`
+        )}`,
+        "unanswered links to status:unsolved status:noreplies with the current date range"
+      );
+  });
+
+  test("restricts Topic outcomes links to every support category when none is selected and solved is not allowed on all topics", async function (assert) {
+    this.siteSettings.allow_solved_on_all_topics = false;
+
+    const data = buildData({
+      category_options: [
+        { id: 1, name: "Bug" },
+        { id: 2, name: "Feature" },
+      ],
+      category_ids: [],
+    });
+
+    await render(
+      <template>
+        <SupportSection
+          @data={{data}}
+          @startDate={{startDate}}
+          @endDate={{endDate}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".db-support-outcomes__row:nth-child(1) a")
+      .hasAttribute(
+        "href",
+        /category%3Abug%2Cfeature/,
+        "restricts to every support category when none is selected"
+      );
+  });
+
+  test("restricts Topic outcomes links to the selected category when one is applied", async function (assert) {
+    this.siteSettings.allow_solved_on_all_topics = false;
+
+    const data = buildData({
+      category_options: [
+        { id: 1, name: "Bug" },
+        { id: 3, name: "Meta" },
+      ],
+      category_ids: [3],
+    });
+
+    await render(
+      <template>
+        <SupportSection
+          @data={{data}}
+          @startDate={{startDate}}
+          @endDate={{endDate}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".db-support-outcomes__row:nth-child(1) a")
+      .hasAttribute(
+        "href",
+        /category%3Ameta(?!%2C)/,
+        "restricts to only the selected category"
+      );
+  });
+
+  test("exposes Topic outcomes rows as focusable links, keeping the bar graphic hidden from assistive tech", async function (assert) {
+    const data = buildData();
+
+    await render(
+      <template>
+        <SupportSection
+          @data={{data}}
+          @startDate={{startDate}}
+          @endDate={{endDate}}
+        />
+      </template>
+    );
+
+    assert
+      .dom(".db-support-outcomes__bars")
+      .doesNotHaveAttribute("role", "no longer collapsed into a single img");
+    assert
+      .dom(".db-support-outcomes__label")
+      .exists({ count: 3 }, "each row renders a focusable label link");
+    assert
+      .dom(".db-support-outcomes__row:nth-child(1) a")
+      .hasAttribute(
+        "href",
+        `/filter?q=${encodeURIComponent(
+          `status:solved created-after:${moment(startDate).format(
+            "YYYY-MM-DD"
+          )} created-before:${moment(endDate).format("YYYY-MM-DD")}`
+        )}`,
+        "resolved links to its full filter query"
+      );
+    assert
+      .dom(".db-support-outcomes__track")
+      .hasAttribute(
+        "aria-hidden",
+        "true",
+        "the decorative bar is hidden from assistive tech"
+      );
+    assert
+      .dom(".db-support-outcomes__share")
+      .doesNotHaveAttribute(
+        "aria-hidden",
+        "the count stays exposed to assistive tech"
+      );
+  });
 });

--- a/plugins/discourse-solved/test/javascripts/integration/support/topic-outcomes-test.gjs
+++ b/plugins/discourse-solved/test/javascripts/integration/support/topic-outcomes-test.gjs
@@ -1,0 +1,110 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import SupportTopicOutcomes from "discourse/plugins/discourse-solved/admin/components/dashboard/support/topic-outcomes";
+
+module(
+  "Integration | Component | Dashboard | Support | SupportTopicOutcomes",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("links each row to the topic list using the query it was given", async function (assert) {
+      const outcomes = { resolved: 4, in_progress: 2, unanswered: 1 };
+      const queries = {
+        resolved: { q: "status:solved created-after:2026-04-01" },
+        in_progress: {
+          q: "status:unsolved posts-min:2 created-after:2026-04-01",
+        },
+        unanswered: {
+          q: "status:unsolved status:noreplies created-after:2026-04-01",
+        },
+      };
+
+      await render(
+        <template>
+          <SupportTopicOutcomes @outcomes={{outcomes}} @queries={{queries}} />
+        </template>
+      );
+
+      assert
+        .dom(".db-support-outcomes__row:nth-child(1) a")
+        .hasAttribute(
+          "href",
+          `/filter?q=${encodeURIComponent(queries.resolved.q)}`,
+          "resolved links to its given query"
+        )
+        .hasText("Resolved", "resolved shows its label")
+        .hasAttribute(
+          "title",
+          "The number of topics that were marked solved.",
+          "resolved keeps its tooltip"
+        );
+
+      assert
+        .dom(".db-support-outcomes__row:nth-child(2) a")
+        .hasAttribute(
+          "href",
+          `/filter?q=${encodeURIComponent(queries.in_progress.q)}`,
+          "in progress links to its given query"
+        );
+
+      assert
+        .dom(".db-support-outcomes__row:nth-child(3) a")
+        .hasAttribute(
+          "href",
+          `/filter?q=${encodeURIComponent(queries.unanswered.q)}`,
+          "unanswered links to its given query"
+        );
+
+      assert
+        .dom(
+          ".db-support-outcomes__row:nth-child(1) .db-support-outcomes__share"
+        )
+        .hasText("4", "still shows the count next to the link");
+    });
+
+    test("keeps the bar graphic hidden from assistive tech while the label and count stay exposed", async function (assert) {
+      const outcomes = { resolved: 1, in_progress: 0, unanswered: 0 };
+
+      await render(
+        <template><SupportTopicOutcomes @outcomes={{outcomes}} /></template>
+      );
+
+      assert
+        .dom(".db-support-outcomes__bars")
+        .doesNotHaveAttribute("role", "no longer collapsed into a single img");
+      assert
+        .dom(".db-support-outcomes__track")
+        .hasAttribute(
+          "aria-hidden",
+          "true",
+          "the decorative bar is hidden from assistive tech"
+        );
+      assert
+        .dom(".db-support-outcomes__share")
+        .doesNotHaveAttribute(
+          "aria-hidden",
+          "the count stays exposed to assistive tech"
+        );
+      assert
+        .dom(".db-support-outcomes__label")
+        .exists({ count: 3 }, "each row renders a focusable label link");
+    });
+
+    test("falls back to an empty query when none is provided for a row", async function (assert) {
+      const outcomes = { resolved: 1, in_progress: 0, unanswered: 0 };
+
+      await render(
+        <template><SupportTopicOutcomes @outcomes={{outcomes}} /></template>
+      );
+
+      assert
+        .dom(".db-support-outcomes__row:nth-child(1) a")
+        .hasAttribute(
+          "href",
+          "/filter",
+          "still links to the filter page without a query"
+        );
+    });
+  }
+);


### PR DESCRIPTION
Resolved, In progress, and Unanswered in the Support section's Topic outcomes chart are now links to topic lists (via the `/filter` route) , filtered to the matching topics for the dashboard's current date range and category selection.