### PR TITLE
SECURITY: Private event invitee details leak through invitees list endpoint [backport 2026.1]

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -5,6 +5,7 @@ module DiscoursePostEvent
     def index
       event = Event.find(params[:post_id])
       guardian.ensure_can_see!(event.post)
+      raise Discourse::InvalidAccess if !guardian.can_display_invitee_details?(event)
 
       filter = params[:filter].downcase if params[:filter]
 

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -116,7 +116,7 @@ module DiscoursePostEvent
     end
 
     def include_raw_invitees?
-      can_display_invitee_details?
+      scope.can_display_invitee_details?(object)
     end
 
     def sample_invitees
@@ -125,49 +125,19 @@ module DiscoursePostEvent
     end
 
     def include_sample_invitees?
-      can_display_invitee_details?
+      scope.can_display_invitee_details?(object)
     end
 
     def include_stats?
-      can_display_invitee_details?
-    end
-
-    def can_display_invitee_details?
-      return @can_display_invitee_details if defined?(@can_display_invitee_details)
-
-      @can_display_invitee_details =
-        if !object.private? || scope.can_act_on_discourse_post_event?(object)
-          true
-        else
-          user = scope.current_user
-          if user && invited_user?(user)
-            true
-          else
-            visible_invited_groups?(user)
-          end
-        end
-    end
-
-    def visible_invited_groups?(user)
-      raw_invitees = Array(object.raw_invitees).uniq
-      return false if raw_invitees.blank?
-
-      Group
-        .visible_groups(user)
-        .members_visible_groups(user)
-        .where(name: raw_invitees)
-        .distinct
-        .count == raw_invitees.length
-    end
-
-    def invited_user?(user)
-      object.invitees.exists?(user_id: user.id) ||
-        user.groups.where(name: Array(object.raw_invitees)).exists?
+      scope.can_display_invitee_details?(object)
     end
 
     def should_display_invitees
       (object.public? && object.invitees.count > 0) ||
-        (object.private? && can_display_invitee_details? && Array(object.raw_invitees).count > 0)
+        (
+          object.private? && scope.can_display_invitee_details?(object) &&
+            Array(object.raw_invitees).count > 0
+        )
     end
 
     def include_url?

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -191,6 +191,26 @@ after_initialize do
     user && user.can_act_on_discourse_post_event?(event)
   end
 
+  add_to_class(:guardian, :can_display_invitee_details?) do |event|
+    return true if !event.private? || can_act_on_discourse_post_event?(event)
+
+    raw_invitees = Array(event.raw_invitees).uniq
+
+    if user &&
+         (event.invitees.exists?(user_id: user.id) || user.groups.where(name: raw_invitees).exists?)
+      return true
+    end
+
+    return false if raw_invitees.blank?
+
+    Group
+      .visible_groups(user)
+      .members_visible_groups(user)
+      .where(name: raw_invitees)
+      .distinct
+      .count == raw_invitees.length
+  end
+
   add_class_method(:group, :discourse_post_event_allowed_groups) do
     where(id: SiteSetting.discourse_post_event_allowed_on_groups.split("|").compact)
   end

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -40,6 +40,44 @@ module DiscoursePostEvent
         end
       end
 
+      context "for a private event in a public topic" do
+        fab!(:event_owner, :admin)
+        fab!(:public_topic) { Fabricate(:topic, user: event_owner) }
+        fab!(:public_post) { Fabricate(:post, user: event_owner, topic: public_topic) }
+        fab!(:viewer, :user)
+        fab!(:invitee_user, :user)
+        fab!(:restricted_group) do
+          Fabricate(
+            :group,
+            visibility_level: Group.visibility_levels[:owners],
+            members_visibility_level: Group.visibility_levels[:owners],
+          ).tap { |group| group.add(invitee_user) }
+        end
+        fab!(:private_event) do
+          Fabricate(
+            :event,
+            post: public_post,
+            status: DiscoursePostEvent::Event.statuses[:private],
+            raw_invitees: [restricted_group.name],
+          )
+        end
+
+        before do
+          private_event.create_invitees(
+            [{ user_id: invitee_user.id, status: Invitee.statuses[:going] }],
+          )
+        end
+
+        it "does not disclose private event invitees to uninvited users" do
+          sign_in(viewer)
+
+          get "/discourse-post-event/events/#{private_event.id}/invitees.json"
+
+          expect(response.body).not_to include(invitee_user.username)
+          expect(response.status).to eq(403)
+        end
+      end
+
       context "when params are included" do
         let(:invitee1) { Fabricate(:user, username: "Francis", name: "Francis") }
         let(:invitee2) { Fabricate(:user, username: "Francisco", name: "Francisco") }
@@ -395,6 +433,49 @@ module DiscoursePostEvent
             end
           end
         end
+      end
+    end
+  end
+
+  describe "anonymous access to InviteesController" do
+    before do
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    fab!(:admin_user) { Fabricate(:user, admin: true) }
+    fab!(:anon_topic) { Fabricate(:topic, user: admin_user) }
+    fab!(:invitee_user, :user)
+
+    context "for a private event in a public topic" do
+      fab!(:private_event_post) { Fabricate(:post, user: admin_user, topic: anon_topic) }
+      fab!(:restricted_group) do
+        Fabricate(
+          :group,
+          visibility_level: Group.visibility_levels[:owners],
+          members_visibility_level: Group.visibility_levels[:owners],
+        ).tap { |group| group.add(invitee_user) }
+      end
+      fab!(:private_event) do
+        Fabricate(
+          :event,
+          post: private_event_post,
+          status: DiscoursePostEvent::Event.statuses[:private],
+          raw_invitees: [restricted_group.name],
+        )
+      end
+
+      before do
+        private_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+      end
+
+      it "does not disclose private event invitees to anonymous viewers" do
+        get "/discourse-post-event/events/#{private_event.id}/invitees.json"
+
+        expect(response.body).not_to include(invitee_user.username)
+        expect(response.status).to eq(403)
       end
     end
   end


### PR DESCRIPTION
Backport of #42109 to release/2026.1.
- This one was a hand backport because the file structure is different

Summary
The invitee-list route for private events previously authorized only host-post visibility, allowing an authenticated viewer to retrieve attendee identities, RSVP states, and attendance totals that should be hidden. The fix enforces the same private-event detail policy used by EventSerializer before returning invitee data, returning a 403 error to unauthorized viewers.