### PR TITLE
SECURITY: Authenticated users can enumerate private/restricted topic IDs via `PUT /u/:username/feature-topic`

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1901,7 +1901,8 @@ class UsersController < ApplicationController
 
   def feature_topic
     user = fetch_user_from_params
-    topic = Topic.find(params[:topic_id].to_i)
+    topic = Topic.find_by(id: params[:topic_id].to_i)
+    raise Discourse::NotFound if topic.blank? || !guardian.can_see_topic?(topic)
 
     if !guardian.can_feature_topic?(user, topic)
       return(

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -7552,6 +7552,13 @@ RSpec.describe UsersController do
         expect(response.status).to eq(403)
       end
 
+      it "returns not found if the user cannot see the topic" do
+        sign_in(user1)
+        put "/u/#{user1.username}/feature-topic.json", params: { topic_id: private_message.id }
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
+      end
+
       it "returns an error if the topic is not visible" do
         sign_in(user1)
         topic.update_status("visible", false, user1)
@@ -7559,12 +7566,13 @@ RSpec.describe UsersController do
         expect(response.status).to eq(403)
       end
 
-      it "returns an error if the topic's category is read_restricted" do
+      it "returns not found if the user cannot see the topic's category" do
         sign_in(user1)
-        category.set_permissions({})
-        topic.update(category_id: category.id)
-        put "/u/#{another_user.username}/feature-topic.json", params: { topic_id: topic.id }
-        expect(response.status).to eq(403)
+        restricted_category = Fabricate(:category, read_restricted: true)
+        topic.update(category: restricted_category)
+        put "/u/#{user1.username}/feature-topic.json", params: { topic_id: topic.id }
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error_type"]).to eq("not_found")
       end
 
       it "sets featured_topic correctly for user created topic" do


### PR DESCRIPTION
## Summary

Prevent the enumeration of private or restricted topic IDs by ensuring the `feature-topic` endpoint returns a 404 Not Found response for topics the user cannot see. This change makes inaccessible topics indistinguishable from non-existent ones to unauthorized users.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1350

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>