### PR TITLE
FEATURE: Add `user_id` to workflow topic payloads

### DIFF
--- a/plugins/discourse-workflows/app/serializers/discourse_workflows/topic_list_item_serializer.rb
+++ b/plugins/discourse-workflows/app/serializers/discourse_workflows/topic_list_item_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DiscourseWorkflows
+  class TopicListItemSerializer < ::TopicListItemSerializer
+    attributes :user_id
+  end
+end

--- a/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/node_type.rb
@@ -78,15 +78,15 @@ module DiscourseWorkflows
     def self.unavailable_reason_key(configuration = nil)
       return nil unless description.key?(:unavailable_reason_key)
 
-      description_value(:unavailable_reason_key, configuration: configuration)
+      description_value(:unavailable_reason_key, configuration:)
     end
 
     def self.inputs(configuration = {})
-      description_value(:inputs, configuration: configuration)
+      description_value(:inputs, configuration:)
     end
 
     def self.outputs(configuration = {})
-      description_value(:outputs, configuration: configuration)
+      description_value(:outputs, configuration:)
     end
 
     def self.properties
@@ -98,7 +98,7 @@ module DiscourseWorkflows
     end
 
     def self.webhooks(configuration = {})
-      Array(description_value(:webhooks, configuration: configuration)).map do |webhook|
+      Array(description_value(:webhooks, configuration:)).map do |webhook|
         webhook.deep_symbolize_keys
       end
     end
@@ -119,11 +119,7 @@ module DiscourseWorkflows
       input_schema = Schema.union(*input_schemas.compact)
 
       active_output_contracts(configuration).map do |contract|
-        Schema.resolve(
-          contract.fetch(:schema),
-          mode: contract.fetch(:mode),
-          input_schema: input_schema,
-        )
+        Schema.resolve(contract.fetch(:schema), mode: contract.fetch(:mode), input_schema:)
       end
     end
 
@@ -208,7 +204,7 @@ module DiscourseWorkflows
 
       {
         schema: Schema.normalize(contract.fetch(:schema, {})),
-        mode: mode,
+        mode:,
         display_options: contract.fetch(:display_options, {}),
       }
     end
@@ -288,11 +284,7 @@ module DiscourseWorkflows
     end
 
     def matches_category_ids?(topic_category_id, category_ids, include_subcategories: true)
-      self.class.matches_category_ids?(
-        topic_category_id,
-        category_ids,
-        include_subcategories: include_subcategories,
-      )
+      self.class.matches_category_ids?(topic_category_id, category_ids, include_subcategories:)
     end
 
     def wrap(data, paired_item: nil)
@@ -317,22 +309,26 @@ module DiscourseWorkflows
     )
       DiscourseWorkflows::Executor::NodeExecutionContext.serialize_post(
         post,
-        guardian: guardian,
-        include_raw: include_raw,
-        include_cooked: include_cooked,
+        guardian:,
+        include_raw:,
+        include_cooked:,
       )
     end
 
     def serialize_topic(topic, guardian: Discourse.system_user.guardian, custom_field_names: [])
       DiscourseWorkflows::Executor::NodeExecutionContext.serialize_topic(
         topic,
-        guardian: guardian,
-        custom_field_names: custom_field_names,
+        guardian:,
+        custom_field_names:,
       )
     end
 
+    def topic_data(topic, scope: Discourse.system_user.guardian)
+      serialize_record(topic, DiscourseWorkflows::TopicListItemSerializer, scope:)
+    end
+
     def serialize_user(user, guardian: Discourse.system_user.guardian)
-      DiscourseWorkflows::Executor::NodeExecutionContext.serialize_user(user, guardian: guardian)
+      DiscourseWorkflows::Executor::NodeExecutionContext.serialize_user(user, guardian:)
     end
 
     def with_paired_item(item, paired_item)

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_button/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_button/v1.rb
@@ -171,10 +171,6 @@ module DiscourseWorkflows
         def post_data(post)
           serialize_post(post)
         end
-
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
       end
     end
   end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_created/v1.rb
