### PR TITLE
FIX: Restrict opening post type transitions to regular and moderator_action

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -729,9 +729,14 @@ class PostsController < ApplicationController
     guardian.ensure_can_change_post_type!
     post = find_post_from_params
     params.require(:post_type)
-    raise Discourse::InvalidParameters.new(:post_type) if Post.types[params[:post_type].to_i].blank?
+    post_type = params[:post_type].to_i
+    raise Discourse::InvalidParameters.new(:post_type) if Post.types[post_type].blank?
 
-    post.revise(current_user, post_type: params[:post_type].to_i)
+    if post.is_first_post? && !post_type.in?([Post.types[:regular], Post.types[:moderator_action]])
+      raise Discourse::InvalidParameters.new(:post_type)
+    end
+
+    post.revise(current_user, post_type: post_type)
 
     render body: nil
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -730,9 +730,7 @@ class PostsController < ApplicationController
     post = find_post_from_params
     params.require(:post_type)
     post_type = params[:post_type].to_i
-    raise Discourse::InvalidParameters.new(:post_type) if Post.types[post_type].blank?
-
-    if post.is_first_post? && !post_type.in?([Post.types[:regular], Post.types[:moderator_action]])
+    unless PostRevisor.valid_post_type?(post, post_type)
       raise Discourse::InvalidParameters.new(:post_type)
     end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -730,7 +730,11 @@ class PostsController < ApplicationController
     post = find_post_from_params
     params.require(:post_type)
     post_type = params[:post_type].to_i
-    unless PostRevisor.valid_post_type?(post, post_type)
+    unless PostRevisor.valid_post_type?(post_type)
+      raise Discourse::InvalidParameters.new(:post_type)
+    end
+
+    if post.is_first_post? && post_type == Post.types[:whisper]
       raise Discourse::InvalidParameters.new(:post_type)
     end
 

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -109,10 +109,8 @@ class PostRevisor
     @@tracked_topic_fields
   end
 
-  def self.valid_post_type?(post, post_type)
-    allowed_post_types = [Post.types[:regular], Post.types[:moderator_action]]
-    allowed_post_types << Post.types[:whisper] unless post.is_first_post?
-    allowed_post_types.include?(post_type)
+  def self.valid_post_type?(post_type)
+    [Post.types[:regular], Post.types[:moderator_action], Post.types[:whisper]].include?(post_type)
   end
 
   def self.track_topic_field(field, &block)
@@ -920,7 +918,7 @@ class PostRevisor
   private
 
   def validate_post_type
-    return true if self.class.valid_post_type?(@post, @fields[:post_type])
+    return true if self.class.valid_post_type?(@fields[:post_type])
 
     @post.errors.add(:post_type, :invalid)
     false

--- a/lib/post_revisor.rb
+++ b/lib/post_revisor.rb
@@ -109,6 +109,12 @@ class PostRevisor
     @@tracked_topic_fields
   end
 
+  def self.valid_post_type?(post, post_type)
+    allowed_post_types = [Post.types[:regular], Post.types[:moderator_action]]
+    allowed_post_types << Post.types[:whisper] unless post.is_first_post?
+    allowed_post_types.include?(post_type)
+  end
+
   def self.track_topic_field(field, &block)
     tracked_topic_fields[field] = block
 
@@ -288,6 +294,10 @@ class PostRevisor
     @fields[:raw] = cleanup_whitespaces(@fields[:raw]) if @fields.has_key?(:raw)
     @fields[:user_id] = @fields[:user_id].to_i if @fields.has_key?(:user_id)
     @fields[:category_id] = @fields[:category_id].to_i if @fields.has_key?(:category_id)
+    if @fields.has_key?(:post_type)
+      @fields[:post_type] = @fields[:post_type].to_i
+      return false unless validate_post_type
+    end
     if @fields.has_key?(:tags) && PostRevisor.tag_change_noop?(@topic, @fields[:tags])
       @fields.delete(:tags)
     end
@@ -908,6 +918,13 @@ class PostRevisor
   end
 
   private
+
+  def validate_post_type
+    return true if self.class.valid_post_type?(@post, @fields[:post_type])
+
+    @post.errors.add(:post_type, :invalid)
+    false
+  end
 
   def resolve_reply_to_change
     new_post_number = @fields[:reply_to_post_number]

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -447,18 +447,16 @@ describe PostRevisor do
       let!(:opening_post) { Fabricate(:post, topic: topic) }
       let!(:reply) { Fabricate(:post, topic: topic) }
 
-      it "rejects unsupported transitions" do
-        expect(opening_post.revise(admin, post_type: Post.types[:whisper])).to eq(false)
+      it "rejects changing a post to a small action" do
         expect(reply.revise(admin, post_type: Post.types[:small_action])).to eq(false)
 
