### PR TITLE
UX: hide timeline for livestream topics, make layout more reliable

### DIFF
--- a/frontend/discourse/app/components/topic-navigation.gjs
+++ b/frontend/discourse/app/components/topic-navigation.gjs
@@ -17,6 +17,7 @@ import SwipeEvents, {
   shouldCloseMenu,
 } from "discourse/lib/swipe-events";
 import TrackedMediaQuery from "discourse/lib/tracked-media-query";
+import { applyValueTransformer } from "discourse/lib/transformer";
 import dConcatClass from "discourse/ui-kit/helpers/d-concat-class";
 import dCloseOnClickOutside from "discourse/ui-kit/modifiers/d-close-on-click-outside";
 import JumpToPost from "./modal/jump-to-post";
@@ -126,6 +127,14 @@ export default class TopicNavigation extends Component {
       return true;
     }
 
+    return applyValueTransformer(
+      "topic-navigation-render-timeline",
+      this.#fitsTimeline,
+      { topic: this.args.topic }
+    );
+  }
+
+  get #fitsTimeline() {
     if (this.site.mobileView || EmbedMode.enabled) {
       return false;
     }

--- a/frontend/discourse/app/lib/registry/transformers.js
+++ b/frontend/discourse/app/lib/registry/transformers.js
@@ -141,6 +141,7 @@ export const VALUE_TRANSFORMERS = Object.freeze([
   "topic-list-item-mobile-layout",
   "topic-list-item-style",
   "topic-list-topics-from",
+  "topic-navigation-render-timeline",
   "topic-reply-count",
   "topic-show-footer-buttons",
   "user-field-components",

--- a/frontend/discourse/tests/integration/components/topic-navigation-test.gjs
+++ b/frontend/discourse/tests/integration/components/topic-navigation-test.gjs
@@ -1,0 +1,54 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import TopicNavigation from "discourse/components/topic-navigation";
+import { forceMobile } from "discourse/lib/mobile";
+import { withPluginApi } from "discourse/lib/plugin-api";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | TopicNavigation", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.topic = this.owner
+      .lookup("service:store")
+      .createRecord("topic", { id: 1234, posts_count: 5 });
+  });
+
+  test("renders the progress bar when there is no room for the timeline", async function (assert) {
+    forceMobile();
+    const topic = this.topic;
+
+    await render(
+      <template>
+        <TopicNavigation @topic={{topic}} as |info|>
+          <span class="render-timeline">{{info.renderTimeline}}</span>
+        </TopicNavigation>
+      </template>
+    );
+
+    assert.dom(".render-timeline").hasText("false");
+    assert.dom(".with-topic-progress").exists();
+  });
+
+  test("topic-navigation-render-timeline value transformer", async function (assert) {
+    forceMobile();
+    withPluginApi((api) => {
+      api.registerValueTransformer(
+        "topic-navigation-render-timeline",
+        ({ context }) => context.topic.id === 1234
+      );
+    });
+    const topic = this.topic;
+
+    await render(
+      <template>
+        <TopicNavigation @topic={{topic}} as |info|>
+          <span class="render-timeline">{{info.renderTimeline}}</span>
+        </TopicNavigation>
+      </template>
+    );
+
+    assert.dom(".render-timeline").hasText("true");
+    assert.dom(".with-timeline").exists();
+  });
+});

--- a/plugins/discourse-calendar/assets/javascripts/discourse/initializers/livestream-chat-overrides.js
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/initializers/livestream-chat-overrides.js
@@ -1,26 +1,57 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import ResponsiveLivestreamChatIcon from "../components/livestream/responsive-livestream-chat-icon";
 
