### PR TITLE
DEV: Improve OIDC and OAuth2 plugin timeout handling

### DIFF
--- a/plugins/discourse-oauth2-basic/lib/oauth2_basic_authenticator.rb
+++ b/plugins/discourse-oauth2-basic/lib/oauth2_basic_authenticator.rb
@@ -30,6 +30,11 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
                             authorize_url: SiteSetting.oauth2_authorize_url,
                             token_url: SiteSetting.oauth2_token_url,
                             token_method: SiteSetting.oauth2_token_url_method.downcase.to_sym,
+                            connection_opts: {
+                              request: {
+                                timeout: request_timeout_seconds,
+                              },
+                            },
                           }
                           opts[:authorize_options] = SiteSetting
                             .oauth2_authorize_options
@@ -190,16 +195,31 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
     user_json_method = SiteSetting.oauth2_user_json_url_method.downcase.to_sym
 
     bearer_token = "Bearer #{token}"
-    connection = Faraday.new { |f| f.adapter FinalDestination::FaradayAdapter }
+    connection =
+      Faraday.new(request: { timeout: request_timeout_seconds }) do |f|
+        f.adapter FinalDestination::FaradayAdapter
+      end
     headers = { "Authorization" => bearer_token, "Accept" => "application/json" }
-    user_json_response = connection.run_request(user_json_method, user_json_url, nil, headers)
 
     log <<-LOG
       user_json request: #{user_json_method} #{user_json_url}
 
       request headers: #{headers}
+    LOG
 
-      response status: #{user_json_response.status}
+    begin
+      user_json_response = connection.run_request(user_json_method, user_json_url, nil, headers)
+    rescue Faraday::Error => e
+      failure_detail =
+        e.is_a?(Faraday::TimeoutError) ? "timed out after #{request_timeout_seconds}s" : "failed"
+      Rails.logger.warn(
+        "OAuth2 Basic: user_json request to #{user_json_url} #{failure_detail}: #{e.class} #{e.message}",
+      )
+      return nil
+    end
+
+    log <<-LOG
+      user_json response: #{user_json_response.status}
 
       response body:
       #{user_json_response.body}
@@ -307,5 +327,9 @@ class OAuth2BasicAuthenticator < Auth::ManagedAuthenticator
 
   def enabled?
     SiteSetting.oauth2_enabled
+  end
+
+  def request_timeout_seconds
+    GlobalSetting.oauth2_request_timeout_seconds
   end
 end

--- a/plugins/discourse-oauth2-basic/lib/omniauth/strategies/oauth2_basic.rb
+++ b/plugins/discourse-oauth2-basic/lib/omniauth/strategies/oauth2_basic.rb
@@ -24,6 +24,19 @@ class OmniAuth::Strategies::Oauth2Basic < ::OmniAuth::Strategies::OAuth2
     end
   end
 
+  def callback_phase
+    super
+  rescue Faraday::Error => e
+    detail =
+      if e.is_a?(Faraday::TimeoutError)
+        "timed out after #{GlobalSetting.oauth2_request_timeout_seconds}s"
+      else
+        "failed"
+      end
+    Rails.logger.warn("OAuth2 Basic: token request #{detail}: #{e.class} #{e.message}")
+    fail!(:oauth2_basic_request_failed, e)
+  end
+
   def callback_url
     Discourse.base_url_no_prefix + script_name + callback_path
   end

--- a/plugins/discourse-oauth2-basic/plugin.rb
+++ b/plugins/discourse-oauth2-basic/plugin.rb
@@ -13,6 +13,8 @@ require_relative "lib/omniauth/strategies/oauth2_basic"
 require_relative "lib/oauth2_faraday_formatter"
 require_relative "lib/oauth2_basic_authenticator"
 
+GlobalSetting.add_default :oauth2_request_timeout_seconds, 10
+
 register_site_setting_area("oauth2")
 register_admin_config_login_route("oauth2")
 

--- a/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
+++ b/plugins/discourse-oauth2-basic/spec/plugin_spec.rb
@@ -98,6 +98,12 @@ describe OAuth2BasicAuthenticator do
         expect(result.failed).to eq(true)
       end
 
+      it "returns a standardised result if the request times out" do
+        stub_request(:get, SiteSetting.oauth2_user_json_url).to_timeout
+        result = authenticator.after_authenticate(auth)
+        expect(result.failed).to eq(true)
+      end
+
       describe "fetch custom attributes" do
         after { DiscoursePluginRegistry.reset_register!(:oauth2_basic_additional_json_paths) }
 

--- a/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
+++ b/plugins/discourse-openid-connect/lib/omniauth_open_id_connect.rb
@@ -144,6 +144,15 @@ module OmniAuth
           fail!(:jwt_nonce_verify_failed, e)
         rescue SubVerifyError => e
           fail!(:openid_connect_sub_mismatch, e)
+        rescue Faraday::Error => e
+          detail =
+            if e.is_a?(Faraday::TimeoutError)
+              "timed out after #{GlobalSetting.openid_connect_request_timeout_seconds}s"
+            else
+              "failed"
+            end
+          Rails.logger.error("OIDC Log: request #{detail}: #{e.class} #{e.message}")
+          fail!(:openid_connect_request_failed, e)
         end
       end
 

--- a/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
+++ b/plugins/discourse-openid-connect/spec/lib/omniauth_open_id_connect_spec.rb
@@ -167,6 +167,17 @@ describe OmniAuth::Strategies::OpenIDConnect do
         expect(@app_called).to eq(false)
       end
 
+      it "fails gracefully when an upstream request errors" do
+        stub_request(:post, "https://id.example.com/token").to_timeout
+
+        callback_response = strategy.callback_phase
+        expect(callback_response[0]).to eq(302)
+        expect(callback_response[1]["Location"]).to eq(
+          "/auth/failure?message=openid_connect_request_failed&strategy=openidconnect",
+        )
+        expect(@app_called).to eq(false)
+      end
+
       context "with userinfo disabled" do
         before do
           stub_request(:post, "https://id.example.com/token").with(


### PR DESCRIPTION
- Make timeout configurable for OAuth2, to match OIDC

- Correctly log timeout errors

- Show nicer auth-failure screen to users, instead of the generic 'something went wrong' page