-        expect(opening_post.reload.post_type).to eq(Post.types[:regular])
         expect(reply.reload.post_type).to eq(Post.types[:regular])
       end
 
-      it "allows changing a reply to a whisper" do
-        expect(reply.revise(admin, post_type: Post.types[:whisper])).to eq(true)
+      it "allows changing a post to a whisper" do
+        expect(opening_post.revise(admin, post_type: Post.types[:whisper])).to eq(true)
 
-        expect(reply.reload).to be_whisper
+        expect(opening_post.reload).to be_whisper
       end
     end
 

--- a/spec/lib/post_revisor_spec.rb
+++ b/spec/lib/post_revisor_spec.rb
@@ -443,6 +443,25 @@ describe PostRevisor do
     let(:post) { Fabricate(:post, post_args) }
     let(:first_version_at) { post.last_version_at }
 
+    describe "post type changes" do
+      let!(:opening_post) { Fabricate(:post, topic: topic) }
+      let!(:reply) { Fabricate(:post, topic: topic) }
+
+      it "rejects unsupported transitions" do
+        expect(opening_post.revise(admin, post_type: Post.types[:whisper])).to eq(false)
+        expect(reply.revise(admin, post_type: Post.types[:small_action])).to eq(false)
+
+        expect(opening_post.reload.post_type).to eq(Post.types[:regular])
+        expect(reply.reload.post_type).to eq(Post.types[:regular])
+      end
+
+      it "allows changing a reply to a whisper" do
+        expect(reply.revise(admin, post_type: Post.types[:whisper])).to eq(true)
+
+        expect(reply.reload).to be_whisper
+      end
+    end
+
     it "destroys last revision if edit is undone" do
       old_raw = post.raw
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1195,6 +1195,13 @@ RSpec.describe PostsController do
         expect(response.status).to eq(400)
       end
 
+      it "rejects changing a reply to a small action" do
+        put "/posts/#{post.id}/post_type.json", params: { post_type: Post.types[:small_action] }
+
+        expect(response).to be_bad_request
+        expect(post.reload.post_type).to eq(Post.types[:regular])
+      end
+
       it "rejects changing a nested topic's opening post to a small action" do
         nested_view_topic = Fabricate(:topic, user: user)
         opening_post = Fabricate(:post, topic: nested_view_topic, user: user, post_number: 1)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1202,6 +1202,15 @@ RSpec.describe PostsController do
         expect(post.reload.post_type).to eq(Post.types[:regular])
       end
 
+      it "rejects changing an opening post to a whisper" do
+        opening_post = Fabricate(:post)
+
+        put "/posts/#{opening_post.id}/post_type.json", params: { post_type: Post.types[:whisper] }
+
+        expect(response).to be_bad_request
+        expect(opening_post.reload.post_type).to eq(Post.types[:regular])
+      end
+
       it "rejects changing a nested topic's opening post to a small action" do
         nested_view_topic = Fabricate(:topic, user: user)
         opening_post = Fabricate(:post, topic: nested_view_topic, user: user, post_number: 1)

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1195,6 +1195,30 @@ RSpec.describe PostsController do
         expect(response.status).to eq(400)
       end
 
+      it "rejects changing a nested topic's opening post to a small action" do
+        nested_view_topic = Fabricate(:topic, user: user)
+        opening_post = Fabricate(:post, topic: nested_view_topic, user: user, post_number: 1)
+        Fabricate(:nested_topic, topic: nested_view_topic)
+        SiteSetting.nested_replies_enabled = true
+
+        put "/posts/#{opening_post.id}/post_type.json",
+            params: {
+              post_type: Post.types[:small_action],
+            }
+
+        aggregate_failures do
+          expect(response).to be_bad_request
+          expect(response.body).to include("post_type")
+          expect(opening_post.reload.post_type).to eq(Post.types[:regular])
+
+          sign_out
+          get "/n/#{nested_view_topic.slug}/#{nested_view_topic.id}.json"
+
+          expect(response).to be_ok
+          expect(response.parsed_body.dig("op_post", "id")).to eq(opening_post.id)
+        end
+      end
+
       it "can change the post type" do
         put "/posts/#{post.id}/post_type.json", params: { post_type: 2 }
 


### PR DESCRIPTION
## Summary

The staff-only post-type endpoint accepted small_action and whisper values for opening posts, which could make a nested-view topic return 500. Now the endpoint rejects any post_type other than regular or moderator_action for the first post in a topic, preventing the invalid state while preserving supported reply-to-whisper conversions.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1569

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>