### PR TITLE
FIX: Prevent browsers from restoring stale documents in bfcache mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,14 +97,15 @@ class ApplicationController < ActionController::Base
     response.cache_control[:extras] = ["immutable"]
   end
 
+  def bfcache_compatibility_mode?
+    SiteSetting.cache_control_bfcache_compatibility
+  end
+  helper_method :bfcache_compatibility_mode?
+
   def dont_cache_page
     if !response.headers["Cache-Control"] && response.cache_control.blank?
-      if SiteSetting.cache_control_bfcache_compatibility
-        response.cache_control[:no_cache] = true
-      else
-        response.cache_control[:no_cache] = true
-        response.cache_control[:extras] = ["no-store"]
-      end
+      response.cache_control[:no_cache] = true
+      response.cache_control[:extras] = [bfcache_compatibility_mode? ? "private" : "no-store"]
     end
     response.headers["Discourse-No-Onebox"] = "1" if SiteSetting.login_required
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,17 @@
 
     <%= build_plugin_html 'server:before-script-load' %>
 
+    <%- if bfcache_compatibility_mode? %>
+      <script id="bfcache-stale-document-check" nonce="<%= csp_nonce_placeholder %>">
+        {
+          const nav = performance.getEntriesByType("navigation")[0];
+          if (nav?.type === "back_forward" && nav.transferSize === 0) {
+            location.reload();
+          }
+        }
+      </script>
+    <%- end %>
+
     <script nonce="<%= csp_nonce_placeholder %>">
       window.EmberENV ??= {};
       window.EmberENV._DEFAULT_ASYNC_OBSERVERS = true;

--- a/config/site_settings.yml
+++ b/config/site_settings.yml
@@ -3235,6 +3235,7 @@ security:
     area: "group_permissions"
   cache_control_bfcache_compatibility:
     default: false
+    client: true
     hidden: true
 
 onebox:

--- a/frontend/discourse/app/instance-initializers/verify-session-after-restore.js
+++ b/frontend/discourse/app/instance-initializers/verify-session-after-restore.js
@@ -1,0 +1,50 @@
+import { isTesting } from "discourse/lib/environment";
+import getURL from "discourse/lib/get-url";
+
+export async function restoredSessionMatches(bootedUserId) {
+  try {
+    const response = await fetch(getURL("/session/current.json"), {
+      headers: { Accept: "application/json" },
+    });
+
+    if (response.status === 404) {
+      return bootedUserId === null;
+    }
+
+    if (!response.ok) {
+      return true;
+    }
+
+    const json = await response.json();
+    return (json.current_user?.id ?? null) === bootedUserId;
+  } catch {
+    return true;
+  }
+}
+
+export default {
+  initialize(owner) {
+    if (isTesting()) {
+      return;
+    }
+
+    const siteSettings = owner.lookup("service:site-settings");
+    if (!siteSettings.cache_control_bfcache_compatibility) {
+      return;
+    }
+
+    const bootedUserId = owner.lookup("service:current-user")?.id ?? null;
+
+    this.handler = async (event) => {
+      if (event.persisted && !(await restoredSessionMatches(bootedUserId))) {
+        window.location.reload();
+      }
+    };
+
+    window.addEventListener("pageshow", this.handler);
+  },
+
+  teardown() {
+    window.removeEventListener("pageshow", this.handler);
+  },
+};

