### PR TITLE
DEV: decouple chat selection from activeChannel

### DIFF
--- a/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-channel.gjs
@@ -832,6 +832,7 @@ export default class ChatChannel extends Component {
             (not @channel.isDirectMessageChannel)
             @channel.canModerate
           }}
+          @channel={{@channel}}
           @pane={{this.pane}}
           @messagesManager={{this.messagesManager}}
         />

--- a/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat-thread.gjs
@@ -621,6 +621,7 @@ export default class ChatThread extends Component {
 
       {{#if this.chatThreadPane.selectingMessages}}
         <ChatSelectionManager
+          @channel={{@thread.channel}}
           @pane={{this.chatThreadPane}}
           @messagesManager={{this.messagesManager}}
         />

--- a/plugins/chat/assets/javascripts/discourse/components/chat/selection-manager.gjs
+++ b/plugins/chat/assets/javascripts/discourse/components/chat/selection-manager.gjs
@@ -27,16 +27,22 @@ export default class ChatSelectionManager extends Component {
     return this.args.enableMove ?? false;
   }
 
+  get selectedMessageIds() {
+    return this.args.messagesManager.selectedMessages.map(
+      (message) => message.id
+    );
+  }
+
   get anyMessagesSelected() {
-    return this.args.pane.selectedMessageIds.length > 0;
+    return this.selectedMessageIds.length > 0;
   }
 
   get deleteCountLimitReached() {
-    return this.args.pane.selectedMessageIds.length > DELETE_COUNT_LIMIT;
+    return this.selectedMessageIds.length > DELETE_COUNT_LIMIT;
   }
 
   get canDeleteMessages() {
-    return this.args.pane.selectedMessageIds.every((id) => {
+    return this.selectedMessageIds.every((id) => {
       return this.canDeleteMessage(id);
     });
   }
@@ -60,7 +66,7 @@ export default class ChatSelectionManager extends Component {
 
   get deleteButtonTitle() {
     return i18n("chat.selection.delete", {
-      selectionCount: this.args.pane.selectedMessageIds.length,
+      selectionCount: this.selectedMessageIds.length,
       totalCount: DELETE_COUNT_LIMIT,
     });
   }
@@ -68,19 +74,25 @@ export default class ChatSelectionManager extends Component {
   @bind
   async generateQuote() {
     const { markdown } = await this.api.generateQuote(
-      this.args.pane.channel.id,
-      this.args.pane.selectedMessageIds
+      this.args.channel.id,
+      this.selectedMessageIds
     );
 
     return new Blob([markdown], { type: "text/plain" });
   }
 
   @action
+  cancelSelecting() {
+    this.args.messagesManager.clearSelectedMessages();
+    this.args.pane.cancelSelecting();
+  }
+
+  @action
   openMoveMessageModal() {
     this.modal.show(ChatModalMoveMessageToChannel, {
       model: {
-        sourceChannel: this.args.pane.channel,
-        selectedMessageIds: this.args.pane.selectedMessageIds,
+        sourceChannel: this.args.channel,
+        selectedMessageIds: this.selectedMessageIds,
       },
     });
   }
@@ -89,8 +101,8 @@ export default class ChatSelectionManager extends Component {
   openDeleteMessagesModal() {
     this.modal.show(DeleteMessagesConfirm, {
       model: {
-        sourceChannel: this.args.pane.channel,
-        selectedMessageIds: this.args.pane.selectedMessageIds,
+        sourceChannel: this.args.channel,
+        selectedMessageIds: this.selectedMessageIds,
       },
     });
   }
@@ -107,15 +119,15 @@ export default class ChatSelectionManager extends Component {
     }
 
     const openOpts = {};
-    if (this.args.pane.channel.isCategoryChannel) {
-      openOpts.categoryId = this.args.pane.channel.chatableId;
+    if (this.args.channel.isCategoryChannel) {
+      openOpts.categoryId = this.args.channel.chatableId;
     }
 
     if (this.site.mobileView) {
       // go to the relevant chatable (e.g. category) and open the
       // composer to insert text
-      if (this.args.pane.channel.chatableUrl) {
-        this.router.transitionTo(this.args.pane.channel.chatableUrl);
+      if (this.args.channel.chatableUrl) {
+        this.router.transitionTo(this.args.channel.chatableUrl);
       }
 
       await this.topicComposer.focusComposer({
@@ -203,7 +215,7 @@ export default class ChatSelectionManager extends Component {
         <DButton
           @icon="xmark"
           @label="chat.selection.cancel"
-          @action={{@pane.cancelSelecting}}
+          @action={{this.cancelSelecting}}
           id="chat-cancel-selection-btn"
           class="btn-secondary cancel-btn"
         />

--- a/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-channel-pane.js
@@ -14,14 +14,9 @@ export default class ChatChannelPane extends Service {
     return this.chat.activeChannel;
   }
 
-  get selectedMessageIds() {
-    return this.channel.messagesManager.selectedMessages.map((item) => item.id);
-  }
-
   @action
   cancelSelecting() {
     this.selectingMessages = false;
-    this.channel.messagesManager.clearSelectedMessages();
   }
 
   @action

--- a/plugins/chat/assets/javascripts/discourse/services/chat-thread-pane.js
+++ b/plugins/chat/assets/javascripts/discourse/services/chat-thread-pane.js
@@ -1,4 +1,3 @@
-import { action } from "@ember/object";
 import { service } from "@ember/service";
 import ChatChannelPane from "./chat-channel-pane";
 
@@ -14,16 +13,6 @@ export default class ChatThreadPane extends ChatChannelPane {
       this.router.currentRoute.name === "chat.channel.thread" ||
       this.router.currentRoute.name === "chat.channel.thread.index"
     );
-  }
-
-  get selectedMessageIds() {
-    return this.thread.messagesManager.selectedMessages.map((item) => item.id);
-  }
-
-  @action
-  cancelSelecting() {
-    this.selectingMessages = false;
-    this.thread.messagesManager.clearSelectedMessages();
   }
 
   async close() {

--- a/plugins/chat/test/javascripts/components/chat-selection-manager-test.gjs
+++ b/plugins/chat/test/javascripts/components/chat-selection-manager-test.gjs
@@ -1,0 +1,79 @@
+import { getOwner } from "@ember/owner";
+import { click, render, settled } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import ChatSelectionManager from "discourse/plugins/chat/discourse/components/chat/selection-manager";
+import ChatFabricators from "discourse/plugins/chat/discourse/lib/fabricators";
+
+module("Component | <Chat::SelectionManager />", function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.channel = new ChatFabricators(getOwner(this)).channel();
+    this.message = new ChatFabricators(getOwner(this)).message({
+      channel: this.channel,
+    });
+    this.channel.messagesManager.addMessages([this.message]);
+
+    this.pane = getOwner(this).lookup("service:chat-channel-pane");
+    this.pane.selectingMessages = true;
+  });
+
+  test("renders its actions when the channel is not the active channel", async function (assert) {
+    const chat = getOwner(this).lookup("service:chat");
+    assert.strictEqual(chat.activeChannel, null, "no active channel is set");
+
+    await render(
+      <template>
+        <ChatSelectionManager
+          @channel={{this.channel}}
+          @pane={{this.pane}}
+          @messagesManager={{this.channel.messagesManager}}
+        />
+      </template>
+    );
+
+    assert.dom("#chat-quote-btn").exists();
+    assert.dom("#chat-copy-btn").exists();
+    assert.dom("#chat-delete-btn").exists();
+    assert.dom("#chat-cancel-selection-btn").exists();
+  });
+
+  test("actions are disabled until messages are selected", async function (assert) {
+    await render(
+      <template>
+        <ChatSelectionManager
+          @channel={{this.channel}}
+          @pane={{this.pane}}
+          @messagesManager={{this.channel.messagesManager}}
+        />
+      </template>
+    );
+
+    assert.dom("#chat-quote-btn").isDisabled();
+
+    this.message.selected = true;
+    await settled();
+
+    assert.dom("#chat-quote-btn").isEnabled();
+  });
+
+  test("cancelling clears the selection", async function (assert) {
+    this.message.selected = true;
+
+    await render(
+      <template>
+        <ChatSelectionManager
+          @channel={{this.channel}}
+          @pane={{this.pane}}
+          @messagesManager={{this.channel.messagesManager}}
+        />
+      </template>
+    );
+
+    await click("#chat-cancel-selection-btn");
+
+    assert.false(this.message.selected, "the message is deselected");
+    assert.false(this.pane.selectingMessages, "selection mode is exited");
+  });
+});


### PR DESCRIPTION
`ChatSelectionManager` reads its selection through the pane service, which gets the channel from `chat.activeChannel`... but this is only available on the full-page chat route and the drawer. 

A `<ChatChannel>` embedded elsewhere (like livestream topics) wouldn't render the buttons on selection, leaving an empty selection bar with no quote, copy, move, delete etc... 

This change passes the channel to the component and gets the selection from the messages manager, so selecting messages will work in any context.