### PR TITLE
FIX: Don't duplicate the poll title in emails

### DIFF
--- a/plugins/poll/plugin.rb
+++ b/plugins/poll/plugin.rb
@@ -101,10 +101,6 @@ after_initialize do
         .each do |poll|
           html = +""
 
-          if title = poll.at_css(".poll-title")
-            html << title.to_html
-          end
-
           if container = poll.at_css(".poll-container")
             container.css("li").each { |li| li.remove_attribute("data-poll-option-id") }
             html << container.inner_html

--- a/plugins/poll/spec/lib/pretty_text_spec.rb
+++ b/plugins/poll/spec/lib/pretty_text_spec.rb
@@ -138,14 +138,18 @@ RSpec.describe PrettyText do
       [/poll]
     MD
 
-    html = PrettyText.format_for_email(post.cooked, post)
-    expect(html).to include("Tabs")
-    expect(html).to include("Spaces")
-    expect(html).to include("Whatever my cat walks on the keyboard")
-    expect(html).to include(I18n.t("poll.email.link_to_poll"))
+    expect(PrettyText.format_for_email(post.cooked, post)).to match_html(<<~HTML)
+      <p>A post with a poll</p>
+      <ul>
+      <li>Tabs</li>
+      <li>Spaces</li>
+      <li>Whatever my cat walks on the keyboard</li>
+      </ul>
+      <p><a href="#{post.full_url}">#{I18n.t("poll.email.link_to_poll")}</a></p>
+    HTML
   end
 
-  it "includes poll title when formatting for email" do
+  it "includes the poll title only once when formatting for email" do
     post = Fabricate(:post, raw: <<~MD)
       [poll]
       # Best bug fix excuse?
@@ -154,11 +158,45 @@ RSpec.describe PrettyText do
       [/poll]
     MD
 
-    html = PrettyText.format_for_email(post.cooked, post)
-    expect(html).to include("Best bug fix excuse?")
-    expect(html).to include("It works on my machine")
-    expect(html).to include("That is not a bug, it is a feature")
-    expect(html).to include(I18n.t("poll.email.link_to_poll"))
+    expect(PrettyText.format_for_email(post.cooked, post)).to match_html(<<~HTML)
+      <div class="poll-title">Best bug fix excuse?</div>
+      <ul>
+      <li>It works on my machine</li>
+      <li>That is not a bug, it is a feature</li>
+      </ul>
+      <p><a href="#{post.full_url}">#{I18n.t("poll.email.link_to_poll")}</a></p>
+    HTML
+  end
+
+  it "includes every poll of a multi-poll post when formatting for email" do
+    post = Fabricate(:post, raw: <<~MD)
+      [poll name=first]
+      # Tabs or spaces?
+      * Tabs
+      * Spaces
+      [/poll]
+
+      [poll name=second type=multiple]
+      # Cats or dogs?
+      * Cats
+      * Dogs
+      [/poll]
+    MD
+
+    expect(PrettyText.format_for_email(post.cooked, post)).to match_html(<<~HTML)
+      <div class="poll-title">Tabs or spaces?</div>
+      <ul>
+      <li>Tabs</li>
+      <li>Spaces</li>
+      </ul>
+      <p><a href="#{post.full_url}">#{I18n.t("poll.email.link_to_poll")}</a></p>
+      <div class="poll-title">Cats or dogs?</div>
+      <ul>
+      <li>Cats</li>
+      <li>Dogs</li>
+      </ul>
+      <p><a href="#{post.full_url}">#{I18n.t("poll.email.link_to_poll")}</a></p>
+    HTML
   end
 
   it "can reduce excerpts" do


### PR DESCRIPTION
Previously, the `reduce_cooked` handler appended the `.poll-title` element and then the inner HTML of `.poll-container`. Since the markdown rule nests the title inside that container, every poll's title showed up twice in HTML emails — and, since they share the same code path, in digests, embedded comments and RSS feeds too.

This change drops the redundant append, leaving the container as the single source of the poll's content, and tightens the email specs to assert on the whole reduced fragment rather than with `include`, which a duplicate satisfies just as well as a single copy.

https://meta.discourse.org/t/408875