### PR TITLE
SECURITY: Prevent topic existence disclosure in profile featuring

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1901,7 +1901,8 @@ class UsersController < ApplicationController
 
   def feature_topic
     user = fetch_user_from_params
-    topic = Topic.find(params[:topic_id].to_i)
+    topic = Topic.find_by(id: params[:topic_id].to_i)
+    raise Discourse::NotFound unless guardian.can_see?(topic)
 
     if !guardian.can_feature_topic?(user, topic)
       return(

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7552,6 +7552,18 @@ RSpec.describe UsersController do
         expect(response.status).to eq(403)
       end
 
+      it "returns not found for missing and inaccessible topics" do
+        sign_in(user1)
+
+        put "/u/#{user1.username}/feature-topic.json", params: { topic_id: private_message.id }
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+
+        put "/u/#{user1.username}/feature-topic.json", params: { topic_id: Topic.maximum(:id) + 1 }
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+      end
+
       it "returns an error if the topic is not visible" do
         sign_in(user1)
         topic.update_status("visible", false, user1)
@@ -7559,12 +7571,25 @@ RSpec.describe UsersController do
         expect(response.status).to eq(403)
       end
 
-      it "returns an error if the topic's category is read_restricted" do
+      it "returns an error if the user can see the topic's read-restricted category" do
         sign_in(user1)
-        category.set_permissions({})
+        group = Fabricate(:group)
+        group.add(user1)
+        category.set_permissions(group => :readonly)
+        category.save!
         topic.update(category_id: category.id)
-        put "/u/#{another_user.username}/feature-topic.json", params: { topic_id: topic.id }
+        put "/u/#{user1.username}/feature-topic.json", params: { topic_id: topic.id }
         expect(response.status).to eq(403)
+      end
+
+      it "returns not found if the user cannot see the topic's category" do
+        sign_in(user1)
+        category.set_permissions(staff: :full)
+        category.save!
+        topic.update(category_id: category.id)
+        put "/u/#{user1.username}/feature-topic.json", params: { topic_id: topic.id }
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
       end
 
       it "sets featured_topic correctly for user created topic" do


### PR DESCRIPTION
Previously, the profile feature-topic endpoint returned different responses for missing topics and existing topics the requester could not access, revealing whether a topic record existed.

This change checks topic visibility before feature eligibility, returning a not-found response for both missing and inaccessible topics.

Relates to this patch: https://patch.discourse.org/patch-triage/1350