### PR TITLE
FIX: Enforce per-section sidebar link cap on partial sidebar section updates

### DIFF
--- a/app/models/sidebar_section.rb
+++ b/app/models/sidebar_section.rb
@@ -32,6 +32,7 @@ class SidebarSection < ActiveRecord::Base
             }
 
   validates :locale, presence: true, length: { maximum: 20 }
+  validate :sidebar_urls_count_within_limit
 
   scope :public_sections, -> { where("public") }
   scope :custom_sections, -> { where(section_type: nil) }
@@ -73,6 +74,14 @@ class SidebarSection < ActiveRecord::Base
   end
 
   private
+
+  def sidebar_urls_count_within_limit
+    count = sidebar_urls.reject(&:marked_for_destruction?).size
+    limit = SiteSetting.max_sidebar_section_links
+    return if count <= limit
+
+    errors.add(:base, "Maximum #{limit} records are allowed. Got #{count} records instead.")
+  end
 
   def set_system_user_for_public_section
     self.user_id = Discourse.system_user.id if public

--- a/app/services/sidebar_section_updater.rb
+++ b/app/services/sidebar_section_updater.rb
@@ -13,7 +13,7 @@ class SidebarSectionUpdater
   end
 
   def update!
-    ActiveRecord::Base.transaction do
+    @sidebar_section.with_lock do
       @sidebar_section.update!(@section_params.merge(sidebar_urls_attributes: @links_params))
       @sidebar_section.sidebar_section_links.update_all(user_id: @sidebar_section.user_id)
       update_link_order

--- a/spec/requests/sidebar_sections_controller_spec.rb
+++ b/spec/requests/sidebar_sections_controller_spec.rb
@@ -629,6 +629,28 @@ RSpec.describe SidebarSectionsController do
       expect(SidebarUrlLocalization.exists?(url_localization.id)).to eq(false)
     end
 
+    it "enforces the total link limit when adding links" do
+      SiteSetting.max_sidebar_section_links = 5
+      sign_in(user)
+
+      put "/sidebar_sections/#{sidebar_section.id}.json",
+          params: {
+            title: "custom section",
+            links: [
+              { icon: "link", name: "latest", value: "/latest" },
+              { icon: "link", name: "new", value: "/new" },
+              { icon: "link", name: "top", value: "/top" },
+              { icon: "link", name: "hot", value: "/hot" },
+            ],
+          }
+
+      expect(response.status).to eq(422)
+      expect(response.parsed_body["errors"]).to eq(
+        ["Maximum 5 records are allowed. Got 6 records instead."],
+      )
+      expect(sidebar_section.reload.sidebar_urls.count).to eq(2)
+    end
+
     it "validates limit of links" do
       SiteSetting.max_sidebar_section_links = 5
 


### PR DESCRIPTION
## Summary

Prevent authenticated users from exceeding the configured per-section sidebar link limit by repeatedly appending link batches through partial update requests. The patch validates the final, non-destroyed link count at the model boundary and serializes concurrent updates with a row lock so the cap holds.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1583

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>