### PR TITLE
SECURITY: Leakage of hidden tags to unauthorized users

### DIFF
--- a/app/controllers/published_pages_controller.rb
+++ b/app/controllers/published_pages_controller.rb
@@ -44,7 +44,7 @@ class PublishedPagesController < ApplicationController
           "published-page",
           params[:slug],
           "topic-#{@topic.id}",
-          @topic.tags.pluck(:name),
+          @topic.tags.visible(guardian).pluck(:name),
         ].flatten.compact,
       )
 

--- a/spec/requests/published_pages_controller_spec.rb
+++ b/spec/requests/published_pages_controller_spec.rb
@@ -137,6 +137,23 @@ RSpec.describe PublishedPagesController do
           )
         end
 
+        it "omits hidden tags from body classes" do
+          hidden_tag = Fabricate(:tag, name: "admins-only")
+          hidden_tag_group =
+            Fabricate(:tag_group, name: "Admins only", tag_names: [hidden_tag.name])
+          hidden_tag_group.permissions = [
+            [Group::AUTO_GROUPS[:admins], TagGroupPermission.permission_types[:full]],
+          ]
+          hidden_tag_group.save!
+          published_page.topic.tags << hidden_tag
+
+          get published_page.path
+
+          expect(response.status).to eq(200)
+          expect(response.body).to include("recipes")
+          expect(response.body).not_to include(hidden_tag.name)
+        end
+
         context "when login is required" do
           before do
             SiteSetting.login_required = true


### PR DESCRIPTION
## Summary

Prevent the leakage of restricted tag names by filtering topic tags through the current user's visibility scope when rendering published pages. This ensures that tags hidden from a user, such as those restricted to specific groups, are not included in the HTML body classes of public pages.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1383

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>