### PR TITLE
UX: Remove update priority handling in version checks

### DIFF
--- a/app/assets/stylesheets/admin/dashboard.scss
+++ b/app/assets/stylesheets/admin/dashboard.scss
@@ -689,14 +689,6 @@
     }
   }
 
-  &.critical .version-notes .normal-note {
-    display: none;
-  }
-
-  &.normal .version-notes .critical-note {
-    display: none;
-  }
-
   .face .fa {
     font-size: var(--font-up-4);
   }

--- a/app/jobs/scheduled/call_discourse_hub.rb
+++ b/app/jobs/scheduled/call_discourse_hub.rb
@@ -15,7 +15,6 @@ module Jobs
           DiscourseUpdates.latest_version = json["latestVersion"]
           DiscourseUpdates.latest_pretty_version = json["latestPrettyVersion"]
           DiscourseUpdates.latest_sha = json["latestSha"]
-          DiscourseUpdates.critical_updates_available = json["criticalUpdates"]
           DiscourseUpdates.missing_versions_count = json["missingVersionsCount"]
           DiscourseUpdates.updated_at = Time.zone.now
           DiscourseUpdates.missing_versions = json["versions"]

--- a/app/models/discourse_version_check.rb
+++ b/app/models/discourse_version_check.rb
@@ -6,7 +6,6 @@ class DiscourseVersionCheck
   attr_accessor :latest_version,
                 :latest_pretty_version,
                 :latest_sha,
-                :critical_updates,
                 :installed_version,
                 :installed_sha,
                 :installed_describe,

--- a/app/serializers/discourse_version_check_serializer.rb
+++ b/app/serializers/discourse_version_check_serializer.rb
@@ -4,7 +4,6 @@ class DiscourseVersionCheckSerializer < ApplicationSerializer
   attributes :latest_version,
              :latest_pretty_version,
              :latest_sha,
-             :critical_updates,
              :installed_version,
              :installed_sha,
              :installed_describe,

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7190,7 +7190,6 @@ en:
         up_to_date_newer_commits:
           one: "You're on the most recent release, but %{count} new change is available."
           other: "You're on the most recent release, but %{count} new changes are available."
-        critical_available: "A critical update is available."
         updates_available: "Updates are available."
         please_update: "Please update!"
         no_check_performed: "A check for updates has not been performed. Ensure Sidekiq is running."

--- a/frontend/discourse/admin/components/version-checks.gjs
+++ b/frontend/discourse/admin/components/version-checks.gjs
@@ -12,10 +12,7 @@ const VersionChecks = <template>
     </h2>
   </div>
 
-  <div
-    class="dashboard-stats version-check
-      {{if @versionCheck.critical_updates 'critical' 'normal'}}"
-  >
+  <div class="dashboard-stats version-check">
     <div class="version-number">
       <h4>
         {{i18n "admin.dashboard.installed_version"}}
@@ -157,14 +154,7 @@ const VersionChecks = <template>
               {{dIcon "far-face-smile"}}
             </span>
           {{else}}
