### PR TITLE
DEV: Switch letter avatar generation, topic OG image generation and dominant color detection to use libvips

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -395,31 +395,38 @@ class Upload < ActiveRecord::Base
 
       color ||=
         begin
-          data =
-            ImageMagick.magick(
+          Dir.mktmpdir("dominant-color") do |directory|
+            pixel = File.join(directory, "pixel.raw")
+
+            # Produce one raw pixel whose color channels represent the image's dominant color.
+            Vips.run(
+              "vips",
+              "thumbnail",
               local_path,
-              "-depth",
-              "8",
-              "-resize",
-              "1x1",
-              "-define",
-              "histogram:unique-colors=true",
-              "-format",
-              "%c",
-              "histogram:info:",
+              pixel,
+              "1",
+              "--height",
+              "1",
+              "--size",
+              "force",
               read: [local_path],
+              write: [directory],
               nice: 10,
               timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS,
             )
 
-          # Output format:
-          # 1: (110.873,116.226,93.8821) #6F745E srgb(43.4798%,45.5789%,36.8165%)
+            components = File.binread(pixel).bytes
+            rgb =
+              case components.length
+              when 1, 2
+                [components.first] * 3
+              when 3, 4
+                components.first(3)
+              end
+            raise "Calculated dominant color but unable to read the output pixel" if rgb.nil?
 
-          color = data[/#([0-9A-F]{6})/, 1]
-
-          raise "Calculated dominant color but unable to parse output:\n#{data}" if color.nil?
-
-          color
+            rgb.map { |component| component.to_s(16).rjust(2, "0") }.join.upcase
+          end
         rescue Discourse::Utils::CommandError
           # Timeout or unable to parse image
           # This can happen due to bad user input - ignore and save

--- a/docs/developer-guides/docs/02-development-environments/04-macos-setup.md
+++ b/docs/developer-guides/docs/02-development-environments/04-macos-setup.md
@@ -24,6 +24,7 @@ You will need the following packages on your system:
 - [Redis][redis_link]
 - [Node.js][node_link]
 - [pnpm][pnpm_link]
+- [libvips][libvips_link]
 - [MailHog][mh_link]\*\*
 - [ImageMagick][imagemagick_link]\*\*
 
@@ -139,6 +140,7 @@ Happy hacking! And to get started with that, see [Beginner’s Guide to Creating
 [pg_link]: http://www.postgresql.org/
 [sqlite_link]: https://sqlite.org/
 [redis_link]: http://redis.io/
+[libvips_link]: https://www.libvips.org/install.html
 [imagemagick_link]: http://www.imagemagick.org/
 [pnpm_link]: https://pnpm.io/
 [mh_link]: https://github.com/mailhog/MailHog

--- a/docs/developer-guides/docs/02-development-environments/05-ubuntu-debian-setup.md
+++ b/docs/developer-guides/docs/02-development-environments/05-ubuntu-debian-setup.md
@@ -40,6 +40,7 @@ You will need the following packages on your system:
 - [Redis][redis_link]
 - [Node.js][node_link]
 - [pnpm][pnpm_link]
+- [libvips][libvips_link]
 - [MailHog][mh_link]\*\*
 - [ImageMagick][imagemagick_link]\*\*
 
@@ -145,6 +146,7 @@ Happy hacking! And to get started with that, see [Beginner’s Guide to Creating
 [pg_link]: http://www.postgresql.org/
 [sqlite_link]: https://sqlite.org/
 [redis_link]: http://redis.io/
+[libvips_link]: https://www.libvips.org/install.html
 [imagemagick_link]: http://www.imagemagick.org/
 [pnpm_link]: https://pnpm.io/
 [mh_link]: https://github.com/mailhog/MailHog

--- a/docs/developer-guides/docs/02-development-environments/06-windows-10-setup.md
+++ b/docs/developer-guides/docs/02-development-environments/06-windows-10-setup.md
@@ -34,6 +34,7 @@ You will need the following packages on your system:
 - [Redis][redis_link]
 - [Node.js][node_link]
 - [pnpm][pnpm_link]
+- [libvips][libvips_link]
 - [MailHog][mh_link]\*\*
 - [ImageMagick][imagemagick_link]\*\*
 
@@ -511,6 +512,7 @@ _Last Reviewed by @SaraDev on [date=2022-06-15 time=19:00:00 timezone="America/L
 [pg_link]: http://www.postgresql.org/
 [sqlite_link]: https://sqlite.org/
 [redis_link]: http://redis.io/
+[libvips_link]: https://www.libvips.org/install.html
 [imagemagick_link]: http://www.imagemagick.org/
 [pnpm_link]: https://pnpm.io/
 [mh_link]: https://github.com/mailhog/MailHog

--- a/docs/developer-guides/docs/02-development-environments/10-fedora-setup.md
+++ b/docs/developer-guides/docs/02-development-environments/10-fedora-setup.md
@@ -12,7 +12,7 @@ If you're looking to install Discourse for a **production environment**, prefer 
 
 ```sh
 sudo dnf update
-sudo dnf install -y "@development-tools" git rpm-build zlib-devel ruby-devel readline-devel libpq-devel ImageMagick sqlite sqlite-devel nodejs npm curl gcc g++ bzip2 openssl-devel libyaml-devel libffi-devel zlib-devel gdbm-devel ncurses-devel optipng pngquant jhead jpegoptim gifsicle oxipng
+sudo dnf install -y "@development-tools" git rpm-build zlib-devel ruby-devel readline-devel libpq-devel ImageMagick vips-tools sqlite sqlite-devel nodejs npm curl gcc g++ bzip2 openssl-devel libyaml-devel libffi-devel zlib-devel gdbm-devel ncurses-devel optipng pngquant jhead jpegoptim gifsicle oxipng
 ```
 
 **Install required npm packages**

--- a/lib/discourse.rb
+++ b/lib/discourse.rb
@@ -1305,7 +1305,7 @@ module Discourse
         require "actionview_precompiler"
         ActionviewPrecompiler.precompile
       end,
-      Thread.new { LetterAvatar.image_magick_version },
+      Thread.new { LetterAvatar.vips_version },
       Thread.new { SvgSprite.core_svgs },
       Thread.new { EmberAssets.script_chunks(exception: false) },
       Thread.new do

--- a/lib/letter_avatar.rb
+++ b/lib/letter_avatar.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "erb"
+
 class LetterAvatar
   class Identity
     attr_accessor :color, :letter
@@ -16,15 +18,19 @@ class LetterAvatar
   end
 
   # BUMP UP if avatar algorithm changes
-  VERSION = 5
+  VERSION = 6
 
   # CHANGE these values to support more pixel ratios
   FULLSIZE = 120 * 3
   POINTSIZE = 280
+  SVG_TEXT_BASELINE = 245
+  private_constant :SVG_TEXT_BASELINE
+  FONT_LIST_TIMEOUT_SECONDS = 10
+  private_constant :FONT_LIST_TIMEOUT_SECONDS
 
   class << self
     def version
-      "#{VERSION}_#{image_magick_version}"
+      "#{VERSION}_#{vips_version}"
     end
 
     def cache_path
@@ -47,10 +53,7 @@ class LetterAvatar
         fullsize = fullsize_path(identity)
         generate_fullsize(identity) if !cache || !File.exist?(fullsize)
 
-        # Optimizing here is dubious, it can save up to 2x for large images (eg 359px)
-        # BUT... we are talking 2400 bytes down to 1200 bytes, both fit in one packet
-        # The cost of this is huge, its a 40% perf hit
-        OptimizedImage.resize(fullsize, filename, size, size)
+        resize(fullsize, filename, size)
 
         filename
       end
@@ -68,57 +71,50 @@ class LetterAvatar
 
     def generate_fullsize(identity)
       color = identity.color
-      letter = identity.letter
-
       filename = fullsize_path(identity)
 
-      # Use NimbusSans-Regular, except for macOS where it is unavailable, use Helvetica there
-      font = RbConfig::CONFIG["host_os"].match?(/darwin/i) ? "Helvetica" : "NimbusSans-Regular"
-      # and adjust vertical offset accordingly
-      vertical_offset = font == "Helvetica" ? 26 : 34
+      Tempfile.create(%w[letter-avatar .svg]) do |svg|
+        svg.write(svg_for(identity))
+        svg.flush
 
-      instructions = %W[
-        -size
-        #{FULLSIZE}x#{FULLSIZE}
-        xc:#{to_rgb(color)}
-        -pointsize
-        #{POINTSIZE}
-        -fill
-        #FFFFFFCC
-        -font
-        #{font}
-        -gravity
-        Center
-        -annotate
-        -0+#{vertical_offset}
-        #{letter}
-        -depth
-        8
-        #{filename}
-      ]
-
-      ImageMagick.magick(*instructions, write: [File.dirname(filename)])
-
-      ## do not optimize image, it will end up larger than original
+        Vips.run(
+          "vips",
+          "flatten",
+          svg.path,
+          filename,
+          "--background",
+          color.join(" "),
+          read: [svg.path],
+          write: [File.dirname(filename)],
+          allow_untrusted: true,
+        )
+      end
       filename
     end
 
-    def to_rgb(color)
-      r, g, b = color
-      "rgb(#{r},#{g},#{b})"
-    end
+    def vips_version
+      return @vips_version if @vips_version
 
-    def image_magick_version
-      @image_magick_version ||=
-        begin
-          Thread.new do
-            sleep 2
-            cleanup_old
-          end
-          Digest::MD5.hexdigest(
-            ImageMagick.magick("--version") << ImageMagick.magick("-list", "font"),
+      fonts =
+        Discourse::Utils
+          .execute_command(
+            "fc-list",
+            "--format",
+            "%{file}\t%{family}\t%{style}\t%{fontversion}\n",
+            timeout: FONT_LIST_TIMEOUT_SECONDS,
           )
-        end
+          .lines
+          .sort
+          .join
+      @vips_version =
+        Digest::MD5.hexdigest([VERSION.to_s, Vips.run("vips", "--version"), fonts].join("\0"))
+
+      Thread.new do
+        sleep 2
+        cleanup_old
+      end
+
+      @vips_version
     end
 
     def cleanup_old
@@ -131,6 +127,71 @@ class LetterAvatar
         end
     rescue Errno::ENOENT
       # no worries, folder doesn't exists
+    end
+
+    private
+
+    def resize(from, to, size)
+      profile = Rails.root.join("vendor/data/RT_sRGB.icm").to_s
+      output = "#{to}[palette,Q=100,compression=6,strip]"
+
+      Tempfile.create(%w[letter-avatar-resized .png], binmode: true) do |resized|
+        resized.close
+        Vips.run(
+          "vips",
+          "thumbnail",
+          from,
+          "#{resized.path}[compression=6,strip]",
+          size.to_s,
+          "--height",
+          size.to_s,
+          "--size",
+          "both",
+          "--crop",
+          "centre",
+          "--output-profile",
+          profile,
+          read: [from, profile],
+          write: [resized.path],
+          nice: 10,
+        )
+        Vips.run(
+          "vips",
+          "sharpen",
+          resized.path,
+          output,
+          "--sigma",
+          "0.5",
+          "--m1",
+          "0.7",
+          read: [resized.path],
+          write: [File.dirname(to)],
+          nice: 10,
+        )
+      end
+    end
+
+    def svg_for(identity)
+      color = identity.color.join(",")
+      letter = ERB::Util.html_escape(identity.letter)
+      baseline = SVG_TEXT_BASELINE + vertical_offset
+
+      <<~SVG
+        <svg xmlns="http://www.w3.org/2000/svg" width="#{FULLSIZE}" height="#{FULLSIZE}" viewBox="0 0 #{FULLSIZE} #{FULLSIZE}">
+          <rect width="#{FULLSIZE}" height="#{FULLSIZE}" fill="rgb(#{color})"/>
+          <text x="#{FULLSIZE / 2}" y="#{baseline}" fill="white" fill-opacity="0.8" font-family="#{font_family}" font-size="#{POINTSIZE}" text-anchor="middle" dominant-baseline="central">#{letter}</text>
+        </svg>
+      SVG
+    end
+
+    # Use Helvetica on macOS because Nimbus Sans is unavailable there.
+    def font_family
+      RbConfig::CONFIG["host_os"].match?(/darwin/i) ? "Helvetica" : "Nimbus Sans"
+    end
+
+    # Helvetica needs a larger offset to keep the glyph vertically centered.
+    def vertical_offset
+      font_family == "Helvetica" ? 26 : 34
     end
   end
 

--- a/lib/topic_og_image_generator.rb
+++ b/lib/topic_og_image_generator.rb
@@ -42,7 +42,7 @@ class TopicOgImageGenerator
 
   private
 
-  def build_svg(asset_directory: nil)
+  def build_svg
     title = truncated_title
     category_name = @topic.category&.name || ""
     category_color = @topic.category&.color || "888888"
@@ -52,7 +52,7 @@ class TopicOgImageGenerator
     colors = fetch_colors
     logo_upload = SiteSetting.logo.presence || SiteSetting.logo_small
     logo_data_uri = fetch_as_data_uri(logo_upload&.url)
-    logo_path = materialize_asset(logo_data_uri, directory: asset_directory, basename: "logo")
+    logo_path = logo_data_uri
 
     title_lines = word_wrap(title, TITLE_LINE_CHARS)
     truncated = title_lines.length > MAX_TITLE_LINES
@@ -75,7 +75,7 @@ class TopicOgImageGenerator
     author = @topic.user
     avatar_data_uri =
       author ? fetch_as_data_uri(author.avatar_template_url.gsub("{size}", "120")) : nil
-    avatar_path = materialize_asset(avatar_data_uri, directory: asset_directory, basename: "avatar")
+    avatar_path = avatar_data_uri
     username = author&.username
     created_at = @topic.created_at&.strftime("%b %-d, %Y")
 
@@ -311,50 +311,6 @@ class TopicOgImageGenerator
     "#{Discourse.base_url_no_prefix}#{url}"
   end
 
-  def materialize_asset(data_uri, directory:, basename:)
-    return data_uri if directory.nil? || data_uri.blank?
-
-    match = data_uri.match(%r{\Adata:(image/[a-z0-9.+-]+);base64,(.+)\z}m)
-    return nil if match.nil?
-
-    content_type = match[1]
-    bytes = Base64.strict_decode64(match[2])
-
-    if content_type == "image/svg+xml"
-      svg_path = File.join(directory, "#{basename}.svg")
-      png_path = File.join(directory, "#{basename}.png")
-      File.binwrite(svg_path, bytes)
-      ImageMagick.magick(
-        "MSVG:#{svg_path}",
-        png_path,
-        read: [svg_path],
-        write: [directory],
-        timeout: 10,
-      )
-      return png_path if File.exist?(png_path)
-
-      return nil
-    end
-
-    extension =
-      { "image/gif" => "gif", "image/jpeg" => "jpg", "image/png" => "png", "image/webp" => "webp" }[
-        content_type
-      ]
-    return nil if extension.nil?
-
-    path = File.join(directory, "#{basename}.#{extension}")
-    File.binwrite(path, bytes)
-    path
-  rescue ArgumentError, Discourse::Utils::CommandError => error
-    Discourse.warn(
-      "Failed to materialize topic OG image asset",
-      topic_id: @topic.id,
-      asset: basename,
-      error: error.message,
-    )
-    nil
-  end
-
   def escape_xml(text)
     text
       .to_s
@@ -370,23 +326,18 @@ class TopicOgImageGenerator
       svg_path = File.join(dir, "og.svg")
       png_path = File.join(dir, "og.png")
 
-      File.write(svg_path, build_svg(asset_directory: dir))
+      File.write(svg_path, build_svg)
 
-      ImageMagick.magick(
-        "-background",
-        "none",
-        "-size",
-        "#{OG_WIDTH}x#{OG_HEIGHT}",
-        "MSVG:#{svg_path}",
-        "-depth",
-        "8",
-        "-define",
-        "png:compression-level=9",
-        png_path,
+      Vips.run(
+        "vips",
+        "flatten",
+        svg_path,
+        "#{png_path}[compression=9]",
         read: [dir],
         write: [dir],
         nice: 10,
         timeout: 20,
+        allow_untrusted: true,
       )
 
       return nil unless File.exist?(png_path)

--- a/lib/vips.rb
+++ b/lib/vips.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+class Vips
+  DEFAULT_TIMEOUT = 30
+  private_constant :DEFAULT_TIMEOUT
+
+  RLIMITS = {
+    cpu_seconds: 300,
+    memory_bytes: 4 * 1024 * 1024 * 1024,
+    file_size_bytes: 10 * 1024 * 1024 * 1024,
+    open_files: 1024,
+  }.freeze
+  private_constant :RLIMITS
+
+  def self.run(
+    *command,
+    read: [],
+    write: [],
+    timeout: nil,
+    nice: nil,
+    allow_untrusted: false,
+    failure_message: ""
+  )
+    command = ["nice", "-n", nice.to_s, *command] if nice
+    Dir.mktmpdir("discourse-vips-") do |scratch|
+      environment = {
+        **ENV.slice("PATH", "LANG", "LC_ALL"),
+        "TMPDIR" => scratch,
+        "HOME" => scratch,
+        "XDG_CACHE_HOME" => scratch,
+        "MALLOC_ARENA_MAX" => "2",
+      }
+      # libvips permits operations marked untrusted by default. Block them unless explicitly allowed.
+      # See https://github.com/libvips/libvips/blob/v8.18.2/doc/developer-checklist.md#L101-L104
+      environment["VIPS_BLOCK_UNTRUSTED"] = "1" if !allow_untrusted
+
+      Discourse::SafeExec.capture(
+        *command,
+        env: environment,
+        unsetenv_others: true,
+        read: [*Discourse::SafeExec.default_read_paths, *read],
+        write: [scratch, *write],
+        execute: Discourse::SafeExec.default_execute_paths,
+        timeout: timeout || DEFAULT_TIMEOUT,
+        rlimits: RLIMITS,
+        failure_message:,
+        seccomp_deny_network: true,
+      )
+    end
+  end
+end

--- a/spec/lib/topic_og_image_generator_spec.rb
+++ b/spec/lib/topic_og_image_generator_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe TopicOgImageGenerator do
   describe "#generate" do
     it "generates a PNG upload for a topic" do
       generator = described_class.new(topic)
-      # Stub the ImageMagick rasterization: rendering an SVG to PNG depends on the
-      # ImageMagick/font setup of the host, which isn't reliable across CI and dev
-      # environments. Here we assert that #generate turns rendered bytes into a
-      # proper PNG Upload.
       generator.stubs(:render_png).returns(File.binread(file_from_fixtures("logo.png").path))
       upload = generator.generate
 
@@ -98,11 +94,6 @@ RSpec.describe TopicOgImageGenerator do
         .with("/invalid-logo.svg")
         .returns(invalid_svg_data_uri)
       described_class.any_instance.stubs(:fetch_as_data_uri).with(avatar_url).returns(nil)
-      Discourse.expects(:warn).with(
-        "Failed to materialize topic OG image asset",
-        has_entries(topic_id: topic.id, asset: "logo"),
-      )
-
       png = ChunkyPNG::Image.from_blob(described_class.new(topic).generate_bytes)
 
       expect([png.width, png.height]).to eq([1200, 630])

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -930,12 +930,6 @@ RSpec.describe Upload do
     let(:white_image) { Fabricate(:image_upload, color: "white") }
     let(:red_image) { Fabricate(:image_upload, color: "red") }
     let(:high_color_image) { Fabricate(:image_upload, color: "#000A00F00", color_depth: 16) }
-    let(:tiny_image) do
-      upload = Fabricate(:upload, extension: "png")
-      file = file_from_fixtures("cropped.png")
-      upload.update!(url: Discourse.store.store_upload(file, upload))
-      upload
-    end
     let(:not_an_image) do
       upload = Fabricate(:upload)
 
@@ -967,24 +961,8 @@ RSpec.describe Upload do
       expect(red_image.dominant_color).to eq("FF0000")
 
       expect(high_color_image.dominant_color).to eq(nil)
-      # original is: #000A00F00
-      # downsamples to: #009FEF
-      # A00 is closer to 9F than A0
-      # EF is closer to F00 than F0
-      expect(high_color_image.dominant_color(calculate_if_missing: true)).to eq("009FEF")
-      expect(high_color_image.dominant_color).to eq("009FEF")
-
-      uncached_tiny_color = tiny_image.dominant_color
-
-      expect(uncached_tiny_color).to eq(nil)
-
-      calculated_tiny_color = tiny_image.dominant_color(calculate_if_missing: true)
-
-      expect(calculated_tiny_color).to eq("524F40")
-
-      cached_tiny_color = tiny_image.dominant_color
-
-      expect(cached_tiny_color).to eq(calculated_tiny_color)
+      expect(high_color_image.dominant_color(calculate_if_missing: true)).to eq("00A0F0")
+      expect(high_color_image.dominant_color).to eq("00A0F0")
     end
 
     it "can be backfilled" do
@@ -1033,16 +1011,16 @@ RSpec.describe Upload do
       expect(invalid_image.dominant_color).to eq("")
     end
 
-    it "correctly handles unparsable ImageMagick output" do
-      ImageMagick.stubs(:magick).returns("someinvalidoutput")
+    it "raises when vips produces a pixel with an unexpected number of channels" do
+      expect(white_image.dominant_color).to eq(nil)
 
-      expect(invalid_image.dominant_color).to eq(nil)
+      Vips.stubs(:run)
+      File.stubs(:binread).returns("\0" * 5)
 
-      expect { invalid_image.dominant_color(calculate_if_missing: true) }.to raise_error(
-        /Calculated dominant color but unable to parse output/,
+      expect { white_image.dominant_color(calculate_if_missing: true) }.to raise_error(
+        "Calculated dominant color but unable to read the output pixel",
       )
-
-      expect(invalid_image.dominant_color).to eq(nil)
+      expect(white_image.dominant_color).to eq(nil)
     end
 
     it "correctly handles error when file is too large to download" do


### PR DESCRIPTION
We are migrating Discourse image processing from ImageMagick to libvips so the ImageMagick dependency can be removed in a future change.

This first step moves the low-risk operations like letter avatar generation and resizing, upload dominant-color extraction, and generated topic OG images to a single sandboxed vips CLI runner. 

### Reviewer notes

#### Letter avatar visual comparison (AI report)

The ImageMagick and Vips implementations were compared in the same published production image:

`discourse/base:2.0.20260731-0206@sha256:55d36eeb4d12f5b2dd01c9b0dad8293fe11af8d7b1755ad3d930e35bbccd5280`

- Before: ImageMagick on `origin/main` (`2bfb79d6aadb1b4a3559aa758ead031afedba634`)
- After: Vips on this branch (`5e94c650fa5fb5115aea91bfd059c421ccc52c43`)
- Sizes: every default configured size (`24, 48, 72, 96, 144, 288`), explicit core call-site size (`25, 40, 45, 90, 120`), and the `360` master size
- Inputs: A–Z through the same `Identity.from_username` path used by reachable internal letter-avatar inputs
- Images are shown at exact intrinsic dimensions with no magnification or `image-rendering` override
- Vips sharpening uses `sigma=0.5` and `m1=0.7`. These settings were selected empirically to preserve the legacy visual weight; they are not a mathematical translation of ImageMagick's unsharp parameters.
- All 312 A–Z outputs were inspected across the 12 sizes. No glyph reaches an image edge, and the background corner pixels are unchanged by sharpening.
- At 45px, where the softness was most visible, sharpening reduces the mean normalized RMSE against ImageMagick from `0.01149` to `0.00882`.
- No Vips concurrency restriction was applied

[Open the self-contained native-size comparison](https://tgxworld.github.io/discourse-vips/letter-avatar-f68f5b1/)
