### PR TITLE
FIX: match `/filter` topic-outcome links to the dashboard's counts

### DIFF
--- a/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support.gjs
+++ b/plugins/discourse-solved/admin/assets/javascripts/admin/components/dashboard/support.gjs
@@ -196,7 +196,10 @@ export default class SupportSection extends Component {
 
   #categoryTerm(categories) {
     const slugs = categories.map((category) => Category.slugFor(category, ":"));
-    return `category:${slugs.join(",")}`;
+    // `=` restricts to these exact categories, excluding subcategories, to
+    // match the dashboard's own count (accepted answers are opt-in per
+    // category and never inherited by subcategories).
+    return `=category:${slugs.join(",")}`;
   }
 
   get dateRangeTerms() {
@@ -207,8 +210,13 @@ export default class SupportSection extends Component {
       );
     }
     if (this.args.endDate) {
+      // `created-before:D` matches created_at <= midnight on D, so pass the
+      // following day to cover all of the selected end date (the dashboard's
+      // own count instead runs through that day's end_of_day).
       terms.push(
-        `created-before:${moment(this.args.endDate).format("YYYY-MM-DD")}`
+        `created-before:${moment(this.args.endDate)
+          .add(1, "day")
+          .format("YYYY-MM-DD")}`
       );
     }
     return terms;

--- a/plugins/discourse-solved/test/javascripts/integration/support-test.gjs
+++ b/plugins/discourse-solved/test/javascripts/integration/support-test.gjs
@@ -291,7 +291,7 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
 
     const dateRange = `created-after:${moment(startDate).format(
       "YYYY-MM-DD"
-    )} created-before:${moment(endDate).format("YYYY-MM-DD")}`;
+    )} created-before:${moment(endDate).add(1, "day").format("YYYY-MM-DD")}`;
 
     assert
       .dom(".db-support-outcomes__row:nth-child(1) a")
@@ -345,7 +345,7 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
       .dom(".db-support-outcomes__row:nth-child(1) a")
       .hasAttribute(
         "href",
-        /category%3Abug%2Cfeature/,
+        /%3Dcategory%3Abug%2Cfeature/,
         "restricts to every support category when none is selected"
       );
   });
@@ -375,7 +375,7 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
       .dom(".db-support-outcomes__row:nth-child(1) a")
       .hasAttribute(
         "href",
-        /category%3Ameta(?!%2C)/,
+        /%3Dcategory%3Ameta(?!%2C)/,
         "restricts to only the selected category"
       );
   });
@@ -406,7 +406,9 @@ module("Integration | Component | Dashboard | Support", function (hooks) {
         `/filter?q=${encodeURIComponent(
           `status:solved created-after:${moment(startDate).format(
             "YYYY-MM-DD"
-          )} created-before:${moment(endDate).format("YYYY-MM-DD")}`
+          )} created-before:${moment(endDate)
+            .add(1, "day")
+            .format("YYYY-MM-DD")}`
         )}`,
         "resolved links to its full filter query"
       );


### PR DESCRIPTION
Clicking Resolved, In progress, or Unanswered in the Support section could show more topics than the number displayed. Two related causes are fixed here: the topic list now sticks to the exact category the dashboard counted instead of also pulling in its subcategories, and it no longer excludes topics created on the last day of the selected date range.