### PR TITLE
DEV: Restore landlock problem-check

### DIFF
--- a/app/models/problem_check.rb
+++ b/app/models/problem_check.rb
@@ -80,6 +80,7 @@ class ProblemCheck
     ProblemCheck::GroupEmailCredentials,
     ProblemCheck::HostNames,
     ProblemCheck::ImageMagick,
+    ProblemCheck::Landlock,
     ProblemCheck::MissingAwsSnsTopicArn,
     ProblemCheck::MissingMailgunApiKey,
     ProblemCheck::OutOfDateThemes,

--- a/app/services/problem_check/landlock.rb
+++ b/app/services/problem_check/landlock.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "discourse/safe_exec"
+
+class ProblemCheck::Landlock < ProblemCheck
+  self.priority = "high"
+
+  def call
+    return no_problem if !Rails.env.production?
+    return no_problem if Discourse::SafeExec.landlock_supported?
+
+    problem
+  end
+end

--- a/spec/services/problem_check/landlock_spec.rb
+++ b/spec/services/problem_check/landlock_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe ProblemCheck::Landlock do
+  subject(:check) { described_class.new }
+
+  describe ".call" do
+    before do
+      Rails.stubs(env: ActiveSupport::StringInquirer.new(environment))
+      Discourse::SafeExec.stubs(landlock_supported?: supported)
+    end
+
+    context "when running in production" do
+      let(:environment) { "production" }
+
+      context "when Landlock is supported" do
+        let(:supported) { true }
+
+        it { expect(check).to be_chill_about_it }
+      end
+
+      context "when Landlock is not supported" do
+        let(:supported) { false }
+
+        it do
+          expect(check).to have_a_problem.with_priority("high").with_message(
+            "Landlock sandboxing is unavailable in this hosting environment, so external commands run without filesystem and network isolation. This is an important security protection that should not be missing in production. Use a Linux kernel with Landlock support (5.13 or later) to restore it.",
+          )
+        end
+      end
+    end
+
+    context "when not running in production" do
+      let(:environment) { "development" }
+      let(:supported) { false }
+
+      it { expect(check).to be_chill_about_it }
+    end
+  end
+end


### PR DESCRIPTION
Reverts #42059, which dropped the `ProblemCheck::Landlock` check. This restores the check, its spec, and re-registers it in the problem-check list. The `landlock` locale string was left in place by the drop, so no locale change is needed.