### PR TITLE
FIX: Show all languages for 'Languages I understand'

### DIFF
--- a/frontend/discourse/app/components/modal/content-language-preferences.gjs
+++ b/frontend/discourse/app/components/modal/content-language-preferences.gjs
@@ -10,7 +10,6 @@ import {
   AUTOMATICALLY_TRANSLATE_COOKIE,
   AUTOMATICALLY_TRANSLATE_COOKIE_EXPIRY,
   automaticallyTranslate,
-  contentLanguageOptions,
   normalizeUnderstoodLanguages,
 } from "discourse/lib/content-localization";
 import cookie from "discourse/lib/cookie";
@@ -49,19 +48,6 @@ export default class ContentLanguagePreferencesModal extends Component {
       value,
       id: value,
     }));
-  }
-
-  get understoodLanguageOptions() {
-    const interfaceLanguage =
-      this.formApi?.get("interfaceLanguage") ?? this.data.interfaceLanguage;
-    const understoodLanguages =
-      this.formApi?.get("understoodLanguages") ?? this.data.understoodLanguages;
-
-    return contentLanguageOptions(
-      this.interfaceLanguageOptions,
-      this.siteSettings.available_content_localization_locales,
-      [interfaceLanguage, ...understoodLanguages]
-    );
   }
 
   get canChangeInterfaceLanguage() {
@@ -211,7 +197,7 @@ export default class ContentLanguagePreferencesModal extends Component {
                 <MultiSelect
                   @valueProperty="value"
                   @langProperty="value"
-                  @content={{this.understoodLanguageOptions}}
+                  @content={{this.interfaceLanguageOptions}}
                   @value={{field.value}}
                   @onChange={{field.set}}
                   @mandatoryValues={{transientData.interfaceLanguage}}

--- a/frontend/discourse/app/controllers/preferences/interface.js
+++ b/frontend/discourse/app/controllers/preferences/interface.js
@@ -14,10 +14,7 @@ import {
   SEND_SHORTCUT_ENTER,
   SEND_SHORTCUT_META_ENTER,
 } from "discourse/lib/constants";
-import {
-  contentLanguageOptions,
-  normalizeUnderstoodLanguages,
-} from "discourse/lib/content-localization";
+import { normalizeUnderstoodLanguages } from "discourse/lib/content-localization";
 import { deepEqual } from "discourse/lib/object";
 import {
   currentThemeId,
@@ -134,19 +131,6 @@ export default class InterfaceController extends Controller {
       ...locale,
       id: locale.value,
     }));
-  }
-
-  @computed(
-    "model.locale",
-    "model.user_option.understood_languages.[]",
-    "siteSettings.available_content_localization_locales"
-  )
-  get understoodLanguageOptions() {
-    return contentLanguageOptions(
-      this.availableLocales,
-      this.siteSettings.available_content_localization_locales,
-      this.understoodLanguages
-    );
   }
 
   @action

--- a/frontend/discourse/app/lib/content-localization.js
+++ b/frontend/discourse/app/lib/content-localization.js
@@ -9,19 +9,6 @@ export function normalizeUnderstoodLanguages(languages, interfaceLanguage) {
   ];
 }
 
