### PR TITLE
SECURITY: Remove stale invitee access for users removed from invited groups on private events [backport 2026.1]

### DIFF
--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -51,7 +51,7 @@ module DiscoursePostEvent
     end
 
     def update
-      invitee = Invitee.find_by(id: params[:invitee_id], post_id: params[:event_id])
+      invitee = Invitee.find_by!(id: params[:invitee_id], post_id: params[:event_id])
       guardian.ensure_can_act_on_invitee!(invitee)
       begin
         invitee.update_attendance!(invitee_params[:status])
@@ -101,8 +101,8 @@ module DiscoursePostEvent
     end
 
     def destroy
-      event = Event.find_by(id: params[:post_id])
-      invitee = event.invitees.find_by(id: params[:id])
+      event = Event.find(params[:post_id])
+      invitee = event.invitees.find(params[:id])
       guardian.ensure_can_act_on_invitee!(invitee)
       invitee.destroy!
       event.publish_update!

--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -56,71 +56,73 @@ module DiscoursePostEvent
     end
 
     def update
-      invitee = Invitee.find_by!(id: params[:invitee_id], post_id: params[:event_id])
-      guardian.ensure_can_act_on_invitee!(invitee)
-      begin
-        invitee.update_attendance!(invitee_params[:status])
-        render json: InviteeSerializer.new(invitee)
-      rescue Discourse::InvalidParameters => e
-        if e.message == "max_attendees"
+      DiscoursePostEvent::UpdateInvitee.call(
+        params: {
+          status: params.dig(:invitee, :status),
+          event_id: params[:event_id],
+          invitee_id: params[:invitee_id],
+        },
+        guardian:,
+      ) do
+        on_success { |invitee:| render json: InviteeSerializer.new(invitee) }
+        on_failed_policy(:can_act_on_invitee) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_see_event) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_update_attendance) { raise Discourse::InvalidAccess }
+        on_failed_policy(:has_capacity) do
           render_json_error(
             I18n.t("discourse_post_event.errors.models.event.max_attendees_reached"),
             422,
           )
-        else
-          raise
         end
+        on_model_not_found(:invitee) { raise Discourse::NotFound }
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_failed_contract { raise Discourse::InvalidParameters }
+        on_failure { render(json: failed_json, status: :unprocessable_entity) }
       end
     end
 
     def create
-      event = Event.find(params[:event_id])
-      guardian.ensure_can_see!(event.post)
-
-      invitee_params = invitee_params(event)
-
-      user = current_user
-      if user_id = invitee_params[:user_id]
-        user = User.find(user_id.to_i)
-      end
-
-      raise Discourse::InvalidAccess if !event.can_user_update_attendance(user)
-
-      if current_user.id != user.id
-        raise Discourse::InvalidAccess if !guardian.can_act_on_discourse_post_event?(event)
-      end
-
-      begin
-        invitee = Invitee.create_attendance!(user.id, params[:event_id], invitee_params[:status])
-        render json: InviteeSerializer.new(invitee)
-      rescue Discourse::InvalidParameters => e
-        if e.message == "max_attendees"
+      DiscoursePostEvent::CreateInvitee.call(
+        params: {
+          status: params[:invitee][:status],
+          user_id: params[:invitee][:user_id],
+          event_id: params[:event_id],
+        },
+        guardian:,
+      ) do
+        on_success { |invitee:| render json: InviteeSerializer.new(invitee) }
+        on_failed_policy(:can_see_event) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_update_attendance) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_invite_user) { raise Discourse::InvalidAccess }
+        on_failed_policy(:has_capacity) do
           render_json_error(
             I18n.t("discourse_post_event.errors.models.event.max_attendees_reached"),
             422,
           )
-        else
-          raise
         end
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_model_not_found(:user) { raise Discourse::NotFound }
+        on_failed_contract { raise Discourse::InvalidParameters }
+        on_failure { render(json: failed_json, status: :unprocessable_entity) }
       end
     end
 
     def destroy
-      event = Event.find(params[:post_id])
-      invitee = event.invitees.find(params[:id])
-      guardian.ensure_can_act_on_invitee!(invitee)
-      invitee.destroy!
-      event.publish_update!
-      render json: success_json
-    end
-
-    private
-
-    def invitee_params(event = nil)
-      if event && guardian.can_act_on_discourse_post_event?(event)
-        params.require(:invitee).permit(:status, :user_id)
-      else
-        params.require(:invitee).permit(:status)
+      DiscoursePostEvent::DestroyInvitee.call(
+        params: {
+          post_id: params[:post_id],
+          id: params[:id],
+        },
+        guardian:,
+      ) do
+        on_success { render json: success_json }
+        on_failed_policy(:can_act_on_invitee) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_see_event) { raise Discourse::InvalidAccess }
+        on_failed_policy(:can_update_attendance) { raise Discourse::InvalidAccess }
+        on_model_not_found(:event) { raise Discourse::NotFound }
+        on_model_not_found(:invitee) { raise Discourse::NotFound }
+        on_failed_contract { raise Discourse::InvalidParameters }
+        on_failure { render(json: failed_json, status: :unprocessable_entity) }
       end
     end
   end

--- a/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
+++ b/plugins/discourse-calendar/app/controllers/discourse_post_event/invitees_controller.rb
@@ -10,7 +10,12 @@ module DiscoursePostEvent
       filter = params[:filter].downcase if params[:filter]
 
       event_invitees = event.invitees
-      event_invitees = event_invitees.with_status(params[:type].to_sym) if params[:type]
+      if params[:type]
+        unless Invitee.statuses.valid?(params[:type].to_sym)
+          raise Discourse::InvalidParameters.new(:type)
+        end
+        event_invitees = event_invitees.with_status(params[:type].to_sym)
+      end
 
       suggested_users = []
       if filter.present? && guardian.can_act_on_discourse_post_event?(event)

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -305,7 +305,7 @@ module DiscoursePostEvent
       self.invitees.where.not(user_id: fetch_users.select(:id)).delete_all
     end
 
-    def can_user_update_attendance(user)
+    def can_user_update_attendance?(user)
       return false if self.closed || self.expired?
       return true if self.public?
 

--- a/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
+++ b/plugins/discourse-calendar/app/models/discourse_post_event/event.rb
@@ -305,15 +305,22 @@ module DiscoursePostEvent
       self.invitees.where.not(user_id: fetch_users.select(:id)).delete_all
     end
 
