### PR TITLE
FIX: Reviewable Insights Metadata

### DIFF
--- a/app/serializers/reviewable_serializer.rb
+++ b/app/serializers/reviewable_serializer.rb
@@ -26,8 +26,8 @@ class ReviewableSerializer < ApplicationSerializer
 
   attribute :status_for_database, key: :status
 
-  has_one :created_by, serializer: UserWithCustomFieldsSerializer, root: "users"
   has_one :target_created_by, root: "users"
+  has_one :created_by, serializer: UserWithCustomFieldsSerializer, root: "users"
   has_one :target_deleted_by, serializer: BasicUserSerializer, root: "users"
   has_one :topic, serializer: ListableTopicSerializer
   has_many :editable_fields, serializer: ReviewableEditableFieldSerializer, embed: :objects

--- a/spec/serializers/reviewable_serializer_spec.rb
+++ b/spec/serializers/reviewable_serializer_spec.rb
@@ -67,6 +67,17 @@ RSpec.describe ReviewableSerializer do
       json = described_class.new(reviewable_user, scope: Guardian.new(admin), root: nil).as_json
       expect(json[:target_created_by_id]).to eq(reviewable_user.target.id)
     end
+
+    it "includes FlaggedUserSerializer fields when the flagger is also the post author" do
+      post = Fabricate(:post, user: admin)
+      reviewable = PostActionCreator.off_topic(admin, post).reviewable
+
+      json = ReviewableFlaggedPostSerializer.new(reviewable, scope: Guardian.new(admin)).as_json
+      target_user = json["users"].find { |u| u[:id] == admin.id }
+
+      expect(target_user).to be_present
+      expect(target_user).to include(:created_at, :post_count, :trust_level)
+    end
   end
 
   describe "target_deleted_by" do


### PR DESCRIPTION
Previously, the reviewable insights metadata was not being serialized correctly for admin users that flagged their own posts. There was a conflict with the order of the `has_one` associations in the `ReviewableSerializer`. When an admin flagged their own post, the user was identical for both the `target_created_by` and `created_by` attributes. This silently dropped the `target_created_by` attribute, resulting in broken metadata (join date, post count) for the flagged post.

This commit reordered the `has_one` associations in the `ReviewableSerializer` to ensure that `target_created_by` is serialized before `created_by`.