### PR TITLE
FIX: Check selected sidebar locales by state

### DIFF
--- a/spec/system/page_objects/modals/sidebar_section_form.rb
+++ b/spec/system/page_objects/modals/sidebar_section_form.rb
@@ -166,7 +166,7 @@ module PageObjects
       def has_selected_translation_language?(locale)
         page.has_css?(
           "#{translation_language_selector(locale)} " \
-            ".sidebar-section-translations__language-select option[value='#{locale}'][selected]",
+            ".sidebar-section-translations__language-select option[value='#{locale}']:checked",
           visible: :all,
         )
       end
@@ -208,7 +208,7 @@ module PageObjects
 
       def has_source_language?(locale)
         page.has_css?(
-          ".sidebar-section-form__source-locale-select option[value='#{locale}'][selected]",
+          ".sidebar-section-form__source-locale-select option[value='#{locale}']:checked",
           visible: :all,
         )
       end


### PR DESCRIPTION
## Summary

Native select state is exposed through the checked pseudo-class, while the selected HTML attribute does not reliably reflect the live selected option. Update the sidebar localization page-object assertions to inspect the current DOM state.

This fixes the two deterministic failures in custom_sidebar_sections_spec introduced by #42027.