### PR TITLE
DEV: Fold boolean mode handling into the expression wrapper

### DIFF
--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/boolean-control.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/boolean-control.gjs
@@ -1,6 +1,4 @@
 import Component from "@glimmer/component";
-import { fn } from "@ember/helper";
-import { action } from "@ember/object";
 import {
   fieldFormat,
   fieldShowDescription,
@@ -11,23 +9,6 @@ import {
   propertyPlaceholder,
 } from "../../../lib/workflows/property-engine";
 import ExpressionWrapper from "./expression-wrapper";
-
-function valueForModeToggle(value) {
-  if (value === null || value === undefined) {
-    return "";
-  }
-
-  return String(value);
-}
-
-function booleanValueForPlainMode(value) {
-  const plainValue = value.startsWith("=") ? value.slice(1) : value;
-  // Unwrap literal expressions so "={{ true }}" round-trips to a plain true.
-  const literal =
-    plainValue.trim().match(/^\{\{\s*(.*?)\s*\}\}$/)?.[1] ?? plainValue;
-
-  return ["true", "1"].includes(literal.trim().toLowerCase());
-}
 
 export default class BooleanControl extends Component {
   // Derived, not tracked, so a dropped variable flips the mode.
@@ -68,47 +49,27 @@ export default class BooleanControl extends Component {
     return this.args.schema?.required ? "required" : undefined;
   }
 
-  @action
-  onModeChange(field, value) {
-    const wantsDynamic = value === "dynamic";
-    // Guards on the field, not `expressionMode`, which is false without a `@configuration`.
-    if (wantsDynamic === isExpression(field.value)) {
-      return;
-    }
-
-    const currentValue = valueForModeToggle(field.value);
-
-    if (wantsDynamic) {
-      field.set(
-        currentValue.startsWith("=") ? currentValue : `=${currentValue}`
-      );
-    } else {
-      field.set(booleanValueForPlainMode(currentValue));
-    }
-  }
-
   <template>
     {{#if this.expressionMode}}
       <@form.Field
         @name={{@fieldName}}
         @title={{this.label}}
-        @showTitle={{true}}
+        @tooltip={{this.tooltip}}
         @showOptional={{@showOptional}}
         @type="custom"
         @format={{this.format}}
+        @validation={{this.validation}}
         @onSet={{@onSet}}
         as |field|
       >
         <field.Control>
           <ExpressionWrapper
-            @expressionMode={{true}}
             @field={{field}}
             @schema={{@schema}}
             @placeholder={{this.placeholder}}
             @supportsExpression={{this.supportsExpression}}
             @dynamicValueHint={{@dynamicValueHint}}
             @session={{@session}}
-            @onModeChange={{fn this.onModeChange field}}
           />
         </field.Control>
       </@form.Field>
@@ -117,20 +78,18 @@ export default class BooleanControl extends Component {
         @name={{@fieldName}}
         @title={{this.label}}
         @tooltip={{this.tooltip}}
+        @showOptional={{@showOptional}}
         @type="toggle"
         @format={{this.format}}
-        @showOptional={{@showOptional}}
         @validation={{this.validation}}
+        @onSet={{@onSet}}
         as |field|
       >
         <ExpressionWrapper
-          @expressionMode={{false}}
           @field={{field}}
           @schema={{@schema}}
           @supportsExpression={{this.supportsExpression}}
           @session={{@session}}
-          @modeControlClass="--toggle"
-          @onModeChange={{fn this.onModeChange field}}
         >
           <field.Control />
         </ExpressionWrapper>

--- a/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-wrapper.gjs
+++ b/plugins/discourse-workflows/admin/assets/javascripts/admin/components/workflows/configurators/expression-wrapper.gjs
@@ -127,6 +127,11 @@ function plainValueForModeToggle(value, schema = {}) {
     return plainArrayValueForModeToggle(value);
   }
 
+  if (type === "boolean") {
+    const literal = wholeExpressionBody(value) ?? value.slice(1);
+    return ["true", "1"].includes(literal.trim().toLowerCase());
+  }
+
   const body = wholeExpressionBody(value);
   if (body) {
     const parsedLiteral = parseJsonLiteral(body);
@@ -153,24 +158,11 @@ export default class ExpressionWrapper extends Component {
   }
 
   get expressionMode() {
-    if (this.args.expressionMode !== undefined) {
-      return Boolean(this.args.expressionMode);
-    }
-
     return isExpression(this.args.field?.value);
-  }
-
-  get modeItems() {
-    return this.args.modeItems || MODE_ITEMS;
   }
 
   @action
   toggleMode(value) {
-    if (this.args.onModeChange) {
-      this.args.onModeChange(value);
-      return;
-    }
-
     const wantsDynamic = value === "dynamic";
     if (wantsDynamic === this.expressionMode) {
       return;
@@ -278,14 +270,11 @@ export default class ExpressionWrapper extends Component {
 
       {{#if @supportsExpression}}
         <DSegmentedControl
-          @items={{this.modeItems}}
+          @items={{MODE_ITEMS}}
           @value={{if this.expressionMode "dynamic" "plain"}}
           @onSelect={{this.toggleMode}}
           @size="small"
-          class={{dConcatClass
-            "workflows-property-engine__mode-control"
-            @modeControlClass
-          }}
+          class="workflows-property-engine__mode-control"
         />
       {{/if}}
     </div>

--- a/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator.scss
+++ b/plugins/discourse-workflows/assets/stylesheets/common/configurator/configurator.scss
@@ -112,6 +112,10 @@
     position: relative;
     width: 100%;
 
+    > .d-toggle-switch {
+      justify-content: flex-end;
+    }
+
     > .combo-box,
     > .d-select,
     > .icon-picker,
@@ -130,7 +134,7 @@
     transform: translateY(-100%);
     inset-inline-end: 0;
 
-    &.--toggle {
+    .form-kit__field-toggle & {
       inset-block-start: 50%;
       transform: translateY(-50%);
       inset-inline-end: 50px;

--- a/plugins/discourse-workflows/test/javascripts/integration/components/workflows/boolean-control-test.gjs
+++ b/plugins/discourse-workflows/test/javascripts/integration/components/workflows/boolean-control-test.gjs
@@ -66,8 +66,8 @@ module("Integration | Component | workflows boolean control", function (hooks) {
 
     assert.dom(".form-kit__control-toggle").exists();
     assert
-      .dom(".workflows-property-engine__mode-control")
-      .hasClass("--toggle", "positions the switcher alongside the toggle");
+      .dom(".form-kit__field-toggle .workflows-property-engine__mode-control")
+      .exists("positions the switcher inside the toggle field");
   });
 
   test("switches to expression mode", async function (assert) {


### PR DESCRIPTION
Stacked on `workflows-boolean-assignment-expressions` — only the last commit is new. Meant as follow-ups to review together with (or fold into) that branch before it ships.

Previously, `BooleanControl` kept a local copy of the plain/dynamic value conversion (so fixes to `ExpressionWrapper`'s converters silently did not apply to booleans), the wrapper carried `@expressionMode`/`@modeItems`/`@onModeChange`/`@modeControlClass` override hooks that only this one control used, and the full-width control wrapper defeated FormKit's end-alignment — the plain toggle sat stranded mid-row with the mode switcher at the far edge.

This change folds the boolean conversion into `plainValueForModeToggle` beside the existing array handling (preserving the `={{ true }}` literal round-trip your tests pin down), removes the now-unused wrapper hooks, derives the switcher positioning in CSS from FormKit's own `form-kit__field-toggle` class instead of a component arg, and re-aligns the toggle flush to the field's end.

All the tests on the base branch pass unchanged except one assertion updated to the new positioning contract (`--toggle` class → rendered inside `form-kit__field-toggle`).