### PR TITLE
FIX: DraftSerializer leaks real names of topic and post authors

### DIFF
--- a/app/serializers/draft_serializer.rb
+++ b/app/serializers/draft_serializer.rb
@@ -47,6 +47,10 @@ class DraftSerializer < ApplicationSerializer
     object.display_user&.name
   end
 
+  def include_name?
+    SiteSetting.enable_names?
+  end
+
   def title
     object.topic&.title
   end

--- a/spec/requests/drafts_controller_spec.rb
+++ b/spec/requests/drafts_controller_spec.rb
@@ -50,6 +50,23 @@ RSpec.describe DraftsController do
       expect(response.parsed_body["drafts"].first["title"]).to eq(nil)
     end
 
+    it "omits display user names when names are disabled" do
+      SiteSetting.enable_names = false
+      topic_author = Fabricate(:user, name: "Hidden Full Name")
+      topic = Fabricate(:topic, user: topic_author)
+      Draft.set(user, "topic_#{topic.id}", 0, { reply: "draft reply" }.to_json)
+
+      sign_in(user)
+      get "/drafts.json"
+
+      draft = response.parsed_body["drafts"].first
+
+      expect(response.status).to eq(200)
+      expect(draft).to include("username" => topic_author.username)
+      expect(draft).not_to have_key("name")
+      expect(response.body).not_to include(topic_author.name)
+    end
+
     it "returns categories when lazy load categories is enabled" do
       SiteSetting.lazy_load_categories_groups = "#{Group::AUTO_GROUPS[:everyone]}"
       category = Fabricate(:category)


### PR DESCRIPTION
## Summary

Prevent the disclosure of topic and post authors' real names in the drafts list by gating the name attribute behind the site-wide display names setting. This ensures that DraftSerializer correctly respects privacy settings when serializing draft metadata for replied-to content.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1322

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>