### PR TITLE
DEV: Promote enable_invite_modal_with_roles upcoming change to beta

### DIFF
--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4821,7 +4821,7 @@ experimental:
     hidden: true
     client: true
     upcoming_change:
-      status: "experimental"
+      status: "beta"
       impact: "feature,admins"
       learn_more_url: "https://meta.discourse.org/t/-/407727"
   update_pending_users_reminder_default:

--- a/spec/system/admin_onboarding_banner_spec.rb
+++ b/spec/system/admin_onboarding_banner_spec.rb
@@ -11,6 +11,7 @@ describe "Admin Onboarding Banner" do
   let(:toasts) { PageObjects::Components::Toasts.new }
 
   before do
+    SiteSetting.enable_invite_modal_with_roles = false
     SiteSetting.enable_site_owner_onboarding = true
     SiteSetting.default_theme_id = Theme.foundation_theme.id
 

--- a/spec/system/create_invite_spec.rb
+++ b/spec/system/create_invite_spec.rb
@@ -18,6 +18,7 @@ describe "Creating Invites" do
   end
 
   before do
+    SiteSetting.enable_invite_modal_with_roles = false
     SiteSetting.invite_allowed_groups = "#{group.id}"
     SiteSetting.invite_link_max_redemptions_limit_users = 7
     SiteSetting.invite_link_max_redemptions_limit = 63


### PR DESCRIPTION
`promote_upcoming_changes_on_status` defaults to `beta`, so promoting the change makes the new invite modal with roles the default everywhere, including in the test environment.

The system spec covering the legacy invite modal now opts out explicitly with `SiteSetting.enable_invite_modal_with_roles = false`.