### PR TITLE
FIX: Keep the selected option in Safari when `DSelect` options re-render

### DIFF
--- a/frontend/discourse/app/ui-kit/d-select.gjs
+++ b/frontend/discourse/app/ui-kit/d-select.gjs
@@ -3,32 +3,45 @@ import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { isNone } from "@ember/utils";
-import { eq } from "discourse/truth-helpers";
+import { modifier } from "ember-modifier";
 import { i18n } from "discourse-i18n";
 
 export const NO_VALUE_OPTION = "__NONE__";
 
+function optionValue(value) {
+  return isNone(value) ? NO_VALUE_OPTION : String(value);
+}
+
+const claimSelectedAfterRender = modifier((element, [selected]) => {
+  if (selected) {
+    element.selected = true;
+  }
+});
+
 export class DSelectOption extends Component {
   get value() {
-    return isNone(this.args.value) ? NO_VALUE_OPTION : this.args.value;
+    return optionValue(this.args.value);
+  }
+
+  get isSelected() {
+    return optionValue(this.args.selected) === this.value;
   }
 
   <template>
     {{! https://github.com/emberjs/ember.js/issues/19115 }}
-    {{#if (eq @selected @value)}}
-      <option
-        class="d-select__option --selected"
-        value={{this.value}}
-        selected
-        ...attributes
-      >
-        {{yield}}
-      </option>
-    {{else}}
-      <option class="d-select__option" value={{this.value}} ...attributes>
-        {{yield}}
-      </option>
-    {{/if}}
+    <option
+      class={{if
+        this.isSelected
+        "d-select__option --selected"
+        "d-select__option"
+      }}
+      value={{this.value}}
+      selected={{this.isSelected}}
+      {{claimSelectedAfterRender this.isSelected}}
+      ...attributes
+    >
+      {{yield}}
+    </option>
   </template>
 }
 
@@ -69,7 +82,10 @@ export default class DSelect extends Component {
       {{on "input" this.handleInput}}
     >
       {{#if this.includeNone}}
-        <DSelectOption @value={{NO_VALUE_OPTION}}>
+        <DSelectOption
+          @value={{NO_VALUE_OPTION}}
+          @selected={{this.htmlSelectValue}}
+        >
           {{#if @nonePlaceholder}}
             {{@nonePlaceholder}}
           {{else}}

--- a/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
+++ b/frontend/discourse/tests/integration/components/setting-definition-field-test.gjs
@@ -460,9 +460,7 @@ module("Integration | Component | SettingDefinitionField", function (hooks) {
       </template>
     );
 
-    assert
-      .dom("[data-name='my_enum'] select option[value='5']")
-      .hasAttribute("selected");
+    assert.form().field("my_enum").hasValue("5");
   });
 
   test("compact_list offers created entries again after they are removed", async function (assert) {

--- a/frontend/discourse/tests/integration/ui-kit/d-select-test.gjs
+++ b/frontend/discourse/tests/integration/ui-kit/d-select-test.gjs
@@ -1,4 +1,5 @@
-import { render, select } from "@ember/test-helpers";
+import { tracked } from "@glimmer/tracking";
+import { render, select, settled } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 import DSelect, { NO_VALUE_OPTION } from "discourse/ui-kit/d-select";
@@ -52,6 +53,73 @@ module("Integration | ui-kit | DSelect", function (hooks) {
       value: "foo",
       label: "The real foo",
     });
+  });
+
+  test("keeps the selection when options are rebuilt", async function (assert) {
+    class State {
+      @tracked
+      options = [
+        { value: "foo", label: "The real foo" },
+        { value: "bar", label: "The real bar" },
+      ];
+    }
+
+    const state = new State();
+
+    await render(
+      <template>
+        <DSelect @value="bar" as |s|>
+          {{#each state.options as |option|}}
+            <s.Option @value={{option.value}}>{{option.label}}</s.Option>
+          {{/each}}
+        </DSelect>
+      </template>
+    );
+
+    assert.dselect().hasSelectedOption({
+      value: "bar",
+      label: "The real bar",
+    });
+
+    state.options = [
+      { value: "baz", label: "The real baz" },
+      { value: "foo", label: "The real foo" },
+      { value: "bar", label: "The real bar" },
+    ];
+    await settled();
+
+    assert.dselect().hasSelectedOption({
+      value: "bar",
+      label: "The real bar",
+    });
+  });
+
+  test("keeps the selection when the value is not a string", async function (assert) {
+    class State {
+      @tracked value = 30;
+    }
+
+    const state = new State();
+    const handleChange = (value) => (state.value = value);
+
+    await render(
+      <template>
+        <DSelect
+          @includeNone={{false}}
+          @value={{state.value}}
+          @onChange={{handleChange}}
+          as |s|
+        >
+          <s.Option @value={{1}}>One</s.Option>
+          <s.Option @value={{30}}>Thirty</s.Option>
+          <s.Option @value={{90}}>Ninety</s.Option>
+        </DSelect>
+      </template>
+    );
+
+    await select(".d-select", "90");
+
+    assert.dselect().hasSelectedOption({ value: "90", label: "Ninety" });
   });
 
   test("required field", async function (assert) {


### PR DESCRIPTION
Previously, in Safari, a `DSelect` whose options were re-rendered visually reset to its first option — WebKit deselects a freshly inserted `<option selected>` while the old selected node is still present (the spec's "last selected option wins" arbitration), then falls back to the first option once it's removed. Nothing re-asserts the value afterwards, since the `value` binding on the `<select>` can't (https://github.com/emberjs/ember.js/issues/19115). In the workflows Filter node this looked like changing one condition's operator updated every condition of the same type: each rebuilt select showed its first option, which happened to be the operator the user had just picked.

This change renders `DSelectOption` as a single `<option>` driven by the `selected` DOM property — a dynamic binding for in-place updates plus a `claimSelectedAfterRender` modifier that re-claims selection after the render settles, i.e. once the old option nodes are gone — which survives WebKit's arbitration and fixes every `DSelect`/FormKit select in Safari. The `selected` attribute consequently no longer appears in the DOM, so the one test asserting it now checks the select's value. CI runs Chrome only (where the freshly inserted option already wins), so the new "keeps the selection when options are rebuilt" test pins the invariant cross-browser while the WebKit behavior was verified directly.