### PR TITLE
FIX: Data table sizes and executions pagination in workflows admin

### DIFF
--- a/plugins/discourse-workflows/app/controllers/discourse_workflows/data_tables_controller.rb
+++ b/plugins/discourse-workflows/app/controllers/discourse_workflows/data_tables_controller.rb
@@ -6,7 +6,7 @@ module DiscourseWorkflows
 
     def index
       DiscourseWorkflows::DataTable::List.call(service_params) do |result|
-        on_success do |data_tables:, total_rows:, table_sizes: {}, load_more_url:|
+        on_success do |data_tables:, total_rows:, table_sizes:, load_more_url:|
           render json: {
                    data_tables:
                      serialize_data(

--- a/plugins/discourse-workflows/app/controllers/discourse_workflows/executions_controller.rb
+++ b/plugins/discourse-workflows/app/controllers/discourse_workflows/executions_controller.rb
@@ -26,7 +26,7 @@ module DiscourseWorkflows
 
     def index
       DiscourseWorkflows::Execution::List.call(service_params) do |result|
-        on_success do |executions:, load_more_url: nil|
+        on_success do |executions:, load_more_url:|
           render json: {
                    executions:
                      serialize_data(executions, DiscourseWorkflows::ExecutionListSerializer),

--- a/plugins/discourse-workflows/app/services/discourse_workflows/execution/list.rb
+++ b/plugins/discourse-workflows/app/services/discourse_workflows/execution/list.rb
@@ -23,7 +23,7 @@ module DiscourseWorkflows
 
     model :executions, optional: true
     model :has_more, :compute_has_more, optional: true
-    only_if(:has_more) { model :load_more_url, :compute_load_more_url, optional: true }
+    model :load_more_url, :compute_load_more_url, optional: true
 
     private
 
@@ -49,6 +49,8 @@ module DiscourseWorkflows
     end
 
     def compute_load_more_url(params:, executions:)
+      return if !has_more || executions.blank?
+
       path =
         if params.workflow_id
           "/admin/plugins/discourse-workflows/workflows/#{params.workflow_id}/executions.json"

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/data_tables_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/data_tables_controller_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe DiscourseWorkflows::DataTablesController do
       json = response.parsed_body
       expect(json["data_tables"].length).to eq(1)
       expect(json["data_tables"][0]["name"]).to eq(data_table.name)
+      expect(json["data_tables"][0]["size"]).to be > 0
     end
 
     it "returns shared pagination meta" do

--- a/plugins/discourse-workflows/spec/requests/discourse_workflows/executions_controller_spec.rb
+++ b/plugins/discourse-workflows/spec/requests/discourse_workflows/executions_controller_spec.rb
@@ -104,6 +104,20 @@ RSpec.describe DiscourseWorkflows::ExecutionsController do
       expect(json["executions"].length).to eq(1)
       expect(json["executions"][0]["id"]).to eq(execution_1.id)
     end
+
+    it "returns load more meta when more executions exist" do
+      Fabricate(:discourse_workflows_execution, workflow: workflow)
+      execution_2 = Fabricate(:discourse_workflows_execution, workflow: workflow)
+
+      get "/admin/plugins/discourse-workflows/executions.json", params: { limit: 1 }
+
+      json = response.parsed_body
+      expect(json["executions"].map { |execution| execution["id"] }).to eq([execution_2.id])
+      expect(json["meta"]).to eq(
+        "load_more_executions" =>
+          "/admin/plugins/discourse-workflows/executions.json?cursor=#{execution_2.id}&limit=1",
+      )
+    end
   end
 
   describe "GET /admin/plugins/discourse-workflows/workflows/:workflow_id/executions" do


### PR DESCRIPTION
Previously, the workflows admin showed "0 Bytes" for every data table and the executions list never loaded more than the first page, because `Service::Runner` only fills **required** keyword arguments of `on_success` blocks from the service result — defaulted kwargs like `table_sizes: {}` and `load_more_url: nil` silently kept their defaults, dropping the values the services computed.

This change declares both keyword arguments as required, and moves `Execution::List`'s `load_more_url` step out of `only_if(:has_more)` (guarding inside the compute method instead, like `Workflow::List`) so the context key always exists and the required kwarg can never raise.