### PR TITLE
FIX: Restrict upcoming-changes toggle to registered upcoming-change settings

### DIFF
--- a/app/services/upcoming_changes/toggle.rb
+++ b/app/services/upcoming_changes/toggle.rb
@@ -39,7 +39,7 @@ class UpcomingChanges::Toggle
   end
 
   def setting_is_available(params:)
-    SiteSetting.respond_to?(params.setting_name)
+    UpcomingChanges.exists?(params.setting_name)
   end
 
   def toggle(params:, guardian:, options:)

--- a/spec/requests/admin/config/upcoming_changes_controller_spec.rb
+++ b/spec/requests/admin/config/upcoming_changes_controller_spec.rb
@@ -187,6 +187,15 @@ RSpec.describe Admin::Config::UpcomingChangesController do
   end
 
   describe "#toggle_change" do
+    before do
+      mock_upcoming_change_metadata(
+        enable_form_templates: {
+          impact: "feature,all_members",
+          status: :experimental,
+        },
+      )
+    end
+
     let(:setting_name) { "enable_form_templates" }
 
     context "when logged in as non-admin" do
@@ -255,6 +264,23 @@ RSpec.describe Admin::Config::UpcomingChangesController do
             }
 
         expect(response.status).to eq(404)
+      end
+
+      it "rejects SiteSetting methods that are not upcoming changes" do
+        messages =
+          MessageBus.track_publish(SiteSettingExtension::SITE_SETTINGS_CHANNEL) do
+            put "/admin/config/upcoming-changes/toggle.json",
+                params: {
+                  setting_name: "notify_changed!",
+                  enabled: true,
+                }
+          end
+
+        aggregate_failures do
+          expect(response.status).to eq(404)
+          expect(response.parsed_body["errors"]).to include(I18n.t("not_found"))
+          expect(messages).to be_empty
+        end
       end
     end
   end

--- a/spec/services/upcoming_changes/toggle_spec.rb
+++ b/spec/services/upcoming_changes/toggle_spec.rb
@@ -9,6 +9,16 @@ RSpec.describe UpcomingChanges::Toggle do
     subject(:result) { described_class.call(params:, **dependencies, options:) }
 
     fab!(:admin)
+
+    before do
+      mock_upcoming_change_metadata(
+        enable_form_templates: {
+          impact: "feature,all_members",
+          status: :experimental,
+        },
+      )
+    end
+
     let(:params) { { setting_name:, enabled: } }
     let(:enabled) { true }
     let(:setting_name) { :enable_form_templates }
@@ -24,6 +34,12 @@ RSpec.describe UpcomingChanges::Toggle do
 
     context "when setting_name is invalid" do
       let(:setting_name) { "wrong_value" }
+
+      it { is_expected.to fail_a_policy(:setting_is_available) }
+    end
+
+    context "when setting_name is not an upcoming change" do
+      let(:setting_name) { :notify_changed! }
 
       it { is_expected.to fail_a_policy(:setting_is_available) }
     end


### PR DESCRIPTION
## Summary

The admin upcoming-changes toggle endpoint accepted any public zero-argument SiteSetting method as a valid setting name. The fix restricts eligibility to registered upcoming-change metadata by checking UpcomingChanges.exists? instead of SiteSetting.respond_to?, preventing invocation of non-setting methods like notify_changed!.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1508

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>