### PR TITLE
FIX: Disabled AI Discover remains usable via continue-conversation endpoint

### DIFF
--- a/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
@@ -70,7 +70,7 @@ module DiscourseAi
       end
 
       def check_permissions
-        if ai_discover_agent.nil? || current_user.nil? ||
+        if !SiteSetting.ai_discover_enabled || ai_discover_agent.nil? || current_user.nil? ||
              !current_user.in_any_groups?(ai_discover_agent.allowed_group_ids.to_a)
           raise Discourse::InvalidAccess.new
         end

--- a/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
+++ b/plugins/discourse-ai/app/controllers/discourse_ai/discover/discoveries_controller.rb
@@ -7,7 +7,7 @@ module DiscourseAi
 
       requires_plugin PLUGIN_NAME
       requires_login
-      before_action :check_permissions
+      before_action :check_permissions!
 
       def reply
         if ai_discover_agent.default_llm_id.blank? && SiteSetting.ai_default_llm_model.blank?
@@ -69,12 +69,13 @@ module DiscourseAi
         @discover_agent ||= AiAgent.find_by_id_from_cache(SiteSetting.ai_discover_agent)
       end
 
-      def check_permissions
-        if !SiteSetting.ai_discover_enabled || ai_discover_agent.nil? || current_user.nil? ||
-             !current_user.in_any_groups?(ai_discover_agent.allowed_group_ids.to_a)
-          raise Discourse::InvalidAccess.new
+      def check_permissions!
+        raise Discourse::InvalidAccess if !SiteSetting.ai_discover_enabled
+        raise Discourse::InvalidAccess if ai_discover_agent.nil?
+        raise Discourse::InvalidAccess if current_user.nil?
+        if !current_user.in_any_groups?(ai_discover_agent.allowed_group_ids.to_a)
+          raise Discourse::InvalidAccess
         end
-
         raise Discourse::InvalidAccess if guardian.is_silenced?
       end
     end

--- a/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
+++ b/plugins/discourse-ai/spec/requests/discover/discoveries_controller_spec.rb
@@ -118,5 +118,22 @@ RSpec.describe DiscourseAi::Discover::DiscoveriesController do
         end
       end
     end
+
+    context "when discovery is disabled" do
+      before do
+        SiteSetting.ai_discover_agent = ai_agent.id
+        SiteSetting.ai_discover_enabled = false
+        group.add(user)
+      end
+
+      it "rejects continuing a conversation without creating a private message" do
+        expect {
+          post "/discourse-ai/discoveries/continue-convo", params: { query:, context: }
+        }.not_to change(Topic, :count)
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["errors"]).to be_present
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

The Discover continuation endpoint now checks the `ai_discover_enabled` setting in its shared permission gate, rejecting both Discover routes with a 403 when the feature is disabled. This prevents authenticated agent-group members from creating AI-bot private-message conversations or queueing replies after an administrator turns off Discovery Search.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1596

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>