### PR TITLE
FIX: Filter hidden tags from chat integration notifications

### DIFF
--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider.rb
@@ -50,6 +50,10 @@ module DiscourseChatIntegration
       end
     end
 
+    def self.display_tag_names(topic)
+      DiscourseTagging.filter_visible(topic.tags, Manager.guardian).map(&:name).join(", ")
+    end
+
     def self.setup(provider_klass, current_user, provider_site_settings)
       if provider_klass.respond_to?(:setup)
         provider_klass.setup(current_user, provider_site_settings)

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/discord/discord_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/discord/discord_provider.rb
@@ -57,7 +57,7 @@ module DiscourseChatIntegration
           embeds: [
             {
               title:
-                "#{topic.title} #{(category == "[uncategorized]") ? "" : category} #{topic.tags.present? ? topic.tags.map(&:name).join(", ") : ""}",
+                "#{topic.title} #{(category == "[uncategorized]") ? "" : category} #{DiscourseChatIntegration::Provider.display_tag_names(topic)}",
               color: topic.category ? topic.category.color.to_i(16) : nil,
               description:
                 post.excerpt(

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/guilded/guilded_provider.rb
@@ -49,7 +49,7 @@ module DiscourseChatIntegration
           embeds: [
             {
               title:
-                "#{topic.title} #{(category == "[uncategorized]") ? "" : category} #{topic.tags.present? ? topic.tags.map(&:name).join(", ") : ""}",
+                "#{topic.title} #{(category == "[uncategorized]") ? "" : category} #{DiscourseChatIntegration::Provider.display_tag_names(topic)}",
               url: post.full_url,
               description:
                 post.excerpt(

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/mattermost/mattermost_provider.rb
@@ -79,7 +79,7 @@ module DiscourseChatIntegration
               remap_emoji: true,
             ),
           title:
-            "#{topic.title} #{category} #{topic.tags.present? ? topic.tags.map(&:name).join(", ") : ""}",
+            "#{topic.title} #{category} #{DiscourseChatIntegration::Provider.display_tag_names(topic)}",
           title_link: post.full_url,
         }
 

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/powerautomate/powerautomate_provider.rb
@@ -75,7 +75,7 @@ module DiscourseChatIntegration::Provider::PowerAutomateProvider
                 size: "Large",
                 weight: "Bolder",
                 text:
-                  "[#{topic.title} #{category} #{topic.tags.present? ? topic.tags.map(&:name).join(", ") : ""}](#{post.full_url})",
+                  "[#{topic.title} #{category} #{DiscourseChatIntegration::Provider.display_tag_names(topic)}](#{post.full_url})",
                 wrap: true,
                 spacing: "None",
               },

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/rocketchat/rocketchat_provider.rb
@@ -43,7 +43,7 @@ module DiscourseChatIntegration::Provider::RocketchatProvider
         ),
       mrkdwn_in: ["text"],
       title:
-        "#{topic.title} #{category} #{topic.tags.present? ? topic.tags.map(&:name).join(", ") : ""}",
+        "#{topic.title} #{category} #{DiscourseChatIntegration::Provider.display_tag_names(topic)}",
       title_link: post.full_url,
     }
 

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/slack/slack_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/slack/slack_provider.rb
@@ -189,7 +189,7 @@ module DiscourseChatIntegration::Provider::SlackProvider
       text: excerpt(post),
       mrkdwn_in: ["text"],
       title:
-        "#{topic.title} #{category} #{topic.tags.present? ? topic.tags.map(&:name).join(", ") : ""}",
+        "#{topic.title} #{category} #{DiscourseChatIntegration::Provider.display_tag_names(topic)}",
       title_link: post.full_url,
       thumb_url: post.full_url,
     }

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/teams/teams_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/teams/teams_provider.rb
@@ -57,7 +57,7 @@ module DiscourseChatIntegration::Provider::TeamsProvider
           end
         )
     end
-    tags = topic.tags.map(&:name).join(", ") if topic.tags.present?
+    tags = DiscourseChatIntegration::Provider.display_tag_names(topic).presence
     category_and_tags_line = [category, tags].compact.join(" | ").presence
 
     body = [

--- a/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/webex/webex_provider.rb
+++ b/plugins/discourse-chat-integration/lib/discourse_chat_integration/provider/webex/webex_provider.rb
@@ -61,7 +61,8 @@ module DiscourseChatIntegration::Provider::WebexProvider
     end
 
     markdown = "**#{topic.title}**: #{category}"
-    markdown += " #{topic.tags.map(&:name).join(", ")} " if topic.tags.present?
+    markdown +=
+      " #{DiscourseChatIntegration::Provider.display_tag_names(topic)} " if topic.tags.present?
     markdown += "(#{post.full_url}) from #{display_name}:\n"
     markdown +=
       post.excerpt(

--- a/plugins/discourse-chat-integration/spec/requests/notifications_spec.rb
+++ b/plugins/discourse-chat-integration/spec/requests/notifications_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe "Chat integration notifications", type: :request do
+  fab!(:attacker) { Fabricate(:user, refresh_auto_groups: true) }
+  fab!(:integration_user) { Fabricate(:user, username: "chat-integration") }
+  fab!(:category)
+  fab!(:visible_tag) { Fabricate(:tag, name: "visible-tag") }
+  fab!(:hidden_tag) { Fabricate(:tag, name: "hidden-tag") }
+  fab!(:staff_tag_group) do
+    Fabricate(:tag_group, permissions: { "staff" => 1 }, tag_names: [hidden_tag.name])
+  end
+  fab!(:topic) { Fabricate(:topic, category:, tags: [visible_tag, hidden_tag]) }
+  fab!(:first_post) { Fabricate(:post, topic:) }
+  fab!(:channel) do
+    DiscourseChatIntegration::Channel.create!(
+      provider: "mattermost",
+      data: {
+        identifier: "#watched-channel",
+      },
+    )
+  end
+  fab!(:rule) do
+    DiscourseChatIntegration::Rule.create!(channel:, category_id: category.id, filter: "watch")
+  end
+
+  before do
+    staff_tag_group
+    SiteSetting.chat_integration_enabled = true
+    SiteSetting.chat_integration_discourse_username = integration_user.username
+    SiteSetting.chat_integration_mattermost_enabled = true
+    SiteSetting.chat_integration_mattermost_webhook_url = "https://mattermost.example/hook"
+  end
+
+  it "omits tags hidden from the integration user in a reply notification" do
+    webhook =
+      stub_request(:post, "https://mattermost.example/hook").to_return(status: 200, body: "ok")
+
+    sign_in(attacker)
+    post "/posts.json", params: { raw: "An ordinary reply", topic_id: topic.id }
+
+    expect(response.status).to eq(200)
+    created_post_id = response.parsed_body["id"]
+    expect(response.body).to include(created_post_id.to_s)
+
+    Jobs::NotifyChats.new.execute(post_id: created_post_id)
+
+    expect(
+      a_request(:post, "https://mattermost.example/hook").with do |request|
+        title = JSON.parse(request.body).dig("attachments", 0, "title")
+        title.include?(visible_tag.name) && !title.include?(hidden_tag.name)
+      end,
+    ).to have_been_made.once
+    expect(webhook).to have_been_requested.once
+  end
+end


### PR DESCRIPTION
## Summary

Chat-integration notification payloads built outbound titles from unfiltered topic tags, so tag names hidden from the configured integration user could be sent to external chat systems. The patch adds a shared display-tag helper that filters tags through the integration user's Guardian and applies it across all eight tag-rendering providers, preventing disclosure of hidden tags in notification titles.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1590

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>