### PR TITLE
FIX: Prevent automation `set_topic_timer` from reopening closed topics [backport 2026.1]

### DIFF
--- a/plugins/automation/lib/discourse_automation/scripts/set_topic_timer.rb
+++ b/plugins/automation/lib/discourse_automation/scripts/set_topic_timer.rb
@@ -28,6 +28,10 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scripts::SET_TOPIC_TIME
     next if !post.topic
     next unless topic = Topic.find_by(id: post.topic_id)
 
+    # Saving a close timer on a closed topic would reopen it via
+    # TopicTimer#after_save (intended for the "Close Temporarily" UI flow).
+    next if topic.closed? && %w[auto_close auto_close_after_last_post].include?(timer_type)
+
     duration_minutes = fields.dig("duration", "value")
 
     case timer_type

--- a/plugins/automation/spec/scripts/set_topic_timer_spec.rb
+++ b/plugins/automation/spec/scripts/set_topic_timer_spec.rb
@@ -48,6 +48,32 @@ describe "SetTopicTimer" do
     end
   end
 
+  it "skips auto_close timer when topic is already closed" do
+    configure_automation("auto_close", 60)
+
+    post =
+      PostCreator.new(Fabricate(:admin), raw: "my new topic", title: "Test topic for timer").create!
+    post.topic.update_status("closed", true, Discourse.system_user)
+
+    expect { PostRevisor.new(post).revise!(post.user, raw: "an edit") }.not_to change {
+      post.topic.reload.topic_timers.count
+    }
+    expect(post.topic.reload.closed).to eq(true)
+  end
+
+  it "skips auto_close_after_last_post timer when topic is already closed" do
+    configure_automation("auto_close_after_last_post", 60)
+
+    post =
+      PostCreator.new(Fabricate(:admin), raw: "my new topic", title: "Test topic for timer").create!
+    post.topic.update_status("closed", true, Discourse.system_user)
+
+    expect { PostRevisor.new(post).revise!(post.user, raw: "an edit") }.not_to change {
+      post.topic.reload.topic_timers.count
+    }
+    expect(post.topic.reload.closed).to eq(true)
+  end
+
   it "handles auto_close_after_last_post timer" do
     configure_automation("auto_close_after_last_post", 60)
 


### PR DESCRIPTION
## Summary

Backports #39375 to `release/2026.1`. This prevents `set_topic_timer` automations from saving close timers on already-closed topics and unintentionally reopening them.

Patch: https://patch.discourse.org/patch-triage/1533