### PR TITLE
UX: improve AI translation configuration

### DIFF
--- a/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
+++ b/plugins/discourse-ai/admin/assets/javascripts/discourse/components/ai-translations.gjs
@@ -6,6 +6,7 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { trustHTML } from "@ember/template";
 import moment from "moment";
+import DTooltip from "discourse/float-kit/components/d-tooltip";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { bind } from "discourse/lib/decorators";
@@ -148,11 +149,25 @@ export default class AiTranslations extends Component {
     );
   }
 
+  get hasSavedLocales() {
+    return this.originalLocales.length > 0;
+  }
+
   get isToggleDisabled() {
     return (
       this.isTogglingTranslation ||
-      (this.args.model?.no_locales_configured &&
-        this.originalLocales.length === 0)
+      !this.hasSavedLocales ||
+      this.selectedLocales.length === 0
+    );
+  }
+
+  get toggleDisabledReason() {
+    if (this.hasSavedLocales && this.selectedLocales.length > 0) {
+      return null;
+    }
+
+    return i18n(
+      "discourse_ai.translations.admin_actions.enable_translations_disabled"
     );
   }
 
@@ -207,10 +222,6 @@ export default class AiTranslations extends Component {
         }
       );
       this.originalLocales = [...this.selectedLocales];