-function showCustomBBCode(isGoing = false) {
+const GOING = "going";
+
+function showCustomBBCode(element, isGoing) {
   // show the content within the [preview] tag if the user is not going to the event
-  document.querySelectorAll(".cooked .preview").forEach((e) => {
+  element.querySelectorAll(".preview").forEach((e) => {
     e.style.setProperty("display", !isGoing ? "block" : "none", "important");
   });
 
   // show the content within the [hidden] tag if the user is going to the event
-  document.querySelectorAll(".cooked .hidden").forEach((e) => {
+  element.querySelectorAll(".hidden").forEach((e) => {
     e.style.setProperty("display", isGoing ? "block" : "none", "important");
   });
 }
 
-async function onAcceptInvite({ status }) {
-  if (status === "going") {
-    showCustomBBCode(true);
-    document.body.classList.add("confirmed-event-assistance");
-  } else if (status !== "going") {
-    showCustomBBCode(false);
-    document.body.classList.remove("confirmed-event-assistance");
+function attendanceStatus(container) {
+  const router = container.lookup("service:router");
+
+  if (!router.currentRouteName?.startsWith("topic.")) {
+    return undefined;
   }
+
+  return container.lookup("controller:topic").model
+    ?.event_watching_invitee_status;
+}
+
+function updateEventStyles(container) {
+  const status = attendanceStatus(container);
+
+  if (status === undefined) {
+    document.body.classList.remove("confirmed-event-assistance");
+    return;
+  }
+
+  document.body.classList.toggle(
+    "confirmed-event-assistance",
+    status === GOING
+  );
+
+  document
+    .querySelectorAll(".cooked")
+    .forEach((cooked) => showCustomBBCode(cooked, status === GOING));
+}
+
+function onAttendanceChange(container, { status }) {
+  // the topic is serialized once per visit, so the answer is kept in sync to
+  // survive later navigation within the topic
+  container
+    .lookup("controller:topic")
+    .model?.set("event_watching_invitee_status", status ?? null);
+
+  updateEventStyles(container);
 }
 
 function overrideChat(api, container) {
@@ -41,9 +72,7 @@ function overrideChat(api, container) {
 
   events.forEach((event) => {
     appEvents.on(event, (data) => {
-      onAcceptInvite({
-        ...data,
-      });
+      onAttendanceChange(container, { ...data });
     });
   });
 
@@ -51,51 +80,30 @@ function overrideChat(api, container) {
     before: "chat",
   });
 
-  api.onPageChange((url) => {
-    const store = container.lookup("service:store");
-    const topic = container.lookup("controller:topic");
-    const allowedPaths =
-      siteSettings.livestream_embeddable_chat_allowed_paths.split("|");
-
-    // non livestream topics
-    if (
-      allowedPaths.every(
-        (path) => !url.includes(path) && !url.startsWith(path)
-      ) ||
-      !topic?.model?.chat_channel_id
-    ) {
-      return false;
-    }
-
-    updateEventStylesByStatus(topic, store, currentUser);
+  api.onPageChange(() => {
+    updateEventStyles(container);
   });
+
+  // posts entered further down the stream are cooked after the styles are
+  // applied, so they are decorated as they render
+  api.decorateCookedElement(
+    (element) => {
+      const status = attendanceStatus(container);
+
+      if (status !== undefined) {
+        showCustomBBCode(element, status === GOING);
+      }
+    },
+    { onlyStream: true }
+  );
 }
 
-async function updateEventStylesByStatus(topic, store, currentUser) {
-  let isGoing;
-  try {
-    const topicPost = parseInt(
-      document.getElementById("post_1").dataset.postId,
-      10
-    );
-    const attendees = await store.findAll("discourse-post-event-invitee", {
-      undefined,
-      post_id: topicPost,
-      type: "going",
-    });
-    isGoing = attendees.content.some(
-      (attendee) => attendee.user.id === currentUser.id
-    );
-    showCustomBBCode(isGoing);
-  } catch {
-    // no event found
-  } finally {
-    if (!isGoing) {
-      document.body.classList.remove("confirmed-event-assistance");
-    } else {
-      document.body.classList.add("confirmed-event-assistance");
-    }
-  }
+function collapseTimeline(api, container) {
+  api.registerValueTransformer(
+    "topic-navigation-render-timeline",
+    ({ value }) =>
+      container.lookup("service:embeddable-chat").isChatDocked ? false : value
+  );
 }
 
 export default {
@@ -103,6 +111,7 @@ export default {
   initialize(container) {
     withPluginApi((api) => {
       overrideChat(api, container);
+      collapseTimeline(api, container);
     });
   },
 };

--- a/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -94,4 +94,11 @@ export default class EmbeddableChat extends Service {
       !this.isChannelOpenInDrawer
     );
   }
+
+  get isChatDocked() {
+    return (
+      this.useLivestreamLayout &&
+      (this.canRenderChatChannel(false) || this.canRenderChatChannel(true))
+    );
+  }
 }

--- a/plugins/discourse-calendar/assets/stylesheets/desktop/livestream.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/desktop/livestream.scss
@@ -40,6 +40,30 @@
     }
   }
 
+  // the timeline is swapped for the progress bar while chat is docked, so the
+  // navigation is placed below the posts rather than in its own column
+  .container.posts .topic-navigation {
+    grid-area: posts;
+    grid-row: 3;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    width: auto;
+    margin-left: 0;
+    margin-top: var(--border-offset);
+    top: auto;
+
+    > * {
+      margin-bottom: 0;
+    }
+
+    .topic-admin-menu-trigger {
+      border-radius: 0;
+      background: var(--secondary);
+      border: 1px solid var(--primary-low);
+    }
+  }
+
   .discourse-calendar-livestream-zoom-entry {
     width: min(100%, 1444px);
     margin-left: auto;

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -969,6 +969,20 @@ after_initialize do
 
   add_to_serializer(:topic_view, :has_livestream) { object.topic.first_post&.event&.livestream? }
 
+  add_to_serializer(
+    :topic_view,
+    :event_watching_invitee_status,
+    include_condition: -> { scope.user.present? && object.topic.first_post&.event.present? },
+  ) do
+    invitee =
+      DiscoursePostEvent::Invitee.find_by(
+        post_id: object.topic.first_post.event.id,
+        user_id: scope.user.id,
+      )
+
+    DiscoursePostEvent::Invitee.statuses[invitee.status] if invitee
+  end
+
   Chat::ChannelSerializer.include(DiscourseCalendar::Livestream::ChannelSerializerExtension)
 
   register_modifier(:chat_channel_fetcher_public_includes) do |includes|

--- a/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
+++ b/plugins/discourse-calendar/spec/serializers/topic_view_serializer_spec.rb
@@ -132,6 +132,56 @@ RSpec.describe TopicViewSerializer do
     end
   end
 
+  describe "#event_watching_invitee_status" do
+    fab!(:viewer, :user)
+
+    def parsed_json_for(user)
+      JSON.parse(
+        described_class.new(TopicView.new(topic), scope: Guardian.new(user), root: false).to_json,
+      )
+    end
+
+    def create_event
+      DiscoursePostEvent::Event.create!(
+        id: first_post.id,
+        original_starts_at: 1.hour.from_now,
+        original_ends_at: 2.hours.from_now,
+      )
+    end
+
+    it "returns the status the current user answered with" do
+      event = create_event
+      DiscoursePostEvent::Invitee.create_attendance!(viewer.id, event.id, :going)
+
+      expect(parsed_json_for(viewer)["event_watching_invitee_status"]).to eq("going")
+    end
+
+    it "is null when the current user has not answered" do
+      create_event
+
+      expect(parsed_json_for(viewer)["event_watching_invitee_status"]).to be_nil
+    end
+
+    it "is not included when the topic has no event" do
+      first_post
+
+      expect(parsed_json_for(viewer)).not_to have_key("event_watching_invitee_status")
+    end
+
+    it "is not included for anonymous users" do
+      create_event
+
+      expect(parsed_json_for(nil)).not_to have_key("event_watching_invitee_status")
+    end
+
+    it "is not affected by other users' answers" do
+      event = create_event
+      DiscoursePostEvent::Invitee.create_attendance!(Fabricate(:user).id, event.id, :going)
+
+      expect(parsed_json_for(viewer)["event_watching_invitee_status"]).to be_nil
+    end
+  end
+
   describe "#chat_channel_id" do
     fab!(:category)
     fab!(:viewer, :user)

--- a/plugins/discourse-calendar/spec/system/livestream_calendar_event_spec.rb
+++ b/plugins/discourse-calendar/spec/system/livestream_calendar_event_spec.rb
@@ -28,6 +28,27 @@ describe "Discourse Livestream - Topic Livestream with events - Authenticated" d
       expect(topic_page).not_to have_css(".confirmed-event-assistance", wait: 25)
     end
 
+    it "keeps the going styles when entering the topic below the first post" do
+      topic = Fabricate(:topic, category:)
+      first_post = Fabricate(:post, topic:)
+      event =
+        DiscoursePostEvent::Event.create!(
+          id: first_post.id,
+          original_starts_at: 1.day.from_now,
+          original_ends_at: 2.days.from_now,
+          livestream: true,
+          location: PageObjects::Pages::TopicLivestream::LIVESTREAM_URL,
+        )
+      DiscoursePostEvent::Invitee.create_attendance!(current_user.id, event.id, :going)
+      25.times { Fabricate(:post, topic:) }
+
+      visit "/t/#{topic.slug}/#{topic.id}/26"
+
+      expect(topic_page).to have_css("#post_26")
+      expect(topic_page).to have_no_css("#post_1")
+      expect(topic_page).to have_css("body.confirmed-event-assistance", wait: 25)
+    end
+
     it "clicks going to join the chat channel for livestream topics" do
       topic_livestream.create_normal_event_topic(composer, topic_page)
 


### PR DESCRIPTION
Livestream topics need as much space as possible because they have an added chat sidebar. This change adds a transformer that allows the plugin to use the progress bar instead of the timeline, which saves a good amount of space while still allowing navigation through many posts. 

This also solves a minor issue when entering 20+ posts deep into a livestream topic would prevent you from getting the livestream layout (hidden avatar) when viewing OP. 

<img width="3012" height="1724" alt="image" src="https://github.com/user-attachments/assets/2576ce2b-b900-4c58-bf25-9c611f9659e4" />
