### PR TITLE
SECURITY: Block requests for hidden post revisions through historical version reconstruction

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1103,6 +1103,7 @@ class PostsController < ApplicationController
       post_revision = PostRevision.find_by(post_id: post.id, number: version + 1)
       if post_revision
         guardian.ensure_can_see!(post_revision)
+        guardian.ensure_can_view_post_version!(post, version)
         post.revert_to(version)
       end
     end

--- a/lib/guardian/post_revision_guardian.rb
+++ b/lib/guardian/post_revision_guardian.rb
@@ -21,6 +21,11 @@ module PostRevisionGuardian
     is_staff?
   end
 
+  def can_view_post_version?(post, version)
+    can_view_hidden_post_revisions? ||
+      !PostRevision.where(post_id: post.id, hidden: true, number: ..version).exists?
+  end
+
   def can_view_hidden_post_revisions?
     is_staff?
   end

--- a/spec/lib/guardian/post_revision_guardian_spec.rb
+++ b/spec/lib/guardian/post_revision_guardian_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe Guardian do
+  fab!(:user)
+  fab!(:moderator)
+  fab!(:post)
+  fab!(:hidden_post_revision) { Fabricate(:post_revision, post:, number: 2, hidden: true) }
+
+  describe "#can_view_post_version?" do
+    it "denies non-staff from reconstructing a version through a hidden revision" do
+      expect(Guardian.new(user).can_view_post_version?(post, 1)).to eq(true)
+      expect(Guardian.new(user).can_view_post_version?(post, 2)).to eq(false)
+    end
+
+    it "allows staff to reconstruct a version through a hidden revision" do
+      expect(Guardian.new(moderator).can_view_post_version?(post, 2)).to eq(true)
+    end
+  end
+end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -125,6 +125,39 @@ RSpec.describe PostsController do
         expect(response.parsed_body["cooked"]).to eq("<p>BEFORE</p>")
       end
 
+      it "rejects a version restored from a hidden revision" do
+        hidden_raw = "hidden moderator-redacted secret"
+        hidden_cooked = "<p>#{hidden_raw}</p>"
+        post_with_hidden_revision =
+          Fabricate(:post, user: user, version: 3, raw: "public current version")
+        Fabricate(
+          :post_revision,
+          post: post_with_hidden_revision,
+          number: 2,
+          hidden: true,
+          modifications: {
+            "cooked" => ["<p>public first version</p>", hidden_cooked],
+            "raw" => ["public first version", hidden_raw],
+          },
+        )
+        Fabricate(
+          :post_revision,
+          post: post_with_hidden_revision,
+          number: 3,
+          modifications: {
+            "cooked" => [hidden_cooked, "<p>public current version</p>"],
+            "raw" => [hidden_raw, "public current version"],
+          },
+        )
+
+        get "/posts/#{post_with_hidden_revision.id}.json", params: { version: 2 }
+
+        aggregate_failures do
+          expect(response).to be_forbidden
+          expect(response.body).not_to include(hidden_raw)
+        end
+      end
+
       context "when the revision is hidden" do
         before { post_revision.update!(hidden: true) }
 


### PR DESCRIPTION
## Summary

Prevent unauthorized disclosure of moderator-hidden post revisions by blocking non-staff historical version requests when a hidden revision exists at or before the requested version. The controller now uses a dedicated Guardian predicate to enforce this range-based authorization before reconstructing post content. Staff retain legitimate access through their existing hidden-revision review permission.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1113

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>