### PR TITLE
PERF: Remove `ai_translation_max_post_length` setting

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23070,6 +23070,7 @@ ALTER TABLE ONLY public.ad_plugin_house_ads_groups
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260729153343'),
 ('20260728162521'),
 ('20260728162516'),
 ('20260728071552'),

--- a/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-feature-setting-groups.js
+++ b/plugins/discourse-ai/assets/javascripts/discourse/lib/ai-feature-setting-groups.js
@@ -196,7 +196,6 @@ export const AI_FEATURE_SETTING_GROUPS = {
         "ai_translation_categories",
         "ai_translation_personal_messages",
         "ai_translation_include_bot_content",
-        "ai_translation_max_post_length",
         "ai_translation_backfill_start_date",
 
         "ai_translation_verbose_logs",

--- a/plugins/discourse-ai/config/locales/server.en.yml
+++ b/plugins/discourse-ai/config/locales/server.en.yml
@@ -171,7 +171,6 @@ en:
     ai_translation_categories: "Categories used when the AI translation category scope is set to <strong>include</strong> or <strong>exclude</strong>."
     ai_translation_personal_messages: "Controls which personal messages are translated. 'none' disables PM translation. 'group' translates only group PMs. 'all' translates all PMs."
     ai_translation_include_bot_content: "When enabled, content written by bots (user IDs below 0) will also be sent for translation."
-    ai_translation_max_post_length: "The maximum number of characters for a post to be translated. Posts longer than this will not be translated."
     ai_translation_backfill_start_date: "The UTC date from which historical posts and topics will be sent for translation backfilling. Leave blank to disable backfilling. New content will continue to be translated."
     ai_translation_backfill_hourly_rate: "The number of posts and topics to translate per hour during backfill operations. Set to 0 to disable automatic backfilling of translations for existing content."
     ai_translation_backfill_parallel_jobs: "The number of parallel post localization jobs to run per backfill cycle. Higher values increase throughput but consume more resources."

--- a/plugins/discourse-ai/config/settings.yml
+++ b/plugins/discourse-ai/config/settings.yml
@@ -577,10 +577,6 @@ discourse_ai:
     default: false
     client: false
     area: "ai-features/translation"
-  ai_translation_max_post_length:
-    default: 10000
-    client: false
-    area: "ai-features/translation"
   ai_translation_backfill_start_date:
     default: ""
     type: "date"

--- a/plugins/discourse-ai/db/post_migrate/20260729153343_remove_ai_translation_max_post_length_setting.rb
+++ b/plugins/discourse-ai/db/post_migrate/20260729153343_remove_ai_translation_max_post_length_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveAiTranslationMaxPostLengthSetting < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'ai_translation_max_post_length'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugins/discourse-ai/lib/translation/post_candidates.rb
+++ b/plugins/discourse-ai/lib/translation/post_candidates.rb
@@ -59,7 +59,6 @@ module DiscourseAi
           (backfill_start_at ? Post.where("posts.created_at >= ?", backfill_start_at) : Post.none)
             .where(deleted_at: nil)
             .where.not(raw: [nil, ""])
-            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
 
         main_posts =
           main_posts.where(
@@ -90,7 +89,6 @@ module DiscourseAi
           Post
             .where(deleted_at: nil)
             .where.not(raw: [nil, ""])
-            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
             .joins(:topic)
             .where(topics: { archetype: Archetype.banner, deleted_at: nil })
         banner_posts =
@@ -227,7 +225,6 @@ module DiscourseAi
           (backfill_start_at ? Post.where("posts.created_at >= ?", backfill_start_at) : Post.none)
             .where(deleted_at: nil)
             .where.not(raw: [nil, ""])
-            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
 
         posts =
           posts.where("posts.user_id > 0") unless SiteSetting.ai_translation_include_bot_content
@@ -261,7 +258,6 @@ module DiscourseAi
           Post
             .where(deleted_at: nil)
             .where.not(raw: [nil, ""])
-            .where("LENGTH(posts.raw) <= ?", SiteSetting.ai_translation_max_post_length)
             .joins(:topic)
             .where(topics: { archetype: Archetype.banner, deleted_at: nil })
         banner_posts =

--- a/plugins/discourse-ai/lib/translation/post_localizer.rb
+++ b/plugins/discourse-ai/lib/translation/post_localizer.rb
@@ -10,7 +10,6 @@ module DiscourseAi
              LocaleNormalizer.is_same?(post.locale, target_locale) || post.raw.blank?
           return
         end
-        return if post.raw.length > SiteSetting.ai_translation_max_post_length
         target_locale = target_locale.to_s.sub("-", "_")
 
         translated_raw =

--- a/plugins/discourse-ai/lib/translation/progress.rb
+++ b/plugins/discourse-ai/lib/translation/progress.rb
@@ -3,9 +3,9 @@
 module DiscourseAi
   module Translation
     class Progress
-      CACHE_VERSION = 1
+      CACHE_VERSION = 2
       CACHE_TTL = 2.hours
-      DETAIL_CACHE_VERSION = 1
+      DETAIL_CACHE_VERSION = 2
       DETAIL_CACHE_TTL = 2.hours
       TARGET_CLASSES = {
         "post" => PostCandidates,
@@ -67,7 +67,6 @@ module DiscourseAi
           SiteSetting.content_localization_supported_locales,
           SiteSetting.ai_translation_backfill_start_date,
           SiteSetting.ai_translation_include_bot_content,
-          SiteSetting.ai_translation_max_post_length,
           SiteSetting.ai_translation_personal_messages,
           DiscourseAi::Translation.category_scope_cache_key,
         ]

--- a/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_candidates_spec.rb
@@ -44,16 +44,6 @@ describe DiscourseAi::Translation::PostCandidates do
       expect(DiscourseAi::Translation::PostCandidates.get).not_to include(post)
     end
 
-    it "does not return posts longer than ai_translation_max_post_length" do
-      SiteSetting.ai_translation_max_post_length = 100
-      short_post = Fabricate(:post, raw: "This is a short post that fits within the limit.")
-      long_post = Fabricate(:post, raw: "a" * 50 + " This is a long post. " + "b" * 50)
-
-      posts = DiscourseAi::Translation::PostCandidates.get
-      expect(posts).to include(short_post)
-      expect(posts).not_to include(long_post)
-    end
-
     describe "category and PM filtering" do
       fab!(:target_category, :category)
       fab!(:non_target_category, :category)

--- a/plugins/discourse-ai/spec/lib/translation/post_localizer_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/post_localizer_spec.rb
@@ -42,13 +42,6 @@ describe DiscourseAi::Translation::PostLocalizer do
       expect(described_class.localize(post, "ja")).to eq(nil)
     end
 
-    it "returns nil if post raw is too long" do
-      SiteSetting.ai_translation_max_post_length = 10
-      post.raw = "This is a very long post that exceeds the limit."
-
-      expect(described_class.localize(post, "ja")).to eq(nil)
-    end
-
     it "translates with post and locale" do
       post_raw_translator_stub({ text: post.raw, target_locale: "ja", translated: translated_raw })
 

--- a/plugins/discourse-ai/spec/lib/translation/progress_spec.rb
+++ b/plugins/discourse-ai/spec/lib/translation/progress_spec.rb
@@ -73,7 +73,7 @@ describe DiscourseAi::Translation::Progress do
       %w[post topic category tag],
     )
     expect(cache).to have_received(:fetch).with(
-      a_string_starting_with("discourse-ai:translation-progress-overview:v1:"),
+      a_string_starting_with("discourse-ai:translation-progress-overview:v2:"),
       expires_in: 2.hours,
     ).twice
     expect(DiscourseAi::Translation::PostCandidates).to have_received(:progress_summary).once
@@ -124,18 +124,18 @@ describe DiscourseAi::Translation::Progress do
       expect(first_post[:cached_at]).to eq(cached_at.utc.iso8601)
       expect(topic[:cached_at]).to eq((cached_at + 1.hour).utc.iso8601)
       expect(cache).to have_received(:fetch).with(
-        a_string_starting_with("discourse-ai:translation-progress-detail:v1:post:"),
+        a_string_starting_with("discourse-ai:translation-progress-detail:v2:post:"),
         expires_in: 2.hours,
       ).once
       expect(cache).to have_received(:fetch).with(
-        a_string_starting_with("discourse-ai:translation-progress-detail:v1:topic:"),
+        a_string_starting_with("discourse-ai:translation-progress-detail:v2:topic:"),
         expires_in: 2.hours,
       ).once
       expect(cache).to have_received(:read).with(
-        a_string_starting_with("discourse-ai:translation-progress-detail:v1:post:"),
+        a_string_starting_with("discourse-ai:translation-progress-detail:v2:post:"),
       ).twice
       expect(cache).to have_received(:read).with(
-        a_string_starting_with("discourse-ai:translation-progress-detail:v1:topic:"),
+        a_string_starting_with("discourse-ai:translation-progress-detail:v2:topic:"),
       ).once
       expect(DiscourseAi::Translation::PostCandidates).to have_received(:progress_details).once
       expect(DiscourseAi::Translation::TopicCandidates).to have_received(:progress_details).once


### PR DESCRIPTION
Previously, every SQL query finding translation candidates (admin progress report and backfill jobs) filtered on `LENGTH(posts.raw)`, which forced detoasting `raw` for every scanned row and made those queries slow, while the limit itself no longer guarded anything — long posts are already split into chunks sized to the model's `max_output_tokens`, and core's `max_post_length` bounds raw size.

This change removes the setting and its query filters, deletes any stored override via a post-deploy migration, and bumps the translation progress cache versions since eligibility counts change.

Note for review: on existing sites, posts previously excluded by the limit become eligible for backfill, so pending counts (and translation spend on long-form content) will increase accordingly.