### PR TITLE
Update developer documentation link in chat plugin README

### DIFF
--- a/plugins/chat/README.md
+++ b/plugins/chat/README.md
@@ -6,4 +6,4 @@ The Discourse Chat plugin adds chat functionality to your Discourse so it can na
 
 For user documentation, see [Discourse Chat](https://meta.discourse.org/t/discourse-chat/230881).
 
-For developer documentation, see [Discourse Documentation](https://discourse.github.io/discourse/).
+For developer documentation, see [Discourse Documentation](https://meta.discourse.org/c/documentation/10).


### PR DESCRIPTION
Hello!

I was browsing the documentation and noticed that the url `https://discourse.github.io/discourse/` brings you to a static 404 page. It seems like this url, added to the docs 3 years ago, is no longer valid. I did some searching and it seems like elsewhere in the documentation `https://meta.discourse.org/c/documentation/10` is provided "developer documentation" home. I also noticed the `https://docs.discourse.org/` docs, although that seems more focused towards api docs than general developer docs. 

Please let me know if some other url would be more appropriate! 

thanks! :) 