### PR TITLE
UX: keep livestream chat position throughout whole topic

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/discourse-post-event/index.gjs
@@ -4,7 +4,6 @@ import { service } from "@ember/service";
 import { modifier } from "ember-modifier";
 import moment from "moment";
 import PluginOutlet from "discourse/components/plugin-outlet";
-import bodyClass from "discourse/helpers/body-class";
 import lazyHash from "discourse/helpers/lazy-hash";
 import routeAction from "discourse/helpers/route-action";
 import { popupAjaxError } from "discourse/lib/ajax-error";
@@ -83,7 +82,6 @@ const StatusPlaceholder = <template>
 export default class DiscoursePostEvent extends Component {
   @service currentUser;
   @service discoursePostEventApi;
-  @service embeddableChat;
   @service messageBus;
   @service siteSettings;
 
@@ -114,14 +112,6 @@ export default class DiscoursePostEvent extends Component {
 
   get event() {
     return this.fetchedEvent ?? this.args.event;
-  }
-
-  get useLivestreamLayout() {
-    return (
-      this.event.livestream &&
-      this.embeddableChat.chatChannelId &&
-      !this.embeddableChat.isChannelOpenInDrawer
-    );
   }
 
   get isPartialEvent() {
@@ -409,9 +399,6 @@ export default class DiscoursePostEvent extends Component {
               {{/if}}
 
               {{#unless @hideLivestreamVideo}}
-                {{#if this.useLivestreamLayout}}
-                  {{bodyClass "livestream-topic"}}
-                {{/if}}
                 <Livestream @event={{event}} />
               {{/unless}}
             </PluginOutlet>

--- a/plugins/discourse-calendar/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
@@ -1,5 +1,6 @@
 import Component from "@glimmer/component";
 import { service } from "@ember/service";
+import bodyClass from "discourse/helpers/body-class";
 import EmbeddableChatChannel from "../../components/livestream/embeddable-chat-channel";
 
 export default class EmbedableChatChannelConnector extends Component {
@@ -29,6 +30,9 @@ export default class EmbedableChatChannelConnector extends Component {
   }
 
   <template>
+    {{#if this.embeddableChat.useLivestreamLayout}}
+      {{bodyClass "livestream-topic"}}
+    {{/if}}
     {{#if this.shouldRender}}
       <EmbeddableChatChannel
         @chatChannelId={{this.embeddableChat.chatChannelId}}

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -86,9 +86,6 @@ export default class EmbeddableChat extends Service {
     return this.topic?.has_livestream;
   }
 
-  // Drives the `livestream-topic` body class. Keyed on the topic rather than on
-  // the event card, which the post-stream cloaks once it is a viewport out of
-  // view — taking the class, and the chat panel's layout, with it.
   get useLivestreamLayout() {
     return (
       this.router.currentRouteName?.startsWith("topic.") &&

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -85,4 +85,16 @@ export default class EmbeddableChat extends Service {
   get topicHasLivestream() {
     return this.topic?.has_livestream;
   }
+
+  // Drives the `livestream-topic` body class. Keyed on the topic rather than on
+  // the event card, which the post-stream cloaks once it is a viewport out of
+  // view — taking the class, and the chat panel's layout, with it.
+  get useLivestreamLayout() {
+    return (
+      this.router.currentRouteName?.startsWith("topic.") &&
+      this.topicHasLivestream &&
+      !!this.chatChannelId &&
+      !this.isChannelOpenInDrawer
+    );
+  }
 }

--- a/plugins/discourse-calendar/test/javascripts/integration/components/embeddable-chat-channel-connector-test.gjs
+++ b/plugins/discourse-calendar/test/javascripts/integration/components/embeddable-chat-channel-connector-test.gjs
@@ -1,0 +1,42 @@
+import { getOwner } from "@ember/owner";
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import EmbeddableChatChannelConnector from "../../discourse/connectors/before-main-outlet/embeddable-chat-channel-connector";
+
+module(
+  "Integration | Component | Livestream | embeddable chat channel connector",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    function stubEmbeddableChat(context, useLivestreamLayout) {
+      const owner = getOwner(context);
+      owner.unregister("service:embeddable-chat");
+      owner.register(
+        "service:embeddable-chat",
+        {
+          useLivestreamLayout,
+          chatChannelId: 9,
+          canRenderChatChannel: () => false,
+        },
+        { instantiate: false }
+      );
+    }
+
+    test("applies the livestream body class from outside the post stream", async function (assert) {
+      stubEmbeddableChat(this, true);
+
+      await render(<template><EmbeddableChatChannelConnector /></template>);
+
+      assert.dom(document.body).hasClass("livestream-topic");
+    });
+
+    test("omits the livestream body class when the layout does not apply", async function (assert) {
+      stubEmbeddableChat(this, false);
+
+      await render(<template><EmbeddableChatChannelConnector /></template>);
+
+      assert.dom(document.body).doesNotHaveClass("livestream-topic");
+    });
+  }
+);


### PR DESCRIPTION
This fixes an issue where scrolling in a livestream topic loses the chat sidebar. The body class had to be based on the topic rather than the event card so the class can persist. Added a test to make sure it doesn't regress. 