### PR TITLE
SECURITY: Regular users can create global banners via archetype mass-assignment

### DIFF
--- a/lib/topic_creator.rb
+++ b/lib/topic_creator.rb
@@ -156,7 +156,7 @@ class TopicCreator
       visible: @opts[:visible],
     }
 
-    %i[subtype archetype import_mode advance_draft locale].each do |key|
+    %i[subtype import_mode advance_draft locale].each do |key|
       topic_params[key] = @opts[key] if @opts[key].present?
     end
 
@@ -184,6 +184,15 @@ class TopicCreator
     topic_params[:pinned_globally] = @opts[:pinned_globally] if @opts[:pinned_globally].present?
     topic_params[:external_id] = @opts[:external_id] if @opts[:external_id].present?
     topic_params[:featured_link] = @opts[:featured_link]
+
+    if @opts[:archetype].present?
+      topic = Topic.new(topic_params)
+
+      if @opts[:archetype] == Archetype.private_message ||
+           @guardian.can_change_archetype?(topic, @opts[:archetype])
+        topic_params[:archetype] = @opts[:archetype]
+      end
+    end
 
     topic_params
   end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1244,6 +1244,37 @@ RSpec.describe PostsController do
       SiteSetting.whispers_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}"
     end
 
+    it "prevents regular users from publishing a global banner while creating a topic" do
+      ApplicationLayoutPreloader.banner_json_cache.clear
+      sign_in(user_trust_level_1)
+
+      post "/posts.json",
+           params: {
+             raw: "this is a test banner topic body",
+             title: "this is a test banner topic title",
+             category: category.id,
+             archetype: Archetype.banner,
+           }
+
+      creation_status = response.status
+      creation_body = response.parsed_body
+      created_topic = Topic.find(creation_body["topic_id"])
+
+      sign_in(user)
+      get "/site/banner.json"
+      banner_status = response.status
+      banner_body = response.parsed_body
+      ApplicationLayoutPreloader.banner_json_cache.clear
+
+      aggregate_failures do
+        expect(creation_status).to eq(200)
+        expect(creation_body["topic_id"]).to eq(created_topic.id)
+        expect(created_topic.archetype).to eq(Archetype.default)
+        expect(banner_status).to eq(200)
+        expect(banner_body).to eq({})
+      end
+    end
+
     context "with api" do
       it "memoizes duplicate requests" do
         raw = "this is a test post 123 #{SecureRandom.hash}"


### PR DESCRIPTION
## Summary

Prevent non-staff users from creating banner topics by validating the archetype parameter against user permissions during topic creation. The TopicCreator now only applies a requested archetype when the user is authorized to use it, or when the archetype is for a private message. Unauthorized archetype requests are silently downgraded to the default archetype, preserving the HTTP 200 response while preventing an attacker from displaying persistent site-wide content.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1321

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>