### PR TITLE
SECURITY: Remove stale invitee access for users removed from invited groups on private events [backport 2026.6]

### DIFF
--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -365,12 +365,35 @@ module DiscoursePostEvent
         end
     end
 
-    def can_user_update_attendance?(user)
-      return false if closed || expired?
+    def user_in_invited_group?(user, group_names: nil)
+      return false if user.blank? || raw_invitees.blank?
+
+      return (Array(raw_invitees) & Array(group_names)).any? unless group_names.nil?
+
+      GroupUser.where(
+        user_id: user.id,
+        group_id: Group.where(name: raw_invitees).select(:id),
+      ).exists?
+    end
+
+    # Unlike can_user_update_attendance?, this stays true after the event
+    # closes or expires so attendees keep access to the livestream chat.
+    #
+    # Callers serializing many events at once (e.g. the chat channel list) can
+    # pass preloaded group_names to avoid a per-event query.
+    def can_access_livestream_chat?(user, group_names: nil)
+      return true if !private?
+      return false if user.blank?
+      return true if user.admin?
+
+      user_in_invited_group?(user, group_names:)
+    end
+
+    def can_user_update_attendance?(user, group_names: nil)
+      return false if user.blank? || closed || expired?
       return true if public?
 
-      private? &&
-        (invitees.exists?(user_id: user.id) || (user.groups.pluck(:name) & raw_invitees).any?)
+      private? && user_in_invited_group?(user, group_names:)
     end
 
     def sync_image_to_post_and_topic(generate_thumbnails: false)

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -121,8 +121,9 @@ module DiscoursePostEvent
     end
 
     def watching_invitee
-      if scope.current_user
-        watching_invitee = Invitee.find_by(user_id: scope.current_user.id, post_id: object.id)
+      user = scope.current_user
+      if user && can_display_current_user_invitee?(user)
+        watching_invitee = Invitee.find_by(user_id: user.id, post_id: object.id)
       end
 
       InviteeSerializer.new(watching_invitee, root: false, scope:) if watching_invitee
@@ -143,6 +144,11 @@ module DiscoursePostEvent
 
     def include_stats?
       can_display_invitee_details?
+    end
+
+    def can_display_current_user_invitee?(user)
+      !object.private? || scope.can_act_on_discourse_post_event?(object) ||
+        object.user_in_invited_group?(user)
     end
 
     def can_display_invitee_details?

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -90,13 +90,20 @@ module DiscoursePostEvent
       # If no user, can only see non-private events
       return events.where.not(status: private_status) if user.nil?
 
-      # User can see private events if they are invited to them
-      events.where(
-        "discourse_post_event_events.status != ? OR (discourse_post_event_events.status = ? AND EXISTS (SELECT 1 FROM discourse_post_event_invitees WHERE post_id = discourse_post_event_events.id AND user_id = ?))",
-        private_status,
-        private_status,
-        user.id,
-      )
+      # User can see private events if they still belong to an invited group.
+      events.where(<<~SQL, private_status, private_status, user.id)
+          discourse_post_event_events.status != ?
+          OR (
+            discourse_post_event_events.status = ?
+            AND EXISTS (
+              SELECT 1
+              FROM group_users
+              INNER JOIN groups ON groups.id = group_users.group_id
+              WHERE group_users.user_id = ?
+                AND groups.name = ANY(discourse_post_event_events.raw_invitees)
+            )
+          )
+        SQL
     end
 
     def self.filter_by_dates(events, params)

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -270,10 +270,7 @@ after_initialize do
 
     raw_invitees = Array(event.raw_invitees).uniq
 
-    if user &&
-         (event.invitees.exists?(user_id: user.id) || user.groups.where(name: raw_invitees).exists?)
-      return true
-    end
+    return true if user && event.user_in_invited_group?(user)
 
     return false if raw_invitees.blank?
 
@@ -741,6 +738,14 @@ after_initialize do
   end
 
   on(:user_destroyed) { |user| DiscoursePostEvent::Invitee.where(user_id: user.id).destroy_all }
+
+  on(:user_removed_from_group) do |user, group|
+    DiscoursePostEvent::Event
+      .where(id: DiscoursePostEvent::Invitee.unscoped.where(user_id: user.id).select(:post_id))
+      .where(status: DiscoursePostEvent::Event.statuses[:private])
+      .where("? = ANY(discourse_post_event_events.raw_invitees)", group.name)
+      .find_each(&:enforce_private_invitees!)
+  end
 
   add_post_revision_notifier_recipients do |post_revision|
     # next if no modifications

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -14,8 +14,15 @@ describe DiscoursePostEvent::EventFinder do
 
   describe "by attending user" do
     fab!(:attending_user, :user)
