### PR TITLE
DEV: Add a dResizeEdge modifier and adopt it in the docked composer

### DIFF
--- a/app/assets/stylesheets/common/components/docked-composer.scss
+++ b/app/assets/stylesheets/common/components/docked-composer.scss
@@ -42,7 +42,6 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    touch-action: none;
     user-select: none;
 
     &::after {

--- a/frontend/discourse/app/components/docked-composer.gjs
+++ b/frontend/discourse/app/components/docked-composer.gjs
@@ -1,7 +1,6 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { fn, hash } from "@ember/helper";
-import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { guidFor } from "@ember/object/internals";
 import { getOwner } from "@ember/owner";
@@ -20,6 +19,7 @@ import { clipboardHelpers } from "discourse/lib/utilities";
 import DButton from "discourse/ui-kit/d-button";
 import DEditor from "discourse/ui-kit/d-editor";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
+import dResizeEdge from "discourse/ui-kit/modifiers/d-resize-edge";
 import { i18n } from "discourse-i18n";
 
 // Reusable chat-style "docked" composer. There is deliberately no
@@ -45,7 +45,6 @@ export default class DockedComposer extends Component {
   inputElement = null;
   uppyUpload = null;
   fileInputEl = null;
-  #dragStart = null;
   #rootElement = null;
 
   #handlePaste = (event) => {
@@ -367,70 +366,12 @@ export default class DockedComposer extends Component {
   }
 
   @action
-  onResizeStart(event) {
-    event.preventDefault();
-    this.#dragStart = {
-      clientY: event.clientY,
-      offset: this.dragOffset,
-    };
-    event.currentTarget.setPointerCapture(event.pointerId);
-  }
-
-  @action
-  onResizeMove(event) {
-    if (!this.#dragStart || !this.#rootElement?.isConnected) {
-      return;
-    }
-    // dragging UP should grow the composer, so invert
-    const delta = this.#dragStart.clientY - event.clientY;
-    const raw = Math.max(0, this.#dragStart.offset + delta);
-    this.dragOffset =
-      this.maxResizeOffset != null ? Math.min(this.maxResizeOffset, raw) : raw;
-    this.#rootElement.style.setProperty(
-      "--docked-composer-drag-offset",
-      `${this.dragOffset}px`
-    );
-  }
-
-  @action
-  onResizeKeyDown(event) {
-    // Arrow keys nudge height; Home/End snap to bounds. We mirror the
-    // dragOffset state so the keyboard interaction stays in sync with
-    // pointer drags.
-    const STEP = 16;
-    const max = this.maxResizeOffset ?? 400;
-    let next;
-    switch (event.key) {
-      case "ArrowUp":
-        next = Math.min(max, this.dragOffset + STEP);
-        break;
-      case "ArrowDown":
-        next = Math.max(0, this.dragOffset - STEP);
-        break;
-      case "Home":
-        next = 0;
-        break;
-      case "End":
-        next = max;
-        break;
-      default:
-        return;
-    }
-    event.preventDefault();
-    this.dragOffset = next;
+  onResize(offset) {
+    this.dragOffset = offset;
     this.#rootElement?.style.setProperty(
       "--docked-composer-drag-offset",
-      `${next}px`
+      `${offset}px`
     );
-  }
-
-  @action
-  onResizeEnd(event) {
-    if (!this.#dragStart) {
-      return;
-    }
-    this.#dragStart = null;
-    event.currentTarget.releasePointerCapture?.(event.pointerId);
   }
 
   <template>
@@ -451,7 +392,6 @@ export default class DockedComposer extends Component {
         {{willDestroy this.teardown}}
       >
         {{#if this.resizable}}
-          {{! eslint-disable ember/template-no-pointer-down-event-binding }}
           <div
             class="docked-composer__resize-handle"
             role="separator"
@@ -461,11 +401,14 @@ export default class DockedComposer extends Component {
             aria-valuemin="0"
             aria-valuemax={{this.resizeAriaMax}}
             tabindex="0"
-            {{on "pointerdown" this.onResizeStart}}
-            {{on "pointermove" this.onResizeMove}}
-            {{on "pointerup" this.onResizeEnd}}
-            {{on "pointercancel" this.onResizeEnd}}
-            {{on "keydown" this.onResizeKeyDown}}
+            {{dResizeEdge
+              value=this.dragOffset
+              min=0
+              max=this.resizeAriaMax
+              axis="vertical"
+              side="end"
+              onResize=this.onResize
+            }}
           ></div>
         {{/if}}
         {{#if (has-block "header")}}

--- a/frontend/discourse/app/ui-kit/modifiers/d-resize-edge.ts
+++ b/frontend/discourse/app/ui-kit/modifiers/d-resize-edge.ts
@@ -1,0 +1,285 @@
+import { registerDestructor } from "@ember/destroyable";
+import type Owner from "@ember/owner";
+import Modifier, { type ArgsFor } from "ember-modifier";
+
+// How far a single arrow key press moves the edge, in pixels.
+const KEYBOARD_STEP = 16;
+
+interface DResizeEdgeSignature {
+  /** The element acting as the edge. */
+  Element: HTMLElement;
+  Args: {
+    Named: {
+      /** The current size, in pixels. */
+      value: number;
+
+      /** The smallest size the edge may be dragged to. */
+      min: number;
+
+      /** The largest size the edge may be dragged to. */
+      max: number;
+
+      /**
+       * The axis the edge moves along. Defaults to `"horizontal"`.
+       *
+       * Note that this is the opposite of the `aria-orientation` the element
+       * should carry: that describes the separator itself, which lies across
+       * the axis it moves along.
+       */
+      axis?: "horizontal" | "vertical";
+
+      /**
+       * Which edge the resized element is docked against, in logical terms.
+       * Combined with the writing direction this decides whether moving the
+       * pointer away from that edge makes it larger or smaller. Defaults to
+       * `"start"`.
+       */
+      side?: "start" | "end";
+
+      /**
+       * Called while dragging, at most once per animation frame. Suitable for
+       * updating the rendered size.
+       */
+      onResize?: (size: number) => void;
+
+      /**
+       * Called once when the interaction finishes. Suitable for persisting the
+       * size.
+       */
+      onResizeEnd?: (size: number) => void;
+    };
+    Positional: [];
+  };
+}
+
+/**
+ * Makes an element behave as a draggable edge that resizes something along one
+ * axis, following the WAI-ARIA window splitter pattern.
+ *
+ * The modifier owns the interaction only. It reports the size it computed and
+ * leaves storing and applying it to the caller, so that the same element can
+ * drive a width held in a component, a service, or a CSS custom property. The
+ * reported number carries no unit of its own: it is whatever `value`, `min`,
+ * and `max` are expressed in, which is a width for a side panel but an offset
+ * from a resting height for a composer.
+ *
+ * Both pointer and keyboard interaction are supported, which is what the
+ * splitter pattern requires: a resize that can only be performed by dragging
+ * is unusable without a pointing device. Pointer events cover mouse, touch,
+ * and pen alike, and the modifier sets `touch-action: none` on the element so
+ * that a touch drag is not claimed by the browser as a scroll gesture.
+ *
+ * ```hbs
+ * <div
+ *   role="separator"
+ *   aria-orientation="vertical"
+ *   aria-valuenow={{this.width}}
+ *   aria-valuemin={{this.minWidth}}
+ *   aria-valuemax={{this.maxWidth}}
+ *   tabindex="0"
+ *   {{dResizeEdge
+ *     value=this.width
+ *     min=this.minWidth
+ *     max=this.maxWidth
+ *     side="start"
+ *     onResize=this.previewWidth
+ *     onResizeEnd=this.commitWidth
+ *   }}
+ * ></div>
+ * ```
+ */
+export default class DResizeEdgeModifier extends Modifier<DResizeEdgeSignature> {
+  /** The options from the most recent invocation, set by `modify`. */
+  #named: DResizeEdgeSignature["Args"]["Named"];
+
+  #onPointerDown = (event: PointerEvent) => {
+    // Ignore anything that is not a primary button press, so that a right
+    // click or a secondary pointer cannot begin a resize.
+    if (event.button !== 0) {
+      return;
+    }
+
+    // A drag is already in progress. Taking this one over would overwrite the
+    // tracked pointer and strand the first one's capture, since its release
+    // would then no longer match.
+    if (this.#pointerId !== null) {
+      return;
+    }
+
+    event.preventDefault();
+
+    this.#pointerId = event.pointerId;
+    this.#startCoordinate = this.#coordinate(event);
+    this.#startValue = this.#named.value;
+
+    this.#element.setPointerCapture(event.pointerId);
+    this.#element.addEventListener("pointermove", this.#onPointerMove);
+    this.#element.addEventListener("pointerup", this.#onPointerUp);
+    this.#element.addEventListener("pointercancel", this.#onPointerUp);
+  };
+  #onPointerMove = (event: PointerEvent) => {
+    if (event.pointerId !== this.#pointerId) {
+      return;
+    }
+
+    // A pointer can move several times between paints, so only the latest
+    // position is kept and reported on the next frame. A size computed for the
+    // positions in between would be replaced before anything rendered it.
+    this.#pendingCoordinate = this.#coordinate(event);
+    this.#frame ??= requestAnimationFrame(() => {
+      this.#frame = undefined;
+      this.#reportMove(this.#pendingCoordinate);
+    });
+  };
+  #onPointerUp = (event: PointerEvent) => {
+    if (event.pointerId !== this.#pointerId) {
+      return;
+    }
+
+    // The committed size is the one the pointer was released at, so any frame
+    // still pending is dropped in favour of reporting that position now.
+    this.#cancelFrame();
+    this.#reportMove(this.#coordinate(event), { final: true });
+    this.#releasePointer();
+  };
+  #onKeyDown = (event: KeyboardEvent) => {
+    const { value, min, max } = this.#named;
+    const [shrinkKey, growKey] =
+      this.#named.axis === "vertical"
+        ? ["ArrowUp", "ArrowDown"]
+        : ["ArrowLeft", "ArrowRight"];
+    let next;
+
+    switch (event.key) {
+      case shrinkKey:
+        next = value - KEYBOARD_STEP * this.#growthDirection;
+        break;
+      case growKey:
+        next = value + KEYBOARD_STEP * this.#growthDirection;
+        break;
+      case "Home":
+        next = min;
+        break;
+      case "End":
+        next = max;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+
+    const clamped = this.#clamp(next);
+    this.#named.onResize?.(clamped);
+    this.#named.onResizeEnd?.(clamped);
+  };
+  #element: HTMLElement;
+  #frame?: number;
+  #pendingCoordinate = 0;
+  #pointerId: number | null = null;
+  #startCoordinate = 0;
+  #startValue = 0;
+
+  constructor(owner: Owner, args: ArgsFor<DResizeEdgeSignature>) {
+    super(owner, args);
+    registerDestructor(this, (instance) => instance.cleanup());
+  }
+
+  modify(
+    element: HTMLElement,
+    _positional: [],
+    named: DResizeEdgeSignature["Args"]["Named"]
+  ) {
+    this.#element = element;
+    this.#named = named;
+
+    // A touch drag would otherwise be claimed by the browser as a scroll and
+    // abort the resize through `pointercancel`. Applied here rather than left
+    // to each caller's stylesheet because the interaction does not work
+    // without it.
+    element.style.touchAction = "none";
+
+    element.addEventListener("pointerdown", this.#onPointerDown);
+    element.addEventListener("keydown", this.#onKeyDown);
+  }
+
+  cleanup() {
+    this.#cancelFrame();
+
+    this.#element.removeEventListener("pointerdown", this.#onPointerDown);
+    this.#element.removeEventListener("keydown", this.#onKeyDown);
+    this.#releasePointer();
+  }
+
+  /**
+   * The multiplier turning pointer movement into a size change.
+   *
+   * An element docked to the start of the axis grows as the pointer moves away
+   * from that edge. On the horizontal axis which physical direction that is
+   * depends on the writing direction, so `side` is interpreted logically and
+   * flipped under RTL — otherwise the edge would move away from the pointer
+   * dragging it. The vertical axis is unaffected: RTL reverses the inline axis
+   * only.
+   *
+   * @returns Either 1 or -1.
+   */
+  get #growthDirection() {
+    const logical = this.#named.side === "end" ? -1 : 1;
+
+    if (this.#named.axis === "vertical") {
+      return logical;
+    }
+
+    const rtl = getComputedStyle(this.#element).direction === "rtl";
+
+    return logical * (rtl ? -1 : 1);
+  }
+
+  /**
+   * The pointer position along the axis being resized.
+   *
+   * @returns The client coordinate, in pixels.
+   */
+  #coordinate(event: PointerEvent) {
+    return this.#named.axis === "vertical" ? event.clientY : event.clientX;
+  }
+
+  #reportMove(coordinate: number, { final = false }: { final?: boolean } = {}) {
+    const delta = (coordinate - this.#startCoordinate) * this.#growthDirection;
+    const size = this.#clamp(this.#startValue + delta);
+
+    this.#named.onResize?.(size);
+
+    if (final) {
+      this.#named.onResizeEnd?.(size);
+    }
+  }
+
+  #clamp(size: number) {
+    return Math.min(Math.max(size, this.#named.min), this.#named.max);
+  }
+
+  #cancelFrame() {
+    if (this.#frame === undefined) {
+      return;
+    }
+
+    cancelAnimationFrame(this.#frame);
+    this.#frame = undefined;
+  }
+
+  #releasePointer() {
+    if (this.#pointerId === null) {
+      return;
+    }
+
+    if (this.#element.hasPointerCapture(this.#pointerId)) {
+      this.#element.releasePointerCapture(this.#pointerId);
+    }
+
+    this.#element.removeEventListener("pointermove", this.#onPointerMove);
+    this.#element.removeEventListener("pointerup", this.#onPointerUp);
+    this.#element.removeEventListener("pointercancel", this.#onPointerUp);
+    this.#pointerId = null;
+  }
+}

--- a/frontend/discourse/tests/integration/components/docked-composer-test.gjs
+++ b/frontend/discourse/tests/integration/components/docked-composer-test.gjs
@@ -272,4 +272,70 @@ module("Integration | Component | DockedComposer", function (hooks) {
       "End key defaults to 400 when no @maxResizeOffset"
     );
   });
+
+  test("the arrow keys grow the composer upward and shrink it back", async function (assert) {
+    await render(
+      <template>
+        <DockedComposer
+          @resizable={{true}}
+          @composerEvents={{false}}
+          @draftKey="test-resize-arrows"
+        />
+      </template>
+    );
+
+    const handle = document.querySelector(".docked-composer__resize-handle");
+    const offset = () =>
+      document
+        .querySelector(".docked-composer")
+        .style.getPropertyValue("--docked-composer-drag-offset");
+
+    await triggerKeyEvent(handle, "keydown", "ArrowUp");
+    assert.dom(handle).hasAttribute("aria-valuenow", "16");
+    assert.strictEqual(
+      offset(),
+      "16px",
+      "dragging the handle up with the keyboard grows the composer"
+    );
+
+    await triggerKeyEvent(handle, "keydown", "ArrowDown");
+    assert.dom(handle).hasAttribute("aria-valuenow", "0");
+    assert.strictEqual(offset(), "0px", "ArrowDown shrinks it back");
+
+    await triggerKeyEvent(handle, "keydown", "ArrowDown");
+    assert
+      .dom(handle)
+      .hasAttribute(
+        "aria-valuenow",
+        "0",
+        "it cannot shrink past its resting size"
+      );
+  });
+
+  test("Home returns the composer to its resting size", async function (assert) {
+    await render(
+      <template>
+        <DockedComposer
+          @resizable={{true}}
+          @composerEvents={{false}}
+          @draftKey="test-resize-home"
+        />
+      </template>
+    );
+
+    const handle = document.querySelector(".docked-composer__resize-handle");
+
+    await triggerKeyEvent(handle, "keydown", "End");
+    assert.dom(handle).hasAttribute("aria-valuenow", "400");
+
+    await triggerKeyEvent(handle, "keydown", "Home");
+    assert.dom(handle).hasAttribute("aria-valuenow", "0");
+    assert.strictEqual(
+      document
+        .querySelector(".docked-composer")
+        .style.getPropertyValue("--docked-composer-drag-offset"),
+      "0px",
+      "the rendered offset follows"
+    );
+  });
 });

