### PR TITLE
DEV: Bump dev container image to 20260803-0122

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Discourse",
-  "image": "docker.io/discourse/discourse_dev:20260707-0040",
+  "image": "docker.io/discourse/discourse_dev:20260803-0122",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/discourse,type=bind",
   "workspaceFolder": "/workspace/discourse",
   "postStartCommand": "./.devcontainer/scripts/start.rb",


### PR DESCRIPTION
Previously, the dev container used `discourse_dev:20260707-0040`, which predates the current development runtime.

This commit updates the dev container to `discourse_dev:20260803-0122`.