@@ -129,10 +129,6 @@ module DiscourseWorkflows
           serialize_post(post)
         end
 
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
-
         def user_data(user)
           serialize_user(user)
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_edited/v1.rb
@@ -100,10 +100,6 @@ module DiscourseWorkflows
 
         private
 
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
-
         def user_data(user)
           serialize_user(user)
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/post_moved/v1.rb
@@ -93,10 +93,6 @@ module DiscourseWorkflows
           serialize_post(post)
         end
 
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
-
         def destination_topic
           @destination_topic ||= ::Topic.find_by(id: @post&.topic_id)
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/send_personal_message/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/send_personal_message/v1.rb
@@ -104,7 +104,7 @@ module DiscourseWorkflows
           post = PostCreator.new(sender, post_args).create!
 
           {
-            topic: topic_data(post.topic, sender.guardian),
+            topic: topic_data(post.topic, scope: sender.guardian),
             post:
               exec_ctx.serialize_post(
                 post,
@@ -142,10 +142,6 @@ module DiscourseWorkflows
             .map(&:strip)
             .reject(&:blank?)
             .join(",")
-        end
-
-        def topic_data(topic, guardian)
-          serialize_record(topic, TopicListItemSerializer, scope: guardian)
         end
       end
     end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/stale_topic/v1.rb
@@ -104,7 +104,7 @@ module DiscourseWorkflows
 
         def self.topic_data(topic)
           MultiJson.load(
-            TopicListItemSerializer.new(
+            DiscourseWorkflows::TopicListItemSerializer.new(
               topic,
               scope: Discourse.system_user.guardian,
               root: false,

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_admin_button/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_admin_button/v1.rb
@@ -43,10 +43,6 @@ module DiscourseWorkflows
         end
 
         private
-
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
       end
     end
   end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_category_changed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_category_changed/v1.rb
@@ -45,10 +45,6 @@ module DiscourseWorkflows
         end
 
         private
-
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
       end
     end
   end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_closed/v1.rb
@@ -71,10 +71,6 @@ module DiscourseWorkflows
 
         private
 
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
-
         def matches_tags?(tag_names)
           tag_names.empty? || (topic_tag_names & tag_names).any?
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_created/v1.rb
@@ -114,10 +114,6 @@ module DiscourseWorkflows
 
         private
 
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
-
         def post_data(post)
           serialize_post(post)
         end

--- a/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/nodes/topic_tag_changed/v1.rb
@@ -90,10 +90,6 @@ module DiscourseWorkflows
         def removed_tags
           @old_tag_names - @new_tag_names
         end
-
-        def topic_data(topic)
-          serialize_record(topic, TopicListItemSerializer)
-        end
       end
     end
   end

--- a/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
+++ b/plugins/discourse-workflows/lib/discourse_workflows/schema.rb
@@ -34,6 +34,7 @@ module DiscourseWorkflows
         "slug": { "type": "string" },
         "posts_count": { "type": "integer" },
         "category_id": { "type": ["integer", "null"] },
+        "user_id": { "type": "integer" },
         "tags": {
           "type": "array",
           "items": {

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_created_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_created_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostCreated::V1 do
       expect(output[:topic][:title]).to eq(topic.title)
       expect(output[:topic][:tags].map { |topic_tag| topic_tag[:name] }).to eq(["test-tag"])
       expect(output[:topic][:category_id]).to eq(topic.category_id)
+      expect(output[:topic][:user_id]).to eq(topic.user_id)
       expect(output[:topic][:archetype]).to eq(topic.archetype)
       expect(output).to match_node_output_schema(described_class)
     end

--- a/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_edited/v1_spec.rb
+++ b/plugins/discourse-workflows/spec/lib/discourse_workflows/nodes/post_edited/v1_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe DiscourseWorkflows::Nodes::PostEdited::V1 do
         trust_level_name: TrustLevel.name(user.trust_level),
       )
       expect(output[:topic][:id]).to eq(topic.id)
+      expect(output[:topic][:user_id]).to eq(topic.user_id)
       expect(output[:topic][:tags].map { |topic_tag| topic_tag[:name] }).to eq(["test-tag"])
       expect(output).not_to have_key(:cooked)
     end


### PR DESCRIPTION
Previously, the topic payloads emitted by workflow triggers and nodes did not include the topic owner, so a condition like "was this post written by the topic owner?" required an extra `action:topic` lookup just to fetch `user_id`.

This change adds `user_id` to the topic payload of every trigger and node — via a plugin-level `TopicListItemSerializer` — so expressions can compare `$json.topic.user_id` to `$json.post.user_id` directly, and consolidates the duplicated per-node `topic_data` helpers into a single `NodeType` helper.
