### PR TITLE
UX: Remove duplicate sign-in CTA in embed mode empty state

### DIFF
--- a/frontend/discourse/app/components/embed-mode-composer.gjs
+++ b/frontend/discourse/app/components/embed-mode-composer.gjs
@@ -82,6 +82,10 @@ export default class EmbedModeComposer extends Component {
     if (!EmbedMode.enabled || this.currentUser) {
       return false;
     }
+    // The empty-state footer already renders its own login CTA
+    if (!this.args.topic?.replyCount) {
+      return false;
+    }
     return this.embedAuthFlow.isActive;
   }
 


### PR DESCRIPTION
**Previously**, an anonymous user viewing an embedded topic with no replies saw two login buttons: the empty state's "Log In to Reply" and the docked "Sign in to reply" CTA.

**In this update**, the docked CTA is hidden when the topic has no replies, since the empty state already offers a login button. It still renders on topics that have replies, where the empty state isn't shown.

| Before | After |
| --- | --- |
| ![before](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/before-0lox7p.png) | ![after](https://github.com/discourse/discourse/releases/download/_gh-attach-assets/after-cuirxm.png) |