### PR TITLE
FIX: Sanitize calendar event tooltip HTML

### DIFF
--- a/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
+++ b/plugins/discourse-calendar/assets/javascripts/discourse/components/full-calendar.gjs
@@ -8,6 +8,7 @@ import { trustHTML } from "@ember/template";
 import { modifier as modifierFn } from "ember-modifier";
 import { iconHTML } from "discourse/lib/icon-library";
 import loadFullCalendar from "discourse/lib/load-full-calendar";
+import { sanitize } from "discourse/lib/text";
 import DiscourseURL from "discourse/lib/url";
 import { i18n } from "discourse-i18n";
 import DiscoursePostEvent from "discourse/plugins/discourse-calendar/discourse/components/discourse-post-event";
@@ -138,7 +139,7 @@ export default class FullCalendar extends Component {
             triggers: ["hover"],
             content: trustHTML(
               // this is a workaround to allow linebreaks in the tooltip
-              "<div>" + htmlContent + "</div>"
+              "<div>" + sanitize(htmlContent) + "</div>"
             ),
           });
         }

--- a/plugins/discourse-calendar/spec/system/post_calendar_spec.rb
+++ b/plugins/discourse-calendar/spec/system/post_calendar_spec.rb
@@ -2,6 +2,8 @@
 
 describe "Post calendar" do
   fab!(:admin)
+  fab!(:calendar_user) { Fabricate(:user, trust_level: 1) }
+  fab!(:viewer, :user)
 
   let(:calendar_post) { create_post(user: admin, raw: "[calendar]\n[/calendar]") }
 
@@ -10,7 +12,23 @@ describe "Post calendar" do
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
     SiteSetting.holiday_calendar_topic_id = calendar_post.topic.id
-    sign_in(admin)
+    sign_in(viewer)
+  end
+
+  it "sanitizes markup from calendar replies in tooltips", time: Time.utc(2026, 8, 1, 12, 0) do
+    create_post(
+      user: calendar_user,
+      topic: calendar_post.topic,
+      raw:
+        "`<a id=\"calendar-tooltip-link\" href=\"https://example.com\" style=\"position: fixed; inset: 0; z-index: 9999\">Cover page</a>` [date=\"2026-08-02\"]",
+    )
+
+    visit(calendar_post.topic.url)
+
+    expect(page.status_code).to eq(200)
+    find(".fc-event", text: calendar_user.username).hover
+    expect(page).to have_css("[data-identifier='post-event-tooltip']")
+    expect(page).to have_no_css("#calendar-tooltip-link")
   end
 
   it "shows the calendar on the post" do


### PR DESCRIPTION
## Summary

Correctly sanitize calendar event tooltip content through the Discourse standard sanitizer immediately before the trustHTML sink, removing unsafe attributes like `id` and `style` while preserving safe formatting such as links, emoji, bold labels, and line breaks.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1578

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>