-            <span
-              class="icon
-                {{if
-                  @versionCheck.critical_updates
-                  'critical-updates-available'
-                  'updates-available'
-                }}"
-            >
+            <span class="icon updates-available">
               {{#if @versionCheck.behindByOneVersion}}
                 {{dIcon "far-face-meh"}}
               {{else}}
@@ -184,12 +174,7 @@ const VersionChecks = <template>
               {{i18n "admin.dashboard.up_to_date"}}
             {{/if}}
           {{else}}
-            <span class="critical-note">
-              {{i18n "admin.dashboard.critical_available"}}
-            </span>
-            <span class="normal-note">
-              {{i18n "admin.dashboard.updates_available"}}
-            </span>
+            {{i18n "admin.dashboard.updates_available"}}
             {{i18n "admin.dashboard.please_update"}}
           {{/if}}
         </div>

--- a/lib/discourse_updates.rb
+++ b/lib/discourse_updates.rb
@@ -16,7 +16,6 @@ module DiscourseUpdates
           latest_version: latest_version,
           latest_pretty_version: latest_pretty_version,
           latest_sha: latest_sha,
-          critical_updates: critical_updates_available?,
           missing_versions_count: missing_versions_count,
         )
       end
@@ -46,10 +45,7 @@ module DiscourseUpdates
           Jobs.enqueue(:call_discourse_hub, all_sites: true)
           version_info.version_check_pending = true
 
-          unless version_info.updated_at.nil?
-            version_info.missing_versions_count = 0
-            version_info.critical_updates = false
-          end
+          version_info.missing_versions_count = 0 unless version_info.updated_at.nil?
         end
 
         version_info.stale_data =
@@ -99,14 +95,6 @@ module DiscourseUpdates
 
     def missing_versions_count=(arg)
       Discourse.redis.set(missing_versions_count_key, arg)
-    end
-
-    def critical_updates_available?
-      (Discourse.redis.get(critical_updates_available_key) || false) == "true"
-    end
-
-    def critical_updates_available=(arg)
-      Discourse.redis.set(critical_updates_available_key, arg)
     end
 
     def updated_at
@@ -332,7 +320,6 @@ module DiscourseUpdates
         latest_version_key,
         latest_pretty_version_key,
         latest_sha_key,
-        critical_updates_available_key,
         missing_versions_count_key,
         updated_at_key,
         missing_versions_list_key,
@@ -375,10 +362,6 @@ module DiscourseUpdates
 
     def latest_sha_key
       "discourse_latest_sha"
-    end
-
-    def critical_updates_available_key
-      "critical_updates_available"
     end
 
     def missing_versions_count_key

--- a/spec/jobs/call_discourse_hub_spec.rb
+++ b/spec/jobs/call_discourse_hub_spec.rb
@@ -23,11 +23,10 @@ RSpec.describe Jobs::CallDiscourseHub do
         DiscourseHub.stubs(:discourse_version_check).returns(
           {
             "latestVersion" => "2026.3.1",
-            "criticalUpdates" => false,
             "missingVersionsCount" => 2,
             "versions" => [
-              { "version" => "2026.3.1", "notes" => "Latest release", "critical" => true },
-              { "version" => "2026.2.5", "notes" => "Security patch", "critical" => false },
+              { "version" => "2026.3.1", "notes" => "Latest release" },
+              { "version" => "2026.2.5", "notes" => "Security patch" },
             ],
           },
         )

--- a/spec/lib/discourse_hub_spec.rb
+++ b/spec/lib/discourse_hub_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe DiscourseHub do
   describe ".discourse_version_check" do
     it "should return just return the json that the hub returns" do
-      hub_response = { "success" => "OK", "latest_version" => "0.8.1", "critical_updates" => false }
+      hub_response = { "success" => "OK", "latest_version" => "0.8.1" }
 
       stub_request(
         :get,

--- a/spec/lib/discourse_updates_spec.rb
+++ b/spec/lib/discourse_updates_spec.rb
@@ -16,10 +16,9 @@ RSpec.describe DiscourseUpdates do
     end
   end
 
-  def stub_data(latest, missing, critical, updated_at)
+  def stub_data(latest, missing, updated_at)
     DiscourseUpdates.latest_version = latest
     DiscourseUpdates.missing_versions_count = missing
-    DiscourseUpdates.critical_updates_available = critical
     DiscourseUpdates.updated_at = updated_at
   end
 
@@ -47,12 +46,11 @@ RSpec.describe DiscourseUpdates do
     context "when a good version check request happened recently" do
       context "when server is up-to-date" do
         let(:time) { 12.hours.ago }
-        before { stub_data(Discourse::VERSION::STRING, 0, false, time) }
+        before { stub_data(Discourse::VERSION::STRING, 0, time) }
 
         it "returns all the version fields" do
           expect(version.latest_version).to eq(Discourse::VERSION::STRING)
           expect(version.missing_versions_count).to eq(0)
-          expect(version.critical_updates).to eq(false)
           expect(version.installed_version).to eq(Discourse::VERSION::STRING)
           expect(version.stale_data).to eq(false)
         end
@@ -64,12 +62,11 @@ RSpec.describe DiscourseUpdates do
 
       context "when server is not up-to-date" do
         let(:time) { 12.hours.ago }
-        before { stub_data("0.9.0", 2, false, time) }
+        before { stub_data("0.9.0", 2, time) }
 
         it "returns all the version fields" do
           expect(version.latest_version).to eq("0.9.0")
           expect(version.missing_versions_count).to eq(2)
-          expect(version.critical_updates).to eq(false)
           expect(version.installed_version).to eq(Discourse::VERSION::STRING)
         end
 
@@ -80,7 +77,7 @@ RSpec.describe DiscourseUpdates do
     end
 
     context "when a version check has never been performed" do
-      before { stub_data(nil, nil, false, nil) }
+      before { stub_data(nil, nil, nil) }
 
       it "returns the installed version" do
         expect(version.installed_version).to eq(Discourse::VERSION::STRING)
@@ -94,7 +91,6 @@ RSpec.describe DiscourseUpdates do
       it "does not return latest version info" do
         expect(version.latest_version).to eq(nil)
         expect(version.missing_versions_count).to eq(nil)
-        expect(version.critical_updates).to eq(nil)
       end
 
       it "queues a version check" do
@@ -120,12 +116,12 @@ RSpec.describe DiscourseUpdates do
       end
 
       context "when installed is latest" do
-        before { stub_data(Discourse::VERSION::STRING, 1, false, 8.hours.ago) }
+        before { stub_data(Discourse::VERSION::STRING, 1, 8.hours.ago) }
         include_examples "queue version check and report that version is ok"
       end
 
       context "when installed does not match latest version, but missing_versions_count is 0" do
-        before { stub_data("0.10.10.123", 0, false, 8.hours.ago) }
+        before { stub_data("0.10.10.123", 0, 8.hours.ago) }
         include_examples "queue version check and report that version is ok"
       end
     end
@@ -149,12 +145,12 @@ RSpec.describe DiscourseUpdates do
     end
 
     context "when missing_versions_count is 0" do
-      before { stub_data("0.9.7", 0, false, 8.hours.ago) }
+      before { stub_data("0.9.7", 0, 8.hours.ago) }
       include_examples "when last_installed_version is old"
     end
 
     context "when missing_versions_count is not 0" do
-      before { stub_data("0.9.7", 1, false, 8.hours.ago) }
+      before { stub_data("0.9.7", 1, 8.hours.ago) }
       include_examples "when last_installed_version is old"
     end
   end
@@ -664,7 +660,7 @@ RSpec.describe DiscourseUpdates do
     end
 
     it "exposes the latest pretty version and sha from the version check" do
-      stub_data(Discourse::VERSION::STRING, 0, false, 12.hours.ago)
+      stub_data(Discourse::VERSION::STRING, 0, 12.hours.ago)
       DiscourseUpdates.latest_pretty_version = "#{Discourse::VERSION::STRING} +444"
       DiscourseUpdates.latest_sha = "abc1234def5678"
 

--- a/spec/requests/admin/versions_controller_spec.rb
+++ b/spec/requests/admin/versions_controller_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Admin::VersionsController do
     Jobs::CallDiscourseHub.any_instance.stubs(:execute).returns(true)
     DiscourseUpdates.stubs(:updated_at).returns(2.hours.ago)
     DiscourseUpdates.stubs(:latest_version).returns("1.2.33")
-    DiscourseUpdates.stubs(:critical_updates_available?).returns(false)
   end
 
   describe "#show" do


### PR DESCRIPTION
Previously, api.dicourse.org would track whether an update is 'critical' or not, and then change the color/design of the 'update available' indicator in the dashboard. These flags have not always been set reliably, and the extra complexity is not worth maintaining. If an admin wants to find out what's included in an update, we now have a clear changelog linked from the dashboard.