### PR TITLE
FIX: Authorize topic visibility before recording or deleting read timings

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -366,7 +366,8 @@ class TopicsController < ApplicationController
   end
 
   def destroy_timings
-    topic_id = params[:topic_id].to_i
+    topic = find_visible_topic_from_topic_id
+    topic_id = topic.id
 
     if params[:last].to_s == "1"
       PostTiming.destroy_last_for(current_user, topic_id: topic_id)
@@ -1110,6 +1111,7 @@ class TopicsController < ApplicationController
     allowed_params = topic_params
 
     topic_id = allowed_params[:topic_id].to_i
+    find_visible_topic_from_topic_id
     topic_time = allowed_params[:topic_time].to_i
     timings = allowed_params[:timings].to_h || {}
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1110,8 +1110,7 @@ class TopicsController < ApplicationController
   def timings
     allowed_params = topic_params
 
-    topic_id = allowed_params[:topic_id].to_i
-    find_visible_topic_from_topic_id
+    topic_id = find_visible_topic_from_topic_id.id
     topic_time = allowed_params[:topic_time].to_i
     timings = allowed_params[:timings].to_h || {}
 

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -1749,6 +1749,29 @@ RSpec.describe TopicsController do
       expect(response.status).to eq(403)
     end
 
+    it "does not delete timings for a topic the user cannot see" do
+      private_category = Fabricate(:private_category, group: Fabricate(:group))
+      private_topic = Fabricate(:topic, category: private_category)
+      private_post = Fabricate(:post, topic: private_topic)
+      PostTiming.create!(
+        topic: private_topic,
+        user: user,
+        post_number: private_post.post_number,
+        msecs: 1000,
+      )
+      TopicUser.create!(topic: private_topic, user: user)
+
+      sign_in(user)
+      delete "/t/#{private_topic.id}/timings.json"
+
+      aggregate_failures do
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+        expect(PostTiming.where(topic: private_topic, user: user)).to exist
+        expect(TopicUser.where(topic: private_topic, user: user)).to exist
+      end
+    end
+
     def topic_user_post_timings_count(user, topic)
       [TopicUser, PostTiming].map { |klass| klass.where(user: user, topic: topic).count }
     end
@@ -6477,6 +6500,28 @@ RSpec.describe TopicsController do
 
       tu = TopicUser.find_by(user: admin, topic: topic)
       expect(tu.last_read_post_number).to eq(whisper.post_number)
+    end
+
+    it "does not record timings for a topic the user cannot see" do
+      private_category = Fabricate(:private_category, group: Fabricate(:group))
+      private_topic = Fabricate(:topic, category: private_category)
+      private_post = Fabricate(:post, topic: private_topic)
+
+      sign_in(user)
+      post "/t/#{private_post.topic_id}/timings.json",
+           params: {
+             topic_time: 5,
+             timings: {
+               private_post.post_number => 2,
+             },
+           }
+
+      aggregate_failures do
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+        expect(PostTiming.where(topic: private_post.topic, user: user)).to be_empty
+        expect(user.user_stat.reload.posts_read_count).to eq(0)
+      end
     end
 
     it "should record the timing" do


### PR DESCRIPTION
## Summary

Authenticated users could submit read timings for topics hidden by category permissions, creating false read records and incrementing their post-read counter. Added a topic visibility guard (`find_visible_topic_from_topic_id`) to both the timing creation and deletion controller actions, so inaccessible topics return a 404 response and no timing state is mutated.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1499

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>