### PR TITLE
SECURITY: validate oEmbed provider_name against URL host in generic Onebox [backport 2026.1]

### DIFF
--- a/lib/onebox/engine/allowlisted_generic_onebox.rb
+++ b/lib/onebox/engine/allowlisted_generic_onebox.rb
@@ -18,7 +18,7 @@ module Onebox
       # include the entire page HTML. However for some providers like Flickr it allows us
       # to return gifv and galleries.
       def self.default_html_providers
-        %w[Flickr Meetup]
+        { "Flickr" => ["flickr.com"], "Meetup" => ["meetup.com"] }
       end
 
       def self.html_providers
@@ -229,7 +229,8 @@ module Onebox
 
       def is_embedded?
         return false if data[:html].blank?
-        return true if AllowlistedGenericOnebox.html_providers.include?(data[:provider_name])
+        provider_hosts = AllowlistedGenericOnebox.html_providers[data[:provider_name]]
+        return true if provider_hosts && AllowlistedGenericOnebox.host_matches(uri, provider_hosts)
         return false unless data[:html]["iframe"]
 
         fragment = Nokogiri::HTML5.fragment(data[:html])

--- a/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
+++ b/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Onebox::Engine::AllowlistedGenericOnebox do
       end
     end
 
-    it "doesn't return the HTML when not in the `html_providers`" do
-      Onebox::Engine::AllowlistedGenericOnebox.html_providers = []
+    it "doesn't return the HTML when the provider does not match the URL host" do
+      Onebox::Engine::AllowlistedGenericOnebox.html_providers = {}
       expect(HTMLOnebox.new("http://coolsite.com").to_html).to be_nil
     end
 
-    it "returns the HMTL when in the `html_providers`" do
-      Onebox::Engine::AllowlistedGenericOnebox.html_providers = ["CoolSite"]
+    it "returns the HTML when the provider matches the URL host" do
+      Onebox::Engine::AllowlistedGenericOnebox.html_providers = { "CoolSite" => ["coolsite.com"] }
       expect(HTMLOnebox.new("http://coolsite.com").to_html).to eq "cool html"
     end
   end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -1762,6 +1762,35 @@ RSpec.describe PostsController do
         )
       end
 
+      it "does not persist HTML from an untrusted oEmbed provider" do
+        Jobs.run_immediately!
+        url = "https://attacker.example.com/onebox"
+        malicious_html =
+          '<div class="onebox-attack" style="position: fixed; inset: 0; z-index: 9999">overlay</div>'
+
+        stub_request(:head, url).to_return(status: 200)
+        stub_request(:get, url).to_return(
+          status: 200,
+          body:
+            '<html><head><link type="application/json+oembed" href="https://attacker.example.com/oembed"></head></html>',
+        )
+        stub_request(:get, "https://attacker.example.com/oembed").to_return(
+          status: 200,
+          body: {
+            title: "Attacker onebox",
+            type: "rich",
+            provider_name: "Flickr",
+            html: malicious_html,
+          }.to_json,
+        )
+
+        post "/posts.json", params: { raw: url, title: "Untrusted oEmbed provider" }
+
+        expect(response.status).to eq(200)
+        cooked = Nokogiri::HTML5.fragment(Post.find(response.parsed_body["id"]).cooked)
+        expect(cooked.at_css(".onebox-attack")).to be_nil
+      end
+
       it "creates the topic and post with the right attributes" do
         post "/posts.json",
              params: {


### PR DESCRIPTION
Backport of #42217 to release/2026.1.

---

## Summary

An attacker-controlled oEmbed response could claim to be Flickr or Meetup and make the generic Onebox engine persist its supplied HTML. The fix validates that the oEmbed response's provider_name matches the host of the original onebox URL before granting the raw-HTML passthrough path.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1571

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>
