### PR TITLE
FIX: add guard to prevent jobs from running (#42140)

### DIFF
--- a/plugins/discourse-gamification/jobs/scheduled/update_scores_for_ten_days.rb
+++ b/plugins/discourse-gamification/jobs/scheduled/update_scores_for_ten_days.rb
@@ -5,6 +5,7 @@ module Jobs
     every 1.day
 
     def execute(args = nil)
+      return unless SiteSetting.discourse_gamification_enabled
       DiscourseGamification::GamificationScore.calculate_scores(since_date: 10.days.ago.midnight)
     end
   end

--- a/plugins/discourse-gamification/jobs/scheduled/update_scores_for_today.rb
+++ b/plugins/discourse-gamification/jobs/scheduled/update_scores_for_today.rb
@@ -5,6 +5,7 @@ module Jobs
     every 1.hour
 
     def execute(args = nil)
+      return unless SiteSetting.discourse_gamification_enabled
       DiscourseGamification::GamificationScore.calculate_scores
 
       DiscourseGamification::LeaderboardCachedView.purge_all_stale

--- a/plugins/discourse-gamification/spec/jobs/update_scores_for_ten_days_spec.rb
+++ b/plugins/discourse-gamification/spec/jobs/update_scores_for_ten_days_spec.rb
@@ -16,6 +16,7 @@ describe Jobs::UpdateScoresForTenDays do
   end
 
   before do
+    SiteSetting.discourse_gamification_enabled = true
     topic_user_created.update(created_at: 8.days.ago)
     topic_user_2_created.update(created_at: 12.days.ago)
   end

--- a/plugins/discourse-gamification/spec/jobs/update_scores_for_today_spec.rb
+++ b/plugins/discourse-gamification/spec/jobs/update_scores_for_today_spec.rb
@@ -20,7 +20,10 @@ describe Jobs::UpdateScoresForToday do
     described_class.new.execute
   end
 
-  before { topic_user_2_created.update(created_at: 2.days.ago) }
+  before do
+    SiteSetting.discourse_gamification_enabled = true
+    topic_user_2_created.update(created_at: 2.days.ago)
+  end
 
   it "updates all scores for today" do
     expect(DiscourseGamification::GamificationScore.find_by(user_id: user.id).score).to eq(0)


### PR DESCRIPTION
- Gamification jobs shouldn't run unless the site setting is enabled