-    def can_user_update_attendance?(user)
-      return false if self.closed || self.expired?
-      return true if self.public?
+    def user_in_invited_group?(user, group_names: nil)
+      return false if user.blank? || raw_invitees.blank?
 
-      self.private? &&
-        (
-          self.invitees.exists?(user_id: user.id) ||
-            (user.groups.pluck(:name) & self.raw_invitees).any?
-        )
+      return (Array(raw_invitees) & Array(group_names)).any? unless group_names.nil?
+
+      GroupUser.where(
+        user_id: user.id,
+        group_id: Group.where(name: raw_invitees).select(:id),
+      ).exists?
+    end
+
+    def can_user_update_attendance?(user, group_names: nil)
+      return false if user.blank? || closed || expired?
+      return true if public?
+
+      private? && user_in_invited_group?(user, group_names:)
     end
 
     def self.update_from_raw(post)

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -108,8 +108,9 @@ module DiscoursePostEvent
     end
 
     def watching_invitee
-      if scope.current_user
-        watching_invitee = Invitee.find_by(user_id: scope.current_user.id, post_id: object.id)
+      user = scope.current_user
+      if user && can_display_current_user_invitee?(user)
+        watching_invitee = Invitee.find_by(user_id: user.id, post_id: object.id)
       end
 
       InviteeSerializer.new(watching_invitee, root: false, scope:) if watching_invitee
@@ -129,7 +130,17 @@ module DiscoursePostEvent
     end
 
     def include_stats?
-      scope.can_display_invitee_details?(object)
+      can_display_invitee_details?
+    end
+
+    def can_display_current_user_invitee?(user)
+      !object.private? || scope.can_act_on_discourse_post_event?(object) ||
+        object.user_in_invited_group?(user)
+    end
+
+    def can_display_invitee_details?
+      return @can_display_invitee_details if defined?(@can_display_invitee_details)
+      @can_display_invitee_details = scope.can_display_invitee_details?(object)
     end
 
     def should_display_invitees

--- a/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
+++ b/plugins/discourse-calendar/app/serializers/discourse_post_event/event_serializer.rb
@@ -96,7 +96,7 @@ module DiscoursePostEvent
     end
 
     def can_update_attendance
-      scope.current_user && object.can_user_update_attendance(scope.current_user)
+      scope.current_user && object.can_user_update_attendance?(scope.current_user)
     end
 
     def creator

--- a/plugins/discourse-calendar/app/services/discourse_post_event/create_invitee.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/create_invitee.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class CreateInvitee
+    include Service::Base
+
+    params do
+      attribute :event_id, :integer
+      attribute :status, :symbol
+      attribute :user_id, :integer
+
+      validates :event_id, presence: true
+      validates :status, inclusion: { in: Invitee.statuses.keys }
+    end
+
+    model :event
+    policy :can_see_event
+    model :user
+    policy :can_update_attendance
+    policy :can_invite_user
+    policy :has_capacity
+
+    model :invitee, :create_invitee
+
+    private
+
+    def fetch_event(params:)
+      Event.find_by(id: params.event_id)
+    end
+
+    def can_see_event(guardian:, event:)
+      guardian.can_see?(event.post)
+    end
+
+    def fetch_user(params:, guardian:)
+      params.user_id ? User.find_by(id: params.user_id) : guardian.user
+    end
+
+    def can_update_attendance(event:, user:)
+      event.can_user_update_attendance?(user)
+    end
+
+    def can_invite_user(guardian:, event:, user:)
+      return true if guardian.user.id == user.id
+      guardian.can_act_on_discourse_post_event?(event)
+    end
+
+    def has_capacity(event:, params:)
+      params.status != :going || !event.at_capacity?
+    end
+
+    def create_invitee(user:, event:, params:)
+      Invitee.create_attendance!(user.id, event.id, params.status)
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/destroy_invitee.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/destroy_invitee.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class DestroyInvitee
+    include Service::Base
+
+    params do
+      attribute :post_id, :integer
+      attribute :id, :integer
+
+      validates :post_id, presence: true
+      validates :id, presence: true
+    end
+
+    model :event
+    model :invitee
+    policy :can_act_on_invitee
+    policy :can_see_event
+    policy :can_update_attendance
+
+    step :destroy
+    step :publish
+
+    private
+
+    def fetch_event(params:)
+      Event.find_by(id: params.post_id)
+    end
+
+    def fetch_invitee(event:, params:)
+      event.invitees.find_by(id: params.id)
+    end
+
+    def can_act_on_invitee(guardian:, invitee:)
+      guardian.can_act_on_invitee?(invitee)
+    end
+
+    def can_see_event(guardian:, event:)
+      guardian.can_see?(event.post)
+    end
+
+    def can_update_attendance(guardian:, event:)
+      event.can_user_update_attendance?(guardian.user)
+    end
+
+    def destroy(invitee:)
+      invitee.destroy!
+    end
+
+    def publish(event:)
+      event.publish_update!
+    end
+  end
+end

--- a/plugins/discourse-calendar/app/services/discourse_post_event/update_invitee.rb
+++ b/plugins/discourse-calendar/app/services/discourse_post_event/update_invitee.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  class UpdateInvitee
+    include Service::Base
+
+    params do
+      attribute :event_id, :integer
+      attribute :invitee_id, :integer
+      attribute :status, :symbol
+
+      validates :event_id, presence: true
+      validates :invitee_id, presence: true
+      validates :status, inclusion: { in: Invitee.statuses.keys }
+    end
+
+    model :invitee
+    policy :can_act_on_invitee
+    model :event
+    policy :can_see_event
+    policy :can_update_attendance
+    policy :has_capacity
+
+    step :update
+
+    private
+
+    def fetch_invitee(params:)
+      Invitee.find_by(id: params.invitee_id, post_id: params.event_id)
+    end
+
+    def can_act_on_invitee(guardian:, invitee:)
+      guardian.can_act_on_invitee?(invitee)
+    end
+
+    def fetch_event(invitee:)
+      invitee.event
+    end
+
+    def can_see_event(guardian:, event:)
+      guardian.can_see?(event.post)
+    end
+
+    def can_update_attendance(guardian:, event:)
+      event.can_user_update_attendance?(guardian.user)
+    end
+
+    def has_capacity(event:, invitee:, params:)
+      params.status != :going || !event.at_capacity? || invitee.status == Invitee.statuses[:going]
+    end
+
+    def update(invitee:, params:)
+      invitee.update_attendance!(params.status)
+    end
+  end
+end