-export function contentLanguageOptions(
-  availableLocales,
-  supportedLocales,
-  retainedLocales = []
-) {
-  const allowedLocales = new Set([
-    ...(supportedLocales ?? []).map((locale) => locale.value ?? locale),
-    ...retainedLocales,
-  ]);
-
-  return availableLocales.filter((locale) => allowedLocales.has(locale.value));
-}
-
 export function automaticallyTranslate(currentUser) {
   if (currentUser) {
     return currentUser.user_option?.automatically_translate ?? true;

--- a/frontend/discourse/app/templates/preferences/interface.gjs
+++ b/frontend/discourse/app/templates/preferences/interface.gjs
@@ -177,7 +177,7 @@ export default <template>
           @id="understood-languages-selector"
           @valueProperty="value"
           @langProperty="value"
-          @content={{@controller.understoodLanguageOptions}}
+          @content={{@controller.availableLocales}}
           @value={{@controller.understoodLanguages}}
           @onChange={{@controller.setUnderstoodLanguages}}
           @mandatoryValues={{@controller.interfaceLanguage}}

--- a/frontend/discourse/tests/unit/lib/content-localization-test.js
+++ b/frontend/discourse/tests/unit/lib/content-localization-test.js
@@ -3,7 +3,6 @@ import { module, test } from "qunit";
 import {
   AUTOMATICALLY_TRANSLATE_COOKIE,
   automaticallyTranslate,
-  contentLanguageOptions,
   normalizeUnderstoodLanguages,
 } from "discourse/lib/content-localization";
 import cookie, { removeCookie } from "discourse/lib/cookie";
@@ -61,35 +60,6 @@ module("Unit | Lib | content-localization", function (hooks) {
       normalizeUnderstoodLanguages(["en"], "ja"),
       ["ja", "en"],
       "it inserts a missing interface language"
-    );
-  });
-
-  test("limits understood language choices without hiding retained values", function (assert) {
-    const availableLocales = [
-      { name: "English", value: "en", id: "en" },
-      { name: "Deutsch", value: "de", id: "de" },
-      { name: "Français", value: "fr", id: "fr" },
-      { name: "日本語", value: "ja", id: "ja" },
-    ];
-
-    assert.deepEqual(
-      contentLanguageOptions(
-        availableLocales,
-        [{ value: "en" }, { value: "ja" }],
-        ["de", "fr"]
-      ),
-      availableLocales,
-      "it includes the interface language and saved values outside the current site setting"
-    );
-
-    assert.deepEqual(
-      contentLanguageOptions(
-        availableLocales,
-        [{ value: "en" }, { value: "ja" }],
-        ["de"]
-      ).map(({ value }) => value),
-      ["en", "de", "ja"],
-      "a removed saved value is no longer offered"
     );
   });
 });

--- a/spec/system/content_localization_spec.rb
+++ b/spec/system/content_localization_spec.rb
@@ -95,6 +95,7 @@ describe "Content Localization" do
       expect(preferences_interface_page).to have_interface_language_section
       expect(preferences_interface_page).to have_content_languages_section
       expect(preferences_interface_page).to have_locked_understood_language
+      expect(preferences_interface_page).to have_understood_language_option("de")
       expect(preferences_interface_page).to be_automatic_translation_enabled
 
       preferences_interface_page.disable_automatic_translation.save_changes
@@ -131,6 +132,7 @@ describe "Content Localization" do
       expect(modal).to have_logged_in_language_controls
       expect(modal).to have_understood_languages_description
       expect(modal).to have_locked_understood_language
+      expect(modal).to have_understood_language_option("de")
       expect(modal).to be_automatic_translation_enabled
       modal.close
 

--- a/spec/system/page_objects/modals/content_language_preferences.rb
+++ b/spec/system/page_objects/modals/content_language_preferences.rb
@@ -40,6 +40,18 @@ module PageObjects
         )
       end
 
+      def has_understood_language_option?(locale)
+        understood_languages_dropdown.expand
+        result =
+          has_css?(
+            "#{full_modal_selector} " \
+              ".form-kit__field[data-name='understoodLanguages'] " \
+              ".select-kit-row[data-value='#{locale}']",
+          )
+        understood_languages_dropdown.collapse
+        result
+      end
+
       def has_locked_understood_language?
         understood_languages_dropdown.expand
         result =

--- a/spec/system/page_objects/pages/user_preferences_interface.rb
+++ b/spec/system/page_objects/pages/user_preferences_interface.rb
@@ -70,6 +70,14 @@ module PageObjects
         result
       end
 
+      def has_understood_language_option?(locale)
+        understood_languages_dropdown.expand
+        result =
+          page.has_css?("#understood-languages-selector .select-kit-row[data-value='#{locale}']")
+        understood_languages_dropdown.collapse
+        result
+      end
+
       def has_locked_understood_language?(language = nil)
         understood_languages_dropdown.expand
         result =


### PR DESCRIPTION
A post may be of any language origin, therefore we should not limit this dropdown to only the languages that "content localization" feature _translates to_.

<img width="622" height="622" alt="Screenshot 2026-07-30 at 2 56 27 PM" src="https://github.com/user-attachments/assets/9675d9c0-518e-4a5e-8e2c-4a5c9edb58bb" />
