### PR TITLE
FIX: Gate permalink fallback redirects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -304,7 +304,7 @@ class ApplicationController < ActionController::Base
 
       # there are some cases where we have a permalink but no url
       # cause category / topic was deleted
-      if permalink.present? && permalink.target_url
+      if permalink.present? && guardian.can_see_permalink_target?(permalink) && permalink.target_url
         # permalink present, redirect to that URL
         redirect_with_client_support permalink.target_url,
                                      status: :moved_permanently,
@@ -590,7 +590,7 @@ class ApplicationController < ActionController::Base
 
   def handle_permalink(path)
     permalink = Permalink.find_by_url(path)
-    if permalink && permalink.target_url
+    if permalink && guardian.can_see_permalink_target?(permalink) && permalink.target_url
       redirect_to permalink.target_url, status: :moved_permanently
     end
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -629,7 +629,8 @@ class TagsController < ::ApplicationController
 
     if !@filter_on_category
       permalink = Permalink.find_by_url("c/#{params[:category_slug_path_with_id]}")
-      if permalink.present? && permalink.category_id
+      if permalink.present? && permalink.category_id &&
+           guardian.can_see_permalink_target?(permalink)
         return(
           redirect_to "#{Discourse.base_path}/tags#{permalink.target_url}/#{params[:tag_name]}",
                       status: :moved_permanently

--- a/spec/requests/categories_controller_spec.rb
+++ b/spec/requests/categories_controller_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe CategoriesController do
       expect(response).to redirect_to(%r{/c/#{category.slug}})
     end
 
+    it "does not disclose restricted topic titles through legacy category permalinks" do
+      group = Fabricate(:group)
+      private_category = Fabricate(:private_category, group: group)
+      private_topic =
+        Fabricate(:topic, category: private_category, title: "Restricted fallback topic title")
+      Permalink.create!(url: "category/old-category", topic: private_topic)
+
+      get "/category/old-category"
+
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to("/c/old-category")
+      expect(response.headers["Location"]).not_to include(private_topic.title)
+      expect(response.body).not_to include(private_topic.title)
+    end
+
     it "returns the right response for a normal user" do
       sign_in(user)
 

--- a/spec/requests/list_controller_spec.rb
+++ b/spec/requests/list_controller_spec.rb
@@ -1570,6 +1570,19 @@ RSpec.describe ListController do
       expect(response.status).to eq(200)
     end
 
+    it "does not disclose restricted topic titles through category route permalink fallbacks" do
+      private_category = Fabricate(:private_category, group: Fabricate(:group))
+      private_topic =
+        Fabricate(:topic, category: private_category, title: "Restricted list fallback topic title")
+      Permalink.create!(url: "c/old-category/999", topic: private_topic)
+
+      get "/c/old-category/999"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.headers["Location"]).to be_nil
+      expect(response.body).not_to include(private_topic.title)
+    end
+
     context "with encoded slugs" do
       it "does not create a redirect loop" do
         category = Fabricate(:category)

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -700,6 +700,17 @@ RSpec.describe TagsController do
 
       fab!(:topic_out_of_category) { Fabricate(:topic, tags: [tag]) }
 
+      it "does not disclose restricted category names through category permalink fallbacks" do
+        private_category = Fabricate(:private_category, group: Fabricate(:group))
+        Permalink.create!(url: "c/old-category", category: private_category)
+
+        get "/tags/c/old-category/#{tag.name}.json"
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.headers["Location"]).to be_nil
+        expect(response.body).not_to include(private_category.name)
+      end
+
       it "should produce the topic inside the category and not the topic outside of it" do
         get "/tags/c/#{category.slug}/#{tag.name}.json"
 


### PR DESCRIPTION
## Summary

Correctly guard legacy permalink fallback redirects with the existing PermalinkGuardian visibility policy. Three fallback paths (not-found category/topic routes, legacy `/category/*` redirects, and `/tags/c/*` category-permalink redirects) were calling `Permalink#target_url` without checking whether the requesting user can see the target. Unauthorized requests now follow the normal non-disclosing fallback or return 404 without exposing the restricted slug.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1539

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>