### PR TITLE
FIX: Map positions when appending trailing inline spaces

### DIFF
--- a/frontend/discourse/app/static/prosemirror/extensions/trailing-inline-space.ts
+++ b/frontend/discourse/app/static/prosemirror/extensions/trailing-inline-space.ts
@@ -105,7 +105,12 @@ const extension: RichEditorExtension = {
           }
           const lastChild = node.lastChild;
           if (lastChild && isInlineContainer(lastChild)) {
-            tr.insert(pos + node.nodeSize - 1, newState.schema.text(" "));
+            // pos is a new-doc position, so it has to be mapped through the
+            // spaces already inserted for earlier nodes.
+            tr.insert(
+              tr.mapping.map(pos + node.nodeSize - 1),
+              newState.schema.text(" ")
+            );
           }
         });
 

--- a/frontend/discourse/tests/integration/components/prosemirror-editor/html-inline-test.js
+++ b/frontend/discourse/tests/integration/components/prosemirror-editor/html-inline-test.js
@@ -33,6 +33,11 @@ module(
         "<p>Text with <sub>subscript</sub> and <sup>superscript</sup> </p>",
         "Text with <sub>subscript</sub> and <sup>superscript</sup> ",
       ],
+      "several blocks ending in inline HTML": [
+        "a <sup>1</sup>\n\nb <mark>m</mark>\n\nc <del>d</del>",
+        "<p>a <sup>1</sup> </p><p>b <mark>m</mark> </p><p>c <del>d</del> </p>",
+        "a <sup>1</sup> \n\nb <mark>m</mark> \n\nc <del>d</del> ",
+      ],
       "HTML mark aliases": [
         "<b>bold</b> and <i>italic</i>",
         "<p><strong>bold</strong> and <em>italic</em></p>",


### PR DESCRIPTION
The trailing space that follows a block ending in an inline container (`kbd`, `sup`, `small`…) was inserted at an unmapped position, so once more than one block changed in the same transaction the space drifted into the container or into a word: typing into a post with a few such lines turned `charlie three` into `charlie thre e`, and undoing the formatting didn't repair it.

This change maps the insertion point through the steps already applied to the transaction, so every block gets its space in the right place.