### PR TITLE
FIX: Prevent moderators from deleting peer moderators

### DIFF
--- a/lib/guardian/user_guardian.rb
+++ b/lib/guardian/user_guardian.rb
@@ -68,16 +68,17 @@ module UserGuardian
     return false if user.nil? || user.admin?
 
     if is_me?(user)
-      !SiteSetting.enable_discourse_connect &&
-        !user.has_more_posts_than?(SiteSetting.delete_user_self_max_post_count)
-    else
-      is_staff? &&
-        (
-          user.first_post_created_at.nil? ||
-            !user.has_more_posts_than?(User::MAX_STAFF_DELETE_POST_COUNT) ||
-            user.first_post_created_at > SiteSetting.delete_user_max_post_age.to_i.days.ago
-        )
+      return false if SiteSetting.enable_discourse_connect
+
+      return !user.has_more_posts_than?(SiteSetting.delete_user_self_max_post_count)
     end
+
+    return false unless is_staff?
+    return false if user.moderator? && !is_admin?
+    return true if user.first_post_created_at.nil?
+    return true unless user.has_more_posts_than?(User::MAX_STAFF_DELETE_POST_COUNT)
+
+    user.first_post_created_at > SiteSetting.delete_user_max_post_age.to_i.days.ago
   end
 
   def can_anonymize_user?(user)

--- a/spec/lib/guardian/user_guardian_spec.rb
+++ b/spec/lib/guardian/user_guardian_spec.rb
@@ -525,6 +525,14 @@ RSpec.describe UserGuardian do
       end
     end
 
+    it "requires an admin to delete another moderator" do
+      another_moderator = Fabricate(:moderator)
+
+      expect(Guardian.new(moderator).can_delete_user?(another_moderator)).to eq(false)
+      expect(Guardian.new(admin).can_delete_user?(another_moderator)).to eq(true)
+      expect(Guardian.new(moderator).can_delete_user?(moderator)).to eq(true)
+    end
+
     context "when deleting myself" do
       let(:guardian) { Guardian.new(user) }
 

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -1734,6 +1734,16 @@ RSpec.describe Admin::UsersController do
       before { sign_in(moderator) }
 
       include_examples "user deletion possible"
+
+      it "prevents deleting another moderator" do
+        target_moderator = Fabricate(:moderator)
+
+        delete "/admin/users/#{target_moderator.id}.json"
+
+        expect(User.exists?(target_moderator.id)).to eq(true)
+        expect(response).to be_forbidden
+        expect(response.parsed_body["errors"]).to include(I18n.t("invalid_access"))
+      end
     end
 
     context "when logged in as a non-staff user" do


### PR DESCRIPTION
## What changed

Small refactor in `can_delete_user?`

All but moderators deleting each other is changed.


## Why

This is inconsistent with the established permission hierarchy that prevents moderators from destructively acting on other staff members.

We have a precedent for this change in:
  - [Prevent moderators from bulk-deleting another moderator's posts](https://github.com/discourse/discourse/commit/bb35a5a2ebbf93659ffd64184e5d9cdcbeb46e21)
  - [Prevent moderators from clearing suspensions and silences from other staff accounts](https://github.com/discourse/discourse/commit/541ef5ac4e853ec087da79aa4c303a57be74348)
  - [Prevent moderators from modifying the trust levels of admin and staff accounts](https://github.com/discourse/discourse/commit/2c8063e078f81f7a0bdef607d27e2d48e2b3e93)

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1484

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>