### PR TITLE
UX: livestream columns need to override theme components

### DIFF
--- a/plugins/discourse-calendar/assets/stylesheets/desktop/livestream.scss
+++ b/plugins/discourse-calendar/assets/stylesheets/desktop/livestream.scss
@@ -41,7 +41,13 @@
   }
 
   // the timeline is swapped for the progress bar while chat is docked, so the
-  // navigation is placed below the posts rather than in its own column
+  // navigation is placed below the posts and the column it occupied is
+  // reclaimed for them
+  .container.posts {
+    // outranks themes and components sizing the timeline column themselves
+    grid-template-columns: minmax(0, 1fr) 0;
+  }
+
   .container.posts .topic-navigation {
     grid-area: posts;
     grid-row: 3;


### PR DESCRIPTION
follow-up to 80df3e21541d0cb16dbc30e1d48bd969685b53dc, this ensures the plugin overrides anything messing around with the columns — most notably the discoTOC component 