### PR TITLE
FIX: Local user onebox bypasses profile visibility checks and exposes hidden profile data

### DIFF
--- a/lib/cooked_processor_mixin.rb
+++ b/lib/cooked_processor_mixin.rb
@@ -34,7 +34,7 @@ module CookedProcessorMixin
           Oneboxer.onebox(
             url,
             invalidate_oneboxes: !!@opts[:invalidate_oneboxes],
-            user_id: @model&.user_id,
+            user_id: @model&.last_editor_id,
             category_id: @category_id,
             locale: @opts[:locale],
           )

--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -315,7 +315,7 @@ module Oneboxer
       when "topics"
         local_topic_html(url, route, opts)
       when "users"
-        local_user_html(url, route)
+        local_user_html(url, route, opts)
       when "list"
         local_category_html(url, route)
       else
@@ -456,11 +456,12 @@ module Oneboxer
     [title, excerpt]
   end
 
-  def self.local_user_html(url, route)
+  def self.local_user_html(url, route, opts)
     username = route[:username] || ""
 
     if user = User.find_by(username_lower: username.downcase)
       return if SiteSetting.allow_users_to_hide_profile && user.user_option&.hide_profile?
+      return unless Guardian.new(User.find_by(id: opts[:user_id])).can_see_profile?(user)
       name = user.name if SiteSetting.enable_names
 
       args = {

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe Oneboxer do
 
     it "links to an user profile" do
       user = Fabricate(:user)
+      user.user_stat.update!(post_count: 1)
 
       expect(preview("/u/does-not-exist")).to match_html(link("/u/does-not-exist"))
       expect(preview("/u/#{user.username}")).to include(user.name)
@@ -172,6 +173,7 @@ RSpec.describe Oneboxer do
 
     it "should respect enable_names site setting" do
       user = Fabricate(:user)
+      user.user_stat.update!(post_count: 1)
 
       SiteSetting.enable_names = true
       expect(preview("/u/#{user.username}")).to include(user.name)
@@ -189,6 +191,7 @@ RSpec.describe Oneboxer do
 
     it "strips HTML from user profile location" do
       user = Fabricate(:user)
+      user.user_stat.update!(post_count: 1)
       profile = user.reload.user_profile
 
       expect(preview("/u/#{user.username}")).not_to include("<span class=\"location\">")

--- a/spec/requests/onebox_controller_spec.rb
+++ b/spec/requests/onebox_controller_spec.rb
@@ -228,8 +228,35 @@ RSpec.describe OneboxController do
         expect(response.body).not_to include("secret.example.com")
       end
 
+      it "does not expose a no-post user's hidden profile fields to a trust level 1 viewer" do
+        new_user = Fabricate(:user, trust_level: TrustLevel[1])
+        new_user.user_stat.update!(post_count: 0)
+        new_user.user_profile.update!(
+          bio_raw: "private new user biography",
+          location: "private new user location",
+          website: "https://private-new-user.example.com",
+        )
+        SiteSetting.hide_new_user_profiles = true
+
+        get "/u/#{new_user.username}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.dig("user", "profile_hidden")).to eq(true)
+        expect(response.body).not_to include(new_user.user_profile.bio_raw)
+        expect(response.body).not_to include(new_user.user_profile.location)
+        expect(response.body).not_to include(new_user.user_profile.website)
+
+        get "/onebox.json", params: { url: "#{Discourse.base_url}/u/#{new_user.username}" }
+
+        expect(response.status).to eq(200)
+        expect(response.body).not_to include(new_user.user_profile.bio_raw)
+        expect(response.body).not_to include(new_user.user_profile.location)
+        expect(response.body).not_to include(new_user.user_profile.website)
+      end
+
       it "oneboxes a user profile when the viewer can see the profile" do
         visible_user = Fabricate(:user)
+        visible_user.user_stat.update!(post_count: 1)
         visible_user.user_profile.update!(location: "visible location")
         url = "#{Discourse.base_url}/u/#{visible_user.username}"
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -599,6 +599,46 @@ RSpec.describe PostsController do
       }
     end
 
+    context "when a trust level 1 user edits a public wiki post" do
+      it "does not publish a hidden new user profile onebox" do
+        author = Fabricate(:user, trust_level: TrustLevel[3], refresh_auto_groups: true)
+        editor = Fabricate(:user, trust_level: TrustLevel[1], refresh_auto_groups: true)
+        profile_user = Fabricate(:user, trust_level: TrustLevel[1])
+        profile_user.user_stat.update!(post_count: 0)
+        profile_user.user_profile.update!(
+          bio_raw: "private new user biography",
+          location: "private new user location",
+          website: "https://private-new-user.example.com",
+        )
+        wiki_post = create_post(user: author, raw: "public wiki post")
+        wiki_post.update!(wiki: true)
+        Group[:trust_level_1].add(editor)
+        editor.reload
+        SiteSetting.edit_wiki_post_allowed_groups = Group::AUTO_GROUPS[:trust_level_1]
+        SiteSetting.hide_new_user_profiles = true
+        CookedPostProcessor.any_instance.stubs(:get_size).returns([100, 100])
+        Jobs.run_immediately!
+
+        sign_in(editor)
+        put "/posts/#{wiki_post.id}.json",
+            params: {
+              post: {
+                raw: "#{Discourse.base_url}/u/#{profile_user.username}",
+              },
+            }
+
+        expect(response.status).to eq(200), response.body
+
+        sign_out
+        get "/posts/#{wiki_post.id}.json"
+
+        expect(response.status).to eq(200)
+        expect(response.body).not_to include(profile_user.user_profile.bio_raw)
+        expect(response.body).not_to include(profile_user.user_profile.location)
+        expect(response.body).not_to include(profile_user.user_profile.website)
+      end
+    end
+
     describe "when logged in as a regular user" do
       before { sign_in(user) }
 


### PR DESCRIPTION
## Summary

An authenticated low-trust user can make the local user-onebox renderer display a no-post low-trust user's biography, location, and website even though the normal profile response is hidden by hide_new_user_profiles. Propagate the onebox caller context and enforce can_see_profile? before rendering profile fields.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1486

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>