--- a/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
+++ b/plugins/discourse-calendar/lib/discourse_post_event/event_finder.rb
@@ -79,13 +79,20 @@ module DiscoursePostEvent
       # If no user, can only see non-private events
       return events.where.not(status: private_status) if user.nil?
 
-      # User can see private events if they are invited to them
-      events.where(
-        "discourse_post_event_events.status != ? OR (discourse_post_event_events.status = ? AND EXISTS (SELECT 1 FROM discourse_post_event_invitees WHERE post_id = discourse_post_event_events.id AND user_id = ?))",
-        private_status,
-        private_status,
-        user.id,
-      )
+      # User can see private events if they still belong to an invited group.
+      events.where(<<~SQL, private_status, private_status, user.id)
+          discourse_post_event_events.status != ?
+          OR (
+            discourse_post_event_events.status = ?
+            AND EXISTS (
+              SELECT 1
+              FROM group_users
+              INNER JOIN groups ON groups.id = group_users.group_id
+              WHERE group_users.user_id = ?
+                AND groups.name = ANY(discourse_post_event_events.raw_invitees)
+            )
+          )
+        SQL
     end
 
     def self.filter_by_dates(events, params)

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -177,14 +177,10 @@ after_initialize do
   end
 
   add_to_class(:user, :can_act_on_discourse_post_event?) do |event|
-    return @can_act_on_discourse_post_event if defined?(@can_act_on_discourse_post_event)
-    @can_act_on_discourse_post_event =
-      begin
-        return true if staff?
-        can_create_discourse_post_event? && Guardian.new(self).can_edit_post?(event.post)
-      rescue StandardError
-        false
-      end
+    return true if staff?
+    can_create_discourse_post_event? && Guardian.new(self).can_edit_post?(event.post)
+  rescue StandardError
+    false
   end
 
   add_to_class(:guardian, :can_act_on_discourse_post_event?) do |event|

--- a/plugins/discourse-calendar/plugin.rb
+++ b/plugins/discourse-calendar/plugin.rb
@@ -192,10 +192,7 @@ after_initialize do
 
     raw_invitees = Array(event.raw_invitees).uniq
 
-    if user &&
-         (event.invitees.exists?(user_id: user.id) || user.groups.where(name: raw_invitees).exists?)
-      return true
-    end
+    return true if user && event.user_in_invited_group?(user)
 
     return false if raw_invitees.blank?
 
@@ -523,6 +520,14 @@ after_initialize do
   end
 
   on(:user_destroyed) { |user| DiscoursePostEvent::Invitee.where(user_id: user.id).destroy_all }
+
+  on(:user_removed_from_group) do |user, group|
+    DiscoursePostEvent::Event
+      .where(id: DiscoursePostEvent::Invitee.unscoped.where(user_id: user.id).select(:post_id))
+      .where(status: DiscoursePostEvent::Event.statuses[:private])
+      .where("? = ANY(discourse_post_event_events.raw_invitees)", group.name)
+      .find_each(&:enforce_private_invitees!)
+  end
 
   add_post_revision_notifier_recipients do |post_revision|
     # next if no modifications

--- a/plugins/discourse-calendar/spec/fabricators/event_fabricator.rb
+++ b/plugins/discourse-calendar/spec/fabricators/event_fabricator.rb
@@ -26,6 +26,18 @@ Fabricator(:event, from: "DiscoursePostEvent::Event") do
   original_ends_at { |attrs| attrs[:original_ends_at] }
 end
 
+Fabricator(:private_event, from: :event) do
+  transient :group
+
+  post do |attrs|
+    group = attrs[:group] || Fabricate(:group)
+    category = Fabricate(:private_category, group:)
+    user = attrs[:user] || Fabricate(:user, admin: true, refresh_auto_groups: true)
+    topic = Fabricate(:topic, user:, category:)
+    Fabricate(:post, user:, topic:)
+  end
+end
+
 Fabricator(:event_date, from: "DiscoursePostEvent::EventDate") do
   event
 

--- a/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
+++ b/plugins/discourse-calendar/spec/lib/discourse_post_event/event_finder_spec.rb
@@ -14,8 +14,15 @@ describe DiscoursePostEvent::EventFinder do
 
   describe "by attending user" do
     fab!(:attending_user, :user)
+    fab!(:invited_group) { Fabricate(:group, users: [attending_user]) }
     fab!(:public_event) { Fabricate(:event, status: DiscoursePostEvent::Event.statuses[:public]) }
-    fab!(:private_event) { Fabricate(:event, status: DiscoursePostEvent::Event.statuses[:private]) }
+    fab!(:private_event) do
+      Fabricate(
+        :event,
+        status: DiscoursePostEvent::Event.statuses[:private],
+        raw_invitees: [invited_group.name],
+      )
+    end
     fab!(:another_event) { Fabricate(:event, status: DiscoursePostEvent::Event.statuses[:public]) }
 
     fab!(:attending_public_event) do
@@ -55,12 +62,8 @@ describe DiscoursePostEvent::EventFinder do
       ).to match_array([public_event, private_event])
     end
 
