### PR TITLE
UX: UC: composer redesign > prevent accidental clicks to close expanded editor

### DIFF
--- a/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
+++ b/app/assets/stylesheets/common/upcoming-changes/uc-enable-composer-redesign.scss
@@ -36,6 +36,14 @@
 
   .reply-area {
     padding: 0 !important;
+
+    @include viewport.until(sm) {
+      &:has(.d-editor-textarea-wrapper.in-focus) {
+        .reply-to {
+          pointer-events: none;
+        }
+      }
+    }
   }
 
   .composer-controls {


### PR DESCRIPTION
Intercepts clicks on the visible top element to avoid accidental clicks when trying to close the expanded editor.