### PR TITLE
MT: Adopt markbridge 0.4.0, where [code] is always a block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport
       colored2
       i18n
-      markbridge (>= 0.3.1)
+      markbridge (>= 0.4.0)
       migrations-core
       pg
       zeitwerk
@@ -350,7 +350,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    markbridge (0.3.1)
+    markbridge (0.4.0)
     matrix (0.4.3)
     maxminddb (0.1.22)
     memory_profiler (1.1.0)
@@ -1125,7 +1125,7 @@ CHECKSUMS
   lru_redux (1.1.0) sha256=ee71d0ccab164c51de146c27b480a68b3631d5b4297b8ffe8eda1c72de87affb
   lz4-ruby (0.3.3) sha256=011be5ee230cfddc8308d4e2e0b05300c7bc755a887de799377ca6c5b6aede89
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
-  markbridge (0.3.1) sha256=a36dff4e79e666fe7f944d4a806f507212191b80d22878ab3ee9008d9df975a3
+  markbridge (0.4.0) sha256=27645fd47489d2fd42068153fa471b7e5231dd8dabb31c1bf38c88aa37535b12
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   maxminddb (0.1.22) sha256=50933be438fbed9dceabef4163eab41884bd8830d171fdb8f739bee769c4907e
   memory_profiler (1.1.0) sha256=79a17df7980a140c83c469785905409d3027ca614c42c086089d128b805aa8f8

--- a/migrations/converters/migrations-converters.gemspec
+++ b/migrations/converters/migrations-converters.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport"
   s.add_dependency "colored2"
   s.add_dependency "i18n"
-  s.add_dependency "markbridge", ">= 0.3.1"
+  s.add_dependency "markbridge", ">= 0.4.0"
   s.add_dependency "pg"
   s.add_dependency "zeitwerk"
 end

--- a/migrations/converters/spec/lib/migrations/converters/markdown_renderer_spec.rb
+++ b/migrations/converters/spec/lib/migrations/converters/markdown_renderer_spec.rb
@@ -121,27 +121,35 @@ RSpec.describe Migrations::Converters::MarkdownRenderer do
       expect(raw).to include(buffer.links.first[:placeholder])
     end
 
-    it "defers a link whose label is inline code carrying a language" do
-      # A language attribute alone never makes code a block, so code-with-a-
-      # language still renders inline inside a link and stays deferrable — only
-      # multi-line code is hoisted out.
-      raw =
-        link_renderer.to_markdown("see [url=https://example.com/t/5][code=ruby]x = 1[/code][/url]")
+    # `[code]` and `[pre]` are code blocks by definition to markbridge, whatever
+    # they hold, so the normalizer lifts them out of a link label — a single line
+    # and a language attribute make no difference. The link is left with an empty
+    # (deferrable) label and the fence lands as a sibling block in the raw. Only
+    # code that is inline to begin with (`[tt]`, or a Code node with no `block`
+    # flag) can stay in a label; the unit test further down covers that.
+    {
+      "single-line, with a language" => [
+        "[url=https://example.com][code=ruby]x = 1[/code][/url]",
+        "```ruby\nx = 1\n```",
+      ],
+      "single-line, no language" => [
+        "[url=https://example.com][code]x = 1[/code][/url]",
+        "```\nx = 1\n```",
+      ],
+      "multi-line" => [
+        "[url=https://example.com][code=ruby]a\nb[/code][/url]",
+        "```ruby\na\nb\n```",
+      ],
+    }.each do |label, (bbcode, fence)|
+      it "hoists #{label} code out of a link label instead of deferring it into text" do
+        raw = link_renderer.to_markdown(bbcode)
 
-      expect(buffer.links.size).to eq(1)
-      expect(buffer.links.first[:text]).to eq("`x = 1`")
-      expect(raw).to include(buffer.links.first[:placeholder])
-    end
-
-    it "hoists multi-line code out of a link label instead of deferring it into text" do
-      # The normalizer pulls multi-line code out of the inline container before
-      # we render, so the link arrives with an empty (deferrable) label and the
-      # code fence lands as a sibling block in the raw.
-      raw = link_renderer.to_markdown("[url=https://example.com][code=ruby]a\nb[/code][/url]")
-
-      expect(buffer.links).to contain_exactly(hash_including(url: "https://example.com", text: nil))
-      expect(raw).to include(buffer.links.first[:placeholder])
-      expect(raw).to include("```ruby\na\nb\n```")
+        expect(buffer.links).to contain_exactly(
+          hash_including(url: "https://example.com", text: nil),
+        )
+        expect(raw).to include(buffer.links.first[:placeholder])
+        expect(raw).to include(fence)
+      end
     end
 
     it "defers a link whose quote label the normalizer hoisted out" do


### PR DESCRIPTION
The isolated gem suite is red on main. markbridge 0.4.0 came out and the
per-gem `Gemfile.lock` is gitignored, so CI resolves the newest gem while a
local checkout keeps whatever it locked earlier — which is why this only shows
up in CI:

    rspec ./spec/lib/migrations/converters/markdown_renderer_spec.rb:124
    expected: "`x = 1`"
         got: nil

0.4.0 gives `AST::Code` a `block` flag and sets it for `[code]` and `[pre]`,
which are code blocks by definition. `[tt]` stays inline teletype and still
leaves the choice to the renderer. So a single-line `[code=ruby]x = 1[/code]`
inside a link label is now lifted out as a fence, exactly like the multi-line
case already was, and the link is left with an empty label.

The spec asserted the old reading — that a language attribute alone never made
code a block, and only multi-line code got hoisted. That premise is gone, so I
folded the three shapes into one table: single-line with a language, single-line
without, and multi-line all hoist. The unit test further down still covers code
that is inline to begin with, which is the case that can stay in a link label.

I also moved the gemspec floor to `>= 0.4.0`, because the specs now describe
0.4.0's behaviour — on 0.3.1 they would fail the other way round.

Ran the four gem suites the way the workflow does
(`bundle exec rspec --tag ~rails`): core 402, tooling 131, converters 97,
importer 83, all green.