### PR TITLE
FIX: Settle rate-limited workflow-call children through failure path

### DIFF
--- a/plugins/discourse-workflows/lib/discourse_workflows/workflow_call_continuation.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/workflow_call_continuation.rb
@@ -124,7 +124,7 @@ module DiscourseWorkflows
 
         if execution.waiting?
           claimed.update!(child_execution_id: execution.id, status: :waiting)
-        elsif execution.error? || execution.rate_limited? || execution.skipped?
+        elsif execution.error? || execution.rate_limited?
           child_failed!(execution)
         end
       rescue => e

--- a/plugins/discourse-workflows/lib/discourse_workflows/workflow_call_continuation.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/workflow_call_continuation.rb
@@ -122,7 +122,11 @@ module DiscourseWorkflows
           )
         execution = executor.run
 
-        claimed.update!(child_execution_id: execution.id, status: :waiting) if execution.waiting?
+        if execution.waiting?
+          claimed.update!(child_execution_id: execution.id, status: :waiting)
+        elsif execution.error? || execution.rate_limited? || execution.skipped?
+          child_failed!(execution)
+        end
       rescue => e
         fail_run!(claimed || run, e.message)
       end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/workflow_call_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/workflow_call_spec.rb
@@ -510,6 +510,36 @@ RSpec.describe DiscourseWorkflows::Nodes::WorkflowCall::V1 do
       expect(run).to be_error
     end
 
+    context "when rate limiting is enabled" do
+      before { RateLimiter.enable }
+      after { RateLimiter.disable }
+
+      it "fails the parent when a child execution is rate limited before it starts" do
+        SiteSetting.discourse_workflows_max_executions_per_minute_per_workflow = 1
+        target = callable_workflow_with_set_fields([assignment("called", "yes")])
+        caller = caller_workflow_for(target)
+
+        warmup_execution = execute_workflow(target, trigger_node_id: "call-trigger")
+        expect(warmup_execution).to be_success
+
+        execution = execute_workflow(caller)
+        expect_parent_waiting_at_call(execution)
+        run_workflow_call_jobs
+
+        execution.reload
+        call_step = execution.execution_data.find_step(node_id: "call-1")
+        run = DiscourseWorkflows::WorkflowCallRun.last
+        child_execution = run.child_execution
+
+        expect(child_execution).to be_rate_limited
+        expect(execution).to be_error
+        expect(execution.error).to include("finished with status 'rate_limited'")
+        expect(call_step["status"]).to eq("error")
+        expect(call_step["error"]).to include("finished with status 'rate_limited'")
+        expect(run).to be_error
+      end
+    end
+
     it "continues through regular output when an async child failure uses continueOnFail" do
       target = failing_callable_workflow
       caller =

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/workflow_call_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/workflow_call_spec.rb
@@ -503,6 +503,8 @@ RSpec.describe DiscourseWorkflows::Nodes::WorkflowCall::V1 do
       execution.reload
       call_step = execution.execution_data.find_step(node_id: "call-1")
       run = DiscourseWorkflows::WorkflowCallRun.last
+      child_execution = run.child_execution
+      expect(child_execution).to be_error
       expect(execution).to be_error
       expect(execution.error).to include("finished with status 'error'")
       expect(call_step["status"]).to eq("error")


### PR DESCRIPTION
## Summary

When a workflow-call child execution is rate limited before starting, the parent execution and call run were left waiting indefinitely because the terminal result bypassed the existing child failure continuation. After the fix, rate-limited children go through that continuation, settling the call run and resuming the parent with an error.

Skipped executions are not reachable for workflow-call children because their executors are always given a pinned workflow version, so the change and its coverage are limited to the reachable error and rate-limited statuses.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1560

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>