### PR TITLE
UX: Always show the "Mark unread" topic button

### DIFF
--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -54,7 +54,6 @@ class SiteSetting < ActiveRecord::Base
     default_other_external_links_in_new_tab
     default_other_enable_quoting
     default_other_enable_smart_lists
-    default_other_enable_defer
     default_other_dynamic_favicon
     default_other_like_notification_frequency
     default_other_skip_new_user_tips

--- a/app/models/user_option.rb
+++ b/app/models/user_option.rb
@@ -21,6 +21,7 @@ class UserOption < ActiveRecord::Base
     "enable_experimental_sidebar", # TODO: Remove when 20250804021210_drop_enable_experimental_sidebar_user_option has been promoted to pre-deploy
     "only_chat_push_notifications", # TODO(2027-01): replaced by push_notification_level; drop the column in a follow-up PR once this has shipped
     "chat_send_shortcut", # TODO(2027-01): replaced by send_shortcut; drop the column in a follow-up PR once this has shipped
+    "enable_defer", # TODO(2027-02): the preference was removed; drop the column in a follow-up PR once this has shipped
   ]
 
   self.primary_key = :user_id
@@ -88,7 +89,6 @@ class UserOption < ActiveRecord::Base
 
     self.enable_quoting = SiteSetting.default_other_enable_quoting
     self.enable_smart_lists = SiteSetting.default_other_enable_smart_lists
-    self.enable_defer = SiteSetting.default_other_enable_defer
     self.enable_markdown_monospace_font = SiteSetting.default_other_enable_markdown_monospace_font
     self.external_links_in_new_tab = SiteSetting.default_other_external_links_in_new_tab
     self.dynamic_favicon = SiteSetting.default_other_dynamic_favicon
@@ -307,7 +307,6 @@ end
 #  email_messages_level                           :integer          default(0), not null
 #  email_previous_replies                         :integer          default(2), not null
 #  enable_allowed_pm_users                        :boolean          default(FALSE), not null
-#  enable_defer                                   :boolean          default(FALSE), not null
 #  enable_markdown_monospace_font                 :boolean          default(TRUE), not null
 #  enable_quoting                                 :boolean          default(TRUE), not null
 #  enable_smart_lists                             :boolean          default(TRUE), not null

--- a/app/serializers/current_user_option_serializer.rb
+++ b/app/serializers/current_user_option_serializer.rb
@@ -13,7 +13,6 @@ class CurrentUserOptionSerializer < ApplicationSerializer
              :hide_profile,
              :hide_presence,
              :title_count_mode,
-             :enable_defer,
              :timezone,
              :skip_new_user_tips,
              :default_calendar,

--- a/app/serializers/user_option_serializer.rb
+++ b/app/serializers/user_option_serializer.rb
@@ -13,7 +13,6 @@ class UserOptionSerializer < ApplicationSerializer
              :dynamic_favicon,
              :enable_quoting,
              :enable_smart_lists,
-             :enable_defer,
              :enable_markdown_monospace_font,
              :digest_after_minutes,
              :automatically_unpin_topics,

--- a/app/services/site_setting_update_existing_users.rb
+++ b/app/services/site_setting_update_existing_users.rb
@@ -58,7 +58,6 @@ class SiteSettingUpdateExistingUsers
       default_email_in_reply_to: "email_in_reply_to",
       default_other_enable_quoting: "enable_quoting",
       default_other_enable_smart_lists: "enable_smart_lists",
-      default_other_enable_defer: "enable_defer",
       default_other_external_links_in_new_tab: "external_links_in_new_tab",
       default_other_dynamic_favicon: "dynamic_favicon",
       default_other_new_topic_duration_minutes: "new_topic_duration_minutes",

--- a/app/services/user_updater.rb
+++ b/app/services/user_updater.rb
@@ -27,7 +27,6 @@ class UserUpdater
     external_links_in_new_tab
     enable_quoting
     enable_smart_lists
-    enable_defer
     enable_markdown_monospace_font
     color_scheme_id
     dark_scheme_id

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1821,7 +1821,6 @@ en:
       external_links_in_new_tab: "Open all external links in a new tab"
       enable_quoting: "Enable quote reply for highlighted text"
       enable_smart_lists: "Enable smart lists when writing in the composer"
-      enable_defer: "Enable mark topics as unread"
       enable_markdown_monospace_font: "Use monospace font in composer's Markdown mode"
       automatically_translate: "Automatically translate topics and posts in other languages"
       content_languages:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2795,7 +2795,6 @@ en:
     default_other_external_links_in_new_tab: "Open external links in a new tab by default."
     default_other_enable_quoting: "Enable quote reply for highlighted text by default."
     default_other_enable_smart_lists: "Enable smart lists when typing in the composer by default."
