### PR TITLE
FIX: Allow bbcode to be used in rich text editor without being escaped

### DIFF
--- a/frontend/discourse/app/static/prosemirror/core/serializer.js
+++ b/frontend/discourse/app/static/prosemirror/core/serializer.js
@@ -13,6 +13,14 @@ export default class Serializer {
       state.write(state.inTable ? "<br>" : "\n");
 
     this.nodes.text = (state, node) => {
+      // A text run whose entire content is a single `[..]` pair comes from
+      // typed BBCode (e.g. `[details="Summary"]`, `[/details]`, `[spoiler]`).
+      // Escaping the brackets to `\[..\]` would let discourse-math's LaTeX
+      // delimiter mode consume the line as display math and lose the BBCode.
+      if (/^\s*\[[^\]]*\]\s*$/.test(node.text)) {
+        state.text(node.text, false);
+        return;
+      }
       state.text(node.text, !state.inAutolink);
     };
 

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-markdown-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/prosemirror-markdown-test.js
@@ -164,6 +164,28 @@ module(
           "`hello -- world`",
         ],
       ],
+      // Typed BBCode-shaped text runs like [details="Summary"] must round-trip
+      // without backslash-escaping the brackets — otherwise `\[..\]` would be
+      // picked up as LaTeX display math when discourse-math is enabled.
+      "bbcode-shaped text": [
+        [
+          '[details="Summary"]',
+          '<p>[details="Summary"]</p>',
+          '[details="Summary"]',
+        ],
+        ["[/details]", "<p>[/details]</p>", "[/details]"],
+        ["[spoiler]", "<p>[spoiler]</p>", "[spoiler]"],
+        ["[quote user]", "<p>[quote user]</p>", "[quote user]"],
+      ],
+      // Brackets that don't wrap a single tag-like run are still escaped so
+      // literal `[text](url)` and similar don't turn into unintended links.
+      "brackets in mixed text": [
+        [
+          "text with \\[brackets\\] inside",
+          "<p>text with [brackets] inside</p>",
+          "text with \\[brackets\\] inside",
+        ],
+      ],
     };
 
     Object.entries(testCases).forEach(([name, tests]) => {


### PR DESCRIPTION
There was a quirk with the rich text editor where if you typed a bbcode tag (e.g. `[details="Summary"]`, `[/details]`, `[spoiler]`) and then hit enter, the brackets would be escaped to `\[..\]`. This was because the serializer was treating the entire text run as a single text node and escaping it.

This is as designed in ProseMirror but does not play nice with the way Discourse uses bbcode in its markdown. It was really apparent when using the discourse-math plugin because the LaTeX delimiter mode would consume the line as display math and lose the bbcode.