### PR TITLE
FIX: Enforce required validation on form template composer fields

### DIFF
--- a/app/assets/stylesheets/common/components/form-template-field.scss
+++ b/app/assets/stylesheets/common/components/form-template-field.scss
@@ -70,7 +70,8 @@
     color: var(--primary-medium);
   }
 
-  &__upload-hidden-input {
+  &__upload-hidden-input,
+  &__composer-hidden-input {
     position: absolute;
     opacity: 0;
     pointer-events: none;

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -95,6 +95,14 @@ export default class FormTemplateFieldComposer extends Component {
       editor.removeAttribute("aria-labelledby");
     }
 
+    // the asterisk marking the field required is decorative, and the input
+    // carrying `required` is hidden, so the editor has to state it itself
+    if (this.args.validations?.required) {
+      editor.setAttribute("aria-required", "true");
+    } else {
+      editor.removeAttribute("aria-required");
+    }
+
     if (this.#validationFailed) {
       editor.setAttribute("aria-invalid", "true");
       editor.setAttribute("aria-describedby", this.errorId);

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -3,7 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { guidFor } from "@ember/object/internals";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
@@ -21,7 +20,6 @@ export default class FormTemplateFieldComposer extends Component {
   fieldUid = `form-template-composer-${guidFor(this)}`;
 
   #claimAbortController = null;
-  #validatedInput = null;
   #editorTarget = null;
   #validationFailed = false;
 
@@ -60,11 +58,6 @@ export default class FormTemplateFieldComposer extends Component {
     schedule("afterRender", () => {
       this.args.onChange?.();
     });
-  }
-
-  @action
-  registerValidatedInput(element) {
-    this.#validatedInput = element;
   }
 
   @action
@@ -118,9 +111,9 @@ export default class FormTemplateFieldComposer extends Component {
       this.args.onChange?.(event);
       // the editor emits no form events of its own, so the input standing in
       // for it has to report the change
-      this.#validatedInput?.dispatchEvent(
-        new Event("input", { bubbles: true })
-      );
+      document
+        .getElementById(this.validationInputId)
+        ?.dispatchEvent(new Event("input", { bubbles: true }));
     });
   }
 
@@ -189,7 +182,6 @@ export default class FormTemplateFieldComposer extends Component {
         class="form-template-field__composer-hidden-input"
         tabindex="-1"
         aria-hidden="true"
-        {{didInsert this.registerValidatedInput}}
         {{on "invalid" this.handleInvalid}}
         {{on "input" this.handleValidationInput}}
       />

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -86,9 +86,8 @@ export default class FormTemplateFieldComposer extends Component {
     }
   }
 
-  // the editor is not a form control, so it carries the state of the input
-  // standing in for it. switching between markdown and rich modes replaces the
-  // editor element, so this reapplies the full state rather than toggling it.
+  // reapplies the full state rather than toggling it, because switching
+  // between markdown and rich modes replaces the editor element
   #syncEditorAccessibility() {
     const editor = this._editorTarget;
 
@@ -96,8 +95,7 @@ export default class FormTemplateFieldComposer extends Component {
       return;
     }
 
-    // the label is only rendered when the template defines one, so pointing at
-    // it unconditionally would leave a dangling reference
+    // the label is only rendered when the template defines one
     if (this.args.attributes?.label) {
       editor.setAttribute("aria-labelledby", this.labelId);
     } else {
@@ -118,8 +116,8 @@ export default class FormTemplateFieldComposer extends Component {
     this.composerValue = event.target.value;
     next(this, () => {
       this.args.onChange?.(event);
-      // the editor is not a form control, so the field backing it has to
-      // announce the change for validation state to refresh
+      // the editor emits no form events of its own, so the input standing in
+      // for it has to report the change
       this._validatedInput?.dispatchEvent(
         new Event("input", { bubbles: true })
       );
@@ -181,7 +179,9 @@ export default class FormTemplateFieldComposer extends Component {
         @placeholder={{@attributes.placeholder}}
         @onSetup={{this.onEditorSetup}}
       />
-      {{! must stay last: the error tip is only inserted after a field with no next sibling }}
+      {{! the editor is not a form control, so this stands in for it to carry the
+      value and native validation. must stay last: the error tip is only
+      inserted after a field with no next sibling }}
       <input
         id={{this.validationInputId}}
         type="text"

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -1,21 +1,28 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
+import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { guidFor } from "@ember/object/internals";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import DEditor from "discourse/ui-kit/d-editor";
 import dIcon from "discourse/ui-kit/helpers/d-icon";
+import { i18n } from "discourse-i18n";
 
 export default class FormTemplateFieldComposer extends Component {
   @service composer;
   @service appEvents;
+  @service a11y;
 
   @tracked composerValue = this.args.value || "";
 
+  fieldUid = `form-template-composer-${guidFor(this)}`;
+
   _claimAbortController = null;
   _validatedInput = null;
+  _editorTarget = null;
 
   constructor() {
     super(...arguments);
@@ -26,6 +33,19 @@ export default class FormTemplateFieldComposer extends Component {
     super.willDestroy(...arguments);
     this.appEvents.off("composer:replace-text", this, this.handleReplaceText);
     this._claimAbortController?.abort();
+  }
+
+  get labelId() {
+    return `${this.fieldUid}-label`;
+  }
+
+  get validationInputId() {
+    return `${this.fieldUid}-validation`;
+  }
+
+  // mirrors the id the shared form template validation gives the error tip
+  get errorId() {
+    return `${this.validationInputId}-error`;
   }
 
   @action
@@ -47,6 +67,25 @@ export default class FormTemplateFieldComposer extends Component {
   }
 
   @action
+  handleInvalid() {
+    this._editorTarget?.setAttribute("aria-invalid", "true");
+    this._editorTarget?.setAttribute("aria-describedby", this.errorId);
+
+    this.a11y.announce(
+      i18n("form_templates.errors.value_missing.default"),
+      "assertive"
+    );
+  }
+
+  @action
+  handleValidationInput(event) {
+    if (event.currentTarget.validity.valid) {
+      this._editorTarget?.setAttribute("aria-invalid", "false");
+      this._editorTarget?.removeAttribute("aria-describedby");
+    }
+  }
+
+  @action
   handleInput(event) {
     this.composerValue = event.target.value;
     next(this, () => {
@@ -61,14 +100,23 @@ export default class FormTemplateFieldComposer extends Component {
 
   @action
   onEditorSetup(textManipulation) {
+    this._editorTarget =
+      textManipulation.textarea || textManipulation.view?.dom;
+
+    // the label is only rendered when the template defines one, so pointing at
+    // it unconditionally would leave a dangling reference
+    if (this.args.attributes?.label) {
+      this._editorTarget?.setAttribute("aria-labelledby", this.labelId);
+    }
+
     if (!this.args.uppyComposerUpload || !this.composer.allowUpload) {
       return;
     }
 
     this.args.uppyComposerUpload.textManipulation = textManipulation;
 
-    const editorTarget =
-      textManipulation.textarea || textManipulation.view?.dom;
+    const editorTarget = this._editorTarget;
+
     if (!editorTarget) {
       return;
     }
@@ -89,7 +137,7 @@ export default class FormTemplateFieldComposer extends Component {
   <template>
     <div class="control-group form-template-field" data-field-type="composer">
       {{#if @attributes.label}}
-        <label class="form-template-field__label">
+        <label id={{this.labelId}} class="form-template-field__label">
           {{@attributes.label}}
           {{#if @validations.required}}
             {{dIcon "asterisk" class="form-template-field__required-indicator"}}
@@ -111,6 +159,7 @@ export default class FormTemplateFieldComposer extends Component {
       />
       {{! must stay last: the error tip is only inserted after a field with no next sibling }}
       <input
+        id={{this.validationInputId}}
         type="text"
         name={{@id}}
         value={{this.composerValue}}
@@ -119,6 +168,8 @@ export default class FormTemplateFieldComposer extends Component {
         tabindex="-1"
         aria-hidden="true"
         {{didInsert this.registerValidatedInput}}
+        {{on "invalid" this.handleInvalid}}
+        {{on "input" this.handleValidationInput}}
       />
     </div>
   </template>

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -137,9 +137,7 @@ export default class FormTemplateFieldComposer extends Component {
 
     this.args.uppyComposerUpload.textManipulation = textManipulation;
 
-    const editorTarget = this._editorTarget;
-
-    if (!editorTarget) {
+    if (!this._editorTarget) {
       return;
     }
 
@@ -152,7 +150,7 @@ export default class FormTemplateFieldComposer extends Component {
     };
 
     for (const event of ["focusin", "dragenter", "dragover"]) {
-      editorTarget.addEventListener(event, claimUploadTarget, { signal });
+      this._editorTarget.addEventListener(event, claimUploadTarget, { signal });
     }
   }
 

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -20,10 +20,10 @@ export default class FormTemplateFieldComposer extends Component {
 
   fieldUid = `form-template-composer-${guidFor(this)}`;
 
-  _claimAbortController = null;
-  _validatedInput = null;
-  _editorTarget = null;
-  _invalid = false;
+  #claimAbortController = null;
+  #validatedInput = null;
+  #editorTarget = null;
+  #validationFailed = false;
 
   constructor() {
     super(...arguments);
@@ -33,7 +33,7 @@ export default class FormTemplateFieldComposer extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.appEvents.off("composer:replace-text", this, this.handleReplaceText);
-    this._claimAbortController?.abort();
+    this.#claimAbortController?.abort();
   }
 
   get labelId() {
@@ -64,12 +64,12 @@ export default class FormTemplateFieldComposer extends Component {
 
   @action
   registerValidatedInput(element) {
-    this._validatedInput = element;
+    this.#validatedInput = element;
   }
 
   @action
   handleInvalid() {
-    this._invalid = true;
+    this.#validationFailed = true;
     this.#syncEditorAccessibility();
 
     this.a11y.announce(
@@ -81,7 +81,7 @@ export default class FormTemplateFieldComposer extends Component {
   @action
   handleValidationInput(event) {
     if (event.currentTarget.validity.valid) {
-      this._invalid = false;
+      this.#validationFailed = false;
       this.#syncEditorAccessibility();
     }
   }
@@ -89,7 +89,7 @@ export default class FormTemplateFieldComposer extends Component {
   // reapplies the full state rather than toggling it, because switching
   // between markdown and rich modes replaces the editor element
   #syncEditorAccessibility() {
-    const editor = this._editorTarget;
+    const editor = this.#editorTarget;
 
     if (!editor) {
       return;
@@ -102,7 +102,7 @@ export default class FormTemplateFieldComposer extends Component {
       editor.removeAttribute("aria-labelledby");
     }
 
-    if (this._invalid) {
+    if (this.#validationFailed) {
       editor.setAttribute("aria-invalid", "true");
       editor.setAttribute("aria-describedby", this.errorId);
     } else {
@@ -118,7 +118,7 @@ export default class FormTemplateFieldComposer extends Component {
       this.args.onChange?.(event);
       // the editor emits no form events of its own, so the input standing in
       // for it has to report the change
-      this._validatedInput?.dispatchEvent(
+      this.#validatedInput?.dispatchEvent(
         new Event("input", { bubbles: true })
       );
     });
@@ -126,7 +126,7 @@ export default class FormTemplateFieldComposer extends Component {
 
   @action
   onEditorSetup(textManipulation) {
-    this._editorTarget =
+    this.#editorTarget =
       textManipulation.textarea || textManipulation.view?.dom;
 
     this.#syncEditorAccessibility();
@@ -137,20 +137,20 @@ export default class FormTemplateFieldComposer extends Component {
 
     this.args.uppyComposerUpload.textManipulation = textManipulation;
 
-    if (!this._editorTarget) {
+    if (!this.#editorTarget) {
       return;
     }
 
-    this._claimAbortController?.abort();
-    this._claimAbortController = new AbortController();
-    const { signal } = this._claimAbortController;
+    this.#claimAbortController?.abort();
+    this.#claimAbortController = new AbortController();
+    const { signal } = this.#claimAbortController;
 
     const claimUploadTarget = () => {
       this.args.uppyComposerUpload.textManipulation = textManipulation;
     };
 
     for (const event of ["focusin", "dragenter", "dragover"]) {
-      this._editorTarget.addEventListener(event, claimUploadTarget, { signal });
+      this.#editorTarget.addEventListener(event, claimUploadTarget, { signal });
     }
   }
 

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -23,6 +23,7 @@ export default class FormTemplateFieldComposer extends Component {
   _claimAbortController = null;
   _validatedInput = null;
   _editorTarget = null;
+  _invalid = false;
 
   constructor() {
     super(...arguments);
@@ -68,8 +69,8 @@ export default class FormTemplateFieldComposer extends Component {
 
   @action
   handleInvalid() {
-    this._editorTarget?.setAttribute("aria-invalid", "true");
-    this._editorTarget?.setAttribute("aria-describedby", this.errorId);
+    this._invalid = true;
+    this.#markEditorInvalid();
 
     this.a11y.announce(
       i18n("form_templates.errors.value_missing.default"),
@@ -80,9 +81,15 @@ export default class FormTemplateFieldComposer extends Component {
   @action
   handleValidationInput(event) {
     if (event.currentTarget.validity.valid) {
+      this._invalid = false;
       this._editorTarget?.setAttribute("aria-invalid", "false");
       this._editorTarget?.removeAttribute("aria-describedby");
     }
+  }
+
+  #markEditorInvalid() {
+    this._editorTarget?.setAttribute("aria-invalid", "true");
+    this._editorTarget?.setAttribute("aria-describedby", this.errorId);
   }
 
   @action
@@ -107,6 +114,12 @@ export default class FormTemplateFieldComposer extends Component {
     // it unconditionally would leave a dangling reference
     if (this.args.attributes?.label) {
       this._editorTarget?.setAttribute("aria-labelledby", this.labelId);
+    }
+
+    // switching between markdown and rich modes swaps the editor element, so
+    // an already-failed validation has to be reapplied to the replacement
+    if (this._invalid) {
+      this.#markEditorInvalid();
     }
 
     if (!this.args.uppyComposerUpload || !this.composer.allowUpload) {

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { next, schedule } from "@ember/runloop";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
@@ -14,6 +15,7 @@ export default class FormTemplateFieldComposer extends Component {
   @tracked composerValue = this.args.value || "";
 
   _claimAbortController = null;
+  _validatedInput = null;
 
   constructor() {
     super(...arguments);
@@ -40,10 +42,20 @@ export default class FormTemplateFieldComposer extends Component {
   }
 
   @action
+  registerValidatedInput(element) {
+    this._validatedInput = element;
+  }
+
+  @action
   handleInput(event) {
     this.composerValue = event.target.value;
     next(this, () => {
       this.args.onChange?.(event);
+      // the editor is not a form control, so the field backing it has to
+      // announce the change for validation state to refresh
+      this._validatedInput?.dispatchEvent(
+        new Event("input", { bubbles: true })
+      );
     });
   }
 
@@ -90,13 +102,23 @@ export default class FormTemplateFieldComposer extends Component {
           {{trustHTML @attributes.description}}
         </span>
       {{/if}}
-      <input type="hidden" name={{@id}} value={{this.composerValue}} />
       <DEditor
         class="form-template-field__composer"
         @value={{this.composerValue}}
         @change={{this.handleInput}}
         @placeholder={{@attributes.placeholder}}
         @onSetup={{this.onEditorSetup}}
+      />
+      {{! must stay last: the error tip is only inserted after a field with no next sibling }}
+      <input
+        type="text"
+        name={{@id}}
+        value={{this.composerValue}}
+        required={{if @validations.required "required" ""}}
+        class="form-template-field__composer-hidden-input"
+        tabindex="-1"
+        aria-hidden="true"
+        {{didInsert this.registerValidatedInput}}
       />
     </div>
   </template>

--- a/frontend/discourse/app/components/form-template-field/composer.gjs
+++ b/frontend/discourse/app/components/form-template-field/composer.gjs
@@ -70,7 +70,7 @@ export default class FormTemplateFieldComposer extends Component {
   @action
   handleInvalid() {
     this._invalid = true;
-    this.#markEditorInvalid();
+    this.#syncEditorAccessibility();
 
     this.a11y.announce(
       i18n("form_templates.errors.value_missing.default"),
@@ -82,14 +82,35 @@ export default class FormTemplateFieldComposer extends Component {
   handleValidationInput(event) {
     if (event.currentTarget.validity.valid) {
       this._invalid = false;
-      this._editorTarget?.setAttribute("aria-invalid", "false");
-      this._editorTarget?.removeAttribute("aria-describedby");
+      this.#syncEditorAccessibility();
     }
   }
 
-  #markEditorInvalid() {
-    this._editorTarget?.setAttribute("aria-invalid", "true");
-    this._editorTarget?.setAttribute("aria-describedby", this.errorId);
+  // the editor is not a form control, so it carries the state of the input
+  // standing in for it. switching between markdown and rich modes replaces the
+  // editor element, so this reapplies the full state rather than toggling it.
+  #syncEditorAccessibility() {
+    const editor = this._editorTarget;
+
+    if (!editor) {
+      return;
+    }
+
+    // the label is only rendered when the template defines one, so pointing at
+    // it unconditionally would leave a dangling reference
+    if (this.args.attributes?.label) {
+      editor.setAttribute("aria-labelledby", this.labelId);
+    } else {
+      editor.removeAttribute("aria-labelledby");
+    }
+
+    if (this._invalid) {
+      editor.setAttribute("aria-invalid", "true");
+      editor.setAttribute("aria-describedby", this.errorId);
+    } else {
+      editor.removeAttribute("aria-invalid");
+      editor.removeAttribute("aria-describedby");
+    }
   }
 
   @action
@@ -110,17 +131,7 @@ export default class FormTemplateFieldComposer extends Component {
     this._editorTarget =
       textManipulation.textarea || textManipulation.view?.dom;
 
-    // the label is only rendered when the template defines one, so pointing at
-    // it unconditionally would leave a dangling reference
-    if (this.args.attributes?.label) {
-      this._editorTarget?.setAttribute("aria-labelledby", this.labelId);
-    }
-
-    // switching between markdown and rich modes swaps the editor element, so
-    // an already-failed validation has to be reapplied to the replacement
-    if (this._invalid) {
-      this.#markEditorInvalid();
-    }
+    this.#syncEditorAccessibility();
 
     if (!this.args.uppyComposerUpload || !this.composer.allowUpload) {
       return;

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -292,7 +292,19 @@ acceptance("Composer Form Template", function (needs) {
       .dom(".d-editor-input")
       .hasAttribute("aria-invalid", "true", "the editor starts out invalid");
 
+    assert
+      .dom(".d-editor-input")
+      .hasAttribute("aria-required", "true", "the editor starts out required");
+
     await click(".composer-toggle-switch");
+
+    assert
+      .dom(".d-editor-input")
+      .hasAttribute(
+        "aria-required",
+        "true",
+        "the replacement editor is still marked required"
+      );
 
     assert
       .dom(".d-editor-input")

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -272,6 +272,41 @@ acceptance("Composer Form Template", function (needs) {
       );
   });
 
+  test("keeps the editor marked invalid after switching editor modes", async function (assert) {
+    await visit("/");
+
+    const composer = this.owner.lookup("service:composer");
+    await composer.openNewTopic({ formTemplate: FORM_TEMPLATES[2] });
+    await settled();
+
+    await fillIn("#reply-title", "A title that is long enough to be valid");
+    await click("#reply-control button.create");
+
+    assert
+      .dom(".d-editor-input")
+      .hasAttribute("aria-invalid", "true", "the editor starts out invalid");
+
+    await click(".composer-toggle-switch");
+
+    assert
+      .dom(".d-editor-input")
+      .hasAttribute(
+        "aria-invalid",
+        "true",
+        "the replacement editor is still marked invalid"
+      );
+
+    const describedBy = document
+      .querySelector(".d-editor-input")
+      .getAttribute("aria-describedby");
+    assert
+      .dom(`#${describedBy}`)
+      .hasText(
+        i18n("form_templates.errors.value_missing.default"),
+        "the replacement editor is still connected to the visible error"
+      );
+  });
+
   test("blocks topic creation when a required composer field is empty even if other fields are filled", async function (assert) {
     pretender.post("/posts", () => {
       assert.true(

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -1,4 +1,11 @@
-import { click, currentURL, fillIn, settled, visit } from "@ember/test-helpers";
+import {
+  click,
+  currentURL,
+  fillIn,
+  find,
+  settled,
+  visit,
+} from "@ember/test-helpers";
 import { test } from "qunit";
 import sinon from "sinon";
 import { cloneJSON } from "discourse/lib/object";
@@ -241,9 +248,8 @@ acceptance("Composer Form Template", function (needs) {
       .dom(".d-editor-input")
       .hasAttribute("aria-invalid", "true", "the editor is marked invalid");
 
-    const describedBy = document
-      .querySelector(".d-editor-input")
-      .getAttribute("aria-describedby");
+    const describedBy =
+      find(".d-editor-input").getAttribute("aria-describedby");
     assert
       .dom(`#${describedBy}`)
       .hasText(
@@ -263,7 +269,7 @@ acceptance("Composer Form Template", function (needs) {
 
     assert
       .dom(".d-editor-input")
-      .hasAttribute("aria-invalid", "false", "the invalid state is cleared");
+      .doesNotHaveAttribute("aria-invalid", "the invalid state is cleared");
     assert
       .dom(".d-editor-input")
       .doesNotHaveAttribute(
@@ -296,9 +302,8 @@ acceptance("Composer Form Template", function (needs) {
         "the replacement editor is still marked invalid"
       );
 
-    const describedBy = document
-      .querySelector(".d-editor-input")
-      .getAttribute("aria-describedby");
+    const describedBy =
+      find(".d-editor-input").getAttribute("aria-describedby");
     assert
       .dom(`#${describedBy}`)
       .hasText(

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -1,7 +1,8 @@
-import { click, fillIn, settled, visit } from "@ember/test-helpers";
+import { click, currentURL, fillIn, settled, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import { cloneJSON } from "discourse/lib/object";
 import TopicFixtures from "discourse/tests/fixtures/topic";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
 
@@ -40,6 +41,34 @@ const FORM_TEMPLATES = [
           type: date
     `,
   },
+  {
+    id: 3,
+    name: "Required Composer Only",
+    template: `
+      - type: composer
+        id: md-description
+        attributes:
+          label: "Description"
+        validations:
+          required: true
+    `,
+  },
+  {
+    id: 4,
+    name: "Required Composer With Other Field",
+    template: `
+      - type: input
+        id: other-field
+        attributes:
+          label: "Other field"
+      - type: composer
+        id: md-description
+        attributes:
+          label: "Description"
+        validations:
+          required: true
+    `,
+  },
 ];
 
 acceptance("Composer Form Template", function (needs) {
@@ -62,7 +91,7 @@ acceptance("Composer Form Template", function (needs) {
         slug: "general",
         permission: 1,
         topic_template: null,
-        form_template_ids: [1, 2],
+        form_template_ids: [1, 2, 3, 4],
       },
       {
         id: 2,
@@ -82,7 +111,7 @@ acceptance("Composer Form Template", function (needs) {
       });
     });
 
-    [1, 2].forEach((id) => {
+    [1, 2, 3, 4].forEach((id) => {
       server.get(`/form-templates/${id}.json`, () => {
         const index = id - 1;
 
@@ -179,5 +208,57 @@ acceptance("Composer Form Template", function (needs) {
     assert
       .dom(".form-template-field__input[name='activity-date']")
       .exists("it renders form template field");
+  });
+
+  test("blocks topic creation and shows a validation message when a required composer field is left empty", async function (assert) {
+    pretender.post("/posts", () => {
+      assert.true(
+        false,
+        "a topic should not be created while the required field is empty"
+      );
+      return response(200, { success: true });
+    });
+
+    await visit("/");
+
+    const composer = this.owner.lookup("service:composer");
+    await composer.openNewTopic({ formTemplate: FORM_TEMPLATES[2] });
+    await settled();
+
+    await fillIn("#reply-title", "A title that is long enough to be valid");
+    await click("#reply-control button.create");
+
+    assert.strictEqual(currentURL(), "/", "the topic is not created");
+    assert
+      .dom(".form-template-field__error")
+      .exists("a validation error message is shown");
+  });
+
+  test("blocks topic creation when a required composer field is empty even if other fields are filled", async function (assert) {
+    pretender.post("/posts", () => {
+      assert.true(
+        false,
+        "a topic should not be created while the required field is empty"
+      );
+      return response(200, { success: true });
+    });
+
+    await visit("/");
+
+    const composer = this.owner.lookup("service:composer");
+    await composer.openNewTopic({ formTemplate: FORM_TEMPLATES[3] });
+    await settled();
+
+    await fillIn("#reply-title", "A title that is long enough to be valid");
+    await fillIn(
+      ".form-template-field__input[name='other-field']",
+      "some content"
+    );
+    await click("#reply-control button.create");
+
+    assert.strictEqual(currentURL(), "/", "the topic is not created");
+    assert
+      .dom(".form-template-field__error")
+      .exists("a validation error message is shown");
   });
 });

--- a/frontend/discourse/tests/acceptance/composer-form-template-test.js
+++ b/frontend/discourse/tests/acceptance/composer-form-template-test.js
@@ -1,10 +1,12 @@
 import { click, currentURL, fillIn, settled, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import sinon from "sinon";
 import { cloneJSON } from "discourse/lib/object";
 import TopicFixtures from "discourse/tests/fixtures/topic";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 import selectKit from "discourse/tests/helpers/select-kit-helper";
+import { i18n } from "discourse-i18n";
 
 const FORM_TEMPLATES = [
   {
@@ -222,6 +224,8 @@ acceptance("Composer Form Template", function (needs) {
     await visit("/");
 
     const composer = this.owner.lookup("service:composer");
+    const announce = sinon.spy(this.owner.lookup("service:a11y"), "announce");
+
     await composer.openNewTopic({ formTemplate: FORM_TEMPLATES[2] });
     await settled();
 
@@ -232,6 +236,40 @@ acceptance("Composer Form Template", function (needs) {
     assert
       .dom(".form-template-field__error")
       .exists("a validation error message is shown");
+
+    assert
+      .dom(".d-editor-input")
+      .hasAttribute("aria-invalid", "true", "the editor is marked invalid");
+
+    const describedBy = document
+      .querySelector(".d-editor-input")
+      .getAttribute("aria-describedby");
+    assert
+      .dom(`#${describedBy}`)
+      .hasText(
+        i18n("form_templates.errors.value_missing.default"),
+        "the editor is connected to the visible error"
+      );
+
+    assert.true(
+      announce.calledWith(
+        i18n("form_templates.errors.value_missing.default"),
+        "assertive"
+      ),
+      "the error is announced to screen readers"
+    );
+
+    await fillIn(".d-editor-input", "some content");
+
+    assert
+      .dom(".d-editor-input")
+      .hasAttribute("aria-invalid", "false", "the invalid state is cleared");
+    assert
+      .dom(".d-editor-input")
+      .doesNotHaveAttribute(
+        "aria-describedby",
+        "the error reference is cleared"
+      );
   });
 
   test("blocks topic creation when a required composer field is empty even if other fields are filled", async function (assert) {

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -12,6 +12,7 @@ import sinon from "sinon";
 import FormComposer from "discourse/components/form-template-field/composer";
 import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { i18n } from "discourse-i18n";
 
 function fakeUppy() {
   return { textManipulation: null };
@@ -386,6 +387,114 @@ module(
         inputEvents.length >= 1,
         "an input event is dispatched on the backing input so validation state can refresh"
       );
+    });
+
+    test("labels the editor with the field label", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @attributes={{hash label="Description"}}
+            @onChange={{noop}}
+          />
+        </template>
+      );
+
+      const label = document.querySelector(".form-template-field__label");
+      assert
+        .dom(".d-editor-input")
+        .hasAttribute(
+          "aria-labelledby",
+          label.id,
+          "the editor is labelled by the field label"
+        );
+    });
+
+    test("does not label the editor when the field has no label", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template><FormComposer @id="field-1" @onChange={{noop}} /></template>
+      );
+
+      assert
+        .dom(".d-editor-input")
+        .doesNotHaveAttribute(
+          "aria-labelledby",
+          "no dangling reference when the template defines no label"
+        );
+    });
+
+    test("mirrors the invalid state onto the editor and announces the error", async function (assert) {
+      stubAllowUpload(this, true);
+
+      const a11y = getOwner(this).lookup("service:a11y");
+      const announce = sinon.spy(a11y, "announce");
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @attributes={{hash label="Description"}}
+            @validations={{hash required=true}}
+            @onChange={{noop}}
+          />
+        </template>
+      );
+
+      const input = document.querySelector("input[name='field-1']");
+      input.checkValidity();
+      await settled();
+
+      assert
+        .dom(".d-editor-input")
+        .hasAttribute("aria-invalid", "true", "the editor is marked invalid");
+      assert
+        .dom(".d-editor-input")
+        .hasAttribute(
+          "aria-describedby",
+          `${input.id}-error`,
+          "the editor points at the error tip the shared validation renders"
+        );
+      assert.true(
+        announce.calledWith(
+          i18n("form_templates.errors.value_missing.default"),
+          "assertive"
+        ),
+        "the translated error is announced assertively"
+      );
+    });
+
+    test("clears the invalid state on the editor once the field has content", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @attributes={{hash label="Description"}}
+            @validations={{hash required=true}}
+            @onChange={{noop}}
+          />
+        </template>
+      );
+
+      document.querySelector("input[name='field-1']").checkValidity();
+      await settled();
+
+      await fillIn(".d-editor-input", "some content");
+
+      assert
+        .dom(".d-editor-input")
+        .hasAttribute("aria-invalid", "false", "the invalid marker is cleared");
+      assert
+        .dom(".d-editor-input")
+        .doesNotHaveAttribute(
+          "aria-describedby",
+          "the error reference is removed"
+        );
     });
 
     test("composer:replace-text is a no-op when the field does not contain the markdown", async function (assert) {

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -391,6 +391,40 @@ module(
         );
     });
 
+    test("marks the editor required when the field is required", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @validations={{hash required=true}}
+            @onChange={{noop}}
+          />
+        </template>
+      );
+
+      assert
+        .dom(".d-editor-input")
+        .hasAttribute(
+          "aria-required",
+          "true",
+          "the editor announces that it is required before submitting"
+        );
+    });
+
+    test("does not mark the editor required when the field is optional", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template><FormComposer @id="field-1" @onChange={{noop}} /></template>
+      );
+
+      assert
+        .dom(".d-editor-input")
+        .doesNotHaveAttribute("aria-required", "the editor is not required");
+    });
+
     test("does not label the editor when the field has no label", async function (assert) {
       stubAllowUpload(this, true);
 

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -2,6 +2,7 @@ import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
 import {
   fillIn,
+  find,
   render,
   settled,
   triggerEvent,
@@ -402,7 +403,7 @@ module(
         </template>
       );
 
-      const label = document.querySelector(".form-template-field__label");
+      const label = find(".form-template-field__label");
       assert
         .dom(".d-editor-input")
         .hasAttribute(
@@ -444,7 +445,7 @@ module(
         </template>
       );
 
-      const input = document.querySelector("input[name='field-1']");
+      const input = find("input[name='field-1']");
       input.checkValidity();
       await settled();
 
@@ -481,14 +482,14 @@ module(
         </template>
       );
 
-      document.querySelector("input[name='field-1']").checkValidity();
+      find("input[name='field-1']").checkValidity();
       await settled();
 
       await fillIn(".d-editor-input", "some content");
 
       assert
         .dom(".d-editor-input")
-        .hasAttribute("aria-invalid", "false", "the invalid marker is cleared");
+        .doesNotHaveAttribute("aria-invalid", "the invalid marker is cleared");
       assert
         .dom(".d-editor-input")
         .doesNotHaveAttribute(

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -1,5 +1,12 @@
+import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
-import { render, settled, triggerEvent, waitUntil } from "@ember/test-helpers";
+import {
+  fillIn,
+  render,
+  settled,
+  triggerEvent,
+  waitUntil,
+} from "@ember/test-helpers";
 import { module, test } from "qunit";
 import sinon from "sinon";
 import FormComposer from "discourse/components/form-template-field/composer";
@@ -325,6 +332,60 @@ module(
         "![image|10x10, 75%](upload://abc.png) and ![image|10x10](upload://abc.png)";
       assert.dom("input[name='field-1']").hasValue(expected);
       assert.dom(".d-editor-input").hasValue(expected);
+    });
+
+    test("marks the backing input as required when the field is required", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template>
+          <FormComposer
+            @id="field-1"
+            @onChange={{noop}}
+            @validations={{hash required=true}}
+          />
+        </template>
+      );
+
+      assert
+        .dom("input[name='field-1']")
+        .hasAttribute(
+          "required",
+          { any: true },
+          "the backing input is required"
+        );
+    });
+
+    test("does not mark the backing input as required when the field is not required", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template><FormComposer @id="field-1" @onChange={{noop}} /></template>
+      );
+
+      assert
+        .dom("input[name='field-1']")
+        .doesNotHaveAttribute("required", "the backing input is not required");
+    });
+
+    test("typing in the editor dispatches an input event on the backing input", async function (assert) {
+      stubAllowUpload(this, true);
+
+      await render(
+        <template><FormComposer @id="field-1" @onChange={{noop}} /></template>
+      );
+
+      const inputEvents = [];
+      document
+        .querySelector("input[name='field-1']")
+        .addEventListener("input", () => inputEvents.push(true));
+
+      await fillIn(".d-editor-input", "some content");
+
+      assert.true(
+        inputEvents.length >= 1,
+        "an input event is dispatched on the backing input so validation state can refresh"
+      );
     });
 
     test("composer:replace-text is a no-op when the field does not contain the markdown", async function (assert) {

--- a/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/form-template-field/composer-test.gjs
@@ -1,7 +1,6 @@
 import { hash } from "@ember/helper";
 import { getOwner } from "@ember/owner";
 import {
-  fillIn,
   find,
   render,
   settled,
@@ -13,7 +12,6 @@ import sinon from "sinon";
 import FormComposer from "discourse/components/form-template-field/composer";
 import noop from "discourse/helpers/noop";
 import { setupRenderingTest } from "discourse/tests/helpers/component-test";
-import { i18n } from "discourse-i18n";
 
 function fakeUppy() {
   return { textManipulation: null };
@@ -370,26 +368,6 @@ module(
         .doesNotHaveAttribute("required", "the backing input is not required");
     });
 
-    test("typing in the editor dispatches an input event on the backing input", async function (assert) {
-      stubAllowUpload(this, true);
-
-      await render(
-        <template><FormComposer @id="field-1" @onChange={{noop}} /></template>
-      );
-
-      const inputEvents = [];
-      document
-        .querySelector("input[name='field-1']")
-        .addEventListener("input", () => inputEvents.push(true));
-
-      await fillIn(".d-editor-input", "some content");
-
-      assert.true(
-        inputEvents.length >= 1,
-        "an input event is dispatched on the backing input so validation state can refresh"
-      );
-    });
-
     test("labels the editor with the field label", async function (assert) {
       stubAllowUpload(this, true);
 
@@ -425,76 +403,6 @@ module(
         .doesNotHaveAttribute(
           "aria-labelledby",
           "no dangling reference when the template defines no label"
-        );
-    });
-
-    test("mirrors the invalid state onto the editor and announces the error", async function (assert) {
-      stubAllowUpload(this, true);
-
-      const a11y = getOwner(this).lookup("service:a11y");
-      const announce = sinon.spy(a11y, "announce");
-
-      await render(
-        <template>
-          <FormComposer
-            @id="field-1"
-            @attributes={{hash label="Description"}}
-            @validations={{hash required=true}}
-            @onChange={{noop}}
-          />
-        </template>
-      );
-
-      const input = find("input[name='field-1']");
-      input.checkValidity();
-      await settled();
-
-      assert
-        .dom(".d-editor-input")
-        .hasAttribute("aria-invalid", "true", "the editor is marked invalid");
-      assert
-        .dom(".d-editor-input")
-        .hasAttribute(
-          "aria-describedby",
-          `${input.id}-error`,
-          "the editor points at the error tip the shared validation renders"
-        );
-      assert.true(
-        announce.calledWith(
-          i18n("form_templates.errors.value_missing.default"),
-          "assertive"
-        ),
-        "the translated error is announced assertively"
-      );
-    });
-
-    test("clears the invalid state on the editor once the field has content", async function (assert) {
-      stubAllowUpload(this, true);
-
-      await render(
-        <template>
-          <FormComposer
-            @id="field-1"
-            @attributes={{hash label="Description"}}
-            @validations={{hash required=true}}
-            @onChange={{noop}}
-          />
-        </template>
-      );
-
-      find("input[name='field-1']").checkValidity();
-      await settled();
-
-      await fillIn(".d-editor-input", "some content");
-
-      assert
-        .dom(".d-editor-input")
-        .doesNotHaveAttribute("aria-invalid", "the invalid marker is cleared");
-      assert
-        .dom(".d-editor-input")
-        .doesNotHaveAttribute(
-          "aria-describedby",
-          "the error reference is removed"
         );
     });
 


### PR DESCRIPTION
The composer field type backed its value with an `<input type="hidden">`, which the HTML spec excludes from constraint validation. `required` had no effect there, and the component never set it in the first place: it only read `validations.required` to draw the asterisk.

`form.checkValidity()` therefore always passed for these fields. When the composer field was the only one in the template, the generated post body came out empty and submission was stopped by a falsy-string check with no visible error. When other fields had content, the body was non-empty and the topic was created with the required field still blank.

Backs the field with a visually hidden text input carrying `required`, as every other field type does, and dispatches an `input` event on it when the editor changes so the shared validation logic can clear the error tip.

That input is `aria-hidden`, so the invalid state and the error tip attached to it were unreachable by assistive technology. It is now treated as a validation proxy: its state is mirrored onto the real editor through `aria-invalid` and `aria-describedby`, the message is announced through the `a11y` service, and the editor is labelled by the field label. Switching between markdown and rich modes replaces the editor element, so that state is reapplied rather than toggled in place.