### PR TITLE
UX: allow mobile chat results to scroll

### DIFF
--- a/plugins/chat/assets/stylesheets/common/chat-search.scss
+++ b/plugins/chat/assets/stylesheets/common/chat-search.scss
@@ -1,6 +1,9 @@
 .c-routes.--search .c-search {
-  padding-block: 1.25rem;
-  margin-inline: 1rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-block: var(--space-5);
+  margin-inline: var(--space-4);
 }
 
 .c-routes.--search .c-search,


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/chat-search-results-cannot-be-scrolled-on-mobile-touch-swipe-unresponsive/408922

On mobile chat search results couldn't scroll (when searching all chat, not an individual channel). This adds the correct overflow styles to allow it. 