### PR TITLE
FIX: Constrain official notice image dimensions to prevent topic layout disruption

### DIFF
--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -1866,6 +1866,17 @@ a.reply-to-tab {
     color: var(--primary-high);
   }
 
+  .post-notice-message {
+    flex: 1;
+    min-width: 0;
+
+    img:not(.emoji) {
+      max-width: 100%;
+      height: auto;
+      display: inline-block;
+    }
+  }
+
   p {
     display: inline;
     margin: 0;

--- a/spec/system/nested_post_admin_menu_spec.rb
+++ b/spec/system/nested_post_admin_menu_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe "Nested view post admin menu" do
     )
   end
   fab!(:reply) { Fabricate(:post, topic: topic, user: user, raw: "Some reply body here") }
-  fab!(:leader, :trust_level_4)
-  fab!(:image_upload) { Fabricate(:image_upload, width: 100, height: 100) }
 
   let(:nested_view) { PageObjects::Pages::NestedView.new }
   let(:flag_modal) { PageObjects::Modals::Flag.new }
@@ -128,24 +126,6 @@ RSpec.describe "Nested view post admin menu" do
       find("[data-content][data-identifier='admin-post-menu'] .change-owner").click
 
       expect(page).to have_css(".change-ownership-modal")
-    end
-  end
-
-  context "as a leader" do
-    it "limits official notice image dimensions for readers" do
-      sign_in(leader)
-      nested_view.visit_nested(topic)
-      open_admin_menu_for(op)
-      find("[data-content][data-identifier='admin-post-menu'] .add-notice").click
-      set_official_notice("![image|100000x100000](#{image_upload.short_url})")
-
-      sign_in(flagger)
-      nested_view.visit_nested(topic)
-
-      notice_image = find("[data-post-number='#{op.post_number}'] .post-notice-message img")
-      expect(notice_image.evaluate_script("this.getAttribute('width')")).to eq("100000")
-      expect(notice_image.evaluate_script("this.getAttribute('height')")).to eq("100000")
-      expect(notice_image.evaluate_script("this.getBoundingClientRect().height")).to be < 1000
     end
   end
 

--- a/spec/system/nested_post_admin_menu_spec.rb
+++ b/spec/system/nested_post_admin_menu_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "Nested view post admin menu" do
     )
   end
   fab!(:reply) { Fabricate(:post, topic: topic, user: user, raw: "Some reply body here") }
+  fab!(:leader, :trust_level_4)
+  fab!(:image_upload) { Fabricate(:image_upload, width: 100, height: 100) }
 
   let(:nested_view) { PageObjects::Pages::NestedView.new }
   let(:flag_modal) { PageObjects::Modals::Flag.new }
@@ -126,6 +128,24 @@ RSpec.describe "Nested view post admin menu" do
       find("[data-content][data-identifier='admin-post-menu'] .change-owner").click
 
       expect(page).to have_css(".change-ownership-modal")
+    end
+  end
+
+  context "as a leader" do
+    it "limits official notice image dimensions for readers" do
+      sign_in(leader)
+      nested_view.visit_nested(topic)
+      open_admin_menu_for(op)
+      find("[data-content][data-identifier='admin-post-menu'] .add-notice").click
+      set_official_notice("![image|100000x100000](#{image_upload.short_url})")
+
+      sign_in(flagger)
+      nested_view.visit_nested(topic)
+
+      notice_image = find("[data-post-number='#{op.post_number}'] .post-notice-message img")
+      expect(notice_image.evaluate_script("this.getAttribute('width')")).to eq("100000")
+      expect(notice_image.evaluate_script("this.getAttribute('height')")).to eq("100000")
+      expect(notice_image.evaluate_script("this.getBoundingClientRect().height")).to be < 1000
     end
   end
 


### PR DESCRIPTION
## Summary

Official notices previously rendered images at their Markdown-specified display dimensions without the responsive constraints applied inside .cooked. A Leader could use Add Official Notice to attach an image with an arbitrarily large dimension (e.g., 100000px) that expanded the notice container past the viewport, making the target topic's body and replies practically unreachable for ordinary readers. This fix adds a CSS rule to .post-notice-message that limits non-emoji images to the available notice width with height: auto, matching the existing cooked-post media behavior. The patch now caps the declared size at what is reasonably scannable in a notice rather than leaving the topic unusable.

## Before

<img width="2008" height="1204" alt="image" src="https://github.com/user-attachments/assets/281b0216-998d-40c8-b0bb-75a5f249ef9c" />

## After

<img width="2008" height="1204" alt="image" src="https://github.com/user-attachments/assets/10ace424-d8ae-4c4e-9e22-9b14f166a57b" />


## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1545

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>