### PR TITLE
FIX: Prevent Flag Score Inflation in PostAction

### DIFF
--- a/lib/post_action_destroyer.rb
+++ b/lib/post_action_destroyer.rb
@@ -53,6 +53,7 @@ class PostActionDestroyer
     ).performed!
 
     post_action.remove_act!(@destroyed_by)
+    remove_reviewable_score if post_action.is_flag?
     if post_action.staff_took_action
       post_action.post.acting_user = @destroyed_by
       post_action.post.unhide!
@@ -94,6 +95,23 @@ class PostActionDestroyer
     elsif self.class.notify_types.include?(name)
       @post.publish_change_to_clients!(:acted)
     end
+  end
+
+  def remove_reviewable_score
+    reviewable = @post.reviewable_flag
+    return if reviewable.blank?
+
+    deleted_count =
+      ReviewableScore
+        .pending
+        .where(
+          reviewable: reviewable,
+          user: @destroyed_by,
+          reviewable_score_type: @post_action_type_id,
+        )
+        .delete_all
+
+    reviewable.recalculate_score if deleted_count > 0
   end
 
   def guardian

--- a/spec/lib/post_action_creator_spec.rb
+++ b/spec/lib/post_action_creator_spec.rb
@@ -217,6 +217,25 @@ RSpec.describe PostActionCreator do
       )
     end
 
+    it "does not auto-hide a post when the same TL2 user repeatedly retracts and recreates a flag" do
+      Reviewable.set_priorities(high: 12.5)
+      SiteSetting.hide_post_sensitivity = Reviewable.sensitivities[:medium]
+      attacker = Fabricate(:user, trust_level: TrustLevel[2], refresh_auto_groups: true)
+
+      2.times do
+        expect(PostActionCreator.inappropriate(attacker, post)).to be_success
+        expect(PostActionDestroyer.destroy(attacker, post, :inappropriate)).to be_success
+      end
+
+      result = PostActionCreator.inappropriate(attacker, post)
+      reviewable = result.reviewable.reload
+
+      expect(result).to be_success
+      expect(post.reload).not_to be_hidden
+      expect(reviewable.score).to eq(ReviewableScore.user_flag_score(attacker))
+      expect(reviewable.reviewable_scores.pending.count).to eq(1)
+    end
+
     describe "Auto hide spam flagged posts" do
       before do
         user.trust_level = TrustLevel[3]


### PR DESCRIPTION
## Summary

Prevent unauthorized post hiding by removing pending reviewable scores when a flag is withdrawn. This ensures that repeated flagging and retracting by a single user cannot inflate a post's score to reach the auto-hide threshold.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1329

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>