--- a/frontend/discourse/tests/unit/instance-initializers/verify-session-after-restore-test.js
+++ b/frontend/discourse/tests/unit/instance-initializers/verify-session-after-restore-test.js
@@ -1,0 +1,68 @@
+import { module, test } from "qunit";
+import sinon from "sinon";
+import { restoredSessionMatches } from "discourse/instance-initializers/verify-session-after-restore";
+
+module(
+  "Unit | Instance Initializer | verify-session-after-restore",
+  function () {
+    function stubSession(status, body = null) {
+      sinon
+        .stub(window, "fetch")
+        .resolves(new Response(body && JSON.stringify(body), { status }));
+    }
+
+    test("matches when the same user is still logged in", async function (assert) {
+      stubSession(200, { current_user: { id: 1 } });
+
+      assert.true(await restoredSessionMatches(1), "same user id matches");
+    });
+
+    test("does not match when a different user is logged in", async function (assert) {
+      stubSession(200, { current_user: { id: 2 } });
+
+      assert.false(await restoredSessionMatches(1), "user id changed");
+    });
+
+    test("does not match when the session became anonymous", async function (assert) {
+      stubSession(404);
+
+      assert.false(
+        await restoredSessionMatches(1),
+        "document has a user but the session is anonymous"
+      );
+    });
+
+    test("matches when both the document and the session are anonymous", async function (assert) {
+      stubSession(404);
+
+      assert.true(await restoredSessionMatches(null), "still anonymous");
+    });
+
+    test("does not match when the session gained a user", async function (assert) {
+      stubSession(200, { current_user: { id: 1 } });
+
+      assert.false(
+        await restoredSessionMatches(null),
+        "anonymous document but the session is logged in"
+      );
+    });
+
+    test("matches on server errors", async function (assert) {
+      stubSession(500);
+
+      assert.true(
+        await restoredSessionMatches(1),
+        "server errors do not trigger a reload"
+      );
+    });
+
+    test("matches on network failures", async function (assert) {
+      sinon.stub(window, "fetch").rejects(new TypeError("network down"));
+
+      assert.true(
+        await restoredSessionMatches(1),
+        "network failures do not trigger a reload"
+      );
+    });
+  }
+);

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -53,26 +53,33 @@ RSpec.describe ApplicationController do
     context "when cache_control_bfcache_compatibility is enabled" do
       before { SiteSetting.cache_control_bfcache_compatibility = true }
 
-      it "sets bfcache-compatible cache control headers" do
+      it "sets bfcache-compatible cache control headers and includes the stale document reload script" do
         get "/latest"
 
         expect(response.status).to eq(200)
-        expect(response.headers["Cache-Control"]).to eq("no-cache")
+        expect(response.headers["Cache-Control"]).to eq("no-cache, private")
+        expect(response.body).to include("bfcache-stale-document-check")
       end
 
       it "sets bfcache-compatible cache control headers on 404" do
         get "/invalid-urlllllllllll"
 
         expect(response.status).to eq(404)
-        expect(response.headers["Cache-Control"]).to eq("no-cache")
+        expect(response.headers["Cache-Control"]).to eq("no-cache, private")
       end
 
       it "sets bfcache-compatible cache control headers on 403" do
         get "/latest.json", headers: { HTTP_API_KEY: "invalid-api-key" }
 
         expect(response.status).to eq(403)
-        expect(response.headers["Cache-Control"]).to eq("no-cache")
+        expect(response.headers["Cache-Control"]).to eq("no-cache, private")
       end
+    end
+
+    it "does not include the stale document reload script in the HTML document by default" do
+      get "/latest"
+
+      expect(response.body).not_to include("bfcache-stale-document-check")
     end
   end
 


### PR DESCRIPTION
Previously, enabling `cache_control_bfcache_compatibility` (the experiment currently running on meta, #38763) made HTML documents storable in the browser HTTP cache, and browsers skip revalidation on history navigations — so back/forward, session restore, and discarded-tab reloads could resurrect a days-old document: stale topic lists that only get older, and logged-in UI shown to logged-out sessions (and vice versa). Reported in https://meta.discourse.org/t/400459.

This change keeps the documents out of shared caches (`no-cache, private`), reloads any document that was served from the HTTP cache on a history navigation (navigation entry with `type === "back_forward"` and `transferSize === 0` — a forced reload gets type `"reload"`, so it cannot loop), and validates the session on `pageshow` restores from the back/forward cache, reloading when the logged-in user no longer matches the one the page booted with. Both client-side checks only run when the setting is enabled; the full rationale (browser-engine specifics, why `transferSize` rather than `deliveryType`, why `fetch` rather than `ajax`) is in the commit message.

Reproduced and verified end-to-end in Chromium and Firefox: with the setting enabled, `goBack()` served `/latest` with zero network contact — stale list, wrong login state, and the exact `403 /u/:username/private-message-topic-tracking-state` errors from the meta report; with this change the same navigation heals with a single automatic reload, and a control run with the setting disabled behaves as before.