+    fab!(:invited_group) { Fabricate(:group, users: [attending_user]) }
     fab!(:public_event) { Fabricate(:event, status: DiscoursePostEvent::Event.statuses[:public]) }
-    fab!(:private_event) { Fabricate(:event, status: DiscoursePostEvent::Event.statuses[:private]) }
+    fab!(:private_event) do
+      Fabricate(
+        :event,
+        status: DiscoursePostEvent::Event.statuses[:private],
+        raw_invitees: [invited_group.name],
+      )
+    end
     fab!(:another_event) { Fabricate(:event, status: DiscoursePostEvent::Event.statuses[:public]) }
 
     fab!(:attending_public_event) do
@@ -55,12 +62,8 @@ describe DiscoursePostEvent::EventFinder do
       ).to match_array([public_event, private_event])
     end
 
-    it "includes private events if the searching user is also invited" do
-      DiscoursePostEvent::Invitee.create!(
-        user: current_user,
-        event: private_event,
-        status: DiscoursePostEvent::Invitee.statuses[:going],
-      )
+    it "includes private events if the searching user belongs to an invited group" do
+      invited_group.add(current_user)
 
       expect(
         finder.search(current_user, { attending_user: attending_user.username }),

--- a/plugins/discourse-calendar/spec/requests/private_event_group_invitees_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/private_event_group_invitees_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  describe "private event group invitees" do
+    fab!(:event_owner, :admin)
+    fab!(:invitee_user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:invited_group) do
+      Fabricate(
+        :group,
+        visibility_level: Group.visibility_levels[:owners],
+        members_visibility_level: Group.visibility_levels[:owners],
+      )
+    end
+    fab!(:topic) { Fabricate(:topic, user: event_owner, category: Fabricate(:category)) }
+    fab!(:post) { Fabricate(:post, user: event_owner, topic:) }
+    fab!(:event) do
+      Fabricate(
+        :event,
+        post:,
+        status: DiscoursePostEvent::Event.statuses[:private],
+        raw_invitees: [invited_group.name],
+      )
+    end
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+      invited_group.add(invitee_user)
+    end
+
+    def create_invitee
+      event.create_invitees(
+        [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+      )
+      event.invitees.find_by(user_id: invitee_user.id)
+    end
+
+    it "removes invitee records when a user leaves an invited group" do
+      invitee = create_invitee
+
+      expect { invited_group.remove(invitee_user) }.to change {
+        DiscoursePostEvent::Invitee.unscoped.exists?(id: invitee.id)
+      }.from(true).to(false)
+    end
+
+    it "blocks a stale invitee from private event details, attendance listings, and RSVP updates" do
+      stale_invitee = create_invitee
+      invited_group.remove(invitee_user)
+      stale_invitee =
+        DiscoursePostEvent::Invitee
+          .unscoped
+          .find_or_create_by!(post_id: event.id, user_id: invitee_user.id) do |invitee|
+            invitee.status = DiscoursePostEvent::Invitee.statuses[:going]
+          end
+
+      sign_in(invitee_user)
+
+      get "/discourse-post-event/events/#{event.id}.json"
+
+      expect(response.status).to eq(200)
+      event_json = response.parsed_body["event"]
+      expect(event_json).not_to have_key("raw_invitees")
+      expect(event_json).not_to have_key("sample_invitees")
+      expect(event_json).not_to have_key("stats")
+      expect(event_json["should_display_invitees"]).to eq(false)
+      expect(event_json["can_update_attendance"]).to eq(false)
+      expect(event_json["watching_invitee"]).to be_nil
+
+      get "/discourse-post-event/events/#{event.id}/invitees.json"
+
+      expect(response.status).to eq(403)
+      expect(response.body).not_to include(invitee_user.username)
+
+      get "/discourse-post-event/events.json",
+          params: {
+            attending_user: invitee_user.username,
+            include_details: "true",
+          }
+
+      expect(response.status).to eq(200)
+      expect(
+        response.parsed_body["events"].map { |listed_event_json| listed_event_json["id"] },
+      ).not_to include(event.id)
+
+      put "/discourse-post-event/events/#{event.id}/invitees/#{stale_invitee.id}.json",
+          params: {
+            invitee: {
+              status: "interested",
+            },
+          }
+
+      expect(response.status).to eq(403)
+      expect(response.parsed_body).not_to have_key("success")
+      expect(stale_invitee.reload.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
+    end
+  end
+end


### PR DESCRIPTION
Backport of #42187 to release/2026.6.

---

## Summary

Correctly restrict private calendar event access to current group members. The patch replaces stale invitee-row authorization with active invited-group membership checks across event detail serialization, attendance searches, RSVP mutations, and livestream chat metadata, and prunes stale invitee records when a user is removed from a group.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1377

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
