### PR TITLE
FIX: Filter unlinked topic visibility in topic-link reflect queries

### DIFF
--- a/app/models/topic_link.rb
+++ b/app/models/topic_link.rb
@@ -228,6 +228,7 @@ class TopicLink < ActiveRecord::Base
   def self.apply_link_visibility_filters(builder, link:, target_topic:, target_posts:)
     builder.where(<<~SQL)
       #{target_topic}.deleted_at IS NULL
+      AND (#{target_topic}.id IS NULL OR #{target_topic}.visible = true)
       AND (#{link}.internal = false OR #{target_topic}.id IS NOT NULL)
       AND (#{link}.link_post_id IS NULL OR (#{target_posts}.id IS NOT NULL AND #{target_posts}.deleted_at IS NULL))
     SQL

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3239,6 +3239,42 @@ RSpec.describe TopicsController do
       )
     end
 
+    it "does not expose stale reflections from unlisted topics to anonymous viewers" do
+      public_post = Fabricate(:post, user: post_author1)
+      public_topic = public_post.topic
+      public_source_topic = Fabricate(:topic, user: post_author1, title: "Public source topic")
+      public_source_post =
+        Fabricate(
+          :post,
+          topic: public_source_topic,
+          user: post_author1,
+          raw:
+            "#{Discourse.base_url_no_prefix}#{public_topic.relative_url(public_post.post_number)}",
+        )
+      unlisted_source_topic = Fabricate(:topic, user: post_author1, title: "Unlisted source topic")
+      unlisted_source_post =
+        Fabricate(
+          :post,
+          topic: unlisted_source_topic,
+          user: post_author1,
+          raw:
+            "#{Discourse.base_url_no_prefix}#{public_topic.relative_url(public_post.post_number)}",
+        )
+
+      TopicLink.extract_from(public_source_post)
+      TopicLink.extract_from(unlisted_source_post)
+      unlisted_source_topic.update_column(:visible, false)
+
+      get "/t/#{public_topic.slug}/#{public_topic.id}.json"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(public_source_topic.title)
+      expect(response.body).not_to include(unlisted_source_topic.title)
+      expect(response.body).not_to include(
+        "#{Discourse.base_url_no_prefix}#{unlisted_source_topic.relative_url(unlisted_source_post.post_number)}",
+      )
+    end
+
     it "does not expose hidden post link counts", :aggregate_failures do
       first_post = Fabricate(:post, user: post_author1)
       test_topic = first_post.topic

--- a/spec/requests/topics_controller_spec.rb
+++ b/spec/requests/topics_controller_spec.rb
@@ -3239,7 +3239,7 @@ RSpec.describe TopicsController do
       )
     end
 
-    it "does not expose stale reflections from unlisted topics to anonymous viewers" do
+    it "does not expose links from unlisted topics to anonymous viewers" do
       public_post = Fabricate(:post, user: post_author1)
       public_topic = public_post.topic
       public_source_topic = Fabricate(:topic, user: post_author1, title: "Public source topic")
@@ -3268,10 +3268,17 @@ RSpec.describe TopicsController do
       get "/t/#{public_topic.slug}/#{public_topic.id}.json"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(public_source_topic.title)
-      expect(response.body).not_to include(unlisted_source_topic.title)
-      expect(response.body).not_to include(
-        "#{Discourse.base_url_no_prefix}#{unlisted_source_topic.relative_url(unlisted_source_post.post_number)}",
+      serialized_public_post =
+        response
+          .parsed_body
+          .dig("post_stream", "posts")
+          .find { |post| post["id"] == public_post.id }
+      expect(serialized_public_post["link_counts"]).to contain_exactly(
+        a_hash_including(
+          "url" =>
+            "#{Discourse.base_url_no_prefix}#{public_source_topic.relative_url(public_source_post.post_number)}",
+          "title" => public_source_topic.title,
+        ),
       )
     end
 


### PR DESCRIPTION
## Summary

Correctly filter out topic links to unlisted topics in TopicLink apply_link_visibility_filters, preventing anonymous exposure of unlisted topic titles and URLs through post link_counts and topic map details.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1502

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>