--- a/frontend/discourse/tests/integration/modifiers/d-resize-edge-test.gjs
+++ b/frontend/discourse/tests/integration/modifiers/d-resize-edge-test.gjs
@@ -1,0 +1,595 @@
+import { tracked } from "@glimmer/tracking";
+import {
+  clearRender,
+  find,
+  render,
+  triggerEvent,
+  triggerKeyEvent,
+} from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import dResizeEdge from "discourse/ui-kit/modifiers/d-resize-edge";
+
+const EDGE = ".resize-edge";
+
+/**
+ * Replaces the pointer capture API with an observable stand-in.
+ *
+ * The real methods reject synthetic pointer IDs, which is all a test can
+ * dispatch, so capture has to be recorded rather than performed.
+ */
+function installPointerCaptureSpy(element) {
+  const captured = new Set();
+  const released = [];
+
+  element.setPointerCapture = (pointerId) => captured.add(pointerId);
+  element.hasPointerCapture = (pointerId) => captured.has(pointerId);
+  element.releasePointerCapture = (pointerId) => {
+    captured.delete(pointerId);
+    released.push(pointerId);
+  };
+
+  return { captured, released };
+}
+
+class Harness {
+  @tracked value;
+
+  resizes = [];
+  resizeEnds = [];
+
+  constructor(value = 300) {
+    this.value = value;
+    this.onResize = (size) => {
+      this.resizes.push(size);
+      this.value = size;
+    };
+    this.onResizeEnd = (size) => this.resizeEnds.push(size);
+  }
+}
+
+module("Integration | Modifier | d-resize-edge", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("a pointer drag reports a clamped size and commits once", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResize=state.onResize
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 300,
+      pointerId: 1,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 380,
+      pointerId: 1,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [380],
+      "the size follows the pointer away from the start edge"
+    );
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 380,
+      pointerId: 2,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 2000,
+      pointerId: 2,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [380, 720],
+      "a drag past the maximum is clamped to it"
+    );
+  });
+
+  test("the element is opted out of browser touch gestures", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge value=state.value min=240 max=720}}
+        ></div>
+      </template>
+    );
+
+    assert
+      .dom(EDGE)
+      .hasStyle(
+        { touchAction: "none" },
+        "a touch drag is not claimed by the browser as a scroll"
+      );
+  });
+
+  test("a secondary button never starts a drag", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    const capture = installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 2,
+      clientX: 300,
+      pointerId: 1,
+    });
+
+    assert.strictEqual(capture.captured.size, 0, "nothing is captured");
+
+    await triggerEvent(edge, "pointerup", {
+      button: 2,
+      clientX: 500,
+      pointerId: 1,
+    });
+
+    assert.deepEqual(state.resizeEnds, [], "no size is committed");
+  });
+
+  test("only the pointer that began a drag may commit it", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    const capture = installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 300,
+      pointerId: 7,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 700,
+      pointerId: 99,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [],
+      "a mismatched pointer cannot finish the drag"
+    );
+    assert.true(capture.captured.has(7), "the active pointer stays captured");
+
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 400,
+      pointerId: 7,
+    });
+
+    assert.deepEqual(state.resizeEnds, [400], "the matching pointer commits");
+    assert.deepEqual(capture.released, [7], "its capture is released");
+  });
+
+  test("a second pointer cannot replace an active drag or strand its capture", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    const capture = installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 300,
+      pointerId: 10,
+    });
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 400,
+      pointerId: 20,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 350,
+      pointerId: 10,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [350],
+      "the original pointer is still the one measured from"
+    );
+    assert.deepEqual(capture.released, [10], "its capture is not stranded");
+    assert.false(
+      capture.captured.has(20),
+      "the second pointer is never captured"
+    );
+  });
+
+  test("teardown during a drag releases capture", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    const capture = installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 300,
+      pointerId: 3,
+    });
+
+    await clearRender();
+
+    assert.deepEqual(capture.released, [3], "the capture is released");
+
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 600,
+      pointerId: 3,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [],
+      "the detached edge no longer commits sizes"
+    );
+  });
+
+  test("arrow keys step the size and Home and End jump to the bounds", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResize=state.onResize
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowRight");
+    assert.strictEqual(
+      state.value,
+      316,
+      "ArrowRight grows a start-docked edge"
+    );
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowLeft");
+    assert.strictEqual(state.value, 300, "ArrowLeft shrinks it again");
+
+    await triggerKeyEvent(EDGE, "keydown", "End");
+    assert.strictEqual(state.value, 720, "End jumps to the maximum");
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowRight");
+    assert.strictEqual(state.value, 720, "growing past the maximum is clamped");
+
+    await triggerKeyEvent(EDGE, "keydown", "Home");
+    assert.strictEqual(state.value, 240, "Home jumps to the minimum");
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowLeft");
+    assert.strictEqual(
+      state.value,
+      240,
+      "shrinking past the minimum is clamped"
+    );
+
+    assert.strictEqual(
+      state.resizeEnds.length,
+      state.resizes.length,
+      "every keyboard step is committed as well as previewed"
+    );
+  });
+
+  test("an unhandled key is left alone", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            onResize=state.onResize
+          }}
+        ></div>
+      </template>
+    );
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowUp");
+
+    assert.deepEqual(
+      state.resizes,
+      [],
+      "the vertical arrows do nothing on a horizontal edge"
+    );
+  });
+
+  test("an end-docked edge inverts the growth direction", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            side="end"
+            onResize=state.onResize
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 300,
+      pointerId: 1,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 220,
+      pointerId: 1,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [380],
+      "moving toward the start edge grows an end-docked element"
+    );
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowLeft");
+    assert.strictEqual(state.value, 396, "ArrowLeft grows it too");
+  });
+
+  test("a right-to-left writing direction flips the horizontal axis only", async function (assert) {
+    const horizontal = new Harness();
+    const vertical = new Harness();
+
+    await render(
+      <template>
+        <div dir="rtl">
+          <div
+            class="resize-edge"
+            {{dResizeEdge
+              value=horizontal.value
+              min=240
+              max=720
+              onResizeEnd=horizontal.onResizeEnd
+            }}
+          ></div>
+          <div
+            class="vertical-edge"
+            {{dResizeEdge
+              value=vertical.value
+              min=240
+              max=720
+              axis="vertical"
+              onResizeEnd=vertical.onResizeEnd
+            }}
+          ></div>
+        </div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 300,
+      pointerId: 1,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 340,
+      pointerId: 1,
+    });
+
+    assert.deepEqual(
+      horizontal.resizeEnds,
+      [260],
+      "moving right shrinks a start-docked element under RTL"
+    );
+
+    const verticalEdge = find(".vertical-edge");
+    installPointerCaptureSpy(verticalEdge);
+
+    await triggerEvent(verticalEdge, "pointerdown", {
+      button: 0,
+      clientY: 300,
+      pointerId: 2,
+    });
+    await triggerEvent(verticalEdge, "pointerup", {
+      button: 0,
+      clientY: 380,
+      pointerId: 2,
+    });
+
+    assert.deepEqual(
+      vertical.resizeEnds,
+      [380],
+      "the vertical axis is unaffected by the writing direction"
+    );
+  });
+
+  test("a vertical edge follows the pointer and the vertical arrows", async function (assert) {
+    const state = new Harness();
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=240
+            max=720
+            axis="vertical"
+            onResize=state.onResize
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientX: 500,
+      clientY: 300,
+      pointerId: 1,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientX: 900,
+      clientY: 360,
+      pointerId: 1,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [360],
+      "the vertical coordinate drives the size and the horizontal one is ignored"
+    );
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowDown");
+    assert.strictEqual(state.value, 376, "ArrowDown grows a top-docked edge");
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowUp");
+    assert.strictEqual(state.value, 360, "ArrowUp shrinks it");
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowRight");
+    assert.strictEqual(
+      state.value,
+      360,
+      "the horizontal arrows do nothing on a vertical edge"
+    );
+  });
+
+  test("a bottom-docked vertical edge grows upward", async function (assert) {
+    const state = new Harness(0);
+
+    await render(
+      <template>
+        <div
+          class="resize-edge"
+          {{dResizeEdge
+            value=state.value
+            min=0
+            max=400
+            axis="vertical"
+            side="end"
+            onResize=state.onResize
+            onResizeEnd=state.onResizeEnd
+          }}
+        ></div>
+      </template>
+    );
+
+    const edge = find(EDGE);
+    installPointerCaptureSpy(edge);
+
+    await triggerEvent(edge, "pointerdown", {
+      button: 0,
+      clientY: 500,
+      pointerId: 1,
+    });
+    await triggerEvent(edge, "pointerup", {
+      button: 0,
+      clientY: 380,
+      pointerId: 1,
+    });
+
+    assert.deepEqual(
+      state.resizeEnds,
+      [120],
+      "dragging up grows an element docked to the bottom"
+    );
+
+    await triggerKeyEvent(EDGE, "keydown", "ArrowUp");
+    assert.strictEqual(state.value, 136, "ArrowUp grows it too");
+  });
+});


### PR DESCRIPTION
Discourse carries several independently written resize implementations. The docked composer had its own: pointer capture, arrow-key stepping, and bound clamping, all inline. `dResizeEdge` extracts that interaction into a ui-kit modifier following the WAI-ARIA window splitter pattern.

The modifier owns the interaction only. It reports the size it computed and leaves storing and applying it to the caller, so one element can drive a width held in a component or an offset written to a CSS custom property. `axis` selects which coordinate and which arrow keys drive it, and `side` is interpreted logically, so a right-to-left writing direction does not send the edge away from the pointer dragging it. It also sets `touch-action: none` on the element itself rather than relying on each caller's stylesheet, since a touch drag is otherwise claimed by the browser as a scroll and cancelled.

`DockedComposer` now invokes the modifier in place of its four pointer and keyboard handlers, keeping its existing custom property names and ARIA values, so the rendered behaviour is unchanged.

Covered by tests for pointer dragging, keyboard stepping and clamping on both axes, growth direction under `side` and under a right-to-left writing direction, and the pointer capture lifecycle. The composer's existing keyboard resize tests pass unchanged against the modifier.