-    default_other_enable_defer: "Enable defer topic functionality by default."
     default_other_enable_markdown_monospace_font: "Use monospace font in composer's Markdown mode by default."
     default_other_dynamic_favicon: "Show new/updated topic count on browser icon by default."
     default_other_skip_new_user_tips: "Skip new user onboarding tips and badges."

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -4330,9 +4330,6 @@ user_preferences:
   default_other_enable_quoting:
     default: true
     area: "user_defaults"
-  default_other_enable_defer:
-    default: false
-    area: "user_defaults"
   default_other_enable_smart_lists:
     default: true
     area: "user_defaults"

--- a/db/post_migrate/20260730183114_remove_default_other_enable_defer_setting.rb
+++ b/db/post_migrate/20260730183114_remove_default_other_enable_defer_setting.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveDefaultOtherEnableDeferSetting < ActiveRecord::Migration[8.0]
+  def up
+    execute "DELETE FROM site_settings WHERE name = 'default_other_enable_defer'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -23130,6 +23130,7 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260803015314'),
 ('20260731055703'),
+('20260730183114'),
 ('20260729153343'),
 ('20260728162521'),
 ('20260728162516'),

--- a/frontend/discourse/admin/lib/constants.js
+++ b/frontend/discourse/admin/lib/constants.js
@@ -71,7 +71,6 @@ export const DEFAULT_USER_PREFERENCES = [
   "default_other_external_links_in_new_tab",
   "default_other_enable_quoting",
   "default_other_enable_smart_lists",
-  "default_other_enable_defer",
   "default_other_dynamic_favicon",
   "default_other_like_notification_frequency",
   "default_other_skip_new_user_tips",

--- a/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
+++ b/frontend/discourse/app/components/bulk-select-topics-dropdown.gjs
@@ -85,7 +85,6 @@ export default class BulkSelectTopicsDropdown extends Component {
         id: "defer",
         icon: "circle",
         name: i18n("topic_bulk_actions.defer.name"),
-        visible: ({ currentUser }) => currentUser.user_option.enable_defer,
       },
       {
         id: "close-topics",

--- a/frontend/discourse/app/components/topic-footer-buttons.gjs
+++ b/frontend/discourse/app/components/topic-footer-buttons.gjs
@@ -47,15 +47,6 @@ export default class TopicFooterButtons extends Component {
     set(this, "topic.details.can_invite_to", value);
   }
 
-  @computed("currentUser.user_option.enable_defer")
-  get canDefer() {
-    return this.currentUser?.user_option?.enable_defer;
-  }
-
-  set canDefer(value) {
-    set(this, "currentUser.user_option.enable_defer", value);
-  }
-
   @computed("topic.archived", "topic.closed", "topic.deleted")
   get inviteDisabled() {
     return this.topic?.archived || this.topic?.closed || this.topic?.deleted;

--- a/frontend/discourse/app/controllers/preferences/interface.js
+++ b/frontend/discourse/app/controllers/preferences/interface.js
@@ -75,7 +75,6 @@ export default class InterfaceController extends Controller {
       "dynamic_favicon",
       "enable_quoting",
       "enable_smart_lists",
-      "enable_defer",
       "automatically_unpin_topics",
       "allow_private_messages",
       "enable_allowed_pm_users",

--- a/frontend/discourse/app/instance-initializers/topic-footer-buttons.js
+++ b/frontend/discourse/app/instance-initializers/topic-footer-buttons.js
@@ -115,9 +115,6 @@ export default {
       title: "topic.defer.help",
       action: "deferTopic",
       classNames: ["defer-topic"],
-      displayed() {
-        return this.canDefer;
-      },
       dropdown() {
         return this.site.mobileView;
       },

--- a/frontend/discourse/app/models/user.js
+++ b/frontend/discourse/app/models/user.js
@@ -126,7 +126,6 @@ let userOptionFields = [
   "email_messages_level",
   "email_previous_replies",
   "enable_allowed_pm_users",
-  "enable_defer",
   "enable_markdown_monospace_font",
   "enable_quoting",
   "enable_smart_lists",
@@ -249,7 +248,6 @@ export default class User extends RestModel.extend(Evented) {
   @userOption("hide_profile") hide_profile;
   @userOption("hide_presence") hide_presence;
   @userOption("title_count_mode") title_count_mode;
-  @userOption("enable_defer") enable_defer;
   @userOption("timezone") timezone;
   @userOption("skip_new_user_tips") skip_new_user_tips;
   @userOption("default_calendar") default_calendar;

--- a/frontend/discourse/app/templates/preferences/interface.gjs
+++ b/frontend/discourse/app/templates/preferences/interface.gjs
@@ -235,12 +235,6 @@ export default <template>
       data-setting-name="user-enable-smart-lists"
       class="pref-enable-smart-lists"
     />
-    <PreferenceCheckbox
-      @labelKey="user.enable_defer"
-      @checked={{@controller.model.user_option.enable_defer}}
-      data-setting-name="user-enable-defer"
-      class="pref-defer-unread"
-    />
     {{#if @controller.siteSettings.automatically_unpin_topics}}
       <PreferenceCheckbox
         @labelKey="user.automatically_unpin_topics"

--- a/frontend/discourse/tests/fixtures/user-fixtures.js
+++ b/frontend/discourse/tests/fixtures/user-fixtures.js
@@ -3115,7 +3115,6 @@ const userFixtures = {
         enable_quoting: true,
         enable_smart_lists: true,
         enable_markdown_monospace_font: false,
-        enable_defer: false,
         digest_after_minutes: 1440,
         automatically_unpin_topics: true,
         auto_track_topics_after_msecs: 240000,

--- a/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
+++ b/frontend/discourse/tests/integration/components/bulk-select-topics-dropdown-test.gjs
@@ -58,11 +58,12 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     await click(".bulk-select-topics-dropdown-trigger");
     assert
       .dom(".fk-d-menu__inner-content .dropdown-menu__item")
-      .exists({ count: 5 });
+      .exists({ count: 6 });
 
     [
       "update-notifications",
       "reset-bump-dates",
+      "defer",
       "close-topics",
       "manage-tags",
       "delete-topics",
@@ -107,23 +108,6 @@ module("Integration | Component | BulkSelectTopicsDropdown", function (hooks) {
     assert
       .dom(".fk-d-menu__inner-content .dropdown-menu__item .relist-topics")
       .doesNotExist();
-  });
-
-  test("allows deferring topics if the user has the preference enabled", async function (assert) {
-    this.currentUser.admin = true;
-    this.currentUser.user_option.enable_defer = true;
-    this.bulkSelectHelper = createBulkSelectHelper(this);
-
-    await render(
-      <template>
-        <BulkSelectTopicsDropdown @bulkSelectHelper={{this.bulkSelectHelper}} />
-      </template>
-    );
-
-    await click(".bulk-select-topics-dropdown-trigger");
-    assert
-      .dom(".fk-d-menu__inner-content .dropdown-menu__item .defer")
-      .exists();
   });
 
   test("does not allow tagging actions if tagging_enabled is false", async function (assert) {

--- a/spec/models/user_option_spec.rb
+++ b/spec/models/user_option_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe UserOption do
       SiteSetting.default_other_enable_quoting = false
       SiteSetting.default_other_enable_smart_lists = false
       SiteSetting.default_other_enable_markdown_monospace_font = false
-      SiteSetting.default_other_enable_defer = true
       SiteSetting.default_other_external_links_in_new_tab = true
       SiteSetting.default_other_dynamic_favicon = true
       SiteSetting.default_other_skip_new_user_tips = true
@@ -119,7 +118,6 @@ RSpec.describe UserOption do
       expect(user.user_option.enable_quoting).to eq(false)
       expect(user.user_option.enable_smart_lists).to eq(false)
       expect(user.user_option.enable_markdown_monospace_font).to eq(false)
-      expect(user.user_option.enable_defer).to eq(true)
       expect(user.user_option.external_links_in_new_tab).to eq(true)
       expect(user.user_option.dynamic_favicon).to eq(true)
       expect(user.user_option.skip_new_user_tips).to eq(true)

--- a/spec/requests/api/schemas/json/user_get_response.json
+++ b/spec/requests/api/schemas/json/user_get_response.json
@@ -739,9 +739,6 @@
             "enable_markdown_monospace_font": {
               "type": "boolean"
             },
-            "enable_defer": {
-              "type": "boolean"
-            },
             "digest_after_minutes": {
               "type": "integer"
             },
@@ -883,7 +880,6 @@
             "enable_quoting",
             "enable_smart_lists",
             "enable_markdown_monospace_font",
-            "enable_defer",
             "digest_after_minutes",
             "automatically_unpin_topics",
             "auto_track_topics_after_msecs",


### PR DESCRIPTION
Previously, the button was hidden behind both a `default_other_enable_defer` site setting and a per-user `enable_defer` preference, which defaulted to off, so most sites never exposed it.

This change removes both settings and always shows the button — and its bulk-select counterpart — to logged-in users.

Note that `enable_defer` also disappears from the user API response (`UserOptionSerializer`, `CurrentUserOptionSerializer`). The `user_options.enable_defer` column is retained and added to `ignored_columns`; dropping it is left to a follow-up PR once this has shipped, matching the existing entries in that list.