### PR TITLE
FIX: Validate assignment note length against max_post_length

### DIFF
--- a/plugins/discourse-assign/config/locales/server.en.yml
+++ b/plugins/discourse-assign/config/locales/server.en.yml
@@ -40,6 +40,7 @@ en:
     already_assigned: "Topic is already assigned to @%{username}"
     too_many_assigns: "@%{username} has already reached the maximum number of assigned topics (%{max})."
     too_many_assigns_for_topic: "Limit of %{limit} assignments per topic has been reached."
+    assignment_note_too_long: "Assignment note must be %{note_max} characters or fewer."
     forbidden_assigner_not_allowed: "You can only assign topics in categories allowed for your groups."
     forbidden_assign_to: "@%{username} can't be assigned since they don't belong to assigned allowed groups."
     forbidden_assignee_not_pm_participant: "@%{username} can't be assigned because they don't have access to this PM. You can grant @%{username} access by inviting them to this PM."

--- a/plugins/discourse-assign/lib/assigner.rb
+++ b/plugins/discourse-assign/lib/assigner.rb
@@ -124,6 +124,7 @@ class ::Assigner
       group: name,
       limit: ASSIGNMENTS_PER_TOPIC_LIMIT,
       max: SiteSetting.max_assigned_topics,
+      note_max: SiteSetting.max_post_length,
     )
   end
 
@@ -222,6 +223,8 @@ class ::Assigner
       end
     when !can_be_assigned?(assign_to)
       assign_to.is_a?(User) ? :forbidden_assign_to : :forbidden_group_assign_to
+    when note.present? && note.length > SiteSetting.max_post_length
+      :assignment_note_too_long
     when !allow_self_reassign && already_assigned?(assign_to, type, note, status)
       assign_to.is_a?(User) ? :already_assigned : :group_already_assigned
     when Assignment.where(topic: topic, active: true).count >= ASSIGNMENTS_PER_TOPIC_LIMIT &&

--- a/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
+++ b/plugins/discourse-assign/spec/requests/assign_controller_spec.rb
@@ -282,6 +282,23 @@ RSpec.describe DiscourseAssign::AssignController do
       expect(post.topic.reload.assignment).to be_nil
     end
 
+    it "rejects assignment notes longer than the maximum post length" do
+      oversized_note = "a" * (SiteSetting.max_post_length + 1)
+
+      put "/assign/assign.json",
+          params: {
+            target_id: post.topic_id,
+            target_type: "Topic",
+            username: allowed_user.username,
+            note: oversized_note,
+          }
+
+      expect(response.status).to eq(400)
+      expect(response.body).not_to include(oversized_note)
+      expect(post.topic.reload.assignment).to be_nil
+      expect(post.topic.posts.pluck(:raw)).not_to include(oversized_note)
+    end
+
     it "assigns topic with note to a user" do
       put "/assign/assign.json",
           params: {


### PR DESCRIPTION
## Summary

Assignment notes longer than the configured maximum post length are now rejected server-side before persistence. The guard in `Assigner` returns a clear error message and prevents the oversized note from being stored on the assignment or appearing in the moderator tracking post, maintaining the expected content boundary across the JSON API and bulk assignment endpoints.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1574

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>