### PR TITLE
DEV: Accept group ids when importing agents

### DIFF
--- a/plugins/discourse-ai/app/services/discourse_ai/agent_exporter.rb
+++ b/plugins/discourse-ai/app/services/discourse_ai/agent_exporter.rb
@@ -50,6 +50,7 @@ module DiscourseAi
           name: ai_agent.name,
           description: ai_agent.description,
           system_prompt: ai_agent.system_prompt,
+          allowed_group_ids: ai_agent.allowed_group_ids,
           examples: ai_agent.examples,
           temperature: ai_agent.temperature,
           top_p: ai_agent.top_p,

--- a/plugins/discourse-ai/app/services/discourse_ai/agent_importer.rb
+++ b/plugins/discourse-ai/app/services/discourse_ai/agent_importer.rb
@@ -45,6 +45,11 @@ module DiscourseAi
           response_format: agent_data["response_format"],
           tools: transform_tools_for_import(agent_data["tools"], tool_name_to_id),
         }
+        if agent_data.key?("allowed_group_ids")
+          attrs[:allowed_group_ids] = Array(agent_data["allowed_group_ids"]).filter_map do |id|
+            Integer(id, exception: false)
+          end
+        end
         mcp_server_assignments = resolve_mcp_server_assignments(agent_data["mcp_servers"])
 
         if existing_agent && overwrite

--- a/plugins/discourse-ai/spec/services/discourse_ai/agent_exporter_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/agent_exporter_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe DiscourseAi::AgentExporter do
 
       it "returns JSON containing the agent and its custom tool" do
         expect(export_json["agent"]["name"]).to eq(ai_agent.name)
+        expect(export_json["agent"]["allowed_group_ids"]).to eq(ai_agent.allowed_group_ids)
         expect(export_json["agent"]["tools"].first.first).to eq("custom-#{ai_tool.tool_name}")
 
         custom_tool = export_json["custom_tools"].first

--- a/plugins/discourse-ai/spec/services/discourse_ai/agent_importer_spec.rb
+++ b/plugins/discourse-ai/spec/services/discourse_ai/agent_importer_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe DiscourseAi::AgentImporter do
           secret_contracts: [{ alias: "giphy_api_key" }],
         )
       end
-      fab!(:ai_agent) { Fabricate(:ai_agent, tools: [["custom-#{ai_tool.id}", nil, false]]) }
+      fab!(:ai_agent) do
+        Fabricate(
+          :ai_agent,
+          allowed_group_ids: [Group::AUTO_GROUPS[:staff]],
+          tools: [["custom-#{ai_tool.id}", nil, false]],
+        )
+      end
 
       let!(:export_json) { DiscourseAi::AgentExporter.new(agent: ai_agent).export }
 
@@ -25,6 +31,7 @@ RSpec.describe DiscourseAi::AgentImporter do
         agent = importer.import!
 
         expect(agent).to be_persisted
+        expect(agent.allowed_group_ids).to eq([Group::AUTO_GROUPS[:staff]])
         expect(agent.tools.first.first).to start_with("custom-")
 
         tool_id = agent.tools.first.first.split("-", 2).last.to_i
@@ -111,6 +118,7 @@ RSpec.describe DiscourseAi::AgentImporter do
           name: "Test Agent",
           description: "New description",
           system_prompt: "New prompt",
+          allowed_group_ids: [Group::AUTO_GROUPS[:staff]],
           tools: [
             ["custom-#{existing_tool.id}", nil, false],
             ["custom-#{new_tool.id}", nil, false],
@@ -129,6 +137,7 @@ RSpec.describe DiscourseAi::AgentImporter do
         expect(agent.id).to eq(existing_agent.id)
         expect(agent.description).to eq("New description")
         expect(agent.system_prompt).to eq("New prompt")
+        expect(agent.allowed_group_ids).to eq([Group::AUTO_GROUPS[:staff]])
         expect(agent.tools.length).to eq(2)
       end
 


### PR DESCRIPTION
This includes allowed groups in exported agent JSON and restores them on import.