### PR TITLE
FIX: Gate notification acting_user_name on enable_names setting

### DIFF
--- a/app/serializers/notification_serializer.rb
+++ b/app/serializers/notification_serializer.rb
@@ -56,6 +56,6 @@ class NotificationSerializer < ApplicationSerializer
   end
 
   def include_acting_user_name?
-    object.acting_user.present?
+    object.acting_user.present? && SiteSetting.enable_names?
   end
 end

--- a/spec/requests/notifications_controller_spec.rb
+++ b/spec/requests/notifications_controller_spec.rb
@@ -505,6 +505,34 @@ RSpec.describe NotificationsController do
           end
         end
 
+        context "with user-menu avatars enabled and names disabled" do
+          fab!(:liker) { Fabricate(:user, name: "Hidden Liker Name") }
+          fab!(:liked_post) { Fabricate(:post, user: user) }
+
+          before do
+            SiteSetting.enable_names = false
+            SiteSetting.show_user_menu_avatars = true
+            user.user_option.update!(
+              like_notification_frequency: UserOption.like_notification_frequency_type[:always],
+            )
+            PostActionNotifier.enable
+            PostActionCreator.like(liker, liked_post)
+          end
+
+          it "does not expose a liker's name" do
+            get "/notifications.json"
+
+            expect(response.status).to eq(200)
+            liked_notification =
+              response.parsed_body["notifications"].find do |notification|
+                notification["notification_type"] == Notification.types[:liked]
+              end
+            expect(liked_notification["acting_user_avatar_template"]).to be_present
+            expect(liked_notification).not_to have_key("acting_user_name")
+            expect(response.body).not_to include(liker.name)
+          end
+        end
+
         context "when a notification topic has localizations" do
           fab!(:english_topic) { Fabricate(:topic, locale: "en") }
           fab!(:topic_localization_es) do


### PR DESCRIPTION
## Summary

When `enable_names` is disabled but `show_user_menu_avatars` is enabled, `NotificationSerializer` uses the acting user's full name in notification JSON responses. The fix adds a `SiteSetting.enable_names?` check to `include_acting_user_name?` so that the full name is only serialized when names are enabled. Avatars and usernames remain available per their respective settings.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1568

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>