### PR TITLE
UX: remove redundant admin plugin nav

### DIFF
--- a/frontend/discourse/admin/components/admin-plugin-config-page.gjs
+++ b/frontend/discourse/admin/components/admin-plugin-config-page.gjs
@@ -18,6 +18,10 @@ export default class AdminPluginConfigPage extends Component {
     return headerActionComponentForPlugin(this.args.plugin.dasherizedName);
   }
 
+  get hideTabs() {
+    return this.adminPluginNavManager.currentConfigNav.links.length <= 1;
+  }
+
   linkText(navLink) {
     if (navLink.label) {
       return i18n(navLink.label);
@@ -33,6 +37,7 @@ export default class AdminPluginConfigPage extends Component {
         @descriptionLabel={{@plugin.about}}
         @learnMoreUrl={{@plugin.linkUrl}}
         @headerActionComponent={{this.headerActionComponent}}
+        @hideTabs={{this.hideTabs}}
       >
         <:breadcrumbs>
           <DBreadcrumbsItem @path="/admin" @label={{i18n "admin_title"}} />

--- a/frontend/discourse/admin/components/admin-plugins-list-item.gjs
+++ b/frontend/discourse/admin/components/admin-plugins-list-item.gjs
@@ -7,6 +7,7 @@ import { service } from "@ember/service";
 import SiteSetting from "discourse/admin/models/site-setting";
 import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
+import { adminRouteValid } from "discourse/lib/admin-utilities";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import DToggleSwitch from "discourse/ui-kit/d-toggle-switch";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
@@ -72,15 +73,23 @@ export default class AdminPluginsListItem extends Component {
 
     if (this.args.plugin.useNewShowRoute) {
       return this.router.urlFor("adminPlugins.show", this.args.plugin);
-    } else {
-      return this.router.urlFor(
-        "adminSiteSettingsCategory",
-        this.args.plugin.settingCategoryName,
-        {
-          queryParams: { filter: `plugin:${this.args.plugin.name}` },
-        }
-      );
     }
+
+    // Plugins that predate the show route keep their config UI on their own
+    // route, so the settings category is only a fallback for plugins that have
+    // no config UI at all.
+    const { adminRoute } = this.args.plugin;
+    if (adminRoute && adminRouteValid(this.router, adminRoute)) {
+      return this.router.urlFor(adminRoute.full_location);
+    }
+
+    return this.router.urlFor(
+      "adminSiteSettingsCategory",
+      this.args.plugin.settingCategoryName,
+      {
+        queryParams: { filter: `plugin:${this.args.plugin.name}` },
+      }
+    );
   }
 
   <template>

--- a/frontend/discourse/admin/controllers/admin-plugins.js
+++ b/frontend/discourse/admin/controllers/admin-plugins.js
@@ -6,20 +6,12 @@ export default class AdminPluginsController extends Controller {
   @service adminPluginNavManager;
   @service router;
 
-  get adminRoutes() {
-    return this.allAdminRoutes.filter((route) =>
-      adminRouteValid(this.router, route)
-    );
-  }
-
   get brokenAdminRoutes() {
     return this.allAdminRoutes.filter(
       (route) => !adminRouteValid(this.router, route)
     );
   }
 
-  // NOTE: See also AdminPluginsIndexController, there is some duplication here
-  // while we convert plugins to use_new_show_route
   get allAdminRoutes() {
     return this.model
       .filter(
@@ -33,10 +25,35 @@ export default class AdminPluginsController extends Controller {
       });
   }
 
-  get showTopNav() {
+  get showBreadcrumbs() {
     return (
       !this.adminPluginNavManager.viewingPluginsList &&
       !this.adminPluginNavManager.currentPlugin
     );
+  }
+
+  // Plugins on the show route get their name breadcrumb from
+  // AdminPluginConfigPage. Ones still routing to their own admin templates
+  // have to be matched against the route they registered.
+  get currentLegacyPlugin() {
+    const currentRouteName = this.router.currentRouteName;
+
+    if (!currentRouteName) {
+      return null;
+    }
+
+    return this.model.find((plugin) => {
+      const route = plugin.adminRoute;
+
+      if (!route || route.use_new_show_route) {
+        return false;
+      }
+
+      const namespace = `adminPlugins.${route.location.split(".")[0]}`;
+      return (
+        currentRouteName === namespace ||
+        currentRouteName.startsWith(`${namespace}.`)
+      );
+    });
   }
 }

--- a/frontend/discourse/admin/controllers/admin-plugins/index.js
+++ b/frontend/discourse/admin/controllers/admin-plugins/index.js
@@ -2,13 +2,11 @@ import Controller from "@ember/controller";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import SiteSetting from "discourse/admin/models/site-setting";
-import { adminRouteValid } from "discourse/lib/admin-utilities";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { i18n } from "discourse-i18n";
 
 export default class AdminPluginsIndexController extends Controller {
   @service session;
-  @service router;
 
   get searchableProps() {
     return ["nameTitleized", "author", "about"];
@@ -49,26 +47,5 @@ export default class AdminPluginsIndexController extends Controller {
       plugin.enabled = oldValue;
       popupAjaxError(e);
     }
-  }
-
-  // NOTE: See also AdminPluginsController, there is some duplication here
-  // while we convert plugins to use_new_show_route
-  get adminRoutes() {
-    return this.allAdminRoutes.filter((route) =>
-      adminRouteValid(this.router, route)
-    );
-  }
-
-  get allAdminRoutes() {
-    return this.model
-      .filter(
-        (plugin) =>
-          plugin?.enabled &&
-          plugin?.adminRoute &&
-          !plugin?.adminRoute?.auto_generated
-      )
-      .map((plugin) => {
-        return Object.assign(plugin.adminRoute, { plugin_id: plugin.id });
-      });
   }
 }

--- a/frontend/discourse/admin/templates/admin-plugins.gjs
+++ b/frontend/discourse/admin/templates/admin-plugins.gjs
@@ -1,11 +1,9 @@
 import DBreadcrumbsContainer from "discourse/ui-kit/d-breadcrumbs-container";
 import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
-import DHorizontalOverflowNav from "discourse/ui-kit/d-horizontal-overflow-nav";
-import DNavItem from "discourse/ui-kit/d-nav-item";
 import { i18n } from "discourse-i18n";
 
 export default <template>
-  {{#if @controller.showTopNav}}
+  {{#if @controller.showBreadcrumbs}}
     <div class="d-page-header">
       <DBreadcrumbsContainer />
       <DBreadcrumbsItem
@@ -16,31 +14,14 @@ export default <template>
       <DBreadcrumbsItem
         @path="/admin/plugins"
         @route="adminPlugins"
-        @label={{i18n "admin.config.plugins.title"}}
+        @label={{i18n "admin.plugins.title"}}
       />
-      <div class="d-nav-submenu">
-        <DHorizontalOverflowNav class="main-nav nav plugin-nav">
-          <DNavItem @route="adminPlugins.index" @label="admin.plugins.title" />
-          {{#each @controller.adminRoutes as |route|}}
-            {{#if route.use_new_show_route}}
-              <DNavItem
-                @route={{route.full_location}}
-                @label={{route.label}}
-                @routeParam={{route.location}}
-                @class="admin-plugin-tab-nav-item"
-                data-plugin-nav-tab-id={{route.plugin_id}}
-              />
-            {{else}}
-              <DNavItem
-                @route={{route.full_location}}
-                @label={{route.label}}
-                @class="admin-plugin-tab-nav-item"
-                data-plugin-nav-tab-id={{route.plugin_id}}
-              />
-            {{/if}}
-          {{/each}}
-        </DHorizontalOverflowNav>
-      </div>
+      {{#if @controller.currentLegacyPlugin}}
+        <DBreadcrumbsItem
+          @route={{@controller.currentLegacyPlugin.adminRoute.full_location}}
+          @label={{@controller.currentLegacyPlugin.nameTitleized}}
+        />
+      {{/if}}
     </div>
   {{/if}}
 

--- a/frontend/discourse/admin/templates/admin-plugins/index.gjs
+++ b/frontend/discourse/admin/templates/admin-plugins/index.gjs
@@ -5,7 +5,6 @@ import PluginOutlet from "discourse/components/plugin-outlet";
 import lazyHash from "discourse/helpers/lazy-hash";
 import DBreadcrumbsItem from "discourse/ui-kit/d-breadcrumbs-item";
 import DFilterControls from "discourse/ui-kit/d-filter-controls";
-import DNavItem from "discourse/ui-kit/d-nav-item";
 import DPageHeader from "discourse/ui-kit/d-page-header";
 import { i18n } from "discourse-i18n";
 
@@ -13,6 +12,7 @@ export default <template>
   <div class="admin-plugins-list-container">
 
     <DPageHeader
+      @hideTabs={{true}}
       @titleLabel={{i18n "admin.config.plugins.title"}}
       @descriptionLabel={{trustHTML
         (concat
@@ -30,27 +30,6 @@ export default <template>
           @label={{i18n "admin.plugins.title"}}
         />
       </:breadcrumbs>
-      <:tabs>
-        <DNavItem @route="adminPlugins.index" @label="admin.plugins.title" />
-        {{#each @controller.adminRoutes as |route|}}
-          {{#if route.use_new_show_route}}
-            <DNavItem
-              @route={{route.full_location}}
-              @label={{route.label}}
-              @routeParam={{route.location}}
-              @class="admin-plugin-tab-nav-item"
-              data-plugin-nav-tab-id={{route.plugin_id}}
-            />
-          {{else}}
-            <DNavItem
-              @route={{route.full_location}}
-              @label={{route.label}}
-              @class="admin-plugin-tab-nav-item"
-              data-plugin-nav-tab-id={{route.plugin_id}}
-            />
-          {{/if}}
-        {{/each}}
-      </:tabs>
     </DPageHeader>
 
     {{#if @controller.model.length}}

--- a/frontend/discourse/admin/templates/admin-plugins/show/settings.gjs
+++ b/frontend/discourse/admin/templates/admin-plugins/show/settings.gjs
@@ -1,14 +1,10 @@
 import AdminAreaSettings from "discourse/admin/components/admin-area-settings";
 
 export default <template>
-  <div
-    class="content-body admin-plugin-config-area__settings admin-detail pull-left"
-  >
-    <AdminAreaSettings
-      @plugin={{@model.plugin.id}}
-      @path="/admin/plugins/{{@model.plugin.name}}/settings"
-      @filter={{@controller.filter}}
-      @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
-    />
-  </div>
+  <AdminAreaSettings
+    @plugin={{@model.plugin.id}}
+    @path="/admin/plugins/{{@model.plugin.name}}/settings"
+    @filter={{@controller.filter}}
+    @adminSettingsFilterChangedCallback={{@controller.adminSettingsFilterChangedCallback}}
+  />
 </template>

--- a/frontend/discourse/tests/integration/components/admin-plugin-config-area-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-plugin-config-area-test.gjs
@@ -2,6 +2,7 @@ import { getOwner } from "@ember/owner";
 import { render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import AdminPluginConfigArea from "discourse/admin/components/admin-plugin-config-area";
+import AdminPluginConfigPage from "discourse/admin/components/admin-plugin-config-page";
 import AdminPlugin from "discourse/admin/models/admin-plugin";
 import { registerAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
@@ -38,5 +39,61 @@ module("Integration | Component | AdminPluginConfigArea", function (hooks) {
     assert
       .dom(".admin-plugin-config-area")
       .hasText("Test content", "renders the yielded content");
+  });
+});
+
+const PLUGIN_ID = "discourse-test-plugin";
+
+module("Integration | Component | AdminPluginConfigPage", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("hides the tab nav when the plugin only has a settings tab", async function (assert) {
+    const plugin = new AdminPlugin({
+      id: PLUGIN_ID,
+      name: PLUGIN_ID,
+      humanized_name: "Test plugin",
+    });
+    getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
+      plugin;
+
+    await render(
+      <template>
+        <AdminPluginConfigPage @plugin={{plugin}}>
+          Test content
+        </AdminPluginConfigPage>
+      </template>
+    );
+
+    assert.dom(".d-nav-submenu").doesNotExist();
+  });
+
+  test("shows the tab nav when the plugin has more than one tab", async function (assert) {
+    registerAdminPluginConfigNav(PLUGIN_ID, [
+      {
+        route: "adminPlugins.show.settings",
+        label: "admin.plugins.change_settings_short",
+      },
+      {
+        route: "adminPlugins.show.discourse-test-plugin.one",
+        label: "admin.title",
+      },
+    ]);
+    const plugin = new AdminPlugin({
+      id: PLUGIN_ID,
+      name: PLUGIN_ID,
+      humanized_name: "Test plugin",
+    });
+    getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
+      plugin;
+
+    await render(
+      <template>
+        <AdminPluginConfigPage @plugin={{plugin}}>
+          Test content
+        </AdminPluginConfigPage>
+      </template>
+    );
+
+    assert.dom(".admin-plugin-config-page__top-nav-item").exists({ count: 2 });
   });
 });

--- a/frontend/discourse/tests/integration/components/admin-plugin-config-page-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-plugin-config-page-test.gjs
@@ -6,11 +6,17 @@ import AdminPlugin from "discourse/admin/models/admin-plugin";
 import { registerAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
 
+const PLUGIN_ID = "discourse-test-plugin";
+
 module("Integration | Component | AdminPluginConfigPage", function (hooks) {
   setupRenderingTest(hooks);
 
   test("hides the tab nav when the plugin only has a settings tab", async function (assert) {
-    const plugin = new AdminPlugin({ id: "discourse-test-plugin" });
+    const plugin = new AdminPlugin({
+      id: PLUGIN_ID,
+      name: PLUGIN_ID,
+      humanized_name: "Test plugin",
+    });
     getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
       plugin;
 
@@ -26,7 +32,7 @@ module("Integration | Component | AdminPluginConfigPage", function (hooks) {
   });
 
   test("shows the tab nav when the plugin has more than one tab", async function (assert) {
-    registerAdminPluginConfigNav("discourse-test-plugin", [
+    registerAdminPluginConfigNav(PLUGIN_ID, [
       {
         route: "adminPlugins.show.settings",
         label: "admin.plugins.change_settings_short",
@@ -36,7 +42,11 @@ module("Integration | Component | AdminPluginConfigPage", function (hooks) {
         label: "admin.title",
       },
     ]);
-    const plugin = new AdminPlugin({ id: "discourse-test-plugin" });
+    const plugin = new AdminPlugin({
+      id: PLUGIN_ID,
+      name: PLUGIN_ID,
+      humanized_name: "Test plugin",
+    });
     getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
       plugin;
 

--- a/frontend/discourse/tests/integration/components/admin-plugin-config-page-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-plugin-config-page-test.gjs
@@ -1,0 +1,53 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import AdminPluginConfigPage from "discourse/admin/components/admin-plugin-config-page";
+import AdminPlugin from "discourse/admin/models/admin-plugin";
+import { registerAdminPluginConfigNav } from "discourse/lib/admin-plugin-config-nav";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | AdminPluginConfigPage", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("hides the tab nav when the plugin only has a settings tab", async function (assert) {
+    const plugin = new AdminPlugin({ id: "discourse-test-plugin" });
+    getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
+      plugin;
+
+    await render(
+      <template>
+        <AdminPluginConfigPage @plugin={{plugin}}>
+          Test content
+        </AdminPluginConfigPage>
+      </template>
+    );
+
+    assert.dom(".d-nav-submenu").doesNotExist();
+  });
+
+  test("shows the tab nav when the plugin has more than one tab", async function (assert) {
+    registerAdminPluginConfigNav("discourse-test-plugin", [
+      {
+        route: "adminPlugins.show.settings",
+        label: "admin.plugins.change_settings_short",
+      },
+      {
+        route: "adminPlugins.show.discourse-test-plugin.one",
+        label: "admin.title",
+      },
+    ]);
+    const plugin = new AdminPlugin({ id: "discourse-test-plugin" });
+    getOwner(this).lookup("service:admin-plugin-nav-manager").currentPlugin =
+      plugin;
+
+    await render(
+      <template>
+        <AdminPluginConfigPage @plugin={{plugin}}>
+          Test content
+        </AdminPluginConfigPage>
+      </template>
+    );
+
+    assert.dom(".admin-plugin-config-page__top-nav-item").exists({ count: 2 });
+  });
+});

--- a/frontend/discourse/tests/integration/components/admin-plugins-list-item-test.gjs
+++ b/frontend/discourse/tests/integration/components/admin-plugins-list-item-test.gjs
@@ -48,6 +48,33 @@ module("Integration | Component | AdminPluginsListItem", function (hooks) {
       .hasAttribute("href", "/admin/plugins/discourse-test-plugin");
   });
 
+  test("name links to the plugin's own route when it predates the show route", async function (assert) {
+    this.currentUser.admin = true;
+    const store = getOwner(this).lookup("service:store");
+    // `full_location` stands in for a route the plugin registers itself; it
+    // only has to resolve for the link to be built.
+    this.plugin = store.createRecord("admin-plugin", pluginAttrs());
+
+    await render(
+      <template><AdminPluginsListItem @plugin={{this.plugin}} /></template>
+    );
+
+    assert.dom("a.admin-plugins-list__name").hasAttribute("href", "/admin");
+
+    this.plugin.adminRoute = null;
+    await render(
+      <template><AdminPluginsListItem @plugin={{this.plugin}} /></template>
+    );
+
+    assert
+      .dom("a.admin-plugins-list__name")
+      .hasAttribute(
+        "href",
+        "/admin/site_settings/category/plugins?filter=plugin%3Adiscourse-test-plugin",
+        "falls back to the settings category when the plugin has no route of its own"
+      );
+  });
+
   test("settings link show or hide", async function (assert) {
     this.currentUser.admin = true;
     const store = getOwner(this).lookup("service:store");

--- a/plugins/automation/spec/system/admin_plugins_list_spec.rb
+++ b/plugins/automation/spec/system/admin_plugins_list_spec.rb
@@ -47,8 +47,10 @@ describe "Admin Plugins List" do
     expect(SiteSetting.discourse_automation_enabled).to eq(true)
   end
 
-  it "shows a navigation tab for each plugin that needs it" do
+  it "links a plugin with a config page to its config page" do
     admin_plugins_list_page.visit
-    expect(admin_plugins_list_page).to have_plugin_tab("automation")
+    admin_plugins_list_page.click_plugin_name("automation")
+
+    expect(page).to have_css(".admin-plugin-config-page .d-page-header__title", text: "Automation")
   end
 end

--- a/plugins/discourse-adplugin/spec/system/admin_house_ad_spec.rb
+++ b/plugins/discourse-adplugin/spec/system/admin_house_ad_spec.rb
@@ -88,7 +88,7 @@ describe "Admin House Ad" do
         "tr[data-plugin-name='discourse-adplugin'] .admin-plugins-list__enabled .d-toggle-switch__checkbox-slider",
       ).click
 
-      find(".admin-plugin-tab-nav-item[data-plugin-nav-tab-id='discourse-adplugin'] a").click
+      find("tr[data-plugin-name='discourse-adplugin'] .admin-plugins-list__name").click
 
       expect(page).to have_css(".admin-plugin-config-page__top-nav-item", text: "House Ads")
     end

--- a/spec/system/page_objects/pages/admin_plugins_list.rb
+++ b/spec/system/page_objects/pages/admin_plugins_list.rb
@@ -16,12 +16,8 @@ module PageObjects
         ".admin-plugins-list .admin-plugins-list__row[data-plugin-name=\"#{plugin}\"]"
       end
 
-      def has_plugin_tab?(plugin)
-        page.has_css?(plugin_nav_tab_selector(plugin))
-      end
-
-      def plugin_nav_tab_selector(plugin)
-        ".d-nav-submenu__tabs .admin-plugin-tab-nav-item[data-plugin-nav-tab-id=\"#{plugin}\"]"
+      def click_plugin_name(plugin)
+        find_plugin(plugin).find(".admin-plugins-list__name").click
       end
     end
   end


### PR DESCRIPTION
Previously, admin plugin pages carried multiple navs that repeated links the surrounding page already offered:

 - the plugins index listed a tab for some plugins, directly above the table that links to those same config pages
- a plugin whose only tab is "Settings" still rendered a one item tab bar

This change drops those and gives the older plugin pages the breadcrumb trail the show route already has, ending on the plugin being configured rather than on "Installed plugins".

- Also removes a duplicate wrapper on the plugin settings route, which repeated `.content-body`

- The breadcrumb fallback in admin-plugins.gjs now only applies to third-party plugins on the legacy admin route


Before (why a tab for only one link?):

<img width="600" alt="image" src="https://github.com/user-attachments/assets/a37a5986-66c0-4cbe-861c-aa453ec8f10a" />


After (no tab for single links):

<img width="450" alt="image" src="https://github.com/user-attachments/assets/3a0c80ee-0459-4df5-81e7-774abe8946d1" />


Before (why tabs for redundant plugin links):
<img width="2240" height="832" alt="image" src="https://github.com/user-attachments/assets/4f4254d8-6a73-4031-9911-f725ff5ae37f" />

After (no tabs): 
<img width="2236" height="728" alt="image" src="https://github.com/user-attachments/assets/24d54ec8-8973-4e39-9844-092d384b61d8" />


Before (wrong breadcrumb):

<img width="350"  alt="image" src="https://github.com/user-attachments/assets/89a43a36-f97b-4a45-b537-670b26de4bc3" />

After (correct breadcrumb pattern): 
<img width="350"  alt="image" src="https://github.com/user-attachments/assets/706f75b1-1245-427d-8913-193dce99703d" />

