### PR TITLE
FEATURE: Render chat actions as standalone messages

### DIFF
--- a/plugins/chat/app/models/chat/message.rb
+++ b/plugins/chat/app/models/chat/message.rb
@@ -308,6 +308,12 @@ module Chat
       cooked
     end
 
+    def action?
+      SLASH_COMMAND_PATTERNS.any? do |_, command|
+        command[:formatter] == :action && message&.match?(command[:pattern])
+      end
+    end
+
     def self.match_slash_command(message, author_username)
       return if message.blank?
 

--- a/plugins/chat/app/serializers/chat/message_serializer.rb
+++ b/plugins/chat/app/serializers/chat/message_serializer.rb
@@ -31,6 +31,7 @@ module Chat
             channel
             thread_title
             pinned
+            is_action
           ]
       ),
     )
@@ -60,6 +61,10 @@ module Chat
 
     def excerpt
       object.excerpt || object.build_excerpt
+    end
+
+    def is_action
+      object.action?
     end
 
     def reactions

--- a/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-message.gjs
@@ -450,6 +450,10 @@ export default class ChatMessage extends Component {
   get hideUserInfo() {
     const message = this.args.message;
 
+    if (message.isAction) {
+      return true;
+    }
+
     if (message.pinned) {
       return false;
     }
@@ -470,6 +474,10 @@ export default class ChatMessage extends Component {
     }
 
     if (previousMessage.deletedAt) {
+      return false;
+    }
+
+    if (previousMessage.isAction) {
       return false;
     }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-channel-subscription-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-channel-subscription-manager.js
@@ -127,6 +127,7 @@ export default class ChatChannelSubscriptionManager {
     stagedMessage.uploads = cloneJSON(data.chat_message.uploads || []);
     stagedMessage.streaming = data.chat_message.streaming;
     stagedMessage.edited = data.chat_message.edited;
+    stagedMessage.isAction = data.chat_message.is_action;
 
     return stagedMessage;
   }
@@ -158,6 +159,7 @@ export default class ChatChannelSubscriptionManager {
       message.edited = data.chat_message.edited;
       message.streaming = data.chat_message.streaming;
       message.blocks = data.chat_message.blocks;
+      message.isAction = data.chat_message.is_action;
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/lib/chat-channel-thread-subscription-manager.js
+++ b/plugins/chat/assets/javascripts/discourse/lib/chat-channel-thread-subscription-manager.js
@@ -113,6 +113,7 @@ export default class ChatChannelThreadSubscriptionManager {
     stagedMessage.uploads = cloneJSON(data.chat_message.uploads || []);
     stagedMessage.streaming = data.chat_message.streaming;
     stagedMessage.edited = data.chat_message.edited;
+    stagedMessage.isAction = data.chat_message.is_action;
 
     return stagedMessage;
   }
@@ -142,6 +143,7 @@ export default class ChatChannelThreadSubscriptionManager {
       message.edited = data.chat_message.edited;
       message.streaming = data.chat_message.streaming;
       message.blocks = data.chat_message.blocks;
+      message.isAction = data.chat_message.is_action;
     }
   }
 

--- a/plugins/chat/assets/javascripts/discourse/models/chat-message.js
+++ b/plugins/chat/assets/javascripts/discourse/models/chat-message.js
@@ -54,6 +54,7 @@ export default class ChatMessage {
   @tracked deletedById;
   @tracked streaming;
   @tracked pinned;
+  @tracked isAction;
   @tracked blocks;
   @autoTrackedArray reactions;
 
@@ -107,6 +108,7 @@ export default class ChatMessage {
     }
 
     this.pinned = args.pinned ?? false;
+    this.isAction = args.isAction ?? args.is_action ?? false;
   }
 
   get url() {

--- a/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
+++ b/plugins/chat/spec/jobs/regular/chat/process_message_spec.rb
@@ -19,6 +19,16 @@ describe Jobs::Chat::ProcessMessage do
     )
   end
 
+  it "preserves action formatting when processing a message" do
+    action_message = Fabricate(:chat_message, message: "/me waves")
+
+    described_class.new.execute(chat_message_id: action_message.id)
+
+    expect(action_message.reload.cooked).to match_html(
+      %(<p><em class="chat-message-action">#{action_message.user.username} waves</em></p>),
+    )
+  end
+
   context "when the cooked message changed" do
     it "publishes the update" do
       chat_message.update!(cooked: "another lovely cat")

--- a/plugins/chat/spec/serializer/chat/chat_message_serializer_spec.rb
+++ b/plugins/chat/spec/serializer/chat/chat_message_serializer_spec.rb
@@ -51,6 +51,16 @@ describe Chat::MessageSerializer do
     end
   end
 
+  describe "#is_action" do
+    it "identifies action slash commands" do
+      message_1.update!(message: "/me waves")
+      expect(serializer.as_json[:is_action]).to eq(true)
+
+      message_1.update!(message: "/shrug")
+      expect(serializer.as_json[:is_action]).to eq(false)
+    end
+  end
+
   describe "#user" do
     context "when user has been destroyed" do
       it "returns a placeholder user" do

--- a/plugins/chat/test/javascripts/components/chat-message-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-message-test.gjs
@@ -98,6 +98,47 @@ module("Component | ChatMessage", function (hooks) {
     assert.dom(".chat-message-container.-not-interactive").exists();
   });
 
+  test("Action messages render without user info and break message grouping", async function (assert) {
+    const fabricators = new ChatFabricators(getOwner(this));
+    const channel = fabricators.channel();
+    const user = new CoreFabricators(getOwner(this)).user();
+    const actionMessage = fabricators.message({
+      channel,
+      user,
+      is_action: true,
+      cooked: `<p><em class="chat-message-action">${user.username} waves</em></p>`,
+      created_at: "2026-07-29T12:00:00Z",
+    });
+    const nextMessage = fabricators.message({
+      channel,
+      user,
+      cooked: "<p>Hello again</p>",
+      created_at: "2026-07-29T12:01:00Z",
+    });
+
+    channel.messagesManager.addMessages([actionMessage, nextMessage]);
+    actionMessage.manager = channel.messagesManager;
+    nextMessage.manager = channel.messagesManager;
+
+    this.message = actionMessage;
+    await render(
+      <template><ChatMessage @message={{this.message}} /></template>
+    );
+
+    assert.dom(".chat-message-avatar").doesNotExist();
+    assert.dom(".chat-message-info").doesNotExist();
+    assert.dom(".chat-message-left-gutter").exists();
+
+    await clearRender();
+    this.message = nextMessage;
+    await render(
+      <template><ChatMessage @message={{this.message}} /></template>
+    );
+
+    assert.dom(".chat-message-avatar").exists();
+    assert.dom(".chat-message-info").exists();
+  });
+
   test("Message with streaming", async function (assert) {
     // admin
     this.currentUser.admin = true;


### PR DESCRIPTION
## Why

Chat action messages already include the author name in the cooked action text, but the message row also rendered the normal avatar and username header. This duplicated the author and made `/me` actions look like ordinary messages rather than standalone IRC-style actions.

## What changed

- Serialize whether a chat message is an action command.
- Hide the normal avatar and username header for action messages while preserving the left gutter and message controls.
- Treat actions as message-group boundaries so a following normal message restores its avatar and username.
- Keep action state synchronized when staged messages are persisted or existing messages are edited.

The message remains associated with its author internally for moderation, editing, reactions, and other message actions.

## Tests

- Serializer coverage for action and non-action slash commands.
- Component coverage for standalone action rendering and the following message grouping behavior.
- Background processing coverage to ensure action formatting is preserved when the message is recooked.

<img width="493" height="237" alt="chat-slash-me-4" src="https://github.com/user-attachments/assets/31232df4-9273-49ac-9bf6-2cad523ba92d" />
