### PR TITLE
FIX: Restrict group SMTP settings updates to administrators

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -853,6 +853,19 @@ class GroupsController < ApplicationController
     if !automatic && current_user.staff?
       attributes.push(
         :incoming_email,
+        :title,
+        :primary_group,
+        :name,
+        :grant_trust_level,
+        :publish_read_state,
+      )
+
+      custom_fields = DiscoursePluginRegistry.editable_group_custom_fields
+      attributes << { custom_fields: custom_fields } if custom_fields.present?
+    end
+
+    if !automatic && current_user.admin
+      attributes.push(
         :smtp_server,
         :smtp_port,
         :smtp_ssl_mode,
@@ -862,16 +875,8 @@ class GroupsController < ApplicationController
         :email_username,
         :email_password,
         :email_from_alias,
-        :title,
-        :primary_group,
-        :name,
-        :grant_trust_level,
-        :publish_read_state,
         :allow_unknown_sender_topic_replies,
       )
-
-      custom_fields = DiscoursePluginRegistry.editable_group_custom_fields
-      attributes << { custom_fields: custom_fields } if custom_fields.present?
     end
 
     if !automatic && group && guardian.can_admin_group?(group)

--- a/spec/requests/groups_controller_spec.rb
+++ b/spec/requests/groups_controller_spec.rb
@@ -1707,6 +1707,50 @@ RSpec.describe GroupsController do
         expect(Jobs::AutomaticGroupMembership.jobs.first["args"].first["group_id"]).to eq(group.id)
       end
 
+      it "keeps SMTP email settings unchanged for moderators", :aggregate_failures do
+        SiteSetting.enable_smtp = true
+        group.update!(
+          allow_unknown_sender_topic_replies: false,
+          email_from_alias: "group-alias@example.com",
+          email_password: "secret_smtp_pass",
+          email_username: "group@example.com",
+          smtp_enabled: true,
+          smtp_port: 587,
+          smtp_server: "smtp.example.com",
+          smtp_ssl_mode: Group.smtp_ssl_modes[:starttls],
+        )
+
+        put "/groups/#{group.id}.json",
+            params: {
+              group: {
+                allow_unknown_sender_topic_replies: true,
+                email_from_alias: "evil-alias@example.com",
+                email_password: "attacker_controlled_pass",
+                email_username: "attacker@example.com",
+                flair_color: "BBB",
+                smtp_enabled: false,
+                smtp_port: 25,
+                smtp_server: "evil.attacker.example.com",
+                smtp_ssl_mode: Group.smtp_ssl_modes[:none],
+              },
+              update_existing_users: false,
+            }
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["success"]).to eq("OK")
+
+        group.reload
+        expect(group.flair_color).to eq("BBB")
+        expect(group.smtp_server).to eq("smtp.example.com")
+        expect(group.smtp_port).to eq(587)
+        expect(group.smtp_ssl_mode).to eq(Group.smtp_ssl_modes[:starttls])
+        expect(group.smtp_enabled).to eq(true)
+        expect(group.email_username).to eq("group@example.com")
+        expect(group.email_password).to eq("secret_smtp_pass")
+        expect(group.email_from_alias).to eq("group-alias@example.com")
+        expect(group.allow_unknown_sender_topic_replies).to eq(false)
+      end
+
       it "should be able to update an automatic group" do
         group = Group.find(Group::AUTO_GROUPS[:trust_level_4])
 


### PR DESCRIPTION
## Summary

Prevent moderators from modifying group SMTP configuration by restricting these parameters to administrators. Previously, moderators with group management permissions could overwrite or clear sensitive mail settings, including credentials and server details, via the group update endpoint.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1150

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>