-
-      if (this.selectedLocales.length > 0) {
-        this.args.model.no_locales_configured = false;
-      }
 
       if (this.translationEnabled) {
         window.location.reload();
@@ -291,13 +302,13 @@ export default class AiTranslations extends Component {
       return;
     }
 
-    if (!this.translationEnabled && this.originalLocales.length === 0) {
+    if (!this.translationEnabled && !this.hasSavedLocales) {
       return;
     }
 
     this.isTogglingTranslation = true;
     try {
-      if (!this.translationEnabled && this.originalLocales.length > 0) {
+      if (!this.translationEnabled && this.hasSavedLocales) {
         await ajax("/admin/site_settings/content_localization_enabled", {
           type: "PUT",
           data: { content_localization_enabled: true },
@@ -310,7 +321,7 @@ export default class AiTranslations extends Component {
       });
       this.translationEnabled = !this.translationEnabled;
 
-      if (this.translationEnabled && !this.args.model.no_locales_configured) {
+      if (this.translationEnabled && this.hasSavedLocales) {
         this.enabled = true;
       } else {
         this.enabled = false;
@@ -512,14 +523,6 @@ export default class AiTranslations extends Component {
       {{/if}}
 
       <div class="ai-translations__settings-panel settings">
-        <div class="setting ai-translations__toggle-container">
-          <DToggleSwitch
-            @state={{this.translationEnabled}}
-            @label="discourse_ai.translations.admin_actions.enable_translations"
-            disabled={{this.isToggleDisabled}}
-            {{on "click" this.toggleTranslationEnabled}}
-          />
-        </div>
         <div class="ai-translations__settings-fields">
           <div class="setting">
             <div class="setting-label">
@@ -646,6 +649,30 @@ export default class AiTranslations extends Component {
                 }}</div>
             </div>
           </div>
+        </div>
+        <div class="setting ai-translations__toggle-container">
+          {{#if this.toggleDisabledReason}}
+            <DTooltip
+              @content={{this.toggleDisabledReason}}
+              class="ai-translations__toggle-disabled-tooltip"
+            >
+              <:trigger>
+                <DToggleSwitch
+                  @state={{this.translationEnabled}}
+                  @label="discourse_ai.translations.admin_actions.enable_translations"
+                  disabled={{this.isToggleDisabled}}
+                  {{on "click" this.toggleTranslationEnabled}}
+                />
+              </:trigger>
+            </DTooltip>
+          {{else}}
+            <DToggleSwitch
+              @state={{this.translationEnabled}}
+              @label="discourse_ai.translations.admin_actions.enable_translations"
+              disabled={{this.isToggleDisabled}}
+              {{on "click" this.toggleTranslationEnabled}}
+            />
+          {{/if}}
         </div>
       </div>
 

--- a/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
+++ b/plugins/discourse-ai/assets/stylesheets/modules/translation/admin/translations.scss
@@ -1,6 +1,6 @@
 .ai-translations {
   &__settings-panel {
-    background: var(--primary-very-low);
+    border: 1px solid var(--content-border-color);
     margin-block: var(--space-4);
     padding: var(--space-2);
     border-radius: var(--d-border-radius);
@@ -71,15 +71,6 @@
       width: auto;
       margin-right: 0;
       padding-right: 0;
-    }
-
-    .setting-value {
-      max-width: 100%;
-
-      .select-kit {
-        // Not ideal, but upstream .select-kit gets a width: 100% !important that is too eager
-        max-width: calc(100% - 100px);
-      }
     }
   }
 

--- a/plugins/discourse-ai/config/locales/client.en.yml
+++ b/plugins/discourse-ai/config/locales/client.en.yml
@@ -516,6 +516,7 @@ en:
           translation_settings: "AI settings"
           localization_settings: "App language settings"
           enable_translations: "Enable automatic translations"
+          enable_translations_disabled: "You must add a supported language to enable translations"
         stats:
           title: "Translation statistics"
           backfill_disabled: "Backfilling is disabled, only new posts will be translated."

--- a/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
+++ b/plugins/discourse-ai/spec/system/admin_ai_translations_spec.rb
@@ -81,9 +81,7 @@ describe "Admin AI translations" do
       )
       expect(page).to have_css(".ai-translations__locale-input-row .multi-select")
       expect(page).to have_css(".ai-translations__category-input-row .combo-box")
-      expect(page).to have_css(
-        ".ai-translations__settings-panel > .setting:first-child .d-toggle-switch",
-      )
+      expect(translations_page).to have_toggle
       expect(page).to have_no_css(".ai-translations__settings-panel.alert-info")
 
       expect(translations_page).to have_overview_cards

--- a/plugins/discourse-ai/test/javascripts/integration/components/ai-translations-test.gjs
+++ b/plugins/discourse-ai/test/javascripts/integration/components/ai-translations-test.gjs
@@ -168,6 +168,37 @@ module("Integration | Component | AiTranslations", function (hooks) {
       .hasText("8", "the refreshed response is rendered");
   });
 
+  test("disables the toggle as soon as every supported language is removed", async function (assert) {
+    this.model = {
+      ...this.model,
+      enabled: false,
+      translation_enabled: false,
+    };
+    pretender.put(
+      "/admin/site_settings/content_localization_supported_locales",
+      () => response({})
+    );
+
+    await render(<template><AiTranslations @model={{this.model}} /></template>);
+
+    const toggle =
+      ".ai-translations__toggle-container .d-toggle-switch__checkbox";
+    assert
+      .dom(toggle)
+      .isNotDisabled("the toggle is usable while locales exist");
+
+    await click(".ai-translations__locale-input-row .setting-controls__undo");
+    assert
+      .dom(toggle)
+      .isDisabled("clearing the locale selection disables the toggle");
+    assert.dom(".ai-translations__toggle-disabled-tooltip").exists();
+
+    await click(".ai-translations__locale-input-row .setting-controls__ok");
+    assert
+      .dom(toggle)
+      .isDisabled("the toggle stays disabled after saving no locales");
+  });
+
   test("shows the fixed backfill start date", async function (assert) {
     this.owner.lookup("service:router").urlFor = () =>
       "/admin/plugins/discourse-ai/ai-features/6/edit";


### PR DESCRIPTION
This makes enabling AI translations clearer by reordering the settings to put the toggle last (language must be selected first) and adding a tooltip when the feature can not be enabled. 

Before:
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/211ea1ed-0b69-4a36-b8b4-4caf5feca691" />


After:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/cc68fd3b-db7c-470b-b64f-63cff392d2e6" />


<img width="1000" alt="image" src="https://github.com/user-attachments/assets/0539e624-7d7d-45ca-a6b8-bb3ac532fc28" />
