### PR TITLE
DEV: Fill defaulted keyword arguments in service runner blocks

### DIFF
--- a/docs/developer-guides/docs/03-code-internals/19-service-objects.md
+++ b/docs/developer-guides/docs/03-code-internals/19-service-objects.md
@@ -534,6 +534,12 @@ on_failed_contract { |contract, my_model:| do_something(contract, my_model) }
 
 You could do all this by only using the result object, but it’s a bit nicer this way (and will ensure the key you’re trying to access actually exists).
 
+A required keyword argument (`my_model:`) will raise if the service didn’t set that key, which is what you want most of the time. For a key that’s only set on some paths (a model fetched by a step that didn’t run, or steps wrapped in an `only_if` block), give the argument a default value and it will be used as a fallback:
+
+```rb
+on_failure { |my_model: nil| do_something(my_model) }
+```
+
 ### `on_success`
 
 Will execute the provided block if the service succeeds.

--- a/lib/service/runner.rb
+++ b/lib/service/runner.rb
@@ -32,6 +32,11 @@
 # argument to their block. `on_model_errors` receives the actual model so it’s
 # easier to inspect it, and `on_exceptions` receives the actual exception.
 #
+# Blocks can also declare keyword arguments, which are filled from the
+# service result (e.g. +on_success do |model:|+). A required keyword argument
+# raises if the service didn’t set that key, while a keyword argument with a
+# default uses its default as a fallback when the key is absent.
+#
 # @example In a controller
 #   def create
 #     MyService.call do
@@ -165,7 +170,7 @@ class Service::Runner
           result[
             [*action[:key], action[:name] || args.first || action[:default_name]].join(".")
           ].public_send(action[:property] || :itself),
-          **result.slice(*block.parameters.filter_map { it.last if it.first == :keyreq }),
+          **result.slice(*block.parameters.filter_map { it.last if it.first.in?(%i[keyreq key]) }),
           &block
         )
       end,

--- a/spec/lib/service/runner_spec.rb
+++ b/spec/lib/service/runner_spec.rb
@@ -247,6 +247,27 @@ RSpec.describe Service::Runner do
       expect(runner.last).to eq :model_found
     end
 
+    context "when a keyword arg has a default value" do
+      let(:actions) { <<-BLOCK }
+          proc do
+            on_success { |fake_model: :default| fake_model }
+            on_failure { |fake_model: :default| fake_model }
+          end
+        BLOCK
+
+      it "uses the value from the result when the key is present" do
+        expect(runner).to eq :model_found
+      end
+
+      context "when the key is not present in the result" do
+        let(:service) { FailureService }
+
+        it "uses the default value" do
+          expect(runner).to eq :default
+        end
+      end
+    end
+
     context "when using the on_success action" do
       let(:actions) { <<-BLOCK }
           proc do


### PR DESCRIPTION
Previously, a `Service::Runner` action block could declare a keyword argument with a default (e.g. `on_success do |table_sizes: {}|`), but the runner only fills **required** keyword arguments from the service result — so the default always won and the service's computed value was silently dropped, producing 200 responses with subtly wrong data (see #42263 where this happened twice in the workflows plugin).

Following review feedback, instead of raising on defaulted keyword arguments (the initial approach), the runner now fills them from the result exactly like required ones. The default only applies when the service didn't set the key at all, making it a proper fallback for keys that are only set on some paths — a model fetched by a step that didn't run, or steps wrapped in an `only_if` block. This matters for outcome blocks in particular, since the caller (possibly a plugin) doesn't always own the service it calls and can't make it always set a key.

Also documents required vs defaulted keyword arguments in the service objects developer guide.