-    it "includes private events if the searching user is also invited" do
-      DiscoursePostEvent::Invitee.create!(
-        user: current_user,
-        event: private_event,
-        status: DiscoursePostEvent::Invitee.statuses[:going],
-      )
+    it "includes private events if the searching user belongs to an invited group" do
+      invited_group.add(current_user)
 
       expect(
         finder.search(current_user, { attending_user: attending_user.username }),

--- a/plugins/discourse-calendar/spec/models/discourse_post_event/user_spec.rb
+++ b/plugins/discourse-calendar/spec/models/discourse_post_event/user_spec.rb
@@ -82,6 +82,28 @@ describe User do
             expect(user_1.can_act_on_discourse_post_event?(post_event_1)).to eq(true)
           end
         end
+
+        context "with multiple events in the same request" do
+          let(:user_2) { Fabricate(:user) }
+
+          let(:own_topic) { Fabricate(:topic, user: user_1) }
+          let(:own_post) { Fabricate(:post, topic: own_topic, user: user_1) }
+          let(:own_event) { Fabricate(:event, post: own_post) }
+
+          let(:other_topic) { Fabricate(:topic, user: user_2) }
+          let(:other_post) { Fabricate(:post, topic: other_topic, user: user_2) }
+          let(:other_event) { Fabricate(:event, post: other_post) }
+
+          it "does not leak the answer from one event to another" do
+            expect(user_1.can_act_on_discourse_post_event?(own_event)).to eq(true)
+            expect(user_1.can_act_on_discourse_post_event?(other_event)).to eq(false)
+          end
+
+          it "does not leak a negative answer either" do
+            expect(user_1.can_act_on_discourse_post_event?(other_event)).to eq(false)
+            expect(user_1.can_act_on_discourse_post_event?(own_event)).to eq(true)
+          end
+        end
       end
 
       context "when user is not in list of allowed groups" do

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -146,6 +146,14 @@ module DiscoursePostEvent
           filteredInvitees = response.parsed_body["invitees"]
           expect(filteredInvitees.count).to eq(2)
         end
+
+        it "returns 400 when filtering by an invalid type" do
+          get "/discourse-post-event/events/#{post_event_1.id}/invitees.json",
+              params: {
+                type: "nonexistent",
+              }
+          expect(response.status).to eq(400)
+        end
       end
     end
 

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -157,307 +157,224 @@ module DiscoursePostEvent
       end
     end
 
-    context "when a post event exists" do
-      context "when an invitee exists" do
-        let(:invitee1) { Fabricate(:user) }
-        let(:post_event_2) do
-          pe = Fabricate(:event, post: post_1)
-          pe.create_invitees([{ user_id: invitee1.id, status: Invitee.statuses[:going] }])
+    describe "#create" do
+      let(:event) { Fabricate(:event, post: post_1) }
+
+      it "creates an invitee" do
+        post "/discourse-post-event/events/#{event.id}/invitees.json",
+             params: {
+               invitee: {
+                 status: "going",
+               },
+             }
+
+        expect(response.status).to eq(200)
+        expect(Invitee).to exist(user_id: user.id, status: Invitee.statuses[:going])
+      end
+
+      it "allows staff to invite another user" do
+        other_user = Fabricate(:user)
+
+        post "/discourse-post-event/events/#{event.id}/invitees.json",
+             params: {
+               invitee: {
+                 status: "interested",
+                 user_id: other_user.id,
+               },
+             }
+
+        expect(response.status).to eq(200)
+        expect(Invitee).to exist(user_id: other_user.id, status: Invitee.statuses[:interested])
+      end
+
+      it "returns 403 when non-staff tries to invite themselves to a private event" do
+        private_event = Fabricate(:event, post: post_1, status: "private")
+        other_user = Fabricate(:user)
+        sign_in(other_user)
+
+        expect do
+          post "/discourse-post-event/events/#{private_event.id}/invitees.json",
+               params: {
+                 invitee: {
+                   status: "going",
+                 },
+               }
+        end.not_to change { Invitee.count }
+
+        expect(response.status).to eq(403)
+      end
+
+      context "when event is at max capacity" do
+        fab!(:post_2) { create_post(user: Fabricate(:admin), category: Fabricate(:category)) }
+        fab!(:user_a, :user)
+        fab!(:user_b, :user)
+        fab!(:full_event) do
+          pe = Fabricate(:event, post: post_2, max_attendees: 1)
+          pe.create_invitees([{ user_id: user_a.id, status: Invitee.statuses[:going] }])
           pe
         end
 
-        describe "updating invitee" do
-          it "updates its status" do
-            invitee = post_event_2.invitees.first
+        it "returns 422 when trying to join as going" do
+          sign_in(user_b)
 
-            expect(invitee.status).to eq(0)
-
-            put "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json",
-                params: {
-                  invitee: {
-                    status: "interested",
-                  },
-                }
-
-            invitee.reload
-
-            expect(invitee.status).to eq(1)
-            expect(invitee.post_id).to eq(post_1.id)
-          end
-
-          it "returns 404 when invitee does not exist" do
-            put "/discourse-post-event/events/#{post_event_2.id}/invitees/999999.json",
-                params: {
-                  invitee: {
-                    status: "interested",
-                  },
-                }
-
-            expect(response.status).to eq(404)
-          end
-        end
-
-        describe "destroying invitee" do
-          context "when acting user can act on discourse event" do
-            it "destroys the invitee" do
-              invitee = post_event_2.invitees.first
-              delete "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json"
-              expect(Invitee.where(id: invitee.id).length).to eq(0)
-              expect(response.status).to eq(200)
-            end
-          end
-
-          context "when acting user can act on invitee" do
-            before { sign_in(invitee1) }
-
-            it "destroys the invitee" do
-              invitee = post_event_2.invitees.first
-              delete "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json"
-              expect(Invitee.where(id: invitee.id).length).to eq(0)
-              expect(response.status).to eq(200)
-            end
-          end
-
-          context "when acting user can't act on invitee" do
-            let(:lurker) { Fabricate(:user) }
-
-            before { sign_in(lurker) }
-
-            it "doesn't destroy the invitee" do
-              invitee = post_event_2.invitees.first
-              delete "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json"
-              expect(Invitee.where(id: invitee.id).length).to eq(1)
-              expect(response.status).to eq(403)
-            end
-          end
-
-          it "returns 404 when invitee does not exist" do
-            delete "/discourse-post-event/events/#{post_event_2.id}/invitees/999999.json"
-
-            expect(response.status).to eq(404)
-          end
-        end
-
-        context "when changing status" do
-          it "sets tracking of the topic" do
-            invitee = post_event_2.invitees.first
-
-            expect(invitee.status).to eq(0)
-
-            put "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json",
-                params: {
-                  invitee: {
-                    status: "interested",
-                  },
-                }
-
-            tu = TopicUser.get(invitee.event.post.topic, invitee.user)
-            expect(tu.notification_level).to eq(TopicUser.notification_levels[:tracking])
-
-            put "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json",
-                params: {
-                  invitee: {
-                    status: "going",
-                  },
-                }
-
-            tu = TopicUser.get(invitee.event.post.topic, invitee.user)
-            expect(tu.notification_level).to eq(TopicUser.notification_levels[:watching])
-
-            put "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json",
-                params: {
-                  invitee: {
-                    status: "not_going",
-                  },
-                }
-
-            tu = TopicUser.get(invitee.event.post.topic, invitee.user)
-            expect(tu.notification_level).to eq(TopicUser.notification_levels[:regular])
-          end
-        end
-      end
-
-      context "when an invitee doesn't exist" do
-        let(:post_event_2) { Fabricate(:event, post: post_1) }
-
-        it "creates an invitee" do
-          post "/discourse-post-event/events/#{post_event_2.id}/invitees.json",
-               params: {
-                 invitee: {
-                   status: "not_going",
-                 },
-               }
-
-          expect(Invitee).to exist(user_id: user.id, status: 2)
-        end
-
-        it "sets tracking of the topic" do
-          post "/discourse-post-event/events/#{post_event_2.id}/invitees.json",
+          post "/discourse-post-event/events/#{full_event.id}/invitees.json",
                params: {
                  invitee: {
                    status: "going",
                  },
                }
 
-          invitee = Invitee.find_by(user_id: user.id)
-
-          tu = TopicUser.get(invitee.event.post.topic, user)
-          expect(tu.notification_level).to eq(TopicUser.notification_levels[:watching])
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"].join).to include("full")
         end
 
-        context "when someone is trying to invite themselves to a private event (creepy)" do
-          let(:post_event_2) { Fabricate(:event, post: post_1, status: "private") }
-          let(:other_user) { Fabricate(:user, username: "creep") }
+        it "allows interested when full" do
+          sign_in(user_b)
 
-          before { sign_in(other_user) }
+          post "/discourse-post-event/events/#{full_event.id}/invitees.json",
+               params: {
+                 invitee: {
+                   status: "interested",
+                 },
+               }
 
-          it "does not create an invitee" do
-            expect do
-              post "/discourse-post-event/events/#{post_event_2.id}/invitees.json",
-                   params: {
-                     invitee: {
-                       status: "going",
-                     },
-                   }
-            end.not_to change { post_event_2.invitees.count }
-          end
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+
+    describe "#update" do
+      let(:invitee_user) { Fabricate(:user) }
+      let(:event) do
+        pe = Fabricate(:event, post: post_1)
+        pe.create_invitees([{ user_id: invitee_user.id, status: Invitee.statuses[:going] }])
+        pe
+      end
+      let(:invitee) { event.invitees.first }
+
+      it "updates the invitee status" do
+        put "/discourse-post-event/events/#{event.id}/invitees/#{invitee.id}.json",
+            params: {
+              invitee: {
+                status: "interested",
+              },
+            }
+
+        expect(response.status).to eq(200)
+        expect(invitee.reload.status).to eq(Invitee.statuses[:interested])
+      end
+
+      it "returns 404 when invitee does not exist" do
+        put "/discourse-post-event/events/#{event.id}/invitees/999999.json",
+            params: {
+              invitee: {
+                status: "interested",
+              },
+            }
+
+        expect(response.status).to eq(404)
+      end
+
+      it "returns 403 when user cannot act on invitee" do
+        lurker = Fabricate(:user)
+        sign_in(lurker)
+
+        put "/discourse-post-event/events/#{event.id}/invitees/#{invitee.id}.json",
+            params: {
+              invitee: {
+                status: "interested",
+              },
+            }
+
+        expect(response.status).to eq(403)
+      end
+
+      context "when event is at max capacity" do
+        fab!(:post_2) { create_post(user: Fabricate(:admin), category: Fabricate(:category)) }
+        fab!(:user_a, :user)
+        fab!(:user_b, :user)
+        fab!(:full_event) do
+          pe = Fabricate(:event, post: post_2, max_attendees: 1)
+          pe.create_invitees([{ user_id: user_a.id, status: Invitee.statuses[:going] }])
+          pe
+        end
+        fab!(:interested_invitee) do
+          Fabricate(
+            :invitee,
+            post_id: post_2.id,
+            user_id: user_b.id,
+            status: Invitee.statuses[:interested],
+          )
         end
 
-        context "when the invitee is the event owner" do
-          let(:post_event_2) { Fabricate(:event, post: post_1) }
+        it "returns 422 when trying to change to going" do
+          sign_in(user_b)
 
-          it "allows inviting other users" do
-            user = Fabricate(:user)
+          put "/discourse-post-event/events/#{full_event.id}/invitees/#{interested_invitee.id}.json",
+              params: {
+                invitee: {
+                  status: "going",
+                },
+              }
 
-            post "/discourse-post-event/events/#{post_event_2.id}/invitees.json",
-                 params: {
-                   invitee: {
-                     status: "interested",
-                     user_id: user.id,
-                   },
-                 }
-
-            post_event_2.reload
-
-            expect(post_event_2.invitees.length).to eq(1)
-            invitee = post_event_2.invitees.first
-            expect(invitee.status).to eq(1)
-            expect(invitee.post_id).to eq(post_1.id)
-            expect(invitee.user_id).to eq(user.id)
-          end
-
-          it "creates an invitee" do
-            expect(post_event_2.invitees.length).to eq(0)
-
-            post "/discourse-post-event/events/#{post_event_2.id}/invitees.json",
-                 params: {
-                   invitee: {
-                     status: "interested",
-                   },
-                 }
-
-            post_event_2.reload
-
-            invitee = post_event_2.invitees.first
-            expect(invitee.status).to eq(1)
-            expect(invitee.post_id).to eq(post_1.id)
-          end
+          expect(response.status).to eq(422)
+          expect(response.parsed_body["errors"].join).to include("full")
         end
 
-        context "when event has max attendees and is full" do
-          fab!(:post_2) { create_post(user: Fabricate(:admin), category: Fabricate(:category)) }
-          fab!(:user_a, :user)
-          fab!(:user_b, :user)
-          fab!(:post_event_full) do
-            pe = Fabricate(:event, post: post_2, max_attendees: 1)
-            pe.create_invitees([{ user_id: user_a.id, status: Invitee.statuses[:going] }])
-            pe
-          end
+        it "allows changing to interested" do
+          sign_in(user_b)
 
-          context "when updating an invitee" do
-            fab!(:invitee) do
-              Fabricate(
-                :invitee,
-                post_id: post_2.id,
-                user_id: user_b.id,
-                status: Invitee.statuses[:interested],
-              )
-            end
+          put "/discourse-post-event/events/#{full_event.id}/invitees/#{interested_invitee.id}.json",
+              params: {
+                invitee: {
+                  status: "interested",
+                },
+              }
 
-            context "when invitee was interested" do
-              it "returns 422 when trying to join as going" do
-                sign_in(user_b)
-
-                put "/discourse-post-event/events/#{post_event_full.id}/invitees/#{invitee.id}.json",
-                    params: {
-                      invitee: {
-                        status: "going",
-                      },
-                    }
-
-                expect(response.status).to eq(422)
-                expect(response.parsed_body["errors"].join).to include("full")
-              end
-            end
-
-            context "when invitee was going" do
-              it "allows upading to interested" do
-                sign_in(user_b)
-
-                put "/discourse-post-event/events/#{post_event_full.id}/invitees/#{invitee.id}.json",
-                    params: {
-                      invitee: {
-                        status: "interested",
-                      },
-                    }
-
-                expect(response.status).to eq(200)
-              end
-            end
-          end
-
-          context "when creating an invitee" do
-            it "returns 422 when trying to join as going" do
-              sign_in(user_b)
-
-              post "/discourse-post-event/events/#{post_event_full.id}/invitees.json",
-                   params: {
-                     invitee: {
-                       status: "going",
-                     },
-                   }
-
-              expect(response.status).to eq(422)
-              expect(response.parsed_body["errors"].join).to include("full")
-            end
-
-            it "allows interested when full" do
-              sign_in(user_b)
-
-              post "/discourse-post-event/events/#{post_event_full.id}/invitees.json",
-                   params: {
-                     invitee: {
-                       status: "interested",
-                     },
-                   }
-
-              expect(response.status).to eq(200)
-            end
-
-            it "allows not_going when full" do
-              sign_in(user_b)
-
-              post "/discourse-post-event/events/#{post_event_full.id}/invitees.json",
-                   params: {
-                     invitee: {
-                       status: "not_going",
-                     },
-                   }
-
-              expect(response.status).to eq(200)
-            end
-          end
+          expect(response.status).to eq(200)
         end
+      end
+    end
+
+    describe "#destroy" do
+      let(:invitee_user) { Fabricate(:user) }
+      let(:event) do
+        pe = Fabricate(:event, post: post_1)
+        pe.create_invitees([{ user_id: invitee_user.id, status: Invitee.statuses[:going] }])
+        pe
+      end
+      let(:invitee) { event.invitees.first }
+
+      it "destroys the invitee as staff" do
+        delete "/discourse-post-event/events/#{event.id}/invitees/#{invitee.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(Invitee.exists?(invitee.id)).to eq(false)
+      end
+
+      it "destroys the invitee as the invitee owner" do
+        sign_in(invitee_user)
+
+        delete "/discourse-post-event/events/#{event.id}/invitees/#{invitee.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(Invitee.exists?(invitee.id)).to eq(false)
+      end
+
+      it "returns 403 when user cannot act on invitee" do
+        lurker = Fabricate(:user)
+        sign_in(lurker)
+
+        delete "/discourse-post-event/events/#{event.id}/invitees/#{invitee.id}.json"
+
+        expect(response.status).to eq(403)
+        expect(Invitee.exists?(invitee.id)).to eq(true)
+      end
+
+      it "returns 404 when invitee does not exist" do
+        delete "/discourse-post-event/events/#{event.id}/invitees/999999.json"
+
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/invitees_controller_spec.rb
@@ -176,6 +176,17 @@ module DiscoursePostEvent
             expect(invitee.status).to eq(1)
             expect(invitee.post_id).to eq(post_1.id)
           end
+
+          it "returns 404 when invitee does not exist" do
+            put "/discourse-post-event/events/#{post_event_2.id}/invitees/999999.json",
+                params: {
+                  invitee: {
+                    status: "interested",
+                  },
+                }
+
+            expect(response.status).to eq(404)
+          end
         end
 
         describe "destroying invitee" do
@@ -199,17 +210,23 @@ module DiscoursePostEvent
             end
           end
 
-          context "when acting user can’t act on discourse event" do
+          context "when acting user can't act on invitee" do
             let(:lurker) { Fabricate(:user) }
 
             before { sign_in(lurker) }
 
-            it "doesn’t destroy the invitee" do
+            it "doesn't destroy the invitee" do
               invitee = post_event_2.invitees.first
               delete "/discourse-post-event/events/#{post_event_2.id}/invitees/#{invitee.id}.json"
               expect(Invitee.where(id: invitee.id).length).to eq(1)
               expect(response.status).to eq(403)
             end
+          end
+
+          it "returns 404 when invitee does not exist" do
+            delete "/discourse-post-event/events/#{post_event_2.id}/invitees/999999.json"
+
+            expect(response.status).to eq(404)
           end
         end
 
@@ -252,7 +269,7 @@ module DiscoursePostEvent
         end
       end
 
-      context "when an invitee doesn’t exist" do
+      context "when an invitee doesn't exist" do
         let(:post_event_2) { Fabricate(:event, post: post_1) }
 
         it "creates an invitee" do

--- a/plugins/discourse-calendar/spec/requests/private_event_group_invitees_spec.rb
+++ b/plugins/discourse-calendar/spec/requests/private_event_group_invitees_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module DiscoursePostEvent
+  describe "private event group invitees" do
+    fab!(:event_owner, :admin)
+    fab!(:invitee_user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:invited_group) do
+      Fabricate(
+        :group,
+        visibility_level: Group.visibility_levels[:owners],
+        members_visibility_level: Group.visibility_levels[:owners],
+      )
+    end
+    fab!(:topic) { Fabricate(:topic, user: event_owner, category: Fabricate(:category)) }
+    fab!(:post) { Fabricate(:post, user: event_owner, topic:) }
+    fab!(:event) do
+      Fabricate(
+        :event,
+        post:,
+        status: DiscoursePostEvent::Event.statuses[:private],
+        raw_invitees: [invited_group.name],
+      )
+    end
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+      invited_group.add(invitee_user)
+    end
+
+    def create_invitee
+      event.create_invitees(
+        [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+      )
+      event.invitees.find_by(user_id: invitee_user.id)
+    end
+
+    it "removes invitee records when a user leaves an invited group" do
+      invitee = create_invitee
+
+      expect { invited_group.remove(invitee_user) }.to change {
+        DiscoursePostEvent::Invitee.unscoped.exists?(id: invitee.id)
+      }.from(true).to(false)
+    end
+
+    it "blocks a stale invitee from private event details, attendance listings, and RSVP updates" do
+      stale_invitee = create_invitee
+      invited_group.remove(invitee_user)
+      stale_invitee =
+        DiscoursePostEvent::Invitee
+          .unscoped
+          .find_or_create_by!(post_id: event.id, user_id: invitee_user.id) do |invitee|
+            invitee.status = DiscoursePostEvent::Invitee.statuses[:going]
+          end
+
+      sign_in(invitee_user)
+
+      get "/discourse-post-event/events/#{event.id}.json"
+
+      expect(response.status).to eq(200)
+      event_json = response.parsed_body["event"]
+      expect(event_json).not_to have_key("raw_invitees")
+      expect(event_json).not_to have_key("sample_invitees")
+      expect(event_json).not_to have_key("stats")
+      expect(event_json["should_display_invitees"]).to eq(false)
+      expect(event_json["can_update_attendance"]).to eq(false)
+      expect(event_json["watching_invitee"]).to be_nil
+
+      get "/discourse-post-event/events/#{event.id}/invitees.json"
+
+      expect(response.status).to eq(403)
+      expect(response.body).not_to include(invitee_user.username)
+
+      get "/discourse-post-event/events.json",
+          params: {
+            attending_user: invitee_user.username,
+            include_details: "true",
+          }
+
+      expect(response.status).to eq(200)
+      expect(
+        response.parsed_body["events"].map { |listed_event_json| listed_event_json["id"] },
+      ).not_to include(event.id)
+
+      put "/discourse-post-event/events/#{event.id}/invitees/#{stale_invitee.id}.json",
+          params: {
+            invitee: {
+              status: "interested",
+            },
+          }
+
+      expect(response.status).to eq(403)
+      expect(response.parsed_body).not_to have_key("success")
+      expect(stale_invitee.reload.status).to eq(DiscoursePostEvent::Invitee.statuses[:going])
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/create_invitee_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/create_invitee_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::CreateInvitee) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:event_id) }
+    it do
+      is_expected.to validate_inclusion_of(:status).in_array(
+        DiscoursePostEvent::Invitee.statuses.keys.map(&:to_s),
+      )
+    end
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:topic) { Fabricate(:topic, user: current_user) }
+    fab!(:post) { Fabricate(:post, user: current_user, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+
+    let(:params) { { event_id: event.id, status: "going" } }
+    let(:dependencies) { { guardian: current_user.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { event_id: event.id, status: "invalid" } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when event does not exist" do
+      let(:params) { { event_id: -1, status: "going" } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when user cannot see the event post" do
+      fab!(:private_event)
+
+      let(:params) { { event_id: private_event.id, status: "going" } }
+
+      it { is_expected.to fail_a_policy(:can_see_event) }
+    end
+
+    context "when event is closed" do
+      fab!(:closed_post) { Fabricate(:post, topic: topic) }
+      fab!(:closed_event) { Fabricate(:event, post: closed_post, closed: true) }
+
+      let(:params) { { event_id: closed_event.id, status: "going" } }
+
+      it { is_expected.to fail_a_policy(:can_update_attendance) }
+    end
+
+    context "when event is expired" do
+      fab!(:expired_post) { Fabricate(:post, topic: topic) }
+      fab!(:expired_event) do
+        Fabricate(
+          :event,
+          post: expired_post,
+          original_starts_at: 2.days.ago,
+          original_ends_at: 1.day.ago,
+        )
+      end
+
+      let(:params) { { event_id: expired_event.id, status: "going" } }
+
+      it { is_expected.to fail_a_policy(:can_update_attendance) }
+    end
+
+    context "when non-staff user tries to invite another user" do
+      fab!(:other_user, :user)
+      let(:params) { { event_id: event.id, status: "going", user_id: other_user.id } }
+
+      it { is_expected.to fail_a_policy(:can_invite_user) }
+    end
+
+    context "when event is at max capacity" do
+      fab!(:other_user, :user)
+      fab!(:full_post) { Fabricate(:post, topic: topic) }
+      fab!(:full_event) { Fabricate(:event, post: full_post, max_attendees: 1) }
+
+      before do
+        full_event.create_invitees(
+          [{ user_id: other_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+      end
+
+      let(:params) { { event_id: full_event.id, status: "going" } }
+
+      it { is_expected.to fail_a_policy(:has_capacity) }
+    end
+
+    context "when everything is valid" do
+      it { is_expected.to run_successfully }
+
+      it "creates the invitee" do
+        expect { result }.to change { DiscoursePostEvent::Invitee.count }.by(1)
+        expect(result[:invitee]).to have_attributes(
+          user_id: current_user.id,
+          post_id: event.id,
+          status: DiscoursePostEvent::Invitee.statuses[:going],
+        )
+      end
+    end
+
+    context "when staff invites another user" do
+      fab!(:admin, :admin)
+      fab!(:other_user, :user)
+
+      let(:dependencies) { { guardian: admin.guardian } }
+      let(:params) { { event_id: event.id, status: "interested", user_id: other_user.id } }
+
+      it { is_expected.to run_successfully }
+
+      it "creates the invitee for the other user" do
+        expect { result }.to change { DiscoursePostEvent::Invitee.count }.by(1)
+        expect(result[:invitee]).to have_attributes(
+          user_id: other_user.id,
+          status: DiscoursePostEvent::Invitee.statuses[:interested],
+        )
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/destroy_invitee_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/destroy_invitee_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::DestroyInvitee) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:post_id) }
+    it { is_expected.to validate_presence_of(:id) }
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+    fab!(:invitee_user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:invitee) do
+      event.create_invitees(
+        [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+      )
+      event.invitees.find_by(user_id: invitee_user.id)
+    end
+
+    let(:params) { { post_id: event.id, id: invitee.id } }
+    let(:dependencies) { { guardian: invitee_user.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { post_id: nil, id: nil } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when event does not exist" do
+      let(:params) { { post_id: -1, id: invitee.id } }
+
+      it { is_expected.to fail_to_find_a_model(:event) }
+    end
+
+    context "when invitee does not exist" do
+      let(:params) { { post_id: event.id, id: -1 } }
+
+      it { is_expected.to fail_to_find_a_model(:invitee) }
+    end
+
+    context "when user cannot act on invitee" do
+      fab!(:other_user, :user)
+      let(:dependencies) { { guardian: other_user.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_act_on_invitee) }
+    end
+
+    context "when user cannot see the event post" do
+      fab!(:private_event)
+      fab!(:private_invitee) do
+        private_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        private_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) { { post_id: private_event.id, id: private_invitee.id } }
+
+      it { is_expected.to fail_a_policy(:can_see_event) }
+    end
+
+    context "when event is closed" do
+      fab!(:closed_post) { Fabricate(:post, topic: topic) }
+      fab!(:closed_event) { Fabricate(:event, post: closed_post, closed: true) }
+      fab!(:closed_invitee) do
+        closed_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        closed_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) { { post_id: closed_event.id, id: closed_invitee.id } }
+
+      it { is_expected.to fail_a_policy(:can_update_attendance) }
+    end
+
+    context "when event is expired" do
+      fab!(:expired_post) { Fabricate(:post, topic: topic) }
+      fab!(:expired_event) do
+        Fabricate(
+          :event,
+          post: expired_post,
+          original_starts_at: 2.days.ago,
+          original_ends_at: 1.day.ago,
+        )
+      end
+      fab!(:expired_invitee) do
+        expired_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        expired_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) { { post_id: expired_event.id, id: expired_invitee.id } }
+
+      it { is_expected.to fail_a_policy(:can_update_attendance) }
+    end
+
+    context "when everything is valid" do
+      it { is_expected.to run_successfully }
+
+      it "destroys the invitee" do
+        expect { result }.to change { DiscoursePostEvent::Invitee.count }.by(-1)
+        expect(DiscoursePostEvent::Invitee.exists?(invitee.id)).to eq(false)
+      end
+    end
+
+    context "when staff destroys another user's invitee" do
+      let(:dependencies) { { guardian: admin.guardian } }
+
+      it { is_expected.to run_successfully }
+
+      it "destroys the invitee" do
+        expect { result }.to change { DiscoursePostEvent::Invitee.count }.by(-1)
+      end
+    end
+  end
+end

--- a/plugins/discourse-calendar/spec/services/discourse_post_event/update_invitee_spec.rb
+++ b/plugins/discourse-calendar/spec/services/discourse_post_event/update_invitee_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe(DiscoursePostEvent::UpdateInvitee) do
+  describe described_class::Contract, type: :model do
+    it { is_expected.to validate_presence_of(:event_id) }
+    it { is_expected.to validate_presence_of(:invitee_id) }
+    it do
+      is_expected.to validate_inclusion_of(:status).in_array(
+        DiscoursePostEvent::Invitee.statuses.keys.map(&:to_s),
+      )
+    end
+  end
+
+  describe ".call" do
+    subject(:result) { described_class.call(params:, **dependencies) }
+
+    fab!(:admin, :admin)
+    fab!(:topic) { Fabricate(:topic, user: admin) }
+    fab!(:post) { Fabricate(:post, user: admin, topic: topic) }
+    fab!(:event) { Fabricate(:event, post: post) }
+    fab!(:invitee_user) { Fabricate(:user, refresh_auto_groups: true) }
+    fab!(:invitee) do
+      event.create_invitees(
+        [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+      )
+      event.invitees.find_by(user_id: invitee_user.id)
+    end
+
+    let(:params) { { event_id: event.id, invitee_id: invitee.id, status: "interested" } }
+    let(:dependencies) { { guardian: invitee_user.guardian } }
+
+    before do
+      Jobs.run_immediately!
+      SiteSetting.calendar_enabled = true
+      SiteSetting.discourse_post_event_enabled = true
+    end
+
+    context "when contract is invalid" do
+      let(:params) { { event_id: event.id, invitee_id: invitee.id, status: "invalid" } }
+
+      it { is_expected.to fail_a_contract }
+    end
+
+    context "when invitee does not exist" do
+      let(:params) { { event_id: event.id, invitee_id: -1, status: "interested" } }
+
+      it { is_expected.to fail_to_find_a_model(:invitee) }
+    end
+
+    context "when user cannot act on invitee" do
+      fab!(:other_user, :user)
+      let(:dependencies) { { guardian: other_user.guardian } }
+
+      it { is_expected.to fail_a_policy(:can_act_on_invitee) }
+    end
+
+    context "when user cannot see the event post" do
+      fab!(:private_event)
+      fab!(:private_invitee) do
+        private_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        private_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) do
+        { event_id: private_event.id, invitee_id: private_invitee.id, status: "interested" }
+      end
+
+      it { is_expected.to fail_a_policy(:can_see_event) }
+    end
+
+    context "when event is closed" do
+      fab!(:closed_post) { Fabricate(:post, topic: topic) }
+      fab!(:closed_event) { Fabricate(:event, post: closed_post, closed: true) }
+      fab!(:closed_invitee) do
+        closed_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        closed_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) do
+        { event_id: closed_event.id, invitee_id: closed_invitee.id, status: "not_going" }
+      end
+
+      it { is_expected.to fail_a_policy(:can_update_attendance) }
+    end
+
+    context "when event is expired" do
+      fab!(:expired_post) { Fabricate(:post, topic: topic) }
+      fab!(:expired_event) do
+        Fabricate(
+          :event,
+          post: expired_post,
+          original_starts_at: 2.days.ago,
+          original_ends_at: 1.day.ago,
+        )
+      end
+      fab!(:expired_invitee) do
+        expired_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        expired_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) do
+        { event_id: expired_event.id, invitee_id: expired_invitee.id, status: "not_going" }
+      end
+
+      it { is_expected.to fail_a_policy(:can_update_attendance) }
+    end
+
+    context "when event is at max capacity" do
+      fab!(:other_user, :user)
+      fab!(:full_post) { Fabricate(:post, topic: topic) }
+      fab!(:full_event) { Fabricate(:event, post: full_post, max_attendees: 1) }
+      fab!(:going_invitee) do
+        full_event.create_invitees(
+          [{ user_id: other_user.id, status: DiscoursePostEvent::Invitee.statuses[:going] }],
+        )
+        full_event.invitees.find_by(user_id: other_user.id)
+      end
+      fab!(:interested_invitee) do
+        full_event.create_invitees(
+          [{ user_id: invitee_user.id, status: DiscoursePostEvent::Invitee.statuses[:interested] }],
+        )
+        full_event.invitees.find_by(user_id: invitee_user.id)
+      end
+
+      let(:params) do
+        { event_id: full_event.id, invitee_id: interested_invitee.id, status: "going" }
+      end
+
+      it { is_expected.to fail_a_policy(:has_capacity) }
+    end
+
+    context "when everything is valid" do
+      it { is_expected.to run_successfully }
+
+      it "updates the invitee status" do
+        expect { result }.to change { invitee.reload.status }.from(
+          DiscoursePostEvent::Invitee.statuses[:going],
+        ).to(DiscoursePostEvent::Invitee.statuses[:interested])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Backport of #42187 to release/2026.1.

Manual backport required since livestream wasn't yet moved into discourse-calendar at this time so related changes were removed, and a couple other fixes were (cleanly) cherry-picked to support the backport:
- #37662 and #37663 
   InviteesController bug fixes
- #38023 
   Moves InivteesController logic into Services and adds additional security checks as policies
- #40487 
   Stops memoizing can_act_on_discourse_post_event? so we don't fall back to a cached value

---

## Summary

Correctly restrict private calendar event access to current group members. The patch replaces stale invitee-row authorization with active invited-group membership checks across event detail serialization, attendance searches, RSVP mutations, and livestream chat metadata, and prunes stale invitee records when a user is removed from a group.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1377

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
